### PR TITLE
feat(launchdarkly): adopt sync budgeting (CHAOS-2687)

### DIFF
--- a/docs/architecture/launchdarkly-sync-budgeting.md
+++ b/docs/architecture/launchdarkly-sync-budgeting.md
@@ -1,31 +1,41 @@
-# LaunchDarkly sync budgeting plan
+# LaunchDarkly sync budgeting
 
-Status: planning contract for CHAOS-2687. This is not a raw sync implementation.
+Status: implemented for CHAOS-2687 feature-flag sync budgeting. The
+`feature-flags` dataset now emits LaunchDarkly budget estimates through the
+existing `SyncRunUnit` pipeline, and `estimate_provider_budget()` dispatches to
+`LaunchDarklyBudgetEstimator` for `provider="launchdarkly"`.
 
 ## Current provider status
 
-The canonical `src/dev_health_ops/providers/launchdarkly/` package is partial. It currently contains code-reference helpers and a code-reference client, but it does not contain a full LaunchDarkly sync provider, a feature-flag/audit planner, or a budget estimator. Existing flag and audit-log fetches still live in the frozen legacy connector path and are called by the feature-flag worker; future provider work must move canonical raw fetch, pagination, retry, rate-limit handling, and normalization under `providers/launchdarkly/` before new sync behavior ships.
+The canonical `src/dev_health_ops/providers/launchdarkly/` package is partial. It currently contains code-reference helpers, a code-reference client, and the LaunchDarkly budget estimator. Existing flag and audit-log fetches still live in the frozen legacy connector path and are called by the feature-flag worker through the `SyncRunUnit` dataset adapter path. Future provider work must move canonical raw fetch, pagination, retry, rate-limit handling, and normalization under `providers/launchdarkly/`; until then, do not add new code under `connectors/`.
 
 ## Estimator contract
 
-The future LaunchDarkly estimator must implement `dev_health_ops.sync.budget_types.BudgetEstimator`:
+The LaunchDarkly estimator implements `dev_health_ops.sync.budget_types.BudgetEstimator`:
 
 ```python
 class LaunchDarklyBudgetEstimator:
     def estimate(self, context: SyncTaskContext) -> tuple[BudgetEstimate, ...]: ...
 ```
 
-Required behavior:
+Implemented behavior:
 
 - Return an empty tuple for non-`launchdarkly` contexts.
-- Return one or more `BudgetEstimate` values for every supported LaunchDarkly `SyncRunUnit`, starting with `DatasetKey.FEATURE_FLAGS`.
+- Return `BudgetEstimate` values for the supported LaunchDarkly `SyncRunUnit`: `DatasetKey.FEATURE_FLAGS`.
 - Build every bucket with `BudgetBucketKey(provider="launchdarkly", org_id=context.org_id, host=<api-host>, credential_fingerprint=<safe fingerprint>, dimension=<BudgetDimension>)`.
 - Use only the shared `BudgetDimension` vocabulary from `budget_types.py`; CHAOS-2687 introduces no new enum values.
 - Use route families from `dev_health_ops.providers.launchdarkly.budget.LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES` so operators can override limits by keys such as `launchdarkly:rest_core:flags` or `launchdarkly:secondary_abuse_risk:audit_log`.
 - Include no API secrets in bucket fingerprints, observations, logs, exceptions, or test snapshots.
-- Treat estimate output as a hard provider-acceptance gate: a new LaunchDarkly sync unit is incomplete until the budget estimator covers its route families and tests assert that `estimate_provider_budget(context)` returns non-empty estimates.
+- Treat estimate output as a hard provider-acceptance gate: any new LaunchDarkly sync unit is incomplete until the budget estimator covers its route families and tests assert that `estimate_provider_budget(context)` returns non-empty estimates.
 
-The dispatch budget guard already consumes provider estimates through `estimate_provider_budget()`, then defers units when `SYNC_BUDGET_BUCKET_LIMITS` would be exceeded. Future LaunchDarkly provider wiring must add `launchdarkly` delegation there before enabling any raw fetch/sync path.
+The dispatch budget guard consumes LaunchDarkly estimates through `estimate_provider_budget()`, then defers units when `SYNC_BUDGET_BUCKET_LIMITS` would be exceeded. Successful units persist the estimate automatically in `SyncRunUnit.result.observations.budget_estimate`.
+
+The current `feature-flags` estimate reserves:
+
+- `flags`: `rest_core`, 2 units, medium confidence.
+- `audit_log`: `rest_core`, 52 units, low confidence.
+- `code_refs`: `rest_core`, 1 unit, medium confidence.
+- `code_refs`: `secondary_abuse_risk`, 1 unit, low confidence.
 
 ## Planned route families and dimensions
 
@@ -36,15 +46,15 @@ LaunchDarkly REST APIs are request-count and route-limit driven, so the first es
 | `projects` | `rest_core` | `GET /api/v2/projects`, `GET /api/v2/projects/{projectKey}/environments`, `GET /api/v2/projects/{projectKey}/environments/{environmentKey}` | project count, environments per project, `expand=environments` nested pagination |
 | `flags` | `rest_core` | `GET /api/v2/flags/{projectKey}` | project count, flag count, environment filtering, `summary=0`, `expand=evaluation,codeReferences,migrationSettings` |
 | `segments` | `rest_core` | `GET /api/v2/segments/{projectKey}/{environmentKey}` | project × environment fanout, segment count, big/synced segment expansion |
-| `audit_log` | `secondary_abuse_risk` | `GET /api/v2/auditlog`, `POST /api/v2/auditlog` | incremental window size, backfill span, resource-scoped searches, 20-entry page cap |
+| `audit_log` | `rest_core` | `GET /api/v2/auditlog`, `POST /api/v2/auditlog` | incremental window size, backfill span, resource-scoped searches, 20-entry page cap |
 | `members` | `rest_core` | `GET /api/v2/members` | member count, custom role expansion, role attribute expansion |
-| `code_refs` | `secondary_abuse_risk` | `GET /api/v2/code-refs/repositories` | repository count, branch count, references per flag, default-branch expansion |
+| `code_refs` | `rest_core`, `secondary_abuse_risk` | `GET /api/v2/code-refs/repositories` | repository count, branch count, references per flag, default-branch expansion |
 
 Flags embed variations and environment-specific configuration in the flag payload, so `variations` is a cost driver inside `flags`, not a standalone route family.
 
 ## Acceptance gate for future LaunchDarkly sync work
 
-Before raw LaunchDarkly fetch/auth/pagination code ships from the canonical provider package, the PR must include all of the following:
+CHAOS-2687 satisfies the budgeting gate for the existing `feature-flags` unit. Before additional raw LaunchDarkly fetch/auth/pagination code ships from the canonical provider package, the PR must include all of the following:
 
 1. A `LaunchDarklyBudgetEstimator` under `src/dev_health_ops/providers/launchdarkly/` that implements `BudgetEstimator` and returns non-empty estimates for `DatasetKey.FEATURE_FLAGS`.
 2. `estimate_provider_budget()` delegation for `context.provider.lower() == "launchdarkly"`.
@@ -52,6 +62,12 @@ Before raw LaunchDarkly fetch/auth/pagination code ships from the canonical prov
 4. Budget-guard coverage proving LaunchDarkly estimates participate in reservation and deferral through `SYNC_BUDGET_BUCKET_LIMITS`.
 5. Documentation updates when a new endpoint family, route family, or default budget limit is added.
 6. No new code under `connectors/`; canonical provider code remains under `providers/launchdarkly/`.
+
+## Follow-ups
+
+- Migrate the full LaunchDarkly provider off the frozen connector path.
+- Replace fixed request estimates with dynamic estimates driven by project, environment, flag, audit-log, and code-reference fanout.
+- Add GitLab feature-flag budgeting when GitLab feature-flag sync units are enabled.
 
 ## Initial operator defaults
 
@@ -62,7 +78,8 @@ No new environment variables are required. Extend the JSON value of `SYNC_BUDGET
   "launchdarkly:rest_core": 200,
   "launchdarkly:rest_core:flags": 120,
   "launchdarkly:rest_core:projects": 40,
-  "launchdarkly:secondary_abuse_risk:audit_log": 25,
+  "launchdarkly:rest_core:audit_log": 25,
+  "launchdarkly:rest_core:code_refs": 20,
   "launchdarkly:secondary_abuse_risk:code_refs": 20
 }
 ```

--- a/docs/architecture/launchdarkly-sync-budgeting.md
+++ b/docs/architecture/launchdarkly-sync-budgeting.md
@@ -1,0 +1,70 @@
+# LaunchDarkly sync budgeting plan
+
+Status: planning contract for CHAOS-2687. This is not a raw sync implementation.
+
+## Current provider status
+
+The canonical `src/dev_health_ops/providers/launchdarkly/` package is partial. It currently contains code-reference helpers and a code-reference client, but it does not contain a full LaunchDarkly sync provider, a feature-flag/audit planner, or a budget estimator. Existing flag and audit-log fetches still live in the frozen legacy connector path and are called by the feature-flag worker; future provider work must move canonical raw fetch, pagination, retry, rate-limit handling, and normalization under `providers/launchdarkly/` before new sync behavior ships.
+
+## Estimator contract
+
+The future LaunchDarkly estimator must implement `dev_health_ops.sync.budget_types.BudgetEstimator`:
+
+```python
+class LaunchDarklyBudgetEstimator:
+    def estimate(self, context: SyncTaskContext) -> tuple[BudgetEstimate, ...]: ...
+```
+
+Required behavior:
+
+- Return an empty tuple for non-`launchdarkly` contexts.
+- Return one or more `BudgetEstimate` values for every supported LaunchDarkly `SyncRunUnit`, starting with `DatasetKey.FEATURE_FLAGS`.
+- Build every bucket with `BudgetBucketKey(provider="launchdarkly", org_id=context.org_id, host=<api-host>, credential_fingerprint=<safe fingerprint>, dimension=<BudgetDimension>)`.
+- Use only the shared `BudgetDimension` vocabulary from `budget_types.py`; CHAOS-2687 introduces no new enum values.
+- Use route families from `dev_health_ops.providers.launchdarkly.budget.LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES` so operators can override limits by keys such as `launchdarkly:rest_core:flags` or `launchdarkly:secondary_abuse_risk:audit_log`.
+- Include no API secrets in bucket fingerprints, observations, logs, exceptions, or test snapshots.
+- Treat estimate output as a hard provider-acceptance gate: a new LaunchDarkly sync unit is incomplete until the budget estimator covers its route families and tests assert that `estimate_provider_budget(context)` returns non-empty estimates.
+
+The dispatch budget guard already consumes provider estimates through `estimate_provider_budget()`, then defers units when `SYNC_BUDGET_BUCKET_LIMITS` would be exceeded. Future LaunchDarkly provider wiring must add `launchdarkly` delegation there before enabling any raw fetch/sync path.
+
+## Planned route families and dimensions
+
+LaunchDarkly REST APIs are request-count and route-limit driven, so the first estimator should reserve abstract request units rather than raw vendor counters. Official API docs describe global limits, route-level limits, `Retry-After`, and paginated list responses; most list endpoints use `limit`/`offset`, while the audit log has a max page size of 20.
+
+| Route family | Dimension | Endpoint patterns | Budget drivers |
+| --- | --- | --- | --- |
+| `projects` | `rest_core` | `GET /api/v2/projects`, `GET /api/v2/projects/{projectKey}/environments`, `GET /api/v2/projects/{projectKey}/environments/{environmentKey}` | project count, environments per project, `expand=environments` nested pagination |
+| `flags` | `rest_core` | `GET /api/v2/flags/{projectKey}` | project count, flag count, environment filtering, `summary=0`, `expand=evaluation,codeReferences,migrationSettings` |
+| `segments` | `rest_core` | `GET /api/v2/segments/{projectKey}/{environmentKey}` | project × environment fanout, segment count, big/synced segment expansion |
+| `audit_log` | `secondary_abuse_risk` | `GET /api/v2/auditlog`, `POST /api/v2/auditlog` | incremental window size, backfill span, resource-scoped searches, 20-entry page cap |
+| `members` | `rest_core` | `GET /api/v2/members` | member count, custom role expansion, role attribute expansion |
+| `code_refs` | `secondary_abuse_risk` | `GET /api/v2/code-refs/repositories` | repository count, branch count, references per flag, default-branch expansion |
+
+Flags embed variations and environment-specific configuration in the flag payload, so `variations` is a cost driver inside `flags`, not a standalone route family.
+
+## Acceptance gate for future LaunchDarkly sync work
+
+Before raw LaunchDarkly fetch/auth/pagination code ships from the canonical provider package, the PR must include all of the following:
+
+1. A `LaunchDarklyBudgetEstimator` under `src/dev_health_ops/providers/launchdarkly/` that implements `BudgetEstimator` and returns non-empty estimates for `DatasetKey.FEATURE_FLAGS`.
+2. `estimate_provider_budget()` delegation for `context.provider.lower() == "launchdarkly"`.
+3. Unit tests proving LaunchDarkly sync contexts emit `BudgetEstimate` values with provider `launchdarkly`, safe host/credential scoping, and route families for flags plus any route families that the sync unit can call.
+4. Budget-guard coverage proving LaunchDarkly estimates participate in reservation and deferral through `SYNC_BUDGET_BUCKET_LIMITS`.
+5. Documentation updates when a new endpoint family, route family, or default budget limit is added.
+6. No new code under `connectors/`; canonical provider code remains under `providers/launchdarkly/`.
+
+## Initial operator defaults
+
+No new environment variables are required. Extend the JSON value of `SYNC_BUDGET_BUCKET_LIMITS` only when LaunchDarkly provider units are enabled. Suggested starting values for observation or enforced rollout:
+
+```json
+{
+  "launchdarkly:rest_core": 200,
+  "launchdarkly:rest_core:flags": 120,
+  "launchdarkly:rest_core:projects": 40,
+  "launchdarkly:secondary_abuse_risk:audit_log": 25,
+  "launchdarkly:secondary_abuse_risk:code_refs": 20
+}
+```
+
+Start with `SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS` for at least one scheduled sync window, then promote to `SYNC_BUDGET_BUCKET_LIMITS` only after observations match expected project, environment, flag, audit-log, and code-reference fanout.

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -127,7 +127,7 @@ The bundled Docker Compose, Kubernetes, and Helm deployments already declare the
 | `SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS` | `300` | Dispatch outbox claim lease duration. |
 | `SYNC_WATERMARK_OVERLAP` | `0` | Subtracts this many seconds from incremental watermark reads to intentionally re-read a lookback margin. |
 
-GitHub budget limits are abstract reservation units derived from the estimated shape of a sync unit. They are not GitHub's raw hourly request counters. Leaving `SYNC_BUDGET_BUCKET_LIMITS` unset disables enforcement; setting it enables deferrals when the reservation would exceed a configured bucket.
+GitHub budget limits are abstract reservation units derived from the estimated shape of a sync unit. They are not GitHub's raw hourly request counters. Leaving `SYNC_BUDGET_BUCKET_LIMITS` unset disables enforcement; setting it enables deferrals when the reservation would exceed a configured bucket. LaunchDarkly provider budgeting is planned in [LaunchDarkly sync budgeting](../architecture/launchdarkly-sync-budgeting.md); when that provider's raw sync path ships, it must use the same JSON maps with `launchdarkly:*` bucket keys before fetch code is accepted.
 
 | Variable | Default in deploy templates | Effect |
 |---|---:|---|
@@ -138,6 +138,8 @@ GitHub budget limits are abstract reservation units derived from the estimated s
 | `SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS` | unset | Observation-only limits; records estimates without deferring work. |
 | `SYNC_BUDGET_DRY_RUN_DEFAULT_LIMIT` | `1000000` | Fallback dry-run limit. |
 | `SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS` | `60` | Observation-only deferral estimate. |
+
+Planned LaunchDarkly bucket examples for dry-run rollout: `launchdarkly:rest_core`, `launchdarkly:rest_core:flags`, `launchdarkly:rest_core:projects`, `launchdarkly:secondary_abuse_risk:audit_log`, and `launchdarkly:secondary_abuse_risk:code_refs`.
 ---
 
 ## Task Registry

--- a/src/dev_health_ops/providers/launchdarkly/__init__.py
+++ b/src/dev_health_ops/providers/launchdarkly/__init__.py
@@ -1,3 +1,8 @@
+from dev_health_ops.providers.launchdarkly.budget import (
+    LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES,
+    LAUNCHDARKLY_BUDGET_ROUTE_FAMILY_KEYS,
+    LaunchDarklyBudgetRouteFamily,
+)
 from dev_health_ops.providers.launchdarkly.code_refs import (
     LD_CODE_REFERENCE_CONFIDENCE,
     LaunchDarklyCodeReference,
@@ -8,7 +13,10 @@ from dev_health_ops.providers.launchdarkly.code_refs import (
 )
 
 __all__ = [
+    "LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES",
+    "LAUNCHDARKLY_BUDGET_ROUTE_FAMILY_KEYS",
     "LD_CODE_REFERENCE_CONFIDENCE",
+    "LaunchDarklyBudgetRouteFamily",
     "LaunchDarklyCodeReference",
     "LaunchDarklyCodeReferencesClient",
     "build_code_reference_links",

--- a/src/dev_health_ops/providers/launchdarkly/budget.py
+++ b/src/dev_health_ops/providers/launchdarkly/budget.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+
+@dataclass(frozen=True)
+class LaunchDarklyBudgetRouteFamily:
+    route_family: str
+    dimension: BudgetDimension
+    endpoint_patterns: tuple[str, ...]
+    cost_drivers: tuple[str, ...]
+    confidence: str
+
+
+LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES: tuple[LaunchDarklyBudgetRouteFamily, ...] = (
+    LaunchDarklyBudgetRouteFamily(
+        route_family="projects",
+        dimension=BudgetDimension.REST_CORE,
+        endpoint_patterns=(
+            "GET /api/v2/projects",
+            "GET /api/v2/projects/{projectKey}/environments",
+            "GET /api/v2/projects/{projectKey}/environments/{environmentKey}",
+        ),
+        cost_drivers=(
+            "project count",
+            "environments per project",
+            "expand=environments nested pagination",
+        ),
+        confidence="medium",
+    ),
+    LaunchDarklyBudgetRouteFamily(
+        route_family="flags",
+        dimension=BudgetDimension.REST_CORE,
+        endpoint_patterns=("GET /api/v2/flags/{projectKey}",),
+        cost_drivers=(
+            "project count",
+            "flag count",
+            "environment-scoped filtering",
+            "summary and expand options",
+        ),
+        confidence="medium",
+    ),
+    LaunchDarklyBudgetRouteFamily(
+        route_family="segments",
+        dimension=BudgetDimension.REST_CORE,
+        endpoint_patterns=("GET /api/v2/segments/{projectKey}/{environmentKey}",),
+        cost_drivers=(
+            "project count",
+            "environment count",
+            "segment count",
+            "big and synced segment expansion",
+        ),
+        confidence="low",
+    ),
+    LaunchDarklyBudgetRouteFamily(
+        route_family="audit_log",
+        dimension=BudgetDimension.SECONDARY_ABUSE_RISK,
+        endpoint_patterns=("GET /api/v2/auditlog", "POST /api/v2/auditlog"),
+        cost_drivers=(
+            "incremental window size",
+            "backfill span",
+            "resource-scoped searches",
+            "20-entry page cap",
+        ),
+        confidence="medium",
+    ),
+    LaunchDarklyBudgetRouteFamily(
+        route_family="members",
+        dimension=BudgetDimension.REST_CORE,
+        endpoint_patterns=("GET /api/v2/members",),
+        cost_drivers=(
+            "member count",
+            "custom role expansion",
+            "role attribute expansion",
+        ),
+        confidence="low",
+    ),
+    LaunchDarklyBudgetRouteFamily(
+        route_family="code_refs",
+        dimension=BudgetDimension.SECONDARY_ABUSE_RISK,
+        endpoint_patterns=("GET /api/v2/code-refs/repositories",),
+        cost_drivers=(
+            "repository count",
+            "branch count",
+            "references per flag",
+            "default branch reference expansion",
+        ),
+        confidence="low",
+    ),
+)
+
+
+LAUNCHDARKLY_BUDGET_ROUTE_FAMILY_KEYS = frozenset(
+    family.route_family for family in LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES
+)

--- a/src/dev_health_ops/providers/launchdarkly/budget.py
+++ b/src/dev_health_ops/providers/launchdarkly/budget.py
@@ -1,8 +1,23 @@
 from __future__ import annotations
 
+import hashlib
+import json
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass
+from urllib.parse import urlparse
 
-from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.budget_types import (
+    BudgetBucketKey,
+    BudgetDimension,
+    BudgetEstimate,
+)
+from dev_health_ops.sync.datasets import DatasetKey
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+_DEFAULT_HOST = "app.launchdarkly.com"
+_DEFAULT_BASE_URL = "https://app.launchdarkly.com"
+_CONFIDENCE_MEDIUM = "medium"
+_CONFIDENCE_LOW = "low"
 
 
 @dataclass(frozen=True)
@@ -56,7 +71,7 @@ LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES: tuple[LaunchDarklyBudgetRouteFamily, ...] = 
     ),
     LaunchDarklyBudgetRouteFamily(
         route_family="audit_log",
-        dimension=BudgetDimension.SECONDARY_ABUSE_RISK,
+        dimension=BudgetDimension.REST_CORE,
         endpoint_patterns=("GET /api/v2/auditlog", "POST /api/v2/auditlog"),
         cost_drivers=(
             "incremental window size",
@@ -79,6 +94,18 @@ LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES: tuple[LaunchDarklyBudgetRouteFamily, ...] = 
     ),
     LaunchDarklyBudgetRouteFamily(
         route_family="code_refs",
+        dimension=BudgetDimension.REST_CORE,
+        endpoint_patterns=("GET /api/v2/code-refs/repositories",),
+        cost_drivers=(
+            "repository count",
+            "branch count",
+            "references per flag",
+            "default branch reference expansion",
+        ),
+        confidence="medium",
+    ),
+    LaunchDarklyBudgetRouteFamily(
+        route_family="code_refs",
         dimension=BudgetDimension.SECONDARY_ABUSE_RISK,
         endpoint_patterns=("GET /api/v2/code-refs/repositories",),
         cost_drivers=(
@@ -95,3 +122,115 @@ LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES: tuple[LaunchDarklyBudgetRouteFamily, ...] = 
 LAUNCHDARKLY_BUDGET_ROUTE_FAMILY_KEYS = frozenset(
     family.route_family for family in LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES
 )
+
+
+class LaunchDarklyBudgetEstimator:
+    def estimate(self, context: SyncTaskContext) -> tuple[BudgetEstimate, ...]:
+        if context.provider.lower() != "launchdarkly":
+            return ()
+        if context.dataset_key != DatasetKey.FEATURE_FLAGS.value:
+            return ()
+
+        credential_fingerprint = _credential_fingerprint(
+            context.decrypted_credentials,
+            credential_id=context.credential_id,
+            integration_id=context.integration_id,
+        )
+        bucket = _bucket_factory(
+            org_id=context.org_id,
+            host=_host_from_credentials(context.decrypted_credentials),
+            credential_fingerprint=credential_fingerprint,
+        )
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE), 2, _CONFIDENCE_MEDIUM, "flags"
+            ),
+            _estimate(
+                bucket(BudgetDimension.REST_CORE), 52, _CONFIDENCE_LOW, "audit_log"
+            ),
+            _estimate(
+                bucket(BudgetDimension.REST_CORE), 1, _CONFIDENCE_MEDIUM, "code_refs"
+            ),
+            _estimate(
+                bucket(BudgetDimension.SECONDARY_ABUSE_RISK),
+                1,
+                _CONFIDENCE_LOW,
+                "code_refs",
+            ),
+        )
+
+
+def _bucket_factory(
+    *, org_id: str, host: str, credential_fingerprint: str
+) -> Callable[[BudgetDimension], BudgetBucketKey]:
+    def _bucket(dimension: BudgetDimension) -> BudgetBucketKey:
+        return BudgetBucketKey(
+            provider="launchdarkly",
+            org_id=org_id,
+            host=host,
+            credential_fingerprint=credential_fingerprint,
+            dimension=dimension,
+        )
+
+    return _bucket
+
+
+def _estimate(
+    bucket: BudgetBucketKey,
+    estimated_units: int,
+    confidence: str,
+    route_family: str,
+    *,
+    notes: tuple[str, ...] = (),
+) -> BudgetEstimate:
+    return BudgetEstimate(
+        bucket=bucket,
+        estimated_units=estimated_units,
+        confidence=confidence,
+        route_family=route_family,
+        notes=notes,
+    )
+
+
+def _host_from_credentials(credentials: object) -> str:
+    base_url = _DEFAULT_BASE_URL
+    if isinstance(credentials, Mapping):
+        raw_base_url = credentials.get("base_url") or credentials.get("baseUrl")
+        if raw_base_url:
+            base_url = str(raw_base_url)
+    host = urlparse(base_url).hostname
+    return host or _DEFAULT_HOST
+
+
+def _credential_fingerprint(
+    credentials: object, *, credential_id: str | None, integration_id: str
+) -> str:
+    safe_credentials = _safe_credential_scope(
+        credentials,
+        credential_id=credential_id,
+        integration_id=integration_id,
+    )
+    payload = json.dumps(
+        safe_credentials, sort_keys=True, default=str, separators=(",", ":")
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _safe_credential_scope(
+    credentials: object, *, credential_id: str | None, integration_id: str
+) -> dict[str, object]:
+    scope: dict[str, object] = {
+        "credential_id": credential_id or "env",
+        "integration_id": integration_id,
+    }
+    if not isinstance(credentials, Mapping):
+        return scope
+
+    for key in ("project_key", "environment"):
+        value = credentials.get(key)
+        if value is not None:
+            scope[key] = value
+    base_url = credentials.get("base_url") or credentials.get("baseUrl")
+    if base_url is not None:
+        scope["base_url"] = base_url
+    return scope

--- a/src/dev_health_ops/sync/budget.py
+++ b/src/dev_health_ops/sync/budget.py
@@ -26,4 +26,10 @@ def estimate_provider_budget(context: SyncTaskContext) -> tuple[BudgetEstimate, 
         from dev_health_ops.providers.github.budget import GitHubBudgetEstimator
 
         return GitHubBudgetEstimator().estimate(context)
+    if context.provider.lower() == "launchdarkly":
+        from dev_health_ops.providers.launchdarkly.budget import (
+            LaunchDarklyBudgetEstimator,
+        )
+
+        return LaunchDarklyBudgetEstimator().estimate(context)
     return ()

--- a/tests/providers/test_github_budget.py
+++ b/tests/providers/test_github_budget.py
@@ -227,7 +227,7 @@ def test_estimate_provider_budget_delegates_to_github_estimator() -> None:
 
 def test_estimate_provider_budget_returns_empty_for_unimplemented_provider() -> None:
     estimates = estimate_provider_budget(
-        _context(provider="gitlab", dataset_key="commits")
+        _context(provider="bitbucket", dataset_key="commits")
     )
 
     assert estimates == ()

--- a/tests/providers/test_gitlab_budget.py
+++ b/tests/providers/test_gitlab_budget.py
@@ -234,7 +234,7 @@ def test_estimate_provider_budget_delegates_to_gitlab_estimator() -> None:
 
 def test_estimate_provider_budget_returns_empty_for_non_gitlab_provider() -> None:
     estimates = estimate_provider_budget(
-        _context(provider="launchdarkly", dataset_key="feature-flags")
+        _context(provider="bitbucket", dataset_key="feature-flags")
     )
 
     assert estimates == ()

--- a/tests/providers/test_launchdarkly_budget_contract.py
+++ b/tests/providers/test_launchdarkly_budget_contract.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dev_health_ops.providers.launchdarkly.budget import (
+    LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES,
+    LAUNCHDARKLY_BUDGET_ROUTE_FAMILY_KEYS,
+)
+from dev_health_ops.sync.budget import BudgetDimension, estimate_provider_budget
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+WINDOW_START = datetime(2026, 1, 10, tzinfo=timezone.utc)
+WINDOW_END = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+
+def _context() -> SyncTaskContext:
+    return SyncTaskContext(
+        unit_id="unit-ld-1",
+        sync_run_id="run-ld-1",
+        org_id="org-1",
+        integration_id="integration-ld-1",
+        source_id="source-ld-1",
+        source_external_id="project:default",
+        provider="launchdarkly",
+        dataset_key="feature-flags",
+        cost_class="medium",
+        mode="incremental",
+        window_start=WINDOW_START,
+        window_end=WINDOW_END,
+        processor_flags={"sync_feature_flags": True},
+        credential_id="credential-ld-1",
+        decrypted_credentials={"api_key": "secret-token", "project_key": "default"},
+        db_url="clickhouse://localhost/default",
+    )
+
+
+def test_launchdarkly_budget_contract_defines_expected_route_families() -> None:
+    assert LAUNCHDARKLY_BUDGET_ROUTE_FAMILY_KEYS == {
+        "projects",
+        "flags",
+        "segments",
+        "audit_log",
+        "members",
+        "code_refs",
+    }
+
+    assert all(
+        family.endpoint_patterns for family in LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES
+    )
+    assert all(family.cost_drivers for family in LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES)
+    assert {family.dimension for family in LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES} == {
+        BudgetDimension.REST_CORE,
+        BudgetDimension.SECONDARY_ABUSE_RISK,
+    }
+
+
+@pytest.mark.xfail(
+    reason=(
+        "CHAOS-2687 is a planning gate; the future LaunchDarkly provider must add "
+        "an estimator before raw sync ships."
+    ),
+    strict=True,
+)
+def test_future_launchdarkly_sync_units_emit_budget_estimates() -> None:
+    estimates = estimate_provider_budget(_context())
+
+    assert estimates
+    assert {estimate.bucket.provider for estimate in estimates} == {"launchdarkly"}
+    assert "flags" in {estimate.route_family for estimate in estimates}

--- a/tests/providers/test_launchdarkly_budget_contract.py
+++ b/tests/providers/test_launchdarkly_budget_contract.py
@@ -2,36 +2,44 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
-import pytest
-
 from dev_health_ops.providers.launchdarkly.budget import (
     LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES,
     LAUNCHDARKLY_BUDGET_ROUTE_FAMILY_KEYS,
+    LaunchDarklyBudgetEstimator,
 )
 from dev_health_ops.sync.budget import BudgetDimension, estimate_provider_budget
+from dev_health_ops.sync.datasets import DatasetKey
 from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
 
 WINDOW_START = datetime(2026, 1, 10, tzinfo=timezone.utc)
 WINDOW_END = datetime(2026, 1, 12, tzinfo=timezone.utc)
 
 
-def _context() -> SyncTaskContext:
+def _context(
+    *,
+    provider: str = "launchdarkly",
+    dataset_key: str = DatasetKey.FEATURE_FLAGS.value,
+    credentials: dict[str, object] | None = None,
+    credential_id: str | None = "credential-ld-1",
+    integration_id: str = "integration-ld-1",
+) -> SyncTaskContext:
     return SyncTaskContext(
         unit_id="unit-ld-1",
         sync_run_id="run-ld-1",
         org_id="org-1",
-        integration_id="integration-ld-1",
+        integration_id=integration_id,
         source_id="source-ld-1",
         source_external_id="project:default",
-        provider="launchdarkly",
-        dataset_key="feature-flags",
+        provider=provider,
+        dataset_key=dataset_key,
         cost_class="medium",
         mode="incremental",
         window_start=WINDOW_START,
         window_end=WINDOW_END,
         processor_flags={"sync_feature_flags": True},
-        credential_id="credential-ld-1",
-        decrypted_credentials={"api_key": "secret-token", "project_key": "default"},
+        credential_id=credential_id,
+        decrypted_credentials=credentials
+        or {"api_key": "secret-token", "project_key": "default"},
         db_url="clickhouse://localhost/default",
     )
 
@@ -54,18 +62,113 @@ def test_launchdarkly_budget_contract_defines_expected_route_families() -> None:
         BudgetDimension.REST_CORE,
         BudgetDimension.SECONDARY_ABUSE_RISK,
     }
+    assert {
+        (family.route_family, family.dimension)
+        for family in LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES
+    } >= {
+        ("flags", BudgetDimension.REST_CORE),
+        ("audit_log", BudgetDimension.REST_CORE),
+        ("code_refs", BudgetDimension.REST_CORE),
+        ("code_refs", BudgetDimension.SECONDARY_ABUSE_RISK),
+    }
 
 
-@pytest.mark.xfail(
-    reason=(
-        "CHAOS-2687 is a planning gate; the future LaunchDarkly provider must add "
-        "an estimator before raw sync ships."
-    ),
-    strict=True,
-)
-def test_future_launchdarkly_sync_units_emit_budget_estimates() -> None:
+def test_launchdarkly_feature_flags_estimator_returns_launchdarkly_buckets() -> None:
+    estimates = LaunchDarklyBudgetEstimator().estimate(_context())
+
+    assert estimates
+    assert {estimate.bucket.provider for estimate in estimates} == {"launchdarkly"}
+    assert {estimate.route_family for estimate in estimates} == {
+        "flags",
+        "audit_log",
+        "code_refs",
+    }
+    assert {estimate.bucket.dimension for estimate in estimates} == {
+        BudgetDimension.REST_CORE,
+        BudgetDimension.SECONDARY_ABUSE_RISK,
+    }
+    assert [
+        (estimate.route_family, estimate.estimated_units) for estimate in estimates
+    ] == [
+        ("flags", 2),
+        ("audit_log", 52),
+        ("code_refs", 1),
+        ("code_refs", 1),
+    ]
+
+
+def test_launchdarkly_budget_estimator_defaults_to_launchdarkly_host() -> None:
+    estimates = LaunchDarklyBudgetEstimator().estimate(_context(credentials={}))
+
+    assert {estimate.bucket.host for estimate in estimates} == {"app.launchdarkly.com"}
+
+
+def test_launchdarkly_budget_estimator_uses_base_url_host_override() -> None:
+    estimates = LaunchDarklyBudgetEstimator().estimate(
+        _context(
+            credentials={
+                "api_key": "secret-token",
+                "baseUrl": "https://ld.example.com",
+                "project_key": "default",
+            }
+        )
+    )
+
+    assert {estimate.bucket.host for estimate in estimates} == {"ld.example.com"}
+
+
+def test_launchdarkly_budget_fingerprint_uses_safe_scope_without_api_key() -> None:
+    base = LaunchDarklyBudgetEstimator().estimate(
+        _context(
+            credentials={
+                "api_key": "secret-token",
+                "project_key": "default",
+                "environment": "production",
+            }
+        )
+    )[0]
+    rotated_key = LaunchDarklyBudgetEstimator().estimate(
+        _context(
+            credentials={
+                "api_key": "rotated-secret-token",
+                "project_key": "default",
+                "environment": "production",
+            }
+        )
+    )[0]
+    different_project = LaunchDarklyBudgetEstimator().estimate(
+        _context(
+            credentials={
+                "api_key": "secret-token",
+                "project_key": "other-project",
+                "environment": "production",
+            }
+        )
+    )[0]
+
+    assert (
+        base.bucket.credential_fingerprint == rotated_key.bucket.credential_fingerprint
+    )
+    assert (
+        base.bucket.credential_fingerprint
+        != different_project.bucket.credential_fingerprint
+    )
+    assert "secret-token" not in str(base.to_dict())
+    assert "rotated-secret-token" not in str(rotated_key.to_dict())
+
+
+def test_launchdarkly_budget_estimator_returns_empty_for_unknown_dataset() -> None:
+    assert (
+        LaunchDarklyBudgetEstimator().estimate(_context(dataset_key="segments")) == ()
+    )
+
+
+def test_estimate_provider_budget_delegates_to_launchdarkly_estimator() -> None:
     estimates = estimate_provider_budget(_context())
 
     assert estimates
     assert {estimate.bucket.provider for estimate in estimates} == {"launchdarkly"}
-    assert "flags" in {estimate.route_family for estimate in estimates}
+
+
+def test_estimate_provider_budget_returns_empty_for_non_launchdarkly_provider() -> None:
+    assert estimate_provider_budget(_context(provider="bitbucket")) == ()

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -113,11 +113,24 @@ def _commit_reconciler_failure(engine, unit_id):
         session.commit()
 
 
-def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
+def _seed_run(
+    session,
+    *,
+    mode=SyncRunMode.INCREMENTAL.value,
+    provider="github",
+    source_type="repo",
+    source_external_id="full-chaos/dev-health",
+    source_name="dev-health",
+    source_full_name="full-chaos/dev-health",
+    dataset_key="commits",
+    processor_flags=None,
+):
+    if processor_flags is None:
+        processor_flags = {"sync_git": True}
     org_id = str(uuid.uuid4())
     integration = Integration(
         org_id=org_id,
-        provider="github",
+        provider=provider,
         name="demo",
         config={},
         is_active=True,
@@ -127,18 +140,18 @@ def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
     source = IntegrationSource(
         org_id=org_id,
         integration_id=integration.id,
-        provider="github",
-        source_type="repo",
-        external_id="full-chaos/dev-health",
-        name="dev-health",
-        full_name="full-chaos/dev-health",
+        provider=provider,
+        source_type=source_type,
+        external_id=source_external_id,
+        name=source_name,
+        full_name=source_full_name,
         metadata_={},
         is_enabled=True,
     )
     dataset = IntegrationDataset(
         org_id=org_id,
         integration_id=integration.id,
-        dataset_key="commits",
+        dataset_key=dataset_key,
         is_enabled=True,
         options={},
     )
@@ -159,15 +172,15 @@ def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
         sync_run_id=run.id,
         integration_id=integration.id,
         source_id=source.id,
-        provider="github",
-        dataset_key="commits",
+        provider=provider,
+        dataset_key=dataset_key,
         cost_class="medium",
         mode=mode,
         since_at=None,
         before_at=datetime.now(timezone.utc),
         status=SyncRunUnitStatus.PLANNED.value,
         attempts=0,
-        processor_flags={"sync_git": True},
+        processor_flags=processor_flags,
     )
     session.add(unit)
     session.flush()
@@ -321,6 +334,53 @@ def test_run_sync_unit_success_persists_status_and_incremental_watermark(
         .one()
     )
     assert finalize_outbox.status == OUTBOX_STATUS_PENDING
+    assert finalize_calls == [((str(run.id),), "sync")]
+
+
+def test_run_sync_unit_success_attaches_launchdarkly_budget_estimate(
+    db_session, monkeypatch
+):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(
+        db_session,
+        provider="launchdarkly",
+        source_type="project",
+        source_external_id="project:default",
+        source_name="default",
+        source_full_name="LaunchDarkly/default",
+        dataset_key="feature-flags",
+        processor_flags={"sync_feature_flags": True},
+    )
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    finalize_calls = _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {"ok": True, "observations": {}},
+    )
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.SUCCESS.value
+    assert unit.result is not None
+    budget_estimate = unit.result["observations"]["budget_estimate"]
+    assert {entry["bucket"]["provider"] for entry in budget_estimate} == {
+        "launchdarkly"
+    }
+    assert {entry["route_family"] for entry in budget_estimate} == {
+        "flags",
+        "audit_log",
+        "code_refs",
+    }
     assert finalize_calls == [((str(run.id),), "sync")]
 
 
@@ -2003,6 +2063,52 @@ def test_dispatch_sync_run_enforces_budget_deferral(db_session, monkeypatch):
     assert unit.result is not None
     assert unit.result["error_category"] == "budget_deferred"
     assert unit.result["budget_guard"][0]["decision"] == "deferred"
+    assert dispatch_calls == []
+    assert finalize_calls == []
+    assert chord_calls == []
+
+
+def test_dispatch_sync_run_enforces_launchdarkly_budget_deferral(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(
+        db_session,
+        provider="launchdarkly",
+        source_type="project",
+        source_external_id="project:default",
+        source_name="default",
+        source_full_name="LaunchDarkly/default",
+        dataset_key="feature-flags",
+        processor_flags={"sync_feature_flags": True},
+    )
+    _patch_db_session(monkeypatch, db_session)
+    dispatch_calls, finalize_calls, chord_calls = _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv(
+        "SYNC_BUDGET_BUCKET_LIMITS",
+        json.dumps(
+            {"launchdarkly:rest_core": 999, "launchdarkly:rest_core:audit_log": 1}
+        ),
+    )
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "120")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(unit)
+    assert result["status"] == "deferred"
+    assert result["queued_units"] == 0
+    assert run.status == SyncRunStatus.PLANNED.value
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+    assert unit.available_at is not None
+    assert unit.result is not None
+    assert unit.result["error_category"] == "budget_deferred"
+    assert any(
+        entry["decision"] == "deferred" and entry["route_family"] == "audit_log"
+        for entry in unit.result["budget_guard"]
+    )
     assert dispatch_calls == []
     assert finalize_calls == []
     assert chord_calls == []


### PR DESCRIPTION
Implements sync budgeting for the LaunchDarkly feature-flags dataset (CHAOS-2687), upgrading the earlier plan-only contract into a working estimator.

## What
- Add `LaunchDarklyBudgetEstimator` (`providers/launchdarkly/budget.py`) implementing `BudgetEstimator`, gated to `provider=launchdarkly` + `dataset_key=feature-flags`. Emits `launchdarkly:*` estimates for route families `flags` (rest_core), `audit_log` (rest_core), and `code_refs` (rest_core + secondary_abuse_risk), matching the real calls in `feature_flag_sync.py`.
- Wire the `launchdarkly` branch into `estimate_provider_budget()` dispatch.
- Safe credential fingerprint (host defaults to `app.launchdarkly.com`); never includes `api_key`.
- Replace the plan-only strict-xfail with real estimator + delegation tests; add `test_sync_units.py` coverage proving (a) successful LD units persist `observations.budget_estimate` and (b) over-budget LD units defer (`RETRYING` + `budget_deferred`) via `BudgetGuard`.
- Repoint `test_github_budget` unimplemented-provider fixture to `bitbucket` (since `launchdarkly` now dispatches).

## How it budgets without new infra
LaunchDarkly feature-flag sync already flows through the `SyncRunUnit` pipeline (`run_sync_unit` -> `dataset_adapters._run_feature_flags_dataset` -> `_sync_launchdarkly_feature_flags`), so the existing `BudgetGuard` observe/enforce + `SyncRunUnit.result` persistence apply automatically once the estimator dispatches. No bolt-on reservation API, no connector changes, no new persistence.

## Follow-ups (not in scope)
- Full migration off the frozen `connectors.launchdarkly` connector into `providers/launchdarkly/`.
- Dynamic estimates from live flag/audit-log counts.
- GitLab feature-flag path budgeting.

Validated: `ci/local_validate.sh` GATE PASSED (ruff, mypy, full unit suite, live-ClickHouse argMax proof).

SCREENSHOT-WAIVER: backend-only, no UI render.