### PR TITLE
fix(sync): guard provider Sync Now dispatch queue

### DIFF
--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -316,6 +316,12 @@ When `PROVIDER_SYNC_QUEUES_ENABLED=false`, provider sync tasks stay on the
 shared `sync` queue. When the flag is enabled, known providers route to their
 `sync.<provider>` queues.
 
+Manual Sync Now dispatch and finalization tasks are still published to the
+shared `sync` queue. Any deployment that splits provider units into a dedicated
+worker pool must keep that provider pool on `sync` too, or Linear/Jira/
+LaunchDarkly unit queues can sit idle while dispatch waits behind saturated
+generic sync work.
+
 ### Clear queued messages
 
 Use Celery to purge one queue or everything on the broker. Run the

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -141,6 +141,18 @@ _K8S_DIR = _REPO_ROOT / "deploy" / "kubernetes"
 _HELM_DIR = _REPO_ROOT / "deploy" / "helm" / "dev-health"
 
 
+def _platform_compose_path() -> Path | None:
+    for parent in _REPO_ROOT.parents:
+        candidate = parent / "compose.yml"
+        if not candidate.exists():
+            continue
+        services = _load_yaml(candidate).get("services") or {}
+        api_volumes = services.get("api", {}).get("volumes") or []
+        if "api" in services and "worker" in services and "./ops:/app" in api_volumes:
+            return candidate
+    return None
+
+
 def _load_yaml(path: Path) -> dict:
     return yaml.safe_load(path.read_text(encoding="utf-8"))
 
@@ -473,16 +485,34 @@ def test_local_compose_workers_import_mounted_source() -> None:
 
 
 def test_platform_compose_workers_and_beat_import_mounted_source() -> None:
-    compose_path = _REPO_ROOT.parent / "compose.yml"
-    if not compose_path.exists():
+    compose_path = _platform_compose_path()
+    if compose_path is None:
         pytest.skip("platform compose.yml is only present in the monorepo checkout")
 
     services = _load_yaml(compose_path).get("services") or {}
 
-    for service_name in ("worker", "worker-ingest", "worker-heavy", "beat"):
+    service_names = ["worker", "worker-ingest", "worker-heavy", "beat"]
+    if "worker-wi" in services:
+        service_names.append("worker-wi")
+
+    for service_name in service_names:
         service = services[service_name]
         assert service["environment"]["PYTHONPATH"] == "/app/src"
         assert "./ops:/app" in service["volumes"]
+
+
+def test_platform_compose_provider_worker_consumes_sync_dispatch_queue() -> None:
+    compose_path = _platform_compose_path()
+    if compose_path is None:
+        pytest.skip("platform compose.yml is only present in the monorepo checkout")
+
+    services = _load_yaml(compose_path).get("services") or {}
+    provider_worker = services.get("worker-wi")
+    if provider_worker is None:
+        pytest.skip("platform compose.yml has no split provider worker")
+
+    queues = _parse_queues(_container_command_string(provider_worker))
+    assert "sync" in queues
 
 
 def test_compose_workers_override_runner_entrypoint() -> None:


### PR DESCRIPTION
## Summary
- document that manual Sync Now dispatch/finalization remains on the shared `sync` queue
- add a platform compose guard that split provider workers consume `sync` directly
- include `worker-wi` in the mounted-source compose regression check when present

## Validation
- `uv run pytest tests/test_compose_config.py tests/test_dispatch_policy.py tests/api/admin/test_sync_configs.py::test_create_non_git_sync_config_is_integration_native_and_triggerable` - 87 passed
- `bash ci/local_validate.sh` - GATE PASSED; 5838 passed, 44 skipped
- live Sync Now QA for Linear and LaunchDarkly completed successfully with unit attempts=1
- LSP diagnostics clean for `tests/test_compose_config.py`
- Oracle review: no blocking findings

SCREENSHOT-WAIVER: backend/worker queue topology and tests only; no rendered UI changed.