### PR TITLE
fix(sync): scope backfill work-item units to their source (CHAOS-2725)

### DIFF
--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -119,9 +119,15 @@ def discover_repos(
     try:
         query = "SELECT id, repo, settings, provider FROM repos"
         params: dict[str, str] = {}
+        filters: list[str] = []
         if org_id:
-            query += " WHERE org_id = {org_id:String}"
+            filters.append("org_id = {org_id:String}")
             params["org_id"] = org_id
+        if repo_name:
+            filters.append("repo = {repo_name:String}")
+            params["repo_name"] = repo_name
+        if filters:
+            query += " WHERE " + " AND ".join(filters)
         rows = primary_sink.client.query(query, parameters=params).result_rows
         return [
             DiscoveredRepo(

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -526,7 +526,7 @@ def run_work_items_sync_job(
             )
             ctx = IngestionContext(
                 window=IngestionWindow(updated_since=since_dt, active_until=until_dt),
-                repo=None,
+                repo=repo_name,
                 org_id=uuid.UUID(org_id) if org_id else None,
             )
             fetched_items = 0

--- a/tests/test_backfill_integration.py
+++ b/tests/test_backfill_integration.py
@@ -66,6 +66,31 @@ def test_discover_repos_sets_source_from_provider():
     assert result_db[1].source == "github"
 
 
+def test_discover_repos_filters_by_repo_name_when_no_repo_id():
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    db_repo_id = uuid.uuid4()
+    mock_sink = SimpleNamespace(client=MagicMock())
+    mock_sink.client.query.return_value = SimpleNamespace(
+        result_rows=[(str(db_repo_id), "org/scoped-repo", {}, "github")]
+    )
+
+    repos = discover_repos(
+        backend="clickhouse",
+        primary_sink=mock_sink,
+        repo_name="org/scoped-repo",
+        org_id="org-1",
+        provider="github",
+    )
+
+    assert [repo.full_name for repo in repos] == ["org/scoped-repo"]
+    mock_sink.client.query.assert_called_once_with(
+        "SELECT id, repo, settings, provider FROM repos "
+        "WHERE org_id = {org_id:String} AND repo = {repo_name:String}",
+        parameters={"org_id": "org-1", "repo_name": "org/scoped-repo"},
+    )
+
+
 class TestSourceFilteringInWorkItemFetchers:
     """Verify that work-item fetcher functions correctly filter repos by source.
 

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -250,6 +250,20 @@ def test_work_item_derivative_dataset_uses_same_work_item_path() -> None:
     assert work_items.call_args.kwargs["jira_project_keys"] == ["ENG"]
 
 
+def test_linear_work_item_unit_threads_team_key_as_repo_scope() -> None:
+    ctx = _context(
+        provider="linear", dataset_key="work-items", source_external_id="ENG"
+    )
+
+    with patch(
+        "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"
+    ) as work_items:
+        run_dataset_unit(ctx, _runtime())
+
+    work_items.assert_called_once()
+    assert work_items.call_args.kwargs["repo_name"] == "ENG"
+
+
 def test_gitlab_feature_flags_route_to_existing_feature_flag_sync() -> None:
     ctx = _context(
         provider="gitlab",


### PR DESCRIPTION
## Summary

Fixes backfills attempting to sync **all items** from a sync config (projects + work items) instead of only the scoped subset. The admin/API backfill path already routes through the planner's `source × dataset × window` scoping, but the provider layer ignored the per-unit source — so a scoped backfill still fanned out.

Linear: CHAOS-2725

## Root cause

Scoped work-item units **did** carry `repo_name`, but the provider interpretation dropped it:

- **Linear** treated work-item units as `IngestionContext(repo=None)` → all teams.
- **GitHub / GitLab** repo discovery fanned out org-wide when no `repo_id` was present, ignoring `repo_name`.

(Jira already scoped correctly via `jira_project_keys`.)

## What changed

- `metrics/job_daily.py` — repo discovery now applies `repo_name` as an exact ClickHouse `repos.repo` filter when no `repo_id` is available, stopping the org-wide `_discover_repos` fan-out for scoped units.
- `metrics/job_work_items.py` — threads `repo_name` into the Linear `IngestionContext.repo`, so Linear syncs only that team instead of all teams.

Jira and GitLab provider behavior is unchanged.

## Scope boundary

This is the surgical source-scoping fix for the admin/API planner path. The structural reference/discovery-tier rework (fetch teams/orgs/projects/cycles once per run) remains owned by EPIC CHAOS-2719 (scope A). The legacy CLI runner path that bypasses planner scoping is tracked separately in CHAOS-2726.

## Testing

- New regression tests: `tests/test_backfill_integration.py` (repo_name discovery filter), `tests/test_dataset_adapters.py` (Linear source scope adapter).
- `bash ci/local_validate.sh` green: ruff, mypy, full unit suite (5982 passed / 44 skipped), live argMax proof. Provider matrix `{jira,gitlab,github,linear} × {teams,projects,members,issues}` stays green.

SCREENSHOT-WAIVER: backend-only change (metrics/ ingest scoping); no web UI render.
