### PR TITLE
fix(sync): unconditional strict pre-sync discovery for direct CLI backfill (CHAOS-2736)

### DIFF
--- a/src/dev_health_ops/backfill/runner.py
+++ b/src/dev_health_ops/backfill/runner.py
@@ -84,8 +84,6 @@ def _run_strict_reference_discovery_for_backfill(
     window_count: int,
     analytics_db_url: str | None,
 ) -> dict[str, Any] | None:
-    if not sync_options.get("auto_import_teams"):
-        return None
     summary = run_team_autoimport_strict(
         provider=provider,
         org_id=org_id,

--- a/tests/test_backfill.py
+++ b/tests/test_backfill.py
@@ -149,6 +149,14 @@ def _patch_session_with_config(monkeypatch: pytest.MonkeyPatch, config: object) 
         "dev_health_ops.backfill.runner.get_postgres_session_sync",
         lambda: _Ctx(),
     )
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner.run_team_autoimport_strict",
+        lambda **_: {"status": "success"},
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner._verify_reference_readback",
+        lambda **_: None,
+    )
 
 
 def test_run_backfill_derives_org_from_config_when_org_omitted(
@@ -188,7 +196,7 @@ def test_run_backfill_strict_reference_discovery_failure_blocks_writes(
         _FakeConfig(
             config_org,
             provider="linear",
-            sync_options={"auto_import_teams": True},
+            sync_options={"auto_import_teams": False},
         ),
     )
     writes: list[dict[str, object]] = []
@@ -211,6 +219,60 @@ def test_run_backfill_strict_reference_discovery_failure_blocks_writes(
         )
 
     assert writes == []
+
+
+def test_run_backfill_strict_reference_discovery_runs_when_autoimport_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    config_org = "55555555-5555-5555-5555-555555555555"
+    _patch_session_with_config(
+        monkeypatch,
+        _FakeConfig(
+            config_org,
+            provider="linear",
+            sync_options={"auto_import_teams": False},
+        ),
+    )
+    calls: list[dict[str, object]] = []
+    writes: list[dict[str, object]] = []
+
+    def _strict_discovery(**kwargs: object) -> dict[str, object]:
+        calls.append(kwargs)
+        return {"status": "success", "teams_imported": 1, "sprints_imported": 1}
+
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner.run_team_autoimport_strict",
+        _strict_discovery,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.backfill.runner.run_work_items_sync_job",
+        lambda *args, **kwargs: writes.append(kwargs),
+    )
+
+    result = run_backfill_for_config(
+        db_url="clickhouse://local",
+        sync_config_id="66666666-6666-6666-6666-666666666666",
+        org_id=None,
+        since=date(2026, 1, 1),
+        before=date(2026, 1, 3),
+    )
+
+    assert len(calls) == 1
+    assert calls[0]["provider"] == "linear"
+    assert calls[0]["scope"] == {
+        "mode": "backfill",
+        "sync_config_id": "66666666-6666-6666-6666-666666666666",
+        "sync_options": {"auto_import_teams": False},
+        "window_count": 1,
+        "since": "2026-01-01",
+        "before": "2026-01-03",
+    }
+    assert len(writes) == 1
+    assert result["team_autoimport"] == {
+        "status": "success",
+        "teams_imported": 1,
+        "sprints_imported": 1,
+    }
 
 
 def test_run_backfill_raises_on_org_mismatch(

--- a/tests/workers/test_team_autoimport_sync_surfaces.py
+++ b/tests/workers/test_team_autoimport_sync_surfaces.py
@@ -26,43 +26,58 @@ _TEAM_AUTOIMPORT_TASK = "dev_health_ops.workers.tasks.run_post_sync_team_autoimp
 _ORG = "team-autoimport-sync-org"
 
 
-def test_backfill_autoimport_false_or_absent_does_not_call(monkeypatch) -> None:
+def test_backfill_autoimport_false_or_absent_runs_strict_discovery(monkeypatch) -> None:
     calls: list[dict[str, Any]] = []
+
+    def fake_run_team_autoimport(**kwargs: Any) -> dict[str, Any]:
+        calls.append(kwargs)
+        return {"status": "success"}
+
     monkeypatch.setattr(
         backfill_runner,
         "run_team_autoimport_strict",
-        lambda **kwargs: calls.append(kwargs),
+        fake_run_team_autoimport,
     )
 
-    assert (
-        backfill_runner._run_strict_reference_discovery_for_backfill(
-            provider="jira",
-            org_id="org-1",
-            credentials={},
-            sync_options={},
-            sync_config_id="cfg-1",
-            since=date(2026, 1, 1),
-            before=date(2026, 1, 7),
-            window_count=1,
-            analytics_db_url=None,
-        )
-        is None
-    )
-    assert (
-        backfill_runner._run_strict_reference_discovery_for_backfill(
-            provider="jira",
-            org_id="org-1",
-            credentials={},
-            sync_options={"auto_import_teams": False},
-            sync_config_id="cfg-1",
-            since=date(2026, 1, 1),
-            before=date(2026, 1, 7),
-            window_count=1,
-            analytics_db_url=None,
-        )
-        is None
-    )
-    assert calls == []
+    assert backfill_runner._run_strict_reference_discovery_for_backfill(
+        provider="jira",
+        org_id="org-1",
+        credentials={},
+        sync_options={},
+        sync_config_id="cfg-1",
+        since=date(2026, 1, 1),
+        before=date(2026, 1, 7),
+        window_count=1,
+        analytics_db_url=None,
+    ) == {"status": "success"}
+    assert backfill_runner._run_strict_reference_discovery_for_backfill(
+        provider="jira",
+        org_id="org-1",
+        credentials={},
+        sync_options={"auto_import_teams": False},
+        sync_config_id="cfg-1",
+        since=date(2026, 1, 1),
+        before=date(2026, 1, 7),
+        window_count=1,
+        analytics_db_url=None,
+    ) == {"status": "success"}
+    assert len(calls) == 2
+    assert calls[0]["scope"] == {
+        "mode": "backfill",
+        "sync_config_id": "cfg-1",
+        "sync_options": {},
+        "window_count": 1,
+        "since": "2026-01-01",
+        "before": "2026-01-07",
+    }
+    assert calls[1]["scope"] == {
+        "mode": "backfill",
+        "sync_config_id": "cfg-1",
+        "sync_options": {"auto_import_teams": False},
+        "window_count": 1,
+        "since": "2026-01-01",
+        "before": "2026-01-07",
+    }
 
 
 def test_backfill_autoimport_true_calls_once(monkeypatch) -> None:


### PR DESCRIPTION
## What
Removes the `if not sync_options.get("auto_import_teams"): return None` early-return in `_run_strict_reference_discovery_for_backfill` so strict pre-sync reference discovery runs **unconditionally** for the direct CLI backfill path, before any work-item windows.

## Why
A direct CLI backfill with `auto_import_teams=false` previously skipped discovery and could run work-item units against a stale/empty reference store. Strict discovery (`run_team_autoimport_strict`, errors bubble) is a correctness prerequisite independent of the user's auto-import preference. The separate **post-sync** team auto-import remains gated by `auto_import_teams` (unchanged). Strict failure still blocks the backfill. Closes CHAOS-2736.

## Tests / validation
- Updated backfill tests: `auto_import_teams=false` now runs strict discovery; failure blocks writes; added a success-path test proving the runner arms+proceeds on discovery success with auto-import disabled. Post-sync gating tests unchanged.
- Full `ci/local_validate.sh` GATE PASSED (lint + mypy + full unit suite + live-ClickHouse argMax proof).
- Oracle review: SOUND, no blocking findings.

SCREENSHOT-WAIVER: backend-only, no UI/render changes.