### PR TITLE
feat(gitlab): adopt sync budgeting (CHAOS-2685)

### DIFF
--- a/src/dev_health_ops/providers/gitlab/budget.py
+++ b/src/dev_health_ops/providers/gitlab/budget.py
@@ -1,0 +1,332 @@
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Callable, Mapping
+from urllib.parse import urlparse
+
+from dev_health_ops.sync.budget_types import (
+    BudgetBucketKey,
+    BudgetDimension,
+    BudgetEstimate,
+)
+from dev_health_ops.sync.datasets import DatasetKey
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+_DEFAULT_HOST = "gitlab.com"
+_DEFAULT_BASE_URL = "https://gitlab.com"
+_CONFIDENCE_HIGH = "high"
+_CONFIDENCE_MEDIUM = "medium"
+_CONFIDENCE_LOW = "low"
+
+
+class GitLabBudgetEstimator:
+    def estimate(self, context: SyncTaskContext) -> tuple[BudgetEstimate, ...]:
+        if context.provider.lower() != "gitlab":
+            return ()
+
+        credential_fingerprint = _credential_fingerprint(
+            context.decrypted_credentials,
+            credential_id=context.credential_id,
+            integration_id=context.integration_id,
+        )
+        host = _host_from_credentials(context.decrypted_credentials)
+        dataset_key = context.dataset_key
+        flags = {
+            str(key): bool(value) for key, value in context.processor_flags.items()
+        }
+
+        estimates = list(
+            _dataset_estimates(
+                dataset_key=dataset_key,
+                flags=flags,
+                org_id=context.org_id,
+                host=host,
+                credential_fingerprint=credential_fingerprint,
+            )
+        )
+        return tuple(estimates)
+
+
+def _dataset_estimates(
+    *,
+    dataset_key: str,
+    flags: Mapping[str, bool],
+    org_id: str,
+    host: str,
+    credential_fingerprint: str,
+) -> tuple[BudgetEstimate, ...]:
+    bucket = _bucket_factory(
+        org_id=org_id,
+        host=host,
+        credential_fingerprint=credential_fingerprint,
+    )
+
+    if dataset_key == DatasetKey.REPO_METADATA.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE), 1, _CONFIDENCE_HIGH, "project"
+            ),
+        )
+
+    if dataset_key == DatasetKey.COMMITS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE), 2, _CONFIDENCE_MEDIUM, "project"
+            ),
+        )
+
+    if dataset_key == DatasetKey.COMMIT_STATS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                4,
+                _CONFIDENCE_LOW,
+                "project",
+                notes=("commit detail expansion varies by commit volume",),
+            ),
+        )
+
+    if dataset_key in {DatasetKey.FILES.value, DatasetKey.BLAME.value}:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                5 if dataset_key == DatasetKey.BLAME.value else 3,
+                _CONFIDENCE_LOW,
+                "project",
+                notes=("repository file expansion is high variance",),
+            ),
+        )
+
+    if dataset_key in {DatasetKey.PRS.value, DatasetKey.PR_REVIEWS.value}:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                4,
+                _CONFIDENCE_MEDIUM,
+                "merge_requests",
+                notes=("merge request iterators are pagination-heavy",),
+            ),
+        )
+
+    if dataset_key == DatasetKey.PR_COMMENTS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                4,
+                _CONFIDENCE_MEDIUM,
+                "merge_requests",
+                notes=("merge request iterators are pagination-heavy",),
+            ),
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                3,
+                _CONFIDENCE_LOW,
+                "notes",
+                notes=("MR note expansion varies by discussion volume",),
+            ),
+        )
+
+    if dataset_key in {
+        DatasetKey.CICD.value,
+        DatasetKey.TESTS.value,
+        DatasetKey.DEPLOYMENTS.value,
+    }:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                6,
+                _CONFIDENCE_LOW,
+                "pipelines",
+                notes=("pipeline job expansion varies by pipeline volume",),
+            ),
+        )
+
+    if dataset_key == DatasetKey.SECURITY.value:
+        return (
+            _estimate(bucket(BudgetDimension.REST_CORE), 2, _CONFIDENCE_LOW, "project"),
+        )
+
+    if dataset_key == DatasetKey.WORK_ITEM_LABELS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE), 1, _CONFIDENCE_MEDIUM, "issues"
+            ),
+        )
+
+    if dataset_key == DatasetKey.WORK_ITEM_PROJECTS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                2,
+                _CONFIDENCE_MEDIUM,
+                "milestones",
+                notes=("project and group milestone iterators may both run",),
+            ),
+        )
+
+    if dataset_key in {
+        DatasetKey.WORK_ITEMS.value,
+        DatasetKey.WORK_ITEM_HISTORY.value,
+        DatasetKey.WORK_ITEM_COMMENTS.value,
+    }:
+        estimates = [
+            _estimate(
+                bucket(BudgetDimension.REST_CORE), 1, _CONFIDENCE_HIGH, "project"
+            ),
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                2,
+                _CONFIDENCE_MEDIUM,
+                "milestones",
+                notes=("project milestone iterator runs before work-item fetch",),
+            ),
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                4,
+                _CONFIDENCE_LOW,
+                "epics",
+                notes=("group epic expansion requires premium APIs when available",),
+            ),
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                4,
+                _CONFIDENCE_MEDIUM,
+                "issues",
+                notes=("issue iterator and per-issue events are pagination-heavy",),
+            ),
+        ]
+        if dataset_key in {
+            DatasetKey.WORK_ITEMS.value,
+            DatasetKey.WORK_ITEM_COMMENTS.value,
+            DatasetKey.WORK_ITEM_HISTORY.value,
+        }:
+            estimates.append(
+                _estimate(
+                    bucket(BudgetDimension.REST_CORE),
+                    3,
+                    _CONFIDENCE_LOW,
+                    "notes",
+                    notes=("issue/MR notes and state events vary by activity",),
+                )
+            )
+        if flags.get("sync_prs", True):
+            estimates.append(
+                _estimate(
+                    bucket(BudgetDimension.REST_CORE),
+                    4,
+                    _CONFIDENCE_MEDIUM,
+                    "merge_requests",
+                    notes=("MR iterator runs alongside issue ingestion by default",),
+                )
+            )
+        return tuple(estimates)
+
+    if dataset_key == DatasetKey.FEATURE_FLAGS.value:
+        return (
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                2,
+                _CONFIDENCE_LOW,
+                "project",
+                notes=("GitLab feature-flag APIs share the REST core budget",),
+            ),
+        )
+
+    return ()
+
+
+def _bucket_factory(
+    *, org_id: str, host: str, credential_fingerprint: str
+) -> Callable[[BudgetDimension], BudgetBucketKey]:
+    def _bucket(dimension: BudgetDimension) -> BudgetBucketKey:
+        return BudgetBucketKey(
+            provider="gitlab",
+            org_id=org_id,
+            host=host,
+            credential_fingerprint=credential_fingerprint,
+            dimension=dimension,
+        )
+
+    return _bucket
+
+
+def _estimate(
+    bucket: BudgetBucketKey,
+    estimated_units: int,
+    confidence: str,
+    route_family: str,
+    *,
+    notes: tuple[str, ...] = (),
+) -> BudgetEstimate:
+    return BudgetEstimate(
+        bucket=bucket,
+        estimated_units=estimated_units,
+        confidence=confidence,
+        route_family=route_family,
+        notes=notes,
+    )
+
+
+def _host_from_credentials(credentials: object) -> str:
+    base_url = _DEFAULT_BASE_URL
+    if isinstance(credentials, Mapping):
+        raw_base_url = credentials.get("base_url") or credentials.get("baseUrl")
+        if raw_base_url:
+            base_url = str(raw_base_url)
+    host = urlparse(base_url).hostname
+    return host or _DEFAULT_HOST
+
+
+def _credential_fingerprint(
+    credentials: object, *, credential_id: str | None, integration_id: str
+) -> str:
+    safe_credentials = _safe_credential_scope(
+        credentials,
+        credential_id=credential_id,
+        integration_id=integration_id,
+    )
+    payload = json.dumps(
+        safe_credentials, sort_keys=True, default=str, separators=(",", ":")
+    )
+    return hashlib.sha256(payload.encode("utf-8")).hexdigest()
+
+
+def _safe_credential_scope(
+    credentials: object, *, credential_id: str | None, integration_id: str
+) -> dict[str, object]:
+    if not isinstance(credentials, Mapping):
+        return _fallback_credential_scope(
+            credential_id=credential_id,
+            integration_id=integration_id,
+        )
+    scope: dict[str, object] = {}
+    for key in ("user_id", "username", "group_id", "project_id"):
+        value = credentials.get(key)
+        if value is not None:
+            scope[key] = value
+    base_url = credentials.get("base_url") or credentials.get("baseUrl")
+    if base_url is not None:
+        scope["base_url"] = base_url
+    token = (
+        credentials.get("token")
+        or credentials.get("private_token")
+        or credentials.get("access_token")
+    )
+    if token:
+        scope["token_sha256"] = hashlib.sha256(str(token).encode("utf-8")).hexdigest()
+    if not scope:
+        return _fallback_credential_scope(
+            credential_id=credential_id,
+            integration_id=integration_id,
+        )
+    return scope
+
+
+def _fallback_credential_scope(
+    *, credential_id: str | None, integration_id: str
+) -> dict[str, object]:
+    return {
+        "credential_id": credential_id or "env",
+        "integration_id": integration_id,
+    }

--- a/src/dev_health_ops/sync/budget.py
+++ b/src/dev_health_ops/sync/budget.py
@@ -26,4 +26,8 @@ def estimate_provider_budget(context: SyncTaskContext) -> tuple[BudgetEstimate, 
         from dev_health_ops.providers.github.budget import GitHubBudgetEstimator
 
         return GitHubBudgetEstimator().estimate(context)
+    if context.provider.lower() == "gitlab":
+        from dev_health_ops.providers.gitlab.budget import GitLabBudgetEstimator
+
+        return GitLabBudgetEstimator().estimate(context)
     return ()

--- a/tests/providers/test_github_budget.py
+++ b/tests/providers/test_github_budget.py
@@ -227,7 +227,7 @@ def test_estimate_provider_budget_delegates_to_github_estimator() -> None:
 
 def test_estimate_provider_budget_returns_empty_for_unimplemented_provider() -> None:
     estimates = estimate_provider_budget(
-        _context(provider="gitlab", dataset_key="commits")
+        _context(provider="launchdarkly", dataset_key="feature-flags")
     )
 
     assert estimates == ()

--- a/tests/providers/test_github_budget.py
+++ b/tests/providers/test_github_budget.py
@@ -227,7 +227,7 @@ def test_estimate_provider_budget_delegates_to_github_estimator() -> None:
 
 def test_estimate_provider_budget_returns_empty_for_unimplemented_provider() -> None:
     estimates = estimate_provider_budget(
-        _context(provider="launchdarkly", dataset_key="feature-flags")
+        _context(provider="bitbucket", dataset_key="feature-flags")
     )
 
     assert estimates == ()

--- a/tests/providers/test_gitlab_budget.py
+++ b/tests/providers/test_gitlab_budget.py
@@ -1,0 +1,240 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+from dev_health_ops.providers.gitlab.budget import GitLabBudgetEstimator
+from dev_health_ops.sync.budget import BudgetDimension, estimate_provider_budget
+from dev_health_ops.sync.budget_guard import (
+    _budget_key,
+    _limit_for_bucket,
+    _parse_budget_limits,
+)
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+WINDOW_START = datetime(2026, 1, 10, tzinfo=timezone.utc)
+WINDOW_END = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+
+def _context(
+    *,
+    provider: str = "gitlab",
+    dataset_key: str,
+    processor_flags: dict[str, bool] | None = None,
+    credentials: Mapping[str, object] | None = None,
+    credential_id: str | None = "credential-1",
+) -> SyncTaskContext:
+    decrypted_credentials: dict[str, object] = {"token": "secret-token"}
+    if credentials is not None:
+        decrypted_credentials = {str(key): value for key, value in credentials.items()}
+    return SyncTaskContext(
+        unit_id="unit-1",
+        sync_run_id="run-1",
+        org_id="org-1",
+        integration_id="integration-1",
+        source_id="source-1",
+        source_external_id="full-chaos/dev-health",
+        provider=provider,
+        dataset_key=dataset_key,
+        cost_class="medium",
+        mode="incremental",
+        window_start=WINDOW_START,
+        window_end=WINDOW_END,
+        processor_flags=processor_flags or {},
+        credential_id=credential_id,
+        decrypted_credentials=decrypted_credentials,
+        db_url="clickhouse://localhost/default",
+    )
+
+
+def test_gitlab_budget_estimator_returns_project_budget_for_repo_metadata() -> None:
+    estimates = GitLabBudgetEstimator().estimate(_context(dataset_key="repo-metadata"))
+
+    assert len(estimates) == 1
+    estimate = estimates[0]
+    assert estimate.bucket.provider == "gitlab"
+    assert estimate.bucket.org_id == "org-1"
+    assert estimate.bucket.host == "gitlab.com"
+    assert estimate.bucket.dimension is BudgetDimension.REST_CORE
+    assert estimate.estimated_units == 1
+    assert estimate.confidence == "high"
+    assert estimate.route_family == "project"
+    assert estimate.to_dict()["bucket"]["dimension"] == "rest_core"
+
+
+def test_gitlab_budget_estimator_maps_known_route_families_to_rest_core() -> None:
+    work_items = GitLabBudgetEstimator().estimate(_context(dataset_key="work-items"))
+    pipelines = GitLabBudgetEstimator().estimate(_context(dataset_key="tests"))
+    pr_comments = GitLabBudgetEstimator().estimate(_context(dataset_key="pr-comments"))
+
+    assert {estimate.bucket.dimension for estimate in work_items} == {
+        BudgetDimension.REST_CORE
+    }
+    assert {estimate.route_family for estimate in work_items} == {
+        "project",
+        "milestones",
+        "epics",
+        "issues",
+        "notes",
+        "merge_requests",
+    }
+    assert [
+        (estimate.bucket.dimension, estimate.route_family) for estimate in pipelines
+    ] == [(BudgetDimension.REST_CORE, "pipelines")]
+    assert {estimate.route_family for estimate in pr_comments} == {
+        "merge_requests",
+        "notes",
+    }
+
+
+def test_gitlab_budget_route_family_limits_override_dimension_defaults() -> None:
+    issues = next(
+        estimate
+        for estimate in GitLabBudgetEstimator().estimate(
+            _context(dataset_key="work-items")
+        )
+        if estimate.route_family == "issues"
+    )
+    notes = next(
+        estimate
+        for estimate in GitLabBudgetEstimator().estimate(
+            _context(dataset_key="work-items")
+        )
+        if estimate.route_family == "notes"
+    )
+    limits = _parse_budget_limits(
+        '{"gitlab:rest_core:issues": 7, "gitlab:rest_core": 1}'
+    )
+
+    assert _budget_key(
+        issues.bucket.to_dict(), route_family=issues.route_family
+    ).endswith(":rest_core:issues")
+    assert (
+        _limit_for_bucket(
+            issues.bucket.to_dict(),
+            route_family=issues.route_family,
+            limits=limits,
+            default_limit=100,
+        )
+        == 7
+    )
+    assert (
+        _limit_for_bucket(
+            notes.bucket.to_dict(),
+            route_family=notes.route_family,
+            limits=limits,
+            default_limit=100,
+        )
+        == 1
+    )
+
+
+def test_gitlab_budget_route_family_override_parsing_ignores_invalid_values() -> None:
+    limits = _parse_budget_limits(
+        '{"gitlab:rest_core:issues": "8", "bad": "nope", "negative": -1}'
+    )
+
+    assert limits == {"gitlab:rest_core:issues": 8, "negative": 0}
+    assert _parse_budget_limits("not-json") == {}
+    assert _parse_budget_limits("[]") == {}
+
+
+def test_gitlab_budget_estimator_uses_pr_flag_for_mr_expansion() -> None:
+    estimates_without_mrs = GitLabBudgetEstimator().estimate(
+        _context(dataset_key="work-items", processor_flags={"sync_prs": False})
+    )
+    estimates_with_mrs = GitLabBudgetEstimator().estimate(
+        _context(dataset_key="work-items", processor_flags={"sync_prs": True})
+    )
+
+    assert "merge_requests" not in {
+        estimate.route_family for estimate in estimates_without_mrs
+    }
+    assert "merge_requests" in {
+        estimate.route_family for estimate in estimates_with_mrs
+    }
+
+
+def test_gitlab_budget_estimator_scopes_bucket_to_host_and_safe_credential_fields() -> (
+    None
+):
+    base_credentials = {
+        "token": "secret-token",
+        "base_url": "https://gitlab.example.com",
+    }
+    rotated_token_credentials = {
+        "token": "rotated-token",
+        "base_url": "https://gitlab.example.com",
+    }
+    user_credentials = {
+        "username": "octavia",
+        "private_token": "secret-private-token",
+        "base_url": "https://gitlab.example.com",
+    }
+
+    base = GitLabBudgetEstimator().estimate(
+        _context(dataset_key="commits", credentials=base_credentials)
+    )[0]
+    rotated = GitLabBudgetEstimator().estimate(
+        _context(dataset_key="commits", credentials=rotated_token_credentials)
+    )[0]
+    user = GitLabBudgetEstimator().estimate(
+        _context(dataset_key="commits", credentials=user_credentials)
+    )[0]
+
+    assert base.bucket.host == "gitlab.example.com"
+    assert base.bucket.credential_fingerprint != rotated.bucket.credential_fingerprint
+    assert base.bucket.credential_fingerprint != user.bucket.credential_fingerprint
+    assert "secret-token" not in str(base.to_dict())
+    assert "rotated-token" not in str(rotated.to_dict())
+    assert "secret-private-token" not in str(user.to_dict())
+
+
+def test_gitlab_budget_estimator_normalizes_camel_case_base_url_for_fingerprint() -> (
+    None
+):
+    snake = GitLabBudgetEstimator().estimate(
+        _context(
+            dataset_key="commits",
+            credentials={"token": "secret-token", "base_url": "https://gitlab.test"},
+        )
+    )[0]
+    camel = GitLabBudgetEstimator().estimate(
+        _context(
+            dataset_key="commits",
+            credentials={"token": "secret-token", "baseUrl": "https://gitlab.test"},
+        )
+    )[0]
+
+    assert snake.bucket.host == camel.bucket.host == "gitlab.test"
+    assert snake.bucket.credential_fingerprint == camel.bucket.credential_fingerprint
+
+
+def test_gitlab_budget_estimator_scopes_empty_credentials_to_integration() -> None:
+    first = GitLabBudgetEstimator().estimate(
+        _context(dataset_key="commits", credentials={}, credential_id=None)
+    )[0]
+    second = GitLabBudgetEstimator().estimate(
+        _context(dataset_key="commits", credentials={}, credential_id="credential-2")
+    )[0]
+
+    assert first.bucket.credential_fingerprint != second.bucket.credential_fingerprint
+
+
+def test_gitlab_budget_estimator_returns_empty_for_unknown_dataset() -> None:
+    assert GitLabBudgetEstimator().estimate(_context(dataset_key="unknown")) == ()
+
+
+def test_estimate_provider_budget_delegates_to_gitlab_estimator() -> None:
+    estimates = estimate_provider_budget(_context(dataset_key="repo-metadata"))
+
+    assert len(estimates) == 1
+    assert estimates[0].bucket.provider == "gitlab"
+
+
+def test_estimate_provider_budget_returns_empty_for_non_gitlab_provider() -> None:
+    estimates = estimate_provider_budget(
+        _context(provider="launchdarkly", dataset_key="feature-flags")
+    )
+
+    assert estimates == ()

--- a/tests/providers/test_linear_budget.py
+++ b/tests/providers/test_linear_budget.py
@@ -273,7 +273,7 @@ def test_estimate_provider_budget_delegates_to_linear_estimator() -> None:
 
 def test_estimate_provider_budget_returns_empty_for_different_provider() -> None:
     estimates = estimate_provider_budget(
-        _context(provider="jira", dataset_key="work-items")
+        _context(provider="bitbucket", dataset_key="work-items")
     )
 
     assert estimates == ()


### PR DESCRIPTION
## Summary
- Implements CHAOS-2685 by adding GitLab sync budget estimates for REST route families.
- Delegates GitLab contexts from the shared budget dispatcher.
- Adds GitLab budget estimator coverage and updates the non-implemented-provider fallback regression.

## Verification
- python -m pytest tests/providers/test_gitlab_budget.py -q
- python -m pytest tests/providers -k gitlab -q
- python -m pytest tests/test_processors_gitlab.py tests/test_gitlab_content_backfill.py tests/test_gitlab_dora.py tests/test_gitlab_mr_reviews.py tests/test_gitlab_provider.py tests/test_gitlab_feature_flags.py tests/test_gitlab_connector.py tests/test_work_items_gitlab_credentials.py tests/workers/test_team_autoimport_github_gitlab.py tests/providers/test_gitlab_client_ratelimit.py tests/providers/test_gitlab_ai_attribution.py -q
- python -m pytest tests/providers/test_gitlab_budget.py tests/providers/test_github_budget.py -q
- python -m ruff format --check .
- python -m ruff check .
- python -m mypy --install-types --non-interactive .
- bash ci/local_validate.sh

SCREENSHOT-WAIVER: backend-only, no UI render