### PR TITLE
fix(sync): fail visibly when a scoped work-item unit has no source (CHAOS-2737)

### DIFF
--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -75,6 +75,16 @@ class WorkItemsSyncLeaseLost(RuntimeError):
         super().__init__(f"sync unit lease lost before {surface} write")
 
 
+class WorkItemUnitMissingSource(ValueError):
+    def __init__(self, provider: str, source_kind: str) -> None:
+        self.provider = provider
+        self.source_kind = source_kind
+        super().__init__(
+            f"{provider} work-item unit had no source ({source_kind}); "
+            "refusing org-wide fan-out"
+        )
+
+
 @contextmanager
 def work_items_sync_lease_check(check: _LeaseCheck) -> Iterator[None]:
     token = _WORK_ITEMS_SYNC_LEASE_CHECK.set(check)
@@ -95,6 +105,35 @@ def _date_range(end_day: date, backfill_days: int) -> list[date]:
         return [end_day]
     start_day = end_day - timedelta(days=backfill_days - 1)
     return [start_day + timedelta(days=i) for i in range(backfill_days)]
+
+
+def _has_text(value: object) -> bool:
+    return isinstance(value, str) and bool(value.strip())
+
+
+def _require_work_item_unit_source(
+    *,
+    provider_set: set[str],
+    repo_name: str | None,
+    jira_project_keys: list[str] | None,
+) -> None:
+    required_sources = {
+        "github": (repo_name, "repo"),
+        "gitlab": (repo_name, "project"),
+        "linear": (repo_name, "team"),
+    }
+    for provider, (source, source_kind) in required_sources.items():
+        if provider in provider_set and not _has_text(source):
+            error = WorkItemUnitMissingSource(provider, source_kind)
+            logger.error(str(error))
+            raise error
+
+    if "jira" in provider_set and not any(
+        _has_text(project_key) for project_key in (jira_project_keys or [])
+    ):
+        error = WorkItemUnitMissingSource("jira", "project_keys")
+        logger.error(str(error))
+        raise error
 
 
 def _build_github_work_client(
@@ -365,6 +404,13 @@ def run_work_items_sync_job(
             for row in _sprints_data
         ]
 
+        if require_source:
+            _require_work_item_unit_source(
+                provider_set=provider_set,
+                repo_name=repo_name,
+                jira_project_keys=jira_project_keys,
+            )
+
         discovered_repos = _discover_repos(
             backend=backend,
             primary_sink=primary_sink,
@@ -387,17 +433,6 @@ def run_work_items_sync_job(
         )
 
         if require_source:
-            if {"github", "gitlab"}.intersection(provider_set) and not repo_name:
-                logger.error("Work-item unit requires a non-empty source context")
-                raise ValueError("Work-item unit requires a non-empty source context")
-            if "jira" in provider_set and not jira_project_keys:
-                logger.error("Jira work-item unit requires a project source context")
-                raise ValueError(
-                    "Jira work-item unit requires a project source context"
-                )
-            if "linear" in provider_set and not repo_name:
-                logger.error("Linear work-item unit requires a team source context")
-                raise ValueError("Linear work-item unit requires a team source context")
             if repo_name and {"github", "gitlab"}.intersection(provider_set):
                 provider_sources = {repo.source for repo in discovered_repos}
                 expected = {

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -849,6 +849,54 @@ class TestCredentialMapping:
 
 
 class TestWorkItemsProviderCredentialIsolation:
+    @pytest.mark.parametrize(
+        ("provider", "source_kwargs", "message_fragment"),
+        [
+            ("github", {"repo_name": None}, "github work-item unit had no source"),
+            ("linear", {"repo_name": "   "}, "linear work-item unit had no source"),
+            ("gitlab", {"repo_name": ""}, "gitlab work-item unit had no source"),
+            (
+                "jira",
+                {"jira_project_keys": ["   "]},
+                "jira work-item unit had no source",
+            ),
+        ],
+    )
+    @patch("dev_health_ops.metrics.job_work_items.ClickHouseMetricsSink")
+    def test_require_source_missing_source_fails_before_org_wide_discovery(
+        self,
+        mock_sink_class,
+        provider,
+        source_kwargs,
+        message_fragment,
+        caplog,
+    ):
+        from dev_health_ops.metrics.job_work_items import (
+            WorkItemUnitMissingSource,
+            run_work_items_sync_job,
+        )
+
+        sink = MagicMock()
+        sink.query_dicts.return_value = []
+        mock_sink_class.return_value = sink
+        caplog.set_level("ERROR", logger="dev_health_ops.metrics.job_work_items")
+
+        with patch("dev_health_ops.metrics.job_work_items._discover_repos") as discover:
+            with pytest.raises(WorkItemUnitMissingSource, match=message_fragment):
+                run_work_items_sync_job(
+                    db_url="clickhouse://localhost/dev",
+                    day=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                    backfill_days=1,
+                    provider=provider,
+                    org_id="00000000-0000-0000-0000-000000000001",
+                    require_source=True,
+                    **source_kwargs,
+                )
+
+        discover.assert_not_called()
+        assert message_fragment in caplog.text
+        assert "refusing org-wide fan-out" in caplog.text
+
     @patch.dict(os.environ, {}, clear=True)
     @patch("dev_health_ops.metrics.job_work_items.ClickHouseMetricsSink")
     @patch("dev_health_ops.providers.linear.client.LinearClient.from_env")
@@ -909,6 +957,42 @@ class TestWorkItemsProviderCredentialIsolation:
                 credentials={"api_key": "lin_explicit"},
                 repo_name="   ",
             )
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("dev_health_ops.metrics.job_work_items.ClickHouseMetricsSink")
+    def test_linear_work_items_without_required_source_keeps_org_wide_path(
+        self, mock_sink_class
+    ):
+        from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
+        from dev_health_ops.providers.linear.client import LinearClient
+
+        sink = MagicMock()
+        sink.query_dicts.return_value = []
+        sink.client.query.return_value = SimpleNamespace(result_rows=[])
+        mock_sink_class.return_value = sink
+
+        captured_repos: list[object] = []
+
+        def _fake_iter_ingest(self, ctx):
+            client = self._make_client()
+            assert isinstance(client, LinearClient)
+            captured_repos.append(ctx.repo)
+            return iter(())
+
+        with patch(
+            "dev_health_ops.providers.linear.provider.LinearProvider.iter_ingest",
+            new=_fake_iter_ingest,
+        ):
+            run_work_items_sync_job(
+                db_url="clickhouse://localhost/dev",
+                day=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                backfill_days=1,
+                provider="linear",
+                org_id="00000000-0000-0000-0000-000000000001",
+                credentials={"api_key": "lin_explicit"},
+            )
+
+        assert captured_repos == [None]
 
     @patch.dict(os.environ, {}, clear=True)
     @patch("dev_health_ops.metrics.job_work_items.ClickHouseMetricsSink")


### PR DESCRIPTION
## What
Adds a provider-agnostic guard `_require_work_item_unit_source()` in `run_work_items_sync_job` that, when `require_source=True` (the unitized path) and the unit's source is missing/unknown, logs an error and raises `WorkItemUnitMissingSource` **before** any `_discover_repos()` / all-team fan-out.

Detection per provider: github/gitlab/linear via blank `repo_name`; jira via empty/all-blank project keys.

## Why
Post-AD-2 scoping, a scoped unit whose source is absent/unknown upstream could silently fan out to all teams/repos (masking an incomplete IntegrationSource inventory). Now it fails visibly. The explicit org-wide path (`require_source=False`: CLI/backfill/webhooks) is unchanged. Closes CHAOS-2737; extends CHAOS-2720 (AD-2).

## Tests / validation
- New parametrized tests across {github, linear, gitlab, jira}: missing-source scoped unit raises `WorkItemUnitMissingSource`, logs, and asserts the all-repo/all-team scan is never called; plus a `require_source=False` org-wide regression.
- Full `ci/local_validate.sh` GATE PASSED (lint + mypy + full unit suite + live-ClickHouse argMax proof).
- Oracle review: SOUND, no blocking findings.

SCREENSHOT-WAIVER: backend-only, no UI/render changes.