### PR TITLE
fix(investment): allocate work-unit effort per repo for Sankey/chord repo mapping

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -12,6 +12,7 @@ from uuid import UUID
 from dev_health_ops.api.queries.investment import (
     LATEST_WORK_UNIT_AUTHORS_CTE,
     LATEST_WORK_UNIT_INVESTMENTS_CTE,
+    LATEST_WORK_UNIT_REPO_EFFORT_CTE,
     fetch_investment_quality_stats,
 )
 
@@ -697,24 +698,40 @@ async def resolve_analytics(
                             )
                             GROUP BY work_unit_id
                         ) AS ut ON ut.work_unit_id = work_unit_investments.work_unit_id
-                        LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
+                        LEFT JOIN latest_work_unit_repo_effort AS wure
+                            ON wure.org_id = work_unit_investments.org_id
+                            AND wure.work_unit_id = work_unit_investments.work_unit_id
+                        LEFT JOIN repos AS r ON toString(r.id) = toString(wure.repo_id)
                         """
 
                 assigned_team_expr = f"lower(ifNull(nullIf({team_col}, ''), 'unassigned')) != 'unassigned'"
                 assigned_repo_expr = f"{repo_col} IS NOT NULL"
                 total_expr = "count()"
+                repo_total_expr = total_expr
                 assigned_team_count_expr = f"countIf({assigned_team_expr})"
                 assigned_repo_count_expr = f"countIf({assigned_repo_expr})"
                 if request.use_investment:
-                    assigned_repo_expr = f"lower({repo_col}) != 'unassigned'"
-                    total_expr = "uniqExact(work_unit_investments.work_unit_id)"
+                    # Effort-weighted, allocation-aware coverage so the numbers
+                    # match the effort-weighted Sankey flows (team coverage was
+                    # previously count-based and disagreed with the visual).
+                    # LEFT JOIN fallback: a work unit with no repo-effort
+                    # allocation row falls back to its scalar repo_id + full
+                    # effort, so it is never silently dropped.
+                    repo_effort_col = (
+                        "if(wure.work_unit_id != '', wure.repo_effort_value, "
+                        "work_unit_investments.effort_value)"
+                    )
+                    repo_assigned_col = (
+                        "if(wure.work_unit_id != '', wure.repo_id, "
+                        "work_unit_investments.repo_id)"
+                    )
+                    total_expr = f"sum({repo_effort_col})"
+                    repo_total_expr = total_expr
                     assigned_team_count_expr = (
-                        "uniqExactIf(work_unit_investments.work_unit_id, "
-                        f"{assigned_team_expr})"
+                        f"sumIf({repo_effort_col}, {assigned_team_expr})"
                     )
                     assigned_repo_count_expr = (
-                        "uniqExactIf(work_unit_investments.work_unit_id, "
-                        f"{assigned_repo_expr})"
+                        f"sumIf({repo_effort_col}, {repo_assigned_col} IS NOT NULL)"
                     )
 
                 has_author_filter = (
@@ -725,11 +742,13 @@ async def resolve_analytics(
                     (
                         f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}, {LATEST_WORK_UNIT_AUTHORS_CTE}"
                         if has_author_filter
-                        else f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}"
+                        else f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}, {LATEST_WORK_UNIT_REPO_EFFORT_CTE}"
                     )
                     if request.use_investment
                     else ""
                 )
+                if request.use_investment and has_author_filter:
+                    with_clause = f"WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}, {LATEST_WORK_UNIT_REPO_EFFORT_CTE}, {LATEST_WORK_UNIT_AUTHORS_CTE}"
                 source_alias = (
                     "work_unit_investments" if request.use_investment else table
                 )
@@ -762,9 +781,7 @@ async def resolve_analytics(
                     resolved_filters,
                     use_investment=bool(request.use_investment),
                     team_column=team_col,
-                    repo_column="work_unit_investments.repo_id"
-                    if request.use_investment
-                    else repo_col,
+                    repo_column="wure.repo_id" if request.use_investment else repo_col,
                     author_column="author_email",
                 )
 
@@ -773,6 +790,7 @@ async def resolve_analytics(
                     SELECT
                         {total_expr} as total,
                         {assigned_team_count_expr} as assigned_team,
+                        {repo_total_expr} as repo_total,
                         {assigned_repo_count_expr} as assigned_repo
                     FROM {base_table}
                     {joins}
@@ -793,11 +811,14 @@ async def resolve_analytics(
                     if c_rows:
                         total = float(c_rows[0].get("total", 0))
                         assigned_team = float(c_rows[0].get("assigned_team", 0))
+                        repo_total = float(c_rows[0].get("repo_total", 0))
                         assigned_repo = float(c_rows[0].get("assigned_repo", 0))
 
                         coverage = SankeyCoverage(
                             team_coverage=assigned_team / total if total > 0 else 0,
-                            repo_coverage=assigned_repo / total if total > 0 else 0,
+                            repo_coverage=assigned_repo / repo_total
+                            if repo_total > 0
+                            else 0,
                         )
                 except Exception as e:
                     logger.error("Coverage query failed: %s", e)

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from dev_health_ops.api.queries.investment import (
     LATEST_WORK_UNIT_AUTHORS_CTE,
     LATEST_WORK_UNIT_INVESTMENTS_CTE,
+    LATEST_WORK_UNIT_REPO_EFFORT_CTE,
 )
 
 from ..authz import enforce_org_scope
@@ -153,6 +154,38 @@ def _get_context_params(
 
     if use_investment:
         joins = []
+        use_repo_allocation = Dimension.REPO in dimensions
+        source_table = "latest_work_unit_investments AS work_unit_investments"
+        if use_repo_allocation:
+            source_table = """
+            (
+                SELECT
+                    wui.work_unit_id AS work_unit_id,
+                    wui.work_unit_type AS work_unit_type,
+                    wui.work_unit_name AS work_unit_name,
+                    wui.from_ts AS from_ts,
+                    wui.to_ts AS to_ts,
+                    if(wure.work_unit_id != '', wure.repo_id, wui.repo_id) AS repo_id,
+                    wui.provider AS provider,
+                    if(wure.work_unit_id != '', wure.effort_metric, wui.effort_metric) AS effort_metric,
+                    if(wure.work_unit_id != '', wure.repo_effort_value, wui.effort_value) AS effort_value,
+                    if(wure.work_unit_id != '', wure.allocation_source, 'scalar_fallback') AS allocation_source,
+                    if(wure.work_unit_id != '', if(wui.effort_value > 0, wure.repo_effort_value / wui.effort_value, 0.0), 1.0) AS allocation_weight,
+                    wui.theme_distribution_json AS theme_distribution_json,
+                    wui.subcategory_distribution_json AS subcategory_distribution_json,
+                    wui.structural_evidence_json AS structural_evidence_json,
+                    wui.evidence_quality AS evidence_quality,
+                    wui.evidence_quality_band AS evidence_quality_band,
+                    wui.categorization_status AS categorization_status,
+                    wui.categorization_model_version AS categorization_model_version,
+                    wui.categorization_run_id AS categorization_run_id,
+                    wui.org_id AS org_id
+                FROM latest_work_unit_investments AS wui
+                LEFT JOIN latest_work_unit_repo_effort AS wure
+                    ON wure.org_id = wui.org_id
+                    AND wure.work_unit_id = wui.work_unit_id
+            ) AS work_unit_investments
+            """
         # ALWAYS join subcategory distribution for investment queries
         joins.append(
             "ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv"
@@ -202,6 +235,8 @@ def _get_context_params(
         # it. Chains LATEST_WORK_UNIT_AUTHORS_CTE onto the WITH clause -- only
         # when actually needed, to avoid the extra join cost otherwise.
         with_parts = [LATEST_WORK_UNIT_INVESTMENTS_CTE]
+        if use_repo_allocation:
+            with_parts.append(LATEST_WORK_UNIT_REPO_EFFORT_CTE)
         if Dimension.AUTHOR in dimensions or needs_author_join:
             with_parts.append(LATEST_WORK_UNIT_AUTHORS_CTE)
             joins.append(
@@ -209,11 +244,12 @@ def _get_context_params(
             )
 
         return {
-            "source_table": "latest_work_unit_investments AS work_unit_investments",
+            "source_table": source_table,
             "date_filter": "work_unit_investments.from_ts < %(end_date)s AND work_unit_investments.to_ts >= %(start_date)s",
             "extra_clauses": "\n".join(joins),
             "with_clause": f"WITH {', '.join(with_parts)}",
             "use_investment": True,
+            "use_repo_allocation": use_repo_allocation,
         }
 
     return {
@@ -222,6 +258,7 @@ def _get_context_params(
         "extra_clauses": "",
         "with_clause": "",
         "use_investment": False,
+        "use_repo_allocation": False,
     }
 
 

--- a/src/dev_health_ops/api/graphql/sql/templates.py
+++ b/src/dev_health_ops/api/graphql/sql/templates.py
@@ -20,12 +20,17 @@ def timeseries_template(
     extra_clauses: str = "",
     with_clause: str = "",
     use_investment: bool = False,
+    use_repo_allocation: bool = False,
     filter_clause: str = "",  # NEW: scope/category filters
 ) -> str:
     """Generate SQL template for timeseries query."""
     dim_col = Dimension.db_column(dimension, use_investment=use_investment)
-    measure_expr = Measure.db_expression(measure, use_investment=use_investment)
-    source_alias = source_table.split(" AS ")[-1]
+    measure_expr = Measure.db_expression(
+        measure,
+        use_investment=use_investment,
+        use_repo_allocation=use_repo_allocation,
+    )
+    source_alias = source_table.split(" AS ")[-1].strip()
     trunc_unit = BucketInterval.date_trunc_unit(interval)
 
     # Extract date column from filter for truncating
@@ -56,12 +61,17 @@ def breakdown_template(
     extra_clauses: str = "",
     with_clause: str = "",
     use_investment: bool = False,
+    use_repo_allocation: bool = False,
     filter_clause: str = "",  # NEW: scope/category filters
 ) -> str:
     """Generate SQL template for breakdown (top-N aggregation) query."""
     dim_col = Dimension.db_column(dimension, use_investment=use_investment)
-    measure_expr = Measure.db_expression(measure, use_investment=use_investment)
-    source_alias = source_table.split(" AS ")[-1]
+    measure_expr = Measure.db_expression(
+        measure,
+        use_investment=use_investment,
+        use_repo_allocation=use_repo_allocation,
+    )
+    source_alias = source_table.split(" AS ")[-1].strip()
 
     return f"""
 {with_clause}
@@ -88,11 +98,16 @@ def sankey_nodes_template(
     extra_clauses: str = "",
     with_clause: str = "",
     use_investment: bool = False,
+    use_repo_allocation: bool = False,
     filter_clause: str = "",  # NEW: scope/category filters
 ) -> str:
     """Generate SQL template for Sankey nodes query."""
-    measure_expr = Measure.db_expression(measure, use_investment=use_investment)
-    source_alias = source_table.split(" AS ")[-1]
+    measure_expr = Measure.db_expression(
+        measure,
+        use_investment=use_investment,
+        use_repo_allocation=use_repo_allocation,
+    )
+    source_alias = source_table.split(" AS ")[-1].strip()
 
     union_parts = []
     for dim in dimensions:
@@ -130,13 +145,18 @@ def sankey_edges_template(
     extra_clauses: str = "",
     with_clause: str = "",
     use_investment: bool = False,
+    use_repo_allocation: bool = False,
     filter_clause: str = "",  # NEW: scope/category filters
 ) -> str:
     """Generate SQL template for Sankey edges query."""
     source_col = Dimension.db_column(source_dim, use_investment=use_investment)
     target_col = Dimension.db_column(target_dim, use_investment=use_investment)
-    measure_expr = Measure.db_expression(measure, use_investment=use_investment)
-    source_alias = source_table.split(" AS ")[-1]
+    measure_expr = Measure.db_expression(
+        measure,
+        use_investment=use_investment,
+        use_repo_allocation=use_repo_allocation,
+    )
+    source_alias = source_table.split(" AS ")[-1].strip()
 
     return f"""
 {with_clause}
@@ -391,7 +411,7 @@ def catalog_values_template(
 ) -> str:
     """Generate SQL template for fetching distinct dimension values."""
     dim_col = Dimension.db_column(dimension, use_investment=use_investment)
-    source_alias = source_table.split(" AS ")[-1]
+    source_alias = source_table.split(" AS ")[-1].strip()
 
     return f"""
 {with_clause}

--- a/src/dev_health_ops/api/graphql/sql/validate.py
+++ b/src/dev_health_ops/api/graphql/sql/validate.py
@@ -48,7 +48,12 @@ class Dimension(str, Enum):
         if use_investment:
             mapping = {
                 cls.TEAM: "ifNull(nullIf(ut.team_label, ''), 'unassigned')",
-                cls.REPO: "ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id)))",
+                # Unassigned repo emits '' (NOT the bare 'unassigned'): the web
+                # adapter renders an empty repo label as a distinct "Unassigned
+                # repo" node. Emitting 'unassigned' collides with the TEAM
+                # unassigned label at the ECharts node-name level and folds
+                # TEAM->THEME->REPO into a cycle ("Sankey is a DAG" error).
+                cls.REPO: "ifNull(nullIf(r.repo, ''), if(repo_id IS NULL, '', toString(repo_id)))",
                 cls.WORK_TYPE: "work_unit_type",
                 cls.THEME: "splitByChar('.', subcategory_kv.1)[1]",
                 cls.SUBCATEGORY: "subcategory_kv.1",
@@ -94,20 +99,26 @@ class Measure(str, Enum):
         return [m.value for m in cls]
 
     @classmethod
-    def db_expression(cls, measure: Measure, use_investment: bool = False) -> str:
+    def db_expression(
+        cls,
+        measure: Measure,
+        use_investment: bool = False,
+        use_repo_allocation: bool = False,
+    ) -> str:
         if use_investment:
+            throughput_expr = "SUM(subcategory_kv.2)"
+            cycle_time_expr = "AVG(dateDiff('hour', from_ts, to_ts))"
+            if use_repo_allocation:
+                throughput_expr = "SUM(subcategory_kv.2 * allocation_weight)"
+                cycle_time_expr = "SUM(dateDiff('hour', from_ts, to_ts) * allocation_weight) / NULLIF(SUM(allocation_weight), 0)"
             mapping: dict[Measure, str] = {
                 cls.COUNT: "SUM(subcategory_kv.2 * effort_value)",
-                # THROUGHPUT: each work unit's subcategory probabilities sum to
-                # ~1.0, so summing them gives the weighted count of work units.
-                cls.THROUGHPUT: "SUM(subcategory_kv.2)",
+                cls.THROUGHPUT: throughput_expr,
                 # CHURN_LOC: effort_value stores the actual churn LOC for work
                 # units whose effort_metric = 'churn_loc'; weight by subcategory
                 # probability to apportion across the ARRAY JOIN fan-out.
                 cls.CHURN_LOC: "SUM(if(effort_metric = 'churn_loc', subcategory_kv.2 * effort_value, 0))",
-                # CYCLE_TIME_HOURS: derived from the stored timestamps (from_ts,
-                # to_ts) as the per-work-unit cycle duration in hours.
-                cls.CYCLE_TIME_HOURS: "AVG(dateDiff('hour', from_ts, to_ts))",
+                cls.CYCLE_TIME_HOURS: cycle_time_expr,
             }
         else:
             mapping = {

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -51,6 +51,23 @@ LATEST_WORK_UNIT_INVESTMENTS_CTE = """
 """.rstrip()
 
 
+LATEST_WORK_UNIT_REPO_EFFORT_CTE = """
+        latest_work_unit_repo_effort AS (
+            SELECT
+                work_unit_id,
+                repo_id,
+                argMax(effort_metric, computed_at) AS effort_metric,
+                argMax(effort_value, computed_at) AS repo_effort_value,
+                argMax(allocation_source, computed_at) AS allocation_source,
+                org_id,
+                max(computed_at) AS latest_repo_effort_computed_at
+            FROM work_unit_repo_effort
+            WHERE org_id = %(org_id)s
+            GROUP BY org_id, work_unit_id, repo_id
+        )
+""".rstrip()
+
+
 # CHAOS-2492: work_unit_investments carries NO author/developer column at all
 # (see the WorkUnitInvestmentRecord write columns in metrics/sinks/clickhouse/
 # investment.py) -- the closest thing to a developer identity is the set of

--- a/src/dev_health_ops/metrics/schemas.py
+++ b/src/dev_health_ops/metrics/schemas.py
@@ -879,6 +879,19 @@ class WorkUnitInvestmentRecord:
 
 
 @dataclass(frozen=True)
+class WorkUnitRepoEffortRecord:
+    work_unit_id: str
+    repo_id: uuid.UUID | None
+    effort_metric: str
+    effort_value: float
+    allocation_weight: float
+    allocation_source: str
+    categorization_run_id: str
+    computed_at: datetime
+    org_id: str = ""
+
+
+@dataclass(frozen=True)
 class WorkUnitMembershipRecord:
     """One row per (node, category) — reverse index for theme/subcategory filtering.
 

--- a/src/dev_health_ops/metrics/sinks/base.py
+++ b/src/dev_health_ops/metrics/sinks/base.py
@@ -56,6 +56,7 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentRecord,
     WorkUnitMembershipRecord,
     WorkUnitMembershipRunRecord,
+    WorkUnitRepoEffortRecord,
     WorkUnitScopedMembershipRunRecord,
 )
 from dev_health_ops.metrics.testops_schemas import (
@@ -371,6 +372,12 @@ class BaseMetricsSink(ABC):
         self, rows: Sequence[WorkUnitInvestmentRecord]
     ) -> None:
         """Write work unit-level investment materializations."""
+        pass
+
+    def write_work_unit_repo_effort(
+        self, rows: Sequence[WorkUnitRepoEffortRecord]
+    ) -> None:
+        """Write per-repository work unit effort allocation rows."""
         pass
 
     @abstractmethod

--- a/src/dev_health_ops/metrics/sinks/clickhouse/investment.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/investment.py
@@ -22,6 +22,7 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentRecord,
     WorkUnitMembershipRecord,
     WorkUnitMembershipRunRecord,
+    WorkUnitRepoEffortRecord,
     WorkUnitScopedMembershipRunRecord,
 )
 
@@ -139,6 +140,27 @@ class InvestmentMixin(_ClickHouseSinkBase):
                 "categorization_errors_json",
                 "categorization_model_version",
                 "categorization_input_hash",
+                "categorization_run_id",
+                "computed_at",
+                "org_id",
+            ],
+            rows,
+        )
+
+    def write_work_unit_repo_effort(
+        self, rows: Sequence[WorkUnitRepoEffortRecord]
+    ) -> None:
+        if not rows:
+            return
+        self._insert_rows(
+            "work_unit_repo_effort",
+            [
+                "work_unit_id",
+                "repo_id",
+                "effort_metric",
+                "effort_value",
+                "allocation_weight",
+                "allocation_source",
                 "categorization_run_id",
                 "computed_at",
                 "org_id",

--- a/src/dev_health_ops/migrations/clickhouse/064_work_unit_repo_effort.sql
+++ b/src/dev_health_ops/migrations/clickhouse/064_work_unit_repo_effort.sql
@@ -1,0 +1,14 @@
+CREATE TABLE IF NOT EXISTS work_unit_repo_effort (
+    work_unit_id String,
+    repo_id Nullable(UUID),
+    effort_metric String,
+    effort_value Float64,
+    allocation_weight Float64,
+    allocation_source String,
+    categorization_run_id String,
+    computed_at DateTime64(3, 'UTC'),
+    org_id String DEFAULT ''
+) ENGINE = ReplacingMergeTree(computed_at)
+PARTITION BY toYYYYMM(computed_at)
+ORDER BY (org_id, work_unit_id, ifNull(toString(repo_id), ''))
+SETTINGS index_granularity = 8192;

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -41,6 +41,7 @@ from dev_health_ops.metrics.llm_token_usage import write_llm_token_usage
 from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
+    WorkUnitRepoEffortRecord,
 )
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 from dev_health_ops.metrics.sinks.factory import create_sink
@@ -909,6 +910,67 @@ def _effort_from_work_unit(
     return "churn_loc", 0.0
 
 
+def _allocate_repo_effort(
+    *,
+    issue_ids: Iterable[str],
+    pr_ids: Iterable[str],
+    commit_ids: Iterable[str],
+    pr_churn: dict[str, float],
+    commit_churn: dict[str, float],
+    active_hours: dict[str, float],
+    effort_metric: str,
+    effort_value: float,
+) -> list[tuple[uuid.UUID | None, float, float, str]]:
+    commit_effort_by_repo: dict[str, float] = {}
+    commit_total = 0.0
+    for commit_id in commit_ids:
+        churn = float(commit_churn.get(commit_id, 0.0))
+        commit_total += churn
+        if churn <= 0:
+            continue
+        repo_id, _ = parse_commit_from_id(commit_id)
+        repo_key = str(repo_id) if repo_id else ""
+        commit_effort_by_repo[repo_key] = (
+            commit_effort_by_repo.get(repo_key, 0.0) + churn
+        )
+    if commit_total > 0:
+        return [
+            (
+                _parse_repo_id(repo_key or None),
+                repo_effort,
+                repo_effort / commit_total,
+                "commit_churn",
+            )
+            for repo_key, repo_effort in sorted(commit_effort_by_repo.items())
+        ]
+
+    pr_effort_by_repo: dict[str, float] = {}
+    pr_total = 0.0
+    for pr_id in pr_ids:
+        churn = float(pr_churn.get(pr_id, 0.0))
+        pr_total += churn
+        if churn <= 0:
+            continue
+        repo_id, _ = parse_pr_from_id(pr_id)
+        repo_key = str(repo_id) if repo_id else ""
+        pr_effort_by_repo[repo_key] = pr_effort_by_repo.get(repo_key, 0.0) + churn
+    if pr_total > 0:
+        return [
+            (
+                _parse_repo_id(repo_key or None),
+                repo_effort,
+                repo_effort / pr_total,
+                "pr_churn",
+            )
+            for repo_key, repo_effort in sorted(pr_effort_by_repo.items())
+        ]
+
+    if effort_metric == "active_hours" and effort_value > 0:
+        return [(None, effort_value, 1.0, "active_hours_unassigned")]
+
+    return [(None, 0.0, 0.0, "empty")]
+
+
 def _collect_repo_ids(edges: list[dict[str, object]]) -> list[str]:
     repo_ids = {str(edge.get("repo_id") or "") for edge in edges if edge.get("repo_id")}
     return sorted(repo_id for repo_id in repo_ids if repo_id)
@@ -1117,6 +1179,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         )
 
         records: list[WorkUnitInvestmentRecord] = []
+        repo_effort_records: list[WorkUnitRepoEffortRecord] = []
         quote_records: list[WorkUnitInvestmentEvidenceQuoteRecord] = []
         run_id = config.run_id or uuid.uuid4().hex
         computed_at = config.computed_at or datetime.now(timezone.utc)
@@ -1431,6 +1494,47 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         # Post-process: create records from outcomes
         for idx, data in preprocessed.items():
             if idx in skipped_existing:
+                # Categorization is unchanged, so skip re-writing the LLM
+                # investment record -- but repo-effort allocation is derived
+                # from structural churn (no LLM), so it MUST still be written
+                # here or unchanged units would never get repo-allocation rows,
+                # leaving the investment repo Sankey empty in steady state.
+                skipped_metric, skipped_value = _effort_from_work_unit(
+                    issue_ids=data.issue_node_ids,
+                    pr_ids=data.pr_node_ids,
+                    commit_ids=data.commit_node_ids,
+                    pr_churn=pr_churn,
+                    commit_churn=commit_churn,
+                    active_hours=active_hours,
+                )
+                repo_effort_records.extend(
+                    WorkUnitRepoEffortRecord(
+                        work_unit_id=data.unit_id,
+                        repo_id=allocated_repo_id,
+                        effort_metric=skipped_metric,
+                        effort_value=allocated_effort_value,
+                        allocation_weight=allocation_weight,
+                        allocation_source=allocation_source,
+                        categorization_run_id=run_id,
+                        computed_at=computed_at,
+                        org_id=config.org_id or "",
+                    )
+                    for (
+                        allocated_repo_id,
+                        allocated_effort_value,
+                        allocation_weight,
+                        allocation_source,
+                    ) in _allocate_repo_effort(
+                        issue_ids=data.issue_node_ids,
+                        pr_ids=data.pr_node_ids,
+                        commit_ids=data.commit_node_ids,
+                        pr_churn=pr_churn,
+                        commit_churn=commit_churn,
+                        active_hours=active_hours,
+                        effort_metric=skipped_metric,
+                        effort_value=skipped_value,
+                    )
+                )
                 continue
             outcome = llm_results.get(idx)
             if outcome is None:
@@ -1518,6 +1622,34 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
                     org_id=config.org_id or "",
                 )
             )
+            repo_effort_records.extend(
+                WorkUnitRepoEffortRecord(
+                    work_unit_id=unit_id,
+                    repo_id=allocated_repo_id,
+                    effort_metric=effort_metric,
+                    effort_value=allocated_effort_value,
+                    allocation_weight=allocation_weight,
+                    allocation_source=allocation_source,
+                    categorization_run_id=run_id,
+                    computed_at=computed_at,
+                    org_id=config.org_id or "",
+                )
+                for (
+                    allocated_repo_id,
+                    allocated_effort_value,
+                    allocation_weight,
+                    allocation_source,
+                ) in _allocate_repo_effort(
+                    issue_ids=issue_node_ids,
+                    pr_ids=pr_node_ids,
+                    commit_ids=commit_node_ids,
+                    pr_churn=pr_churn,
+                    commit_churn=commit_churn,
+                    active_hours=active_hours,
+                    effort_metric=effort_metric,
+                    effort_value=effort_value,
+                )
+            )
 
             # NOTE (CHAOS-2433 round-3 finding #2): the materializer NO LONGER
             # writes work_unit_membership rows or completion markers.  It only
@@ -1552,6 +1684,8 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         logger.info("Finished component loop, writing %d records to sink", len(records))
         if records:
             sink.write_work_unit_investments(records)
+        if repo_effort_records:
+            sink.write_work_unit_repo_effort(repo_effort_records)
         if quote_records:
             sink.write_work_unit_investment_quotes(quote_records)
         # CHAOS-2433 round-3 finding #2: membership rows + completion markers are
@@ -1567,6 +1701,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             "components": len(components),
             "total_components": total_components,
             "records": len(records),
+            "repo_effort_records": len(repo_effort_records),
             "quotes": len(quote_records),
             "skipped_existing": len(skipped_existing),
             "llm_calls": llm_calls,

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -264,6 +264,44 @@ class TestCompileSankey:
             assert "source" in edge_sql.lower() or "target" in edge_sql.lower()
             assert edge_params["org_id"] == org_id
 
+    def test_investment_sankey_repo_path_uses_allocation(self):
+        """Multi-repo fan-out: a TEAM->THEME->REPO investment Sankey reads the
+        persisted per-repo effort allocation (LATEST_WORK_UNIT_REPO_EFFORT_CTE)
+        so effort splits across a work unit's repos instead of collapsing to a
+        single scalar repo_id."""
+        request = SankeyRequest(
+            path=["team", "theme", "repo"],
+            measure="count",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 31),
+            max_nodes=50,
+            max_edges=200,
+            use_investment=True,
+        )
+        nodes_queries, edges_queries = compile_sankey(request, "test-org")
+        nodes_sql, _ = nodes_queries[0]
+        assert "latest_work_unit_repo_effort" in nodes_sql
+        assert "repo_effort_value" in nodes_sql
+        # LEFT JOIN fallback so units without an allocation row are not dropped
+        assert "LEFT JOIN latest_work_unit_repo_effort" in nodes_sql
+        for edge_sql, _ in edges_queries:
+            assert "latest_work_unit_repo_effort" in edge_sql
+
+    def test_investment_sankey_non_repo_path_skips_allocation(self):
+        """A path WITHOUT repo must not pay the repo-allocation fan-out."""
+        request = SankeyRequest(
+            path=["team", "theme"],
+            measure="count",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 31),
+            max_nodes=50,
+            max_edges=200,
+            use_investment=True,
+        )
+        nodes_queries, _ = compile_sankey(request, "test-org")
+        nodes_sql, _ = nodes_queries[0]
+        assert "latest_work_unit_repo_effort" not in nodes_sql
+
     def test_investment_sankey_who_developers_filter_uses_author_join(self):
         """CHAOS-2492: who.developers on an investment Sankey must chain the
         work_unit_authors CTE/join and filter nodes+edges via
@@ -339,6 +377,36 @@ class TestCompileSankey:
 
         nodes_sql, _nodes_params = nodes_queries[0]
         assert "work_unit_authors" not in nodes_sql
+
+    def test_investment_sankey_repo_path_uses_repo_effort_allocation(self):
+        request = SankeyRequest(
+            path=["team", "theme", "repo"],
+            measure="count",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 31),
+            max_nodes=50,
+            max_edges=200,
+            use_investment=True,
+        )
+
+        nodes_queries, edges_queries = compile_sankey(request, "test-org")
+        all_sql = "\n".join([nodes_queries[0][0], *(sql for sql, _ in edges_queries)])
+
+        assert "latest_work_unit_repo_effort" in all_sql
+        # LEFT JOIN + scalar fallback so units without an allocation row are
+        # not dropped (an INNER JOIN silently discarded them and skewed
+        # coverage / hid effort).
+        assert "LEFT JOIN latest_work_unit_repo_effort AS wure" in all_sql
+        assert "wure.repo_effort_value, wui.effort_value) AS effort_value" in all_sql
+        assert "wure.repo_id, wui.repo_id) AS repo_id" in all_sql
+        assert "SUM(subcategory_kv.2 * effort_value)" in all_sql
+        # Unassigned repo emits '' (NOT 'unassigned') so it does not collide
+        # with the unassigned team node name in ECharts (the "Sankey is a DAG"
+        # cycle bug).
+        assert (
+            "ifNull(nullIf(r.repo, ''), if(repo_id IS NULL, '', toString(repo_id)))"
+            in all_sql
+        )
 
     def test_invalid_path(self):
         """Test that invalid path raises ValidationError."""

--- a/tests/work_graph/test_investment_helpers.py
+++ b/tests/work_graph/test_investment_helpers.py
@@ -205,3 +205,81 @@ def test_fetch_work_item_active_hours_omits_org_filter_when_unscoped(monkeypatch
     query, params = captured[-1]
     assert "org_id" not in query
     assert "org_id" not in params
+
+
+REPO_A = "11111111-1111-1111-1111-111111111111"
+REPO_B = "22222222-2222-2222-2222-222222222222"
+
+
+def test_allocate_repo_effort_splits_pr_churn_across_repos():
+    from dev_health_ops.work_graph.investment.materialize import (
+        _allocate_repo_effort,
+    )
+
+    pr_a = f"{REPO_A}#pr1"
+    pr_b = f"{REPO_B}#pr2"
+    allocs = _allocate_repo_effort(
+        issue_ids=["extkey:CHAOS-1"],
+        pr_ids=[pr_a, pr_b],
+        commit_ids=[],
+        pr_churn={pr_a: 40.0, pr_b: 60.0},
+        commit_churn={},
+        active_hours={},
+        effort_metric="churn_loc",
+        effort_value=100.0,
+    )
+    by_repo = {str(repo): (effort, weight, src) for repo, effort, weight, src in allocs}
+    assert by_repo[REPO_A][0] == 40.0
+    assert by_repo[REPO_B][0] == 60.0
+    assert by_repo[REPO_A][2] == "pr_churn"
+    # allocations MUST sum back to the work unit's total effort (no loss/gain)
+    assert abs(sum(e for _, e, _, _ in allocs) - 100.0) < 1e-6
+    assert abs(sum(w for _, _, w, _ in allocs) - 1.0) < 1e-6
+
+
+def test_allocate_repo_effort_prefers_commit_churn_over_pr():
+    from dev_health_ops.work_graph.investment.materialize import (
+        _allocate_repo_effort,
+    )
+
+    commit_a = f"{REPO_A}@" + "a" * 40
+    commit_b = f"{REPO_B}@" + "b" * 40
+    pr_a = f"{REPO_A}#pr1"
+    allocs = _allocate_repo_effort(
+        issue_ids=[],
+        pr_ids=[pr_a],
+        commit_ids=[commit_a, commit_b],
+        pr_churn={pr_a: 999.0},
+        commit_churn={commit_a: 30.0, commit_b: 70.0},
+        active_hours={},
+        effort_metric="churn_loc",
+        effort_value=100.0,
+    )
+    assert {src for _, _, _, src in allocs} == {"commit_churn"}
+    by_repo = {str(repo): effort for repo, effort, _, _ in allocs}
+    assert by_repo[REPO_A] == 30.0
+    assert by_repo[REPO_B] == 70.0
+    assert abs(sum(by_repo.values()) - 100.0) < 1e-6
+
+
+def test_allocate_repo_effort_active_hours_falls_back_to_unassigned():
+    from dev_health_ops.work_graph.investment.materialize import (
+        _allocate_repo_effort,
+    )
+
+    allocs = _allocate_repo_effort(
+        issue_ids=["I-1"],
+        pr_ids=[],
+        commit_ids=[],
+        pr_churn={},
+        commit_churn={},
+        active_hours={"I-1": 12.0},
+        effort_metric="active_hours",
+        effort_value=12.0,
+    )
+    assert len(allocs) == 1
+    repo, effort, weight, src = allocs[0]
+    assert repo is None
+    assert effort == 12.0
+    assert weight == 1.0
+    assert src == "active_hours_unassigned"

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -26,6 +26,7 @@ from dev_health_ops.metrics.schemas import (
     LLMTokenUsageRecord,
     WorkUnitInvestmentEvidenceQuoteRecord,
     WorkUnitInvestmentRecord,
+    WorkUnitRepoEffortRecord,
 )
 from dev_health_ops.work_graph.investment.categorize import CategorizationOutcome
 from dev_health_ops.work_graph.investment.llm_schema import EvidenceQuote
@@ -42,6 +43,7 @@ class FakeSink:
     def __init__(self) -> None:
         self.client = object()
         self.investment_rows: list[WorkUnitInvestmentRecord] = []
+        self.repo_effort_rows: list[WorkUnitRepoEffortRecord] = []
         self.quote_rows: list[WorkUnitInvestmentEvidenceQuoteRecord] = []
         self.llm_token_rows: list[LLMTokenUsageRecord] = []
         self.membership_rows: list = []
@@ -54,6 +56,9 @@ class FakeSink:
 
     def write_work_unit_investments(self, rows) -> None:
         self.investment_rows.extend(rows)
+
+    def write_work_unit_repo_effort(self, rows) -> None:
+        self.repo_effort_rows.extend(rows)
 
     def write_work_unit_investment_quotes(self, rows) -> None:
         self.quote_rows.extend(rows)
@@ -1540,6 +1545,144 @@ async def test_materialize_writes_records_with_org_id(monkeypatch):
     # Evidence quotes must be org-tagged too (same reader-scoping concern).
     assert sink.quote_rows, "expected at least one evidence quote row"
     assert all(q.org_id == "org-real-123" for q in sink.quote_rows)
+
+
+@pytest.mark.asyncio
+async def test_materialize_allocates_multi_repo_pr_effort(monkeypatch):
+    now = datetime.now(timezone.utc)
+    repo_one = str(uuid.uuid4())
+    repo_two = str(uuid.uuid4())
+    edges = [
+        {
+            "edge_id": "edge-1",
+            "source_type": "issue",
+            "source_id": "linear:ABC-1",
+            "target_type": "pr",
+            "target_id": f"{repo_one}#pr1",
+            "repo_id": repo_one,
+            "confidence": 0.9,
+        },
+        {
+            "edge_id": "edge-2",
+            "source_type": "issue",
+            "source_id": "linear:ABC-1",
+            "target_type": "pr",
+            "target_id": f"{repo_two}#pr2",
+            "repo_id": repo_two,
+            "confidence": 0.9,
+        },
+    ]
+    work_items = [
+        {
+            "work_item_id": "linear:ABC-1",
+            "provider": "linear",
+            "repo_id": None,
+            "title": "Ship cross-repo workflow",
+            "description": "Ship cross-repo workflow. " * 20,
+            "type": "story",
+            "labels": ["feature"],
+            "parent_id": "",
+            "epic_id": "",
+            "created_at": now - timedelta(days=2),
+            "updated_at": now - timedelta(days=1),
+            "completed_at": now - timedelta(days=1),
+        }
+    ]
+    prs = [
+        {
+            "repo_id": repo_one,
+            "number": 1,
+            "title": "Frontend workflow",
+            "created_at": now - timedelta(days=2),
+            "merged_at": now - timedelta(days=1),
+            "additions": 30,
+            "deletions": 10,
+        },
+        {
+            "repo_id": repo_two,
+            "number": 2,
+            "title": "Backend workflow",
+            "created_at": now - timedelta(days=2),
+            "merged_at": now - timedelta(days=1),
+            "additions": 20,
+            "deletions": 40,
+        },
+    ]
+    sink = FakeSink()
+
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.create_sink", lambda dsn: sink
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.get_provider",
+        lambda *args, **kwargs: FakeProvider(),
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.fetch_work_graph_edges",
+        lambda client, repo_ids=None, **kwargs: edges,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.fetch_work_items",
+        lambda client, work_item_ids, **kwargs: work_items,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.fetch_work_item_active_hours",
+        lambda client, work_item_ids, **kwargs: {},
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.fetch_pull_requests",
+        lambda client, repo_numbers, **kwargs: prs,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.fetch_commits",
+        lambda client, repo_commits, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.fetch_commit_churn",
+        lambda client, repo_commits, **kwargs: {},
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.fetch_parent_titles",
+        lambda client, work_item_ids, **kwargs: {},
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.resolve_repo_ids_for_teams",
+        lambda client, team_ids, **kwargs: [],
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.materialize.categorize_text_bundle",
+        _ok_categorize,
+    )
+
+    stats = await materialize_investments(
+        MaterializeConfig(
+            dsn="clickhouse://localhost:8123/default",
+            from_ts=now - timedelta(days=5),
+            to_ts=now,
+            repo_ids=[repo_one, repo_two],
+            llm_provider="mock",
+            persist_evidence_snippets=False,
+            llm_model="test-model",
+            org_id="org-real-123",
+        )
+    )
+
+    assert stats["records"] == 1
+    assert stats["repo_effort_records"] == 2
+    investment_row = sink.investment_rows[0]
+    assert investment_row.repo_id is None
+    assert investment_row.effort_metric == "churn_loc"
+    assert investment_row.effort_value == pytest.approx(100.0)
+    by_repo = {str(row.repo_id): row for row in sink.repo_effort_rows}
+    assert by_repo[repo_one].effort_value == pytest.approx(40.0)
+    assert by_repo[repo_one].allocation_weight == pytest.approx(0.4)
+    assert by_repo[repo_one].allocation_source == "pr_churn"
+    assert by_repo[repo_two].effort_value == pytest.approx(60.0)
+    assert by_repo[repo_two].allocation_weight == pytest.approx(0.6)
+    assert sum(row.effort_value for row in sink.repo_effort_rows) == pytest.approx(
+        investment_row.effort_value,
+        abs=1e-6,
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/work_graph/test_work_unit_membership.py
+++ b/tests/work_graph/test_work_unit_membership.py
@@ -24,6 +24,7 @@ from dev_health_ops.metrics.schemas import (
     WorkUnitInvestmentRecord,
     WorkUnitMembershipRecord,
     WorkUnitMembershipRunRecord,
+    WorkUnitRepoEffortRecord,
 )
 from dev_health_ops.work_graph.investment.categorize import CategorizationOutcome
 from dev_health_ops.work_graph.investment.constants import (
@@ -147,6 +148,7 @@ class FakeSink:
     def __init__(self) -> None:
         self.client = object()
         self.investment_rows: list[WorkUnitInvestmentRecord] = []
+        self.repo_effort_rows: list[WorkUnitRepoEffortRecord] = []
         self.quote_rows: list[WorkUnitInvestmentEvidenceQuoteRecord] = []
         self.membership_rows: list[WorkUnitMembershipRecord] = []
         self.membership_run_records: list[WorkUnitMembershipRunRecord] = []
@@ -158,6 +160,9 @@ class FakeSink:
 
     def write_work_unit_investments(self, rows) -> None:
         self.investment_rows.extend(rows)
+
+    def write_work_unit_repo_effort(self, rows) -> None:
+        self.repo_effort_rows.extend(rows)
 
     def write_work_unit_investment_quotes(self, rows) -> None:
         self.quote_rows.extend(rows)


### PR DESCRIPTION
## Problem

The Investment **Team → Theme → Repo** Sankey (and the team-exchange chord) collapsed **~98% of effort into a single "Unassigned repo" node**, and repo coverage falsely read 100%.

Root cause is in compute, not display: the materializer stores **one scalar `work_unit_investments.repo_id` per work unit**, set to `NULL` whenever a unit's PRs/commits span more than one repo — the normal case for a cross-cutting Linear issue (`issue → PRs → repos`). The Sankey read that single column, so multi-repo effort had no repo to land on. Measured on a representative org: ~94% of effort sat on `repo_id IS NULL` work units, dominated by issue-rooted units whose linked PRs spanned up to 5 repos.

The documented model (`docs/architecture/team-attribution.md`, `docs/architecture/investment-data-model.md`) already says an issue maps to many PRs and repos; the single scalar column just couldn't represent it.

## Change

Persist a per-`(work_unit, repo)` effort allocation and read it in the investment repo dimension so effort fans out across a unit's actual repos.

- **migration 064** `work_unit_repo_effort` (`ReplacingMergeTree(computed_at)`).
- **`WorkUnitRepoEffortRecord`** + sink writer (`write_work_unit_repo_effort`).
- **`_allocate_repo_effort()`** splits effort by commit/PR churn per repo, matching `_effort_from_work_unit` precedence (commit churn → PR churn → active-hours-unassigned → empty). Per-repo effort sums back to the unit's total effort (invariant asserted in tests and verified against real data).
- Repo-effort is written **even for categorization-skipped units** (it is LLM-free structural data), so steady-state materialize runs self-populate the table instead of leaving unchanged units without allocation rows.
- **Query side** (`compiler`, `validate`, `analytics`): the REPO investment path reads the allocation via a **`LEFT JOIN` with scalar fallback** — a unit without an allocation row falls back to its scalar `repo_id` + full effort and is never silently dropped. `THROUGHPUT`/`CYCLE_TIME` are weighted by `allocation_weight` to avoid N× fan-out overcount; `COUNT`/`CHURN_LOC` use the already-allocated effort.
- **Coverage** is now **effort-weighted and allocation-aware** for both team and repo (previously team coverage was count-based and disagreed with the effort-weighted flows).
- Unassigned repo emits `''` (not the bare `'unassigned'`) so it does not collide with the unassigned **team** node name in ECharts — that collision folded `TEAM → THEME → REPO` into a cycle (`Sankey is a DAG, the original data has cycle!`).

## Tests

- `_allocate_repo_effort`: multi-repo PR-churn split + sum invariant, commit-churn precedence, active-hours fallback.
- Materializer: multi-repo work unit emits per-repo allocation rows summing to the unit effort.
- Compiler: `TEAM→THEME→REPO` investment path uses the allocation CTE with `LEFT JOIN` fallback; non-repo path skips the fan-out.
- Full local gate green: `ruff format --check`, `ruff check`, `mypy`, migration `upgrade + status --check`, full unit suite (6156 passed), and the live-ClickHouse `argMax` proof.

## Rollout / backfill

- Migration creates the table; the **event-driven post-sync investment materialize** builds over the full work graph and writes repo-effort per org — no rolling-window limitation on that path.
- The daily beat job is membership-only and does **not** write repo-effort; repo-effort comes from the investment materialize.
- For immediate history backfill, run the partitioned investment materialize once per org (or org-batched) with a wide `--from/--to`. The `LEFT JOIN` fallback keeps the UI correct/complete during the rollout window, so there is no hard cutover.

## Out of scope (follow-ups)

- The phantom `extkey:` issue-key fusion (dependency-bot branch tokens like `deps-1`/`node-20` minting fake issue nodes that over-cluster work units) is a separate compute bug and not addressed here.
- Corrupt `work_item_team_attributions.source = 0` enum rows (reads can crash) — separate data-hygiene fix.

SCREENSHOT-WAIVER: backend-only change (`ops/`, Python + ClickHouse SQL); no `web/` render code is modified. Behavior is covered by unit/compiler tests and the local validation gate.
