### PR TITLE
fix(sync): watermark work-item derivative datasets (CHAOS-2707)

### DIFF
--- a/src/dev_health_ops/sync/datasets.py
+++ b/src/dev_health_ops/sync/datasets.py
@@ -120,8 +120,6 @@ _LEGACY_TARGETS_BY_DATASET: dict[str, frozenset[str]] = {
 _NO_WATERMARK_DATASETS = frozenset(
     {
         DatasetKey.REPO_METADATA.value,
-        DatasetKey.WORK_ITEM_LABELS.value,
-        DatasetKey.WORK_ITEM_PROJECTS.value,
     }
 )
 

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping
+from dataclasses import replace
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -507,7 +508,7 @@ def test_work_item_derivative_preserves_non_null_window_start_not_midnight(
     # WINDOW_START is 2026-01-10T00:00:00+00:00 — but the key invariant is
     # that a non-midnight context.window_start (e.g. mid-day) is preserved.
     mid_day_start = WINDOW_START.replace(hour=14, minute=30, second=0)
-    ctx = ctx.__replace__(window_start=mid_day_start)
+    ctx = replace(ctx, window_start=mid_day_start)
 
     with patch(
         "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -486,3 +486,38 @@ def test_non_github_work_items_leave_include_pull_requests_unset() -> None:
     work_items.assert_called_once()
     assert "include_issues" not in work_items.call_args.kwargs
     assert "include_pull_requests" not in work_items.call_args.kwargs
+
+
+@pytest.mark.parametrize(
+    "dataset_key",
+    ["work-item-labels", "work-item-projects"],
+)
+def test_work_item_derivative_preserves_non_null_window_start_not_midnight(
+    dataset_key: str,
+) -> None:
+    """CHAOS-2707: work-item-labels and work-item-projects must echo the
+    context's window_start in result["window_start"] verbatim, not fall back
+    to midnight of the window day.
+    """
+    ctx = _context(
+        provider="jira",
+        dataset_key=dataset_key,
+        source_external_id="ENG",
+    )
+    # WINDOW_START is 2026-01-10T00:00:00+00:00 — but the key invariant is
+    # that a non-midnight context.window_start (e.g. mid-day) is preserved.
+    mid_day_start = WINDOW_START.replace(hour=14, minute=30, second=0)
+    ctx = ctx.__replace__(window_start=mid_day_start)
+
+    with patch(
+        "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"
+    ) as work_items:
+        result = run_dataset_unit(ctx, _runtime())
+
+    work_items.assert_called_once()
+    # The adapter must NOT fall back to midnight; it must preserve the exact
+    # window_start from context.
+    assert result["window_start"] == mid_day_start.isoformat(), (
+        f"Expected window_start={mid_day_start.isoformat()!r} but got {result['window_start']!r}; "
+        "adapter fell back to midnight instead of preserving context.window_start"
+    )

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -466,15 +466,15 @@ def test_existing_watermark_incremental_unchanged(db_session):
 
 
 def test_none_watermark_behavior_incremental_keeps_since_at_none(db_session):
-    """NONE-behavior datasets (repo-metadata, work-item-labels, etc.) must
-    keep since_at=None on incremental — cold-start depth must NOT be applied.
+    """NONE-behavior datasets (repo-metadata only) must keep since_at=None on
+    incremental — cold-start depth must NOT be applied.
     """
     integration = _create_integration(db_session)
     integration.config = {"initial_sync_depth": 30}
     db_session.flush()
     _create_source(db_session, integration, external_id="full-chaos/dev-health")
-    # work-item-labels has WatermarkBehavior.NONE
-    _create_dataset(db_session, integration, "work-item-labels")
+    # repo-metadata is the only remaining WatermarkBehavior.NONE dataset
+    _create_dataset(db_session, integration, "repo-metadata")
 
     plan = plan_sync_run(
         db_session,
@@ -489,7 +489,7 @@ def test_none_watermark_behavior_incremental_keeps_since_at_none(db_session):
     units = _planned_units(db_session, plan.sync_run_id)
     assert len(units) == 1
     assert units[0].since_at is None, (
-        "NONE-behavior dataset must keep since_at=None on incremental, "
+        "NONE-behavior dataset (repo-metadata) must keep since_at=None on incremental, "
         "not receive a cold-start depth window"
     )
 
@@ -908,3 +908,174 @@ def test_github_work_items_unit_omits_prs_signal_when_prs_disabled(db_session):
     assert work_items_units
     for unit in work_items_units:
         assert (unit.processor_flags or {}).get("sync_prs") is False
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2707: work-item-labels / work-item-projects are now INCREMENTAL
+# ---------------------------------------------------------------------------
+
+
+def test_work_item_labels_incremental_cold_start_uses_depth(db_session):
+    """work-item-labels has WatermarkBehavior.INCREMENTAL (CHAOS-2707).
+
+    With no saved watermark, since_at must equal now - initial_sync_depth,
+    not None.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session, provider="github")
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_dataset(db_session, integration, "work-item-labels")
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    assert units[0].since_at is not None, (
+        "work-item-labels must use cold-start depth (INCREMENTAL), not since_at=None"
+    )
+    expected_start = now - timedelta(days=30)
+    since = units[0].since_at.replace(tzinfo=timezone.utc)
+    assert abs((since - expected_start).total_seconds()) < 2
+
+
+def test_work_item_projects_incremental_cold_start_uses_depth(db_session):
+    """work-item-projects has WatermarkBehavior.INCREMENTAL (CHAOS-2707).
+
+    With no saved watermark, since_at must equal now - initial_sync_depth,
+    not None.
+    """
+    from datetime import timedelta
+
+    integration = _create_integration(db_session, provider="jira")
+    integration.config = {"initial_sync_depth": 14}
+    db_session.flush()
+    _create_source(db_session, integration, external_id="jira-project", provider="jira")
+    _create_dataset(db_session, integration, "work-item-projects")
+
+    now = datetime.now(timezone.utc)
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    assert units[0].since_at is not None, (
+        "work-item-projects must use cold-start depth (INCREMENTAL), not since_at=None"
+    )
+    expected_start = now - timedelta(days=14)
+    since = units[0].since_at.replace(tzinfo=timezone.utc)
+    assert abs((since - expected_start).total_seconds()) < 2
+
+
+def test_work_item_labels_incremental_uses_saved_watermark(db_session):
+    """work-item-labels: when a watermark exists, since_at == watermark (CHAOS-2707).
+
+    Proves the saved watermark is honoured, not overridden by cold-start depth.
+    """
+    integration = _create_integration(db_session, provider="github")
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="full-chaos/dev-health"
+    )
+    _create_dataset(db_session, integration, "work-item-labels")
+    watermark = datetime(2026, 6, 15, 8, 0, tzinfo=timezone.utc)
+    set_watermark(db_session, ORG_ID, source.external_id, "work-item-labels", watermark)
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc),
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    assert units[0].since_at is not None
+    assert units[0].since_at.replace(tzinfo=timezone.utc) == watermark
+
+
+def test_work_item_projects_incremental_uses_saved_watermark(db_session):
+    """work-item-projects: when a watermark exists, since_at == watermark (CHAOS-2707).
+
+    Proves the saved watermark is honoured, not overridden by cold-start depth.
+    """
+    integration = _create_integration(db_session, provider="jira")
+    integration.config = {"initial_sync_depth": 30}
+    db_session.flush()
+    source = _create_source(
+        db_session, integration, external_id="jira-project", provider="jira"
+    )
+    _create_dataset(db_session, integration, "work-item-projects")
+    watermark = datetime(2026, 6, 10, 0, 0, tzinfo=timezone.utc)
+    set_watermark(
+        db_session, ORG_ID, source.external_id, "work-item-projects", watermark
+    )
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+            before=datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc),
+        ),
+    )
+
+    units = _planned_units(db_session, plan.sync_run_id)
+    assert len(units) == 1
+    assert units[0].since_at is not None
+    assert units[0].since_at.replace(tzinfo=timezone.utc) == watermark
+
+
+def test_repo_metadata_still_none_watermark_behavior(db_session):
+    """repo-metadata remains WatermarkBehavior.NONE after CHAOS-2707.
+
+    Regression guard: removing work-item-labels/projects from _NO_WATERMARK_DATASETS
+    must not accidentally change repo-metadata.
+    """
+    from dev_health_ops.sync.datasets import WatermarkBehavior, get_dataset_spec
+
+    spec = get_dataset_spec("github", "repo-metadata")
+    assert spec is not None
+    assert spec.watermark_behavior == WatermarkBehavior.NONE
+
+
+def test_work_item_labels_and_projects_are_incremental_behavior(db_session):
+    """Registry-level assertion: both datasets now carry WatermarkBehavior.INCREMENTAL.
+
+    Covers all providers that support these datasets.
+    """
+    from dev_health_ops.sync.datasets import WatermarkBehavior, get_dataset_spec
+
+    for provider in ("github", "gitlab", "jira", "linear"):
+        for dataset_key in ("work-item-labels", "work-item-projects"):
+            spec = get_dataset_spec(provider, dataset_key)
+            assert spec is not None, f"{provider}/{dataset_key} not in registry"
+            assert spec.watermark_behavior == WatermarkBehavior.INCREMENTAL, (
+                f"{provider}/{dataset_key} must be INCREMENTAL after CHAOS-2707, "
+                f"got {spec.watermark_behavior}"
+            )

--- a/tests/test_sync_watermarks.py
+++ b/tests/test_sync_watermarks.py
@@ -230,6 +230,25 @@ class TestLegacyTargetAliasWarmsPlanner:
             "repo-metadata must not be warmed by the raw legacy git row (WatermarkBehavior.NONE)"
         )
 
+    def test_work_item_legacy_target_warms_derivative_datasets(self, db_session):
+        from dev_health_ops.sync.watermarks import set_legacy_repo_watermark
+
+        ts = datetime(2026, 6, 26, 12, 0, 0, tzinfo=timezone.utc)
+        set_legacy_repo_watermark(db_session, ORG_ID, REPO_ID, "work-items", ts)
+
+        for dataset_key in (
+            "work-items",
+            "work-item-labels",
+            "work-item-projects",
+            "work-item-history",
+            "work-item-comments",
+        ):
+            stored = get_watermark(db_session, ORG_ID, REPO_ID, dataset_key)
+            assert stored is not None, (
+                f"Planner read for {dataset_key!r} must find the raw work-items row"
+            )
+            assert stored.replace(tzinfo=timezone.utc) == ts
+
     def test_legacy_read_after_canonical_write(self, db_session):
         """Write via canonical dataset_key; legacy read via target must find the row.
 


### PR DESCRIPTION
## Summary
- Treat work-item-labels and work-item-projects as incremental datasets so saved watermarks are honored.
- Keep repo-metadata as the only non-watermarked dataset.
- Add planner, watermark, and adapter regression coverage for CHAOS-2707.

## Verification
- bash ci/local_validate.sh
- Focused suite: uv run pytest tests/test_sync_planner.py tests/test_dataset_adapters.py tests/test_sync_watermarks.py -k 'watermark or work_item'
- Manual in-memory planner QA confirmed labels/projects use saved watermarks while repo-metadata remains NULL.
- Oracle review completed; unintended uv.lock drift was reverted.

SCREENSHOT-WAIVER: backend sync planner/test-only change; no rendered UI.