### PR TITLE
docs(fixtures): align onboarding seed data

### DIFF
--- a/docs/architecture/auth-journey.md
+++ b/docs/architecture/auth-journey.md
@@ -4,9 +4,11 @@ Backend authentication and authorization flows for the Dev Health platform. Each
 
 All auth endpoints live under `/api/v1/auth/` in `src/dev_health_ops/api/auth/router.py`.
 
+Source-of-truth tests for the first-run path: `tests/test_onboarding.py`, `tests/api/auth/test_register.py`, `tests/api/auth/test_onboarding_state.py`, `tests/api/auth/test_onboarding_skip.py`, `tests/api/test_new_user_journey.py`, and `tests/api/admin/test_setup_status.py`.
+
 ## Journey 1: Registration
 
-A new user registers with email and password. The backend creates the user, an organization, and a membership in a single transaction, then sends a verification email asynchronously.
+A new user registers with email and password. In the first-run onboarding model, identity creation is separate from workspace creation. By default for Phase 2, registration creates only the user identity and email-verification token, then sends a verification email asynchronously. Organization/workspace creation happens later through the explicit onboarding workspace step.
 
 ```mermaid
 sequenceDiagram
@@ -27,17 +29,15 @@ sequenceDiagram
         R-->>C: 400 "Email already registered"
     end
     R->>DB: INSERT User (is_verified=false, auth_provider="local")
-    R->>DB: INSERT Organization (tier="community")
-    R->>DB: INSERT Membership (role="owner")
     R->>DB: create_email_verification_token
     R->>DB: COMMIT
     R->>E: send_verification_email (async, non-blocking)
-    R-->>C: 201 RegisterResponse {message, user_id, org_id}
+    R-->>C: 201 RegisterResponse {message, user_id, org_id: null}
 ```
 
 **Rate limit:** `AUTH_REGISTER_LIMIT` (3/hour per IP).
 
-**Key detail:** Registration auto-creates org + membership, so newly registered users do NOT need onboarding (`needs_onboarding=false` on login).
+**Key detail:** Registration creates the identity only when `AUTH_AUTO_CREATE_ORG_ON_REGISTER=false`. Newly registered and verified users authenticate with orgless tokens and route to the workspace step. The temporary compatibility flag `AUTH_AUTO_CREATE_ORG_ON_REGISTER=true` preserves the legacy behavior that creates a community org + owner membership during registration; tests pin both modes in `tests/api/auth/test_register.py` and `tests/api/auth/test_onboarding_foundation.py`.
 
 ## Journey 2: Email Verification
 
@@ -65,7 +65,7 @@ sequenceDiagram
 
 ## Journey 3: Login (Happy Path — Verified User)
 
-User submits credentials. Backend validates password, checks verification status, resolves membership, and returns tokens.
+User submits credentials. Backend validates password, checks verification status, resolves membership when present, and returns tokens. Verified orgless users are valid authenticated users; their token carries no org claim until they complete workspace creation or invite acceptance.
 
 ```mermaid
 sequenceDiagram
@@ -81,11 +81,11 @@ sequenceDiagram
     Note over L: Constant-time comparison<br/>using DUMMY_PASSWORD_HASH<br/>even for missing users
     L->>DB: clear_attempts(email)
     L->>L: Check is_verified == true
-    L->>DB: SELECT Membership WHERE user_id
+    L->>DB: SELECT Membership WHERE user_id (optional)
     L->>DB: UPDATE last_login_at
     L->>DB: emit_audit_log(LOGIN)
     L->>DB: COMMIT
-    L->>A: create_token_pair(user_id, email, org_id, role)
+    L->>A: create_token_pair(user_id, email, org_id?, role?)
     L->>DB: INSERT refresh_token record
     L-->>C: 200 LoginResponse {access_token, refresh_token, needs_onboarding, user}
 ```
@@ -94,7 +94,7 @@ sequenceDiagram
 - `AUTH_LOGIN_IP_LIMIT` per IP
 - `AUTH_LOGIN_LIMIT` per auth key
 
-**`needs_onboarding`:** `true` only when user has no memberships and is not superuser. Since registration auto-creates a membership, this is typically `false` for self-registered users.
+**`needs_onboarding`:** `true` when a verified non-superuser has no membership. The client must call `GET /api/v1/auth/onboarding/state` for the canonical next step instead of inferring state from login alone.
 
 ## Journey 4: Login (Unverified Email)
 
@@ -151,36 +151,62 @@ sequenceDiagram
 
 ## Journey 6: Onboarding
 
-For users who authenticated but have no organization membership (e.g., invited users who haven't accepted yet). Supports two actions: `create_org` or `join_org`.
+First-run onboarding is a server-routed sequence after identity verification. It separates workspace creation from integration setup and persists an explicit skip for users who choose to defer the first integration.
 
 ```mermaid
 sequenceDiagram
     participant C as Client
+    participant S as GET /onboarding/state
     participant O as POST /onboard
+    participant G as GitHub App install
+    participant K as POST /onboarding/skip-integration
     participant DB as PostgreSQL
     participant A as AuthService
 
-    C->>O: OnboardRequest {action, org_name?, invite_code?}
-    O->>DB: SELECT User WHERE id = jwt.sub
-    O->>DB: SELECT Membership WHERE user_id
-    alt already has membership
-        O-->>C: 400 "Already onboarded"
-    end
-    alt action == "create_org"
+    C->>S: Bearer orgless or org-scoped token
+    S->>DB: SELECT User + Membership + Organization + IntegrationCredential
+    alt verified user has no membership
+        S-->>C: OnboardingState {next_step: "workspace"}
+        C->>O: OnboardRequest {action: "create_org", org_name}
+        O->>DB: validate required workspace name
         O->>DB: INSERT Organization
         O->>DB: INSERT Membership (role="owner")
         O->>DB: emit_audit_log(CREATE, ORGANIZATION)
-    else action == "join_org"
-        O->>DB: validate_org_invite(invite_code)
-        O->>DB: accept_org_invite — INSERT Membership
-        O->>DB: emit_audit_log(MEMBER_JOINED)
+        O->>DB: COMMIT
+        O->>A: create_token_pair (new tokens with org_id)
+        O-->>C: 200 OnboardResponse {tokens, org_id, org_name, role}
+        C->>S: Bearer org-scoped token
     end
-    O->>DB: COMMIT
-    O->>A: create_token_pair (new tokens with org_id)
-    O-->>C: 200 OnboardResponse {tokens, org_id, org_name, role}
+    alt workspace exists and no active integration
+        S-->>C: OnboardingState {next_step: "integration", recommended_provider: "github"}
+        C->>G: Start GitHub App install with return URL
+        G-->>C: Return-aware install completes or returns
+    else user defers integration
+        C->>K: Bearer org-scoped token
+        K->>DB: SET Organization.onboarding_integration_skipped_at
+        K-->>C: OnboardingState {next_step: "complete", integration_skipped: true}
+    else active integration exists or skip is persisted
+        S-->>C: OnboardingState {next_step: "complete"}
+    end
 ```
 
-**Requires authentication:** JWT bearer token in `Authorization` header.
+**Route sequence:**
+
+1. `POST /register` creates identity. With `AUTH_AUTO_CREATE_ORG_ON_REGISTER=false`, `org_id` is `null`.
+2. `GET /verify` marks the identity verified.
+3. `POST /login` returns orgless tokens for verified users without memberships.
+4. `GET /onboarding/state` returns `next_step="workspace"` for verified orgless non-superusers.
+5. `POST /onboard` with `action="create_org"` requires `org_name`, creates the workspace organization and owner membership, and returns org-scoped tokens. `join_org` remains the invite path.
+6. `GET /onboarding/state` returns `next_step="integration"` until the org has an active integration credential or a persisted skip.
+7. The primary first integration is GitHub App installation. Return-aware install handling sends users back to the onboarding flow after installation.
+8. `POST /onboarding/skip-integration` records `Organization.onboarding_integration_skipped_at` and returns a state with `next_step="complete"` and `integration_skipped=true` unless an integration is already connected.
+9. `GET /api/v1/admin/setup/status` powers admin setup gating after onboarding by distinguishing missing integration, missing sync config, failed sync, running sync, and ready states.
+
+**Completion:** Non-admin users complete onboarding when a first integration is connected or the integration step is skipped. Superusers/admins route to `dashboard` in onboarding state and do not block on first-run setup.
+
+**Requires authentication:** JWT bearer token in `Authorization` header. `GET /onboarding/state` accepts verified orgless tokens; `POST /onboarding/skip-integration` requires an org-scoped token and membership.
+
+**Migration behavior:** Alembic `0026_add_org_onboarding_integration_skipped_at.py` adds `organizations.onboarding_integration_skipped_at` for the C6 skip contract. Alembic `0027_make_refresh_tokens_org_id_nullable.py` allows refresh-token records without `org_id` so orgless verified identities can maintain sessions before workspace creation.
 
 ## Journey 7: Password Reset
 
@@ -302,11 +328,14 @@ sequenceDiagram
 | `/forgot-password` | POST | None | 3/hour | `VerifyEmailResponse` |
 | `/reset-password` | POST | None | None | `VerifyEmailResponse` |
 | `/onboard` | POST | Bearer | None | `OnboardResponse` |
+| `/onboarding/state` | GET | Bearer | None | `OnboardingStateResponse` |
+| `/onboarding/skip-integration` | POST | Bearer | None | `OnboardingStateResponse` |
 | `/accept-invite` | POST | Bearer | None | `AcceptInviteResponse` |
 | `/refresh` | POST | None | Per limit | `TokenRefreshResponse` |
 | `/validate` | POST | None | Per limit | `TokenValidateResponse` |
 | `/me` | GET | Bearer | None | `MeResponse` |
 | `/logout` | POST | Optional | None | `{message}` |
+| `/api/v1/admin/setup/status` | GET | Org-scoped admin bearer | None | `SetupStatusResponse` |
 
 ## Security Notes
 
@@ -315,3 +344,4 @@ sequenceDiagram
 - **Token rotation:** Refresh tokens are single-use with family-based reuse detection.
 - **Anti-enumeration:** Forgot-password and resend-verification return generic messages regardless of account existence.
 - **Audit logging:** All auth events (login, logout, registration, failures) are recorded with IP and user-agent.
+- **Onboarding routing:** `GET /onboarding/state` is the single backend source of truth for workspace/integration/complete/dashboard routing.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -83,6 +83,7 @@ CLI flags override environment variables.
 | `GITHUB_TOKEN`, `GITLAB_TOKEN`, `JIRA_*`, `ATLASSIAN_*`, `LINEAR_API_KEY` | Optional | Provider auth for sync commands |
 | `EMAIL_PROVIDER`, `EMAIL_API_KEY`, `EMAIL_FROM_ADDRESS` | Optional (`console` default) | Email delivery via [Resend](./email-setup.md) |
 | `APP_BASE_URL`, `JWT_SECRET_KEY`, `SETTINGS_ENCRYPTION_KEY` | Optional in dev, required in production | API callback/auth/encryption settings |
+| `AUTH_AUTO_CREATE_ORG_ON_REGISTER` | Temporary compatibility flag (default `true`) | Set `false` for the first-run onboarding model where registration creates an identity only and workspace creation happens through `/api/v1/auth/onboard` |
 | `STRIPE_SECRET_KEY`, `STRIPE_WEBHOOK_SECRET` | Required for billing | Stripe API and webhook verification |
 | `STRIPE_PRICE_ID_TEAM`, `STRIPE_PRICE_ID_ENTERPRISE` | Required for billing | Stripe Price IDs for checkout |
 | `TRIAL_DAYS` | Optional (default: 14) | Free trial duration for Team tier |

--- a/src/dev_health_ops/fixtures/demo_identity.py
+++ b/src/dev_health_ops/fixtures/demo_identity.py
@@ -22,6 +22,14 @@ from __future__ import annotations
 # the human-readable name is sourced here.
 DEMO_ORG_NAME = "Meridian"
 
+ONBOARDING_ORGLESS_USER_EMAIL = "onboarding@devhealth.example"
+ONBOARDING_ORGLESS_USER_USERNAME = "onboarding"
+ONBOARDING_ORGLESS_USER_FULL_NAME = "Onboarding Fixture User"
+
+ONBOARDED_ADMIN_USER_EMAIL = "admin@devhealth.example"
+ONBOARDED_ADMIN_USER_USERNAME = "admin"
+ONBOARDED_ADMIN_USER_FULL_NAME = "Onboarded Admin Fixture User"
+
 # Curated, realistic repository names. The fixture runner assigns these to the
 # generated repos in order; only when the requested repo count exceeds this list
 # does it fall back to the legacy numeric-suffix scheme.

--- a/src/dev_health_ops/fixtures/generators/teams.py
+++ b/src/dev_health_ops/fixtures/generators/teams.py
@@ -8,7 +8,15 @@ import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from dev_health_ops.fixtures.demo_identity import DEMO_ORG_NAME
+from dev_health_ops.fixtures.demo_identity import (
+    DEMO_ORG_NAME,
+    ONBOARDED_ADMIN_USER_EMAIL,
+    ONBOARDED_ADMIN_USER_FULL_NAME,
+    ONBOARDED_ADMIN_USER_USERNAME,
+    ONBOARDING_ORGLESS_USER_EMAIL,
+    ONBOARDING_ORGLESS_USER_FULL_NAME,
+    ONBOARDING_ORGLESS_USER_USERNAME,
+)
 from dev_health_ops.fixtures.generators.base import BaseGeneratorMixin
 from dev_health_ops.metrics.schemas import RepoMetricsDailyRecord
 from dev_health_ops.models.git import Repo
@@ -90,6 +98,18 @@ class TeamsGeneratorMixin(BaseGeneratorMixin):
         include_admin: bool = True,
         org_id: str | None = None,
     ) -> dict[str, Any]:
+        """Generate auth fixtures for the two supported first-run states.
+
+        The seeded identities are deliberately minimal and purpose-specific:
+
+        * one verified orgless user for onboarding/workspace tests;
+        * one verified onboarded admin user with the demo workspace, owner
+          membership, and enterprise license for admin/integration tests.
+
+        End-to-end fixture users are not reused across these incompatible states.
+        Synthetic authors remain analytics-only identities and are not created as
+        login users here.
+        """
         import bcrypt
 
         from dev_health_ops.licensing.types import LicenseTier
@@ -106,6 +126,23 @@ class TeamsGeneratorMixin(BaseGeneratorMixin):
         ).decode("utf-8")
 
         _DEFAULT_NS = uuid.UUID("6ba7b810-9dad-11d1-80b4-00c04fd430c8")
+
+        onboarding_user = User(
+            id=uuid.uuid5(
+                _DEFAULT_NS,
+                ONBOARDING_ORGLESS_USER_EMAIL,
+            ),
+            email=ONBOARDING_ORGLESS_USER_EMAIL,
+            username=ONBOARDING_ORGLESS_USER_USERNAME,
+            password_hash=password_hash,
+            full_name=ONBOARDING_ORGLESS_USER_FULL_NAME,
+            auth_provider="local",
+            is_active=True,
+            is_verified=True,
+            is_superuser=False,
+        )
+        users.append(onboarding_user)
+
         # Resolve the target Postgres Organization identity from the supplied
         # CLI/sink-level org_id, so that seeded users/memberships/licenses live
         # in the SAME tenant as the analytics rows. Without this, the fixture
@@ -130,12 +167,12 @@ class TeamsGeneratorMixin(BaseGeneratorMixin):
             admin_user = User(
                 id=uuid.uuid5(
                     _DEFAULT_NS,
-                    "admin@devhealth.example",
+                    ONBOARDED_ADMIN_USER_EMAIL,
                 ),
-                email="admin@devhealth.example",
-                username="admin",
+                email=ONBOARDED_ADMIN_USER_EMAIL,
+                username=ONBOARDED_ADMIN_USER_USERNAME,
                 password_hash=password_hash,
-                full_name="Admin User",
+                full_name=ONBOARDED_ADMIN_USER_FULL_NAME,
                 auth_provider="local",
                 is_active=True,
                 is_verified=True,
@@ -173,36 +210,6 @@ class TeamsGeneratorMixin(BaseGeneratorMixin):
             )
             admin_license.id = uuid.uuid5(admin_org.id, "org-license")
             licenses.append(admin_license)
-
-        default_org_id = None
-        if orgs:
-            default_org_id = orgs[0].id
-
-        for name, email in self.authors[:5]:
-            user_id = uuid.uuid5(_DEFAULT_NS, email)
-            user = User(
-                id=user_id,
-                email=email,
-                username=email.split("@")[0],
-                password_hash=password_hash,
-                full_name=name,
-                auth_provider="local",
-                is_active=True,
-                is_verified=True,
-                is_superuser=False,
-            )
-            users.append(user)
-
-            if default_org_id:
-                memberships.append(
-                    Membership(
-                        id=uuid.uuid5(user_id, str(default_org_id)),
-                        user_id=user_id,
-                        org_id=default_org_id,
-                        role="member",
-                        joined_at=datetime.now(timezone.utc),
-                    )
-                )
 
         return {
             "users": users,

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -462,12 +462,14 @@ async def _seed_auth_data(
             safe_org_ids.add(org.id)
     await session.commit()
 
-    # Gate fixture-user insertion on safe-org insertion (CHAOS-2458): on the
-    # default path, never introduce a fixture account (e.g. the known-password
-    # admin@devhealth.example superuser) for a tenant that already exists. A
-    # fixture user is eligible only if it belongs to at least one org that was
-    # freshly inserted this run; users tied only to pre-existing (skipped) orgs
-    # are left out entirely. overwrite_real_users=True keeps the full pass.
+    # Gate fixture-user insertion on safe-org insertion (CHAOS-2458) while
+    # preserving the CHAOS-2670 first-run fixture contract: the seed contains
+    # one verified orgless identity for workspace-onboarding tests and one
+    # onboarded admin identity for admin/integration tests. On the default path,
+    # the empty-graph guard above means orgless fixture users can only be added
+    # into an empty auth DB; users tied to orgs are eligible only when at least
+    # one of their orgs was freshly inserted this run. overwrite_real_users=True
+    # keeps the full pass for isolated demo/CI refreshes.
     all_memberships = user_data.get("memberships") or []
     user_org_map: dict[Any, set[Any]] = {}
     for membership in all_memberships:
@@ -475,8 +477,10 @@ async def _seed_auth_data(
 
     safe_user_ids: set[Any] = set()
     for user in user_data["users"]:
+        user_org_ids = user_org_map.get(user.id, set())
+        is_orgless_fixture_user = not user_org_ids
         if not overwrite_real_users and not (
-            user_org_map.get(user.id, set()) & safe_org_ids
+            is_orgless_fixture_user or (user_org_ids & safe_org_ids)
         ):
             logging.warning(
                 "FIXTURES-GUARD: skipping fixture user %s (%s) because it is not "

--- a/tests/fixtures/test_demo_identity.py
+++ b/tests/fixtures/test_demo_identity.py
@@ -21,6 +21,8 @@ from dev_health_ops.fixtures.demo_identity import (
     DEMO_ORG_NAME,
     DEMO_REPO_NAMES,
     DEMO_TEAMS,
+    ONBOARDED_ADMIN_USER_EMAIL,
+    ONBOARDING_ORGLESS_USER_EMAIL,
     demo_repo_name,
     demo_team_identity,
 )
@@ -81,6 +83,26 @@ def test_generated_org_name_is_curated_without_org_id():
     data = SyntheticDataGenerator(seed=1).generate_users(org_id=None)
     for org in data["organizations"]:
         assert org.name == DEMO_ORG_NAME
+
+
+def test_generated_auth_users_are_purpose_specific_journey_fixtures():
+    data = SyntheticDataGenerator(seed=1).generate_users(org_id=str(uuid.uuid4()))
+
+    users_by_email = {user.email: user for user in data["users"]}
+    assert set(users_by_email) == {
+        ONBOARDING_ORGLESS_USER_EMAIL,
+        ONBOARDED_ADMIN_USER_EMAIL,
+    }
+
+    orgless_user = users_by_email[ONBOARDING_ORGLESS_USER_EMAIL]
+    admin_user = users_by_email[ONBOARDED_ADMIN_USER_EMAIL]
+    assert orgless_user.is_verified is True
+    assert admin_user.is_superuser is True
+
+    memberships_by_user_id = {membership.user_id for membership in data["memberships"]}
+    assert orgless_user.id not in memberships_by_user_id
+    assert admin_user.id in memberships_by_user_id
+    assert len(data["memberships"]) == 1
 
 
 def test_demo_team_identity_is_curated_and_distinct():

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -4,6 +4,10 @@ import uuid
 import pytest
 
 from dev_health_ops.fixtures import runner
+from dev_health_ops.fixtures.demo_identity import (
+    ONBOARDED_ADMIN_USER_EMAIL,
+    ONBOARDING_ORGLESS_USER_EMAIL,
+)
 from dev_health_ops.fixtures.generator import SyntheticDataGenerator
 from dev_health_ops.fixtures.runner import (
     _build_repo_team_assignments,
@@ -626,8 +630,11 @@ class TestGenerateUsersRespectsOrgId:
         assert org.slug != "default-org"
         assert org.slug == f"fixture-{uuid.UUID(self._UUID_ORG).hex[:8]}"
 
-        # Every membership (admin + first 5 authors) must target the supplied org.
-        assert len(data["memberships"]) >= 2, "expected admin + at least 1 author"
+        assert {user.email for user in data["users"]} == {
+            ONBOARDING_ORGLESS_USER_EMAIL,
+            ONBOARDED_ADMIN_USER_EMAIL,
+        }
+        assert len(data["memberships"]) == 1
         for m in data["memberships"]:
             assert m.org_id == uuid.UUID(self._UUID_ORG), (
                 f"membership {m.id} for user {m.user_id} bound to wrong org "
@@ -664,6 +671,11 @@ class TestGenerateUsersRespectsOrgId:
         assert data["organizations"][0].id == expected
         assert data["organizations"][0].slug == "default-org"
         assert data["organizations"][0].name == "Meridian"
+        assert {user.email for user in data["users"]} == {
+            ONBOARDING_ORGLESS_USER_EMAIL,
+            ONBOARDED_ADMIN_USER_EMAIL,
+        }
+        assert len(data["memberships"]) == 1
         for m in data["memberships"]:
             assert m.org_id == expected
 

--- a/tests/test_fixtures_seed_auth_idempotent.py
+++ b/tests/test_fixtures_seed_auth_idempotent.py
@@ -18,6 +18,14 @@ import pytest_asyncio
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from dev_health_ops.fixtures.demo_identity import (
+    ONBOARDED_ADMIN_USER_EMAIL,
+    ONBOARDED_ADMIN_USER_FULL_NAME,
+    ONBOARDED_ADMIN_USER_USERNAME,
+    ONBOARDING_ORGLESS_USER_EMAIL,
+    ONBOARDING_ORGLESS_USER_FULL_NAME,
+    ONBOARDING_ORGLESS_USER_USERNAME,
+)
 from dev_health_ops.fixtures.runner import _seed_auth_data
 from dev_health_ops.licensing.types import LicenseTier
 from dev_health_ops.models.git import Base
@@ -49,28 +57,29 @@ async def session_maker(tmp_path: Path):
 def _build_user_data() -> dict:
     """Build the same user_data shape the fixtures generator produces.
 
-    Two users (admin + alice) bound to one org, one license. Deterministic
-    UUIDs so a second invocation lands on identical PKs.
+    Two users matching the fixture journeys: one orgless onboarding identity
+    and one onboarded admin bound to one org/license. Deterministic UUIDs make
+    repeated invocations land on identical PKs.
     """
     target_org_id = uuid.UUID("ae600a94-76bc-4166-bf36-051ee4247c73")
 
     admin = User(
-        id=uuid.uuid5(_NS, "admin@devhealth.example"),
-        email="admin@devhealth.example",
-        username="admin",
+        id=uuid.uuid5(_NS, ONBOARDED_ADMIN_USER_EMAIL),
+        email=ONBOARDED_ADMIN_USER_EMAIL,
+        username=ONBOARDED_ADMIN_USER_USERNAME,
         password_hash="$2b$12$dummy",
-        full_name="Admin",
+        full_name=ONBOARDED_ADMIN_USER_FULL_NAME,
         auth_provider="local",
         is_active=True,
         is_verified=True,
         is_superuser=True,
     )
-    alice = User(
-        id=uuid.uuid5(_NS, "alice@example.com"),
-        email="alice@example.com",
-        username="alice",
+    onboarding = User(
+        id=uuid.uuid5(_NS, ONBOARDING_ORGLESS_USER_EMAIL),
+        email=ONBOARDING_ORGLESS_USER_EMAIL,
+        username=ONBOARDING_ORGLESS_USER_USERNAME,
         password_hash="$2b$12$dummy",
-        full_name="Alice",
+        full_name=ONBOARDING_ORGLESS_USER_FULL_NAME,
         auth_provider="local",
         is_active=True,
         is_verified=True,
@@ -91,13 +100,6 @@ def _build_user_data() -> dict:
         role="owner",
         joined_at=now,
     )
-    alice_membership = Membership(
-        id=uuid.uuid5(alice.id, str(org.id)),
-        user_id=alice.id,
-        org_id=org.id,
-        role="member",
-        joined_at=now,
-    )
     license_row = OrgLicense(
         org_id=org.id,
         tier=LicenseTier.ENTERPRISE.value,
@@ -109,8 +111,8 @@ def _build_user_data() -> dict:
     license_row.id = uuid.uuid5(org.id, "org-license")
     return {
         "organizations": [org],
-        "users": [admin, alice],
-        "memberships": [admin_membership, alice_membership],
+        "users": [onboarding, admin],
+        "memberships": [admin_membership],
         "licenses": [license_row],
     }
 
@@ -140,8 +142,8 @@ async def test_seed_auth_data_is_idempotent_on_rerun(session_maker):
 
     assert len(orgs) == 1
     assert len(users) == 2
-    assert len(memberships) == 2
-    assert {m.role for m in memberships} == {"owner", "member"}
+    assert len(memberships) == 1
+    assert {m.role for m in memberships} == {"owner"}
     assert len(licenses) == 1
 
 
@@ -155,9 +157,9 @@ async def test_seed_auth_data_first_invocation_writes_everything(session_maker):
     async with session_maker() as session:
         memberships = (await session.execute(select(Membership))).scalars().all()
 
-    assert len(memberships) == 2
+    assert len(memberships) == 1
     user_org_pairs = {(m.user_id, m.org_id) for m in memberships}
-    assert len(user_org_pairs) == 2  # no accidental collision
+    assert len(user_org_pairs) == 1
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- seed one verified orgless onboarding fixture user and one onboarded admin fixture user
- keep orgless/auth fixture state explicit and update fixture tests for the new model
- document the backend first-run onboarding journey, skip persistence, setup state, flags, and migrations

Refs CHAOS-2684, CHAOS-2680, parent CHAOS-2670.

## Validation
- bash ci/local_validate.sh — GATE PASSED
- pre-push hook: ruff format --check, ruff check, mypy

SCREENSHOT-WAIVER: backend fixtures/docs only; no rendered UI changes.