### PR TITLE
fix(workers): evaluate schedule crons in the selected timezone (CHAOS-2689)

### DIFF
--- a/docs/user-guide/reports.md
+++ b/docs/user-guide/reports.md
@@ -45,12 +45,12 @@ When a report is created without an explicit `ReportPlan`, the system generates 
 Clicking **Run Now** on the report detail page triggers the `triggerReport` mutation. This creates a `ReportRun` (with `triggered_by="api"` and status `PENDING`) and dispatches the `execute_saved_report` Celery task to the `reports` queue. The mutation serves as an example of the preferred Celery-job trigger pattern (CHAOS-2475, CHAOS-2482) to avoid running resource-intensive or credential-heavy operations inline. Using this pattern ensures credentials aren't exposed or bypassed. See [workers.md](../ops/workers.md) for details on Celery worker configuration.
 ### Scheduled Execution
 
-Reports with a schedule (Weekly or Monthly) are triggered automatically by the `dispatch_scheduled_reports` beat task, which runs every 5 minutes and checks for due reports based on their cron expression.
+Reports with a schedule (Weekly or Monthly) are triggered automatically by the `dispatch_scheduled_reports` beat task, which runs every 5 minutes and checks for due reports based on their cron expression. The cron is evaluated in the schedule's selected **timezone** (`ScheduledJob.timezone`, defaulting to UTC), so the times below are wall-clock times in that zone — a report scheduled in `America/Los_Angeles` fires at 09:00 Pacific, not 09:00 UTC (CHAOS-2689).
 
 | Schedule | Cron Expression |
 |----------|----------------|
-| Weekly | `0 9 * * 1` (Mondays at 09:00 UTC) |
-| Monthly | `0 9 1 * *` (1st of month at 09:00 UTC) |
+| Weekly | `0 9 * * 1` (Mondays at 09:00 in the report's timezone) |
+| Monthly | `0 9 1 * *` (1st of month at 09:00 in the report's timezone) |
 
 ---
 

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -51,6 +51,7 @@ from dev_health_ops.sync.trigger_routing import (
     mark_sync_run_failed,
     planner_request_for_config_if_routed,
 )
+from dev_health_ops.utils.datetime import validate_timezone_name
 from dev_health_ops.workers.sync_units import dispatch_sync_run
 
 from .common import get_session
@@ -1388,6 +1389,11 @@ async def create_sync_config(
                 status_code=422, detail=f"Invalid cron expression: {exc}"
             )
 
+        try:
+            validate_timezone_name(sync_options.get("timezone"))
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
+
         def _get_min_interval(sync_session) -> float | None:
             tier_svc = TierLimitService(sync_session)
             val = tier_svc.get_limit(uuid.UUID(org_id), "min_sync_interval_hours")
@@ -1563,6 +1569,11 @@ async def update_sync_config(
             raise HTTPException(
                 status_code=422, detail=f"Invalid cron expression: {exc}"
             )
+
+        try:
+            validate_timezone_name(sync_options.get("timezone"))
+        except ValueError as exc:
+            raise HTTPException(status_code=422, detail=str(exc))
 
         def _get_min_interval(sync_session) -> float | None:
             tier_svc = TierLimitService(sync_session)

--- a/src/dev_health_ops/api/graphql/resolvers/reports.py
+++ b/src/dev_health_ops/api/graphql/resolvers/reports.py
@@ -10,6 +10,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
 from dev_health_ops.models.settings import JobStatus, ScheduledJob
+from dev_health_ops.utils.datetime import validate_timezone_name
 
 
 @strawberry.type
@@ -323,6 +324,10 @@ async def _ensure_or_update_schedule(
 ) -> None:
     if cron is None:
         return
+
+    # Reject invalid timezones up front so a schedule never silently runs in UTC
+    # at dispatch time (CHAOS-2689). Raises ValueError -> surfaced as a GraphQL error.
+    validate_timezone_name(tz)
 
     if report.schedule_id:
         result = await session.execute(

--- a/src/dev_health_ops/utils/datetime.py
+++ b/src/dev_health_ops/utils/datetime.py
@@ -1,5 +1,6 @@
 from datetime import date, datetime, timezone
 from typing import overload
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 
 @overload
@@ -31,3 +32,18 @@ def naive_utc(dt: datetime) -> datetime:
 def utc_today() -> date:
     """Return the current date in UTC, independent of container timezone."""
     return datetime.now(timezone.utc).date()
+
+
+def validate_timezone_name(tz_name: str | None) -> None:
+    """Raise ``ValueError`` if ``tz_name`` is a non-empty, unrecognized IANA zone.
+
+    Empty / ``None`` is allowed (callers default to UTC). Used at schedule write
+    paths so an invalid timezone is rejected up front with a user-visible error
+    instead of silently falling back to UTC at dispatch time (CHAOS-2689).
+    """
+    if not tz_name:
+        return
+    try:
+        ZoneInfo(tz_name)
+    except (ZoneInfoNotFoundError, ValueError) as exc:
+        raise ValueError(f"Invalid timezone: {tz_name!r}") from exc

--- a/src/dev_health_ops/workers/metrics_daily.py
+++ b/src/dev_health_ops/workers/metrics_daily.py
@@ -15,6 +15,7 @@ from dev_health_ops.workers.task_utils import (
     _as_str,
     _get_db_url,
     _invalidate_metrics_cache,
+    cron_next_run,
 )
 
 logger = logging.getLogger(__name__)
@@ -25,7 +26,6 @@ logger = logging.getLogger(__name__)
 )
 def dispatch_scheduled_metrics(self) -> dict:
     """Check ScheduledJob entries with job_type='metrics' and dispatch any that are due."""
-    from croniter import croniter
 
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models.settings import (
@@ -63,8 +63,7 @@ def dispatch_scheduled_metrics(self) -> dict:
                     if isinstance(job.last_run_at, datetime)
                     else _as_datetime(job.created_at)
                 )
-                cron = croniter(cron_expr, last_run)
-                next_run = cron.get_next(datetime)
+                next_run = cron_next_run(cron_expr, last_run, _as_str(job.timezone))
 
                 if next_run <= now:
                     job_config: dict[str, Any] = _as_dict(job.job_config)

--- a/src/dev_health_ops/workers/report_scheduler.py
+++ b/src/dev_health_ops/workers/report_scheduler.py
@@ -6,6 +6,7 @@ from datetime import datetime, timezone
 
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.org_guard import organization_exists_sync
+from dev_health_ops.workers.task_utils import _as_str, cron_next_run
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +27,6 @@ def _datetime_value(value: object) -> datetime:
     bind=True, name="dev_health_ops.workers.tasks.dispatch_scheduled_reports"
 )
 def dispatch_scheduled_reports(self) -> dict:
-    from croniter import croniter
 
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
@@ -72,8 +72,9 @@ def dispatch_scheduled_reports(self) -> dict:
                     if isinstance(report.last_run_at, datetime)
                     else _datetime_value(report.created_at)
                 )
-                cron = croniter(str(job.schedule_cron), last_run)
-                next_run = cron.get_next(datetime)
+                next_run = cron_next_run(
+                    str(job.schedule_cron), last_run, _as_str(job.timezone)
+                )
 
                 if next_run <= now:
                     run = ReportRun(

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -13,6 +13,7 @@ from dev_health_ops.workers.task_utils import (
     _as_dict,
     _as_str,
     _as_uuid,
+    cron_next_run,
 )
 
 if TYPE_CHECKING:
@@ -153,7 +154,6 @@ def _maybe_dispatch_config(
     queue purge), the config becomes dispatchable again at the next cron
     occurrence -- at most one cron interval of delay, no manual cleanup.
     """
-    from croniter import croniter
 
     from dev_health_ops.models.settings import JobStatus, ScheduledJob
 
@@ -205,12 +205,17 @@ def _maybe_dispatch_config(
             return False
 
     cron_expr = _as_str(job.schedule_cron) if job is not None else config_cron
+    tz_name = (
+        _as_str(job.timezone)
+        if job is not None
+        else _as_str(_as_dict(config.sync_options).get("timezone"))
+    ) or "UTC"
     last_sync = (
         config.last_sync_at
         if isinstance(config.last_sync_at, datetime)
         else _as_datetime(config.created_at)
     )
-    next_run = croniter(cron_expr, last_sync).get_next(datetime)
+    next_run = cron_next_run(cron_expr, last_sync, tz_name)
 
     if not next_run <= now:
         return False
@@ -238,7 +243,7 @@ def _maybe_dispatch_config(
                 STALE_RUNNING_TTL_SECONDS,
             )
 
-    marker = croniter(cron_expr, now).get_next(datetime)
+    marker = cron_next_run(cron_expr, now, tz_name)
     if isinstance(marker, datetime):
         job.next_run_at = marker
     session.flush()

--- a/src/dev_health_ops/workers/task_utils.py
+++ b/src/dev_health_ops/workers/task_utils.py
@@ -4,9 +4,10 @@ import json
 import logging
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timezone, tzinfo
 from typing import Any
 from urllib.parse import urlparse
+from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 logger = logging.getLogger(__name__)
 
@@ -295,3 +296,47 @@ def _invalidate_sync_cache(sync_type: str, org_id: str) -> None:
         logger.info("Invalidated %d cache entries after %s sync", count, sync_type)
     except Exception as e:
         logger.warning("Cache invalidation failed (non-fatal): %s", e)
+
+
+def cron_next_run(
+    cron_expr: str, base: datetime, tz_name: str | None = None
+) -> datetime:
+    """Return the next cron occurrence after ``base``, evaluated in ``tz_name``.
+
+    Cron fields are wall-clock times in the schedule's selected timezone. The
+    cron is evaluated in **naive local** wall-clock time and the result is then
+    localized back to the zone, so each cron occurrence maps to exactly one
+    instant: at a DST fall-back the repeated wall-clock hour is not emitted
+    twice (which would double-fire a schedule), and a spring-forward gap still
+    resolves to a single instant. The result is returned as an aware UTC
+    datetime so callers can compare it against a UTC ``now`` and persist it.
+
+    A naive ``base`` is treated as UTC (SQLite returns naive timestamps). An
+    empty or unknown ``tz_name`` falls back to UTC -- this is runtime
+    defense-in-depth only; user-supplied timezones are validated at the
+    schedule write path (see ``api/admin/routers/sync.py`` and the report
+    schedule resolver), so a bad value here means a legacy/corrupt row, not
+    new input.
+    """
+    from croniter import croniter
+
+    if base.tzinfo is None:
+        base = base.replace(tzinfo=timezone.utc)
+
+    tz: tzinfo = timezone.utc
+    if tz_name:
+        try:
+            tz = ZoneInfo(tz_name)
+        except (ZoneInfoNotFoundError, ValueError):
+            logger.warning(
+                "Unknown schedule timezone %r; evaluating cron in UTC", tz_name
+            )
+
+    # Evaluate the cron against naive wall-clock time in the target zone so
+    # croniter advances by wall clock; then localize the result back. ``fold``
+    # defaults to 0, picking the earlier offset for an ambiguous fall-back time.
+    local_base = base.astimezone(tz).replace(tzinfo=None)
+    next_local = croniter(cron_expr, local_base).get_next(datetime)
+    if not isinstance(next_local, datetime):  # defensive: honour croniter contract
+        raise TypeError("croniter.get_next did not return a datetime")
+    return next_local.replace(tzinfo=tz).astimezone(timezone.utc)

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -395,6 +395,35 @@ async def test_create_sync_config_folds_top_level_schedule_fields(
 
 
 @pytest.mark.asyncio
+async def test_create_sync_config_rejects_invalid_timezone(client):
+    """Invalid selected timezone is rejected at write time (CHAOS-2689) instead
+    of silently falling back to UTC at dispatch time."""
+    ac, _ = client
+
+    with (
+        patch(
+            "dev_health_ops.licensing.gating._check_org_feature_async",
+            return_value=True,
+        ),
+        patch.object(sync_router_module, "Croniter", _CroniterStub),
+    ):
+        resp = await ac.post(
+            "/api/v1/admin/sync-configs",
+            json={
+                "name": "bad-tz",
+                "provider": "linear",
+                "sync_targets": ["work-items"],
+                "sync_options": {"backfill_days": 1},
+                "schedule_cron": "30 2 * * *",
+                "timezone": "Not/AZone",
+            },
+        )
+
+    assert resp.status_code == 422, resp.text
+    assert "timezone" in resp.text.lower()
+
+
+@pytest.mark.asyncio
 async def test_batch_create_linear_without_repos_creates_active_config_and_job(
     client, session_maker
 ):

--- a/tests/test_scheduler_timezone.py
+++ b/tests/test_scheduler_timezone.py
@@ -1,0 +1,368 @@
+"""Schedulers honour the selected timezone (CHAOS-2689).
+
+The sync / report / metrics dispatchers must evaluate cron schedules in the
+schedule's **selected** timezone, not UTC. Previously the persisted ``timezone``
+was ignored and every cron was interpreted as UTC, so any non-UTC schedule fired
+on the wrong wall-clock slots and looked like it "never ran". These tests pin:
+
+1. ``cron_next_run`` math: a non-UTC cron resolves to the local wall-clock slot
+   (with correct DST offset), naive bases are treated as UTC, and unknown/empty
+   timezones fall back to UTC instead of crashing.
+2. Wiring: each dispatcher forwards the job's stored timezone into the cron
+   computation (a regression that drops the argument is caught).
+"""
+
+from __future__ import annotations
+
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.git import Base
+
+# Importing these at module load registers their tables on the shared ``Base``
+# metadata so ``create_all`` builds them for the in-memory SQLite fixture.
+from dev_health_ops.models.reports import SavedReport
+from dev_health_ops.models.settings import (
+    ScheduledJob,
+    SyncConfiguration,
+)
+from dev_health_ops.utils.datetime import validate_timezone_name
+from dev_health_ops.workers.task_utils import cron_next_run
+
+LA = "America/Los_Angeles"
+
+
+class TestCronNextRun:
+    """Direct proof of the timezone-aware cron math (real ``croniter``)."""
+
+    def test_non_utc_cron_evaluates_on_local_wall_clock(self):
+        # base 2026-06-26 12:00Z == 05:00 PDT. The next LA midnight is
+        # 2026-06-27 00:00 PDT == 2026-06-27 07:00Z (PDT = UTC-7 in June).
+        base = datetime(2026, 6, 26, 12, 0, tzinfo=timezone.utc)
+        assert cron_next_run("0 0 * * *", base, LA) == datetime(
+            2026, 6, 27, 7, 0, tzinfo=timezone.utc
+        )
+
+    def test_utc_cron_matches_utc_slot(self):
+        base = datetime(2026, 6, 26, 12, 0, tzinfo=timezone.utc)
+        assert cron_next_run("0 0 * * *", base, "UTC") == datetime(
+            2026, 6, 27, 0, 0, tzinfo=timezone.utc
+        )
+
+    def test_dst_offset_tracks_the_season(self):
+        # January: PST = UTC-8, so LA midnight resolves to 08:00Z.
+        winter = datetime(2026, 1, 15, 12, 0, tzinfo=timezone.utc)
+        assert cron_next_run("0 0 * * *", winter, LA) == datetime(
+            2026, 1, 16, 8, 0, tzinfo=timezone.utc
+        )
+
+    def test_result_is_aware_utc(self):
+        base = datetime(2026, 6, 26, 12, 0, tzinfo=timezone.utc)
+        assert cron_next_run("0 */6 * * *", base, LA).tzinfo is timezone.utc
+
+    def test_naive_base_is_treated_as_utc(self):
+        naive = datetime(2026, 6, 26, 12, 0)
+        aware = datetime(2026, 6, 26, 12, 0, tzinfo=timezone.utc)
+        assert cron_next_run("0 0 * * *", naive, LA) == cron_next_run(
+            "0 0 * * *", aware, LA
+        )
+
+    @pytest.mark.parametrize("tz_name", ["", None])
+    def test_missing_timezone_defaults_to_utc(self, tz_name):
+        # Empty / None is a legacy/unset value and is intentionally treated as UTC.
+        base = datetime(2026, 6, 26, 12, 0, tzinfo=timezone.utc)
+        assert cron_next_run("0 0 * * *", base, tz_name) == cron_next_run(
+            "0 0 * * *", base, "UTC"
+        )
+
+    def test_invalid_timezone_is_defense_in_depth_utc_fallback(self):
+        # Invalid timezones are rejected at the schedule write path (see
+        # TestTimezoneValidation); if a corrupt/legacy row still reaches the
+        # dispatcher, the helper must NOT crash -- it falls back to UTC so other
+        # due jobs keep dispatching.
+        base = datetime(2026, 6, 26, 12, 0, tzinfo=timezone.utc)
+        assert cron_next_run("0 0 * * *", base, "Not/AZone") == cron_next_run(
+            "0 0 * * *", base, "UTC"
+        )
+
+    def test_dst_fall_back_does_not_emit_repeated_hour_twice(self):
+        # 2026-11-01 in America/Los_Angeles: 02:00 PDT falls back to 01:00 PST,
+        # so 01:30 occurs twice (08:30Z PDT, then 09:30Z PST). A '30 1 * * *'
+        # schedule must fire the slot ONCE: the first occurrence resolves to the
+        # earlier offset, and advancing from there jumps to the NEXT DAY -- never
+        # the same-day second fold (which would double-fire the job).
+        before = datetime(
+            2026, 11, 1, 6, 0, tzinfo=timezone.utc
+        )  # 2026-10-31 23:00 PDT
+        first = cron_next_run("30 1 * * *", before, LA)
+        assert first == datetime(2026, 11, 1, 8, 30, tzinfo=timezone.utc)
+        # Advancing the marker from the first fire skips the repeated 09:30Z slot.
+        nxt = cron_next_run("30 1 * * *", first, LA)
+        assert nxt == datetime(2026, 11, 2, 9, 30, tzinfo=timezone.utc)
+
+    def test_dst_spring_forward_nonexistent_time_resolves_once(self):
+        # 2026-03-08 in America/Los_Angeles: 02:00 -> 03:00, so 02:30 does not
+        # exist. A '30 2 * * *' schedule must still resolve to a single instant
+        # without raising.
+        before = datetime(2026, 3, 8, 9, 0, tzinfo=timezone.utc)  # 2026-03-08 01:00 PST
+        result = cron_next_run("30 2 * * *", before, LA)
+        assert result.tzinfo is timezone.utc
+        assert result == datetime(2026, 3, 8, 10, 30, tzinfo=timezone.utc)
+
+
+@contextmanager
+def _session_ctx(session):
+    yield session
+
+
+class TestDispatchersForwardSelectedTimezone:
+    """Each dispatcher must pass the job's stored timezone into the cron eval.
+
+    The spy returns a far-future occurrence so dispatch short-circuits as
+    "not due" before any enqueue/planner work, while still capturing the
+    ``tz_name`` the dispatcher forwarded.
+    """
+
+    @pytest.fixture
+    def db_session(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+        engine.dispose()
+
+    @staticmethod
+    def _call(task) -> dict:
+        task.push_request(id=str(uuid.uuid4()))
+        try:
+            return task()
+        finally:
+            task.pop_request()
+
+    def test_sync_dispatch_forwards_timezone(self, monkeypatch, db_session):
+        from dev_health_ops.workers import sync_scheduler
+
+        now = datetime.now(timezone.utc)
+        config = SyncConfiguration(
+            name="linear",
+            provider="linear",
+            org_id="default",
+            sync_targets=["work-items"],
+            sync_options={"schedule_cron": "0 */6 * * *", "timezone": LA},
+            is_active=True,
+        )
+        config.last_sync_at = now - timedelta(hours=2)
+        db_session.add(config)
+        db_session.flush()
+        job = ScheduledJob(
+            name=f"sync-config-{config.id}",
+            job_type="sync",
+            schedule_cron="0 */6 * * *",
+            org_id="default",
+            provider="linear",
+            sync_config_id=config.id,
+            tz=LA,
+        )
+        db_session.add(job)
+        db_session.flush()
+
+        seen: dict[str, str | None] = {}
+
+        def spy(cron_expr, base, tz_name=None):
+            seen["tz"] = tz_name
+            return now + timedelta(hours=99)  # far future => not due
+
+        monkeypatch.setattr(sync_scheduler, "cron_next_run", spy)
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session_sync",
+            lambda: _session_ctx(db_session),
+        )
+        monkeypatch.setattr(
+            sync_scheduler, "organization_exists_sync", lambda _s, _o: True
+        )
+
+        result = self._call(sync_scheduler.dispatch_scheduled_syncs)
+        assert result["dispatched"] == []
+        assert seen["tz"] == LA
+
+    def test_metrics_dispatch_forwards_timezone(self, monkeypatch, db_session):
+        from dev_health_ops.workers import metrics_daily
+
+        now = datetime.now(timezone.utc)
+        job = ScheduledJob(
+            name="metrics-default",
+            job_type="metrics",
+            schedule_cron="0 0 * * *",
+            org_id="default",
+            job_config={"org_id": "default"},
+            tz=LA,
+        )
+        db_session.add(job)
+        db_session.flush()
+
+        seen: dict[str, str | None] = {}
+
+        def spy(cron_expr, base, tz_name=None):
+            seen["tz"] = tz_name
+            return now + timedelta(hours=99)
+
+        monkeypatch.setattr(metrics_daily, "cron_next_run", spy)
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session_sync",
+            lambda: _session_ctx(db_session),
+        )
+        monkeypatch.setattr(
+            metrics_daily, "organization_exists_sync", lambda _s, _o: True
+        )
+
+        result = self._call(metrics_daily.dispatch_scheduled_metrics)
+        assert result["dispatched"] == []
+        assert seen["tz"] == LA
+
+    def test_report_dispatch_forwards_timezone(self, monkeypatch, db_session):
+        from dev_health_ops.workers import report_scheduler
+
+        now = datetime.now(timezone.utc)
+        job = ScheduledJob(
+            name="report-1",
+            job_type="report",
+            schedule_cron="0 0 * * *",
+            org_id="default",
+            tz=LA,
+        )
+        db_session.add(job)
+        db_session.flush()
+        report = SavedReport(
+            org_id="default",
+            name="weekly",
+            report_plan={},
+            schedule_id=job.id,
+            is_active=True,
+        )
+        db_session.add(report)
+        db_session.flush()
+
+        seen: dict[str, str | None] = {}
+
+        def spy(cron_expr, base, tz_name=None):
+            seen["tz"] = tz_name
+            return now + timedelta(hours=99)
+
+        monkeypatch.setattr(report_scheduler, "cron_next_run", spy)
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session_sync",
+            lambda: _session_ctx(db_session),
+        )
+        monkeypatch.setattr(
+            report_scheduler, "organization_exists_sync", lambda _s, _o: True
+        )
+
+        result = self._call(report_scheduler.dispatch_scheduled_reports)
+        assert result["dispatched"] == []
+        assert seen["tz"] == LA
+
+
+class TestTimezoneValidation:
+    """``validate_timezone_name`` rejects bad zones at the schedule write path."""
+
+    @pytest.mark.parametrize("good", ["America/Los_Angeles", "UTC", "Europe/Berlin"])
+    def test_accepts_valid_zone(self, good):
+        validate_timezone_name(good)  # must not raise
+
+    @pytest.mark.parametrize("empty", ["", None])
+    def test_allows_empty_as_utc_default(self, empty):
+        validate_timezone_name(empty)  # must not raise
+
+    @pytest.mark.parametrize(
+        "bad", ["Not/AZone", "America/Nowhere", "garbage", "Totally/Bogus"]
+    )
+    def test_rejects_invalid_zone(self, bad):
+        with pytest.raises(ValueError, match="Invalid timezone"):
+            validate_timezone_name(bad)
+
+
+class TestSyncDispatchDstFold:
+    """The real sync due/marker path fires a DST fall-back fold slot only once."""
+
+    @pytest.fixture
+    def db_session(self):
+        engine = create_engine("sqlite:///:memory:")
+        Base.metadata.create_all(engine)
+        with Session(engine) as session:
+            yield session
+        engine.dispose()
+
+    def test_fall_back_slot_dispatches_once(self, monkeypatch, db_session):
+        from types import SimpleNamespace
+        from unittest.mock import MagicMock
+
+        from dev_health_ops.workers import sync_scheduler
+
+        # 2026-11-01 America/Los_Angeles fall-back: 01:30 occurs at 08:30Z (PDT)
+        # and again at 09:30Z (PST).
+        first_fold = datetime(2026, 11, 1, 8, 30, tzinfo=timezone.utc)
+        second_fold = datetime(2026, 11, 1, 9, 30, tzinfo=timezone.utc)
+
+        config = SyncConfiguration(
+            name="linear",
+            provider="linear",
+            org_id="default",
+            sync_targets=["work-items"],
+            sync_options={"schedule_cron": "30 1 * * *", "timezone": LA},
+            is_active=True,
+        )
+        config.last_sync_at = datetime(2026, 11, 1, 6, 0, tzinfo=timezone.utc)
+        db_session.add(config)
+        db_session.flush()
+        job = ScheduledJob(
+            name=f"sync-config-{config.id}",
+            job_type="sync",
+            schedule_cron="30 1 * * *",
+            org_id="default",
+            provider="linear",
+            sync_config_id=config.id,
+            tz=LA,
+        )
+        db_session.add(job)
+        db_session.flush()
+
+        dispatch_mock = MagicMock()
+        monkeypatch.setattr(
+            sync_scheduler, "organization_exists_sync", lambda *_a: True
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.sync.trigger_routing.planner_request_for_config_if_routed",
+            lambda *a, **k: object(),
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.sync.planner.plan_sync_run",
+            lambda *a, **k: SimpleNamespace(sync_run_id="run-1"),
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.workers.sync_units.dispatch_sync_run", dispatch_mock
+        )
+
+        # First fold instant: due -> dispatched exactly once.
+        assert (
+            sync_scheduler._maybe_dispatch_config(db_session, config, first_fold)
+            is True
+        )
+        assert dispatch_mock.apply_async.call_count == 1
+        # The marker advanced past the repeated hour to the next day's slot.
+        marker = job.next_run_at
+        assert marker is not None
+        if marker.tzinfo is None:
+            marker = marker.replace(tzinfo=timezone.utc)
+        assert marker == datetime(2026, 11, 2, 9, 30, tzinfo=timezone.utc)
+
+        # Second fold instant (same wall-clock 01:30): must NOT re-dispatch.
+        assert (
+            sync_scheduler._maybe_dispatch_config(db_session, config, second_fold)
+            is False
+        )
+        assert dispatch_mock.apply_async.call_count == 1

--- a/tests/workers/test_planner_only_routing.py
+++ b/tests/workers/test_planner_only_routing.py
@@ -284,8 +284,9 @@ def test_scheduler_routes_migrated_config_through_planner(db_session, monkeypatc
     )
     _patch_db_session(monkeypatch, db_session)
 
-    # Pass a naive now to match croniter's naive output.
-    now = datetime.utcnow()
+    # Production passes an aware UTC now (dispatch_scheduled_syncs uses
+    # datetime.now(timezone.utc)); the scheduler now compares against aware UTC.
+    now = datetime.now(timezone.utc)
     result = _maybe_dispatch_config(db_session, config, now)
 
     assert result is True, (


### PR DESCRIPTION
## Summary

Scheduled syncs, reports, and metrics ran on **UTC** cron slots regardless of the **timezone the user selected**. The `timezone` was persisted on both the sync config (`sync_options.timezone`) and the `ScheduledJob` row, but none of the three Celery dispatchers read it — they evaluated the cron against a UTC `now`. Any non-UTC schedule fired at the wrong wall-clock time, so from the user's perspective the schedule "never ran."

Fixes **CHAOS-2689**.

### Live evidence (before fix)

A `0 */6 * * *` / `America/Los_Angeles` sync persisted `next_run_at = 12:00:00Z` (the UTC interpretation) instead of the selected Pacific slots (`07:00Z` / `13:00Z` / …), and only the `06:00 UTC` slot ever fired.

## Changes

- **`workers/task_utils.py`** — new `cron_next_run(cron_expr, base, tz_name)`: evaluates the cron in the job's timezone using **naive local wall-clock**, then localizes back to aware UTC. Each cron occurrence maps to exactly one instant, so a DST fall-back fold does **not** double-fire the repeated hour, and a spring-forward gap still resolves once. Coerces naive bases to UTC (closes a latent naive-vs-aware comparison crash).
- **`workers/sync_scheduler.py`** — due-check **and** `next_run_at` marker now use the helper, reading the tz from `ScheduledJob.timezone` (falling back to `sync_options.timezone` on the create path).
- **`workers/report_scheduler.py`**, **`workers/metrics_daily.py`** — same, reading `ScheduledJob.timezone`.
- **`utils/datetime.py`** — new `validate_timezone_name()`; wired into the sync-config write path (`api/admin/routers/sync.py`, create + update → HTTP 422) and the report-schedule resolver (`api/graphql/resolvers/reports.py` → GraphQL error). Invalid zones are now rejected up front instead of silently running in UTC; the helper's UTC fallback remains only as runtime defense-in-depth for legacy/corrupt rows.
- **`docs/user-guide/reports.md`** — schedule docs corrected (cron evaluated in the report's timezone, not hard UTC).

Read-path only for dispatch — the `timezone` column was already persisted, so no schema/migration.

## Tests

`tests/test_scheduler_timezone.py` (new) covers the tz math, DST fall-back fold-collapse, spring-forward, timezone-validator accept/reject, and a **real `_maybe_dispatch_config` marker-path test** proving a fall-back slot dispatches exactly once. `tests/api/admin/test_sync_configs.py` adds an HTTP-422 rejection test. `tests/workers/test_planner_only_routing.py` updated to pass an aware UTC `now` (matching production).

## Validation

- `bash ci/local_validate.sh` → **GATE PASSED** (ruff format/check, mypy, full unit suite `5748 passed`, live-ClickHouse argMax proof).

## Review

Ran an adversarial Codex review; both medium findings (DST fall-back double-fire, invalid-timezone silent UTC) are addressed in this PR.

SCREENSHOT-WAIVER: backend/worker + API validation change with no rendered UI surface.
