### PR TITLE
fix(alembic): resolve dual 0024 migration head

### DIFF
--- a/src/dev_health_ops/alembic/versions/0025_add_sync_compute_checkpoints.py
+++ b/src/dev_health_ops/alembic/versions/0025_add_sync_compute_checkpoints.py
@@ -1,7 +1,7 @@
 """Add sync compute checkpoints.
 
-Revision ID: 0024
-Revises: 0023
+Revision ID: 0025
+Revises: 0024
 Create Date: 2026-06-25 00:00:00
 
 """
@@ -14,8 +14,8 @@ import sqlalchemy as sa
 from alembic import op
 from sqlalchemy.dialects.postgresql import UUID
 
-revision: str = "0024"
-down_revision: str | None = "0023"
+revision: str = "0025"
+down_revision: str | None = "0024"
 branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 


### PR DESCRIPTION
## Problem

Prod migrations fail with:

```
alembic.util.exc.CommandError: Multiple head revisions are present for given argument 'head'
```

Two migrations merged independently both claimed `revision = "0024"` with `down_revision = "0023"`, producing two heads:

- `0024_add_investment_batch_tables` (#1049, merged first)
- `0024_add_sync_compute_checkpoints` (#1050, merged later)

`alembic upgrade head` then refuses to run because it cannot pick a single head.

## Fix

Keep the earlier-merged `0024_add_investment_batch_tables` as `0024`, and renumber `0024_add_sync_compute_checkpoints` → `0025`, chaining it after `0024` (`down_revision = "0024"`). Result is a single linear head:

```
0023 -> 0024 (investment batch tables) -> 0025 (sync compute checkpoints)
```

No migration referenced `0024` as a child, so nothing downstream is affected.

## Prod safety

Idempotent regardless of prod's current revision:
- If prod is at `0023` → applies `0024` then `0025`.
- If `#1049` already deployed and prod is at `0024` → applies only `0025`.

## Verification

- `alembic heads` → single head `0025`.
- `alembic history` shows the linear chain `0023 -> 0024 -> 0025`.
- Pre-commit ruff + mypy clean.

SCREENSHOT-WAIVER: backend migration renumber, no UI render.