### PR TITLE
fix(sync): accept GitHub App credentials in strict reference discovery (CHAOS-2738)

### DIFF
--- a/src/dev_health_ops/workers/team_autoimport_github.py
+++ b/src/dev_health_ops/workers/team_autoimport_github.py
@@ -63,7 +63,17 @@ async def _populate_async(
             )
         return _zero_summary(org_id=org_id, reason="provider_not_import_capable")
 
-    token = _first_string(credentials, "token", "access_token", "github_token")
+    try:
+        token = _github_access_token(credentials)
+    except Exception as exc:
+        if strict:
+            raise
+        logger.info(
+            "Skipping GitHub team auto-import for org_id=%s: credential token exchange failed: %s",
+            org_id,
+            exc,
+        )
+        return _zero_summary(org_id=org_id, reason="provider_discovery_skipped")
     org_name = _github_org(credentials=credentials, scope=scope)
     if not token or not org_name:
         if strict:
@@ -153,6 +163,31 @@ def _zero_summary(*, org_id: str, reason: str) -> dict[str, Any]:
         "team_repo_ownership_imported": 0,
         "work_item_team_attributions_imported": 0,
     }
+
+
+def _github_access_token(credentials: Mapping[str, Any]) -> str | None:
+    token = _first_string(credentials, "token", "access_token", "github_token")
+    if token:
+        return token
+
+    from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
+    from dev_health_ops.credentials.resolver import github_credentials_from_mapping
+
+    github_credentials = github_credentials_from_mapping(dict(credentials))
+    if github_credentials is None or not github_credentials.is_app_auth:
+        return None
+    if (
+        github_credentials.app_id is None
+        or github_credentials.private_key is None
+        or github_credentials.installation_id is None
+    ):
+        return None
+    return GitHubAppTokenProvider(
+        app_id=github_credentials.app_id,
+        private_key=github_credentials.private_key,
+        installation_id=github_credentials.installation_id,
+        api_base_url=github_credentials.base_url or "https://api.github.com",
+    ).get_token()
 
 
 def _github_org(

--- a/tests/workers/test_team_autoimport_github_gitlab.py
+++ b/tests/workers/test_team_autoimport_github_gitlab.py
@@ -172,6 +172,113 @@ def test_github_org_import_writes_provider_access_repo_grants_and_nested_specifi
     ]
 
 
+def test_github_strict_reference_discovery_uses_app_installation_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.connectors.utils import github_app
+
+    token_provider_args: list[dict[str, str]] = []
+    discovery_calls: list[tuple[str, str]] = []
+
+    class FakeGitHubAppTokenProvider:
+        def __init__(
+            self,
+            *,
+            app_id: str,
+            private_key: str,
+            installation_id: str,
+            api_base_url: str,
+        ) -> None:
+            token_provider_args.append(
+                {
+                    "app_id": app_id,
+                    "private_key": private_key,
+                    "installation_id": installation_id,
+                    "api_base_url": api_base_url,
+                }
+            )
+
+        def get_token(self) -> str:
+            return "installation-token"
+
+    async def discover_github(self, token: str, org_name: str) -> list[DiscoveredTeam]:
+        discovery_calls.append((token, org_name))
+        return []
+
+    monkeypatch.setattr(
+        github_app, "GitHubAppTokenProvider", FakeGitHubAppTokenProvider
+    )
+    monkeypatch.setattr(
+        team_autoimport_github.TeamDiscoveryService,
+        "discover_github",
+        discover_github,
+    )
+
+    summary = team_autoimport_github.populate(
+        org_id="org-1",
+        credentials={
+            "app_id": "123",
+            "private_key": "private-key",
+            "installation_id": "456",
+        },
+        scope={
+            "strict_reference_discovery": True,
+            "sync_options": {"owner": "full-chaos"},
+        },
+    )
+
+    assert summary["status"] == "skipped"
+    assert summary["reason"] == "no_provider_teams"
+    assert token_provider_args == [
+        {
+            "app_id": "123",
+            "private_key": "private-key",
+            "installation_id": "456",
+            "api_base_url": "https://api.github.com",
+        }
+    ]
+    assert discovery_calls == [("installation-token", "full-chaos")]
+
+
+def test_github_strict_reference_discovery_with_app_auth_still_fails_provider_errors(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.connectors.utils import github_app
+
+    class FakeGitHubAppTokenProvider:
+        def __init__(self, **_: str) -> None:
+            return None
+
+        def get_token(self) -> str:
+            return "installation-token"
+
+    async def discover_github(self, token: str, org_name: str) -> list[DiscoveredTeam]:
+        raise RuntimeError("github discovery unavailable")
+
+    monkeypatch.setattr(
+        github_app, "GitHubAppTokenProvider", FakeGitHubAppTokenProvider
+    )
+    monkeypatch.setattr(
+        team_autoimport_github.TeamDiscoveryService,
+        "discover_github",
+        discover_github,
+    )
+
+    with pytest.raises(RuntimeError, match="github discovery unavailable"):
+        team_autoimport_github.populate(
+            org_id="org-1",
+            credentials={
+                "app_id": "123",
+                "private_key": "private-key",
+                "installation_id": "456",
+            },
+            scope={
+                "strict_reference_discovery": True,
+                "sync_options": {"owner": "full-chaos"},
+            },
+        )
+
+
 def test_gitlab_group_import_writes_provider_access_project_ownership(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:


### PR DESCRIPTION
## What
Strict pre-sync reference discovery (`workers/team_autoimport_github`) now resolves a usable GitHub token for **both** PAT and **GitHub App** auth, via a new `_github_access_token()` helper that exchanges App credentials through `GitHubAppTokenProvider` (the same path the GitHub work-item sync uses).

## Why (production bug, found via `sync now`)
The integration uses GitHub App auth (`auth_mode=github_app`, `installation_id`), but the strict populator only accepted PAT keys (`token`/`access_token`/`github_token`), so valid credentials were treated as missing and the run failed with `missing GitHub credentials or org for strict reference discovery`. Strict mode still **fails visibly** on genuinely missing creds or token-exchange failure; non-strict stays best-effort. Closes CHAOS-2738.

## Tests / validation
- New regressions: strict discovery succeeds via a GitHub App installation token; an in-scope credentialed provider discovery error still fails visibly.
- Full `ci/local_validate.sh` GATE PASSED (lint + mypy + full unit suite + live-ClickHouse argMax proof).
- Oracle review: SOUND, no blocking findings.

SCREENSHOT-WAIVER: backend-only, no UI/render changes.