### PR TITLE
docs(architecture): sync unit model + reference-tier cardinality (CHAOS-2719)

### DIFF
--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -291,6 +291,8 @@ Backfill depth is gated by organization billing tier:
 
 ### Composition with Incremental Sync (no date gap)
 
+> Unit decomposition and reference-data cardinality: see [Sync Unit Model](sync-unit-model.md). The work-item-family collapse writes per-dataset watermarks only for incremental/full-resync units, preserving the invariant below.
+
 Backfill **never seeds the watermark** (CHAOS-2514), so the first incremental
 sync after a backfill cold-starts. Continuity across the seam is provided by the
 incremental **cold-start depth** (CHAOS-2569): with no watermark, the planner

--- a/docs/architecture/dispatch-outbox.md
+++ b/docs/architecture/dispatch-outbox.md
@@ -57,6 +57,8 @@ At-most-once provider execution is not enforced by the outbox. It is guaranteed 
 
 `JobRun` is not an execution lock. It is the activity/index row used by admin history surfaces. `SyncRun` and `SyncRunUnit` remain the execution source of truth, and the outbox remains the durable dispatch mechanism.
 
+For how each `SyncRunUnit` is decomposed (`source × dataset × window`) and the reference-tier vs work-item-tier distinction, see [Sync Unit Model](sync-unit-model.md).
+
 ---
 
 ## Crash-Window Recovery Flow

--- a/docs/architecture/sync-unit-model.md
+++ b/docs/architecture/sync-unit-model.md
@@ -1,0 +1,90 @@
+# Sync Unit Model
+
+> **What this documents:** how a sync run is decomposed into executable units, and why **reference data** (teams, orgs, members, projects, boards/cycles/sprints) belongs on a different axis than **work items** (issues, PRs/MRs). This conceptual page was missing, which is why a structural request-amplification went unnoticed (CHAOS-2719). Target-state behavior is labeled where it is not yet shipped.
+
+## Overview
+
+A sync run is decomposed by the planner (`sync/planner.py` `_build_planned_units`) into units of:
+
+```
+source × dataset × date-window
+```
+
+Each `PlannedUnit` becomes one `SyncRunUnit` row and one `run_sync_unit` Celery task (see [Durable Dispatch Outbox](dispatch-outbox.md) for the task hierarchy). This axis is **correct for work items**, which are per-source and time-sliced: a 90-day backfill of issues legitimately splits into windows, and each window legitimately scopes to one source.
+
+The axis is **wrong for reference entities**. Teams, orgs, members, projects, and boards/cycles/sprints are **source-independent and time-independent** — their true cardinality is *once per integration per run*. When a provider fetches reference data *inside* a work-item unit, it pays for that data `windows × datasets × sources` times.
+
+```mermaid
+graph TD
+    Run[SyncRun] --> Plan[plan_sync_run: _build_planned_units]
+    Plan -->|source × dataset × window| U1[unit: src A · work-items · win1]
+    Plan --> U2[unit: src A · work-items · win2]
+    Plan --> U3[unit: src A · work-item-labels · win1]
+    Plan --> U4[unit: src B · work-items · win1]
+
+    subgraph WT [Work-item tier — correct on this axis]
+        U1
+        U2
+        U3
+        U4
+    end
+
+    subgraph RT [Reference tier — should be once per run, NOT per unit]
+        R1[teams / orgs]
+        R2[members]
+        R3[projects / boards]
+        R4[cycles / sprints]
+    end
+
+    U1 -.->|amplifier: re-fetches reference data<br/>windows × datasets × sources| R1
+    U2 -.-> R1
+    U3 -.-> R4
+    U4 -.-> R1
+
+    style WT fill:#dfd,stroke:#333
+    style RT fill:#bbf,stroke:#333
+```
+
+For a 90-day Linear backfill: `ceil(90/14)=7 windows × 5 work-item-family datasets = 35 units`, each running the **complete** Linear ingest, each calling `iter_teams()` (all teams) plus `iter_cycles()` per team. The teams/cycles cardinality should be *one fetch per run*; instead it is `35× (× team count)`. This is the unmeasured amplifier behind Linear backfill request saturation, and it is **not Linear-specific**.
+
+## The two tiers
+
+| Tier | Entities | Correct cardinality | Correct axis |
+| ---- | -------- | ------------------- | ------------ |
+| **Reference / discovery tier** | teams, orgs, members, projects, boards/cycles/sprints | **once per integration per run** | source-independent, time-independent |
+| **Work-item tier** | issues, pull/merge requests, labels, history, comments, worklogs | per source, time-sliced | `source × dataset × window` |
+
+**Design rule:** work-item units **read** reference data from a once-per-run source; they must never **fetch** it inline. The persisted ClickHouse store (`teams`, `sprints`) is the read source of truth — but a missing/stale row is **never** proof that an entity is absent. On a store miss, a unit fetches only **its own source's** reference data and persists it; it never falls back to an all-teams / all-repos scan.
+
+## Per-provider entity × cardinality matrix
+
+Legend: **once/run** = fetched once per sync run (correct); **per-unit** = re-fetched inside every work-item unit (amplifier); **discovery** = already pulled out into the once-per-run `team_autoimport` relay.
+
+| Provider | teams / orgs | members | projects / boards | cycles / sprints | issues / PRs |
+| -------- | ------------ | ------- | ----------------- | ---------------- | ------------ |
+| **GitHub** | discovery (once/run) | discovery | discovery | n/a | per source/window (work-item) |
+| **GitLab** | discovery (once/run) | discovery | discovery | n/a | per source/window (work-item) |
+| **Jira** | once/run (resolver) | n/a here | per-unit JQL scope ✅ | **per-unit** ⚠️ (`get_sprint` in issue loop) | per source/window (work-item) |
+| **Linear** | **per-unit** ⚠️ (`iter_teams()` all teams) | discovery | discovery | **per-unit** ⚠️ (`iter_cycles()` per team) | per source/window (work-item) |
+
+The ⚠️ cells are the work this epic removes. GitHub/GitLab already solved this by pulling org/team/member/project discovery out of the sync unit into a once-per-run [`team_autoimport`](dispatch-outbox.md) relay; Linear (teams + cycles in-unit) and Jira (sprints in-unit) never got that tier. The permanent fix **generalizes the discovery tier to the work-item path** and adds the missing cycle/sprint read-back loader.
+
+## The three amplifiers and their fixes
+
+1. **Per-unit reference re-fetch** (Linear teams+cycles; Jira sprints). The dominant fixed overhead. **Fix (P2):** read teams/cycles/sprints from the persisted store via a once-per-run resolver; add a `get_all_sprints` loader and a cycle/sprint producer; bounded source-scoped API fallback on a store miss.
+2. **Work-item-family redundancy.** The 5 family datasets (`work-items`, `work-item-labels`, `work-item-projects`, `work-item-history`, `work-item-comments`) each re-run the *full* ingest, so enabling the family multiplies cost ×5 per source/window. **Fix (P3, target-state):** plan-time collapse to **one** composite ingest per `(source, window)`, writing per-dataset watermarks for each enabled family key.
+3. **Source fan-out.** Work-item units that ignore their own source — Linear `IngestionContext(repo=None)` → all teams; GitHub `discover_repos` without a repo filter → all org repos. **Fix (P1, shipped on the source-scoping branch):** thread the unit's `source_external_id` so a unit syncs only its one source; preserve the no-source CLI/org-wide path.
+
+**Target acceptance:** total provider API requests for a backfill scale `O(issues + teams + cycles/projects)`, not `O(windows × datasets × sources)`, across all four providers.
+
+## Invariants this model must preserve
+
+- **Backfill never writes watermarks.** Backfill units (`mode="backfill"`) must never update `sync_watermarks`; see [Data Pipeline](data-pipeline.md) and the planner module contract (CHAOS-2514). The work-item-family collapse writes per-dataset watermarks only for incremental/full-resync units.
+- **Provider coverage matrix.** Behavior stays green across `{jira, gitlab, github, linear} × {teams, projects, members, issues}` — see [Team Attribution](team-attribution.md). Never make a fix Linear-only.
+- **ClickHouse idempotency.** Reference reads and collapsed/scoped writes stay idempotent (`teams FINAL`, `sprints FINAL`).
+- **No Postgres team/identity attribution.** Reference data is read from ClickHouse, never a Postgres attribution bridge.
+
+## References
+
+- Epic: CHAOS-2719 (sync unit model); children CHAOS-2718 (Linear reference re-fetch), CHAOS-2720 (GitHub source fan-out), CHAOS-2721 (work-item-family fan-in), CHAOS-2722 (window-aware budget), CHAOS-2725 (scoped backfill).
+- Related: [Durable Dispatch Outbox](dispatch-outbox.md), [Data Pipeline](data-pipeline.md), [Team Attribution](team-attribution.md), [Connector Inventory](../ops/connector-inventory.md).

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -26,6 +26,7 @@ Operators can trigger background operations on-demand through three primary API 
 1. **Data Sync Trigger**
    * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/trigger` (defined in `api/admin/routers/sync.py:997-1164`)
    * **Flow**: Creates a canonical `JobRun` activity row, builds a `SyncPlanRequest` from the config's migrated integration, plans a `SyncRun` (one `SyncRunUnit` per source/dataset/window), stores `sync_run_id` in `JobRun.result`, and enqueues `dispatch_sync_run` onto the `sync` queue. The integration planner is the only routing path — the legacy `run_sync_config` / `dispatch_batch_sync` in-process workers were removed in CHAOS-2647.
+     * The `source × dataset × window` decomposition and why **reference data** (teams/cycles/sprints) belongs on a once-per-run axis is documented in [Sync Unit Model](../architecture/sync-unit-model.md).
 
 2. **Historical Backfill Trigger**
    * **Endpoint**: `POST /api/v1/admin/sync-configs/{config_id}/backfill` (defined in `api/admin/routers/sync.py:1167-1233`)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -38,6 +38,7 @@ nav:
       - Overview: architecture.md
       - Data Pipeline: architecture/data-pipeline.md
       - Durable Dispatch Outbox: architecture/dispatch-outbox.md
+      - Sync Unit Model: architecture/sync-unit-model.md
       - Team Attribution: architecture/team-attribution.md
       - Investment Categorization Pipeline: architecture/investment-categorization-pipeline.md
       - Investment Data Model: architecture/investment-data-model.md


### PR DESCRIPTION
## Summary

Part of EPIC **CHAOS-2719**. Adds the first-class design doc the epic identified as a root cause (AD-5): the unit-decomposition model and reference-data cardinality were never documented, which is why the request amplification went unnoticed.

## What changed

- New `docs/architecture/sync-unit-model.md`: `SyncRun -> units (source x dataset x window)` fan-out diagram, the reference-tier vs work-item-tier distinction, a per-provider entity x cardinality matrix (once-per-run vs per-unit), the three amplifiers + their fixes, and the backfill-never-writes-watermarks invariant cross-link.
- Registered in `mkdocs.yml` nav under Architecture (adjacent to Data Pipeline / Durable Dispatch Outbox).
- Cross-link reconciles in workers/dispatch-outbox/data-pipeline/team-attribution docs.

## Testing

`mkdocs build --strict` passes (no broken links / nav warnings).

SCREENSHOT-WAIVER: documentation-only change.

Refs CHAOS-2719.
