### PR TITLE
fix(attribution): index every membership identity facet (CHAOS-2625)

### DIFF
--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -175,13 +175,17 @@ One path: `run_team_autoimport` → `team_autoimport_<provider>.populate()` → 
 > **aliased** member resolves to the **same canonical identity** an aliased assignee does (e.g.
 > `github:lead` → `lead@example.com`), and a non-aliased member stays `github:<login>` /
 > `gitlab:<username>` / `jira:accountid:<account_id>`. Deriving the identity directly (bypassing the
-> alias map) is the bug that broke aliased orgs. The alias-resolved identity lands in **both**
-> `team_memberships.raw_provider_user_id` (the one facet the ladder's `member_by_identity` indexes that
-> is free) **and** the `teams.members` roster (read by `TeamResolver`). `membership_facets` returns
-> *every* identity an assignee for this member could resolve to — the no-email identity, the
-> provider-qualified id, AND (when the member has an email) the resolver-mapped + normalized **email** —
-> so the roster matches an email-bearing assignee too (the ladder already matched it via `raw_email`,
-> but the roster used to miss). The `member_id` **primary** keeps its `gh:`/`gl:`/`jira:<id>`
+> alias map) is the bug that broke aliased orgs. `membership_facets` returns *every* identity an
+> assignee for this member could resolve to — the no-email identity, the provider-qualified id, AND
+> (when the member has an email) the resolver-mapped canonical + normalized **email**. ALL of them are
+> persisted to the `team_memberships.identity_facets` `Array(String)` column (migration **060**); the
+> loader `argMax`-reads it and fans **every** facet into the ladder's `member_by_identity` (alongside
+> the legacy `raw_provider_user_id` = `facets[0]` + `raw_email` slots), **and** writes them to the
+> `teams.members` roster (read by `TeamResolver`). This closes the deferred
+> **email-alias-distinct-canonical** edge (**CHAOS-2625**): when an org maps a member's provider id and
+> email to *different* canonicals (`github:lead` → canonicalA, `personal@…` → canonicalB), an assignee
+> resolving to canonicalB now hits the canonical ladder directly with `assignee_membership` provenance
+> instead of the weaker roster fallback. The `member_id` **primary** keeps its `gh:`/`gl:`/`jira:<id>`
 > form (untouched — it is the ReplacingMergeTree dedup key). A `members` cell is `yes` only when this
 > end-to-end resolution is **proven** (a no-email assignee — aliased AND non-aliased — resolves to the
 > auto-imported team via *both* paths —
@@ -212,6 +216,14 @@ One path: `run_team_autoimport` → `team_autoimport_<provider>.populate()` → 
   resolves to its team via both the canonical ladder and the roster — previously the roster stored a
   bare login the resolver never matched, so member attribution silently missed for no-email
   github/gitlab/jira assignees. The matrix above is the source of truth for what is/ isn't proven.
+- **Email-alias-distinct-canonical edge → CLOSED by CHAOS-2625:** the canonical ladder now indexes
+  *every* facet a member resolves to via the `team_memberships.identity_facets` `Array(String)` column
+  (migration 060) + loader fan-out, so a member mapped to *two different* canonicals (provider id →
+  canonicalA, email → canonicalB) attributes via the ladder on **either** canonical — previously only
+  `facets[0]` + `raw_email` were indexed, so an assignee resolving to canonicalB missed the ladder and
+  fell back to the weaker roster path. Proven in `tests/test_team_autoimport_executor.py` (canonicalB
+  ladder hit) + the provider×entity writer assertions in
+  `tests/workers/test_team_autoimport_{github_gitlab,jira,linear}.py`.
 
 ### 0.5 Drift-review reconciliation (CHAOS-2622) — rebuilt on ClickHouse
 

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -456,6 +456,7 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
                 g.member_id,
                 g.raw_provider_user_id,
                 g.raw_email,
+                g.identity_facets,
                 g.is_primary,
                 g.specificity,
                 g.priority,
@@ -469,6 +470,8 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
                     argMax(o.raw_provider_user_id, (o.updated_at, o.valid_from))
                         AS raw_provider_user_id,
                     argMax(o.raw_email, (o.updated_at, o.valid_from)) AS raw_email,
+                    argMax(o.identity_facets, (o.updated_at, o.valid_from))
+                        AS identity_facets,
                     argMax(o.is_primary, (o.updated_at, o.valid_from)) AS is_primary,
                     argMax(o.specificity, (o.updated_at, o.valid_from)) AS specificity,
                     argMax(o.priority, (o.updated_at, o.valid_from)) AS priority,
@@ -540,13 +543,21 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
                 "assignee_membership",
                 f"assignee_membership={row.get('member_id') or row.get('raw_email')}",
             )
-            for identity in (
+            identity_values = [
                 row.get("member_id"),
                 row.get("raw_provider_user_id"),
                 row.get("raw_email"),
-            ):
+            ]
+            identity_facets = row.get("identity_facets") or []
+            if isinstance(identity_facets, (list, tuple)):
+                identity_values.extend(identity_facets)
+            else:
+                identity_values.append(identity_facets)
+            seen_identity_keys: set[str] = set()
+            for identity in identity_values:
                 key = " ".join(str(identity or "").strip().lower().split())
-                if key:
+                if key and key not in seen_identity_keys:
+                    seen_identity_keys.add(key)
                     context.member_by_identity.setdefault(
                         (str(row.get("provider") or ""), key), []
                     ).append(candidate)

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -343,6 +343,7 @@ class TeamMembershipRecord:
     updated_at: datetime
     raw_provider_user_id: str | None = None
     raw_email: str | None = None
+    identity_facets: list[str] = field(default_factory=list)
     valid_to: datetime | None = None
     org_id: str = ""
 

--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -228,6 +228,7 @@ class ClickHouseCore(BaseMetricsSink):
                 "member_id",
                 "raw_provider_user_id",
                 "raw_email",
+                "identity_facets",
                 "source",
                 "is_primary",
                 "specificity",

--- a/src/dev_health_ops/migrations/clickhouse/060_team_membership_identity_facets.sql
+++ b/src/dev_health_ops/migrations/clickhouse/060_team_membership_identity_facets.sql
@@ -1,0 +1,1 @@
+ALTER TABLE team_memberships ADD COLUMN IF NOT EXISTS identity_facets Array(String) DEFAULT [];

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -1860,6 +1860,7 @@ class ClickHouseStore:
                 "member_id",
                 "raw_provider_user_id",
                 "raw_email",
+                "identity_facets",
                 "source",
                 "is_primary",
                 "specificity",
@@ -2039,6 +2040,8 @@ class ClickHouseStore:
             "source",
         }:
             return str(value or "")
+        if column == "identity_facets":
+            return list(value or [])
         return value
 
     async def insert_jira_project_ops_team_links(

--- a/src/dev_health_ops/workers/team_autoimport_github.py
+++ b/src/dev_health_ops/workers/team_autoimport_github.py
@@ -258,10 +258,9 @@ async def _membership_rows(
             # facets[0] is the alias-resolved identity (canonical email when the
             # github:<login> is aliased, else github:<login>) — the facet a
             # no-email assignee resolves to. It goes into raw_provider_user_id
-            # (the only member_by_identity slot free; member_id is the PK and
-            # keeps the bare login) AND, with the provider-qualified id, into the
-            # teams.members roster so BOTH attribution paths match aliased and
-            # non-aliased members (CHAOS-2609).
+            # (member_id is the PK and keeps the bare login), identity_facets,
+            # AND the teams.members roster so BOTH attribution paths match
+            # aliased and non-aliased members (CHAOS-2609, CHAOS-2625).
             facets = resolver.membership_facets(
                 provider=PROVIDER,
                 username=raw_identity,
@@ -279,6 +278,7 @@ async def _membership_rows(
                     member_id=member_id,
                     raw_provider_user_id=facets[0],
                     raw_email=getattr(member, "email", None),
+                    identity_facets=facets,
                     source="provider_access",
                     is_primary=0,
                     specificity=BASE_SPECIFICITY,

--- a/src/dev_health_ops/workers/team_autoimport_gitlab.py
+++ b/src/dev_health_ops/workers/team_autoimport_gitlab.py
@@ -277,10 +277,9 @@ async def _membership_rows(
             # facets[0] is the alias-resolved identity (canonical email when the
             # gitlab:<username> is aliased, else gitlab:<username>) — the facet a
             # no-email assignee resolves to. It goes into raw_provider_user_id
-            # (the only member_by_identity slot free; member_id is the PK and
-            # keeps the bare username) AND, with the provider-qualified id, into
-            # the teams.members roster so BOTH attribution paths match aliased and
-            # non-aliased members (CHAOS-2609).
+            # (member_id is the PK and keeps the bare username), identity_facets,
+            # AND the teams.members roster so BOTH attribution paths match
+            # aliased and non-aliased members (CHAOS-2609, CHAOS-2625).
             facets = resolver.membership_facets(
                 provider=PROVIDER,
                 username=raw_identity,
@@ -298,6 +297,7 @@ async def _membership_rows(
                     member_id=member_id,
                     raw_provider_user_id=facets[0],
                     raw_email=getattr(member, "email", None),
+                    identity_facets=facets,
                     source="provider_access",
                     is_primary=0,
                     specificity=BASE_SPECIFICITY,

--- a/src/dev_health_ops/workers/team_autoimport_jira.py
+++ b/src/dev_health_ops/workers/team_autoimport_jira.py
@@ -281,8 +281,9 @@ def populate(
         # facets[0] is the alias-resolved identity (canonical email when the
         # accountId is aliased, else jira:accountid:<id>) — the facet a no-email
         # assignee resolves to. raw_provider_user_id stores it (member_id PK keeps
-        # the jira:<id> form); the roster carries all facets so BOTH attribution
-        # paths match aliased and non-aliased members (CHAOS-2609).
+        # the jira:<id> form); identity_facets and the roster carry all facets so
+        # BOTH attribution paths match aliased and non-aliased members
+        # (CHAOS-2609, CHAOS-2625).
         roster_facets: list[str] = []
         for member in discovered_members:
             member_id = _member_id("jira", member.provider_identity)
@@ -315,6 +316,7 @@ def populate(
                     member_id=member_id,
                     raw_provider_user_id=facets[0],
                     raw_email=member.email,
+                    identity_facets=facets,
                     source="native",
                     is_primary=1 if member.role == "lead" else 0,
                     specificity=100,

--- a/src/dev_health_ops/workers/team_autoimport_linear.py
+++ b/src/dev_health_ops/workers/team_autoimport_linear.py
@@ -28,6 +28,7 @@ from dev_health_ops.metrics.schemas import (
     TeamProjectOwnershipRecord,
 )
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.providers.identity import load_identity_resolver
 
 _T = TypeVar("_T")
 _REAL_CLICKHOUSE_SINK_TYPE = ClickHouseMetricsSink
@@ -155,6 +156,7 @@ def populate(
         }
 
     now = datetime.now(timezone.utc)
+    resolver = load_identity_resolver()
     discovery = TeamDiscoveryService(None, org_id)
     membership = TeamMembershipService(cast(AsyncSession, None), org_id)
     teams = _run(discovery.discover_linear(api_key=linear_credentials.api_key))
@@ -224,11 +226,17 @@ def populate(
                 team_key=team_id,
             )
         )
-        team_rows[-1]["members"] = [
-            member.provider_identity for member in discovered_members
-        ]
+        roster_facets: list[str] = []
         for member in discovered_members:
             member_id = _member_id("linear", member.provider_identity)
+            facets = resolver.membership_facets(
+                provider="linear",
+                username=member.provider_identity,
+                email=member.email,
+            ) or [member.provider_identity]
+            for facet in facets:
+                if facet not in roster_facets:
+                    roster_facets.append(facet)
             member_rows.append(
                 MemberRecord(
                     org_id=org_id,
@@ -248,8 +256,9 @@ def populate(
                     provider="linear",
                     team_id=team_id,
                     member_id=member_id,
-                    raw_provider_user_id=member.provider_identity,
+                    raw_provider_user_id=facets[0],
                     raw_email=member.email,
+                    identity_facets=facets,
                     source="native",
                     is_primary=1,
                     specificity=100,
@@ -258,6 +267,7 @@ def populate(
                     updated_at=now,
                 )
             )
+        team_rows[-1]["members"] = roster_facets
 
     sink, should_close = _sink_from_kwargs(scope, kwargs)
     try:

--- a/tests/test_team_autoimport_executor.py
+++ b/tests/test_team_autoimport_executor.py
@@ -4,7 +4,10 @@ from datetime import datetime, timezone
 
 import pytest
 
+from dev_health_ops.metrics.compute_work_items import resolve_team_attribution
 from dev_health_ops.metrics.loaders.clickhouse import ClickHouseDataLoader
+from dev_health_ops.models.work_items import WorkItem
+from dev_health_ops.providers.teams import TeamResolver
 
 
 @pytest.mark.asyncio
@@ -53,6 +56,11 @@ async def test_loader_builds_team_attribution_context(
                     "member_id": "member-1",
                     "raw_provider_user_id": "jira-user-1",
                     "raw_email": "ADA@EXAMPLE.COM",
+                    "identity_facets": [
+                        "jira-user-1",
+                        "jira:accountid:member-1",
+                        "canonicalb@example.com",
+                    ],
                     "is_primary": 1,
                     "specificity": 50,
                     "priority": 20,
@@ -101,6 +109,12 @@ async def test_loader_builds_team_attribution_context(
         context.member_by_identity[("jira", "ada@example.com")][0].team_id
         == "team-member"
     )
+    assert (
+        context.member_by_identity[("jira", "canonicalb@example.com")][0].team_id
+        == "team-member"
+    )
+    membership_query = next(q for q in calls if "team_memberships" in q)
+    assert "identity_facets" in membership_query
 
     assert len(context.manual_fallbacks) == 1
     manual = context.manual_fallbacks[0]
@@ -111,3 +125,94 @@ async def test_loader_builds_team_attribution_context(
     assert manual.priority == 5
     manual_query = next(q for q in calls if "manual_attribution_fallbacks" in q)
     assert "FINAL" in manual_query
+
+
+@pytest.mark.asyncio
+async def test_loader_identity_facets_feed_assignee_membership_before_roster_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime(2026, 6, 1, tzinfo=timezone.utc)
+
+    async def fake_query(_client: object, query: str, _params: dict[str, object]):
+        if "team_project_ownership" in query or "team_repo_ownership" in query:
+            return []
+        if "team_memberships" in query:
+            return [
+                {
+                    "provider": "github",
+                    "team_id": "team-platform",
+                    "team_name": "Platform Team",
+                    "member_id": "gh:lead",
+                    "raw_provider_user_id": "canonicala@example.com",
+                    "raw_email": "personal@example.com",
+                    "identity_facets": [
+                        "canonicala@example.com",
+                        "github:lead",
+                        "canonicalb@example.com",
+                        "personal@example.com",
+                    ],
+                    "is_primary": 1,
+                    "specificity": 100,
+                    "priority": 10,
+                    "updated_at": now,
+                }
+            ]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.metrics.loaders.clickhouse._clickhouse_query_dicts",
+        fake_query,
+    )
+
+    context = await ClickHouseDataLoader(
+        object(), org_id="org-1"
+    ).load_team_attribution_context(as_of=now)
+    assert (
+        context.member_by_identity[("github", "canonicalb@example.com")][0].evidence
+        == "assignee_membership=gh:lead"
+    )
+
+    item = WorkItem(
+        work_item_id="gh:full-chaos/dev-health#2625",
+        provider="github",
+        title="Distinct canonical assignee",
+        type="issue",
+        status="done",
+        status_raw="Done",
+        created_at=now,
+        updated_at=now,
+        assignees=["canonicalb@example.com"],
+        labels=[],
+    )
+    roster_fallback = TeamResolver(
+        member_to_team={"canonicalb@example.com": ("team-platform", "Platform Team")}
+    )
+
+    team_id, _, candidates = resolve_team_attribution(
+        item,
+        roster_fallback,
+        None,
+        attribution_context=context,
+    )
+
+    assert team_id == "team-platform"
+    assert candidates[0].source == "assignee_membership"
+    assert candidates[0].evidence == "assignee_membership=gh:lead"
+    assert candidates[0].specificity == 100
+    assert any(
+        candidate.evidence == "assignee=canonicalb@example.com"
+        for candidate in candidates
+    )
+    assert candidates.index(
+        next(
+            candidate
+            for candidate in candidates
+            if candidate.evidence == "assignee_membership=gh:lead"
+        )
+    ) < candidates.index(
+        next(
+            candidate
+            for candidate in candidates
+            if candidate.evidence == "assignee=canonicalb@example.com"
+        )
+    )

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -9,6 +9,7 @@ from dev_health_ops.api.admin.schemas_flat import DiscoveredMember, DiscoveredTe
 from dev_health_ops.api.services.configuration.team_discovery import (
     GitLabDiscoveryResult,
 )
+from dev_health_ops.providers.identity import IdentityResolver
 from dev_health_ops.workers import team_autoimport_github, team_autoimport_gitlab
 
 
@@ -47,6 +48,14 @@ def test_github_org_import_writes_provider_access_repo_grants_and_nested_specifi
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sink = RecordingSink()
+    resolver = IdentityResolver(
+        alias_to_canonical={
+            "github:platform-lead": "canonical-platform-id@example.com",
+            "platform@example.com": "canonical-platform-email@example.com",
+            "github:platform-api-lead": "canonical-platform-api-id@example.com",
+            "platform-api@example.com": "canonical-platform-api-email@example.com",
+        }
+    )
 
     async def discover_github(self, token: str, org_name: str) -> list[DiscoveredTeam]:
         return [
@@ -96,6 +105,9 @@ def test_github_org_import_writes_provider_access_repo_grants_and_nested_specifi
     monkeypatch.setattr(
         team_autoimport_github, "ClickHouseMetricsSink", lambda dsn: sink
     )
+    monkeypatch.setattr(
+        team_autoimport_github, "load_identity_resolver", lambda: resolver
+    )
 
     summary = team_autoimport_github.populate(
         org_id="org-1",
@@ -126,22 +138,50 @@ def test_github_org_import_writes_provider_access_repo_grants_and_nested_specifi
     # resolver-consumed github:<login> (no-email assignee) AND the member's email
     # (email-bearing assignee) — so the secondary TeamResolver matches both.
     rosters = {row["id"]: row["members"] for row in sink.teams}
-    assert rosters["gh:platform"] == ["github:platform-lead", "platform@example.com"]
+    assert rosters["gh:platform"] == [
+        "canonical-platform-id@example.com",
+        "github:platform-lead",
+        "canonical-platform-email@example.com",
+        "platform@example.com",
+    ]
     assert rosters["gh:platform-api"] == [
+        "canonical-platform-api-id@example.com",
         "github:platform-api-lead",
+        "canonical-platform-api-email@example.com",
         "platform-api@example.com",
     ]
     # The single canonical-ladder facet (raw_provider_user_id) carries the
     # no-email identity; raw_email carries the email; member_id (PK) keeps gh:.
     by_member = {row.member_id: row for row in sink.memberships}
-    assert by_member["gh:platform-lead"].raw_provider_user_id == "github:platform-lead"
+    assert (
+        by_member["gh:platform-lead"].raw_provider_user_id
+        == "canonical-platform-id@example.com"
+    )
     assert by_member["gh:platform-lead"].raw_email == "platform@example.com"
+    assert by_member["gh:platform-lead"].identity_facets == [
+        "canonical-platform-id@example.com",
+        "github:platform-lead",
+        "canonical-platform-email@example.com",
+        "platform@example.com",
+    ]
+    assert by_member["gh:platform-api-lead"].identity_facets == [
+        "canonical-platform-api-id@example.com",
+        "github:platform-api-lead",
+        "canonical-platform-api-email@example.com",
+        "platform-api@example.com",
+    ]
 
 
 def test_gitlab_group_import_writes_provider_access_project_ownership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     sink = RecordingSink()
+    resolver = IdentityResolver(
+        alias_to_canonical={
+            "gitlab:full-chaos": "canonical-gitlab-root@example.com",
+            "gitlab:full-chaos-dev-health": "canonical-gitlab-dev-health@example.com",
+        }
+    )
 
     async def discover_gitlab(
         self, token: str, group_path: str, url: str
@@ -193,6 +233,9 @@ def test_gitlab_group_import_writes_provider_access_project_ownership(
     monkeypatch.setattr(
         team_autoimport_gitlab, "ClickHouseMetricsSink", lambda dsn: sink
     )
+    monkeypatch.setattr(
+        team_autoimport_gitlab, "load_identity_resolver", lambda: resolver
+    )
 
     summary = team_autoimport_gitlab.populate(
         org_id="org-1",
@@ -234,10 +277,27 @@ def test_gitlab_group_import_writes_provider_access_project_ownership(
     # entries are the RESOLVER-CONSUMED identity (gitlab:<username>), and the
     # canonical-ladder facet (raw_provider_user_id) carries the same identity.
     rosters = {row["id"]: row["members"] for row in sink.teams}
-    assert rosters["gl:full-chaos"] == ["gitlab:full-chaos"]
-    assert rosters["gl:full-chaos/dev-health"] == ["gitlab:full-chaos-dev-health"]
+    assert rosters["gl:full-chaos"] == [
+        "canonical-gitlab-root@example.com",
+        "gitlab:full-chaos",
+    ]
+    assert rosters["gl:full-chaos/dev-health"] == [
+        "canonical-gitlab-dev-health@example.com",
+        "gitlab:full-chaos-dev-health",
+    ]
     by_member = {row.member_id: row for row in sink.memberships}
-    assert by_member["gl:full-chaos"].raw_provider_user_id == "gitlab:full-chaos"
+    assert (
+        by_member["gl:full-chaos"].raw_provider_user_id
+        == "canonical-gitlab-root@example.com"
+    )
+    assert by_member["gl:full-chaos"].identity_facets == [
+        "canonical-gitlab-root@example.com",
+        "gitlab:full-chaos",
+    ]
+    assert by_member["gl:full-chaos-dev-health"].identity_facets == [
+        "canonical-gitlab-dev-health@example.com",
+        "gitlab:full-chaos-dev-health",
+    ]
     # CHAOS-2609 (CS-COV) item 7: a nested subgroup's ownership is more specific
     # than its parent group's, so it wins on specificity tie-breaks.
     parent_proj = next(

--- a/tests/workers/test_team_autoimport_jira.py
+++ b/tests/workers/test_team_autoimport_jira.py
@@ -13,6 +13,7 @@ from dev_health_ops.metrics.schemas import (
     TeamMembershipRecord,
     TeamProjectOwnershipRecord,
 )
+from dev_health_ops.providers.identity import IdentityResolver
 from dev_health_ops.workers import team_autoimport, team_autoimport_jira
 
 
@@ -97,6 +98,13 @@ class CapturingClickHouseSink(FakeDimensionSink):
 def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_links(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    resolver = IdentityResolver(
+        alias_to_canonical={
+            "jira:accountid:account-1": "canonical-jira-id@example.com",
+            "ops@example.com": "canonical-jira-email@example.com",
+        }
+    )
+
     async def discover_jira(
         self: object, email: str, api_token: str, url: str
     ) -> list[DiscoveredTeam]:
@@ -136,6 +144,9 @@ def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_
         team_autoimport_jira.TeamMembershipService,
         "discover_members_jira_bulk",
         discover_members_jira_bulk,
+    )
+    monkeypatch.setattr(
+        team_autoimport_jira, "load_identity_resolver", lambda: resolver
     )
     legacy_links = [
         {
@@ -177,6 +188,21 @@ def test_jira_populate_writes_native_and_jira_legacy_ownership_without_touching_
         "jira_legacy",
     ) in sink.ownership
     assert ("org-1", "jira:account-1") in sink.members
+    membership = sink.memberships[("org-1", "jira", "OPS", "jira:account-1", "native")]
+    assert membership.raw_provider_user_id == "canonical-jira-id@example.com"
+    assert membership.raw_email == "ops@example.com"
+    assert membership.identity_facets == [
+        "canonical-jira-id@example.com",
+        "jira:accountid:account-1",
+        "canonical-jira-email@example.com",
+        "ops@example.com",
+    ]
+    assert sink.teams[("org-1", "OPS")]["members"] == [
+        "canonical-jira-id@example.com",
+        "jira:accountid:account-1",
+        "canonical-jira-email@example.com",
+        "ops@example.com",
+    ]
     # CHAOS-2609 (CS-COV) item 6: assert the emitted native ProjectRecord fields.
     project = sink.projects[("org-1", "jira", "org-1:jira:OPS")]
     assert project.project_key == "OPS"

--- a/tests/workers/test_team_autoimport_linear.py
+++ b/tests/workers/test_team_autoimport_linear.py
@@ -12,6 +12,7 @@ from dev_health_ops.metrics.schemas import (
     TeamMembershipRecord,
     TeamProjectOwnershipRecord,
 )
+from dev_health_ops.providers.identity import IdentityResolver
 from dev_health_ops.workers import team_autoimport, team_autoimport_linear
 
 
@@ -82,6 +83,13 @@ class CapturingClickHouseSink(FakeDimensionSink):
 def test_linear_populate_writes_projects_memberships_and_project_ownership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    resolver = IdentityResolver(
+        alias_to_canonical={
+            "linear:dev@example.com": "canonical-linear-id@example.com",
+            "dev@example.com": "canonical-linear-email@example.com",
+        }
+    )
+
     async def discover_linear(self: object, api_key: str) -> list[DiscoveredTeam]:
         return [
             DiscoveredTeam(
@@ -114,6 +122,12 @@ def test_linear_populate_writes_projects_memberships_and_project_ownership(
         "discover_members_linear",
         discover_members_linear,
     )
+    monkeypatch.setattr(
+        team_autoimport_linear,
+        "load_identity_resolver",
+        lambda: resolver,
+        raising=False,
+    )
     sink = _fake_sink()
 
     summary = team_autoimport_linear.populate(
@@ -136,6 +150,17 @@ def test_linear_populate_writes_projects_memberships_and_project_ownership(
         "linear:dev@example.com",
         "native",
     ) in sink.memberships
+    membership = sink.memberships[
+        ("org-1", "linear", "ENG", "linear:dev@example.com", "native")
+    ]
+    assert membership.raw_provider_user_id == "canonical-linear-id@example.com"
+    assert membership.raw_email == "dev@example.com"
+    assert membership.identity_facets == [
+        "canonical-linear-id@example.com",
+        "linear:dev@example.com",
+        "canonical-linear-email@example.com",
+        "dev@example.com",
+    ]
     assert (
         "org-1",
         "linear",
@@ -144,6 +169,12 @@ def test_linear_populate_writes_projects_memberships_and_project_ownership(
         "native",
     ) in sink.ownership
     assert sink.teams[("org-1", "ENG")]["native_team_key"] == "ENG"
+    assert sink.teams[("org-1", "ENG")]["members"] == [
+        "canonical-linear-id@example.com",
+        "linear:dev@example.com",
+        "canonical-linear-email@example.com",
+        "dev@example.com",
+    ]
     # CHAOS-2609 (CS-COV) item 5: linear native projects ARE ingested via
     # team.associations.project_keys — assert the emitted ProjectRecord fields.
     project = sink.projects[("org-1", "linear", "org-1:linear:ENG")]


### PR DESCRIPTION
## CHAOS-2625 — CS-COV follow-up: email-alias-distinct-canonical membership edge

Closes the edge deferred from CHAOS-2609 (parent CHAOS-2600).

### Problem
An org's `identity_mapping` can map a member's provider id and email to **different** canonicals (`github:lead` → canonicalA, `personal@…` → canonicalB). The authoritative attribution ladder (`member_by_identity`, built from `team_memberships`) indexed only `raw_provider_user_id` (= `facets[0]`) + `raw_email`, so an assignee resolving to the **alternate** canonical missed the ladder and fell back to the weaker secondary roster path (degraded `assignee_membership` provenance).

`IdentityResolver.membership_facets()` already computes every canonical a member resolves to — only `facets[0]` was being persisted.

### Fix — store & index every facet
- **Migration 060**: `team_memberships.identity_facets Array(String) DEFAULT []` (additive; `member_id` RMT dedup key untouched — mirrors the existing `teams.members Array(String)` pattern).
- **Writers** (github/gitlab/jira/linear) persist the full `membership_facets()` list.
- **Loader** `argMax`-reads `identity_facets` and fans **every** facet into `member_by_identity`, deduped, using the same normalization key as the assignee lookup.
- **Storage normalizer** coerces `identity_facets` to a list so a dict row missing the key cannot insert null into the non-nullable `Array`.
- **Back-compat**: `raw_provider_user_id = facets[0]` + `raw_email` still written and indexed. Resolver precedence unchanged.

### Tests & validation
- `ci/local_validate.sh`: **GATE PASSED** — ruff + mypy clean, **5749 passed / 45 skipped**, live-ClickHouse argMax exec proof green.
- New marquee e2e: a member with `github:lead → canonicalA` AND `personal@… → canonicalB` — an assignee resolving to canonicalB now hits the ladder (`member_by_identity[(provider, canonicalB)]`) with real `assignee_membership` provenance, asserted to win over the roster fallback.
- Provider × entity writer coverage for `identity_facets` across github/gitlab/jira/linear.
- Docs `architecture/team-attribution.md` §0.4/§0.4a mark the edge **CLOSED**; matrix stays green.

### Rollout note
Existing `team_memberships` rows get `identity_facets = []` until auto-import reruns — **no regression** (`member_id`/`raw_provider_user_id`/`raw_email` still indexed). Rerun auto-import for immediate closure on existing orgs.

SCREENSHOT-WAIVER: backend attribution storage/read path, no UI render.
