### PR TITLE
fix(sync): org-wide Linear placeholder source must use all-teams path, not crash (CHAOS-2739)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -790,15 +790,21 @@ def _non_git_source_rows(
     Jira project key) so every non-git config materializes exactly one
     planner-tagged source.
     """
-    external_id = str(
+    explicit_external_id = (
         sync_options.get("project_id")
         or sync_options.get("project_key")
         or sync_options.get("team_id")
         or sync_options.get("repo")
-        or name
+    )
+    is_linear_org_wide = provider.lower() == "linear" and not explicit_external_id
+    external_id = str(
+        explicit_external_id or (provider.lower() if is_linear_org_wide else name)
     )
     source_type = "project" if provider.lower() in {"jira", "linear"} else "source"
     full_name = str(sync_options.get("full_name") or external_id)
+    metadata: dict[str, Any] = {"planner_managed_sync_config_id": str(config_id)}
+    if is_linear_org_wide:
+        metadata["org_wide_placeholder"] = True
     return [
         IntegrationSource(
             org_id=org_id,
@@ -808,7 +814,7 @@ def _non_git_source_rows(
             external_id=external_id,
             name=name,
             full_name=full_name,
-            metadata_={"planner_managed_sync_config_id": str(config_id)},
+            metadata_=metadata,
             is_enabled=True,
         )
     ]

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -170,7 +170,11 @@ def _work_item_kwargs(context: SyncTaskContext) -> dict[str, Any]:
         "require_source": True,
     }
     if context.provider in {"github", "gitlab", "linear"}:
-        kwargs["repo_name"] = context.source_external_id
+        repo_name: str | None = context.source_external_id
+        if context.provider == "linear" and context.source_is_org_wide_placeholder:
+            repo_name = None
+            kwargs["require_source"] = False
+        kwargs["repo_name"] = repo_name
     if context.provider == "jira":
         kwargs["jira_project_keys"] = [context.source_external_id]
     if context.provider == "gitlab" and kwargs["credentials"]:

--- a/src/dev_health_ops/workers/sync_bootstrap.py
+++ b/src/dev_health_ops/workers/sync_bootstrap.py
@@ -60,6 +60,32 @@ class SyncTaskContext:
     credential_id: str | None
     decrypted_credentials: Any
     db_url: str
+    source_is_org_wide_placeholder: bool = False
+
+
+_NON_GIT_SOURCE_SCOPE_KEYS = ("project_id", "project_key", "team_id", "repo")
+
+
+def _linear_org_wide_placeholder_source(source: Any, integration: Any) -> bool:
+    provider = str(getattr(source, "provider", "") or integration.provider).lower()
+    if provider != "linear":
+        return False
+
+    metadata = dict(getattr(source, "metadata_", None) or {})
+    if metadata.get("org_wide_placeholder") is True:
+        return True
+
+    external_id = str(getattr(source, "external_id", "") or "").strip().lower()
+    if external_id != provider:
+        return False
+
+    if not metadata.get("planner_managed_sync_config_id"):
+        return False
+
+    config = dict(getattr(integration, "config", None) or {})
+    return not any(
+        str(config.get(key) or "").strip() for key in _NON_GIT_SOURCE_SCOPE_KEYS
+    )
 
 
 @dataclass(frozen=True)
@@ -193,6 +219,9 @@ class SyncTaskBootstrap:
             credential_id=str(credential_id) if credential_id is not None else None,
             decrypted_credentials=decrypted_credentials,
             db_url=_get_db_url(),
+            source_is_org_wide_placeholder=_linear_org_wide_placeholder_source(
+                source, integration
+            ),
         )
 
 

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -38,6 +38,7 @@ def _context(
     provider: str = "github",
     dataset_key: str,
     source_external_id: str = "full-chaos/dev-health",
+    source_is_org_wide_placeholder: bool = False,
     processor_flags: dict[str, bool] | None = None,
     credentials: Mapping[str, object] | None = None,
 ) -> SyncTaskContext:
@@ -58,6 +59,7 @@ def _context(
         credential_id="credential-1",
         decrypted_credentials=dict(credentials or {"token": "secret-token"}),
         db_url="clickhouse://localhost/default",
+        source_is_org_wide_placeholder=source_is_org_wide_placeholder,
     )
 
 
@@ -234,6 +236,45 @@ def test_work_item_datasets_route_to_work_item_sync_scoped_to_source(
         assert "include_issues" not in kwargs
     assert result["work_items_synced"] is True
     assert result["source"] == source_external_id
+
+
+def test_linear_org_wide_provider_name_placeholder_routes_to_no_source() -> None:
+    ctx = _context(
+        provider="linear",
+        dataset_key="work-items",
+        source_external_id="linear",
+        source_is_org_wide_placeholder=True,
+    )
+
+    with patch(
+        "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"
+    ) as work_items:
+        result = run_dataset_unit(ctx, _runtime())
+
+    work_items.assert_called_once()
+    kwargs = work_items.call_args.kwargs
+    assert kwargs["provider"] == "linear"
+    assert kwargs["repo_name"] is None
+    assert kwargs["require_source"] is False
+    assert result["source"] == "linear"
+
+
+def test_linear_provider_name_scoped_source_stays_visible_to_provider() -> None:
+    ctx = _context(
+        provider="linear",
+        dataset_key="work-items",
+        source_external_id="linear",
+    )
+
+    with patch(
+        "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"
+    ) as work_items:
+        run_dataset_unit(ctx, _runtime())
+
+    work_items.assert_called_once()
+    kwargs = work_items.call_args.kwargs
+    assert kwargs["repo_name"] == "linear"
+    assert kwargs["require_source"] is True
 
 
 def test_work_item_derivative_dataset_uses_same_work_item_path() -> None:

--- a/tests/test_linear_provider.py
+++ b/tests/test_linear_provider.py
@@ -814,9 +814,11 @@ class TestLinearProviderIngest:
 
     @patch.dict(os.environ, {"LINEAR_API_KEY": "test-api-key"}, clear=False)
     @patch("dev_health_ops.providers.linear.client.LinearClient.from_env")
+    @pytest.mark.parametrize("team_key", ["NONEXISTENT", "linear"])
     def test_ingest_team_not_found(
         self,
         mock_from_env: MagicMock,
+        team_key: str,
         mock_identity: IdentityResolver,
         mock_status_mapping: StatusMapping,
     ) -> None:
@@ -834,7 +836,7 @@ class TestLinearProviderIngest:
 
         ctx = IngestionContext(
             window=IngestionWindow(),
-            repo="NONEXISTENT",
+            repo=team_key,
         )
 
         with pytest.raises(ValueError, match="not found"):

--- a/tests/test_reference_discovery_stage.py
+++ b/tests/test_reference_discovery_stage.py
@@ -233,6 +233,44 @@ def test_reference_discovery_fails_when_unit_source_inventory_is_incomplete(
         reference_discovery._load_discovery_context(run.id)
 
 
+def test_sync_task_bootstrap_marks_linear_provider_name_source_as_org_wide(
+    db_session: Session,
+) -> None:
+    from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
+
+    run, unit = _seed_unitized_run(db_session, external_id="linear")
+    integration = db_session.query(Integration).filter_by(id=run.integration_id).one()
+    integration.config = {"auto_import_teams": False}
+    source = db_session.query(IntegrationSource).filter_by(id=unit.source_id).one()
+    source.source_type = "project"
+    source.metadata_ = {"planner_managed_sync_config_id": str(uuid.uuid4())}
+    db_session.flush()
+
+    context = SyncTaskBootstrap.load(db_session, str(unit.id))
+
+    assert context.source_external_id == "linear"
+    assert context.source_is_org_wide_placeholder is True
+
+
+def test_sync_task_bootstrap_keeps_explicit_provider_name_source_scoped(
+    db_session: Session,
+) -> None:
+    from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
+
+    run, unit = _seed_unitized_run(db_session, external_id="linear")
+    integration = db_session.query(Integration).filter_by(id=run.integration_id).one()
+    integration.config = {"team_id": "linear"}
+    source = db_session.query(IntegrationSource).filter_by(id=unit.source_id).one()
+    source.source_type = "project"
+    source.metadata_ = {"planner_managed_sync_config_id": str(uuid.uuid4())}
+    db_session.flush()
+
+    context = SyncTaskBootstrap.load(db_session, str(unit.id))
+
+    assert context.source_external_id == "linear"
+    assert context.source_is_org_wide_placeholder is False
+
+
 @pytest.mark.parametrize(
     ("module_name", "message"),
     [

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -944,6 +944,77 @@ class TestWorkItemsProviderCredentialIsolation:
 
         assert captured_repos == ["ENG"]
 
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("dev_health_ops.metrics.job_work_items.ClickHouseMetricsSink")
+    @patch("dev_health_ops.providers.linear.client.LinearClient.from_env")
+    def test_linear_work_items_org_wide_placeholder_reaches_unscoped_ingest(
+        self, mock_from_env, mock_sink_class
+    ):
+        from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
+
+        sink = MagicMock()
+        sink.query_dicts.return_value = []
+        mock_sink_class.return_value = sink
+
+        captured_repos: list[object] = []
+
+        def _fake_iter_ingest(self, ctx):
+            captured_repos.append(ctx.repo)
+            return iter(())
+
+        with patch(
+            "dev_health_ops.providers.linear.provider.LinearProvider.iter_ingest",
+            new=_fake_iter_ingest,
+        ):
+            run_work_items_sync_job(
+                db_url="clickhouse://localhost/dev",
+                day=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                backfill_days=1,
+                provider="linear",
+                org_id="00000000-0000-0000-0000-000000000001",
+                credentials={"api_key": "lin_explicit"},
+                repo_name=None,
+                require_source=False,
+            )
+
+        assert captured_repos == [None]
+
+    @patch.dict(os.environ, {}, clear=True)
+    @patch("dev_health_ops.metrics.job_work_items.ClickHouseMetricsSink")
+    @patch("dev_health_ops.providers.linear.client.LinearClient.from_env")
+    def test_linear_work_items_scoped_provider_name_still_fails_visibly(
+        self, mock_from_env, mock_sink_class
+    ):
+        from dev_health_ops.metrics.job_work_items import run_work_items_sync_job
+
+        sink = MagicMock()
+        sink.query_dicts.return_value = []
+        mock_sink_class.return_value = sink
+
+        captured_repos: list[object] = []
+
+        def _fake_iter_ingest(self, ctx):
+            captured_repos.append(ctx.repo)
+            raise ValueError("Linear team 'linear' not found")
+
+        with patch(
+            "dev_health_ops.providers.linear.provider.LinearProvider.iter_ingest",
+            new=_fake_iter_ingest,
+        ):
+            with pytest.raises(ValueError, match="Linear team 'linear' not found"):
+                run_work_items_sync_job(
+                    db_url="clickhouse://localhost/dev",
+                    day=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                    backfill_days=1,
+                    provider="linear",
+                    org_id="00000000-0000-0000-0000-000000000001",
+                    credentials={"api_key": "lin_explicit"},
+                    repo_name="linear",
+                    require_source=True,
+                )
+
+        assert captured_repos == ["linear"]
+
     @patch.dict(
         os.environ,
         {"JIRA_JQL": "project = ENV", "JIRA_PROJECT_KEYS": "ENV"},


### PR DESCRIPTION
## What
Recognizes the org-wide Linear **placeholder** source (planner-managed config with no explicit team/project key, whose `IntegrationSource.external_id` fell back to the provider name `"linear"`) and routes it to the Linear **all-teams** path: `repo_name=None` **and** `require_source=False`, so it reaches `LinearProvider.iter_ingest` with `ctx.repo is None`. New configs are marked via source metadata; legacy rows are detected by provider + `external_id=="linear"` + absence of an explicit project/team/repo key.

## Why (production bug, found via `sync now`)
`_non_git_source_rows()` fell back to the config name, creating an `IntegrationSource` with `external_id="linear"`. Post-AD-2 source scoping passed it as `ctx.repo`, and the Linear provider raised `ValueError("Linear team 'linear' not found")`. Genuinely scoped Linear units with an unknown source **still fail visibly**. Closes CHAOS-2739 (CHAOS-2719 regression).

## Tests / validation
- `_work_item_kwargs` sets `require_source=False` only for the org-wide placeholder; scoped units keep `require_source=True`.
- Job-level regressions: org-wide placeholder reaches `iter_ingest` with `ctx.repo is None` (all-teams path runs); scoped `repo_name="linear"` still fails visibly.
- Full `ci/local_validate.sh` GATE PASSED (lint + mypy + full unit suite + live-ClickHouse argMax proof).
- Oracle review: blocker (require_source guard) identified and fixed; re-validated.

SCREENSHOT-WAIVER: backend-only, no UI/render changes.