### PR TITLE
fix(observability): configure Sentry Strawberry async execution

### DIFF
--- a/src/dev_health_ops/sentry.py
+++ b/src/dev_health_ops/sentry.py
@@ -45,6 +45,7 @@ def init_sentry() -> bool:
         from sentry_sdk.integrations.fastapi import FastApiIntegration
         from sentry_sdk.integrations.logging import LoggingIntegration
         from sentry_sdk.integrations.starlette import StarletteIntegration
+        from sentry_sdk.integrations.strawberry import StrawberryIntegration
 
         environment = os.getenv("SENTRY_ENVIRONMENT", "production")
         traces_rate = float(os.getenv("SENTRY_TRACES_RATE", "0.0"))
@@ -59,6 +60,7 @@ def init_sentry() -> bool:
             integrations=[
                 StarletteIntegration(transaction_style="endpoint"),
                 FastApiIntegration(transaction_style="endpoint"),
+                StrawberryIntegration(async_execution=True),
                 CeleryIntegration(monitor_beat_tasks=True),
                 LoggingIntegration(
                     level=logging.INFO,

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+from typing import Any
+
+from dev_health_ops import sentry
+
+
+class _Integration:
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+
+def _install_integration_module(
+    monkeypatch: Any,
+    module_name: str,
+    class_name: str,
+) -> type[_Integration]:
+    module = ModuleType(module_name)
+    integration_class = type(class_name, (_Integration,), {})
+    setattr(module, class_name, integration_class)
+    monkeypatch.setitem(sys.modules, module_name, module)
+    return integration_class
+
+
+def test_init_sentry_configures_strawberry_async_execution(monkeypatch: Any) -> None:
+    captured: dict[str, Any] = {}
+    sentry_sdk = ModuleType("sentry_sdk")
+
+    def init(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    sentry_sdk.init = init  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentry_sdk", sentry_sdk)
+    monkeypatch.setitem(
+        sys.modules, "sentry_sdk.integrations", ModuleType("integrations")
+    )
+    _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.celery",
+        "CeleryIntegration",
+    )
+    _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.fastapi",
+        "FastApiIntegration",
+    )
+    _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.logging",
+        "LoggingIntegration",
+    )
+    _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.starlette",
+        "StarletteIntegration",
+    )
+    strawberry_integration = _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.strawberry",
+        "StrawberryIntegration",
+    )
+    monkeypatch.setattr(sentry, "_initialized", False)
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.com/1")
+
+    assert sentry.init_sentry() is True
+
+    strawberry_instances = [
+        integration
+        for integration in captured["integrations"]
+        if isinstance(integration, strawberry_integration)
+    ]
+    assert len(strawberry_instances) == 1
+    assert strawberry_instances[0].kwargs == {"async_execution": True}


### PR DESCRIPTION
## Summary
- Configure Sentry's Strawberry integration with `async_execution=True` for the async GraphQL schema/router
- Add a regression test that verifies the Strawberry integration is explicitly configured for async execution

## Verification
- `PYTHONPATH=src python -m ruff check src/dev_health_ops/sentry.py tests/test_sentry.py`
- `PYTHONPATH=src python -m pytest tests/test_sentry.py`
- `PYTHONPATH=src SENTRY_DSN=... SENTRY_TRACES_RATE=0 python` import driver confirmed the Strawberry sync warning is absent
- Pre-commit/pre-push hooks ran `ruff`, `ruff format`, and `mypy` successfully

SCREENSHOT-WAIVER: backend-only observability configuration change; no rendered UI changed.