### PR TITLE
fix(workers): run complexity before post-sync metrics

### DIFF
--- a/src/dev_health_ops/workers/post_sync_dispatch.py
+++ b/src/dev_health_ops/workers/post_sync_dispatch.py
@@ -161,22 +161,18 @@ def _dispatch_post_sync_tasks(
     if metrics_backfill_days is not None:
         daily_metrics_kwargs["backfill_days"] = metrics_backfill_days
 
-    if has_git and not has_work_items:
-        celery_app.send_task(
-            "dev_health_ops.workers.tasks.run_daily_metrics",
-            kwargs=daily_metrics_kwargs,
-            queue="metrics",
-        )
-        dispatched.append("run_daily_metrics")
-
     if has_work_items:
         dispatched.append("run_daily_metrics")
+    elif has_git:
+        dispatched.append("run_daily_metrics")
 
+    complexity_sig = None
     if has_git:
-        celery_app.send_task(
+        complexity_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_complexity_job",
             kwargs={"org_id": org_id},
             queue="metrics",
+            immutable=True,
         )
         dispatched.append("run_complexity_job")
 
@@ -199,7 +195,7 @@ def _dispatch_post_sync_tasks(
             "dev_health_ops.workers.tasks.run_work_graph_build",
             kwargs=build_kwargs,
             queue="metrics",
-            immutable=has_work_items,
+            immutable=has_work_items or has_git,
         )
         materialize_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned",
@@ -207,14 +203,20 @@ def _dispatch_post_sync_tasks(
             queue="default",
             immutable=True,
         )
-        if has_work_items:
+        if has_work_items or has_git:
             daily_metrics_sig = celery_app.signature(
                 "dev_health_ops.workers.tasks.run_daily_metrics",
                 kwargs=daily_metrics_kwargs,
                 queue="metrics",
                 immutable=True,
             )
-            chain(daily_metrics_sig, build_sig, materialize_sig).apply_async()
+            chain(
+                *(
+                    [complexity_sig, daily_metrics_sig, build_sig, materialize_sig]
+                    if complexity_sig is not None
+                    else [daily_metrics_sig, build_sig, materialize_sig]
+                )
+            ).apply_async()
         else:
             chain(build_sig, materialize_sig).apply_async()
         dispatched.append("run_work_graph_build")

--- a/src/dev_health_ops/workers/post_sync_dispatch.py
+++ b/src/dev_health_ops/workers/post_sync_dispatch.py
@@ -161,11 +161,23 @@ def _dispatch_post_sync_tasks(
     if metrics_backfill_days is not None:
         daily_metrics_kwargs["backfill_days"] = metrics_backfill_days
 
-    if has_work_items:
-        dispatched.append("run_daily_metrics")
-    elif has_git:
+    if has_git or has_work_items:
         dispatched.append("run_daily_metrics")
 
+    # run_complexity_job writes file_complexity_snapshots, which run_daily_metrics
+    # reads (job_daily._load_complexity_map_for_repo). Chaining complexity ->
+    # daily guarantees the daily risk/hotspot rows reflect the just-synced file
+    # contents instead of the previous cycle's snapshot — important for a newly
+    # onboarded org's first daily run, which would otherwise show zero complexity.
+    #
+    # Trade-off (CHAOS review #1078): as the chain head, a *terminal* complexity
+    # failure (after its 3 internal retries) aborts the rest of the chain
+    # (daily/build/materialize), so the /investment refresh is skipped for that
+    # sync. This is accepted as fresh-or-nothing: terminal complexity failures are
+    # rare and usually stem from ClickHouse being unavailable, in which case the
+    # downstream steps would fail anyway; daily also degrades gracefully on a
+    # missing snapshot, so the next cycle recovers. If hard isolation is ever
+    # needed, decouple via a non-raising wrapper task rather than link_error.
     complexity_sig = None
     if has_git:
         complexity_sig = celery_app.signature(
@@ -191,11 +203,13 @@ def _dispatch_post_sync_tasks(
         if to_date is not None:
             materialize_kwargs["to_date"] = to_date
 
+        # Every link below the chain head must be immutable so a parent's return
+        # value is not injected as a positional arg into the next task.
         build_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.run_work_graph_build",
             kwargs=build_kwargs,
             queue="metrics",
-            immutable=has_work_items or has_git,
+            immutable=True,
         )
         materialize_sig = celery_app.signature(
             "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned",
@@ -203,22 +217,16 @@ def _dispatch_post_sync_tasks(
             queue="default",
             immutable=True,
         )
-        if has_work_items or has_git:
-            daily_metrics_sig = celery_app.signature(
-                "dev_health_ops.workers.tasks.run_daily_metrics",
-                kwargs=daily_metrics_kwargs,
-                queue="metrics",
-                immutable=True,
-            )
-            chain(
-                *(
-                    [complexity_sig, daily_metrics_sig, build_sig, materialize_sig]
-                    if complexity_sig is not None
-                    else [daily_metrics_sig, build_sig, materialize_sig]
-                )
-            ).apply_async()
-        else:
-            chain(build_sig, materialize_sig).apply_async()
+        daily_metrics_sig = celery_app.signature(
+            "dev_health_ops.workers.tasks.run_daily_metrics",
+            kwargs=daily_metrics_kwargs,
+            queue="metrics",
+            immutable=True,
+        )
+        chain_sigs = [daily_metrics_sig, build_sig, materialize_sig]
+        if complexity_sig is not None:
+            chain_sigs.insert(0, complexity_sig)
+        chain(*chain_sigs).apply_async()
         dispatched.append("run_work_graph_build")
         dispatched.append("dispatch_investment_materialize_partitioned")
 

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -36,6 +36,7 @@ _INVESTMENT_TASK = (
 _WORK_GRAPH_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
 _PROJECTION_TASK = "dev_health_ops.workers.tasks.run_membership_backfill"
 _DAILY_METRICS_TASK = "dev_health_ops.workers.tasks.run_daily_metrics"
+_COMPLEXITY_TASK = "dev_health_ops.workers.tasks.run_complexity_job"
 
 
 def _run_dispatch(provider: str, sync_targets: list[str], org_id: str):
@@ -80,15 +81,16 @@ def test_investment_chain_dispatched_with_git_and_work_items() -> None:
     )
 
     assert mock_chain.call_count == 1
-    # CHAOS-2600 CS5: the team-sync bridge step was removed from the chain;
-    # ClickHouse is written directly by sync_teams / auto-import, not a daily
-    # Postgres->ClickHouse bridge. Chain is daily_metrics -> build -> materialize.
-    daily_sig, build_sig, materialize_sig = mock_chain.call_args.args
+    complexity_sig, daily_sig, build_sig, materialize_sig = mock_chain.call_args.args
+    assert complexity_sig.task_name == _COMPLEXITY_TASK
     assert daily_sig.task_name == _DAILY_METRICS_TASK
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
 
     # All signatures are org-scoped onto the metrics queue.
+    assert complexity_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    assert complexity_sig.sig_kwargs["queue"] == "metrics"
+    assert complexity_sig.sig_kwargs.get("immutable") is True
     assert daily_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
     assert daily_sig.sig_kwargs["queue"] == "metrics"
     assert daily_sig.sig_kwargs.get("immutable") is True
@@ -120,7 +122,9 @@ def test_investment_chain_dispatched_with_git_only() -> None:
     )
 
     assert mock_chain.call_count == 1
-    build_sig, materialize_sig = mock_chain.call_args.args
+    complexity_sig, daily_sig, build_sig, materialize_sig = mock_chain.call_args.args
+    assert complexity_sig.task_name == _COMPLEXITY_TASK
+    assert daily_sig.task_name == _DAILY_METRICS_TASK
     assert build_sig.task_name == _WORK_GRAPH_TASK
     assert materialize_sig.task_name == _INVESTMENT_TASK
     chain_instance.apply_async.assert_called_once_with()


### PR DESCRIPTION
## Summary
- chain `run_complexity_job` before post-sync daily metrics for git sync paths
- keep work graph and investment materialization after daily metrics in the same chain
- add regression coverage for the complexity-before-daily ordering

## Verification
- `python -m pytest tests/test_post_sync_investment_dispatch.py -q`
- `ruff-fix`, `ruff-format`, and `mypy` via commit hook
- `ruff-format-check`, `ruff-check`, and `mypy` via pre-push hook
