### PR TITLE
feat(auth): CHAOS-2670 Phase-0 onboarding foundation

### DIFF
--- a/src/dev_health_ops/alembic/versions/0026_add_org_onboarding_integration_skipped_at.py
+++ b/src/dev_health_ops/alembic/versions/0026_add_org_onboarding_integration_skipped_at.py
@@ -1,0 +1,59 @@
+"""Add organizations.onboarding_integration_skipped_at.
+
+First-run onboarding (CHAOS-2670 / contract C6): records when an org explicitly
+skipped the first-integration onboarding step so the onboarding-state API
+(CHAOS-2673) and dashboard setup surfaces (CHAOS-2678) can distinguish "skipped"
+from "not yet connected". Nullable timestamp; null = not skipped. The column add
+is guarded for rerun safety (mirrors 0022).
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-06-26 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0026"
+down_revision: str | None = "0025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    _add_column_if_missing(
+        "organizations",
+        sa.Column(
+            "onboarding_integration_skipped_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    _drop_column_if_present("organizations", "onboarding_integration_skipped_at")
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    existing_columns = _column_names(table_name)
+    if column.name not in existing_columns:
+        op.add_column(table_name, column)
+
+
+def _drop_column_if_present(table_name: str, column_name: str) -> None:
+    existing_columns = _column_names(table_name)
+    if column_name in existing_columns:
+        op.drop_column(table_name, column_name)
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -803,3 +803,52 @@ class PlatformStatsResponse(BaseModel):
     active_sync_configs: int
     recent_syncs_success: int
     recent_syncs_failed: int
+
+
+class OnboardingStateResponse(BaseModel):
+    """CHAOS-2670 contract C1: GET /api/v1/auth/onboarding/state.
+
+    Single source of truth for first-run routing. ``next_step`` is computed
+    server-side from membership + connected-integration + persisted skip state
+    (organizations.onboarding_integration_skipped_at). Callable with a verified
+    orgless token; superuser/admin resolves to ``dashboard``.
+    """
+
+    needs_onboarding: bool
+    org_created: bool
+    org_id: str | None = None
+    org_name: str | None = None
+    first_integration_connected: bool
+    integration_skipped: bool
+    recommended_provider: str = "github"
+    next_step: Literal["workspace", "integration", "complete", "dashboard"]
+    blocker: str | None = None
+
+
+class SetupStatusResponse(BaseModel):
+    """CHAOS-2670 contract C2: GET /api/v1/admin/setup/status.
+
+    Powers the dashboard "value-or-precise-blocker" surface: distinguishes
+    not-connected, connected-no-config, config-failed, and sync-running states.
+    Org-scoped admin auth.
+    """
+
+    has_integration: bool
+    providers: list[str] = Field(default_factory=list)
+    has_sync_config: bool
+    sync_config_id: str | None = None
+    first_sync_started: bool
+    sync_status: Literal[
+        "none", "pending", "running", "partial", "complete", "failed"
+    ] = "none"
+    selected_repositories_count: int = 0
+    last_sync_error: str | None = None
+    can_start_sync: bool = False
+    next_action: Literal[
+        "connect_integration",
+        "select_repositories",
+        "create_sync_config",
+        "start_sync",
+        "complete",
+    ]
+    blocker: str | None = None

--- a/src/dev_health_ops/api/auth/config.py
+++ b/src/dev_health_ops/api/auth/config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+AUTH_AUTO_CREATE_ORG_ENV = "AUTH_AUTO_CREATE_ORG_ON_REGISTER"
+
+
+def auth_auto_create_org_on_register(default: bool = True) -> bool:
+    """Whether self-registration auto-creates an Organization + owner Membership.
+
+    Controlled by ``AUTH_AUTO_CREATE_ORG_ON_REGISTER`` (default ``True`` to
+    preserve current production behavior). When ``False``, registration creates
+    the user identity only and the verified user is routed into guided onboarding
+    (CHAOS-2670 / CHAOS-2671 / CHAOS-2682). Unrecognized values fall back to the
+    default so a typo never silently disables org creation in production.
+    """
+    raw = os.getenv(AUTH_AUTO_CREATE_ORG_ENV)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    return default

--- a/src/dev_health_ops/api/auth/routers/register.py
+++ b/src/dev_health_ops/api/auth/routers/register.py
@@ -38,7 +38,7 @@ class RegisterRequest(BaseModel):
 class RegisterResponse(BaseModel):
     message: str
     user_id: str
-    org_id: str
+    org_id: str | None = None
 
 
 @router.post("/register", response_model=RegisterResponse, status_code=201)

--- a/src/dev_health_ops/models/users.py
+++ b/src/dev_health_ops/models/users.py
@@ -199,6 +199,13 @@ class Organization(Base):
         nullable=False,
     )
 
+    # First-run onboarding (CHAOS-2670 / contract C6): when set, the org
+    # explicitly skipped the first-integration onboarding step. Null = not
+    # skipped. Connecting an integration later overrides this for display.
+    onboarding_integration_skipped_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # Relationships
     memberships: Mapped[list[Membership]] = relationship(
         "Membership",

--- a/tests/api/auth/test_onboarding_foundation.py
+++ b/tests/api/auth/test_onboarding_foundation.py
@@ -1,0 +1,81 @@
+"""CHAOS-2670 Phase-0 foundation contracts.
+
+Locks the additive, non-behavior-changing foundation that the parallel streams
+build on: the ``AUTH_AUTO_CREATE_ORG_ON_REGISTER`` flag resolver (C5), the
+nullable ``RegisterResponse.org_id`` (C5), and the frozen C1/C2 response models.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import (
+    OnboardingStateResponse,
+    SetupStatusResponse,
+)
+from dev_health_ops.api.auth.config import auth_auto_create_org_on_register
+from dev_health_ops.api.auth.routers.register import RegisterResponse
+
+
+def test_auth_auto_create_org_defaults_true_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", raising=False)
+    assert auth_auto_create_org_on_register() is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "False", "  OFF "])
+def test_auth_auto_create_org_falsy_values_disable(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", value)
+    assert auth_auto_create_org_on_register() is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on", "TRUE", " On "])
+def test_auth_auto_create_org_truthy_values_enable(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", value)
+    assert auth_auto_create_org_on_register() is True
+
+
+def test_auth_auto_create_org_unknown_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", "banana")
+    assert auth_auto_create_org_on_register() is True
+    assert auth_auto_create_org_on_register(default=False) is False
+
+
+def test_register_response_org_id_is_optional() -> None:
+    orgless = RegisterResponse(message="ok", user_id="u1")
+    assert orgless.org_id is None
+    with_org = RegisterResponse(message="ok", user_id="u1", org_id="o1")
+    assert with_org.org_id == "o1"
+
+
+def test_onboarding_state_response_contract() -> None:
+    resp = OnboardingStateResponse(
+        needs_onboarding=True,
+        org_created=False,
+        first_integration_connected=False,
+        integration_skipped=False,
+        next_step="workspace",
+    )
+    assert resp.recommended_provider == "github"
+    assert resp.org_id is None
+    assert resp.blocker is None
+
+
+def test_setup_status_response_contract_defaults() -> None:
+    resp = SetupStatusResponse(
+        has_integration=False,
+        has_sync_config=False,
+        first_sync_started=False,
+        next_action="connect_integration",
+    )
+    assert resp.providers == []
+    assert resp.sync_status == "none"
+    assert resp.selected_repositories_count == 0
+    assert resp.can_start_sync is False


### PR DESCRIPTION
## What

Phase-0 (lead-owned) foundation for the first-run workspace + integration onboarding epic (CHAOS-2670). Additive and **non-behavior-changing** — it lands the shared seam that the four parallel Phase-1 streams build on without re-coordination.

## Changes
- `AUTH_AUTO_CREATE_ORG_ON_REGISTER` flag resolver (default `true` → preserves prod) — `api/auth/config.py` (C5 / CHAOS-2682)
- `RegisterResponse.org_id` made optional (`str | None`) for the future orgless-register path (C5 / CHAOS-2671)
- `Organization.onboarding_integration_skipped_at` nullable column + Alembic migration `0026` (single linear head; retry-safe column add) — integration-skip persistence (C6)
- Frozen `OnboardingStateResponse` (C1) + `SetupStatusResponse` (C2) Pydantic models in `schemas_flat.py`
- Foundation tests (17 passing): flag resolver, nullable org_id, C1/C2 model contracts

## Validation
- `bash ci/local_validate.sh` → **GATE PASSED** (ruff format+check, mypy, full pytest suite, live-ClickHouse argMax proof)
- pre-commit + pre-push hooks green (ruff, mypy)

## Notes
No production behavior changes: the flag defaults to current behavior, the new column is nullable/unused, and the response models are not yet wired to endpoints. Behavior lands in the Phase-1 stream PRs (CHAOS-2671/2672/2673/2677/2676/2681).

Refs CHAOS-2670, CHAOS-2682.