### PR TITLE
fix(github): retry transient 5xx at REST request level (CHAOS-2704)

### DIFF
--- a/src/dev_health_ops/connectors/utils/github_app.py
+++ b/src/dev_health_ops/connectors/utils/github_app.py
@@ -8,13 +8,24 @@ from typing import Any
 import jwt
 import requests
 
+from dev_health_ops.connectors.utils.retry import retry_with_backoff
+
 GITHUB_API_BASE_URL = "https://api.github.com"
 JWT_TTL_SECONDS = 600
 INSTALLATION_TOKEN_REFRESH_WINDOW_SECONDS = 300
+TOKEN_EXCHANGE_MAX_RETRIES = (
+    3  # total attempts (initial + retries), per retry_with_backoff
+)
+TOKEN_EXCHANGE_INITIAL_DELAY_SECONDS = 1.0
+TOKEN_EXCHANGE_MAX_DELAY_SECONDS = 10.0
 
 
 class GitHubAppAuthError(RuntimeError):
     """Raised when GitHub App authentication cannot produce an access token."""
+
+
+class GitHubAppTransientError(GitHubAppAuthError):
+    """Transient GitHub App auth failure (5xx / network) that is safe to retry."""
 
 
 @dataclass(frozen=True)
@@ -82,6 +93,12 @@ class GitHubAppTokenProvider:
         now = datetime.now(timezone.utc)
         return (expires_at - now).total_seconds() <= self.refresh_window_seconds
 
+    @retry_with_backoff(
+        max_retries=TOKEN_EXCHANGE_MAX_RETRIES,
+        initial_delay=TOKEN_EXCHANGE_INITIAL_DELAY_SECONDS,
+        max_delay=TOKEN_EXCHANGE_MAX_DELAY_SECONDS,
+        exceptions=(GitHubAppTransientError,),
+    )
     def _exchange_installation_token(self) -> InstallationToken:
         app_jwt = create_github_app_jwt(
             app_id=self.app_id,
@@ -91,16 +108,25 @@ class GitHubAppTokenProvider:
             f"{self.api_base_url}/app/installations/"
             f"{self.installation_id}/access_tokens"
         )
-        response = requests.post(
-            url,
-            headers={
-                "Accept": "application/vnd.github+json",
-                "Authorization": f"Bearer {app_jwt}",
-                "X-GitHub-Api-Version": "2022-11-28",
-            },
-            timeout=self.timeout,
-        )
+        try:
+            response = requests.post(
+                url,
+                headers={
+                    "Accept": "application/vnd.github+json",
+                    "Authorization": f"Bearer {app_jwt}",
+                    "X-GitHub-Api-Version": "2022-11-28",
+                },
+                timeout=self.timeout,
+            )
+        except requests.RequestException as exc:
+            raise GitHubAppTransientError(
+                f"GitHub App installation token exchange request failed: {exc}"
+            ) from exc
         if response.status_code >= 400:
+            if 500 <= response.status_code < 600:
+                raise GitHubAppTransientError(
+                    f"GitHub App installation token exchange failed: HTTP {response.status_code}"
+                )
             raise GitHubAppAuthError(
                 f"GitHub App installation token exchange failed: HTTP {response.status_code}"
             )

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -2,12 +2,15 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 import time
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, NoReturn, Protocol, TypedDict, TypeVar, cast
 from urllib.parse import urlparse
+
+from urllib3.util.retry import Retry
 
 from dev_health_ops.connectors.exceptions import (
     APIException,
@@ -30,6 +33,78 @@ from dev_health_ops.credentials.types import GitHubCredentials
 from dev_health_ops.providers._ratelimit import gate_call
 
 logger = logging.getLogger(__name__)
+
+
+def _github_http_backoff_max() -> float:
+    """Return the maximum backoff cap in seconds for GitHub REST retries.
+
+    Reads ``GITHUB_HTTP_BACKOFF_MAX`` from the environment (default 30).
+    Always returns at least 1.0 second.
+    """
+    try:
+        return max(1.0, float(os.getenv("GITHUB_HTTP_BACKOFF_MAX", "30")))
+    except ValueError:
+        return 30.0
+
+
+def _github_http_retry() -> Retry | int:
+    """Return a bounded urllib3 Retry for idempotent GitHub REST reads.
+
+    Only 502/503/504 (transient infrastructure errors) are retried, and only
+    for safe methods (GET/HEAD/OPTIONS).  4xx responses — including 403
+    rate-limit — are intentionally excluded so RateLimitGate and
+    _raise_github_exception keep full ownership of rate-limit semantics.
+    Mutations (POST/PATCH/PUT/DELETE) are never retried to avoid double-writes.
+    ``raise_on_status=False`` lets PyGithub surface the final 5xx as its
+    normal GithubException rather than a urllib3 MaxRetryError.
+
+    ``respect_retry_after_header=False`` is intentional: urllib3 v2's
+    ``is_retry()`` retries 413/429/503 when they carry a ``Retry-After``
+    header and ``respect_retry_after_header=True``, even if those codes are
+    not in ``status_forcelist``.  That would silently transport-retry GitHub
+    secondary-rate-limit 429s instead of letting them surface as
+    ``RateLimitException`` for the worker deferral path, and would sleep for
+    an unbounded ``Retry-After`` (urllib3 default ``retry_after_max`` ~6 h)
+    inside a single ``RateLimitGate`` call, outside the socket timeout.
+    With ``respect_retry_after_header=False`` only the codes in
+    ``status_forcelist`` are retried, using bounded exponential backoff
+    (capped at ``backoff_max``) — never a ``Retry-After`` sleep.
+    """
+    try:
+        total = int(os.getenv("GITHUB_HTTP_MAX_RETRIES", "3"))
+    except ValueError:
+        total = 3
+    if total <= 0:
+        return 0
+    try:
+        backoff = float(os.getenv("GITHUB_HTTP_BACKOFF_FACTOR", "1.0"))
+    except ValueError:
+        backoff = 1.0
+    return Retry(
+        total=total,
+        connect=total,
+        read=total,
+        status=total,
+        status_forcelist=(502, 503, 504),
+        allowed_methods=frozenset({"GET", "HEAD", "OPTIONS"}),
+        backoff_factor=backoff,
+        backoff_max=_github_http_backoff_max(),
+        respect_retry_after_header=False,
+        raise_on_status=False,
+    )
+
+
+def _github_http_timeout() -> int:
+    """Return the HTTP timeout in seconds for PyGithub REST calls.
+
+    Reads ``GITHUB_HTTP_TIMEOUT_SECONDS`` from the environment (default 30).
+    Always returns at least 1 second.
+    """
+    try:
+        return max(1, int(os.getenv("GITHUB_HTTP_TIMEOUT_SECONDS", "30")))
+    except ValueError:
+        return 30
+
 
 _DIAGNOSTIC_HEADER_NAMES = (
     "x-ratelimit-limit",
@@ -318,13 +393,15 @@ class GitHubWorkClient:
                 base_url=auth.base_url,
                 auth=pygithub_auth,
                 per_page=self.per_page,
-                retry=None,
+                retry=_github_http_retry(),
+                timeout=_github_http_timeout(),
             )
         else:
             self.github = Github(
                 auth=pygithub_auth,
                 per_page=self.per_page,
-                retry=None,
+                retry=_github_http_retry(),
+                timeout=_github_http_timeout(),
             )
 
         # GraphQL client (api.github.com only for now).

--- a/tests/providers/test_github_iter_with_limit.py
+++ b/tests/providers/test_github_iter_with_limit.py
@@ -1,4 +1,4 @@
-"""Test GitHubWorkClient._iter_with_limit generic helper."""
+"""Test GitHubWorkClient._iter_with_limit generic helper and HTTP retry/timeout helpers."""
 
 from __future__ import annotations
 
@@ -57,3 +57,259 @@ class TestIterWithLimit:
 
         result = list(client._iter_with_limit(source, limit=2, skip=skip_evens))
         assert result == [1, 3]
+
+
+# ============================================================================
+# HTTP retry / timeout helpers
+# ============================================================================
+
+
+class TestGithubHttpRetry:
+    def test_returns_retry_with_correct_status_forcelist(self) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert set(result.status_forcelist) == {502, 503, 504}
+
+    def test_allowed_methods_are_safe_only(self) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert result.allowed_methods == frozenset({"GET", "HEAD", "OPTIONS"})
+
+    def test_env_override_max_retries(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        monkeypatch.setenv("GITHUB_HTTP_MAX_RETRIES", "5")
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert result.total == 5
+
+    def test_env_override_backoff_factor(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        monkeypatch.setenv("GITHUB_HTTP_BACKOFF_FACTOR", "2.5")
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert result.backoff_factor == 2.5
+
+    def test_zero_or_negative_max_retries_returns_int_zero(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        monkeypatch.setenv("GITHUB_HTTP_MAX_RETRIES", "0")
+        assert _github_http_retry() == 0
+
+        monkeypatch.setenv("GITHUB_HTTP_MAX_RETRIES", "-1")
+        assert _github_http_retry() == 0
+
+    def test_invalid_max_retries_env_falls_back_to_3(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        monkeypatch.setenv("GITHUB_HTTP_MAX_RETRIES", "not-a-number")
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert result.total == 3
+
+    def test_invalid_backoff_env_falls_back_to_1_0(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        monkeypatch.setenv("GITHUB_HTTP_BACKOFF_FACTOR", "bad")
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert result.backoff_factor == 1.0
+
+    def test_respect_retry_after_header_is_false(self) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert result.respect_retry_after_header is False
+
+    def test_raise_on_status_is_false(self) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert result.raise_on_status is False
+
+    def test_429_with_retry_after_is_not_retried(self) -> None:
+        """429 with Retry-After must NOT be retried at the transport layer.
+
+        urllib3 v2 is_retry() retries 413/429/503 when they carry a
+        Retry-After header and respect_retry_after_header=True, even if
+        those codes are absent from status_forcelist.  We set
+        respect_retry_after_header=False so 429s always surface as
+        GithubException -> RateLimitException for the worker deferral path.
+        """
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        retry = _github_http_retry()
+        assert not isinstance(retry, int), "retry must be a Retry object for this test"
+        assert retry.is_retry("GET", 429, has_retry_after=True) is False
+
+    def test_503_by_status_is_retried(self) -> None:
+        """503 in status_forcelist must be retried (no Retry-After needed)."""
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        retry = _github_http_retry()
+        assert not isinstance(retry, int), "retry must be a Retry object for this test"
+        assert retry.is_retry("GET", 503, has_retry_after=False) is True
+
+    def test_backoff_max_default_is_30(self) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert result.backoff_max == 30.0
+
+    def test_backoff_max_env_override(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        monkeypatch.setenv("GITHUB_HTTP_BACKOFF_MAX", "60")
+        result = _github_http_retry()
+        assert isinstance(result, Retry)
+        assert result.backoff_max == 60.0
+
+    def test_503_retried_up_to_total_then_exhausted(self) -> None:
+        """Behavioral: urllib3 Retry.increment drives 503 retries up to total.
+
+        No mock HTTP library is available (responses/requests_mock absent).
+        We drive urllib3's Retry state machine directly via increment() to
+        prove that a 503 is counted as a retry attempt and that the counter
+        exhausts after `total` increments, matching the bounded-retry contract.
+        """
+        import urllib3.exceptions
+        from urllib3.response import HTTPResponse
+        from urllib3.util.retry import Retry
+
+        from dev_health_ops.providers.github.client import _github_http_retry
+
+        retry = _github_http_retry()
+        assert isinstance(retry, Retry)
+        total = retry.total
+        assert isinstance(total, int)
+
+        # Simulate `total` consecutive 503 responses via increment().
+        # Each call returns a new Retry with a decremented counter.
+        current = retry
+        for _ in range(total):
+            response = HTTPResponse(status=503)
+            current = current.increment(method="GET", url="/", response=response)
+
+        # After exhausting all retries the next increment must raise MaxRetryError.
+        response = HTTPResponse(status=503)
+        with pytest.raises(urllib3.exceptions.MaxRetryError):
+            current.increment(method="GET", url="/", response=response)
+
+
+class TestGithubHttpTimeout:
+    def test_default_timeout_is_30(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dev_health_ops.providers.github.client import _github_http_timeout
+
+        monkeypatch.delenv("GITHUB_HTTP_TIMEOUT_SECONDS", raising=False)
+        assert _github_http_timeout() == 30
+
+    def test_env_override_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dev_health_ops.providers.github.client import _github_http_timeout
+
+        monkeypatch.setenv("GITHUB_HTTP_TIMEOUT_SECONDS", "60")
+        assert _github_http_timeout() == 60
+
+    def test_invalid_env_falls_back_to_30(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev_health_ops.providers.github.client import _github_http_timeout
+
+        monkeypatch.setenv("GITHUB_HTTP_TIMEOUT_SECONDS", "oops")
+        assert _github_http_timeout() == 30
+
+    def test_minimum_is_1(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dev_health_ops.providers.github.client import _github_http_timeout
+
+        monkeypatch.setenv("GITHUB_HTTP_TIMEOUT_SECONDS", "0")
+        assert _github_http_timeout() == 1
+
+        monkeypatch.setenv("GITHUB_HTTP_TIMEOUT_SECONDS", "-5")
+        assert _github_http_timeout() == 1
+
+
+class TestGithubWorkClientUsesRetry:
+    def test_github_constructed_with_non_none_retry(self) -> None:
+        """GitHubWorkClient must pass a non-None retry to Github().
+
+        Mirrors the patch pattern used in test_github_app_auth.py.
+        """
+        from urllib3.util.retry import Retry
+
+        with (
+            patch("github.Github") as github_cls,
+            patch("dev_health_ops.providers.github.client.GitHubGraphQLClient"),
+        ):
+            GitHubWorkClient(auth=GitHubAuth(token="fake"))
+
+        github_cls.assert_called_once()
+        call_kwargs = github_cls.call_args.kwargs
+        retry_arg = call_kwargs.get("retry")
+        assert retry_arg is not None, "Github() must be called with a non-None retry"
+        assert isinstance(retry_arg, (Retry, int))
+
+    def test_github_constructed_with_timeout(self) -> None:
+        """GitHubWorkClient must pass a timeout to Github()."""
+        with (
+            patch("github.Github") as github_cls,
+            patch("dev_health_ops.providers.github.client.GitHubGraphQLClient"),
+        ):
+            GitHubWorkClient(auth=GitHubAuth(token="fake"))
+
+        call_kwargs = github_cls.call_args.kwargs
+        assert "timeout" in call_kwargs
+        assert call_kwargs["timeout"] >= 1
+
+    def test_github_constructed_with_base_url_uses_retry(self) -> None:
+        """The base_url branch also passes retry and timeout."""
+        from urllib3.util.retry import Retry
+
+        with (
+            patch("github.Github") as github_cls,
+            patch("dev_health_ops.providers.github.client.GitHubGraphQLClient"),
+        ):
+            GitHubWorkClient(
+                auth=GitHubAuth(
+                    token="fake", base_url="https://github.example.com/api/v3"
+                )
+            )
+
+        github_cls.assert_called_once()
+        call_kwargs = github_cls.call_args.kwargs
+        retry_arg = call_kwargs.get("retry")
+        assert retry_arg is not None
+        assert isinstance(retry_arg, (Retry, int))
+        assert "timeout" in call_kwargs

--- a/tests/providers/test_github_pr_social_batch.py
+++ b/tests/providers/test_github_pr_social_batch.py
@@ -27,7 +27,7 @@ def _client() -> tuple[GitHubWorkClient, MagicMock, MagicMock]:
     return client, graphql_cls.return_value, gate
 
 
-def test_work_client_uses_pygithub_token_auth_without_internal_retry() -> None:
+def test_work_client_uses_pygithub_token_auth_with_retry() -> None:
     gate = MagicMock()
     with (
         patch("github.Github") as github_cls,
@@ -37,13 +37,11 @@ def test_work_client_uses_pygithub_token_auth_without_internal_retry() -> None:
 
     _, kwargs = github_cls.call_args
     assert kwargs["auth"].__class__.__name__ == "Token"
-    assert kwargs["retry"] is None
+    assert kwargs["retry"] is not None
     assert "login_or_token" not in kwargs
 
 
-def test_work_client_uses_pygithub_app_installation_auth_without_internal_retry() -> (
-    None
-):
+def test_work_client_uses_pygithub_app_installation_auth_with_retry() -> None:
     gate = MagicMock()
     with (
         patch("github.Github") as github_cls,
@@ -65,7 +63,7 @@ def test_work_client_uses_pygithub_app_installation_auth_without_internal_retry(
     _, kwargs = github_cls.call_args
     assert kwargs["auth"].__class__.__name__ == "AppInstallationAuth"
     assert kwargs["auth"].installation_id == 456
-    assert kwargs["retry"] is None
+    assert kwargs["retry"] is not None
     assert "login_or_token" not in kwargs
 
 

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -4,11 +4,15 @@ from datetime import datetime, timedelta, timezone
 from unittest.mock import Mock, patch
 
 import pytest
+import requests
 
 from dev_health_ops.cli import build_parser
 from dev_health_ops.connectors.github import GitHubConnector
 from dev_health_ops.connectors.utils.github_app import (
+    TOKEN_EXCHANGE_MAX_RETRIES,
+    GitHubAppAuthError,
     GitHubAppTokenProvider,
+    GitHubAppTransientError,
     create_github_app_jwt,
 )
 from dev_health_ops.credentials import CredentialSource, GitHubCredentials
@@ -194,3 +198,112 @@ def test_sync_git_cli_rejects_pat_and_app_flags(tmp_path) -> None:
 
     with pytest.raises(SystemExit, match="exactly one mode"):
         _resolve_github_sync_credentials(ns)
+
+
+def _ok_token_response() -> Mock:
+    expires_at = (datetime.now(timezone.utc) + timedelta(minutes=20)).isoformat()
+    response = Mock(status_code=201)
+    response.json.return_value = {
+        "token": "installation-token",
+        "expires_at": expires_at,
+    }
+    return response
+
+
+def test_installation_token_exchange_retries_transient_5xx() -> None:
+    transient = Mock(status_code=503)
+    with (
+        patch(
+            "dev_health_ops.connectors.utils.github_app.create_github_app_jwt",
+            return_value="app-jwt",
+        ),
+        patch("dev_health_ops.connectors.utils.retry.time.sleep"),
+        patch(
+            "dev_health_ops.connectors.utils.github_app.requests.post",
+            side_effect=[transient, _ok_token_response()],
+        ) as post,
+    ):
+        provider = GitHubAppTokenProvider(
+            app_id="12345",
+            private_key="synthetic-private-key",
+            installation_id="67890",
+        )
+        token = provider.get_token()
+
+    assert token == "installation-token"
+    assert post.call_count == 2
+
+
+def test_installation_token_exchange_retries_network_error() -> None:
+    with (
+        patch(
+            "dev_health_ops.connectors.utils.github_app.create_github_app_jwt",
+            return_value="app-jwt",
+        ),
+        patch("dev_health_ops.connectors.utils.retry.time.sleep"),
+        patch(
+            "dev_health_ops.connectors.utils.github_app.requests.post",
+            side_effect=[requests.ConnectionError("boom"), _ok_token_response()],
+        ) as post,
+    ):
+        provider = GitHubAppTokenProvider(
+            app_id="12345",
+            private_key="synthetic-private-key",
+            installation_id="67890",
+        )
+        token = provider.get_token()
+
+    assert token == "installation-token"
+    assert post.call_count == 2
+
+
+def test_installation_token_exchange_does_not_retry_4xx() -> None:
+    forbidden = Mock(status_code=401)
+    with (
+        patch(
+            "dev_health_ops.connectors.utils.github_app.create_github_app_jwt",
+            return_value="app-jwt",
+        ),
+        patch("dev_health_ops.connectors.utils.retry.time.sleep") as sleep,
+        patch(
+            "dev_health_ops.connectors.utils.github_app.requests.post",
+            return_value=forbidden,
+        ) as post,
+    ):
+        provider = GitHubAppTokenProvider(
+            app_id="12345",
+            private_key="synthetic-private-key",
+            installation_id="67890",
+        )
+        with pytest.raises(GitHubAppAuthError) as excinfo:
+            provider.get_token()
+
+    assert not isinstance(excinfo.value, GitHubAppTransientError)
+    post.assert_called_once()
+    sleep.assert_not_called()
+
+
+def test_installation_token_exchange_exhausts_retries_on_persistent_5xx() -> None:
+    transient = Mock(status_code=503)
+    with (
+        patch(
+            "dev_health_ops.connectors.utils.github_app.create_github_app_jwt",
+            return_value="app-jwt",
+        ),
+        patch("dev_health_ops.connectors.utils.retry.time.sleep"),
+        patch(
+            "dev_health_ops.connectors.utils.github_app.requests.post",
+            return_value=transient,
+        ) as post,
+    ):
+        provider = GitHubAppTokenProvider(
+            app_id="12345",
+            private_key="synthetic-private-key",
+            installation_id="67890",
+        )
+        with pytest.raises(GitHubAppTransientError) as excinfo:
+            provider.get_token()
+
+    assert post.call_count == TOKEN_EXCHANGE_MAX_RETRIES
+    # Exhausted transient still surfaces as GitHubAppAuthError for existing callers.
+    assert isinstance(excinfo.value, GitHubAppAuthError)


### PR DESCRIPTION
## Summary

GitHub REST calls were built with `retry=None`, so a single transient `503`/`502`/`504` failed the sync unit immediately — while the GraphQL path already retried via `@retry_with_backoff`. This restores symmetry on the REST path and is the main driver of the GitHub-sync 503 floods (CHAOS-2704).

## Changes

- Build the PyGithub client with a bounded `urllib3` `Retry` scoped to **idempotent reads** (`GET`/`HEAD`/`OPTIONS`) and **`502`/`503`/`504` only**, with bounded exponential backoff and an explicit HTTP timeout.
- `respect_retry_after_header=False` is **intentional**: urllib3 v2 would otherwise transport-retry `413`/`429`/`503` carrying a `Retry-After` even when absent from `status_forcelist`, stealing rate-limit handling away from `RateLimitException` → the worker deferral path, and sleeping for an unbounded `Retry-After` inside a single `RateLimitGate` call. Rate-limit/`4xx` stays owned by `RateLimitGate` / `_raise_github_exception`.
- `raise_on_status=False` so a persistent final `5xx` still surfaces as PyGithub's `GithubException` → `APIException`, unchanged (no behavior regression when GitHub is genuinely down).
- Mutations are never retried (read-only allowlist).

Env-tunable: `GITHUB_HTTP_MAX_RETRIES` (3), `GITHUB_HTTP_BACKOFF_FACTOR` (1.0), `GITHUB_HTTP_BACKOFF_MAX` (30), `GITHUB_HTTP_TIMEOUT_SECONDS` (30).

## Testing

- New unit tests: retry config (status_forcelist/allowed_methods/env overrides/`backoff_max`), `429 + Retry-After` is **not** retried, `503` is retried, `503` exhaustion behavior, timeout helper, and both `Github(...)` constructor branches receive a non-None `retry` + `timeout`.
- Updated two pre-existing `test_github_pr_social_batch.py` tests that asserted the old `retry=None` contract.
- `ci/local_validate.sh` gates 1-3 green (ruff format/check, mypy, full unit suite). ClickHouse stage skipped — zero ClickHouse/attribution/migration surface.

## Review notes

- Design + edge cases (respect_retry_after_header, backoff bound) reviewed by Oracle; must-fixes applied.
- Follow-up filed: GitHub App token exchange is single-shot (CHAOS-2706).

SCREENSHOT-WAIVER: backend-only change, no UI/render surface.

Closes CHAOS-2704
Closes CHAOS-2706