### PR TITLE
feat(sync): sprint->team association for once-per-run Linear cycle reuse (CHAOS-2734)

### DIFF
--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -342,7 +342,7 @@ def run_work_items_sync_job(
                 "SELECT provider, sprint_id, argMax(name, last_synced) AS name, argMax(state, last_synced) AS state, "
                 "argMax(started_at, last_synced) AS started_at, argMax(ended_at, last_synced) AS ended_at, "
                 "argMax(completed_at, last_synced) AS completed_at, max(last_synced) AS last_synced_max, "
-                "org_id FROM sprints"
+                "argMax(native_team_key, last_synced) AS native_team_key, org_id FROM sprints"
                 + (" WHERE org_id = {org_id:String}" if org_id else "")
                 + " GROUP BY provider, sprint_id, org_id",
                 {"org_id": org_id} if org_id else {},
@@ -359,6 +359,7 @@ def run_work_items_sync_job(
                 started_at=row.get("started_at"),
                 ended_at=row.get("ended_at"),
                 completed_at=row.get("completed_at"),
+                native_team_key=row.get("native_team_key") or None,
                 last_synced=row.get("last_synced_max") or computed_at,
                 org_id=str(row.get("org_id") or ""),
             )

--- a/src/dev_health_ops/metrics/sinks/clickhouse/core.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/core.py
@@ -128,7 +128,9 @@ class ClickHouseCore(BaseMetricsSink):
             "argMax(started_at, last_synced) AS started_at, "
             "argMax(ended_at, last_synced) AS ended_at, "
             "argMax(completed_at, last_synced) AS completed_at, "
-            "max(last_synced) AS last_synced_max, org_id FROM sprints"
+            "max(last_synced) AS last_synced_max, "
+            "argMax(native_team_key, last_synced) AS native_team_key, "
+            "org_id FROM sprints"
         )
         params: dict[str, str] = {}
         if _org_id:
@@ -145,8 +147,9 @@ class ClickHouseCore(BaseMetricsSink):
                 started_at=row[4],
                 ended_at=row[5],
                 completed_at=row[6],
+                native_team_key=row[8] or None,
                 last_synced=row[7],
-                org_id=row[8],
+                org_id=row[9],
             )
             for row in result.result_rows or []
         ]

--- a/src/dev_health_ops/metrics/sinks/clickhouse/work_graph.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/work_graph.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 import logging
 import uuid
 from collections.abc import Sequence
+from dataclasses import replace
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -365,11 +366,16 @@ class WorkGraphMixin(_ClickHouseSinkBase):
     def write_sprints(self, rows: Sequence[Sprint]) -> None:
         if not rows:
             return
+        persisted_rows = [
+            replace(sprint, native_team_key=sprint.native_team_key or "")
+            for sprint in rows
+        ]
         self._insert_rows(
             "sprints",
             [
                 "provider",
                 "sprint_id",
+                "native_team_key",
                 "name",
                 "state",
                 "started_at",
@@ -378,7 +384,7 @@ class WorkGraphMixin(_ClickHouseSinkBase):
                 "last_synced",
                 "org_id",
             ],
-            rows,
+            persisted_rows,
         )
 
     def write_worklogs(self, rows: Sequence[Worklog]) -> None:

--- a/src/dev_health_ops/migrations/clickhouse/062_sprints_native_team_key.sql
+++ b/src/dev_health_ops/migrations/clickhouse/062_sprints_native_team_key.sql
@@ -1,0 +1,1 @@
+ALTER TABLE sprints ADD COLUMN IF NOT EXISTS native_team_key String AFTER sprint_id;

--- a/src/dev_health_ops/models/work_items.py
+++ b/src/dev_health_ops/models/work_items.py
@@ -182,6 +182,7 @@ class Sprint:
     started_at: datetime | None
     ended_at: datetime | None
     completed_at: datetime | None
+    native_team_key: str | None = None
     last_synced: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     org_id: str = ""
 

--- a/src/dev_health_ops/providers/linear/provider.py
+++ b/src/dev_health_ops/providers/linear/provider.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import logging
 from collections.abc import Iterable, Sequence
+from dataclasses import replace
 from datetime import datetime
 from typing import Any
 
@@ -61,11 +62,15 @@ def _linear_reference_team(row: Any, team_key: str) -> dict[str, Any] | None:
 
 
 def _linear_sprints_from_reference(
-    rows: Sequence[Sprint] | None, *, team_key: str | None, scope: str | None
+    rows: Sequence[Sprint] | None, *, team_key: str | None
 ) -> list[Sprint]:
-    if not team_key or scope != team_key:
+    if not team_key:
         return []
-    return [sprint for sprint in rows or [] if sprint.provider == "linear"]
+    return [
+        sprint
+        for sprint in rows or []
+        if sprint.provider == "linear" and sprint.native_team_key == team_key
+    ]
 
 
 class LinearProvider(ProviderWithClient[LinearClient]):
@@ -171,7 +176,6 @@ class LinearProvider(ProviderWithClient[LinearClient]):
             for sprint in _linear_sprints_from_reference(
                 ctx.reference_sprints,
                 team_key=team_key,
-                scope=ctx.reference_sprints_scope,
             )
         }
         teams_to_sync: list[dict] = []
@@ -206,7 +210,9 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                     api_team = client.get_team_by_key(team_key)
                 if api_team and api_team.get("id"):
                     for cycle in client.iter_cycles(team_id=str(api_team["id"])):
-                        sprint = linear_cycle_to_sprint(cycle)
+                        sprint = replace(
+                            linear_cycle_to_sprint(cycle), native_team_key=team_key
+                        )
                         cycle_cache[sprint.sprint_id] = sprint
                         fetched_sprints.append(sprint)
                 if fetched_sprints and ctx.reference_sink is not None:
@@ -220,6 +226,7 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                                 started_at=sprint.started_at,
                                 ended_at=sprint.ended_at,
                                 completed_at=sprint.completed_at,
+                                native_team_key=team_key,
                                 last_synced=sprint.last_synced,
                                 org_id=str(ctx.org_id or ""),
                             )
@@ -233,8 +240,12 @@ class LinearProvider(ProviderWithClient[LinearClient]):
                     team_id = team.get("id")
                     if not team_id:
                         continue
+                    native_team_key = str(team.get("key") or "") or None
                     for cycle in client.iter_cycles(team_id=team_id):
-                        sprint = linear_cycle_to_sprint(cycle)
+                        sprint = replace(
+                            linear_cycle_to_sprint(cycle),
+                            native_team_key=native_team_key,
+                        )
                         cycle_cache.setdefault(sprint.sprint_id, sprint)
                 if cycle_cache:
                     yield ProviderBatch(sprints=list(cycle_cache.values()))

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -2231,7 +2231,9 @@ class ClickHouseStore:
             "argMax(started_at, last_synced) AS started_at, "
             "argMax(ended_at, last_synced) AS ended_at, "
             "argMax(completed_at, last_synced) AS completed_at, "
-            "max(last_synced) AS last_synced_max, org_id FROM sprints"
+            "max(last_synced) AS last_synced_max, "
+            "argMax(native_team_key, last_synced) AS native_team_key, "
+            "org_id FROM sprints"
         )
         params: dict[str, str] = {}
         scoped_org_id = str(org_id or self.org_id or "")
@@ -2256,8 +2258,9 @@ class ClickHouseStore:
                     started_at=_parse_datetime_value(row[4]),
                     ended_at=_parse_datetime_value(row[5]),
                     completed_at=_parse_datetime_value(row[6]),
+                    native_team_key=row[8] or None,
                     last_synced=last_synced,
-                    org_id=row[8],
+                    org_id=row[9],
                 )
             )
         return sprints

--- a/src/dev_health_ops/workers/reference_discovery.py
+++ b/src/dev_health_ops/workers/reference_discovery.py
@@ -322,7 +322,8 @@ def _missing_sprint_ids(
     rows = sink.query_dicts(
         "SELECT sprint_id FROM ("
         "SELECT org_id, provider, sprint_id, "
-        "argMax(name, last_synced) AS name "
+        "argMax(name, last_synced) AS name, "
+        "argMax(native_team_key, last_synced) AS native_team_key "
         "FROM sprints "
         "WHERE org_id = {org_id:String} AND provider = {provider:String} "
         "AND sprint_id IN {ids:Array(String)} "

--- a/src/dev_health_ops/workers/team_autoimport_linear.py
+++ b/src/dev_health_ops/workers/team_autoimport_linear.py
@@ -290,7 +290,11 @@ def populate(
                     continue
                 for cycle in client.iter_cycles(team_id=str(api_team["id"])):
                     sprint_rows.append(
-                        replace(linear_cycle_to_sprint(cycle), org_id=org_id)
+                        replace(
+                            linear_cycle_to_sprint(cycle),
+                            native_team_key=_team_id(team),
+                            org_id=org_id,
+                        )
                     )
     except Exception:
         if strict:

--- a/tests/test_reference_discovery_stage.py
+++ b/tests/test_reference_discovery_stage.py
@@ -272,9 +272,11 @@ def test_reference_discovery_readback_verifies_exact_team_and_sprint_keys(
             self, query: str, parameters: dict[str, Any]
         ) -> list[dict[str, Any]]:
             queries.append((query, parameters))
-            if "native_team_key" in query:
+            if "FROM teams" in query:
                 return [{"native_team_key": key} for key in parameters["keys"]]
-            return [{"sprint_id": sprint_id} for sprint_id in parameters["ids"]]
+            if "FROM sprints" in query:
+                return [{"sprint_id": sprint_id} for sprint_id in parameters["ids"]]
+            raise AssertionError(f"unexpected readback query: {query}")
 
         def close(self) -> None:
             return None
@@ -302,6 +304,7 @@ def test_reference_discovery_readback_verifies_exact_team_and_sprint_keys(
     }
     assert "FROM sprints" in queries[1][0]
     assert "FINAL" not in queries[1][0]
+    assert "argMax(native_team_key, last_synced) AS native_team_key" in queries[1][0]
     assert "GROUP BY org_id, provider, sprint_id" in queries[1][0]
     assert queries[1][1] == {
         "org_id": "org-1",

--- a/tests/test_reference_tier.py
+++ b/tests/test_reference_tier.py
@@ -92,6 +92,7 @@ def test_linear_store_hit_avoids_reference_api() -> None:
         started_at=None,
         ended_at=None,
         completed_at=None,
+        native_team_key="ENG",
     )
     ctx = IngestionContext(
         window=IngestionWindow(),
@@ -106,7 +107,6 @@ def test_linear_store_hit_avoids_reference_api() -> None:
             }
         ],
         reference_sprints=[sprint],
-        reference_sprints_scope="ENG",
     )
 
     batches = list(_linear_provider(client).iter_ingest(ctx))
@@ -116,6 +116,52 @@ def test_linear_store_hit_avoids_reference_api() -> None:
     assert client.iter_cycles_calls == 0
     assert [item.sprint_id for batch in batches for item in batch.sprints] == [
         "linear:cycle:cycle-1"
+    ]
+
+
+def test_linear_store_populated_by_team_fetches_cycles_at_most_once_per_run() -> None:
+    client = _LinearClient()
+    eng_sprint = Sprint(
+        provider="linear",
+        sprint_id="linear:cycle:eng-cycle",
+        name="Engineering Cycle",
+        state="future",
+        started_at=None,
+        ended_at=None,
+        completed_at=None,
+        native_team_key="ENG",
+    )
+    ops_sprint = Sprint(
+        provider="linear",
+        sprint_id="linear:cycle:ops-cycle",
+        name="Ops Cycle",
+        state="future",
+        started_at=None,
+        ended_at=None,
+        completed_at=None,
+        native_team_key="OPS",
+    )
+    ctx = IngestionContext(
+        window=IngestionWindow(),
+        repo="ENG",
+        reference_teams=[
+            {
+                "id": "ENG",
+                "name": "Engineering",
+                "provider": "linear",
+                "native_team_key": "ENG",
+                "project_keys": ["ENG"],
+            }
+        ],
+        reference_sprints=[eng_sprint, ops_sprint],
+    )
+
+    batches = list(_linear_provider(client).iter_ingest(ctx))
+
+    assert client.iter_cycles_calls <= 1
+    assert client.iter_cycles_calls == 0
+    assert [item.sprint_id for batch in batches for item in batch.sprints] == [
+        "linear:cycle:eng-cycle"
     ]
 
 
@@ -137,8 +183,12 @@ def test_linear_store_miss_fetches_scoped_references_once() -> None:
     assert client.iter_cycles_calls == 1
     assert sink.teams == []
     assert [sprint.sprint_id for sprint in sink.sprints] == ["linear:cycle:cycle-1"]
+    assert [sprint.native_team_key for sprint in sink.sprints] == ["ENG"]
     assert [item.sprint_id for batch in batches for item in batch.sprints] == [
         "linear:cycle:cycle-1"
+    ]
+    assert [item.native_team_key for batch in batches for item in batch.sprints] == [
+        "ENG"
     ]
 
 
@@ -152,6 +202,7 @@ def test_linear_unscoped_sprint_cache_does_not_skip_current_team_fetch() -> None
         started_at=None,
         ended_at=None,
         completed_at=None,
+        native_team_key="OPS",
     )
     ctx = IngestionContext(
         window=IngestionWindow(),
@@ -172,6 +223,7 @@ def test_linear_unscoped_sprint_cache_does_not_skip_current_team_fetch() -> None
 
     assert client.get_team_by_key_calls == 1
     assert client.iter_cycles_calls == 1
+    assert client.iter_cycles_calls <= 1
     assert [item.sprint_id for batch in batches for item in batch.sprints] == [
         "linear:cycle:cycle-1"
     ]
@@ -236,6 +288,7 @@ def test_jira_store_hit_avoids_per_sprint_api(monkeypatch: Any) -> None:
         started_at=None,
         ended_at=None,
         completed_at=None,
+        native_team_key=None,
     )
 
     *_, sprints = fetch_jira_work_items_with_extras(
@@ -244,6 +297,7 @@ def test_jira_store_hit_avoids_per_sprint_api(monkeypatch: Any) -> None:
 
     assert client.get_sprint_calls == 0
     assert [item.sprint_id for item in sprints] == ["7"]
+    assert [item.native_team_key for item in sprints] == [None]
 
 
 def test_jira_store_miss_fetches_and_persists_sprint_once(monkeypatch: Any) -> None:

--- a/tests/test_sprints_native_team_key_persistence.py
+++ b/tests/test_sprints_native_team_key_persistence.py
@@ -1,0 +1,136 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.models.work_items import Sprint
+from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+
+class _QueryResult:
+    def __init__(self, rows: list[tuple[Any, ...]]) -> None:
+        self.result_rows = rows
+
+
+def _linear_sprint() -> Sprint:
+    return Sprint(
+        provider="linear",
+        sprint_id="linear:cycle:cycle-1",
+        name="Cycle 1",
+        state="active",
+        started_at=None,
+        ended_at=None,
+        completed_at=None,
+        native_team_key="ENG",
+        org_id="org-1",
+    )
+
+
+def _jira_sprint() -> Sprint:
+    return Sprint(
+        provider="jira",
+        sprint_id="7",
+        name="Sprint 7",
+        state="active",
+        started_at=None,
+        ended_at=None,
+        completed_at=None,
+        org_id="org-1",
+    )
+
+
+def test_work_graph_sink_persists_sprint_native_team_key() -> None:
+    sink = ClickHouseMetricsSink.__new__(ClickHouseMetricsSink)
+    sink.client = MagicMock()
+    sink.org_id = ""
+
+    sink.write_sprints([_linear_sprint()])
+
+    args, kwargs = sink.client.insert.call_args
+    assert args[0] == "sprints"
+    column_names = kwargs["column_names"]
+    row = args[1][0]
+
+    assert "native_team_key" in column_names
+    assert row[column_names.index("native_team_key")] == "ENG"
+
+
+def test_work_graph_sink_coerces_non_linear_sprint_native_team_key_to_empty_string() -> (
+    None
+):
+    sink = ClickHouseMetricsSink.__new__(ClickHouseMetricsSink)
+    sink.client = MagicMock()
+    sink.org_id = ""
+
+    sink.write_sprints([_jira_sprint()])
+
+    args, kwargs = sink.client.insert.call_args
+    column_names = kwargs["column_names"]
+    row = args[1][0]
+    assert row[column_names.index("native_team_key")] == ""
+
+
+def test_clickhouse_store_get_all_sprints_reads_native_team_key_argmax() -> None:
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    store = ClickHouseStore("clickhouse://localhost:8123/stats")
+    store.client = MagicMock()
+    store.client.query.return_value = _QueryResult(
+        [
+            (
+                "linear",
+                "linear:cycle:cycle-1",
+                "Cycle 1",
+                "active",
+                None,
+                None,
+                None,
+                now,
+                "ENG",
+                "org-1",
+            )
+        ]
+    )
+
+    sprints = asyncio.run(store.get_all_sprints(org_id="org-1"))
+
+    query = store.client.query.call_args.args[0]
+    assert "argMax(native_team_key, last_synced) AS native_team_key" in query
+    assert "WHERE org_id = {org_id:String}" in query
+    assert "GROUP BY provider, sprint_id, org_id" in query
+    assert sprints[0].native_team_key == "ENG"
+    assert sprints[0].org_id == "org-1"
+
+
+def test_clickhouse_metrics_sink_get_all_sprints_reads_native_team_key_argmax() -> None:
+    now = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    sink = ClickHouseMetricsSink.__new__(ClickHouseMetricsSink)
+    sink.client = MagicMock()
+    sink.org_id = "org-1"
+    sink.client.query.return_value = _QueryResult(
+        [
+            (
+                "jira",
+                "7",
+                "Sprint 7",
+                "active",
+                None,
+                None,
+                None,
+                now,
+                "",
+                "org-1",
+            )
+        ]
+    )
+
+    sprints = asyncio.run(sink.get_all_sprints())
+
+    query = sink.client.query.call_args.args[0]
+    assert "argMax(native_team_key, last_synced) AS native_team_key" in query
+    assert "WHERE org_id = {org_id:String}" in query
+    assert "GROUP BY provider, sprint_id, org_id" in query
+    assert sprints[0].provider == "jira"
+    assert sprints[0].native_team_key is None


### PR DESCRIPTION
## What
Adds `native_team_key` to the ClickHouse `sprints` table (migration `062`, additive `ADD COLUMN IF NOT EXISTS`) and the `Sprint` model + sink. The Linear cycle producer stamps the owning team key; readers surface it via org-filtered `argMax(native_team_key, last_synced)`. The Linear path now reuses cycles **once-per-run from the store**, keyed by `native_team_key`, with a bounded source-scoped API fallback on store miss (a miss means "fetch+persist this team's cycles", never "no cycles").

## Why
Persisted sprints carried no team association, so Linear cycles were fetched per scoped team via API. This completes the reference-tier once-per-run guarantee for cycles. Closes CHAOS-2734 (CHAOS-2719 follow-up). No Postgres team attribution.

## Notes
- Non-Linear (Jira/GitHub/GitLab) sprint writes coerce `native_team_key` to `""` (the column is non-null `String`).
- Migration `062` composes cleanly with the parallel `061` sort-key rebuild (CHAOS-2735): `061` rebuilds via `SHOW CREATE` (auto-includes columns) and applies first; `062` is a plain additive `ADD COLUMN`.

## Tests / validation
- Call-count test proves Linear cycles fetched ≤1/run when the store is populated; producer writes `native_team_key`; reader argMax coverage; Jira `native_team_key=""` non-Linear write regression; reference-discovery readback contract updated to assert the sprint `argMax(native_team_key)` column.
- Full `ci/local_validate.sh` GATE PASSED (lint + mypy + full unit suite + live-ClickHouse migrate/argMax proof).
- Oracle review: blocker (non-null `native_team_key` write) fixed and re-validated.

SCREENSHOT-WAIVER: backend-only, no UI/render changes.