### PR TITLE
fix(sync): bound RUNNING lease so stuck/killed sync units fail timely (CHAOS-2705)

### DIFF
--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -414,6 +414,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
     should_finalize = False
     started_at = datetime.now(timezone.utc)
     lease_owner: str | None = None
+    deadline: datetime = started_at + timedelta(seconds=_max_unit_lifetime_seconds())
     terminal_txn_started = False
     heartbeat_stop: threading.Event | None = None
     heartbeat_thread: threading.Thread | None = None
@@ -439,7 +440,10 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     "reason": "terminal",
                 }
             lease_owner = str(uuid.uuid4())
-            lease_expires_at = started_at + timedelta(seconds=_running_lease_seconds())
+            deadline = started_at + timedelta(seconds=_max_unit_lifetime_seconds())
+            lease_expires_at = min(
+                started_at + timedelta(seconds=_running_lease_seconds()), deadline
+            )
             claim_result: Any = session.execute(
                 update(SyncRunUnit)
                 .where(
@@ -466,7 +470,9 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 }
             session.flush()
 
-        heartbeat_stop, heartbeat_thread = _start_unit_heartbeat(unit_id, lease_owner)
+        heartbeat_stop, heartbeat_thread = _start_unit_heartbeat(
+            unit_id, lease_owner, deadline
+        )
 
         with get_postgres_session_sync() as session:
             ctx = SyncTaskBootstrap.load(session, unit_id)
@@ -492,7 +498,9 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     SyncRunUnit.sync_run_id.in_(_nonterminal_run_ids_select()),
                 )
                 .values(
-                    lease_expires_at=now + timedelta(seconds=_running_lease_seconds()),
+                    lease_expires_at=min(
+                        now + timedelta(seconds=_running_lease_seconds()), deadline
+                    ),
                     last_heartbeat_at=now,
                 )
                 .execution_options(synchronize_session=False)
@@ -541,6 +549,10 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 .execution_options(synchronize_session=False)
             )
             if int(terminal_result.rowcount or 0) == 0:
+                logger.warning(
+                    "run_sync_unit.success_stamp_noop",
+                    extra={**_log_ctx},
+                )
                 return {
                     "status": "skipped",
                     "unit_id": unit_id,
@@ -1304,16 +1316,6 @@ def _stale_dispatch_seconds() -> int:
         return 900
 
 
-def _stale_running_seconds() -> int:
-    try:
-        return max(
-            1,
-            int(os.getenv("SYNC_UNIT_RUNNING_STALE_SECONDS", "3600")),
-        )
-    except ValueError:
-        return 3600
-
-
 def _as_aware(value: datetime) -> datetime:
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
@@ -1321,11 +1323,27 @@ def _as_aware(value: datetime) -> datetime:
 
 
 def _running_lease_seconds() -> int:
-    return _stale_running_seconds()
+    try:
+        return max(1, int(os.getenv("SYNC_UNIT_RUNNING_LEASE_SECONDS", "300")))
+    except ValueError:
+        return 300
 
 
 def _heartbeat_interval_seconds() -> int:
     return max(1, min(60, _running_lease_seconds() // 4))
+
+
+def _max_unit_lifetime_seconds() -> int:
+    """Absolute cap on how long a heartbeat may renew a unit's lease.
+
+    Floored at 3600 (the Celery hard task_time_limit) so a misconfigured value
+    cannot prematurely expire a still-progressing unit.  The heartbeat will stop
+    renewing once this deadline is reached, allowing the reconciler to reclaim.
+    """
+    try:
+        return max(3600, int(os.getenv("SYNC_UNIT_MAX_LIFETIME_SECONDS", "3720")))
+    except ValueError:
+        return 3720
 
 
 def _unit_lease_is_owned_and_live(
@@ -1343,13 +1361,14 @@ def _unit_lease_is_owned_and_live(
 def _start_unit_heartbeat(
     unit_id: str,
     lease_owner: str | None,
+    deadline: datetime,
 ) -> tuple[threading.Event, threading.Thread] | tuple[None, None]:
     if lease_owner is None:
         return None, None
     stop_event = threading.Event()
     thread = threading.Thread(
         target=_heartbeat_unit_lease,
-        args=(unit_id, lease_owner, stop_event),
+        args=(unit_id, lease_owner, stop_event, deadline),
         name=f"sync-unit-heartbeat-{unit_id}",
         daemon=True,
     )
@@ -1361,6 +1380,7 @@ def _heartbeat_unit_lease(
     unit_id: str,
     lease_owner: str,
     stop_event: threading.Event,
+    deadline: datetime,
 ) -> None:
     from dev_health_ops.db import get_postgres_session_sync
 
@@ -1368,7 +1388,14 @@ def _heartbeat_unit_lease(
     lease_seconds = _running_lease_seconds()
     while not stop_event.wait(interval):
         now = datetime.now(timezone.utc)
-        lease_expires_at = now + timedelta(seconds=lease_seconds)
+        if now >= deadline:
+            logger.warning(
+                "run_sync_unit.heartbeat_deadline_exceeded",
+                extra={"unit_id": unit_id},
+            )
+            stop_event.set()
+            break
+        lease_expires_at = min(now + timedelta(seconds=lease_seconds), deadline)
         try:
             with get_postgres_session_sync() as session:
                 heartbeat_result: Any = session.execute(

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -1179,14 +1179,14 @@ def _claim_units(
     writes).  Stale ``dispatching`` units (a worker died before the unit started
     running) are reclaimed by age.
 
-    F2 fix: RUNNING units are NEVER reclaimed here.  ``run_sync_unit`` does not
-    heartbeat during the provider call, so a legitimately long-running unit past
-    SYNC_UNIT_RUNNING_STALE_SECONDS would be re-dispatched and run a second time
-    concurrently, causing duplicate provider writes.  Durable dead-worker
-    recovery (heartbeat + lease) is a separate follow-up (CHAOS-2577).
-
-    INTERIM: a capped run whose only blocker is a DEAD RUNNING unit may stall
-    — acceptable, preserves at-most-once provider execution.
+    F2: RUNNING units are NEVER reclaimed by the dispatch path — re-dispatching a
+    RUNNING unit would run it a second time concurrently and cause duplicate
+    provider writes.  Durable dead-worker recovery is handled instead by
+    ``reconcile_sync_dispatch``, which fails a RUNNING unit once its
+    ``lease_expires_at`` lapses and re-arms dispatch/finalize.  ``run_sync_unit``
+    renews that lease via a heartbeat bounded by an absolute deadline
+    (``SYNC_UNIT_MAX_LIFETIME_SECONDS``), so even a wedged-but-alive worker's lease
+    eventually lapses and the unit is reclaimed (CHAOS-2705).
 
     ``capped_ids`` is the set of unit IDs that the concurrency guard deferred.
     Those units are left in PLANNED status so a later redispatch can claim them

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -605,7 +605,10 @@ def test_heartbeat_extends_live_matching_lease(db_session, monkeypatch):
             self.calls += 1
             return self.calls > 1
 
-    sync_units._heartbeat_unit_lease(str(unit.id), "worker-1", OneHeartbeatStop())
+    deadline = now + timedelta(seconds=3720)
+    sync_units._heartbeat_unit_lease(
+        str(unit.id), "worker-1", OneHeartbeatStop(), deadline
+    )
 
     db_session.refresh(unit)
     lease_expires_at = unit.lease_expires_at
@@ -646,7 +649,10 @@ def test_heartbeat_loses_after_reconciler_terminalizes(tmp_path, monkeypatch):
                 self.calls += 1
                 return self.calls > 1
 
-        sync_units._heartbeat_unit_lease(str(unit_id), "worker-1", OneHeartbeatStop())
+        deadline = now + timedelta(seconds=3720)
+        sync_units._heartbeat_unit_lease(
+            str(unit_id), "worker-1", OneHeartbeatStop(), deadline
+        )
 
         with Session(engine) as assert_session:
             unit = (
@@ -928,7 +934,7 @@ def test_slow_bootstrap_loses_lease_before_provider_does_not_execute(
         heartbeat_started = []
         original_load = SyncTaskBootstrap.load
 
-        def start_heartbeat(unit_id_arg, lease_owner):
+        def start_heartbeat(unit_id_arg, lease_owner, deadline):
             heartbeat_started.append((unit_id_arg, lease_owner))
             return None, None
 
@@ -3045,3 +3051,279 @@ def test_rate_limit_budget_exhaustion_falls_through_to_failed(db_session, monkey
     assert unit.lease_owner is None
     assert unit.lease_expires_at is None
     assert finalize_calls == [((str(run.id),), "sync")]
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2705: lease helpers, heartbeat deadline cap, success stamp no-op
+# ---------------------------------------------------------------------------
+
+
+def test_running_lease_seconds_default(monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.delenv("SYNC_UNIT_RUNNING_LEASE_SECONDS", raising=False)
+    assert sync_units._running_lease_seconds() == 300
+
+
+def test_running_lease_seconds_env_override(monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_UNIT_RUNNING_LEASE_SECONDS", "120")
+    assert sync_units._running_lease_seconds() == 120
+
+
+def test_running_lease_seconds_invalid_env_fallback(monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_UNIT_RUNNING_LEASE_SECONDS", "not-a-number")
+    assert sync_units._running_lease_seconds() == 300
+
+
+def test_max_unit_lifetime_seconds_default(monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.delenv("SYNC_UNIT_MAX_LIFETIME_SECONDS", raising=False)
+    assert sync_units._max_unit_lifetime_seconds() == 3720
+
+
+def test_max_unit_lifetime_seconds_env_override(monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_UNIT_MAX_LIFETIME_SECONDS", "7200")
+    assert sync_units._max_unit_lifetime_seconds() == 7200
+
+
+def test_max_unit_lifetime_seconds_floored_at_hard_limit(monkeypatch):
+    """Values below the Celery hard task_time_limit (3600) are floored to 3600."""
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_UNIT_MAX_LIFETIME_SECONDS", "60")
+    assert sync_units._max_unit_lifetime_seconds() == 3600
+
+
+def test_max_unit_lifetime_seconds_invalid_env_fallback(monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SYNC_UNIT_MAX_LIFETIME_SECONDS", "bad")
+    assert sync_units._max_unit_lifetime_seconds() == 3720
+
+
+def test_heartbeat_stops_when_deadline_exceeded(db_session, monkeypatch):
+    """When now >= deadline the heartbeat loop stops without issuing an UPDATE."""
+    import threading
+    from unittest.mock import patch
+
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    now = datetime.now(timezone.utc)
+    unit.status = SyncRunUnitStatus.RUNNING.value
+    unit.lease_owner = "worker-1"
+    unit.lease_expires_at = now + timedelta(seconds=30)
+    unit.last_heartbeat_at = now
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setattr(sync_units, "_heartbeat_interval_seconds", lambda: 1)
+    monkeypatch.setattr(sync_units, "_running_lease_seconds", lambda: 120)
+
+    # Deadline is already in the past so the first iteration should bail.
+    past_deadline = now - timedelta(seconds=1)
+
+    class OneHeartbeatStop(threading.Event):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def wait(self, timeout=None):
+            self.calls += 1
+            return self.calls > 1
+
+    db_update_calls = []
+    original_execute = db_session.execute
+
+    def tracking_execute(stmt, *args, **kwargs):
+        db_update_calls.append(stmt)
+        return original_execute(stmt, *args, **kwargs)
+
+    stop = OneHeartbeatStop()
+    with patch.object(db_session, "execute", side_effect=tracking_execute):
+        sync_units._heartbeat_unit_lease(str(unit.id), "worker-1", stop, past_deadline)
+
+    # stop_event must be set (loop exited)
+    assert stop.is_set()
+    # No UPDATE should have been issued for the heartbeat renewal
+    from sqlalchemy.sql.dml import Update
+
+    update_stmts = [s for s in db_update_calls if isinstance(s, Update)]
+    assert update_stmts == [], "heartbeat must not issue UPDATE after deadline"
+
+
+def test_heartbeat_lease_capped_at_deadline(db_session, monkeypatch):
+    """When now < deadline, the renewed lease_expires_at must not exceed deadline."""
+    import threading
+
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    now = datetime.now(timezone.utc)
+    unit.status = SyncRunUnitStatus.RUNNING.value
+    unit.lease_owner = "worker-1"
+    unit.lease_expires_at = now + timedelta(seconds=30)
+    unit.last_heartbeat_at = now
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setattr(sync_units, "_heartbeat_interval_seconds", lambda: 1)
+    # lease_seconds=600 but deadline is only 60s away — cap must win
+    monkeypatch.setattr(sync_units, "_running_lease_seconds", lambda: 600)
+
+    deadline = now + timedelta(seconds=60)
+
+    class OneHeartbeatStop(threading.Event):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
+        def wait(self, timeout=None):
+            self.calls += 1
+            return self.calls > 1
+
+    sync_units._heartbeat_unit_lease(
+        str(unit.id), "worker-1", OneHeartbeatStop(), deadline
+    )
+
+    db_session.refresh(unit)
+    assert unit.lease_expires_at is not None
+    # The persisted lease must not exceed the deadline
+    assert _aware(unit.lease_expires_at) <= deadline + timedelta(seconds=1)
+    # And it must be strictly less than now + 600s (the uncapped value)
+    assert _aware(unit.lease_expires_at) < now + timedelta(seconds=600)
+
+
+def test_success_stamp_noop_when_lease_already_lost(tmp_path, monkeypatch, caplog):
+    """When the success UPDATE matches 0 rows the task returns skipped/lease_lost
+    and does NOT set should_finalize (no finalize enqueue).
+    """
+    import logging
+
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers import sync_units
+
+    engine = _file_backed_engine(tmp_path)
+    try:
+        with Session(engine) as seed_session:
+            run, unit = _seed_run(seed_session)
+            _mark_dispatching(seed_session, unit)
+            unit_id = unit.id
+            seed_session.commit()
+        _patch_db_session_factory(monkeypatch, engine)
+        _patch_runtime(monkeypatch)
+        finalize_calls = _patch_finalize_apply(monkeypatch)
+        monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+        monkeypatch.delenv("DATABASE_URI", raising=False)
+        monkeypatch.delenv("DATABASE_URL", raising=False)
+
+        def run_dataset_and_steal_lease(ctx, runtime):
+            # Simulate reconciler marking the unit FAILED while provider runs
+            _commit_reconciler_failure(engine, unit_id)
+            return {"ok": True}
+
+        monkeypatch.setattr(
+            dataset_adapters, "run_dataset_unit", run_dataset_and_steal_lease
+        )
+
+        with caplog.at_level(
+            logging.WARNING, logger="dev_health_ops.workers.sync_units"
+        ):
+            result = getattr(sync_units.run_sync_unit, "run")(str(unit_id))
+
+        assert result == {
+            "status": "skipped",
+            "unit_id": str(unit_id),
+            "reason": "lease_lost",
+        }
+        # Finalize must NOT be enqueued
+        assert finalize_calls == [], (
+            "finalize must not be enqueued on success stamp no-op"
+        )
+        # Warning must have been logged
+        assert any("success_stamp_noop" in r.message for r in caplog.records), (
+            "expected success_stamp_noop warning"
+        )
+        # Unit must remain FAILED (reconciler's stamp wins)
+        with Session(engine) as assert_session:
+            persisted = (
+                assert_session.query(SyncRunUnit)
+                .filter(SyncRunUnit.id == unit_id)
+                .one()
+            )
+            assert persisted.status == SyncRunUnitStatus.FAILED.value
+    finally:
+        engine.dispose()
+
+
+def test_bootstrap_live_refresh_lease_capped_at_deadline(db_session, monkeypatch):
+    """The bootstrap live-lease-refresh UPDATE must not write lease_expires_at > deadline.
+
+    Regression guard for CHAOS-2705 MUST-FIX 1: the second lease write inside
+    run_sync_unit (after _start_unit_heartbeat, before provider execution) must
+    be capped at deadline just like the initial claim and the heartbeat loop.
+    """
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    # Use a very short running lease (10s) and a tight deadline (20s) so that
+    # now + lease_seconds (10s) < deadline (20s) — the cap should be the lease.
+    # More importantly, if lease_seconds were large (e.g. 600) and deadline were
+    # small (20s), the cap must be deadline.  We test the latter scenario.
+    monkeypatch.setenv("SYNC_UNIT_RUNNING_LEASE_SECONDS", "600")
+
+    captured_lease: list = []
+
+    def run_dataset_capture_lease(ctx, runtime):
+        db_session.refresh(unit)
+        if unit.lease_expires_at is not None:
+            captured_lease.append(unit.lease_expires_at)
+        return {"ok": True}
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", run_dataset_capture_lease)
+
+    # Patch _max_unit_lifetime_seconds to return a tight deadline (3600 floor
+    # means we can't go below that, so we patch the function directly).
+    deadline_seconds = 3600  # floor value
+    monkeypatch.setattr(
+        sync_units, "_max_unit_lifetime_seconds", lambda: deadline_seconds
+    )
+
+    result = getattr(sync_units.run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    assert len(captured_lease) == 1, "expected exactly one lease snapshot from provider"
+    from datetime import timezone as _tz
+
+    lease_at = captured_lease[0]
+    if lease_at.tzinfo is None:
+        lease_at = lease_at.replace(tzinfo=_tz.utc)
+    # The live-refresh write must not have pushed lease_expires_at past deadline.
+    # started_at + deadline_seconds is the absolute cap; allow 2s clock slack.
+
+    # We can't know exact started_at, but we know the lease must be <= now + deadline_seconds.
+    # Since the test runs in well under 1s, now() + deadline_seconds is a safe upper bound.
+    now = datetime.now(timezone.utc)
+    assert lease_at <= now + timedelta(seconds=deadline_seconds + 2), (
+        f"live-refresh lease {lease_at} exceeds deadline cap"
+    )
+    # And it must NOT be now + 600s (the uncapped running lease).
+    assert lease_at < now + timedelta(seconds=600), (
+        f"live-refresh lease {lease_at} was not capped (got full 600s lease)"
+    )


### PR DESCRIPTION
## Summary

A GitHub sync unit could stop silently and sit at `RUNNING` with no terminal status. The daemon heartbeat renewed `lease_expires_at = now + 3600s` every ~60s while `RUNNING`, so:

1. a **wedged-but-alive** worker (main thread blocked, e.g. inside a slow call) never had its lease expire → the reconciler never reclaimed it; and
2. a **hard-killed** worker (SIGKILL at the 3600s hard `task_time_limit`, OOM) left the unit `RUNNING` for ~1h before the reconciler stamped it `FAILED`.

This is the "silent stoppage failures that don't persist statuses" symptom (CHAOS-2705).

## Changes

- **Decouple + shorten the RUNNING lease** from the 1h stale window: new `SYNC_UNIT_RUNNING_LEASE_SECONDS` (default `300`).
- **Absolute deadline cap**: `deadline = started_at + SYNC_UNIT_MAX_LIFETIME_SECONDS` (default `3720`, **floored at the 3600 hard `task_time_limit`** so misconfig cannot prematurely fail a progressing unit). **Every** future-expiry lease write — initial claim, bootstrap live-refresh, and the heartbeat loop — is capped with `min(now + lease, deadline)`. The heartbeat stops renewing past the deadline, so the reconciler reclaims a wedged unit within ~`lease + reconciler interval` instead of ~1h.
- **Late success stamp is a logged no-op**: when the success UPDATE matches 0 rows (lease already lost / reconciler already failed the unit), it logs `run_sync_unit.success_stamp_noop` and does not finalize — it cannot resurrect a `FAILED` unit.

## Design notes (Oracle-reviewed)

- A `task_failure`/`task_revoked` signal handler was **explicitly rejected** — those signals don't fire on SIGKILL/OOM (the actual silent case), and the soft-time-limit case they would catch is already handled by the in-task `except`. The DB lease + reconciler is the correct recovery mechanism.
- `acks_late=True` / `reject_on_worker_lost=True` were **not** enabled — broker redelivery would collide with the guarded `DISPATCHING → RUNNING` claim and needs a fencing/idempotency design first.
- Reconciler unchanged: it already fails `RUNNING` units whose `lease_expires_at <= now`; this PR just stops the heartbeat from indefinitely deferring that.

## Testing

- New/updated unit tests: lease/lifetime env helpers + floor, heartbeat stops at deadline (no renew), every lease write capped at deadline (incl. bootstrap refresh), success no-op on lost lease. Existing heartbeat/reconciler/run_sync_unit tests updated for the new `deadline` arg and still pass.
- `ci/local_validate.sh` gates 1-3 green (ruff format/check, mypy, full unit suite). ClickHouse stage skipped — zero ClickHouse/attribution/migration surface.

## Note

The in-code TODO at `src/dev_health_ops/workers/sync_units.py` cited `CHAOS-2577` as the heartbeat/lease-recovery follow-up, but that issue is closed and about a different topic. This PR supersedes it; the stale comment is repointed/removed here.

SCREENSHOT-WAIVER: backend-only change, no UI/render surface.

Closes CHAOS-2705