### PR TITLE
docs(general): Validate cockpit live-data fixture coverage (CHAOS-2731/2732)

### DIFF
--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -604,7 +604,7 @@ dev-hops fixtures generate \
 | `--pr-count` | `20` | Total pull requests to generate |
 | `--seed` | random | Deterministic seed for repeatable runs |
 | `--provider` | `synthetic` | Provider label: `synthetic`, `github`, `gitlab`, `jira` |
-| `--with-metrics` | off | Also generate derived metrics (daily, DORA, complexity, investment, etc.) |
+| `--with-metrics` | off | Also generate derived metrics (daily, DORA, complexity, investment, Cockpit/TestOps risk inputs, etc.) |
 | `--with-work-graph` | off | Build work graph edges after generation (ClickHouse only) |
 | `--team-count` | `8` | Number of synthetic teams to create |
 
@@ -625,6 +625,13 @@ tables are also seeded: `ai_attribution`, `ai_workflow_runs`,
 `ai_workflow_artifact_edges`, and `ai_workflow_issue_edges`. The daily metrics
 job then computes `ai_impact_metrics_daily`, `ai_governance_coverage_daily`,
 and `ai_policy_events` from those source rows.
+
+`--with-metrics` also writes the Cockpit/Govern risk inputs used by Compounding
+Risk and TestOps Delivery Risk: `repo_complexity_daily`, `repo_metrics_daily`,
+`compounding_risk_daily`, `testops_pipeline_metrics_daily`,
+`testops_test_metrics_daily`, and `testops_coverage_metrics_daily`. A base
+fixture run without this flag is suitable for raw-ingest checks, but those risk
+surfaces should be expected to report missing inputs until metrics are computed.
 
 ### `fixtures validate`
 

--- a/docs/ops/runbook-ingestion-failures.md
+++ b/docs/ops/runbook-ingestion-failures.md
@@ -42,6 +42,23 @@ WHERE repo_id = '...'
 GROUP BY repo_id;
 ```
 
+For Cockpit/Govern risk surfaces, also confirm the derived analytics inputs are
+present. Delivery Risk/TestOps requires all three TestOps daily rollups;
+Compounding Risk requires review latency in `repo_metrics_daily` plus complexity
+rows in `repo_complexity_daily`:
+
+```sql
+SELECT 'testops_pipeline_metrics_daily' AS table_name, count() AS rows FROM testops_pipeline_metrics_daily
+UNION ALL
+SELECT 'testops_test_metrics_daily', count() FROM testops_test_metrics_daily
+UNION ALL
+SELECT 'testops_coverage_metrics_daily', count() FROM testops_coverage_metrics_daily
+UNION ALL
+SELECT 'repo_metrics_daily.review_latency', count() FROM repo_metrics_daily WHERE pr_first_review_p90_hours IS NOT NULL
+UNION ALL
+SELECT 'repo_complexity_daily.complexity', count() FROM repo_complexity_daily WHERE cyclomatic_per_kloc IS NOT NULL;
+```
+
 ### 3. Inspect Job Status
 Check for failed jobs in the `ci_job_runs` table:
 ```sql
@@ -55,18 +72,60 @@ LIMIT 10;
 ## Recovery Procedures
 
 ### 1. Manual Sync Trigger
-Trigger a manual sync for the affected provider:
+Trigger manual syncs for the affected provider. CI/CD pipeline runs/jobs and test
+artifacts are separate sync targets; run both when Delivery Risk/TestOps surfaces
+are missing pipeline, test, or coverage inputs:
 ```bash
-dev-hops sync testops --provider github --owner <org> --repo <repo>
+dev-hops sync cicd --provider github \
+  --auth "$GITHUB_TOKEN" \
+  --owner <org> \
+  --repo <repo>
+
+dev-hops sync tests --provider github \
+  --auth "$GITHUB_TOKEN" \
+  --owner <org> \
+  --repo <repo>
 ```
 
-### 2. Data Backfill
-If data is missing for a specific period, use the backfill command:
+### 2. Recompute Daily Metrics
+After source rows are restored, recompute the daily TestOps rollups for the
+affected window. Use `--repo-id` for a single repository or omit it for all repos:
 ```bash
-dev-hops backfill run --since 2024-01-01 --until 2024-01-07 --repo <repo_id>
+dev-hops metrics daily \
+  --since 2024-01-01 \
+  --before 2024-01-08 \
+  --repo-id <repo_id>
 ```
 
-### 3. Clear Watermarks
+For Compounding Risk, daily metrics restore the review-latency input, but the
+complexity input is produced by the complexity job. Rebuild complexity before
+recomputing the composite score:
+
+```bash
+dev-hops metrics complexity \
+  --since 2024-01-01 \
+  --before 2024-01-08 \
+  --repo-id <repo_id>
+
+dev-hops metrics compounding-risk \
+  --org <org_id> \
+  --day 2024-01-08 \
+  --backfill 7
+```
+
+### 3. Historical Backfill
+If the source sync configuration itself needs a historical replay, prefer the
+admin backfill API described in `workers.md`. For inline recovery, use the
+sync-configuration based command:
+
+```bash
+dev-hops backfill run \
+  --config-id <sync_config_uuid> \
+  --since 2024-01-01 \
+  --before 2024-01-08
+```
+
+### 4. Clear Watermarks
 If the sync is stuck due to a bad cursor, you may need to clear the watermark in the metadata store (PostgreSQL) to force a full re-sync of recent data.
 
 ## Alert Thresholds

--- a/docs/ops/testops-demo-pack.md
+++ b/docs/ops/testops-demo-pack.md
@@ -22,15 +22,27 @@ To ensure a rich demo experience, you should seed the environment with realistic
 Use the `dev-hops` CLI to generate 30 days of synthetic TestOps fixtures:
 
 ```bash
-# Generate fixtures for the last 30 days
-CLICKHOUSE_URI=clickhouse://... dev-hops fixtures generate --sink "$CLICKHOUSE_URI" --days 30
+# Generate fixtures and derived metrics for the last 30 days
+CLICKHOUSE_URI=clickhouse://... dev-hops fixtures generate \
+  --sink "$CLICKHOUSE_URI" \
+  --days 30 \
+  --with-metrics
 ```
 
-This command appears to populate the following tables:
+This command populates the raw TestOps tables and the daily rollup tables
+consumed by TestOps risk/reporting surfaces:
 - `ci_pipeline_runs`
 - `ci_job_runs`
-- `test_executions`
+- `test_suite_results`
+- `test_case_results`
 - `coverage_snapshots`
+- `testops_pipeline_metrics_daily`
+- `testops_test_metrics_daily`
+- `testops_coverage_metrics_daily`
+
+Omitting `--with-metrics` seeds only raw fixture rows; Delivery Risk and Govern
+cards remain under-ingested until `dev-hops metrics daily` computes these
+rollups.
 
 ---
 

--- a/src/dev_health_ops/fixtures/runner.py
+++ b/src/dev_health_ops/fixtures/runner.py
@@ -1587,6 +1587,77 @@ AI_FIXTURE_TABLES: tuple[str, ...] = (
     "ai_policy_events",
 )
 
+COCKPIT_LIVE_DATA_TABLES: tuple[str, ...] = (
+    "repo_complexity_daily",
+    "repo_metrics_daily",
+    "compounding_risk_daily",
+    "testops_pipeline_metrics_daily",
+    "testops_test_metrics_daily",
+    "testops_coverage_metrics_daily",
+)
+
+
+def _validate_cockpit_live_data_fixture_tables(client: Any, table_exists) -> bool:
+    counts: dict[str, int] = {}
+    for table in COCKPIT_LIVE_DATA_TABLES:
+        if not table_exists(table):
+            logging.error(
+                "FAIL: Cockpit live-data table %s missing (run fixtures with --with-metrics).",
+                table,
+            )
+            return False
+        try:
+            counts[table] = _query_int(client, f"SELECT count() FROM {table}")
+        except Exception as exc:
+            logging.error("FAIL: Could not count %s rows: %s", table, exc)
+            return False
+        if counts[table] == 0:
+            logging.error(
+                "FAIL: Cockpit live-data table %s is empty (regression in --with-metrics).",
+                table,
+            )
+            return False
+
+    try:
+        review_latency_rows = _query_int(
+            client,
+            """
+            SELECT count()
+            FROM repo_metrics_daily
+            WHERE pr_first_review_p90_hours IS NOT NULL
+            """,
+        )
+        complexity_rows = _query_int(
+            client,
+            """
+            SELECT count()
+            FROM repo_complexity_daily
+            WHERE cyclomatic_per_kloc IS NOT NULL
+            """,
+        )
+    except Exception as exc:
+        logging.error("FAIL: Could not validate Compounding Risk inputs: %s", exc)
+        return False
+
+    if review_latency_rows == 0:
+        logging.error(
+            "FAIL: repo_metrics_daily has no pr_first_review_p90_hours rows; "
+            "Compounding Risk review-latency input is absent."
+        )
+        return False
+    if complexity_rows == 0:
+        logging.error(
+            "FAIL: repo_complexity_daily has no cyclomatic_per_kloc rows; "
+            "Compounding Risk complexity input is absent."
+        )
+        return False
+
+    logging.info(
+        "Cockpit live-data fixture tables: "
+        + ", ".join(f"{name}={counts[name]}" for name in COCKPIT_LIVE_DATA_TABLES)
+    )
+    return True
+
 
 def _validate_ai_fixture_tables(client: Any, table_exists) -> bool:
     """Verify every AI fixture/rollup table is present and non-empty."""
@@ -1898,6 +1969,9 @@ def run_fixtures_validation(ns: argparse.Namespace) -> int:
             )
     except Exception as e:
         logging.error(f"FAIL: Could not validate Phase 2 metrics: {e}")
+        return 1
+
+    if not _validate_cockpit_live_data_fixture_tables(client, _table_exists):
         return 1
 
     # 2. Check prerequisites

--- a/tests/test_fixtures_runner.py
+++ b/tests/test_fixtures_runner.py
@@ -404,6 +404,91 @@ def test_validate_ai_fixture_tables_rejects_unlinked_runs():
     assert runner._validate_ai_fixture_tables(client, _all_ai_tables_exist) is False
 
 
+class _CockpitLiveDataValidationClient:
+    def __init__(
+        self,
+        counts: dict[str, int],
+        *,
+        review_latency_rows: int = 3,
+        complexity_rows: int = 3,
+    ):
+        self.counts = counts
+        self.review_latency_rows = review_latency_rows
+        self.complexity_rows = complexity_rows
+
+    def query(self, sql: str):
+        normalized = " ".join(sql.split())
+        if "pr_first_review_p90_hours IS NOT NULL" in normalized:
+            return _QueryResult(self.review_latency_rows)
+        if "cyclomatic_per_kloc IS NOT NULL" in normalized:
+            return _QueryResult(self.complexity_rows)
+        for table, value in self.counts.items():
+            if f"FROM {table}" in normalized:
+                return _QueryResult(value)
+        raise AssertionError(f"Unexpected query: {normalized}")
+
+
+def _all_cockpit_live_data_tables_exist(name: str) -> bool:
+    return name in set(runner.COCKPIT_LIVE_DATA_TABLES)
+
+
+def test_validate_cockpit_live_data_fixture_tables_accepts_populated_state():
+    counts = {table: 10 for table in runner.COCKPIT_LIVE_DATA_TABLES}
+    client = _CockpitLiveDataValidationClient(counts)
+
+    assert (
+        runner._validate_cockpit_live_data_fixture_tables(
+            client, _all_cockpit_live_data_tables_exist
+        )
+        is True
+    )
+
+
+def test_validate_cockpit_live_data_fixture_tables_rejects_missing_table():
+    counts = {table: 10 for table in runner.COCKPIT_LIVE_DATA_TABLES}
+    client = _CockpitLiveDataValidationClient(counts)
+    present = set(runner.COCKPIT_LIVE_DATA_TABLES) - {"testops_test_metrics_daily"}
+
+    assert (
+        runner._validate_cockpit_live_data_fixture_tables(
+            client, lambda name: name in present
+        )
+        is False
+    )
+
+
+def test_validate_cockpit_live_data_fixture_tables_rejects_empty_table():
+    counts = {table: 10 for table in runner.COCKPIT_LIVE_DATA_TABLES}
+    counts["testops_coverage_metrics_daily"] = 0
+    client = _CockpitLiveDataValidationClient(counts)
+
+    assert (
+        runner._validate_cockpit_live_data_fixture_tables(
+            client, _all_cockpit_live_data_tables_exist
+        )
+        is False
+    )
+
+
+def test_validate_cockpit_live_data_fixture_tables_rejects_missing_compounding_inputs():
+    counts = {table: 10 for table in runner.COCKPIT_LIVE_DATA_TABLES}
+    no_review_latency = _CockpitLiveDataValidationClient(counts, review_latency_rows=0)
+    no_complexity = _CockpitLiveDataValidationClient(counts, complexity_rows=0)
+
+    assert (
+        runner._validate_cockpit_live_data_fixture_tables(
+            no_review_latency, _all_cockpit_live_data_tables_exist
+        )
+        is False
+    )
+    assert (
+        runner._validate_cockpit_live_data_fixture_tables(
+            no_complexity, _all_cockpit_live_data_tables_exist
+        )
+        is False
+    )
+
+
 class _SecurityAlertsClient:
     """Stub ClickHouse client for security_alerts validation tests."""
 


### PR DESCRIPTION
## Oracle review packet

### Diff summary
- Adds fixture validation for Cockpit live-data coverage: required Compounding Risk and TestOps Delivery Risk derived ClickHouse tables must exist and be non-empty.
- Validates Compounding Risk inputs include non-null `repo_metrics_daily.pr_first_review_p90_hours` and `repo_complexity_daily.cyclomatic_per_kloc`.
- Documents recovery commands for TestOps sync, daily metrics recompute, complexity rebuild, and compounding-risk backfill.
- Corrects TestOps demo seed instructions to require `--with-metrics` for daily rollup tables.

### Files
- `src/dev_health_ops/fixtures/runner.py`
- `tests/test_fixtures_runner.py`
- `docs/ops/runbook-ingestion-failures.md`
- `docs/ops/testops-demo-pack.md`
- `docs/ops/cli-reference.md`

### Linear issues
- CHAOS-2731 — Compounding Risk data coverage
- CHAOS-2732 — Govern/TestOps Delivery Risk data coverage

### Tests run + results
- `python -m pytest tests/test_fixtures_runner.py -q` — passed: 31 passed.
- `bash ci/local_validate.sh` — passed: ruff format/check, mypy, scratch ClickHouse migrate, full unit suite (6058 passed, 44 skipped), argMax live-exec proof.
- Push hook — passed: ruff check, ruff format check, mypy.

### QA evidence
- Seed/runbook/pipeline remediation only; no frontend/demo fallback added.
- Fixture validation now fails fast if `--with-metrics` does not populate the real ClickHouse-derived tables needed by the Cockpit/Govern risk surfaces.

### Screenshots
- SCREENSHOT-WAIVER: ops-only seed validation and documentation changes; no rendered web UI changed.

### Risks
- `fixtures validate` is stricter for Cockpit live-data readiness and will now fail when metrics-derived tables are absent or sparse. This is intentional for demo/live-data coverage validation, but raw-only fixture users should not use it as proof of risk-surface readiness.
- Review-latency and complexity checks require at least one non-null row, not perfect day-by-day density.

### Platform-contract checks
- ClickHouse remains source of truth for analytics.
- Persistence remains through existing metrics/sinks paths; no new persistence outside `metrics/sinks/*`.
- No frontend/demo fallback or UX-time recompute.
- No Postgres attribution mappings or attribution behavior changes.
- Documentation updated with matching seed/runbook contract.