### PR TITLE
feat(graphql): expose PR detail resolver (CHAOS-2387)

### DIFF
--- a/src/dev_health_ops/api/graphql/models/pr.py
+++ b/src/dev_health_ops/api/graphql/models/pr.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import datetime
+
+import strawberry
+
+
+@strawberry.type
+class PullRequestReview:
+    review_id: str
+    reviewer: str
+    state: str
+    submitted_at: datetime
+
+
+@strawberry.type
+class PullRequestCommit:
+    hash: str
+    message: str | None = None
+    author_name: str | None = None
+    author_email: str | None = None
+    author_when: datetime | None = None
+    confidence: float | None = None
+    provenance: str | None = None
+    evidence: str | None = None
+
+
+@strawberry.type
+class PullRequestIssueLink:
+    work_item_id: str
+    confidence: float
+    provenance: str
+    evidence: str
+
+
+@strawberry.type
+class PullRequestDetail:
+    id: strawberry.ID
+    org_id: str
+    repo_id: strawberry.ID
+    repo_name: str | None = None
+    number: int
+    title: str | None = None
+    body: str | None = None
+    state: str | None = None
+    author_name: str | None = None
+    author_email: str | None = None
+    created_at: datetime
+    merged_at: datetime | None = None
+    closed_at: datetime | None = None
+    head_branch: str | None = None
+    base_branch: str | None = None
+    additions: int | None = None
+    deletions: int | None = None
+    changed_files: int | None = None
+    first_review_at: datetime | None = None
+    first_comment_at: datetime | None = None
+    changes_requested_count: int = 0
+    reviews_count: int = 0
+    comments_count: int = 0
+    reviews: list[PullRequestReview] = strawberry.field(default_factory=list)
+    commits: list[PullRequestCommit] = strawberry.field(default_factory=list)
+    linked_issues: list[PullRequestIssueLink] = strawberry.field(default_factory=list)

--- a/src/dev_health_ops/api/graphql/resolvers/pr.py
+++ b/src/dev_health_ops/api/graphql/resolvers/pr.py
@@ -1,0 +1,263 @@
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any, NamedTuple
+
+import strawberry
+
+from dev_health_ops.api.queries.client import query_dicts
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..models.pr import (
+    PullRequestCommit,
+    PullRequestDetail,
+    PullRequestIssueLink,
+    PullRequestReview,
+)
+
+logger = logging.getLogger(__name__)
+
+_PR_ID_RE = re.compile(r"^(?P<repo>[0-9a-fA-F-]{36})(?:#pr|#|:|/pr/)(?P<number>\d+)$")
+
+
+class _ParsedPrId(NamedTuple):
+    repo_id: str
+    number: int
+
+
+def parse_pr_id(value: str) -> _ParsedPrId | None:
+    match = _PR_ID_RE.match(value.strip())
+    if match is None:
+        return None
+    return _ParsedPrId(
+        repo_id=match.group("repo").lower(), number=int(match.group("number"))
+    )
+
+
+def _require_client(context: GraphQLContext) -> Any:
+    if context.client is None:
+        raise RuntimeError("Database client not available for PullRequest resolver")
+    return context.client
+
+
+async def _fetch_pr_row(
+    client: Any, *, org_id: str, repo_id: str, number: int
+) -> dict[str, Any] | None:
+    rows = await query_dicts(
+        client,
+        """
+        SELECT
+            toString(pr.repo_id) AS repo_id,
+            anyLast(repos.repo) AS repo_name,
+            pr.number AS number,
+            pr.title AS title,
+            pr.body AS body,
+            pr.state AS state,
+            pr.author_name AS author_name,
+            pr.author_email AS author_email,
+            pr.created_at AS created_at,
+            pr.merged_at AS merged_at,
+            pr.closed_at AS closed_at,
+            pr.head_branch AS head_branch,
+            pr.base_branch AS base_branch,
+            pr.additions AS additions,
+            pr.deletions AS deletions,
+            pr.changed_files AS changed_files,
+            pr.first_review_at AS first_review_at,
+            pr.first_comment_at AS first_comment_at,
+            pr.changes_requested_count AS changes_requested_count,
+            pr.reviews_count AS reviews_count,
+            pr.comments_count AS comments_count
+        FROM git_pull_requests FINAL AS pr
+        LEFT JOIN repos FINAL AS repos
+            ON repos.org_id = pr.org_id AND repos.id = pr.repo_id
+        WHERE pr.org_id = {org_id:String}
+          AND toString(pr.repo_id) = {repo_id:String}
+          AND pr.number = {number:UInt32}
+        GROUP BY
+            pr.repo_id,
+            pr.number,
+            pr.title,
+            pr.body,
+            pr.state,
+            pr.author_name,
+            pr.author_email,
+            pr.created_at,
+            pr.merged_at,
+            pr.closed_at,
+            pr.head_branch,
+            pr.base_branch,
+            pr.additions,
+            pr.deletions,
+            pr.changed_files,
+            pr.first_review_at,
+            pr.first_comment_at,
+            pr.changes_requested_count,
+            pr.reviews_count,
+            pr.comments_count
+        LIMIT 1
+        """,
+        {"org_id": org_id, "repo_id": repo_id, "number": number},
+    )
+    return rows[0] if rows else None
+
+
+async def _fetch_reviews(
+    client: Any, *, org_id: str, repo_id: str, number: int
+) -> list[PullRequestReview]:
+    rows = await query_dicts(
+        client,
+        """
+        SELECT review_id, reviewer, state, submitted_at
+        FROM git_pull_request_reviews FINAL
+        WHERE org_id = {org_id:String}
+          AND toString(repo_id) = {repo_id:String}
+          AND number = {number:UInt32}
+        ORDER BY submitted_at ASC, review_id ASC
+        LIMIT 500
+        """,
+        {"org_id": org_id, "repo_id": repo_id, "number": number},
+    )
+    return [
+        PullRequestReview(
+            review_id=str(row.get("review_id") or ""),
+            reviewer=str(row.get("reviewer") or ""),
+            state=str(row.get("state") or ""),
+            submitted_at=row["submitted_at"],
+        )
+        for row in rows
+    ]
+
+
+async def _fetch_commits(
+    client: Any, *, org_id: str, repo_id: str, number: int
+) -> list[PullRequestCommit]:
+    rows = await query_dicts(
+        client,
+        """
+        SELECT
+            link.commit_hash AS hash,
+            anyLast(commit.message) AS message,
+            anyLast(commit.author_name) AS author_name,
+            anyLast(commit.author_email) AS author_email,
+            anyLast(commit.author_when) AS author_when,
+            argMax(link.confidence, link.last_synced) AS confidence,
+            argMax(link.provenance, link.last_synced) AS provenance,
+            argMax(link.evidence, link.last_synced) AS evidence
+        FROM work_graph_pr_commit FINAL AS link
+        LEFT JOIN git_commits FINAL AS commit
+            ON commit.org_id = link.org_id
+           AND commit.repo_id = link.repo_id
+           AND commit.hash = link.commit_hash
+        WHERE link.org_id = {org_id:String}
+          AND toString(link.repo_id) = {repo_id:String}
+          AND link.pr_number = {number:UInt32}
+        GROUP BY link.commit_hash
+        ORDER BY anyLast(commit.author_when) ASC, link.commit_hash ASC
+        LIMIT 500
+        """,
+        {"org_id": org_id, "repo_id": repo_id, "number": number},
+    )
+    return [
+        PullRequestCommit(
+            hash=str(row.get("hash") or ""),
+            message=row.get("message"),
+            author_name=row.get("author_name"),
+            author_email=row.get("author_email"),
+            author_when=row.get("author_when"),
+            confidence=float(row["confidence"])
+            if row.get("confidence") is not None
+            else None,
+            provenance=row.get("provenance"),
+            evidence=row.get("evidence"),
+        )
+        for row in rows
+    ]
+
+
+async def _fetch_linked_issues(
+    client: Any, *, org_id: str, repo_id: str, number: int
+) -> list[PullRequestIssueLink]:
+    rows = await query_dicts(
+        client,
+        """
+        SELECT
+            work_item_id,
+            argMax(confidence, last_synced) AS confidence,
+            argMax(provenance, last_synced) AS provenance,
+            argMax(evidence, last_synced) AS evidence
+        FROM work_graph_issue_pr FINAL
+        WHERE org_id = {org_id:String}
+          AND toString(repo_id) = {repo_id:String}
+          AND pr_number = {number:UInt32}
+        GROUP BY work_item_id
+        ORDER BY confidence DESC, work_item_id ASC
+        LIMIT 500
+        """,
+        {"org_id": org_id, "repo_id": repo_id, "number": number},
+    )
+    return [
+        PullRequestIssueLink(
+            work_item_id=str(row.get("work_item_id") or ""),
+            confidence=float(row.get("confidence") or 0.0),
+            provenance=str(row.get("provenance") or ""),
+            evidence=str(row.get("evidence") or ""),
+        )
+        for row in rows
+    ]
+
+
+async def resolve_pr(context: GraphQLContext, id: str) -> PullRequestDetail | None:
+    org_id = require_org_id(context)
+    parsed = parse_pr_id(id)
+    if parsed is None:
+        logger.debug("Invalid PR detail id %r", id)
+        return None
+
+    client = _require_client(context)
+    pr_row = await _fetch_pr_row(
+        client, org_id=org_id, repo_id=parsed.repo_id, number=parsed.number
+    )
+    if pr_row is None:
+        return None
+
+    reviews = await _fetch_reviews(
+        client, org_id=org_id, repo_id=parsed.repo_id, number=parsed.number
+    )
+    commits = await _fetch_commits(
+        client, org_id=org_id, repo_id=parsed.repo_id, number=parsed.number
+    )
+    linked_issues = await _fetch_linked_issues(
+        client, org_id=org_id, repo_id=parsed.repo_id, number=parsed.number
+    )
+
+    return PullRequestDetail(
+        id=strawberry.ID(f"{parsed.repo_id}#pr{parsed.number}"),
+        org_id=org_id,
+        repo_id=strawberry.ID(parsed.repo_id),
+        repo_name=pr_row.get("repo_name"),
+        number=int(pr_row.get("number") or parsed.number),
+        title=pr_row.get("title"),
+        body=pr_row.get("body"),
+        state=pr_row.get("state"),
+        author_name=pr_row.get("author_name"),
+        author_email=pr_row.get("author_email"),
+        created_at=pr_row["created_at"],
+        merged_at=pr_row.get("merged_at"),
+        closed_at=pr_row.get("closed_at"),
+        head_branch=pr_row.get("head_branch"),
+        base_branch=pr_row.get("base_branch"),
+        additions=pr_row.get("additions"),
+        deletions=pr_row.get("deletions"),
+        changed_files=pr_row.get("changed_files"),
+        first_review_at=pr_row.get("first_review_at"),
+        first_comment_at=pr_row.get("first_comment_at"),
+        changes_requested_count=int(pr_row.get("changes_requested_count") or 0),
+        reviews_count=int(pr_row.get("reviews_count") or 0),
+        comments_count=int(pr_row.get("comments_count") or 0),
+        reviews=reviews,
+        commits=commits,
+        linked_issues=linked_issues,
+    )

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -57,6 +57,7 @@ from .models.outputs import (
     WorkItemTeamAttribution,
     WorkUnitTeamAttribution,
 )
+from .models.pr import PullRequestDetail
 from .models.recommendations import (
     Recommendation,
     WindowInput,
@@ -79,6 +80,7 @@ from .resolvers.complexity import resolve_complexity_timeseries, resolve_hotspot
 from .resolvers.compounding_risk import resolve_compounding_risk
 from .resolvers.data_health import resolve_data_health
 from .resolvers.improve import resolve_improve_opportunities
+from .resolvers.pr import resolve_pr
 from .resolvers.product_telemetry import (
     resolve_product_telemetry_dashboard,
     resolve_product_telemetry_platform_dashboard,
@@ -269,6 +271,21 @@ class Query:
 
         context = get_context(info)
         return await resolve_work_graph_edges(context, filters)
+
+    @strawberry.field(
+        description=(
+            "Pull request detail by stable id ({repo_id}#pr{number}) from "
+            "persisted ClickHouse PR, review, commit, and Work Graph tables."
+        )
+    )
+    async def pr(
+        self,
+        info: Info,
+        org_id: str,
+        id: strawberry.ID,
+    ) -> PullRequestDetail | None:
+        context = get_context(info)
+        return await resolve_pr(context, str(id))
 
     @strawberry.field(
         description="Per-node-type inflow/outflow over the full work graph"

--- a/tests/api/graphql/test_pr_resolver.py
+++ b/tests/api/graphql/test_pr_resolver.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.pr import parse_pr_id, resolve_pr
+
+ORG_ID = "org-pr-detail-test"
+REPO_ID = "11111111-1111-1111-1111-111111111111"
+PR_ID = f"{REPO_ID}#pr42"
+NOW = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+
+
+def _ctx() -> GraphQLContext:
+    ctx = GraphQLContext(org_id=ORG_ID, db_url="clickhouse://localhost:8123/d")
+    ctx.client = MagicMock(spec=["query"])
+    return ctx
+
+
+def _qresult(columns: list[str], rows: list[list[Any]]) -> Any:
+    result = MagicMock()
+    result.column_names = columns
+    result.result_rows = rows
+    return result
+
+
+@pytest.mark.asyncio
+async def test_pr_resolver_returns_pr_reviews_commits_and_provenance() -> None:
+    ctx = _ctx()
+    ctx.client.query.side_effect = [
+        _qresult(
+            [
+                "repo_id",
+                "repo_name",
+                "number",
+                "title",
+                "body",
+                "state",
+                "author_name",
+                "author_email",
+                "created_at",
+                "merged_at",
+                "closed_at",
+                "head_branch",
+                "base_branch",
+                "additions",
+                "deletions",
+                "changed_files",
+                "first_review_at",
+                "first_comment_at",
+                "changes_requested_count",
+                "reviews_count",
+                "comments_count",
+            ],
+            [
+                [
+                    REPO_ID,
+                    "full-chaos/dev-health",
+                    42,
+                    "Wire PR detail",
+                    "Body",
+                    "merged",
+                    "Ada",
+                    "ada@example.com",
+                    NOW,
+                    NOW,
+                    None,
+                    "feature/pr-detail",
+                    "main",
+                    12,
+                    3,
+                    4,
+                    NOW,
+                    NOW,
+                    1,
+                    2,
+                    5,
+                ]
+            ],
+        ),
+        _qresult(
+            ["review_id", "reviewer", "state", "submitted_at"],
+            [["r1", "reviewer@example.com", "APPROVED", NOW]],
+        ),
+        _qresult(
+            [
+                "hash",
+                "message",
+                "author_name",
+                "author_email",
+                "author_when",
+                "confidence",
+                "provenance",
+                "evidence",
+            ],
+            [
+                [
+                    "abc123",
+                    "commit msg",
+                    "Ada",
+                    "ada@example.com",
+                    NOW,
+                    0.99,
+                    "native",
+                    "api_pr_commits",
+                ]
+            ],
+        ),
+        _qresult(
+            ["work_item_id", "confidence", "provenance", "evidence"],
+            [["jira:CHAOS-2387", 0.95, "native", "linked issue"]],
+        ),
+    ]
+
+    result = await resolve_pr(ctx, PR_ID)
+
+    assert result is not None
+    assert result.id == PR_ID
+    assert result.repo_id == REPO_ID
+    assert result.title == "Wire PR detail"
+    assert result.reviews[0].reviewer == "reviewer@example.com"
+    assert result.commits[0].hash == "abc123"
+    assert result.commits[0].provenance == "native"
+    assert result.linked_issues[0].work_item_id == "jira:CHAOS-2387"
+    assert result.linked_issues[0].provenance == "native"
+
+
+@pytest.mark.asyncio
+async def test_pr_resolver_returns_none_for_missing_pr() -> None:
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult([], [])
+
+    result = await resolve_pr(ctx, PR_ID)
+
+    assert result is None
+    assert ctx.client.query.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_pr_resolver_returns_none_for_invalid_id_without_querying() -> None:
+    ctx = _ctx()
+
+    result = await resolve_pr(ctx, "not-a-pr-id")
+
+    assert result is None
+    ctx.client.query.assert_not_called()
+
+
+def test_parse_pr_id_accepts_stable_work_graph_format() -> None:
+    parsed = parse_pr_id(PR_ID)
+
+    assert parsed is not None
+    assert parsed.repo_id == REPO_ID
+    assert parsed.number == 42


### PR DESCRIPTION
## Summary
- add the GraphQL pr(orgId, id) field for stable PR ids like repo_id#prnumber
- read persisted ClickHouse PR, review, commit, and Work Graph linked-issue data
- cover happy path, invalid id, not found, and provenance behavior

## Validation
- python -m pytest tests/api/graphql/test_pr_resolver.py
- bash ci/local_validate.sh

Linear: CHAOS-2387