### PR TITLE
feat(forecast): expose stale WIP signal (CHAOS-2729)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -823,6 +823,12 @@ class ThroughputRiskOverlay:
 
 
 @strawberry.type
+class ThroughputStaleWip:
+    p50_age_hours: float | None = None
+    p90_age_hours: float | None = None
+
+
+@strawberry.type
 class ThroughputForecast:
     """Throughput-based capacity forecast result.
 
@@ -842,6 +848,7 @@ class ThroughputForecast:
     rolling_windows: list[ThroughputRollingWindow]
     primary_risk: ThroughputRiskOverlay
     wip_congestion: ThroughputRiskOverlay
+    stale_wip: ThroughputStaleWip | None = None
     review_bottleneck: ThroughputRiskOverlay
     incident_load: ThroughputRiskOverlay
     insufficient_history: bool

--- a/src/dev_health_ops/api/graphql/resolvers/forecast.py
+++ b/src/dev_health_ops/api/graphql/resolvers/forecast.py
@@ -23,6 +23,7 @@ from ..models.outputs import (
     ThroughputForecast,
     ThroughputRiskOverlay,
     ThroughputRollingWindow,
+    ThroughputStaleWip,
 )
 
 
@@ -37,7 +38,11 @@ def _risk_to_output(risk: RiskOverlay) -> ThroughputRiskOverlay:
     )
 
 
-def _result_to_output(result: ThroughputForecastResult) -> ThroughputForecast:
+def _result_to_output(
+    result: ThroughputForecastResult,
+    *,
+    stale_wip: ThroughputStaleWip | None = None,
+) -> ThroughputForecast:
     return ThroughputForecast(
         forecast_id=result.forecast_id,
         computed_at=result.computed_at.isoformat(),
@@ -59,6 +64,7 @@ def _result_to_output(result: ThroughputForecastResult) -> ThroughputForecast:
         ],
         primary_risk=_risk_to_output(result.primary_risk),
         wip_congestion=_risk_to_output(result.wip_congestion),
+        stale_wip=stale_wip,
         review_bottleneck=_risk_to_output(result.review_bottleneck),
         incident_load=_risk_to_output(result.incident_load),
         insufficient_history=result.insufficient_history,
@@ -187,6 +193,55 @@ async def _load_work_item_overlay(
     )
     row = rows[0] if rows else {}
     return float(row.get("current_wip") or 0.0), float(row.get("average_wip") or 0.0)
+
+
+async def _load_stale_wip(
+    context: GraphQLContext,
+    *,
+    team_ids: list[str] | None,
+    work_scope_id: str | None,
+) -> ThroughputStaleWip | None:
+    conditions: list[str] = ["org_id = {org_id:String}"]
+    params: dict[str, Any] = {"org_id": context.org_id}
+    _team_filter(team_ids, conditions, params)
+    if work_scope_id:
+        conditions.append("work_scope_id = {work_scope_id:String}")
+        params["work_scope_id"] = work_scope_id
+    where_sql = (" WHERE " + " AND ".join(conditions)) if conditions else ""
+
+    rows = await query_dicts(
+        context.client,
+        f"""
+        SELECT
+            avg(wip_age_p50_hours) AS p50_age_hours,
+            avg(wip_age_p90_hours) AS p90_age_hours
+        FROM (
+            SELECT
+                provider,
+                work_scope_id,
+                team_id,
+                argMax(wip_age_p50_hours, computed_at) AS wip_age_p50_hours,
+                argMax(wip_age_p90_hours, computed_at) AS wip_age_p90_hours
+            FROM work_item_metrics_daily
+            WHERE day = (
+                SELECT max(day) FROM work_item_metrics_daily{where_sql}
+            )
+            {("AND " + " AND ".join(conditions)) if conditions else ""}
+            GROUP BY provider, work_scope_id, team_id
+        )
+        WHERE wip_age_p50_hours IS NOT NULL OR wip_age_p90_hours IS NOT NULL
+        """,
+        params,
+    )
+    row = rows[0] if rows else {}
+    p50_age_hours = row.get("p50_age_hours")
+    p90_age_hours = row.get("p90_age_hours")
+    if p50_age_hours is None and p90_age_hours is None:
+        return None
+    return ThroughputStaleWip(
+        p50_age_hours=float(p50_age_hours) if p50_age_hours is not None else None,
+        p90_age_hours=float(p90_age_hours) if p90_age_hours is not None else None,
+    )
 
 
 async def _load_review_overlay(
@@ -349,6 +404,11 @@ async def resolve_throughput_forecast(
         work_scope_id=input.work_scope_id,
         history_weeks=input.history_weeks,
     )
+    stale_wip = await _load_stale_wip(
+        context,
+        team_ids=input.team_ids,
+        work_scope_id=input.work_scope_id,
+    )
     review_latency_hours = await _load_review_overlay(
         context,
         history_weeks=input.history_weeks,
@@ -368,4 +428,4 @@ async def resolve_throughput_forecast(
         review_latency_hours=review_latency_hours,
         incident_count=incident_count,
     )
-    return _result_to_output(result)
+    return _result_to_output(result, stale_wip=stale_wip)

--- a/tests/api/graphql/test_throughput_forecast_resolver.py
+++ b/tests/api/graphql/test_throughput_forecast_resolver.py
@@ -94,6 +94,7 @@ def ctx():
 async def test_resolver_aggregates_org_wide_when_team_ids_is_none(ctx):
     """``team_ids=None`` must NOT short-circuit to None or sample data."""
     from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.models.outputs import ThroughputStaleWip
     from dev_health_ops.api.graphql.resolvers.forecast import (
         resolve_throughput_forecast,
     )
@@ -109,6 +110,11 @@ async def test_resolver_aggregates_org_wide_when_team_ids_is_none(ctx):
             new_callable=AsyncMock,
             return_value=(0.0, 0.0),
         ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_stale_wip",
+            new_callable=AsyncMock,
+            return_value=ThroughputStaleWip(p50_age_hours=24.0, p90_age_hours=96.0),
+        ) as load_stale_wip,
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
             new_callable=AsyncMock,
@@ -134,7 +140,10 @@ async def test_resolver_aggregates_org_wide_when_team_ids_is_none(ctx):
     assert result is not None
     assert result.team_id is None
     assert result.backlog_size == 42
+    assert result.stale_wip is not None
+    assert result.stale_wip.p90_age_hours == 96.0
     load_backlog.assert_awaited_once_with(ctx, team_ids=None, work_scope_id=None)
+    load_stale_wip.assert_awaited_once_with(ctx, team_ids=None, work_scope_id=None)
 
 
 @pytest.mark.asyncio
@@ -156,6 +165,11 @@ async def test_resolver_aggregates_multi_team_selection(ctx):
             new_callable=AsyncMock,
             return_value=(0.0, 0.0),
         ) as load_wip,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_stale_wip",
+            new_callable=AsyncMock,
+            return_value=None,
+        ) as load_stale_wip,
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
             new_callable=AsyncMock,
@@ -192,6 +206,9 @@ async def test_resolver_aggregates_multi_team_selection(ctx):
     load_wip.assert_awaited_once_with(
         ctx, team_ids=["team-1", "team-2"], work_scope_id=None, history_weeks=12
     )
+    load_stale_wip.assert_awaited_once_with(
+        ctx, team_ids=["team-1", "team-2"], work_scope_id=None
+    )
     load_backlog.assert_awaited_once_with(
         ctx, team_ids=["team-1", "team-2"], work_scope_id=None
     )
@@ -215,6 +232,11 @@ async def test_resolver_single_team_sets_result_team_id(ctx):
             "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
             new_callable=AsyncMock,
             return_value=(0.0, 0.0),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_stale_wip",
+            new_callable=AsyncMock,
+            return_value=None,
         ),
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
@@ -262,6 +284,11 @@ async def test_resolver_skips_backlog_query_when_caller_provides_size(ctx):
             "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
             new_callable=AsyncMock,
             return_value=(0.0, 0.0),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_stale_wip",
+            new_callable=AsyncMock,
+            return_value=None,
         ),
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
@@ -359,6 +386,50 @@ async def test_load_backlog_uses_equality_for_single_team(ctx):
     assert "team_ids" not in params
 
 
+@pytest.mark.asyncio
+async def test_load_stale_wip_reads_latest_scoped_wip_age(ctx):
+    from dev_health_ops.api.graphql.resolvers.forecast import _load_stale_wip
+
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.forecast.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[{"p50_age_hours": 24.0, "p90_age_hours": 96.0}],
+    ) as query:
+        stale_wip = await _load_stale_wip(
+            ctx, team_ids=["team-a"], work_scope_id="scope-a"
+        )
+
+    assert stale_wip is not None
+    assert stale_wip.p50_age_hours == 24.0
+    assert stale_wip.p90_age_hours == 96.0
+    call_args = query.await_args
+    assert call_args is not None
+    sql = call_args.args[1]
+    params = call_args.args[2]
+    assert "argMax(wip_age_p50_hours, computed_at)" in sql
+    assert "argMax(wip_age_p90_hours, computed_at)" in sql
+    assert "org_id = {org_id:String}" in sql
+    assert "team_id = {team_id:String}" in sql
+    assert "work_scope_id = {work_scope_id:String}" in sql
+    assert params["org_id"] == ctx.org_id
+    assert params["team_id"] == "team-a"
+    assert params["work_scope_id"] == "scope-a"
+
+
+@pytest.mark.asyncio
+async def test_load_stale_wip_returns_none_without_age_rows(ctx):
+    from dev_health_ops.api.graphql.resolvers.forecast import _load_stale_wip
+
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.forecast.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[{"p50_age_hours": None, "p90_age_hours": None}],
+    ):
+        stale_wip = await _load_stale_wip(ctx, team_ids=None, work_scope_id=None)
+
+    assert stale_wip is None
+
+
 def _insufficient_result() -> ThroughputForecastResult:
     """Short-history forecast: no estimate, every window flagged insufficient."""
     return ThroughputForecastResult(
@@ -406,6 +477,11 @@ async def test_resolver_surfaces_insufficient_history_and_sample_count(ctx):
             "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
             new_callable=AsyncMock,
             return_value=(0.0, 0.0),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_stale_wip",
+            new_callable=AsyncMock,
+            return_value=None,
         ),
         patch(
             "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",


### PR DESCRIPTION
## Summary
- Exposes stale WIP forecast fields in the backlog-risk GraphQL response.
- Adds resolver coverage for the stale WIP no-data and populated states.

## Verification
- `bash ci/local_validate.sh` passed: 6056 passed, 44 skipped.

## Manual QA
- Backend/API slice only; paired web PR verified `/plan/backlog-risk` renders the stale WIP no-data state against the API with 200 responses.

## Phase Context
- CHAOS-2729 stale WIP slice only.
- Remaining forecast cockpit phases continue in CHAOS-2730, CHAOS-2731, CHAOS-2732, CHAOS-2733, and Phase 4.

## Linear
- https://linear.app/fullchaos/issue/CHAOS-2729/backlog-risk-wire-stale-wip-card-to-existing-wip-age-data
