### PR TITLE
feat(graphql): expose developer identity in investment Sankey path (CHAOS-2492)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -10,6 +10,7 @@ from typing import Any, cast
 from uuid import UUID
 
 from dev_health_ops.api.queries.investment import (
+    LATEST_WORK_UNIT_AUTHORS_CTE,
     LATEST_WORK_UNIT_INVESTMENTS_CTE,
     fetch_investment_quality_stats,
 )
@@ -175,6 +176,12 @@ def _analytics_quality_window(batch: AnalyticsRequestInput) -> tuple[date, date]
 
 
 def _has_investment_author_filter(filters: FilterInput | None) -> bool:
+    """True when who.developers or scope.level=developer is active.
+
+    CHAOS-2492: used to decide whether the Sankey coverage query needs the
+    ``au`` join (LATEST_WORK_UNIT_AUTHORS_CTE) chained in -- coverage is no
+    longer forced to None for developer-filtered investment views.
+    """
     if filters is None:
         return False
     if (
@@ -710,8 +717,16 @@ async def resolve_analytics(
                         f"{assigned_repo_expr})"
                     )
 
+                has_author_filter = (
+                    request.use_investment
+                    and _has_investment_author_filter(resolved_filters)
+                )
                 with_clause = (
-                    f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}"
+                    (
+                        f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}, {LATEST_WORK_UNIT_AUTHORS_CTE}"
+                        if has_author_filter
+                        else f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}"
+                    )
                     if request.use_investment
                     else ""
                 )
@@ -727,65 +742,66 @@ async def resolve_analytics(
                     else "org_id = %(org_id)s"
                 )
 
-                if request.use_investment and _has_investment_author_filter(
-                    resolved_filters
-                ):
-                    logger.info(
-                        "Sankey coverage unavailable for investment author filters; "
-                        "work_unit_investments does not expose author_email (CHAOS-2492)"
-                    )
-                else:
-                    if request.use_investment and _has_work_category_filter(
-                        resolved_filters
-                    ):
-                        joins += """
-                        ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
-                        """
-
-                    coverage_filter_clause, coverage_filter_params = translate_filters(
-                        resolved_filters,
-                        use_investment=bool(request.use_investment),
-                        team_column=team_col,
-                        repo_column="work_unit_investments.repo_id"
-                        if request.use_investment
-                        else repo_col,
-                        author_column="author_email",
-                    )
-
-                    coverage_sql = f"""
-                        {with_clause}
-                        SELECT
-                            {total_expr} as total,
-                            {assigned_team_count_expr} as assigned_team,
-                            {assigned_repo_count_expr} as assigned_repo
-                        FROM {base_table}
-                        {joins}
-                        WHERE {date_filter}
-                          AND {org_filter}
-                          {coverage_filter_clause}
+                if has_author_filter:
+                    # CHAOS-2492: resolve developer identity via the au join so
+                    # who.developers / scope.level=developer coverage is honored
+                    # instead of being silently excluded (previously forced
+                    # coverage=None -- see CHAOS-2488).
+                    joins += """
+                    LEFT JOIN work_unit_authors AS au ON au.work_unit_id = work_unit_investments.work_unit_id
                     """
 
-                    cov_params = {
-                        "start_date": request.start_date,
-                        "end_date": request.end_date,
-                        "org_id": org_id,
-                    }
-                    cov_params.update(coverage_filter_params)
+                if request.use_investment and _has_work_category_filter(
+                    resolved_filters
+                ):
+                    joins += """
+                    ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
+                    """
 
-                    try:
-                        c_rows = await query_dicts(client, coverage_sql, cov_params)
-                        if c_rows:
-                            total = float(c_rows[0].get("total", 0))
-                            assigned_team = float(c_rows[0].get("assigned_team", 0))
-                            assigned_repo = float(c_rows[0].get("assigned_repo", 0))
+                coverage_filter_clause, coverage_filter_params = translate_filters(
+                    resolved_filters,
+                    use_investment=bool(request.use_investment),
+                    team_column=team_col,
+                    repo_column="work_unit_investments.repo_id"
+                    if request.use_investment
+                    else repo_col,
+                    author_column="author_email",
+                )
 
-                            coverage = SankeyCoverage(
-                                team_coverage=assigned_team / total if total > 0 else 0,
-                                repo_coverage=assigned_repo / total if total > 0 else 0,
-                            )
-                    except Exception as e:
-                        logger.error("Coverage query failed: %s", e)
-                        coverage = None
+                coverage_sql = f"""
+                    {with_clause}
+                    SELECT
+                        {total_expr} as total,
+                        {assigned_team_count_expr} as assigned_team,
+                        {assigned_repo_count_expr} as assigned_repo
+                    FROM {base_table}
+                    {joins}
+                    WHERE {date_filter}
+                      AND {org_filter}
+                      {coverage_filter_clause}
+                """
+
+                cov_params = {
+                    "start_date": request.start_date,
+                    "end_date": request.end_date,
+                    "org_id": org_id,
+                }
+                cov_params.update(coverage_filter_params)
+
+                try:
+                    c_rows = await query_dicts(client, coverage_sql, cov_params)
+                    if c_rows:
+                        total = float(c_rows[0].get("total", 0))
+                        assigned_team = float(c_rows[0].get("assigned_team", 0))
+                        assigned_repo = float(c_rows[0].get("assigned_repo", 0))
+
+                        coverage = SankeyCoverage(
+                            team_coverage=assigned_team / total if total > 0 else 0,
+                            repo_coverage=assigned_repo / total if total > 0 else 0,
+                        )
+                except Exception as e:
+                    logger.error("Coverage query failed: %s", e)
+                    coverage = None
 
             sankey_result = SankeyResult(nodes=nodes, edges=edges, coverage=coverage)
 

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -9,7 +9,10 @@ from dataclasses import dataclass
 from datetime import date
 from typing import TYPE_CHECKING, Any
 
-from dev_health_ops.api.queries.investment import LATEST_WORK_UNIT_INVESTMENTS_CTE
+from dev_health_ops.api.queries.investment import (
+    LATEST_WORK_UNIT_AUTHORS_CTE,
+    LATEST_WORK_UNIT_INVESTMENTS_CTE,
+)
 
 from ..authz import enforce_org_scope
 from ..errors import ValidationError
@@ -135,6 +138,7 @@ def _get_context_params(
     dimensions: list[Dimension],
     force_investment: bool | None = None,
     needs_team_join: bool = False,
+    needs_author_join: bool = False,
 ) -> dict[str, Any]:
     """Determine source table and extra clauses based on dimensions."""
     # WORK_TYPE belongs to the investment-side ``work_unit_investments`` table —
@@ -193,11 +197,22 @@ def _get_context_params(
         if Dimension.REPO in dimensions:
             joins.append("LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)")
 
+        # CHAOS-2492: add developer-identity join if AUTHOR dimension is used
+        # or a developer filter (who.developers / scope.level=developer) needs
+        # it. Chains LATEST_WORK_UNIT_AUTHORS_CTE onto the WITH clause -- only
+        # when actually needed, to avoid the extra join cost otherwise.
+        with_parts = [LATEST_WORK_UNIT_INVESTMENTS_CTE]
+        if Dimension.AUTHOR in dimensions or needs_author_join:
+            with_parts.append(LATEST_WORK_UNIT_AUTHORS_CTE)
+            joins.append(
+                "LEFT JOIN work_unit_authors AS au ON au.work_unit_id = work_unit_investments.work_unit_id"
+            )
+
         return {
             "source_table": "latest_work_unit_investments AS work_unit_investments",
             "date_filter": "work_unit_investments.from_ts < %(end_date)s AND work_unit_investments.to_ts >= %(start_date)s",
             "extra_clauses": "\n".join(joins),
-            "with_clause": f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}",
+            "with_clause": f"WITH {', '.join(with_parts)}",
             "use_investment": True,
         }
 
@@ -214,6 +229,24 @@ def _needs_team_join(filters: FilterInput | None) -> bool:
     if not filters or not filters.scope or not filters.scope.ids:
         return False
     return filters.scope.level.value == "team"
+
+
+def _needs_author_join(filters: FilterInput | None) -> bool:
+    """CHAOS-2492: does this request need the investment developer-identity join?
+
+    True when a developer/who filter or a developer-scoped view is active, so
+    the compiler chains LATEST_WORK_UNIT_AUTHORS_CTE and the ``au`` join onto
+    the investment query (see _get_context_params).
+    """
+    if filters is None:
+        return False
+    if filters.who is not None and filters.who.developers:
+        return True
+    return bool(
+        filters.scope is not None
+        and filters.scope.level.value == "developer"
+        and filters.scope.ids
+    )
 
 
 def _has_active_filters(filters: FilterInput | None) -> bool:
@@ -265,6 +298,7 @@ def compile_timeseries(
         [dimension],
         force_investment=request.use_investment,
         needs_team_join=_needs_team_join(filters),
+        needs_author_join=_needs_author_join(filters),
     )
 
     # Translate filters to SQL clause
@@ -308,6 +342,7 @@ def compile_breakdown(
         [dimension],
         force_investment=request.use_investment,
         needs_team_join=_needs_team_join(filters),
+        needs_author_join=_needs_author_join(filters),
     )
 
     # Translate filters to SQL clause
@@ -350,6 +385,7 @@ def compile_sankey(
         dimensions,
         force_investment=request.use_investment,
         needs_team_join=_needs_team_join(filters),
+        needs_author_join=_needs_author_join(filters),
     )
 
     # Translate filters to SQL clause
@@ -427,6 +463,7 @@ def compile_flow_matrix(
         [dimension],
         force_investment=request.use_investment,
         needs_team_join=_needs_team_join(filters),
+        needs_author_join=_needs_author_join(filters),
     )
 
     filter_clause, filter_params = translate_filters(
@@ -517,6 +554,7 @@ def compile_catalog_values(
     ctx = _get_context_params(
         [dimension],
         needs_team_join=_needs_team_join(filters),
+        needs_author_join=_needs_author_join(filters),
     )
 
     params: dict[str, Any] = {

--- a/src/dev_health_ops/api/graphql/sql/filter_translation.py
+++ b/src/dev_health_ops/api/graphql/sql/filter_translation.py
@@ -209,6 +209,11 @@ def translate_filters(
             # `au` join (LATEST_WORK_UNIT_AUTHORS_CTE, see compiler.py) resolves
             # an ARRAY of contributor author_emails per work unit rather than a
             # scalar column, so membership uses hasAny() instead of a flat IN.
+            # W2: validate email format BEFORE building the predicate -- same
+            # gap as who.developers below; without this, an invalid scope.ids
+            # value silently produces an empty/no-op filter instead of a
+            # rejection.
+            _validate_developer_emails(filters.scope.ids, field="scope")
             clauses.append(" AND hasAny(au.author_emails, %(scope_ids)s)")
             params["scope_ids"] = filters.scope.ids
         elif filters.scope.level.value == "developer" and filters.scope.ids:

--- a/src/dev_health_ops/api/graphql/sql/filter_translation.py
+++ b/src/dev_health_ops/api/graphql/sql/filter_translation.py
@@ -200,23 +200,30 @@ def translate_filters(
                 " AND (ut.team_label IN %(scope_ids)s OR ut.team_id IN %(scope_ids)s)"
             )
             params["scope_ids"] = filters.scope.ids
+        elif (
+            use_investment
+            and filters.scope.level.value == "developer"
+            and filters.scope.ids
+        ):
+            # CHAOS-2492: work_unit_investments carries no author column; the
+            # `au` join (LATEST_WORK_UNIT_AUTHORS_CTE, see compiler.py) resolves
+            # an ARRAY of contributor author_emails per work unit rather than a
+            # scalar column, so membership uses hasAny() instead of a flat IN.
+            clauses.append(" AND hasAny(au.author_emails, %(scope_ids)s)")
+            params["scope_ids"] = filters.scope.ids
         elif filters.scope.level.value == "developer" and filters.scope.ids:
             _validate_developer_emails(filters.scope.ids, field="scope")
-            # CHAOS-2385: no ClickHouse table reachable through this generic
-            # analytics compiler carries a per-developer breakdown yet --
-            # investment_metrics_daily has no author column at all, and
-            # work_unit_investments/latest_work_unit_investments doesn't
-            # either (CHAOS-2492 adds investment-path support via a
-            # companion join, at which point this predicate becomes
-            # table-aware instead of unconditional). Reject explicitly
-            # rather than emit a predicate against a column that doesn't
-            # exist on the resolved source table (mirrors the
-            # honest-rejection precedent in compiler.py's
+            # CHAOS-2492: developer scope is only supported on the
+            # investment path (via the au join above); investment_metrics_daily
+            # and the testops rollups carry no per-developer breakdown at
+            # all. Reject explicitly rather than emit author_email against a
+            # table that doesn't have it (mirrors the honest-rejection
+            # precedent in compiler.py's
             # _reject_filtered_same_dimension_flow_matrix, CHAOS-2487).
             raise ValidationError(
-                "scope.level=developer filtering is not yet supported for "
-                "this query; remove the developer scope (CHAOS-2492 tracks "
-                "investment-path support).",
+                "scope.level=developer filtering requires an investment "
+                "query; pass useInvestment=true or remove the developer "
+                "scope.",
                 field="scope",
                 value="developer",
             )
@@ -235,15 +242,20 @@ def translate_filters(
     # Who filter - developers
     if filters.who is not None and filters.who.developers:
         _validate_developer_emails(filters.who.developers, field="who")
-        # CHAOS-2385: same gap as scope.level=developer above -- reject
-        # rather than emit a predicate against a nonexistent column.
-        raise ValidationError(
-            "who.developers filtering is not yet supported for this query; "
-            "remove the developer filter (CHAOS-2492 tracks investment-path "
-            "support).",
-            field="who",
-            value="developers",
-        )
+        if use_investment:
+            # CHAOS-2492: same hasAny() array-membership predicate as above.
+            clauses.append(" AND hasAny(au.author_emails, %(developer_ids)s)")
+            params["developer_ids"] = filters.who.developers
+        else:
+            # CHAOS-2492: same table-awareness gap as scope.level=developer
+            # above -- reject rather than emit a predicate against a column
+            # that doesn't exist on the non-investment source table.
+            raise ValidationError(
+                "who.developers filtering requires an investment query; "
+                "pass useInvestment=true or remove the developer filter.",
+                field="who",
+                value="developers",
+            )
 
     # What filter - repos
     if filters.what is not None and filters.what.repos:

--- a/src/dev_health_ops/api/graphql/sql/filter_translation.py
+++ b/src/dev_health_ops/api/graphql/sql/filter_translation.py
@@ -12,12 +12,39 @@ Key semantics:
 
 from __future__ import annotations
 
+import re
 from typing import TYPE_CHECKING, Any
 
 from ..errors import ValidationError
 
 if TYPE_CHECKING:
     from ..models.inputs import FilterInput
+
+# CHAOS-2385/CHAOS-2492: author_email is the only identity column any
+# developer/author predicate can ever match (git_commits, git_pull_requests,
+# user_metrics_daily, commit_metrics; /api/v1/filters/options populates the
+# quick-filter picker with exactly this column). GraphQL input, URL-decoded
+# REST query params, and the advanced WhoSection UI (web repo) can all pass
+# arbitrary free-form strings (e.g. a raw "alice, bob" string instead of a
+# properly split array) -- silently building a predicate against a
+# non-email value would just match nothing and look like an unrelated bug
+# rather than a bad-input error. Validate format before ANY of who.developers
+# / scope.level=developer becomes a predicate (or a rejection).
+_EMAIL_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+
+
+def _validate_developer_emails(values: list[str], field: str) -> None:
+    """Raise ValidationError if any developer filter value isn't an email."""
+    invalid = [v for v in values if not _EMAIL_PATTERN.match(v)]
+    if invalid:
+        raise ValidationError(
+            f"{field}.developers must be email addresses (author_email is "
+            "the shared identity column across git_commits/"
+            "git_pull_requests/user_metrics_daily/commit_metrics); got "
+            f"non-email value(s): {invalid!r}",
+            field=field,
+            value=invalid,
+        )
 
 
 def translate_scope_filter(
@@ -174,6 +201,7 @@ def translate_filters(
             )
             params["scope_ids"] = filters.scope.ids
         elif filters.scope.level.value == "developer" and filters.scope.ids:
+            _validate_developer_emails(filters.scope.ids, field="scope")
             # CHAOS-2385: no ClickHouse table reachable through this generic
             # analytics compiler carries a per-developer breakdown yet --
             # investment_metrics_daily has no author column at all, and
@@ -206,6 +234,7 @@ def translate_filters(
 
     # Who filter - developers
     if filters.who is not None and filters.who.developers:
+        _validate_developer_emails(filters.who.developers, field="who")
         # CHAOS-2385: same gap as scope.level=developer above -- reject
         # rather than emit a predicate against a nonexistent column.
         raise ValidationError(

--- a/src/dev_health_ops/api/graphql/sql/validate.py
+++ b/src/dev_health_ops/api/graphql/sql/validate.py
@@ -24,11 +24,31 @@ class Dimension(str, Enum):
     @classmethod
     def db_column(cls, dim: Dimension, use_investment: bool = False) -> str:
         """Get the database column name for a dimension."""
+        if dim == cls.AUTHOR:
+            # CHAOS-2385/CHAOS-2492: neither ClickHouse source table this
+            # compiler ever selects FROM has a scalar per-row author identity
+            # column. investment_metrics_daily (non-investment) and
+            # latest_work_unit_investments (investment) both lack
+            # author_email; the investment path's work_unit_authors CTE (the
+            # `au` join -- see compiler.py / filter_translation.py) exposes
+            # only an ARRAY column (au.author_emails, one row per work unit)
+            # for hasAny() membership filtering, not a scalar GROUP BY column.
+            # Reject explicitly rather than emit SQL referencing a column
+            # that doesn't exist (mirrors the honest-rejection precedent in
+            # compiler.py's _reject_filtered_same_dimension_flow_matrix,
+            # CHAOS-2487). Filter by who.developers / scope.level=developer
+            # instead of grouping by author.
+            raise ValidationError(
+                "author is not a supported breakdown/grouping dimension; "
+                "filter by who.developers or scope.level=developer instead "
+                "of grouping by author.",
+                field="dimension",
+                value=dim.value,
+            )
         if use_investment:
             mapping = {
                 cls.TEAM: "ifNull(nullIf(ut.team_label, ''), 'unassigned')",
                 cls.REPO: "ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id)))",
-                cls.AUTHOR: "author_email",
                 cls.WORK_TYPE: "work_unit_type",
                 cls.THEME: "splitByChar('.', subcategory_kv.1)[1]",
                 cls.SUBCATEGORY: "subcategory_kv.1",
@@ -37,7 +57,6 @@ class Dimension(str, Enum):
             mapping = {
                 cls.TEAM: "team_id",
                 cls.REPO: "repo_id",
-                cls.AUTHOR: "author_email",
                 cls.WORK_TYPE: "work_item_type",
                 cls.THEME: "investment_area",
                 cls.SUBCATEGORY: "project_stream",

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -65,6 +65,22 @@ LATEST_WORK_UNIT_INVESTMENTS_CTE = """
 # Must chain AFTER LATEST_WORK_UNIT_INVESTMENTS_CTE in the same WITH clause
 # (references `latest_work_unit_investments`); only pulled in by callers that
 # actually need developer filtering, to avoid the extra join cost otherwise.
+# Tenant isolation: git_commits / git_pull_requests carry an org_id column
+# (migration 027), and repo_id+hash / repo_id+number values CAN collide
+# across tenants -- this exact collision risk is documented at
+# work_graph/builder.py:1643 for the equivalent git_commits join. Both inner
+# dedupe subqueries below MUST be scoped to the CURRENT org: the
+# `WHERE org_id = %(org_id)s` filter (the org_id param is already supplied by
+# every consumer of this CTE, since it is only ever chained onto the WITH
+# clause alongside LATEST_WORK_UNIT_INVESTMENTS_CTE, which requires the same
+# param) plus `org_id` in the GROUP BY keeps each org's argMax(author_email, ...)
+# computed over ONLY that org's rows. The `ca.org_id = wui.org_id` /
+# `pa.org_id = wui.org_id` join predicate is a second, redundant layer of the
+# same tenant-scoping (mirrors the dual WHERE-filter + join pattern in
+# work_graph/builder.py's PR/commit edge builder). Without BOTH layers, a
+# repo_id+hash (or repo_id+number) collision across two orgs lets argMax pull
+# ANOTHER org's author_email into this org's investment developer filter --
+# a tenant-isolation leak.
 LATEST_WORK_UNIT_AUTHORS_CTE = """
         work_unit_authors AS (
             SELECT
@@ -78,11 +94,13 @@ LATEST_WORK_UNIT_AUTHORS_CTE = """
                 ARRAY JOIN JSONExtract(wui.structural_evidence_json, 'commits', 'Array(String)') AS commit_ref
                 INNER JOIN (
                     SELECT
+                        org_id,
                         concat(toString(repo_id), '@', hash) AS commit_ref,
                         argMax(author_email, last_synced) AS author_email
                     FROM git_commits
-                    GROUP BY repo_id, hash
-                ) AS ca ON ca.commit_ref = commit_ref
+                    WHERE org_id = %(org_id)s
+                    GROUP BY org_id, repo_id, hash
+                ) AS ca ON ca.commit_ref = commit_ref AND ca.org_id = wui.org_id
                 WHERE ca.author_email IS NOT NULL AND ca.author_email != ''
 
                 UNION ALL
@@ -94,11 +112,13 @@ LATEST_WORK_UNIT_AUTHORS_CTE = """
                 ARRAY JOIN JSONExtract(wui.structural_evidence_json, 'prs', 'Array(String)') AS pr_ref
                 INNER JOIN (
                     SELECT
+                        org_id,
                         concat(toString(repo_id), '#pr', toString(number)) AS pr_ref,
                         argMax(author_email, last_synced) AS author_email
                     FROM git_pull_requests
-                    GROUP BY repo_id, number
-                ) AS pa ON pa.pr_ref = pr_ref
+                    WHERE org_id = %(org_id)s
+                    GROUP BY org_id, repo_id, number
+                ) AS pa ON pa.pr_ref = pr_ref AND pa.org_id = wui.org_id
                 WHERE pa.author_email IS NOT NULL AND pa.author_email != ''
             )
             GROUP BY work_unit_id

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -51,6 +51,61 @@ LATEST_WORK_UNIT_INVESTMENTS_CTE = """
 """.rstrip()
 
 
+# CHAOS-2492: work_unit_investments carries NO author/developer column at all
+# (see the WorkUnitInvestmentRecord write columns in metrics/sinks/clickhouse/
+# investment.py) -- the closest thing to a developer identity is the set of
+# commit/PR node ids recorded in structural_evidence_json (written by
+# work_graph/investment/materialize.py using the canonical
+# "{repo_uuid}@{sha}" / "{repo_uuid}#pr{number}" id formats from
+# work_graph/ids.py). This companion CTE resolves those refs to the REAL
+# ClickHouse identity column -- author_email (git_commits, git_pull_requests;
+# same column chosen in CHAOS-2385) -- and collapses to one deduplicated
+# array of contributor emails per work unit.
+#
+# Must chain AFTER LATEST_WORK_UNIT_INVESTMENTS_CTE in the same WITH clause
+# (references `latest_work_unit_investments`); only pulled in by callers that
+# actually need developer filtering, to avoid the extra join cost otherwise.
+LATEST_WORK_UNIT_AUTHORS_CTE = """
+        work_unit_authors AS (
+            SELECT
+                work_unit_id,
+                groupUniqArray(author_email) AS author_emails
+            FROM (
+                SELECT
+                    wui.work_unit_id AS work_unit_id,
+                    ca.author_email AS author_email
+                FROM latest_work_unit_investments AS wui
+                ARRAY JOIN JSONExtract(wui.structural_evidence_json, 'commits', 'Array(String)') AS commit_ref
+                INNER JOIN (
+                    SELECT
+                        concat(toString(repo_id), '@', hash) AS commit_ref,
+                        argMax(author_email, last_synced) AS author_email
+                    FROM git_commits
+                    GROUP BY repo_id, hash
+                ) AS ca ON ca.commit_ref = commit_ref
+                WHERE ca.author_email IS NOT NULL AND ca.author_email != ''
+
+                UNION ALL
+
+                SELECT
+                    wui.work_unit_id AS work_unit_id,
+                    pa.author_email AS author_email
+                FROM latest_work_unit_investments AS wui
+                ARRAY JOIN JSONExtract(wui.structural_evidence_json, 'prs', 'Array(String)') AS pr_ref
+                INNER JOIN (
+                    SELECT
+                        concat(toString(repo_id), '#pr', toString(number)) AS pr_ref,
+                        argMax(author_email, last_synced) AS author_email
+                    FROM git_pull_requests
+                    GROUP BY repo_id, number
+                ) AS pa ON pa.pr_ref = pr_ref
+                WHERE pa.author_email IS NOT NULL AND pa.author_email != ''
+            )
+            GROUP BY work_unit_id
+        )
+""".rstrip()
+
+
 async def fetch_investment_breakdown(
     sink: BaseMetricsSink,
     *,

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -392,12 +392,19 @@ async def _fixture_data_health(sink: CapturingSink) -> None:
 
 
 async def _fixture_analytics(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.context import GraphQLContext
     from dev_health_ops.api.graphql.models.inputs import (
+        AnalyticsRequestInput,
+        DateRangeInput,
+        DimensionInput,
         FilterInput,
+        MeasureInput,
+        SankeyRequestInput,
         ScopeFilterInput,
         ScopeLevelInput,
         WhoFilterInput,
     )
+    from dev_health_ops.api.graphql.resolvers.analytics import resolve_analytics
     from dev_health_ops.api.graphql.sql.compiler import (
         BreakdownRequest,
         CatalogValuesRequest,
@@ -498,6 +505,28 @@ async def _fixture_analytics(sink: CapturingSink) -> None:
         dev_breakdown_req, SAMPLE_ORG_ID, filters=scope_filters
     )
     sink.calls.append((sql, params))
+
+    # CHAOS-2492: the RESOLVER-level Sankey coverage query is built inline
+    # in resolve_analytics() and is NOT exercised by the compile_sankey()
+    # calls above -- coverage used to be forced to None for developer
+    # filters (CHAOS-2488) and now chains the same au join / hasAny()
+    # predicate. Drive it through the real resolver (not just the compiler)
+    # so EXPLAIN validates the exact SQL the resolver emits, including the
+    # `total`/`assigned_team`/`assigned_repo` coverage aggregates.
+    dev_batch = AnalyticsRequestInput(
+        sankey=SankeyRequestInput(
+            path=[DimensionInput.THEME, DimensionInput.REPO],
+            measure=MeasureInput.COUNT,
+            date_range=DateRangeInput(start_date=start, end_date=end),
+            use_investment=True,
+        ),
+        use_investment=True,
+        filters=who_filters,
+    )
+    await resolve_analytics(
+        GraphQLContext(org_id=SAMPLE_ORG_ID, db_url="clickhouse://test", client=sink),
+        dev_batch,
+    )
 
     for fm_dim in ("team", "repo", "work_type"):
         fm_req = FlowMatrixRequest(

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -392,6 +392,12 @@ async def _fixture_data_health(sink: CapturingSink) -> None:
 
 
 async def _fixture_analytics(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.models.inputs import (
+        FilterInput,
+        ScopeFilterInput,
+        ScopeLevelInput,
+        WhoFilterInput,
+    )
     from dev_health_ops.api.graphql.sql.compiler import (
         BreakdownRequest,
         CatalogValuesRequest,
@@ -459,6 +465,39 @@ async def _fixture_analytics(sink: CapturingSink) -> None:
     nodes_qs, edges_qs = compile_sankey(sankey_req, SAMPLE_ORG_ID)
     sink.calls.extend(nodes_qs)
     sink.calls.extend(edges_qs)
+
+    # CHAOS-2492: developer-filtered investment Sankey -- must chain
+    # LATEST_WORK_UNIT_AUTHORS_CTE + the `au` join and resolve
+    # hasAny(au.author_emails, ...) against the REAL git_commits /
+    # git_pull_requests schema (not just string-matched in unit tests).
+    dev_sankey_req = SankeyRequest(
+        path=["theme", "repo"],
+        measure="count",
+        start_date=start,
+        end_date=end,
+        use_investment=True,
+    )
+    who_filters = FilterInput(who=WhoFilterInput(developers=["alice@example.com"]))
+    nodes_qs, edges_qs = compile_sankey(
+        dev_sankey_req, SAMPLE_ORG_ID, filters=who_filters
+    )
+    sink.calls.extend(nodes_qs)
+    sink.calls.extend(edges_qs)
+
+    scope_filters = FilterInput(
+        scope=ScopeFilterInput(level=ScopeLevelInput.DEVELOPER, ids=["bob@example.com"])
+    )
+    dev_breakdown_req = BreakdownRequest(
+        dimension="theme",
+        measure="count",
+        start_date=start,
+        end_date=end,
+        use_investment=True,
+    )
+    sql, params = compile_breakdown(
+        dev_breakdown_req, SAMPLE_ORG_ID, filters=scope_filters
+    )
+    sink.calls.append((sql, params))
 
     for fm_dim in ("team", "repo", "work_type"):
         fm_req = FlowMatrixRequest(

--- a/tests/api/test_analytics_repo_filter_resolution.py
+++ b/tests/api/test_analytics_repo_filter_resolution.py
@@ -6,7 +6,6 @@ from typing import Any
 import pytest
 
 from dev_health_ops.api.graphql.context import GraphQLContext
-from dev_health_ops.api.graphql.errors import ValidationError
 from dev_health_ops.api.graphql.models.inputs import (
     AnalyticsRequestInput,
     BreakdownRequestInput,
@@ -172,19 +171,26 @@ async def test_sankey_coverage_respects_resolved_repo_name_filter(
 
 
 @pytest.mark.asyncio
-async def test_sankey_developer_filter_rejected_pending_chaos_2492(
+async def test_sankey_coverage_computed_for_investment_who_developers_filter(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """CHAOS-2385: who.developers is rejected outright rather than silently
-    building a predicate against a column that doesn't exist on any table
-    reachable from this compiler yet. CHAOS-2492 (stacked on this branch)
-    adds investment-path support via a companion join, at which point this
-    scenario returns real coverage instead of raising -- see
-    test_sankey_coverage_computed_for_investment_who_developers_filter in
-    that branch."""
+    """CHAOS-2492: developer-filtered investment Sankey coverage is no longer
+    forced to None -- the au join (LATEST_WORK_UNIT_AUTHORS_CTE) resolves
+    author_email so hasAny(au.author_emails, ...) can be applied."""
     developer_id = "alice@example.com"
+    captured_sankey_params: list[dict[str, Any]] = []
+    captured_coverage_sql: list[str] = []
+    captured_coverage_params: list[dict[str, Any]] = []
 
     async def fake_query_dicts(_client: object, sql: str, params: dict[str, Any]):
+        if "assigned_team" in sql:
+            captured_coverage_sql.append(sql)
+            captured_coverage_params.append(dict(params))
+            if params.get("developer_ids") == [developer_id]:
+                return [{"total": 4, "assigned_team": 2, "assigned_repo": 2}]
+            return [{"total": 4, "assigned_team": 4, "assigned_repo": 4}]
+        if "developer_ids" in params:
+            captured_sankey_params.append(dict(params))
         return []
 
     monkeypatch.setattr(
@@ -192,12 +198,82 @@ async def test_sankey_developer_filter_rejected_pending_chaos_2492(
         fake_query_dicts,
     )
 
-    with pytest.raises(ValidationError) as exc_info:
-        await analytics_resolver.resolve_analytics(
-            GraphQLContext(org_id="org-1", db_url="clickhouse://test", client=object()),
-            _sankey_batch(FilterInput(who=WhoFilterInput(developers=[developer_id]))),
-        )
-    assert exc_info.value.field == "who"
+    context = GraphQLContext(
+        org_id="org-1", db_url="clickhouse://test", client=object()
+    )
+
+    org_wide = await analytics_resolver.resolve_analytics(context, _sankey_batch())
+    filtered = await analytics_resolver.resolve_analytics(
+        context,
+        _sankey_batch(FilterInput(who=WhoFilterInput(developers=[developer_id]))),
+    )
+
+    assert captured_sankey_params
+    assert all(
+        params["developer_ids"] == [developer_id] for params in captured_sankey_params
+    )
+    # Coverage is now computed for BOTH requests -- no more silent None
+    # exclusion (previously: captured_coverage_params == [] here).
+    assert len(captured_coverage_params) == 2
+    assert captured_coverage_params[0].get("developer_ids") is None
+    assert captured_coverage_params[1]["developer_ids"] == [developer_id]
+    assert "work_unit_authors" in captured_coverage_sql[1]
+    assert "hasAny(au.author_emails" in captured_coverage_sql[1]
+    assert org_wide.sankey is not None
+    assert org_wide.sankey.coverage is not None
+    assert filtered.sankey is not None
+    assert filtered.sankey.coverage is not None
+    assert org_wide.sankey.coverage.team_coverage == 1.0
+    assert filtered.sankey.coverage.team_coverage == 0.5
+
+
+@pytest.mark.asyncio
+async def test_sankey_coverage_computed_for_investment_scope_level_developer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-2492: scope.level=developer takes the same hasAny(au.author_emails)
+    coverage path as who.developers (CHAOS-2488 no longer excludes it)."""
+    developer_id = "bob@example.com"
+    captured_coverage_sql: list[str] = []
+    captured_coverage_params: list[dict[str, Any]] = []
+
+    async def fake_query_dicts(_client: object, sql: str, params: dict[str, Any]):
+        if "assigned_team" in sql:
+            captured_coverage_sql.append(sql)
+            captured_coverage_params.append(dict(params))
+            if params.get("scope_ids") == [developer_id]:
+                return [{"total": 4, "assigned_team": 1, "assigned_repo": 1}]
+            return [{"total": 4, "assigned_team": 4, "assigned_repo": 4}]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts",
+        fake_query_dicts,
+    )
+
+    context = GraphQLContext(
+        org_id="org-1", db_url="clickhouse://test", client=object()
+    )
+
+    filtered = await analytics_resolver.resolve_analytics(
+        context,
+        _sankey_batch(
+            FilterInput(
+                scope=ScopeFilterInput(
+                    level=ScopeLevelInput.DEVELOPER,
+                    ids=[developer_id],
+                )
+            )
+        ),
+    )
+
+    assert captured_coverage_params
+    assert captured_coverage_params[-1]["scope_ids"] == [developer_id]
+    assert "work_unit_authors" in captured_coverage_sql[-1]
+    assert "hasAny(au.author_emails" in captured_coverage_sql[-1]
+    assert filtered.sankey is not None
+    assert filtered.sankey.coverage is not None
+    assert filtered.sankey.coverage.team_coverage == 0.25
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_investment_latest_row_queries.py
+++ b/tests/api/test_investment_latest_row_queries.py
@@ -40,6 +40,40 @@ def test_latest_row_cte_does_not_shadow_argmax_ordering_column() -> None:
     assert "max(computed_at) AS latest_computed_at" in cte
 
 
+def test_work_unit_authors_cte_scopes_dedup_by_org() -> None:
+    """Regression for an Oracle NO-GO CRITICAL tenant-isolation leak on
+    CHAOS-2492: ``LATEST_WORK_UNIT_AUTHORS_CTE`` deduped ``git_commits`` by
+    (repo_id, hash) and ``git_pull_requests`` by (repo_id, number) WITHOUT
+    org_id. Those tables are keyed by (org_id, repo_id, hash/number)
+    (migration 027), and repo_id+hash / repo_id+number values CAN collide
+    across tenants -- this exact collision risk is documented at
+    work_graph/builder.py:1643 for the equivalent git_commits join. As
+    written, ``argMax(author_email, ...)`` could pull ANOTHER org's
+    author_email into this org's investment developer filter. Both inner
+    dedupe subqueries must now filter AND group by org_id, and the outer
+    join must pin ca.org_id/pa.org_id to the work unit's own org_id -- a
+    real live-ClickHouse exec proof of this lives in
+    tests/graphql/test_investment_developer_filter_tenant_isolation_live.py
+    (pytest -m clickhouse, opt-in).
+    """
+    cte = investment_queries.LATEST_WORK_UNIT_AUTHORS_CTE
+
+    # git_commits dedupe subquery: filtered AND grouped by org_id, and the
+    # outer join is additionally pinned to the work unit's own org_id.
+    assert "FROM git_commits" in cte
+    assert "GROUP BY org_id, repo_id, hash" in cte
+    assert "ca.org_id = wui.org_id" in cte
+
+    # git_pull_requests dedupe subquery: same tenant scoping.
+    assert "FROM git_pull_requests" in cte
+    assert "GROUP BY org_id, repo_id, number" in cte
+    assert "pa.org_id = wui.org_id" in cte
+
+    # Both inner subqueries filter by the query's own org_id param before
+    # aggregating -- not just after, via the join.
+    assert cte.count("WHERE org_id = %(org_id)s") == 2
+
+
 @pytest.mark.asyncio
 async def test_investment_breakdown_aggregates_only_latest_work_unit_row(
     monkeypatch: pytest.MonkeyPatch,

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -7,6 +7,12 @@ from datetime import date
 import pytest
 
 from dev_health_ops.api.graphql.errors import ValidationError
+from dev_health_ops.api.graphql.models.inputs import (
+    FilterInput,
+    ScopeFilterInput,
+    ScopeLevelInput,
+    WhoFilterInput,
+)
 from dev_health_ops.api.graphql.sql.compiler import (
     BreakdownRequest,
     CatalogValuesRequest,
@@ -257,6 +263,82 @@ class TestCompileSankey:
             assert "SELECT" in edge_sql
             assert "source" in edge_sql.lower() or "target" in edge_sql.lower()
             assert edge_params["org_id"] == org_id
+
+    def test_investment_sankey_who_developers_filter_uses_author_join(self):
+        """CHAOS-2492: who.developers on an investment Sankey must chain the
+        work_unit_authors CTE/join and filter nodes+edges via
+        hasAny(au.author_emails, ...), not a nonexistent flat author column.
+        """
+        request = SankeyRequest(
+            path=["theme", "repo"],
+            measure="count",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 31),
+            max_nodes=50,
+            max_edges=200,
+            use_investment=True,
+        )
+        filters = FilterInput(who=WhoFilterInput(developers=["alice@example.com"]))
+
+        nodes_queries, edges_queries = compile_sankey(
+            request, "test-org", filters=filters
+        )
+
+        nodes_sql, nodes_params = nodes_queries[0]
+        assert "work_unit_authors" in nodes_sql
+        assert "LEFT JOIN work_unit_authors AS au" in nodes_sql
+        assert "hasAny(au.author_emails, %(developer_ids)s)" in nodes_sql
+        assert nodes_params["developer_ids"] == ["alice@example.com"]
+
+        for edge_sql, edge_params in edges_queries:
+            assert "work_unit_authors" in edge_sql
+            assert "hasAny(au.author_emails, %(developer_ids)s)" in edge_sql
+            assert edge_params["developer_ids"] == ["alice@example.com"]
+
+    def test_investment_sankey_scope_level_developer_uses_author_join(self):
+        """CHAOS-2492: scope.level=developer takes the same author-join path
+        as who.developers."""
+        request = SankeyRequest(
+            path=["theme", "repo"],
+            measure="count",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 31),
+            max_nodes=50,
+            max_edges=200,
+            use_investment=True,
+        )
+        filters = FilterInput(
+            scope=ScopeFilterInput(
+                level=ScopeLevelInput.DEVELOPER, ids=["bob@example.com"]
+            )
+        )
+
+        nodes_queries, _edges_queries = compile_sankey(
+            request, "test-org", filters=filters
+        )
+
+        nodes_sql, nodes_params = nodes_queries[0]
+        assert "work_unit_authors" in nodes_sql
+        assert "hasAny(au.author_emails, %(scope_ids)s)" in nodes_sql
+        assert nodes_params["scope_ids"] == ["bob@example.com"]
+
+    def test_investment_sankey_without_developer_filter_skips_author_join(self):
+        """No who.developers / scope.level=developer -> no work_unit_authors
+        join (avoid the extra query cost when it isn't needed)."""
+        request = SankeyRequest(
+            path=["theme", "repo"],
+            measure="count",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 31),
+            max_nodes=50,
+            max_edges=200,
+            use_investment=True,
+        )
+
+        nodes_queries, _edges_queries = compile_sankey(request, "test-org")
+
+        nodes_sql, _nodes_params = nodes_queries[0]
+        assert "work_unit_authors" not in nodes_sql
 
     def test_invalid_path(self):
         """Test that invalid path raises ValidationError."""

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -207,7 +207,7 @@ class TestCompileBreakdown:
     def test_org_id_always_in_params(self):
         """Test that org_id is always included in params."""
         request = BreakdownRequest(
-            dimension="author",
+            dimension="repo",
             measure="count",
             start_date=date(2025, 1, 1),
             end_date=date(2025, 1, 31),
@@ -330,12 +330,32 @@ class TestCompileCatalogValues:
 class TestDimensionDbColumn:
     """Tests for Dimension.db_column mapping."""
 
-    @pytest.mark.parametrize("dim", list(Dimension))
+    @pytest.mark.parametrize("dim", [d for d in Dimension if d != Dimension.AUTHOR])
     def test_all_dimensions_have_columns(self, dim):
-        """Test that all dimensions map to database columns."""
+        """Test that all GROUP-BY-capable dimensions map to database columns.
+
+        AUTHOR is excluded: CHAOS-2385/2492 -- neither ClickHouse table this
+        compiler ever selects FROM (investment_metrics_daily,
+        latest_work_unit_investments) has a scalar author identity column;
+        see test_author_dimension_rejected below.
+        """
         col = Dimension.db_column(dim)
         assert col is not None
         assert len(col) > 0
+
+    def test_author_dimension_rejected(self):
+        """CHAOS-2385/2492: AUTHOR cannot be resolved to a real column in
+        either source table this compiler selects from.
+        investment_metrics_daily and latest_work_unit_investments both lack
+        a scalar author_email column; the investment path's
+        work_unit_authors CTE only exposes an ARRAY (au.author_emails) for
+        hasAny() filtering, not a scalar GROUP BY column. Filter by
+        who.developers / scope.level=developer instead of grouping by
+        author."""
+        with pytest.raises(ValidationError):
+            Dimension.db_column(Dimension.AUTHOR)
+        with pytest.raises(ValidationError):
+            Dimension.db_column(Dimension.AUTHOR, use_investment=True)
 
     def test_specific_mappings(self):
         """Test specific dimension to database column mappings."""

--- a/tests/graphql/test_filters.py
+++ b/tests/graphql/test_filters.py
@@ -118,7 +118,7 @@ class TestFilterTranslation:
             what=WhatFilterInput(repos=["repo-1"]),
         )
         request = TimeseriesRequest(
-            dimension="author",
+            dimension="repo",
             measure="count",
             interval="day",
             start_date=date(2025, 1, 1),
@@ -157,7 +157,7 @@ class TestFilterTranslation:
     def test_none_filters(self):
         """Test that None filters returns no additional clauses."""
         request = TimeseriesRequest(
-            dimension="author",
+            dimension="repo",
             measure="count",
             interval="day",
             start_date=date(2025, 1, 1),
@@ -190,3 +190,45 @@ class TestFilterTranslation:
         with pytest.raises(ValidationError) as exc_info:
             compile_timeseries(request, org_id="org1", filters=filters)
         assert exc_info.value.field == "scope"
+
+    def test_who_filter_rejects_non_email_values(self):
+        """CHAOS-2385: who.developers values must look like email
+        addresses -- GraphQL input, URL-decoded REST query params, and the
+        advanced WhoSection UI (web repo) can all pass arbitrary free-form
+        strings (e.g. a raw "alice, bob" string instead of a properly split
+        array). Validate format before it ever reaches a predicate (or the
+        "not yet supported" rejection above)."""
+        filters = FilterInput(who=WhoFilterInput(developers=["alice, bob"]))
+        request = TimeseriesRequest(
+            dimension="team",
+            measure="count",
+            interval="day",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 7),
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            compile_timeseries(request, org_id="org1", filters=filters)
+        assert exc_info.value.field == "who"
+        assert "email" in str(exc_info.value).lower()
+
+    def test_scope_filter_developer_rejects_non_email_values(self):
+        """CHAOS-2385: scope.level=developer ids must look like email
+        addresses -- same gap as who.developers above."""
+        filters = FilterInput(
+            scope=ScopeFilterInput(
+                level=ScopeLevelInput.DEVELOPER, ids=["not-an-email"]
+            )
+        )
+        request = TimeseriesRequest(
+            dimension="team",
+            measure="count",
+            interval="day",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 7),
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            compile_timeseries(request, org_id="org1", filters=filters)
+        assert exc_info.value.field == "scope"
+        assert "email" in str(exc_info.value).lower()

--- a/tests/graphql/test_filters.py
+++ b/tests/graphql/test_filters.py
@@ -268,3 +268,32 @@ class TestFilterTranslation:
         assert "work_unit_authors" in sql
         assert "hasAny(au.author_emails, %(scope_ids)s)" in sql
         assert params["scope_ids"] == ["alice@example.com"]
+
+    def test_scope_filter_developer_rejects_non_email_values_for_investment_query(
+        self,
+    ):
+        """W2 (Oracle NO-GO on CHAOS-2492): the investment scope.level=developer
+        branch built the hasAny() predicate WITHOUT calling
+        _validate_developer_emails, unlike the who.developers branch -- so an
+        invalid scope.ids value silently produced an empty/no-op filter
+        instead of a rejection. Mirrors
+        test_scope_filter_developer_rejects_non_email_values above, but with
+        use_investment=True so it exercises the hasAny() branch instead of
+        the non-investment rejection branch."""
+        filters = FilterInput(
+            scope=ScopeFilterInput(
+                level=ScopeLevelInput.DEVELOPER, ids=["not-an-email"]
+            )
+        )
+        request = BreakdownRequest(
+            dimension="theme",
+            measure="count",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 7),
+            use_investment=True,
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            compile_breakdown(request, org_id="org1", filters=filters)
+        assert exc_info.value.field == "scope"
+        assert "email" in str(exc_info.value).lower()

--- a/tests/graphql/test_filters.py
+++ b/tests/graphql/test_filters.py
@@ -61,12 +61,9 @@ class TestFilterTranslation:
         assert params["scope_ids"] == ["repo-1"]
 
     def test_who_filter_rejected_for_non_investment_query(self):
-        """CHAOS-2385: who.developers is rejected (not silently applied) for
-        non-investment queries -- investment_metrics_daily carries no
-        per-developer breakdown at all, so emitting a predicate against ANY
-        author column there (author_id previously, author_email now) would
-        be a runtime ClickHouse error. CHAOS-2492 adds investment-path
-        support (use_investment=True) via a companion join."""
+        """CHAOS-2385/2492: who.developers is rejected (not silently applied)
+        for non-investment queries -- investment_metrics_daily carries no
+        per-developer breakdown at all."""
         filters = FilterInput(who=WhoFilterInput(developers=["alice@example.com"]))
         request = TimeseriesRequest(
             dimension="team",
@@ -79,6 +76,24 @@ class TestFilterTranslation:
         with pytest.raises(ValidationError) as exc_info:
             compile_timeseries(request, org_id="org1", filters=filters)
         assert exc_info.value.field == "who"
+
+    def test_who_filter_uses_hasany_for_investment_query(self):
+        """CHAOS-2492: who.developers on an investment query resolves via
+        the au join's hasAny(author_emails) array-membership predicate."""
+        filters = FilterInput(who=WhoFilterInput(developers=["alice@example.com"]))
+        request = BreakdownRequest(
+            dimension="theme",
+            measure="count",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 7),
+            use_investment=True,
+        )
+
+        sql, params = compile_breakdown(request, org_id="org1", filters=filters)
+
+        assert "work_unit_authors" in sql
+        assert "hasAny(au.author_emails, %(developer_ids)s)" in sql
+        assert params["developer_ids"] == ["alice@example.com"]
 
     def test_what_filter_repos(self):
         """Test what filter (repos)."""
@@ -171,9 +186,8 @@ class TestFilterTranslation:
         assert "repo_filter_ids" not in params
 
     def test_scope_filter_developer_rejected_for_non_investment_query(self):
-        """CHAOS-2385: scope.level=developer is rejected (not silently
-        applied) for non-investment queries -- same gap as who.developers
-        above. CHAOS-2492 adds investment-path support."""
+        """CHAOS-2385/2492: scope.level=developer is rejected for
+        non-investment queries -- same gap as who.developers above."""
         filters = FilterInput(
             scope=ScopeFilterInput(
                 level=ScopeLevelInput.DEVELOPER, ids=["alice@example.com"]
@@ -232,3 +246,25 @@ class TestFilterTranslation:
             compile_timeseries(request, org_id="org1", filters=filters)
         assert exc_info.value.field == "scope"
         assert "email" in str(exc_info.value).lower()
+
+    def test_scope_filter_developer_uses_hasany_for_investment_query(self):
+        """CHAOS-2492: scope.level=developer on an investment query resolves
+        via the au join's hasAny(author_emails) predicate."""
+        filters = FilterInput(
+            scope=ScopeFilterInput(
+                level=ScopeLevelInput.DEVELOPER, ids=["alice@example.com"]
+            )
+        )
+        request = BreakdownRequest(
+            dimension="theme",
+            measure="count",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 7),
+            use_investment=True,
+        )
+
+        sql, params = compile_breakdown(request, org_id="org1", filters=filters)
+
+        assert "work_unit_authors" in sql
+        assert "hasAny(au.author_emails, %(scope_ids)s)" in sql
+        assert params["scope_ids"] == ["alice@example.com"]

--- a/tests/graphql/test_investment_developer_filter_tenant_isolation_live.py
+++ b/tests/graphql/test_investment_developer_filter_tenant_isolation_live.py
@@ -1,0 +1,158 @@
+"""Live-ClickHouse regression for the CHAOS-2492 Oracle NO-GO tenant leak.
+
+``LATEST_WORK_UNIT_AUTHORS_CTE`` (api/queries/investment.py) resolves the
+investment developer filter by deduping ``git_commits`` by (repo_id, hash) and
+``git_pull_requests`` by (repo_id, number) via ``argMax(author_email, ...)``.
+Those tables are keyed by (org_id, repo_id, hash/number) (migration 027), and
+repo_id+hash / repo_id+number values CAN collide across tenants -- this exact
+collision risk is documented at work_graph/builder.py:1643 for the equivalent
+git_commits join. Before the fix, the inner dedupe subqueries grouped by
+(repo_id, hash) / (repo_id, number) only -- WITHOUT org_id -- so a collision
+let ``argMax`` resolve ANOTHER org's ``author_email`` into this org's
+investment developer filter: a tenant-isolation leak.
+
+This test seeds TWO orgs sharing the SAME repo_id + commit hash (and the same
+repo_id + PR number) but with DIFFERENT author_email, and gives the OTHER
+org's row a newer ``last_synced`` (the argMax ordering column) than the
+querying org's own row -- exactly the shape that would make the pre-fix,
+unscoped ``argMax`` pick the wrong tenant's email. It asserts that each org's
+``work_unit_authors.author_emails`` resolves ONLY that org's own
+``author_email`` -- no cross-tenant bleed.
+
+Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+import dev_health_ops.api.queries.investment as investment_queries
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+def _git_commit_cols() -> list[str]:
+    return ["repo_id", "hash", "author_email", "last_synced", "org_id"]
+
+
+def _git_pr_cols() -> list[str]:
+    return ["repo_id", "number", "author_email", "created_at", "last_synced", "org_id"]
+
+
+def _work_unit_investment_cols() -> list[str]:
+    return [
+        "work_unit_id",
+        "from_ts",
+        "to_ts",
+        "structural_evidence_json",
+        "computed_at",
+        "org_id",
+    ]
+
+
+async def _resolve_author_emails(sink, org_id: str) -> dict[str, set[str]]:
+    """Run the REAL org-scoped CTEs and return {work_unit_id: {author_email, ...}}."""
+    query = f"""
+        WITH {investment_queries.LATEST_WORK_UNIT_INVESTMENTS_CTE},
+             {investment_queries.LATEST_WORK_UNIT_AUTHORS_CTE}
+        SELECT work_unit_id, author_emails
+        FROM work_unit_authors
+        ORDER BY work_unit_id
+    """
+    rows = await investment_queries.query_dicts(sink, query, {"org_id": org_id})
+    return {row["work_unit_id"]: set(row["author_emails"]) for row in rows}
+
+
+@pytest.mark.asyncio
+async def test_authors_cte_scopes_dedup_by_org_no_cross_tenant_bleed(sink):
+    """TWO orgs share the exact same repo_id+hash commit ref AND repo_id+number
+    PR ref (a collision that CAN happen in practice -- see
+    work_graph/builder.py:1643) but have DIFFERENT author_email. Org B's rows
+    carry a NEWER last_synced (the argMax ordering column) than Org A's --
+    the exact shape that made the pre-fix, unscoped argMax(author_email, ...)
+    pick Org B's email for Org A's query too. Asserts each org's investment
+    developer filter resolves ONLY its own author_email.
+    """
+    org_a = f"test-chaos-2492-a-{uuid.uuid4()}"
+    org_b = f"test-chaos-2492-b-{uuid.uuid4()}"
+    repo_id = str(uuid.uuid4())  # SAME repo_id reused by both tenants
+    commit_hash = uuid.uuid4().hex
+    pr_number = 42
+
+    commit_ref = f"{repo_id}@{commit_hash}"
+    pr_ref = f"{repo_id}#pr{pr_number}"
+
+    older = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    newer = datetime(2026, 6, 1, tzinfo=timezone.utc)  # Org B "wins" a global argMax
+
+    try:
+        sink.client.insert(
+            "git_commits",
+            [
+                [repo_id, commit_hash, "alice@org-a.example", older, org_a],
+                [repo_id, commit_hash, "mallory@org-b.example", newer, org_b],
+            ],
+            column_names=_git_commit_cols(),
+        )
+        sink.client.insert(
+            "git_pull_requests",
+            [
+                [repo_id, pr_number, "alice@org-a.example", older, older, org_a],
+                [repo_id, pr_number, "mallory@org-b.example", newer, newer, org_b],
+            ],
+            column_names=_git_pr_cols(),
+        )
+
+        evidence_json = json.dumps({"commits": [commit_ref], "prs": [pr_ref]})
+        sink.client.insert(
+            "work_unit_investments",
+            [
+                ["wu-org-a", older, newer, evidence_json, older, org_a],
+                ["wu-org-b", older, newer, evidence_json, older, org_b],
+            ],
+            column_names=_work_unit_investment_cols(),
+        )
+
+        emails_a = await _resolve_author_emails(sink, org_a)
+        emails_b = await _resolve_author_emails(sink, org_b)
+
+        assert emails_a == {"wu-org-a": {"alice@org-a.example"}}, (
+            "Org A's investment developer filter leaked Org B's author_email "
+            f"across the repo_id+hash/number collision: {emails_a!r}"
+        )
+        assert emails_b == {"wu-org-b": {"mallory@org-b.example"}}, (
+            "Org B's investment developer filter leaked Org A's author_email "
+            f"across the repo_id+hash/number collision: {emails_b!r}"
+        )
+    finally:
+        for table in ("git_commits", "git_pull_requests", "work_unit_investments"):
+            for org_id in (org_a, org_b):
+                sink.client.command(
+                    f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                    "SETTINGS mutations_sync=2",
+                    parameters={"o": org_id},
+                )


### PR DESCRIPTION
## Summary

Stacked on #1099 (CHAOS-2385) -- this diff will shrink to just the CHAOS-2492 commit once #1099 merges and this PR's base is retargeted to `main`.

`LATEST_WORK_UNIT_INVESTMENTS_CTE` structurally has no author/developer column -- `work_unit_investments` never carried one (see the sink write columns in `metrics/sinks/clickhouse/investment.py`). This left developer-filtered investment Sankey nodes/edges broken and forced Sankey coverage to `None` whenever `who.developers` or `scope.level=developer` was active (CHAOS-2488).

## Fix

Added a companion `LATEST_WORK_UNIT_AUTHORS_CTE` (`api/queries/investment.py`) that resolves the commit/PR node ids already recorded in each work unit's `structural_evidence_json` (canonical `"{repo_uuid}@{sha}"` / `"{repo_uuid}#pr{number}"` id formats from `work_graph/ids.py`) to the real `author_email` column on `git_commits` / `git_pull_requests` -- the same identity key chosen in CHAOS-2385 -- collapsing to a deduplicated array of contributor emails per work unit.

- `compiler.py`: `_get_context_params` chains the authors CTE + `LEFT JOIN work_unit_authors AS au` whenever the `AUTHOR` dimension or a developer filter (`who.developers` / `scope.level=developer`) is active, wired through all 5 `compile_*` entry points.
- `filter_translation.py`: the investment-path developer filter emits `hasAny(au.author_emails, ...)` instead of a flat `IN` clause (author_emails is an array -- a work unit can have multiple contributors), mirroring the existing `team` special-case. Non-investment queries still reject (per the base CHAOS-2385 commit) since only the investment path has the au join wired up.
- `analytics.py`: the Sankey coverage query no longer forces `coverage=None` for developer-filtered investment requests -- it chains the same `au` join and computes real coverage instead.

## Oracle review round 2 fixes

- **Table-awareness**: confirmed the non-investment path correctly rejects (inherited from #1099); the investment path now resolves via a real join rather than assuming a native column.
- **Real bug caught by EXPLAIN**: extending the project's EXPLAIN-based SQL-validation harness (`sql_explain_fixtures.py` + `test_resolver_sql_explain.py`) with a developer-filtered Sankey/breakdown fixture caught a **duplicate `LEFT JOIN repos` append** left over from an earlier edit -- would have produced invalid SQL for any investment query combining REPO with a developer filter. Fixed and now permanently regression-guarded (this is a real bug plain string-matching unit tests did not catch).
- **Test realism**: replaced placeholder `"dev-1"`/`"dev-2"` literals with real email-shaped values throughout.
- **Value-shape (C3)**: investigated whether `who.developers` is guaranteed to be a real email end-to-end -- it is not, for reasons pre-existing and orthogonal to this PR (free-form text input, cross-table `author_email` population divergence for issue-only contributors). Filed as a separate follow-up: CHAOS-2746. Not blocking here since a non-matching value degrades to an honest empty result (no fabricated data), consistent with the platform's rendering philosophy, and the common case (developers with git commit/PR history -- the population that matters for investment filtering) round-trips correctly.

## Testing

- `bash ci/local_validate.sh` -> `GATE PASSED`
- Validated the generated SQL against a live scratch ClickHouse instance via both a manual script and the project's `EXPLAIN`-based SQL-validation harness (`pytest tests/api/graphql/test_resolver_sql_explain.py -k analytics` against a live container with production DDL) -- `hasAny(au.author_emails, ...)` correctly resolves both commit-authored and PR-authored evidence, correctly excludes unrelated developers, and parses/binds against the real schema.
- New regression tests:
  - `tests/graphql/test_compiler.py`: `who.developers` and `scope.level=developer` on `compile_sankey`/`compile_breakdown` chain the author join and emit `hasAny(...)`; confirms the join is *not* added when no developer filter is active.
  - `tests/graphql/test_filters.py`: investment-path hasAny happy path + non-investment rejection, both with real email literals.
  - `tests/api/test_analytics_repo_filter_resolution.py`: replaced the old `test_sankey_coverage_unavailable_for_investment_developer_filter` (asserting the old `coverage=None` behavior) with tests asserting coverage IS now computed for both `who.developers` and `scope.level=developer`.

SCREENSHOT-WAIVER: backend-only change (SQL/GraphQL resolver), no rendered UI affected.