### PR TITLE
feat(sync): budget estimator window/volume scaling (CHAOS-2722)

### DIFF
--- a/src/dev_health_ops/providers/github/budget.py
+++ b/src/dev_health_ops/providers/github/budget.py
@@ -9,6 +9,7 @@ from dev_health_ops.sync.budget_types import (
     BudgetBucketKey,
     BudgetDimension,
     BudgetEstimate,
+    window_span_days,
 )
 from dev_health_ops.sync.datasets import DatasetKey
 from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
@@ -43,6 +44,7 @@ class GitHubBudgetEstimator:
                 org_id=context.org_id,
                 host=host,
                 credential_fingerprint=credential_fingerprint,
+                span_days=window_span_days(context),
             )
         )
         return tuple(estimates)
@@ -55,6 +57,7 @@ def _dataset_estimates(
     org_id: str,
     host: str,
     credential_fingerprint: str,
+    span_days: int,
 ) -> tuple[BudgetEstimate, ...]:
     bucket = _bucket_factory(
         org_id=org_id,
@@ -69,17 +72,25 @@ def _dataset_estimates(
 
     if dataset_key == DatasetKey.COMMITS.value:
         return (
-            _estimate(bucket(BudgetDimension.REST_CORE), 2, _CONFIDENCE_MEDIUM, "git"),
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                _scaled_units(2, span_days),
+                _CONFIDENCE_MEDIUM,
+                "git",
+            ),
         )
 
     if dataset_key == DatasetKey.COMMIT_STATS.value:
         return (
             _estimate(
-                bucket(BudgetDimension.REST_CORE), 4, _CONFIDENCE_LOW, "commit_stats"
+                bucket(BudgetDimension.REST_CORE),
+                _scaled_units(4, span_days),
+                _CONFIDENCE_LOW,
+                "commit_stats",
             ),
             _estimate(
                 bucket(BudgetDimension.CONTENTS_BLOB),
-                2,
+                _scaled_units(2, span_days),
                 _CONFIDENCE_LOW,
                 "commit_stats",
                 notes=("commit-file expansion varies by commit volume",),
@@ -88,10 +99,15 @@ def _dataset_estimates(
 
     if dataset_key == DatasetKey.FILES.value:
         return (
-            _estimate(bucket(BudgetDimension.REST_CORE), 3, _CONFIDENCE_LOW, "files"),
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                _scaled_units(3, span_days),
+                _CONFIDENCE_LOW,
+                "files",
+            ),
             _estimate(
                 bucket(BudgetDimension.CONTENTS_BLOB),
-                5,
+                _scaled_units(5, span_days),
                 _CONFIDENCE_LOW,
                 "files",
                 notes=("repository tree/blob expansion is high variance",),
@@ -103,7 +119,7 @@ def _dataset_estimates(
             _estimate(bucket(BudgetDimension.REST_CORE), 3, _CONFIDENCE_LOW, "blame"),
             _estimate(
                 bucket(BudgetDimension.CONTENTS_BLOB),
-                8,
+                _scaled_units(8, span_days),
                 _CONFIDENCE_LOW,
                 "blame",
                 notes=("blame expansion is file-count dependent",),
@@ -116,10 +132,15 @@ def _dataset_estimates(
         DatasetKey.PR_COMMENTS.value,
     }:
         return (
-            _estimate(bucket(BudgetDimension.REST_CORE), 2, _CONFIDENCE_MEDIUM, "prs"),
+            _estimate(
+                bucket(BudgetDimension.REST_CORE),
+                _scaled_units(2, span_days),
+                _CONFIDENCE_MEDIUM,
+                "prs",
+            ),
             _estimate(
                 bucket(BudgetDimension.GRAPHQL_COST),
-                4,
+                _scaled_units(4, span_days),
                 _CONFIDENCE_MEDIUM,
                 "pr_social",
             ),
@@ -139,11 +160,14 @@ def _dataset_estimates(
     }:
         return (
             _estimate(
-                bucket(BudgetDimension.REST_CORE), 4, _CONFIDENCE_LOW, dataset_key
+                bucket(BudgetDimension.REST_CORE),
+                _scaled_units(4, span_days),
+                _CONFIDENCE_LOW,
+                dataset_key,
             ),
             _estimate(
                 bucket(BudgetDimension.CONTENTS_BLOB),
-                2,
+                _scaled_units(2, span_days),
                 _CONFIDENCE_LOW,
                 dataset_key,
                 notes=("workflow artifact expansion varies by repository activity",),
@@ -153,7 +177,10 @@ def _dataset_estimates(
     if dataset_key == DatasetKey.SECURITY.value:
         return (
             _estimate(
-                bucket(BudgetDimension.REST_CORE), 2, _CONFIDENCE_LOW, "security"
+                bucket(BudgetDimension.REST_CORE),
+                _scaled_units(2, span_days),
+                _CONFIDENCE_LOW,
+                "security",
             ),
         )
 
@@ -167,7 +194,10 @@ def _dataset_estimates(
         estimates = [
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                2 if dataset_key == DatasetKey.WORK_ITEMS.value else 1,
+                _scaled_units(
+                    2 if dataset_key == DatasetKey.WORK_ITEMS.value else 1,
+                    span_days,
+                ),
                 _CONFIDENCE_MEDIUM,
                 "work_items",
             )
@@ -176,7 +206,7 @@ def _dataset_estimates(
             estimates.append(
                 _estimate(
                     bucket(BudgetDimension.GRAPHQL_COST),
-                    3,
+                    _scaled_units(3, span_days),
                     _CONFIDENCE_MEDIUM,
                     "work_item_prs",
                 )
@@ -225,6 +255,10 @@ def _estimate(
         route_family=route_family,
         notes=notes,
     )
+
+
+def _scaled_units(fixed_floor: int, span_days: int) -> int:
+    return max(fixed_floor, fixed_floor * max(1, span_days))
 
 
 def _host_from_credentials(credentials: object) -> str:

--- a/src/dev_health_ops/providers/gitlab/budget.py
+++ b/src/dev_health_ops/providers/gitlab/budget.py
@@ -9,6 +9,7 @@ from dev_health_ops.sync.budget_types import (
     BudgetBucketKey,
     BudgetDimension,
     BudgetEstimate,
+    window_span_days,
 )
 from dev_health_ops.sync.datasets import DatasetKey
 from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
@@ -43,6 +44,7 @@ class GitLabBudgetEstimator:
                 org_id=context.org_id,
                 host=host,
                 credential_fingerprint=credential_fingerprint,
+                span_days=window_span_days(context),
             )
         )
         return tuple(estimates)
@@ -55,6 +57,7 @@ def _dataset_estimates(
     org_id: str,
     host: str,
     credential_fingerprint: str,
+    span_days: int,
 ) -> tuple[BudgetEstimate, ...]:
     bucket = _bucket_factory(
         org_id=org_id,
@@ -72,7 +75,10 @@ def _dataset_estimates(
     if dataset_key == DatasetKey.COMMITS.value:
         return (
             _estimate(
-                bucket(BudgetDimension.REST_CORE), 2, _CONFIDENCE_MEDIUM, "project"
+                bucket(BudgetDimension.REST_CORE),
+                _scaled_units(2, span_days),
+                _CONFIDENCE_MEDIUM,
+                "project",
             ),
         )
 
@@ -80,7 +86,7 @@ def _dataset_estimates(
         return (
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                4,
+                _scaled_units(4, span_days),
                 _CONFIDENCE_LOW,
                 "project",
                 notes=("commit detail expansion varies by commit volume",),
@@ -91,7 +97,10 @@ def _dataset_estimates(
         return (
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                5 if dataset_key == DatasetKey.BLAME.value else 3,
+                _scaled_units(
+                    5 if dataset_key == DatasetKey.BLAME.value else 3,
+                    span_days,
+                ),
                 _CONFIDENCE_LOW,
                 "project",
                 notes=("repository file expansion is high variance",),
@@ -102,7 +111,7 @@ def _dataset_estimates(
         return (
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                4,
+                _scaled_units(4, span_days),
                 _CONFIDENCE_MEDIUM,
                 "merge_requests",
                 notes=("merge request iterators are pagination-heavy",),
@@ -113,14 +122,14 @@ def _dataset_estimates(
         return (
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                4,
+                _scaled_units(4, span_days),
                 _CONFIDENCE_MEDIUM,
                 "merge_requests",
                 notes=("merge request iterators are pagination-heavy",),
             ),
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                3,
+                _scaled_units(3, span_days),
                 _CONFIDENCE_LOW,
                 "notes",
                 notes=("MR note expansion varies by discussion volume",),
@@ -135,7 +144,7 @@ def _dataset_estimates(
         return (
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                6,
+                _scaled_units(6, span_days),
                 _CONFIDENCE_LOW,
                 "pipelines",
                 notes=("pipeline job expansion varies by pipeline volume",),
@@ -183,7 +192,7 @@ def _dataset_estimates(
             ),
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                4,
+                _scaled_units(4, span_days),
                 _CONFIDENCE_LOW,
                 "epics",
                 notes=("group epic expansion requires premium APIs when available",),
@@ -204,7 +213,7 @@ def _dataset_estimates(
             estimates.append(
                 _estimate(
                     bucket(BudgetDimension.REST_CORE),
-                    3,
+                    _scaled_units(3, span_days),
                     _CONFIDENCE_LOW,
                     "notes",
                     notes=("issue/MR notes and state events vary by activity",),
@@ -214,7 +223,7 @@ def _dataset_estimates(
             estimates.append(
                 _estimate(
                     bucket(BudgetDimension.REST_CORE),
-                    4,
+                    _scaled_units(4, span_days),
                     _CONFIDENCE_MEDIUM,
                     "merge_requests",
                     notes=("MR iterator runs alongside issue ingestion by default",),
@@ -226,7 +235,7 @@ def _dataset_estimates(
         return (
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                2,
+                _scaled_units(2, span_days),
                 _CONFIDENCE_LOW,
                 "project",
                 notes=("GitLab feature-flag APIs share the REST core budget",),
@@ -266,6 +275,10 @@ def _estimate(
         route_family=route_family,
         notes=notes,
     )
+
+
+def _scaled_units(fixed_floor: int, span_days: int) -> int:
+    return max(fixed_floor, fixed_floor * max(1, span_days))
 
 
 def _host_from_credentials(credentials: object) -> str:

--- a/src/dev_health_ops/providers/gitlab/budget.py
+++ b/src/dev_health_ops/providers/gitlab/budget.py
@@ -199,7 +199,7 @@ def _dataset_estimates(
             ),
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                4,
+                _scaled_units(4, span_days),
                 _CONFIDENCE_MEDIUM,
                 "issues",
                 notes=("issue iterator and per-issue events are pagination-heavy",),

--- a/src/dev_health_ops/providers/gitlab/client.py
+++ b/src/dev_health_ops/providers/gitlab/client.py
@@ -18,6 +18,24 @@ from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
 
+_DIAGNOSTIC_HEADER_NAMES = (
+    "ratelimit-limit",
+    "ratelimit-remaining",
+    "ratelimit-reset",
+    "retry-after",
+    "x-request-id",
+    "x-runtime",
+)
+_MAX_USAGE_OBSERVATION_KEYS = 50
+
+
+def _diagnostic_headers(headers: object) -> dict[str, str]:
+    get_items = getattr(headers, "items", None)
+    if get_items is None:
+        return {}
+    lowered = {str(k).lower(): str(v) for k, v in get_items()}
+    return {name: lowered[name] for name in _DIAGNOSTIC_HEADER_NAMES if name in lowered}
+
 
 def _maybe_raise_gitlab_rate_limit(exc: BaseException) -> None:
     """Raise RateLimitException if exc is a GitLab rate-limit error (HTTP 429,
@@ -116,6 +134,8 @@ class GitLabWorkClient:
             host=host,
             config=RateLimitConfig(initial_backoff_seconds=1.0),
         )
+        self._usage_observations: dict[tuple[str, str], dict[str, Any]] = {}
+        self._usage_observation_overflow = 0
 
         self.gl = gitlab.Gitlab(
             auth.base_url,
@@ -143,10 +163,101 @@ class GitLabWorkClient:
     def get_project(self, project_id_or_path: str) -> Any:
         try:
             with gate_call(self.gate):
-                return self.gl.projects.get(project_id_or_path)
+                project = self.gl.projects.get(project_id_or_path)
+            self._record_last_response_usage("GET /projects/:id")
+            return project
         except Exception as exc:
+            self._record_exception_usage("GET /projects/:id", exc)
             _maybe_raise_gitlab_rate_limit(exc)
             raise
+
+    def _record_usage_observation(
+        self,
+        *,
+        transport: str,
+        operation: str,
+        headers: dict[str, str],
+        rate_limit: dict[str, Any],
+        status: int | None = None,
+    ) -> None:
+        if not headers and not rate_limit and status is None:
+            return
+        key = (transport, operation)
+        observation = self._usage_observations.get(key)
+        if observation is None:
+            if len(self._usage_observations) >= _MAX_USAGE_OBSERVATION_KEYS:
+                self._usage_observation_overflow += 1
+                return
+            observation = {
+                "transport": transport,
+                "operation": operation,
+                "request_count": 0,
+            }
+            self._usage_observations[key] = observation
+        observation["request_count"] = int(observation["request_count"]) + 1
+        if status is not None:
+            observation["latest_status"] = status
+        if headers:
+            observation["latest_headers"] = dict(headers)
+        if rate_limit:
+            observation["rate_limit"] = dict(rate_limit)
+
+    def _record_rest_usage(
+        self,
+        operation: str,
+        *,
+        headers: object | None = None,
+        status: int | None = None,
+    ) -> None:
+        safe_headers = _diagnostic_headers(headers or {})
+        rate_limit: dict[str, Any] = {}
+        for source, target in {
+            "ratelimit-remaining": "remaining",
+            "ratelimit-reset": "reset",
+            "ratelimit-limit": "limit",
+            "retry-after": "retry_after",
+        }.items():
+            value = safe_headers.get(source)
+            if value is not None:
+                rate_limit[target] = value
+        self._record_usage_observation(
+            transport="rest",
+            operation=operation,
+            headers=safe_headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
+
+    def _record_last_response_usage(self, operation: str) -> None:
+        headers = getattr(self.gl, "last_response_headers", None)
+        status = getattr(self.gl, "last_response_code", None)
+        self._record_rest_usage(
+            operation,
+            headers=headers,
+            status=status if isinstance(status, int) else None,
+        )
+
+    def _record_exception_usage(self, operation: str, exc: BaseException) -> None:
+        status = getattr(exc, "response_code", None)
+        self._record_rest_usage(
+            operation,
+            headers=getattr(exc, "response_headers", None),
+            status=status if isinstance(status, int) else None,
+        )
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        observations = [dict(value) for value in self._usage_observations.values()]
+        if self._usage_observation_overflow:
+            observations.append(
+                {
+                    "transport": "summary",
+                    "operation": "overflow",
+                    "dropped_operation_count": self._usage_observation_overflow,
+                }
+            )
+        self._usage_observations.clear()
+        self._usage_observation_overflow = 0
+        return observations
 
     def _gated_iter(self, iterable: Any) -> Iterator[Any]:
         """Consume a python-gitlab lazy iterator with each page fetch routed
@@ -163,9 +274,11 @@ class GitLabWorkClient:
                         item = next(iterator)
                     except StopIteration:
                         return
+                self._record_last_response_usage("GET iterator page")
             except StopIteration:
                 return
             except Exception as exc:
+                self._record_exception_usage("GET iterator page", exc)
                 _maybe_raise_gitlab_rate_limit(exc)
                 raise
             yield item

--- a/src/dev_health_ops/providers/jira/budget.py
+++ b/src/dev_health_ops/providers/jira/budget.py
@@ -10,6 +10,7 @@ from dev_health_ops.sync.budget_types import (
     BudgetBucketKey,
     BudgetDimension,
     BudgetEstimate,
+    window_span_days,
 )
 from dev_health_ops.sync.datasets import DatasetKey
 from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
@@ -41,6 +42,7 @@ class JiraBudgetEstimator:
             org_id=context.org_id,
             host=host,
             credential_fingerprint=credential_fingerprint,
+            span_days=window_span_days(context),
         )
 
 
@@ -51,6 +53,7 @@ def _dataset_estimates(
     org_id: str,
     host: str,
     credential_fingerprint: str,
+    span_days: int,
 ) -> tuple[BudgetEstimate, ...]:
     bucket = _bucket_factory(
         org_id=org_id,
@@ -81,14 +84,14 @@ def _dataset_estimates(
     estimates: list[BudgetEstimate] = [
         _estimate(
             bucket(BudgetDimension.SEARCH),
-            2,
+            _scaled_units(2, span_days),
             _CONFIDENCE_MEDIUM,
             "jira_jql",
             notes=("Jira work-item listing uses REST /search/jql pagination",),
         ),
         _estimate(
             bucket(BudgetDimension.REST_CORE),
-            2,
+            _scaled_units(2, span_days),
             _CONFIDENCE_MEDIUM,
             "jira_issue_enrichment",
             notes=(
@@ -101,7 +104,7 @@ def _dataset_estimates(
         estimates.append(
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                2,
+                _scaled_units(2, span_days),
                 _CONFIDENCE_LOW,
                 "jira_comments",
                 notes=("comment pagination is issue-activity dependent",),
@@ -112,7 +115,7 @@ def _dataset_estimates(
         estimates.append(
             _estimate(
                 bucket(BudgetDimension.REST_CORE),
-                3,
+                _scaled_units(3, span_days),
                 _CONFIDENCE_LOW,
                 "jira_worklogs",
                 notes=("JIRA_FETCH_WORKLOGS adds per-issue worklog expansion",),
@@ -123,7 +126,7 @@ def _dataset_estimates(
         estimates.append(
             _estimate(
                 bucket(BudgetDimension.GRAPHQL_COST),
-                3,
+                _scaled_units(3, span_days),
                 _CONFIDENCE_MEDIUM,
                 "jira_gql_enrichment",
                 notes=("ATLASSIAN_GQL_ENABLED routes Jira enrichment through AGG",),
@@ -163,6 +166,10 @@ def _estimate(
         route_family=route_family,
         notes=notes,
     )
+
+
+def _scaled_units(fixed_floor: int, span_days: int) -> int:
+    return max(fixed_floor, fixed_floor * max(1, span_days))
 
 
 def _flag_enabled(flags: Mapping[str, bool], *names: str) -> bool:

--- a/src/dev_health_ops/providers/jira/client.py
+++ b/src/dev_health_ops/providers/jira/client.py
@@ -20,6 +20,19 @@ from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 
 logger = logging.getLogger(__name__)
 
+_DIAGNOSTIC_HEADER_NAMES = (
+    "x-ratelimit-limit",
+    "x-ratelimit-remaining",
+    "x-ratelimit-reset",
+    "ratelimit-limit",
+    "ratelimit-remaining",
+    "ratelimit-reset",
+    "retry-after",
+    "x-request-id",
+    "atl-traceid",
+)
+_MAX_USAGE_OBSERVATION_KEYS = 50
+
 
 def _require_jira() -> Any:
     try:
@@ -51,6 +64,14 @@ def _normalize_jira_base_url(value: str) -> str:
     if url.startswith("https://"):
         return url
     return "https://" + url.lstrip("/")
+
+
+def _diagnostic_headers(headers: object) -> dict[str, str]:
+    get_items = getattr(headers, "items", None)
+    if get_items is None:
+        return {}
+    lowered = {str(k).lower(): str(v) for k, v in get_items()}
+    return {name: lowered[name] for name in _DIAGNOSTIC_HEADER_NAMES if name in lowered}
 
 
 @dataclass(frozen=True)
@@ -95,6 +116,8 @@ class JiraClient:
             config=RateLimitConfig(initial_backoff_seconds=1.0),
         )
         self.max_retries_429 = max(0, int(max_retries_429))
+        self._usage_observations: dict[tuple[str, str], dict[str, Any]] = {}
+        self._usage_observation_overflow = 0
 
         self.session = requests.Session()
         self.session.auth = (auth.email, auth.api_token)
@@ -143,6 +166,9 @@ class JiraClient:
                 resp = self.session.get(
                     url, params=params, timeout=self.timeout_seconds
                 )
+                self._record_rest_usage(
+                    f"GET {path}", headers=resp.headers, status=resp.status_code
+                )
                 if resp.status_code == 429:
                     retry_after = parse_retry_after_header(resp.headers)
                     applied = penalize_from_response(self.gate, resp)
@@ -176,6 +202,80 @@ class JiraClient:
                 )
                 raise
         raise RuntimeError("Jira request retry loop exited without a result")
+
+    def _record_usage_observation(
+        self,
+        *,
+        transport: str,
+        operation: str,
+        headers: dict[str, str],
+        rate_limit: dict[str, Any],
+        status: int | None = None,
+    ) -> None:
+        if not headers and not rate_limit and status is None:
+            return
+        key = (transport, operation)
+        observation = self._usage_observations.get(key)
+        if observation is None:
+            if len(self._usage_observations) >= _MAX_USAGE_OBSERVATION_KEYS:
+                self._usage_observation_overflow += 1
+                return
+            observation = {
+                "transport": transport,
+                "operation": operation,
+                "request_count": 0,
+            }
+            self._usage_observations[key] = observation
+        observation["request_count"] = int(observation["request_count"]) + 1
+        if status is not None:
+            observation["latest_status"] = status
+        if headers:
+            observation["latest_headers"] = dict(headers)
+        if rate_limit:
+            observation["rate_limit"] = dict(rate_limit)
+
+    def _record_rest_usage(
+        self,
+        operation: str,
+        *,
+        headers: object | None = None,
+        status: int | None = None,
+    ) -> None:
+        safe_headers = _diagnostic_headers(headers or {})
+        rate_limit: dict[str, Any] = {}
+        for source, target in {
+            "x-ratelimit-remaining": "remaining",
+            "ratelimit-remaining": "remaining",
+            "x-ratelimit-reset": "reset",
+            "ratelimit-reset": "reset",
+            "x-ratelimit-limit": "limit",
+            "ratelimit-limit": "limit",
+            "retry-after": "retry_after",
+        }.items():
+            value = safe_headers.get(source)
+            if value is not None:
+                rate_limit[target] = value
+        self._record_usage_observation(
+            transport="rest",
+            operation=operation,
+            headers=safe_headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        observations = [dict(value) for value in self._usage_observations.values()]
+        if self._usage_observation_overflow:
+            observations.append(
+                {
+                    "transport": "summary",
+                    "operation": "overflow",
+                    "dropped_operation_count": self._usage_observation_overflow,
+                }
+            )
+        self._usage_observations.clear()
+        self._usage_observation_overflow = 0
+        return observations
 
     def search_issues_page(
         self,

--- a/src/dev_health_ops/providers/jira/client.py
+++ b/src/dev_health_ops/providers/jira/client.py
@@ -243,18 +243,18 @@ class JiraClient:
     ) -> None:
         safe_headers = _diagnostic_headers(headers or {})
         rate_limit: dict[str, Any] = {}
-        for source, target in {
-            "x-ratelimit-remaining": "remaining",
-            "ratelimit-remaining": "remaining",
-            "x-ratelimit-reset": "reset",
-            "ratelimit-reset": "reset",
-            "x-ratelimit-limit": "limit",
-            "ratelimit-limit": "limit",
-            "retry-after": "retry_after",
-        }.items():
+        for source, target in [
+            ("x-ratelimit-remaining", "remaining"),
+            ("x-ratelimit-reset", "reset"),
+            ("x-ratelimit-limit", "limit"),
+            ("ratelimit-remaining", "remaining"),
+            ("ratelimit-reset", "reset"),
+            ("ratelimit-limit", "limit"),
+            ("retry-after", "retry_after"),
+        ]:
             value = safe_headers.get(source)
             if value is not None:
-                rate_limit[target] = value
+                rate_limit.setdefault(target, value)
         self._record_usage_observation(
             transport="rest",
             operation=operation,

--- a/src/dev_health_ops/providers/linear/budget.py
+++ b/src/dev_health_ops/providers/linear/budget.py
@@ -9,6 +9,7 @@ from dev_health_ops.sync.budget_types import (
     BudgetBucketKey,
     BudgetDimension,
     BudgetEstimate,
+    window_span_days,
 )
 from dev_health_ops.sync.datasets import DatasetKey
 from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
@@ -36,6 +37,7 @@ class LinearBudgetEstimator:
                 org_id=context.org_id,
                 host=host,
                 credential_fingerprint=credential_fingerprint,
+                span_days=window_span_days(context),
             )
         )
 
@@ -46,6 +48,7 @@ def _dataset_estimates(
     org_id: str,
     host: str,
     credential_fingerprint: str,
+    span_days: int,
 ) -> tuple[BudgetEstimate, ...]:
     bucket = _bucket_factory(
         org_id=org_id,
@@ -60,7 +63,7 @@ def _dataset_estimates(
             ),
             _estimate(
                 bucket(BudgetDimension.GRAPHQL_COST),
-                5,
+                _scaled_units(5, span_days, per_day_weight=2),
                 _CONFIDENCE_LOW,
                 "issues",
                 notes=(
@@ -71,13 +74,22 @@ def _dataset_estimates(
                 bucket(BudgetDimension.GRAPHQL_COST), 2, _CONFIDENCE_LOW, "cycles"
             ),
             _estimate(
-                bucket(BudgetDimension.GRAPHQL_COST), 2, _CONFIDENCE_LOW, "comments"
+                bucket(BudgetDimension.GRAPHQL_COST),
+                _scaled_units(2, span_days),
+                _CONFIDENCE_LOW,
+                "comments",
             ),
             _estimate(
-                bucket(BudgetDimension.GRAPHQL_COST), 1, _CONFIDENCE_LOW, "attachments"
+                bucket(BudgetDimension.GRAPHQL_COST),
+                _scaled_units(1, span_days),
+                _CONFIDENCE_LOW,
+                "attachments",
             ),
             _estimate(
-                bucket(BudgetDimension.GRAPHQL_COST), 2, _CONFIDENCE_LOW, "history"
+                bucket(BudgetDimension.GRAPHQL_COST),
+                _scaled_units(2, span_days),
+                _CONFIDENCE_LOW,
+                "history",
             ),
         )
 
@@ -107,14 +119,20 @@ def _dataset_estimates(
     if dataset_key == DatasetKey.WORK_ITEM_HISTORY.value:
         return (
             _estimate(
-                bucket(BudgetDimension.GRAPHQL_COST), 3, _CONFIDENCE_LOW, "history"
+                bucket(BudgetDimension.GRAPHQL_COST),
+                _scaled_units(3, span_days),
+                _CONFIDENCE_LOW,
+                "history",
             ),
         )
 
     if dataset_key == DatasetKey.WORK_ITEM_COMMENTS.value:
         return (
             _estimate(
-                bucket(BudgetDimension.GRAPHQL_COST), 3, _CONFIDENCE_LOW, "comments"
+                bucket(BudgetDimension.GRAPHQL_COST),
+                _scaled_units(3, span_days),
+                _CONFIDENCE_LOW,
+                "comments",
             ),
         )
 
@@ -151,6 +169,12 @@ def _estimate(
         route_family=route_family,
         notes=notes,
     )
+
+
+def _scaled_units(fixed_floor: int, span_days: int, *, per_day_weight: int = 1) -> int:
+    if span_days <= 1:
+        return fixed_floor
+    return max(fixed_floor, fixed_floor * span_days * max(1, per_day_weight))
 
 
 def _host_from_credentials(credentials: object) -> str:

--- a/src/dev_health_ops/sync/budget_types.py
+++ b/src/dev_health_ops/sync/budget_types.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime
 from enum import Enum
 from typing import TYPE_CHECKING, Any, Protocol
 
@@ -55,3 +56,11 @@ class BudgetEstimate:
 class BudgetEstimator(Protocol):
     def estimate(self, context: SyncTaskContext) -> tuple[BudgetEstimate, ...]:
         return ()
+
+
+def window_span_days(context: SyncTaskContext) -> int:
+    start = context.window_start
+    end = context.window_end
+    if not isinstance(start, datetime) or not isinstance(end, datetime):
+        return 1
+    return max(1, (end - start).days)

--- a/src/dev_health_ops/sync/budget_types.py
+++ b/src/dev_health_ops/sync/budget_types.py
@@ -63,4 +63,8 @@ def window_span_days(context: SyncTaskContext) -> int:
     end = context.window_end
     if not isinstance(start, datetime) or not isinstance(end, datetime):
         return 1
-    return max(1, (end - start).days)
+    try:
+        days = (end - start).days
+    except TypeError:
+        return 1
+    return max(1, days)

--- a/tests/providers/test_jira_budget.py
+++ b/tests/providers/test_jira_budget.py
@@ -179,7 +179,7 @@ def test_jira_budget_estimator_returns_jql_and_enrichment_budgets() -> None:
     assert estimates[0].bucket.provider == "jira"
     assert estimates[0].bucket.org_id == "org-1"
     assert estimates[0].bucket.host == "chaos.atlassian.net"
-    assert estimates[0].estimated_units == 2
+    assert estimates[0].estimated_units == 4
     assert estimates[0].confidence == "medium"
     assert estimates[0].to_dict()["bucket"]["dimension"] == "search"
 
@@ -305,7 +305,7 @@ def test_jira_budget_guard_defers_second_unit_by_jql_reservation(
     db_session.add(second)
     db_session.flush()
     monkeypatch.setenv(
-        "SYNC_BUDGET_BUCKET_LIMITS", json.dumps({"jira:search:jira_jql": 2})
+        "SYNC_BUDGET_BUCKET_LIMITS", json.dumps({"jira:search:jira_jql": 4})
     )
     monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
     monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
@@ -352,7 +352,7 @@ def test_jira_budget_guard_active_reservation_blocks_planned_unit(
     db_session.flush()
     active.updated_at = datetime.now(timezone.utc)
     monkeypatch.setenv(
-        "SYNC_BUDGET_BUCKET_LIMITS", json.dumps({"jira:search:jira_jql": 2})
+        "SYNC_BUDGET_BUCKET_LIMITS", json.dumps({"jira:search:jira_jql": 4})
     )
     monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
     monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")

--- a/tests/test_budget_estimators.py
+++ b/tests/test_budget_estimators.py
@@ -1,0 +1,306 @@
+from __future__ import annotations
+
+import json
+import uuid
+from collections.abc import Mapping
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import (
+    Base,
+    Integration,
+    IntegrationSource,
+    SyncRun,
+    SyncRunMode,
+    SyncRunStatus,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+)
+from dev_health_ops.providers.github.budget import GitHubBudgetEstimator
+from dev_health_ops.providers.gitlab.budget import GitLabBudgetEstimator
+from dev_health_ops.providers.gitlab.client import GitLabWorkClient
+from dev_health_ops.providers.jira.budget import JiraBudgetEstimator
+from dev_health_ops.providers.jira.client import JiraClient
+from dev_health_ops.providers.linear.budget import LinearBudgetEstimator
+from dev_health_ops.sync.budget_guard import BudgetGuard
+from dev_health_ops.sync.budget_types import BudgetEstimator
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+NARROW_START = datetime(2026, 1, 1, tzinfo=timezone.utc)
+NARROW_END = datetime(2026, 1, 4, tzinfo=timezone.utc)
+WIDE_END = datetime(2026, 4, 1, tzinfo=timezone.utc)
+
+
+def _context(
+    *,
+    provider: str,
+    dataset_key: str,
+    window_start: datetime | None = NARROW_START,
+    window_end: datetime | None = NARROW_END,
+    processor_flags: dict[str, bool] | None = None,
+    credentials: Mapping[str, object] | None = None,
+) -> SyncTaskContext:
+    default_credentials: dict[str, dict[str, object]] = {
+        "github": {"token": "secret-token"},
+        "gitlab": {"token": "secret-token"},
+        "jira": {
+            "email": "ops@example.com",
+            "api_token": "secret-token",
+            "base_url": "https://chaos.atlassian.net",
+        },
+        "linear": {"api_key": "secret-api-key"},
+    }
+    return SyncTaskContext(
+        unit_id="unit-1",
+        sync_run_id="run-1",
+        org_id="org-1",
+        integration_id="integration-1",
+        source_id="source-1",
+        source_external_id="source-1",
+        provider=provider,
+        dataset_key=dataset_key,
+        cost_class="medium",
+        mode="incremental",
+        window_start=window_start,
+        window_end=window_end,
+        processor_flags=processor_flags or {},
+        credential_id="credential-1",
+        decrypted_credentials=dict(credentials or default_credentials[provider]),
+        db_url="clickhouse://localhost/default",
+    )
+
+
+@pytest.mark.parametrize(
+    ("provider", "dataset_key", "estimator"),
+    [
+        ("linear", "work-items", LinearBudgetEstimator()),
+        ("github", "commits", GitHubBudgetEstimator()),
+        ("jira", "work-items", JiraBudgetEstimator()),
+        ("gitlab", "work-items", GitLabBudgetEstimator()),
+    ],
+)
+def test_budget_estimates_are_monotonic_by_window_span(
+    provider: str,
+    dataset_key: str,
+    estimator: BudgetEstimator,
+) -> None:
+    narrow = estimator.estimate(_context(provider=provider, dataset_key=dataset_key))
+    wide = estimator.estimate(
+        _context(
+            provider=provider,
+            dataset_key=dataset_key,
+            window_start=NARROW_START,
+            window_end=WIDE_END,
+        )
+    )
+
+    narrow_by_route = {
+        (estimate.bucket.dimension, estimate.route_family): estimate.estimated_units
+        for estimate in narrow
+    }
+    wide_by_route = {
+        (estimate.bucket.dimension, estimate.route_family): estimate.estimated_units
+        for estimate in wide
+    }
+    assert wide_by_route.keys() == narrow_by_route.keys()
+    assert all(
+        wide_by_route[key] >= narrow_by_route[key] for key in narrow_by_route.keys()
+    )
+    assert sum(wide_by_route.values()) > sum(narrow_by_route.values())
+
+
+def test_budget_estimate_missing_window_falls_back_to_fixed_floor() -> None:
+    no_window = LinearBudgetEstimator().estimate(
+        _context(
+            provider="linear",
+            dataset_key="work-items",
+            window_start=None,
+            window_end=None,
+        )
+    )
+
+    assert {
+        estimate.route_family: estimate.estimated_units for estimate in no_window
+    } == {
+        "teams": 1,
+        "issues": 5,
+        "cycles": 2,
+        "comments": 2,
+        "attachments": 1,
+        "history": 2,
+    }
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _seed_linear_run(session: Session) -> tuple[SyncRun, SyncRunUnit]:
+    org_id = str(uuid.uuid4())
+    integration = Integration(
+        org_id=org_id,
+        provider="linear",
+        name="linear-demo",
+        config={},
+        is_active=True,
+    )
+    session.add(integration)
+    session.flush()
+    source = IntegrationSource(
+        org_id=org_id,
+        integration_id=integration.id,
+        provider="linear",
+        source_type="team",
+        external_id="CHAOS",
+        name="CHAOS",
+        full_name="CHAOS",
+        metadata_={},
+        is_enabled=True,
+    )
+    run = SyncRun(
+        org_id=org_id,
+        integration_id=integration.id,
+        triggered_by="manual",
+        mode=SyncRunMode.BACKFILL.value,
+        status=SyncRunStatus.PLANNED.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
+    )
+    session.add_all([source, run])
+    session.flush()
+    unit = SyncRunUnit(
+        org_id=org_id,
+        sync_run_id=run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider="linear",
+        dataset_key="work-items",
+        cost_class="high",
+        mode=SyncRunMode.BACKFILL.value,
+        since_at=NARROW_START,
+        before_at=WIDE_END,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={},
+    )
+    session.add(unit)
+    session.flush()
+    return run, unit
+
+
+def test_linear_backfill_budget_guard_defers_wide_window_unit(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LINEAR_API_KEY", "secret-linear-token")
+    monkeypatch.setenv(
+        "SYNC_BUDGET_BUCKET_LIMITS", json.dumps({"linear:graphql_cost": 500})
+    )
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+    run, unit = _seed_linear_run(db_session)
+
+    result = BudgetGuard.enforce_run(db_session, str(run.id))
+
+    db_session.refresh(unit)
+    assert result.deferred_unit_ids == frozenset({str(unit.id)})
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+    assert unit.result is not None
+    issue_observation = next(
+        observation
+        for observation in unit.result["budget_guard"]
+        if observation["route_family"] == "issues"
+    )
+    assert issue_observation["estimated_units"] > 500
+    assert issue_observation["bucket"]["provider"] == "linear"
+
+
+def test_jira_usage_observation_captures_rate_headers_without_tokens() -> None:
+    client = JiraClient.__new__(JiraClient)
+    client._usage_observations = {}
+    client._usage_observation_overflow = 0
+
+    client._record_rest_usage(
+        "GET /rest/api/3/search/jql",
+        headers={
+            "RateLimit-Remaining": "42",
+            "RateLimit-Reset": "1710000000",
+            "Retry-After": "3",
+            "Authorization": "Bearer secret-token",
+            "X-Request-Id": "req-1",
+        },
+        status=200,
+    )
+
+    observations = client.drain_usage_observations()
+
+    assert observations == [
+        {
+            "transport": "rest",
+            "operation": "GET /rest/api/3/search/jql",
+            "request_count": 1,
+            "latest_status": 200,
+            "latest_headers": {
+                "ratelimit-remaining": "42",
+                "ratelimit-reset": "1710000000",
+                "retry-after": "3",
+                "x-request-id": "req-1",
+            },
+            "rate_limit": {
+                "remaining": "42",
+                "reset": "1710000000",
+                "retry_after": "3",
+            },
+        }
+    ]
+    assert "secret-token" not in str(observations)
+
+
+def test_gitlab_usage_observation_captures_rate_headers_without_tokens() -> None:
+    client = GitLabWorkClient.__new__(GitLabWorkClient)
+    client._usage_observations = {}
+    client._usage_observation_overflow = 0
+
+    client._record_rest_usage(
+        "GET /projects/:id/issues",
+        headers={
+            "RateLimit-Remaining": "17",
+            "RateLimit-Reset": "1710000000",
+            "Retry-After": "9",
+            "PRIVATE-TOKEN": "secret-token",
+            "X-Request-Id": "req-2",
+        },
+        status=429,
+    )
+
+    observations = client.drain_usage_observations()
+
+    assert observations == [
+        {
+            "transport": "rest",
+            "operation": "GET /projects/:id/issues",
+            "request_count": 1,
+            "latest_status": 429,
+            "latest_headers": {
+                "ratelimit-remaining": "17",
+                "ratelimit-reset": "1710000000",
+                "retry-after": "9",
+                "x-request-id": "req-2",
+            },
+            "rate_limit": {
+                "remaining": "17",
+                "reset": "1710000000",
+                "retry_after": "9",
+            },
+        }
+    ]
+    assert "secret-token" not in str(observations)

--- a/tests/test_budget_estimators.py
+++ b/tests/test_budget_estimators.py
@@ -143,7 +143,9 @@ def db_session():
     engine.dispose()
 
 
-def _seed_linear_run(session: Session) -> tuple[SyncRun, SyncRunUnit]:
+def _seed_linear_run(
+    session: Session, before_at: datetime = WIDE_END
+) -> tuple[SyncRun, SyncRunUnit]:
     org_id = str(uuid.uuid4())
     integration = Integration(
         org_id=org_id,
@@ -187,7 +189,7 @@ def _seed_linear_run(session: Session) -> tuple[SyncRun, SyncRunUnit]:
         cost_class="high",
         mode=SyncRunMode.BACKFILL.value,
         since_at=NARROW_START,
-        before_at=WIDE_END,
+        before_at=before_at,
         status=SyncRunUnitStatus.PLANNED.value,
         attempts=0,
         processor_flags={},
@@ -222,6 +224,25 @@ def test_linear_backfill_budget_guard_defers_wide_window_unit(
     )
     assert issue_observation["estimated_units"] > 500
     assert issue_observation["bucket"]["provider"] == "linear"
+
+
+def test_linear_incremental_narrow_window_not_deferred(
+    db_session: Session,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("LINEAR_API_KEY", "secret-linear-token")
+    monkeypatch.setenv(
+        "SYNC_BUDGET_BUCKET_LIMITS", json.dumps({"linear:graphql_cost": 500})
+    )
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+    run, unit = _seed_linear_run(db_session, before_at=NARROW_END)
+
+    result = BudgetGuard.enforce_run(db_session, str(run.id))
+
+    db_session.refresh(unit)
+    assert result.deferred_unit_ids == frozenset()
+    assert unit.status == SyncRunUnitStatus.PLANNED.value
 
 
 def test_jira_usage_observation_captures_rate_headers_without_tokens() -> None:


### PR DESCRIPTION
## Summary

Part of EPIC **CHAOS-2719**. Makes the sync budget estimators window/volume-aware (AD-4, CHAOS-2722).

Previously every provider estimator ignored the unit's `window_start`/`window_end` and returned fixed unit counts, so `SYNC_BUDGET_BUCKET_LIMITS` structurally could not defer an amplifying unit — the guard projected the same cost whether a unit scanned 3 days or 90. This change scales the dominant dimension by window-span days so a wide backfill window estimates materially higher than a narrow incremental one, restoring the deferral signal the reservation machinery (CHAOS-2666) depends on.

## Key files

- `src/dev_health_ops/providers/{linear,github,jira,gitlab}/budget.py` — span-aware estimate
- Tests asserting monotonic estimate vs window span (wide > narrow) and the CHAOS-2717-scenario deferral

## Testing

Full local gate green: `bash ci/local_validate.sh` -> `GATE PASSED`. Code-review pass applied.

## Scope boundary

This PR owns only the estimator **inputs** (D). The shared cross-queue request token-bucket / reservation pool (E) stays in its own plan and is explicitly out of scope here.

SCREENSHOT-WAIVER: backend-only change, no UI render surface.

Refs CHAOS-2722, CHAOS-2719.
