### PR TITLE
feat(jira): adopt sync budgeting

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,15 +43,15 @@ SYNC_DISPATCH_REDISPATCH_COUNTDOWN="60"
 SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS="300"
 SYNC_WATERMARK_OVERLAP="0"
 
-# GitHub sync budget guard. Values are abstract reservation units, not raw
-# GitHub requests. Setting SYNC_BUDGET_BUCKET_LIMITS enables enforcement.
-SYNC_BUDGET_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+# GitHub/Jira sync budget guard. Values are abstract reservation units, not raw
+# provider requests. Setting SYNC_BUDGET_BUCKET_LIMITS enables enforcement.
+SYNC_BUDGET_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"jira:search:jira_jql":250,"jira:rest_core:jira_issue_enrichment":250,"jira:rest_core:jira_worklogs":100,"jira:graphql_cost:jira_gql_enrichment":250}'
 SYNC_BUDGET_DEFAULT_LIMIT="1000000"
 SYNC_BUDGET_DEFERRAL_SECONDS="60"
 SYNC_BUDGET_DEFERRAL_JITTER_SECONDS="5"
 
 # Optional dry-run/observation-only budget logging knobs.
-# SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+# SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"jira:search:jira_jql":250,"jira:rest_core:jira_issue_enrichment":250,"jira:rest_core:jira_worklogs":100,"jira:graphql_cost:jira_gql_enrichment":250}'
 SYNC_BUDGET_DRY_RUN_DEFAULT_LIMIT="1000000"
 SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS="60"
 

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -39,13 +39,13 @@ SYNC_DISPATCH_REDISPATCH_COUNTDOWN=60
 SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS=300
 SYNC_WATERMARK_OVERLAP=0
 
-# GitHub sync budget guard. Values are abstract reservation units, not raw
-# GitHub requests. Setting SYNC_BUDGET_BUCKET_LIMITS enables enforcement.
-SYNC_BUDGET_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+# GitHub/Jira sync budget guard. Values are abstract reservation units, not raw
+# provider requests. Setting SYNC_BUDGET_BUCKET_LIMITS enables enforcement.
+SYNC_BUDGET_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"jira:search:jira_jql":250,"jira:rest_core:jira_issue_enrichment":250,"jira:rest_core:jira_worklogs":100,"jira:graphql_cost:jira_gql_enrichment":250}'
 SYNC_BUDGET_DEFAULT_LIMIT=1000000
 SYNC_BUDGET_DEFERRAL_SECONDS=60
 SYNC_BUDGET_DEFERRAL_JITTER_SECONDS=5
-# SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+# SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"jira:search:jira_jql":250,"jira:rest_core:jira_issue_enrichment":250,"jira:rest_core:jira_worklogs":100,"jira:graphql_cost:jira_gql_enrichment":250}'
 SYNC_BUDGET_DRY_RUN_DEFAULT_LIMIT=1000000
 SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS=60
 

--- a/docs/ops/deployment-guide.md
+++ b/docs/ops/deployment-guide.md
@@ -86,11 +86,11 @@ All deployment methods use the same environment variables:
 | `SYNC_DISPATCH_REDISPATCH_COUNTDOWN` | Delay before redispatching sync-run work. | 60 |
 | `SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS` | Dispatch outbox claim lease duration. | 300 |
 | `SYNC_WATERMARK_OVERLAP` | Seconds subtracted from incremental watermark reads to intentionally re-read a lookback margin. | 0 |
-| `SYNC_BUDGET_BUCKET_LIMITS` | JSON map that enables enforced GitHub budget deferrals. Values are reservation units, not raw GitHub request counts. | `{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}` |
+| `SYNC_BUDGET_BUCKET_LIMITS` | JSON map that enables enforced GitHub/Jira budget deferrals. Values are reservation units, not raw provider request counts. Jira supports route-family keys such as `jira:search:jira_jql`, `jira:rest_core:jira_issue_enrichment`, `jira:rest_core:jira_worklogs`, and `jira:graphql_cost:jira_gql_enrichment`. | `{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"jira:search:jira_jql":250,"jira:rest_core:jira_issue_enrichment":250,"jira:rest_core:jira_worklogs":100,"jira:graphql_cost:jira_gql_enrichment":250}` |
 | `SYNC_BUDGET_DEFAULT_LIMIT` | Fallback enforced budget limit for unnamed buckets. | 1000000 |
 | `SYNC_BUDGET_DEFERRAL_SECONDS` | Base countdown when budget enforcement defers a unit. | 60 |
 | `SYNC_BUDGET_DEFERRAL_JITTER_SECONDS` | Jitter added to budget deferrals. | 5 |
-| `SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS` | Optional observation-only GitHub budget limits. | unset |
+| `SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS` | Optional observation-only GitHub/Jira budget limits. | unset |
 | `SYNC_BUDGET_DRY_RUN_DEFAULT_LIMIT` | Fallback dry-run budget limit. | 1000000 |
 | `SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS` | Observation-only deferral estimate. | 60 |
 

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -127,11 +127,11 @@ The bundled Docker Compose, Kubernetes, and Helm deployments already declare the
 | `SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS` | `300` | Dispatch outbox claim lease duration. |
 | `SYNC_WATERMARK_OVERLAP` | `0` | Subtracts this many seconds from incremental watermark reads to intentionally re-read a lookback margin. |
 
-GitHub budget limits are abstract reservation units derived from the estimated shape of a sync unit. They are not GitHub's raw hourly request counters. Leaving `SYNC_BUDGET_BUCKET_LIMITS` unset disables enforcement; setting it enables deferrals when the reservation would exceed a configured bucket.
+GitHub and Jira budget limits are abstract reservation units derived from the estimated shape of a sync unit. They are not provider raw hourly request counters. Jira emits separate route-family buckets for REST/JQL listing (`jira:search:jira_jql`), REST issue enrichment (`jira:rest_core:jira_issue_enrichment`), optional worklog fetching (`jira:rest_core:jira_worklogs` when `JIRA_FETCH_WORKLOGS=true`), and Atlassian GraphQL enrichment (`jira:graphql_cost:jira_gql_enrichment` when `ATLASSIAN_GQL_ENABLED=true`). Leaving `SYNC_BUDGET_BUCKET_LIMITS` unset disables enforcement; setting it enables deferrals when the reservation would exceed a configured bucket.
 
 | Variable | Default in deploy templates | Effect |
 |---|---:|---|
-| `SYNC_BUDGET_BUCKET_LIMITS` | `{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}` | Enforced per-bucket reservation limits. |
+| `SYNC_BUDGET_BUCKET_LIMITS` | `{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"jira:search:jira_jql":250,"jira:rest_core:jira_issue_enrichment":250,"jira:rest_core:jira_worklogs":100,"jira:graphql_cost:jira_gql_enrichment":250}` | Enforced per-bucket reservation limits. |
 | `SYNC_BUDGET_DEFAULT_LIMIT` | `1000000` | Fallback enforced limit for buckets not named in the JSON map. |
 | `SYNC_BUDGET_DEFERRAL_SECONDS` | `60` | Base countdown when enforcement defers a unit. |
 | `SYNC_BUDGET_DEFERRAL_JITTER_SECONDS` | `5` | Random jitter added to enforced deferrals. |

--- a/src/dev_health_ops/providers/jira/budget.py
+++ b/src/dev_health_ops/providers/jira/budget.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+from collections.abc import Callable, Mapping
+from urllib.parse import urlparse
+
+from dev_health_ops.sync.budget_types import (
+    BudgetBucketKey,
+    BudgetDimension,
+    BudgetEstimate,
+)
+from dev_health_ops.sync.datasets import DatasetKey
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+_DEFAULT_HOST = "atlassian.net"
+_DEFAULT_BASE_URL = "https://atlassian.net"
+_CONFIDENCE_HIGH = "high"
+_CONFIDENCE_MEDIUM = "medium"
+_CONFIDENCE_LOW = "low"
+
+
+class JiraBudgetEstimator:
+    def estimate(self, context: SyncTaskContext) -> tuple[BudgetEstimate, ...]:
+        if context.provider.lower() != "jira":
+            return ()
+
+        credential_fingerprint = _credential_fingerprint(
+            context.decrypted_credentials,
+            credential_id=context.credential_id,
+            integration_id=context.integration_id,
+        )
+        host = _host_from_credentials(context.decrypted_credentials)
+        flags = {
+            str(key): bool(value) for key, value in context.processor_flags.items()
+        }
+        return _dataset_estimates(
+            dataset_key=context.dataset_key,
+            flags=flags,
+            org_id=context.org_id,
+            host=host,
+            credential_fingerprint=credential_fingerprint,
+        )
+
+
+def _dataset_estimates(
+    *,
+    dataset_key: str,
+    flags: Mapping[str, bool],
+    org_id: str,
+    host: str,
+    credential_fingerprint: str,
+) -> tuple[BudgetEstimate, ...]:
+    bucket = _bucket_factory(
+        org_id=org_id,
+        host=host,
+        credential_fingerprint=credential_fingerprint,
+    )
+
+    if dataset_key in {
+        DatasetKey.WORK_ITEM_LABELS.value,
+        DatasetKey.WORK_ITEM_PROJECTS.value,
+    }:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                1,
+                _CONFIDENCE_HIGH,
+                "jira_metadata",
+            ),
+        )
+
+    if dataset_key not in {
+        DatasetKey.WORK_ITEMS.value,
+        DatasetKey.WORK_ITEM_HISTORY.value,
+        DatasetKey.WORK_ITEM_COMMENTS.value,
+    }:
+        return ()
+
+    estimates: list[BudgetEstimate] = [
+        _estimate(
+            bucket(BudgetDimension.SEARCH),
+            2,
+            _CONFIDENCE_MEDIUM,
+            "jira_jql",
+            notes=("Jira work-item listing uses REST /search/jql pagination",),
+        ),
+        _estimate(
+            bucket(BudgetDimension.REST_CORE),
+            2,
+            _CONFIDENCE_MEDIUM,
+            "jira_issue_enrichment",
+            notes=(
+                "per-issue changelog/comment/sprint enrichment varies by issue count",
+            ),
+        ),
+    ]
+
+    if dataset_key == DatasetKey.WORK_ITEM_COMMENTS.value:
+        estimates.append(
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                2,
+                _CONFIDENCE_LOW,
+                "jira_comments",
+                notes=("comment pagination is issue-activity dependent",),
+            )
+        )
+
+    if _flag_enabled(flags, "jira_fetch_worklogs", "fetch_worklogs"):
+        estimates.append(
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                3,
+                _CONFIDENCE_LOW,
+                "jira_worklogs",
+                notes=("JIRA_FETCH_WORKLOGS adds per-issue worklog expansion",),
+            )
+        )
+
+    if _flag_enabled(flags, "atlassian_gql_enabled", "gql_enabled"):
+        estimates.append(
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST),
+                3,
+                _CONFIDENCE_MEDIUM,
+                "jira_gql_enrichment",
+                notes=("ATLASSIAN_GQL_ENABLED routes Jira enrichment through AGG",),
+            )
+        )
+
+    return tuple(estimates)
+
+
+def _bucket_factory(
+    *, org_id: str, host: str, credential_fingerprint: str
+) -> Callable[[BudgetDimension], BudgetBucketKey]:
+    def _bucket(dimension: BudgetDimension) -> BudgetBucketKey:
+        return BudgetBucketKey(
+            provider="jira",
+            org_id=org_id,
+            host=host,
+            credential_fingerprint=credential_fingerprint,
+            dimension=dimension,
+        )
+
+    return _bucket
+
+
+def _estimate(
+    bucket: BudgetBucketKey,
+    estimated_units: int,
+    confidence: str,
+    route_family: str,
+    *,
+    notes: tuple[str, ...] = (),
+) -> BudgetEstimate:
+    return BudgetEstimate(
+        bucket=bucket,
+        estimated_units=estimated_units,
+        confidence=confidence,
+        route_family=route_family,
+        notes=notes,
+    )
+
+
+def _flag_enabled(flags: Mapping[str, bool], *names: str) -> bool:
+    if any(flags.get(name, False) for name in names):
+        return True
+    env_names = {
+        "jira_fetch_worklogs": "JIRA_FETCH_WORKLOGS",
+        "fetch_worklogs": "JIRA_FETCH_WORKLOGS",
+        "atlassian_gql_enabled": "ATLASSIAN_GQL_ENABLED",
+        "gql_enabled": "ATLASSIAN_GQL_ENABLED",
+    }
+    return any(_env_flag(env_names[name]) for name in names if name in env_names)
+
+
+def _env_flag(name: str) -> bool:
+    return (os.getenv(name) or "").strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _host_from_credentials(credentials: object) -> str:
+    base_url = os.getenv("ATLASSIAN_JIRA_BASE_URL") or os.getenv("JIRA_BASE_URL")
+    if isinstance(credentials, Mapping):
+        raw_base_url = (
+            credentials.get("base_url")
+            or credentials.get("baseUrl")
+            or credentials.get("jira_base_url")
+            or credentials.get("jiraBaseUrl")
+        )
+        if raw_base_url:
+            base_url = str(raw_base_url)
+    host = urlparse(_normalize_base_url(base_url or _DEFAULT_BASE_URL)).hostname
+    return host or _DEFAULT_HOST
+
+
+def _credential_fingerprint(
+    credentials: object, *, credential_id: str | None, integration_id: str
+) -> str:
+    safe_credentials = _safe_credential_scope(
+        credentials,
+        credential_id=credential_id,
+        integration_id=integration_id,
+    )
+    payload = json.dumps(
+        safe_credentials, sort_keys=True, default=str, separators=(",", ":")
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _safe_credential_scope(
+    credentials: object, *, credential_id: str | None, integration_id: str
+) -> dict[str, object]:
+    if not isinstance(credentials, Mapping):
+        return _fallback_credential_scope(
+            credential_id=credential_id,
+            integration_id=integration_id,
+        )
+    scope: dict[str, object] = {}
+    for key in (
+        "email",
+        "cloud_id",
+        "cloudId",
+        "client_id",
+        "clientId",
+    ):
+        value = credentials.get(key)
+        if value is not None:
+            scope[key] = value
+    base_url = (
+        credentials.get("base_url")
+        or credentials.get("baseUrl")
+        or credentials.get("jira_base_url")
+        or credentials.get("jiraBaseUrl")
+    )
+    if base_url is not None:
+        scope["base_url"] = _normalize_base_url(str(base_url))
+    for secret_key in (
+        "api_token",
+        "apiToken",
+        "access_token",
+        "accessToken",
+        "refresh_token",
+        "refreshToken",
+    ):
+        value = credentials.get(secret_key)
+        if value:
+            scope[f"{secret_key}_sha256"] = hashlib.sha256(
+                str(value).encode("utf-8")
+            ).hexdigest()
+    if not scope:
+        return _fallback_credential_scope(
+            credential_id=credential_id,
+            integration_id=integration_id,
+        )
+    return scope
+
+
+def _fallback_credential_scope(
+    *, credential_id: str | None, integration_id: str
+) -> dict[str, object]:
+    return {
+        "credential_id": credential_id or "env",
+        "integration_id": integration_id,
+    }
+
+
+def _normalize_base_url(value: str) -> str:
+    url = (value or "").strip().rstrip("/")
+    if not url:
+        return url
+    if url.startswith("http://"):
+        return "https://" + url[len("http://") :]
+    if url.startswith("https://"):
+        return url
+    return "https://" + url.lstrip("/")

--- a/src/dev_health_ops/sync/budget.py
+++ b/src/dev_health_ops/sync/budget.py
@@ -26,4 +26,8 @@ def estimate_provider_budget(context: SyncTaskContext) -> tuple[BudgetEstimate, 
         from dev_health_ops.providers.github.budget import GitHubBudgetEstimator
 
         return GitHubBudgetEstimator().estimate(context)
+    if context.provider.lower() == "jira":
+        from dev_health_ops.providers.jira.budget import JiraBudgetEstimator
+
+        return JiraBudgetEstimator().estimate(context)
     return ()

--- a/tests/providers/test_jira_budget.py
+++ b/tests/providers/test_jira_budget.py
@@ -1,0 +1,425 @@
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Mapping
+from contextlib import contextmanager
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import (
+    Base,
+    Integration,
+    IntegrationDataset,
+    IntegrationSource,
+    SyncRun,
+    SyncRunMode,
+    SyncRunStatus,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+)
+from dev_health_ops.providers.jira.budget import JiraBudgetEstimator
+from dev_health_ops.sync.budget import BudgetDimension, estimate_provider_budget
+from dev_health_ops.sync.budget_guard import BudgetGuard, _budget_key, _limit_for_bucket
+from dev_health_ops.sync.dispatch_policy import route
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+WINDOW_START = datetime(2026, 1, 10, tzinfo=timezone.utc)
+WINDOW_END = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+
+def _context(
+    *,
+    provider: str = "jira",
+    dataset_key: str,
+    processor_flags: dict[str, bool] | None = None,
+    credentials: Mapping[str, object] | None = None,
+    credential_id: str | None = "credential-1",
+) -> SyncTaskContext:
+    decrypted_credentials: dict[str, object] = {
+        "email": "ops@example.com",
+        "api_token": "secret-token",
+        "base_url": "https://chaos.atlassian.net",
+    }
+    if credentials is not None:
+        decrypted_credentials = {str(key): value for key, value in credentials.items()}
+    return SyncTaskContext(
+        unit_id="unit-1",
+        sync_run_id="run-1",
+        org_id="org-1",
+        integration_id="integration-1",
+        source_id="source-1",
+        source_external_id="CHAOS",
+        provider=provider,
+        dataset_key=dataset_key,
+        cost_class="medium",
+        mode="incremental",
+        window_start=WINDOW_START,
+        window_end=WINDOW_END,
+        processor_flags=processor_flags or {},
+        credential_id=credential_id,
+        decrypted_credentials=decrypted_credentials,
+        db_url="clickhouse://localhost/default",
+    )
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@contextmanager
+def _fake_session_ctx(session):
+    try:
+        yield session
+    except Exception:
+        session.rollback()
+        raise
+    else:
+        session.commit()
+
+
+def _patch_db_session(monkeypatch, session) -> None:
+    import dev_health_ops.db as db
+
+    session.commit()
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(session)
+    )
+
+
+def _seed_jira_run(
+    session,
+    *,
+    dataset_key: str = "work-items",
+    processor_flags: dict[str, bool] | None = None,
+):
+    org_id = str(uuid.uuid4())
+    integration = Integration(
+        org_id=org_id,
+        provider="jira",
+        name="jira-demo",
+        config={},
+        is_active=True,
+    )
+    session.add(integration)
+    session.flush()
+    source = IntegrationSource(
+        org_id=org_id,
+        integration_id=integration.id,
+        provider="jira",
+        source_type="project",
+        external_id="CHAOS",
+        name="CHAOS",
+        full_name="CHAOS",
+        metadata_={},
+        is_enabled=True,
+    )
+    dataset = IntegrationDataset(
+        org_id=org_id,
+        integration_id=integration.id,
+        dataset_key=dataset_key,
+        is_enabled=True,
+        options={},
+    )
+    run = SyncRun(
+        org_id=org_id,
+        integration_id=integration.id,
+        triggered_by="manual",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.PLANNED.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
+    )
+    session.add_all([source, dataset, run])
+    session.flush()
+    unit = SyncRunUnit(
+        org_id=org_id,
+        sync_run_id=run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="jira",
+        dataset_key=dataset_key,
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        since_at=WINDOW_START,
+        before_at=WINDOW_END,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags=processor_flags or {},
+    )
+    session.add(unit)
+    session.flush()
+    return run, unit
+
+
+def _jira_env(monkeypatch) -> None:
+    monkeypatch.setenv("JIRA_BASE_URL", "https://chaos.atlassian.net")
+    monkeypatch.setenv("JIRA_EMAIL", "ops@example.com")
+    monkeypatch.setenv("JIRA_API_TOKEN", "secret-token")
+
+
+def test_jira_budget_estimator_returns_jql_and_enrichment_budgets() -> None:
+    estimates = JiraBudgetEstimator().estimate(_context(dataset_key="work-items"))
+
+    assert [
+        (estimate.bucket.dimension, estimate.route_family) for estimate in estimates
+    ] == [
+        (BudgetDimension.SEARCH, "jira_jql"),
+        (BudgetDimension.REST_CORE, "jira_issue_enrichment"),
+    ]
+    assert estimates[0].bucket.provider == "jira"
+    assert estimates[0].bucket.org_id == "org-1"
+    assert estimates[0].bucket.host == "chaos.atlassian.net"
+    assert estimates[0].estimated_units == 2
+    assert estimates[0].confidence == "medium"
+    assert estimates[0].to_dict()["bucket"]["dimension"] == "search"
+
+
+def test_jira_budget_estimator_adds_optional_worklog_and_gql_budgets() -> None:
+    estimates = JiraBudgetEstimator().estimate(
+        _context(
+            dataset_key="work-items",
+            processor_flags={
+                "jira_fetch_worklogs": True,
+                "atlassian_gql_enabled": True,
+            },
+        )
+    )
+
+    assert {estimate.route_family for estimate in estimates} == {
+        "jira_jql",
+        "jira_issue_enrichment",
+        "jira_worklogs",
+        "jira_gql_enrichment",
+    }
+    assert {estimate.bucket.dimension for estimate in estimates} == {
+        BudgetDimension.SEARCH,
+        BudgetDimension.REST_CORE,
+        BudgetDimension.GRAPHQL_COST,
+    }
+
+
+def test_jira_budget_estimator_reads_worklog_and_gql_env_flags(monkeypatch) -> None:
+    monkeypatch.setenv("JIRA_FETCH_WORKLOGS", "true")
+    monkeypatch.setenv("ATLASSIAN_GQL_ENABLED", "true")
+
+    estimates = JiraBudgetEstimator().estimate(_context(dataset_key="work-items"))
+
+    assert "jira_worklogs" in {estimate.route_family for estimate in estimates}
+    assert "jira_gql_enrichment" in {estimate.route_family for estimate in estimates}
+
+
+def test_jira_budget_route_family_limits_override_dimension_defaults() -> None:
+    jql = next(
+        estimate
+        for estimate in JiraBudgetEstimator().estimate(
+            _context(dataset_key="work-items")
+        )
+        if estimate.route_family == "jira_jql"
+    )
+    limits = {"jira:search:jira_jql": 3, "jira:search": 1}
+
+    assert _budget_key(jql.bucket.to_dict(), route_family=jql.route_family).endswith(
+        ":search:jira_jql"
+    )
+    assert (
+        _limit_for_bucket(
+            jql.bucket.to_dict(),
+            route_family=jql.route_family,
+            limits=limits,
+            default_limit=100,
+        )
+        == 3
+    )
+
+
+def test_jira_budget_estimator_scopes_bucket_to_host_and_safe_credentials() -> None:
+    base = JiraBudgetEstimator().estimate(
+        _context(
+            dataset_key="work-items",
+            credentials={
+                "email": "ops@example.com",
+                "api_token": "secret-token",
+                "base_url": "chaos.atlassian.net",
+            },
+        )
+    )[0]
+    rotated = JiraBudgetEstimator().estimate(
+        _context(
+            dataset_key="work-items",
+            credentials={
+                "email": "ops@example.com",
+                "api_token": "rotated-token",
+                "base_url": "chaos.atlassian.net",
+            },
+        )
+    )[0]
+
+    assert base.bucket.host == "chaos.atlassian.net"
+    assert base.bucket.credential_fingerprint != rotated.bucket.credential_fingerprint
+    assert "secret-token" not in str(base.to_dict())
+    assert "rotated-token" not in str(rotated.to_dict())
+
+
+def test_estimate_provider_budget_delegates_to_jira_estimator() -> None:
+    estimates = estimate_provider_budget(_context(dataset_key="work-items"))
+
+    assert len(estimates) == 2
+    assert estimates[0].bucket.provider == "jira"
+
+
+def test_jira_budget_estimator_returns_empty_for_unknown_dataset() -> None:
+    assert JiraBudgetEstimator().estimate(_context(dataset_key="commits")) == ()
+
+
+def test_jira_budget_guard_defers_second_unit_by_jql_reservation(
+    db_session, monkeypatch
+):
+    _jira_env(monkeypatch)
+    run, first = _seed_jira_run(db_session)
+    second = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=first.integration_id,
+        source_id=first.source_id,
+        provider="jira",
+        dataset_key="work-items",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        since_at=WINDOW_START,
+        before_at=WINDOW_END,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={},
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+    monkeypatch.setenv(
+        "SYNC_BUDGET_BUCKET_LIMITS", json.dumps({"jira:search:jira_jql": 2})
+    )
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    result = BudgetGuard.enforce_run(db_session, str(run.id))
+
+    db_session.refresh(first)
+    db_session.refresh(second)
+    assert len(result.deferred_unit_ids) == 1
+    statuses = {first.status, second.status}
+    assert statuses == {
+        SyncRunUnitStatus.PLANNED.value,
+        SyncRunUnitStatus.RETRYING.value,
+    }
+    deferred = first if first.status == SyncRunUnitStatus.RETRYING.value else second
+    assert deferred.available_at is not None
+    assert deferred.result is not None
+    assert deferred.result["budget_guard"][0]["bucket"]["provider"] == "jira"
+    assert deferred.result["budget_guard"][0]["route_family"] == "jira_jql"
+
+
+def test_jira_budget_guard_active_reservation_blocks_planned_unit(
+    db_session, monkeypatch
+):
+    _jira_env(monkeypatch)
+    run, planned = _seed_jira_run(db_session)
+    active = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=planned.integration_id,
+        source_id=planned.source_id,
+        provider="jira",
+        dataset_key="work-items",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        since_at=WINDOW_START,
+        before_at=WINDOW_END,
+        status=SyncRunUnitStatus.DISPATCHING.value,
+        attempts=0,
+        processor_flags={},
+    )
+    run.total_units = 2
+    db_session.add(active)
+    db_session.flush()
+    active.updated_at = datetime.now(timezone.utc)
+    monkeypatch.setenv(
+        "SYNC_BUDGET_BUCKET_LIMITS", json.dumps({"jira:search:jira_jql": 2})
+    )
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    result = BudgetGuard.enforce_run(db_session, str(run.id))
+
+    db_session.refresh(planned)
+    db_session.refresh(active)
+    assert result.deferred_unit_ids == frozenset({str(planned.id)})
+    assert planned.status == SyncRunUnitStatus.RETRYING.value
+    assert active.status == SyncRunUnitStatus.DISPATCHING.value
+
+
+def test_jira_budget_estimate_is_persisted_on_success(db_session, monkeypatch):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers import sync_units
+
+    _jira_env(monkeypatch)
+    run, unit = _seed_jira_run(db_session)
+    unit.status = SyncRunUnitStatus.DISPATCHING.value
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters, "run_dataset_unit", lambda ctx, runtime: {"ok": True}
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run, "apply_async", lambda *args, **kwargs: None
+    )
+
+    class RuntimeCache:
+        def get(self, context):
+            return None
+
+    monkeypatch.setattr(sync_units, "_runtime_cache", RuntimeCache())
+
+    result = getattr(sync_units.run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result["status"] == "success"
+    assert unit.result is not None
+    budget_estimate = unit.result["observations"]["budget_estimate"]
+    assert budget_estimate[0]["bucket"]["provider"] == "jira"
+    assert budget_estimate[0]["route_family"] == "jira_jql"
+
+
+def test_jira_provider_queue_routing_supports_provider_and_cost_class_queues(
+    monkeypatch,
+) -> None:
+    monkeypatch.setenv("PROVIDER_SYNC_QUEUES_ENABLED", "true")
+    monkeypatch.delenv("SYNC_COST_CLASS_QUEUES", raising=False)
+    provider_route = route(
+        org_id="org-1",
+        provider="jira",
+        cost_class="medium",
+        cost_class_queues_enabled=False,
+    )
+
+    monkeypatch.setenv("SYNC_COST_CLASS_QUEUES", "true")
+    cost_route = route(
+        org_id="org-1",
+        provider="jira",
+        cost_class="medium",
+        cost_class_queues_enabled=True,
+    )
+
+    assert provider_route.queue == "sync.jira"
+    assert cost_route.queue == "sync.jira.medium"

--- a/tests/providers/test_linear_budget.py
+++ b/tests/providers/test_linear_budget.py
@@ -273,7 +273,7 @@ def test_estimate_provider_budget_delegates_to_linear_estimator() -> None:
 
 def test_estimate_provider_budget_returns_empty_for_different_provider() -> None:
     estimates = estimate_provider_budget(
-        _context(provider="jira", dataset_key="work-items")
+        _context(provider="bitbucket", dataset_key="work-items")
     )
 
     assert estimates == ()


### PR DESCRIPTION
## Summary
- add a Jira sync budget estimator with REST/JQL, issue enrichment, optional worklog, and Atlassian GraphQL route-family buckets
- route Jira units through `estimate_provider_budget` so unit execution and budget guard observations persist estimates
- cover Jira estimates, worklog/GQL toggles, budget deferral/reservation behavior, persisted observations, and queue routing
- document Jira budget dimensions/defaults in ops docs and env templates

## Verification
- `python -m pytest tests/providers/test_jira_budget.py -q`
- `python -m pytest tests/test_jira_extras.py tests/test_jira_jql.py tests/test_jira_normalize_dict.py tests/providers/test_jira_client_ratelimit.py tests/workers/test_team_autoimport_jira.py tests/api/services/test_jira_bulk_members.py -q`
- `python -m pytest tests/providers/test_github_budget.py tests/providers/test_jira_budget.py -q`
- `python -m ruff format --check src/dev_health_ops/providers/jira/budget.py src/dev_health_ops/sync/budget.py tests/providers/test_jira_budget.py`
- `python -m ruff check src/dev_health_ops/providers/jira/budget.py src/dev_health_ops/sync/budget.py tests/providers/test_jira_budget.py`
- `python -m mypy src/dev_health_ops/providers/jira/budget.py src/dev_health_ops/sync/budget.py tests/providers/test_jira_budget.py`
- `bash ci/local_validate.sh`

Linked issue: CHAOS-2686

SCREENSHOT-WAIVER: backend-only, no UI render