### PR TITLE
fix(graphql): apply work_type/bucket scope filters in aiAttributionOverview (CHAOS-2744)

### DIFF
--- a/docs/api/graphql-ai.md
+++ b/docs/api/graphql-ai.md
@@ -142,6 +142,14 @@ returns two projections of the same window:
   base table) plus `teamId` resolved via `RepoPatternTeamResolver`, the same
   mechanism `aiAttributedPrs` uses.
 
+Scoped by `AIAttributionScopeInput` (`repoId`, `teamId`, `buckets`), not the
+shared `AIScopeInput` — `ai_attribution_resolved` carries no `work_type`
+column, so `workType` is deliberately **not exposed** on this query rather
+than accepted and silently ignored (CHAOS-2744). `repoId`/`teamId` are
+applied as a real `WHERE repo_id = ...` / resolved-repo-set predicate before
+`GROUP BY`/`LIMIT`, and `buckets` filters `WHERE kind IN (...)` against the
+view's own `kind` column — all before the SQL `LIMIT`.
+
 ### `aiWorkflowDrilldown`
 
 Partial Work Graph rooted at an issue, PR, or work_unit.  Returns
@@ -157,6 +165,17 @@ input AIScopeInput {
   repoId: String
   teamId: String
   workType: String
+  buckets: [AIAttributionBucketInput!]
+}
+```
+
+`aiAttributionOverview` instead takes the narrower `AIAttributionScopeInput`
+(no `workType` — see above):
+
+```graphql
+input AIAttributionScopeInput {
+  repoId: String
+  teamId: String
   buckets: [AIAttributionBucketInput!]
 }
 ```

--- a/src/dev_health_ops/api/graphql/models/ai.py
+++ b/src/dev_health_ops/api/graphql/models/ai.py
@@ -69,6 +69,24 @@ class AIScopeInput:
     buckets: list[AIAttributionBucketInput] | None = None
 
 
+@strawberry.input
+class AIAttributionScopeInput:
+    """Scope filters for the dedicated ``aiAttributionOverview`` query.
+
+    Deliberately narrower than :class:`AIScopeInput`: ``ai_attribution_resolved``
+    carries no ``work_type`` column (unlike ``ai_impact_metrics_daily``, which
+    projects it from a ``work_items`` join), so exposing a ``work_type`` filter
+    here would silently no-op against the live page's active filters (CHAOS-2744).
+    ``buckets`` filters on the resolved view's own ``kind`` column instead.
+
+    All filters are AND-combined; ``None`` means "no filter at this level".
+    """
+
+    repo_id: str | None = None
+    team_id: str | None = None
+    buckets: list[AIAttributionBucketInput] | None = None
+
+
 # =============================================================================
 # Outputs
 # =============================================================================

--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -41,6 +41,7 @@ from ..models.ai import (
     AIAttributionEvidenceRow,
     AIAttributionMixRow,
     AIAttributionOverviewResult,
+    AIAttributionScopeInput,
     AIComparison,
     AIComparisonDelta,
     AIComparisonSide,
@@ -99,6 +100,26 @@ def _normalize_scope(
         _parse_uuid(scope.repo_id),
         scope.team_id or None,
         scope.work_type or None,
+    )
+
+
+def _normalize_attribution_scope(
+    scope: AIAttributionScopeInput | None,
+) -> tuple[uuid.UUID | None, str | None, list[str] | None]:
+    """Normalize the narrower attribution-overview scope (no ``work_type``).
+
+    ``ai_attribution_resolved`` has no ``work_type`` column, so that
+    dimension is not exposed on :class:`AIAttributionScopeInput` at all
+    (CHAOS-2744) -- there is nothing to silently drop here. ``buckets``
+    maps 1:1 onto the resolved view's own ``kind`` column.
+    """
+    if scope is None:
+        return None, None, None
+    kinds = [bucket.value for bucket in scope.buckets] if scope.buckets else None
+    return (
+        _parse_uuid(scope.repo_id),
+        scope.team_id or None,
+        kinds,
     )
 
 
@@ -1334,7 +1355,7 @@ _MAX_AI_ATTRIBUTION_EVIDENCE_PAGE = 200
 async def resolve_ai_attribution_overview(
     context: GraphQLContext,
     date_range: AIDateRangeInput,
-    scope: AIScopeInput | None = None,
+    scope: AIAttributionScopeInput | None = None,
     limit: int = 50,
     offset: int = 0,
 ) -> AIAttributionOverviewResult:
@@ -1348,7 +1369,7 @@ async def resolve_ai_attribution_overview(
 
     org_id = require_org_id(context)
     _validate_date_range(date_range)
-    repo_id, team_id, _work_type = _normalize_scope(scope)
+    repo_id, team_id, kinds = _normalize_attribution_scope(scope)
 
     page_size = max(1, min(int(limit), _MAX_AI_ATTRIBUTION_EVIDENCE_PAGE))
     page_offset = max(0, int(offset))
@@ -1385,6 +1406,7 @@ async def resolve_ai_attribution_overview(
         end=end_dt,
         repo_id=repo_id,
         repo_ids=team_repo_ids,
+        kinds=kinds,
     )
     total_mix = sum(int(row.get("count") or 0) for row in mix_raw)
     mix = [
@@ -1402,6 +1424,7 @@ async def resolve_ai_attribution_overview(
         end=end_dt,
         repo_id=repo_id,
         repo_ids=team_repo_ids,
+        kinds=kinds,
         limit=page_size + 1,
         offset=page_offset,
     )

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -12,6 +12,7 @@ from .extensions import ConfiguredValidationRules, OrgIdAuthExtension
 from .models.ai import (
     AiAttributedPrsResult,
     AIAttributionOverviewResult,
+    AIAttributionScopeInput,
     AIComparison,
     AIDateRangeInput,
     AIGovernanceSummary,
@@ -799,7 +800,7 @@ class Query:
         info: Info,
         org_id: str,
         date_range: AIDateRangeInput,
-        scope: AIScopeInput | None = None,
+        scope: AIAttributionScopeInput | None = None,
         limit: int = 50,
         offset: int = 0,
     ) -> AIAttributionOverviewResult:

--- a/src/dev_health_ops/metrics/loaders/ai_attribution.py
+++ b/src/dev_health_ops/metrics/loaders/ai_attribution.py
@@ -33,6 +33,7 @@ class AIAttributionClickHouseLoader:
         end: datetime,
         repo_id: uuid.UUID | None = None,
         repo_ids: list[uuid.UUID] | None = None,
+        kinds: list[str] | None = None,
     ) -> list[dict[str, Any]]:
         """Count resolved attribution records per kind in the window.
 
@@ -48,6 +49,7 @@ class AIAttributionClickHouseLoader:
             "end": end.replace(tzinfo=None),
         }
         repo_filter = self._repo_filter(params, repo_id, repo_ids)
+        kind_filter = self._kind_filter(params, kinds)
         params = self._scope.inject(params)
         org_filter = self._scope.filter_uuid()
 
@@ -59,6 +61,7 @@ class AIAttributionClickHouseLoader:
         WHERE observed_at >= {{start:DateTime}}
           AND observed_at < {{end:DateTime}}
           {repo_filter}
+          {kind_filter}
           {org_filter}
         GROUP BY kind
         ORDER BY kind
@@ -72,6 +75,7 @@ class AIAttributionClickHouseLoader:
         end: datetime,
         repo_id: uuid.UUID | None = None,
         repo_ids: list[uuid.UUID] | None = None,
+        kinds: list[str] | None = None,
         limit: int | None = None,
         offset: int = 0,
     ) -> list[dict[str, Any]]:
@@ -89,6 +93,7 @@ class AIAttributionClickHouseLoader:
             "end": end.replace(tzinfo=None),
         }
         repo_filter = self._repo_filter(params, repo_id, repo_ids)
+        kind_filter = self._kind_filter(params, kinds)
         limit_clause = ""
         if limit is not None and int(limit) > 0:
             params["limit"] = int(limit)
@@ -113,6 +118,7 @@ class AIAttributionClickHouseLoader:
         WHERE observed_at >= {{start:DateTime}}
           AND observed_at < {{end:DateTime}}
           {repo_filter}
+          {kind_filter}
           {org_filter}
         ORDER BY observed_at DESC, subject_id
         {limit_clause}
@@ -150,3 +156,19 @@ class AIAttributionClickHouseLoader:
             params["repo_ids"] = [str(r) for r in repo_ids]
             clause += "\n          AND toString(repo_id) IN {repo_ids:Array(String)}"
         return clause
+
+    def _kind_filter(
+        self,
+        params: dict[str, Any],
+        kinds: list[str] | None,
+    ) -> str:
+        """AND-filter on the resolved view's ``kind`` column (CHAOS-2744).
+
+        Backs the GraphQL ``AIAttributionScopeInput.buckets`` filter -- the
+        UI's active bucket filters must reach the SQL WHERE clause, not be
+        silently dropped after the query already ran.
+        """
+        if not kinds:
+            return ""
+        params["kinds"] = list(kinds)
+        return "\n          AND kind IN {kinds:Array(String)}"

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Awaitable, Callable
-from datetime import date, timedelta
+from datetime import date, datetime, time, timedelta
 
 from _sql_explain_helpers import CapturingSink, FakeGraphQLContext
 
@@ -331,6 +331,45 @@ async def _fixture_bus_factor(sink: CapturingSink) -> None:
 
 
 # ---------------------------------------------------------------------------
+# ai_attribution (aiAttributionOverview via AIAttributionClickHouseLoader,
+# CHAOS-2744 -- also regression-guards the scope.buckets kind filter)
+# ---------------------------------------------------------------------------
+
+
+async def _fixture_ai_attribution(sink: CapturingSink) -> None:
+    from dev_health_ops.metrics.loaders.ai_attribution import (
+        AIAttributionClickHouseLoader,
+    )
+
+    loader = AIAttributionClickHouseLoader(sink, org_id=SAMPLE_ORG_ID)
+    start = datetime.combine(SAMPLE_DAY, time.min)
+    end = datetime.combine(SAMPLE_DAY + timedelta(days=7), time.min)
+
+    # Unscoped mix + evidence.
+    await loader.load_mix(start=start, end=end)
+    await loader.load_evidence(start=start, end=end, limit=50, offset=0)
+    # scope.buckets -> kind filter (CHAOS-2744 Oracle NO-GO regression: this
+    # must parse and bind against the real ai_attribution_resolved.kind column).
+    await loader.load_mix(start=start, end=end, kinds=["ai_assisted", "agent_created"])
+    await loader.load_evidence(
+        start=start,
+        end=end,
+        kinds=["ai_assisted", "agent_created"],
+        limit=50,
+        offset=0,
+    )
+    # repo_id / repo_ids (team-resolved) scopes.
+    await loader.load_mix(start=start, end=end, repo_id=uuid.UUID(SAMPLE_REPO_ID))
+    await loader.load_evidence(
+        start=start,
+        end=end,
+        repo_ids=[uuid.UUID(SAMPLE_REPO_ID)],
+        limit=50,
+        offset=0,
+    )
+
+
+# ---------------------------------------------------------------------------
 # data_health
 # ---------------------------------------------------------------------------
 
@@ -455,6 +494,7 @@ ALL_RESOLVER_SQL_FIXTURES: list[tuple[str, ResolverSQLFixture]] = [
     ("bus_factor", _fixture_bus_factor),
     ("data_health", _fixture_data_health),
     ("analytics", _fixture_analytics),
+    ("ai_attribution", _fixture_ai_attribution),
 ]
 """Registry of ``(resolver_name, fixture)`` pairs.
 

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -28,6 +28,7 @@ import pytest
 from dev_health_ops.api.graphql.context import GraphQLContext
 from dev_health_ops.api.graphql.models.ai import (
     AIAttributionBucketInput,
+    AIAttributionScopeInput,
     AIDateRangeInput,
     AIOpportunity,
     AIOpportunityKind,
@@ -1429,7 +1430,7 @@ async def test_ai_attribution_overview_reports_has_more_and_pages():
 
 @pytest.mark.asyncio
 async def test_ai_attribution_overview_passes_repo_scope_to_loaders():
-    scope = AIScopeInput(repo_id=str(REPO_ID))
+    scope = AIAttributionScopeInput(repo_id=str(REPO_ID))
     with (
         _patch_mix_loader([]) as mock_mix,
         _patch_evidence_loader([]) as mock_evidence,
@@ -1441,6 +1442,53 @@ async def test_ai_attribution_overview_passes_repo_scope_to_loaders():
 
 
 @pytest.mark.asyncio
+async def test_ai_attribution_overview_bucket_scope_filters_kind_in_sql():
+    """CHAOS-2744 (Oracle NO-GO): scope.buckets must reach the loaders as a
+    kind filter -- not be silently dropped. Regression coverage for the
+    finding that aiAttributionOverview never applied scope.buckets."""
+    scope = AIAttributionScopeInput(
+        buckets=[
+            AIAttributionBucketInput.AI_ASSISTED,
+            AIAttributionBucketInput.AGENT_CREATED,
+        ]
+    )
+    with (
+        _patch_mix_loader([]) as mock_mix,
+        _patch_evidence_loader([]) as mock_evidence,
+    ):
+        await resolve_ai_attribution_overview(_ctx(), _range(), scope)
+
+    assert mock_mix.await_args.kwargs["kinds"] == ["ai_assisted", "agent_created"]
+    assert mock_evidence.await_args.kwargs["kinds"] == [
+        "ai_assisted",
+        "agent_created",
+    ]
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_no_bucket_scope_omits_kinds_filter():
+    with (
+        _patch_mix_loader([]) as mock_mix,
+        _patch_evidence_loader([]) as mock_evidence,
+    ):
+        await resolve_ai_attribution_overview(_ctx(), _range())
+
+    assert mock_mix.await_args.kwargs["kinds"] is None
+    assert mock_evidence.await_args.kwargs["kinds"] is None
+
+
+def test_ai_attribution_scope_input_does_not_expose_work_type():
+    """CHAOS-2744 (Oracle NO-GO): ai_attribution_resolved has no work_type
+    column, so AIAttributionScopeInput must not expose the field at all --
+    accepting-and-ignoring it was the original bug (silent no-op filter).
+    Use the shared AIScopeInput (which does carry work_type) for queries
+    backed by tables that actually have that column.
+    """
+    with pytest.raises(TypeError):
+        AIAttributionScopeInput(work_type="bug")  # type: ignore[call-arg]
+
+
+@pytest.mark.asyncio
 async def test_ai_attribution_overview_rejects_reversed_date_range():
     bad_range = AIDateRangeInput(start_date=DAY_END, end_date=DAY_START)
     with pytest.raises(ValueError, match="end_date must be >= start_date"):
@@ -1449,7 +1497,7 @@ async def test_ai_attribution_overview_rejects_reversed_date_range():
 
 @pytest.mark.asyncio
 async def test_ai_attribution_overview_team_with_no_repos_returns_empty():
-    scope = AIScopeInput(team_id="team-empty")
+    scope = AIAttributionScopeInput(team_id="team-empty")
     with (
         _patch_mix_loader([_mix_row("ai_assisted", 1)]) as mock_mix,
         _patch_evidence_loader([_evidence_row(subject_id="1")]) as mock_evidence,
@@ -1470,7 +1518,7 @@ async def test_ai_attribution_overview_team_scope_filters_in_sql_before_limit():
     applies to the already-filtered universe (dense pages), mirroring
     resolve_ai_attributed_prs (CHAOS-2180 Wave 2)."""
     rows = [_evidence_row(subject_id="1"), _evidence_row(subject_id="2")]
-    scope = AIScopeInput(team_id="team-a")
+    scope = AIAttributionScopeInput(team_id="team-a")
     repo_team_map = {str(REPO_ID): "team-a"}
     with (
         _patch_mix_loader([_mix_row("ai_assisted", 2)]) as mock_mix,
@@ -1499,7 +1547,7 @@ async def test_ai_attribution_overview_team_scope_drops_rows_outside_team():
         _evidence_row(subject_id="1", repo_id=REPO_ID),
         _evidence_row(subject_id="2", repo_id=REPO_B),
     ]
-    scope = AIScopeInput(team_id="team-a")
+    scope = AIAttributionScopeInput(team_id="team-a")
     repo_team_map = {str(REPO_ID): "team-a", str(REPO_B): "team-b"}
     with (
         _patch_mix_loader([_mix_row("ai_assisted", 2)]),

--- a/tests/metrics/test_ai_attribution_loader.py
+++ b/tests/metrics/test_ai_attribution_loader.py
@@ -104,6 +104,34 @@ async def test_load_mix_applies_repo_ids_filter():
 
 
 @pytest.mark.asyncio
+async def test_load_mix_applies_kinds_filter():
+    """CHAOS-2744: the AIAttributionScopeInput.buckets filter must reach
+    the SQL WHERE clause before GROUP BY -- not be silently dropped."""
+    queries, params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_mix(
+            start=START, end=END, kinds=["ai_assisted", "agent_created"]
+        )
+
+    sql = queries[0]
+    assert "AND kind IN {kinds:Array(String)}" in sql
+    assert sql.index("AND kind IN") < sql.index("GROUP BY kind")
+    assert params[0]["kinds"] == ["ai_assisted", "agent_created"]
+
+
+@pytest.mark.asyncio
+async def test_load_mix_omits_kind_filter_when_no_buckets():
+    queries, params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_mix(start=START, end=END)
+
+    assert "kind IN" not in queries[0]
+    assert "kinds" not in params[0]
+
+
+@pytest.mark.asyncio
 async def test_load_mix_returns_grouped_counts():
     rows = [{"kind": "ai_assisted", "count": 5}, {"kind": "unknown", "count": 2}]
     _queries, _params, fake_qd = _capture(rows)
@@ -141,6 +169,32 @@ async def test_load_evidence_selects_full_provenance_columns():
     ):
         assert column in sql, f"expected {column!r} to be selected"
     assert "FROM ai_attribution_resolved" in sql
+
+
+@pytest.mark.asyncio
+async def test_load_evidence_applies_kinds_filter():
+    """CHAOS-2744: the AIAttributionScopeInput.buckets filter must reach
+    the SQL WHERE clause before ORDER BY/LIMIT -- not be silently dropped."""
+    queries, params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_evidence(start=START, end=END, kinds=["ai_review"])
+
+    sql = queries[0]
+    assert "AND kind IN {kinds:Array(String)}" in sql
+    assert sql.index("AND kind IN") < sql.index("ORDER BY observed_at")
+    assert params[0]["kinds"] == ["ai_review"]
+
+
+@pytest.mark.asyncio
+async def test_load_evidence_omits_kind_filter_when_no_buckets():
+    queries, params, fake_qd = _capture([])
+    loader = AIAttributionClickHouseLoader(object(), org_id=ORG_ID)
+    with patch("dev_health_ops.api.queries.client.query_dicts", side_effect=fake_qd):
+        await loader.load_evidence(start=START, end=END)
+
+    assert "kind IN" not in queries[0]
+    assert "kinds" not in params[0]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Fix-forward for the Oracle **CRITICAL** finding on CHAOS-2744. PR #1096 merged the `aiAttributionOverview` resolver but it silently ignored `scope.work_type` and `scope.buckets`, so active UI filters returned unfiltered mix/evidence.

## Changes
- **`buckets` → real filter**: `AIAttributionClickHouseLoader._kind_filter()` appends `AND kind IN {kinds:Array(String)}` before `GROUP BY`/`LIMIT` in both `load_mix` and `load_evidence` (matches existing `_repo_filter` named-binding style).
- **`work_type` → removed from exposed scope** (no backing column = don't silently ignore): new resolver-specific `AIAttributionScopeInput` (`repo_id`, `team_id`, `buckets` — no `work_type`) wired through `schema.py` + a new `_normalize_attribution_scope()`. The `ai_attribution_resolved` view has no `work_type` column. Shared `AIScopeInput` is untouched for every other AI query.
- `repo_id`/`team_id` confirmed already applied at SQL level (unchanged).

## Tests
- Loader: `kind IN` filter present/positioned + bound-param assertions (`load_mix`/`load_evidence`).
- Resolver: bucket-scope filters SQL; work-type kwarg genuinely rejected (`TypeError`), not ignored.
- Live ClickHouse `EXPLAIN PLAN` fixture (`_fixture_ai_attribution`) exercising unscoped/kind-scoped/repo-scoped queries.

## Validation
`bash ci/local_validate.sh` → GATE PASSED (ruff/mypy, full unit suite 6114 passed/44 skipped, live-ClickHouse argMax + EXPLAIN proof). `uv.lock` reverted after sync.

SCREENSHOT-WAIVER: backend GraphQL resolver SQL/schema fix, no UI render.