### PR TITLE
feat(investment): add provider batch materialization

### DIFF
--- a/docs/ops/investment-materialization.md
+++ b/docs/ops/investment-materialization.md
@@ -76,6 +76,37 @@ dev-hops investment materialize \
 | `--persist-evidence-snippets` | **on** | Persist extractive evidence quotes to `work_unit_investment_quotes` |
 | `--no-persist-evidence-snippets` | off | Skip quote persistence for storage-constrained backfills |
 | `--force` | off | Force re-materialization |
+| `--llm-batch-mode` | `sync` | LLM execution mode: `sync`, `auto`, or `provider_batch` |
+| `--llm-batch-min-items` | `25` | Minimum eligible items before `auto` chooses provider batch |
+| `--llm-batch-poll-interval-seconds` | `30` | Poll interval for CLI/worker provider batch completion waits |
+| `--llm-batch-timeout-seconds` | `3000` | Timeout for CLI/worker provider batch completion waits |
+
+### Provider batch mode
+
+The default `sync` mode keeps the existing one-request-per-WorkUnit behavior.
+`auto` uses provider batch only when the selected provider supports it and the
+eligible item count is at least `--llm-batch-min-items`; otherwise it logs the
+reason and uses `sync`. `provider_batch` requires provider batch support and fails
+clearly if the selected provider does not support it.
+
+Provider support:
+
+| Provider | Batch support | Notes |
+| --- | --- | --- |
+| `openai` | yes | Uses OpenAI JSONL batch jobs and maps `custom_id` back to WorkUnits. |
+| `qwen` | yes | Uses DashScope/OpenAI-compatible batch configuration; no OpenAI credentials required. |
+| `mock`, `none`, `anthropic`, `gemini`, local-only aliases | no | `auto` falls back to `sync`; `provider_batch` fails. |
+
+Batch job and per-item state is mutable control-plane data stored in Postgres.
+Final `work_unit_investments` and evidence quotes still write only through the
+ClickHouse investment sink. Every eligible item ends in one terminal outcome:
+reused/skipped, validated provider result, repaired result, or deterministic
+fallback. Only terminal validated or fallback outcomes are written to ClickHouse.
+
+HTTP-triggered sync paths enqueue or resume work without blocking the request.
+The Celery materialization chain does not advance membership projection/finalization
+until provider-batch outcomes have been written to ClickHouse, so downstream reads
+do not project from stale investments.
 
 For local OpenAI-compatible servers, set the endpoint before running the command:
 

--- a/docs/ops/investment-materialization.md
+++ b/docs/ops/investment-materialization.md
@@ -76,10 +76,10 @@ dev-hops investment materialize \
 | `--persist-evidence-snippets` | **on** | Persist extractive evidence quotes to `work_unit_investment_quotes` |
 | `--no-persist-evidence-snippets` | off | Skip quote persistence for storage-constrained backfills |
 | `--force` | off | Force re-materialization |
-| `--llm-batch-mode` | `sync` | LLM execution mode: `sync`, `auto`, or `provider_batch` |
-| `--llm-batch-min-items` | `25` | Minimum eligible items before `auto` chooses provider batch |
-| `--llm-batch-poll-interval-seconds` | `30` | Poll interval for CLI/worker provider batch completion waits |
-| `--llm-batch-timeout-seconds` | `3000` | Timeout for CLI/worker provider batch completion waits |
+| `--llm-batch-mode` | `sync` | LLM execution mode: `sync`, `auto`, or `provider_batch`; env: `INVESTMENT_LLM_BATCH_MODE` |
+| `--llm-batch-min-items` | `25` | Minimum eligible items before `auto` chooses provider batch; env: `INVESTMENT_LLM_BATCH_MIN_ITEMS` |
+| `--llm-batch-poll-interval-seconds` | `30` | Poll interval for CLI/worker provider batch completion waits; env: `INVESTMENT_LLM_BATCH_POLL_INTERVAL_SECONDS` |
+| `--llm-batch-timeout-seconds` | `3000` | Timeout for CLI/worker provider batch completion waits; env: `INVESTMENT_LLM_BATCH_TIMEOUT_SECONDS` |
 
 ### Provider batch mode
 
@@ -88,6 +88,19 @@ The default `sync` mode keeps the existing one-request-per-WorkUnit behavior.
 eligible item count is at least `--llm-batch-min-items`; otherwise it logs the
 reason and uses `sync`. `provider_batch` requires provider batch support and fails
 clearly if the selected provider does not support it.
+
+Queue runners use the same defaults from environment when a task payload omits
+batch kwargs. Set these on Celery workers to enable batch mode for post-sync and
+scheduled materialization without changing dispatch call sites:
+
+```bash
+export INVESTMENT_LLM_BATCH_MODE=auto
+export INVESTMENT_LLM_BATCH_MIN_ITEMS=25
+export INVESTMENT_LLM_BATCH_POLL_INTERVAL_SECONDS=30
+export INVESTMENT_LLM_BATCH_TIMEOUT_SECONDS=3000
+```
+
+Explicit CLI flags or task kwargs override the environment for that run.
 
 Provider support:
 

--- a/src/dev_health_ops/alembic/versions/0024_add_investment_batch_tables.py
+++ b/src/dev_health_ops/alembic/versions/0024_add_investment_batch_tables.py
@@ -1,0 +1,194 @@
+"""Add investment provider batch control-plane tables.
+
+Revision ID: 0024
+Revises: 0023
+Create Date: 2026-06-25 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0024"
+down_revision: str | None = "0023"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    op.create_table(
+        "investment_batch_jobs",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("provider", sa.String(), nullable=False),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("provider_job_id", sa.String(), nullable=True),
+        sa.Column("local_correlation_id", sa.String(), nullable=False),
+        sa.Column("run_id", sa.String(), nullable=False),
+        sa.Column("prompt_version", sa.String(), nullable=False),
+        sa.Column("contract_version", sa.String(), nullable=False),
+        sa.Column("total_items", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("completed_items", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("failed_items", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deadline_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("error", sa.Text(), nullable=True),
+        sa.Column("provider_metadata", sa.JSON(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "org_id",
+            "local_correlation_id",
+            name="uq_investment_batch_jobs_org_correlation",
+        ),
+    )
+    op.create_index(
+        "ix_investment_batch_jobs_org_id", "investment_batch_jobs", ["org_id"]
+    )
+    op.create_index(
+        "ix_investment_batch_jobs_status", "investment_batch_jobs", ["status"]
+    )
+    op.create_index(
+        "ix_investment_batch_jobs_provider_job_id",
+        "investment_batch_jobs",
+        ["provider_job_id"],
+    )
+    op.create_index(
+        "ix_investment_batch_jobs_local_correlation_id",
+        "investment_batch_jobs",
+        ["local_correlation_id"],
+    )
+    op.create_index(
+        "ix_investment_batch_jobs_run_id", "investment_batch_jobs", ["run_id"]
+    )
+    op.create_index(
+        "ix_investment_batch_jobs_org_status",
+        "investment_batch_jobs",
+        ["org_id", "status"],
+    )
+    op.create_index(
+        "ix_investment_batch_jobs_org_provider_job",
+        "investment_batch_jobs",
+        ["org_id", "provider_job_id"],
+    )
+
+    op.create_table(
+        "investment_batch_items",
+        sa.Column("id", UUID(as_uuid=True), nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("job_id", UUID(as_uuid=True), nullable=False),
+        sa.Column("work_unit_id", sa.Text(), nullable=False),
+        sa.Column("component_index", sa.Integer(), nullable=False),
+        sa.Column("custom_id", sa.String(), nullable=False),
+        sa.Column("input_hash", sa.String(), nullable=False),
+        sa.Column("provider", sa.String(), nullable=False),
+        sa.Column("model", sa.String(), nullable=False),
+        sa.Column("prompt_version", sa.String(), nullable=False),
+        sa.Column("contract_version", sa.String(), nullable=False),
+        sa.Column("status", sa.String(), nullable=False),
+        sa.Column("validation_status", sa.String(), nullable=True),
+        sa.Column("repair_status", sa.String(), nullable=True),
+        sa.Column("fallback_status", sa.String(), nullable=True),
+        sa.Column("provider_response", sa.JSON(), nullable=True),
+        sa.Column("provider_error", sa.JSON(), nullable=True),
+        sa.Column("audit", sa.JSON(), nullable=True),
+        sa.Column("submitted_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["job_id"], ["investment_batch_jobs.id"], ondelete="CASCADE"
+        ),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint(
+            "org_id",
+            "job_id",
+            "custom_id",
+            name="uq_investment_batch_items_job_custom",
+        ),
+    )
+    op.create_index(
+        "ix_investment_batch_items_org_id", "investment_batch_items", ["org_id"]
+    )
+    op.create_index(
+        "ix_investment_batch_items_status", "investment_batch_items", ["status"]
+    )
+    op.create_index(
+        "ix_investment_batch_items_org_job",
+        "investment_batch_items",
+        ["org_id", "job_id"],
+    )
+    op.create_index(
+        "ix_investment_batch_items_org_custom",
+        "investment_batch_items",
+        ["org_id", "custom_id"],
+    )
+    op.create_index(
+        "ix_investment_batch_items_org_status",
+        "investment_batch_items",
+        ["org_id", "status"],
+    )
+    op.create_index(
+        "ix_investment_batch_items_idempotency_lookup",
+        "investment_batch_items",
+        [
+            "org_id",
+            "work_unit_id",
+            "component_index",
+            "input_hash",
+            "provider",
+            "model",
+            "prompt_version",
+            "contract_version",
+        ],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_investment_batch_items_idempotency_lookup",
+        table_name="investment_batch_items",
+    )
+    op.drop_index(
+        "ix_investment_batch_items_org_status", table_name="investment_batch_items"
+    )
+    op.drop_index(
+        "ix_investment_batch_items_org_custom", table_name="investment_batch_items"
+    )
+    op.drop_index(
+        "ix_investment_batch_items_org_job", table_name="investment_batch_items"
+    )
+    op.drop_index(
+        "ix_investment_batch_items_status", table_name="investment_batch_items"
+    )
+    op.drop_index(
+        "ix_investment_batch_items_org_id", table_name="investment_batch_items"
+    )
+    op.drop_table("investment_batch_items")
+    op.drop_index(
+        "ix_investment_batch_jobs_org_provider_job", table_name="investment_batch_jobs"
+    )
+    op.drop_index(
+        "ix_investment_batch_jobs_org_status", table_name="investment_batch_jobs"
+    )
+    op.drop_index("ix_investment_batch_jobs_run_id", table_name="investment_batch_jobs")
+    op.drop_index(
+        "ix_investment_batch_jobs_local_correlation_id",
+        table_name="investment_batch_jobs",
+    )
+    op.drop_index(
+        "ix_investment_batch_jobs_provider_job_id", table_name="investment_batch_jobs"
+    )
+    op.drop_index("ix_investment_batch_jobs_status", table_name="investment_batch_jobs")
+    op.drop_index("ix_investment_batch_jobs_org_id", table_name="investment_batch_jobs")
+    op.drop_table("investment_batch_jobs")

--- a/src/dev_health_ops/llm/providers/batch.py
+++ b/src/dev_health_ops/llm/providers/batch.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from enum import Enum
+from typing import Any, Protocol, runtime_checkable
+
+
+class BatchJobStatus(str, Enum):
+    CREATED = "created"
+    SUBMITTING = "submitting"
+    SUBMITTED = "submitted"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    EXPIRED = "expired"
+
+
+class BatchItemStatus(str, Enum):
+    PENDING = "pending"
+    SUBMITTED = "submitted"
+    PROVIDER_SUCCEEDED = "provider_succeeded"
+    PROVIDER_FAILED = "provider_failed"
+    VALIDATED = "validated"
+    REPAIRING = "repairing"
+    REPAIRED = "repaired"
+    FALLBACK = "fallback"
+    REUSED = "reused"
+    FAILED = "failed"
+
+
+class BatchProviderFeature(str, Enum):
+    SUBMIT = "submit"
+    POLL = "poll"
+    FETCH_RESULTS = "fetch_results"
+    CANCEL = "cancel"
+
+
+@dataclass(frozen=True)
+class BatchCapability:
+    provider: str
+    model: str
+    supported: bool
+    features: frozenset[BatchProviderFeature] = frozenset()
+    reason: str = ""
+
+
+@dataclass(frozen=True)
+class BatchItemRequest:
+    custom_id: str
+    prompt: str
+    response_format: dict[str, Any] | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        custom_id = self.custom_id.strip()
+        if not custom_id:
+            raise ValueError("Batch item custom_id is required")
+        if any(char.isspace() for char in custom_id):
+            raise ValueError("Batch item custom_id must not contain whitespace")
+        if not self.prompt:
+            raise ValueError("Batch item prompt is required")
+        object.__setattr__(self, "custom_id", custom_id)
+
+
+@dataclass(frozen=True)
+class BatchJobSubmission:
+    provider_job_id: str
+    provider: str
+    model: str
+    item_count: int
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if not self.provider_job_id.strip():
+            raise ValueError("provider_job_id is required")
+        if self.item_count < 0:
+            raise ValueError("item_count must be non-negative")
+
+
+@dataclass(frozen=True)
+class BatchJobState:
+    provider_job_id: str
+    status: BatchJobStatus
+    total_count: int
+    completed_count: int = 0
+    failed_count: int = 0
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def __post_init__(self) -> None:
+        if self.total_count < 0:
+            raise ValueError("total_count must be non-negative")
+        if self.completed_count < 0 or self.failed_count < 0:
+            raise ValueError("completed_count and failed_count must be non-negative")
+
+
+@dataclass(frozen=True)
+class BatchItemResult:
+    custom_id: str
+    raw_response: str | None = None
+    error_code: str | None = None
+    error_message: str | None = None
+    provider_metadata: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def succeeded(self) -> bool:
+        return self.error_code is None and self.raw_response is not None
+
+
+@runtime_checkable
+class BatchProvider(Protocol):
+    def batch_capability(self, model: str | None = None) -> BatchCapability:
+        raise NotImplementedError
+
+    async def submit_batch(self, items: list[BatchItemRequest]) -> BatchJobSubmission:
+        raise NotImplementedError
+
+    async def poll_batch(self, provider_job_id: str) -> BatchJobState:
+        raise NotImplementedError
+
+    async def fetch_batch_results(self, provider_job_id: str) -> list[BatchItemResult]:
+        raise NotImplementedError
+
+    async def cancel_batch(self, provider_job_id: str) -> None:
+        raise NotImplementedError
+
+
+def unsupported_batch_capability(
+    provider: str, model: str | None = None, *, reason: str = "unsupported"
+) -> BatchCapability:
+    return BatchCapability(
+        provider=provider,
+        model=model or "",
+        supported=False,
+        features=frozenset(),
+        reason=reason,
+    )
+
+
+def batch_capability_for(provider: object, model: str | None = None) -> BatchCapability:
+    capability = getattr(provider, "batch_capability", None)
+    if callable(capability):
+        result = capability(model)
+        if isinstance(result, BatchCapability):
+            return result
+    provider_name = str(getattr(provider, "provider_name", type(provider).__name__))
+    return unsupported_batch_capability(provider_name, model)

--- a/src/dev_health_ops/llm/providers/openai.py
+++ b/src/dev_health_ops/llm/providers/openai.py
@@ -14,6 +14,8 @@ Notes:
 from __future__ import annotations
 
 import asyncio
+import io
+import json
 import logging
 from dataclasses import dataclass
 from typing import Any
@@ -32,6 +34,15 @@ from .base import (
     CompletionResult,
     LLMProviderBase,
     usage_token_count,
+)
+from .batch import (
+    BatchCapability,
+    BatchItemRequest,
+    BatchItemResult,
+    BatchJobState,
+    BatchJobStatus,
+    BatchJobSubmission,
+    BatchProviderFeature,
 )
 
 logger = logging.getLogger(__name__)
@@ -67,6 +78,151 @@ def system_message(prompt: str) -> str:
         "Do NOT introduce new conclusions or recommendations.\n"
         "Return ONLY valid JSON."
     )
+
+
+def _map_openai_batch_status(status: str) -> BatchJobStatus:
+    normalized = (status or "").strip().lower()
+    if normalized in {"validating", "in_progress", "finalizing"}:
+        return BatchJobStatus.RUNNING
+    if normalized == "completed":
+        return BatchJobStatus.SUCCEEDED
+    if normalized in {"failed", "expired"}:
+        return (
+            BatchJobStatus.EXPIRED if normalized == "expired" else BatchJobStatus.FAILED
+        )
+    if normalized in {"cancelling", "cancelled"}:
+        return BatchJobStatus.CANCELLED
+    return BatchJobStatus.SUBMITTED
+
+
+async def _openai_file_text(client: Any, file_id: str) -> str:
+    content = await client.files.content(file_id)
+    text_attr = getattr(content, "text", None)
+    if callable(text_attr):
+        maybe_text = text_attr()
+        if isinstance(maybe_text, str):
+            return maybe_text
+    read_attr = getattr(content, "read", None)
+    if callable(read_attr):
+        raw = read_attr()
+        if isinstance(raw, bytes):
+            return raw.decode("utf-8")
+        if isinstance(raw, str):
+            return raw
+    if isinstance(content, bytes):
+        return content.decode("utf-8")
+    return str(content)
+
+
+def _extract_batch_response_text(body: object) -> str | None:
+    if not isinstance(body, dict):
+        return None
+    output_text = body.get("output_text")
+    if isinstance(output_text, str) and output_text.strip():
+        return validate_json_or_empty(output_text) or output_text
+    choices = body.get("choices")
+    if isinstance(choices, list) and choices:
+        first = choices[0]
+        if isinstance(first, dict):
+            message = first.get("message")
+            if isinstance(message, dict):
+                content = message.get("content")
+                if isinstance(content, str):
+                    return validate_json_or_empty(content) or content
+    output = body.get("output")
+    if isinstance(output, list):
+        parts: list[str] = []
+        for item in output:
+            if not isinstance(item, dict):
+                continue
+            content = item.get("content")
+            if not isinstance(content, list):
+                continue
+            for chunk in content:
+                if isinstance(chunk, dict):
+                    text = chunk.get("text")
+                    if isinstance(text, str):
+                        parts.append(text)
+        joined = "".join(parts)
+        if joined:
+            return validate_json_or_empty(joined) or joined
+    return None
+
+
+def _parse_openai_batch_lines(text: str) -> list[BatchItemResult]:
+    results: list[BatchItemResult] = []
+    for line in text.splitlines():
+        if not line.strip():
+            continue
+        payload = json.loads(line)
+        custom_id = str(payload.get("custom_id") or "")
+        error = payload.get("error")
+        if isinstance(error, dict):
+            results.append(
+                BatchItemResult(
+                    custom_id=custom_id,
+                    error_code=str(error.get("code") or error.get("type") or "error"),
+                    error_message=str(error.get("message") or error),
+                    provider_metadata=_batch_payload_metadata(payload),
+                )
+            )
+            continue
+        response = payload.get("response")
+        if isinstance(response, dict):
+            body = response.get("body")
+            raw_response = _extract_batch_response_text(body)
+            status_code = response.get("status_code")
+            if raw_response is not None:
+                results.append(
+                    BatchItemResult(
+                        custom_id=custom_id,
+                        raw_response=raw_response,
+                        provider_metadata=_batch_payload_metadata(payload),
+                    )
+                )
+            else:
+                results.append(
+                    BatchItemResult(
+                        custom_id=custom_id,
+                        error_code=f"http_{status_code or 'unknown'}",
+                        error_message="Batch response did not contain completion text",
+                        provider_metadata=_batch_payload_metadata(payload),
+                    )
+                )
+    return results
+
+
+def _batch_payload_metadata(payload: dict[str, Any]) -> dict[str, Any]:
+    metadata: dict[str, Any] = {}
+    if payload.get("id") is not None:
+        metadata["id"] = str(payload["id"])
+    if payload.get("custom_id") is not None:
+        metadata["custom_id"] = str(payload["custom_id"])
+    response = payload.get("response")
+    if isinstance(response, dict):
+        if response.get("request_id") is not None:
+            metadata["request_id"] = str(response["request_id"])
+        if response.get("status_code") is not None:
+            metadata["status_code"] = response["status_code"]
+        body = response.get("body")
+        if isinstance(body, dict):
+            usage = body.get("usage")
+            if isinstance(usage, dict):
+                input_tokens = usage.get("input_tokens", usage.get("prompt_tokens"))
+                output_tokens = usage.get(
+                    "output_tokens", usage.get("completion_tokens")
+                )
+                if input_tokens is not None:
+                    metadata["input_tokens"] = int(input_tokens or 0)
+                if output_tokens is not None:
+                    metadata["output_tokens"] = int(output_tokens or 0)
+    error = payload.get("error")
+    if isinstance(error, dict):
+        if error.get("code") is not None:
+            metadata["error_code"] = str(error["code"])
+        if error.get("type") is not None:
+            metadata["error_type"] = str(error["type"])
+    return metadata
 
 
 def categorization_json_schema() -> dict[str, Any]:
@@ -168,6 +324,21 @@ class OpenAIProvider(LLMProviderBase):
     async def complete(self, prompt: str) -> CompletionResult:
         return await self._impl.complete(prompt)
 
+    def batch_capability(self, model: str | None = None) -> BatchCapability:
+        return self._impl.batch_capability(model)
+
+    async def submit_batch(self, items: list[BatchItemRequest]) -> BatchJobSubmission:
+        return await self._impl.submit_batch(items)
+
+    async def poll_batch(self, provider_job_id: str) -> BatchJobState:
+        return await self._impl.poll_batch(provider_job_id)
+
+    async def fetch_batch_results(self, provider_job_id: str) -> list[BatchItemResult]:
+        return await self._impl.fetch_batch_results(provider_job_id)
+
+    async def cancel_batch(self, provider_job_id: str) -> None:
+        await self._impl.cancel_batch(provider_job_id)
+
     async def aclose(self) -> None:
         await self._impl.aclose()
 
@@ -242,6 +413,139 @@ class _OpenAIProviderBase(LLMProviderBase):
 
     async def complete(self, prompt: str) -> CompletionResult:
         raise NotImplementedError
+
+    def batch_capability(self, model: str | None = None) -> BatchCapability:
+        resolved_model = model or self.cfg.model
+        return BatchCapability(
+            provider=self.cfg.validation_provider_name,
+            model=resolved_model,
+            supported=True,
+            features=frozenset(
+                {
+                    BatchProviderFeature.SUBMIT,
+                    BatchProviderFeature.POLL,
+                    BatchProviderFeature.FETCH_RESULTS,
+                    BatchProviderFeature.CANCEL,
+                }
+            ),
+        )
+
+    def _batch_endpoint(self) -> str:
+        return (
+            "/v1/responses"
+            if _is_gpt5_family(self.cfg.model)
+            else "/v1/chat/completions"
+        )
+
+    def _batch_body(self, prompt: str) -> dict[str, Any]:
+        sys_msg = system_message(prompt)
+        if _is_gpt5_family(self.cfg.model):
+            text_format: dict[str, Any]
+            if is_json_schema_prompt(prompt):
+                text_format = {
+                    "format": {
+                        "type": "json_schema",
+                        "name": "categorization",
+                        "strict": True,
+                        "schema": categorization_json_schema(),
+                    }
+                }
+            else:
+                text_format = {"format": {"type": "json_object"}}
+            body: dict[str, Any] = {
+                "model": self.cfg.model,
+                "instructions": sys_msg,
+                "input": prompt,
+                "text": text_format,
+                "reasoning": {"effort": "low"},
+                "max_output_tokens": max(self.cfg.max_output_tokens, 2048),
+            }
+            if self._supports_temperature():
+                body["temperature"] = self.cfg.temperature
+            return body
+        body = {
+            "model": self.cfg.model,
+            "messages": [
+                {"role": "system", "content": sys_msg},
+                {"role": "user", "content": prompt},
+            ],
+            "response_format": {"type": "json_object"},
+            "max_completion_tokens": max(self.cfg.max_output_tokens, 2048),
+        }
+        if self._supports_temperature():
+            body["temperature"] = self.cfg.temperature
+        return body
+
+    def _batch_line(self, item: BatchItemRequest) -> str:
+        return json.dumps(
+            {
+                "custom_id": item.custom_id,
+                "method": "POST",
+                "url": self._batch_endpoint(),
+                "body": self._batch_body(item.prompt),
+            },
+            separators=(",", ":"),
+        )
+
+    async def submit_batch(self, items: list[BatchItemRequest]) -> BatchJobSubmission:
+        if not items:
+            raise ValueError("Cannot submit an empty provider batch")
+        client = self._get_client()
+        payload = "\n".join(self._batch_line(item) for item in items).encode("utf-8")
+        file_obj = io.BytesIO(payload)
+        file_obj.name = "investment-categorization-batch.jsonl"
+        uploaded = await client.files.create(file=file_obj, purpose="batch")
+        batch = await client.batches.create(
+            input_file_id=uploaded.id,
+            endpoint=self._batch_endpoint(),
+            completion_window="24h",
+            metadata={"source": "investment_materialize"},
+        )
+        return BatchJobSubmission(
+            provider_job_id=batch.id,
+            provider=self.cfg.validation_provider_name,
+            model=self.cfg.model,
+            item_count=len(items),
+            metadata={"input_file_id": uploaded.id},
+        )
+
+    async def poll_batch(self, provider_job_id: str) -> BatchJobState:
+        client = self._get_client()
+        batch = await client.batches.retrieve(provider_job_id)
+        status = _map_openai_batch_status(str(getattr(batch, "status", "")))
+        counts = getattr(batch, "request_counts", None)
+        total = int(getattr(counts, "total", 0) or 0)
+        completed = int(getattr(counts, "completed", 0) or 0)
+        failed = int(getattr(counts, "failed", 0) or 0)
+        return BatchJobState(
+            provider_job_id=provider_job_id,
+            status=status,
+            total_count=total,
+            completed_count=completed,
+            failed_count=failed,
+            metadata={
+                "output_file_id": getattr(batch, "output_file_id", None),
+                "error_file_id": getattr(batch, "error_file_id", None),
+            },
+        )
+
+    async def fetch_batch_results(self, provider_job_id: str) -> list[BatchItemResult]:
+        client = self._get_client()
+        batch = await client.batches.retrieve(provider_job_id)
+        results: list[BatchItemResult] = []
+        output_file_id = getattr(batch, "output_file_id", None)
+        error_file_id = getattr(batch, "error_file_id", None)
+        if output_file_id:
+            output_text = await _openai_file_text(client, output_file_id)
+            results.extend(_parse_openai_batch_lines(output_text))
+        if error_file_id:
+            error_text = await _openai_file_text(client, error_file_id)
+            results.extend(_parse_openai_batch_lines(error_text))
+        return results
+
+    async def cancel_batch(self, provider_job_id: str) -> None:
+        client = self._get_client()
+        await client.batches.cancel(provider_job_id)
 
     async def _retry_transient_error(
         self,
@@ -384,12 +688,12 @@ class OpenAIGPT5Provider(_OpenAIProviderBase):
 
                 # Final failure: return empty string (caller handles)
                 logger.error(
-                    "Invalid JSON returned from responses API (reason=%s, is_schema=%s, p_len=%d, budget=%d). Sample=%s",
+                    "Invalid JSON returned from responses API (reason=%s, is_schema=%s, p_len=%d, budget=%d, content_length=%d).",
                     finish_reason,
                     is_schema_prompt,
                     len(prompt),
                     token_budget,
-                    (content.strip()[:200] + "...") if content else "<empty>",
+                    len(content.strip()),
                 )
                 return self._completion_result("", usage)
 
@@ -477,12 +781,12 @@ class OpenAIGPTLegacyProvider(_OpenAIProviderBase):
 
                 is_schema_prompt = is_json_schema_prompt(prompt)
                 logger.error(
-                    "Invalid JSON returned from chat completions (reason=%s, is_schema=%s, p_len=%d, budget=%d). Sample=%s",
+                    "Invalid JSON returned from chat completions (reason=%s, is_schema=%s, p_len=%d, budget=%d, content_length=%d).",
                     finish_reason,
                     is_schema_prompt,
                     len(prompt),
                     max_tokens,
-                    (content.strip()[:200] + "...") if content else "<empty>",
+                    len(content.strip()),
                 )
                 return self._completion_result("", usage)
 

--- a/src/dev_health_ops/llm/providers/qwen.py
+++ b/src/dev_health_ops/llm/providers/qwen.py
@@ -12,7 +12,15 @@ from __future__ import annotations
 import os
 
 from .base import DEFAULT_MODEL_BY_PROVIDER
+from .batch import (
+    BatchCapability,
+    BatchItemRequest,
+    BatchItemResult,
+    BatchJobState,
+    BatchJobSubmission,
+)
 from .local import DEFAULT_ENDPOINTS, LocalProvider
+from .openai import OpenAIGPTLegacyProvider, OpenAIProviderConfig
 
 # Default DashScope (China) OpenAI-compatible endpoint.
 # Users can override with DASHSCOPE_BASE_URL for international regions:
@@ -40,6 +48,7 @@ class QwenProvider(LocalProvider):
         base_url: str | None = None,
         **kwargs,
     ) -> None:
+        self._batch_impl: OpenAIGPTLegacyProvider | None = None
         super().__init__(
             api_key=api_key
             or os.getenv("QWEN_API_KEY")
@@ -49,6 +58,35 @@ class QwenProvider(LocalProvider):
             model=model or os.getenv("QWEN_MODEL", DEFAULT_MODEL_BY_PROVIDER["qwen"]),
             **kwargs,
         )
+
+    def _get_batch_impl(self) -> OpenAIGPTLegacyProvider:
+        if self._batch_impl is None:
+            self._batch_impl = OpenAIGPTLegacyProvider(
+                OpenAIProviderConfig(
+                    api_key=self.api_key or "",
+                    base_url=self.base_url,
+                    model=self.model,
+                    max_output_tokens=self.max_completion_tokens,
+                    temperature=self.temperature,
+                    validation_provider_name="qwen",
+                )
+            )
+        return self._batch_impl
+
+    def batch_capability(self, model: str | None = None) -> BatchCapability:
+        return self._get_batch_impl().batch_capability(model or self.model)
+
+    async def submit_batch(self, items: list[BatchItemRequest]) -> BatchJobSubmission:
+        return await self._get_batch_impl().submit_batch(items)
+
+    async def poll_batch(self, provider_job_id: str) -> BatchJobState:
+        return await self._get_batch_impl().poll_batch(provider_job_id)
+
+    async def fetch_batch_results(self, provider_job_id: str) -> list[BatchItemResult]:
+        return await self._get_batch_impl().fetch_batch_results(provider_job_id)
+
+    async def cancel_batch(self, provider_job_id: str) -> None:
+        await self._get_batch_impl().cancel_batch(provider_job_id)
 
 
 class QwenLocalProvider(LocalProvider):

--- a/src/dev_health_ops/models/__init__.py
+++ b/src/dev_health_ops/models/__init__.py
@@ -27,6 +27,12 @@ from .integrations import (
     SyncRunUnit,
     SyncRunUnitStatus,
 )
+from .investment_batch import (
+    InvestmentBatchItem,
+    InvestmentBatchItemStatus,
+    InvestmentBatchJob,
+    InvestmentBatchJobStatus,
+)
 from .invoices import Invoice, InvoiceLineItem
 from .ip_allowlist import OrgIPAllowlist
 from .licensing import (
@@ -113,6 +119,10 @@ __all__ = [
     "IntegrationDataset",
     "IntegrationProvider",
     "IntegrationSource",
+    "InvestmentBatchItem",
+    "InvestmentBatchItemStatus",
+    "InvestmentBatchJob",
+    "InvestmentBatchJobStatus",
     "Invoice",
     "InvoiceLineItem",
     "JobRun",

--- a/src/dev_health_ops/models/investment_batch.py
+++ b/src/dev_health_ops/models/investment_batch.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+from typing import Any
+
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+)
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from dev_health_ops.models.git import GUID, Base
+
+
+class InvestmentBatchJobStatus(str, Enum):
+    CREATED = "created"
+    SUBMITTING = "submitting"
+    SUBMITTED = "submitted"
+    RUNNING = "running"
+    SUCCEEDED = "succeeded"
+    FAILED = "failed"
+    CANCELLED = "cancelled"
+    EXPIRED = "expired"
+
+
+class InvestmentBatchItemStatus(str, Enum):
+    PENDING = "pending"
+    SUBMITTED = "submitted"
+    PROVIDER_SUCCEEDED = "provider_succeeded"
+    PROVIDER_FAILED = "provider_failed"
+    VALIDATED = "validated"
+    REPAIRING = "repairing"
+    REPAIRED = "repaired"
+    FALLBACK = "fallback"
+    REUSED = "reused"
+    FAILED = "failed"
+
+
+class InvestmentBatchJob(Base):
+    __tablename__ = "investment_batch_jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    model: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        default=InvestmentBatchJobStatus.CREATED.value,
+        index=True,
+    )
+    provider_job_id: Mapped[str | None] = mapped_column(
+        String, nullable=True, index=True
+    )
+    local_correlation_id: Mapped[str] = mapped_column(
+        String, nullable=False, index=True
+    )
+    run_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    prompt_version: Mapped[str] = mapped_column(String, nullable=False)
+    contract_version: Mapped[str] = mapped_column(String, nullable=False)
+    total_items: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    completed_items: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    failed_items: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    submitted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    deadline_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    provider_metadata: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    items: Mapped[list[InvestmentBatchItem]] = relationship(
+        back_populates="job", cascade="all, delete-orphan"
+    )
+
+    __table_args__ = (
+        Index(
+            "uq_investment_batch_jobs_org_correlation",
+            "org_id",
+            "local_correlation_id",
+            unique=True,
+        ),
+        Index("ix_investment_batch_jobs_org_status", "org_id", "status"),
+        Index("ix_investment_batch_jobs_org_provider_job", "org_id", "provider_job_id"),
+    )
+
+
+class InvestmentBatchItem(Base):
+    __tablename__ = "investment_batch_items"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    job_id: Mapped[uuid.UUID] = mapped_column(
+        GUID, ForeignKey("investment_batch_jobs.id", ondelete="CASCADE"), nullable=False
+    )
+    work_unit_id: Mapped[str] = mapped_column(Text, nullable=False)
+    component_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    custom_id: Mapped[str] = mapped_column(String, nullable=False)
+    input_hash: Mapped[str] = mapped_column(String, nullable=False)
+    provider: Mapped[str] = mapped_column(String, nullable=False)
+    model: Mapped[str] = mapped_column(String, nullable=False)
+    prompt_version: Mapped[str] = mapped_column(String, nullable=False)
+    contract_version: Mapped[str] = mapped_column(String, nullable=False)
+    status: Mapped[str] = mapped_column(
+        String,
+        nullable=False,
+        default=InvestmentBatchItemStatus.PENDING.value,
+        index=True,
+    )
+    validation_status: Mapped[str | None] = mapped_column(String, nullable=True)
+    repair_status: Mapped[str | None] = mapped_column(String, nullable=True)
+    fallback_status: Mapped[str | None] = mapped_column(String, nullable=True)
+    provider_response: Mapped[dict[str, Any] | None] = mapped_column(
+        JSON, nullable=True
+    )
+    provider_error: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    audit: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
+    submitted_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    job: Mapped[InvestmentBatchJob] = relationship(back_populates="items")
+
+    __table_args__ = (
+        Index(
+            "ix_investment_batch_items_idempotency_lookup",
+            "org_id",
+            "work_unit_id",
+            "component_index",
+            "input_hash",
+            "provider",
+            "model",
+            "prompt_version",
+            "contract_version",
+        ),
+        Index(
+            "uq_investment_batch_items_job_custom",
+            "org_id",
+            "job_id",
+            "custom_id",
+            unique=True,
+        ),
+        Index("ix_investment_batch_items_org_job", "org_id", "job_id"),
+        Index("ix_investment_batch_items_org_custom", "org_id", "custom_id"),
+        Index("ix_investment_batch_items_org_status", "org_id", "status"),
+    )

--- a/src/dev_health_ops/work_graph/investment/batch_store.py
+++ b/src/dev_health_ops/work_graph/investment/batch_store.py
@@ -1,0 +1,230 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.investment_batch import (
+    InvestmentBatchItem,
+    InvestmentBatchItemStatus,
+    InvestmentBatchJob,
+    InvestmentBatchJobStatus,
+)
+
+TERMINAL_ITEM_STATUSES = frozenset(
+    {
+        InvestmentBatchItemStatus.VALIDATED.value,
+        InvestmentBatchItemStatus.REPAIRED.value,
+        InvestmentBatchItemStatus.FALLBACK.value,
+        InvestmentBatchItemStatus.REUSED.value,
+        InvestmentBatchItemStatus.FAILED.value,
+    }
+)
+
+
+@dataclass(frozen=True)
+class InvestmentBatchItemSpec:
+    work_unit_id: str
+    component_index: int
+    custom_id: str
+    input_hash: str
+
+
+class InvestmentBatchStore:
+    def __init__(self, session: Session, org_id: str) -> None:
+        self.session = session
+        self.org_id = org_id
+
+    def create_job(
+        self,
+        *,
+        provider: str,
+        model: str,
+        run_id: str,
+        prompt_version: str,
+        contract_version: str,
+        items: list[InvestmentBatchItemSpec],
+        deadline_at: datetime | None = None,
+        local_correlation_id: str | None = None,
+    ) -> InvestmentBatchJob:
+        now = datetime.now(timezone.utc)
+        job = InvestmentBatchJob(
+            org_id=self.org_id,
+            provider=provider,
+            model=model,
+            status=InvestmentBatchJobStatus.CREATED.value,
+            local_correlation_id=local_correlation_id or uuid.uuid4().hex,
+            run_id=run_id,
+            prompt_version=prompt_version,
+            contract_version=contract_version,
+            total_items=len(items),
+            deadline_at=deadline_at,
+            created_at=now,
+            updated_at=now,
+        )
+        self.session.add(job)
+        self.session.flush()
+        for item in items:
+            self.session.add(
+                InvestmentBatchItem(
+                    org_id=self.org_id,
+                    job_id=job.id,
+                    work_unit_id=item.work_unit_id,
+                    component_index=item.component_index,
+                    custom_id=item.custom_id,
+                    input_hash=item.input_hash,
+                    provider=provider,
+                    model=model,
+                    prompt_version=prompt_version,
+                    contract_version=contract_version,
+                    status=InvestmentBatchItemStatus.PENDING.value,
+                    created_at=now,
+                    updated_at=now,
+                )
+            )
+        self.session.flush()
+        return job
+
+    def get_job(self, job_id: str | uuid.UUID) -> InvestmentBatchJob | None:
+        return self.session.scalar(
+            select(InvestmentBatchJob).where(
+                InvestmentBatchJob.org_id == self.org_id,
+                InvestmentBatchJob.id == uuid.UUID(str(job_id)),
+            )
+        )
+
+    def get_job_by_correlation(
+        self, local_correlation_id: str
+    ) -> InvestmentBatchJob | None:
+        return self.session.scalar(
+            select(InvestmentBatchJob).where(
+                InvestmentBatchJob.org_id == self.org_id,
+                InvestmentBatchJob.local_correlation_id == local_correlation_id,
+            )
+        )
+
+    def get_item_by_custom_id(
+        self, *, job_id: str | uuid.UUID, custom_id: str
+    ) -> InvestmentBatchItem | None:
+        return self.session.scalar(
+            select(InvestmentBatchItem).where(
+                InvestmentBatchItem.org_id == self.org_id,
+                InvestmentBatchItem.job_id == uuid.UUID(str(job_id)),
+                InvestmentBatchItem.custom_id == custom_id,
+            )
+        )
+
+    def find_reusable_items(
+        self,
+        *,
+        provider: str,
+        model: str,
+        prompt_version: str,
+        keys: list[tuple[str, int, str]],
+    ) -> dict[tuple[str, int, str], InvestmentBatchItem]:
+        if not keys:
+            return {}
+        rows = self.session.scalars(
+            select(InvestmentBatchItem).where(
+                InvestmentBatchItem.org_id == self.org_id,
+                InvestmentBatchItem.provider == provider,
+                InvestmentBatchItem.model == model,
+                InvestmentBatchItem.prompt_version == prompt_version,
+                InvestmentBatchItem.status.in_(
+                    [
+                        InvestmentBatchItemStatus.VALIDATED.value,
+                        InvestmentBatchItemStatus.REPAIRED.value,
+                        InvestmentBatchItemStatus.REUSED.value,
+                    ]
+                ),
+            )
+        ).all()
+        wanted = set(keys)
+        reusable: dict[tuple[str, int, str], InvestmentBatchItem] = {}
+        for row in rows:
+            key = (row.work_unit_id, row.component_index, row.input_hash)
+            if key in wanted:
+                reusable[key] = row
+        return reusable
+
+    def transition_job(
+        self,
+        job: InvestmentBatchJob,
+        status: InvestmentBatchJobStatus | str,
+        *,
+        provider_job_id: str | None = None,
+        error: str | None = None,
+        provider_metadata: dict[str, Any] | None = None,
+    ) -> InvestmentBatchJob:
+        job.status = (
+            status.value if isinstance(status, InvestmentBatchJobStatus) else status
+        )
+        if provider_job_id is not None:
+            job.provider_job_id = provider_job_id
+        if error is not None:
+            job.error = error
+        if provider_metadata is not None:
+            job.provider_metadata = provider_metadata
+        now = datetime.now(timezone.utc)
+        if job.status == InvestmentBatchJobStatus.SUBMITTED.value:
+            job.submitted_at = now
+        if job.status in {
+            InvestmentBatchJobStatus.SUCCEEDED.value,
+            InvestmentBatchJobStatus.FAILED.value,
+            InvestmentBatchJobStatus.CANCELLED.value,
+            InvestmentBatchJobStatus.EXPIRED.value,
+        }:
+            job.completed_at = now
+        job.updated_at = now
+        self.session.flush()
+        return job
+
+    def transition_item(
+        self,
+        item: InvestmentBatchItem,
+        status: InvestmentBatchItemStatus | str,
+        *,
+        provider_response: dict[str, Any] | None = None,
+        provider_error: dict[str, Any] | None = None,
+        audit: dict[str, Any] | None = None,
+    ) -> InvestmentBatchItem:
+        item.status = (
+            status.value if isinstance(status, InvestmentBatchItemStatus) else status
+        )
+        if provider_response is not None:
+            item.provider_response = provider_response
+        if provider_error is not None:
+            item.provider_error = provider_error
+        if audit is not None:
+            item.audit = audit
+        now = datetime.now(timezone.utc)
+        if item.status == InvestmentBatchItemStatus.SUBMITTED.value:
+            item.submitted_at = now
+        if item.status in TERMINAL_ITEM_STATUSES:
+            item.completed_at = now
+        item.updated_at = now
+        self.session.flush()
+        return item
+
+    def terminal_counts(self, job: InvestmentBatchJob) -> tuple[int, int]:
+        items = list(job.items)
+        completed = sum(1 for item in items if item.status in TERMINAL_ITEM_STATUSES)
+        failed = sum(
+            1
+            for item in items
+            if item.status
+            in {
+                InvestmentBatchItemStatus.PROVIDER_FAILED.value,
+                InvestmentBatchItemStatus.FALLBACK.value,
+                InvestmentBatchItemStatus.FAILED.value,
+            }
+        )
+        job.completed_items = completed
+        job.failed_items = failed
+        job.updated_at = datetime.now(timezone.utc)
+        self.session.flush()
+        return completed, failed

--- a/src/dev_health_ops/work_graph/investment/categorize.py
+++ b/src/dev_health_ops/work_graph/investment/categorize.py
@@ -169,6 +169,10 @@ def _build_prompt(source_block: str) -> str:
     return f"{prompt}\n\nSource text (quotes must be exact substrings):\n(EMPTY)"
 
 
+def build_categorization_prompt(bundle: TextBundle) -> str:
+    return _build_prompt(bundle.source_block)
+
+
 def _build_repair_prompt(errors: list[str], source_block: str) -> str:
     errors_text = "\n".join(f"- {err}" for err in errors)
     repair = REPAIR_PROMPT.format(errors=errors_text)
@@ -191,7 +195,32 @@ async def categorize_text_bundle(
     output_tokens = _token_count(raw_completion.output_tokens)
     llm_calls = 1
     resolved_model = raw_completion.model
-    payload, parse_errors = parse_llm_json(raw_completion.text)
+    return await categorize_text_bundle_completion(
+        bundle,
+        raw_completion.text,
+        llm_provider=llm_provider,
+        llm_model=llm_model,
+        provider=provider,
+        input_tokens=input_tokens,
+        output_tokens=output_tokens,
+        llm_calls=llm_calls,
+        resolved_model=resolved_model,
+    )
+
+
+async def categorize_text_bundle_completion(
+    bundle: TextBundle,
+    completion_text: str,
+    *,
+    llm_provider: str,
+    llm_model: str | None = None,
+    provider: LLMProvider | None = None,
+    input_tokens: int = 0,
+    output_tokens: int = 0,
+    llm_calls: int = 0,
+    resolved_model: str | None = None,
+) -> CategorizationOutcome:
+    payload, parse_errors = parse_llm_json(completion_text)
     if parse_errors:
         validation = LLMValidationResult(
             ok=False,

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -6,6 +6,7 @@ import asyncio
 import inspect
 import json
 import logging
+import os
 import uuid
 from collections import Counter
 from collections.abc import Iterable
@@ -697,6 +698,53 @@ def _membership_categories(
     return out
 
 
+_LLM_BATCH_MODES = {"sync", "auto", "provider_batch"}
+
+
+def resolve_llm_batch_mode(value: object | None = None) -> str:
+    raw = value if value is not None else os.getenv("INVESTMENT_LLM_BATCH_MODE", "sync")
+    mode = str(raw or "sync").strip().lower().replace("-", "_")
+    if mode not in _LLM_BATCH_MODES:
+        raise ValueError("llm_batch_mode must be one of: sync, auto, provider_batch")
+    return mode
+
+
+def resolve_llm_batch_min_items(value: object | None = None) -> int:
+    raw = (
+        value
+        if value is not None
+        else os.getenv("INVESTMENT_LLM_BATCH_MIN_ITEMS", "25")
+    )
+    try:
+        return max(1, int(str(raw)))
+    except (TypeError, ValueError):
+        return 25
+
+
+def resolve_llm_batch_poll_interval_seconds(value: object | None = None) -> float:
+    raw = (
+        value
+        if value is not None
+        else os.getenv("INVESTMENT_LLM_BATCH_POLL_INTERVAL_SECONDS", "30")
+    )
+    try:
+        return max(0.001, float(str(raw)))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def resolve_llm_batch_timeout_seconds(value: object | None = None) -> float:
+    raw = (
+        value
+        if value is not None
+        else os.getenv("INVESTMENT_LLM_BATCH_TIMEOUT_SECONDS", "3000")
+    )
+    try:
+        return max(0.001, float(str(raw)))
+    except (TypeError, ValueError):
+        return 3000.0
+
+
 @dataclass(frozen=True)
 class MaterializeConfig:
     dsn: str
@@ -723,7 +771,7 @@ class MaterializeConfig:
     llm_batch_timeout_seconds: float = 3000.0
 
     def __post_init__(self) -> None:
-        if self.llm_batch_mode not in {"sync", "auto", "provider_batch"}:
+        if self.llm_batch_mode not in _LLM_BATCH_MODES:
             raise ValueError(
                 "llm_batch_mode must be one of: sync, auto, provider_batch"
             )

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import inspect
 import json
 import logging
 import uuid
@@ -10,7 +11,10 @@ from collections import Counter
 from collections.abc import Iterable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
+from time import monotonic
 from typing import Any
+
+from sqlalchemy.exc import IntegrityError
 
 from dev_health_ops.llm import (
     LLMAuthError,
@@ -24,6 +28,13 @@ from dev_health_ops.llm import (
     resolve_model_name,
     resolve_provider_name,
 )
+from dev_health_ops.llm.providers.batch import (
+    BatchItemRequest,
+    BatchItemResult,
+    BatchItemStatus,
+    BatchJobStatus,
+    batch_capability_for,
+)
 from dev_health_ops.llm.providers.none import NoneProvider
 from dev_health_ops.metrics.llm_token_usage import write_llm_token_usage
 from dev_health_ops.metrics.schemas import (
@@ -33,10 +44,16 @@ from dev_health_ops.metrics.schemas import (
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 from dev_health_ops.metrics.sinks.factory import create_sink
 from dev_health_ops.work_graph.ids import parse_commit_from_id, parse_pr_from_id
+from dev_health_ops.work_graph.investment.batch_store import (
+    InvestmentBatchItemSpec,
+    InvestmentBatchStore,
+)
 from dev_health_ops.work_graph.investment.categorize import (
     PROMPT_VERSION,
     TAXONOMY_VERSION,
+    build_categorization_prompt,
     categorize_text_bundle,
+    categorize_text_bundle_completion,
     fallback_outcome,
 )
 from dev_health_ops.work_graph.investment.constants import (
@@ -133,6 +150,435 @@ def _effective_model_version(provider: str, model: str | None) -> str:
         f"provider={provider};model={resolved_model};"
         f"taxonomy={TAXONOMY_VERSION};prompt={PROMPT_VERSION}"
     )
+
+
+def _batch_contract_version() -> str:
+    return f"taxonomy={TAXONOMY_VERSION};prompt={PROMPT_VERSION};batch=v1"
+
+
+def _batch_error_label(exc: Exception) -> str:
+    return type(exc).__name__
+
+
+def _batch_correlation_id(run_id: str, chunk_index: int | None) -> str:
+    if chunk_index is None:
+        return run_id
+    return f"{run_id}:chunk:{chunk_index}"
+
+
+def _batch_custom_id(batch_correlation_id: str, component_index: int) -> str:
+    return f"{batch_correlation_id}-{component_index}"
+
+
+def _create_batch_job(
+    *,
+    org_id: str,
+    provider: str,
+    model: str,
+    run_id: str,
+    local_correlation_id: str,
+    specs: list[InvestmentBatchItemSpec],
+) -> str:
+    from dev_health_ops.db import get_postgres_session_sync
+
+    with get_postgres_session_sync() as session:
+        store = InvestmentBatchStore(session, org_id)
+        existing = store.get_job_by_correlation(local_correlation_id)
+        if existing is not None:
+            return str(existing.id)
+        try:
+            job = store.create_job(
+                provider=provider,
+                model=model,
+                run_id=run_id,
+                prompt_version=PROMPT_VERSION,
+                contract_version=_batch_contract_version(),
+                items=specs,
+                local_correlation_id=local_correlation_id,
+            )
+        except IntegrityError:
+            session.rollback()
+            store = InvestmentBatchStore(session, org_id)
+            existing = store.get_job_by_correlation(local_correlation_id)
+            if existing is None:
+                raise
+            return str(existing.id)
+        return str(job.id)
+
+
+def _transition_batch_job(
+    *,
+    org_id: str,
+    job_id: str,
+    status: str,
+    provider_job_id: str | None = None,
+    error: str | None = None,
+    provider_metadata: dict[str, Any] | None = None,
+) -> None:
+    from dev_health_ops.db import get_postgres_session_sync
+
+    with get_postgres_session_sync() as session:
+        store = InvestmentBatchStore(session, org_id)
+        job = store.get_job(job_id)
+        if job is not None:
+            store.transition_job(
+                job,
+                status,
+                provider_job_id=provider_job_id,
+                error=error,
+                provider_metadata=provider_metadata,
+            )
+
+
+def _transition_batch_item(
+    *,
+    org_id: str,
+    job_id: str,
+    custom_id: str,
+    status: str,
+    provider_response: dict[str, Any] | None = None,
+    provider_error: dict[str, Any] | None = None,
+    audit: dict[str, Any] | None = None,
+) -> None:
+    from dev_health_ops.db import get_postgres_session_sync
+
+    with get_postgres_session_sync() as session:
+        store = InvestmentBatchStore(session, org_id)
+        item = store.get_item_by_custom_id(job_id=job_id, custom_id=custom_id)
+        if item is not None:
+            store.transition_item(
+                item,
+                status,
+                provider_response=provider_response,
+                provider_error=provider_error,
+                audit=audit,
+            )
+
+
+def _update_batch_counts(*, org_id: str, job_id: str) -> None:
+    from dev_health_ops.db import get_postgres_session_sync
+
+    with get_postgres_session_sync() as session:
+        store = InvestmentBatchStore(session, org_id)
+        job = store.get_job(job_id)
+        if job is not None:
+            completed, failed = store.terminal_counts(job)
+            terminal_status = job.status
+            if job.status not in {
+                BatchJobStatus.FAILED.value,
+                BatchJobStatus.CANCELLED.value,
+                BatchJobStatus.EXPIRED.value,
+            } and completed >= int(job.total_items or 0):
+                terminal_status = BatchJobStatus.SUCCEEDED.value
+            store.transition_job(job, terminal_status)
+            job.completed_items = completed
+            job.failed_items = failed
+            session.flush()
+
+
+async def _fallback_unresolved_batch_items(
+    *,
+    org_id: str,
+    job_id: str,
+    pending_llm: list[tuple[int, Any]],
+    run_id: str,
+    batch_correlation_id: str,
+    audit_reason: str,
+    provider_error: dict[str, Any] | None = None,
+) -> dict[int, Any]:
+    outcomes: dict[int, Any] = {}
+    for idx, _bundle in pending_llm:
+        outcomes[idx] = fallback_outcome("llm_task_failed")
+        await asyncio.to_thread(
+            _transition_batch_item,
+            org_id=org_id,
+            job_id=job_id,
+            custom_id=_batch_custom_id(batch_correlation_id, idx),
+            status=BatchItemStatus.FALLBACK.value,
+            provider_error=provider_error,
+            audit={"reason": audit_reason},
+        )
+    await asyncio.to_thread(_update_batch_counts, org_id=org_id, job_id=job_id)
+    return outcomes
+
+
+async def _categorize_with_provider_batch(
+    *,
+    config: MaterializeConfig,
+    provider_instance: Any,
+    resolved_llm_provider: str,
+    model_version: str,
+    run_id: str,
+    pending_llm: list[tuple[int, Any]],
+    preprocessed: dict[int, PreprocessedComponent],
+) -> dict[int, Any] | None:
+    if not pending_llm:
+        return {}
+    capability = batch_capability_for(provider_instance, config.llm_model)
+    if not capability.supported:
+        if config.llm_batch_mode == "provider_batch":
+            raise ValueError(
+                f"LLM provider '{resolved_llm_provider}' does not support provider_batch"
+            )
+        logger.info(
+            "LLM batch mode auto fell back to sync: provider=%s reason=%s",
+            resolved_llm_provider,
+            capability.reason or "unsupported",
+        )
+        return None
+    if (
+        config.llm_batch_mode == "auto"
+        and len(pending_llm) < config.llm_batch_min_items
+    ):
+        logger.info(
+            "LLM batch mode auto fell back to sync: pending=%d threshold=%d",
+            len(pending_llm),
+            config.llm_batch_min_items,
+        )
+        return None
+
+    org_id = config.org_id or ""
+    batch_correlation_id = _batch_correlation_id(run_id, config.chunk_index)
+    specs = [
+        InvestmentBatchItemSpec(
+            work_unit_id=preprocessed[idx].unit_id,
+            component_index=idx,
+            custom_id=_batch_custom_id(batch_correlation_id, idx),
+            input_hash=bundle.input_hash,
+        )
+        for idx, bundle in pending_llm
+    ]
+    job_id = await asyncio.to_thread(
+        _create_batch_job,
+        org_id=org_id,
+        provider=resolved_llm_provider,
+        model=model_version,
+        run_id=run_id,
+        local_correlation_id=batch_correlation_id,
+        specs=specs,
+    )
+    await asyncio.to_thread(
+        _transition_batch_job,
+        org_id=org_id,
+        job_id=job_id,
+        status=BatchJobStatus.SUBMITTING.value,
+    )
+
+    requests = [
+        BatchItemRequest(
+            custom_id=_batch_custom_id(batch_correlation_id, idx),
+            prompt=build_categorization_prompt(bundle),
+            metadata={
+                "org_id": org_id,
+                "work_unit_id": preprocessed[idx].unit_id,
+                "component_index": idx,
+                "input_hash": bundle.input_hash,
+            },
+        )
+        for idx, bundle in pending_llm
+    ]
+    try:
+        submission = await provider_instance.submit_batch(requests)
+    except Exception as exc:
+        await asyncio.to_thread(
+            _transition_batch_job,
+            org_id=org_id,
+            job_id=job_id,
+            status=BatchJobStatus.FAILED.value,
+            error=_batch_error_label(exc),
+        )
+        raise
+
+    await asyncio.to_thread(
+        _transition_batch_job,
+        org_id=org_id,
+        job_id=job_id,
+        status=BatchJobStatus.SUBMITTED.value,
+        provider_job_id=submission.provider_job_id,
+        provider_metadata=submission.metadata,
+    )
+    for request in requests:
+        await asyncio.to_thread(
+            _transition_batch_item,
+            org_id=org_id,
+            job_id=job_id,
+            custom_id=request.custom_id,
+            status=BatchItemStatus.SUBMITTED.value,
+        )
+
+    started = monotonic()
+    final_state = None
+    while monotonic() - started < config.llm_batch_timeout_seconds:
+        final_state = await provider_instance.poll_batch(submission.provider_job_id)
+        await asyncio.to_thread(
+            _transition_batch_job,
+            org_id=org_id,
+            job_id=job_id,
+            status=final_state.status.value,
+            provider_metadata=final_state.metadata,
+        )
+        if final_state.status in {
+            BatchJobStatus.SUCCEEDED,
+            BatchJobStatus.FAILED,
+            BatchJobStatus.CANCELLED,
+            BatchJobStatus.EXPIRED,
+        }:
+            break
+        await asyncio.sleep(config.llm_batch_poll_interval_seconds)
+
+    if final_state is None or final_state.status not in {
+        BatchJobStatus.SUCCEEDED,
+        BatchJobStatus.FAILED,
+        BatchJobStatus.CANCELLED,
+        BatchJobStatus.EXPIRED,
+    }:
+        cancel_batch = getattr(provider_instance, "cancel_batch", None)
+        if callable(cancel_batch):
+            try:
+                maybe_cancelled = cancel_batch(submission.provider_job_id)
+                if inspect.isawaitable(maybe_cancelled):
+                    await maybe_cancelled
+            except Exception as exc:
+                logger.warning(
+                    "Provider batch cancellation failed: provider=%s job_id=%s error_type=%s",
+                    resolved_llm_provider,
+                    submission.provider_job_id,
+                    _batch_error_label(exc),
+                )
+        await asyncio.to_thread(
+            _transition_batch_job,
+            org_id=org_id,
+            job_id=job_id,
+            status=BatchJobStatus.EXPIRED.value,
+            error="provider batch timed out",
+        )
+        return await _fallback_unresolved_batch_items(
+            org_id=org_id,
+            job_id=job_id,
+            pending_llm=pending_llm,
+            run_id=run_id,
+            batch_correlation_id=batch_correlation_id,
+            audit_reason="provider_batch_timeout",
+        )
+
+    if final_state.status != BatchJobStatus.SUCCEEDED:
+        return await _fallback_unresolved_batch_items(
+            org_id=org_id,
+            job_id=job_id,
+            pending_llm=pending_llm,
+            run_id=run_id,
+            batch_correlation_id=batch_correlation_id,
+            audit_reason=f"provider_batch_{final_state.status.value}",
+            provider_error={"status": final_state.status.value},
+        )
+
+    try:
+        raw_results = await provider_instance.fetch_batch_results(
+            submission.provider_job_id
+        )
+    except Exception as exc:
+        await asyncio.to_thread(
+            _transition_batch_job,
+            org_id=org_id,
+            job_id=job_id,
+            status=BatchJobStatus.FAILED.value,
+            error=_batch_error_label(exc),
+        )
+        return await _fallback_unresolved_batch_items(
+            org_id=org_id,
+            job_id=job_id,
+            pending_llm=pending_llm,
+            run_id=run_id,
+            batch_correlation_id=batch_correlation_id,
+            audit_reason="provider_batch_fetch_failed",
+            provider_error={"error_type": _batch_error_label(exc)},
+        )
+    results_by_custom_id: dict[str, BatchItemResult] = {
+        result.custom_id: result for result in raw_results if result.custom_id
+    }
+    outcomes: dict[int, Any] = {}
+    for idx, bundle in pending_llm:
+        custom_id = _batch_custom_id(batch_correlation_id, idx)
+        item_result = results_by_custom_id.get(custom_id)
+        if item_result is None:
+            outcome = fallback_outcome("llm_task_failed")
+            await asyncio.to_thread(
+                _transition_batch_item,
+                org_id=org_id,
+                job_id=job_id,
+                custom_id=custom_id,
+                status=BatchItemStatus.FALLBACK.value,
+                audit={"reason": "missing_batch_result"},
+            )
+        elif item_result.succeeded and item_result.raw_response is not None:
+            try:
+                outcome = await categorize_text_bundle_completion(
+                    bundle,
+                    item_result.raw_response,
+                    llm_provider=resolved_llm_provider,
+                    llm_model=config.llm_model,
+                    provider=provider_instance,
+                    input_tokens=int(
+                        item_result.provider_metadata.get("input_tokens") or 0
+                    ),
+                    output_tokens=int(
+                        item_result.provider_metadata.get("output_tokens") or 0
+                    ),
+                    llm_calls=1,
+                    resolved_model=model_version,
+                )
+            except Exception as exc:
+                outcome = fallback_outcome("llm_task_failed")
+                await asyncio.to_thread(
+                    _transition_batch_item,
+                    org_id=org_id,
+                    job_id=job_id,
+                    custom_id=custom_id,
+                    status=BatchItemStatus.FALLBACK.value,
+                    provider_error={"error_type": _batch_error_label(exc)},
+                    audit={"reason": "batch_result_validation_failed"},
+                )
+                outcomes[idx] = outcome
+                continue
+            status = (
+                BatchItemStatus.VALIDATED.value
+                if outcome.status == "ok"
+                else BatchItemStatus.REPAIRED.value
+                if outcome.status == "repaired"
+                else BatchItemStatus.FALLBACK.value
+            )
+            await asyncio.to_thread(
+                _transition_batch_item,
+                org_id=org_id,
+                job_id=job_id,
+                custom_id=custom_id,
+                status=status,
+                provider_response={"metadata": item_result.provider_metadata},
+                audit={"status": outcome.status, "errors": outcome.errors},
+            )
+        else:
+            outcome = fallback_outcome("llm_task_failed")
+            await asyncio.to_thread(
+                _transition_batch_item,
+                org_id=org_id,
+                job_id=job_id,
+                custom_id=custom_id,
+                status=BatchItemStatus.FALLBACK.value,
+                provider_error={
+                    "code": item_result.error_code,
+                    "message": item_result.error_message,
+                    "metadata": item_result.provider_metadata,
+                },
+            )
+        outcomes[idx] = outcome
+    await asyncio.to_thread(_update_batch_counts, org_id=org_id, job_id=job_id)
+    logger.info(
+        "Completed provider batch categorization: provider=%s items=%d job_id=%s",
+        resolved_llm_provider,
+        len(outcomes),
+        job_id,
+    )
+    return outcomes
 
 
 def _fetch_existing_investment_keys(
@@ -269,7 +715,24 @@ class MaterializeConfig:
     run_id: str | None = None
     computed_at: datetime | None = None
     component_indexes: list[int] | None = None
+    chunk_index: int | None = None
     allow_unscoped: bool = False
+    llm_batch_mode: str = "sync"
+    llm_batch_min_items: int = 25
+    llm_batch_poll_interval_seconds: float = 30.0
+    llm_batch_timeout_seconds: float = 3000.0
+
+    def __post_init__(self) -> None:
+        if self.llm_batch_mode not in {"sync", "auto", "provider_batch"}:
+            raise ValueError(
+                "llm_batch_mode must be one of: sync, auto, provider_batch"
+            )
+        if self.llm_batch_min_items < 1:
+            raise ValueError("llm_batch_min_items must be >= 1")
+        if self.llm_batch_poll_interval_seconds <= 0:
+            raise ValueError("llm_batch_poll_interval_seconds must be > 0")
+        if self.llm_batch_timeout_seconds <= 0:
+            raise ValueError("llm_batch_timeout_seconds must be > 0")
 
 
 def _build_components(
@@ -835,7 +1298,21 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             finally:
                 await adaptive_concurrency.release()
 
-        if pending_llm:
+        batch_results: dict[int, Any] | None = None
+        if pending_llm and config.llm_batch_mode != "sync":
+            batch_results = await _categorize_with_provider_batch(
+                config=config,
+                provider_instance=provider_instance,
+                resolved_llm_provider=resolved_llm_provider,
+                model_version=model_version,
+                run_id=run_id,
+                pending_llm=pending_llm,
+                preprocessed=preprocessed,
+            )
+            if batch_results is not None:
+                llm_results.update(batch_results)
+
+        if pending_llm and batch_results is None:
             logger.info(
                 "Starting parallel LLM categorization (%d tasks, concurrency=%d)",
                 len(pending_llm),

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -9,6 +9,10 @@ from dev_health_ops.work_graph.builder import BuildConfig, WorkGraphBuilder
 from dev_health_ops.work_graph.investment.materialize import (
     MaterializeConfig,
     materialize_investments,
+    resolve_llm_batch_min_items,
+    resolve_llm_batch_mode,
+    resolve_llm_batch_poll_interval_seconds,
+    resolve_llm_batch_timeout_seconds,
 )
 
 
@@ -233,13 +237,15 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
         force=getattr(ns, "force", False),
         org_id=org_id,
         allow_unscoped=getattr(ns, "allow_unscoped", False),
-        llm_batch_mode=getattr(ns, "llm_batch_mode", "sync"),
-        llm_batch_min_items=int(getattr(ns, "llm_batch_min_items", 25) or 25),
-        llm_batch_poll_interval_seconds=float(
-            getattr(ns, "llm_batch_poll_interval_seconds", 30.0) or 30.0
+        llm_batch_mode=resolve_llm_batch_mode(getattr(ns, "llm_batch_mode", None)),
+        llm_batch_min_items=resolve_llm_batch_min_items(
+            getattr(ns, "llm_batch_min_items", None)
         ),
-        llm_batch_timeout_seconds=float(
-            getattr(ns, "llm_batch_timeout_seconds", 3000.0) or 3000.0
+        llm_batch_poll_interval_seconds=resolve_llm_batch_poll_interval_seconds(
+            getattr(ns, "llm_batch_poll_interval_seconds", None)
+        ),
+        llm_batch_timeout_seconds=resolve_llm_batch_timeout_seconds(
+            getattr(ns, "llm_batch_timeout_seconds", None)
         ),
     )
 
@@ -470,26 +476,30 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     investment_materialize.add_argument(
         "--llm-batch-mode",
         choices=("sync", "auto", "provider_batch"),
-        default="sync",
-        help="LLM categorization execution mode (default: sync).",
+        default=argparse.SUPPRESS,
+        help="LLM categorization execution mode. Env: INVESTMENT_LLM_BATCH_MODE. "
+        "Default: sync.",
     )
     investment_materialize.add_argument(
         "--llm-batch-min-items",
         type=int,
-        default=25,
-        help="Minimum eligible LLM items before auto mode uses provider batch.",
+        default=argparse.SUPPRESS,
+        help="Minimum eligible LLM items before auto mode uses provider batch. "
+        "Env: INVESTMENT_LLM_BATCH_MIN_ITEMS. Default: 25.",
     )
     investment_materialize.add_argument(
         "--llm-batch-poll-interval-seconds",
         type=float,
-        default=30.0,
-        help="Provider batch polling interval for CLI/worker completion waits.",
+        default=argparse.SUPPRESS,
+        help="Provider batch polling interval for CLI/worker completion waits. "
+        "Env: INVESTMENT_LLM_BATCH_POLL_INTERVAL_SECONDS. Default: 30.",
     )
     investment_materialize.add_argument(
         "--llm-batch-timeout-seconds",
         type=float,
-        default=3000.0,
-        help="Provider batch timeout for CLI/worker completion waits.",
+        default=argparse.SUPPRESS,
+        help="Provider batch timeout for CLI/worker completion waits. "
+        "Env: INVESTMENT_LLM_BATCH_TIMEOUT_SECONDS. Default: 3000.",
     )
     investment_materialize.add_argument(
         "--allow-unscoped",

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -233,6 +233,14 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
         force=getattr(ns, "force", False),
         org_id=org_id,
         allow_unscoped=getattr(ns, "allow_unscoped", False),
+        llm_batch_mode=getattr(ns, "llm_batch_mode", "sync"),
+        llm_batch_min_items=int(getattr(ns, "llm_batch_min_items", 25) or 25),
+        llm_batch_poll_interval_seconds=float(
+            getattr(ns, "llm_batch_poll_interval_seconds", 30.0) or 30.0
+        ),
+        llm_batch_timeout_seconds=float(
+            getattr(ns, "llm_batch_timeout_seconds", 3000.0) or 3000.0
+        ),
     )
 
     # CHAOS-2433 round-4 finding #1: the materializer writes work_unit_investments
@@ -458,6 +466,30 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
     )
     investment_materialize.add_argument(
         "--force", action="store_true", help="Force re-materialization."
+    )
+    investment_materialize.add_argument(
+        "--llm-batch-mode",
+        choices=("sync", "auto", "provider_batch"),
+        default="sync",
+        help="LLM categorization execution mode (default: sync).",
+    )
+    investment_materialize.add_argument(
+        "--llm-batch-min-items",
+        type=int,
+        default=25,
+        help="Minimum eligible LLM items before auto mode uses provider batch.",
+    )
+    investment_materialize.add_argument(
+        "--llm-batch-poll-interval-seconds",
+        type=float,
+        default=30.0,
+        help="Provider batch polling interval for CLI/worker completion waits.",
+    )
+    investment_materialize.add_argument(
+        "--llm-batch-timeout-seconds",
+        type=float,
+        default=3000.0,
+        help="Provider batch timeout for CLI/worker completion waits.",
     )
     investment_materialize.add_argument(
         "--allow-unscoped",

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -170,10 +170,10 @@ def run_investment_materialize(
     force: bool = False,
     org_id: str = "",
     allow_unscoped: bool = False,
-    llm_batch_mode: str = "sync",
-    llm_batch_min_items: int = 25,
-    llm_batch_poll_interval_seconds: float = 30.0,
-    llm_batch_timeout_seconds: float = 3000.0,
+    llm_batch_mode: str | None = None,
+    llm_batch_min_items: int | None = None,
+    llm_batch_poll_interval_seconds: float | None = None,
+    llm_batch_timeout_seconds: float | None = None,
 ) -> dict:
     """Materialize investment distributions from work graph.
 
@@ -200,6 +200,10 @@ def run_investment_materialize(
     from dev_health_ops.work_graph.investment.materialize import (
         MaterializeConfig,
         materialize_investments,
+        resolve_llm_batch_min_items,
+        resolve_llm_batch_mode,
+        resolve_llm_batch_poll_interval_seconds,
+        resolve_llm_batch_timeout_seconds,
     )
 
     db_url = db_url or _get_db_url()
@@ -237,10 +241,14 @@ def run_investment_materialize(
             force=force,
             org_id=org_id or None,
             allow_unscoped=allow_unscoped,
-            llm_batch_mode=llm_batch_mode,
-            llm_batch_min_items=llm_batch_min_items,
-            llm_batch_poll_interval_seconds=llm_batch_poll_interval_seconds,
-            llm_batch_timeout_seconds=llm_batch_timeout_seconds,
+            llm_batch_mode=resolve_llm_batch_mode(llm_batch_mode),
+            llm_batch_min_items=resolve_llm_batch_min_items(llm_batch_min_items),
+            llm_batch_poll_interval_seconds=resolve_llm_batch_poll_interval_seconds(
+                llm_batch_poll_interval_seconds
+            ),
+            llm_batch_timeout_seconds=resolve_llm_batch_timeout_seconds(
+                llm_batch_timeout_seconds
+            ),
         )
         stats = run_async(materialize_investments(config))
         return {"status": "success", "stats": stats}
@@ -281,10 +289,10 @@ def run_investment_materialize_chunk(
     computed_at: str = "",
     component_indexes: list[int] | None = None,
     chunk_index: int = 0,
-    llm_batch_mode: str = "sync",
-    llm_batch_min_items: int = 25,
-    llm_batch_poll_interval_seconds: float = 30.0,
-    llm_batch_timeout_seconds: float = 3000.0,
+    llm_batch_mode: str | None = None,
+    llm_batch_min_items: int | None = None,
+    llm_batch_poll_interval_seconds: float | None = None,
+    llm_batch_timeout_seconds: float | None = None,
 ) -> dict:
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.llm import LLMAuthError, LLMError, resolve_provider_name
@@ -298,6 +306,10 @@ def run_investment_materialize_chunk(
     from dev_health_ops.work_graph.investment.materialize import (
         MaterializeConfig,
         materialize_investments,
+        resolve_llm_batch_min_items,
+        resolve_llm_batch_mode,
+        resolve_llm_batch_poll_interval_seconds,
+        resolve_llm_batch_timeout_seconds,
     )
 
     db_url = db_url or _get_db_url()
@@ -362,10 +374,14 @@ def run_investment_materialize_chunk(
             computed_at=shared_computed_at,
             component_indexes=component_indexes,
             chunk_index=chunk_index,
-            llm_batch_mode=llm_batch_mode,
-            llm_batch_min_items=llm_batch_min_items,
-            llm_batch_poll_interval_seconds=llm_batch_poll_interval_seconds,
-            llm_batch_timeout_seconds=llm_batch_timeout_seconds,
+            llm_batch_mode=resolve_llm_batch_mode(llm_batch_mode),
+            llm_batch_min_items=resolve_llm_batch_min_items(llm_batch_min_items),
+            llm_batch_poll_interval_seconds=resolve_llm_batch_poll_interval_seconds(
+                llm_batch_poll_interval_seconds
+            ),
+            llm_batch_timeout_seconds=resolve_llm_batch_timeout_seconds(
+                llm_batch_timeout_seconds
+            ),
         )
         stats = run_async(materialize_investments(config))
 
@@ -476,15 +492,19 @@ def dispatch_investment_materialize_partitioned(
     org_id: str = "",
     allow_unscoped: bool = False,
     chunk_size: int | None = None,
-    llm_batch_mode: str = "sync",
-    llm_batch_min_items: int = 25,
-    llm_batch_poll_interval_seconds: float = 30.0,
-    llm_batch_timeout_seconds: float = 3000.0,
+    llm_batch_mode: str | None = None,
+    llm_batch_min_items: int | None = None,
+    llm_batch_poll_interval_seconds: float | None = None,
+    llm_batch_timeout_seconds: float | None = None,
 ) -> dict:
     from dev_health_ops.metrics.sinks.factory import create_sink
     from dev_health_ops.work_graph.investment.materialize import (
         _build_components,
         _resolve_repo_ids,
+        resolve_llm_batch_min_items,
+        resolve_llm_batch_mode,
+        resolve_llm_batch_poll_interval_seconds,
+        resolve_llm_batch_timeout_seconds,
     )
     from dev_health_ops.work_graph.investment.queries import fetch_work_graph_edges
 
@@ -513,6 +533,14 @@ def dispatch_investment_materialize_partitioned(
     chunks = [indexes[i : i + size] for i in range(0, len(indexes), size)]
     run_id = uuid.uuid4().hex
     computed_at = datetime.now(timezone.utc).isoformat()
+    resolved_llm_batch_mode = resolve_llm_batch_mode(llm_batch_mode)
+    resolved_llm_batch_min_items = resolve_llm_batch_min_items(llm_batch_min_items)
+    resolved_llm_batch_poll_interval_seconds = resolve_llm_batch_poll_interval_seconds(
+        llm_batch_poll_interval_seconds
+    )
+    resolved_llm_batch_timeout_seconds = resolve_llm_batch_timeout_seconds(
+        llm_batch_timeout_seconds
+    )
 
     header = []
     for chunk_index, chunk_indexes in enumerate(chunks):
@@ -526,10 +554,10 @@ def dispatch_investment_materialize_partitioned(
             "llm_provider": llm_provider,
             "llm_model": llm_model,
             "llm_concurrency": llm_concurrency,
-            "llm_batch_mode": llm_batch_mode,
-            "llm_batch_min_items": llm_batch_min_items,
-            "llm_batch_poll_interval_seconds": llm_batch_poll_interval_seconds,
-            "llm_batch_timeout_seconds": llm_batch_timeout_seconds,
+            "llm_batch_mode": resolved_llm_batch_mode,
+            "llm_batch_min_items": resolved_llm_batch_min_items,
+            "llm_batch_poll_interval_seconds": resolved_llm_batch_poll_interval_seconds,
+            "llm_batch_timeout_seconds": resolved_llm_batch_timeout_seconds,
             "force": force,
             "org_id": org_id,
             "run_id": run_id,

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -170,6 +170,10 @@ def run_investment_materialize(
     force: bool = False,
     org_id: str = "",
     allow_unscoped: bool = False,
+    llm_batch_mode: str = "sync",
+    llm_batch_min_items: int = 25,
+    llm_batch_poll_interval_seconds: float = 30.0,
+    llm_batch_timeout_seconds: float = 3000.0,
 ) -> dict:
     """Materialize investment distributions from work graph.
 
@@ -233,6 +237,10 @@ def run_investment_materialize(
             force=force,
             org_id=org_id or None,
             allow_unscoped=allow_unscoped,
+            llm_batch_mode=llm_batch_mode,
+            llm_batch_min_items=llm_batch_min_items,
+            llm_batch_poll_interval_seconds=llm_batch_poll_interval_seconds,
+            llm_batch_timeout_seconds=llm_batch_timeout_seconds,
         )
         stats = run_async(materialize_investments(config))
         return {"status": "success", "stats": stats}
@@ -273,6 +281,10 @@ def run_investment_materialize_chunk(
     computed_at: str = "",
     component_indexes: list[int] | None = None,
     chunk_index: int = 0,
+    llm_batch_mode: str = "sync",
+    llm_batch_min_items: int = 25,
+    llm_batch_poll_interval_seconds: float = 30.0,
+    llm_batch_timeout_seconds: float = 3000.0,
 ) -> dict:
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.llm import LLMAuthError, LLMError, resolve_provider_name
@@ -349,6 +361,11 @@ def run_investment_materialize_chunk(
             run_id=run_id,
             computed_at=shared_computed_at,
             component_indexes=component_indexes,
+            chunk_index=chunk_index,
+            llm_batch_mode=llm_batch_mode,
+            llm_batch_min_items=llm_batch_min_items,
+            llm_batch_poll_interval_seconds=llm_batch_poll_interval_seconds,
+            llm_batch_timeout_seconds=llm_batch_timeout_seconds,
         )
         stats = run_async(materialize_investments(config))
 
@@ -459,6 +476,10 @@ def dispatch_investment_materialize_partitioned(
     org_id: str = "",
     allow_unscoped: bool = False,
     chunk_size: int | None = None,
+    llm_batch_mode: str = "sync",
+    llm_batch_min_items: int = 25,
+    llm_batch_poll_interval_seconds: float = 30.0,
+    llm_batch_timeout_seconds: float = 3000.0,
 ) -> dict:
     from dev_health_ops.metrics.sinks.factory import create_sink
     from dev_health_ops.work_graph.investment.materialize import (
@@ -505,6 +526,10 @@ def dispatch_investment_materialize_partitioned(
             "llm_provider": llm_provider,
             "llm_model": llm_model,
             "llm_concurrency": llm_concurrency,
+            "llm_batch_mode": llm_batch_mode,
+            "llm_batch_min_items": llm_batch_min_items,
+            "llm_batch_poll_interval_seconds": llm_batch_poll_interval_seconds,
+            "llm_batch_timeout_seconds": llm_batch_timeout_seconds,
             "force": force,
             "org_id": org_id,
             "run_id": run_id,

--- a/tests/llm/test_batch_contract.py
+++ b/tests/llm/test_batch_contract.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.llm.providers.batch import (
+    BatchCapability,
+    BatchItemRequest,
+    BatchProviderFeature,
+    batch_capability_for,
+)
+
+
+class _SupportingProvider:
+    provider_name = "supporting"
+
+    def batch_capability(self, model=None):
+        return BatchCapability(
+            provider="supporting",
+            model=model or "model-a",
+            supported=True,
+            features=frozenset({BatchProviderFeature.SUBMIT}),
+        )
+
+
+class _PlainProvider:
+    provider_name = "plain"
+
+
+def test_batch_item_request_requires_stable_custom_id():
+    with pytest.raises(ValueError, match="custom_id"):
+        BatchItemRequest(custom_id="", prompt="prompt")
+
+    with pytest.raises(ValueError, match="whitespace"):
+        BatchItemRequest(custom_id="bad id", prompt="prompt")
+
+    request = BatchItemRequest(custom_id=" item-1 ", prompt="prompt")
+    assert request.custom_id == "item-1"
+
+
+def test_batch_capability_is_explicit_for_supporting_provider():
+    capability = batch_capability_for(_SupportingProvider(), "model-b")
+
+    assert capability.supported is True
+    assert capability.provider == "supporting"
+    assert capability.model == "model-b"
+    assert BatchProviderFeature.SUBMIT in capability.features
+
+
+def test_batch_capability_defaults_to_unsupported():
+    capability = batch_capability_for(_PlainProvider(), "model-c")
+
+    assert capability.supported is False
+    assert capability.provider == "plain"
+    assert capability.model == "model-c"

--- a/tests/llm/test_openai_batch_provider.py
+++ b/tests/llm/test_openai_batch_provider.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from dev_health_ops.llm.providers.batch import BatchItemRequest, BatchJobStatus
+from dev_health_ops.llm.providers.openai import OpenAIProvider
+
+
+class _Files:
+    def __init__(self) -> None:
+        self.uploaded = b""
+
+    async def create(self, *, file, purpose):
+        self.uploaded = file.read()
+        assert purpose == "batch"
+        return SimpleNamespace(id="file-1")
+
+    async def content(self, file_id):
+        body = {
+            "choices": [{"message": {"content": json.dumps({"ok": True})}}],
+            "usage": {"prompt_tokens": 11, "completion_tokens": 7},
+        }
+        if file_id == "output-1":
+            line = json.dumps(
+                {
+                    "custom_id": "item-1",
+                    "response": {"status_code": 200, "body": body},
+                }
+            )
+            return SimpleNamespace(text=lambda: line)
+        if file_id == "error-1":
+            line = json.dumps(
+                {
+                    "custom_id": "item-2",
+                    "error": {
+                        "code": "rate_limit_exceeded",
+                        "message": "provider rejected item",
+                        "type": "rate_limit_error",
+                    },
+                }
+            )
+            return SimpleNamespace(text=lambda: line)
+        raise AssertionError(f"unexpected file id {file_id}")
+
+
+class _Batches:
+    def __init__(self) -> None:
+        self.created: dict[str, Any] | None = None
+
+    async def create(self, **kwargs):
+        self.created = kwargs
+        return SimpleNamespace(id="batch-1")
+
+    async def retrieve(self, provider_job_id):
+        assert provider_job_id == "batch-1"
+        return SimpleNamespace(
+            status="completed",
+            request_counts=SimpleNamespace(total=2, completed=1, failed=1),
+            output_file_id="output-1",
+            error_file_id="error-1",
+        )
+
+    async def cancel(self, provider_job_id):
+        assert provider_job_id == "batch-1"
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.files = _Files()
+        self.batches = _Batches()
+
+
+@pytest.mark.asyncio
+async def test_openai_batch_submit_poll_and_fetch():
+    provider = OpenAIProvider(api_key="sk-test", model="gpt-4o-mini")
+    fake_client = _Client()
+    provider._impl._client = fake_client
+
+    submission = await provider.submit_batch(
+        [BatchItemRequest(custom_id="item-1", prompt="Return JSON")]
+    )
+    state = await provider.poll_batch(submission.provider_job_id)
+    results = await provider.fetch_batch_results(submission.provider_job_id)
+
+    assert submission.provider_job_id == "batch-1"
+    assert fake_client.batches.created is not None
+    assert fake_client.batches.created["input_file_id"] == "file-1"
+    assert fake_client.batches.created["endpoint"] == "/v1/chat/completions"
+    assert b'"custom_id":"item-1"' in fake_client.files.uploaded
+    assert state.status == BatchJobStatus.SUCCEEDED
+    assert state.total_count == 2
+    assert state.completed_count == 1
+    assert state.failed_count == 1
+    assert results[0].custom_id == "item-1"
+    assert results[0].raw_response == json.dumps({"ok": True})
+    assert results[0].provider_metadata == {
+        "custom_id": "item-1",
+        "status_code": 200,
+        "input_tokens": 11,
+        "output_tokens": 7,
+    }
+    assert "body" not in json.dumps(results[0].provider_metadata)
+    assert results[1].custom_id == "item-2"
+    assert results[1].error_code == "rate_limit_exceeded"
+    assert results[1].error_message == "provider rejected item"
+    assert "body" not in json.dumps(results[1].provider_metadata)

--- a/tests/llm/test_qwen_batch_provider.py
+++ b/tests/llm/test_qwen_batch_provider.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from dev_health_ops.llm.providers.batch import BatchProviderFeature
+from dev_health_ops.llm.providers.qwen import QwenProvider
+
+
+def test_qwen_batch_capability_uses_dashscope_config_without_openai_credentials(
+    monkeypatch,
+):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    provider = QwenProvider(
+        api_key="dashscope-key",
+        base_url="https://dashscope.example/v1",
+        model="qwen-plus",
+    )
+
+    capability = provider.batch_capability()
+
+    assert capability.supported is True
+    assert capability.provider == "qwen"
+    assert capability.model == "qwen-plus"
+    assert BatchProviderFeature.SUBMIT in capability.features

--- a/tests/test_batch_storage.py
+++ b/tests/test_batch_storage.py
@@ -1,0 +1,166 @@
+from __future__ import annotations
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import Base
+from dev_health_ops.models.investment_batch import (
+    InvestmentBatchItem,
+    InvestmentBatchItemStatus,
+    InvestmentBatchJob,
+    InvestmentBatchJobStatus,
+)
+from dev_health_ops.work_graph.investment.batch_store import (
+    InvestmentBatchItemSpec,
+    InvestmentBatchStore,
+)
+from tests._helpers import tables_of
+
+_TABLES = tables_of(InvestmentBatchJob, InvestmentBatchItem)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=_TABLES)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _item_spec(index: int = 0, *, custom_id: str | None = None):
+    return InvestmentBatchItemSpec(
+        work_unit_id="wu-1",
+        component_index=index,
+        custom_id=custom_id or f"run-{index}",
+        input_hash="hash-1",
+    )
+
+
+def test_create_job_scopes_items_by_org(db_session):
+    store = InvestmentBatchStore(db_session, "org-a")
+    job = store.create_job(
+        provider="openai",
+        model="gpt-5-mini",
+        run_id="run-1",
+        prompt_version="prompt-v1",
+        contract_version="contract-v1",
+        items=[_item_spec()],
+    )
+
+    assert job.org_id == "org-a"
+    assert job.total_items == 1
+    assert job.items[0].org_id == "org-a"
+    assert job.items[0].status == InvestmentBatchItemStatus.PENDING.value
+
+
+def test_item_idempotency_lookup_allows_retry_jobs(db_session):
+    store = InvestmentBatchStore(db_session, "org-a")
+    store.create_job(
+        provider="openai",
+        model="gpt-5-mini",
+        run_id="run-1",
+        prompt_version="prompt-v1",
+        contract_version="contract-v1",
+        items=[_item_spec()],
+    )
+    db_session.commit()
+
+    store.create_job(
+        provider="openai",
+        model="gpt-5-mini",
+        run_id="run-2",
+        prompt_version="prompt-v1",
+        contract_version="contract-v1",
+        items=[_item_spec(custom_id="other-custom")],
+    )
+    db_session.commit()
+
+    assert db_session.query(InvestmentBatchItem).count() == 2
+
+
+def test_item_idempotency_allows_contract_version_bump(db_session):
+    store = InvestmentBatchStore(db_session, "org-a")
+    store.create_job(
+        provider="openai",
+        model="gpt-5-mini",
+        run_id="run-1",
+        prompt_version="prompt-v1",
+        contract_version="contract-v1",
+        items=[_item_spec()],
+    )
+    db_session.commit()
+
+    store.create_job(
+        provider="openai",
+        model="gpt-5-mini",
+        run_id="run-2",
+        prompt_version="prompt-v1",
+        contract_version="contract-v2",
+        items=[_item_spec(custom_id="other-custom")],
+    )
+    db_session.commit()
+
+    assert db_session.query(InvestmentBatchItem).count() == 2
+
+
+def test_custom_id_constraint_is_per_job(db_session):
+    store = InvestmentBatchStore(db_session, "org-a")
+    with pytest.raises(IntegrityError):
+        store.create_job(
+            provider="openai",
+            model="gpt-5-mini",
+            run_id="run-1",
+            prompt_version="prompt-v1",
+            contract_version="contract-v1",
+            items=[_item_spec(0, custom_id="dup"), _item_spec(1, custom_id="dup")],
+        )
+        db_session.commit()
+
+
+def test_status_transitions_update_terminal_counts(db_session):
+    store = InvestmentBatchStore(db_session, "org-a")
+    job = store.create_job(
+        provider="openai",
+        model="gpt-5-mini",
+        run_id="run-1",
+        prompt_version="prompt-v1",
+        contract_version="contract-v1",
+        items=[_item_spec()],
+    )
+    item = job.items[0]
+
+    store.transition_job(
+        job, InvestmentBatchJobStatus.SUBMITTED, provider_job_id="batch-1"
+    )
+    store.transition_item(item, InvestmentBatchItemStatus.VALIDATED)
+    completed, failed = store.terminal_counts(job)
+
+    assert job.status == InvestmentBatchJobStatus.SUBMITTED.value
+    assert job.provider_job_id == "batch-1"
+    assert completed == 1
+    assert failed == 0
+    assert job.completed_items == 1
+
+
+def test_fallback_items_count_as_failed_terminal_outcomes(db_session):
+    store = InvestmentBatchStore(db_session, "org-a")
+    job = store.create_job(
+        provider="openai",
+        model="gpt-5-mini",
+        run_id="run-1",
+        prompt_version="prompt-v1",
+        contract_version="contract-v1",
+        items=[_item_spec()],
+    )
+    item = job.items[0]
+
+    store.transition_item(item, InvestmentBatchItemStatus.FALLBACK)
+    completed, failed = store.terminal_counts(job)
+
+    assert completed == 1
+    assert failed == 1
+    assert job.completed_items == 1
+    assert job.failed_items == 1

--- a/tests/test_investment_batch_docs.py
+++ b/tests/test_investment_batch_docs.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_investment_batch_operator_docs_cover_modes_and_providers():
+    text = Path("docs/ops/investment-materialization.md").read_text()
+
+    for required in (
+        "--llm-batch-mode",
+        "sync",
+        "auto",
+        "provider_batch",
+        "openai",
+        "qwen",
+        "deterministic\nfallback",
+        "Postgres",
+        "ClickHouse",
+    ):
+        assert required in text

--- a/tests/test_investment_materialize_partitioned.py
+++ b/tests/test_investment_materialize_partitioned.py
@@ -109,6 +109,38 @@ def test_dispatch_partitioned_materialize_includes_allow_unscoped_when_true() ->
     assert chunk_kwargs["allow_unscoped"] is True
 
 
+def test_dispatch_partitioned_materialize_uses_env_batch_defaults(monkeypatch) -> None:
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_MODE", "provider_batch")
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_MIN_ITEMS", "11")
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_POLL_INTERVAL_SECONDS", "3.5")
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_TIMEOUT_SECONDS", "123")
+    with (
+        patch(
+            "dev_health_ops.metrics.sinks.factory.create_sink",
+            return_value=_FakeSink(),
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.queries.fetch_work_graph_edges",
+            return_value=[_edge(1)],
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.celery_app.signature",
+            side_effect=_signature_factory,
+        ),
+        patch("dev_health_ops.workers.work_graph_tasks.chord") as mock_chord,
+    ):
+        mock_chord.return_value = MagicMock()
+        task = cast(Any, dispatch_investment_materialize_partitioned)
+        task.run(db_url="clickhouse://x", org_id="org-1", chunk_size=2)
+
+    header = mock_chord.call_args.args[0]
+    chunk_kwargs = header[0].sig_kwargs["kwargs"]
+    assert chunk_kwargs["llm_batch_mode"] == "provider_batch"
+    assert chunk_kwargs["llm_batch_min_items"] == 11
+    assert chunk_kwargs["llm_batch_poll_interval_seconds"] == 3.5
+    assert chunk_kwargs["llm_batch_timeout_seconds"] == 123.0
+
+
 def test_dispatch_partitioned_materialize_skips_marker_for_windowed_run() -> None:
     with (
         patch(

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -324,6 +324,49 @@ def test_run_investment_materialize_empty_org_id_becomes_none() -> None:
     assert captured["org_id"] is None
 
 
+def test_run_investment_materialize_uses_env_batch_defaults(monkeypatch) -> None:
+    from typing import Any, cast
+
+    from dev_health_ops.workers.work_graph_tasks import run_investment_materialize
+
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_MODE", "auto")
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_MIN_ITEMS", "9")
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_POLL_INTERVAL_SECONDS", "2.5")
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_TIMEOUT_SECONDS", "99")
+    captured: dict[str, Any] = {}
+
+    class _FakeConfig:
+        def __init__(self, **kwargs: Any) -> None:
+            captured.update(kwargs)
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.investment.materialize.MaterializeConfig",
+            _FakeConfig,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.materialize.materialize_investments",
+            return_value=None,
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.run_async",
+            side_effect=closing_coroutine_runner(
+                {"components": 0, "records": 0, "quotes": 0}
+            ),
+        ),
+    ):
+        task = cast(Any, run_investment_materialize)
+        result = task.run(
+            db_url="clickhouse://x", org_id="org-123", llm_provider="mock"
+        )
+
+    assert result["status"] == "success"
+    assert captured["llm_batch_mode"] == "auto"
+    assert captured["llm_batch_min_items"] == 9
+    assert captured["llm_batch_poll_interval_seconds"] == 2.5
+    assert captured["llm_batch_timeout_seconds"] == 99.0
+
+
 def test_run_investment_materialize_resolves_worker_llm_credentials(
     monkeypatch,
 ) -> None:

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -12,6 +12,16 @@ from pathlib import Path
 import pytest
 
 from dev_health_ops.llm import LLMAuthError, LLMRateLimitError
+from dev_health_ops.llm.providers.batch import (
+    BatchCapability,
+    BatchItemRequest,
+    BatchItemResult,
+    BatchItemStatus,
+    BatchJobState,
+    BatchJobStatus,
+    BatchJobSubmission,
+    BatchProviderFeature,
+)
 from dev_health_ops.metrics.schemas import (
     LLMTokenUsageRecord,
     WorkUnitInvestmentEvidenceQuoteRecord,
@@ -23,6 +33,7 @@ from dev_health_ops.work_graph.investment.materialize import (
     MaterializeConfig,
     materialize_investments,
 )
+from dev_health_ops.work_graph.investment.utils import ensure_full_subcategory_vector
 
 
 class FakeSink:
@@ -69,6 +80,140 @@ class FakeSink:
 class FakeProvider:
     async def aclose(self) -> None:
         return None
+
+
+class FakeBatchProvider(FakeProvider):
+    def __init__(self, status: BatchJobStatus = BatchJobStatus.SUCCEEDED) -> None:
+        self.requests: list[BatchItemRequest] = []
+        self.status = status
+        self.fetch_calls = 0
+        self.cancel_calls = 0
+
+    def batch_capability(self, model=None):
+        return BatchCapability(
+            provider="openai",
+            model=model or "gpt-test",
+            supported=True,
+            features=frozenset(
+                {
+                    BatchProviderFeature.SUBMIT,
+                    BatchProviderFeature.POLL,
+                    BatchProviderFeature.FETCH_RESULTS,
+                }
+            ),
+        )
+
+    async def submit_batch(self, items):
+        self.requests = list(items)
+        return BatchJobSubmission(
+            provider_job_id="provider-batch-1",
+            provider="openai",
+            model="gpt-test",
+            item_count=len(items),
+        )
+
+    async def poll_batch(self, provider_job_id):
+        return BatchJobState(
+            provider_job_id=provider_job_id,
+            status=self.status,
+            total_count=len(self.requests),
+            completed_count=len(self.requests)
+            if self.status == BatchJobStatus.SUCCEEDED
+            else 0,
+            failed_count=len(self.requests)
+            if self.status == BatchJobStatus.FAILED
+            else 0,
+        )
+
+    async def fetch_batch_results(self, provider_job_id):
+        self.fetch_calls += 1
+        payload = {
+            "subcategories": ensure_full_subcategory_vector(
+                {"feature_delivery.roadmap": 1.0}
+            ),
+            "evidence_quotes": [
+                {"quote": "Ship workflow improvement 1", "source": "issue", "id": "E1"}
+            ],
+            "uncertainty": "Limited evidence.",
+        }
+        return [
+            BatchItemResult(
+                custom_id=request.custom_id,
+                raw_response=json.dumps(payload),
+                provider_metadata={"input_tokens": 11, "output_tokens": 7},
+            )
+            for request in self.requests
+        ]
+
+    async def cancel_batch(self, provider_job_id):
+        self.cancel_calls += 1
+
+
+class PartialBatchProvider(FakeBatchProvider):
+    async def fetch_batch_results(self, provider_job_id):
+        self.fetch_calls += 1
+        results: list[BatchItemResult] = []
+        for idx, request in enumerate(self.requests):
+            if idx == 0:
+                payload = {
+                    "subcategories": ensure_full_subcategory_vector(
+                        {"feature_delivery.roadmap": 1.0}
+                    ),
+                    "evidence_quotes": [
+                        {
+                            "quote": "Ship workflow improvement 1",
+                            "source": "issue",
+                            "id": "E1",
+                        }
+                    ],
+                    "uncertainty": "Limited evidence.",
+                }
+                results.append(
+                    BatchItemResult(
+                        custom_id=request.custom_id,
+                        raw_response=json.dumps(payload),
+                        provider_metadata={"input_tokens": 11, "output_tokens": 7},
+                    )
+                )
+            elif idx == 1:
+                results.append(
+                    BatchItemResult(
+                        custom_id=request.custom_id,
+                        error_code="provider_item_failed",
+                        error_message="provider rejected item",
+                        provider_metadata={"status_code": 429},
+                    )
+                )
+        return results
+
+
+def test_materialize_config_defaults_to_sync_batch_mode():
+    config = MaterializeConfig(
+        dsn="clickhouse://localhost:9000/default",
+        from_ts=datetime.now(timezone.utc) - timedelta(days=1),
+        to_ts=datetime.now(timezone.utc),
+        repo_ids=None,
+        llm_provider="mock",
+        persist_evidence_snippets=True,
+        llm_model=None,
+    )
+
+    assert config.llm_batch_mode == "sync"
+    assert config.llm_batch_min_items == 25
+
+
+def test_materialize_config_rejects_invalid_batch_mode():
+    with pytest.raises(ValueError, match="llm_batch_mode"):
+        MaterializeConfig(
+            dsn="clickhouse://localhost:9000/default",
+            from_ts=datetime.now(timezone.utc) - timedelta(days=1),
+            to_ts=datetime.now(timezone.utc),
+            repo_ids=None,
+            llm_provider="mock",
+            persist_evidence_snippets=True,
+            llm_model=None,
+            llm_batch_mode="invalid",
+        )
 
 
 def _sample_data():
@@ -289,6 +434,366 @@ async def test_materialize_mock_provider_permits_empty_org(monkeypatch):
 
     assert stats["records"] == 1
     assert sink.investment_rows[0].org_id == ""
+
+
+@pytest.mark.asyncio
+async def test_materialize_provider_batch_writes_investment_records(monkeypatch):
+    _repo_ids, edges, work_items, commits = _multi_component_data(1)
+    sink = FakeSink()
+    batch_provider = FakeBatchProvider()
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.get_provider",
+        lambda *args, **kwargs: batch_provider,
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._create_batch_job",
+        lambda **kwargs: "batch-job-1",
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_job",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_item",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._update_batch_counts",
+        lambda **kwargs: None,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=None,
+            llm_provider="openai",
+            persist_evidence_snippets=True,
+            llm_model="gpt-test",
+            org_id="org-a",
+            llm_batch_mode="provider_batch",
+            llm_batch_poll_interval_seconds=0.01,
+        )
+    )
+
+    assert stats["records"] == 1
+    assert len(batch_provider.requests) == 1
+    assert sink.investment_rows[0].categorization_status == "ok"
+    assert sink.investment_rows[0].subcategory_distribution_json[
+        "feature_delivery.roadmap"
+    ] == pytest.approx(1.0)
+    assert sink.quote_rows[0].quote == "Ship workflow improvement 1"
+    assert sink.llm_token_rows[0].input_tokens == 11
+    assert sink.llm_token_rows[0].output_tokens == 7
+
+
+@pytest.mark.asyncio
+async def test_materialize_provider_batch_uses_chunk_scoped_correlation(monkeypatch):
+    _repo_ids, edges, work_items, commits = _multi_component_data(2)
+    sink = FakeSink()
+    batch_provider = FakeBatchProvider()
+    created_jobs: list[dict] = []
+
+    def _record_created_job(**kwargs):
+        created_jobs.append(kwargs)
+        return "batch-job-1"
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.get_provider",
+        lambda *args, **kwargs: batch_provider,
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._create_batch_job",
+        _record_created_job,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_job",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_item",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._update_batch_counts",
+        lambda **kwargs: None,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=None,
+            llm_provider="openai",
+            persist_evidence_snippets=False,
+            llm_model="gpt-test",
+            org_id="org-a",
+            run_id="shared-run",
+            component_indexes=[1],
+            chunk_index=1,
+            llm_batch_mode="provider_batch",
+            llm_batch_poll_interval_seconds=0.01,
+        )
+    )
+
+    assert stats["records"] == 1
+    assert created_jobs[0]["run_id"] == "shared-run"
+    assert created_jobs[0]["local_correlation_id"] == "shared-run:chunk:1"
+    assert created_jobs[0]["specs"][0].custom_id == "shared-run:chunk:1-0"
+    assert batch_provider.requests[0].custom_id == "shared-run:chunk:1-0"
+
+
+@pytest.mark.asyncio
+async def test_materialize_provider_batch_failed_job_falls_back_without_fetch(
+    monkeypatch,
+):
+    _repo_ids, edges, work_items, commits = _multi_component_data(1)
+    sink = FakeSink()
+    batch_provider = FakeBatchProvider(status=BatchJobStatus.FAILED)
+    item_transitions: list[dict] = []
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.get_provider",
+        lambda *args, **kwargs: batch_provider,
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._create_batch_job",
+        lambda **kwargs: "batch-job-1",
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_job",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_item",
+        lambda **kwargs: item_transitions.append(kwargs),
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._update_batch_counts",
+        lambda **kwargs: None,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=None,
+            llm_provider="openai",
+            persist_evidence_snippets=False,
+            llm_model="gpt-test",
+            org_id="org-a",
+            llm_batch_mode="provider_batch",
+            llm_batch_poll_interval_seconds=0.01,
+        )
+    )
+
+    assert stats["records"] == 1
+    assert batch_provider.fetch_calls == 0
+    assert sink.investment_rows[0].categorization_status == "llm_task_failed"
+    assert any(
+        transition["status"] == BatchItemStatus.FALLBACK.value
+        and transition["audit"] == {"reason": "provider_batch_failed"}
+        for transition in item_transitions
+    )
+
+
+@pytest.mark.asyncio
+async def test_materialize_provider_batch_partial_item_failures_fall_back(monkeypatch):
+    _repo_ids, edges, work_items, commits = _multi_component_data(3)
+    sink = FakeSink()
+    batch_provider = PartialBatchProvider()
+    item_transitions: list[dict] = []
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.get_provider",
+        lambda *args, **kwargs: batch_provider,
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._create_batch_job",
+        lambda **kwargs: "batch-job-1",
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_job",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_item",
+        lambda **kwargs: item_transitions.append(kwargs),
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._update_batch_counts",
+        lambda **kwargs: None,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=None,
+            llm_provider="openai",
+            persist_evidence_snippets=False,
+            llm_model="gpt-test",
+            org_id="org-a",
+            llm_batch_mode="provider_batch",
+            llm_batch_poll_interval_seconds=0.01,
+        )
+    )
+
+    assert stats["records"] == 3
+    assert [row.categorization_status for row in sink.investment_rows].count("ok") == 1
+    assert [row.categorization_status for row in sink.investment_rows].count(
+        "llm_task_failed"
+    ) == 2
+    assert any(
+        transition["status"] == BatchItemStatus.FALLBACK.value
+        and transition.get("provider_error", {}).get("code") == "provider_item_failed"
+        for transition in item_transitions
+    )
+    assert any(
+        transition["status"] == BatchItemStatus.FALLBACK.value
+        and transition.get("audit") == {"reason": "missing_batch_result"}
+        for transition in item_transitions
+    )
+
+
+@pytest.mark.asyncio
+async def test_materialize_provider_batch_validation_error_terminalizes_item(
+    monkeypatch,
+):
+    _repo_ids, edges, work_items, commits = _multi_component_data(1)
+    sink = FakeSink()
+    batch_provider = FakeBatchProvider()
+    item_transitions: list[dict] = []
+
+    async def _raise_validation_error(*args, **kwargs):
+        raise RuntimeError("repair provider unavailable")
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.get_provider",
+        lambda *args, **kwargs: batch_provider,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle_completion",
+        _raise_validation_error,
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._create_batch_job",
+        lambda **kwargs: "batch-job-1",
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_job",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_item",
+        lambda **kwargs: item_transitions.append(kwargs),
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._update_batch_counts",
+        lambda **kwargs: None,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=None,
+            llm_provider="openai",
+            persist_evidence_snippets=False,
+            llm_model="gpt-test",
+            org_id="org-a",
+            llm_batch_mode="provider_batch",
+            llm_batch_poll_interval_seconds=0.01,
+        )
+    )
+
+    assert stats["records"] == 1
+    assert sink.investment_rows[0].categorization_status == "llm_task_failed"
+    assert any(
+        transition["status"] == BatchItemStatus.FALLBACK.value
+        and transition["audit"] == {"reason": "batch_result_validation_failed"}
+        for transition in item_transitions
+    )
+
+
+@pytest.mark.asyncio
+async def test_materialize_provider_batch_timeout_cancels_batch(monkeypatch):
+    _repo_ids, edges, work_items, commits = _multi_component_data(1)
+    sink = FakeSink()
+    batch_provider = FakeBatchProvider(status=BatchJobStatus.RUNNING)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.get_provider",
+        lambda *args, **kwargs: batch_provider,
+    )
+    _patch_queries(monkeypatch, edges, work_items, commits)
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._create_batch_job",
+        lambda **kwargs: "batch-job-1",
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_job",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._transition_batch_item",
+        lambda **kwargs: None,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize._update_batch_counts",
+        lambda **kwargs: None,
+    )
+
+    now = datetime.now(timezone.utc)
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=None,
+            llm_provider="openai",
+            persist_evidence_snippets=False,
+            llm_model="gpt-test",
+            org_id="org-a",
+            llm_batch_mode="provider_batch",
+            llm_batch_poll_interval_seconds=0.01,
+            llm_batch_timeout_seconds=0.01,
+        )
+    )
+
+    assert stats["records"] == 1
+    assert batch_provider.cancel_calls == 1
+    assert batch_provider.fetch_calls == 0
 
 
 @pytest.mark.asyncio

--- a/tests/work_graph/test_runner.py
+++ b/tests/work_graph/test_runner.py
@@ -306,6 +306,36 @@ def test_cli_materialize_threads_batch_settings():
     backfill_mock.assert_not_called()
 
 
+def test_cli_materialize_uses_env_batch_defaults(monkeypatch):
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_MODE", "auto")
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_MIN_ITEMS", "7")
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_POLL_INTERVAL_SECONDS", "1.5")
+    monkeypatch.setenv("INVESTMENT_LLM_BATCH_TIMEOUT_SECONDS", "42")
+    fake_materialize, materialize_mock, backfill_mock = (
+        _patch_materialize_and_projection()
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            fake_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        rc = run_investment_materialization(_materialize_ns(repo_id=["repo-uuid-1"]))
+
+    assert rc == 0
+    config = materialize_mock.call_args.args[0]
+    assert config.llm_batch_mode == "auto"
+    assert config.llm_batch_min_items == 7
+    assert config.llm_batch_poll_interval_seconds == 1.5
+    assert config.llm_batch_timeout_seconds == 42.0
+    backfill_mock.assert_not_called()
+
+
 def test_cli_materialize_threads_allow_unscoped():
     fake_materialize, materialize_mock, backfill_mock = (
         _patch_materialize_and_projection()

--- a/tests/work_graph/test_runner.py
+++ b/tests/work_graph/test_runner.py
@@ -272,6 +272,40 @@ def test_cli_materialize_threads_inline_llm_credentials_and_concurrency():
     backfill_mock.assert_not_called()
 
 
+def test_cli_materialize_threads_batch_settings():
+    fake_materialize, materialize_mock, backfill_mock = (
+        _patch_materialize_and_projection()
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            fake_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        rc = run_investment_materialization(
+            _materialize_ns(
+                repo_id=["repo-uuid-1"],
+                llm_batch_mode="auto",
+                llm_batch_min_items=3,
+                llm_batch_poll_interval_seconds=0.5,
+                llm_batch_timeout_seconds=12.0,
+            )
+        )
+
+    assert rc == 0
+    config = materialize_mock.call_args.args[0]
+    assert config.llm_batch_mode == "auto"
+    assert config.llm_batch_min_items == 3
+    assert config.llm_batch_poll_interval_seconds == 0.5
+    assert config.llm_batch_timeout_seconds == 12.0
+    backfill_mock.assert_not_called()
+
+
 def test_cli_materialize_threads_allow_unscoped():
     fake_materialize, materialize_mock, backfill_mock = (
         _patch_materialize_and_projection()


### PR DESCRIPTION
## Summary
- Adds a provider-batch contract for investment LLM work and durable Postgres orchestration tables for provider batch jobs/items.
- Implements OpenAI and Qwen/DashScope batch adapters with sanitized operational metadata only.
- Wires investment materialization, CLI, and Celery controls for `sync`, `auto`, and `provider_batch` modes, including repair/fallback/idempotency behavior.
- Adds queue-runner friendly env-var defaults for batch mode: `INVESTMENT_LLM_BATCH_MODE`, `INVESTMENT_LLM_BATCH_MIN_ITEMS`, `INVESTMENT_LLM_BATCH_POLL_INTERVAL_SECONDS`, and `INVESTMENT_LLM_BATCH_TIMEOUT_SECONDS`. Explicit CLI flags/task kwargs still win.
- Documents operator usage, provider support, and env-var controls for batch materialization.

## CHAOS-2493 coverage
- CHAOS-2494: config/CLI/Celery batch controls, including env defaults for queue runners.
- CHAOS-2495: shared provider batch contract/capability detection.
- CHAOS-2496: durable batch job/item storage with Alembic migration.
- CHAOS-2497: OpenAI batch provider support.
- CHAOS-2499: Qwen/DashScope batch provider support.
- CHAOS-2500: materializer provider-batch integration.
- CHAOS-2501: repair/fallback handling for provider errors and missing results.
- CHAOS-2502: idempotency and retry semantics.
- CHAOS-2503: operational state/counts/token usage/logging.
- CHAOS-2504: operator documentation.
- CHAOS-2505: mocked end-to-end materialization coverage plus local-provider smoke validation.
- CHAOS-2506: phase-2 Anthropic/Gemini planning noted as non-goal for this PR.

## Validation
- `bash ci/local_validate.sh` passed after env-var follow-up: 5688 passed; GATE PASSED.
- Focused env-var tests passed: `python -m pytest tests/work_graph/test_runner.py tests/test_post_sync_investment_dispatch.py tests/test_investment_materialize_partitioned.py tests/test_investment_batch_docs.py` -> 31 passed.
- Push hook passed: ruff check, ruff format check, mypy.
- GitHub PR checks passed on head `f243e88eba751167ff1987cb9a7c7e9dae8bc9a6`.
- Manual smoke validation used the local provider surface before PR prep: `categorize_text_bundle` returned ok; `materialize_investments` produced one investment record, two quotes, one LLM call, and token usage.

SCREENSHOT-WAIVER: backend/provider-batch orchestration only; no rendered UI changes.

Linear: CHAOS-2493