### PR TITLE
feat(forecast): add estimate coverage backend metric (CHAOS-2730)

### DIFF
--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -169,7 +169,7 @@ Estimate coverage is the Backlog Risk metric for how much open backlog has an ex
 - Denominator `backlog_size`: work items created before the end of `day` and not completed/canceled before the end of `day`.
 - Numerator `estimated_count`: denominator items where normalized `WorkItem.story_points IS NOT NULL`.
 - `unestimated_count`: `backlog_size - estimated_count`.
-- `ratio`: `estimated_count / backlog_size` when `backlog_size > 0`; otherwise `NULL`.
+- `ratio`: `estimated_count / backlog_size` when `backlog_size > 0`; otherwise `NULL`. If a previously known grain has no open backlog at the end of the day, persist `backlog_size = 0`, `estimated_count = 0`, `unestimated_count = 0`, and `ratio = NULL` rather than surfacing older coverage.
 - Null-vs-zero semantics: `story_points = NULL` means unestimated. `story_points = 0` is still an explicit estimate and counts in `estimated_count`.
 
 Provider normalization maps native fields into `WorkItem.story_points` before this metric is computed:
@@ -179,7 +179,7 @@ Provider normalization maps native fields into `WorkItem.story_points` before th
 - GitHub: Projects v2 numeric fields named `estimate`, `points`, `story points`, or `size`.
 - Linear: issue `estimate`, including `0` as an explicit estimate.
 
-GraphQL exposes the latest persisted estimate coverage on `ThroughputForecast.estimateCoverage` using the frozen `ThroughputEstimateCoverage` type: `ratio`, `estimatedCount`, `unestimatedCount`, and `backlogSize`.
+GraphQL exposes the latest persisted estimate coverage on `ThroughputForecast.estimateCoverage` using the frozen `ThroughputEstimateCoverage` type: `ratio`, `estimatedCount`, `unestimatedCount`, and `backlogSize`. Forecasts with `backlogSize = 0` return no `estimateCoverage` object because the coverage ratio is undefined for an empty backlog.
 
 ### Work item facts (`work_item_cycle_times`)
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -54,6 +54,7 @@ Note: Jira Ops/Service Desk incidents are planned once project-to-repo or deploy
 ### Work Tracking
 
 - `work_item_metrics_daily` (daily aggregates, by provider/team/repo)
+- `estimate_coverage_metrics_daily` (daily backlog estimate coverage, by provider/team/scope)
 - `work_item_user_metrics_daily` (daily aggregates, by provider/user/team)
 - `work_item_cycle_times` (per-work-item fact rows for completed items)
 
@@ -159,6 +160,26 @@ Keyed by `(day, provider, team_id, work_scope_id)`.
 - `bug_completed_ratio`: completed bugs / total completed
 - `story_points_completed`: sum of story points completed (Jira only, when configured)
 - `predictability_score`: Completion Rate = `items_completed / (items_completed + wip_count_end_of_day)`
+
+### Estimate coverage (`estimate_coverage_metrics_daily`)
+
+Estimate coverage is the Backlog Risk metric for how much open backlog has an explicit story-point/estimate value.
+
+- Grain: one row per `(day, provider, work_scope_id, team_id)`.
+- Denominator `backlog_size`: work items created before the end of `day` and not completed/canceled before the end of `day`.
+- Numerator `estimated_count`: denominator items where normalized `WorkItem.story_points IS NOT NULL`.
+- `unestimated_count`: `backlog_size - estimated_count`.
+- `ratio`: `estimated_count / backlog_size` when `backlog_size > 0`; otherwise `NULL`.
+- Null-vs-zero semantics: `story_points = NULL` means unestimated. `story_points = 0` is still an explicit estimate and counts in `estimated_count`.
+
+Provider normalization maps native fields into `WorkItem.story_points` before this metric is computed:
+
+- Jira: configured story-points custom field.
+- GitLab: issue or merge-request `weight`.
+- GitHub: Projects v2 numeric fields named `estimate`, `points`, `story points`, or `size`.
+- Linear: issue `estimate`, including `0` as an explicit estimate.
+
+GraphQL exposes the latest persisted estimate coverage on `ThroughputForecast.estimateCoverage` using the frozen `ThroughputEstimateCoverage` type: `ratio`, `estimatedCount`, `unestimatedCount`, and `backlogSize`.
 
 ### Work item facts (`work_item_cycle_times`)
 

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -829,6 +829,14 @@ class ThroughputStaleWip:
 
 
 @strawberry.type
+class ThroughputEstimateCoverage:
+    ratio: float | None = None
+    estimated_count: int
+    unestimated_count: int
+    backlog_size: int
+
+
+@strawberry.type
 class ThroughputForecast:
     """Throughput-based capacity forecast result.
 
@@ -849,6 +857,7 @@ class ThroughputForecast:
     primary_risk: ThroughputRiskOverlay
     wip_congestion: ThroughputRiskOverlay
     stale_wip: ThroughputStaleWip | None = None
+    estimate_coverage: ThroughputEstimateCoverage | None = None
     review_bottleneck: ThroughputRiskOverlay
     incident_load: ThroughputRiskOverlay
     insufficient_history: bool

--- a/src/dev_health_ops/api/graphql/resolvers/forecast.py
+++ b/src/dev_health_ops/api/graphql/resolvers/forecast.py
@@ -430,11 +430,13 @@ async def resolve_throughput_forecast(
         )
     if backlog_size < 0:
         raise ValueError("backlog_size must be non-negative")
-    estimate_coverage = await _load_estimate_coverage(
-        context,
-        team_ids=input.team_ids,
-        work_scope_id=input.work_scope_id,
-    )
+    estimate_coverage = None
+    if backlog_size > 0:
+        estimate_coverage = await _load_estimate_coverage(
+            context,
+            team_ids=input.team_ids,
+            work_scope_id=input.work_scope_id,
+        )
     if not history.samples:
         # Empty scope / new team: return a structured no-estimate payload
         # instead of null so callers can distinguish "no data yet" from a

--- a/src/dev_health_ops/api/graphql/resolvers/forecast.py
+++ b/src/dev_health_ops/api/graphql/resolvers/forecast.py
@@ -20,6 +20,7 @@ from ..authz import require_org_id
 from ..context import GraphQLContext
 from ..models.inputs import ThroughputForecastInput
 from ..models.outputs import (
+    ThroughputEstimateCoverage,
     ThroughputForecast,
     ThroughputRiskOverlay,
     ThroughputRollingWindow,
@@ -42,6 +43,7 @@ def _result_to_output(
     result: ThroughputForecastResult,
     *,
     stale_wip: ThroughputStaleWip | None = None,
+    estimate_coverage: ThroughputEstimateCoverage | None = None,
 ) -> ThroughputForecast:
     return ThroughputForecast(
         forecast_id=result.forecast_id,
@@ -65,6 +67,7 @@ def _result_to_output(
         primary_risk=_risk_to_output(result.primary_risk),
         wip_congestion=_risk_to_output(result.wip_congestion),
         stale_wip=stale_wip,
+        estimate_coverage=estimate_coverage,
         review_bottleneck=_risk_to_output(result.review_bottleneck),
         incident_load=_risk_to_output(result.incident_load),
         insufficient_history=result.insufficient_history,
@@ -244,6 +247,61 @@ async def _load_stale_wip(
     )
 
 
+async def _load_estimate_coverage(
+    context: GraphQLContext,
+    *,
+    team_ids: list[str] | None,
+    work_scope_id: str | None,
+) -> ThroughputEstimateCoverage | None:
+    conditions: list[str] = ["org_id = {org_id:String}"]
+    params: dict[str, Any] = {"org_id": context.org_id}
+    _team_filter(team_ids, conditions, params)
+    if work_scope_id:
+        conditions.append("work_scope_id = {work_scope_id:String}")
+        params["work_scope_id"] = work_scope_id
+    where_sql = " AND ".join(conditions)
+
+    rows = await query_dicts(
+        context.client,
+        f"""
+        SELECT
+            sum(estimated_count) AS estimated_count,
+            sum(unestimated_count) AS unestimated_count,
+            sum(backlog_size) AS backlog_size
+        FROM (
+            SELECT
+                provider,
+                work_scope_id,
+                team_id,
+                argMax(estimated_count, computed_at) AS estimated_count,
+                argMax(unestimated_count, computed_at) AS unestimated_count,
+                argMax(backlog_size, computed_at) AS backlog_size
+            FROM estimate_coverage_metrics_daily
+            WHERE day = (
+                SELECT max(day) FROM estimate_coverage_metrics_daily WHERE {where_sql}
+            )
+            AND {where_sql}
+            GROUP BY provider, work_scope_id, team_id
+        )
+        """,
+        params,
+    )
+    row = rows[0] if rows else {}
+    backlog_size_raw = row.get("backlog_size")
+    if backlog_size_raw is None:
+        return None
+    estimated_count = int(row.get("estimated_count") or 0)
+    unestimated_count = int(row.get("unestimated_count") or 0)
+    backlog_size = int(backlog_size_raw or 0)
+    ratio = (float(estimated_count) / float(backlog_size)) if backlog_size else None
+    return ThroughputEstimateCoverage(
+        ratio=ratio,
+        estimated_count=estimated_count,
+        unestimated_count=unestimated_count,
+        backlog_size=backlog_size,
+    )
+
+
 async def _load_review_overlay(
     context: GraphQLContext,
     *,
@@ -372,6 +430,11 @@ async def resolve_throughput_forecast(
         )
     if backlog_size < 0:
         raise ValueError("backlog_size must be non-negative")
+    estimate_coverage = await _load_estimate_coverage(
+        context,
+        team_ids=input.team_ids,
+        work_scope_id=input.work_scope_id,
+    )
     if not history.samples:
         # Empty scope / new team: return a structured no-estimate payload
         # instead of null so callers can distinguish "no data yet" from a
@@ -396,7 +459,7 @@ async def resolve_throughput_forecast(
             incident_load=incident,
             insufficient_history=True,
         )
-        return _result_to_output(no_estimate)
+        return _result_to_output(no_estimate, estimate_coverage=estimate_coverage)
 
     current_wip, average_wip = await _load_work_item_overlay(
         context,
@@ -428,4 +491,6 @@ async def resolve_throughput_forecast(
         review_latency_hours=review_latency_hours,
         incident_count=incident_count,
     )
-    return _result_to_output(result, stale_wip=stale_wip)
+    return _result_to_output(
+        result, stale_wip=stale_wip, estimate_coverage=estimate_coverage
+    )

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -8,6 +8,7 @@ from datetime import date, datetime, time, timedelta, timezone
 from typing import Literal, TypedDict
 
 from dev_health_ops.metrics.schemas import (
+    EstimateCoverageMetricsDailyRecord,
     WorkItemCycleTimeRecord,
     WorkItemMetricsDailyRecord,
     WorkItemTeamAttributionRecord,
@@ -739,6 +740,12 @@ class GroupBucket(TypedDict):
     predictability_score: float
 
 
+class EstimateCoverageBucket(TypedDict):
+    team_name: str
+    estimated_count: int
+    unestimated_count: int
+
+
 class UserBucket(TypedDict):
     team_name: str
     items_started: int
@@ -1094,6 +1101,78 @@ def compute_work_item_metrics_daily(
         )
 
     return group_records, user_records, cycle_time_records
+
+
+def compute_estimate_coverage_metrics_daily(
+    *,
+    day: date,
+    work_items: Sequence[WorkItem],
+    computed_at: datetime,
+    team_resolver: TeamResolver | None = None,
+    project_key_resolver: ProjectKeyTeamResolver | None = None,
+    linked_issue_resolver: LinkedIssueTeamResolver | None = None,
+    attribution_context: TeamAttributionContext | None = None,
+) -> list[EstimateCoverageMetricsDailyRecord]:
+    _start, end = _utc_day_window(day)
+    computed_at_utc = to_utc(computed_at)
+    by_group: dict[tuple[str, str, str | None], EstimateCoverageBucket] = {}
+
+    for item in work_items:
+        created_at = to_utc(item.created_at)
+        completed_at = to_utc(item.completed_at) if item.completed_at else None
+        if created_at >= end:
+            continue
+        if completed_at is not None and completed_at < end:
+            continue
+
+        team_id, team_name, _ = resolve_team_attribution(
+            item,
+            team_resolver,
+            project_key_resolver,
+            linked_issue_resolver=linked_issue_resolver,
+            attribution_context=attribution_context,
+        )
+        team_id_norm = normalize_team_id(team_id)
+        team_name_norm = normalize_team_name(team_name)
+        key = (item.provider, item.work_scope_id or "", team_id_norm)
+        bucket = by_group.get(key)
+        if bucket is None:
+            new_bucket: EstimateCoverageBucket = {
+                "team_name": team_name_norm,
+                "estimated_count": 0,
+                "unestimated_count": 0,
+            }
+            by_group[key] = new_bucket
+            bucket = new_bucket
+
+        if item.story_points is None:
+            bucket["unestimated_count"] += 1
+        else:
+            bucket["estimated_count"] += 1
+
+    records: list[EstimateCoverageMetricsDailyRecord] = []
+    for (provider, work_scope_id, team_id), bucket in sorted(
+        by_group.items(), key=lambda kv: (kv[0][0], kv[0][1], str(kv[0][2] or ""))
+    ):
+        estimated_count = bucket["estimated_count"]
+        unestimated_count = bucket["unestimated_count"]
+        backlog_size = estimated_count + unestimated_count
+        ratio = (float(estimated_count) / float(backlog_size)) if backlog_size else None
+        records.append(
+            EstimateCoverageMetricsDailyRecord(
+                day=day,
+                provider=provider,
+                work_scope_id=work_scope_id,
+                team_id=normalize_team_id(team_id),
+                team_name=bucket["team_name"],
+                estimated_count=estimated_count,
+                unestimated_count=unestimated_count,
+                backlog_size=backlog_size,
+                ratio=ratio,
+                computed_at=computed_at_utc,
+            )
+        )
+    return records
 
 
 def compute_work_item_team_attributions(

--- a/src/dev_health_ops/metrics/compute_work_items.py
+++ b/src/dev_health_ops/metrics/compute_work_items.py
@@ -52,6 +52,11 @@ def _percentile(values: Sequence[float], percentile: float) -> float:
     return sorted_vals[lo] * (1.0 - frac) + sorted_vals[hi] * frac
 
 
+def _earliest_utc(*values: datetime | None) -> datetime | None:
+    timestamps = [to_utc(value) for value in values if value is not None]
+    return min(timestamps) if timestamps else None
+
+
 def _resolve_team(
     team_resolver: TeamResolver | None, identity: str | None
 ) -> tuple[str | None, str | None]:
@@ -799,6 +804,7 @@ def compute_work_item_metrics_daily(
         created_at = to_utc(item.created_at)
         started_at = to_utc(item.started_at) if item.started_at else None
         completed_at = to_utc(item.completed_at) if item.completed_at else None
+        terminal_at = _earliest_utc(item.completed_at, item.closed_at)
 
         # Ignore items that don't exist yet on this day.
         if created_at >= end:
@@ -820,7 +826,7 @@ def compute_work_item_metrics_daily(
         wip_end_of_day = (
             started_at is not None
             and started_at < end
-            and (completed_at is None or completed_at >= end)
+            and (terminal_at is None or terminal_at >= end)
         )
 
         # Only emit a bucket for groups/users that have activity for this day.
@@ -1119,10 +1125,8 @@ def compute_estimate_coverage_metrics_daily(
 
     for item in work_items:
         created_at = to_utc(item.created_at)
-        completed_at = to_utc(item.completed_at) if item.completed_at else None
+        terminal_at = _earliest_utc(item.completed_at, item.closed_at)
         if created_at >= end:
-            continue
-        if completed_at is not None and completed_at < end:
             continue
 
         team_id, team_name, _ = resolve_team_attribution(
@@ -1144,6 +1148,9 @@ def compute_estimate_coverage_metrics_daily(
             }
             by_group[key] = new_bucket
             bucket = new_bucket
+
+        if terminal_at is not None and terminal_at < end:
+            continue
 
         if item.story_points is None:
             bucket["unestimated_count"] += 1

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -42,6 +42,7 @@ from dev_health_ops.metrics.compute_work_item_state_durations import (
 )
 from dev_health_ops.metrics.compute_work_items import (
     build_linked_issue_team_resolver,
+    compute_estimate_coverage_metrics_daily,
     compute_work_item_metrics_daily,
     compute_work_item_team_attributions,
 )
@@ -990,6 +991,7 @@ async def run_daily_metrics_job(
         wi_metrics: list[Any] = []
         wi_user_metrics: list[Any] = []
         wi_cycle_times: list[Any] = []
+        estimate_coverage_metrics: list[Any] = []
         wi_team_attributions: list[Any] = []
         wi_state_durations: list[Any] = []
         if work_items:
@@ -1006,6 +1008,15 @@ async def run_daily_metrics_job(
                 )
             )
             wi_team_attributions = compute_work_item_team_attributions(
+                work_items=work_items,
+                computed_at=computed_at,
+                team_resolver=team_resolver,
+                project_key_resolver=project_key_resolver,
+                linked_issue_resolver=linked_issue_resolver,
+                attribution_context=team_attribution_context,
+            )
+            estimate_coverage_metrics = compute_estimate_coverage_metrics_daily(
+                day=d,
                 work_items=work_items,
                 computed_at=computed_at,
                 team_resolver=team_resolver,
@@ -1231,6 +1242,8 @@ async def run_daily_metrics_job(
             s.write_team_metrics(team_metrics)
             if wi_metrics:
                 s.write_work_item_metrics(wi_metrics)
+            if estimate_coverage_metrics:
+                s.write_estimate_coverage_metrics(estimate_coverage_metrics)
             if wi_user_metrics:
                 s.write_work_item_user_metrics(wi_user_metrics)
             if wi_cycle_times:

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -18,6 +18,7 @@ from dev_health_ops.metrics.compute_work_item_state_durations import (
 )
 from dev_health_ops.metrics.compute_work_items import (
     build_linked_issue_team_resolver,
+    compute_estimate_coverage_metrics_daily,
     compute_work_item_metrics_daily,
     compute_work_item_team_attributions,
     resolve_team_attribution,
@@ -858,6 +859,15 @@ def run_work_items_sync_job(
                     attribution_context=team_attribution_context,
                 )
             )
+            estimate_coverage_metrics = compute_estimate_coverage_metrics_daily(
+                day=d,
+                work_items=work_items,
+                computed_at=computed_at,
+                team_resolver=team_resolver,
+                project_key_resolver=pk_resolver,
+                linked_issue_resolver=linked_issue_resolver,
+                attribution_context=team_attribution_context,
+            )
             wi_team_attributions = compute_work_item_team_attributions(
                 work_items=work_items,
                 computed_at=computed_at,
@@ -1050,6 +1060,11 @@ def run_work_items_sync_job(
                 if wi_metrics:
                     _ensure_unit_lease_for_write("work_item_metrics_daily")
                     s.write_work_item_metrics(wi_metrics)
+                if estimate_coverage_metrics and hasattr(
+                    s, "write_estimate_coverage_metrics"
+                ):
+                    _ensure_unit_lease_for_write("estimate_coverage_metrics_daily")
+                    s.write_estimate_coverage_metrics(estimate_coverage_metrics)
                 if wi_user_metrics:
                     _ensure_unit_lease_for_write("work_item_user_metrics_daily")
                     s.write_work_item_user_metrics(wi_user_metrics)

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -476,6 +476,21 @@ class WorkItemMetricsDailyRecord:
 
 
 @dataclass(frozen=True)
+class EstimateCoverageMetricsDailyRecord:
+    day: date
+    provider: str
+    work_scope_id: str
+    team_id: str | None
+    team_name: str | None
+    estimated_count: int
+    unestimated_count: int
+    backlog_size: int
+    ratio: float | None
+    computed_at: datetime
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
 class WorkItemUserMetricsDailyRecord:
     day: date
     provider: str

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -18,6 +18,7 @@ from dev_health_ops.metrics.schemas import (
     CommitMetricsRecord,
     DeployMetricsDailyRecord,
     DORAMetricsRecord,
+    EstimateCoverageMetricsDailyRecord,
     FeatureFlagEventRecord,
     FeatureFlagLinkRecord,
     FeatureFlagRecord,
@@ -174,6 +175,11 @@ class BaseMetricsSink(ABC):
     ) -> None:
         """Write daily aggregate work item metrics."""
         ...
+
+    @abstractmethod
+    def write_estimate_coverage_metrics(
+        self, rows: Sequence[EstimateCoverageMetricsDailyRecord]
+    ) -> None: ...
 
     @abstractmethod
     def write_work_item_user_metrics(

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -179,7 +179,11 @@ class BaseMetricsSink(ABC):
     @abstractmethod
     def write_estimate_coverage_metrics(
         self, rows: Sequence[EstimateCoverageMetricsDailyRecord]
-    ) -> None: ...
+    ) -> None:
+        """Write daily estimate coverage metrics."""
+        raise NotImplementedError(
+            "BaseMetricsSink.write_estimate_coverage_metrics() must be implemented by subclasses."
+        )
 
     @abstractmethod
     def write_work_item_user_metrics(

--- a/src/dev_health_ops/metrics/sinks/clickhouse/work_graph.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/work_graph.py
@@ -24,6 +24,7 @@ from typing import TYPE_CHECKING, Any
 from dev_health_ops.metrics.schemas import (
     CapacityForecastRecord,
     CommitMetricsRecord,
+    EstimateCoverageMetricsDailyRecord,
     FileComplexitySnapshot,
     FileHotspotDaily,
     FileMetricsRecord,
@@ -224,6 +225,29 @@ class WorkGraphMixin(_ClickHouseSinkBase):
                 "defect_intro_rate",
                 "wip_congestion_ratio",
                 "predictability_score",
+                "computed_at",
+                "org_id",
+            ],
+            rows,
+        )
+
+    def write_estimate_coverage_metrics(
+        self, rows: Sequence[EstimateCoverageMetricsDailyRecord]
+    ) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "estimate_coverage_metrics_daily",
+            [
+                "day",
+                "provider",
+                "work_scope_id",
+                "team_id",
+                "team_name",
+                "estimated_count",
+                "unestimated_count",
+                "backlog_size",
+                "ratio",
                 "computed_at",
                 "org_id",
             ],

--- a/src/dev_health_ops/migrations/clickhouse/063_estimate_coverage_metrics.sql
+++ b/src/dev_health_ops/migrations/clickhouse/063_estimate_coverage_metrics.sql
@@ -1,0 +1,16 @@
+CREATE TABLE IF NOT EXISTS estimate_coverage_metrics_daily (
+    day Date,
+    provider String,
+    work_scope_id String,
+    team_id Nullable(String),
+    team_name Nullable(String),
+    estimated_count UInt32,
+    unestimated_count UInt32,
+    backlog_size UInt32,
+    ratio Nullable(Float64),
+    computed_at DateTime64(3, 'UTC'),
+    org_id String DEFAULT ''
+) ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(day)
+ORDER BY (org_id, day, provider, work_scope_id, ifNull(team_id, ''))
+SETTINGS index_granularity = 8192;

--- a/src/dev_health_ops/providers/linear/normalize.py
+++ b/src/dev_health_ops/providers/linear/normalize.py
@@ -325,7 +325,7 @@ def linear_issue_to_work_item(
         closed_at=closed_at,
         due_at=due_date,
         labels=labels,
-        story_points=float(estimate) if estimate else None,
+        story_points=float(estimate) if estimate is not None else None,
         sprint_id=sprint_id,
         sprint_name=sprint_name,
         parent_id=parent_id,

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -147,6 +147,7 @@ _LINEAR_BACKFILL_WORK_ITEM_IN_BAND_WRITE_SURFACES = frozenset(
 #                                 rows collapse to one persisted edge (no global FINAL needed)
 #   ai_attribution                -> RMT(computed_at) + FINAL+ROW_NUMBER resolved view
 #   work_item_metrics_daily       -> RMT(computed_at) (migration 055) + FINAL/argMax readers
+#   estimate_coverage_metrics_daily -> RMT(computed_at) (migration 063) + argMax readers
 #   work_item_user_metrics_daily  -> RMT(computed_at) (migration 055) + FINAL readers
 #   work_item_cycle_times         -> RMT(computed_at) + argMax/FINAL readers
 #   work_item_state_durations_daily -> argMax(duration, computed_at) readers over the key
@@ -168,6 +169,7 @@ _CLICKHOUSE_RETRY_PROVEN_SAFE_SURFACES = frozenset(
         "sprints",
         "ai_attribution",
         "work_item_metrics_daily",
+        "estimate_coverage_metrics_daily",
         "work_item_user_metrics_daily",
         "work_item_cycle_times",
         "work_item_state_durations_daily",

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -126,6 +126,7 @@ _LINEAR_BACKFILL_WORK_ITEM_IN_BAND_WRITE_SURFACES = frozenset(
         "sprints",
         "ai_attribution",
         "work_item_metrics_daily",
+        "estimate_coverage_metrics_daily",
         "work_item_user_metrics_daily",
         "work_item_cycle_times",
         "work_item_state_durations_daily",

--- a/tests/api/graphql/test_throughput_forecast_resolver.py
+++ b/tests/api/graphql/test_throughput_forecast_resolver.py
@@ -225,6 +225,69 @@ async def test_resolver_surfaces_estimate_coverage(ctx):
 
 
 @pytest.mark.asyncio
+async def test_resolver_suppresses_stale_estimate_coverage_for_zero_backlog(ctx):
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.models.outputs import ThroughputEstimateCoverage
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+
+    stale_coverage = ThroughputEstimateCoverage(
+        ratio=1.0,
+        estimated_count=4,
+        unestimated_count=0,
+        backlog_size=4,
+    )
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+            new_callable=AsyncMock,
+            return_value=_history(),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
+            new_callable=AsyncMock,
+            return_value=(0.0, 0.0),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_stale_wip",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_estimate_coverage",
+            new_callable=AsyncMock,
+            return_value=stale_coverage,
+        ) as load_estimate_coverage,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_incident_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_backlog",
+            new_callable=AsyncMock,
+            return_value=0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast.forecast_throughput_capacity",
+            return_value=_result(team_id=None, backlog_size=0),
+        ),
+    ):
+        result = await resolve_throughput_forecast(ctx, ThroughputForecastInput())
+
+    assert result is not None
+    assert result.backlog_size == 0
+    assert result.estimate_coverage is None
+    load_estimate_coverage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
 async def test_resolver_aggregates_multi_team_selection(ctx):
     """Multi-team ``team_ids`` must NOT collapse to one team's data."""
     from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput

--- a/tests/api/graphql/test_throughput_forecast_resolver.py
+++ b/tests/api/graphql/test_throughput_forecast_resolver.py
@@ -90,6 +90,16 @@ def ctx():
     return c
 
 
+@pytest.fixture(autouse=True)
+def default_estimate_coverage_loader(monkeypatch, request):
+    if request.node.name.startswith("test_load_estimate_coverage"):
+        return
+    monkeypatch.setattr(
+        "dev_health_ops.api.graphql.resolvers.forecast._load_estimate_coverage",
+        AsyncMock(return_value=None),
+    )
+
+
 @pytest.mark.asyncio
 async def test_resolver_aggregates_org_wide_when_team_ids_is_none(ctx):
     """``team_ids=None`` must NOT short-circuit to None or sample data."""
@@ -144,6 +154,74 @@ async def test_resolver_aggregates_org_wide_when_team_ids_is_none(ctx):
     assert result.stale_wip.p90_age_hours == 96.0
     load_backlog.assert_awaited_once_with(ctx, team_ids=None, work_scope_id=None)
     load_stale_wip.assert_awaited_once_with(ctx, team_ids=None, work_scope_id=None)
+
+
+@pytest.mark.asyncio
+async def test_resolver_surfaces_estimate_coverage(ctx):
+    from dev_health_ops.api.graphql.models.inputs import ThroughputForecastInput
+    from dev_health_ops.api.graphql.models.outputs import ThroughputEstimateCoverage
+    from dev_health_ops.api.graphql.resolvers.forecast import (
+        resolve_throughput_forecast,
+    )
+
+    estimate_coverage = ThroughputEstimateCoverage(
+        ratio=0.75,
+        estimated_count=3,
+        unestimated_count=1,
+        backlog_size=4,
+    )
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_throughput_history",
+            new_callable=AsyncMock,
+            return_value=_history(),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_work_item_overlay",
+            new_callable=AsyncMock,
+            return_value=(0.0, 0.0),
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_stale_wip",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_estimate_coverage",
+            new_callable=AsyncMock,
+            return_value=estimate_coverage,
+        ) as load_estimate_coverage,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_review_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_incident_overlay",
+            new_callable=AsyncMock,
+            return_value=0.0,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast._load_backlog",
+            new_callable=AsyncMock,
+            return_value=4,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.forecast.forecast_throughput_capacity",
+            return_value=_result(team_id=None, backlog_size=4),
+        ),
+    ):
+        result = await resolve_throughput_forecast(ctx, ThroughputForecastInput())
+
+    assert result is not None
+    assert result.estimate_coverage is not None
+    assert result.estimate_coverage.ratio == 0.75
+    assert result.estimate_coverage.estimated_count == 3
+    assert result.estimate_coverage.unestimated_count == 1
+    assert result.estimate_coverage.backlog_size == 4
+    load_estimate_coverage.assert_awaited_once_with(
+        ctx, team_ids=None, work_scope_id=None
+    )
 
 
 @pytest.mark.asyncio
@@ -428,6 +506,55 @@ async def test_load_stale_wip_returns_none_without_age_rows(ctx):
         stale_wip = await _load_stale_wip(ctx, team_ids=None, work_scope_id=None)
 
     assert stale_wip is None
+
+
+@pytest.mark.asyncio
+async def test_load_estimate_coverage_passes_org_id_and_returns_ratio(ctx):
+    from dev_health_ops.api.graphql.resolvers.forecast import _load_estimate_coverage
+
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.forecast.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[
+            {"estimated_count": 3, "unestimated_count": 1, "backlog_size": 4}
+        ],
+    ) as query:
+        coverage = await _load_estimate_coverage(
+            ctx, team_ids=["team-a", "team-b"], work_scope_id="scope-a"
+        )
+
+    assert coverage is not None
+    assert coverage.ratio == 0.75
+    assert coverage.estimated_count == 3
+    assert coverage.unestimated_count == 1
+    assert coverage.backlog_size == 4
+    call_args = query.await_args
+    assert call_args is not None
+    sql: str = call_args.args[1]
+    params: dict = call_args.args[2]
+    assert "estimate_coverage_metrics_daily" in sql
+    assert "{org_id:String}" in sql
+    assert params["org_id"] == ctx.org_id
+    assert "team_id IN {team_ids:Array(String)}" in sql
+    assert params["team_ids"] == ["team-a", "team-b"]
+    assert "work_scope_id = {work_scope_id:String}" in sql
+    assert params["work_scope_id"] == "scope-a"
+
+
+@pytest.mark.asyncio
+async def test_load_estimate_coverage_returns_none_without_rows(ctx):
+    from dev_health_ops.api.graphql.resolvers.forecast import _load_estimate_coverage
+
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.forecast.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[
+            {"estimated_count": None, "unestimated_count": None, "backlog_size": None}
+        ],
+    ):
+        coverage = await _load_estimate_coverage(ctx, team_ids=None, work_scope_id=None)
+
+    assert coverage is None
 
 
 def _insufficient_result() -> ThroughputForecastResult:

--- a/tests/metrics/test_estimate_coverage_metrics.py
+++ b/tests/metrics/test_estimate_coverage_metrics.py
@@ -7,19 +7,33 @@ import pytest
 from dev_health_ops.metrics.compute_work_items import (
     compute_estimate_coverage_metrics_daily,
 )
-from dev_health_ops.models.work_items import WorkItem, WorkItemProvider
+from dev_health_ops.models.work_items import (
+    WorkItem,
+    WorkItemProvider,
+    WorkItemStatusCategory,
+)
 
 
-def _item(provider: WorkItemProvider, item_id: str, points: float | None) -> WorkItem:
+def _item(
+    provider: WorkItemProvider,
+    item_id: str,
+    points: float | None,
+    *,
+    status: WorkItemStatusCategory = "todo",
+    completed_at: datetime | None = None,
+    closed_at: datetime | None = None,
+) -> WorkItem:
     return WorkItem(
         work_item_id=f"{provider}:{item_id}",
         provider=provider,
         title=item_id,
         type="task",
-        status="todo",
-        status_raw="todo",
+        status=status,
+        status_raw=status,
         project_id="scope-a",
         created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        completed_at=completed_at,
+        closed_at=closed_at,
         story_points=points,
     )
 
@@ -89,3 +103,50 @@ def test_compute_estimate_coverage_excludes_completed_backlog_items():
     assert records[0].estimated_count == 0
     assert records[0].unestimated_count == 1
     assert records[0].backlog_size == 1
+
+
+@pytest.mark.parametrize("provider", ["jira", "gitlab", "github", "linear"])
+def test_compute_estimate_coverage_excludes_closed_terminal_backlog_items(
+    provider: WorkItemProvider,
+):
+    records = compute_estimate_coverage_metrics_daily(
+        day=datetime(2026, 6, 30, tzinfo=timezone.utc).date(),
+        work_items=[
+            _item(provider, "open", None),
+            _item(
+                provider,
+                "canceled",
+                8.0,
+                status="canceled",
+                closed_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+            ),
+        ],
+        computed_at=datetime(2026, 6, 30, 12, tzinfo=timezone.utc),
+    )
+
+    assert len(records) == 1
+    assert records[0].estimated_count == 0
+    assert records[0].unestimated_count == 1
+    assert records[0].backlog_size == 1
+
+
+def test_compute_estimate_coverage_emits_zero_backlog_for_known_empty_grain():
+    records = compute_estimate_coverage_metrics_daily(
+        day=datetime(2026, 6, 30, tzinfo=timezone.utc).date(),
+        work_items=[
+            _item(
+                "linear",
+                "canceled",
+                8.0,
+                status="canceled",
+                closed_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+            ),
+        ],
+        computed_at=datetime(2026, 6, 30, 12, tzinfo=timezone.utc),
+    )
+
+    assert len(records) == 1
+    assert records[0].estimated_count == 0
+    assert records[0].unestimated_count == 0
+    assert records[0].backlog_size == 0
+    assert records[0].ratio is None

--- a/tests/metrics/test_estimate_coverage_metrics.py
+++ b/tests/metrics/test_estimate_coverage_metrics.py
@@ -1,0 +1,91 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dev_health_ops.metrics.compute_work_items import (
+    compute_estimate_coverage_metrics_daily,
+)
+from dev_health_ops.models.work_items import WorkItem, WorkItemProvider
+
+
+def _item(provider: WorkItemProvider, item_id: str, points: float | None) -> WorkItem:
+    return WorkItem(
+        work_item_id=f"{provider}:{item_id}",
+        provider=provider,
+        title=item_id,
+        type="task",
+        status="todo",
+        status_raw="todo",
+        project_id="scope-a",
+        created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        story_points=points,
+    )
+
+
+def test_compute_estimate_coverage_counts_null_as_unestimated_and_zero_as_estimated():
+    records = compute_estimate_coverage_metrics_daily(
+        day=datetime(2026, 6, 30, tzinfo=timezone.utc).date(),
+        work_items=[
+            _item("jira", "estimated", 3.0),
+            _item("jira", "zero", 0.0),
+            _item("jira", "missing", None),
+        ],
+        computed_at=datetime(2026, 6, 30, 12, tzinfo=timezone.utc),
+    )
+
+    assert len(records) == 1
+    record = records[0]
+    assert record.estimated_count == 2
+    assert record.unestimated_count == 1
+    assert record.backlog_size == 3
+    assert record.ratio == pytest.approx(2 / 3)
+
+
+@pytest.mark.parametrize("provider", ["jira", "gitlab", "github", "linear"])
+def test_compute_estimate_coverage_provider_matrix_uses_normalized_story_points(
+    provider: WorkItemProvider,
+):
+    records = compute_estimate_coverage_metrics_daily(
+        day=datetime(2026, 6, 30, tzinfo=timezone.utc).date(),
+        work_items=[
+            _item(provider, "estimated", 5.0),
+            _item(provider, "zero", 0.0),
+            _item(provider, "missing", None),
+        ],
+        computed_at=datetime(2026, 6, 30, 12, tzinfo=timezone.utc),
+    )
+
+    assert len(records) == 1
+    assert records[0].provider == provider
+    assert records[0].estimated_count == 2
+    assert records[0].unestimated_count == 1
+    assert records[0].backlog_size == 3
+
+
+def test_compute_estimate_coverage_excludes_completed_backlog_items():
+    records = compute_estimate_coverage_metrics_daily(
+        day=datetime(2026, 6, 30, tzinfo=timezone.utc).date(),
+        work_items=[
+            _item("github", "open", None),
+            WorkItem(
+                work_item_id="github:done",
+                provider="github",
+                title="done",
+                type="task",
+                status="done",
+                status_raw="done",
+                project_id="scope-a",
+                created_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+                completed_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+                story_points=8.0,
+            ),
+        ],
+        computed_at=datetime(2026, 6, 30, 12, tzinfo=timezone.utc),
+    )
+
+    assert len(records) == 1
+    assert records[0].estimated_count == 0
+    assert records[0].unestimated_count == 1
+    assert records[0].backlog_size == 1

--- a/tests/test_clickhouse_org_id.py
+++ b/tests/test_clickhouse_org_id.py
@@ -14,6 +14,7 @@ from dev_health_ops.metrics.schemas import (
     CommitMetricsRecord,
     DeployMetricsDailyRecord,
     DORAMetricsRecord,
+    EstimateCoverageMetricsDailyRecord,
     FileComplexitySnapshot,
     FileHotspotDaily,
     FileMetricsRecord,
@@ -64,6 +65,7 @@ ALL_SCHEMA_CLASSES = [
     FileMetricsRecord,
     TeamMetricsDailyRecord,
     WorkItemMetricsDailyRecord,
+    EstimateCoverageMetricsDailyRecord,
     WorkItemUserMetricsDailyRecord,
     WorkItemCycleTimeRecord,
     WorkItemStateDurationDailyRecord,
@@ -200,6 +202,44 @@ def test_clickhouse_sink_write_repo_metrics_includes_org_id():
         matrix = call_args[0][1]
         org_id_idx = list(column_names).index("org_id")
         assert matrix[0][org_id_idx] == "test-org"
+
+
+def test_clickhouse_sink_write_estimate_coverage_metrics_includes_org_id():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    with patch.object(
+        ClickHouseMetricsSink, "__init__", lambda self, dsn, client=None: None
+    ):
+        sink = ClickHouseMetricsSink("clickhouse://dummy")
+        sink.client = MagicMock()
+
+        row = EstimateCoverageMetricsDailyRecord(
+            day=date(2026, 6, 30),
+            provider="jira",
+            work_scope_id="PROJ",
+            team_id="team-a",
+            team_name="Team A",
+            estimated_count=2,
+            unestimated_count=1,
+            backlog_size=3,
+            ratio=2 / 3,
+            computed_at=datetime(2026, 6, 30, tzinfo=timezone.utc),
+            org_id="test-org",
+        )
+        sink.write_estimate_coverage_metrics([row])
+
+        assert sink.client.insert.called
+        call_args = sink.client.insert.call_args
+        column_names = call_args[1].get("column_names") or call_args[0][2]
+        assert call_args[0][0] == "estimate_coverage_metrics_daily"
+        assert "org_id" in column_names
+        assert "ratio" in column_names
+
+        matrix = call_args[0][1]
+        org_id_idx = list(column_names).index("org_id")
+        ratio_idx = list(column_names).index("ratio")
+        assert matrix[0][org_id_idx] == "test-org"
+        assert matrix[0][ratio_idx] == 2 / 3
 
 
 def test_clickhouse_sink_write_work_graph_edges_includes_org_id():

--- a/tests/test_linear_provider.py
+++ b/tests/test_linear_provider.py
@@ -332,6 +332,19 @@ class TestLinearIssueToWorkItem:
 
         assert work_item.story_points == 5.0
 
+    def test_issue_with_zero_estimate_preserves_story_points(
+        self, mock_identity: IdentityResolver, mock_status_mapping: StatusMapping
+    ) -> None:
+        issue = _mock_linear_issue(estimate=0.0)
+
+        work_item, _ = linear_issue_to_work_item(
+            issue=issue,
+            status_mapping=mock_status_mapping,
+            identity=mock_identity,
+        )
+
+        assert work_item.story_points == 0.0
+
     def test_issue_with_labels(
         self, mock_identity: IdentityResolver, mock_status_mapping: StatusMapping
     ) -> None:


### PR DESCRIPTION
## Summary
- Defines and documents the Estimate Coverage metric contract before implementation.
- Adds ClickHouse-backed estimate coverage daily metric persistence via metrics/sinks only.
- Computes backlog estimate coverage in the metrics layer from normalized WorkItem.story_points.
- Exposes latest persisted coverage on ThroughputForecast.estimateCoverage.
- Preserves Linear estimate=0 as an explicit story-point estimate.

## Frozen GraphQL Contract
- Field: ThroughputForecast.estimateCoverage
- Type: ThroughputEstimateCoverage
- Fields: ratio: Float, estimatedCount: Int!, unestimatedCount: Int!, backlogSize: Int!

## Metric Contract
- Grain: (day, provider, work_scope_id, team_id)
- Numerator: backlog items with normalized WorkItem.story_points IS NOT NULL
- Denominator: open backlog items created before day end and not completed/canceled before day end
- Null-vs-zero: story_points NULL means unestimated; story_points 0 is estimated
- ratio: estimatedCount / backlogSize when backlogSize > 0; otherwise null

## Files Changed
- docs/metrics.md
- src/dev_health_ops/migrations/clickhouse/063_estimate_coverage_metrics.sql
- src/dev_health_ops/metrics/{compute_work_items.py,schemas.py,job_daily.py,job_work_items.py}
- src/dev_health_ops/metrics/sinks/{base.py,clickhouse/work_graph.py}
- src/dev_health_ops/api/graphql/{models/outputs.py,resolvers/forecast.py}
- src/dev_health_ops/providers/linear/normalize.py
- src/dev_health_ops/workers/sync_units.py
- tests covering metrics, GraphQL resolver, sink/org_id, Linear normalization

## Linear
- CHAOS-2730
- Related epic: CHAOS-2728

## Validation / QA Evidence
- lsp_diagnostics on changed Python files: clean
- Targeted tests: PASS (30 passed)
  - tests/metrics/test_estimate_coverage_metrics.py
  - tests/api/graphql/test_throughput_forecast_resolver.py
  - tests/test_linear_provider.py::TestLinearIssueToWorkItem::test_issue_with_zero_estimate_preserves_story_points
  - tests/test_clickhouse_org_id.py::test_clickhouse_sink_write_estimate_coverage_metrics_includes_org_id
- bash ci/local_validate.sh attempt 1: failed at ClickHouse migration due nullable key; fixed migration ORDER BY.
- bash ci/local_validate.sh attempt 2: lint/typecheck/migration passed; unit suite failed on 5 stale write-surface/fake-sink tests; fixed retry registry and fake-sink guard.
- Targeted rerun of the 5 failed cases: PASS (5 passed)
- pre-push hook: PASS (ruff format check, ruff check, mypy)
- SCREENSHOT-WAIVER: backend/data-contract only, no rendered UI.

## Platform Contract Checks
- ClickHouse-only analytics persistence: yes, new table is ClickHouse migration and writes via metrics/sinks/clickhouse.
- No persistence outside metrics/sinks/*: yes.
- No Postgres team/identity attribution mappings: yes.
- Provider coverage: estimate coverage test covers jira/gitlab/github/linear normalized story-point semantics; Linear zero estimate regression added.
- UX-time recompute: no web changes; GraphQL reads persisted estimate coverage.
- GraphQL field/type frozen before web work: ThroughputForecast.estimateCoverage / ThroughputEstimateCoverage.
- CHAOS-2729 packaging untouched: yes.

## Risks
- Full local_validate was not rerun a third time after the final stale-test fixes due the two-check stop rule; targeted failing tests and pre-push quality hooks are green.
- Backfill cadence depends on daily/work-item sync jobs writing the new table before GraphQL returns estimateCoverage for an org.