### PR TITLE
feat(sync): freeze run auth context by stamping credential at plan time (CHAOS-2755)

### DIFF
--- a/docs/architecture/sync-unit-model.md
+++ b/docs/architecture/sync-unit-model.md
@@ -84,8 +84,57 @@ The ⚠️ cells are the work this epic removes. GitHub/GitLab already solved th
 - **ClickHouse idempotency.** Reference reads and collapsed/scoped writes stay idempotent (`teams FINAL`, `sprints FINAL`).
 - **No Postgres team/identity attribution.** Reference data is read from ClickHouse, never a Postgres attribution bridge.
 
+## Run auth freeze (CHAOS-2755)
+
+A sync run's auth is **resolved once, at plan time, and frozen for the whole run.**
+Before this, credentials were re-resolved from the *mutable*
+`Integration.credential_id` at four independent points — reference discovery
+(`_load_discovery_context`), the three BudgetGuard passes (`observe_run`,
+`enforce_run`, `_active_budget_consumption`), and unit execution (`run_sync_unit`) —
+so a credential edit *mid-run* could split one run across two identities
+(mixed-auth). Freezing makes a run's auth **deterministic**.
+
+**How it is stamped.** `plan_sync_run` resolves the credential immediately after
+loading the integration and stamps three RUN-level columns on `sync_runs`:
+
+| Column | Meaning |
+| ------ | ------- |
+| `credential_id` | The credential UUID resolved at plan time. **Plain UUID, no foreign key** — deleting a stamped credential mid-run is deliberately not blocked; it surfaces as the existing "Credential not found" unit failure. `NULL` for environment auth. |
+| `credential_fingerprint` | A **safe-scope content witness** (`credentials/fingerprint.py`): a SHA-256 digest over non-secret identifiers plus per-secret SHA-256 markers. Never a raw secret, and deliberately **not** the full-payload runtime-cache hash (`sync_bootstrap._credential_fingerprint`). |
+| `auth_source` | `integration_credential` \| `environment`. **`NULL` marks a legacy / pre-migration / in-flight-at-deploy run** that was never stamped and falls back to the mutable resolution path. |
+
+**How it is read.** Every later phase resolves auth through
+`sync_bootstrap.resolve_run_auth(run, integration, …)`, which is the single choke
+point behind `SyncTaskBootstrap.load` (so BudgetGuard and `run_sync_unit` inherit
+it) and is called directly by reference discovery. When `auth_source` is non-NULL
+it uses the run-stamped credential; when `NULL` it falls back to today's
+`Integration.credential_id` path so runs already in flight at deploy keep working.
+
+**Deliberate asymmetries (this is what "freezing" means):**
+
+- **`is_active` is enforced at plan-time stamping ONLY.** A run stamped against an
+  active credential tolerates that credential being *deactivated* mid-run — the
+  run finishes on the frozen credential. There is intentionally no bootstrap-time
+  `is_active` check.
+- **In-place secret edit (fingerprint mismatch).** If a credential's *secret bytes*
+  change mid-run (same id, rotated token), the recomputed fingerprint no longer
+  matches the stamp. Default behavior is **warn-and-continue** with the new secret
+  (rotation-to-fix-a-bad-token is the common legitimate edit); set
+  **`SYNC_RUN_AUTH_STRICT`** (`1`/`true`/`yes`/`on`) to hard-fail such units
+  non-retryably during rollout.
+
+**Capacity invariant (binding).** Run-level stamping is for **determinism only**.
+No credential field is added to `PlannedUnit` or `SyncRunUnit`, and
+`RuntimeCacheKey` is byte-unchanged. Credentials are auth state, **never** dispatch
+capacity — changing or rotating credentials must never increase sync dispatch
+capacity.
+
+**Migration.** Alembic `0030` adds the three nullable `sync_runs` columns using the
+retry-safe guarded-column pattern (revision `0022`).
+
 ## References
 
 - Epic: CHAOS-2719 (sync unit model); children CHAOS-2718 (Linear reference re-fetch), CHAOS-2720 (GitHub source fan-out), CHAOS-2721 (work-item-family fan-in), CHAOS-2722 (window-aware budget), CHAOS-2725 (scoped backfill).
+- Run auth freeze: CHAOS-2755 (parent CHAOS-2742 — harden sync budget / rate-limit without credential capacity).
 - Related: [Durable Dispatch Outbox](dispatch-outbox.md), [Data Pipeline](data-pipeline.md), [Team Attribution](team-attribution.md), [Connector Inventory](../ops/connector-inventory.md).
 - Rate limits & budget: [Provider Rate-Limit Policy](../providers/rate-limit-policy.md) — per-provider quota dimensions/headers/retry semantics, the credentials-are-not-capacity invariant, and how work-item units reserve budget by route family before dispatch.

--- a/src/dev_health_ops/alembic/versions/0030_add_sync_run_credential_stamp.py
+++ b/src/dev_health_ops/alembic/versions/0030_add_sync_run_credential_stamp.py
@@ -1,0 +1,78 @@
+"""Add run-auth freeze credential stamp columns to sync_runs (CHAOS-2755).
+
+Stamps the credential resolved once at plan time onto the run so every later
+phase (reference discovery, BudgetGuard, unit execution) reads the run-frozen
+credential instead of re-resolving the mutable ``Integration.credential_id``.
+
+Three nullable columns are added to ``sync_runs``:
+  * ``credential_id`` — plain UUID, deliberately NO foreign key so deleting a
+    stamped credential mid-run is not blocked and instead surfaces as the
+    existing "Credential not found" unit failure (the honest outcome).
+  * ``credential_fingerprint`` — safe-scope content witness (no raw secret).
+  * ``auth_source`` — 'integration_credential' | 'environment'; NULL marks a
+    legacy/pre-migration or in-flight-at-deploy run.
+
+These are RUN-level columns; per CHAOS-2755 no credential field is added to
+``sync_run_units`` (credentials are auth state, never dispatch capacity).
+
+Retry safety: each column is guarded individually (per revision 0022) so a
+rerun after a partial failure resumes instead of failing on duplicate columns.
+
+Revision ID: 0030
+Revises: 0029
+Create Date: 2026-07-01 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0030"
+down_revision: str | None = "0029"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+
+def upgrade() -> None:
+    _add_column_if_missing(
+        "sync_runs",
+        sa.Column("credential_id", UUID(as_uuid=True), nullable=True),
+    )
+    _add_column_if_missing(
+        "sync_runs",
+        sa.Column("credential_fingerprint", sa.Text(), nullable=True),
+    )
+    _add_column_if_missing(
+        "sync_runs",
+        sa.Column("auth_source", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    _drop_column_if_present("sync_runs", "auth_source")
+    _drop_column_if_present("sync_runs", "credential_fingerprint")
+    _drop_column_if_present("sync_runs", "credential_id")
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    existing_columns = _column_names(table_name)
+    if column.name not in existing_columns:
+        op.add_column(table_name, column)
+
+
+def _drop_column_if_present(table_name: str, column_name: str) -> None:
+    existing_columns = _column_names(table_name)
+    if column_name in existing_columns:
+        op.drop_column(table_name, column_name)
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}

--- a/src/dev_health_ops/credentials/fingerprint.py
+++ b/src/dev_health_ops/credentials/fingerprint.py
@@ -1,0 +1,164 @@
+"""Safe-scope credential fingerprinting for run-auth freezing (CHAOS-2755).
+
+A sync run's auth is resolved once at planning and stamped onto the ``SyncRun``
+row (``credential_id`` + ``credential_fingerprint`` + ``auth_source``). Every
+later phase — reference discovery, BudgetGuard, unit execution — reads the
+run-stamped credential instead of re-resolving the mutable
+``Integration.credential_id``, so a mid-run credential edit can no longer produce
+a mixed-auth run.
+
+The stamped ``credential_fingerprint`` is a **content witness**: it detects an
+*in-place secret edit* (same credential id, rotated secret bytes) while never
+persisting raw secret material. It is deliberately a NEW, independent helper —
+it does NOT reuse the per-provider ``providers/*/budget.py`` fingerprints, whose
+output feeds ``BudgetBucketKey`` identity (budget-bucket keying is owned by the
+reservation machinery and must not change). This module derives the same
+safe-scope *approach* but is scoped only to run-auth stamping/verification.
+
+Safety contract:
+  * Secret-bearing fields (tokens, API keys, private keys) are only ever
+    SHA-256 hashed into ``<field>_sha256`` markers — never stored verbatim.
+  * The returned fingerprint is a single SHA-256 hex digest of the safe scope,
+    so the persisted column carries no plaintext identifier or secret byte.
+  * Never persist the full-payload secret hash used by the runtime cache
+    (``workers/sync_bootstrap.py`` ``_credential_fingerprint``) — that hashes
+    the *entire* decrypted payload and is a per-process cache key, not a durable
+    witness.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from collections.abc import Mapping
+
+__all__ = [
+    "AUTH_SOURCE_ENVIRONMENT",
+    "AUTH_SOURCE_INTEGRATION_CREDENTIAL",
+    "credential_fingerprint",
+    "safe_credential_scope",
+]
+
+# ``SyncRun.auth_source`` discriminator values. A NULL ``auth_source`` marks a
+# legacy (pre-migration) or in-flight-at-deploy run that was never stamped; such
+# runs fall back to the mutable ``Integration.credential_id`` resolution path.
+AUTH_SOURCE_INTEGRATION_CREDENTIAL = "integration_credential"
+AUTH_SOURCE_ENVIRONMENT = "environment"
+
+# Non-secret identifiers that scope a credential to a host/tenant/app identity.
+# Persisting them (indirectly, via the final digest) is safe — none is a secret.
+_IDENTIFIER_KEYS: tuple[str, ...] = (
+    "app_id",
+    "installation_id",
+    "email",
+    "cloud_id",
+    "cloudId",
+    "client_id",
+    "clientId",
+    "user_id",
+    "username",
+    "group_id",
+    "project_id",
+    "project_key",
+    "environment",
+    "schema_version",
+    "organization_id",
+    "workspace_id",
+    "team_id",
+)
+
+# Secret-bearing fields. Each present value is SHA-256 hashed into a
+# ``<key>_sha256`` marker so an in-place secret edit changes the fingerprint,
+# while the raw secret is never included in the scope.
+_SECRET_KEYS: tuple[str, ...] = (
+    "token",
+    "private_token",
+    "access_token",
+    "accessToken",
+    "refresh_token",
+    "refreshToken",
+    "api_token",
+    "apiToken",
+    "api_key",
+    "apiKey",
+    "private_key",
+    "privateKey",
+)
+
+
+def _sha256(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8")).hexdigest()
+
+
+def _normalize_base_url(value: str) -> str:
+    return value.strip().rstrip("/")
+
+
+def _fallback_scope(
+    *, credential_id: str | None, integration_id: str
+) -> dict[str, object]:
+    return {
+        "credential_id": credential_id or "env",
+        "integration_id": integration_id,
+    }
+
+
+def safe_credential_scope(
+    credentials: object,
+    *,
+    credential_id: str | None,
+    integration_id: str,
+) -> dict[str, object]:
+    """Return a provider-agnostic, secret-free scope of a decrypted credential.
+
+    Identifiers are copied verbatim; secret-bearing fields are SHA-256 hashed.
+    Falls back to ``{credential_id, integration_id}`` when the credentials are
+    not a mapping or expose no recognizable field, so the witness is always
+    deterministic and non-empty.
+    """
+    if not isinstance(credentials, Mapping):
+        return _fallback_scope(
+            credential_id=credential_id, integration_id=integration_id
+        )
+
+    scope: dict[str, object] = {}
+    for key in _IDENTIFIER_KEYS:
+        value = credentials.get(key)
+        if value is not None:
+            scope[key] = value
+
+    base_url = credentials.get("base_url") or credentials.get("baseUrl")
+    if base_url is not None:
+        scope["base_url"] = _normalize_base_url(str(base_url))
+
+    for key in _SECRET_KEYS:
+        value = credentials.get(key)
+        if value:
+            scope[f"{key}_sha256"] = _sha256(str(value))
+
+    if not scope:
+        return _fallback_scope(
+            credential_id=credential_id, integration_id=integration_id
+        )
+    return scope
+
+
+def credential_fingerprint(
+    credentials: object,
+    *,
+    credential_id: str | None,
+    integration_id: str,
+) -> str:
+    """Return a stable SHA-256 hex digest of the credential's safe scope.
+
+    The same decrypted credential content yields the same digest at plan time
+    and at every later read; a rotated secret (same credential id) yields a
+    different digest, which is how the run-auth freeze detects an in-place edit.
+    """
+    scope = safe_credential_scope(
+        credentials,
+        credential_id=credential_id,
+        integration_id=integration_id,
+    )
+    payload = json.dumps(scope, sort_keys=True, default=str, separators=(",", ":"))
+    return _sha256(payload)

--- a/src/dev_health_ops/models/integrations.py
+++ b/src/dev_health_ops/models/integrations.py
@@ -189,6 +189,17 @@ class SyncRun(Base):
     )
     result: Mapped[dict[str, Any] | None] = mapped_column(JSON, nullable=True)
     error: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # Run-auth freeze (CHAOS-2755): the credential resolved once at plan time and
+    # frozen for the whole run. ``credential_id`` is a PLAIN UUID with NO foreign
+    # key — a stamped credential deleted mid-run must not be blocked by an FK and
+    # instead surfaces as the existing "Credential not found" unit failure.
+    # ``credential_fingerprint`` is a safe-scope content witness (no raw secret).
+    # ``auth_source`` is 'integration_credential' | 'environment'; NULL marks a
+    # legacy/pre-migration or in-flight-at-deploy run that falls back to the
+    # mutable ``Integration.credential_id`` resolution path.
+    credential_id: Mapped[uuid.UUID | None] = mapped_column(GUID, nullable=True)
+    credential_fingerprint: Mapped[str | None] = mapped_column(Text, nullable=True)
+    auth_source: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -41,6 +41,11 @@ from datetime import datetime, time, timedelta, timezone
 from typing import TYPE_CHECKING
 
 from dev_health_ops.backfill.chunker import chunk_date_range
+from dev_health_ops.credentials.fingerprint import (
+    AUTH_SOURCE_ENVIRONMENT,
+    AUTH_SOURCE_INTEGRATION_CREDENTIAL,
+    credential_fingerprint,
+)
 from dev_health_ops.models import (
     Integration,
     IntegrationDataset,
@@ -133,6 +138,12 @@ def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
 
     integration = _load_integration(session, request.integration_id, request.org_id)
     mode = _validate_mode(request.mode)
+    # Freeze this run's auth at plan time (CHAOS-2755): resolve the credential
+    # ONCE here so every later phase reads the run-stamped credential and a
+    # mid-run credential edit can never produce a mixed-auth run.
+    credential_id, credential_fp, auth_source = _resolve_credential_stamp(
+        session, integration
+    )
     sources = _load_enabled_sources(session, integration, request.source_ids)
     datasets = _load_enabled_datasets(session, integration, request.dataset_keys)
     now = datetime.now(timezone.utc)
@@ -156,6 +167,9 @@ def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
         total_units=len(planned_units),
         completed_units=0,
         failed_units=0,
+        credential_id=credential_id,
+        credential_fingerprint=credential_fp,
+        auth_source=auth_source,
     )
     session.add(sync_run)
     session.flush()
@@ -217,6 +231,71 @@ def _load_integration(
     if integration is None:
         raise ValueError(f"Integration not found for org {org_id}: {integration_id}")
     return integration
+
+
+def _resolve_credential_stamp(
+    session: Session, integration: Integration
+) -> tuple[uuid.UUID | None, str, str]:
+    """Resolve the run-level auth stamp for :func:`plan_sync_run` (CHAOS-2755).
+
+    Returns ``(credential_id, credential_fingerprint, auth_source)``:
+
+      * ``Integration.credential_id`` is NULL -> environment auth. The stamp
+        carries ``credential_id=None``, ``auth_source='environment'`` and a
+        best-effort fingerprint of the resolved env credentials. This is
+        deliberately distinguishable from a legacy NULL-stamped run (whose
+        ``auth_source`` column itself is NULL).
+      * Otherwise the referenced ``IntegrationCredential`` is stamped. Its
+        ``is_active`` flag is enforced HERE, at plan time only — a run stamped
+        against an active credential deliberately tolerates that credential
+        being deactivated mid-run (that asymmetry is exactly what "freezing"
+        means; see docs/architecture/sync-unit-model.md). We do NOT persist the
+        full-payload secret hash; only the safe-scope content witness.
+    """
+    # Imported lazily: task_utils pulls in worker/encryption machinery, and the
+    # planner is imported from those layers — a module-level import would risk a
+    # cycle (mirrors the lazy TierLimitService import below).
+    from dev_health_ops.models import IntegrationCredential
+    from dev_health_ops.workers.task_utils import (
+        _credential_mapping,
+        _resolve_env_credentials,
+    )
+
+    provider = str(integration.provider)
+    integration_id = str(integration.id)
+
+    if integration.credential_id is None:
+        env_credentials = dict(_resolve_env_credentials(provider))
+        fingerprint = credential_fingerprint(
+            env_credentials, credential_id=None, integration_id=integration_id
+        )
+        return None, fingerprint, AUTH_SOURCE_ENVIRONMENT
+
+    credential = (
+        session.query(IntegrationCredential)
+        .filter(
+            IntegrationCredential.id == integration.credential_id,
+            IntegrationCredential.org_id == integration.org_id,
+        )
+        .one_or_none()
+    )
+    if credential is None:
+        raise ValueError(
+            "Integration credential not found at plan time: "
+            f"{integration.credential_id}"
+        )
+    if not credential.is_active:
+        raise ValueError(
+            f"Integration credential is inactive: {integration.credential_id}"
+        )
+
+    decrypted = _credential_mapping(credential)
+    fingerprint = credential_fingerprint(
+        decrypted,
+        credential_id=str(integration.credential_id),
+        integration_id=integration_id,
+    )
+    return integration.credential_id, fingerprint, AUTH_SOURCE_INTEGRATION_CREDENTIAL
 
 
 def _load_enabled_sources(

--- a/src/dev_health_ops/workers/reference_discovery.py
+++ b/src/dev_health_ops/workers/reference_discovery.py
@@ -17,7 +17,6 @@ from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 from dev_health_ops.models import (
     Integration,
-    IntegrationCredential,
     IntegrationSource,
     SyncRun,
     SyncRunReferenceDiscovery,
@@ -31,11 +30,8 @@ from dev_health_ops.sync.dispatch_outbox import (
     upsert_outbox_wakeup,
 )
 from dev_health_ops.workers.celery_app import celery_app
-from dev_health_ops.workers.task_utils import (
-    _credential_mapping,
-    _get_db_url,
-    _resolve_env_credentials,
-)
+from dev_health_ops.workers.sync_bootstrap import resolve_run_auth
+from dev_health_ops.workers.task_utils import _get_db_url
 from dev_health_ops.workers.team_autoimport import run_team_autoimport_strict
 
 logger = logging.getLogger(__name__)
@@ -192,22 +188,17 @@ def _load_discovery_context(run_uuid: uuid.UUID) -> dict[str, Any]:
         )
         if integration is None:
             raise ValueError(f"integration not found for sync run: {run_uuid}")
-        if integration.credential_id is None:
-            credentials: dict[str, Any] = dict(
-                _resolve_env_credentials(integration.provider)
-            )
-        else:
-            credential = (
-                session.query(IntegrationCredential)
-                .filter(
-                    IntegrationCredential.id == integration.credential_id,
-                    IntegrationCredential.org_id == run.org_id,
-                )
-                .one_or_none()
-            )
-            if credential is None:
-                raise ValueError(f"credential not found for sync run: {run_uuid}")
-            credentials = _credential_mapping(credential)
+        # Prefer the run-stamped credential frozen at plan time (CHAOS-2755) so
+        # discovery resolves the SAME auth as this run's units. NULL-stamped
+        # (legacy/in-flight) runs fall back to integration.credential_id.
+        _stamped_credential_id, resolved_credentials = resolve_run_auth(
+            session,
+            run=run,
+            integration=integration,
+            provider=integration.provider,
+            error_label=f"sync run: {run_uuid}",
+        )
+        credentials: dict[str, Any] = dict(resolved_credentials)
         units = (
             session.query(SyncRunUnit)
             .filter(SyncRunUnit.sync_run_id == run_uuid)

--- a/src/dev_health_ops/workers/sync_bootstrap.py
+++ b/src/dev_health_ops/workers/sync_bootstrap.py
@@ -22,6 +22,7 @@ import hashlib
 import inspect
 import json
 import logging
+import os
 import threading
 import uuid
 from collections import OrderedDict
@@ -29,11 +30,168 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING, Any
 
+from dev_health_ops.credentials.fingerprint import credential_fingerprint
+
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
 
 logger = logging.getLogger(__name__)
+
+
+class RunAuthFingerprintMismatchError(ValueError):
+    """A run's stamped credential fingerprint no longer matches the credential
+    resolved at execution time (an in-place secret edit mid-run, CHAOS-2755).
+
+    Raised only under ``SYNC_RUN_AUTH_STRICT``; the default is warn-and-continue.
+    Subclasses :class:`ValueError` so it is treated as a non-retryable failure by
+    the unit/discovery error handlers (rotation is a legitimate mid-run edit, so
+    retrying the old stamp would be wrong).
+    """
+
+
+def _sync_run_auth_strict() -> bool:
+    """Hard-fail on a mid-run credential-content change when truthy.
+
+    Default (warn-and-continue) tolerates rotation-to-fix-a-bad-token, the
+    common legitimate in-place edit; operators flip this on for a strict rollout.
+    """
+    return os.getenv("SYNC_RUN_AUTH_STRICT", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _load_credential(session: Session, credential_id: Any, org_id: str) -> Any:
+    """Load an ``IntegrationCredential`` by id within an org.
+
+    Deliberately does NOT filter on ``is_active``: ``is_active`` is enforced only
+    at plan-time stamping (``sync/planner.py``); a stamped run tolerates its
+    credential being deactivated mid-run — that asymmetry is what "freezing" a
+    run's auth means.
+    """
+    from dev_health_ops.models import IntegrationCredential
+
+    return (
+        session.query(IntegrationCredential)
+        .filter(
+            IntegrationCredential.id == credential_id,
+            IntegrationCredential.org_id == org_id,
+        )
+        .one_or_none()
+    )
+
+
+def _resolve_integration_auth(
+    session: Session, integration: Any, provider: str, error_label: str
+) -> tuple[Any, Any]:
+    """Today's mutable-resolution path: read auth from ``Integration.credential_id``.
+
+    Used for NULL-stamped runs (legacy / pre-migration / in-flight at deploy).
+    """
+    from dev_health_ops.workers.task_utils import (
+        _credential_mapping,
+        _resolve_env_credentials,
+    )
+
+    credential_id = integration.credential_id
+    if credential_id is None:
+        return None, _resolve_env_credentials(provider)
+    credential = _load_credential(session, credential_id, integration.org_id)
+    if credential is None:
+        raise ValueError(f"Credential not found for {error_label}")
+    return credential_id, _credential_mapping(credential)
+
+
+def _verify_stamped_fingerprint(
+    run: Any,
+    *,
+    decrypted_credentials: Any,
+    credential_id: Any,
+    integration: Any,
+    error_label: str,
+) -> None:
+    """Detect an in-place secret edit against the run's stamped fingerprint.
+
+    No-op when the run carries no stamped fingerprint. On mismatch: hard-fail
+    under ``SYNC_RUN_AUTH_STRICT``, otherwise warn and continue with the newly
+    resolved secret. Logs carry no secret material.
+    """
+    stamped_fingerprint = getattr(run, "credential_fingerprint", None)
+    if not stamped_fingerprint:
+        return
+    current_fingerprint = credential_fingerprint(
+        decrypted_credentials,
+        credential_id=str(credential_id) if credential_id is not None else None,
+        integration_id=str(integration.id),
+    )
+    if current_fingerprint == stamped_fingerprint:
+        return
+    if _sync_run_auth_strict():
+        raise RunAuthFingerprintMismatchError(
+            f"Sync run auth fingerprint mismatch for {error_label}: "
+            "stamped credential content changed mid-run"
+        )
+    logger.warning(
+        "sync_run_auth.fingerprint_mismatch",
+        extra={
+            "error_label": error_label,
+            "integration_id": str(integration.id),
+            "auth_source": getattr(run, "auth_source", None),
+            "strict": False,
+        },
+    )
+
+
+def resolve_run_auth(
+    session: Session,
+    *,
+    run: Any,
+    integration: Any,
+    provider: str,
+    error_label: str,
+) -> tuple[Any, Any]:
+    """Resolve ``(credential_id, decrypted_credentials)`` for a unit/discovery.
+
+    When the run was stamped at plan time (``auth_source`` non-NULL, CHAOS-2755),
+    the run-frozen credential is used, so a mid-run edit to
+    ``Integration.credential_id`` cannot change this run's auth. NULL-stamped
+    runs fall back to the mutable ``Integration.credential_id`` path so runs that
+    were already in flight when this change deployed keep working.
+    """
+    from dev_health_ops.workers.task_utils import (
+        _credential_mapping,
+        _resolve_env_credentials,
+    )
+
+    auth_source = getattr(run, "auth_source", None) if run is not None else None
+    if auth_source is None:
+        return _resolve_integration_auth(session, integration, provider, error_label)
+
+    stamped_credential_id = getattr(run, "credential_id", None)
+    if stamped_credential_id is None:
+        decrypted_credentials: Any = dict(_resolve_env_credentials(provider))
+        credential_id: Any = None
+    else:
+        credential = _load_credential(
+            session, stamped_credential_id, integration.org_id
+        )
+        if credential is None:
+            # Stamped credential deleted mid-run: the intended, honest failure
+            # surface (the run was frozen against a now-absent credential).
+            raise ValueError(f"Credential not found for {error_label}")
+        decrypted_credentials = _credential_mapping(credential)
+        credential_id = stamped_credential_id
+    _verify_stamped_fingerprint(
+        run,
+        decrypted_credentials=decrypted_credentials,
+        credential_id=credential_id,
+        integration=integration,
+        error_label=error_label,
+    )
+    return credential_id, decrypted_credentials
 
 
 @dataclass(frozen=True)
@@ -142,15 +300,11 @@ class SyncTaskBootstrap:
 
         from dev_health_ops.models import (
             Integration,
-            IntegrationCredential,
             IntegrationSource,
+            SyncRun,
             SyncRunUnit,
         )
-        from dev_health_ops.workers.task_utils import (
-            _credential_mapping,
-            _get_db_url,
-            _resolve_env_credentials,
-        )
+        from dev_health_ops.workers.task_utils import _get_db_url
 
         unit_uuid = uuid.UUID(str(unit_id))
         unit = (
@@ -182,21 +336,21 @@ class SyncTaskBootstrap:
         if source is None:
             raise ValueError(f"Integration source not found for unit: {unit_id}")
 
-        credential_id = integration.credential_id
-        if credential_id is None:
-            decrypted_credentials = _resolve_env_credentials(str(unit.provider))
-        else:
-            credential = (
-                session.query(IntegrationCredential)
-                .filter(
-                    IntegrationCredential.id == credential_id,
-                    IntegrationCredential.org_id == unit.org_id,
-                )
-                .one_or_none()
-            )
-            if credential is None:
-                raise ValueError(f"Credential not found for unit: {unit_id}")
-            decrypted_credentials = _credential_mapping(credential)
+        # Prefer the run-stamped credential frozen at plan time (CHAOS-2755). A
+        # NULL-stamped (legacy/in-flight) run falls back to the mutable
+        # integration.credential_id path inside resolve_run_auth.
+        run = (
+            session.query(SyncRun)
+            .filter(SyncRun.id == unit.sync_run_id, SyncRun.org_id == unit.org_id)
+            .one_or_none()
+        )
+        credential_id, decrypted_credentials = resolve_run_auth(
+            session,
+            run=run,
+            integration=integration,
+            provider=str(unit.provider),
+            error_label=f"unit: {unit_id}",
+        )
 
         processor_flags = {
             str(key): bool(value)

--- a/src/dev_health_ops/workers/team_autoimport.py
+++ b/src/dev_health_ops/workers/team_autoimport.py
@@ -205,27 +205,26 @@ def run_post_sync_team_autoimport(sync_run_id: str) -> dict[str, Any]:
     Restores the legacy post-sync team auto-import (CHAOS-2647) on the unitized
     fan-out path. The post-sync relay dispatches this once per terminal SyncRun
     when the run's canonical config has ``auto_import_teams`` enabled. Credentials
-    are resolved from the run's ``Integration.credential_id`` — the SAME source the
-    unit workers used — so auto-import authenticates identically to the sync that
-    just completed (never the legacy ``SyncConfiguration.credential_id`` row, which
-    can drift). Best-effort and non-fatal: :func:`run_team_autoimport` capability-
+    are resolved via :func:`resolve_run_auth` — the SAME run-stamped auth context
+    the unit workers used (CHAOS-2755) — so auto-import authenticates identically
+    to the sync that just completed even if ``Integration.credential_id`` was
+    repointed mid-run (and never the legacy ``SyncConfiguration.credential_id``
+    row, which can drift). Best-effort and non-fatal: :func:`run_team_autoimport` capability-
     gates providers and swallows populator exceptions, so a failure here never
     fails the sync.
     """
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models import (
         Integration,
-        IntegrationCredential,
         SyncRun,
         SyncRunStatus,
     )
     from dev_health_ops.sync.trigger_routing import (
         canonical_sync_config_for_sync_run,
     )
+    from dev_health_ops.workers.sync_bootstrap import resolve_run_auth
     from dev_health_ops.workers.task_utils import (
-        _credential_mapping,
         _get_db_url,
-        _resolve_env_credentials,
     )
 
     run_uuid = uuid.UUID(str(sync_run_id))
@@ -287,25 +286,26 @@ def run_post_sync_team_autoimport(sync_run_id: str) -> dict[str, Any]:
                 "reason": "integration_not_found",
                 "sync_run_id": sync_run_id,
             }
-        credential_id = integration.credential_id
-        if credential_id is None:
-            credentials: dict[str, Any] = dict(_resolve_env_credentials(provider))
-        else:
-            credential = (
-                session.query(IntegrationCredential)
-                .filter(
-                    IntegrationCredential.id == credential_id,
-                    IntegrationCredential.org_id == org_id,
-                )
-                .one_or_none()
+        # CHAOS-2755: resolve via the run-stamped auth context (resolve_run_auth)
+        # so a mid-run credential repoint cannot make post-sync attribution use a
+        # different credential than the units that produced the synced data.
+        # Best-effort contract preserved: resolution failures (stamped credential
+        # deleted, strict fingerprint mismatch) skip rather than fail the task.
+        try:
+            _credential_id, credentials = resolve_run_auth(
+                session,
+                run=run,
+                integration=integration,
+                provider=provider,
+                error_label=f"team_autoimport run: {sync_run_id}",
             )
-            if credential is None:
-                return {
-                    "status": "skipped",
-                    "reason": "credential_not_found",
-                    "sync_run_id": sync_run_id,
-                }
-            credentials = _credential_mapping(credential)
+        except Exception as exc:
+            return {
+                "status": "skipped",
+                "reason": "credential_resolution_failed",
+                "detail": str(exc),
+                "sync_run_id": sync_run_id,
+            }
 
     summary = run_team_autoimport(
         provider=provider,

--- a/tests/test_credential_capacity_invariants.py
+++ b/tests/test_credential_capacity_invariants.py
@@ -33,9 +33,11 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from dev_health_ops.core.encryption import encrypt_value
 from dev_health_ops.models import (
     Base,
     Integration,
+    IntegrationCredential,
     IntegrationDataset,
     IntegrationSource,
     SyncRun,
@@ -311,18 +313,43 @@ def test_sync_run_unit_model_has_no_credential_column() -> None:
 # --- Behavior guards ----------------------------------------------------------
 
 
-def test_plan_sync_run_identical_under_credential_swap(db_session: Session) -> None:
+def test_plan_sync_run_identical_under_credential_swap(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Planning is credential-blind: swapping the integration's credential
     yields byte-identical units (count, datasets, windows, cost).
 
     Backfill mode with explicit ``since``/``before`` keeps windows deterministic
     (chunker-derived, wall-clock-independent) so equality is not flaky.
-    """
 
-    credential_a = uuid.uuid4()
-    credential_b = uuid.uuid4()
+    Both credentials are REAL active rows: since CHAOS-2755 the planner stamps
+    the run's auth at plan time and fail-fasts on a missing/inactive credential,
+    so a dangling UUID would abort planning — that fail-fast has its own test;
+    THIS invariant is about unit shapes being identical across valid swaps.
+    """
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-capacity-invariants-secret")
+    org = str(uuid.uuid4())
+
+    def _make_credential(name: str, token: str) -> IntegrationCredential:
+        credential = IntegrationCredential(
+            provider="github",
+            name=name,
+            org_id=org,
+            credentials_encrypted=encrypt_value(json.dumps({"token": token})),
+            config={},
+            is_active=True,
+        )
+        db_session.add(credential)
+        db_session.flush()
+        return credential
+
+    credential_a = _make_credential("primary", "tok-A").id
+    credential_b = _make_credential("secondary", "tok-B").id
     integration, _source = _seed_github_integration(
-        db_session, credential_id=credential_a, dataset_keys=("commits", "prs")
+        db_session,
+        org_id=org,
+        credential_id=credential_a,
+        dataset_keys=("commits", "prs"),
     )
 
     plan_a = plan_sync_run(db_session, _backfill_request(integration))

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -164,6 +164,50 @@ def test_enabled_sources_and_enabled_datasets_fan_out_to_units(db_session):
     assert discovery.org_id == ORG_ID
 
 
+def test_planner_stamps_single_credential_per_run(db_session):
+    """CHAOS-2755: plan_sync_run stamps credential_id + fingerprint + auth_source
+    ONCE on the SyncRun, and neither PlannedUnit nor SyncRunUnit gains a
+    credential field (credentials are auth state, never dispatch capacity)."""
+    import dataclasses
+
+    from dev_health_ops.credentials.fingerprint import AUTH_SOURCE_ENVIRONMENT
+    from dev_health_ops.sync.planner import PlannedUnit
+
+    integration = _create_integration(db_session)  # env auth (credential_id=None)
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_source(db_session, integration, external_id="full-chaos/dev-health-web")
+    _create_dataset(db_session, integration, "commits")
+    _create_dataset(db_session, integration, "prs")
+
+    plan = plan_sync_run(
+        db_session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+
+    sync_run = db_session.get(SyncRun, plan.sync_run_id)
+    assert sync_run is not None
+    # Stamped exactly once, on the run.
+    assert sync_run.auth_source == AUTH_SOURCE_ENVIRONMENT
+    assert sync_run.credential_id is None  # environment auth
+    assert isinstance(sync_run.credential_fingerprint, str)
+    assert len(sync_run.credential_fingerprint) == 64  # sha256 hex digest
+
+    # The run-level columns exist ONLY on sync_runs, never on sync_run_units.
+    unit_columns = set(SyncRunUnit.__table__.columns.keys())
+    assert "credential_id" not in unit_columns
+    assert "credential_fingerprint" not in unit_columns
+    assert "auth_source" not in unit_columns
+
+    # PlannedUnit likewise carries no credential field.
+    planned_fields = {f.name for f in dataclasses.fields(PlannedUnit)}
+    assert not any("credential" in name for name in planned_fields)
+
+
 def test_unsupported_provider_dataset_pairs_are_skipped(db_session):
     integration = _create_integration(db_session, provider="jira")
     _create_source(db_session, integration, external_id="jira-project", provider="jira")

--- a/tests/test_sync_run_auth_freeze.py
+++ b/tests/test_sync_run_auth_freeze.py
@@ -1,0 +1,338 @@
+"""Run-auth freeze: a run's credential is resolved once at plan time and frozen
+for every later phase (CHAOS-2755).
+
+These tests exercise the full path: ``plan_sync_run`` stamps the credential onto
+the ``SyncRun``; ``SyncTaskBootstrap.load`` and
+``reference_discovery._load_discovery_context`` prefer the run-stamped credential;
+mid-run edits to ``Integration.credential_id`` (repoint) or to the credential's
+secret bytes (in-place rotation) can no longer change a stamped run's auth.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from contextlib import contextmanager
+from datetime import datetime, timezone
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.core.encryption import encrypt_value
+from dev_health_ops.credentials.fingerprint import (
+    AUTH_SOURCE_ENVIRONMENT,
+    AUTH_SOURCE_INTEGRATION_CREDENTIAL,
+)
+from dev_health_ops.models import (
+    Base,
+    Integration,
+    IntegrationDataset,
+    IntegrationSource,
+    SyncRun,
+    SyncRunMode,
+    SyncRunStatus,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+)
+from dev_health_ops.models.settings import IntegrationCredential
+from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
+from dev_health_ops.workers import reference_discovery
+from dev_health_ops.workers.sync_bootstrap import (
+    RunAuthFingerprintMismatchError,
+    SyncTaskBootstrap,
+)
+
+ORG_ID = "auth-freeze-org"
+
+
+@pytest.fixture(autouse=True)
+def _encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Deterministic key so encrypt_value / decrypt_value round-trip regardless of
+    # the ambient (direnv-scrubbed) environment.
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-run-auth-freeze-secret")
+    monkeypatch.delenv("SYNC_RUN_AUTH_STRICT", raising=False)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@contextmanager
+def _fake_session_ctx(session: Session):
+    try:
+        yield session
+    except Exception:
+        session.rollback()
+        raise
+    else:
+        session.commit()
+
+
+def _make_credential(
+    session: Session,
+    *,
+    token: str,
+    provider: str = "github",
+    name: str = "default",
+    is_active: bool = True,
+) -> IntegrationCredential:
+    credential = IntegrationCredential(
+        provider=provider,
+        name=name,
+        org_id=ORG_ID,
+        credentials_encrypted=encrypt_value(json.dumps({"token": token})),
+        config={},
+        is_active=is_active,
+    )
+    session.add(credential)
+    session.flush()
+    return credential
+
+
+def _make_integration(
+    session: Session,
+    *,
+    provider: str = "github",
+    credential_id: uuid.UUID | None = None,
+) -> Integration:
+    integration = Integration(
+        org_id=ORG_ID,
+        provider=provider,
+        name=f"{provider} integration",
+        config={},
+        is_active=True,
+        credential_id=credential_id,
+    )
+    session.add(integration)
+    session.flush()
+    return integration
+
+
+def _make_source(
+    session: Session,
+    integration: Integration,
+    *,
+    external_id: str = "full-chaos/dev-health",
+) -> IntegrationSource:
+    source = IntegrationSource(
+        org_id=ORG_ID,
+        integration_id=integration.id,
+        provider=integration.provider,
+        source_type="repo",
+        external_id=external_id,
+        name=external_id.rsplit("/", 1)[-1],
+        full_name=external_id,
+        metadata_={},
+        is_enabled=True,
+        discovered_at=datetime.now(timezone.utc),
+        last_seen_at=datetime.now(timezone.utc),
+    )
+    session.add(source)
+    session.flush()
+    return source
+
+
+def _make_dataset(
+    session: Session, integration: Integration, *, dataset_key: str = "commits"
+) -> IntegrationDataset:
+    dataset = IntegrationDataset(
+        org_id=ORG_ID,
+        integration_id=integration.id,
+        dataset_key=dataset_key,
+        is_enabled=True,
+        options={},
+    )
+    session.add(dataset)
+    session.flush()
+    return dataset
+
+
+def _plan(session: Session, integration: Integration) -> tuple[SyncRun, SyncRunUnit]:
+    _make_source(session, integration)
+    _make_dataset(session, integration)
+    plan = plan_sync_run(
+        session,
+        SyncPlanRequest(
+            integration_id=str(integration.id),
+            org_id=ORG_ID,
+            mode=SyncRunMode.INCREMENTAL.value,
+            triggered_by="manual",
+        ),
+    )
+    run = session.get(SyncRun, plan.sync_run_id)
+    assert run is not None
+    unit = (
+        session.query(SyncRunUnit)
+        .filter(SyncRunUnit.sync_run_id == plan.sync_run_id)
+        .one()
+    )
+    return run, unit
+
+
+def test_midrun_credential_repoint_does_not_change_stamped_run_auth(db_session):
+    """The core invariant: repointing Integration.credential_id AFTER planning
+    leaves every later resolution on the stamped credential."""
+    cred_a = _make_credential(db_session, token="tok-A", name="primary")
+    cred_b = _make_credential(db_session, token="tok-B", name="secondary")
+    integration = _make_integration(db_session, credential_id=cred_a.id)
+
+    run, unit = _plan(db_session, integration)
+    assert run.auth_source == AUTH_SOURCE_INTEGRATION_CREDENTIAL
+    assert run.credential_id == cred_a.id
+
+    # Mid-run repoint of the mutable integration pointer.
+    integration.credential_id = cred_b.id
+    db_session.flush()
+
+    ctx = SyncTaskBootstrap.load(db_session, str(unit.id))
+    # Frozen on the stamped credential, NOT the repointed one.
+    assert ctx.credential_id == str(cred_a.id)
+    assert ctx.decrypted_credentials.get("token") == "tok-A"
+
+
+def test_null_stamp_legacy_run_falls_back_to_integration(db_session):
+    """Pre-migration runs (auth_source NULL) keep working via the mutable
+    integration.credential_id path, and remain mutable (not frozen)."""
+    cred_a = _make_credential(db_session, token="tok-A", name="primary")
+    cred_b = _make_credential(db_session, token="tok-B", name="secondary")
+    integration = _make_integration(db_session, credential_id=cred_a.id)
+    source = _make_source(db_session, integration)
+
+    # A run persisted BEFORE this feature: no stamp columns set.
+    run = SyncRun(
+        org_id=ORG_ID,
+        integration_id=integration.id,
+        triggered_by="manual",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunStatus.PLANNED.value,
+        total_units=1,
+        completed_units=0,
+        failed_units=0,
+    )
+    db_session.add(run)
+    db_session.flush()
+    unit = SyncRunUnit(
+        org_id=ORG_ID,
+        sync_run_id=run.id,
+        integration_id=integration.id,
+        source_id=source.id,
+        provider=integration.provider,
+        dataset_key="commits",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+    )
+    db_session.add(unit)
+    db_session.flush()
+
+    assert run.auth_source is None
+
+    ctx = SyncTaskBootstrap.load(db_session, str(unit.id))
+    assert ctx.credential_id == str(cred_a.id)
+    assert ctx.decrypted_credentials.get("token") == "tok-A"
+
+    # Legacy runs stay on the mutable path: repointing changes resolution.
+    integration.credential_id = cred_b.id
+    db_session.flush()
+    ctx2 = SyncTaskBootstrap.load(db_session, str(unit.id))
+    assert ctx2.credential_id == str(cred_b.id)
+    assert ctx2.decrypted_credentials.get("token") == "tok-B"
+
+
+def test_env_auth_run_stamped_as_environment(db_session, monkeypatch):
+    """A NULL integration credential yields auth_source='environment', which is
+    distinguishable from a legacy NULL stamp (auth_source column itself NULL)."""
+    for env_var in ("GITHUB_TOKEN", "GITHUB_URL", "GITHUB_APP_ID"):
+        monkeypatch.delenv(env_var, raising=False)
+    integration = _make_integration(db_session, credential_id=None)
+
+    run, _unit = _plan(db_session, integration)
+
+    assert run.auth_source == AUTH_SOURCE_ENVIRONMENT
+    assert run.auth_source is not None  # distinguishable from legacy NULL stamp
+    assert run.credential_id is None
+    assert isinstance(run.credential_fingerprint, str)
+    assert len(run.credential_fingerprint) == 64
+
+
+def test_stamp_contains_no_raw_secret_material(db_session):
+    """The stamped fingerprint is a safe-scope digest — no token bytes and NOT
+    the full-payload runtime-cache hash."""
+    from dev_health_ops.workers.sync_bootstrap import (
+        _credential_fingerprint as full_payload_fingerprint,
+    )
+
+    secret = "super-secret-token-value-1234567890"
+    cred = _make_credential(db_session, token=secret)
+    integration = _make_integration(db_session, credential_id=cred.id)
+
+    run, _unit = _plan(db_session, integration)
+
+    fingerprint = run.credential_fingerprint
+    assert isinstance(fingerprint, str)
+    assert len(fingerprint) == 64
+    # Raw secret never appears in the persisted witness.
+    assert secret not in fingerprint
+    # Must NOT be the full-payload hash of the decrypted secret mapping.
+    assert fingerprint != full_payload_fingerprint({"token": secret})
+
+
+def test_reference_discovery_uses_run_stamped_credential(db_session, monkeypatch):
+    """Discovery resolves the SAME credential as the units of the same run, even
+    after the integration pointer is repointed mid-run."""
+    import dev_health_ops.db as db
+
+    cred_a = _make_credential(db_session, token="tok-A", name="primary")
+    cred_b = _make_credential(db_session, token="tok-B", name="secondary")
+    integration = _make_integration(db_session, credential_id=cred_a.id)
+    run, _unit = _plan(db_session, integration)
+
+    integration.credential_id = cred_b.id
+    db_session.flush()
+
+    monkeypatch.setattr(
+        db, "get_postgres_session_sync", lambda: _fake_session_ctx(db_session)
+    )
+    context = reference_discovery._load_discovery_context(run.id)
+    assert context["credentials"].get("token") == "tok-A"
+
+
+def test_fingerprint_mismatch_warns_by_default_fails_when_strict(
+    db_session, monkeypatch, caplog
+):
+    """An in-place secret edit (same credential id, rotated token): warn and
+    continue with the new secret by default; hard-fail under SYNC_RUN_AUTH_STRICT."""
+    cred = _make_credential(db_session, token="tok-A")
+    integration = _make_integration(db_session, credential_id=cred.id)
+    run, unit = _plan(db_session, integration)
+    stamped_fingerprint = run.credential_fingerprint
+
+    # Rotate the secret in place (same credential id) — the stamped fingerprint
+    # no longer matches the credential's content.
+    cred.credentials_encrypted = encrypt_value(json.dumps({"token": "tok-A-rotated"}))
+    db_session.flush()
+
+    # Default: warn-and-continue with the new secret.
+    with caplog.at_level("WARNING"):
+        ctx = SyncTaskBootstrap.load(db_session, str(unit.id))
+    assert ctx.decrypted_credentials.get("token") == "tok-A-rotated"
+    assert ctx.credential_id == str(cred.id)
+    assert any(
+        "sync_run_auth.fingerprint_mismatch" in record.message
+        or "fingerprint_mismatch" in record.getMessage()
+        for record in caplog.records
+    )
+    # The stamp itself is untouched (freeze is about reads, not rewrites).
+    assert run.credential_fingerprint == stamped_fingerprint
+
+    # Strict: the same edit hard-fails the unit non-retryably.
+    monkeypatch.setenv("SYNC_RUN_AUTH_STRICT", "1")
+    with pytest.raises(RunAuthFingerprintMismatchError):
+        SyncTaskBootstrap.load(db_session, str(unit.id))

--- a/tests/workers/test_team_autoimport_sync_surfaces.py
+++ b/tests/workers/test_team_autoimport_sync_surfaces.py
@@ -380,6 +380,69 @@ def test_post_sync_team_autoimport_resolves_credentials_from_integration(
     assert captured[0]["credentials"] == {"token": "from-integration-cred"}
 
 
+def test_post_sync_team_autoimport_uses_run_stamped_credential_after_repoint(
+    db_session, monkeypatch
+) -> None:
+    """CHAOS-2755 freeze reaches post-sync attribution: a mid-run repoint of
+    ``Integration.credential_id`` must not switch auto-import onto a different
+    credential than the units that produced the synced data (PR #1109 review M1)."""
+    from dev_health_ops.credentials.fingerprint import (
+        AUTH_SOURCE_INTEGRATION_CREDENTIAL,
+    )
+
+    cred_a = IntegrationCredential(
+        org_id=_ORG,
+        provider="github",
+        name="stamped",
+        credentials_encrypted=None,
+        config={},
+    )
+    cred_b = IntegrationCredential(
+        org_id=_ORG,
+        provider="github",
+        name="repointed",
+        credentials_encrypted=None,
+        config={},
+    )
+    db_session.add_all([cred_a, cred_b])
+    db_session.flush()
+    run, integration, _config = _seed_run_with_config(
+        db_session,
+        status=SyncRunStatus.SUCCESS.value,
+        sync_options={"auto_import_teams": True},
+        credential_id=cred_a.id,
+    )
+    # Mimic the planner stamp (fingerprint None -> verification no-op), then
+    # repoint the mutable integration pointer mid-run.
+    run.credential_id = cred_a.id
+    run.auth_source = AUTH_SOURCE_INTEGRATION_CREDENTIAL
+    run.credential_fingerprint = None
+    integration.credential_id = cred_b.id
+    db_session.flush()
+
+    _patch_session(monkeypatch, db_session)
+    import dev_health_ops.workers.task_utils as task_utils
+
+    monkeypatch.setattr(
+        task_utils,
+        "_credential_mapping",
+        lambda cred: {"token": f"tok-{cred.name}"},
+    )
+    captured: list[dict[str, Any]] = []
+
+    def _run_autoimport(**kwargs: Any) -> dict[str, Any]:
+        captured.append(kwargs)
+        return {"status": "success"}
+
+    monkeypatch.setattr(team_autoimport, "run_team_autoimport", _run_autoimport)
+
+    team_autoimport.run_post_sync_team_autoimport(str(run.id))
+
+    assert len(captured) == 1
+    # Frozen on the stamped credential, NOT the repointed one.
+    assert captured[0]["credentials"] == {"token": "tok-stamped"}
+
+
 def test_post_sync_team_autoimport_skips_when_integration_missing(
     db_session, monkeypatch
 ) -> None:


### PR DESCRIPTION
## Problem

A sync run's auth was re-resolved from the **mutable** `Integration.credential_id` at four independent points — reference discovery (`_load_discovery_context`), the three BudgetGuard passes, and unit execution (`run_sync_unit`, all via `SyncTaskBootstrap.load`). A credential edit *mid-run* could therefore split one run across two identities (mixed-auth). A run's auth was non-deterministic.

## Fix

Resolve a run's credential **once, at plan time**, and freeze it for the whole run.

- **`alembic 0030`** (chained from `0029`, retry-safe guarded-column pattern per `0022`): three nullable columns on `sync_runs` — `credential_id` (**plain UUID, NO FK** so a deleted stamped credential surfaces as the existing "Credential not found" unit failure), `credential_fingerprint` (TEXT), `auth_source` (`integration_credential` | `environment`). **Run-level only — no credential column on `sync_run_units`.**
- **`credentials/fingerprint.py`** (new): a provider-agnostic **safe-scope content witness** — non-secret identifiers verbatim, secret bytes only ever SHA-256 hashed, final value is a single sha256 hex. Deliberately independent of the per-provider `providers/*/budget.py` budget-bucket fingerprints (those key `BudgetBucketKey` and must not change) and NOT the full-payload runtime-cache hash.
- **`planner.plan_sync_run`**: stamp `credential_id` + `credential_fingerprint` + `auth_source`; enforce `IntegrationCredential.is_active` **at plan time only**.
- **`sync_bootstrap.resolve_run_auth`**: single choke point behind `SyncTaskBootstrap.load` (BudgetGuard + `run_sync_unit` inherit the fix) that prefers the run-stamped credential when `auth_source` is non-NULL. NULL-stamp (legacy / in-flight-at-deploy) runs fall back to today's mutable path. Mid-run deactivation is tolerated; an in-place secret edit (fingerprint mismatch) **warns and continues by default**, and **hard-fails under `SYNC_RUN_AUTH_STRICT`**. `RuntimeCacheKey` is byte-unchanged.
- **`reference_discovery._load_discovery_context`**: same run-stamped resolution (run row already loaded).
- **`docs/architecture/sync-unit-model.md`**: documents the freeze flow, the deliberate asymmetries, and the capacity invariant.

**Product invariant (binding):** run-level stamping is for **determinism only** — no credential field on `PlannedUnit`/`SyncRunUnit`, `RuntimeCacheKey` unchanged. Changing or rotating credentials must never increase sync dispatch capacity.

## Tests

New `tests/test_sync_run_auth_freeze.py` (7 tests) + a stamping test in `tests/test_sync_planner.py`:
- `test_planner_stamps_single_credential_per_run` — stamp written once on the run; `PlannedUnit`/`SyncRunUnit` carry no credential field.
- `test_midrun_credential_repoint_does_not_change_stamped_run_auth` — **core invariant**: repointing `Integration.credential_id` after planning leaves later resolutions on the stamped credential.
- `test_null_stamp_legacy_run_falls_back_to_integration` — pre-migration runs keep working (and stay mutable).
- `test_env_auth_run_stamped_as_environment` — env auth stamps `auth_source='environment'`, distinguishable from legacy NULL.
- `test_stamp_contains_no_raw_secret_material` — fingerprint is safe-scope, not the full-payload hash, no token bytes.
- `test_reference_discovery_uses_run_stamped_credential` — discovery resolves the same credential as the run's units.
- `test_fingerprint_mismatch_warns_by_default_fails_when_strict` — rollout flag behavior.

Gate: `bash ci/local_validate.sh` **PASSED** (ruff + mypy + full unit suite 6162 passed + CH scratch migrate + argMax live proof). Postgres migration idempotency, downgrade, and retry-safe re-add verified on a real scratch DB; `credential_id` confirmed FK-free.

Part of CHAOS-2742
Fixes CHAOS-2755

https://linear.app/fullchaos/issue/CHAOS-2755