### PR TITLE
fix(github): harden sync rate-limit windows

### DIFF
--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -113,8 +113,15 @@ def _fetch_github_commits_sync(
     since: datetime | None = None,
     until: datetime | None = None,
 ):
-    """Sync helper to fetch and parse GitHub commits."""
-    raw_commits = []
+    """Sync helper to fetch and parse GitHub commits.
+
+    Returns ``(raw_commits, commit_objects, window_truncated)``. ``window_truncated``
+    is True only when ``max_commits`` was hit AND at least one more commit existed
+    beyond it (peeked but not kept) — i.e. the window genuinely held more commits
+    than we fetched. A complete window of exactly ``max_commits`` returns False, so
+    callers can cover it instead of skipping stats as a false-truncation.
+    """
+    raw_commits: list[Any] = []
     commits_kwargs: dict[str, Any] = {}
     if since is not None:
         commits_kwargs["since"] = since
@@ -122,10 +129,14 @@ def _fetch_github_commits_sync(
         commits_kwargs["until"] = until
     commits_iter = gh_repo.get_commits(**commits_kwargs)
 
+    window_truncated = False
     for commit in commits_iter:
-        raw_commits.append(commit)
         if max_commits is not None and len(raw_commits) >= max_commits:
+            # We already have ``max_commits`` and the iterator yielded one more:
+            # proof the window was truncated. Don't keep this extra commit.
+            window_truncated = True
             break
+        raw_commits.append(commit)
 
     commit_objects = []
     for commit in raw_commits:
@@ -202,7 +213,7 @@ def _fetch_github_commits_sync(
             parents=len(commit.parents),
         )
         commit_objects.append(git_commit)
-    return raw_commits, commit_objects
+    return raw_commits, commit_objects, window_truncated
 
 
 def _fetch_github_commit_stats_sync(
@@ -1165,12 +1176,12 @@ async def _sync_github_commits(
     max_commits: int | None,
     since: datetime | None,
     until: datetime | None = None,
-) -> tuple[list[Any], int]:
+) -> tuple[list[Any], int, bool]:
     if max_commits is None:
         logging.info("Fetching all commits from GitHub...")
     else:
         logging.info("Fetching up to %d commits from GitHub...", max_commits)
-    raw_commits, commit_objects = await loop.run_in_executor(
+    raw_commits, commit_objects, *rest = await loop.run_in_executor(
         None,
         _fetch_github_commits_sync,
         gh_repo,
@@ -1179,10 +1190,40 @@ async def _sync_github_commits(
         since,
         until,
     )
+    window_truncated = bool(rest[0]) if rest else False
     if commit_objects:
         await ingestion_sink.insert_git_commit_data(commit_objects)
         logging.info("Stored %d commits from GitHub", len(commit_objects))
-    return raw_commits, len(commit_objects)
+    return raw_commits, len(commit_objects), window_truncated
+
+
+def _windowed_commit_stats_truncated(
+    raw_commit_count: int,
+    window_truncated: bool,
+    max_commits: int | None,
+    since: datetime | None,
+) -> bool:
+    """Whether a since-bounded commit window is too large to cover fully.
+
+    Per-file commit stats cost one extra API call each, so the window is capped
+    (by ``max_commits`` and by ``resolve_commit_stats_limit``'s hard cap). When
+    the window exceeds a cap we skip stats entirely rather than persist a partial
+    day, which would corrupt churn/hotspot/bus-factor daily metrics. Full-history
+    syncs (``since is None``) intentionally use a capped sample and are never
+    treated as truncated.
+
+    ``window_truncated`` comes from the fetch (``_fetch_github_commits_sync`` peeks
+    one commit past ``max_commits``); it is the ONLY reliable signal for the
+    ``max_commits`` cap, because a complete window of exactly ``max_commits``
+    commits is otherwise indistinguishable from a truncated one — counting alone
+    (``raw_commit_count >= max_commits``) would false-positive on the exact-size
+    complete case and silently drop its stats. ``raw_commit_count > stats_limit``
+    independently catches the hard-cap case for uncapped fetches.
+    """
+    if since is None:
+        return False
+    stats_limit = resolve_commit_stats_limit(raw_commit_count, max_commits, since)
+    return window_truncated or raw_commit_count > stats_limit
 
 
 async def _sync_github_commit_stats(
@@ -1195,9 +1236,10 @@ async def _sync_github_commit_stats(
     since: datetime | None,
     until: datetime | None = None,
     raw_commits: list[Any] | None = None,
+    window_truncated: bool = False,
 ) -> int:
     if raw_commits is None:
-        raw_commits, _ = await loop.run_in_executor(
+        raw_commits, _, *rest = await loop.run_in_executor(
             None,
             _fetch_github_commits_sync,
             gh_repo,
@@ -1206,9 +1248,12 @@ async def _sync_github_commit_stats(
             since,
             until,
         )
+        window_truncated = bool(rest[0]) if rest else False
     logging.info("Fetching commit stats from GitHub...")
     stats_limit = resolve_commit_stats_limit(len(raw_commits), max_commits, since)
-    if since is not None and len(raw_commits) > stats_limit:
+    if _windowed_commit_stats_truncated(
+        len(raw_commits), window_truncated, max_commits, since
+    ):
         logging.warning(
             "Skipped GitHub commit-stat sync for repo %s after hitting cap %d; "
             "narrow the sync window or raise the commit-stat cap",
@@ -1566,8 +1611,9 @@ async def process_github_repo(
                 return
 
             raw_commits: list[Any] | None = None
+            window_truncated = False
             if run_commits:
-                raw_commits, _ = await _sync_github_commits(
+                raw_commits, _, window_truncated = await _sync_github_commits(
                     gh_repo=gh_repo,
                     db_repo=db_repo,
                     ingestion_sink=ingestion_sink,
@@ -1587,6 +1633,7 @@ async def process_github_repo(
                     since=since,
                     until=until,
                     raw_commits=raw_commits,
+                    window_truncated=window_truncated,
                 )
 
             if sync_prs:
@@ -1862,7 +1909,7 @@ async def process_github_repos_batch(
             try:
                 if gh_repo is None:
                     gh_repo = connector.github.get_repo(repo_info.full_name)
-                raw_commits, commit_objects = await loop.run_in_executor(
+                raw_commits, commit_objects, *rest = await loop.run_in_executor(
                     None,
                     _fetch_github_commits_sync,
                     gh_repo,
@@ -1870,18 +1917,15 @@ async def process_github_repos_batch(
                     db_repo.id,
                     since,
                 )
+                window_truncated = bool(rest[0]) if rest else False
                 if commit_objects:
                     await ingestion_sink.insert_git_commit_data(commit_objects)
 
                 stats_limit = resolve_commit_stats_limit(
                     len(raw_commits), max_commits_per_repo, since
                 )
-                skipped_windowed_commit_stats = since is not None and (
-                    len(raw_commits) > stats_limit
-                    or (
-                        max_commits_per_repo is not None
-                        and len(raw_commits) >= stats_limit
-                    )
+                skipped_windowed_commit_stats = _windowed_commit_stats_truncated(
+                    len(raw_commits), window_truncated, max_commits_per_repo, since
                 )
                 if skipped_windowed_commit_stats:
                     logging.warning(
@@ -1899,6 +1943,7 @@ async def process_github_repos_batch(
                         max_commits=max_commits_per_repo,
                         since=since,
                         raw_commits=raw_commits,
+                        window_truncated=window_truncated,
                     )
             except (RateLimitException, RateLimitExceededException):
                 raise
@@ -2175,6 +2220,10 @@ async def process_github_repos_batch(
                         ),
                     )
 
+                # Wait for the queue to drain, but bail out if the consumer dies
+                # first: store_result may propagate a RateLimitException, leaving
+                # un-task_done()'d items so results_queue.join() would hang forever.
+                # FIRST_COMPLETED lets us detect that and re-raise instead.
                 join_task = asyncio.create_task(results_queue.join())
                 done, _pending = await asyncio.wait(
                     {join_task, consumer_task}, return_when=asyncio.FIRST_COMPLETED
@@ -2185,8 +2234,7 @@ async def process_github_repos_batch(
                         await join_task
                     except asyncio.CancelledError:
                         pass
-                    await consumer_task
-                await join_task
+                    await consumer_task  # re-raises the consumer's exception
                 await results_queue.put(_queue_sentinel)
                 await consumer_task
             else:

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -9,6 +9,7 @@ from dev_health_ops.analytics.complexity import (
     ComplexityScanner,
 )
 from dev_health_ops.credentials.types import GitHubCredentials
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models import git as git_models
 from dev_health_ops.models.git import (
@@ -256,6 +257,8 @@ def _fetch_github_commit_stats_sync(
                     new_file_mode="unknown",
                 )
                 stats_objects.append(stat)
+        except (RateLimitException, RateLimitExceededException):
+            raise
         except Exception as e:
             logging.warning(
                 "Failed to get stats for commit %s: %s",
@@ -919,6 +922,8 @@ async def _backfill_github_missing_data(
     include_files: bool = True,
     include_blame: bool = True,
     include_commit_stats: bool = True,
+    since: datetime | None = None,
+    until: datetime | None = None,
 ) -> None:
     # Logic matches the CLI sync orchestration.
     logging.info(
@@ -1006,18 +1011,35 @@ async def _backfill_github_missing_data(
                 "Backfilling commit stats for %s...",
                 repo_full_name,
             )
-            commits_iter = gh_repo.get_commits()
-            async with AsyncBatchCollector(
-                ingestion_sink.insert_git_commit_stats
-            ) as stats_collector:
-                for commit in commits_iter:
-                    if max_commits and commit_count >= max_commits:
-                        break
+            commits_kwargs: dict[str, Any] = {}
+            if since is not None:
+                commits_kwargs["since"] = since
+            if until is not None:
+                commits_kwargs["until"] = until
+            commits_iter = gh_repo.get_commits(**commits_kwargs)
+            commit_count_for_limit = (
+                max_commits if max_commits is not None else 1_000_000_000
+            )
+            stats_limit = resolve_commit_stats_limit(
+                commit_count_for_limit,
+                max_commits,
+                since,
+            )
+            candidate_commits: list[Any] = []
+            truncated = False
+            for commit in commits_iter:
+                if len(candidate_commits) >= stats_limit:
+                    truncated = True
+                    break
+                candidate_commits.append(commit)
+            stats_rows: list[GitCommitStat] = []
+            if not (truncated and since is not None):
+                for commit in candidate_commits:
                     commit_count += 1
                     try:
                         detailed = gh_repo.get_commit(commit.sha)
                         for file in getattr(detailed, "files", []) or []:
-                            stats_collector.add(
+                            stats_rows.append(
                                 GitCommitStat(
                                     repo_id=db_repo.id,
                                     commit_hash=commit.sha,
@@ -1030,7 +1052,8 @@ async def _backfill_github_missing_data(
                                     new_file_mode="unknown",
                                 )
                             )
-                            await stats_collector.maybe_flush()
+                    except (RateLimitException, RateLimitExceededException):
+                        raise
                     except Exception as e:
                         logging.debug(
                             "Failed commit stat fetch for %s@%s: %s",
@@ -1038,11 +1061,27 @@ async def _backfill_github_missing_data(
                             commit.sha,
                             e,
                         )
-            logging.info(
-                "Backfilled commit stats for %d commits in %s",
-                commit_count,
-                repo_full_name,
-            )
+            if truncated and since is not None:
+                logging.warning(
+                    "Skipped GitHub commit-stat backfill for %s after hitting cap %d; "
+                    "narrow the sync window or raise the commit-stat cap",
+                    repo_full_name,
+                    stats_limit,
+                )
+            else:
+                async with AsyncBatchCollector(
+                    ingestion_sink.insert_git_commit_stats
+                ) as stats_collector:
+                    for stat in stats_rows:
+                        stats_collector.add(stat)
+                        await stats_collector.maybe_flush()
+                logging.info(
+                    "Backfilled commit stats for %d commits in %s",
+                    commit_count,
+                    repo_full_name,
+                )
+        except (RateLimitException, RateLimitExceededException):
+            raise
         except Exception as e:
             logging.warning(
                 "Failed to backfill GitHub commit stats for %s: %s",
@@ -1169,6 +1208,14 @@ async def _sync_github_commit_stats(
         )
     logging.info("Fetching commit stats from GitHub...")
     stats_limit = resolve_commit_stats_limit(len(raw_commits), max_commits, since)
+    if since is not None and len(raw_commits) > stats_limit:
+        logging.warning(
+            "Skipped GitHub commit-stat sync for repo %s after hitting cap %d; "
+            "narrow the sync window or raise the commit-stat cap",
+            db_repo.id,
+            stats_limit,
+        )
+        return 0
     stats_objects = await loop.run_in_executor(
         None,
         _fetch_github_commit_stats_sync,
@@ -1508,6 +1555,8 @@ async def process_github_repo(
                     default_branch=repo_info.default_branch,
                     max_commits=max_commits,
                     blame_only=True,
+                    since=since,
+                    until=until,
                 )
                 logging.info(
                     "Completed blame-only sync for GitHub repository: %s/%s",
@@ -1671,6 +1720,8 @@ async def process_github_repo(
                         include_files=run_files,
                         include_blame=run_blame,
                         include_commit_stats=False,
+                        since=since,
+                        until=until,
                     )
                 except Exception as e:
                     logging.warning(
@@ -1788,6 +1839,7 @@ async def process_github_repos_batch(
                     default_branch=repo_info.default_branch,
                     max_commits=max_commits_per_repo,
                     blame_only=True,
+                    since=since,
                 )
             except Exception as e:
                 logging.debug(
@@ -1798,6 +1850,8 @@ async def process_github_repos_batch(
             return
 
         gh_repo = None
+        skipped_windowed_commit_stats = False
+        commit_stats_available = True
         if sync_git:
             # Fetch commits and stats to populate git_commits/git_commit_stats.
             commit_limit: int | None
@@ -1819,17 +1873,37 @@ async def process_github_repos_batch(
                 if commit_objects:
                     await ingestion_sink.insert_git_commit_data(commit_objects)
 
-                stats_objects = await loop.run_in_executor(
-                    None,
-                    _fetch_github_commit_stats_sync,
-                    raw_commits,
-                    db_repo.id,
-                    50 if commit_limit is None else min(commit_limit, 50),
-                    since,
+                stats_limit = resolve_commit_stats_limit(
+                    len(raw_commits), max_commits_per_repo, since
                 )
-                if stats_objects:
-                    await ingestion_sink.insert_git_commit_stats(stats_objects)
+                skipped_windowed_commit_stats = since is not None and (
+                    len(raw_commits) > stats_limit
+                    or (
+                        max_commits_per_repo is not None
+                        and len(raw_commits) >= stats_limit
+                    )
+                )
+                if skipped_windowed_commit_stats:
+                    logging.warning(
+                        "Skipped GitHub commit stats for %s after hitting cap %d; "
+                        "narrow the sync window or raise the commit-stat cap",
+                        repo_info.full_name,
+                        stats_limit,
+                    )
+                else:
+                    await _sync_github_commit_stats(
+                        gh_repo=gh_repo,
+                        db_repo=db_repo,
+                        ingestion_sink=ingestion_sink,
+                        loop=loop,
+                        max_commits=max_commits_per_repo,
+                        since=since,
+                        raw_commits=raw_commits,
+                    )
+            except (RateLimitException, RateLimitExceededException):
+                raise
             except Exception as e:
+                commit_stats_available = False
                 logging.warning(
                     "Failed to fetch commits for GitHub repo %s: %s",
                     repo_info.full_name,
@@ -1978,7 +2052,12 @@ async def process_github_repos_batch(
                     e,
                 )
 
-        if result.stats and sync_git:
+        if (
+            result.stats
+            and sync_git
+            and commit_stats_available
+            and not skipped_windowed_commit_stats
+        ):
             stat = GitCommitStat(
                 repo_id=db_repo.id,
                 commit_hash=AGGREGATE_STATS_MARKER,
@@ -2007,6 +2086,7 @@ async def process_github_repos_batch(
                     max_commits=max_commits_per_repo,
                     include_blame=True,
                     include_commit_stats=False,
+                    since=since,
                 )
             except Exception as e:
                 logging.debug(
@@ -2095,7 +2175,18 @@ async def process_github_repos_batch(
                         ),
                     )
 
-                await results_queue.join()
+                join_task = asyncio.create_task(results_queue.join())
+                done, _pending = await asyncio.wait(
+                    {join_task, consumer_task}, return_when=asyncio.FIRST_COMPLETED
+                )
+                if consumer_task in done:
+                    join_task.cancel()
+                    try:
+                        await join_task
+                    except asyncio.CancelledError:
+                        pass
+                    await consumer_task
+                await join_task
                 await results_queue.put(_queue_sentinel)
                 await consumer_task
             else:

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -144,6 +144,20 @@ def _parse_github_datetime(value: object) -> datetime | None:
     return parsed.astimezone(timezone.utc)
 
 
+def _item_updated_before(item: object, cutoff: datetime | None) -> bool:
+    if cutoff is None:
+        return False
+    updated_at = _parse_github_datetime(getattr(item, "updated_at", None))
+    return updated_at is not None and updated_at < cutoff
+
+
+def _item_updated_after(item: object, cutoff: datetime | None) -> bool:
+    if cutoff is None:
+        return False
+    updated_at = _parse_github_datetime(getattr(item, "updated_at", None))
+    return updated_at is not None and updated_at > cutoff
+
+
 def _diagnostic_headers(headers: object) -> dict[str, str]:
     if not isinstance(headers, dict):
         return {}
@@ -639,16 +653,35 @@ class GitHubWorkClient:
         *,
         limit: int | None,
         skip: Callable[[_TItem], bool] | None = None,
+        stop: Callable[[_TItem], bool] | None = None,
+        scan_limit: int | None = None,
+        operation: str | None = None,
     ) -> Iterable[_TItem]:
-        """Yield items from ``source`` respecting ``limit`` and optional skip filter.
+        """Yield items from ``source`` respecting ``limit`` and optional filters.
 
         ``skip`` receives each item and returns ``True`` when the item should be
         excluded (used for PR-vs-issue filtering on the issues feed).
+        ``stop`` receives each item and returns ``True`` when pagination can stop.
         """
         if limit is not None and int(limit) <= 0:
             return
+        if scan_limit is not None and int(scan_limit) <= 0:
+            return
         count = 0
+        scanned = 0
         for item in source:
+            if scan_limit is not None and scanned >= int(scan_limit):
+                if operation is not None:
+                    logger.warning(
+                        "GitHub: stopped %s after scanning %s items before reaching result limit %s",
+                        operation,
+                        scan_limit,
+                        limit,
+                    )
+                return
+            scanned += 1
+            if stop is not None and stop(item):
+                return
             if skip is not None and skip(item):
                 continue
             yield item
@@ -663,10 +696,19 @@ class GitHubWorkClient:
         operation: str,
         limit: int | None,
         skip: Callable[[_TItem], bool] | None = None,
+        stop: Callable[[_TItem], bool] | None = None,
+        scan_limit: int | None = None,
     ) -> Iterable[_TItem]:
         with gate_call(self.gate):
             try:
-                yield from self._iter_with_limit(source, limit=limit, skip=skip)
+                yield from self._iter_with_limit(
+                    source,
+                    limit=limit,
+                    skip=skip,
+                    stop=stop,
+                    scan_limit=scan_limit,
+                    operation=operation,
+                )
                 self._record_rest_usage(operation)
             except Exception as exc:
                 self._raise_github_exception(exc, operation=operation)
@@ -678,18 +720,28 @@ class GitHubWorkClient:
         repo: str,
         state: str = "all",
         since: datetime | None = None,
+        until: datetime | None = None,
         limit: int | None = None,
+        scan_limit: int | None = None,
     ) -> Iterable[_GitHubIssueLike]:
         gh_repo = self.get_repo(owner=owner, repo=repo)
         operation = f"GET /repos/{owner}/{repo}/issues"
         issues = self._call_github(
             operation, lambda: gh_repo.get_issues(state=state, since=since)
         )
+        cutoff = _parse_github_datetime(until) if until is not None else None
+
+        def skip_issue(issue: _GitHubIssueLike) -> bool:
+            return getattr(
+                issue, "pull_request", None
+            ) is not None or _item_updated_after(issue, cutoff)
+
         yield from self._iter_github_items(
             issues,
             operation=operation,
             limit=limit,
-            skip=lambda issue: getattr(issue, "pull_request", None) is not None,
+            skip=skip_issue,
+            scan_limit=scan_limit,
         )
 
     def iter_issue_events(
@@ -726,7 +778,10 @@ class GitHubWorkClient:
         state: str = "all",
         sort: str = "updated",
         direction: str = "desc",
+        since: datetime | None = None,
+        until: datetime | None = None,
         limit: int | None = None,
+        scan_limit: int | None = None,
     ) -> Iterable[_GitHubPullRequestLike]:
         """
         Iterate pull requests in a repository via REST.
@@ -737,7 +792,30 @@ class GitHubWorkClient:
             operation,
             lambda: gh_repo.get_pulls(state=state, sort=sort, direction=direction),
         )
-        yield from self._iter_github_items(pulls, operation=operation, limit=limit)
+        cutoff = _parse_github_datetime(since) if since is not None else None
+        until_cutoff = _parse_github_datetime(until) if until is not None else None
+        stop: Callable[[_GitHubPullRequestLike], bool] | None = None
+        if sort == "updated" and direction == "desc" and cutoff is not None:
+
+            def stop_at_cutoff(pr: _GitHubPullRequestLike) -> bool:
+                return _item_updated_before(pr, cutoff)
+
+            stop = stop_at_cutoff
+        skip: Callable[[_GitHubPullRequestLike], bool] | None = None
+        if until_cutoff is not None:
+
+            def skip_after_until(pr: _GitHubPullRequestLike) -> bool:
+                return _item_updated_after(pr, until_cutoff)
+
+            skip = skip_after_until
+        yield from self._iter_github_items(
+            pulls,
+            operation=operation,
+            limit=limit,
+            skip=skip,
+            stop=stop,
+            scan_limit=scan_limit,
+        )
 
     def iter_issue_comments(
         self, issue: _GitHubIssueBaseLike, *, limit: int | None = None

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -8,9 +8,11 @@ the underlying ingestion behavior.
 from __future__ import annotations
 
 import logging
+import os
 from datetime import datetime, timezone
 from typing import Any
 
+from dev_health_ops.connectors.exceptions import RateLimitException
 from dev_health_ops.models.ai_attribution import AIAttributionRecord
 from dev_health_ops.models.work_items import (
     Sprint,
@@ -158,11 +160,30 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
         since: datetime | None = None
         if ctx.window.updated_since:
             since = _to_utc(ctx.window.updated_since)
+        until: datetime | None = None
+        if ctx.window.active_until:
+            until = _to_utc(ctx.window.active_until)
+
+        def within_active_window(item: Any) -> bool:
+            if until is None:
+                return True
+            updated_at = _to_utc(getattr(item, "updated_at", None))
+            return updated_at is None or updated_at <= until
+
+        active_window_scan_limit: int | None = None
+        if until is not None:
+            if ctx.limit is not None:
+                active_window_scan_limit = env_int(
+                    "GITHUB_ACTIVE_WINDOW_SCAN_LIMIT", max(ctx.limit * 10, 100)
+                )
+            elif "GITHUB_ACTIVE_WINDOW_SCAN_LIMIT" in os.environ:
+                active_window_scan_limit = env_int("GITHUB_ACTIVE_WINDOW_SCAN_LIMIT", 0)
 
         logger.info(
-            "GitHub: fetching work items from %s (since=%s)",
+            "GitHub: fetching work items from %s (since=%s, until=%s)",
             repo_full_name,
             since,
+            until,
         )
 
         fetched_count = 0
@@ -178,6 +199,8 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                     )
                     sprint_cache[sprint.sprint_id] = sprint
                     sprints.append(sprint)
+            except RateLimitException:
+                raise
             except Exception as exc:
                 logger.warning(
                     "GitHub: failed to fetch milestones for %s: %s", repo_full_name, exc
@@ -191,12 +214,16 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                     repo=repo,
                     state="all",
                     since=since,
+                    until=until,
                     limit=ctx.limit,
+                    scan_limit=active_window_scan_limit,
                 )
                 if include_issues
                 else ()
             )
             for issue in issues_iter:
+                if not within_active_window(issue):
+                    continue
                 if ctx.limit is not None and fetched_count >= ctx.limit:
                     break
 
@@ -249,6 +276,8 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                             )
                             if event:
                                 interactions.append(event)
+                    except RateLimitException:
+                        raise
                     except Exception as exc:
                         logger.debug(
                             "GitHub: failed to fetch comments for issue %s: %s",
@@ -264,13 +293,14 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
             )
             raise
 
+        if ctx.limit is not None and fetched_count >= ctx.limit:
+            include_prs = False
+
         # Fetch pull requests
         if include_prs:
             remaining_limit = None
             if ctx.limit is not None:
                 remaining_limit = ctx.limit - fetched_count
-                if remaining_limit <= 0:
-                    remaining_limit = None
 
             try:
                 prs = list(
@@ -278,9 +308,18 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                         owner=owner,
                         repo=repo,
                         state="all",
+                        since=since,
+                        until=until,
                         limit=remaining_limit,
+                        scan_limit=active_window_scan_limit,
                     )
                 )
+                if until is not None:
+                    prs = [pr for pr in prs if within_active_window(pr)]
+                    if ctx.limit is not None:
+                        prs = prs[: ctx.limit - fetched_count]
+            except RateLimitException:
+                raise
             except Exception as exc:
                 logger.warning(
                     "GitHub: failed to fetch PRs from %s: %s", repo_full_name, exc
@@ -309,6 +348,8 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                             pr_comments_by_number[payload.number] = (
                                 payload.issue_comments
                             )
+                except RateLimitException:
+                    raise
                 except Exception as exc:
                     logger.warning(
                         "GitHub: failed to fetch PR social data from %s: %s",

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -170,6 +170,12 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
             updated_at = _to_utc(getattr(item, "updated_at", None))
             return updated_at is None or updated_at <= until
 
+        # Cap how many items we page through to find the active window. With no
+        # caller limit we leave it unbounded (None) UNLESS the env var is set.
+        # env_int falls back to its default only for a missing/empty/invalid
+        # value, so a present-but-empty/invalid var here resolves to 0, which
+        # _iter_with_limit treats as "scan nothing". Set a positive integer to
+        # cap, or leave the var unset to keep historical scans unbounded.
         active_window_scan_limit: int | None = None
         if until is not None:
             if ctx.limit is not None:
@@ -222,6 +228,10 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                 else ()
             )
             for issue in issues_iter:
+                # The client already bounds the window (server `since` + `skip`/
+                # scan_limit pagination); re-checking here keeps correctness
+                # independent of client internals and is the enforcement point
+                # for clients/mocks that don't filter. Intentional, not redundant.
                 if not within_active_window(issue):
                     continue
                 if ctx.limit is not None and fetched_count >= ctx.limit:
@@ -314,6 +324,10 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                         scan_limit=active_window_scan_limit,
                     )
                 )
+                # Belt-and-suspenders: iter_pull_requests already applies the
+                # `until` skip + `limit`, so in production these are no-ops. We
+                # re-apply so the window holds regardless of the client impl and
+                # so tests with non-paginating mock clients stay correct.
                 if until is not None:
                     prs = [pr for pr in prs if within_active_window(pr)]
                     if ctx.limit is not None:

--- a/tests/providers/test_github_pr_social_batch.py
+++ b/tests/providers/test_github_pr_social_batch.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Iterable
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, cast
 from unittest.mock import MagicMock, patch
 
@@ -319,6 +319,100 @@ def _pr(number: int) -> MagicMock:
         "REST review comments should not be used"
     )
     return pr
+
+
+def _issue(number: int) -> MagicMock:
+    issue = MagicMock()
+    issue.number = number
+    issue.pull_request = None
+    return issue
+
+
+def test_work_client_iter_issues_filters_until_before_counting_limit() -> None:
+    client, _graphql, _gate = _client()
+    until = datetime(2026, 1, 10, tzinfo=timezone.utc)
+    future = _issue(1)
+    future.updated_at = until + timedelta(days=1)
+    in_window = _issue(2)
+    in_window.updated_at = until
+    repo = MagicMock()
+    repo.get_issues.return_value = [future, in_window]
+    cast(Any, client.github).get_repo.return_value = repo
+
+    result = list(
+        client.iter_issues(
+            owner="full-chaos",
+            repo="dev-health",
+            until=until,
+            limit=1,
+            scan_limit=2,
+        )
+    )
+
+    assert [issue.number for issue in result] == [2]
+
+
+def test_work_client_iter_pull_requests_warns_when_stopping_at_scan_limit(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    client, _graphql, _gate = _client()
+    until = datetime(2026, 1, 10, tzinfo=timezone.utc)
+    future = _pr(1)
+    future.updated_at = until + timedelta(days=1)
+    in_window = _pr(2)
+    in_window.updated_at = until
+    repo = MagicMock()
+
+    def pulls() -> Iterable[MagicMock]:
+        yield future
+        yield in_window
+        raise AssertionError("scan should stop before this item")
+
+    repo.get_pulls.return_value = pulls()
+    cast(Any, client.github).get_repo.return_value = repo
+
+    result = list(
+        client.iter_pull_requests(
+            owner="full-chaos",
+            repo="dev-health",
+            until=until,
+            limit=1,
+            scan_limit=1,
+        )
+    )
+
+    assert result == []
+    assert (
+        "stopped GET /repos/full-chaos/dev-health/pulls after scanning 1 items"
+        in caplog.text
+    )
+
+
+def test_work_client_iter_pull_requests_stops_at_since_cutoff() -> None:
+    client, _graphql, _gate = _client()
+    since = datetime(2026, 1, 10, tzinfo=timezone.utc)
+    newer = _pr(1)
+    newer.updated_at = since + timedelta(seconds=1)
+    equal = _pr(2)
+    equal.updated_at = since
+    older = _pr(3)
+    older.updated_at = since - timedelta(seconds=1)
+    repo = MagicMock()
+
+    def pulls() -> Iterable[MagicMock]:
+        yield newer
+        yield equal
+        yield older
+        raise AssertionError("pagination should stop after the first older PR")
+
+    repo.get_pulls.return_value = pulls()
+    cast(Any, client.github).get_repo.return_value = repo
+
+    result = list(
+        client.iter_pull_requests(owner="full-chaos", repo="dev-health", since=since)
+    )
+
+    assert [pr.number for pr in result] == [1, 2]
 
 
 def _comment_node(comment_id: int, body: str = "comment") -> dict[str, object]:

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -17,6 +17,7 @@ from dev_health_ops.connectors import (
     GitLabConnector,
     match_repo_pattern,
 )
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.models.git import GitCommit, GitCommitStat, get_repo_uuid_from_repo
 from dev_health_ops.processors import github as _github_processor
 from dev_health_ops.processors import gitlab as _gitlab_processor
@@ -375,7 +376,7 @@ async def test_process_github_repos_batch_stores_commits_and_stats(monkeypatch):
         )
         return ["raw"], [commit]
 
-    def fake_fetch_commit_stats(raw_commits, repo_id, max_stats, since=None):
+    def fake_fetch_commit_stats(raw_commits, repo_id, max_stats, since=None, gate=None):
         return [
             GitCommitStat(
                 repo_id=repo_id,
@@ -443,6 +444,531 @@ async def test_process_github_repos_batch_stores_commits_and_stats(monkeypatch):
     expected_repo_id = get_repo_uuid_from_repo(repo.full_name)
     assert all(c.repo_id == expected_repo_id for c in recorded_commits)
     assert "abc123" in {s.commit_hash for s in recorded_stats}
+
+
+@pytest.mark.asyncio
+async def test_process_github_repos_batch_over_cap_window_skips_stats(monkeypatch):
+    """Windowed (since-bound) batch sync over the hard cap must skip per-commit
+    detail fetch and persist zero commit stats rather than a partial day.
+
+    Regression: the batch path bypassed ``_sync_github_commit_stats`` and wrote
+    partial commit stats for since-bound over-cap windows.
+    """
+    _enable_connector_stubs(monkeypatch)
+
+    monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "300")
+    since = datetime(2026, 5, 13, tzinfo=timezone.utc)
+
+    recorded_stats = []
+    stats_fetch_calls = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    repo = Mock()
+    repo.id = 999
+    repo.full_name = "org/over-cap"
+    repo.url = "https://example.com/org/over-cap"
+    repo.default_branch = "main"
+    repo.language = "Python"
+
+    stats = Mock()
+    stats.total_commits = 301
+    stats.additions = 999
+    stats.deletions = 111
+    result = BatchResult(repository=repo, stats=stats, success=True)
+
+    raw_commits = [SimpleNamespace(sha=f"sha-{i}") for i in range(301)]
+
+    def fake_fetch_commits(gh_repo, max_commits, repo_id, since=None):
+        return raw_commits, []
+
+    def fake_fetch_commit_stats(*args, **kwargs):
+        stats_fetch_calls.append(args)
+        return []
+
+    class DummyRepo:
+        def get_pulls(self, state="all"):
+            return iter([])
+
+    class DummyGithub:
+        def get_repo(self, full_name: str):
+            return DummyRepo()
+
+    class DummyConnector:
+        def __init__(self, token: str):
+            self.github = DummyGithub()
+
+        async def get_repos_with_stats_async(self, **kwargs):
+            on_repo_complete = kwargs.get("on_repo_complete")
+            if on_repo_complete:
+                on_repo_complete(result)
+            return [result]
+
+        def get_rate_limit(self):
+            return {"remaining": 0, "limit": 0}
+
+        def close(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+    )
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commit_stats_sync", fake_fetch_commit_stats
+    )
+
+    store = DummyStore()
+
+    await processors.github.process_github_repos_batch(
+        store=store,
+        token="test_token",
+        org_name="org",
+        pattern="org/*",
+        batch_size=1,
+        max_concurrent=1,
+        rate_limit_delay=0,
+        use_async=True,
+        since=since,
+        sync_prs=False,
+        sync_cicd=False,
+        sync_deployments=False,
+        sync_incidents=False,
+        sync_security=False,
+        sync_tests=False,
+        backfill_missing=False,
+    )
+
+    assert stats_fetch_calls == []
+    assert recorded_stats == []
+
+
+@pytest.mark.asyncio
+async def test_process_github_repos_batch_exact_cap_window_skips_stats(monkeypatch):
+    _enable_connector_stubs(monkeypatch)
+
+    since = datetime(2026, 5, 13, tzinfo=timezone.utc)
+    recorded_stats = []
+    stats_fetch_calls = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    repo = Mock()
+    repo.id = 1000
+    repo.full_name = "org/exact-cap"
+    repo.url = "https://example.com/org/exact-cap"
+    repo.default_branch = "main"
+    repo.language = "Python"
+
+    stats = Mock()
+    stats.total_commits = 2
+    stats.additions = 999
+    stats.deletions = 111
+    result = BatchResult(repository=repo, stats=stats, success=True)
+
+    raw_commits = [SimpleNamespace(sha="sha-0"), SimpleNamespace(sha="sha-1")]
+
+    def fake_fetch_commits(gh_repo, max_commits, repo_id, since=None):
+        assert max_commits == 2
+        return raw_commits, []
+
+    def fake_fetch_commit_stats(*args, **kwargs):
+        stats_fetch_calls.append(args)
+        return []
+
+    class DummyRepo:
+        def get_pulls(self, state="all"):
+            return iter([])
+
+    class DummyGithub:
+        def get_repo(self, full_name: str):
+            return DummyRepo()
+
+    class DummyConnector:
+        def __init__(self, token: str):
+            self.github = DummyGithub()
+
+        async def get_repos_with_stats_async(self, **kwargs):
+            on_repo_complete = kwargs.get("on_repo_complete")
+            if on_repo_complete:
+                on_repo_complete(result)
+            return [result]
+
+        def get_rate_limit(self):
+            return {"remaining": 0, "limit": 0}
+
+        def close(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+    )
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commit_stats_sync", fake_fetch_commit_stats
+    )
+
+    await processors.github.process_github_repos_batch(
+        store=DummyStore(),
+        token="test_token",
+        org_name="org",
+        pattern="org/*",
+        batch_size=1,
+        max_concurrent=1,
+        rate_limit_delay=0,
+        use_async=True,
+        since=since,
+        max_commits_per_repo=2,
+        sync_prs=False,
+        sync_cicd=False,
+        sync_deployments=False,
+        sync_incidents=False,
+        sync_security=False,
+        sync_tests=False,
+        backfill_missing=False,
+    )
+
+    assert stats_fetch_calls == []
+    assert recorded_stats == []
+
+
+@pytest.mark.asyncio
+async def test_process_github_repos_batch_commit_stats_rate_limit_propagates(
+    monkeypatch,
+):
+    _enable_connector_stubs(monkeypatch)
+
+    since = datetime(2026, 5, 13, tzinfo=timezone.utc)
+    recorded_stats = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    repo = Mock()
+    repo.id = 1001
+    repo.full_name = "org/rate-limited"
+    repo.url = "https://example.com/org/rate-limited"
+    repo.default_branch = "main"
+    repo.language = "Python"
+
+    stats = Mock()
+    stats.total_commits = 1
+    stats.additions = 999
+    stats.deletions = 111
+    result = BatchResult(repository=repo, stats=stats, success=True)
+
+    def fake_fetch_commits(gh_repo, max_commits, repo_id, since=None):
+        raise RateLimitException("limited", retry_after_seconds=42.0)
+
+    class DummyRepo:
+        def get_pulls(self, state="all"):
+            return iter([])
+
+    class DummyGithub:
+        def get_repo(self, full_name: str):
+            return DummyRepo()
+
+    class DummyConnector:
+        def __init__(self, token: str):
+            self.github = DummyGithub()
+
+        async def get_repos_with_stats_async(self, **kwargs):
+            on_repo_complete = kwargs.get("on_repo_complete")
+            if on_repo_complete:
+                on_repo_complete(result)
+            return [result]
+
+        def get_rate_limit(self):
+            return {"remaining": 0, "limit": 0}
+
+        def close(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+    )
+
+    with pytest.raises(RateLimitException) as exc_info:
+        await processors.github.process_github_repos_batch(
+            store=DummyStore(),
+            token="test_token",
+            org_name="org",
+            pattern="org/*",
+            batch_size=1,
+            max_concurrent=1,
+            rate_limit_delay=0,
+            use_async=True,
+            since=since,
+            sync_prs=False,
+            sync_cicd=False,
+            sync_deployments=False,
+            sync_incidents=False,
+            sync_security=False,
+            sync_tests=False,
+            backfill_missing=False,
+        )
+
+    assert exc_info.value.retry_after_seconds == 42.0
+    assert recorded_stats == []
+
+
+@pytest.mark.asyncio
+async def test_process_github_repos_batch_multi_repo_rate_limit_does_not_hang(
+    monkeypatch,
+):
+    _enable_connector_stubs(monkeypatch)
+
+    since = datetime(2026, 5, 13, tzinfo=timezone.utc)
+    recorded_stats = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    def make_result(index: int):
+        repo = Mock()
+        repo.id = index
+        repo.full_name = f"org/rate-limited-{index}"
+        repo.url = f"https://example.com/org/rate-limited-{index}"
+        repo.default_branch = "main"
+        repo.language = "Python"
+        stats = Mock()
+        stats.total_commits = 1
+        stats.additions = 999
+        stats.deletions = 111
+        return BatchResult(repository=repo, stats=stats, success=True)
+
+    results = [make_result(index) for index in range(3)]
+
+    def fake_fetch_commits(gh_repo, max_commits, repo_id, since=None):
+        raise RateLimitException("limited", retry_after_seconds=42.0)
+
+    class DummyRepo:
+        def get_pulls(self, state="all"):
+            return iter([])
+
+    class DummyGithub:
+        def get_repo(self, full_name: str):
+            return DummyRepo()
+
+    class DummyConnector:
+        def __init__(self, token: str):
+            self.github = DummyGithub()
+
+        async def get_repos_with_stats_async(self, **kwargs):
+            on_repo_complete = kwargs.get("on_repo_complete")
+            if on_repo_complete:
+                for result in results:
+                    on_repo_complete(result)
+            return results
+
+        def get_rate_limit(self):
+            return {"remaining": 0, "limit": 0}
+
+        def close(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+    )
+
+    with pytest.raises(RateLimitException) as exc_info:
+        await asyncio.wait_for(
+            processors.github.process_github_repos_batch(
+                store=DummyStore(),
+                token="test_token",
+                org_name="org",
+                pattern="org/*",
+                batch_size=1,
+                max_concurrent=1,
+                rate_limit_delay=0,
+                use_async=True,
+                since=since,
+                sync_prs=False,
+                sync_cicd=False,
+                sync_deployments=False,
+                sync_incidents=False,
+                sync_security=False,
+                sync_tests=False,
+                backfill_missing=False,
+            ),
+            timeout=2,
+        )
+
+    assert exc_info.value.retry_after_seconds == 42.0
+    assert recorded_stats == []
+
+
+@pytest.mark.asyncio
+async def test_process_github_repos_batch_commit_detail_rate_limit_propagates(
+    monkeypatch,
+):
+    _enable_connector_stubs(monkeypatch)
+
+    since = datetime(2026, 5, 13, tzinfo=timezone.utc)
+    recorded_stats = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    repo = Mock()
+    repo.id = 1002
+    repo.full_name = "org/detail-rate-limited"
+    repo.url = "https://example.com/org/detail-rate-limited"
+    repo.default_branch = "main"
+    repo.language = "Python"
+
+    stats = Mock()
+    stats.total_commits = 1
+    stats.additions = 999
+    stats.deletions = 111
+    result = BatchResult(repository=repo, stats=stats, success=True)
+
+    class RateLimitedCommit:
+        sha = "sha-rate-limited"
+        commit = None
+
+        @property
+        def files(self):
+            raise RateLimitException("limited", retry_after_seconds=43.0)
+
+    def fake_fetch_commits(gh_repo, max_commits, repo_id, since=None):
+        return [RateLimitedCommit()], []
+
+    class DummyRepo:
+        def get_pulls(self, state="all"):
+            return iter([])
+
+    class DummyGithub:
+        def get_repo(self, full_name: str):
+            return DummyRepo()
+
+    class DummyConnector:
+        def __init__(self, token: str):
+            self.github = DummyGithub()
+
+        async def get_repos_with_stats_async(self, **kwargs):
+            on_repo_complete = kwargs.get("on_repo_complete")
+            if on_repo_complete:
+                on_repo_complete(result)
+            return [result]
+
+        def get_rate_limit(self):
+            return {"remaining": 0, "limit": 0}
+
+        def close(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+    )
+
+    with pytest.raises(RateLimitException) as exc_info:
+        await processors.github.process_github_repos_batch(
+            store=DummyStore(),
+            token="test_token",
+            org_name="org",
+            pattern="org/*",
+            batch_size=1,
+            max_concurrent=1,
+            rate_limit_delay=0,
+            use_async=True,
+            since=since,
+            sync_prs=False,
+            sync_cicd=False,
+            sync_deployments=False,
+            sync_incidents=False,
+            sync_security=False,
+            sync_tests=False,
+            backfill_missing=False,
+        )
+
+    assert exc_info.value.retry_after_seconds == 43.0
+    assert recorded_stats == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -561,7 +561,11 @@ async def test_process_github_repos_batch_over_cap_window_skips_stats(monkeypatc
 
 
 @pytest.mark.asyncio
-async def test_process_github_repos_batch_exact_cap_window_skips_stats(monkeypatch):
+async def test_process_github_repos_batch_truncated_window_skips_stats(monkeypatch):
+    """A since-bounded window that hits ``max_commits_per_repo`` AND has more
+    commits beyond it (the fetch reports ``window_truncated=True``) must skip
+    per-file stats rather than persist a partial day.
+    """
     _enable_connector_stubs(monkeypatch)
 
     since = datetime(2026, 5, 13, tzinfo=timezone.utc)
@@ -598,7 +602,9 @@ async def test_process_github_repos_batch_exact_cap_window_skips_stats(monkeypat
 
     def fake_fetch_commits(gh_repo, max_commits, repo_id, since=None):
         assert max_commits == 2
-        return raw_commits, []
+        # window_truncated=True: cap hit and at least one more commit existed in
+        # the window beyond it, so the fetched stats would be a partial day.
+        return raw_commits, [], True
 
     def fake_fetch_commit_stats(*args, **kwargs):
         stats_fetch_calls.append(args)
@@ -664,6 +670,259 @@ async def test_process_github_repos_batch_exact_cap_window_skips_stats(monkeypat
 
     assert stats_fetch_calls == []
     assert recorded_stats == []
+
+
+@pytest.mark.asyncio
+async def test_process_github_repos_batch_undersized_window_writes_stats(monkeypatch):
+    """Regression: a windowed sync that sets ``max_commits_per_repo`` but whose
+    window is *fully covered* (fewer commits than the cap) MUST still write
+    commit stats. The old skip used ``len(raw_commits) >= stats_limit`` — always
+    true once a cap was set — so it silently dropped stats for small windows.
+    """
+    _enable_connector_stubs(monkeypatch)
+
+    since = datetime(2026, 5, 13, tzinfo=timezone.utc)
+    recorded_stats = []
+    stats_fetch_calls = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    repo = Mock()
+    repo.id = 1001
+    repo.full_name = "org/undersized"
+    repo.url = "https://example.com/org/undersized"
+    repo.default_branch = "main"
+    repo.language = "Python"
+
+    stats = Mock()
+    stats.total_commits = 2
+    stats.additions = 999
+    stats.deletions = 111
+    result = BatchResult(repository=repo, stats=stats, success=True)
+
+    # 2 commits in the window, well under the max_commits_per_repo=10 cap.
+    raw_commits = [SimpleNamespace(sha="sha-0"), SimpleNamespace(sha="sha-1")]
+
+    def fake_fetch_commits(gh_repo, max_commits, repo_id, since=None):
+        assert max_commits == 10
+        return raw_commits, []
+
+    def fake_fetch_commit_stats(*args, **kwargs):
+        stats_fetch_calls.append(args)
+        repo_id = args[1]
+        return [
+            GitCommitStat(
+                repo_id=repo_id,
+                commit_hash="sha-0",
+                file_path="file.txt",
+                additions=1,
+                deletions=0,
+                old_file_mode="unknown",
+                new_file_mode="unknown",
+            )
+        ]
+
+    class DummyRepo:
+        def get_pulls(self, state="all"):
+            return iter([])
+
+    class DummyGithub:
+        def get_repo(self, full_name: str):
+            return DummyRepo()
+
+    class DummyConnector:
+        def __init__(self, token: str):
+            self.github = DummyGithub()
+
+        async def get_repos_with_stats_async(self, **kwargs):
+            on_repo_complete = kwargs.get("on_repo_complete")
+            if on_repo_complete:
+                on_repo_complete(result)
+            return [result]
+
+        def get_rate_limit(self):
+            return {"remaining": 0, "limit": 0}
+
+        def close(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+    )
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commit_stats_sync", fake_fetch_commit_stats
+    )
+
+    await processors.github.process_github_repos_batch(
+        store=DummyStore(),
+        token="test_token",
+        org_name="org",
+        pattern="org/*",
+        batch_size=1,
+        max_concurrent=1,
+        rate_limit_delay=0,
+        use_async=True,
+        since=since,
+        max_commits_per_repo=10,
+        sync_prs=False,
+        sync_cicd=False,
+        sync_deployments=False,
+        sync_incidents=False,
+        sync_security=False,
+        sync_tests=False,
+        backfill_missing=False,
+    )
+
+    # Detail fetch was invoked and the real per-file stat was persisted.
+    assert stats_fetch_calls != []
+    assert "sha-0" in {s.commit_hash for s in recorded_stats}
+
+
+@pytest.mark.asyncio
+async def test_process_github_repos_batch_exact_complete_window_writes_stats(
+    monkeypatch,
+):
+    """Codex adversarial-review regression: a since-bounded window whose commit
+    count lands *exactly* on ``max_commits_per_repo`` but is COMPLETE (the fetch
+    reports ``window_truncated=False`` — no commit existed beyond the cap) MUST
+    write stats. Counting alone (``>= max_commits``) cannot tell this apart from a
+    truncated window, so it would silently drop a complete day's stats.
+    """
+    _enable_connector_stubs(monkeypatch)
+
+    since = datetime(2026, 5, 13, tzinfo=timezone.utc)
+    recorded_stats = []
+    stats_fetch_calls = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    repo = Mock()
+    repo.id = 1002
+    repo.full_name = "org/exact-complete"
+    repo.url = "https://example.com/org/exact-complete"
+    repo.default_branch = "main"
+    repo.language = "Python"
+
+    stats = Mock()
+    stats.total_commits = 2
+    stats.additions = 999
+    stats.deletions = 111
+    result = BatchResult(repository=repo, stats=stats, success=True)
+
+    # Exactly max_commits_per_repo=2 commits in the window, and nothing beyond it.
+    raw_commits = [SimpleNamespace(sha="sha-0"), SimpleNamespace(sha="sha-1")]
+
+    def fake_fetch_commits(gh_repo, max_commits, repo_id, since=None):
+        assert max_commits == 2
+        # window_truncated=False: the iterator ended at the cap, proving the
+        # window held exactly max_commits commits (complete, not truncated).
+        return raw_commits, [], False
+
+    def fake_fetch_commit_stats(*args, **kwargs):
+        stats_fetch_calls.append(args)
+        repo_id = args[1]
+        return [
+            GitCommitStat(
+                repo_id=repo_id,
+                commit_hash="sha-0",
+                file_path="file.txt",
+                additions=1,
+                deletions=0,
+                old_file_mode="unknown",
+                new_file_mode="unknown",
+            )
+        ]
+
+    class DummyRepo:
+        def get_pulls(self, state="all"):
+            return iter([])
+
+    class DummyGithub:
+        def get_repo(self, full_name: str):
+            return DummyRepo()
+
+    class DummyConnector:
+        def __init__(self, token: str):
+            self.github = DummyGithub()
+
+        async def get_repos_with_stats_async(self, **kwargs):
+            on_repo_complete = kwargs.get("on_repo_complete")
+            if on_repo_complete:
+                on_repo_complete(result)
+            return [result]
+
+        def get_rate_limit(self):
+            return {"remaining": 0, "limit": 0}
+
+        def close(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+    )
+    monkeypatch.setattr(
+        processors.github, "_fetch_github_commit_stats_sync", fake_fetch_commit_stats
+    )
+
+    await processors.github.process_github_repos_batch(
+        store=DummyStore(),
+        token="test_token",
+        org_name="org",
+        pattern="org/*",
+        batch_size=1,
+        max_concurrent=1,
+        rate_limit_delay=0,
+        use_async=True,
+        since=since,
+        max_commits_per_repo=2,
+        sync_prs=False,
+        sync_cicd=False,
+        sync_deployments=False,
+        sync_incidents=False,
+        sync_security=False,
+        sync_tests=False,
+        backfill_missing=False,
+    )
+
+    # Exact-but-complete window: stats ARE fetched and persisted.
+    assert stats_fetch_calls != []
+    assert "sha-0" in {s.commit_hash for s in recorded_stats}
 
 
 @pytest.mark.asyncio

--- a/tests/test_commit_stats_limit.py
+++ b/tests/test_commit_stats_limit.py
@@ -46,6 +46,68 @@ def test_hard_cap_default_is_300():
     assert resolve_commit_stats_limit(5000, None, SINCE) == 300
 
 
+def test_windowed_truncation_predicate():
+    # Truncation for the max_commits cap is decided by ``window_truncated`` (the
+    # fetch peeked one commit past the cap), NOT by counting: a complete window of
+    # exactly ``max_commits`` commits is indistinguishable from a truncated one by
+    # count alone, so counting (``>= max_commits``) would false-skip the exact-size
+    # complete case. ``raw_commit_count > stats_limit`` still catches the hard-cap
+    # (300) case for uncapped fetches.
+    # signature: (raw_commit_count, window_truncated, max_commits, since)
+    trunc = github._windowed_commit_stats_truncated
+    assert trunc(2, False, 10, SINCE) is False  # undersized + complete -> write
+    assert trunc(2, True, 2, SINCE) is True  # cap hit AND more beyond -> truncated
+    assert trunc(2, False, 2, SINCE) is False  # exact-size COMPLETE window -> write
+    assert trunc(10, True, 10, SINCE) is True  # cap hit AND more beyond
+    assert trunc(2, False, None, SINCE) is False
+    assert trunc(301, False, None, SINCE) is True  # over hard cap (300)
+    assert trunc(50, False, 100, None) is False  # full-history is never truncated
+
+
+def test_fetch_commits_reports_window_truncation():
+    # The look-ahead: _fetch_github_commits_sync peeks ONE commit past max_commits
+    # so callers can distinguish a complete exact-size window (truncated=False)
+    # from a genuinely truncated one (truncated=True). Counting alone cannot.
+    def _fake_commit(sha: str):
+        person = SimpleNamespace(
+            name="Dev", email=None, date=datetime(2026, 5, 20, tzinfo=timezone.utc)
+        )
+        inner = SimpleNamespace(author=person, committer=person, message="msg")
+        return SimpleNamespace(
+            sha=sha, author=None, committer=None, commit=inner, parents=[]
+        )
+
+    class _FakeRepo:
+        def __init__(self, n: int) -> None:
+            self._commits = [_fake_commit(f"sha-{i}") for i in range(n)]
+
+        def get_commits(self, **kwargs):
+            return iter(self._commits)
+
+    fetch = github._fetch_github_commits_sync
+
+    # window 5, cap 3 -> truncated (a 4th commit existed past the cap, not kept)
+    raw, objs, truncated = fetch(_FakeRepo(5), 3, "repo-1")
+    assert [c.sha for c in raw] == ["sha-0", "sha-1", "sha-2"]
+    assert len(objs) == 3
+    assert truncated is True
+
+    # window EXACTLY 3, cap 3 -> complete (iterator ended at the cap)
+    raw, _objs, truncated = fetch(_FakeRepo(3), 3, "repo-1")
+    assert len(raw) == 3
+    assert truncated is False
+
+    # window 2, under cap 3 -> complete
+    raw, _objs, truncated = fetch(_FakeRepo(2), 3, "repo-1")
+    assert len(raw) == 2
+    assert truncated is False
+
+    # no cap -> never truncated
+    raw, _objs, truncated = fetch(_FakeRepo(10), None, "repo-1")
+    assert len(raw) == 10
+    assert truncated is False
+
+
 class _RecordingSink:
     def __init__(self) -> None:
         self.stats: list[Any] = []

--- a/tests/test_commit_stats_limit.py
+++ b/tests/test_commit_stats_limit.py
@@ -7,12 +7,18 @@ and starved churn/hotspot/bus-factor daily metrics with partial days.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import Any, cast
 
 # Initialize the connectors package before processors to avoid the
 # pre-existing providers._base <-> connectors circular import when this file
 # is collected in isolation.
 import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.metrics.sinks.ingestion import IngestionSink
+from dev_health_ops.models.git import Repo
+from dev_health_ops.processors import github
 from dev_health_ops.processors.base_git import resolve_commit_stats_limit
 
 SINCE = datetime(2026, 5, 13, tzinfo=timezone.utc)
@@ -38,3 +44,65 @@ def test_max_commits_caps_both_modes():
 
 def test_hard_cap_default_is_300():
     assert resolve_commit_stats_limit(5000, None, SINCE) == 300
+
+
+class _RecordingSink:
+    def __init__(self) -> None:
+        self.stats: list[Any] = []
+
+    async def insert_git_commit_stats(self, stats):
+        self.stats.extend(stats)
+
+
+def _run_sync_commit_stats(monkeypatch, *, raw_commits, since):
+    """Drive ``_sync_github_commit_stats`` with a pre-fetched commit list."""
+    fetch_calls: list[int] = []
+
+    def _fake_fetch(raw, repo_id, max_stats, window, gate):
+        fetch_calls.append(max_stats)
+        return [
+            SimpleNamespace(commit_hash=getattr(c, "sha", c)) for c in raw[:max_stats]
+        ]
+
+    monkeypatch.setattr(github, "_fetch_github_commit_stats_sync", _fake_fetch)
+    sink = _RecordingSink()
+
+    async def _drive():
+        return await github._sync_github_commit_stats(
+            gh_repo=object(),
+            db_repo=cast(Repo, SimpleNamespace(id="repo-1")),
+            ingestion_sink=cast(IngestionSink, sink),
+            loop=asyncio.get_running_loop(),
+            max_commits=None,
+            since=since,
+            raw_commits=list(raw_commits),
+        )
+
+    written = asyncio.run(_drive())
+    return written, sink.stats, fetch_calls
+
+
+def test_over_cap_window_skips_detail_and_writes_no_stats(monkeypatch):
+    # A windowed (since-bound) sync whose commit list exceeds the hard cap must
+    # skip every per-commit detail/file access and persist zero stats rather
+    # than write a partial day. (Regression: the skip existed only in the
+    # backfill path, not the normal _sync_github_commit_stats path.)
+    raw_commits = [SimpleNamespace(sha=f"sha-{i}") for i in range(301)]
+    written, stats, fetch_calls = _run_sync_commit_stats(
+        monkeypatch, raw_commits=raw_commits, since=SINCE
+    )
+    assert written == 0
+    assert stats == []
+    assert fetch_calls == []  # detail fetch never invoked
+
+
+def test_full_history_capped_sample_still_writes_stats(monkeypatch):
+    # since=None full-history syncs use a capped sample (50) and MUST still
+    # write stats even when the commit list exceeds the cap.
+    raw_commits = [SimpleNamespace(sha=f"sha-{i}") for i in range(5000)]
+    written, stats, fetch_calls = _run_sync_commit_stats(
+        monkeypatch, raw_commits=raw_commits, since=None
+    )
+    assert fetch_calls == [50]  # capped sample fetched
+    assert written == 50
+    assert len(stats) == 50

--- a/tests/test_github_content_backfill.py
+++ b/tests/test_github_content_backfill.py
@@ -9,7 +9,8 @@ loud-failure exit when an org has no scannable contents at all.
 from __future__ import annotations
 
 import uuid
-from datetime import date
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
 import pytest
@@ -19,6 +20,7 @@ import pytest
 # is collected in isolation.
 import dev_health_ops.connectors  # noqa: F401
 import dev_health_ops.metrics.job_complexity_db as job
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.processors.base_git import backfill_file_records
 from dev_health_ops.processors.github import (
     CONTENT_FETCH_MAX_BYTES,
@@ -252,3 +254,345 @@ class TestPathsOnlyUpgrade:
 
         connector.github.get_repo.assert_not_called()
         sink.insert_git_file_data.assert_not_called()
+
+
+class TestCommitStatsBackfill:
+    @pytest.mark.asyncio
+    async def test_backfill_commit_stats_uses_window_and_persists_when_cap_not_hit(
+        self, monkeypatch
+    ):
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "2")
+        since = datetime(2026, 1, 10, tzinfo=timezone.utc)
+        until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=False)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        written = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_commit_stats = AsyncMock(side_effect=insert)
+
+        commits = [SimpleNamespace(sha=f"sha-{idx}") for idx in range(2)]
+        details_by_sha = {
+            commit.sha: SimpleNamespace(
+                files=[
+                    SimpleNamespace(
+                        filename=f"{commit.sha}.py",
+                        additions=1,
+                        deletions=0,
+                    )
+                ]
+            )
+            for commit in commits
+        }
+
+        gh_repo = Mock()
+        gh_repo.get_commits.return_value = commits
+        gh_repo.get_commit.side_effect = lambda sha: details_by_sha[sha]
+
+        connector = Mock()
+        connector.github.get_repo.return_value = gh_repo
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_github_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_files=False,
+            include_blame=False,
+            since=since,
+            until=until,
+        )
+
+        gh_repo.get_commits.assert_called_once_with(since=since, until=until)
+        assert [call.args[0] for call in gh_repo.get_commit.call_args_list] == [
+            "sha-0",
+            "sha-1",
+        ]
+        assert [row.commit_hash for row in written] == ["sha-0", "sha-1"]
+
+    @pytest.mark.asyncio
+    async def test_backfill_commit_stats_over_cap_writes_nothing(self, monkeypatch):
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "2")
+        since = datetime(2026, 1, 10, tzinfo=timezone.utc)
+        until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=False)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        sink = Mock()
+        sink.insert_git_commit_stats = AsyncMock()
+
+        commits = [SimpleNamespace(sha=f"sha-{idx}") for idx in range(3)]
+        details_by_sha = {
+            commit.sha: SimpleNamespace(
+                files=[
+                    SimpleNamespace(
+                        filename=f"{commit.sha}.py",
+                        additions=1,
+                        deletions=0,
+                    )
+                ]
+            )
+            for commit in commits
+        }
+
+        gh_repo = Mock()
+        gh_repo.get_commits.return_value = commits
+        gh_repo.get_commit.side_effect = lambda sha: details_by_sha[sha]
+
+        connector = Mock()
+        connector.github.get_repo.return_value = gh_repo
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_github_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_files=False,
+            include_blame=False,
+            since=since,
+            until=until,
+        )
+
+        gh_repo.get_commits.assert_called_once_with(since=since, until=until)
+        gh_repo.get_commit.assert_not_called()
+        sink.insert_git_commit_stats.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backfill_commit_stats_rate_limit_propagates_without_partial_write(
+        self, monkeypatch
+    ):
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "3")
+        since = datetime(2026, 1, 10, tzinfo=timezone.utc)
+        until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=False)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        sink = Mock()
+        sink.insert_git_commit_stats = AsyncMock()
+
+        commits = [SimpleNamespace(sha="sha-0"), SimpleNamespace(sha="sha-1")]
+        gh_repo = Mock()
+        gh_repo.get_commits.return_value = commits
+        gh_repo.get_commit.side_effect = [
+            SimpleNamespace(
+                files=[
+                    SimpleNamespace(
+                        filename="sha-0.py",
+                        additions=1,
+                        deletions=0,
+                    )
+                ]
+            ),
+            RateLimitException("limited", retry_after_seconds=42.0),
+        ]
+
+        connector = Mock()
+        connector.github.get_repo.return_value = gh_repo
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        with pytest.raises(RateLimitException) as exc_info:
+            await _backfill_github_missing_data(
+                store=store,
+                ingestion_sink=sink,
+                connector=connector,
+                db_repo=db_repo,
+                repo_full_name="octo/repo",
+                default_branch="main",
+                max_commits=None,
+                include_files=False,
+                include_blame=False,
+                since=since,
+                until=until,
+            )
+
+        assert exc_info.value.retry_after_seconds == 42.0
+        sink.insert_git_commit_stats.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_backfill_commit_stats_over_cap_still_runs_blame(self, monkeypatch):
+        from dev_health_ops.connectors.models import BlameRange, FileBlame
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "2")
+        since = datetime(2026, 1, 10, tzinfo=timezone.utc)
+        until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=False)
+        store.has_any_git_blame = AsyncMock(return_value=False)
+        store.get_blamed_paths = AsyncMock(return_value=set())
+
+        blame_rows = []
+
+        async def insert_blame(batch):
+            blame_rows.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_commit_stats = AsyncMock()
+        sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
+
+        commits = [SimpleNamespace(sha=f"sha-{idx}") for idx in range(3)]
+        details_by_sha = {
+            commit.sha: SimpleNamespace(
+                files=[
+                    SimpleNamespace(
+                        filename=f"{commit.sha}.py",
+                        additions=1,
+                        deletions=0,
+                    )
+                ]
+            )
+            for commit in commits
+        }
+
+        gh_repo = Mock()
+        gh_repo.get_branch.return_value = Mock(commit=Mock(sha="tree-sha"))
+        gh_repo.get_git_tree.return_value = Mock(tree=[_FakeTreeEntry("src/app.py")])
+        gh_repo.get_commits.return_value = commits
+        gh_repo.get_commit.side_effect = lambda sha: details_by_sha[sha]
+
+        connector = Mock()
+        connector.github.get_repo.return_value = gh_repo
+        connector.get_file_blame.return_value = FileBlame(
+            file_path="src/app.py",
+            ranges=[
+                BlameRange(
+                    starting_line=1,
+                    ending_line=1,
+                    commit_sha="sha-0",
+                    author="A",
+                    author_email="a@example.com",
+                    age_seconds=0,
+                )
+            ],
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_github_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_files=False,
+            include_blame=True,
+            since=since,
+            until=until,
+        )
+
+        sink.insert_git_commit_stats.assert_not_called()
+        gh_repo.get_commit.assert_not_called()
+        connector.get_file_blame.assert_called_once_with(
+            owner="octo",
+            repo="repo",
+            path="src/app.py",
+            ref="main",
+        )
+        assert [row.path for row in blame_rows] == ["src/app.py"]
+
+    @pytest.mark.asyncio
+    async def test_backfill_commit_stats_full_history_writes_capped_sample(
+        self, monkeypatch
+    ):
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "2")
+
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=False)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        written = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_commit_stats = AsyncMock(side_effect=insert)
+
+        commits = [SimpleNamespace(sha=f"sha-{idx}") for idx in range(3)]
+        details_by_sha = {
+            commit.sha: SimpleNamespace(
+                files=[
+                    SimpleNamespace(
+                        filename=f"{commit.sha}.py",
+                        additions=1,
+                        deletions=0,
+                    )
+                ]
+            )
+            for commit in commits
+        }
+
+        gh_repo = Mock()
+        gh_repo.get_commits.return_value = commits
+        gh_repo.get_commit.side_effect = lambda sha: details_by_sha[sha]
+
+        connector = Mock()
+        connector.github.get_repo.return_value = gh_repo
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_github_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_files=False,
+            include_blame=False,
+        )
+
+        gh_repo.get_commits.assert_called_once_with()
+        assert [call.args[0] for call in gh_repo.get_commit.call_args_list] == [
+            "sha-0",
+            "sha-1",
+        ]
+        assert [row.commit_hash for row in written] == ["sha-0", "sha-1"]

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -22,7 +22,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dev_health_ops.connectors.exceptions import NotFoundException
+from dev_health_ops.connectors.exceptions import NotFoundException, RateLimitException
 from dev_health_ops.models.work_items import WorkItem
 from dev_health_ops.providers.base import (
     IngestionContext,
@@ -969,6 +969,67 @@ def test_github_provider_pr_social_404_does_not_drop_fetched_prs(
 
 
 @patch.dict(os.environ, {}, clear=True)
+def test_github_provider_pr_fetch_rate_limit_propagates(
+    mock_status_mapping, mock_identity
+):
+    client = _options_client()
+    client.iter_pull_requests.side_effect = RateLimitException(
+        "limited", retry_after_seconds=42.0
+    )
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(repo="owner/repo", window=IngestionWindow())
+
+    with pytest.raises(RateLimitException) as exc_info:
+        provider.ingest(ctx)
+
+    assert exc_info.value.retry_after_seconds == 42.0
+    client.iter_pr_social_data_batch.assert_not_called()
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_github_provider_issue_comment_rate_limit_propagates(
+    mock_status_mapping, mock_identity
+):
+    client = _options_client()
+    client.iter_issues.return_value = [_mock_issue(number=1)]
+    client.iter_issue_comments.side_effect = RateLimitException(
+        "limited", retry_after_seconds=41.0
+    )
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(repo="owner/repo", window=IngestionWindow())
+
+    with pytest.raises(RateLimitException) as exc_info:
+        provider.ingest(ctx)
+
+    assert exc_info.value.retry_after_seconds == 41.0
+    client.iter_pull_requests.assert_not_called()
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_github_provider_pr_social_rate_limit_propagates(
+    mock_status_mapping, mock_identity
+):
+    client = _options_client()
+    client.iter_pull_requests.return_value = [_mock_pr(number=100, title="Test PR")]
+    client.iter_pr_social_data_batch.side_effect = RateLimitException(
+        "limited", retry_after_seconds=43.0
+    )
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(repo="owner/repo", window=IngestionWindow())
+
+    with pytest.raises(RateLimitException) as exc_info:
+        provider.ingest(ctx)
+
+    assert exc_info.value.retry_after_seconds == 43.0
+
+
+@patch.dict(os.environ, {}, clear=True)
 def test_github_provider_pr_processing_404_is_not_logged_as_fetch_failure(
     caplog, mock_status_mapping, mock_identity
 ):
@@ -998,6 +1059,61 @@ def test_github_provider_pr_processing_404_is_not_logged_as_fetch_failure(
     assert [item.work_item_id for item in batch.work_items] == ["ghpr:owner/repo#100"]
     assert "GitHub: failed to fetch PRs from owner/repo" not in caplog.text
     assert "GitHub: failed to process PRs from owner/repo" in caplog.text
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_github_provider_threads_window_since_to_pull_requests(
+    mock_status_mapping, mock_identity
+):
+    from dev_health_ops.providers.base import WorkItemIngestionOptions
+
+    since = datetime(2026, 1, 10, tzinfo=timezone.utc)
+    client = _options_client()
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(updated_since=since),
+        work_item_options=WorkItemIngestionOptions(
+            include_issues=False,
+            include_pull_requests=True,
+        ),
+    )
+
+    provider.ingest(ctx)
+
+    client.iter_pull_requests.assert_called_once_with(
+        owner="owner",
+        repo="repo",
+        state="all",
+        since=since,
+        until=None,
+        limit=None,
+        scan_limit=None,
+    )
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_github_provider_skips_pr_fetch_when_limit_consumed_by_issues(
+    mock_status_mapping, mock_identity
+):
+    client = _options_client()
+    client.iter_issues.return_value = [_mock_issue(number=1)]
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(),
+        limit=1,
+    )
+
+    batch = provider.ingest(ctx)
+
+    assert [item.work_item_id for item in batch.work_items] == ["gh:owner/repo#1"]
+    client.iter_pull_requests.assert_not_called()
+    client.iter_pr_social_data_batch.assert_not_called()
 
 
 @patch.dict(os.environ, {}, clear=True)
@@ -1081,6 +1197,7 @@ def _options_client() -> MagicMock:
     client.iter_repo_milestones.return_value = []
     client.iter_issues.return_value = []
     client.iter_issue_events.return_value = []
+    client.iter_issue_comments.return_value = []
     client.iter_pull_requests.return_value = []
     client.iter_pr_comments_batch.return_value = []
     return client
@@ -1171,3 +1288,177 @@ def test_work_item_options_ctx_overrides_env(mock_status_mapping, mock_identity)
     )
     provider.ingest(ctx)
     client.iter_pull_requests.assert_called_once()
+
+
+# ============================================================================
+# active_until windowing — CHAOS-2573 (post-fetch enforcement, no limit drain)
+# ============================================================================
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_github_provider_active_until_excludes_future_issues_without_consuming_limit(
+    mock_status_mapping, mock_identity
+):
+    """active_until is enforced post-fetch: issues updated after the bound are
+    skipped and must not consume ctx.limit, so an in-window issue sitting past a
+    future one is still captured."""
+    until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+    in_window_a = _mock_issue(
+        number=1, updated_at=datetime(2026, 1, 10, tzinfo=timezone.utc)
+    )
+    future = _mock_issue(number=2, updated_at=datetime(2026, 2, 1, tzinfo=timezone.utc))
+    in_window_b = _mock_issue(
+        number=3, updated_at=datetime(2026, 1, 11, tzinfo=timezone.utc)
+    )
+    client = _options_client()
+    client.iter_issues.return_value = [in_window_a, future, in_window_b]
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(active_until=until),
+        limit=2,
+    )
+
+    batch = provider.ingest(ctx)
+
+    assert [item.work_item_id for item in batch.work_items] == [
+        "gh:owner/repo#1",
+        "gh:owner/repo#3",
+    ]
+    client.iter_issues.assert_called_once_with(
+        owner="owner",
+        repo="repo",
+        state="all",
+        since=None,
+        until=until,
+        limit=2,
+        scan_limit=100,
+    )
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_github_provider_active_until_filters_prs_before_social_batch(
+    mock_status_mapping, mock_identity
+):
+    """active_until is enforced post-fetch for PRs: future PRs are excluded, do
+    not consume ctx.limit, and the PR social batch only receives in-window PRs."""
+    from dev_health_ops.providers.base import WorkItemIngestionOptions
+
+    until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+    in_window_a = _mock_pr(
+        number=1, updated_at=datetime(2026, 1, 10, tzinfo=timezone.utc)
+    )
+    future = _mock_pr(number=2, updated_at=datetime(2026, 2, 1, tzinfo=timezone.utc))
+    in_window_b = _mock_pr(
+        number=3, updated_at=datetime(2026, 1, 11, tzinfo=timezone.utc)
+    )
+    client = _options_client()
+    client.iter_pull_requests.return_value = [in_window_a, future, in_window_b]
+    client.iter_pr_social_data_batch.return_value = []
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(active_until=until),
+        limit=2,
+        work_item_options=WorkItemIngestionOptions(include_issues=False),
+    )
+
+    batch = provider.ingest(ctx)
+
+    assert [item.work_item_id for item in batch.work_items] == [
+        "ghpr:owner/repo#1",
+        "ghpr:owner/repo#3",
+    ]
+    client.iter_pull_requests.assert_called_once_with(
+        owner="owner",
+        repo="repo",
+        state="all",
+        since=None,
+        until=until,
+        limit=2,
+        scan_limit=100,
+    )
+    social_prs = client.iter_pr_social_data_batch.call_args.kwargs["prs"]
+    assert [pr.number for pr in social_prs] == [1, 3]
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_github_provider_active_until_without_limit_does_not_default_scan_cap(
+    mock_status_mapping, mock_identity
+):
+    until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+    client = _options_client()
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(active_until=until),
+    )
+
+    provider.ingest(ctx)
+
+    client.iter_issues.assert_called_once_with(
+        owner="owner",
+        repo="repo",
+        state="all",
+        since=None,
+        until=until,
+        limit=None,
+        scan_limit=None,
+    )
+    client.iter_pull_requests.assert_called_once_with(
+        owner="owner",
+        repo="repo",
+        state="all",
+        since=None,
+        until=until,
+        limit=None,
+        scan_limit=None,
+    )
+
+
+@patch.dict(os.environ, {"GITHUB_ACTIVE_WINDOW_SCAN_LIMIT": "25"}, clear=True)
+def test_github_provider_active_until_without_limit_uses_explicit_scan_cap(
+    mock_status_mapping, mock_identity
+):
+    until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+    client = _options_client()
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(
+        repo="owner/repo",
+        window=IngestionWindow(active_until=until),
+    )
+
+    provider.ingest(ctx)
+
+    assert client.iter_issues.call_args.kwargs["scan_limit"] == 25
+    assert client.iter_pull_requests.call_args.kwargs["scan_limit"] == 25
+
+
+@patch.dict(os.environ, {}, clear=True)
+def test_github_provider_milestone_rate_limit_propagates(
+    mock_status_mapping, mock_identity
+):
+    """A RateLimitException raised while fetching milestones must propagate
+    instead of being swallowed by the milestone best-effort handler."""
+    client = _options_client()
+    client.iter_repo_milestones.side_effect = RateLimitException(
+        "limited", retry_after_seconds=44.0
+    )
+    provider = GitHubProvider(
+        status_mapping=mock_status_mapping, identity=mock_identity, client=client
+    )
+    ctx = IngestionContext(repo="owner/repo", window=IngestionWindow())
+
+    with pytest.raises(RateLimitException) as exc_info:
+        provider.ingest(ctx)
+
+    assert exc_info.value.retry_after_seconds == 44.0
+    client.iter_issues.assert_not_called()


### PR DESCRIPTION
## Summary
- Bound GitHub issue/PR window iteration without letting future items consume result limits
- Propagate GitHub rate limits from milestone, PR, comment, social-data, and commit-stat paths
- Skip partial since-bound commit-stat writes and aggregate markers when windows exceed safe caps
- Preserve unbounded historical active-window scans unless a caller limit or explicit scan cap is provided

## Verification
- pre-commit hooks: ruff format, ruff check, mypy
- pre-push hooks: ruff format --check, ruff check, mypy
- Targeted pytest: 194 passed, 1 warning
- Manual driver: backfill rate-limit aborts without partial stats; active_until without limit has no implicit scan cap
- Reviewer pass: PASS, 0 critical, 0 warnings

SCREENSHOT-WAIVER: backend-only provider/processor changes; no rendered UI.