### PR TITLE
fix(sync): no-op strict reference discovery for non-import-capable providers (CHAOS-2740)

### DIFF
--- a/src/dev_health_ops/workers/reference_discovery.py
+++ b/src/dev_health_ops/workers/reference_discovery.py
@@ -261,6 +261,10 @@ def _verify_reference_readback(
 ) -> None:
     expected_team_keys = _strings(summary.get("reference_team_keys"))
     expected_sprint_ids = _strings(summary.get("reference_sprint_ids"))
+    if not expected_team_keys and not expected_sprint_ids:
+        # Nothing claimed to verify (e.g. a non-import-capable provider's no-op
+        # discovery) — a true no-op that must not depend on ClickHouse.
+        return
     deadline = time.monotonic() + _readback_timeout_seconds()
     sink = ClickHouseMetricsSink(dsn=analytics_db_url)
     try:

--- a/src/dev_health_ops/workers/team_autoimport.py
+++ b/src/dev_health_ops/workers/team_autoimport.py
@@ -150,7 +150,24 @@ def run_team_autoimport_strict(
 ) -> dict[str, Any]:
     normalized_provider = provider.strip().lower()
     if not _provider_capability(normalized_provider):
-        raise ValueError(f"provider is not import-capable: {normalized_provider}")
+        # Providers without a reference tier (e.g. launchdarkly) have nothing
+        # to discover today, so strict reference discovery is a successful
+        # no-op rather than a hard failure that would fail the whole sync run.
+        # (LD work-item association — Commits<>PRs<>Issues — is planned but not
+        # implemented yet; CHAOS-2740.) Genuine failures still surface: a capable
+        # provider with a missing populator raises below, and a capable provider
+        # with bad credentials raises inside the populator.
+        logger.info(
+            "Reference discovery no-op for provider=%s org_id=%s: provider is "
+            "not import-capable (nothing to discover yet)",
+            normalized_provider,
+            org_id,
+        )
+        return _zero_summary(
+            provider=normalized_provider,
+            org_id=org_id,
+            reason="provider_not_import_capable",
+        )
     populator = _resolve_populator(normalized_provider)
     if populator is None:
         raise ValueError(

--- a/tests/test_reference_discovery_stage.py
+++ b/tests/test_reference_discovery_stage.py
@@ -542,3 +542,42 @@ def test_backfill_runner_dispatch_path_blocks_until_discovery(
     assert run is not None
     assert _outbox_rows(db_session, run, OUTBOX_KIND_DISCOVERY)
     assert _outbox_rows(db_session, run, OUTBOX_KIND_DISPATCH) == []
+
+
+def test_reference_discovery_noop_for_non_capable_provider_arms_dispatch(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-import-capable provider (e.g. launchdarkly) yields a skip summary
+    with no reference keys; discovery must stamp success and arm dispatch
+    WITHOUT requiring ClickHouse (a true no-op). CHAOS-2740."""
+    from dev_health_ops.workers import reference_discovery
+
+    run, _unit = _seed_unitized_run(db_session)
+    _add_discovery(db_session, run)
+    _patch_db_session(monkeypatch, db_session)
+    # Point CLICKHOUSE_URI at an unreachable host to prove the no-op readback
+    # never connects (the early-return short-circuits before sink construction).
+    monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://unreachable.invalid:9000/db")
+
+    def strict_skip(**kwargs: Any) -> dict[str, Any]:
+        return {
+            "status": "skipped",
+            "provider": "launchdarkly",
+            "org_id": kwargs["org_id"],
+            "reason": "provider_not_import_capable",
+            "projects_imported": 0,
+        }
+
+    monkeypatch.setattr(reference_discovery, "run_team_autoimport_strict", strict_skip)
+
+    result = reference_discovery.run_sync_reference_discovery(str(run.id))
+
+    ledger = (
+        db_session.query(SyncRunReferenceDiscovery).filter_by(sync_run_id=run.id).one()
+    )
+    dispatch_outbox = _outbox_rows(db_session, run, OUTBOX_KIND_DISPATCH)
+    assert result["status"] == "success"
+    assert ledger.status == "success"
+    assert ledger.completed_at is not None
+    assert len(dispatch_outbox) == 1
+    assert dispatch_outbox[0].status == OUTBOX_STATUS_PENDING

--- a/tests/workers/test_team_autoimport_executor.py
+++ b/tests/workers/test_team_autoimport_executor.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import logging
 from typing import Any
 
+import pytest
+
 from dev_health_ops.workers import team_autoimport
 
 
@@ -72,3 +74,41 @@ def test_run_team_autoimport_calls_resolved_populator(monkeypatch) -> None:
             },
         }
     ]
+
+
+def test_run_team_autoimport_strict_noops_non_capable_provider(caplog) -> None:
+    """A provider with no reference tier (e.g. launchdarkly) must NOT fail the
+    strict pre-sync discovery stage — it is a successful no-op so the run can
+    proceed to dispatch (CHAOS-2740)."""
+    caplog.set_level(logging.INFO)
+
+    result = team_autoimport.run_team_autoimport_strict(
+        provider="launchdarkly",
+        org_id="org-1",
+        credentials={"token": "secret"},
+    )
+
+    assert result["status"] == "skipped"
+    assert result["reason"] == "provider_not_import_capable"
+    assert result["projects_imported"] == 0
+    assert "not import-capable" in caplog.text
+    # No reference keys claimed -> _verify_reference_readback no-ops and the
+    # discovery ledger is stamped success.
+    assert "reference_team_keys" not in result
+    assert "reference_sprint_ids" not in result
+
+
+def test_run_team_autoimport_strict_raises_capable_provider_missing_populator(
+    monkeypatch,
+) -> None:
+    """Genuine failures are preserved: a capable provider whose populator module
+    is unavailable still fails strict discovery visibly."""
+    monkeypatch.setattr(team_autoimport, "_provider_capability", lambda provider: True)
+    monkeypatch.setattr(team_autoimport, "_resolve_populator", lambda provider: None)
+
+    with pytest.raises(ValueError, match="populator is unavailable"):
+        team_autoimport.run_team_autoimport_strict(
+            provider="github",
+            org_id="org-1",
+            credentials={"token": "secret"},
+        )


### PR DESCRIPTION
## What
A non-import-capable provider (no reference-tier populator — only github/gitlab/jira/linear are import-capable) now makes strict pre-sync reference discovery a **graceful no-op success** instead of raising. `_verify_reference_readback` also early-returns when nothing is claimed, so the no-op never constructs a ClickHouse sink.

## Why (production bug, found via `sync now`)
The pre-sync strict discovery stage (CHAOS-2718) arms for **every** sync run, and `run_team_autoimport_strict` raised `ValueError("provider is not import-capable: <provider>")` for providers like **launchdarkly** that have no teams/cycles/sprints to discover today — failing the entire run. Genuine failures are preserved: a capable provider with a missing populator or bad credentials still raises. Closes CHAOS-2740.

> Note: LaunchDarkly work-item association (Commits↔PRs↔Issues) is planned but not implemented yet; until then it correctly no-ops.

## Tests / validation
- Unit: `run_team_autoimport_strict` returns skip-success for launchdarkly; a capable provider with a missing populator still raises.
- Discovery-stage: a non-capable skip summary stamps the ledger `success` and arms dispatch **without** connecting to ClickHouse (CLICKHOUSE_URI pointed at an unreachable host).
- Full `ci/local_validate.sh` GATE PASSED (lint + mypy + full unit suite + live-ClickHouse argMax proof).
- Oracle review: SOUND; both nits applied.

SCREENSHOT-WAIVER: backend-only, no UI/render changes.