### PR TITLE
fix(sync): scope GitHub work-item units to their source repo (CHAOS-2720)

### DIFF
--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -434,6 +434,43 @@ def run_work_items_sync_job(
             before,
         )
 
+        # CHAOS-2720: A config-aware work-item unit carries exactly one source
+        # repo in ``repo_name``. ``_discover_repos`` only short-circuits on
+        # ``repo_id`` and otherwise returns every repo for the org, so without
+        # scoping the GitHub ingest loop below runs a full ``iter_ingest`` per
+        # org repo — one unit fanning out into N-repo API amplification. Scope
+        # the discovered GitHub repos to the unit's source so a GitHub unit
+        # ingests only its own repo. Matching is case-insensitive on
+        # ``full_name`` because both the source ``external_id`` and
+        # ``repos.repo`` are the GitHub ``owner/repo`` slug (admin sync planner,
+        # api/admin/routers/sync.py). GitLab is intentionally left org-wide
+        # here: its ``repo_name`` is a numeric project id that does not match
+        # ``repos.repo`` (``path_with_namespace``), so a ``full_name`` filter
+        # would empty GitLab discovery and trip the require_source guard below
+        # (CHAOS-2737). Only GitHub-source repos are touched; every other
+        # source passes through unchanged. When ``repo_name`` is absent
+        # (CLI/org-wide), discovery stays org-wide as before.
+        if repo_name and "github" in provider_set:
+            wanted = repo_name.strip().lower()
+            scoped: list[Any] = []
+            dropped = 0
+            for repo in discovered_repos:
+                if (
+                    repo.source == "github"
+                    and (repo.full_name or "").strip().lower() != wanted
+                ):
+                    dropped += 1
+                    continue
+                scoped.append(repo)
+            if dropped:
+                logger.info(
+                    "Scoped GitHub work-item unit to source repo '%s': "
+                    "dropped %d off-source repo(s)",
+                    repo_name,
+                    dropped,
+                )
+            discovered_repos = scoped
+
         if require_source:
             if repo_name and {"github", "gitlab"}.intersection(provider_set):
                 provider_sources = {repo.source for repo in discovered_repos}

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -238,6 +238,31 @@ def test_work_item_datasets_route_to_work_item_sync_scoped_to_source(
     assert result["source"] == source_external_id
 
 
+def test_github_work_item_unit_threads_source_scope_contract() -> None:
+    """CHAOS-2720: the adapter must hand ``run_work_items_sync_job`` the source
+    identity that lets it scope a GitHub unit to its own repo — ``repo_name`` set
+    to the ``owner/repo`` slug AND ``require_source=True`` (fail closed if the
+    source repo is not discovered). ``run_work_items_sync_job`` then drops
+    off-source GitHub repos before ingest, so one unit no longer fans out across
+    every org repo (call-count proof in tests/test_work_item_source_scope.py).
+    """
+    ctx = _context(
+        provider="github",
+        dataset_key="work-items",
+        source_external_id="full-chaos/dev-health",
+    )
+
+    with patch(
+        "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"
+    ) as work_items:
+        run_dataset_unit(ctx, _runtime())
+
+    work_items.assert_called_once()
+    kwargs = work_items.call_args.kwargs
+    assert kwargs["repo_name"] == "full-chaos/dev-health"
+    assert kwargs["require_source"] is True
+
+
 def test_linear_org_wide_provider_name_placeholder_routes_to_no_source() -> None:
     ctx = _context(
         provider="linear",

--- a/tests/test_work_item_source_scope.py
+++ b/tests/test_work_item_source_scope.py
@@ -1,0 +1,245 @@
+"""CHAOS-2720: a GitHub work-item unit must ingest only its own source repo.
+
+``run_work_items_sync_job`` resolves repos via ``_discover_repos``, which only
+short-circuits on ``repo_id`` and otherwise returns *every* repo for the org.
+Before CHAOS-2720 the GitHub ingest loop iterated the full org list, so a single
+config-aware work-item unit (scoped to one source repo) ran a full
+``iter_ingest`` per org repo — N units × all repos of API amplification.
+
+These tests pin the scope contract at the ``run_work_items_sync_job`` seam:
+
+* a GitHub unit with a ``repo_name`` ingests exactly its source repo,
+* the CLI/org-wide path (``repo_name is None``) still fans out to every repo,
+* matching is case-insensitive on the ``owner/repo`` slug,
+* a source repo absent from discovery fails closed (CHAOS-2737), and
+* GitLab units are intentionally left org-wide (numeric project-id source id
+  can't be matched against ``repos.repo`` path-with-namespace here).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+
+import pytest
+
+import dev_health_ops.metrics.job_work_items as job
+from dev_health_ops.metrics.work_items import DiscoveredRepo
+
+
+@dataclass
+class _Classification:
+    investment_area: str = "Maintenance / Tech Debt"
+    project_stream: str = ""
+    confidence: float = 1.0
+    rule_id: str = "test"
+
+
+class _Classifier:
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def classify(self, _payload: object) -> _Classification:
+        return _Classification()
+
+
+class _FakeClickHouseSink:
+    """Minimal metrics sink — records nothing, satisfies the write contract."""
+
+    def __init__(self, _dsn: str) -> None:
+        self.org_id = ""
+
+    def ensure_tables(self) -> None:
+        return None
+
+    def query_dicts(
+        self, _query: str, _params: dict[str, object]
+    ) -> list[dict[str, object]]:
+        return []
+
+    def __getattr__(self, name: str) -> Any:
+        # Any ``write_*`` / ``close`` call is a no-op; the scope tests only care
+        # about which repos the provider ingest loop touched.
+        if name.startswith("write_") or name == "close":
+            return lambda *_args, **_kwargs: None
+        raise AttributeError(name)
+
+
+class _FakeGitHubProvider:
+    """Records the repo of every ``iter_ingest`` call; yields no batches."""
+
+    calls: list[str] = []
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def iter_ingest(self, ctx: Any) -> Any:
+        type(self).calls.append(ctx.repo)
+        return iter(())
+
+
+def _patch_common(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", _FakeClickHouseSink)
+    monkeypatch.setattr(job, "InvestmentClassifier", _Classifier)
+    monkeypatch.setattr(
+        job, "compute_work_item_metrics_daily", lambda **_kwargs: ([], [], [])
+    )
+    monkeypatch.setattr(
+        job, "compute_estimate_coverage_metrics_daily", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(
+        job, "compute_work_item_team_attributions", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(
+        job, "compute_work_item_state_durations_daily", lambda **_kwargs: []
+    )
+    monkeypatch.setattr(job, "parse_github_projects_v2_env", lambda: [])
+
+
+def _github_repos() -> list[DiscoveredRepo]:
+    return [
+        DiscoveredRepo(
+            repo_id=uuid.uuid4(),
+            full_name=f"acme/repo-{name}",
+            source="github",
+            settings={},
+        )
+        for name in ("a", "b", "c")
+    ]
+
+
+def _run_github(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    repo_name: str | None,
+    require_source: bool,
+    repos: list[DiscoveredRepo],
+) -> None:
+    _patch_common(monkeypatch)
+    _FakeGitHubProvider.calls = []
+    monkeypatch.setattr(job, "_discover_repos", lambda **_kwargs: list(repos))
+    monkeypatch.setattr(job, "_build_github_work_client", lambda **_kwargs: object())
+    monkeypatch.setattr(
+        "dev_health_ops.providers.github.provider.GitHubProvider",
+        _FakeGitHubProvider,
+    )
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="github",
+        org_id=str(uuid.uuid4()),
+        repo_name=repo_name,
+        require_source=require_source,
+    )
+
+
+def test_github_unit_scopes_iter_ingest_to_source_repo(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repos = _github_repos()  # acme/repo-a, acme/repo-b, acme/repo-c
+    _run_github(
+        monkeypatch,
+        repo_name="acme/repo-a",
+        require_source=True,
+        repos=repos,
+    )
+    # Exactly one ingest, for the source repo only — no org-wide fan-out.
+    assert _FakeGitHubProvider.calls == ["acme/repo-a"]
+
+
+def test_github_unit_source_scope_is_case_insensitive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repos = _github_repos()
+    _run_github(
+        monkeypatch,
+        repo_name="ACME/Repo-A",
+        require_source=True,
+        repos=repos,
+    )
+    assert _FakeGitHubProvider.calls == ["acme/repo-a"]
+
+
+def test_github_cli_org_wide_path_still_fans_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repos = _github_repos()
+    # No source (CLI/org-wide) → discovery stays org-wide, every repo ingested.
+    _run_github(
+        monkeypatch,
+        repo_name=None,
+        require_source=False,
+        repos=repos,
+    )
+    assert sorted(_FakeGitHubProvider.calls) == [
+        "acme/repo-a",
+        "acme/repo-b",
+        "acme/repo-c",
+    ]
+
+
+def test_github_unit_missing_source_repo_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repos = _github_repos()  # none named repo-z
+    with pytest.raises(ValueError, match="source was not discovered"):
+        _run_github(
+            monkeypatch,
+            repo_name="acme/repo-z",
+            require_source=True,
+            repos=repos,
+        )
+    # Nothing was ingested — the unit refused to fan out to sibling repos.
+    assert _FakeGitHubProvider.calls == []
+
+
+def test_gitlab_unit_stays_org_wide(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Non-regression: GitLab units keep org-wide discovery (CHAOS-2720 scopes
+    GitHub only). A GitLab source id is a numeric project id that does not match
+    ``repos.repo`` (path_with_namespace), so it must not be used as a GitHub-style
+    ``full_name`` filter — doing so would empty discovery and trip require_source.
+    """
+    _patch_common(monkeypatch)
+    gitlab_repos = [
+        DiscoveredRepo(
+            repo_id=uuid.uuid4(),
+            full_name=f"grp/proj-{name}",
+            source="gitlab",
+            settings={"project_id": pid},
+        )
+        for name, pid in (("a", 123), ("b", 456), ("c", 789))
+    ]
+    monkeypatch.setattr(job, "_discover_repos", lambda **_kwargs: list(gitlab_repos))
+    monkeypatch.setattr(
+        job, "_build_gitlab_work_client", lambda **_kwargs: ("gl-token", None)
+    )
+
+    captured: dict[str, Any] = {}
+
+    def _fake_fetch(*, repos: list[DiscoveredRepo], **_kwargs: object) -> Any:
+        captured["repos"] = list(repos)
+        return ([], [], [])
+
+    monkeypatch.setattr(job, "fetch_gitlab_work_items", _fake_fetch)
+
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="gitlab",
+        org_id=str(uuid.uuid4()),
+        repo_name="123",  # numeric project id — the GitLab source external id
+        require_source=True,
+    )
+
+    # All three GitLab projects reach the fetcher — unchanged by CHAOS-2720.
+    assert {r.full_name for r in captured["repos"]} == {
+        "grp/proj-a",
+        "grp/proj-b",
+        "grp/proj-c",
+    }


### PR DESCRIPTION
## Problem

A config-aware GitHub **work-item** sync unit is scoped to a single source repo (the planner stamps its `owner/repo` slug into `source_external_id`, which the dataset adapter passes as `repo_name` with `require_source=True`). But `run_work_items_sync_job` resolved repos via `_discover_repos`, which **only short-circuits on `repo_id`** and otherwise returns *every* repo for the org — `repo_name` was accepted but never used as a filter. The GitHub ingest loop then ran a full `github_provider.iter_ingest(ctx)` for **every** GitHub repo in the org.

Net effect: one GitHub work-item unit (which should touch a single repo) ingested every GitHub repo in the org — N units × all repos of GitHub API request amplification. The `search_pattern` post-filter is a no-op when `None`, and the CHAOS-2737 `require_source` guard only checked that *some* GitHub repo was discovered, not that it was *this unit's* repo.

## Fix

In `run_work_items_sync_job`, after discovery and before the `require_source` guard, scope the discovered **GitHub-source** repos to the unit's source: keep a GitHub repo only when its `full_name` case-insensitively equals `repo_name` (both are the GitHub `owner/repo` slug — the source `external_id` and `repos.repo` come from the same admin-sync planner value). Consequences:

- A GitHub work-item unit ingests **only its own repo** — no org-wide enumeration when a source is present.
- Fails **closed**: if the source repo isn't discovered, the GitHub set empties and the existing `require_source` guard raises `Work-item unit source was not discovered` (CHAOS-2737), instead of silently fanning out to sibling repos.
- Org-wide discovery is **preserved** when `repo_name` is absent (CLI / `metrics sync work-items` without `--repo-name`).

### GitLab / Linear scoping decision (intentional scope boundary)

- **GitLab left org-wide in this PR.** A GitLab work-item unit's source id is a **numeric project id** (`str(project_id)`, admin `sync.py`), which does **not** match `repos.repo` (`path_with_namespace`, e.g. `group/project`). A `full_name` filter would empty GitLab discovery and trip the CHAOS-2737 `ValueError`, breaking currently-working GitLab units. Only GitHub-source repos are touched; GitLab-source repos pass through unchanged. Scoping GitLab (via its numeric project id) is tracked separately.
- **Linear unaffected.** Linear ingest consumes `repo_name` (a team key) directly and never uses `discovered_repos`; the filter only runs when `github` is in the provider set.

## Tests

- `tests/test_work_item_source_scope.py` (new) — call-count/scope proof at the `run_work_items_sync_job` seam:
  - `test_github_unit_scopes_iter_ingest_to_source_repo` — org has 3 GitHub repos; a unit for repo A ⇒ `iter_ingest` invoked **exactly once**, for repo A only.
  - `test_github_unit_source_scope_is_case_insensitive` — `ACME/Repo-A` scopes to `acme/repo-a`.
  - `test_github_cli_org_wide_path_still_fans_out` — `repo_name=None` ⇒ all 3 repos ingested (CLI/org-wide unchanged).
  - `test_github_unit_missing_source_repo_fails_closed` — source repo absent ⇒ `require_source` raises, nothing ingested.
  - `test_gitlab_unit_stays_org_wide` — non-regression: a GitLab unit (numeric project-id source) still passes all discovered GitLab projects to `fetch_gitlab_work_items`.
- `tests/test_dataset_adapters.py` — added `test_github_work_item_unit_threads_source_scope_contract`, mirroring `test_work_item_datasets_route_to_work_item_sync_scoped_to_source`: the adapter threads `repo_name=owner/repo` + `require_source=True`, the identity that drives the scoping.

Full `bash ci/local_validate.sh` green: ruff format/check, mypy, scratch-ClickHouse migrate, FULL unit suite (6161 passed / 44 skipped), and the live argMax proof.

Fixes CHAOS-2720
https://linear.app/fullchaos/issue/CHAOS-2720