### PR TITLE
fix(sync): reconcile sync activity workflow

### DIFF
--- a/docs/architecture/dispatch-outbox.md
+++ b/docs/architecture/dispatch-outbox.md
@@ -4,13 +4,13 @@ The durable dispatch outbox guarantees that committed sync runs do not get stran
 
 ## Architectural Overview
 
-The outbox pattern separates database transactions from message broker publishing. Producers write outbox entries within the same database transaction that updates the sync run state. A periodic reconciler relay then polls, claims, and publishes these entries to the Celery broker.
+The outbox pattern separates database transactions from message broker publishing. Producers write outbox entries within the same database transaction that updates the sync run state. A periodic reconciler relay then polls, claims, and publishes these entries to the Celery broker. Sync-config entrypoints first create the admin-visible `JobRun` activity row, then plan the execution-truth `SyncRun`, and link the two through `JobRun.result.sync_run_id`.
 
 ```mermaid
 graph TD
     subgraph Producers [Producers (In-Transaction Write)]
         P1[Planner / plan_sync_run]
-        P2[Trigger Sites (4 sites)]
+        P2[Sync Execution Triggers<br/>manual / scheduled / backfill]
         P3[run_sync_unit]
         P4[finalize_sync_run]
     end
@@ -54,6 +54,8 @@ graph TD
 ```
 
 At-most-once provider execution is not enforced by the outbox. It is guaranteed by the separate unit claim and lease-token CAS guards. The atomic `DISPATCHING` to `RUNNING` claim and the lease checks prevent duplicate execution of provider units even if a task is published multiple times.
+
+`JobRun` is not an execution lock. It is the activity/index row used by admin history surfaces. `SyncRun` and `SyncRunUnit` remain the execution source of truth, and the outbox remains the durable dispatch mechanism.
 
 ---
 

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -25,11 +25,11 @@ Operators can trigger background operations on-demand through three primary API 
 
 1. **Data Sync Trigger**
    * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/trigger` (defined in `api/admin/routers/sync.py:997-1164`)
-   * **Flow**: Builds a `SyncPlanRequest` from the config's migrated integration, plans a `SyncRun` (one `SyncRunUnit` per source/dataset/window), and enqueues `dispatch_sync_run` onto the `sync` queue. The integration planner is the only routing path — the legacy `run_sync_config` / `dispatch_batch_sync` in-process workers were removed in CHAOS-2647.
+   * **Flow**: Creates a canonical `JobRun` activity row, builds a `SyncPlanRequest` from the config's migrated integration, plans a `SyncRun` (one `SyncRunUnit` per source/dataset/window), stores `sync_run_id` in `JobRun.result`, and enqueues `dispatch_sync_run` onto the `sync` queue. The integration planner is the only routing path — the legacy `run_sync_config` / `dispatch_batch_sync` in-process workers were removed in CHAOS-2647.
 
 2. **Historical Backfill Trigger**
    * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/backfill` (defined in `api/admin/routers/sync.py:1167-1233`)
-   * **Flow**: Creates a `BackfillJob` record, plans a backfill-mode `SyncRun`, and enqueues `dispatch_sync_run` onto the `sync` queue (fan-out). The `BackfillJob` is linked to its run via a `sync_run:<id>` marker on `celery_task_id`, so `finalize_sync_run` updates its status and chunk counts.
+   * **Flow**: Creates a `BackfillJob` domain record plus the same canonical `JobRun` activity row used by manual and scheduled sync, plans a backfill-mode `SyncRun`, stores `sync_run_id` in `JobRun.result`, and enqueues `dispatch_sync_run` onto the `sync` queue (fan-out). The `BackfillJob` is linked to its run via a `sync_run:<id>` marker on `celery_task_id`, so `finalize_sync_run` updates its status and chunk counts.
 
 3. **Report Execution Trigger**
    * **Trigger**: GraphQL `triggerReport` mutation or the "Run Now" button in the Report Center UI.
@@ -53,7 +53,7 @@ Triggering `run_investment_materialize` via the worker ensures the worker-side L
 
 ### Observability Caveat
 
-Tasks like `run_work_graph_build` and `run_investment_materialize` don't persist a `JobRun` row in the database. Their execution status and progress can only be tracked through worker logs and distributed traces. For more details on sync observability, see the [Platform Sync Observability](../architecture/platform-sync-observability.md) documentation.
+Manual sync, scheduled sync, and sync-config backfill all persist a `JobRun` row as the admin-visible activity index and link it to the execution-truth `SyncRun` via `JobRun.result.sync_run_id`. The only difference between manual and scheduled sync is timing: the manual endpoint enqueues immediately, while `dispatch_scheduled_syncs` enqueues when the cron marker is due. Tasks like `run_work_graph_build` and `run_investment_materialize` don't persist a `JobRun` row in the database. Their execution status and progress can only be tracked through worker logs and distributed traces. For more details on sync observability, see the [Platform Sync Observability](../architecture/platform-sync-observability.md) documentation.
 
 ---
 

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -4,7 +4,6 @@ import logging
 import os
 import uuid
 from collections.abc import Callable, Sequence
-from dataclasses import replace
 from datetime import datetime, timezone
 from typing import Any, Protocol, cast
 
@@ -46,10 +45,14 @@ from dev_health_ops.models.settings import (
     SyncConfiguration,
 )
 from dev_health_ops.sync.datasets import supported_datasets, supported_legacy_targets
-from dev_health_ops.sync.planner import plan_sync_run
+from dev_health_ops.sync.execution_trigger import (
+    create_sync_execution_trigger,
+    ensure_pending_sync_job_run,
+    mark_job_run_failed,
+    merge_job_run_result,
+)
 from dev_health_ops.sync.trigger_routing import (
     mark_sync_run_failed,
-    planner_request_for_config_if_routed,
 )
 from dev_health_ops.utils.datetime import validate_timezone_name
 from dev_health_ops.workers.sync_units import dispatch_sync_run
@@ -62,40 +65,13 @@ logger = logging.getLogger(__name__)
 
 
 def _mark_job_run_failed(sync_session, run_id: str, error: str) -> None:
-    completed_at = datetime.now(timezone.utc)
-    run = (
-        sync_session.query(JobRun)
-        .filter(JobRun.id == uuid.UUID(str(run_id)))
-        .one_or_none()
-    )
-    if run is None:
-        return
-    run.status = JobRunStatus.FAILED.value
-    run.completed_at = completed_at
-    run.error = error
-    started_at = getattr(run, "started_at", None)
-    if started_at is not None:
-        if started_at.tzinfo is None:
-            started_at = started_at.replace(tzinfo=timezone.utc)
-        run.duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
-    sync_session.flush()
+    mark_job_run_failed(sync_session, run_id, error)
 
 
 def _merge_job_run_result(
     sync_session, run_id: str, result: dict[str, Any] | None = None
 ) -> None:
-    if result is None:
-        return
-    run = (
-        sync_session.query(JobRun)
-        .filter(JobRun.id == uuid.UUID(str(run_id)))
-        .one_or_none()
-    )
-    if run is None:
-        return
-    current = run.result if isinstance(run.result, dict) else {}
-    run.result = {**current, **result}
-    sync_session.flush()
+    merge_job_run_result(sync_session, run_id, result)
 
 
 def _mark_backfill_job_failed(
@@ -149,59 +125,9 @@ def _ensure_pending_sync_job_run(
     triggered_by: str,
     result: dict[str, Any] | None = None,
 ) -> str:
-    """Find-or-create the ScheduledJob anchor and create a PENDING JobRun.
-
-    Returns the new JobRun id as a string.  Used by both the regular
-    /trigger handler and the legacy backfill path so the sync-activity list
-    shows the run immediately.
-    """
-    import uuid as _uuid
-
-    config_uuid = _uuid.UUID(str(config.id))
-    job = (
-        sync_session.query(ScheduledJob)
-        .filter(
-            ScheduledJob.org_id == org_id,
-            ScheduledJob.sync_config_id == config_uuid,
-            ScheduledJob.job_type == "sync",
-        )
-        .one_or_none()
+    return ensure_pending_sync_job_run(
+        sync_session, config, org_id, triggered_by, result
     )
-    if job is None:
-        _sync_options = dict(config.sync_options or {})
-        _provider = str(config.provider or "")
-        _explicit_cron = _sync_options.get("schedule_cron")
-        job = ScheduledJob(
-            name=f"sync-config-{config_uuid}",
-            job_type="sync",
-            schedule_cron=str(_explicit_cron or "0 * * * *"),
-            org_id=org_id,
-            provider=_provider,
-            job_config={
-                "provider": _provider,
-                "sync_config_id": str(config_uuid),
-            },
-            sync_config_id=config_uuid,
-            tz=str(_sync_options.get("timezone") or "UTC"),
-            # Manual-only configs keep the job row for JobRun anchoring
-            # but must not be picked up by the scheduler (CHAOS-2297).
-            status=(
-                JobStatus.ACTIVE.value
-                if bool(config.is_active) and _explicit_cron
-                else JobStatus.PAUSED.value
-            ),
-        )
-        sync_session.add(job)
-        sync_session.flush()
-    run = JobRun(
-        job_id=_uuid.UUID(str(job.id)),
-        triggered_by=triggered_by,
-        status=JobRunStatus.PENDING.value,
-    )
-    run.result = result
-    sync_session.add(run)
-    sync_session.flush()
-    return str(run.id)
 
 
 async def _active_repo_usage_count_for_limit(session: AsyncSession, org_id: str) -> int:
@@ -1717,48 +1643,40 @@ async def trigger_sync_config(
                 # ClickHouse unavailable — allow the sync to proceed rather than block it.
                 pass
 
-    plan_request = await session.run_sync(
-        lambda sync_session: planner_request_for_config_if_routed(
-            sync_session, config, triggered_by="manual", mode="incremental"
-        )
-    )
-    if plan_request is None:
-        raise HTTPException(
-            status_code=400,
-            detail="Sync configuration has no linked integration",
-        )
     await session.run_sync(
         lambda sync_session: _preflight_planner_credential(sync_session, config)
     )
     try:
-        plan = await session.run_sync(
-            lambda sync_session: plan_sync_run(sync_session, plan_request)
+        trigger = await session.run_sync(
+            lambda sync_session: create_sync_execution_trigger(
+                sync_session,
+                config,
+                org_id,
+                triggered_by="manual",
+                mode="incremental",
+            )
         )
     except ValueError as exc:
         raise HTTPException(status_code=400, detail=str(exc))
-    planner_pending_run_id = await session.run_sync(
-        lambda sync_session: _ensure_pending_sync_job_run(
-            sync_session,
-            config,
-            org_id,
-            "manual",
-            {"sync_run_id": plan.sync_run_id},
+    if trigger is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Sync configuration has no linked integration",
         )
-    )
     await session.commit()
     try:
         dispatch_result = getattr(dispatch_sync_run, "apply_async")(
-            args=(plan.sync_run_id,), queue="sync"
+            args=(trigger.sync_run_id,), queue="sync"
         )
     except Exception as exc:
         error_message = f"dispatch enqueue failed: {exc}"
         await session.run_sync(
             lambda s: mark_sync_run_failed(
-                s, plan.sync_run_id, "dispatch enqueue failed"
+                s, trigger.sync_run_id, "dispatch enqueue failed"
             )
         )
         await session.run_sync(
-            lambda s: _mark_job_run_failed(s, planner_pending_run_id, error_message)
+            lambda s: _mark_job_run_failed(s, trigger.job_run_id, error_message)
         )
         await session.commit()
         raise HTTPException(status_code=503, detail=f"Task queue unavailable: {exc}")
@@ -1766,7 +1684,7 @@ async def trigger_sync_config(
     await session.run_sync(
         lambda s: _merge_job_run_result(
             s,
-            planner_pending_run_id,
+            trigger.job_run_id,
             {"dispatch_task_id": dispatch_task_id} if dispatch_task_id else None,
         )
     )
@@ -1774,9 +1692,9 @@ async def trigger_sync_config(
     return {
         "status": "triggered",
         "config_id": str(config.id),
-        "sync_run_id": plan.sync_run_id,
-        "run_id": planner_pending_run_id,
-        "total_units": plan.total_units,
+        "sync_run_id": trigger.sync_run_id,
+        "run_id": trigger.job_run_id,
+        "total_units": trigger.total_units,
     }
 
 
@@ -1809,68 +1727,50 @@ async def trigger_sync_config_backfill(
 
     from dev_health_ops.models.backfill import BackfillJob as BackfillJobModel
 
-    planner_backfill_request = await session.run_sync(
-        lambda sync_session: planner_request_for_config_if_routed(
-            sync_session, config, triggered_by="backfill", mode="backfill"
-        )
-    )
-    if planner_backfill_request is None:
-        raise HTTPException(
-            status_code=400,
-            detail="Sync configuration has no linked integration",
-        )
-    planner_backfill_request = replace(
-        planner_backfill_request,
-        since=datetime.combine(payload.since, datetime.min.time(), tzinfo=timezone.utc),
-        before=datetime.combine(
-            payload.before, datetime.max.time(), tzinfo=timezone.utc
-        ),
-    )
     await session.run_sync(
         lambda sync_session: _preflight_planner_credential(sync_session, config)
     )
-    backfill_job = BackfillJobModel(
-        org_id=org_id,
-        sync_config_id=uuid.UUID(config_id),
-        status="pending",
-        since_date=payload.since,
-        before_date=payload.before,
-        total_chunks=0,
-    )
-    session.add(backfill_job)
-    await session.flush()
-    backfill_job_id = str(backfill_job.id)
-
     try:
-        pending_run_id = await session.run_sync(
-            lambda sync_session: _ensure_pending_sync_job_run(
+        trigger = await session.run_sync(
+            lambda sync_session: create_sync_execution_trigger(
                 sync_session,
                 config,
                 org_id,
-                "backfill",
-                {"planner_managed": True},
+                triggered_by="backfill",
+                mode="backfill",
+                since=datetime.combine(
+                    payload.since, datetime.min.time(), tzinfo=timezone.utc
+                ),
+                before=datetime.combine(
+                    payload.before, datetime.max.time(), tzinfo=timezone.utc
+                ),
+                initial_job_result={"planner_managed": True},
             )
         )
-        plan = await session.run_sync(
-            lambda sync_session: plan_sync_run(sync_session, planner_backfill_request)
-        )
-        await session.run_sync(
-            lambda s: _merge_job_run_result(
-                s, pending_run_id, {"sync_run_id": plan.sync_run_id}
+        if trigger is None:
+            raise HTTPException(
+                status_code=400,
+                detail="Sync configuration has no linked integration",
             )
-        )
 
-        # Persist the sync_run marker BEFORE dispatch so a crash between enqueue
-        # and the post-dispatch commit still lets finalize_sync_run link this
-        # BackfillJob (matched via celery_task_id.contains("sync_run:<id>")). On
-        # enqueue failure the marker is cleared in _mark_backfill_job_failed.
-        backfill_job.celery_task_id = f"sync_run:{plan.sync_run_id}"
+        backfill_job = BackfillJobModel(
+            org_id=org_id,
+            sync_config_id=uuid.UUID(config_id),
+            status="pending",
+            since_date=payload.since,
+            before_date=payload.before,
+            total_chunks=0,
+        )
+        session.add(backfill_job)
+        await session.flush()
+        backfill_job_id = str(backfill_job.id)
+        backfill_job.celery_task_id = f"sync_run:{trigger.sync_run_id}"
 
         await session.commit()
 
         try:
             result = getattr(dispatch_sync_run, "apply_async")(
-                args=(plan.sync_run_id,), queue="sync"
+                args=(trigger.sync_run_id,), queue="sync"
             )
         except Exception as e:
             error_message = f"enqueue failed: {e}"
@@ -1880,27 +1780,26 @@ async def trigger_sync_config_backfill(
                     sync_session, backfill_job_id, error_message, completed_at
                 )
             )
-            if pending_run_id is not None:
-                await session.run_sync(
-                    lambda sync_session: _mark_job_run_failed(
-                        sync_session, pending_run_id, error_message
-                    )
+            await session.run_sync(
+                lambda sync_session: _mark_job_run_failed(
+                    sync_session, trigger.job_run_id, error_message
                 )
+            )
             await session.run_sync(
                 lambda sync_session: mark_sync_run_failed(
-                    sync_session, plan.sync_run_id, "dispatch enqueue failed"
+                    sync_session, trigger.sync_run_id, "dispatch enqueue failed"
                 )
             )
             await session.commit()
             raise HTTPException(status_code=503, detail=f"Task queue unavailable: {e}")
-        backfill_job.celery_task_id = f"{result.id}|sync_run:{plan.sync_run_id}"
+        backfill_job.celery_task_id = f"{result.id}|sync_run:{trigger.sync_run_id}"
         await session.commit()
         return {
             "status": "accepted",
             "config_id": str(config.id),
             "task_id": result.id,
             "backfill_job_id": backfill_job_id,
-            "sync_run_id": plan.sync_run_id,
+            "sync_run_id": trigger.sync_run_id,
             "mode": "fanout",
             "since": payload.since.isoformat(),
             "before": payload.before.isoformat(),

--- a/src/dev_health_ops/sync/execution_trigger.py
+++ b/src/dev_health_ops/sync/execution_trigger.py
@@ -1,0 +1,146 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, replace
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.settings import (
+    JobRun,
+    JobRunStatus,
+    JobStatus,
+    ScheduledJob,
+    SyncConfiguration,
+)
+from dev_health_ops.sync.planner import SyncRunPlan, plan_sync_run
+from dev_health_ops.sync.trigger_routing import planner_request_for_config_if_routed
+
+
+@dataclass(frozen=True)
+class SyncExecutionTriggerResult:
+    sync_run_id: str
+    job_run_id: str
+    total_units: int
+
+
+def ensure_pending_sync_job_run(
+    session: Session,
+    config: SyncConfiguration,
+    org_id: str,
+    triggered_by: str,
+    result: dict[str, Any] | None = None,
+) -> str:
+    config_uuid = uuid.UUID(str(config.id))
+    job = (
+        session.query(ScheduledJob)
+        .filter(
+            ScheduledJob.org_id == org_id,
+            ScheduledJob.sync_config_id == config_uuid,
+            ScheduledJob.job_type == "sync",
+        )
+        .one_or_none()
+    )
+    if job is None:
+        sync_options = dict(config.sync_options or {})
+        provider = str(config.provider or "")
+        explicit_cron = sync_options.get("schedule_cron")
+        job = ScheduledJob(
+            name=f"sync-config-{config_uuid}",
+            job_type="sync",
+            schedule_cron=str(explicit_cron or "0 * * * *"),
+            org_id=org_id,
+            provider=provider,
+            job_config={
+                "provider": provider,
+                "sync_config_id": str(config_uuid),
+            },
+            sync_config_id=config_uuid,
+            tz=str(sync_options.get("timezone") or "UTC"),
+            status=(
+                JobStatus.ACTIVE.value
+                if bool(config.is_active) and explicit_cron
+                else JobStatus.PAUSED.value
+            ),
+        )
+        session.add(job)
+        session.flush()
+
+    run = JobRun(
+        job_id=uuid.UUID(str(job.id)),
+        triggered_by=triggered_by,
+        status=JobRunStatus.PENDING.value,
+    )
+    run.result = result
+    session.add(run)
+    session.flush()
+    return str(run.id)
+
+
+def merge_job_run_result(
+    session: Session, run_id: str, result: dict[str, Any] | None = None
+) -> None:
+    if result is None:
+        return
+    run = (
+        session.query(JobRun).filter(JobRun.id == uuid.UUID(str(run_id))).one_or_none()
+    )
+    if run is None:
+        return
+    current = run.result if isinstance(run.result, dict) else {}
+    run.result = {**current, **result}
+    session.flush()
+
+
+def mark_job_run_failed(session: Session, run_id: str, error: str) -> None:
+    completed_at = datetime.now(timezone.utc)
+    run = (
+        session.query(JobRun).filter(JobRun.id == uuid.UUID(str(run_id))).one_or_none()
+    )
+    if run is None:
+        return
+    run.status = JobRunStatus.FAILED.value
+    run.completed_at = completed_at
+    run.error = error
+    started_at = getattr(run, "started_at", None)
+    if started_at is not None:
+        if started_at.tzinfo is None:
+            started_at = started_at.replace(tzinfo=completed_at.tzinfo)
+        run.duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
+    session.flush()
+
+
+def create_sync_execution_trigger(
+    session: Session,
+    config: SyncConfiguration,
+    org_id: str,
+    *,
+    triggered_by: str,
+    mode: str,
+    since: datetime | None = None,
+    before: datetime | None = None,
+    initial_job_result: dict[str, Any] | None = None,
+) -> SyncExecutionTriggerResult | None:
+    request = planner_request_for_config_if_routed(
+        session, config, triggered_by=triggered_by, mode=mode
+    )
+    if request is None:
+        return None
+    if since is not None or before is not None:
+        request = replace(request, since=since, before=before)
+
+    job_run_id = ensure_pending_sync_job_run(
+        session,
+        config,
+        org_id,
+        triggered_by,
+        initial_job_result,
+    )
+    plan: SyncRunPlan = plan_sync_run(session, request)
+    merge_job_run_result(session, job_run_id, {"sync_run_id": plan.sync_run_id})
+    return SyncExecutionTriggerResult(
+        sync_run_id=plan.sync_run_id,
+        job_run_id=job_run_id,
+        total_units=plan.total_units,
+    )

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -250,25 +250,24 @@ def _maybe_dispatch_config(
 
     session.commit()
 
-    from dev_health_ops.sync.planner import plan_sync_run
-    from dev_health_ops.sync.trigger_routing import (
-        planner_request_for_config_if_routed,
-    )
+    from dev_health_ops.sync.execution_trigger import create_sync_execution_trigger
     from dev_health_ops.workers.sync_units import dispatch_sync_run
-
-    request = planner_request_for_config_if_routed(
-        session, config, triggered_by="schedule", mode="incremental"
-    )
-    if request is None:
-        logger.warning(
-            "Skipping sync config %s because it has no linked integration",
-            config.id,
-        )
-        return False
 
     logger.info("Routing config %s through fan-out planner", config.id)
     try:
-        plan = plan_sync_run(session, request)
+        trigger = create_sync_execution_trigger(
+            session,
+            config,
+            org_id,
+            triggered_by="schedule",
+            mode="incremental",
+        )
+        if trigger is None:
+            logger.warning(
+                "Skipping sync config %s because it has no linked integration",
+                config.id,
+            )
+            return False
         session.commit()
     except Exception:
         logger.exception("Fan-out planner failed for config %s", config.id)
@@ -277,12 +276,12 @@ def _maybe_dispatch_config(
 
     try:
         getattr(dispatch_sync_run, "apply_async")(
-            args=(plan.sync_run_id,), queue="sync"
+            args=(trigger.sync_run_id,), queue="sync"
         )
     except Exception:
         logger.warning(
             "sync_scheduler.dispatch_fastpath_failed",
-            extra={"config_id": str(config.id), "sync_run_id": plan.sync_run_id},
+            extra={"config_id": str(config.id), "sync_run_id": trigger.sync_run_id},
             exc_info=True,
         )
     return True

--- a/tests/test_scheduler_timezone.py
+++ b/tests/test_scheduler_timezone.py
@@ -298,9 +298,9 @@ class TestSyncDispatchDstFold:
         engine.dispose()
 
     def test_fall_back_slot_dispatches_once(self, monkeypatch, db_session):
-        from types import SimpleNamespace
         from unittest.mock import MagicMock
 
+        from dev_health_ops.sync.execution_trigger import SyncExecutionTriggerResult
         from dev_health_ops.workers import sync_scheduler
 
         # 2026-11-01 America/Los_Angeles fall-back: 01:30 occurs at 08:30Z (PDT)
@@ -336,12 +336,10 @@ class TestSyncDispatchDstFold:
             sync_scheduler, "organization_exists_sync", lambda *_a: True
         )
         monkeypatch.setattr(
-            "dev_health_ops.sync.trigger_routing.planner_request_for_config_if_routed",
-            lambda *a, **k: object(),
-        )
-        monkeypatch.setattr(
-            "dev_health_ops.sync.planner.plan_sync_run",
-            lambda *a, **k: SimpleNamespace(sync_run_id="run-1"),
+            "dev_health_ops.sync.execution_trigger.create_sync_execution_trigger",
+            lambda *a, **k: SyncExecutionTriggerResult(
+                sync_run_id="run-1", job_run_id="job-run-1", total_units=1
+            ),
         )
         monkeypatch.setattr(
             "dev_health_ops.workers.sync_units.dispatch_sync_run", dispatch_mock

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -31,8 +31,11 @@ from dev_health_ops.models.integrations import (
     Integration,
     IntegrationDataset,
     IntegrationSource,
+    SyncRun,
 )
 from dev_health_ops.models.settings import (
+    JobRun,
+    JobRunStatus,
     JobStatus,
     ScheduledJob,
     SyncConfiguration,
@@ -226,13 +229,23 @@ class TestDispatchIdempotency:
         assert dispatch_mock.apply_async.call_count == 1
         # Fan-out dispatch enqueues the planner run on the shared sync queue.
         assert dispatch_mock.apply_async.call_args.kwargs["queue"] == "sync"
+        sync_run_id = dispatch_mock.apply_async.call_args.kwargs["args"][0]
         # The dispatch marker was stamped to the next cron occurrence.
         assert job.next_run_at is not None
         assert _aware(job.next_run_at) > now
 
+        sync_run = db_session.query(SyncRun).filter(SyncRun.id == sync_run_id).one()
+        runs = db_session.query(JobRun).filter(JobRun.job_id == job.id).all()
+        assert sync_run is not None
+        assert len(runs) == 1
+        assert runs[0].status == JobRunStatus.PENDING.value
+        assert runs[0].triggered_by == "schedule"
+        assert runs[0].result["sync_run_id"] == str(sync_run.id)
+
         second = _call(task)
         assert second["dispatched"] == []
         assert dispatch_mock.apply_async.call_count == 1
+        assert db_session.query(JobRun).count() == 1
 
     def test_expired_dispatch_marker_allows_redispatch(self, monkeypatch, db_session):
         now = datetime.now(timezone.utc)

--- a/tests/workers/test_planner_only_routing.py
+++ b/tests/workers/test_planner_only_routing.py
@@ -263,16 +263,16 @@ def test_scheduler_routes_migrated_config_through_planner(db_session, monkeypatc
     plan_calls: list[object] = []
     dispatch_calls: list[object] = []
 
-    from dev_health_ops.sync import planner as planner_mod
+    from dev_health_ops.sync import execution_trigger as execution_trigger_mod
     from dev_health_ops.workers import sync_units as sync_units_mod
 
-    original_plan = planner_mod.plan_sync_run
+    original_plan = execution_trigger_mod.plan_sync_run
 
     def fake_plan(session, request):
         plan_calls.append(request)
         return original_plan(session, request)
 
-    monkeypatch.setattr(planner_mod, "plan_sync_run", fake_plan)
+    monkeypatch.setattr(execution_trigger_mod, "plan_sync_run", fake_plan)
     monkeypatch.setattr(
         sync_units_mod.dispatch_sync_run,
         "apply_async",


### PR DESCRIPTION
## Summary
- add a shared sync execution trigger helper that creates JobRun activity rows and links them to planned SyncRun records
- route manual Sync Now, scheduled sync dispatch, and sync-config backfill through the canonical activity/execution workflow
- update scheduler regression tests and docs for the JobRun-to-SyncRun contract

## Validation
- bash ci/local_validate.sh
- Codex adversarial review: approved, no material findings
- unspecified-high changeset review: blocking test seam fixed before PR

SCREENSHOT-WAIVER: backend/docs-only change; no rendered web UI changed.