### PR TITLE
fix(graphql): sanitize AI risk hotspot averages (CHAOS-2747)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import strawberry
 
+from dev_health_ops.api.utils.numeric import safe_optional_float
 from dev_health_ops.metrics.ai_impact import (
     AI_BUCKETS as AI_ATTRIBUTION_BUCKETS,
 )
@@ -901,9 +902,7 @@ async def _load_overlap_rows(
                 prs_total=prs_total,
                 prs_touching_hotspots=touching,
                 hotspot_overlap_rate=_ratio(touching, prs_total),
-                avg_hotspot_risk_score=(
-                    float(avg_risk) if avg_risk is not None else None
-                ),
+                avg_hotspot_risk_score=safe_optional_float(avg_risk),
             )
         )
     hotspot_rows.sort(key=lambda r: r.bucket)

--- a/src/dev_health_ops/metrics/loaders/ai_impact.py
+++ b/src/dev_health_ops/metrics/loaders/ai_impact.py
@@ -602,7 +602,11 @@ class AIImpactClickHouseLoader:
             uniqExactIf(
                 (pf.repo_id, pf.number), h.file_path != ''
             ) AS prs_touching_hotspots,
-            avgIf(h.risk_score, h.file_path != '') AS avg_hotspot_risk_score
+            if(
+                isNaN(avgIf(h.risk_score, h.file_path != '')),
+                NULL,
+                avgIf(h.risk_score, h.file_path != '')
+            ) AS avg_hotspot_risk_score
         FROM pr_files AS pf
         LEFT JOIN hotspots AS h
             ON h.repo_id = pf.repo_id AND h.file_path = pf.file_path

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -46,6 +46,7 @@ from dev_health_ops.api.graphql.resolvers.ai import (
     resolve_ai_risk_breakdown,
     resolve_ai_workflow_drilldown,
 )
+from dev_health_ops.api.graphql.schema import schema
 from dev_health_ops.metrics.ai_impact import AttributionBucket
 from dev_health_ops.metrics.schemas import (
     AIImpactMetricsDailyRecord,
@@ -1109,6 +1110,100 @@ async def test_risk_breakdown_populated_overlaps_drop_missing_states():
     assert cx.complexity_overlap_rate == pytest.approx(0.2)
     # Real data present → missing states must be gone.
     assert {s.key for s in result.missing_states} == set()
+
+
+@pytest.mark.asyncio
+async def test_risk_breakdown_hotspot_nan_average_becomes_null():
+    hotspot_raw = [
+        {
+            "bucket": "agent_created",
+            "prs_total": 1,
+            "prs_touching_hotspots": 0,
+            "avg_hotspot_risk_score": float("nan"),
+        }
+    ]
+    complexity_raw = [
+        {
+            "bucket": "agent_created",
+            "prs_total": 1,
+            "prs_touching_high_complexity": 0,
+        }
+    ]
+    with (
+        _patch_loader(_populated_rows()),
+        _patch_hotspot_overlap(hotspot_raw),
+        _patch_complexity_overlap(complexity_raw),
+    ):
+        result = await resolve_ai_risk_breakdown(_ctx(), _range())
+
+    assert len(result.hotspot_overlap) == 1
+    hs = result.hotspot_overlap[0]
+    assert hs.bucket == "agent_created"
+    assert hs.prs_total == 1
+    assert hs.prs_touching_hotspots == 0
+    assert hs.hotspot_overlap_rate == pytest.approx(0.0)
+    assert hs.avg_hotspot_risk_score is None
+
+
+@pytest.mark.asyncio
+async def test_risk_breakdown_graphql_serializes_nan_average_as_null():
+    hotspot_raw = [
+        {
+            "bucket": "agent_created",
+            "prs_total": 1,
+            "prs_touching_hotspots": 0,
+            "avg_hotspot_risk_score": float("nan"),
+        }
+    ]
+    complexity_raw = [
+        {
+            "bucket": "agent_created",
+            "prs_total": 1,
+            "prs_touching_high_complexity": 0,
+        }
+    ]
+    query = """
+    query AIRiskBreakdown($orgId: String!, $dateRange: AIDateRangeInput!) {
+      aiRiskBreakdown(orgId: $orgId, dateRange: $dateRange) {
+        hotspotOverlap {
+          bucket
+          prsTotal
+          prsTouchingHotspots
+          hotspotOverlapRate
+          avgHotspotRiskScore
+        }
+      }
+    }
+    """
+    variables = {
+        "orgId": ORG_ID,
+        "dateRange": {
+            "startDate": DAY_START.isoformat(),
+            "endDate": DAY_END.isoformat(),
+        },
+    }
+    with (
+        _patch_loader(_populated_rows()),
+        _patch_hotspot_overlap(hotspot_raw),
+        _patch_complexity_overlap(complexity_raw),
+    ):
+        result = await schema.execute(
+            query,
+            variable_values=variables,
+            context_value=_ctx(),
+        )
+
+    assert result.errors is None
+    assert result.data is not None
+    assert result.data["aiRiskBreakdown"]["hotspotOverlap"] == [
+        {
+            "bucket": "agent_created",
+            "prsTotal": 1,
+            "prsTouchingHotspots": 0,
+            "hotspotOverlapRate": 0.0,
+            "avgHotspotRiskScore": None,
+        }
+    ]
 
 
 @pytest.mark.asyncio

--- a/tests/metrics/test_ai_impact_loader.py
+++ b/tests/metrics/test_ai_impact_loader.py
@@ -341,6 +341,8 @@ async def test_load_hotspot_overlap_uses_risk_score_convention():
     assert "work_graph_pr_commit" in query
     assert "git_commit_stats" in query
     assert "uniqExact((pf.repo_id, pf.number))" in query
+    assert "isNaN(avgIf(h.risk_score, h.file_path != ''))" in query
+    assert "NULL" in query
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Fixes CHAOS-2747 by preventing empty hotspot-overlap averages from surfacing as GraphQL `Float` NaN values.
- Converts ClickHouse `avgIf(...)` NaN results to `NULL` for buckets with assessable PRs but zero hotspot matches.
- Adds resolver-side `safe_optional_float` protection before exposing `avgHotspotRiskScore`.
- Adds resolver/schema execution regression coverage plus loader SQL guard coverage.

## Root cause
The 90-day AI risk window includes one `agent_created` PR that has assessable changed files but touches zero top-decile hotspot files. ClickHouse `avgIf(h.risk_score, h.file_path != '\)` averaged over an empty matched set and returned `NaN`; Strawberry rejected that for the nullable GraphQL Float. The 30-day window does not include that PR/bucket, so it stayed finite.\n\n## Verification\n- Red tests reproduced the resolver `nan` and Strawberry serialization error before the fix.\n- `pytest tests/api/graphql/test_ai_resolver.py -q`\n- `pytest tests/metrics/test_ai_impact_loader.py::test_load_hotspot_overlap_uses_risk_score_convention -q`\n- Manual ASGI GraphQL POST against the 90-day live data returned HTTP 200, no GraphQL errors, and `agent_created.avgHotspotRiskScore: null`.\n- `bash ci/local_validate.sh` passed: ruff format/check, mypy, full unit suite, scratch ClickHouse migration, and live argMax proof.\n\nSCREENSHOT-WAIVER: Backend GraphQL/API-only change; no rendered UI changed.\n