### PR TITLE
feat(linear): add sync budget estimator

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -43,15 +43,15 @@ SYNC_DISPATCH_REDISPATCH_COUNTDOWN="60"
 SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS="300"
 SYNC_WATERMARK_OVERLAP="0"
 
-# GitHub sync budget guard. Values are abstract reservation units, not raw
-# GitHub requests. Setting SYNC_BUDGET_BUCKET_LIMITS enables enforcement.
-SYNC_BUDGET_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+# Provider sync budget guard. Values are abstract reservation units, not raw
+# Provider API work. Setting SYNC_BUDGET_BUCKET_LIMITS enables enforcement.
+SYNC_BUDGET_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"linear:graphql_cost":500}'
 SYNC_BUDGET_DEFAULT_LIMIT="1000000"
 SYNC_BUDGET_DEFERRAL_SECONDS="60"
 SYNC_BUDGET_DEFERRAL_JITTER_SECONDS="5"
 
 # Optional dry-run/observation-only budget logging knobs.
-# SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+# SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"linear:graphql_cost":500}'
 SYNC_BUDGET_DRY_RUN_DEFAULT_LIMIT="1000000"
 SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS="60"
 

--- a/deploy/docker-compose/.env.example
+++ b/deploy/docker-compose/.env.example
@@ -39,13 +39,13 @@ SYNC_DISPATCH_REDISPATCH_COUNTDOWN=60
 SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS=300
 SYNC_WATERMARK_OVERLAP=0
 
-# GitHub sync budget guard. Values are abstract reservation units, not raw
-# GitHub requests. Setting SYNC_BUDGET_BUCKET_LIMITS enables enforcement.
-SYNC_BUDGET_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+# Provider sync budget guard. Values are abstract reservation units, not raw
+# Provider API work. Setting SYNC_BUDGET_BUCKET_LIMITS enables enforcement.
+SYNC_BUDGET_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"linear:graphql_cost":500}'
 SYNC_BUDGET_DEFAULT_LIMIT=1000000
 SYNC_BUDGET_DEFERRAL_SECONDS=60
 SYNC_BUDGET_DEFERRAL_JITTER_SECONDS=5
-# SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+# SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS='{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"linear:graphql_cost":500}'
 SYNC_BUDGET_DRY_RUN_DEFAULT_LIMIT=1000000
 SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS=60
 

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -368,7 +368,7 @@ config:
   SYNC_DISPATCH_REDISPATCH_COUNTDOWN: "60"
   SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS: "300"
   SYNC_WATERMARK_OVERLAP: "0"
-  SYNC_BUDGET_BUCKET_LIMITS: '{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+  SYNC_BUDGET_BUCKET_LIMITS: '{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"linear:graphql_cost":500}'
   SYNC_BUDGET_DEFAULT_LIMIT: "1000000"
   SYNC_BUDGET_DEFERRAL_SECONDS: "60"
   SYNC_BUDGET_DEFERRAL_JITTER_SECONDS: "5"

--- a/deploy/kubernetes/configmap.yaml
+++ b/deploy/kubernetes/configmap.yaml
@@ -35,7 +35,7 @@ data:
   SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS: "300"
   SYNC_WATERMARK_OVERLAP: "0"
 
-  SYNC_BUDGET_BUCKET_LIMITS: '{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}'
+  SYNC_BUDGET_BUCKET_LIMITS: '{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"linear:graphql_cost":500}'
   SYNC_BUDGET_DEFAULT_LIMIT: "1000000"
   SYNC_BUDGET_DEFERRAL_SECONDS: "60"
   SYNC_BUDGET_DEFERRAL_JITTER_SECONDS: "5"

--- a/docs/ops/deployment-guide.md
+++ b/docs/ops/deployment-guide.md
@@ -86,11 +86,11 @@ All deployment methods use the same environment variables:
 | `SYNC_DISPATCH_REDISPATCH_COUNTDOWN` | Delay before redispatching sync-run work. | 60 |
 | `SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS` | Dispatch outbox claim lease duration. | 300 |
 | `SYNC_WATERMARK_OVERLAP` | Seconds subtracted from incremental watermark reads to intentionally re-read a lookback margin. | 0 |
-| `SYNC_BUDGET_BUCKET_LIMITS` | JSON map that enables enforced GitHub budget deferrals. Values are reservation units, not raw GitHub request counts. | `{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}` |
+| `SYNC_BUDGET_BUCKET_LIMITS` | JSON map that enables enforced provider budget deferrals. Values are reservation units, not raw request or GraphQL cost counters. | `{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"linear:graphql_cost":500}` |
 | `SYNC_BUDGET_DEFAULT_LIMIT` | Fallback enforced budget limit for unnamed buckets. | 1000000 |
 | `SYNC_BUDGET_DEFERRAL_SECONDS` | Base countdown when budget enforcement defers a unit. | 60 |
 | `SYNC_BUDGET_DEFERRAL_JITTER_SECONDS` | Jitter added to budget deferrals. | 5 |
-| `SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS` | Optional observation-only GitHub budget limits. | unset |
+| `SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS` | Optional observation-only provider budget limits. | unset |
 | `SYNC_BUDGET_DRY_RUN_DEFAULT_LIMIT` | Fallback dry-run budget limit. | 1000000 |
 | `SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS` | Observation-only deferral estimate. | 60 |
 

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -17,7 +17,7 @@ In contrast, Celery-triggered jobs run inside the worker process, which is start
 Key implementation details:
 - **Broker and Result Backend**: Configured in `workers/config.py:8-64` and initialized in `workers/celery_app.py:66-84`. The default broker and result backend URL is `redis://localhost:6379/0` (controlled by `CELERY_BROKER_URL` and `CELERY_RESULT_BACKEND`).
 - **Queue Routing**: Defined in `workers/queues.py:7-62`. The `PROVIDER_SYNC_QUEUES_ENABLED` flag gates provider-specific queues; `SYNC_COST_CLASS_QUEUES` further routes eligible units to light/medium/heavy sub-queues.
-- **Sync Budget Guard**: Defined in `sync/budget_guard.py`. `SYNC_BUDGET_BUCKET_LIMITS` enables enforced GitHub budget deferrals; dry-run limits record observations without deferring work.
+- **Sync Budget Guard**: Defined in `sync/budget_guard.py`. `SYNC_BUDGET_BUCKET_LIMITS` enables enforced provider budget deferrals; dry-run limits record observations without deferring work.
 
 ### On-Demand Trigger Paths
 
@@ -127,11 +127,11 @@ The bundled Docker Compose, Kubernetes, and Helm deployments already declare the
 | `SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS` | `300` | Dispatch outbox claim lease duration. |
 | `SYNC_WATERMARK_OVERLAP` | `0` | Subtracts this many seconds from incremental watermark reads to intentionally re-read a lookback margin. |
 
-GitHub budget limits are abstract reservation units derived from the estimated shape of a sync unit. They are not GitHub's raw hourly request counters. Leaving `SYNC_BUDGET_BUCKET_LIMITS` unset disables enforcement; setting it enables deferrals when the reservation would exceed a configured bucket.
+Provider budget limits are abstract reservation units derived from the estimated shape of a sync unit. They are not the provider's raw request or GraphQL cost counters. Leaving `SYNC_BUDGET_BUCKET_LIMITS` unset disables enforcement; setting it enables deferrals when the reservation would exceed a configured bucket.
 
 | Variable | Default in deploy templates | Effect |
 |---|---:|---|
-| `SYNC_BUDGET_BUCKET_LIMITS` | `{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25}` | Enforced per-bucket reservation limits. |
+| `SYNC_BUDGET_BUCKET_LIMITS` | `{"github:rest_core":250,"github:graphql_cost":500,"github:contents_blob":100,"github:secondary_abuse_risk":25,"linear:graphql_cost":500}` | Enforced per-bucket reservation limits. |
 | `SYNC_BUDGET_DEFAULT_LIMIT` | `1000000` | Fallback enforced limit for buckets not named in the JSON map. |
 | `SYNC_BUDGET_DEFERRAL_SECONDS` | `60` | Base countdown when enforcement defers a unit. |
 | `SYNC_BUDGET_DEFERRAL_JITTER_SECONDS` | `5` | Random jitter added to enforced deferrals. |

--- a/src/dev_health_ops/providers/linear/budget.py
+++ b/src/dev_health_ops/providers/linear/budget.py
@@ -1,0 +1,214 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from urllib.parse import urlparse
+
+from dev_health_ops.sync.budget_types import (
+    BudgetBucketKey,
+    BudgetDimension,
+    BudgetEstimate,
+)
+from dev_health_ops.sync.datasets import DatasetKey
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+_DEFAULT_HOST = "api.linear.app"
+_DEFAULT_BASE_URL = "https://api.linear.app/graphql"
+_CONFIDENCE_HIGH = "high"
+_CONFIDENCE_MEDIUM = "medium"
+_CONFIDENCE_LOW = "low"
+
+
+class LinearBudgetEstimator:
+    def estimate(self, context: SyncTaskContext) -> tuple[BudgetEstimate, ...]:
+        if context.provider.lower() != "linear":
+            return ()
+
+        credential_fingerprint = _credential_fingerprint(
+            context.decrypted_credentials,
+            credential_id=context.credential_id,
+            integration_id=context.integration_id,
+        )
+        host = _host_from_credentials(context.decrypted_credentials)
+        return tuple(
+            _dataset_estimates(
+                dataset_key=context.dataset_key,
+                org_id=context.org_id,
+                host=host,
+                credential_fingerprint=credential_fingerprint,
+            )
+        )
+
+
+def _dataset_estimates(
+    *,
+    dataset_key: str,
+    org_id: str,
+    host: str,
+    credential_fingerprint: str,
+) -> tuple[BudgetEstimate, ...]:
+    bucket = _bucket_factory(
+        org_id=org_id,
+        host=host,
+        credential_fingerprint=credential_fingerprint,
+    )
+
+    if dataset_key == DatasetKey.WORK_ITEMS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST), 1, _CONFIDENCE_MEDIUM, "teams"
+            ),
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST),
+                5,
+                _CONFIDENCE_LOW,
+                "issues",
+                notes=(
+                    "Linear issue pages include nested labels, project, comments, attachments, and history edges",
+                ),
+            ),
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST), 2, _CONFIDENCE_LOW, "cycles"
+            ),
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST), 2, _CONFIDENCE_LOW, "comments"
+            ),
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST), 1, _CONFIDENCE_LOW, "attachments"
+            ),
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST), 2, _CONFIDENCE_LOW, "history"
+            ),
+        )
+
+    if dataset_key == DatasetKey.WORK_ITEM_LABELS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST), 1, _CONFIDENCE_MEDIUM, "teams"
+            ),
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST),
+                1,
+                _CONFIDENCE_MEDIUM,
+                "team_members",
+                notes=(
+                    "Linear team pages include a small member edge; large teams require member pagination",
+                ),
+            ),
+        )
+
+    if dataset_key == DatasetKey.WORK_ITEM_PROJECTS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST), 2, _CONFIDENCE_MEDIUM, "projects"
+            ),
+        )
+
+    if dataset_key == DatasetKey.WORK_ITEM_HISTORY.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST), 3, _CONFIDENCE_LOW, "history"
+            ),
+        )
+
+    if dataset_key == DatasetKey.WORK_ITEM_COMMENTS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.GRAPHQL_COST), 3, _CONFIDENCE_LOW, "comments"
+            ),
+        )
+
+    return ()
+
+
+def _bucket_factory(
+    *, org_id: str, host: str, credential_fingerprint: str
+) -> Callable[[BudgetDimension], BudgetBucketKey]:
+    def _bucket(dimension: BudgetDimension) -> BudgetBucketKey:
+        return BudgetBucketKey(
+            provider="linear",
+            org_id=org_id,
+            host=host,
+            credential_fingerprint=credential_fingerprint,
+            dimension=dimension,
+        )
+
+    return _bucket
+
+
+def _estimate(
+    bucket: BudgetBucketKey,
+    estimated_units: int,
+    confidence: str,
+    route_family: str,
+    *,
+    notes: tuple[str, ...] = (),
+) -> BudgetEstimate:
+    return BudgetEstimate(
+        bucket=bucket,
+        estimated_units=estimated_units,
+        confidence=confidence,
+        route_family=route_family,
+        notes=notes,
+    )
+
+
+def _host_from_credentials(credentials: object) -> str:
+    base_url = _DEFAULT_BASE_URL
+    if isinstance(credentials, Mapping):
+        raw_base_url = credentials.get("base_url") or credentials.get("baseUrl")
+        if raw_base_url:
+            base_url = str(raw_base_url)
+    host = urlparse(base_url).hostname
+    return host or _DEFAULT_HOST
+
+
+def _credential_fingerprint(
+    credentials: object, *, credential_id: str | None, integration_id: str
+) -> str:
+    safe_credentials = _safe_credential_scope(
+        credentials,
+        credential_id=credential_id,
+        integration_id=integration_id,
+    )
+    payload = json.dumps(
+        safe_credentials, sort_keys=True, default=str, separators=(",", ":")
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _safe_credential_scope(
+    credentials: object, *, credential_id: str | None, integration_id: str
+) -> dict[str, object]:
+    if not isinstance(credentials, Mapping):
+        return _fallback_credential_scope(
+            credential_id=credential_id,
+            integration_id=integration_id,
+        )
+    scope: dict[str, object] = {}
+    for key in ("organization_id", "workspace_id", "team_id"):
+        value = credentials.get(key)
+        if value is not None:
+            scope[key] = value
+    base_url = credentials.get("base_url") or credentials.get("baseUrl")
+    if base_url is not None:
+        scope["base_url"] = base_url
+    token = credentials.get("api_key") or credentials.get("token")
+    if token:
+        scope["token_sha256"] = hashlib.sha256(str(token).encode("utf-8")).hexdigest()
+    if not scope:
+        return _fallback_credential_scope(
+            credential_id=credential_id,
+            integration_id=integration_id,
+        )
+    return scope
+
+
+def _fallback_credential_scope(
+    *, credential_id: str | None, integration_id: str
+) -> dict[str, object]:
+    return {
+        "credential_id": credential_id or "env",
+        "integration_id": integration_id,
+    }

--- a/src/dev_health_ops/providers/linear/budget.py
+++ b/src/dev_health_ops/providers/linear/budget.py
@@ -15,7 +15,6 @@ from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
 
 _DEFAULT_HOST = "api.linear.app"
 _DEFAULT_BASE_URL = "https://api.linear.app/graphql"
-_CONFIDENCE_HIGH = "high"
 _CONFIDENCE_MEDIUM = "medium"
 _CONFIDENCE_LOW = "low"
 
@@ -186,7 +185,10 @@ def _safe_credential_scope(
             credential_id=credential_id,
             integration_id=integration_id,
         )
-    scope: dict[str, object] = {}
+    scope: dict[str, object] = {
+        "credential_id": credential_id or "env",
+        "integration_id": integration_id,
+    }
     for key in ("organization_id", "workspace_id", "team_id"):
         value = credentials.get(key)
         if value is not None:
@@ -194,14 +196,6 @@ def _safe_credential_scope(
     base_url = credentials.get("base_url") or credentials.get("baseUrl")
     if base_url is not None:
         scope["base_url"] = base_url
-    token = credentials.get("api_key") or credentials.get("token")
-    if token:
-        scope["token_sha256"] = hashlib.sha256(str(token).encode("utf-8")).hexdigest()
-    if not scope:
-        return _fallback_credential_scope(
-            credential_id=credential_id,
-            integration_id=integration_id,
-        )
     return scope
 
 

--- a/src/dev_health_ops/sync/budget.py
+++ b/src/dev_health_ops/sync/budget.py
@@ -26,4 +26,8 @@ def estimate_provider_budget(context: SyncTaskContext) -> tuple[BudgetEstimate, 
         from dev_health_ops.providers.github.budget import GitHubBudgetEstimator
 
         return GitHubBudgetEstimator().estimate(context)
+    if context.provider.lower() == "linear":
+        from dev_health_ops.providers.linear.budget import LinearBudgetEstimator
+
+        return LinearBudgetEstimator().estimate(context)
     return ()

--- a/tests/providers/test_linear_budget.py
+++ b/tests/providers/test_linear_budget.py
@@ -1,0 +1,275 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+from dev_health_ops.providers.linear.budget import LinearBudgetEstimator
+from dev_health_ops.sync.budget import BudgetDimension, estimate_provider_budget
+from dev_health_ops.sync.budget_guard import (
+    _budget_key,
+    _limit_for_bucket,
+    _parse_budget_limits,
+)
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+WINDOW_START = datetime(2026, 1, 10, tzinfo=timezone.utc)
+WINDOW_END = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+
+def _context(
+    *,
+    provider: str = "linear",
+    dataset_key: str,
+    processor_flags: dict[str, bool] | None = None,
+    credentials: Mapping[str, object] | None = None,
+    credential_id: str | None = "credential-1",
+) -> SyncTaskContext:
+    decrypted_credentials: dict[str, object] = {"api_key": "secret-api-key"}
+    if credentials is not None:
+        decrypted_credentials = {str(key): value for key, value in credentials.items()}
+    return SyncTaskContext(
+        unit_id="unit-1",
+        sync_run_id="run-1",
+        org_id="org-1",
+        integration_id="integration-1",
+        source_id="source-1",
+        source_external_id="TEAM",
+        provider=provider,
+        dataset_key=dataset_key,
+        cost_class="medium",
+        mode="incremental",
+        window_start=WINDOW_START,
+        window_end=WINDOW_END,
+        processor_flags=processor_flags or {},
+        credential_id=credential_id,
+        decrypted_credentials=decrypted_credentials,
+        db_url="clickhouse://localhost/default",
+    )
+
+
+def test_linear_budget_estimator_returns_graphql_budget_for_work_items() -> None:
+    estimates = LinearBudgetEstimator().estimate(_context(dataset_key="work-items"))
+
+    assert len(estimates) == 6
+    estimate = estimates[0]
+    assert estimate.bucket.provider == "linear"
+    assert estimate.bucket.org_id == "org-1"
+    assert estimate.bucket.host == "api.linear.app"
+    assert estimate.bucket.dimension is BudgetDimension.GRAPHQL_COST
+    assert estimate.estimated_units == 1
+    assert estimate.confidence == "medium"
+    assert estimate.to_dict()["bucket"]["dimension"] == "graphql_cost"
+
+
+def test_linear_budget_work_item_routes_model_cursor_paginated_edges() -> None:
+    estimates = LinearBudgetEstimator().estimate(_context(dataset_key="work-items"))
+
+    assert [estimate.bucket.dimension for estimate in estimates] == [
+        BudgetDimension.GRAPHQL_COST,
+        BudgetDimension.GRAPHQL_COST,
+        BudgetDimension.GRAPHQL_COST,
+        BudgetDimension.GRAPHQL_COST,
+        BudgetDimension.GRAPHQL_COST,
+        BudgetDimension.GRAPHQL_COST,
+    ]
+    assert {estimate.route_family for estimate in estimates} == {
+        "attachments",
+        "comments",
+        "cycles",
+        "history",
+        "issues",
+        "teams",
+    }
+
+
+def test_linear_budget_estimator_splits_work_item_dimension_datasets() -> None:
+    labels = LinearBudgetEstimator().estimate(_context(dataset_key="work-item-labels"))
+    projects = LinearBudgetEstimator().estimate(
+        _context(dataset_key="work-item-projects")
+    )
+    history = LinearBudgetEstimator().estimate(
+        _context(dataset_key="work-item-history")
+    )
+    comments = LinearBudgetEstimator().estimate(
+        _context(dataset_key="work-item-comments")
+    )
+
+    assert {estimate.route_family for estimate in labels} == {"teams", "team_members"}
+    assert [estimate.route_family for estimate in projects] == ["projects"]
+    assert [estimate.route_family for estimate in history] == ["history"]
+    assert [estimate.route_family for estimate in comments] == ["comments"]
+    assert all(
+        estimate.bucket.dimension is BudgetDimension.GRAPHQL_COST
+        for estimate in labels + projects + history + comments
+    )
+
+
+def test_linear_budget_route_family_limits_override_dimension_defaults() -> None:
+    issue_budget = next(
+        estimate
+        for estimate in LinearBudgetEstimator().estimate(
+            _context(dataset_key="work-items")
+        )
+        if estimate.route_family == "issues"
+    )
+    comment_budget = next(
+        estimate
+        for estimate in LinearBudgetEstimator().estimate(
+            _context(dataset_key="work-items")
+        )
+        if estimate.route_family == "comments"
+    )
+    limits = _parse_budget_limits(
+        '{"linear:graphql_cost:issues": 9, "linear:graphql_cost": 2}'
+    )
+
+    assert _budget_key(
+        issue_budget.bucket.to_dict(), route_family=issue_budget.route_family
+    ).endswith(":graphql_cost:issues")
+    assert (
+        _limit_for_bucket(
+            issue_budget.bucket.to_dict(),
+            route_family=issue_budget.route_family,
+            limits=limits,
+            default_limit=100,
+        )
+        == 9
+    )
+    assert (
+        _limit_for_bucket(
+            comment_budget.bucket.to_dict(),
+            route_family=comment_budget.route_family,
+            limits=limits,
+            default_limit=100,
+        )
+        == 2
+    )
+
+
+def test_linear_budget_all_route_families_can_override_graphql_default() -> None:
+    estimates = LinearBudgetEstimator().estimate(_context(dataset_key="work-items"))
+    limits = _parse_budget_limits(
+        "{"
+        '"linear:graphql_cost:teams": 1,'
+        '"linear:graphql_cost:issues": 2,'
+        '"linear:graphql_cost:cycles": 3,'
+        '"linear:graphql_cost:comments": 4,'
+        '"linear:graphql_cost:attachments": 5,'
+        '"linear:graphql_cost:history": 6,'
+        '"linear:graphql_cost": 99'
+        "}"
+    )
+
+    assert {
+        estimate.route_family: _limit_for_bucket(
+            estimate.bucket.to_dict(),
+            route_family=estimate.route_family,
+            limits=limits,
+            default_limit=100,
+        )
+        for estimate in estimates
+    } == {
+        "teams": 1,
+        "issues": 2,
+        "cycles": 3,
+        "comments": 4,
+        "attachments": 5,
+        "history": 6,
+    }
+
+
+def test_linear_budget_route_family_override_parsing_ignores_invalid_values() -> None:
+    limits = _parse_budget_limits(
+        '{"linear:graphql_cost:issues": "8", "bad": "nope", "negative": -1}'
+    )
+
+    assert limits == {"linear:graphql_cost:issues": 8, "negative": 0}
+    assert _parse_budget_limits("not-json") == {}
+    assert _parse_budget_limits("[]") == {}
+
+
+def test_linear_budget_estimator_scopes_bucket_to_host_and_safe_credential_fields() -> (
+    None
+):
+    base_credentials = {
+        "api_key": "secret-api-key",
+        "base_url": "https://linear.example.com/graphql",
+    }
+    rotated_key_credentials = {
+        "api_key": "rotated-api-key",
+        "base_url": "https://linear.example.com/graphql",
+    }
+    workspace_credentials = {
+        "api_key": "secret-api-key",
+        "workspace_id": "workspace-1",
+        "base_url": "https://linear.example.com/graphql",
+    }
+
+    base = LinearBudgetEstimator().estimate(
+        _context(dataset_key="work-items", credentials=base_credentials)
+    )[0]
+    rotated = LinearBudgetEstimator().estimate(
+        _context(dataset_key="work-items", credentials=rotated_key_credentials)
+    )[0]
+    workspace = LinearBudgetEstimator().estimate(
+        _context(dataset_key="work-items", credentials=workspace_credentials)
+    )[0]
+
+    assert base.bucket.host == "linear.example.com"
+    assert base.bucket.credential_fingerprint != rotated.bucket.credential_fingerprint
+    assert base.bucket.credential_fingerprint != workspace.bucket.credential_fingerprint
+    assert "secret-api-key" not in str(base.to_dict())
+    assert "rotated-api-key" not in str(rotated.to_dict())
+
+
+def test_linear_budget_estimator_normalizes_camel_case_base_url_for_fingerprint() -> (
+    None
+):
+    snake = LinearBudgetEstimator().estimate(
+        _context(
+            dataset_key="work-items",
+            credentials={
+                "api_key": "secret-api-key",
+                "base_url": "https://linear.test",
+            },
+        )
+    )[0]
+    camel = LinearBudgetEstimator().estimate(
+        _context(
+            dataset_key="work-items",
+            credentials={"api_key": "secret-api-key", "baseUrl": "https://linear.test"},
+        )
+    )[0]
+
+    assert snake.bucket.host == camel.bucket.host == "linear.test"
+    assert snake.bucket.credential_fingerprint == camel.bucket.credential_fingerprint
+
+
+def test_linear_budget_estimator_scopes_empty_credentials_to_integration() -> None:
+    first = LinearBudgetEstimator().estimate(
+        _context(dataset_key="work-items", credentials={}, credential_id=None)
+    )[0]
+    second = LinearBudgetEstimator().estimate(
+        _context(dataset_key="work-items", credentials={}, credential_id="credential-2")
+    )[0]
+
+    assert first.bucket.credential_fingerprint != second.bucket.credential_fingerprint
+
+
+def test_linear_budget_estimator_returns_empty_for_unknown_dataset() -> None:
+    assert LinearBudgetEstimator().estimate(_context(dataset_key="unknown")) == ()
+
+
+def test_estimate_provider_budget_delegates_to_linear_estimator() -> None:
+    estimates = estimate_provider_budget(_context(dataset_key="work-items"))
+
+    assert len(estimates) == 6
+    assert estimates[0].bucket.provider == "linear"
+
+
+def test_estimate_provider_budget_returns_empty_for_different_provider() -> None:
+    estimates = estimate_provider_budget(
+        _context(provider="jira", dataset_key="work-items")
+    )
+
+    assert estimates == ()

--- a/tests/providers/test_linear_budget.py
+++ b/tests/providers/test_linear_budget.py
@@ -209,7 +209,11 @@ def test_linear_budget_estimator_scopes_bucket_to_host_and_safe_credential_field
         _context(dataset_key="work-items", credentials=base_credentials)
     )[0]
     rotated = LinearBudgetEstimator().estimate(
-        _context(dataset_key="work-items", credentials=rotated_key_credentials)
+        _context(
+            dataset_key="work-items",
+            credentials=rotated_key_credentials,
+            credential_id="credential-2",
+        )
     )[0]
     workspace = LinearBudgetEstimator().estimate(
         _context(dataset_key="work-items", credentials=workspace_credentials)

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -113,11 +113,22 @@ def _commit_reconciler_failure(engine, unit_id):
         session.commit()
 
 
-def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
+def _seed_run(
+    session,
+    *,
+    mode=SyncRunMode.INCREMENTAL.value,
+    provider="github",
+    source_type="repo",
+    external_id="full-chaos/dev-health",
+    name="dev-health",
+    full_name="full-chaos/dev-health",
+    dataset_key="commits",
+    processor_flags=None,
+):
     org_id = str(uuid.uuid4())
     integration = Integration(
         org_id=org_id,
-        provider="github",
+        provider=provider,
         name="demo",
         config={},
         is_active=True,
@@ -127,18 +138,18 @@ def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
     source = IntegrationSource(
         org_id=org_id,
         integration_id=integration.id,
-        provider="github",
-        source_type="repo",
-        external_id="full-chaos/dev-health",
-        name="dev-health",
-        full_name="full-chaos/dev-health",
+        provider=provider,
+        source_type=source_type,
+        external_id=external_id,
+        name=name,
+        full_name=full_name,
         metadata_={},
         is_enabled=True,
     )
     dataset = IntegrationDataset(
         org_id=org_id,
         integration_id=integration.id,
-        dataset_key="commits",
+        dataset_key=dataset_key,
         is_enabled=True,
         options={},
     )
@@ -159,15 +170,15 @@ def _seed_run(session, *, mode=SyncRunMode.INCREMENTAL.value):
         sync_run_id=run.id,
         integration_id=integration.id,
         source_id=source.id,
-        provider="github",
-        dataset_key="commits",
+        provider=provider,
+        dataset_key=dataset_key,
         cost_class="medium",
         mode=mode,
         since_at=None,
         before_at=datetime.now(timezone.utc),
         status=SyncRunUnitStatus.PLANNED.value,
         attempts=0,
-        processor_flags={"sync_git": True},
+        processor_flags=processor_flags or {"sync_git": True},
     )
     session.add(unit)
     session.flush()
@@ -322,6 +333,57 @@ def test_run_sync_unit_success_persists_status_and_incremental_watermark(
     )
     assert finalize_outbox.status == OUTBOX_STATUS_PENDING
     assert finalize_calls == [((str(run.id),), "sync")]
+
+
+def test_run_sync_unit_success_attaches_linear_budget_estimate(db_session, monkeypatch):
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(
+        db_session,
+        provider="linear",
+        source_type="team",
+        external_id="TEAM",
+        name="TEAM",
+        full_name="TEAM",
+        dataset_key="work-items",
+        processor_flags={},
+    )
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {"ok": True, "observations": {}},
+    )
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.SUCCESS.value
+    assert unit.result is not None
+    observations = unit.result["observations"]
+    budget_estimate = observations["budget_estimate"]
+    assert {estimate["bucket"]["provider"] for estimate in budget_estimate} == {
+        "linear"
+    }
+    assert {estimate["bucket"]["dimension"] for estimate in budget_estimate} == {
+        "graphql_cost"
+    }
+    assert {estimate["route_family"] for estimate in budget_estimate} == {
+        "attachments",
+        "comments",
+        "cycles",
+        "history",
+        "issues",
+        "teams",
+    }
 
 
 def test_run_sync_unit_success_survives_finalize_enqueue_failure(
@@ -1977,6 +2039,55 @@ def test_dispatch_sync_run_logs_budget_guard_would_defer_without_deferring(
     assert record.budget_limit == 1
     assert record.projected_units == 2
     assert record.suggested_available_at is not None
+
+
+def test_dispatch_sync_run_logs_linear_budget_guard_route_family_dry_run(
+    db_session, monkeypatch, caplog
+):
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(
+        db_session,
+        provider="linear",
+        source_type="team",
+        external_id="TEAM",
+        name="TEAM",
+        full_name="TEAM",
+        dataset_key="work-items",
+        processor_flags={},
+    )
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv(
+        "SYNC_BUDGET_DRY_RUN_BUCKET_LIMITS",
+        json.dumps({"linear:graphql_cost:issues": 1, "linear:graphql_cost": 100}),
+    )
+    monkeypatch.setenv("SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS", "120")
+
+    with caplog.at_level(logging.INFO, logger="dev_health_ops.sync.budget_guard"):
+        result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(unit)
+    records = [
+        record
+        for record in caplog.records
+        if record.getMessage() == "dispatch_sync_run.budget_guard_dry_run"
+    ]
+    issue_record = next(record for record in records if record.route_family == "issues")
+    team_record = next(record for record in records if record.route_family == "teams")
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert run.status == SyncRunStatus.DISPATCHING.value
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert unit.available_at is None
+    assert issue_record.bucket["provider"] == "linear"
+    assert issue_record.bucket["dimension"] == "graphql_cost"
+    assert issue_record.decision == "would_defer"
+    assert issue_record.budget_limit == 1
+    assert issue_record.projected_units == 5
+    assert issue_record.suggested_available_at is not None
+    assert team_record.decision == "would_allow"
+    assert team_record.budget_limit == 100
 
 
 def test_dispatch_sync_run_enforces_budget_deferral(db_session, monkeypatch):


### PR DESCRIPTION
## Summary
- Add Linear sync budget estimator using GraphQL cost route families for issues, teams, projects, comments, attachments, cycles, and history
- Route Linear through the shared estimate_provider_budget dispatcher
- Extend budget docs/env defaults and add Linear estimator, dry-run, route-family, and sync-unit coverage

## Tests
- python -m pytest tests/providers/test_linear_budget.py tests/test_sync_units.py -q
- python -m pytest tests/providers/test_linear_budget.py tests/test_sync_units.py tests/test_linear_provider.py tests/test_linear_team_sync.py tests/workers/test_team_autoimport_linear.py -q
- bash ci/local_validate.sh

Refs CHAOS-2688
SCREENSHOT-WAIVER: backend-only, no UI render