### PR TITLE
docs(auth): correct registration default-flag behavior (CHAOS-2680 follow-up)

### DIFF
--- a/docs/architecture/auth-journey.md
+++ b/docs/architecture/auth-journey.md
@@ -8,7 +8,7 @@ Source-of-truth tests for the first-run path: `tests/test_onboarding.py`, `tests
 
 ## Journey 1: Registration
 
-A new user registers with email and password. In the first-run onboarding model, identity creation is separate from workspace creation. By default for Phase 2, registration creates only the user identity and email-verification token, then sends a verification email asynchronously. Organization/workspace creation happens later through the explicit onboarding workspace step.
+A new user registers with email and password. In the first-run onboarding model, identity creation is separate from workspace creation. The rollout is gated by `AUTH_AUTO_CREATE_ORG_ON_REGISTER`, which **defaults to `true`** (production-preserving): registration creates the user identity **and** a community organization + owner membership. When the flag is set to `false` (guided-onboarding mode), registration creates **only** the user identity and email-verification token, and organization/workspace creation happens later through the explicit onboarding workspace step. A verification email is sent asynchronously in both modes.
 
 ```mermaid
 sequenceDiagram
@@ -29,10 +29,17 @@ sequenceDiagram
         R-->>C: 400 "Email already registered"
     end
     R->>DB: INSERT User (is_verified=false, auth_provider="local")
+    alt AUTH_AUTO_CREATE_ORG_ON_REGISTER=true (default, legacy)
+        R->>DB: INSERT Organization + owner Membership
+    end
     R->>DB: create_email_verification_token
     R->>DB: COMMIT
     R->>E: send_verification_email (async, non-blocking)
-    R-->>C: 201 RegisterResponse {message, user_id, org_id: null}
+    alt AUTH_AUTO_CREATE_ORG_ON_REGISTER=true (default)
+        R-->>C: 201 RegisterResponse {message, user_id, org_id}
+    else flag=false (guided onboarding)
+        R-->>C: 201 RegisterResponse {message, user_id, org_id: null}
+    end
 ```
 
 **Rate limit:** `AUTH_REGISTER_LIMIT` (3/hour per IP).


### PR DESCRIPTION
## What

Docs-only follow-up to the adversarial review of #1068 (already merged). The auth-journey doc incorrectly stated that identity-only registration is the Phase-2 **default**, contradicting the actual code: `AUTH_AUTO_CREATE_ORG_ON_REGISTER` **defaults to `true`** (production-preserving), so registration creates user + organization + owner membership by default; identity-only happens only when the flag is `false`.

## Changes
- `docs/architecture/auth-journey.md`: rewrote the Journey 1 opening paragraph to state the flag default (`true`) and both branches; made the registration sequence diagram flag-conditional (org+membership created when flag true; `org_id: null` only on the flag-false guided path).

The fixtures half of #1068 was verified correct by review; this only corrects the docs.

SCREENSHOT-WAIVER: docs-only, no rendered UI.

Refs CHAOS-2680, CHAOS-2670.