### PR TITLE
feat(auth): add first-run onboarding auth flow

### DIFF
--- a/src/dev_health_ops/alembic/versions/0026_add_org_onboarding_integration_skipped_at.py
+++ b/src/dev_health_ops/alembic/versions/0026_add_org_onboarding_integration_skipped_at.py
@@ -1,0 +1,59 @@
+"""Add organizations.onboarding_integration_skipped_at.
+
+First-run onboarding (CHAOS-2670 / contract C6): records when an org explicitly
+skipped the first-integration onboarding step so the onboarding-state API
+(CHAOS-2673) and dashboard setup surfaces (CHAOS-2678) can distinguish "skipped"
+from "not yet connected". Nullable timestamp; null = not skipped. The column add
+is guarded for rerun safety (mirrors 0022).
+
+Revision ID: 0026
+Revises: 0025
+Create Date: 2026-06-26 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0026"
+down_revision: str | None = "0025"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    _add_column_if_missing(
+        "organizations",
+        sa.Column(
+            "onboarding_integration_skipped_at",
+            sa.DateTime(timezone=True),
+            nullable=True,
+        ),
+    )
+
+
+def downgrade() -> None:
+    _drop_column_if_present("organizations", "onboarding_integration_skipped_at")
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    existing_columns = _column_names(table_name)
+    if column.name not in existing_columns:
+        op.add_column(table_name, column)
+
+
+def _drop_column_if_present(table_name: str, column_name: str) -> None:
+    existing_columns = _column_names(table_name)
+    if column_name in existing_columns:
+        op.drop_column(table_name, column_name)
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}

--- a/src/dev_health_ops/alembic/versions/0027_make_refresh_tokens_org_id_nullable.py
+++ b/src/dev_health_ops/alembic/versions/0027_make_refresh_tokens_org_id_nullable.py
@@ -1,0 +1,39 @@
+"""Allow orgless refresh-token records.
+
+Revision ID: 0027
+Revises: 0026
+Create Date: 2026-06-26 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0027"
+down_revision: str | None = "0026"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    op.alter_column(
+        "refresh_tokens",
+        "org_id",
+        existing_type=sa.UUID(),
+        nullable=True,
+    )
+
+
+def downgrade() -> None:
+    op.alter_column(
+        "refresh_tokens",
+        "org_id",
+        existing_type=sa.UUID(),
+        nullable=False,
+    )

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -803,3 +803,52 @@ class PlatformStatsResponse(BaseModel):
     active_sync_configs: int
     recent_syncs_success: int
     recent_syncs_failed: int
+
+
+class OnboardingStateResponse(BaseModel):
+    """CHAOS-2670 contract C1: GET /api/v1/auth/onboarding/state.
+
+    Single source of truth for first-run routing. ``next_step`` is computed
+    server-side from membership + connected-integration + persisted skip state
+    (organizations.onboarding_integration_skipped_at). Callable with a verified
+    orgless token; superuser/admin resolves to ``dashboard``.
+    """
+
+    needs_onboarding: bool
+    org_created: bool
+    org_id: str | None = None
+    org_name: str | None = None
+    first_integration_connected: bool
+    integration_skipped: bool
+    recommended_provider: str = "github"
+    next_step: Literal["workspace", "integration", "complete", "dashboard"]
+    blocker: str | None = None
+
+
+class SetupStatusResponse(BaseModel):
+    """CHAOS-2670 contract C2: GET /api/v1/admin/setup/status.
+
+    Powers the dashboard "value-or-precise-blocker" surface: distinguishes
+    not-connected, connected-no-config, config-failed, and sync-running states.
+    Org-scoped admin auth.
+    """
+
+    has_integration: bool
+    providers: list[str] = Field(default_factory=list)
+    has_sync_config: bool
+    sync_config_id: str | None = None
+    first_sync_started: bool
+    sync_status: Literal[
+        "none", "pending", "running", "partial", "complete", "failed"
+    ] = "none"
+    selected_repositories_count: int = 0
+    last_sync_error: str | None = None
+    can_start_sync: bool = False
+    next_action: Literal[
+        "connect_integration",
+        "select_repositories",
+        "create_sync_config",
+        "start_sync",
+        "complete",
+    ]
+    blocker: str | None = None

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from datetime import date, datetime
 from typing import Any, Literal
 
-from pydantic import BaseModel, ConfigDict, Field
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 
 class SettingResponse(BaseModel):
@@ -507,12 +507,20 @@ class DeletionResultResponse(BaseModel):
 
 
 class OrganizationCreate(BaseModel):
-    name: str = Field(..., min_length=1)
+    name: str = Field(..., min_length=1, max_length=100)
     slug: str | None = None
     description: str | None = None
     tier: str = "community"
     settings: dict[str, Any] = Field(default_factory=dict)
     owner_user_id: str | None = None
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("Workspace name is required")
+        return normalized
 
 
 class OrganizationUpdate(BaseModel):

--- a/src/dev_health_ops/api/auth/config.py
+++ b/src/dev_health_ops/api/auth/config.py
@@ -1,0 +1,28 @@
+from __future__ import annotations
+
+import os
+
+_TRUTHY = {"1", "true", "yes", "on"}
+_FALSY = {"0", "false", "no", "off"}
+
+AUTH_AUTO_CREATE_ORG_ENV = "AUTH_AUTO_CREATE_ORG_ON_REGISTER"
+
+
+def auth_auto_create_org_on_register(default: bool = True) -> bool:
+    """Whether self-registration auto-creates an Organization + owner Membership.
+
+    Controlled by ``AUTH_AUTO_CREATE_ORG_ON_REGISTER`` (default ``True`` to
+    preserve current production behavior). When ``False``, registration creates
+    the user identity only and the verified user is routed into guided onboarding
+    (CHAOS-2670 / CHAOS-2671 / CHAOS-2682). Unrecognized values fall back to the
+    default so a typo never silently disables org creation in production.
+    """
+    raw = os.getenv(AUTH_AUTO_CREATE_ORG_ENV)
+    if raw is None:
+        return default
+    normalized = raw.strip().lower()
+    if normalized in _TRUTHY:
+        return True
+    if normalized in _FALSY:
+        return False
+    return default

--- a/src/dev_health_ops/api/auth/router.py
+++ b/src/dev_health_ops/api/auth/router.py
@@ -18,6 +18,7 @@ from .routers import (
     invites_router,
     login_router,
     oauth_router,
+    onboarding_router,
     password_reset_router,
     refresh_router,
     register_router,
@@ -34,6 +35,7 @@ router.include_router(verify_router)
 router.include_router(password_reset_router)
 router.include_router(login_router)
 router.include_router(invites_router)
+router.include_router(onboarding_router)
 router.include_router(session_router)
 router.include_router(refresh_router)
 router.include_router(oauth_router)

--- a/src/dev_health_ops/api/auth/routers/__init__.py
+++ b/src/dev_health_ops/api/auth/routers/__init__.py
@@ -16,6 +16,7 @@ from .dependencies import get_current_user, get_current_user_optional
 from .invites import router as invites_router
 from .login import router as login_router
 from .oauth import router as oauth_router
+from .onboarding import router as onboarding_router
 from .password_reset import router as password_reset_router
 from .refresh import router as refresh_router
 from .register import router as register_router
@@ -40,6 +41,7 @@ __all__ = [
     "invites_router",
     "login_router",
     "oauth_router",
+    "onboarding_router",
     "password_reset_router",
     "refresh_router",
     "register_router",

--- a/src/dev_health_ops/api/auth/routers/common.py
+++ b/src/dev_health_ops/api/auth/routers/common.py
@@ -268,7 +268,7 @@ async def _issue_membership_tokens(
     refresh_payload = auth_service.validate_token(
         token_pair.refresh_token, token_type="refresh"
     )
-    if membership is not None and refresh_payload and refresh_payload.get("jti"):
+    if refresh_payload and refresh_payload.get("jti"):
         expires_at = _expiry_to_utc(refresh_payload.get("exp"))
         if expires_at is not None:
             await create_refresh_token_record(

--- a/src/dev_health_ops/api/auth/routers/invites.py
+++ b/src/dev_health_ops/api/auth/routers/invites.py
@@ -16,6 +16,7 @@ from dev_health_ops.api.services.invites import (
 from dev_health_ops.api.services.invites import (
     validate_invite as validate_org_invite,
 )
+from dev_health_ops.api.services.users import validate_organization_name
 from dev_health_ops.api.utils.audit import emit_audit_log
 from dev_health_ops.api.utils.errors import error_detail
 from dev_health_ops.models.audit import AuditAction, AuditResourceType
@@ -250,7 +251,13 @@ async def onboard(
                 detail=error_detail("Invalid action. Use 'create_org' or 'join_org'"),
             )
 
-        org_name = payload.org_name or "My Organization"
+        try:
+            org_name = validate_organization_name(payload.org_name)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=422,
+                detail=error_detail(str(exc), errors=[str(exc)]),
+            ) from exc
         org_slug = f"{_slugify_org_name(org_name)}-{str(db_user.id)[:8]}"
 
         org = Organization(

--- a/src/dev_health_ops/api/auth/routers/onboarding.py
+++ b/src/dev_health_ops/api/auth/routers/onboarding.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import uuid as uuid_mod
+from datetime import datetime, timezone
 from typing import Annotated, Any
 
 from fastapi import APIRouter, Depends, HTTPException
@@ -133,4 +134,27 @@ async def onboarding_state(
     from dev_health_ops.api.auth.router import get_postgres_session
 
     async with get_postgres_session() as db:
+        return await _build_onboarding_state(db, user)
+
+
+@router.post("/skip-integration")
+async def skip_integration(
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> Any:
+    from dev_health_ops.api.auth.router import get_postgres_session
+
+    if not user.org_id:
+        raise HTTPException(status_code=400, detail="organization_required")
+    try:
+        org_uuid = uuid_mod.UUID(user.org_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail="organization_required") from exc
+
+    async with get_postgres_session() as db:
+        org = await db.scalar(select(Organization).where(Organization.id == org_uuid))
+        if org is None:
+            raise HTTPException(status_code=404, detail="organization_not_found")
+        if org.onboarding_integration_skipped_at is None:
+            org.onboarding_integration_skipped_at = datetime.now(timezone.utc)
+        await db.commit()
         return await _build_onboarding_state(db, user)

--- a/src/dev_health_ops/api/auth/routers/onboarding.py
+++ b/src/dev_health_ops/api/auth/routers/onboarding.py
@@ -36,11 +36,11 @@ async def _load_membership(
     token_org_id: str,
 ) -> Membership | None:
     stmt = select(Membership).where(Membership.user_id == db_user.id)
-    try:
-        org_uuid = uuid_mod.UUID(token_org_id) if token_org_id else None
-    except ValueError:
-        org_uuid = None
-    if org_uuid is not None:
+    if token_org_id:
+        try:
+            org_uuid = uuid_mod.UUID(token_org_id)
+        except ValueError:
+            return None
         stmt = stmt.where(Membership.org_id == org_uuid)
     stmt = stmt.order_by(Membership.joined_at.asc(), Membership.created_at.asc()).limit(
         1
@@ -151,6 +151,16 @@ async def skip_integration(
         raise HTTPException(status_code=400, detail="organization_required") from exc
 
     async with get_postgres_session() as db:
+        membership = await db.scalar(
+            select(Membership).where(
+                Membership.org_id == org_uuid,
+                Membership.user_id == _parse_user_id(user.user_id),
+            )
+        )
+        if membership is None:
+            raise HTTPException(
+                status_code=403, detail="organization_membership_required"
+            )
         org = await db.scalar(select(Organization).where(Organization.id == org_uuid))
         if org is None:
             raise HTTPException(status_code=404, detail="organization_not_found")

--- a/src/dev_health_ops/api/auth/routers/onboarding.py
+++ b/src/dev_health_ops/api/auth/routers/onboarding.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import uuid as uuid_mod
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.settings import IntegrationCredential
+from dev_health_ops.models.users import Membership, Organization, User
+
+from .dependencies import get_current_user
+
+router = APIRouter(prefix="/onboarding")
+
+
+def _state_response(**kwargs: Any) -> Any:
+    from dev_health_ops.api.admin.schemas_flat import OnboardingStateResponse
+
+    return OnboardingStateResponse(**kwargs)
+
+
+def _parse_user_id(user_id: str) -> uuid_mod.UUID:
+    try:
+        return uuid_mod.UUID(user_id)
+    except ValueError as exc:
+        raise HTTPException(status_code=401, detail="invalid_user") from exc
+
+
+async def _load_membership(
+    db: AsyncSession,
+    db_user: User,
+    token_org_id: str,
+) -> Membership | None:
+    stmt = select(Membership).where(Membership.user_id == db_user.id)
+    try:
+        org_uuid = uuid_mod.UUID(token_org_id) if token_org_id else None
+    except ValueError:
+        org_uuid = None
+    if org_uuid is not None:
+        stmt = stmt.where(Membership.org_id == org_uuid)
+    stmt = stmt.order_by(Membership.joined_at.asc(), Membership.created_at.asc()).limit(
+        1
+    )
+    result = await db.execute(stmt)
+    return result.scalar_one_or_none()
+
+
+async def _has_connected_integration(db: AsyncSession, org: Organization) -> bool:
+    result = await db.execute(
+        select(IntegrationCredential.id)
+        .where(
+            IntegrationCredential.org_id == str(org.id),
+            IntegrationCredential.is_active == True,  # noqa: E712
+        )
+        .limit(1)
+    )
+    return result.scalar_one_or_none() is not None
+
+
+async def _build_onboarding_state(
+    db: AsyncSession,
+    user: AuthenticatedUser,
+) -> Any:
+    user_uuid = _parse_user_id(user.user_id)
+    db_user = await db.scalar(select(User).where(User.id == user_uuid))
+    if db_user is None:
+        raise HTTPException(status_code=401, detail="user_not_found")
+    if not bool(db_user.is_verified):
+        raise HTTPException(status_code=403, detail="email_unverified")
+
+    membership = await _load_membership(db, db_user, user.org_id)
+    if membership is None:
+        if bool(db_user.is_superuser):
+            return _state_response(
+                needs_onboarding=False,
+                org_created=False,
+                first_integration_connected=False,
+                integration_skipped=False,
+                next_step="dashboard",
+            )
+        return _state_response(
+            needs_onboarding=True,
+            org_created=False,
+            first_integration_connected=False,
+            integration_skipped=False,
+            next_step="workspace",
+        )
+
+    org = await db.scalar(
+        select(Organization).where(Organization.id == membership.org_id)
+    )
+    if org is None:
+        return _state_response(
+            needs_onboarding=True,
+            org_created=False,
+            first_integration_connected=False,
+            integration_skipped=False,
+            next_step="workspace",
+            blocker="organization_not_found",
+        )
+
+    integration_connected = await _has_connected_integration(db, org)
+    integration_skipped = org.onboarding_integration_skipped_at is not None
+    privileged_dashboard = bool(db_user.is_superuser) or user.role == "admin"
+    if privileged_dashboard:
+        next_step = "dashboard"
+        needs_onboarding = False
+    elif integration_connected or integration_skipped:
+        next_step = "complete"
+        needs_onboarding = False
+    else:
+        next_step = "integration"
+        needs_onboarding = True
+
+    return _state_response(
+        needs_onboarding=needs_onboarding,
+        org_created=True,
+        org_id=str(org.id),
+        org_name=str(org.name),
+        first_integration_connected=integration_connected,
+        integration_skipped=integration_skipped,
+        next_step=next_step,
+    )
+
+
+@router.get("/state")
+async def onboarding_state(
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+) -> Any:
+    from dev_health_ops.api.auth.router import get_postgres_session
+
+    async with get_postgres_session() as db:
+        return await _build_onboarding_state(db, user)

--- a/src/dev_health_ops/api/auth/routers/onboarding.py
+++ b/src/dev_health_ops/api/auth/routers/onboarding.py
@@ -104,7 +104,9 @@ async def _build_onboarding_state(
         )
 
     integration_connected = await _has_connected_integration(db, org)
-    integration_skipped = org.onboarding_integration_skipped_at is not None
+    integration_skipped = (
+        org.onboarding_integration_skipped_at is not None and not integration_connected
+    )
     privileged_dashboard = bool(db_user.is_superuser) or user.role == "admin"
     if privileged_dashboard:
         next_step = "dashboard"

--- a/src/dev_health_ops/api/auth/routers/register.py
+++ b/src/dev_health_ops/api/auth/routers/register.py
@@ -9,6 +9,7 @@ from fastapi import APIRouter, HTTPException, Request
 from pydantic import BaseModel, EmailStr, Field
 from sqlalchemy import func, select
 
+from dev_health_ops.api.auth.config import auth_auto_create_org_on_register
 from dev_health_ops.api.middleware.rate_limit import (
     AUTH_REGISTER_LIMIT,
     get_forwarded_ip,
@@ -113,39 +114,46 @@ async def register(payload: RegisterRequest, request: Request) -> RegisterRespon
         await db.flush()
         user_id = _require_uuid(user.id, "user.id")
 
-        org_name = payload.org_name or "My Organization"
-        org_slug = org_name.lower().replace(" ", "-")[:50]
-        org_slug = f"{org_slug}-{str(user.id)[:8]}"
+        org_id = None
+        if auth_auto_create_org_on_register():
+            org_name = payload.org_name or "My Organization"
+            org_slug = org_name.lower().replace(" ", "-")[:50]
+            org_slug = f"{org_slug}-{str(user.id)[:8]}"
 
-        org = Organization(
-            slug=org_slug,
-            name=org_name,
-            tier="community",
-            is_active=True,
-        )
-        db.add(org)
-        await db.flush()
-        org_id = _require_uuid(org.id, "org.id")
+            org = Organization(
+                slug=org_slug,
+                name=org_name,
+                tier="community",
+                is_active=True,
+            )
+            db.add(org)
+            await db.flush()
+            org_id = _require_uuid(org.id, "org.id")
 
-        membership = Membership(
-            user_id=user_id,
-            org_id=org_id,
-            role="owner",
-            joined_at=datetime.now(timezone.utc),
-        )
-        db.add(membership)
+            membership = Membership(
+                user_id=user_id,
+                org_id=org_id,
+                role="owner",
+                joined_at=datetime.now(timezone.utc),
+            )
+            db.add(membership)
 
-        emit_audit_log(
-            db,
-            org_id=org_id,
-            action=AuditAction.CREATE,
-            resource_type=AuditResourceType.USER,
-            resource_id=str(user_id),
-            user_id=user_id,
-            description="User registered",
-            changes={"email": email_normalized, "organization_id": str(org_id)},
-            request=request,
-        )
+            emit_audit_log(
+                db,
+                org_id=org_id,
+                action=AuditAction.CREATE,
+                resource_type=AuditResourceType.USER,
+                resource_id=str(user_id),
+                user_id=user_id,
+                description="User registered",
+                changes={"email": email_normalized, "organization_id": str(org_id)},
+                request=request,
+            )
+        else:
+            logger.info(
+                "User registered without organization for first-run onboarding: %s",
+                sanitize_for_log(email_normalized),
+            )
 
         verification_token = await create_verification_token(db, user_id)
 
@@ -169,5 +177,5 @@ async def register(payload: RegisterRequest, request: Request) -> RegisterRespon
         return RegisterResponse(
             message="Registration successful",
             user_id=str(user_id),
-            org_id=str(org_id),
+            org_id=str(org_id) if org_id is not None else None,
         )

--- a/src/dev_health_ops/api/auth/routers/register.py
+++ b/src/dev_health_ops/api/auth/routers/register.py
@@ -38,7 +38,7 @@ class RegisterRequest(BaseModel):
 class RegisterResponse(BaseModel):
     message: str
     user_id: str
-    org_id: str
+    org_id: str | None = None
 
 
 @router.post("/register", response_model=RegisterResponse, status_code=201)

--- a/src/dev_health_ops/api/services/refresh_tokens.py
+++ b/src/dev_health_ops/api/services/refresh_tokens.py
@@ -17,7 +17,7 @@ def _hash_token(token: str) -> str:
 async def create_refresh_token(
     db: AsyncSession,
     user_id: str,
-    org_id: str,
+    org_id: str | None,
     token_hash: str,
     family_id: str,
     expires_at: datetime,
@@ -26,7 +26,7 @@ async def create_refresh_token(
 ) -> RefreshToken:
     record = RefreshToken(
         user_id=uuid.UUID(user_id),
-        org_id=uuid.UUID(org_id),
+        org_id=uuid.UUID(org_id) if org_id else None,
         token_hash=_hash_token(token_hash),
         family_id=uuid.UUID(family_id),
         expires_at=expires_at,

--- a/src/dev_health_ops/api/services/users.py
+++ b/src/dev_health_ops/api/services/users.py
@@ -45,6 +45,15 @@ def _slugify(name: str) -> str:
     return slug[:50]
 
 
+def validate_organization_name(name: str | None) -> str:
+    normalized = (name or "").strip()
+    if not normalized:
+        raise ValueError("Workspace name is required")
+    if len(normalized) > 100:
+        raise ValueError("Workspace name must be 100 characters or fewer")
+    return normalized
+
+
 class UserService:
     def __init__(self, session: AsyncSession):
         self.session = session
@@ -290,6 +299,7 @@ class OrganizationService:
         tier: str = "community",
         owner_user_id: str | None = None,
     ) -> Organization:
+        name = validate_organization_name(name)
         slug = slug or _slugify(name)
         if await self.get_by_slug(slug):
             slug = f"{slug}-{secrets.token_hex(4)}"

--- a/src/dev_health_ops/models/refresh_token.py
+++ b/src/dev_health_ops/models/refresh_token.py
@@ -23,10 +23,10 @@ class RefreshToken(Base):
         nullable=False,
         index=True,
     )
-    org_id: Mapped[uuid.UUID] = mapped_column(
+    org_id: Mapped[uuid.UUID | None] = mapped_column(
         GUID(),
         ForeignKey("organizations.id", ondelete="CASCADE"),
-        nullable=False,
+        nullable=True,
     )
     token_hash: Mapped[str] = mapped_column(
         Text, nullable=False, unique=True, index=True

--- a/src/dev_health_ops/models/users.py
+++ b/src/dev_health_ops/models/users.py
@@ -199,6 +199,13 @@ class Organization(Base):
         nullable=False,
     )
 
+    # First-run onboarding (CHAOS-2670 / contract C6): when set, the org
+    # explicitly skipped the first-integration onboarding step. Null = not
+    # skipped. Connecting an integration later overrides this for display.
+    onboarding_integration_skipped_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
     # Relationships
     memberships: Mapped[list[Membership]] = relationship(
         "Membership",

--- a/tests/api/admin/test_orgs_auth.py
+++ b/tests/api/admin/test_orgs_auth.py
@@ -10,6 +10,7 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
@@ -114,3 +115,25 @@ async def test_get_org_by_id_accepts_superuser(session_maker):
         resp = await ac.get(f"/admin/orgs/{org_id}")
     assert resp.status_code == 200, resp.text
     assert resp.json()["id"] == org_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("name", ["   ", "x" * 101])
+async def test_create_org_rejects_invalid_name(session_maker, name):
+    su = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="su@example.com",
+        org_id=str(uuid.uuid4()),
+        role="owner",
+        is_superuser=True,
+    )
+    app = _app(session_maker, current_user=su)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as ac:
+        resp = await ac.post("/admin/orgs", json={"name": name})
+
+    assert resp.status_code == 422, resp.text
+    async with session_maker() as session:
+        org_count = await session.scalar(select(func.count()).select_from(Organization))
+    assert org_count == 0

--- a/tests/api/auth/test_invite_flow.py
+++ b/tests/api/auth/test_invite_flow.py
@@ -293,3 +293,64 @@ async def test_accepting_as_already_member_returns_error(
         response.json()["detail"]["message"]
         == "User is already a member of this organization"
     )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("org_name", [None, "", "   ", "x" * 101])
+async def test_onboard_create_org_requires_workspace_name(
+    client, seeded_state, org_name
+):
+    async_client, current_user = client
+    current_user["value"] = AuthenticatedUser(
+        user_id=seeded_state["invitee_id"],
+        email=seeded_state["invitee_email"],
+        org_id="",
+        role="member",
+        is_superuser=False,
+    )
+    payload = {"action": "create_org"}
+    if org_name is not None:
+        payload["org_name"] = org_name
+
+    response = await async_client.post("/api/v1/auth/onboard", json=payload)
+
+    assert response.status_code == 422
+    assert response.json()["detail"]["message"] in {
+        "Workspace name is required",
+        "Workspace name must be 100 characters or fewer",
+    }
+    assert response.json()["detail"]["errors"]
+
+
+@pytest.mark.asyncio
+async def test_onboard_create_org_trims_workspace_name_and_returns_tokens(
+    client, session_maker, seeded_state
+):
+    async_client, current_user = client
+    current_user["value"] = AuthenticatedUser(
+        user_id=seeded_state["invitee_id"],
+        email=seeded_state["invitee_email"],
+        org_id="",
+        role="member",
+        is_superuser=False,
+    )
+
+    response = await async_client.post(
+        "/api/v1/auth/onboard",
+        json={"action": "create_org", "org_name": "  First Workspace  "},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["org_name"] == "First Workspace"
+    assert data["role"] == "owner"
+    assert data["access_token"]
+    assert data["refresh_token"]
+
+    async with session_maker() as session:
+        org = await session.scalar(
+            select(Organization).where(Organization.id == uuid.UUID(data["org_id"]))
+        )
+
+    assert org is not None
+    assert org.name == "First Workspace"

--- a/tests/api/auth/test_onboarding_foundation.py
+++ b/tests/api/auth/test_onboarding_foundation.py
@@ -1,0 +1,81 @@
+"""CHAOS-2670 Phase-0 foundation contracts.
+
+Locks the additive, non-behavior-changing foundation that the parallel streams
+build on: the ``AUTH_AUTO_CREATE_ORG_ON_REGISTER`` flag resolver (C5), the
+nullable ``RegisterResponse.org_id`` (C5), and the frozen C1/C2 response models.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.admin.schemas_flat import (
+    OnboardingStateResponse,
+    SetupStatusResponse,
+)
+from dev_health_ops.api.auth.config import auth_auto_create_org_on_register
+from dev_health_ops.api.auth.routers.register import RegisterResponse
+
+
+def test_auth_auto_create_org_defaults_true_when_unset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", raising=False)
+    assert auth_auto_create_org_on_register() is True
+
+
+@pytest.mark.parametrize("value", ["false", "0", "no", "off", "False", "  OFF "])
+def test_auth_auto_create_org_falsy_values_disable(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", value)
+    assert auth_auto_create_org_on_register() is False
+
+
+@pytest.mark.parametrize("value", ["true", "1", "yes", "on", "TRUE", " On "])
+def test_auth_auto_create_org_truthy_values_enable(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", value)
+    assert auth_auto_create_org_on_register() is True
+
+
+def test_auth_auto_create_org_unknown_falls_back_to_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", "banana")
+    assert auth_auto_create_org_on_register() is True
+    assert auth_auto_create_org_on_register(default=False) is False
+
+
+def test_register_response_org_id_is_optional() -> None:
+    orgless = RegisterResponse(message="ok", user_id="u1")
+    assert orgless.org_id is None
+    with_org = RegisterResponse(message="ok", user_id="u1", org_id="o1")
+    assert with_org.org_id == "o1"
+
+
+def test_onboarding_state_response_contract() -> None:
+    resp = OnboardingStateResponse(
+        needs_onboarding=True,
+        org_created=False,
+        first_integration_connected=False,
+        integration_skipped=False,
+        next_step="workspace",
+    )
+    assert resp.recommended_provider == "github"
+    assert resp.org_id is None
+    assert resp.blocker is None
+
+
+def test_setup_status_response_contract_defaults() -> None:
+    resp = SetupStatusResponse(
+        has_integration=False,
+        has_sync_config=False,
+        first_sync_started=False,
+        next_action="connect_integration",
+    )
+    assert resp.providers == []
+    assert resp.sync_status == "none"
+    assert resp.selected_repositories_count == 0
+    assert resp.can_start_sync is False

--- a/tests/api/auth/test_onboarding_skip.py
+++ b/tests/api/auth/test_onboarding_skip.py
@@ -157,3 +157,40 @@ async def test_skip_integration_is_idempotent(client, session_maker, seeded_org_
     assert first_timestamp is not None
     assert second_timestamp == first_timestamp
     assert second.json()["integration_skipped"] is True
+
+
+@pytest.mark.asyncio
+async def test_skip_integration_requires_membership(client, session_maker):
+    async_client, auth_service = client
+    user = User(
+        id=uuid.uuid4(),
+        email="outsider@example.com",
+        is_active=True,
+        is_verified=True,
+    )
+    org = Organization(id=uuid.uuid4(), slug="other", name="Other Workspace")
+    async with session_maker() as session:
+        session.add_all([user, org])
+        await session.commit()
+    token = auth_service.create_access_token(
+        user_id=str(user.id),
+        email=str(user.email),
+        org_id=str(org.id),
+        role="owner",
+        token_version=int(user.token_version or 0),
+    )
+
+    response = await async_client.post(
+        "/api/v1/auth/onboarding/skip-integration",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "organization_membership_required"}
+    async with session_maker() as session:
+        skipped_at = await session.scalar(
+            select(Organization.onboarding_integration_skipped_at).where(
+                Organization.id == org.id
+            )
+        )
+    assert skipped_at is None

--- a/tests/api/auth/test_onboarding_skip.py
+++ b/tests/api/auth/test_onboarding_skip.py
@@ -1,0 +1,159 @@
+from __future__ import annotations
+
+import importlib
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.auth import AuthService
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import IntegrationCredential
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+SECRET = "onboarding-skip-test-secret-32-chars"
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "onboarding-skip.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(
+                    User,
+                    Organization,
+                    Membership,
+                    IntegrationCredential,
+                ),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch: pytest.MonkeyPatch, session_maker):
+    app = FastAPI()
+    app.include_router(auth_router_module.router)
+
+    @asynccontextmanager
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+
+    auth_service = AuthService(secret_key=SECRET)
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", _session_override)
+    monkeypatch.setattr(auth_router_module, "get_auth_service", lambda: auth_service)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client, auth_service
+
+
+@pytest_asyncio.fixture
+async def seeded_org_user(session_maker):
+    user = User(
+        id=uuid.uuid4(),
+        email="owner@example.com",
+        is_active=True,
+        is_verified=True,
+    )
+    org = Organization(id=uuid.uuid4(), slug="first", name="First Workspace")
+    membership = Membership(org_id=org.id, user_id=user.id, role="owner")
+    async with session_maker() as session:
+        session.add_all([user, org, membership])
+        await session.commit()
+    return user, org
+
+
+def _token(auth_service: AuthService, user: User, org: Organization) -> str:
+    return auth_service.create_access_token(
+        user_id=str(user.id),
+        email=str(user.email),
+        org_id=str(org.id),
+        role="owner",
+        token_version=int(user.token_version or 0),
+    )
+
+
+@pytest.mark.asyncio
+async def test_skip_integration_persists_flag_and_returns_complete_state(
+    client, session_maker, seeded_org_user
+):
+    async_client, auth_service = client
+    user, org = seeded_org_user
+    token = _token(auth_service, user, org)
+
+    response = await async_client.post(
+        "/api/v1/auth/onboarding/skip-integration",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["org_id"] == str(org.id)
+    assert data["org_name"] == "First Workspace"
+    assert data["first_integration_connected"] is False
+    assert data["integration_skipped"] is True
+    assert data["needs_onboarding"] is False
+    assert data["next_step"] == "complete"
+
+    async with session_maker() as session:
+        db_org = await session.scalar(
+            select(Organization).where(Organization.id == org.id)
+        )
+
+    assert db_org is not None
+    assert db_org.onboarding_integration_skipped_at is not None
+
+
+@pytest.mark.asyncio
+async def test_skip_integration_is_idempotent(client, session_maker, seeded_org_user):
+    async_client, auth_service = client
+    user, org = seeded_org_user
+    token = _token(auth_service, user, org)
+
+    first = await async_client.post(
+        "/api/v1/auth/onboarding/skip-integration",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert first.status_code == 200
+    async with session_maker() as session:
+        first_timestamp = await session.scalar(
+            select(Organization.onboarding_integration_skipped_at).where(
+                Organization.id == org.id
+            )
+        )
+
+    second = await async_client.post(
+        "/api/v1/auth/onboarding/skip-integration",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+    assert second.status_code == 200
+    async with session_maker() as session:
+        second_timestamp = await session.scalar(
+            select(Organization.onboarding_integration_skipped_at).where(
+                Organization.id == org.id
+            )
+        )
+
+    assert first_timestamp is not None
+    assert second_timestamp == first_timestamp
+    assert second.json()["integration_skipped"] is True

--- a/tests/api/auth/test_onboarding_state.py
+++ b/tests/api/auth/test_onboarding_state.py
@@ -174,6 +174,43 @@ async def test_state_membership_without_integration_routes_to_integration(
 
 
 @pytest.mark.asyncio
+async def test_state_uses_selected_org_claim_for_multi_membership(
+    client, session_maker
+):
+    async_client, auth_service = client
+    user = await _seed_user(session_maker)
+    first_org = await _seed_org_membership(session_maker, user)
+    second_org = Organization(
+        id=uuid.uuid4(),
+        slug="second-workspace",
+        name="Second Workspace",
+        onboarding_integration_skipped_at=datetime.now(timezone.utc),
+    )
+    async with session_maker() as session:
+        session.add_all(
+            [
+                second_org,
+                Membership(org_id=second_org.id, user_id=user.id, role="owner"),
+            ]
+        )
+        await session.commit()
+    token = _access_token(auth_service, user, org_id=str(second_org.id), role="owner")
+
+    response = await async_client.get(
+        "/api/v1/auth/onboarding/state",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["org_id"] == str(second_org.id)
+    assert data["org_id"] != str(first_org.id)
+    assert data["org_name"] == "Second Workspace"
+    assert data["integration_skipped"] is True
+    assert data["next_step"] == "complete"
+
+
+@pytest.mark.asyncio
 async def test_state_connected_integration_routes_to_complete(client, session_maker):
     async_client, auth_service = client
     user = await _seed_user(session_maker)

--- a/tests/api/auth/test_onboarding_state.py
+++ b/tests/api/auth/test_onboarding_state.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import importlib
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.auth import AuthService
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import IntegrationCredential
+from dev_health_ops.models.users import Membership, Organization, User
+from tests._helpers import tables_of
+
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+SECRET = "onboarding-state-test-secret-32-chars"
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "onboarding-state.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn,
+                tables=tables_of(
+                    User,
+                    Organization,
+                    Membership,
+                    IntegrationCredential,
+                ),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(monkeypatch: pytest.MonkeyPatch, session_maker):
+    app = FastAPI()
+    app.include_router(auth_router_module.router)
+
+    @asynccontextmanager
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+
+    auth_service = AuthService(secret_key=SECRET)
+    monkeypatch.setattr(auth_router_module, "get_postgres_session", _session_override)
+    monkeypatch.setattr(auth_router_module, "get_auth_service", lambda: auth_service)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client, auth_service
+
+
+def _access_token(
+    auth_service: AuthService,
+    user: User,
+    org_id: str = "",
+    role: str = "member",
+) -> str:
+    return auth_service.create_access_token(
+        user_id=str(user.id),
+        email=str(user.email),
+        org_id=org_id,
+        role=role,
+        token_version=int(user.token_version or 0),
+    )
+
+
+async def _seed_user(
+    session_maker,
+    *,
+    email: str = "user@example.com",
+    verified: bool = True,
+    superuser: bool = False,
+) -> User:
+    user = User(
+        id=uuid.uuid4(),
+        email=email,
+        is_active=True,
+        is_verified=verified,
+        is_superuser=superuser,
+    )
+    async with session_maker() as session:
+        session.add(user)
+        await session.commit()
+    return user
+
+
+async def _seed_org_membership(
+    session_maker,
+    user: User,
+    *,
+    role: str = "owner",
+    skipped: bool = False,
+) -> Organization:
+    org = Organization(
+        id=uuid.uuid4(),
+        slug=f"org-{uuid.uuid4().hex[:8]}",
+        name="First Workspace",
+    )
+    if skipped:
+        org.onboarding_integration_skipped_at = datetime.now(timezone.utc)
+    membership = Membership(org_id=org.id, user_id=user.id, role=role)
+    async with session_maker() as session:
+        session.add_all([org, membership])
+        await session.commit()
+    return org
+
+
+@pytest.mark.asyncio
+async def test_state_orgless_verified_user_routes_to_workspace(client, session_maker):
+    async_client, auth_service = client
+    user = await _seed_user(session_maker)
+    token = _access_token(auth_service, user)
+
+    response = await async_client.get(
+        "/api/v1/auth/onboarding/state",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "needs_onboarding": True,
+        "org_created": False,
+        "org_id": None,
+        "org_name": None,
+        "first_integration_connected": False,
+        "integration_skipped": False,
+        "recommended_provider": "github",
+        "next_step": "workspace",
+        "blocker": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_state_membership_without_integration_routes_to_integration(
+    client, session_maker
+):
+    async_client, auth_service = client
+    user = await _seed_user(session_maker)
+    org = await _seed_org_membership(session_maker, user)
+    token = _access_token(auth_service, user, org_id=str(org.id), role="owner")
+
+    response = await async_client.get(
+        "/api/v1/auth/onboarding/state",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["needs_onboarding"] is True
+    assert data["org_created"] is True
+    assert data["org_id"] == str(org.id)
+    assert data["org_name"] == "First Workspace"
+    assert data["first_integration_connected"] is False
+    assert data["integration_skipped"] is False
+    assert data["next_step"] == "integration"
+
+
+@pytest.mark.asyncio
+async def test_state_connected_integration_routes_to_complete(client, session_maker):
+    async_client, auth_service = client
+    user = await _seed_user(session_maker)
+    org = await _seed_org_membership(session_maker, user)
+    async with session_maker() as session:
+        session.add(
+            IntegrationCredential(
+                org_id=str(org.id),
+                provider="github",
+                name="default",
+                is_active=True,
+            )
+        )
+        await session.commit()
+    token = _access_token(auth_service, user, org_id=str(org.id), role="owner")
+
+    response = await async_client.get(
+        "/api/v1/auth/onboarding/state",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["needs_onboarding"] is False
+    assert data["first_integration_connected"] is True
+    assert data["integration_skipped"] is False
+    assert data["next_step"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_state_skipped_integration_routes_to_complete(client, session_maker):
+    async_client, auth_service = client
+    user = await _seed_user(session_maker)
+    org = Organization(
+        id=uuid.uuid4(),
+        slug="skipped",
+        name="Skipped Workspace",
+        onboarding_integration_skipped_at=datetime.now(timezone.utc),
+    )
+    async with session_maker() as session:
+        session.add_all([org, Membership(org_id=org.id, user_id=user.id, role="owner")])
+        await session.commit()
+    token = _access_token(auth_service, user, org_id=str(org.id), role="owner")
+
+    response = await async_client.get(
+        "/api/v1/auth/onboarding/state",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["needs_onboarding"] is False
+    assert data["integration_skipped"] is True
+    assert data["next_step"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_state_admin_routes_to_dashboard(client, session_maker):
+    async_client, auth_service = client
+    user = await _seed_user(session_maker)
+    org = await _seed_org_membership(session_maker, user, role="admin")
+    token = _access_token(auth_service, user, org_id=str(org.id), role="admin")
+
+    response = await async_client.get(
+        "/api/v1/auth/onboarding/state",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["needs_onboarding"] is False
+    assert data["next_step"] == "dashboard"
+
+
+@pytest.mark.asyncio
+async def test_state_unverified_user_rejected(client, session_maker):
+    async_client, auth_service = client
+    user = await _seed_user(session_maker, verified=False)
+    token = _access_token(auth_service, user)
+
+    response = await async_client.get(
+        "/api/v1/auth/onboarding/state",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "email_unverified"}

--- a/tests/api/auth/test_onboarding_state.py
+++ b/tests/api/auth/test_onboarding_state.py
@@ -241,6 +241,38 @@ async def test_state_connected_integration_routes_to_complete(client, session_ma
 
 
 @pytest.mark.asyncio
+async def test_state_connected_integration_overrides_skip_display(
+    client, session_maker
+):
+    async_client, auth_service = client
+    user = await _seed_user(session_maker)
+    org = await _seed_org_membership(session_maker, user, skipped=True)
+    async with session_maker() as session:
+        session.add(
+            IntegrationCredential(
+                org_id=str(org.id),
+                provider="github",
+                name="default",
+                is_active=True,
+            )
+        )
+        await session.commit()
+    token = _access_token(auth_service, user, org_id=str(org.id), role="owner")
+
+    response = await async_client.get(
+        "/api/v1/auth/onboarding/state",
+        headers={"Authorization": f"Bearer {token}"},
+    )
+
+    assert response.status_code == 200
+    data = response.json()
+    assert data["needs_onboarding"] is False
+    assert data["first_integration_connected"] is True
+    assert data["integration_skipped"] is False
+    assert data["next_step"] == "complete"
+
+
+@pytest.mark.asyncio
 async def test_state_skipped_integration_routes_to_complete(client, session_maker):
     async_client, auth_service = client
     user = await _seed_user(session_maker)

--- a/tests/api/auth/test_register.py
+++ b/tests/api/auth/test_register.py
@@ -20,6 +20,7 @@ from dev_health_ops.api.services.auth import AuthService
 from dev_health_ops.models.audit import AuditLog
 from dev_health_ops.models.email_verification_token import EmailVerificationToken
 from dev_health_ops.models.git import Base
+from dev_health_ops.models.refresh_token import RefreshToken
 from dev_health_ops.models.users import LoginAttempt, Membership, Organization, User
 from tests._helpers import tables_of
 
@@ -45,6 +46,7 @@ async def session_maker(tmp_path: Path):
                     AuditLog,
                     LoginAttempt,
                     EmailVerificationToken,
+                    RefreshToken,
                 ),
             )
         )
@@ -82,6 +84,7 @@ async def client(monkeypatch: pytest.MonkeyPatch, session_maker):
     async def _session_override():
         async with session_maker() as session:
             yield session
+            await session.commit()
 
     monkeypatch.setattr(auth_router_module, "get_postgres_session", _session_override)
     monkeypatch.setattr(rate_limiter, "enabled", False)
@@ -90,16 +93,10 @@ async def client(monkeypatch: pytest.MonkeyPatch, session_maker):
         AsyncMock(),
     )
 
-    async def _noop_refresh(*args, **kwargs):
-        return None
-
     monkeypatch.setattr(
         auth_router_module,
         "get_auth_service",
         lambda: AuthService(secret_key="register-test-secret-key-32-chars"),
-    )
-    monkeypatch.setattr(
-        auth_router_module, "create_refresh_token_record", _noop_refresh
     )
 
     transport = ASGITransport(app=app)
@@ -285,6 +282,45 @@ async def test_verified_orgless_login_sets_needs_onboarding(
     data = login_response.json()
     assert data["needs_onboarding"] is True
     assert data["user"]["org_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_verified_orgless_login_refresh_token_rotates(
+    client, session_maker, monkeypatch
+):
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", "false")
+
+    register_response = await client.post(
+        "/api/v1/auth/register",
+        json={"email": "refresh-orgless@example.com", "password": VALID_PASSWORD},
+    )
+    assert register_response.status_code == 201
+
+    async with session_maker() as session:
+        user = await session.scalar(
+            select(User).where(User.email == "refresh-orgless@example.com")
+        )
+        assert user is not None
+        user.is_verified = True
+        await session.commit()
+
+    login_response = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "refresh-orgless@example.com", "password": VALID_PASSWORD},
+    )
+    assert login_response.status_code == 200
+    refresh_token = login_response.json()["refresh_token"]
+
+    refresh_response = await client.post(
+        "/api/v1/auth/refresh",
+        json={"refresh_token": refresh_token},
+    )
+
+    assert refresh_response.status_code == 200
+    data = refresh_response.json()
+    assert data["access_token"]
+    assert data["refresh_token"]
+    assert data["user"]["org_id"] == ""
 
 
 @pytest.mark.asyncio

--- a/tests/api/auth/test_register.py
+++ b/tests/api/auth/test_register.py
@@ -12,10 +12,11 @@ from fastapi import FastAPI
 from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.middleware.rate_limit import limiter as rate_limiter
+from dev_health_ops.api.services.auth import AuthService
 from dev_health_ops.models.audit import AuditLog
 from dev_health_ops.models.email_verification_token import EmailVerificationToken
 from dev_health_ops.models.git import Base
@@ -87,6 +88,18 @@ async def client(monkeypatch: pytest.MonkeyPatch, session_maker):
     monkeypatch.setattr(
         "dev_health_ops.api.services.email_verification.send_verification_email",
         AsyncMock(),
+    )
+
+    async def _noop_refresh(*args, **kwargs):
+        return None
+
+    monkeypatch.setattr(
+        auth_router_module,
+        "get_auth_service",
+        lambda: AuthService(secret_key="register-test-secret-key-32-chars"),
+    )
+    monkeypatch.setattr(
+        auth_router_module, "create_refresh_token_record", _noop_refresh
     )
 
     transport = ASGITransport(app=app)
@@ -214,6 +227,88 @@ async def test_register_without_org_name_defaults_to_my_organization(
 
     assert org is not None
     assert org.name == "My Organization"
+
+
+@pytest.mark.asyncio
+async def test_register_flag_off_creates_identity_only(
+    client, session_maker, monkeypatch
+):
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", "false")
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={"email": "identity-only@example.com", "password": VALID_PASSWORD},
+    )
+
+    assert response.status_code == 201
+    data = response.json()
+    assert data["org_id"] is None
+
+    async with session_maker() as session:
+        user_count = await session.scalar(select(func.count()).select_from(User))
+        org_count = await session.scalar(select(func.count()).select_from(Organization))
+        membership_count = await session.scalar(
+            select(func.count()).select_from(Membership)
+        )
+
+    assert user_count == 1
+    assert org_count == 0
+    assert membership_count == 0
+
+
+@pytest.mark.asyncio
+async def test_verified_orgless_login_sets_needs_onboarding(
+    client, session_maker, monkeypatch
+):
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", "false")
+
+    register_response = await client.post(
+        "/api/v1/auth/register",
+        json={"email": "verified-orgless@example.com", "password": VALID_PASSWORD},
+    )
+    assert register_response.status_code == 201
+
+    async with session_maker() as session:
+        user = await session.scalar(
+            select(User).where(User.email == "verified-orgless@example.com")
+        )
+        assert user is not None
+        user.is_verified = True
+        await session.commit()
+
+    login_response = await client.post(
+        "/api/v1/auth/login",
+        json={"email": "verified-orgless@example.com", "password": VALID_PASSWORD},
+    )
+
+    assert login_response.status_code == 200
+    data = login_response.json()
+    assert data["needs_onboarding"] is True
+    assert data["user"]["org_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_register_flag_on_keeps_auto_org_behavior(
+    client, session_maker, monkeypatch
+):
+    monkeypatch.setenv("AUTH_AUTO_CREATE_ORG_ON_REGISTER", "true")
+
+    response = await client.post(
+        "/api/v1/auth/register",
+        json={"email": "flag-on@example.com", "password": VALID_PASSWORD},
+    )
+
+    assert response.status_code == 201
+    assert response.json()["org_id"] is not None
+
+    async with session_maker() as session:
+        org_count = await session.scalar(select(func.count()).select_from(Organization))
+        membership_count = await session.scalar(
+            select(func.count()).select_from(Membership)
+        )
+
+    assert org_count == 1
+    assert membership_count == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Implements CHAOS-2671 identity-only registration when org auto-create is disabled, while preserving default org creation when enabled.
- Implements CHAOS-2672 workspace-name validation for onboarding org creation.
- Implements CHAOS-2673 GET /api/v1/auth/onboarding/state using the C1 state contract.
- Implements C6 POST /api/v1/auth/onboarding/skip-integration with persisted idempotent skip state.

Parent: CHAOS-2670

## Validation
- bash ci/local_validate.sh — GATE PASSED
- LSP diagnostics clean on changed files

## Linear
- CHAOS-2671
- CHAOS-2672
- CHAOS-2673