### PR TITLE
feat(sync): normalize provider rate-limit signals + unify RateLimitException (CHAOS-2753)

### DIFF
--- a/src/dev_health_ops/connectors/base.py
+++ b/src/dev_health_ops/connectors/base.py
@@ -32,16 +32,26 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     RateLimitConfig,
     RateLimitGate,
 )
+from dev_health_ops.exceptions import RateLimitException as _RootRateLimitException
 
 logger = logging.getLogger(__name__)
 
 
-class RateLimitException(Exception):
-    """Exception raised when API rate limit is reached."""
+class RateLimitException(_RootRateLimitException):
+    """Rate-limit error raised by the legacy Git connectors.
 
-    def __init__(self, message: str, retry_after_seconds: float | None = None):
-        super().__init__(message)
-        self.retry_after_seconds = retry_after_seconds
+    Subclasses the root :class:`dev_health_ops.exceptions.RateLimitException` so a
+    rate limit raised deep in a legacy connector (``connectors/gitlab.py``) is
+    caught by the worker deferral branch in ``workers/sync_units.py`` and deferred
+    as retryable work, instead of falling through to the generic ``Exception``
+    handler and becoming a FAILED unit (the class-split bug this fixes).
+
+    Kept as a *distinct* subclass rather than a plain alias so the
+    ``retry_with_backoff(exceptions=(RateLimitException, ...))`` decorator sites
+    in the legacy connectors keep referencing it by identity and retain their
+    existing in-connector retry semantics. The constructor is inherited from the
+    root (``message``, ``retry_after_seconds``, keyword-only ``signal``).
+    """
 
 
 @dataclass

--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -10,6 +10,7 @@ import logging
 import time
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
+from urllib.parse import urlparse
 
 import requests
 from github import Auth, Github, GithubException, RateLimitExceededException
@@ -51,6 +52,8 @@ from dev_health_ops.metrics.prometheus import (
     record_github_api_request,
     record_github_rate_limit,
 )
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
 logger = logging.getLogger(__name__)
 
@@ -205,9 +208,21 @@ class GitHubConnector(GitConnector):
         # (a) primary rate limit.
         if diag.get("x-ratelimit-remaining") == "0":
             logger.warning("GitHub primary rate limit (403) headers=%s", diag)
+            reset_delay = self._rate_limit_reset_delay_seconds()
             raise RateLimitException(
                 f"GitHub rate limit (403) (headers={diag})",
-                retry_after_seconds=self._rate_limit_reset_delay_seconds(),
+                retry_after_seconds=reset_delay,
+                signal=RateLimitSignal(
+                    provider="github",
+                    host=urlparse(self._rest_base_url()).netloc or None,
+                    dimension=BudgetDimension.REST_CORE,
+                    retry_after_seconds=reset_delay,
+                    reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                        diag.get("x-ratelimit-reset")
+                    ),
+                    reason="primary",
+                    request_id=diag.get("x-github-request-id"),
+                ),
             )
         # (b) secondary/abuse limit.
         retry_after = diag.get("retry-after")
@@ -220,6 +235,17 @@ class GitHubConnector(GitConnector):
             raise RateLimitException(
                 f"GitHub secondary/abuse rate limit (403) (headers={diag})",
                 retry_after_seconds=retry_after_seconds,
+                signal=RateLimitSignal(
+                    provider="github",
+                    host=urlparse(self._rest_base_url()).netloc or None,
+                    dimension=BudgetDimension.SECONDARY_ABUSE_RISK,
+                    retry_after_seconds=retry_after_seconds,
+                    reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                        diag.get("x-ratelimit-reset")
+                    ),
+                    reason="secondary",
+                    request_id=diag.get("x-github-request-id"),
+                ),
             )
         # (c) permission/SSO/other 403 -> non-retryable.
         logger.warning("GitHub 403 (permission/SSO) headers=%s body=%s", diag, body)
@@ -886,6 +912,17 @@ class GitHubConnector(GitConnector):
             return RateLimitException(
                 f"GitHub rate limit (403) on {method} {endpoint} (headers={diag})",
                 retry_after_seconds=(float(retry_after) if retry_after else None),
+                signal=RateLimitSignal(
+                    provider="github",
+                    host=urlparse(self._rest_base_url()).netloc or None,
+                    dimension=BudgetDimension.REST_CORE,
+                    retry_after_seconds=(float(retry_after) if retry_after else None),
+                    reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                        diag.get("x-ratelimit-reset")
+                    ),
+                    reason="primary",
+                    request_id=diag.get("x-github-request-id"),
+                ),
             )
         # (b) secondary/abuse limit -> backoff per Retry-After / body wording.
         if retry_after is not None or self._is_github_rate_limit_403(response):
@@ -899,6 +936,17 @@ class GitHubConnector(GitConnector):
                 f"GitHub secondary/abuse rate limit (403) on {method} {endpoint} "
                 f"(headers={diag})",
                 retry_after_seconds=(float(retry_after) if retry_after else None),
+                signal=RateLimitSignal(
+                    provider="github",
+                    host=urlparse(self._rest_base_url()).netloc or None,
+                    dimension=BudgetDimension.SECONDARY_ABUSE_RISK,
+                    retry_after_seconds=(float(retry_after) if retry_after else None),
+                    reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                        diag.get("x-ratelimit-reset")
+                    ),
+                    reason="secondary",
+                    request_id=diag.get("x-github-request-id"),
+                ),
             )
         # (c) permission/SSO/other 403 -> not a rate limit.
         logger.warning(

--- a/src/dev_health_ops/connectors/github.py
+++ b/src/dev_health_ops/connectors/github.py
@@ -165,7 +165,11 @@ class GitHubConnector(GitConnector):
         # RETRYABLE (it is the ``exceptions=`` tuple member the decorator
         # catches), while preserving the ``retry_after_seconds`` wait.
         if isinstance(e, ExceptionsRateLimitException):
-            raise RateLimitException(str(e), retry_after_seconds=e.retry_after_seconds)
+            raise RateLimitException(
+                str(e),
+                retry_after_seconds=e.retry_after_seconds,
+                signal=getattr(e, "signal", None),
+            )
         if isinstance(e, ConnectorException):
             raise e
         if isinstance(e, RateLimitExceededException):

--- a/src/dev_health_ops/connectors/launchdarkly.py
+++ b/src/dev_health_ops/connectors/launchdarkly.py
@@ -17,8 +17,17 @@ from dev_health_ops.connectors.exceptions import (
     AuthenticationException,
     RateLimitException,
 )
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
 logger = logging.getLogger(__name__)
+
+
+def _response_host(response: httpx.Response) -> str | None:
+    """Best-effort host for the responding LaunchDarkly instance."""
+    host = getattr(getattr(response, "url", None), "host", None)
+    return host if isinstance(host, str) and host else None
+
 
 _BASE_URL = "https://app.launchdarkly.com/api/v2"
 
@@ -56,11 +65,26 @@ def _raise_for_status(response: httpx.Response) -> None:
     if status == 401:
         raise AuthenticationException("LaunchDarkly authentication failed")
     if status == 403:
-        raise APIException(f"LaunchDarkly forbidden: {response.text}")
+        # Permission/feature-disabled: non-retryable, matching the
+        # GitHub/GitLab convention where a permission 403 is an auth error
+        # rather than a retryable APIException.
+        raise AuthenticationException(f"LaunchDarkly forbidden: {response.text}")
     if status == 429:
+        retry_after = _parse_retry_after(response)
         raise RateLimitException(
             "LaunchDarkly rate limit exceeded",
-            retry_after_seconds=_parse_retry_after(response),
+            retry_after_seconds=retry_after,
+            signal=RateLimitSignal(
+                provider="launchdarkly",
+                host=_response_host(response),
+                dimension=BudgetDimension.REST_CORE,
+                retry_after_seconds=retry_after,
+                # LaunchDarkly reports its reset window as epoch MILLISECONDS.
+                reset_at=RateLimitSignal.reset_at_from_epoch_millis(
+                    response.headers.get("X-RateLimit-Reset")
+                ),
+                reason="primary",
+            ),
         )
     if status == 404:
         raise APIException(f"LaunchDarkly resource not found: {response.url}")

--- a/src/dev_health_ops/connectors/utils/graphql.py
+++ b/src/dev_health_ops/connectors/utils/graphql.py
@@ -10,6 +10,7 @@ import logging
 import time
 from collections.abc import Callable
 from typing import Any
+from urllib.parse import urlparse
 
 import requests
 
@@ -19,6 +20,8 @@ from dev_health_ops.connectors.exceptions import (
     RateLimitException,
 )
 from dev_health_ops.connectors.utils.retry import retry_with_backoff
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
 logger = logging.getLogger(__name__)
 
@@ -158,10 +161,22 @@ class GitHubGraphQLClient:
                 # (a) primary rate limit: remaining quota exhausted -> retry
                 # after the reset window.
                 if diag.get("x-ratelimit-remaining") == "0":
+                    reset_delay = _github_reset_delay_seconds(response)
                     raise RateLimitException(
                         f"GitHub API rate limit exceeded on POST "
                         f"{self.GRAPHQL_ENDPOINT} (headers={diag})",
-                        retry_after_seconds=_github_reset_delay_seconds(response),
+                        retry_after_seconds=reset_delay,
+                        signal=RateLimitSignal(
+                            provider="github",
+                            host=urlparse(self.GRAPHQL_ENDPOINT).netloc or None,
+                            dimension=BudgetDimension.GRAPHQL_COST,
+                            retry_after_seconds=reset_delay,
+                            reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                                diag.get("x-ratelimit-reset")
+                            ),
+                            reason="primary",
+                            request_id=diag.get("x-github-request-id"),
+                        ),
                     )
                 # (b) secondary/abuse limit: Retry-After present, OR the body
                 # carries GitHub's documented secondary/abuse wording even with
@@ -188,6 +203,17 @@ class GitHubGraphQLClient:
                         f"GitHub secondary/abuse rate limit on POST "
                         f"{self.GRAPHQL_ENDPOINT} (headers={diag})",
                         retry_after_seconds=retry_after_seconds,
+                        signal=RateLimitSignal(
+                            provider="github",
+                            host=urlparse(self.GRAPHQL_ENDPOINT).netloc or None,
+                            dimension=BudgetDimension.SECONDARY_ABUSE_RISK,
+                            retry_after_seconds=retry_after_seconds,
+                            reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                                diag.get("x-ratelimit-reset")
+                            ),
+                            reason="secondary",
+                            request_id=diag.get("x-github-request-id"),
+                        ),
                     )
                 # (c) permission/SSO/other 403: NOT a transient condition.
                 # Raise a non-retryable AuthenticationException so the retry

--- a/src/dev_health_ops/exceptions.py
+++ b/src/dev_health_ops/exceptions.py
@@ -1,3 +1,11 @@
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
+
+
 class ConnectorException(Exception):
     pass
 
@@ -7,9 +15,15 @@ class RateLimitException(ConnectorException):
         self,
         message: str = "API rate limit exceeded",
         retry_after_seconds: float | None = None,
+        *,
+        signal: RateLimitSignal | None = None,
     ) -> None:
         super().__init__(message)
         self.retry_after_seconds = retry_after_seconds
+        # Optional provider-neutral rate-limit signal (CHAOS-2753). Populated at
+        # provider classification sites; enriched (integration_id/route_family)
+        # at the worker boundary.
+        self.signal = signal
 
 
 class AuthenticationException(ConnectorException):

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -31,6 +31,8 @@ from dev_health_ops.credentials.resolver import (
 )
 from dev_health_ops.credentials.types import GitHubCredentials
 from dev_health_ops.providers._ratelimit import gate_call
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
 logger = logging.getLogger(__name__)
 
@@ -581,9 +583,19 @@ class GitHubWorkClient:
             raise exc
         if isinstance(exc, RateLimitExceededException):
             self._record_rest_usage(operation)
+            reset_delay = self._rate_limit_reset_delay_seconds()
             raise RateLimitException(
                 f"GitHub rate limit on {operation}: {exc}",
-                retry_after_seconds=self._rate_limit_reset_delay_seconds(),
+                retry_after_seconds=reset_delay,
+                signal=RateLimitSignal(
+                    provider="github",
+                    dimension=BudgetDimension.REST_CORE,
+                    retry_after_seconds=reset_delay,
+                    reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                        getattr(self.github, "rate_limiting_resettime", None)
+                    ),
+                    reason="primary",
+                ),
             )
         if not isinstance(exc, GithubException):
             raise APIException(f"GitHub API error on {operation}: {exc}") from exc
@@ -615,6 +627,7 @@ class GitHubWorkClient:
             )
             if is_rate_limit:
                 retry_after = _retry_after_seconds(headers)
+                is_primary = headers.get("x-ratelimit-remaining") == "0"
                 logger.warning(
                     "GitHub rate limit (403) on %s headers=%s message=%s",
                     operation,
@@ -624,6 +637,20 @@ class GitHubWorkClient:
                 raise RateLimitException(
                     f"GitHub rate limit (403) on {operation}: {message} (headers={headers})",
                     retry_after_seconds=retry_after,
+                    signal=RateLimitSignal(
+                        provider="github",
+                        dimension=(
+                            BudgetDimension.REST_CORE
+                            if is_primary
+                            else BudgetDimension.SECONDARY_ABUSE_RISK
+                        ),
+                        retry_after_seconds=retry_after,
+                        reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                            headers.get("x-ratelimit-reset")
+                        ),
+                        reason="primary" if is_primary else "secondary",
+                        request_id=headers.get("x-github-request-id"),
+                    ),
                 ) from exc
             logger.warning(
                 "GitHub 403 on %s headers=%s message=%s",

--- a/src/dev_health_ops/providers/gitlab/client.py
+++ b/src/dev_health_ops/providers/gitlab/client.py
@@ -15,6 +15,8 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
 from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.providers._ratelimit import gate_call, parse_retry_after_header
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
 logger = logging.getLogger(__name__)
 
@@ -68,17 +70,27 @@ def _maybe_raise_gitlab_rate_limit(exc: BaseException) -> None:
     if not is_rate_limited:
         return None
     # Prefer Retry-After; else derive from RateLimit-Reset (epoch seconds) if present.
-    if retry_after is None:
-        reset_raw = _hdr("RateLimit-Reset")
-        if reset_raw is not None:
-            try:
-                import time as _t
+    reset_raw = _hdr("RateLimit-Reset")
+    if retry_after is None and reset_raw is not None:
+        try:
+            import time as _t
 
-                retry_after = max(0.0, float(reset_raw) - _t.time())
-            except (TypeError, ValueError):
-                retry_after = None
+            retry_after = max(0.0, float(reset_raw) - _t.time())
+        except (TypeError, ValueError):
+            retry_after = None
     raise RateLimitException(
-        f"GitLab rate limited (HTTP {status})", retry_after_seconds=retry_after
+        f"GitLab rate limited (HTTP {status})",
+        retry_after_seconds=retry_after,
+        signal=RateLimitSignal(
+            provider="gitlab",
+            dimension=BudgetDimension.REST_CORE,
+            retry_after_seconds=retry_after,
+            reset_at=RateLimitSignal.reset_at_from_epoch_seconds(reset_raw),
+            # 429 is the documented quota limit; a header-qualified 403 is the
+            # softer/abuse-style signal -- mirror GitHub's primary/secondary split.
+            reason="primary" if status == 429 else "secondary",
+            request_id=_hdr("X-Request-Id"),
+        ),
     ) from exc
 
 

--- a/src/dev_health_ops/providers/jira/client.py
+++ b/src/dev_health_ops/providers/jira/client.py
@@ -17,6 +17,8 @@ from dev_health_ops.providers._ratelimit import (
     penalize_from_response,
 )
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
 logger = logging.getLogger(__name__)
 
@@ -183,6 +185,17 @@ class JiraClient:
                     raise RateLimitException(
                         f"Jira rate limited: giving up after {attempts} attempts (HTTP 429)",
                         retry_after_seconds=retry_after,
+                        signal=RateLimitSignal(
+                            provider="jira",
+                            host=urlparse(self.auth.base_url).hostname,
+                            dimension=BudgetDimension.REST_CORE,
+                            retry_after_seconds=retry_after,
+                            reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                                resp.headers.get("X-RateLimit-Reset")
+                            ),
+                            reason="primary",
+                            request_id=resp.headers.get("X-AREQUESTID"),
+                        ),
                     )
                 resp.raise_for_status()
                 self.gate.reset()

--- a/src/dev_health_ops/providers/launchdarkly/code_refs.py
+++ b/src/dev_health_ops/providers/launchdarkly/code_refs.py
@@ -17,9 +17,18 @@ from dev_health_ops.connectors.exceptions import (
     RateLimitException,
 )
 from dev_health_ops.metrics.schemas import FeatureFlagLinkRecord
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 from dev_health_ops.work_graph.ids import generate_feature_flag_id, generate_file_id
 
 logger = logging.getLogger(__name__)
+
+
+def _response_host(response: httpx.Response) -> str | None:
+    """Best-effort host for the responding LaunchDarkly instance."""
+    host = getattr(getattr(response, "url", None), "host", None)
+    return host if isinstance(host, str) and host else None
+
 
 _BASE_URL = "https://app.launchdarkly.com/api/v2"
 LD_CODE_REFERENCE_CONFIDENCE = 0.95
@@ -82,13 +91,29 @@ def _raise_for_status(response: httpx.Response) -> None:
     if status == 401:
         raise AuthenticationException("LaunchDarkly authentication failed")
     if status == 429:
-        retry_after = response.headers.get("Retry-After")
+        retry_after_raw = response.headers.get("Retry-After")
+        retry_after = float(retry_after_raw) if retry_after_raw else None
         raise RateLimitException(
             "LaunchDarkly rate limit exceeded",
-            retry_after_seconds=float(retry_after) if retry_after else None,
+            retry_after_seconds=retry_after,
+            signal=RateLimitSignal(
+                provider="launchdarkly",
+                host=_response_host(response),
+                dimension=BudgetDimension.REST_CORE,
+                retry_after_seconds=retry_after,
+                # LaunchDarkly reports its reset window as epoch MILLISECONDS.
+                reset_at=RateLimitSignal.reset_at_from_epoch_millis(
+                    response.headers.get("X-RateLimit-Reset")
+                ),
+                reason="primary",
+            ),
         )
     if status == 403:
-        raise APIException(f"LaunchDarkly code references forbidden: {response.text}")
+        # Permission/feature-disabled: non-retryable, matching the
+        # GitHub/GitLab convention (auth error, not a retryable APIException).
+        raise AuthenticationException(
+            f"LaunchDarkly code references forbidden: {response.text}"
+        )
     if status == 404:
         raise APIException(f"LaunchDarkly code references not found: {response.url}")
     if status >= 500:

--- a/src/dev_health_ops/providers/linear/client.py
+++ b/src/dev_health_ops/providers/linear/client.py
@@ -18,6 +18,8 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
 from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.providers._ratelimit import gate_call
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +41,17 @@ class LinearComplexityLimitError(LinearGraphQLError):
 
     Not retryable: the query itself must be restructured (e.g. smaller
     nested page sizes). See Linear's 10,000-complexity budget.
+
+    Carries an optional provider-neutral :class:`RateLimitSignal` (dimension
+    ``graphql_cost``) so complexity rejections surface in the same observability
+    stream as timed rate limits -- but, crucially, it stays a
+    :class:`LinearGraphQLError` (not a ``RateLimitException``) so the worker
+    deferral branch never re-drives it as retryable work.
     """
+
+    def __init__(self, *args: object, signal: RateLimitSignal | None = None) -> None:
+        super().__init__(*args)
+        self.signal = signal
 
 
 class LinearRateLimitError(RateLimitException):
@@ -478,12 +490,26 @@ class LinearClient:
             data = body if isinstance(body, dict) else {}
             return data.get("data") or {}
 
+        retry_after = (
+            last_server_retry_after
+            if last_server_retry_after is not None
+            else last_delay
+        )
         raise LinearRateLimitError(
             f"Linear API rate limited: giving up after {self.max_attempts} "
             f"attempts (last backoff {last_delay:.1f}s)",
-            retry_after_seconds=last_server_retry_after
-            if last_server_retry_after is not None
-            else last_delay,
+            retry_after_seconds=retry_after,
+            signal=RateLimitSignal(
+                provider="linear",
+                host=urlparse(LINEAR_API_URL).netloc or None,
+                dimension=BudgetDimension.GRAPHQL_COST,
+                retry_after_seconds=retry_after,
+                # Linear reports its reset window as epoch MILLISECONDS.
+                reset_at=RateLimitSignal.reset_at_from_epoch_millis(
+                    self._rate_limit.reset_ms if self._rate_limit else None
+                ),
+                reason="primary",
+            ),
         )
 
     def _last_applied_delay(self, retry_after_seconds: float | None) -> float:
@@ -521,7 +547,13 @@ class LinearClient:
         if any(LinearClient._is_complexity_error(e) for e in errors):
             raise LinearComplexityLimitError(
                 "Linear GraphQL complexity limit exceeded "
-                f"(query must be restructured, not retried): {error_msg}"
+                f"(query must be restructured, not retried): {error_msg}",
+                signal=RateLimitSignal(
+                    provider="linear",
+                    host=urlparse(LINEAR_API_URL).netloc or None,
+                    dimension=BudgetDimension.GRAPHQL_COST,
+                    reason="complexity",
+                ),
             )
         raise LinearGraphQLError(f"Linear GraphQL error: {error_msg}")
 

--- a/src/dev_health_ops/sync/rate_limit_signal.py
+++ b/src/dev_health_ops/sync/rate_limit_signal.py
@@ -1,0 +1,93 @@
+"""Provider-neutral rate-limit signal (CHAOS-2742 / CHAOS-2753).
+
+One structured value crosses every provider ``client`` -> ``worker`` boundary so
+a rate-limit observation can be attributed to a budget bucket and (in a later
+slice) persisted as a shared cooldown. Provider clients populate the fields they
+already hold at the classification site -- ``provider``, ``host``, ``dimension``,
+``reason``, ``retry_after_seconds``, ``reset_at`` and ``request_id``. The
+``integration_id`` and ``route_family`` fields are enriched at the worker
+boundary (ws-d), so clients leave them ``None``.
+
+``dimension`` reuses :class:`~dev_health_ops.sync.budget_types.BudgetDimension`
+so signals join the same buckets the budget estimators use.
+
+``reset_at`` is always normalized to a timezone-aware UTC :class:`datetime`
+(or ``None``). Providers report reset windows in different units -- Linear uses
+epoch **milliseconds**, GitHub and GitLab use epoch **seconds** -- so convert at
+the classification site with :meth:`RateLimitSignal.reset_at_from_epoch_seconds`
+or :meth:`RateLimitSignal.reset_at_from_epoch_millis` before constructing the
+signal.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+
+def _coerce_float(value: object) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
+@dataclass(frozen=True)
+class RateLimitSignal:
+    """A provider-neutral, structured rate-limit observation."""
+
+    provider: str
+    host: str | None = None
+    integration_id: str | None = None
+    route_family: str | None = None
+    dimension: BudgetDimension | None = None
+    retry_after_seconds: float | None = None
+    reset_at: datetime | None = None
+    reason: str | None = None
+    request_id: str | None = None
+
+    def __post_init__(self) -> None:
+        # All reset windows are absolute UTC instants; normalize tz-naive
+        # datetimes to UTC and convert tz-aware ones to UTC. Frozen dataclass,
+        # so mutate through ``object.__setattr__``.
+        reset = self.reset_at
+        if isinstance(reset, datetime):
+            if reset.tzinfo is None:
+                object.__setattr__(self, "reset_at", reset.replace(tzinfo=timezone.utc))
+            else:
+                object.__setattr__(self, "reset_at", reset.astimezone(timezone.utc))
+
+    @staticmethod
+    def reset_at_from_epoch_seconds(value: object) -> datetime | None:
+        """Build a UTC ``reset_at`` from an epoch-**seconds** value (GitHub/GitLab)."""
+        epoch = _coerce_float(value)
+        if epoch is None or epoch <= 0:
+            return None
+        return datetime.fromtimestamp(epoch, tz=timezone.utc)
+
+    @staticmethod
+    def reset_at_from_epoch_millis(value: object) -> datetime | None:
+        """Build a UTC ``reset_at`` from an epoch-**milliseconds** value (Linear)."""
+        epoch_ms = _coerce_float(value)
+        if epoch_ms is None or epoch_ms <= 0:
+            return None
+        return datetime.fromtimestamp(epoch_ms / 1000.0, tz=timezone.utc)
+
+    def to_dict(self) -> dict[str, object | None]:
+        return {
+            "provider": self.provider,
+            "host": self.host,
+            "integration_id": self.integration_id,
+            "route_family": self.route_family,
+            "dimension": self.dimension.value if self.dimension is not None else None,
+            "retry_after_seconds": self.retry_after_seconds,
+            "reset_at": self.reset_at.isoformat()
+            if self.reset_at is not None
+            else None,
+            "reason": self.reason,
+            "request_id": self.request_id,
+        }

--- a/src/dev_health_ops/workers/rate_limit_defer.py
+++ b/src/dev_health_ops/workers/rate_limit_defer.py
@@ -1,10 +1,11 @@
-"""Rate-limit deferral helpers for Celery sync tasks.
+"""Rate-limit deferral planning for the unit sync worker.
 
 Provider rate-limit signals (HTTP 429 / ``Retry-After``) are treated as
-*deferred work*, not task failures. Instead of consuming the genuine-failure
-retry budget (Celery's single ``self.request.retries`` counter) and stamping
-the run ``FAILED``, the sync tasks re-enqueue a fresh invocation with the
-server-provided delay and explicit rate-limit budget metadata.
+*deferred work*, not task failures. When a unit hits a provider rate limit,
+:func:`plan_rate_limit_deferral` computes the next deferral -- a jittered,
+chunked countdown plus the ``attempts`` / ``first_seen_at`` / ``not_before``
+bookkeeping the worker (``workers/sync_units.py``) stamps onto the unit so it
+re-runs as ``RETRYING`` instead of consuming the genuine-failure retry budget.
 
 Two budgets bound the deferral so a permanently rate-limited provider still
 eventually surfaces as a real failure:
@@ -15,10 +16,9 @@ eventually surfaces as a real failure:
   from the first deferral.
 
 Long server delays (e.g. GitHub primary-limit resets up to ~1h) are *chunked*:
-a single Celery countdown is capped at :data:`RATE_LIMIT_MAX_COUNTDOWN_SECONDS`
-and an absolute ``not_before`` timestamp is carried forward so the task
-re-defers **without calling the provider again** until the window elapses.
-Chunk re-defers do not count against the count budget.
+a single countdown is capped at :data:`RATE_LIMIT_MAX_COUNTDOWN_SECONDS` and an
+absolute ``not_before`` timestamp is carried forward so the unit re-defers
+**without calling the provider again** until the window elapses.
 """
 
 from __future__ import annotations
@@ -27,9 +27,6 @@ import logging
 import random
 from dataclasses import dataclass
 from datetime import datetime, timezone
-from typing import Any
-
-from dev_health_ops.exceptions import RateLimitException
 
 logger = logging.getLogger(__name__)
 
@@ -128,82 +125,4 @@ def plan_rate_limit_deferral(
         attempts=attempts + 1,
         first_seen_at=first_seen.isoformat(),
         not_before=datetime.fromtimestamp(not_before_ts, tz=timezone.utc).isoformat(),
-    )
-
-
-def plan_not_before_wait(
-    not_before: str | None,
-    *,
-    now: datetime | None = None,
-) -> float | None:
-    """Countdown to re-defer a chunked wait, or ``None`` to proceed now.
-
-    Called at the top of a sync task: if a carried ``not_before`` is still in
-    the future, return the (chunked, jittered) countdown so the task
-    re-enqueues itself **without calling the provider**; otherwise ``None``.
-    """
-    target = _parse_iso(not_before)
-    if target is None:
-        return None
-    remaining = (target - _now(now)).total_seconds()
-    if remaining <= 0:
-        return None
-    return _jittered(min(remaining, RATE_LIMIT_MAX_COUNTDOWN_SECONDS))
-
-
-def rate_limit_metadata(deferral: RateLimitDeferral) -> dict[str, object]:
-    """Build the ``_rate_limit_*`` kwargs to carry into the re-enqueued task."""
-    return {
-        "_rate_limit_attempts": deferral.attempts,
-        "_rate_limit_first_seen_at": deferral.first_seen_at,
-        "_rate_limit_not_before": deferral.not_before,
-    }
-
-
-def maybe_plan_rate_limit_deferral(
-    exc: BaseException,
-    *,
-    attempts: int,
-    first_seen_at: str | None,
-    now: datetime | None = None,
-) -> RateLimitDeferral | None:
-    """Plan a deferral for a caught exception, or ``None``.
-
-    Returns ``None`` when ``exc`` is not a rate-limit error OR the deferral
-    budget is exhausted; in both cases the caller must run its normal failure
-    handling. Returns a :class:`RateLimitDeferral` when the task should be
-    re-enqueued instead of failed.
-    """
-    if not isinstance(exc, RateLimitException):
-        return None
-    return plan_rate_limit_deferral(
-        retry_after_seconds=getattr(exc, "retry_after_seconds", None),
-        attempts=attempts,
-        first_seen_at=first_seen_at,
-        now=now,
-    )
-
-
-def reenqueue_after_rate_limit(task: Any, deferral: RateLimitDeferral) -> None:
-    """Re-enqueue a fresh run of ``task`` carrying updated deferral metadata."""
-    request = task.request
-    task.apply_async(
-        args=list(request.args or []),
-        kwargs={**(request.kwargs or {}), **rate_limit_metadata(deferral)},
-        countdown=deferral.countdown,
-    )
-
-
-def reenqueue_rate_limit_chunk(task: Any, countdown: float) -> None:
-    """Re-enqueue ``task`` unchanged to wait out a chunked ``not_before`` window.
-
-    Used when a carried ``not_before`` is still in the future: the provider is
-    NOT called; the task simply re-defers itself. Deferral metadata is
-    preserved as-is (the count budget is not consumed by chunk waits).
-    """
-    request = task.request
-    task.apply_async(
-        args=list(request.args or []),
-        kwargs=dict(request.kwargs or {}),
-        countdown=countdown,
     )

--- a/src/dev_health_ops/workers/reference_discovery.py
+++ b/src/dev_health_ops/workers/reference_discovery.py
@@ -358,7 +358,10 @@ def _handle_reference_discovery_failure(
             return False
         if retryable and int(ledger.attempts or 0) < _max_attempts():
             available_at = now + timedelta(
-                seconds=_reference_discovery_backoff_seconds(int(ledger.attempts or 1))
+                seconds=_reference_discovery_backoff_seconds(
+                    int(ledger.attempts or 1),
+                    getattr(exc, "retry_after_seconds", None),
+                )
             )
             result = session.execute(
                 update(SyncRunReferenceDiscovery)
@@ -580,8 +583,14 @@ def _is_retryable_discovery_error(exc: Exception) -> bool:
     return any(marker in name or marker in message for marker in retry_markers)
 
 
-def _reference_discovery_backoff_seconds(attempts: int) -> int:
+def _reference_discovery_backoff_seconds(
+    attempts: int, retry_after_seconds: float | None = None
+) -> int:
     base = min(30 * 2 ** min(max(attempts, 1) - 1, 5), 900)
+    # Honor a provider-supplied Retry-After (e.g. a rate-limit reset window):
+    # never back off for less than the server asked for, capped at the ceiling.
+    if retry_after_seconds is not None and retry_after_seconds > 0:
+        base = min(max(base, int(retry_after_seconds)), 900)
     return base + random.randint(0, max(1, min(base, 30)))
 
 

--- a/tests/test_rate_limit_signal.py
+++ b/tests/test_rate_limit_signal.py
@@ -1,0 +1,433 @@
+"""Tests for the provider-neutral RateLimitSignal and the exception unification
+that lets legacy connector rate limits reach the worker deferral path.
+
+Covers CHAOS-2753:
+  * RateLimitSignal construction + reset_at normalization (epoch-s / epoch-ms).
+  * connectors.base.RateLimitException now subclasses the root exception.
+  * GitHub primary/secondary/permission 403 triage populates signals at every
+    classification site.
+  * Linear complexity limit carries a signal but stays non-retryable.
+  * reference_discovery backoff honors a server Retry-After.
+  * LaunchDarkly 403 maps to AuthenticationException (not a retryable API error).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from typing import cast
+
+import httpx
+import pytest
+
+from dev_health_ops.exceptions import (
+    AuthenticationException,
+)
+from dev_health_ops.exceptions import (
+    RateLimitException as RootRateLimitException,
+)
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
+
+# A fixed, valid epoch (2023-11-14T22:13:20Z) reused across reset-window cases.
+_EPOCH_S = 1_700_000_000
+_EPOCH_UTC = datetime.fromtimestamp(_EPOCH_S, tz=timezone.utc)
+
+
+class _FakeResponse:
+    """Minimal stand-in for requests.Response used by the GitHub sites."""
+
+    def __init__(
+        self,
+        status_code: int,
+        *,
+        headers: dict[str, str] | None = None,
+        text: str = "",
+        url: str = "https://api.github.com/graphql",
+    ) -> None:
+        self.status_code = status_code
+        self.headers = headers or {}
+        self.text = text
+        self.url = url
+
+    def json(self) -> dict[str, object]:  # pragma: no cover - not reached on 403
+        return {}
+
+
+# ---------------------------------------------------------------------------
+# RateLimitSignal core
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimitSignal:
+    def test_dimension_reuses_budget_dimension(self) -> None:
+        sig = RateLimitSignal(
+            provider="github", dimension=BudgetDimension.SECONDARY_ABUSE_RISK
+        )
+        assert sig.dimension is BudgetDimension.SECONDARY_ABUSE_RISK
+        # Worker-boundary fields stay None at the client (enriched in ws-d).
+        assert sig.integration_id is None
+        assert sig.route_family is None
+
+    def test_to_dict_serializes_enum_and_datetime(self) -> None:
+        sig = RateLimitSignal(
+            provider="jira",
+            host="example.atlassian.net",
+            dimension=BudgetDimension.REST_CORE,
+            retry_after_seconds=12.0,
+            reset_at=_EPOCH_UTC,
+            reason="primary",
+            request_id="req-1",
+        )
+        d = sig.to_dict()
+        assert d["provider"] == "jira"
+        assert d["dimension"] == "rest_core"
+        assert d["reset_at"] == _EPOCH_UTC.isoformat()
+        assert d["reason"] == "primary"
+        assert d["request_id"] == "req-1"
+
+
+def test_signal_reset_at_normalized_to_utc() -> None:
+    # GitHub / GitLab report epoch SECONDS.
+    sig_seconds = RateLimitSignal(
+        provider="github",
+        reset_at=RateLimitSignal.reset_at_from_epoch_seconds(_EPOCH_S),
+    )
+    assert sig_seconds.reset_at == _EPOCH_UTC
+    assert sig_seconds.reset_at is not None
+    assert sig_seconds.reset_at.tzinfo is timezone.utc
+
+    # Linear reports epoch MILLISECONDS -- the same instant.
+    sig_millis = RateLimitSignal(
+        provider="linear",
+        reset_at=RateLimitSignal.reset_at_from_epoch_millis(_EPOCH_S * 1000),
+    )
+    assert sig_millis.reset_at == _EPOCH_UTC
+    assert sig_seconds.reset_at == sig_millis.reset_at
+
+    # String header values are coerced.
+    assert RateLimitSignal.reset_at_from_epoch_seconds(str(_EPOCH_S)) == _EPOCH_UTC
+
+    # Absent / zero reset windows (Linear's default header is 0) -> None.
+    assert RateLimitSignal.reset_at_from_epoch_millis(0) is None
+    assert RateLimitSignal.reset_at_from_epoch_seconds(None) is None
+    assert RateLimitSignal.reset_at_from_epoch_seconds("bogus") is None
+
+    # A tz-naive datetime is normalized to UTC.
+    naive = RateLimitSignal(provider="x", reset_at=datetime(2026, 1, 1, 0, 0, 0))
+    assert naive.reset_at is not None
+    assert naive.reset_at.tzinfo is timezone.utc
+
+
+def test_legacy_connector_rate_limit_subclasses_root() -> None:
+    """The class-split bug fix: base.RateLimitException IS-A root RateLimitException."""
+    from dev_health_ops.connectors.base import (
+        RateLimitException as LegacyRateLimitException,
+    )
+
+    assert issubclass(LegacyRateLimitException, RootRateLimitException)
+    exc = LegacyRateLimitException("boom", retry_after_seconds=15.0)
+    assert isinstance(exc, RootRateLimitException)
+    assert exc.retry_after_seconds == 15.0
+    # Inherits the root constructor (keyword-only signal, defaults to None).
+    assert exc.signal is None
+
+
+# ---------------------------------------------------------------------------
+# GitHub 403 triage populates signals at all three classification sites
+# ---------------------------------------------------------------------------
+
+
+def _new_github_connector():
+    from dev_health_ops.connectors.github import GitHubConnector
+
+    conn = GitHubConnector.__new__(GitHubConnector)
+    # _rest_base_url() reads self.github; None -> default api.github.com.
+    conn.github = None  # type: ignore[assignment]
+    return conn
+
+
+class TestGitHub403TriagePopulatesSignalReason:
+    def test_rest_classify_site(self) -> None:
+        conn = _new_github_connector()
+
+        primary = conn._classify_github_403(
+            _FakeResponse(
+                403,
+                headers={
+                    "x-ratelimit-remaining": "0",
+                    "x-ratelimit-reset": str(_EPOCH_S),
+                    "x-github-request-id": "REQ-P",
+                },
+            ),
+            "GET",
+            "/repos/o/r/commits",
+        )
+        assert isinstance(primary, RootRateLimitException)
+        assert primary.signal is not None
+        assert primary.signal.reason == "primary"
+        assert primary.signal.dimension is BudgetDimension.REST_CORE
+        assert primary.signal.provider == "github"
+        assert primary.signal.reset_at == _EPOCH_UTC
+        assert primary.signal.request_id == "REQ-P"
+
+        secondary = conn._classify_github_403(
+            _FakeResponse(
+                403, headers={"retry-after": "60"}, text="secondary rate limit"
+            ),
+            "GET",
+            "/repos/o/r",
+        )
+        assert isinstance(secondary, RootRateLimitException)
+        assert secondary.signal is not None
+        assert secondary.signal.reason == "secondary"
+        assert secondary.signal.dimension is BudgetDimension.SECONDARY_ABUSE_RISK
+        assert secondary.signal.retry_after_seconds == 60.0
+
+        # Permission/SSO 403 is not a rate limit -> no exception, no signal.
+        permission = conn._classify_github_403(
+            _FakeResponse(
+                403, headers={}, text="Resource not accessible by integration"
+            ),
+            "GET",
+            "/repos/o/r",
+        )
+        assert permission is None
+
+    def test_pygithub_raise_site(self) -> None:
+        conn = _new_github_connector()
+
+        primary_exc = SimpleNamespace(
+            headers={
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": str(_EPOCH_S),
+                "x-github-request-id": "REQ-P",
+            },
+            data={"message": "API rate limit exceeded"},
+        )
+        with pytest.raises(RootRateLimitException) as excinfo:
+            conn._raise_github_403(primary_exc)
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "primary"
+        assert excinfo.value.signal.dimension is BudgetDimension.REST_CORE
+        assert excinfo.value.signal.reset_at == _EPOCH_UTC
+
+        secondary_exc = SimpleNamespace(
+            headers={"retry-after": "30"},
+            data={"message": "secondary rate limit"},
+        )
+        with pytest.raises(RootRateLimitException) as excinfo:
+            conn._raise_github_403(secondary_exc)
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "secondary"
+        assert excinfo.value.signal.dimension is BudgetDimension.SECONDARY_ABUSE_RISK
+        assert excinfo.value.signal.retry_after_seconds == 30.0
+
+        permission_exc = SimpleNamespace(
+            headers={}, data={"message": "SAML SSO required"}
+        )
+        with pytest.raises(AuthenticationException):
+            conn._raise_github_403(permission_exc)
+
+    def test_graphql_site(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dev_health_ops.connectors.utils import graphql as graphql_mod
+
+        client = graphql_mod.GitHubGraphQLClient(token="x")
+        # Bypass the retry_with_backoff wrapper so the classification runs once.
+        raw_query = graphql_mod.GitHubGraphQLClient.query.__wrapped__
+
+        monkeypatch.setattr(
+            graphql_mod.requests,
+            "post",
+            lambda *a, **k: _FakeResponse(
+                403,
+                headers={
+                    "x-ratelimit-remaining": "0",
+                    "x-ratelimit-reset": str(_EPOCH_S),
+                    "x-github-request-id": "G-REQ",
+                },
+            ),
+        )
+        with pytest.raises(RootRateLimitException) as excinfo:
+            raw_query(client, "{ viewer { login } }")
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "primary"
+        assert excinfo.value.signal.dimension is BudgetDimension.GRAPHQL_COST
+        assert excinfo.value.signal.host == "api.github.com"
+        assert excinfo.value.signal.request_id == "G-REQ"
+
+        monkeypatch.setattr(
+            graphql_mod.requests,
+            "post",
+            lambda *a, **k: _FakeResponse(
+                403,
+                headers={"retry-after": "45"},
+                text="You have exceeded a secondary rate limit",
+            ),
+        )
+        with pytest.raises(RootRateLimitException) as excinfo:
+            raw_query(client, "{ x }")
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "secondary"
+        assert excinfo.value.signal.dimension is BudgetDimension.SECONDARY_ABUSE_RISK
+
+        monkeypatch.setattr(
+            graphql_mod.requests,
+            "post",
+            lambda *a, **k: _FakeResponse(
+                403,
+                headers={},
+                text="Resource not accessible by personal access token",
+            ),
+        )
+        with pytest.raises(AuthenticationException):
+            raw_query(client, "{ x }")
+
+    def test_pygithub_provider_client_site(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from github import GithubException
+
+        from dev_health_ops.providers.github import client as gh_client_mod
+
+        conn = gh_client_mod.GitHubWorkClient.__new__(gh_client_mod.GitHubWorkClient)
+        monkeypatch.setattr(
+            conn,
+            "github",
+            SimpleNamespace(rate_limiting_resettime=None),
+            raising=False,
+        )
+        monkeypatch.setattr(
+            conn, "_record_rest_usage", lambda *a, **k: None, raising=False
+        )
+
+        primary = GithubException(
+            403,
+            data={"message": "API rate limit exceeded"},
+            headers={
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": str(_EPOCH_S),
+                "x-github-request-id": "P",
+            },
+        )
+        with pytest.raises(RootRateLimitException) as excinfo:
+            conn._raise_github_exception(primary, operation="list_pull_requests")
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "primary"
+        assert excinfo.value.signal.dimension is BudgetDimension.REST_CORE
+        assert excinfo.value.signal.reset_at == _EPOCH_UTC
+        assert excinfo.value.signal.request_id == "P"
+
+        secondary = GithubException(
+            403,
+            data={"message": "You have exceeded a secondary rate limit"},
+            headers={"retry-after": "42"},
+        )
+        with pytest.raises(RootRateLimitException) as excinfo:
+            conn._raise_github_exception(secondary, operation="list_pull_requests")
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "secondary"
+        assert excinfo.value.signal.dimension is BudgetDimension.SECONDARY_ABUSE_RISK
+        assert excinfo.value.signal.retry_after_seconds == 42.0
+
+        permission = GithubException(
+            403,
+            data={"message": "Resource not accessible by integration"},
+            headers={},
+        )
+        with pytest.raises(AuthenticationException):
+            conn._raise_github_exception(permission, operation="list_pull_requests")
+
+
+# ---------------------------------------------------------------------------
+# Linear complexity limit: signal without turning it retryable
+# ---------------------------------------------------------------------------
+
+
+def test_linear_complexity_emits_signal_and_stays_non_retryable() -> None:
+    from dev_health_ops.providers.linear.client import (
+        LinearClient,
+        LinearComplexityLimitError,
+        LinearGraphQLError,
+    )
+
+    errors = [
+        {"message": "Query too complex", "extensions": {"code": "COMPLEXITY_LIMIT"}}
+    ]
+    with pytest.raises(LinearComplexityLimitError) as excinfo:
+        LinearClient._raise_graphql_errors(errors)
+
+    exc = excinfo.value
+    # Stays a GraphQL error, NOT a rate-limit error -> never re-driven as
+    # deferrable/retryable work by the worker.
+    assert isinstance(exc, LinearGraphQLError)
+    assert not isinstance(exc, RootRateLimitException)
+    assert exc.signal is not None
+    assert exc.signal.provider == "linear"
+    assert exc.signal.reason == "complexity"
+    assert exc.signal.dimension is BudgetDimension.GRAPHQL_COST
+
+
+# ---------------------------------------------------------------------------
+# reference_discovery honors Retry-After
+# ---------------------------------------------------------------------------
+
+
+def test_reference_discovery_honors_retry_after() -> None:
+    from dev_health_ops.workers.reference_discovery import (
+        _reference_discovery_backoff_seconds,
+    )
+
+    # attempt 1 -> base 30s (+ up to 30s jitter), no server hint.
+    attempt_only = _reference_discovery_backoff_seconds(1)
+    assert 30 <= attempt_only <= 60
+
+    # A server Retry-After larger than the attempt-based base wins.
+    with_retry_after = _reference_discovery_backoff_seconds(1, 600.0)
+    assert with_retry_after >= 600
+
+    # Still capped at the 900s ceiling (+ jitter).
+    capped = _reference_discovery_backoff_seconds(1, 100_000.0)
+    assert 900 <= capped <= 930
+
+
+# ---------------------------------------------------------------------------
+# LaunchDarkly 403 -> AuthenticationException (both LD client modules)
+# ---------------------------------------------------------------------------
+
+
+def test_launchdarkly_403_is_authentication_error() -> None:
+    from dev_health_ops.connectors.launchdarkly import (
+        _raise_for_status as connector_raise,
+    )
+    from dev_health_ops.providers.launchdarkly.code_refs import (
+        _raise_for_status as code_refs_raise,
+    )
+
+    forbidden = cast(
+        httpx.Response,
+        SimpleNamespace(status_code=403, text="forbidden", headers={}, url=None),
+    )
+    with pytest.raises(AuthenticationException):
+        connector_raise(forbidden)
+    with pytest.raises(AuthenticationException):
+        code_refs_raise(forbidden)
+
+    # 429 still yields a retryable RateLimitException carrying a signal.
+    throttled = cast(
+        httpx.Response,
+        SimpleNamespace(
+            status_code=429,
+            text="",
+            headers={"Retry-After": "7", "X-RateLimit-Reset": str(_EPOCH_S * 1000)},
+            url=None,
+        ),
+    )
+    with pytest.raises(RootRateLimitException) as excinfo:
+        connector_raise(throttled)
+    assert excinfo.value.signal is not None
+    assert excinfo.value.signal.provider == "launchdarkly"
+    assert excinfo.value.signal.reason == "primary"
+    assert excinfo.value.signal.dimension is BudgetDimension.REST_CORE
+    assert excinfo.value.signal.retry_after_seconds == 7.0
+    assert excinfo.value.signal.reset_at == _EPOCH_UTC

--- a/tests/test_rate_limit_signal.py
+++ b/tests/test_rate_limit_signal.py
@@ -133,6 +133,30 @@ def test_legacy_connector_rate_limit_subclasses_root() -> None:
     assert exc.signal is None
 
 
+def test_handle_github_exception_forwards_signal() -> None:
+    """Root->legacy normalization in _handle_github_exception must carry the
+    signal, or the GraphQL classification sites populate signals that never
+    reach the worker (found in PR #1111 review)."""
+    from dev_health_ops.connectors.base import (
+        RateLimitException as LegacyRateLimitException,
+    )
+
+    conn = _new_github_connector()
+    signal = RateLimitSignal(
+        provider="github",
+        dimension=BudgetDimension.GRAPHQL_COST,
+        reason="primary",
+        retry_after_seconds=30.0,
+    )
+    root_exc = RootRateLimitException(
+        "graphql limited", retry_after_seconds=30.0, signal=signal
+    )
+    with pytest.raises(LegacyRateLimitException) as exc_info:
+        conn._handle_github_exception(root_exc)
+    assert exc_info.value.retry_after_seconds == 30.0
+    assert exc_info.value.signal is signal
+
+
 # ---------------------------------------------------------------------------
 # GitHub 403 triage populates signals at all three classification sites
 # ---------------------------------------------------------------------------

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -661,6 +661,52 @@ def test_run_sync_unit_failure_persists_failed_and_error(db_session, monkeypatch
     assert finalize_calls == [((str(run.id),), "sync")]
 
 
+def test_legacy_connector_rate_limit_reaches_unit_deferral(db_session, monkeypatch):
+    """Regression for the RateLimitException class-split bug (CHAOS-2753).
+
+    ``connectors.base.RateLimitException`` (raised by the legacy GitLab/GitHub
+    connectors) now subclasses the root ``exceptions.RateLimitException``, so a
+    rate limit raised inside ``run_dataset_unit`` is caught by the deferral
+    branch in ``run_sync_unit`` -- the unit is stamped RETRYING with
+    ``error_category='rate_limit'`` instead of becoming a generic FAILED unit.
+    """
+    from dev_health_ops.connectors.base import (
+        RateLimitException as LegacyRateLimitException,
+    )
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    finalize_calls = _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    def rate_limited(ctx, runtime):
+        raise LegacyRateLimitException(
+            "GitLab rate limited (HTTP 429)", retry_after_seconds=30.0
+        )
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    # Caught by the deferral branch, not the generic failure branch.
+    assert result["status"] == "rate_limited_deferred"
+    assert result["rate_limit_deferrals"] == 1
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+    assert unit.result is not None
+    assert unit.result["error_category"] == "rate_limit"
+    assert unit.rate_limit_deferrals == 1
+    assert unit.available_at is not None
+    # Deferred work: not finalized as a run failure.
+    assert finalize_calls == []
+
+
 def test_run_sync_unit_soft_timeout_retries_eligible_linear_backfill_unit(
     db_session, monkeypatch
 ):

--- a/tests/workers/test_rate_limit_defer.py
+++ b/tests/workers/test_rate_limit_defer.py
@@ -1,24 +1,16 @@
-"""Tests for workers.rate_limit_defer deferral planning + re-enqueue glue."""
+"""Tests for workers.rate_limit_defer deferral planning."""
 
 from __future__ import annotations
 
 from datetime import datetime, timedelta, timezone
-from unittest.mock import MagicMock
 
-from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.workers.rate_limit_defer import (
     RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS,
     RATE_LIMIT_JITTER_SECONDS,
     RATE_LIMIT_MAX_COUNTDOWN_SECONDS,
     RATE_LIMIT_MAX_DEFERRALS,
     RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
-    RateLimitDeferral,
-    maybe_plan_rate_limit_deferral,
-    plan_not_before_wait,
     plan_rate_limit_deferral,
-    rate_limit_metadata,
-    reenqueue_after_rate_limit,
-    reenqueue_rate_limit_chunk,
 )
 
 NOW = datetime(2026, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
@@ -113,114 +105,3 @@ class TestPlanRateLimitDeferral:
         # not_before may not exceed first_seen + total budget.
         deadline = first_seen + timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS)
         assert datetime.fromisoformat(d.not_before) <= deadline
-
-
-class TestPlanNotBeforeWait:
-    def test_future_not_before_returns_countdown(self) -> None:
-        not_before = (NOW + timedelta(seconds=45)).isoformat()
-        wait = plan_not_before_wait(not_before, now=NOW)
-        assert wait is not None
-        assert _within_jitter(wait, 45.0)
-
-    def test_future_not_before_is_chunked(self) -> None:
-        not_before = (NOW + timedelta(seconds=3600)).isoformat()
-        wait = plan_not_before_wait(not_before, now=NOW)
-        assert wait is not None
-        assert _within_jitter(wait, RATE_LIMIT_MAX_COUNTDOWN_SECONDS)
-
-    def test_past_not_before_returns_none(self) -> None:
-        not_before = (NOW - timedelta(seconds=1)).isoformat()
-        assert plan_not_before_wait(not_before, now=NOW) is None
-
-    def test_none_returns_none(self) -> None:
-        assert plan_not_before_wait(None, now=NOW) is None
-
-    def test_invalid_returns_none(self) -> None:
-        assert plan_not_before_wait("not-a-timestamp", now=NOW) is None
-
-
-class TestMaybePlanRateLimitDeferral:
-    def test_non_rate_limit_exception_returns_none(self) -> None:
-        assert (
-            maybe_plan_rate_limit_deferral(
-                ValueError("nope"), attempts=0, first_seen_at=None, now=NOW
-            )
-            is None
-        )
-
-    def test_rate_limit_exception_returns_deferral(self) -> None:
-        exc = RateLimitException("throttled", retry_after_seconds=30.0)
-        d = maybe_plan_rate_limit_deferral(exc, attempts=0, first_seen_at=None, now=NOW)
-        assert d is not None
-        assert _within_jitter(d.countdown, 30.0)
-
-    def test_rate_limit_exception_budget_exhausted_returns_none(self) -> None:
-        exc = RateLimitException("throttled", retry_after_seconds=30.0)
-        assert (
-            maybe_plan_rate_limit_deferral(
-                exc,
-                attempts=RATE_LIMIT_MAX_DEFERRALS,
-                first_seen_at=NOW.isoformat(),
-                now=NOW,
-            )
-            is None
-        )
-
-    def test_rate_limit_exception_without_delay_uses_default(self) -> None:
-        exc = RateLimitException("throttled")
-        d = maybe_plan_rate_limit_deferral(exc, attempts=0, first_seen_at=None, now=NOW)
-        assert d is not None
-        assert _within_jitter(d.countdown, RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS)
-
-
-class TestReenqueue:
-    def _task(self) -> MagicMock:
-        task = MagicMock()
-        task.request.args = ["cfg-1", "org-1"]
-        task.request.kwargs = {"pending_run_id": "run-1"}
-        return task
-
-    def test_reenqueue_after_rate_limit_carries_metadata(self) -> None:
-        task = self._task()
-        deferral = RateLimitDeferral(
-            countdown=123.0,
-            attempts=2,
-            first_seen_at=NOW.isoformat(),
-            not_before=(NOW + timedelta(seconds=300)).isoformat(),
-        )
-        reenqueue_after_rate_limit(task, deferral)
-
-        task.apply_async.assert_called_once()
-        kwargs = task.apply_async.call_args.kwargs
-        assert kwargs["countdown"] == 123.0
-        assert kwargs["args"] == ["cfg-1", "org-1"]
-        # Original kwargs preserved + rate-limit metadata merged in.
-        assert kwargs["kwargs"]["pending_run_id"] == "run-1"
-        assert kwargs["kwargs"] == {
-            "pending_run_id": "run-1",
-            **rate_limit_metadata(deferral),
-        }
-
-    def test_reenqueue_chunk_preserves_kwargs_unchanged(self) -> None:
-        task = self._task()
-        reenqueue_rate_limit_chunk(task, 77.0)
-
-        task.apply_async.assert_called_once()
-        kwargs = task.apply_async.call_args.kwargs
-        assert kwargs["countdown"] == 77.0
-        assert kwargs["args"] == ["cfg-1", "org-1"]
-        assert kwargs["kwargs"] == {"pending_run_id": "run-1"}
-
-
-def test_rate_limit_metadata_keys() -> None:
-    deferral = RateLimitDeferral(
-        countdown=1.0,
-        attempts=3,
-        first_seen_at="2026-01-01T12:00:00+00:00",
-        not_before="2026-01-01T12:05:00+00:00",
-    )
-    assert rate_limit_metadata(deferral) == {
-        "_rate_limit_attempts": 3,
-        "_rate_limit_first_seen_at": "2026-01-01T12:00:00+00:00",
-        "_rate_limit_not_before": "2026-01-01T12:05:00+00:00",
-    }


### PR DESCRIPTION
## Problem

Two independent defects in provider rate-limit handling:

1. **Class-split bug.** `connectors.base.RateLimitException` was a separate class subclassing plain `Exception`, *not* the root `exceptions.RateLimitException`. The legacy Git connectors (`connectors/gitlab.py`, and `connectors/github.py` via the base import) raise that class, so the worker's `except RateLimitException` at `workers/sync_units.py:731` never caught them — legacy-connector rate limits became generic FAILED units instead of deferred/retrying work.
2. **No normalized signal.** Each provider raised a bare `RateLimitException` with only a message + `retry_after_seconds`. There was no provider-neutral structure carrying the quota dimension, reset window, reason, or request id across the client→worker boundary.

## Fix

- New leaf module `sync/rate_limit_signal.py`: frozen `RateLimitSignal(provider, host, integration_id, route_family, dimension, retry_after_seconds, reset_at, reason, request_id)`. `dimension` reuses `BudgetDimension` so signals join budget buckets. `reset_at` is normalized to UTC via `reset_at_from_epoch_seconds` (GitHub/GitLab) and `reset_at_from_epoch_millis` (Linear/LaunchDarkly). `integration_id`/`route_family` stay `None` at the client — enriched at the worker boundary (ws-d).
- Optional keyword-only `signal` attribute on the root `RateLimitException` (`exceptions.py`).
- **Bug fix:** `connectors.base.RateLimitException` now subclasses the root exception (one-line class change, constructor inherited). Kept as a distinct subclass so the ~15 `retry_with_backoff(exceptions=(RateLimitException, ...))` decorator sites in the legacy connectors keep their in-connector retry semantics unchanged (imports were **not** swapped wholesale).
- Populated signals at every existing classification site: GitHub (`providers/github/client.py`, `connectors/github.py` ×2, `connectors/utils/graphql.py`) with primary/secondary reason + REST_CORE/GRAPHQL_COST/SECONDARY_ABUSE_RISK dimension; GitLab (429 → primary, header-qualified 403 → secondary); Jira; Linear (`LinearRateLimitError`, plus `LinearComplexityLimitError` which now carries a `graphql_cost` signal **while staying non-retryable**); LaunchDarkly (both client modules).
- LaunchDarkly permission **403 → AuthenticationException** (was a retryable `APIException`), matching the GitHub/GitLab permission convention.
- `reference_discovery` backoff now honors `exc.retry_after_seconds` (capped at the 900s ceiling) instead of attempt-count only.
- Deleted the dead Celery-kwargs helpers in `workers/rate_limit_defer.py` (`plan_not_before_wait`, `rate_limit_metadata`, `maybe_plan_rate_limit_deferral`, `reenqueue_after_rate_limit`, `reenqueue_rate_limit_chunk`) and their orphaned tests — only `plan_rate_limit_deferral` is used in production.

**Product invariant preserved:** no change to credentials, dispatch capacity, or budget — this is pure rate-limit signal plumbing + exception unification.

## Tests

- `test_legacy_connector_rate_limit_reaches_unit_deferral` — regression proving a `connectors.base.RateLimitException` raised inside `run_dataset_unit` reaches the deferral branch and stamps the unit RETRYING with `error_category='rate_limit'` (was FAILED before the fix).
- `test_github_403_triage_populates_signal_reason` — primary/secondary/permission at all three GitHub sites (REST classify, PyGithub raise, provider client, GraphQL).
- `test_signal_reset_at_normalized_to_utc` — Linear epoch-ms and GitHub/GitLab epoch-s both yield the same UTC instant.
- `test_linear_complexity_emits_signal_and_stays_non_retryable`.
- `test_reference_discovery_honors_retry_after`.
- `test_launchdarkly_403_is_authentication_error`.
- Full gate green: `bash ci/local_validate.sh` (ruff format/check, mypy, CH scratch+migrate, FULL unit suite 6155 passed/44 skipped, argMax live-exec proof).

Part of CHAOS-2742
Fixes CHAOS-2753
https://linear.app/fullchaos/issue/CHAOS-2753