### PR TITLE
fix(graphql): add repo_id filter to cognitiveLoad resolver (CHAOS-2386)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/cognitive_load.py
+++ b/src/dev_health_ops/api/graphql/resolvers/cognitive_load.py
@@ -74,13 +74,19 @@ async def _fetch_user_metrics(
     Filters by ``org_id`` (always), date range, and optionally ``team_id`` /
     ``repo_id`` (the latter is valid here since ``user_metrics_daily`` carries
     a ``repo_id`` column per row; ``team_metrics_daily`` does not, so
-    ``repo_id`` is never applied to the team-metrics query). ``repo_id`` is a
-    ``UUID``-typed column, so the predicate casts it via ``toString(...)``
-    before comparing — mirroring ``resolvers/complexity.py``'s
-    ``toString(repo_id) IN {repo_ids:Array(String)}`` convention — rather than
-    comparing the column directly against the ``String`` parameter, which
-    would force ClickHouse to parse the parameter as a UUID and raise
-    ``CANNOT_PARSE_UUID`` for any non-UUID value.
+    ``repo_id`` is never applied to the team-metrics query).
+
+    The GraphQL ``repoId`` input may be EITHER the repo's UUID (``repos.id``)
+    OR its human-readable full_name/slug (``repos.repo``, e.g.
+    ``"org/repo"``) — the web repo picker's option list
+    (``/api/v1/filters/options``) is populated from ``repos.repo`` slugs, not
+    UUIDs (see CHAOS-2745 for the broader platform-wide follow-up to make
+    every repo-scoped resolver accept slugs consistently). The predicate
+    below resolves either form via an org-scoped subquery over ``repos``
+    rather than comparing ``repo_id`` (a ``UUID``-typed column) directly
+    against the ``String`` parameter, which would force ClickHouse to parse
+    the parameter as a UUID and raise ``CANNOT_PARSE_UUID`` whenever a slug
+    is supplied.
     """
     inner_where = """
             WHERE org_id = {org_id:String}
@@ -96,7 +102,12 @@ async def _fetch_user_metrics(
         inner_where += "\n              AND team_id = {team_id:String}"
         params["team_id"] = team_id
     if repo_id:
-        inner_where += "\n              AND toString(repo_id) = {repo_id:String}"
+        inner_where += """
+              AND repo_id IN (
+                  SELECT id FROM repos
+                  WHERE org_id = {org_id:String}
+                    AND (repo = {repo_id:String} OR toString(id) = {repo_id:String})
+              )"""
         params["repo_id"] = repo_id
 
     query = f"""

--- a/src/dev_health_ops/api/graphql/resolvers/cognitive_load.py
+++ b/src/dev_health_ops/api/graphql/resolvers/cognitive_load.py
@@ -61,6 +61,7 @@ async def _fetch_user_metrics(
     since_date: str,
     until_date: str,
     team_id: str | None,
+    repo_id: str | None,
 ) -> list[dict[str, Any]]:
     """SUM of latest-per-developer cognitive load columns, grouped by day.
 
@@ -70,7 +71,16 @@ async def _fetch_user_metrics(
     ``argMax(<col>, computed_at)``; the outer query SUMs those deduplicated
     rows by day. This prevents double-counting from re-computation passes.
 
-    Filters by ``org_id`` (always), date range, and optionally ``team_id``.
+    Filters by ``org_id`` (always), date range, and optionally ``team_id`` /
+    ``repo_id`` (the latter is valid here since ``user_metrics_daily`` carries
+    a ``repo_id`` column per row; ``team_metrics_daily`` does not, so
+    ``repo_id`` is never applied to the team-metrics query). ``repo_id`` is a
+    ``UUID``-typed column, so the predicate casts it via ``toString(...)``
+    before comparing — mirroring ``resolvers/complexity.py``'s
+    ``toString(repo_id) IN {repo_ids:Array(String)}`` convention — rather than
+    comparing the column directly against the ``String`` parameter, which
+    would force ClickHouse to parse the parameter as a UUID and raise
+    ``CANNOT_PARSE_UUID`` for any non-UUID value.
     """
     inner_where = """
             WHERE org_id = {org_id:String}
@@ -85,6 +95,9 @@ async def _fetch_user_metrics(
     if team_id:
         inner_where += "\n              AND team_id = {team_id:String}"
         params["team_id"] = team_id
+    if repo_id:
+        inner_where += "\n              AND toString(repo_id) = {repo_id:String}"
+        params["repo_id"] = repo_id
 
     query = f"""
         SELECT
@@ -202,6 +215,7 @@ async def resolve_cognitive_load(
         since_date=since_date,
         until_date=until_date,
         team_id=input.team_id,
+        repo_id=input.repo_id,
     )
     team_rows = await _fetch_team_metrics(
         client,

--- a/src/dev_health_ops/api/graphql/types/cognitive_load.py
+++ b/src/dev_health_ops/api/graphql/types/cognitive_load.py
@@ -24,6 +24,10 @@ class CognitiveLoadInput:
     #: Optional filter to a single team.  When absent, data across all teams
     #: is aggregated.
     team_id: str | None = strawberry.field(default=None, name="teamId")
+    #: Optional filter to a single repo (UUID string). Mirrors the ``team_id``
+    #: filter above; only ``user_metrics_daily`` carries a ``repo_id`` column,
+    #: so this has no effect on the team-level after-hours/weekend ratios.
+    repo_id: str | None = strawberry.field(default=None, name="repoId")
 
 
 @strawberry.type

--- a/tests/api/graphql/test_cognitive_load_resolver.py
+++ b/tests/api/graphql/test_cognitive_load_resolver.py
@@ -15,6 +15,8 @@ Tests exercise the resolver against a mocked ClickHouse client and verify:
 * The org-id gate raises ``AuthorizationError`` when ``context.org_id`` is
   missing.
 * The ``team_id`` filter passes through to both SQL queries.
+* The ``repo_id`` filter passes through to the user-metrics query only
+  (``team_metrics_daily`` has no ``repo_id`` column).
 
 All tests are read-only; no ClickHouse tables are modified.
 """
@@ -71,12 +73,15 @@ def _squash_ws(sql: str) -> str:
     return re.sub(r"\s+", " ", sql)
 
 
-def _input(team_id: str | None = None) -> CognitiveLoadInput:
+def _input(
+    team_id: str | None = None, repo_id: str | None = None
+) -> CognitiveLoadInput:
     return CognitiveLoadInput(
         org_id=ORG_ID,
         since_date=SINCE,
         until_date=UNTIL,
         team_id=team_id,
+        repo_id=repo_id,
     )
 
 
@@ -274,6 +279,61 @@ async def test_cognitive_load_team_id_reflected_in_result() -> None:
     second_query: str = ctx.client.query.call_args_list[1].args[0]
     assert "team_id" in first_query
     assert "team_id" in second_query
+
+
+# ---------------------------------------------------------------------------
+# repo_id filter (CHAOS-2386)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_repo_id_filters_user_query_only() -> None:
+    """repo_id is embedded in the user-metrics query only.
+
+    ``team_metrics_daily`` has no ``repo_id`` column, so the team-metrics
+    query must remain unfiltered by repo even when ``repo_id`` is supplied —
+    regression test for CHAOS-2386 (the resolver previously had no repo_id
+    field/predicate at all, making the UI repo control a no-op). The
+    predicate casts the UUID column via ``toString(...)`` before comparing,
+    so a non-UUID value degrades to a no-match rather than a ClickHouse
+    ``CANNOT_PARSE_UUID`` exception (mirrors ``resolvers/complexity.py``).
+    """
+    ctx = _ctx()
+    user_cols = [
+        "day",
+        "pr_interruption_load",
+        "context_spread_count",
+        "review_request_load",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(user_cols, [[DAY_1, 4, 9, 2]]),
+            _qresult([], []),
+        ],
+    )
+
+    await resolve_cognitive_load(
+        ctx, _input(repo_id="3fa85f64-5717-4562-b3fc-2c963f66afa6")
+    )
+
+    assert ctx.client.query.call_count == 2
+    first_query: str = ctx.client.query.call_args_list[0].args[0]
+    second_query: str = ctx.client.query.call_args_list[1].args[0]
+    assert "toString(repo_id) = {repo_id:String}" in first_query
+    assert "repo_id" not in second_query
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_no_repo_id_omits_predicate() -> None:
+    """When repo_id is absent, no repo_id predicate is added to either query."""
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], [])])
+
+    await resolve_cognitive_load(ctx, _input())
+
+    first_query: str = ctx.client.query.call_args_list[0].args[0]
+    assert "toString(repo_id) = {repo_id:String}" not in first_query
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/graphql/test_cognitive_load_resolver.py
+++ b/tests/api/graphql/test_cognitive_load_resolver.py
@@ -294,9 +294,11 @@ async def test_cognitive_load_repo_id_filters_user_query_only() -> None:
     query must remain unfiltered by repo even when ``repo_id`` is supplied —
     regression test for CHAOS-2386 (the resolver previously had no repo_id
     field/predicate at all, making the UI repo control a no-op). The
-    predicate casts the UUID column via ``toString(...)`` before comparing,
-    so a non-UUID value degrades to a no-match rather than a ClickHouse
-    ``CANNOT_PARSE_UUID`` exception (mirrors ``resolvers/complexity.py``).
+    predicate resolves against an org-scoped subquery over ``repos`` (by
+    UUID or slug) rather than comparing the UUID column directly against
+    the parameter, so a non-UUID value degrades to a no-match rather than a
+    ClickHouse ``CANNOT_PARSE_UUID`` exception (mirrors
+    ``resolvers/complexity.py``'s org-scoped repo-label lookup).
     """
     ctx = _ctx()
     user_cols = [
@@ -320,8 +322,51 @@ async def test_cognitive_load_repo_id_filters_user_query_only() -> None:
     assert ctx.client.query.call_count == 2
     first_query: str = ctx.client.query.call_args_list[0].args[0]
     second_query: str = ctx.client.query.call_args_list[1].args[0]
-    assert "toString(repo_id) = {repo_id:String}" in first_query
+    assert "repo_id IN (" in first_query
+    assert "SELECT id FROM repos" in first_query
+    assert "org_id = {org_id:String}" in first_query
+    assert "repo = {repo_id:String}" in first_query
+    assert "toString(id) = {repo_id:String}" in first_query
     assert "repo_id" not in second_query
+
+
+@pytest.mark.asyncio
+async def test_cognitive_load_repo_id_accepts_slug_from_filter_options() -> None:
+    """repo_id also accepts a repos.repo full_name slug (CHAOS-2386 acceptance).
+
+    ``/api/v1/filters/options`` populates the web repo picker from
+    ``repos.repo`` slugs (e.g. "org/repo"), not UUIDs — a normal UI repo
+    selection sends a slug, not a UUID. The predicate must resolve either
+    form via the org-scoped ``repos`` subquery so a real UI selection
+    actually narrows the query, not just a UUID passed directly.
+    """
+    ctx = _ctx()
+    user_cols = [
+        "day",
+        "pr_interruption_load",
+        "context_spread_count",
+        "review_request_load",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(user_cols, [[DAY_1, 6, 11, 3]]),
+            _qresult([], []),
+        ],
+    )
+
+    result = await resolve_cognitive_load(
+        ctx, _input(repo_id="full-chaos/dev-health-ops")
+    )
+
+    assert len(result.signals) == 1
+    first_query: str = ctx.client.query.call_args_list[0].args[0]
+    first_params: dict = ctx.client.query.call_args_list[0].kwargs["parameters"]
+    assert "repo_id IN (" in first_query
+    # The slug is passed through unmodified as the single {repo_id:String}
+    # parameter binding — the resolver does not attempt to detect/parse the
+    # input shape itself; ClickHouse's OR of repo/toString(id) resolves it.
+    assert first_params["repo_id"] == "full-chaos/dev-health-ops"
 
 
 @pytest.mark.asyncio
@@ -333,7 +378,7 @@ async def test_cognitive_load_no_repo_id_omits_predicate() -> None:
     await resolve_cognitive_load(ctx, _input())
 
     first_query: str = ctx.client.query.call_args_list[0].args[0]
-    assert "toString(repo_id) = {repo_id:String}" not in first_query
+    assert "repo_id IN (" not in first_query
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`CognitiveLoadInput` had no `repo` field and the resolver had no `repo_id` WHERE clause, despite `user_metrics_daily` carrying a `repo_id` column — making the web repo filter control a no-op on `/cognitive-load` (CHAOS-2386).

## Changes

- Add `repo_id: str | None` to `CognitiveLoadInput` (GraphQL field `repoId`), mirroring the existing `team_id` filter.
- Thread `repo_id` into `_fetch_user_metrics` only. `team_metrics_daily` is team-scoped and has no `repo_id` column, so team-level after-hours/weekend ratios are intentionally unaffected.
- `repo_id` is a **UUID-typed** ClickHouse column. The predicate casts it via `toString(repo_id) = {repo_id:String}` before comparing — mirroring `resolvers/complexity.py`'s `toString(repo_id) IN {repo_ids:Array(String)}` convention — rather than comparing the raw UUID column directly against the `String` parameter (which forces ClickHouse to parse the parameter as a UUID and raises `CANNOT_PARSE_UUID` for any non-UUID value, verified live against the local ClickHouse instance during development).

## Verification

- `tests/api/graphql/test_cognitive_load_resolver.py`: 2 new tests (repo_id embeds in user-metrics query only via `toString(repo_id) = {repo_id:String}`; absent repo_id omits the predicate). 14/14 tests pass.
- Verified live against ClickHouse: unfiltered `sum(pr_interruption_load)` for the demo window = 48; filtered to one real repo UUID = 42 (predicate genuinely narrows results).
- `bash ci/local_validate.sh` → `GATE PASSED`.

## Follow-up filed

CHAOS-2745: `/api/v1/filters/options` returns repo **full_name slugs**, but every repo-scoped GraphQL resolver (this one included, plus `complexity.py`, `compounding_risk.py`, `review_edges.py`, `ai.py`) expects the **repo UUID**. This means the web repo picker can't yet supply a value this resolver's predicate will actually match end-to-end — that's a separate, platform-wide gap (not introduced by this PR, and shared by the sibling resolvers) tracked for a follow-up fix.

## Companion PR

full-chaos/dev-health-web#733 (web-side `repoId` extraction/threading)

---

## Update: addressed Oracle review (C2 — core acceptance)

The original `toString(repo_id) = {repo_id:String}` predicate degraded gracefully (no crash) but was still a no-op end-to-end, because `/api/v1/filters/options` (the web repo picker's option source) returns `repos.repo` **slugs**, not UUIDs — so a real UI selection would silently match zero rows.

Fixed: the predicate now resolves `repoId` against an org-scoped subquery over `repos` matching EITHER the UUID (`repos.id`) or the slug (`repos.repo`), mirroring `resolvers/complexity.py`'s org-scoped repo-label lookup pattern:

```sql
AND repo_id IN (
    SELECT id FROM repos
    WHERE org_id = {org_id:String}
      AND (repo = {repo_id:String} OR toString(id) = {repo_id:String})
)
```

Added a new test (`test_cognitive_load_repo_id_accepts_slug_from_filter_options`) asserting a slug value flows through unmodified and the subquery predicate text is present. 15/15 resolver tests pass. Re-verified live against ClickHouse with the exact org_id/slug combination the seeded admin session uses: `sum(pr_interruption_load)` narrows from 48 (unfiltered) to 42 (slug-filtered) — matching the earlier UUID-driven check exactly, and matching what the live web UI now shows end-to-end (screenshots on the companion PR).

`bash ci/local_validate.sh` re-run -> `GATE PASSED` (6117 tests, +1 for the new slug test).
