### PR TITLE
feat(admin): setup status endpoint + return-aware GitHub App install (CHAOS-2677/2676/2681)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0026_add_org_onboarding_integration_skipped_at.py
+++ b/src/dev_health_ops/alembic/versions/0026_add_org_onboarding_integration_skipped_at.py
@@ -1,0 +1,59 @@
+"""Add organizations.onboarding_integration_skipped_at.
+
+First-run onboarding (CHAOS-2670 / contract C6): records when an org explicitly
+skipped the first-integration onboarding step so the onboarding-state API
+(CHAOS-2673) and dashboard setup surfaces (CHAOS-2678) can distinguish "skipped"
+from "not yet connected". Nullable timestamp; null = not skipped. The column add
+is guarded for rerun safety (mirrors 0022).
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-06-26 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0026"
+down_revision: str | None = "0025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    _add_column_if_missing(
+        "organizations",
+        sa.Column(
+            "onboarding_integration_skipped_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    _drop_column_if_present("organizations", "onboarding_integration_skipped_at")
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    existing_columns = _column_names(table_name)
+    if column.name not in existing_columns:
+        op.add_column(table_name, column)
+
+
+def _drop_column_if_present(table_name: str, column_name: str) -> None:
+    existing_columns = _column_names(table_name)
+    if column_name in existing_columns:
+        op.drop_column(table_name, column_name)
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}

--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -17,6 +17,7 @@ from .routers import (
     orgs_router,
     platform_router,
     settings_router,
+    setup_router,
     sync_router,
     teams_router,
     users_router,
@@ -36,6 +37,7 @@ router = APIRouter(
 )
 
 router.include_router(settings_router)
+router.include_router(setup_router)
 router.include_router(credentials_router)
 router.include_router(sync_router)
 router.include_router(identities_router)

--- a/src/dev_health_ops/api/admin/routers/__init__.py
+++ b/src/dev_health_ops/api/admin/routers/__init__.py
@@ -16,6 +16,7 @@ from .integrations import router as integrations_router
 from .orgs import router as orgs_router
 from .platform import router as platform_router
 from .settings import router as settings_router
+from .setup import router as setup_router
 from .sync import router as sync_router
 from .teams import router as teams_router
 from .users import router as users_router
@@ -33,6 +34,7 @@ __all__ = [
     "orgs_router",
     "platform_router",
     "settings_router",
+    "setup_router",
     "sync_router",
     "teams_router",
     "users_router",

--- a/src/dev_health_ops/api/admin/routers/github_app.py
+++ b/src/dev_health_ops/api/admin/routers/github_app.py
@@ -37,6 +37,38 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
+# CHAOS-2676 (C4): the frontend may ask the backend to remember where the
+# browser should land after the GitHub App install round-trip. The value is
+# signed into the install-state JWT and echoed back by the callback; the Next
+# route performs the actual redirect. Only an exact, in-app path from this
+# allowlist is ever trusted: anything else (absolute URLs, protocol-relative
+# //host, backslashes, encoded traversal, query strings, unknown paths) falls
+# back to the admin default so a tampered value can never become an open
+# redirect.
+RETURN_TO_ADMIN_DEFAULT = "/org/admin/integrations/github"
+RETURN_TO_ONBOARDING = "/auth/onboard/integration"
+_ALLOWED_RETURN_TO = frozenset({RETURN_TO_ONBOARDING, RETURN_TO_ADMIN_DEFAULT})
+
+
+def canonicalize_return_to(raw: str | None) -> str:
+    """Return a safe, exact in-app redirect path for the install round-trip.
+
+    Accepts only the two allowlisted paths verbatim; every other input —
+    including ``None``, absolute URLs, protocol-relative ``//host``, paths with
+    backslashes, percent-encoded traversal, or any query/fragment — collapses
+    to :data:`RETURN_TO_ADMIN_DEFAULT`.
+    """
+    if not isinstance(raw, str):
+        return RETURN_TO_ADMIN_DEFAULT
+    candidate = raw.strip()
+    if candidate in _ALLOWED_RETURN_TO:
+        return candidate
+    return RETURN_TO_ADMIN_DEFAULT
+
+
+class GitHubInstallUrlRequest(BaseModel):
+    return_to: str | None = None
+
 
 class GitHubInstallUrlResponse(BaseModel):
     install_url: str
@@ -53,6 +85,7 @@ class GitHubInstallCallbackResponse(BaseModel):
     connected: bool
     installation_id: int
     credential_name: str
+    return_to: str
 
 
 @router.post(
@@ -60,12 +93,14 @@ class GitHubInstallCallbackResponse(BaseModel):
     response_model=GitHubInstallUrlResponse,
 )
 async def create_github_install_url(
+    body: GitHubInstallUrlRequest | None = None,
     org_id: str = Depends(get_admin_org_id),
 ) -> GitHubInstallUrlResponse:
     slug = github_app_slug()
     if not slug:
         raise HTTPException(status_code=400, detail="GITHUB_APP_SLUG is not configured")
-    state = mint_github_app_install_state(org_id)
+    return_to = canonicalize_return_to(body.return_to if body else None)
+    state = mint_github_app_install_state(org_id, return_to=return_to)
     params: dict[str, str] = {"state": state}
     callback_url = github_app_callback_url()
     if callback_url:
@@ -144,6 +179,7 @@ async def complete_github_install(
         connected=True,
         installation_id=body.installation_id,
         credential_name="github-app",
+        return_to=canonicalize_return_to(verified_state.return_to),
     )
 
 

--- a/src/dev_health_ops/api/admin/routers/github_app.py
+++ b/src/dev_health_ops/api/admin/routers/github_app.py
@@ -60,9 +60,8 @@ def canonicalize_return_to(raw: str | None) -> str:
     """
     if not isinstance(raw, str):
         return RETURN_TO_ADMIN_DEFAULT
-    candidate = raw.strip()
-    if candidate in _ALLOWED_RETURN_TO:
-        return candidate
+    if raw in _ALLOWED_RETURN_TO:
+        return raw
     return RETURN_TO_ADMIN_DEFAULT
 
 

--- a/src/dev_health_ops/api/admin/routers/setup.py
+++ b/src/dev_health_ops/api/admin/routers/setup.py
@@ -71,6 +71,16 @@ def _select_primary_config(
     return sorted(parents, key=_key, reverse=True)[0]
 
 
+def _active_parent_configs(
+    configs: list[SyncConfiguration],
+) -> list[SyncConfiguration]:
+    return [
+        c
+        for c in configs
+        if getattr(c, "parent_id") is None and bool(getattr(c, "is_active"))
+    ]
+
+
 async def _selected_repository_count(
     session: AsyncSession, org_id: str, integration_id: object
 ) -> int:
@@ -101,6 +111,64 @@ async def _latest_job_run(
     )
     result = await session.execute(stmt)
     return result.scalars().first()
+
+
+async def _latest_active_parent_run(
+    session: AsyncSession, org_id: str, configs: list[SyncConfiguration]
+) -> tuple[JobRun, SyncConfiguration] | None:
+    active_parents = _active_parent_configs(configs)
+    config_by_id = {getattr(config, "id"): config for config in active_parents}
+    if not config_by_id:
+        return None
+    stmt = (
+        select(JobRun, ScheduledJob.sync_config_id)
+        .join(ScheduledJob, JobRun.job_id == ScheduledJob.id)
+        .where(
+            ScheduledJob.org_id == org_id,
+            ScheduledJob.sync_config_id.in_(config_by_id),
+        )
+        .order_by(JobRun.created_at.desc())
+    )
+    result = await session.execute(stmt)
+    latest_by_config: dict[object, JobRun] = {}
+    for run, config_id in result.all():
+        if config_id not in latest_by_config:
+            latest_by_config[config_id] = run
+
+    status_priority = (
+        JobRunStatus.RUNNING.value,
+        JobRunStatus.PENDING.value,
+        JobRunStatus.FAILED.value,
+        JobRunStatus.CANCELLED.value,
+    )
+    for status in status_priority:
+        for config_id, run in latest_by_config.items():
+            if int(getattr(run, "status")) == status:
+                return run, config_by_id[config_id]
+    return None
+
+
+def _sync_status_from_job_run(run: JobRun) -> SyncStatus:
+    status_int = int(getattr(run, "status"))
+    run_result = getattr(run, "result")
+    run_result = run_result if isinstance(run_result, dict) else {}
+    sync_run_status = str(run_result.get("sync_run_status") or "")
+    if status_int == JobRunStatus.PENDING.value:
+        sync_status: SyncStatus = "pending"
+    elif status_int == JobRunStatus.RUNNING.value:
+        sync_status = "running"
+    elif status_int == JobRunStatus.SUCCESS.value:
+        sync_status = "complete"
+    elif status_int in (
+        JobRunStatus.FAILED.value,
+        JobRunStatus.CANCELLED.value,
+    ):
+        sync_status = "failed"
+    else:
+        sync_status = "running"
+    if sync_run_status in ("partial_failed", "partial"):
+        sync_status = "partial"
+    return sync_status
 
 
 @router.get("/setup/status", response_model=SetupStatusResponse)
@@ -140,31 +208,19 @@ async def get_setup_status(
         else:
             has_repo_selection = True
 
-        latest = await _latest_job_run(session, org_id, getattr(primary, "id"))
+        latest_active = await _latest_active_parent_run(session, org_id, configs)
+        latest = (
+            latest_active[0]
+            if latest_active is not None
+            else await _latest_job_run(session, org_id, getattr(primary, "id"))
+        )
+        latest_config = latest_active[1] if latest_active is not None else primary
         if latest is not None:
             first_sync_started = True
-            status_int = int(getattr(latest, "status"))
-            run_result = getattr(latest, "result")
-            run_result = run_result if isinstance(run_result, dict) else {}
-            sync_run_status = str(run_result.get("sync_run_status") or "")
-            if status_int == JobRunStatus.PENDING.value:
-                sync_status = "pending"
-            elif status_int == JobRunStatus.RUNNING.value:
-                sync_status = "running"
-            elif status_int == JobRunStatus.SUCCESS.value:
-                sync_status = "complete"
-            elif status_int in (
-                JobRunStatus.FAILED.value,
-                JobRunStatus.CANCELLED.value,
-            ):
-                sync_status = "failed"
-            else:
-                sync_status = "running"
-            if sync_run_status in ("partial_failed", "partial"):
-                sync_status = "partial"
+            sync_status = _sync_status_from_job_run(latest)
             if sync_status == "failed":
                 last_sync_error = getattr(latest, "error") or getattr(
-                    primary, "last_sync_error"
+                    latest_config, "last_sync_error"
                 )
         else:
             # No planner run yet — fall back to the config-level last-sync facts

--- a/src/dev_health_ops/api/admin/routers/setup.py
+++ b/src/dev_health_ops/api/admin/routers/setup.py
@@ -1,0 +1,225 @@
+"""CHAOS-2677: first-run setup status endpoint (contract C2).
+
+``GET /api/v1/admin/setup/status`` powers the dashboard
+"value-or-precise-blocker" surface. It is a read-only projection over the
+semantic layer (integration credentials + sync configuration + planner job
+runs) that distinguishes the four first-run states:
+
+* **not-connected** — no active integration credential.
+* **connected-no-config** — credentials exist but no sync config yet.
+* **config-failed** — a sync config exists and its last/most-recent run failed.
+* **sync-running** — a planner job run is pending or running.
+
+The endpoint never starts work and never persists; it only reflects the
+current state so the frontend can route the user to the precise next action.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from fastapi import APIRouter, Depends
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.admin.middleware import get_admin_org_id
+from dev_health_ops.api.admin.schemas_flat import SetupStatusResponse
+from dev_health_ops.api.services.configuration import (
+    IntegrationCredentialsService,
+    SyncConfigurationService,
+)
+from dev_health_ops.models.integrations import IntegrationSource
+from dev_health_ops.models.settings import (
+    JobRun,
+    JobRunStatus,
+    ScheduledJob,
+    SyncConfiguration,
+)
+
+from .common import get_session
+
+router = APIRouter()
+
+_REPO_PROVIDERS = {"github", "gitlab"}
+
+SyncStatus = Literal["none", "pending", "running", "partial", "complete", "failed"]
+NextAction = Literal[
+    "connect_integration",
+    "select_repositories",
+    "create_sync_config",
+    "start_sync",
+    "complete",
+]
+
+
+def _select_primary_config(
+    configs: list[SyncConfiguration],
+) -> SyncConfiguration | None:
+    """Pick the most relevant parent (non-child) sync config.
+
+    Prefer active configs, then the most recently created one, so the status
+    surface tracks the config the operator most likely just set up.
+    """
+    parents = [c for c in configs if getattr(c, "parent_id") is None]
+    if not parents:
+        return None
+
+    def _key(config: SyncConfiguration) -> tuple[int, str]:
+        created = getattr(config, "created_at", None)
+        return (1 if bool(getattr(config, "is_active")) else 0, str(created or ""))
+
+    return sorted(parents, key=_key, reverse=True)[0]
+
+
+async def _selected_repository_count(
+    session: AsyncSession, org_id: str, integration_id: object
+) -> int:
+    if integration_id is None:
+        return 0
+    count = await session.scalar(
+        select(func.count(IntegrationSource.id)).where(
+            IntegrationSource.org_id == org_id,
+            IntegrationSource.integration_id == integration_id,
+            IntegrationSource.is_enabled.is_(True),
+        )
+    )
+    return int(count or 0)
+
+
+async def _latest_job_run(
+    session: AsyncSession, org_id: str, config_id: object
+) -> JobRun | None:
+    stmt = (
+        select(JobRun)
+        .join(ScheduledJob, JobRun.job_id == ScheduledJob.id)
+        .where(
+            ScheduledJob.org_id == org_id,
+            ScheduledJob.sync_config_id == config_id,
+        )
+        .order_by(JobRun.created_at.desc())
+        .limit(1)
+    )
+    result = await session.execute(stmt)
+    return result.scalars().first()
+
+
+@router.get("/setup/status", response_model=SetupStatusResponse)
+async def get_setup_status(
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> SetupStatusResponse:
+    cred_svc = IntegrationCredentialsService(session, org_id)
+    credentials = await cred_svc.list_all(active_only=True)
+    providers = sorted({str(getattr(c, "provider")) for c in credentials})
+    has_integration = bool(providers)
+
+    sync_svc = SyncConfigurationService(session, org_id)
+    configs = await sync_svc.list_all()
+    primary = _select_primary_config(configs)
+    has_sync_config = primary is not None
+
+    sync_config_id: str | None = None
+    sync_status: SyncStatus = "none"
+    first_sync_started = False
+    selected_repositories_count = 0
+    last_sync_error: str | None = None
+    can_start_sync = False
+    has_repo_selection = True
+
+    if primary is not None:
+        sync_config_id = str(getattr(primary, "id"))
+        provider = str(getattr(primary, "provider")).lower()
+        sync_options = dict(getattr(primary, "sync_options") or {})
+        selected_repositories_count = await _selected_repository_count(
+            session, org_id, getattr(primary, "integration_id")
+        )
+        if provider in _REPO_PROVIDERS:
+            has_repo_selection = selected_repositories_count > 0 or bool(
+                sync_options.get("all_repos")
+            )
+        else:
+            has_repo_selection = True
+
+        latest = await _latest_job_run(session, org_id, getattr(primary, "id"))
+        if latest is not None:
+            first_sync_started = True
+            status_int = int(getattr(latest, "status"))
+            run_result = getattr(latest, "result")
+            run_result = run_result if isinstance(run_result, dict) else {}
+            sync_run_status = str(run_result.get("sync_run_status") or "")
+            if status_int == JobRunStatus.PENDING.value:
+                sync_status = "pending"
+            elif status_int == JobRunStatus.RUNNING.value:
+                sync_status = "running"
+            elif status_int == JobRunStatus.SUCCESS.value:
+                sync_status = "complete"
+            elif status_int in (
+                JobRunStatus.FAILED.value,
+                JobRunStatus.CANCELLED.value,
+            ):
+                sync_status = "failed"
+            else:
+                sync_status = "running"
+            if sync_run_status in ("partial_failed", "partial"):
+                sync_status = "partial"
+            if sync_status == "failed":
+                last_sync_error = getattr(latest, "error") or getattr(
+                    primary, "last_sync_error"
+                )
+        else:
+            # No planner run yet — fall back to the config-level last-sync facts
+            # so a sync recorded outside the job-run anchor still surfaces.
+            if getattr(primary, "last_sync_success") is True:
+                sync_status = "complete"
+                first_sync_started = True
+            elif (
+                getattr(primary, "last_sync_error")
+                or getattr(primary, "last_sync_success") is False
+            ):
+                sync_status = "failed"
+                first_sync_started = True
+                last_sync_error = getattr(primary, "last_sync_error")
+            else:
+                sync_status = "none"
+
+        in_flight = sync_status in ("pending", "running")
+        can_start_sync = (
+            bool(getattr(primary, "is_active")) and not in_flight and has_repo_selection
+        )
+
+    next_action: NextAction
+    blocker: str | None = None
+    if not has_integration:
+        next_action = "connect_integration"
+        blocker = "No integration connected"
+    elif not has_sync_config:
+        next_action = (
+            "select_repositories"
+            if any(p in _REPO_PROVIDERS for p in providers)
+            else "create_sync_config"
+        )
+        blocker = "No sync configuration"
+    elif sync_status == "failed":
+        next_action = "start_sync"
+        blocker = last_sync_error or "Last sync failed"
+    elif sync_status in ("pending", "running", "complete", "partial"):
+        next_action = "complete"
+    elif not has_repo_selection:
+        next_action = "select_repositories"
+        blocker = "No repositories selected"
+    else:
+        next_action = "start_sync"
+
+    return SetupStatusResponse(
+        has_integration=has_integration,
+        providers=providers,
+        has_sync_config=has_sync_config,
+        sync_config_id=sync_config_id,
+        first_sync_started=first_sync_started,
+        sync_status=sync_status,
+        selected_repositories_count=selected_repositories_count,
+        last_sync_error=last_sync_error,
+        can_start_sync=can_start_sync,
+        next_action=next_action,
+        blocker=blocker,
+    )

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -803,3 +803,52 @@ class PlatformStatsResponse(BaseModel):
     active_sync_configs: int
     recent_syncs_success: int
     recent_syncs_failed: int
+
+
+class OnboardingStateResponse(BaseModel):
+    """CHAOS-2670 contract C1: GET /api/v1/auth/onboarding/state.
+
+    Single source of truth for first-run routing. ``next_step`` is computed
+    server-side from membership + connected-integration + persisted skip state
+    (organizations.onboarding_integration_skipped_at). Callable with a verified
+    orgless token; superuser/admin resolves to ``dashboard``.
+    """
+
+    needs_onboarding: bool
+    org_created: bool
+    org_id: str | None = None
+    org_name: str | None = None
+    first_integration_connected: bool
+    integration_skipped: bool
+    recommended_provider: str = "github"
+    next_step: Literal["workspace", "integration", "complete", "dashboard"]
+    blocker: str | None = None
+
+
+class SetupStatusResponse(BaseModel):
+    """CHAOS-2670 contract C2: GET /api/v1/admin/setup/status.
+
+    Powers the dashboard "value-or-precise-blocker" surface: distinguishes
+    not-connected, connected-no-config, config-failed, and sync-running states.
+    Org-scoped admin auth.
+    """
+
+    has_integration: bool
+    providers: list[str] = Field(default_factory=list)
+    has_sync_config: bool
+    sync_config_id: str | None = None
+    first_sync_started: bool
+    sync_status: Literal[
+        "none", "pending", "running", "partial", "complete", "failed"
+    ] = "none"
+    selected_repositories_count: int = 0
+    last_sync_error: str | None = None
+    can_start_sync: bool = False
+    next_action: Literal[
+        "connect_integration",
+        "select_repositories",
+        "create_sync_config",
+        "start_sync",
+        "complete",
+    ]
+    blocker: str | None = None

--- a/src/dev_health_ops/api/auth/config.py
+++ b/src/dev_health_ops/api/auth/config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+AUTH_AUTO_CREATE_ORG_ENV = "AUTH_AUTO_CREATE_ORG_ON_REGISTER"
+
+
+def auth_auto_create_org_on_register(default: bool = True) -> bool:
+    """Whether self-registration auto-creates an Organization + owner Membership.
+
+    Controlled by ``AUTH_AUTO_CREATE_ORG_ON_REGISTER`` (default ``True`` to
+    preserve current production behavior). When ``False``, registration creates
+    the user identity only and the verified user is routed into guided onboarding
+    (CHAOS-2670 / CHAOS-2671 / CHAOS-2682). Unrecognized values fall back to the
+    default so a typo never silently disables org creation in production.
+    """
+    raw = os.getenv(AUTH_AUTO_CREATE_ORG_ENV)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    return default

--- a/src/dev_health_ops/api/auth/routers/register.py
+++ b/src/dev_health_ops/api/auth/routers/register.py
@@ -38,7 +38,7 @@ class RegisterRequest(BaseModel):
 class RegisterResponse(BaseModel):
     message: str
     user_id: str
-    org_id: str
+    org_id: str | None = None
 
 
 @router.post("/register", response_model=RegisterResponse, status_code=201)

--- a/src/dev_health_ops/api/integrations/github_app_state.py
+++ b/src/dev_health_ops/api/integrations/github_app_state.py
@@ -27,9 +27,10 @@ class GitHubAppStateError(ValueError):
 class GitHubAppInstallState:
     org_id: str
     jti: str
+    return_to: str | None = None
 
 
-def mint_github_app_install_state(org_id: str) -> str:
+def mint_github_app_install_state(org_id: str, return_to: str | None = None) -> str:
     now = datetime.now(timezone.utc)
     payload: dict[str, Any] = {
         "org_id": org_id,
@@ -40,6 +41,8 @@ def mint_github_app_install_state(org_id: str) -> str:
         "iat": now,
         "exp": now + timedelta(minutes=GITHUB_APP_STATE_TTL_MINUTES),
     }
+    if return_to is not None:
+        payload["return_to"] = return_to
     return jwt.encode(payload, _get_jwt_secret(), algorithm=JWT_ALGORITHM)
 
 
@@ -63,4 +66,6 @@ def verify_github_app_install_state(state: str) -> GitHubAppInstallState:
     jti = payload.get("jti")
     if not isinstance(jti, str) or not jti:
         raise GitHubAppStateError("Invalid GitHub App installation state identifier")
-    return GitHubAppInstallState(org_id=org_id, jti=jti)
+    raw_return_to = payload.get("return_to")
+    return_to = raw_return_to if isinstance(raw_return_to, str) else None
+    return GitHubAppInstallState(org_id=org_id, jti=jti, return_to=return_to)

--- a/src/dev_health_ops/models/users.py
+++ b/src/dev_health_ops/models/users.py
@@ -199,6 +199,13 @@ class Organization(Base):
         nullable=False,
     )
 
+    # First-run onboarding (CHAOS-2670 / contract C6): when set, the org
+    # explicitly skipped the first-integration onboarding step. Null = not
+    # skipped. Connecting an integration later overrides this for display.
+    onboarding_integration_skipped_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # Relationships
     memberships: Mapped[list[Membership]] = relationship(
         "Membership",

--- a/tests/api/admin/test_github_app_install.py
+++ b/tests/api/admin/test_github_app_install.py
@@ -206,6 +206,7 @@ async def test_install_callback_writes_credential_and_installation(
         "connected": True,
         "installation_id": 987654,
         "credential_name": "github-app",
+        "return_to": "/org/admin/integrations/github",
     }
     async with session_maker() as session:
         installation = (
@@ -591,3 +592,145 @@ async def test_install_url_omits_redirect_uri_when_not_configured(
     qs = parse_qs(parsed.query)
     assert "redirect_uri" not in qs
     assert "state" in qs
+    assert verify_github_app_install_state(qs["state"][0]).org_id == org_id
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2676 (C4): return_to is allowlist-validated, signed into the state, and
+# echoed back by the callback so the Next route (not the backend) redirects.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_install_url_signs_allowlisted_return_to(session_maker, monkeypatch):
+    org_id = str(uuid.uuid4())
+    monkeypatch.setenv("GITHUB_APP_SLUG", "dev-health-test")
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-url",
+            json={"return_to": "/auth/onboard/integration"},
+        )
+
+    assert response.status_code == 200, response.text
+    state = parse_qs(urlparse(response.json()["install_url"]).query)["state"][0]
+    verified = verify_github_app_install_state(state)
+    assert verified.org_id == org_id
+    assert verified.return_to == "/auth/onboard/integration"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "unsafe",
+    [
+        "https://evil.example.com/phish",
+        "http://localhost:3000/auth/onboard/integration",
+        "//evil.example.com",
+        "/auth/onboard/integration/../../evil",
+        "/auth/onboard/integration%2f..%2fevil",
+        "/auth/onboard/integration?next=https://evil.example.com",
+        "\\\\evil.example.com",
+        "/org/admin/integrations/github?x=1",
+        "/unknown/path",
+        "javascript:alert(1)",
+        "",
+    ],
+)
+async def test_install_url_rejects_unsafe_return_to(session_maker, monkeypatch, unsafe):
+    org_id = str(uuid.uuid4())
+    monkeypatch.setenv("GITHUB_APP_SLUG", "dev-health-test")
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-url",
+            json={"return_to": unsafe},
+        )
+
+    assert response.status_code == 200, response.text
+    state = parse_qs(urlparse(response.json()["install_url"]).query)["state"][0]
+    verified = verify_github_app_install_state(state)
+    # Every unsafe value collapses to the admin default — never the raw input.
+    assert verified.return_to == "/org/admin/integrations/github"
+
+
+@pytest.mark.asyncio
+async def test_install_url_defaults_return_to_when_absent(session_maker, monkeypatch):
+    org_id = str(uuid.uuid4())
+    monkeypatch.setenv("GITHUB_APP_SLUG", "dev-health-test")
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post("/admin/integrations/github/install-url")
+
+    assert response.status_code == 200, response.text
+    state = parse_qs(urlparse(response.json()["install_url"]).query)["state"][0]
+    assert (
+        verify_github_app_install_state(state).return_to
+        == "/org/admin/integrations/github"
+    )
+
+
+@pytest.mark.asyncio
+async def test_install_callback_returns_validated_return_to(session_maker, monkeypatch):
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    _patch_github_user_installations(monkeypatch, [_installation()])
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": "install",
+                "state": mint_github_app_install_state(
+                    org_id, return_to="/auth/onboard/integration"
+                ),
+                "code": "oauth-code",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["return_to"] == "/auth/onboard/integration"
+
+
+@pytest.mark.asyncio
+async def test_install_callback_recanonicalizes_tampered_state_return_to(
+    session_maker, monkeypatch
+):
+    # Defense-in-depth: even if a signed state somehow carried an unsafe path,
+    # the callback re-validates before echoing it back.
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    _patch_github_user_installations(monkeypatch, [_installation()])
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": "install",
+                "state": mint_github_app_install_state(
+                    org_id, return_to="https://evil.example.com"
+                ),
+                "code": "oauth-code",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    assert response.json()["return_to"] == "/org/admin/integrations/github"

--- a/tests/api/admin/test_github_app_install.py
+++ b/tests/api/admin/test_github_app_install.py
@@ -9,7 +9,7 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.integrations.github_app_state import (
@@ -18,7 +18,13 @@ from dev_health_ops.api.integrations.github_app_state import (
 )
 from dev_health_ops.api.services.configuration import IntegrationCredentialsService
 from dev_health_ops.models.git import Base
-from dev_health_ops.models.settings import GithubAppInstallation, IntegrationCredential
+from dev_health_ops.models.settings import (
+    GithubAppInstallation,
+    IntegrationCredential,
+    JobRun,
+    ScheduledJob,
+    SyncConfiguration,
+)
 from tests._helpers import tables_of
 
 github_app_router_module = importlib.import_module(
@@ -36,7 +42,13 @@ async def session_maker(tmp_path: Path, monkeypatch):
         await conn.run_sync(
             lambda sync_conn: Base.metadata.create_all(
                 sync_conn,
-                tables=tables_of(GithubAppInstallation, IntegrationCredential),
+                tables=tables_of(
+                    GithubAppInstallation,
+                    IntegrationCredential,
+                    SyncConfiguration,
+                    ScheduledJob,
+                    JobRun,
+                ),
             )
         )
     maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
@@ -227,6 +239,41 @@ async def test_install_callback_writes_credential_and_installation(
     }
     assert credential is not None
     assert credential.is_active is True
+
+
+@pytest.mark.asyncio
+async def test_install_callback_does_not_create_sync_work(
+    session_maker,
+    monkeypatch,
+):
+    org_id = str(uuid.uuid4())
+    _configure_github_app(monkeypatch)
+    _patch_cache(monkeypatch)
+    _patch_github_user_installations(monkeypatch, [_installation()])
+    app = _app(session_maker, org_id)
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.post(
+            "/admin/integrations/github/install-callback",
+            json={
+                "installation_id": 987654,
+                "setup_action": "install",
+                "state": mint_github_app_install_state(org_id),
+                "code": "oauth-code",
+            },
+        )
+
+    assert response.status_code == 200, response.text
+    async with session_maker() as session:
+        sync_configs = await session.scalar(select(func.count(SyncConfiguration.id)))
+        scheduled_jobs = await session.scalar(select(func.count(ScheduledJob.id)))
+        job_runs = await session.scalar(select(func.count(JobRun.id)))
+
+    assert sync_configs == 0
+    assert scheduled_jobs == 0
+    assert job_runs == 0
 
 
 @pytest.mark.asyncio
@@ -512,10 +559,11 @@ async def test_install_callback_rejects_replayed_state(session_maker, monkeypatc
         [_installation()],
         token_responses=[
             FakeGitHubResponse(200, {"access_token": "user-token"}),
-            FakeGitHubResponse(400, {"error": "bad_verification_code"}),
+            FakeGitHubResponse(200, {"access_token": "user-token"}),
         ],
     )
     app = _app(session_maker, org_id)
+    state = mint_github_app_install_state(org_id)
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"
@@ -525,7 +573,7 @@ async def test_install_callback_rejects_replayed_state(session_maker, monkeypatc
             json={
                 "installation_id": 987654,
                 "setup_action": None,
-                "state": mint_github_app_install_state(org_id),
+                "state": state,
                 "code": "oauth-code",
             },
         )
@@ -534,14 +582,14 @@ async def test_install_callback_rejects_replayed_state(session_maker, monkeypatc
             json={
                 "installation_id": 987654,
                 "setup_action": None,
-                "state": mint_github_app_install_state(org_id),
+                "state": state,
                 "code": "oauth-code",
             },
         )
 
     assert first.status_code == 200, first.text
     assert second.status_code == 400, second.text
-    assert second.json()["detail"] == "GitHub user authorization could not be verified"
+    assert second.json()["detail"] == "GitHub App installation state already used"
 
 
 @pytest.mark.asyncio
@@ -629,6 +677,15 @@ async def test_install_url_signs_allowlisted_return_to(session_maker, monkeypatc
         "https://evil.example.com/phish",
         "http://localhost:3000/auth/onboard/integration",
         "//evil.example.com",
+        " /auth/onboard/integration ",
+        "\n/auth/onboard/integration\r",
+        "/auth/onboard/\nintegration",
+        "/auth/onboard/integration#next",
+        "/auth/onboard/integration%3Fnext%3D%2Fadmin",
+        "/auth/onboard/integration%23next",
+        "/Auth/Onboard/Integration",
+        "／auth／onboard／integration",
+        "/auth/onboard/integration%252f..%252fevil",
         "/auth/onboard/integration/../../evil",
         "/auth/onboard/integration%2f..%2fevil",
         "/auth/onboard/integration?next=https://evil.example.com",

--- a/tests/api/admin/test_setup_status.py
+++ b/tests/api/admin/test_setup_status.py
@@ -371,6 +371,36 @@ async def test_setup_status_sync_running(client, session_maker, status, expected
 
 
 @pytest.mark.asyncio
+async def test_setup_status_sync_running_on_non_primary_config_blocks_start(
+    client, session_maker
+):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"])
+    older_config_id = await _add_config(
+        session_maker, seeded_state["org_id"], name="older"
+    )
+    newer_config_id = await _add_config(
+        session_maker, seeded_state["org_id"], name="newer"
+    )
+    await _add_job_run(
+        session_maker,
+        seeded_state["org_id"],
+        older_config_id,
+        status=JobRunStatus.RUNNING.value,
+    )
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["sync_config_id"] == newer_config_id
+    assert data["first_sync_started"] is True
+    assert data["sync_status"] == "running"
+    assert data["can_start_sync"] is False
+    assert data["next_action"] == "complete"
+
+
+@pytest.mark.asyncio
 async def test_setup_status_sync_complete(client, session_maker):
     ac, seeded_state = client
     await _add_credential(session_maker, seeded_state["org_id"])

--- a/tests/api/admin/test_setup_status.py
+++ b/tests/api/admin/test_setup_status.py
@@ -1,0 +1,409 @@
+"""CHAOS-2677: GET /api/v1/admin/setup/status (contract C2).
+
+Seeds each of the four first-run states the dashboard must distinguish
+(not-connected, connected-no-config, config-failed, sync-running) plus a
+non-admin 403, and asserts the C2 projection over credentials + sync config +
+planner job runs.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.integrations import (
+    Integration,
+    IntegrationDataset,
+    IntegrationSource,
+    SyncRun,
+    SyncRunUnit,
+)
+from dev_health_ops.models.settings import (
+    IntegrationCredential,
+    JobRun,
+    JobRunStatus,
+    ScheduledJob,
+    SyncConfiguration,
+)
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+admin_router_module = importlib.import_module("dev_health_ops.api.admin")
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    Membership,
+    IntegrationCredential,
+    SyncConfiguration,
+    ScheduledJob,
+    JobRun,
+    Integration,
+    IntegrationSource,
+    IntegrationDataset,
+    SyncRun,
+    SyncRunUnit,
+)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "setup-status.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_state(session_maker):
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    org = Organization(id=org_id, slug="test-org", name="Test Org")
+    user = User(id=user_id, email="admin@example.com", is_active=True)
+    async with session_maker() as session:
+        session.add_all([org, user])
+        session.add(Membership(org_id=org_id, user_id=user_id, role="owner"))
+        await session.commit()
+    return {"org_id": str(org_id), "user_id": str(user_id)}
+
+
+def _build_app(session_maker, current_user: AuthenticatedUser) -> FastAPI:
+    app = FastAPI()
+    app.include_router(admin_router_module.router)
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: current_user
+    app.dependency_overrides[admin_router_module.get_session] = _session_override
+    return app
+
+
+@pytest_asyncio.fixture
+async def client(session_maker, seeded_state):
+    admin_user = AuthenticatedUser(
+        user_id=seeded_state["user_id"],
+        email="admin@example.com",
+        org_id=seeded_state["org_id"],
+        role="owner",
+        is_superuser=False,
+    )
+    app = _build_app(session_maker, admin_user)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, seeded_state
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Seeding helpers
+# ---------------------------------------------------------------------------
+
+
+async def _add_credential(session_maker, org_id: str, provider: str = "github") -> None:
+    async with session_maker() as session:
+        session.add(
+            IntegrationCredential(
+                provider=provider,
+                name="github-app",
+                org_id=org_id,
+                credentials_encrypted="enc",
+                is_active=True,
+            )
+        )
+        await session.commit()
+
+
+async def _add_config(
+    session_maker,
+    org_id: str,
+    *,
+    provider: str = "github",
+    name: str = "primary",
+    with_repo_source: bool = True,
+    last_sync_success: bool | None = None,
+    last_sync_error: str | None = None,
+) -> str:
+    async with session_maker() as session:
+        integration = Integration(
+            org_id=org_id,
+            provider=provider,
+            name=f"{name}-integration",
+            config={},
+            is_active=True,
+        )
+        session.add(integration)
+        await session.flush()
+        config = SyncConfiguration(
+            name=name,
+            provider=provider,
+            org_id=org_id,
+            sync_targets=["git"],
+            sync_options={},
+            is_active=True,
+            integration_id=integration.id,
+        )
+        config.planner_managed = True
+        config.last_sync_success = last_sync_success
+        config.last_sync_error = last_sync_error
+        session.add(config)
+        if with_repo_source:
+            session.add(
+                IntegrationSource(
+                    org_id=org_id,
+                    integration_id=integration.id,
+                    provider=provider,
+                    source_type="repository",
+                    external_id="acme/repo",
+                    name="repo",
+                    full_name="acme/repo",
+                    metadata_={},
+                    is_enabled=True,
+                )
+            )
+        await session.flush()
+        config_id = str(config.id)
+        await session.commit()
+    return config_id
+
+
+async def _add_job_run(
+    session_maker,
+    org_id: str,
+    config_id: str,
+    *,
+    status: int,
+    error: str | None = None,
+) -> None:
+    async with session_maker() as session:
+        job = ScheduledJob(
+            name=f"sync-config-{config_id}",
+            job_type="sync",
+            schedule_cron="0 * * * *",
+            org_id=org_id,
+            provider="github",
+            sync_config_id=uuid.UUID(config_id),
+        )
+        session.add(job)
+        await session.flush()
+        run = JobRun(job_id=job.id, triggered_by="manual", status=status)
+        run.error = error
+        run.created_at = datetime.now(timezone.utc)
+        session.add(run)
+        await session.commit()
+
+
+# ---------------------------------------------------------------------------
+# State coverage
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_setup_status_not_connected(client):
+    ac, _ = client
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["has_integration"] is False
+    assert data["providers"] == []
+    assert data["has_sync_config"] is False
+    assert data["sync_status"] == "none"
+    assert data["next_action"] == "connect_integration"
+    assert data["blocker"] == "No integration connected"
+
+
+@pytest.mark.asyncio
+async def test_setup_status_connected_no_config_github(client, session_maker):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"], provider="github")
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["has_integration"] is True
+    assert data["providers"] == ["github"]
+    assert data["has_sync_config"] is False
+    assert data["sync_config_id"] is None
+    assert data["next_action"] == "select_repositories"
+    assert data["blocker"] == "No sync configuration"
+
+
+@pytest.mark.asyncio
+async def test_setup_status_connected_no_config_non_repo_provider(
+    client, session_maker
+):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"], provider="jira")
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["providers"] == ["jira"]
+    assert data["next_action"] == "create_sync_config"
+
+
+@pytest.mark.asyncio
+async def test_setup_status_config_ready_to_start(client, session_maker):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"])
+    config_id = await _add_config(session_maker, seeded_state["org_id"])
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["has_sync_config"] is True
+    assert data["sync_config_id"] == config_id
+    assert data["selected_repositories_count"] == 1
+    assert data["first_sync_started"] is False
+    assert data["sync_status"] == "none"
+    assert data["can_start_sync"] is True
+    assert data["next_action"] == "start_sync"
+
+
+@pytest.mark.asyncio
+async def test_setup_status_config_without_repo_selection_blocks(client, session_maker):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"])
+    await _add_config(session_maker, seeded_state["org_id"], with_repo_source=False)
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["selected_repositories_count"] == 0
+    assert data["can_start_sync"] is False
+    assert data["next_action"] == "select_repositories"
+    assert data["blocker"] == "No repositories selected"
+
+
+@pytest.mark.asyncio
+async def test_setup_status_config_failed_via_job_run(client, session_maker):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"])
+    config_id = await _add_config(session_maker, seeded_state["org_id"])
+    await _add_job_run(
+        session_maker,
+        seeded_state["org_id"],
+        config_id,
+        status=JobRunStatus.FAILED.value,
+        error="boom: credentials expired",
+    )
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["first_sync_started"] is True
+    assert data["sync_status"] == "failed"
+    assert data["last_sync_error"] == "boom: credentials expired"
+    assert data["next_action"] == "start_sync"
+    assert data["blocker"] == "boom: credentials expired"
+
+
+@pytest.mark.asyncio
+async def test_setup_status_config_failed_via_last_sync_fields(client, session_maker):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"])
+    await _add_config(
+        session_maker,
+        seeded_state["org_id"],
+        last_sync_success=False,
+        last_sync_error="prior failure",
+    )
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["sync_status"] == "failed"
+    assert data["last_sync_error"] == "prior failure"
+    assert data["next_action"] == "start_sync"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("status", "expected"),
+    [
+        (JobRunStatus.PENDING.value, "pending"),
+        (JobRunStatus.RUNNING.value, "running"),
+    ],
+)
+async def test_setup_status_sync_running(client, session_maker, status, expected):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"])
+    config_id = await _add_config(session_maker, seeded_state["org_id"])
+    await _add_job_run(session_maker, seeded_state["org_id"], config_id, status=status)
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["first_sync_started"] is True
+    assert data["sync_status"] == expected
+    assert data["can_start_sync"] is False
+    assert data["next_action"] == "complete"
+    assert data["blocker"] is None
+
+
+@pytest.mark.asyncio
+async def test_setup_status_sync_complete(client, session_maker):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"])
+    config_id = await _add_config(session_maker, seeded_state["org_id"])
+    await _add_job_run(
+        session_maker,
+        seeded_state["org_id"],
+        config_id,
+        status=JobRunStatus.SUCCESS.value,
+    )
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["sync_status"] == "complete"
+    assert data["first_sync_started"] is True
+    assert data["next_action"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_setup_status_requires_admin(session_maker, seeded_state):
+    non_admin = AuthenticatedUser(
+        user_id=seeded_state["user_id"],
+        email="member@example.com",
+        org_id=seeded_state["org_id"],
+        role="member",
+        is_superuser=False,
+    )
+    app = _build_app(session_maker, non_admin)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/admin/setup/status")
+    app.dependency_overrides.clear()
+
+    assert resp.status_code == 403, resp.text

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -26,6 +26,7 @@ from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import (
     IntegrationCredential,
     JobRun,
+    JobRunStatus,
     JobStatus,
     ScheduledJob,
     Setting,
@@ -2001,3 +2002,90 @@ async def test_batch_create_gitlab_numeric_entry_not_in_listing_used_as_id(
         source = (await session.execute(select(IntegrationSource))).scalar_one()
     assert source.external_id == "12345"
     assert source.full_name == "acme-group/12345"
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2681: connecting an integration must NOT silently create+start a broad
+# sync. The connect step alone yields no sync config (no enabled, no running);
+# a sync only starts after explicit repository selection (/sync-configs/batch)
+# followed by an explicit start (/sync-configs/{id}/trigger).
+# ---------------------------------------------------------------------------
+
+
+async def _simulate_connect(session_maker, org_id: str) -> None:
+    """Mimic the GitHub App connect step: a credential, nothing else."""
+    async with session_maker() as session:
+        session.add(
+            IntegrationCredential(
+                provider="github",
+                name="github-app",
+                org_id=org_id,
+                credentials_encrypted="enc",
+                is_active=True,
+            )
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_connect_only_creates_no_enabled_or_running_sync(client, session_maker):
+    ac, seeded_state = client
+    await _simulate_connect(session_maker, seeded_state["org_id"])
+
+    # The connect step alone must not materialize any sync config or job run.
+    list_resp = await ac.get("/api/v1/admin/sync-configs")
+    assert list_resp.status_code == 200
+    assert list_resp.json() == []
+
+    async with session_maker() as session:
+        configs = (await session.execute(select(SyncConfiguration))).scalars().all()
+        jobs = (await session.execute(select(ScheduledJob))).scalars().all()
+        runs = (await session.execute(select(JobRun))).scalars().all()
+
+    assert configs == []
+    assert jobs == []
+    assert runs == []
+
+
+@pytest.mark.asyncio
+async def test_sync_starts_only_after_explicit_select_and_start(client, session_maker):
+    ac, seeded_state = client
+    await _simulate_connect(session_maker, seeded_state["org_id"])
+
+    # Step 1 (explicit select): batch-create with concrete repos. This enables a
+    # planner config but must NOT dispatch a run on its own.
+    select_resp = await ac.post(
+        "/api/v1/admin/sync-configs/batch",
+        json={
+            "name": "explicit-select",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"owner": "acme"},
+            "repos": ["web"],
+        },
+    )
+    assert select_resp.status_code == 201, select_resp.text
+    config_id = select_resp.json()["parent"]["id"]
+
+    async with session_maker() as session:
+        runs_after_select = (await session.execute(select(JobRun))).scalars().all()
+    # Selecting repositories enables the config but starts no sync run.
+    assert runs_after_select == []
+
+    # Step 2 (explicit start): trigger dispatches a run and persists a PENDING
+    # JobRun. dispatch is mocked so no Celery broker is needed.
+    mock_dispatch = MagicMock()
+    mock_dispatch.apply_async.return_value = MagicMock(id="task-id")
+    with patch(
+        "dev_health_ops.api.admin.routers.sync.dispatch_sync_run", mock_dispatch
+    ):
+        trigger_resp = await ac.post(f"/api/v1/admin/sync-configs/{config_id}/trigger")
+
+    assert trigger_resp.status_code == 202, trigger_resp.text
+    assert trigger_resp.json()["status"] == "triggered"
+    mock_dispatch.apply_async.assert_called_once()
+
+    async with session_maker() as session:
+        runs_after_start = (await session.execute(select(JobRun))).scalars().all()
+    assert len(runs_after_start) == 1
+    assert runs_after_start[0].status == JobRunStatus.PENDING.value

--- a/tests/api/auth/test_onboarding_foundation.py
+++ b/tests/api/auth/test_onboarding_foundation.py
@@ -1,0 +1,81 @@
+"""CHAOS-2670 Phase-0 foundation contracts.
+
+Locks the additive, non-behavior-changing foundation that the parallel streams
+build on: the ``AUTH_AUTO_CREATE_ORG_ON_REGISTER`` flag resolver (C5), the
+nullable ``RegisterResponse.org_id`` (C5), and the frozen C1/C2 response models.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import (
+    OnboardingStateResponse,
+    SetupStatusResponse,
+)
+from dev_health_ops.api.auth.config import auth_auto_create_org_on_register
+from dev_health_ops.api.auth.routers.register import RegisterResponse
+
+
+def test_auth_auto_create_org_defaults_true_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", raising=False)
+    assert auth_auto_create_org_on_register() is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "False", "  OFF "])
+def test_auth_auto_create_org_falsy_values_disable(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", value)
+    assert auth_auto_create_org_on_register() is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on", "TRUE", " On "])
+def test_auth_auto_create_org_truthy_values_enable(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", value)
+    assert auth_auto_create_org_on_register() is True
+
+
+def test_auth_auto_create_org_unknown_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", "banana")
+    assert auth_auto_create_org_on_register() is True
+    assert auth_auto_create_org_on_register(default=False) is False
+
+
+def test_register_response_org_id_is_optional() -> None:
+    orgless = RegisterResponse(message="ok", user_id="u1")
+    assert orgless.org_id is None
+    with_org = RegisterResponse(message="ok", user_id="u1", org_id="o1")
+    assert with_org.org_id == "o1"
+
+
+def test_onboarding_state_response_contract() -> None:
+    resp = OnboardingStateResponse(
+        needs_onboarding=True,
+        org_created=False,
+        first_integration_connected=False,
+        integration_skipped=False,
+        next_step="workspace",
+    )
+    assert resp.recommended_provider == "github"
+    assert resp.org_id is None
+    assert resp.blocker is None
+
+
+def test_setup_status_response_contract_defaults() -> None:
+    resp = SetupStatusResponse(
+        has_integration=False,
+        has_sync_config=False,
+        first_sync_started=False,
+        next_action="connect_integration",
+    )
+    assert resp.providers == []
+    assert resp.sync_status == "none"
+    assert resp.selected_repositories_count == 0
+    assert resp.can_start_sync is False


### PR DESCRIPTION
## Summary

Backend setup/integration stream for the CHAOS-2670 first-run onboarding epic. Implements three sub-issues:

- **CHAOS-2677 (contract C2):** new `GET /api/v1/admin/setup/status`. Org-scoped admin-auth endpoint that projects integration credentials + sync configuration + planner job runs into the frozen `SetupStatusResponse`, distinguishing the four first-run states — **not-connected**, **connected-no-config**, **config-failed**, **sync-running** — and deriving `next_action`/`blocker`. Read-only; no persistence.
- **CHAOS-2676 (contract C4):** make the GitHub App install flow return-aware. `install-url` accepts an optional `return_to` body field, canonicalized + allowlist-validated to exact in-app paths (`/auth/onboard/integration`, `/org/admin/integrations/github`). Every unsafe value (absolute URLs, protocol-relative `//host`, whitespace/newline padding, fragments, percent-encoded query/fragment, mixed-case paths, unicode slash variants, double-encoded traversal, backslashes, encoded traversal, query strings, unknown paths, empty) collapses to the admin default. `return_to` is signed into the install-state JWT and echoed back by `install-callback`; the Next route performs the browser redirect (backend never 302s). Org-binding + replay protection are unchanged.
- **CHAOS-2681:** connecting an integration does not silently create or start a broad sync. The connect step yields **no enabled/running** sync; a sync only starts after explicit repository selection (`/sync-configs/batch`) followed by an explicit `/sync-configs/{id}/trigger`. Pending/failed/complete is surfaced through the C2 status.

## Review follow-up

- Filed **CHAOS-2708** as a child of CHAOS-2670 for the pre-existing GitHub App install-state replay-store hardening: replace get-then-set with atomic nonce consume (`SET NX EX` or DB-backed equivalent), use durable fallback when Redis is unavailable, and fail closed if replay storage is unavailable.

## Contract notes (frozen surfaces consumed by fe-dashboard)

- `SetupStatusResponse` shape is reused as-is from `api/admin/schemas_flat.py` (not modified).
- `install-callback` response gains `return_to` (validated path) alongside `connected`/`installation_id`/`credential_name`.

## Tests

- `tests/api/admin/test_setup_status.py` (new): all four C2 states + ready-to-start, no-repo-selection, complete, non-primary active config in-flight blocking start, and a non-admin **403**.
- `tests/api/admin/test_github_app_install.py`: safe `return_to` round-trip, exact-path unsafe inputs falling back, default when absent, callback echo + defensive re-canonicalization, replay test reusing the exact same state token, and callback no-auto-sync coverage with sync tables present.
- `tests/api/admin/test_sync_configs.py`: connect-only → no enabled/running sync; sync starts only after explicit select + start.

Full local gate (`ci/local_validate.sh`) green: ruff format/check, mypy, full unit suite, ClickHouse migrate + argMax live-exec proof.

## Issues

- Closes CHAOS-2677
- Closes CHAOS-2676
- Closes CHAOS-2681
- Parent: CHAOS-2670
- Follow-up: CHAOS-2708

SCREENSHOT-WAIVER: backend-only change (new JSON API + install-state signing); no rendered UI.