### PR TITLE
feat(sync): cancel running sync jobs (CHAOS-2724)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -44,6 +44,12 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
+from dev_health_ops.sync.cancellation import (
+    SyncCancellationResult,
+    cancel_sync_run,
+    cancel_sync_run_for_backfill_job,
+    cancel_sync_run_for_job_run,
+)
 from dev_health_ops.sync.datasets import supported_datasets, supported_legacy_targets
 from dev_health_ops.sync.execution_trigger import (
     create_sync_execution_trigger,
@@ -283,6 +289,17 @@ def _planner_job_run_status(run_status: str) -> int:
     return JobRunStatus.RUNNING.value
 
 
+def _cancellation_response(result: SyncCancellationResult) -> dict[str, Any]:
+    return {
+        "status": result.status,
+        "sync_run_id": result.sync_run_id,
+        "cancelled_units": result.cancelled_units,
+        "cleared_outbox_rows": result.cleared_outbox_rows,
+        "cancelled_job_runs": result.cancelled_job_runs,
+        "cancelled_backfill_jobs": result.cancelled_backfill_jobs,
+    }
+
+
 async def _planner_sync_runs_for_job_runs(
     session: AsyncSession, runs: Sequence[object], org_id: str
 ) -> dict[str, SyncRun]:
@@ -328,6 +345,11 @@ def _job_run_response(
             "failed_units": int(getattr(planner_sync_run, "failed_units")),
         }
         status_value = _planner_job_run_status(str(getattr(planner_sync_run, "status")))
+        sync_cancelled = bool(
+            isinstance(sync_result, dict) and sync_result.get("cancelled")
+        )
+        if sync_cancelled:
+            status_value = JobRunStatus.CANCELLED.value
         started_at = getattr(planner_sync_run, "started_at")
         completed_at = getattr(planner_sync_run, "completed_at")
         duration_seconds = _elapsed_seconds(started_at, completed_at)
@@ -1810,6 +1832,51 @@ async def trigger_sync_config_backfill(
         raise HTTPException(status_code=503, detail=f"Task queue unavailable: {e}")
 
 
+@router.post("/sync-runs/{sync_run_id}/cancel", status_code=202)
+async def cancel_sync_run_endpoint(
+    sync_run_id: str,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> dict[str, Any]:
+    result = await session.run_sync(
+        lambda sync_session: cancel_sync_run(
+            sync_session,
+            sync_run_id,
+            org_id=org_id,
+            reason="cancelled by operator",
+        )
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Sync run not found")
+    await session.commit()
+    return _cancellation_response(result)
+
+
+@router.post("/sync-configs/{config_id}/jobs/{run_id}/cancel", status_code=202)
+async def cancel_sync_config_job_run(
+    config_id: str,
+    run_id: str,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> dict[str, Any]:
+    svc = SyncConfigurationService(session, org_id)
+    existing = await svc.get_by_id(config_id)
+    if existing is None:
+        raise HTTPException(status_code=404, detail="Sync configuration not found")
+    result = await session.run_sync(
+        lambda sync_session: cancel_sync_run_for_job_run(
+            sync_session,
+            run_id,
+            org_id=org_id,
+            reason="cancelled by operator",
+        )
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Sync job run not found")
+    await session.commit()
+    return _cancellation_response(result)
+
+
 @router.get("/sync-configs/{config_id}/jobs", response_model=list[JobRunResponse])
 async def list_sync_config_jobs(
     config_id: str,
@@ -1896,3 +1963,23 @@ async def get_backfill_job(
         raise HTTPException(status_code=404, detail="Backfill job not found")
     run_counts = await _backfill_job_run_counts(session, job)
     return _backfill_job_response(job, run_counts)
+
+
+@router.post("/backfill-jobs/{job_id}/cancel", status_code=202)
+async def cancel_backfill_job(
+    job_id: str,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> dict[str, Any]:
+    result = await session.run_sync(
+        lambda sync_session: cancel_sync_run_for_backfill_job(
+            sync_session,
+            job_id,
+            org_id=org_id,
+            reason="cancelled by operator",
+        )
+    )
+    if result is None:
+        raise HTTPException(status_code=404, detail="Backfill job not found")
+    await session.commit()
+    return _cancellation_response(result)

--- a/src/dev_health_ops/sync/cancellation.py
+++ b/src/dev_health_ops/sync/cancellation.py
@@ -1,0 +1,257 @@
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import delete, update
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import (
+    BackfillJob,
+    JobRun,
+    JobRunStatus,
+    ScheduledJob,
+    SyncDispatchOutbox,
+    SyncRun,
+    SyncRunStatus,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+)
+
+_TERMINAL_RUN_STATUSES = {
+    SyncRunStatus.SUCCESS.value,
+    SyncRunStatus.PARTIAL_FAILED.value,
+    SyncRunStatus.FAILED.value,
+}
+_TERMINAL_UNIT_STATUSES = {
+    SyncRunUnitStatus.SUCCESS.value,
+    SyncRunUnitStatus.FAILED.value,
+}
+
+
+@dataclass(frozen=True)
+class SyncCancellationResult:
+    sync_run_id: str
+    status: str
+    cancelled_units: int
+    cleared_outbox_rows: int
+    cancelled_job_runs: int
+    cancelled_backfill_jobs: int
+
+
+def cancel_sync_run(
+    session: Session,
+    sync_run_id: str | uuid.UUID,
+    *,
+    org_id: str | None = None,
+    reason: str = "cancelled by operator",
+) -> SyncCancellationResult | None:
+    run_uuid = uuid.UUID(str(sync_run_id))
+    query = session.query(SyncRun).filter(SyncRun.id == run_uuid)
+    if org_id is not None:
+        query = query.filter(SyncRun.org_id == org_id)
+    run = query.one_or_none()
+    if run is None:
+        return None
+
+    if run.status in _TERMINAL_RUN_STATUSES:
+        return SyncCancellationResult(
+            sync_run_id=str(run.id),
+            status="already_terminal",
+            cancelled_units=0,
+            cleared_outbox_rows=0,
+            cancelled_job_runs=0,
+            cancelled_backfill_jobs=0,
+        )
+
+    now = datetime.now(timezone.utc)
+    cancelled_units = _cancel_nonterminal_units(session, run_uuid, reason, now)
+    cleared_outbox_rows = _clear_pending_outbox(session, run_uuid)
+
+    run.status = SyncRunStatus.FAILED.value
+    run.completed_at = now
+    run.error = reason
+    run.failed_units = int(run.failed_units or 0) + cancelled_units
+    run.result = {
+        **(run.result if isinstance(run.result, dict) else {}),
+        "cancelled": True,
+        "cancelled_at": now.isoformat(),
+        "cancel_reason": reason,
+        "sync_run_status": SyncRunStatus.FAILED.value,
+        "total_units": int(run.total_units or 0),
+        "completed_units": int(run.completed_units or 0),
+        "failed_units": int(run.failed_units or 0),
+    }
+
+    cancelled_job_runs = _cancel_job_runs(session, run, reason, now)
+    cancelled_backfill_jobs = _cancel_backfill_jobs(session, run, reason, now)
+    session.flush()
+    return SyncCancellationResult(
+        sync_run_id=str(run.id),
+        status="cancelled",
+        cancelled_units=cancelled_units,
+        cleared_outbox_rows=cleared_outbox_rows,
+        cancelled_job_runs=cancelled_job_runs,
+        cancelled_backfill_jobs=cancelled_backfill_jobs,
+    )
+
+
+def cancel_sync_run_for_job_run(
+    session: Session,
+    job_run_id: str | uuid.UUID,
+    *,
+    org_id: str,
+    reason: str = "cancelled by operator",
+) -> SyncCancellationResult | None:
+    job_run = (
+        session.query(JobRun)
+        .join(ScheduledJob, ScheduledJob.id == JobRun.job_id)
+        .filter(
+            JobRun.id == uuid.UUID(str(job_run_id)),
+            ScheduledJob.org_id == org_id,
+            ScheduledJob.job_type == "sync",
+        )
+        .one_or_none()
+    )
+    if job_run is None:
+        return None
+    sync_run_id = _sync_run_id_from_result(job_run.result)
+    if sync_run_id is None:
+        return None
+    return cancel_sync_run(session, sync_run_id, org_id=org_id, reason=reason)
+
+
+def cancel_sync_run_for_backfill_job(
+    session: Session,
+    backfill_job_id: str | uuid.UUID,
+    *,
+    org_id: str,
+    reason: str = "cancelled by operator",
+) -> SyncCancellationResult | None:
+    job = (
+        session.query(BackfillJob)
+        .filter(
+            BackfillJob.id == uuid.UUID(str(backfill_job_id)),
+            BackfillJob.org_id == org_id,
+        )
+        .one_or_none()
+    )
+    if job is None:
+        return None
+    sync_run_id = _sync_run_id_from_backfill_marker(job.celery_task_id)
+    if sync_run_id is None:
+        return None
+    return cancel_sync_run(session, sync_run_id, org_id=org_id, reason=reason)
+
+
+def _cancel_nonterminal_units(
+    session: Session, run_uuid: uuid.UUID, reason: str, now: datetime
+) -> int:
+    result: Any = session.execute(
+        update(SyncRunUnit)
+        .where(
+            SyncRunUnit.sync_run_id == run_uuid,
+            SyncRunUnit.status.not_in(_TERMINAL_UNIT_STATUSES),
+        )
+        .values(
+            status=SyncRunUnitStatus.FAILED.value,
+            available_at=None,
+            error=reason,
+            result={"error_category": "cancelled", "cancelled": True},
+            lease_owner=None,
+            lease_expires_at=None,
+            last_heartbeat_at=now,
+            updated_at=now,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    return int(result.rowcount or 0)
+
+
+def _clear_pending_outbox(session: Session, run_uuid: uuid.UUID) -> int:
+    result: Any = session.execute(
+        delete(SyncDispatchOutbox).where(
+            SyncDispatchOutbox.sync_run_id == run_uuid,
+            SyncDispatchOutbox.status == "pending",
+        )
+    )
+    return int(result.rowcount or 0)
+
+
+def _cancel_job_runs(
+    session: Session, run: SyncRun, reason: str, completed_at: datetime
+) -> int:
+    job_runs = (
+        session.query(JobRun)
+        .filter(
+            JobRun.status.in_({JobRunStatus.PENDING.value, JobRunStatus.RUNNING.value})
+        )
+        .all()
+    )
+    cancelled = 0
+    for job_run in job_runs:
+        result = job_run.result if isinstance(job_run.result, dict) else {}
+        if str(result.get("sync_run_id") or "") != str(run.id):
+            continue
+        job_run.status = JobRunStatus.CANCELLED.value
+        job_run.completed_at = completed_at
+        job_run.error = reason
+        job_run.result = {
+            **result,
+            **(run.result if isinstance(run.result, dict) else {}),
+        }
+        if job_run.started_at is not None:
+            started_at = job_run.started_at
+            if started_at.tzinfo is None:
+                started_at = started_at.replace(tzinfo=completed_at.tzinfo)
+            job_run.duration_seconds = max(
+                0, int((completed_at - started_at).total_seconds())
+            )
+        cancelled += 1
+    return cancelled
+
+
+def _cancel_backfill_jobs(
+    session: Session, run: SyncRun, reason: str, completed_at: datetime
+) -> int:
+    marker = f"sync_run:{run.id}"
+    jobs = (
+        session.query(BackfillJob)
+        .filter(BackfillJob.org_id == str(run.org_id))
+        .filter(BackfillJob.celery_task_id.contains(marker))
+        .all()
+    )
+    for job in jobs:
+        job.status = "cancelled"
+        job.total_chunks = int(run.total_units or 0)
+        job.completed_chunks = int(run.completed_units or 0)
+        job.failed_chunks = int(run.failed_units or 0)
+        job.completed_at = completed_at
+        job.error_message = reason
+    return len(jobs)
+
+
+def _sync_run_id_from_result(result: Any) -> str | None:
+    if not isinstance(result, dict):
+        return None
+    value = result.get("sync_run_id")
+    if value is None:
+        return None
+    try:
+        return str(uuid.UUID(str(value)))
+    except ValueError:
+        return None
+
+
+def _sync_run_id_from_backfill_marker(task_id: str | None) -> str | None:
+    marker = "sync_run:"
+    raw = str(task_id or "")
+    if marker not in raw:
+        return None
+    candidate = raw.split(marker, 1)[1].split("|", 1)[0]
+    try:
+        return str(uuid.UUID(candidate))
+    except ValueError:
+        return None

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -1453,16 +1453,23 @@ def sync_observers_for_terminal_sync_run(session, run: SyncRun) -> None:
     completed_at = run.completed_at or datetime.now(timezone.utc)
     run.completed_at = completed_at
     success = run.status == SyncRunStatus.SUCCESS.value
+    run_result = run.result if isinstance(run.result, dict) else {}
+    cancelled = bool(run_result.get("cancelled"))
     job_run_status = (
-        JobRunStatus.SUCCESS.value if success else JobRunStatus.FAILED.value
+        JobRunStatus.SUCCESS.value
+        if success
+        else JobRunStatus.CANCELLED.value
+        if cancelled
+        else JobRunStatus.FAILED.value
     )
-    backfill_status = "completed" if success else "failed"
+    backfill_status = "completed" if success else "cancelled" if cancelled else "failed"
     error = None if success else (run.error or "Sync run completed with failed units")
     result_patch = {
         "sync_run_status": run.status,
         "total_units": int(run.total_units or 0),
         "completed_units": int(run.completed_units or 0),
         "failed_units": int(run.failed_units or 0),
+        **({"cancelled": True} if cancelled else {}),
     }
 
     marker = f"sync_run:{run.id}"

--- a/tests/test_sync_cancellation.py
+++ b/tests/test_sync_cancellation.py
@@ -1,0 +1,203 @@
+from __future__ import annotations
+
+import uuid
+from datetime import date, datetime, timedelta, timezone
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import (
+    BackfillJob,
+    Base,
+    Integration,
+    IntegrationDataset,
+    IntegrationSource,
+    JobRun,
+    JobRunStatus,
+    ScheduledJob,
+    SyncConfiguration,
+    SyncDispatchOutbox,
+    SyncRun,
+    SyncRunMode,
+    SyncRunStatus,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+    SyncWatermark,
+)
+from dev_health_ops.sync.cancellation import cancel_sync_run
+from dev_health_ops.sync.dispatch_outbox import OUTBOX_KIND_DISPATCH
+from dev_health_ops.workers.sync_units import sync_observers_for_terminal_sync_run
+
+
+def test_cancel_sync_run_clears_leases_outbox_and_activity_rows():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            run, unit, job_run, backfill_job = _seed_running_backfill(session)
+            session.add(
+                SyncDispatchOutbox(
+                    org_id=run.org_id,
+                    sync_run_id=run.id,
+                    kind=OUTBOX_KIND_DISPATCH,
+                    status="pending",
+                    available_at=datetime.now(timezone.utc),
+                )
+            )
+            session.add(
+                SyncWatermark(
+                    org_id=run.org_id,
+                    repo_id="linear-team",
+                    source_id="linear-team",
+                    target="work-items",
+                    dataset_key="work_items",
+                    last_synced_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+                )
+            )
+            session.flush()
+
+            result = cancel_sync_run(session, run.id, org_id=run.org_id)
+            session.commit()
+
+            assert result is not None
+            assert result.status == "cancelled"
+            assert result.cancelled_units == 1
+            assert result.cleared_outbox_rows == 1
+            session.refresh(run)
+            session.refresh(unit)
+            session.refresh(job_run)
+            session.refresh(backfill_job)
+            assert run.status == SyncRunStatus.FAILED.value
+            assert run.result is not None
+            assert run.result["cancelled"] is True
+            assert unit.status == SyncRunUnitStatus.FAILED.value
+            assert unit.lease_owner is None
+            assert unit.lease_expires_at is None
+            assert unit.result is not None
+            assert unit.result["error_category"] == "cancelled"
+            assert job_run.status == JobRunStatus.CANCELLED.value
+            assert backfill_job.status == "cancelled"
+            assert session.query(SyncDispatchOutbox).count() == 0
+            watermark = session.query(SyncWatermark).one()
+            assert watermark.last_synced_at == datetime(2024, 1, 1)
+    finally:
+        engine.dispose()
+
+
+def test_terminal_observer_preserves_cancelled_job_status():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            run, _unit, job_run, backfill_job = _seed_running_backfill(session)
+            run.status = SyncRunStatus.FAILED.value
+            run.completed_at = datetime.now(timezone.utc)
+            run.error = "cancelled by operator"
+            run.result = {"cancelled": True}
+
+            sync_observers_for_terminal_sync_run(session, run)
+            session.commit()
+
+            session.refresh(job_run)
+            session.refresh(backfill_job)
+            assert job_run.status == JobRunStatus.CANCELLED.value
+            assert backfill_job.status == "cancelled"
+    finally:
+        engine.dispose()
+
+
+def _seed_running_backfill(session: Session):
+    org_id = str(uuid.uuid4())
+    integration = Integration(
+        org_id=org_id,
+        provider="linear",
+        name="linear",
+        config={},
+        is_active=True,
+    )
+    session.add(integration)
+    session.flush()
+    source = IntegrationSource(
+        org_id=org_id,
+        integration_id=integration.id,
+        provider="linear",
+        source_type="team",
+        external_id="linear-team",
+        name="Linear Team",
+        full_name="Linear Team",
+        metadata_={},
+        is_enabled=True,
+    )
+    dataset = IntegrationDataset(
+        org_id=org_id,
+        integration_id=integration.id,
+        dataset_key="work_items",
+        is_enabled=True,
+        options={},
+    )
+    config = SyncConfiguration(
+        name="linear",
+        provider="linear",
+        org_id=org_id,
+        sync_targets=["work-items"],
+        integration_id=integration.id,
+    )
+    session.add_all([source, dataset, config])
+    session.flush()
+    scheduled_job = ScheduledJob(
+        name=f"sync-config-{config.id}",
+        job_type="sync",
+        schedule_cron="0 * * * *",
+        org_id=org_id,
+        provider="linear",
+        job_config={"sync_config_id": str(config.id)},
+        sync_config_id=config.id,
+    )
+    run = SyncRun(
+        org_id=org_id,
+        integration_id=integration.id,
+        triggered_by="backfill",
+        mode=SyncRunMode.BACKFILL.value,
+        status=SyncRunStatus.RUNNING.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
+        started_at=datetime.now(timezone.utc),
+    )
+    session.add_all([scheduled_job, run])
+    session.flush()
+    unit = SyncRunUnit(
+        org_id=org_id,
+        sync_run_id=run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="linear",
+        dataset_key="work_items",
+        cost_class="medium",
+        mode=SyncRunMode.BACKFILL.value,
+        since_at=None,
+        before_at=datetime.now(timezone.utc),
+        status=SyncRunUnitStatus.RUNNING.value,
+        attempts=1,
+        lease_owner="worker-1",
+        lease_expires_at=datetime.now(timezone.utc) + timedelta(minutes=5),
+        processor_flags={"sync_work_items": True},
+    )
+    job_run = JobRun(
+        job_id=scheduled_job.id,
+        triggered_by="backfill",
+        status=JobRunStatus.RUNNING.value,
+    )
+    job_run.started_at = datetime.now(timezone.utc)
+    job_run.result = {"sync_run_id": str(run.id)}
+    backfill_job = BackfillJob(
+        org_id=org_id,
+        sync_config_id=config.id,
+        celery_task_id=f"celery-task|sync_run:{run.id}",
+        status="running",
+        since_date=date(2024, 1, 1),
+        before_date=date(2024, 1, 31),
+    )
+    session.add_all([unit, job_run, backfill_job])
+    session.flush()
+    return run, unit, job_run, backfill_job


### PR DESCRIPTION
## Summary

Adds an operator-facing capability to **cancel a running sync job**, so a long/failing backfill can be aborted and scheduled syncs unblocked. This is a control-plane mitigation; the structural fix (not making the redundant/unscoped requests) is tracked in the EPIC CHAOS-2719.

Linear: CHAOS-2724

## What changed

- **New `sync/cancellation.py`** — terminalizes a non-terminal `SyncRun` (`failed` + `cancelled=true`), fails/clears nonterminal unit leases, deletes pending dispatch outbox rows, and marks linked `JobRun`/`BackfillJob` cancelled.
- **Admin cancel endpoints** (`api/admin/routers/sync.py`) for a direct sync run, job run, and backfill job, plus a cancelled job-status response.
- **Observer preservation** (`workers/sync_units.py`) — the existing terminal observer repair path no longer downgrades a cancelled job back to `failed`.

## Safety / correctness

- **No re-dispatch race.** The durable at-least-once reconciler relay hard-stops terminal runs across all four paths: `_dispatchable_run_ids` and `_finalizable_run_ids` exclude terminal statuses; claimed-outbox publish re-checks dispatchable/finalizable; expired-lease repair uses the nonterminal-run select. A cancelled run is terminal (`failed`), so none of these regenerate outbox rows or leases for it.
- **Watermarks protected.** A worker mid-flight loses its lease/nonterminal-run check before any sink write, and the success/watermark CAS remains guarded by the nonterminal-run predicate — a cancelled run cannot stamp a watermark.
- **Scheduled syncs unblocked.** Clearing leases frees guard capacity (capacity counts live RUNNING leases), so scheduled syncs proceed.

## Testing

- New regression coverage in `tests/test_sync_cancellation.py` asserting lease release, outbox clearing, activity/job cancellation, and unchanged watermark.
- `bash ci/local_validate.sh` green: ruff format/check, mypy, ClickHouse migrate/status, full unit suite (5982 passed / 44 skipped), live argMax proof.

SCREENSHOT-WAIVER: backend-only change (sync control-plane + admin API); no web UI render.
