### PR TITLE
feat(providers): unify actuals capture — shared usage recorder, route-family keying, GitLab/Jira/Linear drains (CHAOS-2754)

### DIFF
--- a/docs/architecture/sync-usage-actuals.md
+++ b/docs/architecture/sync-usage-actuals.md
@@ -1,0 +1,87 @@
+# Sync usage actuals capture (CHAOS-2754)
+
+Status: implemented for CHAOS-2754 (wave 1 of CHAOS-2742). Provider work-item
+sync now records **actual** request/page counts per
+`(transport, route_family, dimension)` and drains them into the `SyncRunUnit`
+result `observations`, so calibration can join actuals against the budget
+*estimate* keyed by the same `(route_family, dimension)` vocabulary.
+
+## Shared recorder
+
+`providers/usage.py` holds the single in-memory recorder
+(`UsageRecorder`) plus the declarative `UsageRouteFamily` / `OperationResolver`
+types. It replaces the three near-identical recorders that previously lived in
+`providers/{github,gitlab,jira}/client.py`. The recorder:
+
+- Re-keys observations by `(transport, route_family, dimension)` instead of the
+  raw interpolated operation string. Per-issue-number labels
+  (`"GET issue events for #123"`) collapse onto one route-family key, which also
+  fixes the 50-key cardinality-cap overflow that previously dropped most
+  actuals as `summary/overflow`.
+- Retains a sampled `example_operation` (the most recent interpolated label) for
+  debugging.
+- Resolves operations with a per-provider `OperationResolver` built from a
+  registry exported by each `providers/<provider>/budget.py`
+  (`<PROVIDER>_USAGE_ROUTE_FAMILIES` / `<PROVIDER>_USAGE_RESOLVER`). Those
+  registries mirror the shape of `LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES` and
+  enumerate the full budget vocabulary each estimator emits — an
+  estimator-coverage contract test asserts every emitted `route_family` has a
+  registry entry, preventing silently-empty calibration joins.
+
+## Observation key
+
+Drains emit two keys on `ProviderBatch.observations` / the unit-result
+`observations`:
+
+- `github_usage` — **legacy**, GitHub-only, unchanged (pinned by
+  `test_dataset_adapters.py`, `test_sync_units.py`, and the admin schema
+  `linear_page_count` / `linear_batch_count` promotion contract). Kept intact.
+- `provider_usage` — **provider-neutral**, emitted alongside `github_usage` and
+  by the GitLab / Jira / Linear drains. Consumers should migrate to this key;
+  `github_usage` is slated for a later cleanup once web/admin consumers are
+  audited (per the CHAOS-2742 adopted-plan decision).
+
+## Instrumented paths
+
+| Provider | Transport | Drain site |
+| --- | --- | --- |
+| GitHub | REST + GraphQL | `GitHubProvider.ingest` (both keys) |
+| GitLab | REST | `GitLabProvider.ingest` **and** `metrics.work_items.fetch_gitlab_work_items` (the live worker path) |
+| Jira | REST | `JiraProvider.ingest` (legacy + atlassian paths) and the `job_work_items` client drain |
+| Linear | GraphQL | `LinearClient` per-POST counting (`X-RateLimit-Requests-*` capture) drained via `job_work_items` |
+
+Failure preservation: work-item clients are built per sync unit (unit-scoped,
+safe to instrument). `run_work_items_sync_job` accumulates observations
+incrementally and, on a mid-sync raise, attaches the partial observations to the
+exception. The worker merges them into the rate-limit **deferral** stamp
+(`workers/sync_units.py`) and `_stamp_sync_unit_failed` **additively** — nesting
+actuals under `observations` and promoting `linear_page_count` /
+`linear_batch_count` while leaving `error_category` / `next_retry_at` and the
+other admin-API-read fields untouched.
+
+### GitLab label coarseness (known limitation)
+
+The GitLab work client labels most paginated reads identically
+(`"GET iterator page"`), so per-entity distinctions (issues vs merge_requests vs
+notes vs milestones vs epics) cannot be recovered from the operation label. The
+resolver maps project-metadata reads to `project` and every other read to the
+dominant work-item entity `issues`; the remaining GitLab families are declared
+for budget-vocabulary coverage but carry no operation markers. Finer GitLab
+attribution would require richer operation labels at the client call sites.
+
+## Out-of-scope actuals gaps (documented, not fixed here)
+
+1. **LaunchDarkly actuals.** LaunchDarkly flag/audit-log fetches still live in
+   the frozen `connectors/` path (see
+   [`launchdarkly-sync-budgeting.md`](launchdarkly-sync-budgeting.md)), which
+   forbids new code. No recorder is wired there. Actuals capture must wait for
+   the canonical-provider migration that moves LaunchDarkly raw fetch under
+   `providers/launchdarkly/`.
+2. **Code-dataset actuals.** The GitHub code datasets (`commits`, `files`,
+   `blame`, `cicd`, `tests`, `deployments`, `security`) run through
+   `processors/dataset_adapters._run_github_dataset`, which uses a shared/reused
+   store rather than an instrumented per-unit work client. Their budget families
+   (`git`, `commit_stats`, `files`, `blame`, `cicd`, `tests`, `deployments`,
+   `security`) are declared in the GitHub usage registry for coverage but carry
+   no operation markers. Instrumenting them needs a recorder threaded through
+   the dataset store and is deferred to a follow-up.

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -53,6 +53,7 @@ from dev_health_ops.providers.teams import (
     load_team_resolver,
     normalize_team_id,
 )
+from dev_health_ops.providers.usage import drain_provider_usage
 from dev_health_ops.storage import detect_db_type
 from dev_health_ops.utils.cli import (
     add_date_range_args,
@@ -290,6 +291,56 @@ def _build_linear_work_client(
     )
 
 
+# Exception attribute carrying best-effort usage observations gathered before a
+# mid-sync raise, so the worker deferral/failure stamp can persist actuals even
+# when the unit never returns normally (CHAOS-2754).
+_PARTIAL_OBSERVATIONS_ATTR = "dev_health_partial_observations"
+
+
+def _build_work_item_observations(
+    *,
+    github_usage: list[dict[str, Any]],
+    provider_usage: list[dict[str, Any]],
+    linear_page_count: int,
+    linear_batch_count: int,
+    include_linear_counts: bool,
+) -> dict[str, Any]:
+    """Assemble the unit-result ``observations`` fragment.
+
+    Emits the provider-neutral ``provider_usage`` key alongside the legacy
+    ``github_usage`` key (kept intact for pinned tests + admin consumers).
+    """
+
+    observations: dict[str, Any] = {}
+    if github_usage:
+        observations["github_usage"] = github_usage
+    if provider_usage:
+        observations["provider_usage"] = provider_usage
+    if include_linear_counts:
+        observations["linear_page_count"] = linear_page_count
+        observations["linear_batch_count"] = linear_batch_count
+    return observations
+
+
+def attach_work_item_partial_observations(
+    exc: BaseException, observations: dict[str, Any]
+) -> None:
+    """Stash partial usage observations on an in-flight exception (no-op when
+    empty) so a rate-limit deferral / failure can still record actuals."""
+
+    if observations:
+        setattr(exc, _PARTIAL_OBSERVATIONS_ATTR, observations)
+
+
+def read_work_item_partial_observations(
+    exc: BaseException,
+) -> dict[str, Any] | None:
+    """Read observations attached by :func:`attach_work_item_partial_observations`."""
+
+    observations = getattr(exc, _PARTIAL_OBSERVATIONS_ATTR, None)
+    return observations if isinstance(observations, dict) else None
+
+
 def run_work_items_sync_job(
     *,
     db_url: str,
@@ -357,6 +408,14 @@ def run_work_items_sync_job(
     sinks: list[Any] = [primary_sink]
     for s in sinks:
         setattr(s, "org_id", org_id)
+
+    # Usage accumulators are declared before the try so the failure/deferral
+    # path (the ``except`` below) can attach whatever actuals were gathered
+    # before a mid-sync raise (CHAOS-2754).
+    github_usage_observations: list[dict[str, Any]] = []
+    provider_usage_observations: list[dict[str, Any]] = []
+    linear_page_count = 0
+    linear_batch_count = 0
 
     try:
         for s in sinks:
@@ -512,11 +571,11 @@ def run_work_items_sync_job(
         # Populated when providers emit attribution signals (GitHub PRs).
         # Written to sink via write_ai_attribution() at end of sync loop.
         ai_attributions: list[Any] = []
-        github_usage_observations: list[dict[str, Any]] = []
-        linear_page_count = 0
-        linear_batch_count = 0
 
         if "jira" in provider_set:
+            jira_client = _build_jira_work_client(
+                org_id=org_id, credentials=credentials
+            )
             (
                 items,
                 tr,
@@ -529,7 +588,7 @@ def run_work_items_sync_job(
                 until=until_dt,
                 status_mapping=status_mapping,
                 identity=identity,
-                client=_build_jira_work_client(org_id=org_id, credentials=credentials),
+                client=jira_client,
                 project_keys=jira_project_keys,
                 jql_override=jira_jql,
                 fetch_all=jira_fetch_all,
@@ -537,6 +596,7 @@ def run_work_items_sync_job(
                 reference_sprints=reference_sprints,
                 reference_sink=primary_sink,
             )
+            provider_usage_observations.extend(drain_provider_usage(jira_client))
             work_items.extend(items)
             transitions.extend(tr)
             dependencies.extend(dep)
@@ -593,6 +653,13 @@ def run_work_items_sync_job(
                         github_usage_observations.extend(
                             item for item in raw_github_usage if isinstance(item, dict)
                         )
+                    raw_provider_usage = batch.observations.get("provider_usage")
+                    if isinstance(raw_provider_usage, list):
+                        provider_usage_observations.extend(
+                            item
+                            for item in raw_provider_usage
+                            if isinstance(item, dict)
+                        )
 
             projects = parse_github_projects_v2_env()
             if projects:
@@ -620,6 +687,7 @@ def run_work_items_sync_job(
                 gitlab_url=gl_url,
                 include_label_events=True,
                 org_id=org_id,
+                usage_observations=provider_usage_observations,
             )
             work_items.extend(items)
             transitions.extend(tr)
@@ -663,12 +731,13 @@ def run_work_items_sync_job(
                     "Linear work-item sync requires a non-empty source team key"
                 )
 
+            linear_client = _build_linear_work_client(
+                org_id=org_id, credentials=credentials
+            )
             linear_provider = LinearProvider(
                 status_mapping=status_mapping,
                 identity=identity,
-                client=_build_linear_work_client(
-                    org_id=org_id, credentials=credentials
-                ),
+                client=linear_client,
             )
             ctx = IngestionContext(
                 window=IngestionWindow(updated_since=since_dt, active_until=until_dt),
@@ -711,6 +780,7 @@ def run_work_items_sync_job(
                 fetched_transitions,
                 fetched_sprints,
             )
+            provider_usage_observations.extend(drain_provider_usage(linear_client))
 
         logger.info(
             "Work item sync: fetched %d items and %d transitions (providers=%s)",
@@ -1129,15 +1199,31 @@ def run_work_items_sync_job(
                 if hasattr(s, "write_investment_metrics") and investment_metrics_rows:
                     _ensure_unit_lease_for_write("investment_metrics_daily")
                     s.write_investment_metrics(investment_metrics_rows)
-        observations: dict[str, Any] = {}
-        if github_usage_observations:
-            observations["github_usage"] = github_usage_observations
-        if "linear" in provider_set:
-            observations["linear_page_count"] = linear_page_count
-            observations["linear_batch_count"] = linear_batch_count
+        observations = _build_work_item_observations(
+            github_usage=github_usage_observations,
+            provider_usage=provider_usage_observations,
+            linear_page_count=linear_page_count,
+            linear_batch_count=linear_batch_count,
+            include_linear_counts="linear" in provider_set,
+        )
         if observations:
             return {"observations": observations}
         return None
+    except Exception as exc:
+        # Preserve actuals gathered before the raise (partial fetch) so the
+        # worker's rate-limit deferral / failure stamp can persist them
+        # (CHAOS-2754). Never suppresses the error.
+        attach_work_item_partial_observations(
+            exc,
+            _build_work_item_observations(
+                github_usage=github_usage_observations,
+                provider_usage=provider_usage_observations,
+                linear_page_count=linear_page_count,
+                linear_batch_count=linear_batch_count,
+                include_linear_counts="linear" in provider_set,
+            ),
+        )
+        raise
     finally:
         for s in sinks:
             try:

--- a/src/dev_health_ops/metrics/work_items.py
+++ b/src/dev_health_ops/metrics/work_items.py
@@ -456,6 +456,7 @@ def fetch_gitlab_work_items(
     include_label_events: bool = True,
     max_label_events: int = 300,
     org_id: str = "",
+    usage_observations: list[dict[str, Any]] | None = None,
 ) -> tuple[
     list[WorkItem],
     list[WorkItemStatusTransition],
@@ -560,4 +561,11 @@ def fetch_gitlab_work_items(
         since_utc.isoformat(),
         len(ai_attributions),
     )
+    if usage_observations is not None:
+        # Drain the live-sync GitLab client's request actuals into the caller's
+        # accumulator (CHAOS-2754). This is the sync path the worker actually
+        # runs (GitLabProvider.ingest is the provider-pattern path); both drain.
+        from dev_health_ops.providers.usage import drain_provider_usage
+
+        usage_observations.extend(drain_provider_usage(client))
     return list(work_items.values()), transitions, ai_attributions

--- a/src/dev_health_ops/providers/github/budget.py
+++ b/src/dev_health_ops/providers/github/budget.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import Callable, Mapping
 from urllib.parse import urlparse
 
+from dev_health_ops.providers.usage import OperationResolver, UsageRouteFamily
 from dev_health_ops.sync.budget_types import (
     BudgetBucketKey,
     BudgetDimension,
@@ -319,3 +320,52 @@ def _fallback_credential_scope(
         "credential_id": credential_id or "env",
         "integration_id": integration_id,
     }
+
+
+# ---------------------------------------------------------------------------
+# Actuals recorder route-family registry (CHAOS-2754)
+# ---------------------------------------------------------------------------
+# Declares the full budget vocabulary the GitHub estimator emits so recorded
+# actuals key by the same (route_family, dimension) an estimate is keyed by.
+# Code-dataset families (git/commit_stats/files/blame/cicd/tests/deployments/
+# security) are budgeted but fetched through the frozen dataset path with no
+# instrumented client, so they carry no operation markers here (documented gap;
+# see docs/architecture/rate-limit-policy.md). Only the work-item families are
+# instrumented: every REST read in a work-item unit consumes the work_items
+# budget and every GraphQL POST consumes the work_item_prs budget, so resolution
+# is transport-based via the resolver defaults below.
+GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
+    UsageRouteFamily("repo", BudgetDimension.REST_CORE),
+    UsageRouteFamily("git", BudgetDimension.REST_CORE),
+    UsageRouteFamily("commit_stats", BudgetDimension.REST_CORE),
+    UsageRouteFamily("commit_stats", BudgetDimension.CONTENTS_BLOB),
+    UsageRouteFamily("files", BudgetDimension.REST_CORE),
+    UsageRouteFamily("files", BudgetDimension.CONTENTS_BLOB),
+    UsageRouteFamily("blame", BudgetDimension.REST_CORE),
+    UsageRouteFamily("blame", BudgetDimension.CONTENTS_BLOB),
+    UsageRouteFamily("prs", BudgetDimension.REST_CORE),
+    UsageRouteFamily("pr_social", BudgetDimension.GRAPHQL_COST),
+    UsageRouteFamily("pr_social", BudgetDimension.SECONDARY_ABUSE_RISK),
+    UsageRouteFamily("cicd", BudgetDimension.REST_CORE),
+    UsageRouteFamily("cicd", BudgetDimension.CONTENTS_BLOB),
+    UsageRouteFamily("tests", BudgetDimension.REST_CORE),
+    UsageRouteFamily("tests", BudgetDimension.CONTENTS_BLOB),
+    UsageRouteFamily("deployments", BudgetDimension.REST_CORE),
+    UsageRouteFamily("deployments", BudgetDimension.CONTENTS_BLOB),
+    UsageRouteFamily("security", BudgetDimension.REST_CORE),
+    UsageRouteFamily("work_items", BudgetDimension.REST_CORE),
+    UsageRouteFamily("work_item_prs", BudgetDimension.GRAPHQL_COST),
+    UsageRouteFamily("work_item_prs", BudgetDimension.SECONDARY_ABUSE_RISK),
+)
+
+GITHUB_USAGE_ROUTE_FAMILY_KEYS = frozenset(
+    family.route_family for family in GITHUB_USAGE_ROUTE_FAMILIES
+)
+
+GITHUB_USAGE_RESOLVER = OperationResolver(
+    families=GITHUB_USAGE_ROUTE_FAMILIES,
+    defaults=(
+        ("rest", "work_items", BudgetDimension.REST_CORE),
+        ("graphql", "work_item_prs", BudgetDimension.GRAPHQL_COST),
+    ),
+)

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -31,6 +31,7 @@ from dev_health_ops.credentials.resolver import (
 )
 from dev_health_ops.credentials.types import GitHubCredentials
 from dev_health_ops.providers._ratelimit import gate_call
+from dev_health_ops.providers.usage import UsageRecorder
 from dev_health_ops.sync.budget_types import BudgetDimension
 from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
@@ -118,7 +119,6 @@ _DIAGNOSTIC_HEADER_NAMES = (
     "x-github-request-id",
     "x-accepted-github-permissions",
 )
-_MAX_USAGE_OBSERVATION_KEYS = 50
 
 _TItem = TypeVar("_TItem")
 
@@ -378,8 +378,9 @@ class GitHubWorkClient:
             host=host,
             config=RateLimitConfig(initial_backoff_seconds=1.0),
         )
-        self._usage_observations: dict[tuple[str, str], dict[str, Any]] = {}
-        self._usage_observation_overflow = 0
+        from dev_health_ops.providers.github.budget import GITHUB_USAGE_RESOLVER
+
+        self._usage = UsageRecorder(resolver=GITHUB_USAGE_RESOLVER)
         self._app_token_provider: GitHubAppTokenProvider | None = None
 
         token = auth.token
@@ -487,33 +488,21 @@ class GitHubWorkClient:
         rate_limit: dict[str, Any],
         status: int | None = None,
     ) -> None:
-        if not headers and not rate_limit and status is None:
+        # Re-keying by (transport, route_family, dimension) now lives in the
+        # shared recorder (CHAOS-2754). This client keeps ownership of the
+        # provider-specific header/rate-limit extraction only. The getattr guard
+        # preserves the pre-refactor tolerance of a stubbed __init__ (some tests
+        # replace __init__ to capture auth without constructing a real client).
+        recorder = getattr(self, "_usage", None)
+        if recorder is None:
             return
-        key = (transport, operation)
-        observations = getattr(self, "_usage_observations", None)
-        if observations is None:
-            observations = {}
-            self._usage_observations = observations
-        observation = observations.get(key)
-        if observation is None:
-            if len(observations) >= _MAX_USAGE_OBSERVATION_KEYS:
-                self._usage_observation_overflow = (
-                    getattr(self, "_usage_observation_overflow", 0) + 1
-                )
-                return
-            observation = {
-                "transport": transport,
-                "operation": operation,
-                "request_count": 0,
-            }
-            observations[key] = observation
-        observation["request_count"] = int(observation["request_count"]) + 1
-        if status is not None:
-            observation["latest_status"] = status
-        if headers:
-            observation["latest_headers"] = dict(headers)
-        if rate_limit:
-            observation["rate_limit"] = dict(rate_limit)
+        recorder.record(
+            transport=transport,
+            operation=operation,
+            headers=headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
 
     def _record_rest_usage(
         self,
@@ -558,21 +547,10 @@ class GitHubWorkClient:
         )
 
     def drain_usage_observations(self) -> list[dict[str, Any]]:
-        usage_observations = getattr(self, "_usage_observations", {})
-        observations = [dict(value) for value in usage_observations.values()]
-        overflow = getattr(self, "_usage_observation_overflow", 0)
-        if overflow:
-            observations.append(
-                {
-                    "transport": "summary",
-                    "operation": "overflow",
-                    "dropped_operation_count": overflow,
-                }
-            )
-        usage_observations.clear()
-        self._usage_observations = usage_observations
-        self._usage_observation_overflow = 0
-        return observations
+        recorder = getattr(self, "_usage", None)
+        if recorder is None:
+            return []
+        return recorder.drain()
 
     def _raise_github_exception(self, exc: Exception, *, operation: str) -> NoReturn:
         from github import GithubException, RateLimitExceededException

--- a/src/dev_health_ops/providers/github/provider.py
+++ b/src/dev_health_ops/providers/github/provider.py
@@ -516,11 +516,19 @@ class GitHubProvider(ProviderWithClient[GitHubWorkClient]):
                 repo_full_name,
             )
 
-        drain_usage = getattr(client, "drain_usage_observations", None)
-        usage_observations = drain_usage() if callable(drain_usage) else []
-        observations = (
-            {"github_usage": usage_observations} if usage_observations else {}
+        from dev_health_ops.providers.usage import (
+            PROVIDER_USAGE_OBSERVATION_KEY,
+            drain_provider_usage,
         )
+
+        usage_observations = drain_provider_usage(client)
+        observations: dict[str, Any] = {}
+        if usage_observations:
+            # Emit the provider-neutral key (CHAOS-2754) alongside the legacy
+            # github_usage key, which is pinned by tests and the admin schema and
+            # must stay intact.
+            observations["github_usage"] = usage_observations
+            observations[PROVIDER_USAGE_OBSERVATION_KEY] = usage_observations
 
         return ProviderBatch(
             work_items=work_items,

--- a/src/dev_health_ops/providers/gitlab/budget.py
+++ b/src/dev_health_ops/providers/gitlab/budget.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import Callable, Mapping
 from urllib.parse import urlparse
 
+from dev_health_ops.providers.usage import OperationResolver, UsageRouteFamily
 from dev_health_ops.sync.budget_types import (
     BudgetBucketKey,
     BudgetDimension,
@@ -343,3 +344,41 @@ def _fallback_credential_scope(
         "credential_id": credential_id or "env",
         "integration_id": integration_id,
     }
+
+
+# ---------------------------------------------------------------------------
+# Actuals recorder route-family registry (CHAOS-2754)
+# ---------------------------------------------------------------------------
+# The GitLab work client labels most paginated reads identically
+# ("GET iterator page"), so per-entity distinctions (issues vs merge_requests vs
+# notes vs milestones vs epics) cannot be recovered from the operation label.
+# The instrumented resolution therefore maps project-metadata reads to
+# ``project`` and every other read to the dominant work-item entity ``issues``
+# (both REST_CORE); the remaining families are declared for budget-vocabulary
+# coverage but carry no operation markers.
+GITLAB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
+    UsageRouteFamily(
+        "project",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=(
+            "/projects/:id",
+            "/projects/",
+        ),
+    ),
+    UsageRouteFamily("issues", BudgetDimension.REST_CORE),
+    UsageRouteFamily("merge_requests", BudgetDimension.REST_CORE),
+    UsageRouteFamily("notes", BudgetDimension.REST_CORE),
+    UsageRouteFamily("pipelines", BudgetDimension.REST_CORE),
+    UsageRouteFamily("milestones", BudgetDimension.REST_CORE),
+    UsageRouteFamily("epics", BudgetDimension.REST_CORE),
+)
+
+GITLAB_USAGE_ROUTE_FAMILY_KEYS = frozenset(
+    family.route_family for family in GITLAB_USAGE_ROUTE_FAMILIES
+)
+
+GITLAB_USAGE_RESOLVER = OperationResolver(
+    families=GITLAB_USAGE_ROUTE_FAMILIES,
+    defaults=(("rest", "issues", BudgetDimension.REST_CORE),),
+)

--- a/src/dev_health_ops/providers/gitlab/client.py
+++ b/src/dev_health_ops/providers/gitlab/client.py
@@ -14,6 +14,7 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
 )
 from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.providers._ratelimit import gate_call, parse_retry_after_header
+from dev_health_ops.providers.usage import UsageRecorder
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 from dev_health_ops.sync.budget_types import BudgetDimension
 from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
@@ -28,7 +29,6 @@ _DIAGNOSTIC_HEADER_NAMES = (
     "x-request-id",
     "x-runtime",
 )
-_MAX_USAGE_OBSERVATION_KEYS = 50
 
 
 def _diagnostic_headers(headers: object) -> dict[str, str]:
@@ -146,8 +146,9 @@ class GitLabWorkClient:
             host=host,
             config=RateLimitConfig(initial_backoff_seconds=1.0),
         )
-        self._usage_observations: dict[tuple[str, str], dict[str, Any]] = {}
-        self._usage_observation_overflow = 0
+        from dev_health_ops.providers.gitlab.budget import GITLAB_USAGE_RESOLVER
+
+        self._usage = UsageRecorder(resolver=GITLAB_USAGE_RESOLVER)
 
         self.gl = gitlab.Gitlab(
             auth.base_url,
@@ -192,27 +193,15 @@ class GitLabWorkClient:
         rate_limit: dict[str, Any],
         status: int | None = None,
     ) -> None:
-        if not headers and not rate_limit and status is None:
-            return
-        key = (transport, operation)
-        observation = self._usage_observations.get(key)
-        if observation is None:
-            if len(self._usage_observations) >= _MAX_USAGE_OBSERVATION_KEYS:
-                self._usage_observation_overflow += 1
-                return
-            observation = {
-                "transport": transport,
-                "operation": operation,
-                "request_count": 0,
-            }
-            self._usage_observations[key] = observation
-        observation["request_count"] = int(observation["request_count"]) + 1
-        if status is not None:
-            observation["latest_status"] = status
-        if headers:
-            observation["latest_headers"] = dict(headers)
-        if rate_limit:
-            observation["rate_limit"] = dict(rate_limit)
+        # Aggregation/keying by route_family lives in the shared recorder
+        # (CHAOS-2754); this client only owns the header extraction below.
+        self._usage.record(
+            transport=transport,
+            operation=operation,
+            headers=headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
 
     def _record_rest_usage(
         self,
@@ -258,18 +247,7 @@ class GitLabWorkClient:
         )
 
     def drain_usage_observations(self) -> list[dict[str, Any]]:
-        observations = [dict(value) for value in self._usage_observations.values()]
-        if self._usage_observation_overflow:
-            observations.append(
-                {
-                    "transport": "summary",
-                    "operation": "overflow",
-                    "dropped_operation_count": self._usage_observation_overflow,
-                }
-            )
-        self._usage_observations.clear()
-        self._usage_observation_overflow = 0
-        return observations
+        return self._usage.drain()
 
     def _gated_iter(self, iterable: Any) -> Iterator[Any]:
         """Consume a python-gitlab lazy iterator with each page fetch routed

--- a/src/dev_health_ops/providers/gitlab/provider.py
+++ b/src/dev_health_ops/providers/gitlab/provider.py
@@ -429,6 +429,8 @@ class GitLabProvider(ProviderWithClient[GitLabWorkClient]):
                 project_path,
             )
 
+        from dev_health_ops.providers.usage import provider_usage_observations
+
         return ProviderBatch(
             work_items=work_items,
             status_transitions=transitions,
@@ -437,4 +439,5 @@ class GitLabProvider(ProviderWithClient[GitLabWorkClient]):
             sprints=sprints,
             reopen_events=reopen_events,
             ai_attributions=ai_attributions,
+            observations=provider_usage_observations(client),
         )

--- a/src/dev_health_ops/providers/jira/budget.py
+++ b/src/dev_health_ops/providers/jira/budget.py
@@ -6,6 +6,7 @@ import os
 from collections.abc import Callable, Mapping
 from urllib.parse import urlparse
 
+from dev_health_ops.providers.usage import OperationResolver, UsageRouteFamily
 from dev_health_ops.sync.budget_types import (
     BudgetBucketKey,
     BudgetDimension,
@@ -283,3 +284,58 @@ def _normalize_base_url(value: str) -> str:
     if url.startswith("https://"):
         return url
     return "https://" + url.lstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Actuals recorder route-family registry (CHAOS-2754)
+# ---------------------------------------------------------------------------
+# The Jira work client labels reads as ``"GET <path>"``; markers match on the
+# REST path so JQL search, comment, worklog and issue-enrichment reads key by
+# the same route_family the estimator emits. The GraphQL enrichment family
+# (jira_gql_enrichment) is served by a separate atlassian-client that this
+# recorder does not instrument, so it is declared for coverage with no markers.
+# Marker order matters: ``/comment`` and ``/worklog`` are tested before the
+# broad ``/issue/`` enrichment marker so a comment/worklog sub-resource is not
+# swallowed by enrichment.
+JIRA_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
+    UsageRouteFamily(
+        "jira_jql",
+        BudgetDimension.SEARCH,
+        transport="rest",
+        operation_markers=("/search/jql",),
+    ),
+    UsageRouteFamily(
+        "jira_comments",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("/comment",),
+    ),
+    UsageRouteFamily(
+        "jira_worklogs",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("/worklog",),
+    ),
+    UsageRouteFamily(
+        "jira_issue_enrichment",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("/issue/",),
+    ),
+    UsageRouteFamily(
+        "jira_metadata",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("/project", "/agile/", "/board", "/sprint"),
+    ),
+    UsageRouteFamily("jira_gql_enrichment", BudgetDimension.GRAPHQL_COST),
+)
+
+JIRA_USAGE_ROUTE_FAMILY_KEYS = frozenset(
+    family.route_family for family in JIRA_USAGE_ROUTE_FAMILIES
+)
+
+JIRA_USAGE_RESOLVER = OperationResolver(
+    families=JIRA_USAGE_ROUTE_FAMILIES,
+    defaults=(("rest", "jira_metadata", BudgetDimension.REST_CORE),),
+)

--- a/src/dev_health_ops/providers/jira/client.py
+++ b/src/dev_health_ops/providers/jira/client.py
@@ -16,6 +16,7 @@ from dev_health_ops.providers._ratelimit import (
     parse_retry_after_header,
     penalize_from_response,
 )
+from dev_health_ops.providers.usage import UsageRecorder
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 from dev_health_ops.sync.budget_types import BudgetDimension
 from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
@@ -33,7 +34,6 @@ _DIAGNOSTIC_HEADER_NAMES = (
     "x-request-id",
     "atl-traceid",
 )
-_MAX_USAGE_OBSERVATION_KEYS = 50
 
 
 def _require_jira() -> Any:
@@ -118,8 +118,10 @@ class JiraClient:
             config=RateLimitConfig(initial_backoff_seconds=1.0),
         )
         self.max_retries_429 = max(0, int(max_retries_429))
-        self._usage_observations: dict[tuple[str, str], dict[str, Any]] = {}
-        self._usage_observation_overflow = 0
+
+        from dev_health_ops.providers.jira.budget import JIRA_USAGE_RESOLVER
+
+        self._usage = UsageRecorder(resolver=JIRA_USAGE_RESOLVER)
 
         self.session = requests.Session()
         self.session.auth = (auth.email, auth.api_token)
@@ -225,27 +227,15 @@ class JiraClient:
         rate_limit: dict[str, Any],
         status: int | None = None,
     ) -> None:
-        if not headers and not rate_limit and status is None:
-            return
-        key = (transport, operation)
-        observation = self._usage_observations.get(key)
-        if observation is None:
-            if len(self._usage_observations) >= _MAX_USAGE_OBSERVATION_KEYS:
-                self._usage_observation_overflow += 1
-                return
-            observation = {
-                "transport": transport,
-                "operation": operation,
-                "request_count": 0,
-            }
-            self._usage_observations[key] = observation
-        observation["request_count"] = int(observation["request_count"]) + 1
-        if status is not None:
-            observation["latest_status"] = status
-        if headers:
-            observation["latest_headers"] = dict(headers)
-        if rate_limit:
-            observation["rate_limit"] = dict(rate_limit)
+        # Aggregation/keying by route_family lives in the shared recorder
+        # (CHAOS-2754); this client only owns the header extraction below.
+        self._usage.record(
+            transport=transport,
+            operation=operation,
+            headers=headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
 
     def _record_rest_usage(
         self,
@@ -277,18 +267,7 @@ class JiraClient:
         )
 
     def drain_usage_observations(self) -> list[dict[str, Any]]:
-        observations = [dict(value) for value in self._usage_observations.values()]
-        if self._usage_observation_overflow:
-            observations.append(
-                {
-                    "transport": "summary",
-                    "operation": "overflow",
-                    "dropped_operation_count": self._usage_observation_overflow,
-                }
-            )
-        self._usage_observations.clear()
-        self._usage_observation_overflow = 0
-        return observations
+        return self._usage.drain()
 
     def search_issues_page(
         self,

--- a/src/dev_health_ops/providers/jira/provider.py
+++ b/src/dev_health_ops/providers/jira/provider.py
@@ -28,6 +28,7 @@ from dev_health_ops.providers.base import (
 from dev_health_ops.providers.jira.atlassian_compat import atlassian_client_enabled
 from dev_health_ops.providers.jira.client import JiraClient
 from dev_health_ops.providers.normalize_common import to_utc as _to_utc
+from dev_health_ops.providers.usage import provider_usage_observations
 from dev_health_ops.providers.utils import env_flag as _env_flag
 
 logger = logging.getLogger(__name__)
@@ -284,6 +285,8 @@ class JiraProvider(ProviderWithClient[JiraClient]):
             except Exception as exc:
                 logger.warning("Failed to close Jira client: %s", exc)
 
+        # Drain after close: the recorder holds in-memory observations that
+        # client.close() (session teardown) does not clear.
         return ProviderBatch(
             work_items=work_items,
             status_transitions=transitions,
@@ -291,6 +294,7 @@ class JiraProvider(ProviderWithClient[JiraClient]):
             interactions=interactions,
             sprints=sprints,
             reopen_events=reopen_events,
+            observations=provider_usage_observations(client),
         )
 
     def _ingest_via_atlassian_client(self, ctx: IngestionContext) -> ProviderBatch:
@@ -567,4 +571,5 @@ class JiraProvider(ProviderWithClient[JiraClient]):
             sprints=list(sprints),
             reopen_events=reopen_events,
             worklogs=worklogs,
+            observations=provider_usage_observations(client),
         )

--- a/src/dev_health_ops/providers/linear/budget.py
+++ b/src/dev_health_ops/providers/linear/budget.py
@@ -5,6 +5,7 @@ import json
 from collections.abc import Callable, Mapping
 from urllib.parse import urlparse
 
+from dev_health_ops.providers.usage import OperationResolver, UsageRouteFamily
 from dev_health_ops.sync.budget_types import (
     BudgetBucketKey,
     BudgetDimension,
@@ -230,3 +231,73 @@ def _fallback_credential_scope(
         "credential_id": credential_id or "env",
         "integration_id": integration_id,
     }
+
+
+# ---------------------------------------------------------------------------
+# Actuals recorder route-family registry (CHAOS-2754)
+# ---------------------------------------------------------------------------
+# Linear is GraphQL-only; the recorder records one observation per POST keyed by
+# the GraphQL operation name (lowercased). Markers map each named query to the
+# route_family the estimator emits. ``WorkflowStates`` has no estimator family
+# and falls through to the ``issues`` default. ``team_members`` is listed before
+# ``teams`` for clarity (the "teams" marker requires the trailing 's', so
+# "teammembers" never collides).
+LINEAR_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
+    UsageRouteFamily(
+        "issues",
+        BudgetDimension.GRAPHQL_COST,
+        transport="graphql",
+        operation_markers=("issues",),
+    ),
+    UsageRouteFamily(
+        "history",
+        BudgetDimension.GRAPHQL_COST,
+        transport="graphql",
+        operation_markers=("issuehistory", "history"),
+    ),
+    UsageRouteFamily(
+        "team_members",
+        BudgetDimension.GRAPHQL_COST,
+        transport="graphql",
+        operation_markers=("teammembers",),
+    ),
+    UsageRouteFamily(
+        "teams",
+        BudgetDimension.GRAPHQL_COST,
+        transport="graphql",
+        operation_markers=("teams", "teambykey"),
+    ),
+    UsageRouteFamily(
+        "cycles",
+        BudgetDimension.GRAPHQL_COST,
+        transport="graphql",
+        operation_markers=("cycles",),
+    ),
+    UsageRouteFamily(
+        "projects",
+        BudgetDimension.GRAPHQL_COST,
+        transport="graphql",
+        operation_markers=("projects",),
+    ),
+    UsageRouteFamily(
+        "comments",
+        BudgetDimension.GRAPHQL_COST,
+        transport="graphql",
+        operation_markers=("comments",),
+    ),
+    UsageRouteFamily(
+        "attachments",
+        BudgetDimension.GRAPHQL_COST,
+        transport="graphql",
+        operation_markers=("attachments",),
+    ),
+)
+
+LINEAR_USAGE_ROUTE_FAMILY_KEYS = frozenset(
+    family.route_family for family in LINEAR_USAGE_ROUTE_FAMILIES
+)
+
+LINEAR_USAGE_RESOLVER = OperationResolver(
+    families=LINEAR_USAGE_ROUTE_FAMILIES,
+    defaults=(("graphql", "issues", BudgetDimension.GRAPHQL_COST),),
+)

--- a/src/dev_health_ops/providers/linear/client.py
+++ b/src/dev_health_ops/providers/linear/client.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import re
 import time
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -17,6 +18,7 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
 )
 from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.providers._ratelimit import gate_call
+from dev_health_ops.providers.usage import UsageRecorder
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
 from dev_health_ops.sync.budget_types import BudgetDimension
 from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
@@ -26,6 +28,25 @@ logger = logging.getLogger(__name__)
 LINEAR_API_URL = "https://api.linear.app/graphql"
 
 DEFAULT_MAX_ATTEMPTS = 5
+
+_GRAPHQL_OPERATION_NAME_RE = re.compile(r"\b(?:query|mutation)\s+(\w+)")
+
+# Linear returns per-request budget headers on every GraphQL POST; capturing
+# them lets recorded actuals join against the GraphQL-cost budget estimate.
+_LINEAR_RATE_LIMIT_HEADERS = (
+    ("x-ratelimit-requests-limit", "limit"),
+    ("x-ratelimit-requests-remaining", "remaining"),
+    ("x-ratelimit-requests-reset", "reset"),
+    ("retry-after", "retry_after"),
+)
+
+
+def _graphql_operation_name(query: str) -> str:
+    """Extract the named GraphQL operation (e.g. ``Issues``) for route-family
+    resolution; falls back to ``graphql`` for anonymous queries."""
+
+    match = _GRAPHQL_OPERATION_NAME_RE.search(query)
+    return match.group(1) if match else "graphql"
 
 
 class LinearGraphQLError(RuntimeError):
@@ -429,6 +450,10 @@ class LinearClient:
         )
         self.max_attempts = max(1, int(max_attempts))
         self._rate_limit: RateLimitInfo | None = None
+
+        from dev_health_ops.providers.linear.budget import LINEAR_USAGE_RESOLVER
+
+        self._usage = UsageRecorder(resolver=LINEAR_USAGE_RESOLVER)
         self._client = httpx.Client(
             headers={
                 "Content-Type": "application/json",
@@ -464,6 +489,9 @@ class LinearClient:
                     self._wait_for_rate_limit()
                     response = self._client.post(LINEAR_API_URL, json=payload)
                     self._update_rate_limit(response)
+                    # Count every POST (including the ones that 429) so recorded
+                    # actuals reflect real GraphQL request volume.
+                    self._record_graphql_usage(query, response)
                     if response.status_code == 429:
                         raise _LinearHTTPRateLimit(self._retry_after_seconds(response))
             except _LinearHTTPRateLimit as exc:
@@ -593,6 +621,23 @@ class LinearClient:
                 "Headers: %s",
                 dict(headers),
             )
+
+    def _record_graphql_usage(self, query: str, response: httpx.Response) -> None:
+        rate_limit: dict[str, Any] = {}
+        for source, target in _LINEAR_RATE_LIMIT_HEADERS:
+            value = response.headers.get(source)
+            if value is not None:
+                rate_limit[target] = str(value)
+        self._usage.record(
+            transport="graphql",
+            operation=_graphql_operation_name(query),
+            headers={},
+            rate_limit=rate_limit,
+            status=response.status_code,
+        )
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        return self._usage.drain()
 
     def iter_issues(
         self,

--- a/src/dev_health_ops/providers/usage.py
+++ b/src/dev_health_ops/providers/usage.py
@@ -1,0 +1,214 @@
+"""Shared provider request-usage recorder (CHAOS-2754).
+
+Three provider clients (github, gitlab, jira) historically carried a
+near-identical in-memory usage recorder that keyed observations by the raw,
+interpolated ``(transport, operation)`` string. That keying had two problems:
+
+* Per-issue-number operation labels (e.g. ``"GET issue events for #123"``)
+  produced an unbounded number of distinct keys, overflowing the 50-key cap so
+  most actuals were dropped as ``summary/overflow``.
+* The keys did not share the ``route_family`` / ``dimension`` vocabulary the
+  budget *estimators* emit (see ``providers/*/budget.py``), so recorded actuals
+  could never be joined against the budget estimate for calibration.
+
+This module extracts the recorder once and re-keys observations by
+``(transport, route_family, dimension)`` using a per-provider
+:class:`OperationResolver` built from the declarative registries exported by
+each ``providers/<provider>/budget.py`` (mirroring the shape of
+``LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES``). Per-issue labels now collapse onto the
+route-family key while the most recent interpolated label is retained as
+``example_operation`` for debugging.
+
+The recorder is deliberately provider-neutral: the per-provider REST/GraphQL
+header extraction (which differs across providers) stays in each client and
+feeds the already-normalized ``headers`` / ``rate_limit`` / ``status`` into
+:meth:`UsageRecorder.record`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+# Bounded key cap retained as a defensive backstop. After re-keying by
+# route_family the key cardinality is inherently small (one per instrumented
+# route_family x dimension x transport), so overflow should never trip in
+# practice; it only fires if a resolver were mis-wired to pass raw labels.
+MAX_USAGE_OBSERVATION_KEYS = 50
+
+# Sentinel route_family used when an operation cannot be resolved to any budget
+# route_family. Aggregating unresolved operations under one key keeps the
+# recorder bounded (no per-operation overflow) instead of leaking cardinality.
+UNCLASSIFIED_ROUTE_FAMILY = "unclassified"
+
+
+@dataclass(frozen=True)
+class UsageRouteFamily:
+    """Declarative operation -> ``(route_family, dimension)`` mapping entry.
+
+    Mirrors ``LaunchDarklyBudgetRouteFamily``: pairs a budget ``route_family`` +
+    ``dimension`` (the identifiers the estimator emits) with the client
+    operation labels that consume that budget, so recorded actuals key by the
+    same vocabulary an estimate is keyed by.
+
+    ``operation_markers`` are lowercase substrings tested against the recorded
+    operation label; the first family whose transport matches and whose marker
+    is present wins. An **empty** ``operation_markers`` marks a family the
+    estimator budgets for but whose fetch path is not instrumented here — such
+    entries document the full budget vocabulary (and satisfy the
+    estimator-coverage contract test) without ever matching a live operation.
+    """
+
+    route_family: str
+    dimension: BudgetDimension
+    transport: str | None = None
+    operation_markers: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class OperationResolver:
+    """Resolves a recorded ``(transport, operation)`` to ``(route_family,
+    dimension)`` using an ordered registry plus per-transport fallbacks.
+
+    ``families`` is scanned in order; marker matching is case-insensitive.
+    When no family matches, the transport's entry in ``defaults`` is used; if
+    the transport itself is unknown the observation collapses onto
+    :data:`UNCLASSIFIED_ROUTE_FAMILY` (still bounded, never per-operation).
+    """
+
+    families: tuple[UsageRouteFamily, ...] = ()
+    # transport -> (route_family, dimension) fallback for instrumented
+    # operations that carry no distinguishing marker (e.g. a client that labels
+    # every paginated read identically).
+    defaults: tuple[tuple[str, str, BudgetDimension], ...] = ()
+
+    def resolve(self, *, transport: str, operation: str) -> tuple[str, BudgetDimension]:
+        lowered = operation.lower()
+        for family in self.families:
+            if family.transport is not None and family.transport != transport:
+                continue
+            if family.operation_markers and any(
+                marker in lowered for marker in family.operation_markers
+            ):
+                return (family.route_family, family.dimension)
+        for default_transport, route_family, dimension in self.defaults:
+            if default_transport == transport:
+                return (route_family, dimension)
+        return (UNCLASSIFIED_ROUTE_FAMILY, _default_dimension_for_transport(transport))
+
+
+def _default_dimension_for_transport(transport: str) -> BudgetDimension:
+    if transport == "graphql":
+        return BudgetDimension.GRAPHQL_COST
+    return BudgetDimension.REST_CORE
+
+
+@dataclass
+class UsageRecorder:
+    """In-memory per-client request-usage recorder keyed by
+    ``(transport, route_family, dimension)``.
+
+    A single instance is owned by one work-item client, which is built per sync
+    unit, so no cross-unit / cross-org state is shared.
+    """
+
+    resolver: OperationResolver
+    _observations: dict[tuple[str, str, str], dict[str, Any]] = field(
+        default_factory=dict
+    )
+    _overflow: int = 0
+
+    def record(
+        self,
+        *,
+        transport: str,
+        operation: str,
+        headers: dict[str, str],
+        rate_limit: dict[str, Any],
+        status: int | None = None,
+    ) -> None:
+        """Aggregate one request into its route-family bucket.
+
+        No-ops when there is nothing worth recording (no diagnostic headers, no
+        rate-limit signal, and no status) so callers can invoke unconditionally.
+        """
+
+        if not headers and not rate_limit and status is None:
+            return
+        route_family, dimension = self.resolver.resolve(
+            transport=transport, operation=operation
+        )
+        dimension_value = dimension.value
+        key = (transport, route_family, dimension_value)
+        observation = self._observations.get(key)
+        if observation is None:
+            if len(self._observations) >= MAX_USAGE_OBSERVATION_KEYS:
+                self._overflow += 1
+                return
+            observation = {
+                "transport": transport,
+                "route_family": route_family,
+                "dimension": dimension_value,
+                "request_count": 0,
+                # Sampled interpolated label kept purely for debugging; the
+                # aggregation key intentionally ignores it.
+                "example_operation": operation,
+            }
+            self._observations[key] = observation
+        observation["request_count"] = int(observation["request_count"]) + 1
+        observation["example_operation"] = operation
+        if status is not None:
+            observation["latest_status"] = status
+        if headers:
+            observation["latest_headers"] = dict(headers)
+        if rate_limit:
+            observation["rate_limit"] = dict(rate_limit)
+
+    def drain(self) -> list[dict[str, Any]]:
+        """Return and clear the accumulated observations."""
+
+        observations = [dict(value) for value in self._observations.values()]
+        if self._overflow:
+            observations.append(
+                {
+                    "transport": "summary",
+                    "route_family": "overflow",
+                    "dimension": "summary",
+                    "dropped_operation_count": self._overflow,
+                }
+            )
+        self._observations.clear()
+        self._overflow = 0
+        return observations
+
+
+# Observation key emitted alongside (never replacing) provider-specific legacy
+# keys such as 'github_usage'. Provider-neutral so gitlab/jira/linear drains and
+# the calibration join can consume a single key regardless of provider.
+PROVIDER_USAGE_OBSERVATION_KEY = "provider_usage"
+
+
+def drain_provider_usage(client: object) -> list[dict[str, Any]]:
+    """Drain a client's usage recorder if it exposes one, else return ``[]``.
+
+    Tolerant of clients built without a recorder (e.g. the atlassian-client Jira
+    path, or a test double) so drains can be wired unconditionally at the
+    provider boundary.
+    """
+
+    drain = getattr(client, "drain_usage_observations", None)
+    if not callable(drain):
+        return []
+    observations = drain()
+    return observations if isinstance(observations, list) else []
+
+
+def provider_usage_observations(client: object) -> dict[str, Any]:
+    """Return a ``ProviderBatch.observations`` fragment carrying a client's
+    drained usage under :data:`PROVIDER_USAGE_OBSERVATION_KEY` (empty when
+    nothing was recorded)."""
+
+    observations = drain_provider_usage(client)
+    return {PROVIDER_USAGE_OBSERVATION_KEY: observations} if observations else {}

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -270,6 +270,32 @@ def _promote_result_observation_fields(result: dict[str, Any]) -> dict[str, Any]
     return result
 
 
+def _merge_partial_observations_into_result(
+    result: dict[str, Any], exc: BaseException
+) -> None:
+    """Merge usage observations captured before a mid-sync raise into a
+    failure/deferral unit result (CHAOS-2754).
+
+    Additive only: it nests the actuals under ``observations`` and promotes the
+    linear page/batch counts to the top level (admin-API contract), leaving
+    ``error_category`` / ``next_retry_at`` and every other top-level field the
+    admin router reads untouched.
+    """
+
+    from dev_health_ops.metrics.job_work_items import (
+        read_work_item_partial_observations,
+    )
+
+    observations = read_work_item_partial_observations(exc)
+    if not observations:
+        return
+    existing = result.get("observations")
+    merged = dict(existing) if isinstance(existing, Mapping) else {}
+    merged.update(observations)
+    result["observations"] = merged
+    _promote_result_observation_fields(result)
+
+
 @celery_app.task(queue="sync", name="dev_health_ops.workers.tasks.dispatch_sync_run")
 def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
     """Authorize, route, and queue all pending units of a planned run.
@@ -764,6 +790,15 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
         now = datetime.now(timezone.utc)
         not_before = datetime.fromisoformat(deferral.not_before)
         first_seen_at = datetime.fromisoformat(deferral.first_seen_at)
+        deferral_result_payload: dict[str, Any] = {
+            "error_category": "rate_limit",
+            "retry_after_seconds": getattr(exc, "retry_after_seconds", None),
+            "not_before": deferral.not_before,
+            "rate_limit_deferrals": deferral.attempts,
+        }
+        # Persist any actuals gathered before the rate-limit raise; never
+        # overwrites error_category / retry fields (CHAOS-2754).
+        _merge_partial_observations_into_result(deferral_result_payload, exc)
         terminal_txn_started = True
         with get_postgres_session_sync() as session:
             deferred_result: Any = session.execute(
@@ -782,14 +817,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     rate_limit_deferrals=deferral.attempts,
                     rate_limit_first_seen_at=first_seen_at,
                     error=str(exc),
-                    result={
-                        "error_category": "rate_limit",
-                        "retry_after_seconds": getattr(
-                            exc, "retry_after_seconds", None
-                        ),
-                        "not_before": deferral.not_before,
-                        "rate_limit_deferrals": deferral.attempts,
-                    },
+                    result=deferral_result_payload,
                     lease_owner=None,
                     lease_expires_at=None,
                     last_heartbeat_at=now,
@@ -1149,6 +1177,10 @@ def _stamp_sync_unit_failed(
     completed_at = datetime.now(timezone.utc)
     duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
     error_category = _classify_error(exc)
+    failed_result_payload: dict[str, Any] = {"error_category": error_category}
+    # Persist any actuals gathered before the raise; error_category stays intact
+    # (admin-API contract) (CHAOS-2754).
+    _merge_partial_observations_into_result(failed_result_payload, exc)
     with get_postgres_session_sync() as session:
         terminal_result: Any = session.execute(
             update(SyncRunUnit)
@@ -1164,7 +1196,7 @@ def _stamp_sync_unit_failed(
                 status=SyncRunUnitStatus.FAILED.value,
                 duration_seconds=duration_seconds,
                 error=str(exc),
-                result={"error_category": error_category},
+                result=failed_result_payload,
                 lease_owner=None,
                 lease_expires_at=None,
                 last_heartbeat_at=completed_at,

--- a/tests/providers/test_github_pr_social_batch.py
+++ b/tests/providers/test_github_pr_social_batch.py
@@ -108,8 +108,10 @@ def test_work_client_records_rest_usage_from_pygithub_rate_limit_state() -> None
     assert observations == [
         {
             "transport": "rest",
-            "operation": "GET /repos/full-chaos/dev-health-web",
+            "route_family": "work_items",
+            "dimension": "rest_core",
             "request_count": 1,
+            "example_operation": "GET /repos/full-chaos/dev-health-web",
             "rate_limit": {
                 "remaining": "42",
                 "reset": "1234567890",
@@ -144,8 +146,10 @@ def test_work_client_records_graphql_usage_from_headers_and_rate_limit_payload()
     assert observations == [
         {
             "transport": "graphql",
-            "operation": "POST /graphql test",
+            "route_family": "work_item_prs",
+            "dimension": "graphql_cost",
             "request_count": 1,
+            "example_operation": "POST /graphql test",
             "latest_status": 200,
             "latest_headers": {
                 "x-ratelimit-remaining": "4998",

--- a/tests/test_budget_estimators.py
+++ b/tests/test_budget_estimators.py
@@ -20,11 +20,18 @@ from dev_health_ops.models import (
     SyncRunUnitStatus,
 )
 from dev_health_ops.providers.github.budget import GitHubBudgetEstimator
-from dev_health_ops.providers.gitlab.budget import GitLabBudgetEstimator
+from dev_health_ops.providers.gitlab.budget import (
+    GITLAB_USAGE_RESOLVER,
+    GitLabBudgetEstimator,
+)
 from dev_health_ops.providers.gitlab.client import GitLabWorkClient
-from dev_health_ops.providers.jira.budget import JiraBudgetEstimator
+from dev_health_ops.providers.jira.budget import (
+    JIRA_USAGE_RESOLVER,
+    JiraBudgetEstimator,
+)
 from dev_health_ops.providers.jira.client import JiraClient
 from dev_health_ops.providers.linear.budget import LinearBudgetEstimator
+from dev_health_ops.providers.usage import UsageRecorder
 from dev_health_ops.sync.budget_guard import BudgetGuard
 from dev_health_ops.sync.budget_types import BudgetEstimator
 from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
@@ -247,8 +254,7 @@ def test_linear_incremental_narrow_window_not_deferred(
 
 def test_jira_usage_observation_captures_rate_headers_without_tokens() -> None:
     client = JiraClient.__new__(JiraClient)
-    client._usage_observations = {}
-    client._usage_observation_overflow = 0
+    client._usage = UsageRecorder(resolver=JIRA_USAGE_RESOLVER)
 
     client._record_rest_usage(
         "GET /rest/api/3/search/jql",
@@ -267,8 +273,10 @@ def test_jira_usage_observation_captures_rate_headers_without_tokens() -> None:
     assert observations == [
         {
             "transport": "rest",
-            "operation": "GET /rest/api/3/search/jql",
+            "route_family": "jira_jql",
+            "dimension": "search",
             "request_count": 1,
+            "example_operation": "GET /rest/api/3/search/jql",
             "latest_status": 200,
             "latest_headers": {
                 "ratelimit-remaining": "42",
@@ -288,11 +296,10 @@ def test_jira_usage_observation_captures_rate_headers_without_tokens() -> None:
 
 def test_gitlab_usage_observation_captures_rate_headers_without_tokens() -> None:
     client = GitLabWorkClient.__new__(GitLabWorkClient)
-    client._usage_observations = {}
-    client._usage_observation_overflow = 0
+    client._usage = UsageRecorder(resolver=GITLAB_USAGE_RESOLVER)
 
     client._record_rest_usage(
-        "GET /projects/:id/issues",
+        "GET iterator page",
         headers={
             "RateLimit-Remaining": "17",
             "RateLimit-Reset": "1710000000",
@@ -308,8 +315,10 @@ def test_gitlab_usage_observation_captures_rate_headers_without_tokens() -> None
     assert observations == [
         {
             "transport": "rest",
-            "operation": "GET /projects/:id/issues",
+            "route_family": "issues",
+            "dimension": "rest_core",
             "request_count": 1,
+            "example_operation": "GET iterator page",
             "latest_status": 429,
             "latest_headers": {
                 "ratelimit-remaining": "17",

--- a/tests/test_github_provider.py
+++ b/tests/test_github_provider.py
@@ -1174,15 +1174,19 @@ def test_github_provider_emits_client_usage_observations(
 
     batch = provider.ingest(ctx)
 
+    # CHAOS-2754: the legacy github_usage key is preserved verbatim and the
+    # provider-neutral provider_usage key is emitted ALONGSIDE it (same payload).
+    expected_usage = [
+        {
+            "transport": "rest",
+            "operation": "GET /repos/owner/repo/issues",
+            "request_count": 1,
+            "rate_limit": {"remaining": "4999", "reset": "1234567890"},
+        }
+    ]
     assert batch.observations == {
-        "github_usage": [
-            {
-                "transport": "rest",
-                "operation": "GET /repos/owner/repo/issues",
-                "request_count": 1,
-                "rate_limit": {"remaining": "4999", "reset": "1234567890"},
-            }
-        ]
+        "github_usage": expected_usage,
+        "provider_usage": expected_usage,
     }
 
 

--- a/tests/test_provider_usage.py
+++ b/tests/test_provider_usage.py
@@ -1,0 +1,351 @@
+"""Tests for the shared provider usage recorder + route-family keying (CHAOS-2754)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+
+import httpx
+
+from dev_health_ops.providers.base import IngestionContext, IngestionWindow
+from dev_health_ops.providers.github.budget import (
+    GITHUB_USAGE_RESOLVER,
+    GITHUB_USAGE_ROUTE_FAMILY_KEYS,
+    GitHubBudgetEstimator,
+)
+from dev_health_ops.providers.gitlab.budget import (
+    GITLAB_USAGE_RESOLVER,
+    GITLAB_USAGE_ROUTE_FAMILY_KEYS,
+    GitLabBudgetEstimator,
+)
+from dev_health_ops.providers.jira.budget import (
+    JIRA_USAGE_RESOLVER,
+    JIRA_USAGE_ROUTE_FAMILY_KEYS,
+    JiraBudgetEstimator,
+)
+from dev_health_ops.providers.linear.budget import (
+    LINEAR_USAGE_RESOLVER,
+    LINEAR_USAGE_ROUTE_FAMILY_KEYS,
+    LinearBudgetEstimator,
+)
+from dev_health_ops.providers.usage import UsageRecorder
+from dev_health_ops.sync.budget_types import BudgetDimension, BudgetEstimator
+from dev_health_ops.sync.datasets import DatasetKey
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+WINDOW_START = datetime(2026, 1, 10, tzinfo=timezone.utc)
+WINDOW_END = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+
+def _context(*, provider: str, dataset_key: str) -> SyncTaskContext:
+    return SyncTaskContext(
+        unit_id="unit-1",
+        sync_run_id="run-1",
+        org_id="org-1",
+        integration_id="integration-1",
+        source_id="source-1",
+        source_external_id="acme/repo",
+        provider=provider,
+        dataset_key=dataset_key,
+        cost_class="medium",
+        mode="incremental",
+        window_start=WINDOW_START,
+        window_end=WINDOW_END,
+        processor_flags={"sync_prs": True},
+        credential_id="cred-1",
+        decrypted_credentials={"token": "secret", "base_url": "https://example.test"},
+        db_url="clickhouse://localhost/default",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Recorder keying / overflow collapse
+# ---------------------------------------------------------------------------
+
+
+def test_usage_keyed_by_route_family_and_dimension() -> None:
+    """Per-issue-number operation labels collapse onto ONE route-family key, so
+    100+ distinct operation strings never overflow the key cap."""
+
+    recorder = UsageRecorder(resolver=GITHUB_USAGE_RESOLVER)
+    for issue_number in range(150):
+        recorder.record(
+            transport="rest",
+            operation=f"GET issue events for #{issue_number}",
+            headers={},
+            rate_limit={"remaining": str(5000 - issue_number)},
+            status=200,
+        )
+
+    observations = recorder.drain()
+
+    assert len(observations) == 1, "per-issue labels must collapse to one key"
+    (obs,) = observations
+    assert obs["route_family"] == "work_items"
+    assert obs["dimension"] == "rest_core"
+    assert obs["request_count"] == 150
+    # No dropped/overflow summary row was produced.
+    assert all(o.get("route_family") != "overflow" for o in observations)
+    # A sampled example operation label is retained for debugging.
+    assert obs["example_operation"].startswith("GET issue events for #")
+
+
+def test_recorder_separates_transports_into_distinct_route_families() -> None:
+    recorder = UsageRecorder(resolver=GITHUB_USAGE_RESOLVER)
+    recorder.record(
+        transport="rest",
+        operation="GET /repos/acme/repo/issues",
+        headers={},
+        rate_limit={"remaining": "10"},
+        status=200,
+    )
+    recorder.record(
+        transport="graphql",
+        operation="POST /graphql PR social data",
+        headers={},
+        rate_limit={},
+        status=200,
+    )
+
+    by_family = {o["route_family"]: o for o in recorder.drain()}
+    assert by_family["work_items"]["dimension"] == "rest_core"
+    assert by_family["work_item_prs"]["dimension"] == "graphql_cost"
+
+
+def test_recorder_skips_empty_observations() -> None:
+    recorder = UsageRecorder(resolver=GITHUB_USAGE_RESOLVER)
+    recorder.record(
+        transport="rest", operation="GET /x", headers={}, rate_limit={}, status=None
+    )
+    assert recorder.drain() == []
+
+
+# ---------------------------------------------------------------------------
+# Per-provider resolver vocabulary
+# ---------------------------------------------------------------------------
+
+
+def test_jira_resolver_maps_rest_paths_to_estimator_families() -> None:
+    cases = {
+        "GET /rest/api/3/search/jql": ("jira_jql", BudgetDimension.SEARCH),
+        "GET /rest/api/3/issue/ABC-1/comment": (
+            "jira_comments",
+            BudgetDimension.REST_CORE,
+        ),
+        "GET /rest/api/3/issue/ABC-1": (
+            "jira_issue_enrichment",
+            BudgetDimension.REST_CORE,
+        ),
+        "GET /rest/api/3/project/search": ("jira_metadata", BudgetDimension.REST_CORE),
+        "GET /rest/agile/1.0/board": ("jira_metadata", BudgetDimension.REST_CORE),
+    }
+    for operation, expected in cases.items():
+        assert JIRA_USAGE_RESOLVER.resolve(transport="rest", operation=operation) == (
+            expected
+        )
+
+
+def test_gitlab_resolver_distinguishes_project_metadata_from_iterators() -> None:
+    assert GITLAB_USAGE_RESOLVER.resolve(
+        transport="rest", operation="GET /projects/:id"
+    ) == ("project", BudgetDimension.REST_CORE)
+    assert GITLAB_USAGE_RESOLVER.resolve(
+        transport="rest", operation="GET iterator page"
+    ) == ("issues", BudgetDimension.REST_CORE)
+
+
+def test_linear_resolver_maps_named_operations() -> None:
+    cases = {
+        "Issues": "issues",
+        "IssueHistory": "history",
+        "Teams": "teams",
+        "TeamByKey": "teams",
+        "TeamMembers": "team_members",
+        "Cycles": "cycles",
+        "Projects": "projects",
+        "Comments": "comments",
+        "Attachments": "attachments",
+        "WorkflowStates": "issues",  # no estimator family -> default
+    }
+    for operation, route_family in cases.items():
+        resolved, dimension = LINEAR_USAGE_RESOLVER.resolve(
+            transport="graphql", operation=operation
+        )
+        assert resolved == route_family, operation
+        assert dimension == BudgetDimension.GRAPHQL_COST
+
+
+# ---------------------------------------------------------------------------
+# Estimator-coverage contract
+# ---------------------------------------------------------------------------
+
+
+def test_operation_route_family_mapping_covers_estimator_families() -> None:
+    """Every route_family an estimator emits must appear in that provider's usage
+    registry, or recorded actuals would key by a family no estimate exists for
+    (a silently-empty calibration join)."""
+
+    providers: list[tuple[str, BudgetEstimator, frozenset[str]]] = [
+        ("github", GitHubBudgetEstimator(), GITHUB_USAGE_ROUTE_FAMILY_KEYS),
+        ("gitlab", GitLabBudgetEstimator(), GITLAB_USAGE_ROUTE_FAMILY_KEYS),
+        ("jira", JiraBudgetEstimator(), JIRA_USAGE_ROUTE_FAMILY_KEYS),
+        ("linear", LinearBudgetEstimator(), LINEAR_USAGE_ROUTE_FAMILY_KEYS),
+    ]
+    for provider, estimator, registry_keys in providers:
+        emitted: set[str] = set()
+        for dataset in DatasetKey:
+            ctx = _context(provider=provider, dataset_key=dataset.value)
+            for estimate in estimator.estimate(ctx):
+                emitted.add(estimate.route_family)
+        assert emitted, f"{provider} estimator emitted no route families"
+        missing = emitted - registry_keys
+        assert not missing, f"{provider} emits families absent from registry: {missing}"
+
+
+# ---------------------------------------------------------------------------
+# Provider drains
+# ---------------------------------------------------------------------------
+
+
+def test_gitlab_provider_drains_usage_observations(monkeypatch) -> None:
+    from dev_health_ops.providers.gitlab.provider import GitLabProvider
+
+    for flag in (
+        "GITLAB_INCLUDE_MRS",
+        "GITLAB_FETCH_MILESTONES",
+        "GITLAB_FETCH_EPICS",
+        "GITLAB_FETCH_NOTES",
+        "GITLAB_FETCH_LINKS",
+    ):
+        monkeypatch.setenv(flag, "false")
+
+    recorder = UsageRecorder(resolver=GITLAB_USAGE_RESOLVER)
+    recorder.record(
+        transport="rest",
+        operation="GET /projects/:id",
+        headers={},
+        rate_limit={"remaining": "100"},
+        status=200,
+    )
+
+    client = MagicMock()
+    client.iter_project_issues.return_value = []
+    client.drain_usage_observations.side_effect = recorder.drain
+
+    provider = GitLabProvider(client=client)
+    ctx = IngestionContext(repo="group/project", window=IngestionWindow())
+    batch = provider.ingest(ctx)
+
+    usage = batch.observations["provider_usage"]
+    assert len(usage) == 1
+    assert usage[0]["route_family"] == "project"
+    assert usage[0]["dimension"] == "rest_core"
+    assert usage[0]["request_count"] == 1
+
+
+def test_jira_provider_drains_usage_observations() -> None:
+    from dev_health_ops.providers.jira.provider import JiraProvider
+
+    recorder = UsageRecorder(resolver=JIRA_USAGE_RESOLVER)
+    recorder.record(
+        transport="rest",
+        operation="GET /rest/api/3/search/jql",
+        headers={},
+        rate_limit={"remaining": "90"},
+        status=200,
+    )
+
+    client = MagicMock()
+    client.iter_issues.return_value = iter([])
+    client.iter_issue_comments.return_value = iter([])
+    client.close.return_value = None
+    client.drain_usage_observations.side_effect = recorder.drain
+
+    provider = JiraProvider(client=client)
+    ctx = IngestionContext(
+        window=IngestionWindow(updated_since=datetime(2025, 1, 1, tzinfo=timezone.utc)),
+        limit=1,
+    )
+    batch = provider.ingest(ctx)
+
+    usage = batch.observations["provider_usage"]
+    assert len(usage) == 1
+    assert usage[0]["route_family"] == "jira_jql"
+    assert usage[0]["dimension"] == "search"
+
+
+# ---------------------------------------------------------------------------
+# Linear per-POST counting
+# ---------------------------------------------------------------------------
+
+
+def test_linear_client_counts_graphql_requests(monkeypatch) -> None:
+    from dev_health_ops.providers.linear.client import (
+        ISSUES_QUERY,
+        TEAMS_QUERY,
+        LinearAuth,
+        LinearClient,
+    )
+
+    client = LinearClient(auth=LinearAuth(api_key="secret"))
+
+    def fake_post(url: str, json: dict | None = None) -> httpx.Response:
+        return httpx.Response(
+            200,
+            headers={
+                "X-RateLimit-Requests-Limit": "1500",
+                "X-RateLimit-Requests-Remaining": "1490",
+                "X-RateLimit-Requests-Reset": "0",
+            },
+            json={"data": {}},
+            request=httpx.Request("POST", url),
+        )
+
+    monkeypatch.setattr(client._client, "post", fake_post)
+
+    client._execute(ISSUES_QUERY, {"first": 50})
+    client._execute(ISSUES_QUERY, {"first": 50})
+    client._execute(TEAMS_QUERY, {"first": 50})
+
+    by_family = {o["route_family"]: o for o in client.drain_usage_observations()}
+
+    assert by_family["issues"]["request_count"] == 2
+    assert by_family["issues"]["dimension"] == "graphql_cost"
+    # X-RateLimit-Requests-* headers are captured onto the observation.
+    assert by_family["issues"]["rate_limit"]["remaining"] == "1490"
+    assert by_family["issues"]["rate_limit"]["limit"] == "1500"
+    assert by_family["teams"]["request_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Backward-compatible observation shape
+# ---------------------------------------------------------------------------
+
+
+def test_github_usage_key_backward_compat() -> None:
+    """The job builder emits provider_usage alongside github_usage and keeps the
+    linear page/batch promotion contract intact."""
+
+    from dev_health_ops.metrics.job_work_items import _build_work_item_observations
+    from dev_health_ops.workers.sync_units import _WORK_ITEM_RESULT_OBSERVATION_FIELDS
+
+    github_usage = [{"transport": "rest", "route_family": "work_items"}]
+    provider_usage = [{"transport": "rest", "route_family": "work_items"}]
+    observations = _build_work_item_observations(
+        github_usage=github_usage,
+        provider_usage=provider_usage,
+        linear_page_count=3,
+        linear_batch_count=5,
+        include_linear_counts=True,
+    )
+    assert observations["github_usage"] == github_usage
+    assert observations["provider_usage"] == provider_usage
+    assert observations["linear_page_count"] == 3
+    assert observations["linear_batch_count"] == 5
+
+    # The admin-API promotion contract (fields lifted to the top-level result)
+    # must not have silently changed.
+    assert _WORK_ITEM_RESULT_OBSERVATION_FIELDS == (
+        "linear_page_count",
+        "linear_batch_count",
+    )

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -3249,6 +3249,67 @@ def test_run_sync_unit_rate_limit_defers_without_failure(db_session, monkeypatch
     )
 
 
+def test_usage_survives_rate_limit_deferral(db_session, monkeypatch):
+    """CHAOS-2754: usage actuals gathered before a rate-limit raise are merged
+    into the deferral stamp WITHOUT clobbering error_category / retry fields the
+    admin API reads."""
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.metrics.job_work_items import (
+        attach_work_item_partial_observations,
+    )
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_dispatching_unit(db_session)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(sync_units, "set_watermark", lambda *a, **kw: None)
+    _patch_finalize_apply(monkeypatch)
+
+    provider_usage = [
+        {
+            "transport": "rest",
+            "route_family": "work_items",
+            "dimension": "rest_core",
+            "request_count": 7,
+        }
+    ]
+
+    def raise_rate_limit(ctx, runtime):
+        exc = RateLimitException("429 Too Many Requests", retry_after_seconds=120)
+        attach_work_item_partial_observations(
+            exc,
+            {
+                "provider_usage": provider_usage,
+                "linear_page_count": 2,
+                "linear_batch_count": 3,
+            },
+        )
+        raise exc
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", raise_rate_limit)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "rate_limited_deferred"
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+
+    # Admin-API-read fields stay intact.
+    assert unit.result["error_category"] == "rate_limit"
+    assert unit.result["not_before"] is not None
+    assert unit.result["rate_limit_deferrals"] == 1
+    # Partial actuals were merged under observations (additive, no clobber).
+    assert unit.result["observations"]["provider_usage"] == provider_usage
+    # Linear page/batch counts promoted to the top level (admin contract).
+    assert unit.result["linear_page_count"] == 2
+    assert unit.result["linear_batch_count"] == 3
+
+
 def test_retrying_unit_not_claimed_before_available_at_and_claimed_after(
     tmp_path, monkeypatch
 ):


### PR DESCRIPTION
## Problem

Actual request/page counts were recorded per interpolated `(transport, operation)` string in three near-identical in-memory recorders (github/gitlab/jira clients). Per-issue-number operation labels blew past the 50-key cap (dropping most actuals as `overflow`), the keys didn't share the `route_family`/`dimension` vocabulary the budget **estimators** emit (so actuals couldn't be joined against estimates for calibration), and only GitHub's recorder was ever drained — GitLab/Jira recorded then dropped, Linear/LaunchDarkly recorded nothing. Actuals were also lost entirely on rate-limit/failure paths.

## Fix

- **Shared recorder** (`providers/usage.py`): extract the triplicated recorder and re-key observations by `(transport, route_family, dimension)`. Per-issue labels collapse onto a route-family key (fixes the cardinality-cap overflow); a sampled `example_operation` is kept for debugging.
- **Route-family registries** exported from each `providers/*/budget.py` (mirroring `LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES`), so actuals key by the same vocabulary an estimate does. An estimator-coverage contract test guards against silent drift.
- **Wire the dead drains**: `GitLabProvider.ingest`, `JiraProvider.ingest` (legacy + atlassian), and the live `fetch_gitlab_work_items` sync path; hoist + drain the Jira/Linear job clients.
- **Linear**: per-GraphQL-POST counting with `X-RateLimit-Requests-*` capture.
- **Additive key**: emit a provider-neutral `provider_usage` **alongside** the legacy `github_usage` (kept byte-for-byte; `linear_page_count`/`linear_batch_count` promotion unchanged).
- **Preserve actuals on failure**: `run_work_items_sync_job` attaches partial observations gathered before a mid-sync raise to the exception; the worker merges them into the rate-limit **deferral** stamp and `_stamp_sync_unit_failed` **additively** — never clobbering `error_category`/`next_retry_at` and the other admin-API-read fields.
- **Documented out-of-scope gaps** (LaunchDarkly actuals — frozen `connectors/`; code-dataset actuals — no instrumented client) in `docs/architecture/sync-usage-actuals.md`.

Product invariant preserved: nothing here changes credential→dispatch-capacity behavior.

## Tests

New `tests/test_provider_usage.py` covers: per-issue label collapse / no-overflow at 150 ops; per-provider resolver vocabulary; the estimator-coverage contract (every emitted `route_family` is in the registry); GitLab & Jira provider drains emit `provider_usage`; Linear per-POST counting with header capture; and the `github_usage`+`provider_usage` backward-compat + promotion contract. `tests/test_sync_units.py` adds `test_usage_survives_rate_limit_deferral` (observations merged, `error_category`/retry fields intact). Existing pinned tests updated for the additive key + re-keyed shape.

Full local gate green: `ruff format`+`ruff check`+`mypy`+full unit suite (6167 passed) + live-ClickHouse argMax proof.

Part of CHAOS-2742
Fixes CHAOS-2754
https://linear.app/fullchaos/issue/CHAOS-2754