### PR TITLE
feat(graphql): add aiAttributionOverview resolver (CHAOS-2744)

### DIFF
--- a/docs/api/graphql-ai.md
+++ b/docs/api/graphql-ai.md
@@ -54,7 +54,7 @@ the GraphQL `AIAttributionBucketInput` enum:
 
 ## Query catalog
 
-All seven queries scope to `orgId` (enforced by `OrgIdAuthExtension`).
+All AI analytics queries scope to `orgId` (enforced by `OrgIdAuthExtension`).
 
 ### `aiImpactSummary`
 
@@ -127,6 +127,20 @@ standalone dashboard card.
 Coverage rollups (`declarationCoverage`, `humanReviewCoverage`,
 `securityScanCoverage`, `inPolicyCoverage`) plus recent violations
 (rule id + severity from the canonical AI policy registry).
+
+### `aiAttributionOverview` (CHAOS-2744)
+
+Backs the dedicated `/ai/attribution` page. Reads `ai_attribution_resolved`
+directly — the highest-precedence, non-superseded signal per subject — and
+returns two projections of the same window:
+
+- `mix`: `[{ kind, count, share }]` from a plain `GROUP BY kind`. No
+  synthesized `human` bucket — use `aiImpactSummary` for the full AI-vs-human
+  PR split, which requires the total PR population, not just detected signals.
+- `rows`: paginated `AIAttributionEvidenceRow` records with `source`,
+  `confidence`, `evidence`, and `actor` always populated (non-nullable on the
+  base table) plus `teamId` resolved via `RepoPatternTeamResolver`, the same
+  mechanism `aiAttributedPrs` uses.
 
 ### `aiWorkflowDrilldown`
 

--- a/docs/architecture/ai-attribution.md
+++ b/docs/architecture/ai-attribution.md
@@ -170,6 +170,28 @@ ClickHouse: SELECT * FROM ai_attribution_resolved
 
 Returns: one row per subject with the effective attribution (highest precedence, non-superseded).
 
+### GraphQL: `aiAttributionOverview` (CHAOS-2744)
+
+The dedicated `/ai/attribution` page reads `ai_attribution_resolved` directly through
+`AIAttributionClickHouseLoader` (`metrics/loaders/ai_attribution.py`) and the
+`aiAttributionOverview` resolver (`api/graphql/resolvers/ai.py`). It returns two
+projections of the same org-scoped window, never fabricated or recomputed client-side:
+
+- `mix: [AIAttributionMixRow!]!` — `GROUP BY kind` counts + share over the resolved
+  view. There is intentionally **no synthesized `human` bucket** here: this view only
+  ever contains subjects with a detected signal, so a human count would require the
+  full PR population — that inference already lives in `ai_impact_metrics_daily` /
+  `aiImpactSummary` and must not be duplicated with a second, undocumented method.
+- `rows: [AIAttributionEvidenceRow!]!` — one row per resolved record with
+  `source`, `confidence`, `evidence`, and `actor` always populated (non-nullable on
+  the base table), plus `teamId` resolved the same way as `aiAttributedPrs`
+  (`RepoPatternTeamResolver` over `teams.repo_patterns`, never a SQL join on UUID).
+
+This is additive: `aiImpactSummary`, `aiGovernanceSummary`, and `aiAttributedPrs` are
+unchanged and remain the source for impact/governance/drilldown-selector use cases.
+
+---
+
 ---
 
 ## Supersession (MANUAL overrides)

--- a/src/dev_health_ops/api/graphql/models/ai.py
+++ b/src/dev_health_ops/api/graphql/models/ai.py
@@ -506,3 +506,63 @@ class AiAttributedPrsResult:
     total: int
     has_more: bool
     data_available: bool
+
+
+@strawberry.type
+class AIAttributionMixRow:
+    """Count of resolved AI attribution records for one kind in the window.
+
+    Sourced from a plain ``GROUP BY kind`` over ``ai_attribution_resolved``,
+    which already carries the winning (highest-precedence, non-superseded)
+    signal per subject, so counts never double a subject across sources.
+    This intentionally does NOT include a synthesized ``human`` bucket:
+    ``ai_attribution_resolved`` only ever contains subjects with a detected
+    signal, so a human count would require the full PR population (that
+    inference already lives in ``aiImpactSummary``).
+    """
+
+    kind: str
+    count: int
+    share: float
+
+
+@strawberry.type
+class AIAttributionEvidenceRow:
+    """A single resolved AI attribution record with full provenance.
+
+    Sourced directly from ``ai_attribution_resolved`` — one row per subject,
+    already resolved to the highest-precedence, non-superseded signal. No
+    aggregation, no fabrication: every row is a persisted signal.
+    """
+
+    subject_type: str
+    subject_id: str
+    repo_id: str | None
+    provider: str
+    kind: str
+    source: str
+    confidence: float
+    actor: str | None
+    evidence: str
+    observed_at: datetime
+    team_id: str | None = None
+
+
+@strawberry.type
+class AIAttributionOverviewResult:
+    """Attribution mix + provenance evidence for the requested window.
+
+    Backs the dedicated ``/ai/attribution`` page. ``mix`` answers "how does
+    detected AI involvement split by kind"; ``rows`` gives the underlying
+    evidence (source/confidence/evidence) so the UI never has to re-derive
+    or guess why a subject was attributed.
+    """
+
+    org_id: str
+    start_date: date
+    end_date: date
+    mix: list[AIAttributionMixRow]
+    total_attributed: int
+    rows: list[AIAttributionEvidenceRow]
+    has_more: bool
+    data_available: bool

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -29,6 +29,7 @@ from dev_health_ops.metrics.ai_impact import (
 from dev_health_ops.metrics.ai_impact import (
     AttributionBucket,
 )
+from dev_health_ops.metrics.loaders.ai_attribution import AIAttributionClickHouseLoader
 from dev_health_ops.metrics.loaders.ai_impact import AIImpactClickHouseLoader
 from dev_health_ops.metrics.opportunities.ai_detector import AIOpportunityDetector
 
@@ -37,6 +38,9 @@ from ..context import GraphQLContext
 from ..models.ai import (
     AiAttributedPr,
     AiAttributedPrsResult,
+    AIAttributionEvidenceRow,
+    AIAttributionMixRow,
+    AIAttributionOverviewResult,
     AIComparison,
     AIComparisonDelta,
     AIComparisonSide,
@@ -1317,4 +1321,139 @@ async def resolve_ai_attributed_prs(
         total=len(rows),
         has_more=has_more,
         data_available=bool(rows),
+    )
+
+
+# =============================================================================
+# resolve_ai_attribution_overview
+# =============================================================================
+
+_MAX_AI_ATTRIBUTION_EVIDENCE_PAGE = 200
+
+
+async def resolve_ai_attribution_overview(
+    context: GraphQLContext,
+    date_range: AIDateRangeInput,
+    scope: AIScopeInput | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> AIAttributionOverviewResult:
+    """Attribution mix + provenance evidence for the dedicated AI Attribution page.
+
+    Reads ``ai_attribution_resolved`` only — the highest-precedence,
+    non-superseded signal per subject. Every returned row corresponds to a
+    persisted signal; source/confidence/evidence are never fabricated or
+    recomputed at request time.
+    """
+
+    org_id = require_org_id(context)
+    _validate_date_range(date_range)
+    repo_id, team_id, _work_type = _normalize_scope(scope)
+
+    page_size = max(1, min(int(limit), _MAX_AI_ATTRIBUTION_EVIDENCE_PAGE))
+    page_offset = max(0, int(offset))
+
+    start_dt = datetime.combine(date_range.start_date, time.min, tzinfo=timezone.utc)
+    end_dt = datetime.combine(date_range.end_date, time.max, tzinfo=timezone.utc)
+
+    # Resolve the team scope to repo UUIDs BEFORE the SQL LIMIT, mirroring
+    # resolve_ai_attributed_prs (CHAOS-2180 Wave 2), so team-scoped pages
+    # stay dense. ``None`` means the catalogs could not be loaded; callers
+    # then fall back to in-memory filtering below.
+    team_repo_ids: list[uuid.UUID] | None = None
+    if team_id:
+        team_repo_ids = await _resolve_team_repo_ids(
+            _require_client(context), org_id=org_id, team_id=team_id
+        )
+        if team_repo_ids is not None and not team_repo_ids:
+            # The team resolves to no repos: honestly empty, not an error.
+            return AIAttributionOverviewResult(
+                org_id=org_id,
+                start_date=date_range.start_date,
+                end_date=date_range.end_date,
+                mix=[],
+                total_attributed=0,
+                rows=[],
+                has_more=False,
+                data_available=False,
+            )
+
+    loader = AIAttributionClickHouseLoader(_require_client(context), org_id=org_id)
+
+    mix_raw = await loader.load_mix(
+        start=start_dt,
+        end=end_dt,
+        repo_id=repo_id,
+        repo_ids=team_repo_ids,
+    )
+    total_mix = sum(int(row.get("count") or 0) for row in mix_raw)
+    mix = [
+        AIAttributionMixRow(
+            kind=str(row.get("kind") or "unknown"),
+            count=int(row.get("count") or 0),
+            share=(int(row.get("count") or 0) / total_mix) if total_mix else 0.0,
+        )
+        for row in mix_raw
+    ]
+
+    # Fetch one extra row so we can report has_more without a COUNT(*) round-trip.
+    raw_rows = await loader.load_evidence(
+        start=start_dt,
+        end=end_dt,
+        repo_id=repo_id,
+        repo_ids=team_repo_ids,
+        limit=page_size + 1,
+        offset=page_offset,
+    )
+    has_more = len(raw_rows) > page_size
+    page_rows = raw_rows[:page_size]
+
+    # Resolve team IDs via RepoPatternTeamResolver before filtering, mirroring
+    # resolve_ai_attributed_prs: teams.repo_patterns holds fnmatch glob
+    # patterns over repo full-names, not repo UUIDs, so a SQL JOIN never
+    # matches — team membership is resolved in app code.
+    if org_id:
+        distinct_repo_ids = list(
+            {str(row["repo_id"]) for row in page_rows if row.get("repo_id") is not None}
+        )
+        team_map = await _resolve_repo_team_map(
+            _require_client(context), org_id=org_id, repo_ids=distinct_repo_ids
+        )
+        if team_map:
+            for row in page_rows:
+                repo_id_val = row.get("repo_id")
+                row["team_id"] = (
+                    team_map.get(str(repo_id_val)) if repo_id_val is not None else None
+                )
+
+    if team_id:
+        page_rows = [row for row in page_rows if (row.get("team_id") or "") == team_id]
+
+    rows: list[AIAttributionEvidenceRow] = []
+    for row in page_rows:
+        rows.append(
+            AIAttributionEvidenceRow(
+                subject_type=str(row.get("subject_type") or ""),
+                subject_id=str(row.get("subject_id") or ""),
+                repo_id=str(row["repo_id"]) if row.get("repo_id") is not None else None,
+                provider=str(row.get("provider") or ""),
+                kind=str(row.get("kind") or "unknown"),
+                source=str(row.get("source") or ""),
+                confidence=float(row.get("confidence") or 0.0),
+                actor=row.get("actor"),
+                evidence=str(row.get("evidence") or "{}"),
+                observed_at=_to_aware(row["observed_at"]),
+                team_id=row.get("team_id") or None,
+            )
+        )
+
+    return AIAttributionOverviewResult(
+        org_id=org_id,
+        start_date=date_range.start_date,
+        end_date=date_range.end_date,
+        mix=mix,
+        total_attributed=total_mix,
+        rows=rows,
+        has_more=has_more,
+        data_available=bool(mix or rows),
     )

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -11,6 +11,7 @@ from .context import GraphQLContext
 from .extensions import ConfiguredValidationRules, OrgIdAuthExtension
 from .models.ai import (
     AiAttributedPrsResult,
+    AIAttributionOverviewResult,
     AIComparison,
     AIDateRangeInput,
     AIGovernanceSummary,
@@ -64,6 +65,7 @@ from .models.recommendations import (
 )
 from .resolvers.ai import (
     resolve_ai_attributed_prs,
+    resolve_ai_attribution_overview,
     resolve_ai_comparison,
     resolve_ai_governance_summary,
     resolve_ai_impact_summary,
@@ -779,6 +781,30 @@ class Query:
     ) -> AiAttributedPrsResult:
         context = get_context(info)
         return await resolve_ai_attributed_prs(
+            context, date_range, scope, limit, offset
+        )
+
+    @strawberry.field(
+        description=(
+            "AI attribution mix and provenance evidence for the requested "
+            "window. Reads ai_attribution_resolved only - the highest-"
+            "precedence, non-superseded signal per subject - so every row "
+            "carries source, confidence, and evidence. Does not include a "
+            "synthesized human bucket; use aiImpactSummary for the full "
+            "AI-vs-human PR split."
+        )
+    )
+    async def ai_attribution_overview(
+        self,
+        info: Info,
+        org_id: str,
+        date_range: AIDateRangeInput,
+        scope: AIScopeInput | None = None,
+        limit: int = 50,
+        offset: int = 0,
+    ) -> AIAttributionOverviewResult:
+        context = get_context(info)
+        return await resolve_ai_attribution_overview(
             context, date_range, scope, limit, offset
         )
 

--- a/src/dev_health_ops/metrics/loaders/ai_attribution.py
+++ b/src/dev_health_ops/metrics/loaders/ai_attribution.py
@@ -1,0 +1,152 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from dev_health_ops.metrics.loaders.base import parse_uuid
+from dev_health_ops.metrics.query_builder import OrgScopedQuery
+
+
+class AIAttributionClickHouseLoader:
+    """Reads resolved AI attribution evidence directly from ClickHouse.
+
+    Sourced from ``ai_attribution_resolved`` — the highest-precedence,
+    non-superseded signal per subject (see docs/architecture/ai-attribution.md).
+    This is the only read path backing the dedicated ``/ai/attribution`` page:
+    it never aggregates away provenance, and it never infers a "human" count
+    by process of elimination (that inference already lives in
+    ``ai_impact_metrics_daily`` / ``aiImpactSummary`` and requires the full PR
+    population, not just detected signals — mixing the two here would silently
+    duplicate that job's methodology with a different, undocumented one).
+    """
+
+    def __init__(self, client: Any, org_id: str = "") -> None:
+        self.client = client
+        self.org_id = org_id
+        self._scope = OrgScopedQuery(org_id)
+
+    async def load_mix(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        repo_id: uuid.UUID | None = None,
+        repo_ids: list[uuid.UUID] | None = None,
+    ) -> list[dict[str, Any]]:
+        """Count resolved attribution records per kind in the window.
+
+        Every row in ``ai_attribution_resolved`` already represents the
+        winning (highest-precedence, non-superseded) signal for its subject,
+        so a plain ``GROUP BY kind`` cannot double-count a subject across
+        sources.
+        """
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {
+            "start": start.replace(tzinfo=None),
+            "end": end.replace(tzinfo=None),
+        }
+        repo_filter = self._repo_filter(params, repo_id, repo_ids)
+        params = self._scope.inject(params)
+        org_filter = self._scope.filter_uuid()
+
+        query = f"""
+        SELECT
+            kind,
+            count() AS count
+        FROM ai_attribution_resolved
+        WHERE observed_at >= {{start:DateTime}}
+          AND observed_at < {{end:DateTime}}
+          {repo_filter}
+          {org_filter}
+        GROUP BY kind
+        ORDER BY kind
+        """
+        return await query_dicts(self.client, query, params)
+
+    async def load_evidence(
+        self,
+        *,
+        start: datetime,
+        end: datetime,
+        repo_id: uuid.UUID | None = None,
+        repo_ids: list[uuid.UUID] | None = None,
+        limit: int | None = None,
+        offset: int = 0,
+    ) -> list[dict[str, Any]]:
+        """Load resolved AI attribution records with full provenance.
+
+        Every row is a persisted, resolved signal — no aggregation, no
+        fabrication. ``source``, ``confidence``, and ``evidence`` are always
+        populated because they are non-nullable on the base ``ai_attribution``
+        table (see ``models/ai_attribution.py::AIAttributionRecord``).
+        """
+        from dev_health_ops.api.queries.client import query_dicts
+
+        params: dict[str, Any] = {
+            "start": start.replace(tzinfo=None),
+            "end": end.replace(tzinfo=None),
+        }
+        repo_filter = self._repo_filter(params, repo_id, repo_ids)
+        limit_clause = ""
+        if limit is not None and int(limit) > 0:
+            params["limit"] = int(limit)
+            params["offset"] = max(0, int(offset))
+            limit_clause = "LIMIT {limit:UInt32} OFFSET {offset:UInt32}"
+        params = self._scope.inject(params)
+        org_filter = self._scope.filter_uuid()
+
+        query = f"""
+        SELECT
+            subject_type,
+            subject_id,
+            repo_id,
+            provider,
+            kind,
+            source,
+            confidence,
+            actor,
+            evidence,
+            observed_at
+        FROM ai_attribution_resolved
+        WHERE observed_at >= {{start:DateTime}}
+          AND observed_at < {{end:DateTime}}
+          {repo_filter}
+          {org_filter}
+        ORDER BY observed_at DESC, subject_id
+        {limit_clause}
+        """
+        raw_rows = await query_dicts(self.client, query, params)
+        rows: list[dict[str, Any]] = []
+        for raw in raw_rows:
+            rows.append(
+                {
+                    "subject_type": raw.get("subject_type"),
+                    "subject_id": raw.get("subject_id"),
+                    "repo_id": parse_uuid(raw.get("repo_id")),
+                    "provider": raw.get("provider"),
+                    "kind": raw.get("kind"),
+                    "source": raw.get("source"),
+                    "confidence": raw.get("confidence"),
+                    "actor": raw.get("actor"),
+                    "evidence": raw.get("evidence"),
+                    "observed_at": raw.get("observed_at"),
+                }
+            )
+        return rows
+
+    def _repo_filter(
+        self,
+        params: dict[str, Any],
+        repo_id: uuid.UUID | None,
+        repo_ids: list[uuid.UUID] | None,
+    ) -> str:
+        clause = ""
+        if repo_id is not None:
+            params["repo_id"] = str(repo_id)
+            clause += "\n          AND repo_id = {repo_id:UUID}"
+        if repo_ids is not None:
+            params["repo_ids"] = [str(r) for r in repo_ids]
+            clause += "\n          AND toString(repo_id) IN {repo_ids:Array(String)}"
+        return clause

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -36,6 +36,7 @@ from dev_health_ops.api.graphql.models.ai import (
 )
 from dev_health_ops.api.graphql.resolvers.ai import (
     resolve_ai_attributed_prs,
+    resolve_ai_attribution_overview,
     resolve_ai_comparison,
     resolve_ai_governance_summary,
     resolve_ai_impact_summary,
@@ -1282,3 +1283,235 @@ async def test_ai_attributed_prs_unresolvable_team_falls_back_to_memory_filter()
 
     assert mock_load.await_args.kwargs["repo_ids"] is None
     assert [r.number for r in result.rows] == [1]
+
+
+# -----------------------------------------------------------------------------
+# CHAOS-2744 -- aiAttributionOverview
+# -----------------------------------------------------------------------------
+
+
+def _mix_row(kind: str, count: int) -> dict[str, Any]:
+    return {"kind": kind, "count": count}
+
+
+def _evidence_row(
+    *,
+    subject_id: str,
+    subject_type: str = "pull_request",
+    kind: str = "ai_assisted",
+    source: str = "pr_label",
+    confidence: float = 0.9,
+    actor: str | None = "github-copilot",
+    evidence: str = '{"label": "ai-assisted"}',
+    observed_at: datetime | None = None,
+    repo_id: UUID | None = REPO_ID,
+    provider: str = "github",
+    team_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "subject_type": subject_type,
+        "subject_id": subject_id,
+        "repo_id": repo_id,
+        "provider": provider,
+        "kind": kind,
+        "source": source,
+        "confidence": confidence,
+        "actor": actor,
+        "evidence": evidence,
+        "observed_at": observed_at or COMPUTED_AT,
+        "team_id": team_id,
+    }
+
+
+def _patch_mix_loader(rows: list[dict[str, Any]]) -> Any:
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_attribution"
+        ".AIAttributionClickHouseLoader.load_mix",
+        new_callable=AsyncMock,
+        return_value=rows,
+    )
+
+
+def _patch_evidence_loader(rows: list[dict[str, Any]]) -> Any:
+    return patch(
+        "dev_health_ops.metrics.loaders.ai_attribution"
+        ".AIAttributionClickHouseLoader.load_evidence",
+        new_callable=AsyncMock,
+        return_value=rows,
+    )
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_empty_state():
+    with _patch_mix_loader([]), _patch_evidence_loader([]):
+        result = await resolve_ai_attribution_overview(_ctx(), _range())
+
+    assert result.org_id == ORG_ID
+    assert result.mix == []
+    assert result.rows == []
+    assert result.total_attributed == 0
+    assert result.has_more is False
+    assert result.data_available is False
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_populated_maps_fields_and_provenance():
+    mix_rows = [_mix_row("ai_assisted", 3), _mix_row("agent_created", 1)]
+    evidence_rows = [
+        _evidence_row(subject_id="101", kind="ai_assisted", confidence=0.9),
+        _evidence_row(
+            subject_id="102",
+            kind="agent_created",
+            source="bot_author",
+            actor="claude-agent",
+            confidence=0.75,
+            evidence='{"bot": "claude-agent"}',
+        ),
+    ]
+    with _patch_mix_loader(mix_rows), _patch_evidence_loader(evidence_rows):
+        result = await resolve_ai_attribution_overview(_ctx(), _range())
+
+    assert result.data_available is True
+    assert result.total_attributed == 4
+    assert [m.kind for m in result.mix] == ["ai_assisted", "agent_created"]
+    assert [m.count for m in result.mix] == [3, 1]
+    assert result.mix[0].share == pytest.approx(0.75)
+    assert result.mix[1].share == pytest.approx(0.25)
+
+    assert len(result.rows) == 2
+    first = result.rows[0]
+    assert first.subject_type == "pull_request"
+    assert first.subject_id == "101"
+    assert first.repo_id == str(REPO_ID)
+    assert first.provider == "github"
+    assert first.kind == "ai_assisted"
+    # Every row must carry full provenance -- never blank source/evidence.
+    assert first.source == "pr_label"
+    assert first.confidence == 0.9
+    assert first.evidence == '{"label": "ai-assisted"}'
+
+    second = result.rows[1]
+    assert second.source == "bot_author"
+    assert second.actor == "claude-agent"
+    assert second.confidence == 0.75
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_mix_has_no_synthesized_human_bucket():
+    """ai_attribution_resolved never carries an inferred human count --
+    only kinds that a detector actually emitted a signal for. A synthesized
+    'human' bucket here would silently duplicate aiImpactSummary's PR-
+    population-based methodology with a different, undocumented one.
+    """
+    mix_rows = [_mix_row("ai_assisted", 2), _mix_row("unknown", 1)]
+    with _patch_mix_loader(mix_rows), _patch_evidence_loader([]):
+        result = await resolve_ai_attribution_overview(_ctx(), _range())
+
+    assert "human" not in {m.kind for m in result.mix}
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_reports_has_more_and_pages():
+    rows = [_evidence_row(subject_id=str(200 + i)) for i in range(51)]
+    with (
+        _patch_mix_loader([_mix_row("ai_assisted", 51)]),
+        _patch_evidence_loader(rows) as mock_load,
+    ):
+        result = await resolve_ai_attribution_overview(
+            _ctx(), _range(), limit=50, offset=0
+        )
+
+    assert mock_load.await_args.kwargs["limit"] == 51
+    assert mock_load.await_args.kwargs["offset"] == 0
+    assert len(result.rows) == 50
+    assert result.has_more is True
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_passes_repo_scope_to_loaders():
+    scope = AIScopeInput(repo_id=str(REPO_ID))
+    with (
+        _patch_mix_loader([]) as mock_mix,
+        _patch_evidence_loader([]) as mock_evidence,
+    ):
+        await resolve_ai_attribution_overview(_ctx(), _range(), scope)
+
+    assert mock_mix.await_args.kwargs["repo_id"] == REPO_ID
+    assert mock_evidence.await_args.kwargs["repo_id"] == REPO_ID
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_rejects_reversed_date_range():
+    bad_range = AIDateRangeInput(start_date=DAY_END, end_date=DAY_START)
+    with pytest.raises(ValueError, match="end_date must be >= start_date"):
+        await resolve_ai_attribution_overview(_ctx(), bad_range)
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_team_with_no_repos_returns_empty():
+    scope = AIScopeInput(team_id="team-empty")
+    with (
+        _patch_mix_loader([_mix_row("ai_assisted", 1)]) as mock_mix,
+        _patch_evidence_loader([_evidence_row(subject_id="1")]) as mock_evidence,
+        _patch_team_repo_ids([]),
+    ):
+        result = await resolve_ai_attribution_overview(_ctx(), _range(), scope)
+
+    mock_mix.assert_not_awaited()
+    mock_evidence.assert_not_awaited()
+    assert result.mix == []
+    assert result.rows == []
+    assert result.data_available is False
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_team_scope_filters_in_sql_before_limit():
+    """Team scope must reach both loaders as repo_ids so the SQL LIMIT
+    applies to the already-filtered universe (dense pages), mirroring
+    resolve_ai_attributed_prs (CHAOS-2180 Wave 2)."""
+    rows = [_evidence_row(subject_id="1"), _evidence_row(subject_id="2")]
+    scope = AIScopeInput(team_id="team-a")
+    repo_team_map = {str(REPO_ID): "team-a"}
+    with (
+        _patch_mix_loader([_mix_row("ai_assisted", 2)]) as mock_mix,
+        _patch_evidence_loader(rows) as mock_evidence,
+        _patch_team_repo_ids([REPO_ID]),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_team_map",
+            new_callable=AsyncMock,
+            return_value=repo_team_map,
+        ),
+    ):
+        result = await resolve_ai_attribution_overview(_ctx(), _range(), scope)
+
+    assert mock_mix.await_args.kwargs["repo_ids"] == [REPO_ID]
+    assert mock_evidence.await_args.kwargs["repo_ids"] == [REPO_ID]
+    assert [r.subject_id for r in result.rows] == ["1", "2"]
+    assert all(r.team_id == "team-a" for r in result.rows)
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_team_scope_drops_rows_outside_team():
+    """Defense in depth: even if a row's resolved team doesn't match the
+    scope, it must be dropped rather than leaking cross-team evidence."""
+    REPO_B = UUID("22222222-2222-2222-2222-222222222222")
+    rows = [
+        _evidence_row(subject_id="1", repo_id=REPO_ID),
+        _evidence_row(subject_id="2", repo_id=REPO_B),
+    ]
+    scope = AIScopeInput(team_id="team-a")
+    repo_team_map = {str(REPO_ID): "team-a", str(REPO_B): "team-b"}
+    with (
+        _patch_mix_loader([_mix_row("ai_assisted", 2)]),
+        _patch_evidence_loader(rows),
+        _patch_team_repo_ids(None),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_team_map",
+            new_callable=AsyncMock,
+            return_value=repo_team_map,
+        ),
+    ):
+        result = await resolve_ai_attribution_overview(_ctx(), _range(), scope)
+
+    assert [r.subject_id for r in result.rows] == ["1"]
+    assert result.rows[0].team_id == "team-a"

--- a/tests/metrics/test_ai_attribution_loader.py
+++ b/tests/metrics/test_ai_attribution_loader.py
@@ -1,0 +1,216 @@
+"""Unit tests for AIAttributionClickHouseLoader (CHAOS-2744).
+
+Pins the SQL shape of the read path backing the dedicated `/ai/attribution`
+page: both `load_mix` and `load_evidence` must read `ai_attribution_resolved`
+only, scope with the UUID-safe org filter (the table's `org_id` column is
+`UUID`, not `String` -- see `OrgScopedQuery.filter_uuid`), and never fabricate
+or drop provenance columns.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import patch
+from uuid import UUID
+
+import pytest
+
+from dev_health_ops.metrics.loaders.ai_attribution import AIAttributionClickHouseLoader
+
+ORG_ID = "org-test"
+REPO_A = UUID("aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa")
+REPO_B = UUID("bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb")
+
+START = datetime(2026, 5, 1, tzinfo=timezone.utc)
+END = datetime(2026, 5, 8, tzinfo=timezone.utc)
+
+
+def _capture(rows: list[dict[str, Any]]) -> tuple[list[str], list[dict[str, Any]], Any]:
+    captured_queries: list[str] = []
+    captured_params: list[dict[str, Any]] = []
+
+    async def fake_qd(_client: Any, query: str, params: Any) -> list[dict[str, Any]]:
+        captured_queries.append(query)
+        captured_params.append(params)
+        return rows
+
+    return captured_queries, captured_params, fake_qd
+
+
+# -----------------------------------------------------------------------------
+# load_mix
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_mix_reads_ai_attribution_resolved_only():
+    queries, _params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_mix(start=START, end=END)
+
+    sql = queries[0]
+    assert "FROM ai_attribution_resolved" in sql
+    assert "GROUP BY kind" in sql
+    assert "ai_attribution FINAL" not in sql
+
+
+@pytest.mark.asyncio
+async def test_load_mix_uses_uuid_safe_org_filter():
+    """ai_attribution_resolved.org_id is UUID -- the filter must cast with
+    toString(), not compare the column directly to a String literal."""
+    queries, params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_mix(start=START, end=END)
+
+    sql = queries[0]
+    assert "toString(org_id) = {org_id:String}" in sql
+    assert params[0]["org_id"] == ORG_ID
+
+
+@pytest.mark.asyncio
+async def test_load_mix_empty_org_id_omits_org_filter():
+    queries, params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id="")
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_mix(start=START, end=END)
+
+    assert "org_id" not in queries[0]
+    assert "org_id" not in params[0]
+
+
+@pytest.mark.asyncio
+async def test_load_mix_applies_single_repo_filter():
+    queries, params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_mix(start=START, end=END, repo_id=REPO_A)
+
+    assert "AND repo_id = {repo_id:UUID}" in queries[0]
+    assert params[0]["repo_id"] == str(REPO_A)
+
+
+@pytest.mark.asyncio
+async def test_load_mix_applies_repo_ids_filter():
+    queries, params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_mix(start=START, end=END, repo_ids=[REPO_A, REPO_B])
+
+    assert "toString(repo_id) IN {repo_ids:Array(String)}" in queries[0]
+    assert params[0]["repo_ids"] == [str(REPO_A), str(REPO_B)]
+
+
+@pytest.mark.asyncio
+async def test_load_mix_returns_grouped_counts():
+    rows = [{"kind": "ai_assisted", "count": 5}, {"kind": "unknown", "count": 2}]
+    _queries, _params, fake_qd = _capture(rows)
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        result = await loader.load_mix(start=START, end=END)
+
+    assert result == rows
+
+
+# -----------------------------------------------------------------------------
+# load_evidence
+# -----------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_load_evidence_selects_full_provenance_columns():
+    queries, _params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_evidence(start=START, end=END)
+
+    sql = queries[0]
+    for column in (
+        "subject_type",
+        "subject_id",
+        "repo_id",
+        "provider",
+        "kind",
+        "source",
+        "confidence",
+        "actor",
+        "evidence",
+        "observed_at",
+    ):
+        assert column in sql, f"expected {column!r} to be selected"
+    assert "FROM ai_attribution_resolved" in sql
+
+
+@pytest.mark.asyncio
+async def test_load_evidence_omits_limit_clause_when_no_limit():
+    queries, _params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_evidence(start=START, end=END)
+
+    assert "LIMIT" not in queries[0]
+
+
+@pytest.mark.asyncio
+async def test_load_evidence_applies_limit_offset_clause():
+    queries, params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_evidence(start=START, end=END, limit=25, offset=10)
+
+    assert "LIMIT {limit:UInt32} OFFSET {offset:UInt32}" in queries[0]
+    assert params[0]["limit"] == 25
+    assert params[0]["offset"] == 10
+
+
+@pytest.mark.asyncio
+async def test_load_evidence_parses_repo_id_and_preserves_provenance():
+    raw = {
+        "subject_type": "pull_request",
+        "subject_id": "42",
+        "repo_id": str(REPO_A),
+        "provider": "github",
+        "kind": "ai_assisted",
+        "source": "pr_label",
+        "confidence": 0.95,
+        "actor": "github-copilot",
+        "evidence": '{"label": "ai-assisted"}',
+        "observed_at": datetime(2026, 5, 2, tzinfo=timezone.utc),
+    }
+    _queries, _params, fake_qd = _capture([raw])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        rows = await loader.load_evidence(start=START, end=END)
+
+    assert len(rows) == 1
+    row = rows[0]
+    assert row["repo_id"] == REPO_A
+    assert row["source"] == "pr_label"
+    assert row["confidence"] == 0.95
+    assert row["evidence"] == '{"label": "ai-assisted"}'
+    assert row["actor"] == "github-copilot"
+
+
+@pytest.mark.asyncio
+async def test_load_evidence_handles_missing_repo_id():
+    """Work-item-level attribution records may carry a null repo_id."""
+    raw = {
+        "subject_type": "issue",
+        "subject_id": "work-item-9",
+        "repo_id": None,
+        "provider": "linear",
+        "kind": "agent_created",
+        "source": "manual",
+        "confidence": 1.0,
+        "actor": "human",
+        "evidence": "{}",
+        "observed_at": datetime(2026, 5, 2, tzinfo=timezone.utc),
+    }
+    _queries, _params, fake_qd = _capture([raw])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        rows = await loader.load_evidence(start=START, end=END)
+
+    assert rows[0]["repo_id"] is None


### PR DESCRIPTION
## Summary
- Adds an org-scoped GraphQL resolver, `aiAttributionOverview`, serving AI attribution mix + provenance evidence for the dedicated `/ai/attribution` web page (currently a structurally-unconnected static preview).
- Reads `ai_attribution_resolved` only (the highest-precedence, non-superseded signal per subject) via a new `AIAttributionClickHouseLoader` -- no aggregation, no fabrication, no persistence outside existing sinks.
- `mix: [AIAttributionMixRow!]!` -- `GROUP BY kind` counts + share. Intentionally **no synthesized `human` bucket**: this view only ever contains subjects with a detected signal, so a human count would require the full PR population -- that inference already lives in `ai_impact_metrics_daily` / `aiImpactSummary` and must not be duplicated with a second, undocumented method.
- `rows: [AIAttributionEvidenceRow!]!` -- paginated evidence with `source`, `confidence`, `evidence`, and `actor` always populated (non-nullable on the base `ai_attribution` table), plus `teamId` resolved the same way as `aiAttributedPrs` (`RepoPatternTeamResolver` over `teams.repo_patterns` -- no SQL join on repo UUID, no Postgres team mapping, no issue-key-prefix inference).
- Additive only: `aiImpactSummary`, `aiGovernanceSummary`, and `aiAttributedPrs` are unchanged and remain the source for impact/governance/drilldown-selector use cases.

## Frozen GraphQL Contract
- Field: `Query.aiAttributionOverview(orgId, dateRange, scope, limit, offset)`
- Type: `AIAttributionOverviewResult { orgId, startDate, endDate, mix: [AIAttributionMixRow!]!, totalAttributed, rows: [AIAttributionEvidenceRow!]!, hasMore, dataAvailable }`
- `AIAttributionMixRow { kind, count, share }`
- `AIAttributionEvidenceRow { subjectType, subjectId, repoId, provider, kind, source, confidence, actor, evidence, observedAt, teamId }`

## Files Changed
- `src/dev_health_ops/metrics/loaders/ai_attribution.py` (new loader: `load_mix`, `load_evidence`)
- `src/dev_health_ops/api/graphql/{models/ai.py,resolvers/ai.py,schema.py}`
- `docs/architecture/ai-attribution.md`, `docs/api/graphql-ai.md`
- `tests/metrics/test_ai_attribution_loader.py` (new), `tests/api/graphql/test_ai_resolver.py`

## Linear
- CHAOS-2744
- Related epic: CHAOS-2728 (Phase 4)

## Validation / QA Evidence
- `lsp_diagnostics` on all changed Python files: clean.
- Targeted tests: PASS (20 passed) -- `tests/metrics/test_ai_attribution_loader.py` + the new `aiAttributionOverview` cases in `tests/api/graphql/test_ai_resolver.py`.
- `bash ci/local_validate.sh`: **GATE PASSED** -- ruff format/check, mypy, full unit suite (6106 passed, 44 skipped), live-ClickHouse argMax proof.
- `PYTHONPATH=src python3 -m dev_health_ops.api.graphql.export_schema` confirms the new SDL is exactly the type/field block mirrored into the paired web PR's `schema.graphql`.

## Platform Contract Checks
- ClickHouse-only analytics persistence: yes -- read-only resolver, no new tables/migrations.
- No persistence outside `metrics/sinks/*`: yes -- this PR adds a read loader only.
- No Postgres team/identity attribution mappings: yes.
- No manual-mapping-as-override, no issue-key-prefix inheritance: yes -- team scoping reuses the existing `_resolve_team_repo_ids`/`_resolve_repo_team_map` repo-pattern helpers already used by `aiAttributedPrs`; no new identity/team inference logic was introduced.
- Provider coverage: attribution records are provider-tagged (`github`/`gitlab`/`jira`/`linear`) at the storage layer already; this resolver is provider-agnostic by construction (reads the resolved view regardless of `provider`).
- UX-time recompute: no -- the paired web PR consumes persisted resolver output only.
- GraphQL field/type frozen before web work: `AIAttributionOverviewResult` / `aiAttributionOverview` (see above).
- Provenance emitted everywhere: yes -- every `AIAttributionEvidenceRow` carries `source`, `confidence`, and `evidence` (non-nullable at the schema and storage layer).

## Ordering dependency (paired web PR)
The paired `dev-health-web` PR mirrors this schema into `src/lib/graphql/schema.graphql`. Until *this* PR merges, that web PR's `live-e2e` schema-drift check (which diffs against `dev-health-ops@main`) will report drift for the new `aiAttributionOverview` field/types -- this is expected and resolves once this PR lands. See the web PR body for the full note (it also has an unrelated pre-existing drift for `PullRequestDetail`/`ThroughputEstimateCoverage` that predates this change).

## Risks
- None identified. Purely additive read-only surface; no schema/behavior changes to existing fields.