### PR TITLE
docs(auth): clarify GitHub App OAuth setup

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,10 +60,17 @@ SYNC_BUDGET_DRY_RUN_DEFERRAL_SECONDS="60"
 # ----------------------------------------------------------------------------
 # Personal access token with repo read permissions
 # GITHUB_TOKEN="ghp_xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+# GitHub App install/connect flow. The App's Client ID/secret can also be reused
+# for Sign in with GitHub; copy them into SOCIAL_GITHUB_* below and
+# AUTH_GITHUB_* in web/.env.
+# GITHUB_APP_SLUG="dev-health"
+# GITHUB_APP_ID="123456"
+# GITHUB_APP_CLIENT_ID="Iv1.xxxxxxxxxxxxxxxx"
+# GITHUB_APP_CLIENT_SECRET="github_app_client_secret"
+# GITHUB_APP_CALLBACK_URL="http://localhost:3000/org/admin/integrations/github-app/callback"
 # GitHub App auth fallback for CLI/worker contexts uses the key-path form.
 # Inline private keys are used by the API GitHub App integration config path.
 # Prefer stored credentials for multi-tenant deployments.
-# GITHUB_APP_ID="123456"
 # GITHUB_APP_PRIVATE_KEY_PATH="/secure/path/dev-health-github-app.pem"
 # GITHUB_APP_PRIVATE_KEY="-----BEGIN PRIVATE KEY-----..."
 # GITHUB_APP_INSTALLATION_ID="987654"

--- a/docs/ops/deployment-guide.md
+++ b/docs/ops/deployment-guide.md
@@ -49,12 +49,18 @@ All deployment methods use the same environment variables:
 | Variable | Description |
 |----------|-------------|
 | `GITHUB_TOKEN` | GitHub Personal Access Token |
+| `GITHUB_APP_SLUG` | GitHub App URL slug for one-click install/connect |
 | `GITHUB_APP_ID` | GitHub App id for app-based auth |
+| `GITHUB_APP_CLIENT_ID` | GitHub App OAuth Client ID for installation authorization |
+| `GITHUB_APP_CLIENT_SECRET` | GitHub App OAuth Client secret for installation authorization |
+| `GITHUB_APP_CALLBACK_URL` | Exact web callback for GitHub App install, for example `https://app.example.com/org/admin/integrations/github-app/callback` |
 | `GITHUB_APP_PRIVATE_KEY_PATH` | Path to a mounted GitHub App private key |
 | `GITHUB_APP_PRIVATE_KEY` | Inline GitHub App private key for the API GitHub App integration config path; worker sync env fallback uses `GITHUB_APP_PRIVATE_KEY_PATH` |
 | `GITHUB_APP_INSTALLATION_ID` | GitHub App installation id for single-installation fallback |
 | `GITHUB_BASE_URL` | GitHub API base URL |
 | `GITHUB_LINEAR_LINKBACK_BOTS` | Comma-separated GitHub bot actors trusted for Linear linkback comments |
+| `SOCIAL_GITHUB_CLIENT_ID` | GitHub OAuth Client ID used by `/auth/social-login`; may be the same value as `GITHUB_APP_CLIENT_ID` |
+| `SOCIAL_GITHUB_CLIENT_SECRET` | GitHub OAuth Client secret used by `/auth/social-login`; may be the same value as `GITHUB_APP_CLIENT_SECRET` |
 | `GITLAB_TOKEN` | GitLab Private Token |
 | `GITLAB_URL` | GitLab instance URL (default: gitlab.com) |
 | `JIRA_BASE_URL` | Jira Cloud URL (e.g., your-org.atlassian.net) |

--- a/docs/user-guide/github-app-setup.md
+++ b/docs/user-guide/github-app-setup.md
@@ -18,7 +18,7 @@ GitHub → **Settings → Developer settings → GitHub Apps → New GitHub App*
 
 | Field | Value |
 | --- | --- |
-| **User authorization callback URL** | `https://YOUR_HOST/admin/integrations/github-app/callback` |
+| **User authorization callback URL** | `https://YOUR_HOST/org/admin/integrations/github-app/callback` |
 | **Request user authorization (OAuth) during installation** | ✅ **Checked** |
 | **Expire user authorization tokens** | ✅ leave checked (the code is used once at install) |
 | **Enable Device Flow** | ⬜ unchecked |
@@ -27,6 +27,17 @@ GitHub Apps support up to 10 registered callback URLs. If you register more than
 one (e.g. a localhost URL and a production URL), set `GITHUB_APP_CALLBACK_URL` to
 the exact URL for the current environment so the install flow redirects
 deterministically — otherwise GitHub uses the first registered callback URL.
+
+If you also use the same GitHub App for **Sign in with GitHub**, add the Auth.js
+callback URL too:
+
+```text
+https://YOUR_HOST/api/auth/callback/github
+```
+
+You do **not** need a separate GitHub OAuth App. The GitHub App's **Client ID**
+and **Client secret** are OAuth credentials and can be reused for both the
+installation flow and social login.
 
 Because OAuth‑during‑install is on, GitHub greys out **Setup URL** and uses the
 callback URL above instead — that is expected; leave Setup URL blank.
@@ -107,15 +118,23 @@ GITHUB_APP_ID=<App ID>
 GITHUB_APP_CLIENT_ID=<Client ID>
 GITHUB_APP_CLIENT_SECRET=<generated client secret>
 GITHUB_WEBHOOK_SECRET=<the webhook secret from step 1>
-GITHUB_APP_CALLBACK_URL=https://YOUR_HOST/admin/integrations/github-app/callback
+GITHUB_APP_CALLBACK_URL=https://YOUR_HOST/org/admin/integrations/github-app/callback
+# backend verification for Sign in with GitHub; use the same Client ID/secret
+SOCIAL_GITHUB_CLIENT_ID=<same Client ID>
+SOCIAL_GITHUB_CLIENT_SECRET=<same client secret>
 # private key — choose ONE (see below)
 GITHUB_APP_PRIVATE_KEY_PATH=/run/secrets/github-app.pem
 # GITHUB_APP_PRIVATE_KEY="<single-line PEM with \n escapes — see 'Providing the private key' below>"
 
-# web (unified social login on the same App)
+# web (Sign in with GitHub on the same App)
+AUTH_URL=https://YOUR_HOST
 AUTH_GITHUB_ID=<same Client ID>
 AUTH_GITHUB_SECRET=<same client secret>
 ```
+
+`compose.yml` loads `ops/.env` into the API/worker services and `web/.env` into
+the web service, but it does not alias these names for you. Copy the same Client
+ID/secret into each required variable above.
 
 ### Providing the private key (PEM)
 
@@ -162,9 +181,11 @@ install + OAuth callback works on `localhost` because GitHub redirects the
 **browser** (which is on your machine), and the backend's OAuth/`/user/installations`
 calls are outbound:
 
-- Set **User authorization callback URL** = `http://localhost:3000/admin/integrations/github-app/callback`.
-- Set `GITHUB_APP_CALLBACK_URL=http://localhost:3000/admin/integrations/github-app/callback` so
+- Set **User authorization callback URL** = `http://localhost:3000/org/admin/integrations/github-app/callback`.
+- If testing **Sign in with GitHub**, also register `http://localhost:3000/api/auth/callback/github`.
+- Set `GITHUB_APP_CALLBACK_URL=http://localhost:3000/org/admin/integrations/github-app/callback` so
   the install flow returns to localhost even if a production callback URL is also registered.
+- Set `AUTH_URL=http://localhost:3000` in `web/.env` when using Docker/reverse proxy local dev.
 - In **Webhook**, **uncheck "Active"** (drops the required URL). You lose only
   automatic credential‑deactivation on uninstall during the test.
 


### PR DESCRIPTION
## Summary

- Correct the GitHub App install callback path to /org/admin/integrations/github-app/callback

- Document that the GitHub App Client ID/secret can be reused for Sign in with GitHub

- Add the required ops env aliases for GitHub App install and social-login verification



## Verification

- git diff --check

- pre-push hooks skipped non-code checks because only docs/env example files changed