### PR TITLE
fix(graphql): use real author_email column instead of nonexistent author_id (CHAOS-2385)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -732,7 +732,7 @@ async def resolve_analytics(
                 ):
                     logger.info(
                         "Sankey coverage unavailable for investment author filters; "
-                        "work_unit_investments does not expose author_id"
+                        "work_unit_investments does not expose author_email (CHAOS-2492)"
                     )
                 else:
                     if request.use_investment and _has_work_category_filter(
@@ -749,7 +749,7 @@ async def resolve_analytics(
                         repo_column="work_unit_investments.repo_id"
                         if request.use_investment
                         else repo_col,
-                        author_column="author_id",
+                        author_column="author_email",
                     )
 
                     coverage_sql = f"""

--- a/src/dev_health_ops/api/graphql/sql/filter_translation.py
+++ b/src/dev_health_ops/api/graphql/sql/filter_translation.py
@@ -14,6 +14,8 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING, Any
 
+from ..errors import ValidationError
+
 if TYPE_CHECKING:
     from ..models.inputs import FilterInput
 
@@ -171,6 +173,25 @@ def translate_filters(
                 " AND (ut.team_label IN %(scope_ids)s OR ut.team_id IN %(scope_ids)s)"
             )
             params["scope_ids"] = filters.scope.ids
+        elif filters.scope.level.value == "developer" and filters.scope.ids:
+            # CHAOS-2385: no ClickHouse table reachable through this generic
+            # analytics compiler carries a per-developer breakdown yet --
+            # investment_metrics_daily has no author column at all, and
+            # work_unit_investments/latest_work_unit_investments doesn't
+            # either (CHAOS-2492 adds investment-path support via a
+            # companion join, at which point this predicate becomes
+            # table-aware instead of unconditional). Reject explicitly
+            # rather than emit a predicate against a column that doesn't
+            # exist on the resolved source table (mirrors the
+            # honest-rejection precedent in compiler.py's
+            # _reject_filtered_same_dimension_flow_matrix, CHAOS-2487).
+            raise ValidationError(
+                "scope.level=developer filtering is not yet supported for "
+                "this query; remove the developer scope (CHAOS-2492 tracks "
+                "investment-path support).",
+                field="scope",
+                value="developer",
+            )
         else:
             clause, scope_params = translate_scope_filter(
                 level=filters.scope.level.value,
@@ -185,13 +206,15 @@ def translate_filters(
 
     # Who filter - developers
     if filters.who is not None and filters.who.developers:
-        clause, dev_params = translate_developer_filter(
-            developers=filters.who.developers,
-            author_column=author_column,
+        # CHAOS-2385: same gap as scope.level=developer above -- reject
+        # rather than emit a predicate against a nonexistent column.
+        raise ValidationError(
+            "who.developers filtering is not yet supported for this query; "
+            "remove the developer filter (CHAOS-2492 tracks investment-path "
+            "support).",
+            field="who",
+            value="developers",
         )
-        if clause:
-            clauses.append(clause)
-            params.update(dev_params)
 
     # What filter - repos
     if filters.what is not None and filters.what.repos:

--- a/src/dev_health_ops/api/graphql/sql/filter_translation.py
+++ b/src/dev_health_ops/api/graphql/sql/filter_translation.py
@@ -23,7 +23,7 @@ def translate_scope_filter(
     ids: list[str],
     team_column: str = "team_id",
     repo_column: str = "repo_id",
-    author_column: str = "author_id",
+    author_column: str = "author_email",
 ) -> tuple[str, dict[str, Any]]:
     """Translate scope filter to SQL predicate.
 
@@ -32,7 +32,7 @@ def translate_scope_filter(
         ids: List of IDs to filter by. Empty means "All" - no filtering.
         team_column: Column name for team filtering
         repo_column: Column name for repo filtering
-        author_column: Column name for developer/author filtering
+        author_column: Column name for developer/author filtering (default: real ClickHouse column `author_email`, e.g. git_commits/user_metrics_daily; CHAOS-2385 -- `author_id` does not exist in any ClickHouse table)
 
     Returns:
         Tuple of (SQL clause string, params dict)
@@ -109,13 +109,13 @@ def translate_repo_filter(
 
 def translate_developer_filter(
     developers: list[str],
-    author_column: str = "author_id",
+    author_column: str = "author_email",
 ) -> tuple[str, dict[str, Any]]:
     """Translate developer filter to SQL predicate.
 
     Args:
         developers: List of developer IDs to filter by. Empty means "All".
-        author_column: Column name for author/developer filtering
+        author_column: Column name for author/developer filtering (default: real ClickHouse column `author_email`; CHAOS-2385)
 
     Returns:
         Tuple of (SQL clause string, params dict)
@@ -131,7 +131,7 @@ def translate_filters(
     use_investment: bool = False,
     team_column: str = "team_id",
     repo_column: str = "repo_id",
-    author_column: str = "author_id",
+    author_column: str = "author_email",
 ) -> tuple[str, dict[str, Any]]:
     """Translate a complete FilterInput to SQL predicates.
 
@@ -143,7 +143,7 @@ def translate_filters(
         use_investment: Whether using investment tables
         team_column: Column name for team filtering
         repo_column: Column name for repo filtering
-        author_column: Column name for author/developer filtering
+        author_column: Column name for author/developer filtering (default: real ClickHouse column `author_email`; CHAOS-2385 -- `author_id` does not exist in any ClickHouse table)
 
     Returns:
         Tuple of (SQL clause string, params dict)

--- a/src/dev_health_ops/api/graphql/sql/validate.py
+++ b/src/dev_health_ops/api/graphql/sql/validate.py
@@ -28,7 +28,7 @@ class Dimension(str, Enum):
             mapping = {
                 cls.TEAM: "ifNull(nullIf(ut.team_label, ''), 'unassigned')",
                 cls.REPO: "ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id)))",
-                cls.AUTHOR: "author_id",
+                cls.AUTHOR: "author_email",
                 cls.WORK_TYPE: "work_unit_type",
                 cls.THEME: "splitByChar('.', subcategory_kv.1)[1]",
                 cls.SUBCATEGORY: "subcategory_kv.1",
@@ -37,7 +37,7 @@ class Dimension(str, Enum):
             mapping = {
                 cls.TEAM: "team_id",
                 cls.REPO: "repo_id",
-                cls.AUTHOR: "author_id",
+                cls.AUTHOR: "author_email",
                 cls.WORK_TYPE: "work_item_type",
                 cls.THEME: "investment_area",
                 cls.SUBCATEGORY: "project_stream",

--- a/tests/api/test_analytics_repo_filter_resolution.py
+++ b/tests/api/test_analytics_repo_filter_resolution.py
@@ -6,6 +6,7 @@ from typing import Any
 import pytest
 
 from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.errors import ValidationError
 from dev_health_ops.api.graphql.models.inputs import (
     AnalyticsRequestInput,
     BreakdownRequestInput,
@@ -171,19 +172,19 @@ async def test_sankey_coverage_respects_resolved_repo_name_filter(
 
 
 @pytest.mark.asyncio
-async def test_sankey_coverage_unavailable_for_investment_developer_filter(
+async def test_sankey_developer_filter_rejected_pending_chaos_2492(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    developer_id = "dev-1"
-    captured_sankey_params: list[dict[str, Any]] = []
-    captured_coverage_params: list[dict[str, Any]] = []
+    """CHAOS-2385: who.developers is rejected outright rather than silently
+    building a predicate against a column that doesn't exist on any table
+    reachable from this compiler yet. CHAOS-2492 (stacked on this branch)
+    adds investment-path support via a companion join, at which point this
+    scenario returns real coverage instead of raising -- see
+    test_sankey_coverage_computed_for_investment_who_developers_filter in
+    that branch."""
+    developer_id = "alice@example.com"
 
     async def fake_query_dicts(_client: object, sql: str, params: dict[str, Any]):
-        if "assigned_team" in sql:
-            captured_coverage_params.append(dict(params))
-            return [{"total": 4, "assigned_team": 4, "assigned_repo": 4}]
-        if "developer_ids" in params:
-            captured_sankey_params.append(dict(params))
         return []
 
     monkeypatch.setattr(
@@ -191,18 +192,12 @@ async def test_sankey_coverage_unavailable_for_investment_developer_filter(
         fake_query_dicts,
     )
 
-    result = await analytics_resolver.resolve_analytics(
-        GraphQLContext(org_id="org-1", db_url="clickhouse://test", client=object()),
-        _sankey_batch(FilterInput(who=WhoFilterInput(developers=[developer_id]))),
-    )
-
-    assert captured_sankey_params
-    assert all(
-        params["developer_ids"] == [developer_id] for params in captured_sankey_params
-    )
-    assert captured_coverage_params == []
-    assert result.sankey is not None
-    assert result.sankey.coverage is None
+    with pytest.raises(ValidationError) as exc_info:
+        await analytics_resolver.resolve_analytics(
+            GraphQLContext(org_id="org-1", db_url="clickhouse://test", client=object()),
+            _sankey_batch(FilterInput(who=WhoFilterInput(developers=[developer_id]))),
+        )
+    assert exc_info.value.field == "who"
 
 
 @pytest.mark.asyncio

--- a/tests/graphql/test_filters.py
+++ b/tests/graphql/test_filters.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from datetime import date
 
+import pytest
+
+from dev_health_ops.api.graphql.errors import ValidationError
 from dev_health_ops.api.graphql.models.inputs import (
     FilterInput,
     ScopeFilterInput,
@@ -57,9 +60,14 @@ class TestFilterTranslation:
         assert "repo_id IN %(scope_ids)s" in sql
         assert params["scope_ids"] == ["repo-1"]
 
-    def test_who_filter(self):
-        """Test who filter (developers)."""
-        filters = FilterInput(who=WhoFilterInput(developers=["dev-1", "dev-2"]))
+    def test_who_filter_rejected_for_non_investment_query(self):
+        """CHAOS-2385: who.developers is rejected (not silently applied) for
+        non-investment queries -- investment_metrics_daily carries no
+        per-developer breakdown at all, so emitting a predicate against ANY
+        author column there (author_id previously, author_email now) would
+        be a runtime ClickHouse error. CHAOS-2492 adds investment-path
+        support (use_investment=True) via a companion join."""
+        filters = FilterInput(who=WhoFilterInput(developers=["alice@example.com"]))
         request = TimeseriesRequest(
             dimension="team",
             measure="count",
@@ -67,14 +75,10 @@ class TestFilterTranslation:
             start_date=date(2025, 1, 1),
             end_date=date(2025, 1, 7),
         )
-        sql, params = compile_timeseries(request, org_id="org1", filters=filters)
 
-        # CHAOS-2385: author_id does not exist in any ClickHouse table; the
-        # real identity column shared across git_commits/user_metrics_daily/
-        # commit_metrics/git_pull_requests is author_email.
-        assert "author_email IN %(developer_ids)s" in sql
-        assert "author_id" not in sql
-        assert params["developer_ids"] == ["dev-1", "dev-2"]
+        with pytest.raises(ValidationError) as exc_info:
+            compile_timeseries(request, org_id="org1", filters=filters)
+        assert exc_info.value.field == "who"
 
     def test_what_filter_repos(self):
         """Test what filter (repos)."""
@@ -166,11 +170,14 @@ class TestFilterTranslation:
         assert "developer_ids" not in params
         assert "repo_filter_ids" not in params
 
-    def test_scope_filter_developer_uses_author_email(self):
-        """CHAOS-2385: scope.level=developer must target the real author_email
-        column, never the nonexistent author_id."""
+    def test_scope_filter_developer_rejected_for_non_investment_query(self):
+        """CHAOS-2385: scope.level=developer is rejected (not silently
+        applied) for non-investment queries -- same gap as who.developers
+        above. CHAOS-2492 adds investment-path support."""
         filters = FilterInput(
-            scope=ScopeFilterInput(level=ScopeLevelInput.DEVELOPER, ids=["dev-1"])
+            scope=ScopeFilterInput(
+                level=ScopeLevelInput.DEVELOPER, ids=["alice@example.com"]
+            )
         )
         request = TimeseriesRequest(
             dimension="team",
@@ -179,8 +186,7 @@ class TestFilterTranslation:
             start_date=date(2025, 1, 1),
             end_date=date(2025, 1, 7),
         )
-        sql, params = compile_timeseries(request, org_id="org1", filters=filters)
 
-        assert "author_email IN %(scope_ids)s" in sql
-        assert "author_id" not in sql
-        assert params["scope_ids"] == ["dev-1"]
+        with pytest.raises(ValidationError) as exc_info:
+            compile_timeseries(request, org_id="org1", filters=filters)
+        assert exc_info.value.field == "scope"

--- a/tests/graphql/test_filters.py
+++ b/tests/graphql/test_filters.py
@@ -69,7 +69,11 @@ class TestFilterTranslation:
         )
         sql, params = compile_timeseries(request, org_id="org1", filters=filters)
 
-        assert "author_id IN %(developer_ids)s" in sql
+        # CHAOS-2385: author_id does not exist in any ClickHouse table; the
+        # real identity column shared across git_commits/user_metrics_daily/
+        # commit_metrics/git_pull_requests is author_email.
+        assert "author_email IN %(developer_ids)s" in sql
+        assert "author_id" not in sql
         assert params["developer_ids"] == ["dev-1", "dev-2"]
 
     def test_what_filter_repos(self):
@@ -161,3 +165,22 @@ class TestFilterTranslation:
         assert "work_categories" not in params
         assert "developer_ids" not in params
         assert "repo_filter_ids" not in params
+
+    def test_scope_filter_developer_uses_author_email(self):
+        """CHAOS-2385: scope.level=developer must target the real author_email
+        column, never the nonexistent author_id."""
+        filters = FilterInput(
+            scope=ScopeFilterInput(level=ScopeLevelInput.DEVELOPER, ids=["dev-1"])
+        )
+        request = TimeseriesRequest(
+            dimension="team",
+            measure="count",
+            interval="day",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 7),
+        )
+        sql, params = compile_timeseries(request, org_id="org1", filters=filters)
+
+        assert "author_email IN %(scope_ids)s" in sql
+        assert "author_id" not in sql
+        assert params["scope_ids"] == ["dev-1"]


### PR DESCRIPTION
## Summary

CHAOS-2385 ops layer: the GraphQL filter-translation module targeted a ClickHouse column (`author_id`) that does not exist on any table. This is a backend-only fix; the web layer of this ticket was verified already-correct on `main` (see Linear comment) and needed no change.

## Root cause

`filter_translation.py::translate_scope_filter/translate_developer_filter/translate_filters`, `validate.py::Dimension.AUTHOR`, and the Sankey coverage query in `resolvers/analytics.py` all defaulted/passed `author_column="author_id"`. Grepping the ClickHouse migrations/DDL confirms no table has an `author_id` column; the real shared identity column across `git_commits`, `git_pull_requests`, `user_metrics_daily`, and `commit_metrics` is `author_email`.

## Fix

- `translate_scope_filter`, `translate_developer_filter`, `translate_filters`: default `author_column` changed from `author_id` to `author_email`.
- `validate.py`: `Dimension.AUTHOR` mapping changed from `author_id` to `author_email` (both investment and non-investment branches).
- `resolvers/analytics.py`: Sankey coverage query's explicit `author_column="author_id"` override changed to `author_email`.

**Oracle review round 2** caught a table-awareness gap in the first commit: renaming the column fixed the *name* but the predicate was still emitted unconditionally -- including against `investment_metrics_daily` and `work_unit_investments`, neither of which carries ANY per-developer column at this point in the stack (CHAOS-2492, stacked on top, adds investment-path support). Fixed by making `translate_filters` **reject** (`ValidationError`) `who.developers` / `scope.level=developer` instead of silently building broken SQL, mirroring the existing honest-rejection precedent in `compiler.py`'s `_reject_filtered_same_dimension_flow_matrix` (CHAOS-2487).

## Testing

- `bash ci/local_validate.sh` -> `GATE PASSED`
- `pytest tests/graphql/test_filters.py tests/api/test_analytics_repo_filter_resolution.py -v` -> all passing
- Regression tests assert the rejection (`pytest.raises(ValidationError)`) using real email-shaped literals, not placeholder strings.

## Notes for follow-up

- `author_email` is the identity key chosen here and reused in CHAOS-2492 to expose developer identity in `LATEST_WORK_UNIT_INVESTMENTS_CTE` (companion PR #1102, stacked on this branch).
- A separate, pre-existing value-shape gap (who.developers isn't guaranteed to be a real email end-to-end) is tracked in CHAOS-2746 -- out of scope for this identity-column-rename fix.

SCREENSHOT-WAIVER: backend-only change (SQL predicate column naming + validation), no rendered UI affected.