### PR TITLE
fix(sync): isolate scheduled sync dispatch queue

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -254,7 +254,7 @@ services:
         SETUPTOOLS_SCM_PRETEND_VERSION: 0.0.0
     container_name: worker
     entrypoint: ["celery"]
-    command: -A dev_health_ops.workers.celery_app worker --loglevel=info --disable-prefetch -Q default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring --concurrency=${WORKER_CONCURRENCY:-4}
+    command: -A dev_health_ops.workers.celery_app worker --loglevel=info --disable-prefetch -Q default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,scheduler,monitoring --concurrency=${WORKER_CONCURRENCY:-4}
     environment:
       <<: *env
       CELERY_BROKER_URL: redis://valkey:6379/0
@@ -287,7 +287,12 @@ services:
     container_name: worker-heavy
     # `monitoring` is consumed here AND by `worker` above: queue telemetry
     # survives either pool being saturated or down.
-    command: -A dev_health_ops.workers.celery_app worker --loglevel=info --disable-prefetch -Q metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy --concurrency=${WORKER_HEAVY_CONCURRENCY:-2}
+    command: -A dev_health_ops.workers.celery_app worker --loglevel=info --disable-prefetch -Q metrics,backfill,scheduler,monitoring,sync.github.heavy,sync.gitlab.heavy --concurrency=${WORKER_HEAVY_CONCURRENCY:-2}
+
+  beat:
+    <<: *worker-base
+    container_name: beat
+    command: -A dev_health_ops.workers.celery_app beat --loglevel=info --schedule=/tmp/celerybeat-schedule
 
   # ---------------------------------------------------------------------------
   # Observability — SigNoz (distributed tracing + metrics)

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -235,7 +235,7 @@ services:
       - --loglevel=info
       - --disable-prefetch
       - -Q
-      - default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring
+      - default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,scheduler,monitoring
       - --concurrency=${WORKER_CONCURRENCY:-4}
     environment:
       POSTGRES_URI: postgresql+asyncpg://${POSTGRES_USER}:${POSTGRES_PASSWORD}@${POSTGRES_HOST}:5432/${POSTGRES_DB}
@@ -319,8 +319,27 @@ services:
       - --loglevel=info
       - --disable-prefetch
       - -Q
-      - metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy
+      - metrics,backfill,scheduler,monitoring,sync.github.heavy,sync.gitlab.heavy
       - --concurrency=${WORKER_HEAVY_CONCURRENCY:-2}
+
+  beat:
+    <<: *worker-base
+    container_name: dev-health-beat
+    command:
+      - -A
+      - dev_health_ops.workers.celery_app
+      - beat
+      - --loglevel=info
+      - --schedule=/tmp/celerybeat-schedule
+    deploy:
+      replicas: 1
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.25"
+        reservations:
+          memory: 128M
+          cpus: "0.05"
 
   pgbouncer:
     # CHAOS-2065: optional transaction-mode pooler in front of a managed

--- a/deploy/docker-swarm/stack.yml
+++ b/deploy/docker-swarm/stack.yml
@@ -195,7 +195,7 @@ services:
       - --loglevel=info
       - --disable-prefetch
       - -Q
-      - default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring
+      - default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,scheduler,monitoring
       - --concurrency=4
     environment:
       POSTGRES_URI: postgresql+asyncpg://devhealth:${POSTGRES_PASSWORD}@postgres:5432/devhealth
@@ -253,8 +253,35 @@ services:
       - --loglevel=info
       - --disable-prefetch
       - -Q
-      - metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy
+      - metrics,backfill,scheduler,monitoring,sync.github.heavy,sync.gitlab.heavy
       - --concurrency=2
+
+  beat:
+    <<: *worker-base
+    command:
+      - -A
+      - dev_health_ops.workers.celery_app
+      - beat
+      - --loglevel=info
+      - --schedule=/tmp/celerybeat-schedule
+    deploy:
+      mode: replicated
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 10s
+        failure_action: rollback
+      resources:
+        limits:
+          memory: 512M
+          cpus: "0.25"
+        reservations:
+          memory: 128M
+          cpus: "0.05"
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
 
 volumes:
   clickhouse_data:

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -95,7 +95,7 @@ worker:
   replicas: 2
   # Default fleet (CHAOS-2278): latency-sensitive queues + light/medium cost-class
   # sub-queues (CHAOS-2517). metrics/backfill/ingest/heavy live on the pools below.
-  queues: "default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring"
+  queues: "default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,scheduler,monitoring"
   concurrency: 4
   logLevel: info
   terminationGracePeriodSeconds: 3700
@@ -156,7 +156,7 @@ workerIngest:
 workerHeavy:
   enabled: true
   replicas: 2
-  queues: "metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy"
+  queues: "metrics,backfill,scheduler,monitoring,sync.github.heavy,sync.gitlab.heavy"
   concurrency: 2
   logLevel: info
   terminationGracePeriodSeconds: 3700

--- a/deploy/kubernetes/beat.yaml
+++ b/deploy/kubernetes/beat.yaml
@@ -1,0 +1,77 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dev-health-beat
+  namespace: dev-health
+  labels:
+    app.kubernetes.io/name: dev-health-beat
+    app.kubernetes.io/component: beat
+    app.kubernetes.io/part-of: dev-health-ops
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dev-health-beat
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dev-health-beat
+    spec:
+      securityContext:
+        runAsNonRoot: true
+      initContainers:
+        - name: wait-for-migrations
+          image: ghcr.io/your-org/dev-health-ops:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+          command:
+            - sh
+            - -c
+            - |
+              attempts=0
+              until dev-hops migrate clickhouse status --check; do
+                attempts=$((attempts + 1))
+                if [ "$attempts" -ge 60 ]; then
+                  echo "ClickHouse migrations still pending after $attempts checks; exiting for restart backoff" >&2
+                  exit 1
+                fi
+                echo "ClickHouse migrations pending; re-checking in 5s (attempt $attempts/60)"
+                sleep 5
+              done
+          envFrom:
+            - configMapRef:
+                name: dev-health-config
+            - secretRef:
+                name: dev-health-secrets
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"
+      containers:
+        - name: beat
+          image: ghcr.io/your-org/dev-health-ops:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+          command:
+            - celery
+            - -A
+            - dev_health_ops.workers.celery_app
+            - beat
+            - --loglevel=info
+            - --schedule=/tmp/celerybeat-schedule
+          envFrom:
+            - configMapRef:
+                name: dev-health-config
+            - secretRef:
+                name: dev-health-secrets
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "50m"
+            limits:
+              memory: "512Mi"
+              cpu: "250m"

--- a/deploy/kubernetes/kustomization.yaml
+++ b/deploy/kubernetes/kustomization.yaml
@@ -18,6 +18,7 @@ resources:
   - migrate-job.yaml
   - api.yaml
   - worker.yaml
+  - beat.yaml
   - cronjobs.yaml
   - ingress.yaml
 

--- a/deploy/kubernetes/worker.yaml
+++ b/deploy/kubernetes/worker.yaml
@@ -70,7 +70,7 @@ spec:
             - --loglevel=info
             - --disable-prefetch
             - -Q
-            - default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,monitoring
+            - default,sync,sync.github,sync.gitlab,sync.linear,sync.jira,sync.launchdarkly,sync.github.light,sync.github.medium,sync.gitlab.light,sync.gitlab.medium,sync.jira.medium,sync.linear.medium,webhooks,reports,scheduler,monitoring
           envFrom:
             - configMapRef:
                 name: dev-health-config
@@ -272,7 +272,7 @@ spec:
             - --loglevel=info
             - --disable-prefetch
             - -Q
-            - metrics,backfill,monitoring,sync.github.heavy,sync.gitlab.heavy
+            - metrics,backfill,scheduler,monitoring,sync.github.heavy,sync.gitlab.heavy
           envFrom:
             - configMapRef:
                 name: dev-health-config

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -93,6 +93,7 @@ task_queues: dict[str, dict[str, Any]] = {
     "webhooks": {},
     "ingest": {},
     "reports": {},
+    "scheduler": {},
     # Dedicated telemetry queue: monitor_queue_depths must not share a queue
     # with floodable work — if `default` backs up, queue-depth telemetry would
     # die exactly when it is needed. Consumed by BOTH `worker` and
@@ -105,7 +106,7 @@ beat_schedule = {
     "dispatch-scheduled-syncs": {
         "task": "dev_health_ops.workers.tasks.dispatch_scheduled_syncs",
         "schedule": 300.0,
-        "options": {"queue": "default"},
+        "options": {"queue": "scheduler"},
     },
     "dispatch-scheduled-metrics": {
         "task": "dev_health_ops.workers.tasks.dispatch_scheduled_metrics",

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -101,6 +101,40 @@ def test_queue_monitor_beat_entry() -> None:
     assert entry["options"] == {"queue": "monitoring"}
 
 
+def test_scheduled_sync_dispatcher_uses_scheduler_queue() -> None:
+    from dev_health_ops.workers.config import beat_schedule
+
+    entry = beat_schedule["dispatch-scheduled-syncs"]
+    assert entry["task"] == "dev_health_ops.workers.tasks.dispatch_scheduled_syncs"
+    assert entry["schedule"] == 300.0
+    assert entry["options"] == {"queue": "scheduler"}
+
+
+def test_scheduler_queue_declared_and_consumed_redundantly() -> None:
+    assert "scheduler" in task_queues
+
+    compose_path = Path(__file__).resolve().parents[1] / "compose.yml"
+    compose_data = yaml.safe_load(compose_path.read_text(encoding="utf-8"))
+
+    consumers: list[str] = []
+    for name, service in compose_data["services"].items():
+        command = service.get("command")
+        if command is None:
+            continue
+        command_str = _container_command_string(service)
+        tokens = command_str.split()
+        if "celery" not in tokens or "worker" not in tokens:
+            continue
+        if "scheduler" in _parse_queues(command_str):
+            consumers.append(name)
+
+    assert "worker-heavy" in consumers
+    assert len(consumers) >= 2, (
+        f"`scheduler` must be consumed by >=2 worker services for redundancy, "
+        f"found: {sorted(consumers)}"
+    )
+
+
 def test_monitoring_queue_declared_and_consumed_redundantly() -> None:
     """The `monitoring` queue must exist in task_queues and be consumed by at
     least two compose worker services so queue telemetry survives one pool
@@ -168,9 +202,13 @@ def _is_beat_service(name: str, service: dict) -> bool:
 
 def _assert_compose_beat_singleton(path: Path) -> None:
     services = _load_yaml(path).get("services") or {}
-    for name, service in services.items():
-        if not _is_beat_service(name, service):
-            continue
+    beat_services = [
+        (name, service)
+        for name, service in services.items()
+        if _is_beat_service(name, service)
+    ]
+    assert len(beat_services) == 1, f"{path.name} must define exactly one beat service"
+    for name, service in beat_services:
         replicas = (service.get("deploy") or {}).get("replicas")
         assert replicas in (None, 1), f"{path.name}:{name} must not exceed 1 replica"
 
@@ -187,7 +225,7 @@ def test_production_compose_has_one_shot_migrate_service() -> None:
 
 def test_production_compose_app_services_gate_on_migrate() -> None:
     services = _load_yaml(_PROD_COMPOSE)["services"]
-    for name in ("api", "billing-edge", "worker"):
+    for name in ("api", "billing-edge", "worker", "beat"):
         deps = services[name].get("depends_on") or {}
         assert (
             deps.get("migrate", {}).get("condition") == "service_completed_successfully"
@@ -196,7 +234,7 @@ def test_production_compose_app_services_gate_on_migrate() -> None:
 
 def test_production_compose_disables_ambient_migrations() -> None:
     services = _load_yaml(_PROD_COMPOSE)["services"]
-    for name in ("api", "worker"):
+    for name in ("api", "worker", "beat"):
         env = services[name].get("environment") or {}
         assert env.get("AUTO_RUN_MIGRATIONS") == "false", (
             f"{name} must set AUTO_RUN_MIGRATIONS=false — schema is applied by "
@@ -393,6 +431,22 @@ def test_deploy_stacks_keep_celery_beat_singleton() -> None:
     for stack in (_REPO_ROOT / "compose.yml", _PROD_COMPOSE, _SWARM_STACK):
         _assert_compose_beat_singleton(stack)
 
+    k8s_beats = []
+    for doc in yaml.safe_load_all((_K8S_DIR / "beat.yaml").read_text()):
+        if not doc or doc.get("kind") != "Deployment":
+            continue
+        containers = doc["spec"]["template"]["spec"].get("containers") or []
+        for container in containers:
+            command = container.get("command") or []
+            if "celery" in command and "beat" in command:
+                k8s_beats.append(doc)
+
+    assert len(k8s_beats) == 1
+    assert k8s_beats[0]["spec"].get("replicas") == 1
+
+    kustomization = _load_yaml(_K8S_DIR / "kustomization.yaml")
+    assert "beat.yaml" in kustomization["resources"]
+
     beat_template = (_HELM_DIR / "templates" / "beat-deployment.yaml").read_text(
         encoding="utf-8"
     )
@@ -518,7 +572,7 @@ def test_platform_compose_provider_worker_consumes_sync_dispatch_queue() -> None
 def test_compose_workers_override_runner_entrypoint() -> None:
     for path in (_LEGACY_COMPOSE, _PROD_COMPOSE, _SWARM_STACK):
         services = _load_yaml(path).get("services") or {}
-        for service_name in ("worker", "worker-ingest", "worker-heavy"):
+        for service_name in ("worker", "worker-ingest", "worker-heavy", "beat"):
             service = services[service_name]
             assert service["entrypoint"] == ["celery"]
             command = _stringify_command(service["command"])


### PR DESCRIPTION
## Summary
- route scheduled sync dispatch beat ticks onto a dedicated scheduler queue
- add redundant scheduler queue consumers across local and deploy worker configs
- add missing Celery beat deployment wiring for Compose, Swarm, and static Kubernetes
- add regression coverage for scheduler queue routing/consumption and singleton beat manifests

## Validation
- bash ci/local_validate.sh
- pre-push lefthook: ruff format check, ruff check, mypy

SCREENSHOT-WAIVER: backend/deployment-only change; no rendered UI surface changed.