### PR TITLE
fix(api): prevent work-unit investment query-size failures

### DIFF
--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -127,6 +127,7 @@ from .webhooks import router as webhooks_router
 
 HOME_CACHE = create_cache(ttl_seconds=60)
 EXPLAIN_CACHE = create_cache(ttl_seconds=120)
+WORK_UNITS_MAX_LIMIT = 1000
 
 logger = logging.getLogger(__name__)
 
@@ -519,7 +520,8 @@ async def work_units_post(
             filter_payload = payload.filters.model_dump(mode="json")
         else:
             filter_payload = payload.filters.dict()
-        log_limit = str(payload.limit or 200).replace("\r", "").replace("\n", "")
+        bounded_limit = _bounded_limit_param(payload.limit or 200, WORK_UNITS_MAX_LIMIT)
+        log_limit = str(bounded_limit).replace("\r", "").replace("\n", "")
         log_include_textual = str(include_textual).replace("\r", "").replace("\n", "")
         logger.debug(
             "WorkUnits POST request include_textual=%s limit=%s filters=%s",
@@ -531,7 +533,7 @@ async def work_units_post(
             db_url=_analytics_db_url(),
             filters=payload.filters,
             org_id=current_user.org_id,
-            limit=payload.limit or 200,
+            limit=bounded_limit,
             include_text=include_textual,
         )
         logger.debug("WorkUnits POST returned count=%s", len(result))
@@ -561,7 +563,8 @@ async def work_units(
             filter_payload = filters.model_dump(mode="json")
         else:
             filter_payload = filters.dict()
-        log_limit = str(limit).replace("\r", "").replace("\n", "")
+        bounded_limit = _bounded_limit_param(limit, WORK_UNITS_MAX_LIMIT)
+        log_limit = str(bounded_limit).replace("\r", "").replace("\n", "")
         log_include_textual = str(include_textual).replace("\r", "").replace("\n", "")
         logger.debug(
             "WorkUnits GET request include_textual=%s limit=%s filters=%s",
@@ -573,7 +576,7 @@ async def work_units(
             db_url=_analytics_db_url(),
             filters=filters,
             org_id=current_user.org_id,
-            limit=limit,
+            limit=bounded_limit,
             include_text=include_textual,
         )
         logger.debug("WorkUnits GET returned count=%s", len(result))

--- a/src/dev_health_ops/api/queries/work_unit_investments.py
+++ b/src/dev_health_ops/api/queries/work_unit_investments.py
@@ -2,11 +2,23 @@ from __future__ import annotations
 
 from collections.abc import Iterable
 from datetime import datetime
-from typing import Any
+from typing import Any, TypeVar
 
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
+
+_LOOKUP_CHUNK_SIZE = 250
+T = TypeVar("T")
+
+
+def _unique_non_empty(values: Iterable[str]) -> list[str]:
+    return list(dict.fromkeys(value for value in values if value))
+
+
+def _chunks(values: list[T], size: int = _LOOKUP_CHUNK_SIZE) -> Iterable[list[T]]:
+    for start in range(0, len(values), size):
+        yield values[start : start + size]
 
 
 async def fetch_work_unit_investments(
@@ -24,15 +36,15 @@ async def fetch_work_unit_investments(
     # ClickHouse may prefer alias over column names in WHERE; always qualify columns
     # to avoid accidentally referencing argMax(...) aliases.
     filters: list[str] = [
-        "work_unit_investments.from_ts < %(end_ts)s",
-        "work_unit_investments.to_ts >= %(start_ts)s",
-        "work_unit_investments.org_id = %(org_id)s",
+        "work_unit_investments.from_ts < {end_ts:DateTime}",
+        "work_unit_investments.to_ts >= {start_ts:DateTime}",
+        "work_unit_investments.org_id = {org_id:String}",
     ]
     if repo_ids:
-        filters.append("work_unit_investments.repo_id IN %(repo_ids)s")
+        filters.append("work_unit_investments.repo_id IN {repo_ids:Array(String)}")
         params["repo_ids"] = repo_ids
     if work_unit_id:
-        filters.append("work_unit_investments.work_unit_id = %(work_unit_id)s")
+        filters.append("work_unit_investments.work_unit_id = {work_unit_id:String}")
         params["work_unit_id"] = work_unit_id
     where_sql = " AND ".join(filters)
     query = f"""
@@ -58,8 +70,8 @@ async def fetch_work_unit_investments(
         FROM work_unit_investments
         WHERE {where_sql}
         GROUP BY org_id, work_unit_id
-        ORDER BY effort_value DESC
-        LIMIT %(limit)s
+        ORDER BY effort_value DESC, work_unit_id ASC
+        LIMIT {{limit:UInt32}}
     """
     return await query_dicts(sink, query, params)
 
@@ -70,7 +82,7 @@ async def fetch_repo_scopes(
     repo_ids: Iterable[str],
     org_id: str = "",
 ) -> dict[str, str]:
-    ids = [repo_id for repo_id in repo_ids if repo_id]
+    ids = _unique_non_empty(repo_ids)
     if not ids:
         return {}
     query = """
@@ -78,12 +90,14 @@ async def fetch_repo_scopes(
             toString(id) AS repo_id,
             repo
         FROM repos
-        WHERE id IN %(repo_ids)s
-          AND org_id = %(org_id)s
+        WHERE id IN {repo_ids:Array(String)}
+          AND org_id = {org_id:String}
     """
-    params: dict[str, Any] = {"repo_ids": ids}
-    params["org_id"] = org_id
-    rows = await query_dicts(sink, query, params)
+    rows: list[dict[str, Any]] = []
+    for chunk in _chunks(ids):
+        rows.extend(
+            await query_dicts(sink, query, {"repo_ids": chunk, "org_id": org_id})
+        )
     return {
         str(row.get("repo_id")): str(row.get("repo") or "")
         for row in rows
@@ -97,7 +111,7 @@ async def fetch_work_item_team_assignments(
     work_item_ids: Iterable[str],
     org_id: str = "",
 ) -> dict[str, dict[str, str]]:
-    ids = [work_item_id for work_item_id in work_item_ids if work_item_id]
+    ids = _unique_non_empty(work_item_ids)
     if not ids:
         return {}
     query = """
@@ -106,13 +120,15 @@ async def fetch_work_item_team_assignments(
             argMax(team_id, computed_at) AS team_id,
             argMax(team_name, computed_at) AS team_name
         FROM work_item_cycle_times
-        WHERE work_item_id IN %(work_item_ids)s
-          AND org_id = %(org_id)s
+        WHERE work_item_id IN {work_item_ids:Array(String)}
+          AND org_id = {org_id:String}
         GROUP BY work_item_id
     """
-    params: dict[str, Any] = {"work_item_ids": ids}
-    params["org_id"] = org_id
-    rows = await query_dicts(sink, query, params)
+    rows: list[dict[str, Any]] = []
+    for chunk in _chunks(ids):
+        rows.extend(
+            await query_dicts(sink, query, {"work_item_ids": chunk, "org_id": org_id})
+        )
     result: dict[str, dict[str, str]] = {}
     for row in rows:
         work_item_id = str(row.get("work_item_id") or "")
@@ -130,7 +146,11 @@ async def fetch_work_unit_investment_quotes(
     unit_runs: Iterable[tuple[str, str]],
     org_id: str = "",
 ) -> list[dict[str, Any]]:
-    pairs = [(unit_id, run_id) for unit_id, run_id in unit_runs if unit_id and run_id]
+    pairs = list(
+        dict.fromkeys(
+            (unit_id, run_id) for unit_id, run_id in unit_runs if unit_id and run_id
+        )
+    )
     if not pairs:
         return []
     query = """
@@ -141,9 +161,10 @@ async def fetch_work_unit_investment_quotes(
             source_id,
             categorization_run_id
         FROM work_unit_investment_quotes
-        WHERE (work_unit_id, categorization_run_id) IN %(pairs)s
-          AND org_id = %(org_id)s
+        WHERE (work_unit_id, categorization_run_id) IN {pairs:Array(Tuple(String, String))}
+          AND org_id = {org_id:String}
     """
-    params: dict[str, Any] = {"pairs": pairs}
-    params["org_id"] = org_id
-    return await query_dicts(sink, query, params)
+    rows: list[dict[str, Any]] = []
+    for chunk in _chunks(pairs):
+        rows.extend(await query_dicts(sink, query, {"pairs": chunk, "org_id": org_id}))
+    return rows

--- a/src/dev_health_ops/api/services/work_units.py
+++ b/src/dev_health_ops/api/services/work_units.py
@@ -340,5 +340,5 @@ async def build_work_unit_investments(
             )
         )
 
-    results.sort(key=lambda item: item.effort.value, reverse=True)
+    results.sort(key=lambda item: (-item.effort.value, item.work_unit_id))
     return results[: max(1, int(limit))]

--- a/tests/api/test_work_unit_investments_query.py
+++ b/tests/api/test_work_unit_investments_query.py
@@ -37,5 +37,66 @@ async def test_work_unit_investments_query_qualifies_columns(monkeypatch):
 
     assert "work_unit_investments.from_ts" in captured["query"]
     assert "work_unit_investments.to_ts" in captured["query"]
+    assert "{start_ts:DateTime}" in captured["query"]
+    assert "{end_ts:DateTime}" in captured["query"]
+    assert "%(start_ts)s" not in captured["query"]
+    assert "%(end_ts)s" not in captured["query"]
     assert "argMax(from_ts, work_unit_investments.computed_at)" in captured["query"]
     assert "argMax(computed_at, computed_at)" not in captured["query"]
+    assert "ORDER BY effort_value DESC, work_unit_id ASC" in captured["query"]
+
+
+@pytest.mark.asyncio
+async def test_work_unit_lookup_queries_use_typed_array_params(monkeypatch):
+    captured: list[_CapturedQuery] = []
+
+    async def _fake_query_dicts(_client, query: str, params):
+        captured.append({"query": query, "params": params})
+        return []
+
+    monkeypatch.setattr(work_unit_investments, "query_dicts", _fake_query_dicts)
+
+    await work_unit_investments.fetch_work_item_team_assignments(
+        cast(BaseMetricsSink, object()),
+        work_item_ids=["linear:CHAOS-1", "linear:CHAOS-2", "linear:CHAOS-1"],
+        org_id="org-1",
+    )
+    await work_unit_investments.fetch_work_unit_investment_quotes(
+        cast(BaseMetricsSink, object()),
+        unit_runs=[("linear:CHAOS-1", "run-1"), ("linear:CHAOS-2", "run-2")],
+        org_id="org-1",
+    )
+
+    assert "work_item_id IN {work_item_ids:Array(String)}" in captured[0]["query"]
+    assert "%(work_item_ids)s" not in captured[0]["query"]
+    assert captured[0]["params"]["work_item_ids"] == [
+        "linear:CHAOS-1",
+        "linear:CHAOS-2",
+    ]
+    assert (
+        "(work_unit_id, categorization_run_id) IN {pairs:Array(Tuple(String, String))}"
+        in captured[1]["query"]
+    )
+    assert "%(pairs)s" not in captured[1]["query"]
+
+
+@pytest.mark.asyncio
+async def test_work_unit_lookup_queries_chunk_large_id_sets(monkeypatch):
+    captured: list[_CapturedQuery] = []
+
+    async def _fake_query_dicts(_client, query: str, params):
+        captured.append({"query": query, "params": params})
+        return []
+
+    monkeypatch.setattr(work_unit_investments, "query_dicts", _fake_query_dicts)
+
+    work_item_ids = [f"linear:CHAOS-{index}" for index in range(251)]
+    await work_unit_investments.fetch_work_item_team_assignments(
+        cast(BaseMetricsSink, object()), work_item_ids=work_item_ids, org_id="org-1"
+    )
+
+    assert len(captured) == 2
+    first_chunk = cast(list[str], captured[0]["params"]["work_item_ids"])
+    second_chunk = cast(list[str], captured[1]["params"]["work_item_ids"])
+    assert len(first_chunk) == 250
+    assert len(second_chunk) == 1


### PR DESCRIPTION
## Summary
- bind work-unit investment ClickHouse queries with typed placeholders instead of pyformat-expanded IN lists
- chunk secondary repo/team/quote lookups so large Linear work-unit evidence does not exceed ClickHouse query-size limits
- add stable work-unit ordering and cap work-unit endpoint limits at 1000

## Verification
- ruff format --check / ruff check on changed files
- mypy via commit and pre-push hooks
- pytest tests/api/test_work_unit_investments_query.py tests/api/test_investment_latest_row_queries.py
- scratch ClickHouse QA: seeded one work unit with 260 linear:CHAOS-* issue IDs and verified team, repo, and quote evidence returned through build_work_unit_investments
- unspecified-high changeset review: PASS, no blocking findings

SCREENSHOT-WAIVER: backend-only API/query fix; no rendered UI changes.