### PR TITLE
feat(admin/sync): expose sync run unit detail metadata (CHAOS-2703)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/integrations.py
+++ b/src/dev_health_ops/api/admin/routers/integrations.py
@@ -128,6 +128,9 @@ def _sync_run_to_response(run: object) -> SyncRunResponse:
 
 
 def _unit_to_response(unit: object) -> SyncRunUnitResponse:
+    source = getattr(unit, "source", None)
+    result = getattr(unit, "result", None)
+    error_category = result.get("error_category") if isinstance(result, dict) else None
     return SyncRunUnitResponse.model_validate(
         {
             "id": str(getattr(unit, "id")),
@@ -135,6 +138,8 @@ def _unit_to_response(unit: object) -> SyncRunUnitResponse:
             "sync_run_id": str(getattr(unit, "sync_run_id")),
             "integration_id": str(getattr(unit, "integration_id")),
             "source_id": str(getattr(unit, "source_id")),
+            "source_name": source.name if source else None,
+            "source_full_name": source.full_name if source else None,
             "provider": str(getattr(unit, "provider")),
             "dataset_key": str(getattr(unit, "dataset_key")),
             "cost_class": str(getattr(unit, "cost_class")),
@@ -143,9 +148,13 @@ def _unit_to_response(unit: object) -> SyncRunUnitResponse:
             "before_at": getattr(unit, "before_at"),
             "status": str(getattr(unit, "status")),
             "attempts": int(getattr(unit, "attempts")),
+            "available_at": getattr(unit, "available_at"),
+            "rate_limit_deferrals": int(getattr(unit, "rate_limit_deferrals")),
             "duration_seconds": getattr(unit, "duration_seconds"),
             "error": getattr(unit, "error"),
-            "result": getattr(unit, "result"),
+            "error_category": error_category,
+            "last_heartbeat_at": getattr(unit, "last_heartbeat_at"),
+            "result": result,
             "created_at": getattr(unit, "created_at"),
             "updated_at": getattr(unit, "updated_at"),
         }
@@ -535,6 +544,11 @@ async def get_sync_run_units(
     units = await svc.list_units(run_id)
     rollups = SyncRunService.build_unit_rollups(units)
     total_units = len(units)
+    retry_times = [
+        unit.available_at
+        for unit in units
+        if unit.status == "retrying" and unit.available_at is not None
+    ]
 
     return SyncRunUnitSummary(
         by_status=rollups["by_status"],
@@ -546,5 +560,6 @@ async def get_sync_run_units(
         partial_failure_summary=rollups["partial_failure_summary"],
         failed_unit_count=rollups["failed_unit_count"],
         unit_count=total_units,
+        next_retry_at=min(retry_times) if retry_times else None,
         units=[_unit_to_response(u) for u in units[:limit]],
     )

--- a/src/dev_health_ops/api/admin/schemas/integrations.py
+++ b/src/dev_health_ops/api/admin/schemas/integrations.py
@@ -173,6 +173,7 @@ class SyncRunUnitSummary(BaseModel):
     failed_unit_count: int = 0
     unit_count: int = 0
     partial_failure_summary: dict[str, Any] | None = None
+    next_retry_at: datetime | None = None
     units: list[SyncRunUnitResponse]
 
 
@@ -182,6 +183,8 @@ class SyncRunUnitResponse(BaseModel):
     sync_run_id: str
     integration_id: str
     source_id: str
+    source_name: str | None
+    source_full_name: str | None
     provider: str
     dataset_key: str
     cost_class: str
@@ -190,9 +193,13 @@ class SyncRunUnitResponse(BaseModel):
     before_at: datetime | None
     status: str
     attempts: int
+    available_at: datetime | None
+    rate_limit_deferrals: int
     duration_seconds: int | None
     error: str | None
-    result: dict[str, Any] | None
+    error_category: str | None
+    last_heartbeat_at: datetime | None
+    result: Any | None
     created_at: datetime
     updated_at: datetime
 

--- a/src/dev_health_ops/api/services/integrations.py
+++ b/src/dev_health_ops/api/services/integrations.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
 
 from dev_health_ops.models.integrations import (
     Integration,
@@ -253,6 +254,7 @@ class SyncRunService:
             return []
         result = await self._session.execute(
             select(SyncRunUnit)
+            .options(selectinload(SyncRunUnit.source))
             .where(
                 SyncRunUnit.sync_run_id == uid,
                 SyncRunUnit.org_id == self._org_id,
@@ -312,8 +314,12 @@ class SyncRunService:
                 failed_sources.add(source)
                 failed_datasets.add(dataset)
                 # Extract error_category from result JSON if present
-                result_data = unit.result or {}
-                cat = result_data.get("error_category", "unknown")
+                result_data = unit.result
+                cat = (
+                    result_data.get("error_category", "unknown")
+                    if isinstance(result_data, dict)
+                    else "unknown"
+                )
                 error_categories[str(cat)] += 1
 
             if unit.duration_seconds is not None:

--- a/tests/api/admin/test_integrations.py
+++ b/tests/api/admin/test_integrations.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import importlib
 import uuid
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -733,6 +734,7 @@ async def test_get_sync_run_units_empty(client, session_maker, seeded_state):
     assert data["by_source"] == {}
     assert data["by_dataset"] == {}
     assert data["by_cost_class"] == {}
+    assert data["next_retry_at"] is None
 
 
 @pytest.mark.asyncio
@@ -772,6 +774,240 @@ async def test_get_sync_run_units_rollups(client, session_maker, seeded_state):
     assert data["by_status"]["failed"] == 1
     assert data["by_cost_class"]["standard"] == 2
     assert "git" in data["by_dataset"]
+    assert data["by_dataset"]["git"]["success"] == 1
+    assert data["by_dataset"]["git"]["failed"] == 1
+    assert data["by_source"][source_id]["success"] == 1
+    assert data["by_source"][source_id]["failed"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_sync_run_units_exposes_source_names(
+    client, session_maker, seeded_state
+):
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+    source_id = await _seed_source(
+        session_maker, seeded_state["org_id"], integration_id
+    )
+    run_id = await _seed_sync_run(session_maker, seeded_state["org_id"], integration_id)
+
+    async with session_maker() as session:
+        session.add(
+            SyncRunUnit(
+                org_id=seeded_state["org_id"],
+                sync_run_id=uuid.UUID(run_id),
+                integration_id=uuid.UUID(integration_id),
+                source_id=uuid.UUID(source_id),
+                provider="github",
+                dataset_key="git",
+                cost_class="standard",
+                mode="incremental",
+                status="success",
+                attempts=1,
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    assert resp.status_code == 200
+    unit = resp.json()["units"][0]
+    assert unit["source_name"] == "repo"
+    assert unit["source_full_name"] == "owner/repo"
+
+
+@pytest.mark.asyncio
+async def test_get_sync_run_units_retry_metadata_and_next_retry_at(
+    client, session_maker, seeded_state
+):
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+    source_id = await _seed_source(
+        session_maker, seeded_state["org_id"], integration_id
+    )
+    run_id = await _seed_sync_run(session_maker, seeded_state["org_id"], integration_id)
+    later_retry = datetime(2026, 6, 26, 12, 15, tzinfo=timezone.utc)
+    earliest_retry = later_retry - timedelta(minutes=10)
+    heartbeat = later_retry - timedelta(minutes=1)
+
+    async with session_maker() as session:
+        session.add_all(
+            [
+                SyncRunUnit(
+                    org_id=seeded_state["org_id"],
+                    sync_run_id=uuid.UUID(run_id),
+                    integration_id=uuid.UUID(integration_id),
+                    source_id=uuid.UUID(source_id),
+                    provider="github",
+                    dataset_key="git",
+                    cost_class="standard",
+                    mode="incremental",
+                    status="retrying",
+                    attempts=2,
+                    available_at=later_retry,
+                    rate_limit_deferrals=3,
+                    last_heartbeat_at=heartbeat,
+                ),
+                SyncRunUnit(
+                    org_id=seeded_state["org_id"],
+                    sync_run_id=uuid.UUID(run_id),
+                    integration_id=uuid.UUID(integration_id),
+                    source_id=uuid.UUID(source_id),
+                    provider="github",
+                    dataset_key="prs",
+                    cost_class="standard",
+                    mode="incremental",
+                    status="retrying",
+                    attempts=1,
+                    available_at=earliest_retry,
+                ),
+                SyncRunUnit(
+                    org_id=seeded_state["org_id"],
+                    sync_run_id=uuid.UUID(run_id),
+                    integration_id=uuid.UUID(integration_id),
+                    source_id=uuid.UUID(source_id),
+                    provider="github",
+                    dataset_key="issues",
+                    cost_class="standard",
+                    mode="incremental",
+                    status="success",
+                    attempts=1,
+                    available_at=earliest_retry - timedelta(minutes=5),
+                ),
+            ]
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert datetime.fromisoformat(data["next_retry_at"]) == earliest_retry.replace(
+        tzinfo=None
+    )
+    retry_unit = next(unit for unit in data["units"] if unit["dataset_key"] == "git")
+    assert datetime.fromisoformat(retry_unit["available_at"]) == later_retry.replace(
+        tzinfo=None
+    )
+    assert retry_unit["rate_limit_deferrals"] == 3
+    assert datetime.fromisoformat(retry_unit["last_heartbeat_at"]) == heartbeat.replace(
+        tzinfo=None
+    )
+
+
+@pytest.mark.asyncio
+async def test_get_sync_run_units_exposes_error_category(
+    client, session_maker, seeded_state
+):
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+    source_id = await _seed_source(
+        session_maker, seeded_state["org_id"], integration_id
+    )
+    run_id = await _seed_sync_run(session_maker, seeded_state["org_id"], integration_id)
+
+    async with session_maker() as session:
+        session.add(
+            SyncRunUnit(
+                org_id=seeded_state["org_id"],
+                sync_run_id=uuid.UUID(run_id),
+                integration_id=uuid.UUID(integration_id),
+                source_id=uuid.UUID(source_id),
+                provider="github",
+                dataset_key="git",
+                cost_class="standard",
+                mode="incremental",
+                status="failed",
+                attempts=1,
+                result={"error_category": "rate_limit"},
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    assert resp.status_code == 200
+    unit = resp.json()["units"][0]
+    assert unit["error_category"] == "rate_limit"
+
+
+@pytest.mark.asyncio
+async def test_get_sync_run_units_non_dict_result_has_no_error_category(
+    client, session_maker, seeded_state
+):
+    ac, _ = client
+    created = await _create_integration(ac)
+    integration_id = created["id"]
+    source_id = await _seed_source(
+        session_maker, seeded_state["org_id"], integration_id
+    )
+    run_id = await _seed_sync_run(session_maker, seeded_state["org_id"], integration_id)
+
+    async with session_maker() as session:
+        session.add(
+            SyncRunUnit(
+                org_id=seeded_state["org_id"],
+                sync_run_id=uuid.UUID(run_id),
+                integration_id=uuid.UUID(integration_id),
+                source_id=uuid.UUID(source_id),
+                provider="github",
+                dataset_key="git",
+                cost_class="standard",
+                mode="incremental",
+                status="failed",
+                attempts=1,
+                result=["unexpected"],
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{run_id}/units")
+    assert resp.status_code == 200
+    unit = resp.json()["units"][0]
+    assert unit["error_category"] is None
+    assert unit["result"] == ["unexpected"]
+
+
+@pytest.mark.asyncio
+async def test_get_sync_run_units_foreign_org_run_returns_404(client, session_maker):
+    ac, _ = client
+    foreign_org_id = str(uuid.uuid4())
+    foreign_integration_id = uuid.uuid4()
+    foreign_run_id = uuid.uuid4()
+
+    async with session_maker() as session:
+        session.add(
+            Organization(
+                id=foreign_org_id, slug="other-org", name="Other Org", tier="pro"
+            )
+        )
+        session.add(
+            Integration(
+                id=foreign_integration_id,
+                org_id=foreign_org_id,
+                provider="github",
+                name="foreign-integration",
+                config={},
+                is_active=True,
+            )
+        )
+        session.add(
+            SyncRun(
+                id=foreign_run_id,
+                org_id=foreign_org_id,
+                integration_id=foreign_integration_id,
+                triggered_by="test",
+                mode="incremental",
+                status="planned",
+                total_units=0,
+                completed_units=0,
+                failed_units=0,
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-runs/{foreign_run_id}/units")
+    assert resp.status_code == 404
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## CHAOS-2703 — Backend: sync run unit detail contract

Extends `GET /api/v1/admin/sync-runs/{run_id}/units` so the new admin run-detail UI can render unit-level progress with resolved source names, retry metadata, and error category — without breaking existing rollups or org scoping.

Linear: CHAOS-2703

### Changes
- `api/admin/schemas/integrations.py`
  - `SyncRunUnitResponse` gains `source_name`, `source_full_name`, `available_at`, `rate_limit_deferrals`, `error_category`, `last_heartbeat_at`.
  - `SyncRunUnitSummary` gains `next_retry_at` (earliest `available_at` among `retrying` units).
- `api/services/integrations.py`
  - `SyncRunService.list_units` eager-loads the source relationship via `selectinload(SyncRunUnit.source)` (avoids async lazy-load under `AsyncSession`).
  - `build_unit_rollups` guards `error_category` extraction for non-dict `result` JSON.
- `api/admin/routers/integrations.py`
  - `_unit_to_response` maps the new fields; `error_category` read from `result` only when it is a dict.
  - `get_sync_run_units` computes `next_retry_at`.

### Contract notes
- Org-scoping unchanged; existing rollups (`by_status`/`by_source`/`by_dataset`/`by_cost_class`/`partial_failure_summary`/`failed_unit_*`/`slowest_unit_ids`) preserved.
- Unit-level `result` widened to `Any | None` to faithfully echo persisted JSON; run-level `SyncRunResponse` unchanged.
- No GraphQL subscription / `publish_sync_progress` usage. No new persistence paths.

### Tests (`tests/api/admin/test_integrations.py`)
- Source labels surfaced from the seeded `IntegrationSource`.
- Retrying units expose `available_at` + summary `next_retry_at` (earliest retrying); non-retrying units ignored.
- Failed unit surfaces `error_category`; non-dict `result` yields `error_category=null` with HTTP 200 (regression).
- Existing rollups intact; foreign-org run returns 404.

### Verification
- `pytest tests/api/admin/test_integrations.py` → 44 passed
- `bash ci/local_validate.sh` → GATE PASSED (ruff format/check, mypy, full unit suite 5778 passed, ClickHouse scratch migrate + argMax live proof)

### Review
- Oracle-reviewed (read-only): PASS-WITH-NITS → the one must-fix (non-dict `result` guard) applied and retested.

SCREENSHOT-WAIVER: backend-only change, no rendered UI.
