### PR TITLE
fix(api): resolve repo slug-or-UUID in repo-scoped GraphQL resolvers (CHAOS-2745)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/ai.py
+++ b/src/dev_health_ops/api/graphql/resolvers/ai.py
@@ -23,6 +23,7 @@ from typing import Any
 
 import strawberry
 
+from dev_health_ops.api.queries.client import query_dicts
 from dev_health_ops.api.utils.numeric import safe_optional_float
 from dev_health_ops.metrics.ai_impact import (
     AI_BUCKETS as AI_ATTRIBUTION_BUCKETS,
@@ -92,21 +93,58 @@ def _parse_uuid(value: str | None) -> uuid.UUID | None:
         return None
 
 
-def _normalize_scope(
+async def _resolve_repo_ref(
+    client: Any, org_id: str, raw_repo_id: str | None
+) -> uuid.UUID | None:
+    if not raw_repo_id:
+        return None
+    try:
+        return uuid.UUID(raw_repo_id)
+    except (TypeError, ValueError):
+        pass
+    rows = await query_dicts(
+        client,
+        """
+        SELECT id
+        FROM repos
+        WHERE org_id = {org_id:String}
+          AND repo = {slug:String}
+        ORDER BY toString(id)
+        """,
+        {"org_id": org_id, "slug": raw_repo_id},
+    )
+    if not rows:
+        return None
+    value = rows[0].get("id")
+    if isinstance(value, uuid.UUID):
+        return value
+    try:
+        return uuid.UUID(str(value))
+    except (TypeError, ValueError):
+        return None
+
+
+async def _normalize_scope(
+    context: GraphQLContext,
+    org_id: str,
     scope: AIScopeInput | None,
-) -> tuple[uuid.UUID | None, str | None, str | None]:
+) -> tuple[uuid.UUID | None, str | None, str | None, bool]:
     if scope is None:
-        return None, None, None
+        return None, None, None, False
+    repo_id = await _resolve_repo_ref(_require_client(context), org_id, scope.repo_id)
     return (
-        _parse_uuid(scope.repo_id),
+        repo_id,
         scope.team_id or None,
         scope.work_type or None,
+        bool(scope.repo_id) and repo_id is None,
     )
 
 
-def _normalize_attribution_scope(
+async def _normalize_attribution_scope(
+    context: GraphQLContext,
+    org_id: str,
     scope: AIAttributionScopeInput | None,
-) -> tuple[uuid.UUID | None, str | None, list[str] | None]:
+) -> tuple[uuid.UUID | None, str | None, list[str] | None, bool]:
     """Normalize the narrower attribution-overview scope (no ``work_type``).
 
     ``ai_attribution_resolved`` has no ``work_type`` column, so that
@@ -115,12 +153,35 @@ def _normalize_attribution_scope(
     maps 1:1 onto the resolved view's own ``kind`` column.
     """
     if scope is None:
-        return None, None, None
+        return None, None, None, False
     kinds = [bucket.value for bucket in scope.buckets] if scope.buckets else None
+    repo_id = await _resolve_repo_ref(_require_client(context), org_id, scope.repo_id)
     return (
-        _parse_uuid(scope.repo_id),
+        repo_id,
         scope.team_id or None,
         kinds,
+        bool(scope.repo_id) and repo_id is None,
+    )
+
+
+async def _normalize_opportunity_scope(
+    context: GraphQLContext, org_id: str, scope: AIScopeInput | None
+) -> tuple[AIScopeInput | None, bool]:
+    if scope is None or not scope.repo_id:
+        return scope, False
+    repo_id = await _resolve_repo_ref(_require_client(context), org_id, scope.repo_id)
+    if repo_id is None:
+        return None, True
+    if scope.repo_id == str(repo_id):
+        return scope, False
+    return (
+        AIScopeInput(
+            repo_id=str(repo_id),
+            team_id=scope.team_id,
+            work_type=scope.work_type,
+            buckets=scope.buckets,
+        ),
+        False,
     )
 
 
@@ -142,7 +203,11 @@ async def _load_daily_records(
     """Load daily AI impact records honoring the scope filter."""
 
     _validate_date_range(date_range)
-    repo_id, team_id, work_type = _normalize_scope(scope)
+    repo_id, team_id, work_type, repo_unresolved = await _normalize_scope(
+        context, org_id, scope
+    )
+    if repo_unresolved:
+        return []
     loader = AIImpactClickHouseLoader(_require_client(context), org_id=org_id)
     return await loader.load_ai_impact_metrics(
         start_day=date_range.start_date,
@@ -552,7 +617,13 @@ async def _load_reviewer_concentration(
     date_range: AIDateRangeInput,
     scope: AIScopeInput | None,
 ) -> AIReviewerConcentrationSummary:
-    repo_id, team_id, _work_type = _normalize_scope(scope)
+    repo_id, team_id, _work_type, repo_unresolved = await _normalize_scope(
+        context, org_id, scope
+    )
+    if repo_unresolved:
+        return AIReviewerConcentrationSummary(
+            data_available=False, reviewer_count=0, reviewer_gini=None
+        )
     loader = AIImpactClickHouseLoader(_require_client(context), org_id=org_id)
     reviewer_gini, reviewer_count = await loader.load_reviewer_concentration(
         start_day=date_range.start_date,
@@ -610,7 +681,11 @@ async def _load_engagement_slices(
     unavailable rather than silently mis-scoped. Team scopes are translated
     to repo ids first; an unresolvable team also yields unavailable.
     """
-    repo_id, team_id, work_type = _normalize_scope(scope)
+    repo_id, team_id, work_type, repo_unresolved = await _normalize_scope(
+        context, org_id, scope
+    )
+    if repo_unresolved:
+        return {}, {}
     if work_type:
         return {}, {}
 
@@ -861,7 +936,11 @@ async def _load_overlap_rows(
     A ``work_type`` scope cannot be applied to the raw-PR join, so overlap
     is reported unavailable for work-type-scoped requests.
     """
-    repo_id, team_id, work_type = _normalize_scope(scope)
+    repo_id, team_id, work_type, repo_unresolved = await _normalize_scope(
+        context, org_id, scope
+    )
+    if repo_unresolved:
+        return [], []
     if work_type:
         return [], []
 
@@ -957,8 +1036,17 @@ async def resolve_ai_opportunities(
 
     org_id = require_org_id(context)
     client = _require_client(context)
+    resolved_scope, repo_unresolved = await _normalize_opportunity_scope(
+        context, org_id, scope
+    )
+    if repo_unresolved:
+        return AIOpportunitiesResult(
+            org_id=org_id, recommendations=[], detector_ready=True
+        )
     detector = AIOpportunityDetector(client)
-    recommendations = await detector.detect(org_id=org_id, scope=scope, limit=limit)
+    recommendations = await detector.detect(
+        org_id=org_id, scope=resolved_scope, limit=limit
+    )
     # detector_ready signals that the detector is wired and ran successfully,
     # NOT that it found candidates.  An empty result is valid (no opportunities
     # right now); False would mislead the frontend into showing "not connected".
@@ -984,7 +1072,18 @@ async def resolve_ai_governance_summary(
 
     org_id = require_org_id(context)
     _validate_date_range(date_range)
-    repo_id, team_id, _work_type = _normalize_scope(scope)
+    repo_id, team_id, _work_type, repo_unresolved = await _normalize_scope(
+        context, org_id, scope
+    )
+    if repo_unresolved:
+        return AIGovernanceSummary(
+            org_id=org_id,
+            start_date=date_range.start_date,
+            end_date=date_range.end_date,
+            coverage=[],
+            recent_violations=[],
+            data_available=False,
+        )
     client = _require_client(context)
 
     loader = AIGovernanceLoader(client)
@@ -1250,7 +1349,19 @@ async def resolve_ai_attributed_prs(
 
     org_id = require_org_id(context)
     _validate_date_range(date_range)
-    repo_id, team_id, work_type = _normalize_scope(scope)
+    repo_id, team_id, work_type, repo_unresolved = await _normalize_scope(
+        context, org_id, scope
+    )
+    if repo_unresolved:
+        return AiAttributedPrsResult(
+            org_id=org_id,
+            start_date=date_range.start_date,
+            end_date=date_range.end_date,
+            rows=[],
+            total=0,
+            has_more=False,
+            data_available=False,
+        )
 
     page_size = max(1, min(int(limit), _MAX_AI_ATTRIBUTED_PRS_PAGE))
     page_offset = max(0, int(offset))
@@ -1368,7 +1479,20 @@ async def resolve_ai_attribution_overview(
 
     org_id = require_org_id(context)
     _validate_date_range(date_range)
-    repo_id, team_id, kinds = _normalize_attribution_scope(scope)
+    repo_id, team_id, kinds, repo_unresolved = await _normalize_attribution_scope(
+        context, org_id, scope
+    )
+    if repo_unresolved:
+        return AIAttributionOverviewResult(
+            org_id=org_id,
+            start_date=date_range.start_date,
+            end_date=date_range.end_date,
+            mix=[],
+            total_attributed=0,
+            rows=[],
+            has_more=False,
+            data_available=False,
+        )
 
     page_size = max(1, min(int(limit), _MAX_AI_ATTRIBUTION_EVIDENCE_PAGE))
     page_offset = max(0, int(offset))

--- a/src/dev_health_ops/api/graphql/resolvers/complexity.py
+++ b/src/dev_health_ops/api/graphql/resolvers/complexity.py
@@ -150,7 +150,13 @@ async def _fetch_repo_timeseries(
     }
     if repo_ids:
         bounded = list(repo_ids)[:limit]
-        query += "\n  AND toString(repo_id) IN {repo_ids:Array(String)}"
+        query += """
+          AND repo_id IN (
+              SELECT id FROM repos
+              WHERE org_id = {org_id:String}
+                AND (repo IN {repo_ids:Array(String)} OR toString(id) IN {repo_ids:Array(String)})
+          )
+        """
         params["repo_ids"] = bounded
     else:
         query += """
@@ -220,7 +226,13 @@ async def _fetch_file_timeseries(
     }
     if repo_ids:
         bounded = list(repo_ids)[:limit]
-        query += "\n  AND toString(repo_id) IN {repo_ids:Array(String)}"
+        query += """
+          AND repo_id IN (
+              SELECT id FROM repos
+              WHERE org_id = {org_id:String}
+                AND (repo IN {repo_ids:Array(String)} OR toString(id) IN {repo_ids:Array(String)})
+          )
+        """
         params["repo_ids"] = bounded
     query += f"\nGROUP BY day, repo_id, file_path\nORDER BY day, repo_id\nLIMIT {limit}"
     return await query_dicts(client, query, params)
@@ -258,7 +270,13 @@ async def _fetch_hotspot_rows(
     }
     if repo_ids:
         bounded = list(repo_ids)[:MAX_ROWS]
-        query += "\n  AND toString(repo_id) IN {repo_ids:Array(String)}"
+        query += """
+          AND repo_id IN (
+              SELECT id FROM repos
+              WHERE org_id = {org_id:String}
+                AND (repo IN {repo_ids:Array(String)} OR toString(id) IN {repo_ids:Array(String)})
+          )
+        """
         params["repo_ids"] = bounded
     query += (
         f"\nGROUP BY repo_id, file_path"

--- a/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
+++ b/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
@@ -128,8 +128,18 @@ async def _fetch_latest_rows(
     params: dict[str, Any] = {"org_id": org_id, "day": day, "scope": scope}
     if scope_ids:
         bounded = list(scope_ids)[:MAX_ROWS]
-        query += "\n  AND scope_id IN {scope_ids:Array(String)}"
-        params["scope_ids"] = bounded
+        if scope == "repo":
+            query += """
+          AND scope_id IN (
+              SELECT toString(id) FROM repos
+              WHERE org_id = {org_id:String}
+                AND (repo IN {repo_ids:Array(String)} OR toString(id) IN {repo_ids:Array(String)})
+          )
+        """
+            params["repo_ids"] = bounded
+        else:
+            query += "\n  AND scope_id IN {scope_ids:Array(String)}"
+            params["scope_ids"] = bounded
     query += f"\nGROUP BY scope_id\nORDER BY score DESC NULLS LAST\nLIMIT {MAX_ROWS}"
     return await query_dicts(client, query, params)
 
@@ -162,7 +172,12 @@ async def _fetch_repo_trend(
     }
     if repo_ids:
         bounded = list(repo_ids)[:MAX_ROWS]
-        query += "\n              AND scope_id IN {repo_ids:Array(String)}"
+        query += """
+              AND scope_id IN (
+                  SELECT toString(id) FROM repos
+                  WHERE org_id = {org_id:String}
+                    AND (repo IN {repo_ids:Array(String)} OR toString(id) IN {repo_ids:Array(String)})
+              )"""
         params["repo_ids"] = bounded
     query += """
             GROUP BY day, scope_id

--- a/src/dev_health_ops/api/graphql/resolvers/review_edges.py
+++ b/src/dev_health_ops/api/graphql/resolvers/review_edges.py
@@ -58,8 +58,9 @@ async def _fetch_review_edges(
     DESC`` (heaviest collaboration pairs first) and apply the row cap.
 
     An optional ``repo_ids`` filter narrows to specific repositories.
-    ``repo_id`` is stored as a UUID; we cast to String for safe comparison
-    with the input list and for the response payload.
+    ``repo_id`` is stored as a UUID; input repo refs may be UUID strings or
+    ``repos.repo`` slugs, so the predicate resolves them through the org-scoped
+    catalog before comparing UUID-to-UUID.
     """
     inner_where = """
             WHERE org_id = {org_id:String}
@@ -72,9 +73,12 @@ async def _fetch_review_edges(
         "until_date": until_date,
     }
     if repo_ids:
-        inner_where += (
-            "\n              AND toString(repo_id) IN {repo_ids:Array(String)}"
-        )
+        inner_where += """
+              AND repo_id IN (
+                  SELECT id FROM repos
+                  WHERE org_id = {org_id:String}
+                    AND (repo IN {repo_ids:Array(String)} OR toString(id) IN {repo_ids:Array(String)})
+              )"""
         params["repo_ids"] = list(repo_ids)
 
     query = f"""

--- a/tests/api/graphql/test_ai_resolver.py
+++ b/tests/api/graphql/test_ai_resolver.py
@@ -36,6 +36,7 @@ from dev_health_ops.api.graphql.models.ai import (
     AIWorkflowRootTypeInput,
 )
 from dev_health_ops.api.graphql.resolvers.ai import (
+    _resolve_repo_ref,
     resolve_ai_attributed_prs,
     resolve_ai_attribution_overview,
     resolve_ai_comparison,
@@ -240,6 +241,25 @@ async def test_impact_summary_empty_state_returns_stable_contract():
     assert result.by_bucket == []
     assert result.daily == []
     assert result.missing_states == []
+    assert result.data_available is False
+
+
+@pytest.mark.asyncio
+async def test_impact_summary_unresolved_repo_slug_returns_empty_without_loader():
+    scope = AIScopeInput(repo_id="full-chaos/missing-repo")
+    with (
+        _patch_loader([]) as mock_load,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_ref",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        result = await resolve_ai_impact_summary(_ctx(), _range(), scope)
+
+    mock_load.assert_not_awaited()
+    assert result.total_prs == 0
+    assert result.daily == []
     assert result.data_available is False
     assert result.computed_at is None
 
@@ -472,6 +492,53 @@ async def test_opportunities_delegates_scope_limit_and_returns_evidence():
     assert result.detector_ready is True
     assert result.recommendations == [opportunity]
     assert result.recommendations[0].evidence_refs
+
+
+@pytest.mark.asyncio
+async def test_opportunities_unresolved_repo_slug_returns_empty_without_detector():
+    detector_cls = MagicMock()
+    scope = AIScopeInput(repo_id="full-chaos/missing-repo")
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai.AIOpportunityDetector",
+            detector_cls,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_ref",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        result = await resolve_ai_opportunities(_ctx(), scope=scope)
+
+    detector_cls.assert_not_called()
+    assert result.recommendations == []
+    assert result.detector_ready is True
+
+
+@pytest.mark.asyncio
+async def test_opportunities_resolves_repo_slug_before_detector():
+    detector = MagicMock()
+    detector.detect = AsyncMock(return_value=[])
+    scope = AIScopeInput(repo_id="full-chaos/dev-health-ops", team_id=TEAM_ID)
+    with (
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai.AIOpportunityDetector",
+            return_value=detector,
+        ),
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_ref",
+            new_callable=AsyncMock,
+            return_value=REPO_ID,
+        ) as mock_resolve,
+    ):
+        await resolve_ai_opportunities(_ctx(), scope=scope, limit=7)
+
+    mock_resolve.assert_awaited_once()
+    call_scope = detector.detect.await_args.kwargs["scope"]
+    assert call_scope.repo_id == str(REPO_ID)
+    assert call_scope.team_id == TEAM_ID
+    assert detector.detect.await_args.kwargs["limit"] == 7
 
 
 # -----------------------------------------------------------------------------
@@ -724,6 +791,99 @@ async def test_ai_attributed_prs_passes_repo_scope_to_loader():
         await resolve_ai_attributed_prs(_ctx(), _range(), scope)
 
     assert mock_load.await_args.kwargs["repo_id"] == REPO_ID
+
+
+@pytest.mark.asyncio
+async def test_resolve_repo_ref_accepts_slug_from_filter_options():
+    ctx = _ctx()
+    slug = "full-chaos/dev-health-ops"
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.ai.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[{"id": str(REPO_ID)}],
+    ) as mock_query:
+        resolved = await _resolve_repo_ref(ctx.client, ORG_ID, slug)
+
+    assert resolved == REPO_ID
+    await_args = mock_query.await_args
+    assert await_args is not None
+    query = await_args.args[1]
+    params = await_args.args[2]
+    assert "SELECT id" in query
+    assert "FROM repos" in query
+    assert "org_id = {org_id:String}" in query
+    assert "repo = {slug:String}" in query
+    assert "ORDER BY toString(id)" in query
+    assert params == {"org_id": ORG_ID, "slug": slug}
+
+
+@pytest.mark.asyncio
+async def test_resolve_repo_ref_duplicate_slug_rows_use_query_order():
+    ctx = _ctx()
+    slug = "full-chaos/dev-health-ops"
+    other_repo_id = UUID("22222222-2222-2222-2222-222222222222")
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.ai.query_dicts",
+        new_callable=AsyncMock,
+        return_value=[{"id": str(REPO_ID)}, {"id": str(other_repo_id)}],
+    ) as mock_query:
+        resolved = await _resolve_repo_ref(ctx.client, ORG_ID, slug)
+
+    await_args = mock_query.await_args
+    assert await_args is not None
+    assert "ORDER BY toString(id)" in await_args.args[1]
+    assert resolved == REPO_ID
+
+
+@pytest.mark.asyncio
+async def test_resolve_repo_ref_uuid_bypasses_lookup():
+    ctx = _ctx()
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.ai.query_dicts", new_callable=AsyncMock
+    ) as mock_query:
+        resolved = await _resolve_repo_ref(ctx.client, ORG_ID, str(REPO_ID))
+
+    assert resolved == REPO_ID
+    mock_query.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_resolves_slug_scope_before_loader():
+    ctx = _ctx()
+    slug = "full-chaos/dev-health-ops"
+    scope = AIScopeInput(repo_id=slug)
+    with (
+        _patch_pr_loader([]) as mock_load,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_ref",
+            new_callable=AsyncMock,
+            return_value=REPO_ID,
+        ) as mock_resolve,
+    ):
+        await resolve_ai_attributed_prs(ctx, _range(), scope)
+
+    mock_resolve.assert_awaited_once_with(ctx.client, ORG_ID, slug)
+    assert mock_load.await_args.kwargs["repo_id"] == REPO_ID
+
+
+@pytest.mark.asyncio
+async def test_ai_attributed_prs_unresolved_repo_slug_returns_empty_without_loader():
+    scope = AIScopeInput(repo_id="full-chaos/missing-repo")
+    with (
+        _patch_pr_loader([]) as mock_load,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_ref",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        result = await resolve_ai_attributed_prs(_ctx(), _range(), scope)
+
+    mock_load.assert_not_awaited()
+    assert result.rows == []
+    assert result.total == 0
+    assert result.has_more is False
+    assert result.data_available is False
 
 
 @pytest.mark.asyncio
@@ -1534,6 +1694,50 @@ async def test_ai_attribution_overview_passes_repo_scope_to_loaders():
 
     assert mock_mix.await_args.kwargs["repo_id"] == REPO_ID
     assert mock_evidence.await_args.kwargs["repo_id"] == REPO_ID
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_resolves_slug_scope_before_loaders():
+    ctx = _ctx()
+    slug = "full-chaos/dev-health-ops"
+    scope = AIAttributionScopeInput(repo_id=slug)
+    with (
+        _patch_mix_loader([]) as mock_mix,
+        _patch_evidence_loader([]) as mock_evidence,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_ref",
+            new_callable=AsyncMock,
+            return_value=REPO_ID,
+        ) as mock_resolve,
+    ):
+        await resolve_ai_attribution_overview(ctx, _range(), scope)
+
+    mock_resolve.assert_awaited_once_with(ctx.client, ORG_ID, slug)
+    assert mock_mix.await_args.kwargs["repo_id"] == REPO_ID
+    assert mock_evidence.await_args.kwargs["repo_id"] == REPO_ID
+
+
+@pytest.mark.asyncio
+async def test_ai_attribution_overview_unresolved_repo_slug_returns_empty_without_loaders():
+    scope = AIAttributionScopeInput(repo_id="full-chaos/missing-repo")
+    with (
+        _patch_mix_loader([]) as mock_mix,
+        _patch_evidence_loader([]) as mock_evidence,
+        patch(
+            "dev_health_ops.api.graphql.resolvers.ai._resolve_repo_ref",
+            new_callable=AsyncMock,
+            return_value=None,
+        ),
+    ):
+        result = await resolve_ai_attribution_overview(_ctx(), _range(), scope)
+
+    mock_mix.assert_not_awaited()
+    mock_evidence.assert_not_awaited()
+    assert result.mix == []
+    assert result.total_attributed == 0
+    assert result.rows == []
+    assert result.has_more is False
+    assert result.data_available is False
 
 
 @pytest.mark.asyncio

--- a/tests/api/graphql/test_complexity_resolver.py
+++ b/tests/api/graphql/test_complexity_resolver.py
@@ -69,6 +69,14 @@ def _setup_client(client: Any, responses: list[Any]) -> None:
     client.query.side_effect = responses
 
 
+def _assert_repo_ids_slug_or_uuid_predicate(query: str) -> None:
+    assert "repo_id IN (" in query
+    assert "SELECT id FROM repos" in query
+    assert "org_id = {org_id:String}" in query
+    assert "repo IN {repo_ids:Array(String)}" in query
+    assert "toString(id) IN {repo_ids:Array(String)}" in query
+
+
 def _timeseries_input(
     *,
     scope: ComplexityScope = ComplexityScope.REPO,
@@ -490,6 +498,56 @@ async def test_timeseries_limit_selects_scopes_not_earliest_rows() -> None:
     assert "latest_complexity" in first_call_query
     assert "ORDER BY day, repo_id\nLIMIT" not in first_call_query
     assert first_call_params["limit"] == 10
+
+
+@pytest.mark.asyncio
+async def test_repo_ids_filter_resolves_slugs_or_uuids_at_all_user_filter_sites() -> (
+    None
+):
+    ctx = _ctx()
+
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], []), _qresult([], [])])
+
+    await resolve_complexity_timeseries(
+        ctx,
+        _timeseries_input(repo_ids=["3fa85f64-5717-4562-b3fc-2c963f66afa6"]),
+    )
+    await resolve_complexity_timeseries(
+        ctx,
+        _timeseries_input(
+            scope=ComplexityScope.FILE,
+            repo_ids=["3fa85f64-5717-4562-b3fc-2c963f66afa6"],
+        ),
+    )
+    await resolve_hotspots(
+        ctx, _hotspots_input(repo_ids=["3fa85f64-5717-4562-b3fc-2c963f66afa6"])
+    )
+
+    repo_query: str = ctx.client.query.call_args_list[0].args[0]
+    file_query: str = ctx.client.query.call_args_list[1].args[0]
+    hotspots_query: str = ctx.client.query.call_args_list[2].args[0]
+    _assert_repo_ids_slug_or_uuid_predicate(repo_query)
+    _assert_repo_ids_slug_or_uuid_predicate(file_query)
+    _assert_repo_ids_slug_or_uuid_predicate(hotspots_query)
+
+
+@pytest.mark.asyncio
+async def test_repo_ids_filter_accepts_slug_from_filter_options() -> None:
+    ctx = _ctx()
+    slug = "full-chaos/dev-health-ops"
+    _setup_client(ctx.client, [_qresult([], []), _qresult([], []), _qresult([], [])])
+
+    await resolve_complexity_timeseries(ctx, _timeseries_input(repo_ids=[slug]))
+    await resolve_complexity_timeseries(
+        ctx, _timeseries_input(scope=ComplexityScope.FILE, repo_ids=[slug])
+    )
+    await resolve_hotspots(ctx, _hotspots_input(repo_ids=[slug]))
+
+    for call in ctx.client.query.call_args_list:
+        query: str = call.args[0]
+        params: dict[str, Any] = call.kwargs["parameters"]
+        _assert_repo_ids_slug_or_uuid_predicate(query)
+        assert params["repo_ids"] == [slug]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/graphql/test_compounding_risk_resolver.py
+++ b/tests/api/graphql/test_compounding_risk_resolver.py
@@ -58,6 +58,14 @@ def _setup_client(client: Any, responses: list[Any]) -> None:
     client.query.side_effect = responses
 
 
+def _assert_scope_id_slug_or_uuid_predicate(query: str) -> None:
+    assert "scope_id IN (" in query
+    assert "SELECT toString(id) FROM repos" in query
+    assert "org_id = {org_id:String}" in query
+    assert "repo IN {repo_ids:Array(String)}" in query
+    assert "toString(id) IN {repo_ids:Array(String)}" in query
+
+
 # ---------------------------------------------------------------------------
 # Day resolution
 # ---------------------------------------------------------------------------
@@ -233,6 +241,56 @@ async def test_null_score_maps_to_unknown_severity() -> None:
     result = await resolve_compounding_risk(ctx, ORG_ID)
     assert result.rows[0].score is None
     assert result.rows[0].severity == CompoundingRiskSeverity.UNKNOWN
+
+
+@pytest.mark.asyncio
+async def test_repo_ids_filter_resolves_slugs_or_uuids_in_latest_and_trend_queries() -> (
+    None
+):
+    ctx = _ctx()
+    _setup_client(
+        ctx.client,
+        [
+            _qresult([], []),
+            _qresult([], []),
+        ],
+    )
+
+    await resolve_compounding_risk(
+        ctx,
+        ORG_ID,
+        CompoundingRiskFilterInput(
+            day=DAY, repo_ids=["3fa85f64-5717-4562-b3fc-2c963f66afa6"]
+        ),
+    )
+
+    latest_query: str = ctx.client.query.call_args_list[0].args[0]
+    trend_query: str = ctx.client.query.call_args_list[1].args[0]
+    _assert_scope_id_slug_or_uuid_predicate(latest_query)
+    _assert_scope_id_slug_or_uuid_predicate(trend_query)
+
+
+@pytest.mark.asyncio
+async def test_repo_ids_filter_accepts_slug_from_filter_options() -> None:
+    ctx = _ctx()
+    slug = "full-chaos/dev-health-ops"
+    _setup_client(
+        ctx.client,
+        [
+            _qresult([], []),
+            _qresult([], []),
+        ],
+    )
+
+    await resolve_compounding_risk(
+        ctx, ORG_ID, CompoundingRiskFilterInput(day=DAY, repo_ids=[slug])
+    )
+
+    for call in ctx.client.query.call_args_list:
+        query: str = call.args[0]
+        params: dict[str, Any] = call.kwargs["parameters"]
+        _assert_scope_id_slug_or_uuid_predicate(query)
+        assert params["repo_ids"] == [slug]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/graphql/test_review_edges_resolver.py
+++ b/tests/api/graphql/test_review_edges_resolver.py
@@ -184,6 +184,37 @@ async def test_review_edges_repo_ids_filter_appears_in_query() -> None:
 
 
 @pytest.mark.asyncio
+async def test_review_edges_repo_ids_filter_resolves_slugs_or_uuids() -> None:
+    ctx = _ctx()
+    ctx.client.query.return_value = _qresult([], [])
+
+    await resolve_review_edges(
+        ctx, _input(repo_ids=["3fa85f64-5717-4562-b3fc-2c963f66afa6"])
+    )
+
+    query: str = ctx.client.query.call_args.args[0]
+    assert "repo_id IN (" in query
+    assert "SELECT id FROM repos" in query
+    assert "org_id = {org_id:String}" in query
+    assert "repo IN {repo_ids:Array(String)}" in query
+    assert "toString(id) IN {repo_ids:Array(String)}" in query
+
+
+@pytest.mark.asyncio
+async def test_review_edges_repo_ids_filter_accepts_slug_from_filter_options() -> None:
+    ctx = _ctx()
+    slug = "full-chaos/dev-health-ops"
+    ctx.client.query.return_value = _qresult([], [])
+
+    await resolve_review_edges(ctx, _input(repo_ids=[slug]))
+
+    query: str = ctx.client.query.call_args.args[0]
+    params: dict[str, Any] = ctx.client.query.call_args.kwargs["parameters"]
+    assert "repo_id IN (" in query
+    assert params["repo_ids"] == [slug]
+
+
+@pytest.mark.asyncio
 async def test_review_edges_no_repo_ids_filter_absent_from_query() -> None:
     """When repo_ids is None, the IN filter must NOT appear in the SQL."""
     ctx = _ctx()


### PR DESCRIPTION
## CHAOS-2745 — repo-scoped resolvers now accept repo full_name slugs, not just UUIDs

Every repo-scoped GraphQL resolver filtered against `repo_id` (a UUID-typed ClickHouse column), but the always-visible web repo picker writes the repo **full_name slug** (e.g. `full-chaos/dev-health-ops`) from `/api/v1/filters/options` into `filters.what.repos`. Result: resolvers that compared the UUID column directly against the string raised `CANNOT_PARSE_UUID` (`Data unavailable` banner), and those that cast via `toString(...)` silently returned zero rows (repo filter = no-op).

This applies the org-scoped slug-or-UUID resolution already shipped in `resolvers/cognitive_load.py` (CHAOS-2386) to the remaining repo-scoped resolvers.

### Changes
| Resolver | Predicate |
|---|---|
| `resolvers/complexity.py` (repo/file/hotspot) | `repo_id IN (SELECT id FROM repos WHERE org_id=… AND (repo IN {repo_ids} OR toString(id) IN {repo_ids}))` — UUID-to-UUID |
| `resolvers/review_edges.py` | same array subquery |
| `resolvers/compounding_risk.py` (latest + trend) | `scope_id IN (SELECT toString(id) FROM repos …)` — `scope_id` is a String holding the repo UUID; repo-scope gated, team scope untouched |
| `resolvers/ai.py` (scalar `repo_id`, all entry points + opportunities) | async `_resolve_repo_ref` — UUID fast-path (no DB); slug → org-scoped `repos` lookup |

`_load_repo_labels` UUID→name helpers are unchanged. `/api/v1/filters/options` and the web layer are unchanged (this is the per-resolver option, not the root-cause `{id,label}` change).

### Correctness (Oracle-reviewed)
- **ai.py no-match semantics:** a requested-but-unresolvable slug now returns an empty / `data_available=False` result instead of leaking **org-wide** data (matching cognitive_load's no-match behavior), via a `repo_unresolved` signal that early-returns at every entry point.
- **`resolve_ai_opportunities`:** resolves the slug before invoking `AIOpportunityDetector` (previously the detector re-parsed the raw slug → `None` → dropped filter).
- **Duplicate slugs:** `repos.repo` is not unique per org (`ReplacingMergeTree ORDER BY id`; `org_id` not in the sorting key), so the ai.py lookup uses deterministic ordering. **Known limitation:** the scalar ai loaders filter to the first match while the array resolvers match all; full multi-UUID scalar filtering would need a loader refactor and is out of scope here.

### Tests / validation
- Slug-acceptance + predicate-shape tests added for all four resolvers; ai.py no-match + opportunity-resolution + duplicate-slug ordering tests added.
- Local gate green: `ruff format --check` + `ruff check` + `mypy` + FULL unit suite (`6146 passed, 44 skipped`) + live-ClickHouse argMax proof.

Closes CHAOS-2745.

SCREENSHOT-WAIVER: backend-only GraphQL resolver SQL change, no rendered UI surface.
