### PR TITLE
fix(graphql): correct ClickHouse FINAL alias ordering in pr(id) resolver (CHAOS-2387)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/pr.py
+++ b/src/dev_health_ops/api/graphql/resolvers/pr.py
@@ -70,8 +70,8 @@ async def _fetch_pr_row(
             pr.changes_requested_count AS changes_requested_count,
             pr.reviews_count AS reviews_count,
             pr.comments_count AS comments_count
-        FROM git_pull_requests FINAL AS pr
-        LEFT JOIN repos FINAL AS repos
+        FROM git_pull_requests AS pr FINAL
+        LEFT JOIN repos AS repos FINAL
             ON repos.org_id = pr.org_id AND repos.id = pr.repo_id
         WHERE pr.org_id = {org_id:String}
           AND toString(pr.repo_id) = {repo_id:String}
@@ -146,8 +146,8 @@ async def _fetch_commits(
             argMax(link.confidence, link.last_synced) AS confidence,
             argMax(link.provenance, link.last_synced) AS provenance,
             argMax(link.evidence, link.last_synced) AS evidence
-        FROM work_graph_pr_commit FINAL AS link
-        LEFT JOIN git_commits FINAL AS commit
+        FROM work_graph_pr_commit AS link FINAL
+        LEFT JOIN git_commits AS commit FINAL
             ON commit.org_id = link.org_id
            AND commit.repo_id = link.repo_id
            AND commit.hash = link.commit_hash

--- a/tests/api/graphql/test_pr_resolver.py
+++ b/tests/api/graphql/test_pr_resolver.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import inspect
+import re
 from datetime import datetime, timezone
+from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -156,3 +159,15 @@ def test_parse_pr_id_accepts_stable_work_graph_format() -> None:
     assert parsed is not None
     assert parsed.repo_id == REPO_ID
     assert parsed.number == 42
+
+
+def test_pr_resolver_sql_has_no_invalid_final_alias_ordering() -> None:
+    """Guard against regressions of the FINAL-before-alias ClickHouse bug (CHAOS-2387).
+
+    ClickHouse requires the table alias before FINAL: 'FROM t AS a FINAL', not
+    'FROM t FINAL AS a'. The latter is a parse error and previously broke every
+    live pr(id) query. Read the resolver source directly so this fails immediately
+    if the invalid ordering is ever reintroduced.
+    """
+    source = Path(inspect.getfile(resolve_pr)).read_text()
+    assert re.search(r"\bFINAL\s+AS\b", source) is None


### PR DESCRIPTION
## Problem

ClickHouse requires the table alias **before** `FINAL`: `FROM t AS a FINAL`. The `pr(id)` resolver merged in #1095 used the invalid ordering (`FROM t FINAL AS a`) in four places in `src/dev_health_ops/api/graphql/resolvers/pr.py`, which is a ClickHouse parse error. As a result, every live `pr(id)` GraphQL query threw before returning a result.

This is a fix-forward for the bug merged in #1095.

## Fix

Swapped alias/`FINAL` ordering at the four affected sites in `src/dev_health_ops/api/graphql/resolvers/pr.py`:

- `FROM git_pull_requests FINAL AS pr` → `FROM git_pull_requests AS pr FINAL`
- `LEFT JOIN repos FINAL AS repos` → `LEFT JOIN repos AS repos FINAL`
- `FROM work_graph_pr_commit FINAL AS link` → `FROM work_graph_pr_commit AS link FINAL`
- `LEFT JOIN git_commits FINAL AS commit` → `LEFT JOIN git_commits AS commit FINAL`

No other SQL, column list, GROUP BY, or logic was touched. The `git_pull_request_reviews FINAL` line (no alias) was already valid and left untouched. Verified no other `FINAL\s+AS` occurrences exist anywhere else in `src/`.

## Regression guard

Added `test_pr_resolver_sql_has_no_invalid_final_alias_ordering` in `tests/api/graphql/test_pr_resolver.py`. It reads the resolver source file directly and asserts the invalid `FINAL AS` pattern (regex `\bFINAL\s+AS\b`) is absent. Verified locally that this test fails against the pre-fix source and passes against the fixed source. It's a plain unmarked pytest test (not `-m clickhouse`), so it runs in the standard unit tier.

## Validation

`bash ci/local_validate.sh` — full gate green:

- ruff format --check ✔
- ruff check ✔
- mypy ✔
- ClickHouse scratch db create + migrate ✔
- full unit suite: 6087 passed, 44 skipped ✔
- live-ClickHouse argMax proof ✔

`GATE PASSED. safe to push.`

SCREENSHOT-WAIVER: backend GraphQL resolver SQL fix, no UI render