### PR TITLE
feat(sync): actual-vs-estimated budget calibration in unit results (CHAOS-2759)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -148,7 +148,7 @@ Every successful `run_sync_unit` result carries a `budget_comparison` under
 `result['observations']`, joining the unit's run-time budget audit
 (`estimate_provider_budget`, same call `budget_estimate` is built from) to
 CHAOS-2754's normalized `provider_usage` actuals, one row per
-`(route_family, dimension)` present in **both**:
+`(route_family, dimension)` with drained actuals this run:
 
 ```json
 {
@@ -158,6 +158,9 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
   "actual_requests": 5,
   "ratio": 2.5,
   "underestimated": true,
+  "underestimation_assessable": true,
+  "underestimation_assessable_reason": null,
+  "unbudgeted_actual": false,
   "incomplete": false,
   "bucket": {"provider": "github", "org_id": "...", "host": "api.github.com",
              "credential_fingerprint": "...", "dimension": "rest_core"},
@@ -169,10 +172,33 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
   (see `SYNC_BUDGET_BUCKET_LIMITS` above), never converted against
   `actual_requests`; the two are reported side by side, not blended into one
   number.
-- **`underestimated`** is `actual_requests > estimated_units`. No row is
-  emitted for a `route_family`/`dimension` with an estimate but no drained
-  actuals this run (code datasets, an unwired LaunchDarkly family, …) — never
-  a fabricated 100% over-estimation.
+- **A route_family/dimension with an estimate but no drained actuals this
+  run produces no row** (code datasets, an unwired LaunchDarkly family, …) —
+  never a fabricated 100% over-estimation.
+- **`unbudgeted_actual`** is the reverse case: actual traffic on a
+  route_family/dimension with **no matching estimate at all**, including the
+  shared recorder's `unclassified` fallback for an operation that couldn't be
+  resolved to any budget family. This is surfaced, not dropped — it is the
+  highest-value calibration signal (real provider calls against zero admitted
+  budget) — with `estimated_units: 0` and `ratio: null`. The row's `bucket` is
+  a shell borrowed from a sibling estimate in the same unit (same
+  provider/org/host/credential — a unit has one ctx, so those fields are
+  constant across every estimate it produces) with only `dimension`
+  overridden to match the actual observation.
+- **`underestimated`** is `actual_requests > estimated_units`, but only
+  trustworthy when **`underestimation_assessable`** is `true`. A raw request
+  count is only comparable to `estimated_units` when the dimension
+  denominates in something request-count-like — `rest_core` ("Standard REST
+  request budget") and `search` ("Search/JQL request budget"), per the
+  dimension table above — or when there is no estimate at all
+  (`unbudgeted_actual`; a zero baseline is never a unit-conversion problem).
+  For `graphql_cost` (query-cost/complexity points), `contents_blob`
+  (high-variance blob/tree expansion), and `secondary_abuse_risk` (a flat
+  risk-flag reservation, not a request count), comparing a request count
+  against a nonzero estimate would invent a conversion the estimator never
+  made: `underestimation_assessable` is `false`,
+  `underestimation_assessable_reason` explains why, `ratio` is `null`, and
+  `underestimated` stays `false` — **no warning is logged** for that row.
 - **`incomplete`** is `true` for every row on a unit whose CHAOS-2754
   recorder hit its 50-key overflow cap. Dropped operations aren't attributed
   to a specific family (the recorder never learns which family they'd have
@@ -180,13 +206,16 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
   confirmed over-estimation. A visible `underestimated: true` stays valid even
   when `incomplete`: a capped (undercounted) actual that already exceeds the
   estimate only understates the true overage.
-- **Underestimation is surfaced, never auto-tuned.** Each underestimated row
-  logs `run_sync_unit.budget_underestimated` with the same structured field
-  vocabulary BudgetGuard's own admission logs use (`bucket`, `budget_key`,
-  `estimated_units`, `route_family` — see `_observe_estimate` above) so an
-  operator can correlate a calibration warning with the run's actual
-  admission decision. The comparison never changes an estimator's output or
-  `SYNC_BUDGET_*` consumption — it is a pure, read-only join
+- **Underestimation is surfaced, never auto-tuned.** Each row with
+  `underestimated: true` (whether a genuine underestimation or an
+  `unbudgeted_actual` row) logs `run_sync_unit.budget_underestimated` with
+  the same structured field vocabulary BudgetGuard's own admission logs use
+  (`bucket`, `budget_key`, `estimated_units`, `route_family` — see
+  `_observe_estimate` above) plus a `reason` of `"underestimated"` or
+  `"unbudgeted_actual"`, so an operator can correlate a calibration warning
+  with the run's actual admission decision and tell the two cases apart. The
+  comparison never changes an estimator's output or `SYNC_BUDGET_*`
+  consumption — it is a pure, read-only join
   (`tests/test_budget_calibration.py::test_estimates_never_mutated_by_comparison`).
 - **Drift caveat.** This compares against the **run-time** budget audit —
   recomputed just before the unit's dataset fetch — not the estimate
@@ -202,7 +231,10 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
 - **Out of scope.** The CLI and backfill runner discard job/task returns
   (`metrics/job_work_items.py`, `backfill/runner.py`), so this comparison only
   surfaces through the unitized sync path (unit result / structured logs /
-  the admin API's `result` passthrough) — not CLI or backfill output.
+  the admin API's `result` passthrough) — not CLI or backfill output. A unit
+  whose estimator produces **no estimate at all** (`budget_audit` empty) is
+  also out of scope — there's no bucket context to attribute even an
+  unbudgeted row to.
 
 ## Per-provider policy
 

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -142,6 +142,68 @@ source of truth and
 `tests/test_rate_limit_policy_doc.py::test_documented_route_families_match_estimators`
 fails if code emits a family this page does not document.
 
+### Actual-vs-estimated calibration (CHAOS-2759)
+
+Every successful `run_sync_unit` result carries a `budget_comparison` under
+`result['observations']`, joining the unit's run-time budget audit
+(`estimate_provider_budget`, same call `budget_estimate` is built from) to
+CHAOS-2754's normalized `provider_usage` actuals, one row per
+`(route_family, dimension)` present in **both**:
+
+```json
+{
+  "route_family": "git",
+  "dimension": "rest_core",
+  "estimated_units": 2,
+  "actual_requests": 5,
+  "ratio": 2.5,
+  "underestimated": true,
+  "incomplete": false,
+  "bucket": {"provider": "github", "org_id": "...", "host": "api.github.com",
+             "credential_fingerprint": "...", "dimension": "rest_core"},
+  "budget_key": "github:...:api.github.com:...:rest_core:git"
+}
+```
+
+- **Raw numbers only.** `estimated_units` are abstract reservation units
+  (see `SYNC_BUDGET_BUCKET_LIMITS` above), never converted against
+  `actual_requests`; the two are reported side by side, not blended into one
+  number.
+- **`underestimated`** is `actual_requests > estimated_units`. No row is
+  emitted for a `route_family`/`dimension` with an estimate but no drained
+  actuals this run (code datasets, an unwired LaunchDarkly family, …) — never
+  a fabricated 100% over-estimation.
+- **`incomplete`** is `true` for every row on a unit whose CHAOS-2754
+  recorder hit its 50-key overflow cap. Dropped operations aren't attributed
+  to a specific family (the recorder never learns which family they'd have
+  joined), so an `incomplete` row's `ratio <= 1` must **not** be read as a
+  confirmed over-estimation. A visible `underestimated: true` stays valid even
+  when `incomplete`: a capped (undercounted) actual that already exceeds the
+  estimate only understates the true overage.
+- **Underestimation is surfaced, never auto-tuned.** Each underestimated row
+  logs `run_sync_unit.budget_underestimated` with the same structured field
+  vocabulary BudgetGuard's own admission logs use (`bucket`, `budget_key`,
+  `estimated_units`, `route_family` — see `_observe_estimate` above) so an
+  operator can correlate a calibration warning with the run's actual
+  admission decision. The comparison never changes an estimator's output or
+  `SYNC_BUDGET_*` consumption — it is a pure, read-only join
+  (`tests/test_budget_calibration.py::test_estimates_never_mutated_by_comparison`).
+- **Drift caveat.** This compares against the **run-time** budget audit —
+  recomputed just before the unit's dataset fetch — not the estimate
+  BudgetGuard admitted at dispatch time. Env-flag-dependent estimators (e.g.
+  Jira's `JIRA_FETCH_WORKLOGS` / `ATLASSIAN_GQL_ENABLED` gating) can in
+  principle disagree between admission and execution; `observations`'s
+  sibling `budget_comparison_computed_at` records when the run-time audit
+  ran so that drift is inspectable. Persisting the admit-time estimate onto
+  the unit for a drift-free comparison is a deliberately **deferred**
+  follow-up (open decision) — it would add an extra UPDATE per admitted unit
+  per dispatch pass, and isn't worth it until calibration data shows material
+  drift.
+- **Out of scope.** The CLI and backfill runner discard job/task returns
+  (`metrics/job_work_items.py`, `backfill/runner.py`), so this comparison only
+  surfaces through the unitized sync path (unit result / structured logs /
+  the admin API's `result` passthrough) — not CLI or backfill output.
+
 ## Per-provider policy
 
 ### GitHub
@@ -343,13 +405,16 @@ paper over:
 - **No cross-unit cooldown gating.** When one unit discovers a real cooldown,
   sibling units still call the provider and re-discover it. (Target:
   [CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760).)
-- **Estimates are not calibrated against actuals.** Budget estimates are static;
-  actual request/page counts by provider/dataset/route-family/dimension are not
-  recorded, so underestimation is invisible. GitHub `pr_social`/`work_item_prs`
-  secondary pressure, Linear request/complexity actuals, and LaunchDarkly
-  route-remaining are all **uninstrumented**. (Target:
-  [CHAOS-2754](https://linear.app/fullchaos/issue/CHAOS-2754) /
-  [CHAOS-2759](https://linear.app/fullchaos/issue/CHAOS-2759).)
+- **Calibration only covers instrumented route families.** [CHAOS-2759](https://linear.app/fullchaos/issue/CHAOS-2759)
+  attaches a `budget_comparison` (see
+  [Actual-vs-estimated calibration](#actual-vs-estimated-calibration-chaos-2759)
+  above) wherever CHAOS-2754's recorder actually drained actuals for a
+  route_family, but the recorder only records where a client calls it.
+  GitHub `pr_social`/`work_item_prs` secondary pressure, Linear
+  request/complexity actuals, and LaunchDarkly route-remaining are still
+  **uninstrumented**, so those families never produce a comparison row.
+  There is also no cross-run aggregation/dashboard yet — calibration today is
+  visible per-unit (result + structured log), not rolled up over time.
 - **Signal handling is not yet provider-neutral.** There are two unrelated
   `RateLimitException` classes — `dev_health_ops.exceptions.RateLimitException`
   (canonical providers, caught by the worker deferral) and
@@ -383,9 +448,6 @@ append its section here in the same changeset (per `AGENTS.md`
   **never** unit-level credential selection for capacity.
 - **Observation store — [CHAOS-2758](https://linear.app/fullchaos/issue/CHAOS-2758).**
   A durable Postgres table / event stream for provider rate-limit observations.
-- **Calibration — [CHAOS-2759](https://linear.app/fullchaos/issue/CHAOS-2759).**
-  Actual-vs-estimated comparison attached to unit results/logs, surfacing
-  underestimation before any auto-tuning.
 - **Cooldown gating — [CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760).**
   Consult recent observations before dispatch and defer sibling units into a
   known provider/integration/route-family cooldown window.

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -44,6 +44,7 @@ import logging
 import os
 import threading
 import uuid
+from collections import defaultdict
 from collections.abc import Mapping
 from datetime import datetime, timedelta, timezone
 from typing import Any, TypedDict
@@ -69,6 +70,7 @@ from dev_health_ops.models import (
     SyncRunUnit,
     SyncRunUnitStatus,
 )
+from dev_health_ops.providers.usage import PROVIDER_USAGE_OBSERVATION_KEY
 from dev_health_ops.sync.budget import estimate_provider_budget
 from dev_health_ops.sync.budget_guard import BudgetGuard
 from dev_health_ops.sync.datasets import DatasetKey
@@ -257,6 +259,175 @@ def _attach_budget_observation(
     )
     observations["budget_estimate"] = budget_audit
     result_payload["observations"] = observations
+    return result_payload
+
+
+def _comparison_budget_key(bucket: Mapping[str, Any], *, route_family: str) -> str:
+    """Mirror ``BudgetGuard._budget_key``'s format (``sync/budget_guard.py``)
+    so a calibration warning's ``budget_key`` correlates 1:1 with the
+    ``budget_key`` BudgetGuard's own admission logs emit for the same bucket.
+    Duplicated rather than imported to avoid reaching into BudgetGuard's
+    private helpers from the calibration join (CHAOS-2759).
+    """
+    return ":".join(
+        (
+            str(bucket.get("provider", "")),
+            str(bucket.get("org_id", "")),
+            str(bucket.get("host", "")),
+            str(bucket.get("credential_fingerprint", "")),
+            str(bucket.get("dimension", "")),
+            route_family,
+        )
+    )
+
+
+def _join_budget_estimates_with_actuals(
+    budget_audit: list[dict[str, Any]],
+    provider_usage: list[Any],
+) -> list[dict[str, Any]]:
+    """Pure join of admit-time-adjacent budget estimates to CHAOS-2754's
+    normalized actuals, per ``(route_family, dimension)`` (CHAOS-2759).
+
+    Read-only: never mutates ``budget_audit`` / ``provider_usage`` and never
+    re-estimates or touches ``SYNC_BUDGET_*`` consumption -- estimator outputs
+    and budget enforcement live entirely in ``sync/budget.py`` /
+    ``sync/budget_guard.py`` and are untouched by this function
+    (``test_estimates_never_mutated_by_comparison``).
+
+    Reports both numbers RAW: ``estimated_units`` are abstract reservation
+    units (docs/ops/deployment-guide.md), never converted against
+    ``actual_requests``. A unit with no drained actuals for a route_family
+    (e.g. code datasets, LaunchDarkly) or no estimate for one produces no row
+    for that family -- never a fabricated 100% over/under-estimation.
+
+    When the CHAOS-2754 recorder's 50-key overflow marker is present, dropped
+    operations could belong to any route_family (the recorder never learns
+    which family a dropped operation would have joined), so every row for this
+    unit is marked ``incomplete`` and no over-estimation conclusion should be
+    drawn from a row where ``actual_requests <= estimated_units``.
+    Underestimation remains a valid signal even when incomplete: a capped
+    (undercounted) actual that already exceeds the estimate only understates
+    the true overage.
+    """
+
+    incomplete = any(
+        isinstance(entry, Mapping) and "dropped_operation_count" in entry
+        for entry in provider_usage
+    )
+
+    actual_requests_by_key: dict[tuple[str, str], int] = defaultdict(int)
+    for entry in provider_usage:
+        if not isinstance(entry, Mapping) or "dropped_operation_count" in entry:
+            continue
+        route_family = entry.get("route_family")
+        dimension = entry.get("dimension")
+        if not route_family or not dimension:
+            continue
+        actual_requests_by_key[(route_family, dimension)] += int(
+            entry.get("request_count") or 0
+        )
+
+    if not actual_requests_by_key:
+        return []
+
+    estimated_units_by_key: dict[tuple[str, str], int] = defaultdict(int)
+    bucket_by_key: dict[tuple[str, str], Mapping[str, Any]] = {}
+    for estimate in budget_audit:
+        if not isinstance(estimate, Mapping):
+            continue
+        route_family = estimate.get("route_family")
+        bucket = estimate.get("bucket")
+        if not isinstance(bucket, Mapping):
+            continue
+        dimension = bucket.get("dimension")
+        if not route_family or not dimension:
+            continue
+        key = (route_family, dimension)
+        estimated_units_by_key[key] += int(estimate.get("estimated_units") or 0)
+        bucket_by_key.setdefault(key, bucket)
+
+    comparisons: list[dict[str, Any]] = []
+    for key in sorted(estimated_units_by_key.keys() & actual_requests_by_key.keys()):
+        route_family, dimension = key
+        estimated_units = estimated_units_by_key[key]
+        actual_requests = actual_requests_by_key[key]
+        bucket = bucket_by_key[key]
+        comparisons.append(
+            {
+                "route_family": route_family,
+                "dimension": dimension,
+                "estimated_units": estimated_units,
+                "actual_requests": actual_requests,
+                "ratio": (
+                    actual_requests / estimated_units if estimated_units else None
+                ),
+                "underestimated": actual_requests > estimated_units,
+                "incomplete": incomplete,
+                "bucket": dict(bucket),
+                "budget_key": _comparison_budget_key(bucket, route_family=route_family),
+            }
+        )
+    return comparisons
+
+
+def _attach_budget_comparison(
+    result: dict[str, Any],
+    budget_audit: list[dict[str, Any]] | None,
+    *,
+    log_ctx: dict[str, Any],
+    computed_at: datetime,
+) -> dict[str, Any]:
+    """Attach ``observations.budget_comparison`` and log underestimation
+    (CHAOS-2759). OBSERVE-ONLY: does not change ``result`` when there is
+    nothing to compare, and never mutates ``budget_audit`` or the estimator
+    inputs it was built from.
+
+    Compares against the RUN-TIME budget audit computed just before this unit
+    dispatched its dataset fetch, not the estimate BudgetGuard admitted at
+    plan/dispatch time -- env-flag-dependent estimators (e.g. Jira's
+    ``JIRA_FETCH_WORKLOGS`` / ``ATLASSIAN_GQL_ENABLED`` gating) can in
+    principle disagree between admission and execution. ``computed_at`` is
+    recorded precisely so this drift is inspectable; persisting the
+    admit-time estimate onto the unit for a drift-free comparison is a
+    deliberately deferred follow-up (open decision), not added speculatively.
+    """
+
+    if not budget_audit:
+        return result
+    observations = result.get("observations")
+    if not isinstance(observations, Mapping):
+        return result
+    provider_usage = observations.get(PROVIDER_USAGE_OBSERVATION_KEY)
+    if not isinstance(provider_usage, list) or not provider_usage:
+        return result
+
+    comparisons = _join_budget_estimates_with_actuals(budget_audit, provider_usage)
+    if not comparisons:
+        return result
+
+    result_payload = dict(result)
+    new_observations = dict(observations)
+    new_observations["budget_comparison"] = comparisons
+    new_observations["budget_comparison_computed_at"] = computed_at.isoformat()
+    result_payload["observations"] = new_observations
+
+    for comparison in comparisons:
+        if not comparison["underestimated"]:
+            continue
+        logger.warning(
+            "run_sync_unit.budget_underestimated",
+            extra={
+                **log_ctx,
+                "bucket": comparison["bucket"],
+                "budget_key": comparison["budget_key"],
+                "estimated_units": comparison["estimated_units"],
+                "actual_requests": comparison["actual_requests"],
+                "route_family": comparison["route_family"],
+                "dimension": comparison["dimension"],
+                "ratio": comparison["ratio"],
+                "incomplete": comparison["incomplete"],
+            },
+        )
     return result_payload
 
 
@@ -645,6 +816,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 }
 
         budget_audit = _budget_estimate_audit(ctx, _log_ctx)
+        budget_audit_computed_at = datetime.now(timezone.utc)
         started_extra = dict(_log_ctx)
         if budget_audit is not None:
             started_extra["budget_estimate"] = budget_audit
@@ -685,7 +857,12 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 "surface": exc.surface,
             }
         result_payload = _promote_result_observation_fields(
-            _attach_budget_observation(dict(result or {}), budget_audit)
+            _attach_budget_comparison(
+                _attach_budget_observation(dict(result or {}), budget_audit),
+                budget_audit,
+                log_ctx=_log_ctx,
+                computed_at=budget_audit_computed_at,
+            )
         )
 
         completed_at = datetime.now(timezone.utc)

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -281,6 +281,28 @@ def _comparison_budget_key(bucket: Mapping[str, Any], *, route_family: str) -> s
     )
 
 
+# Dimensions whose estimated_units approximate a literal request/page count
+# (see docs/providers/rate-limit-policy.md's dimension table: rest_core is
+# "Standard REST request budget", search is "Search/JQL request budget"), so a
+# raw actual_requests comparison is meaningful. graphql_cost (query-cost /
+# complexity points), contents_blob (high-variance blob/tree expansion), and
+# secondary_abuse_risk (a flat risk-flag reservation, not a request count) are
+# NOT -- comparing a request COUNT against one of those would invent a
+# conversion the estimator never made (CHAOS-2759 adversarial review finding).
+_REQUEST_COUNT_COMPARABLE_DIMENSIONS = frozenset({"rest_core", "search"})
+
+
+def _shell_bucket(template: Mapping[str, Any], *, dimension: str) -> dict[str, Any]:
+    """Build a bucket for a route_family/dimension with no estimate of its
+    own, borrowing the provider/org_id/host/credential_fingerprint of a
+    sibling estimate from the SAME unit (they share one ctx, so those fields
+    are constant across every estimate a unit's audit produces) and swapping
+    in the actual observation's own dimension.
+    """
+
+    return {**dict(template), "dimension": dimension}
+
+
 def _join_budget_estimates_with_actuals(
     budget_audit: list[dict[str, Any]],
     provider_usage: list[Any],
@@ -296,9 +318,23 @@ def _join_budget_estimates_with_actuals(
 
     Reports both numbers RAW: ``estimated_units`` are abstract reservation
     units (docs/ops/deployment-guide.md), never converted against
-    ``actual_requests``. A unit with no drained actuals for a route_family
-    (e.g. code datasets, LaunchDarkly) or no estimate for one produces no row
-    for that family -- never a fabricated 100% over/under-estimation.
+    ``actual_requests``. A route_family/dimension with an estimate but no
+    drained actuals this run (e.g. code datasets, LaunchDarkly) produces no
+    row -- never a fabricated 100% over-estimation. The reverse -- actual
+    traffic with NO matching estimate at all, including the shared recorder's
+    ``unclassified`` fallback -- is the highest-value calibration signal (real
+    provider calls against zero admitted budget) and IS surfaced, with
+    ``estimated_units: 0`` and ``unbudgeted_actual: True``.
+
+    ``underestimated``/``ratio`` are only computed when the comparison is
+    unit-comparable (``underestimation_assessable``): either the dimension
+    denominates in something request-count-like
+    (``_REQUEST_COUNT_COMPARABLE_DIMENSIONS``), or there is no estimate at all
+    (a zero baseline is never a unit-conversion problem, unlike comparing a
+    request count to a nonzero abstract quantity of e.g. GraphQL cost
+    points). Otherwise both are left unassessed (``ratio: None``,
+    ``underestimated: False``) with a ``underestimation_assessable_reason``
+    explaining why, and no warning is logged for that row.
 
     When the CHAOS-2754 recorder's 50-key overflow marker is present, dropped
     operations could belong to any route_family (the recorder never learns
@@ -346,22 +382,48 @@ def _join_budget_estimates_with_actuals(
         estimated_units_by_key[key] += int(estimate.get("estimated_units") or 0)
         bucket_by_key.setdefault(key, bucket)
 
+    if not bucket_by_key:
+        # No usable bucket to attribute even an unbudgeted row to.
+        return []
+    bucket_template = next(iter(bucket_by_key.values()))
+
     comparisons: list[dict[str, Any]] = []
-    for key in sorted(estimated_units_by_key.keys() & actual_requests_by_key.keys()):
+    for key in sorted(actual_requests_by_key):
         route_family, dimension = key
-        estimated_units = estimated_units_by_key[key]
         actual_requests = actual_requests_by_key[key]
-        bucket = bucket_by_key[key]
+        unbudgeted_actual = key not in estimated_units_by_key
+        estimated_units = 0 if unbudgeted_actual else estimated_units_by_key[key]
+        bucket = bucket_by_key.get(key)
+        if bucket is None:
+            bucket = _shell_bucket(bucket_template, dimension=dimension)
+
+        assessable = (
+            unbudgeted_actual or dimension in _REQUEST_COUNT_COMPARABLE_DIMENSIONS
+        )
+        if assessable:
+            ratio = actual_requests / estimated_units if estimated_units else None
+            underestimated = actual_requests > estimated_units
+            assessable_reason = None
+        else:
+            ratio = None
+            underestimated = False
+            assessable_reason = (
+                f"{dimension!r} is an abstract reservation unit, not a 1:1 "
+                "request count -- comparing actual_requests against it would "
+                "invent a conversion the estimator never made"
+            )
+
         comparisons.append(
             {
                 "route_family": route_family,
                 "dimension": dimension,
                 "estimated_units": estimated_units,
                 "actual_requests": actual_requests,
-                "ratio": (
-                    actual_requests / estimated_units if estimated_units else None
-                ),
-                "underestimated": actual_requests > estimated_units,
+                "ratio": ratio,
+                "underestimated": underestimated,
+                "underestimation_assessable": assessable,
+                "underestimation_assessable_reason": assessable_reason,
+                "unbudgeted_actual": unbudgeted_actual,
                 "incomplete": incomplete,
                 "bucket": dict(bucket),
                 "budget_key": _comparison_budget_key(bucket, route_family=route_family),
@@ -412,8 +474,15 @@ def _attach_budget_comparison(
     result_payload["observations"] = new_observations
 
     for comparison in comparisons:
+        # underestimated is only ever True for an underestimation_assessable
+        # row (see _join_budget_estimates_with_actuals), so this already
+        # excludes abstract-unit dimensions -- no warning is invented from a
+        # request-count vs. reservation-unit mismatch.
         if not comparison["underestimated"]:
             continue
+        reason = (
+            "unbudgeted_actual" if comparison["unbudgeted_actual"] else "underestimated"
+        )
         logger.warning(
             "run_sync_unit.budget_underestimated",
             extra={
@@ -426,6 +495,7 @@ def _attach_budget_comparison(
                 "dimension": comparison["dimension"],
                 "ratio": comparison["ratio"],
                 "incomplete": comparison["incomplete"],
+                "reason": reason,
             },
         )
     return result_payload

--- a/tests/test_budget_calibration.py
+++ b/tests/test_budget_calibration.py
@@ -1,0 +1,326 @@
+"""Actual-vs-estimated calibration join (CHAOS-2759).
+
+Pure-function tests for ``workers/sync_units.py``'s
+``_join_budget_estimates_with_actuals`` / ``_attach_budget_comparison``: the
+join between a unit's run-time budget audit (``estimate_provider_budget``
+output shape, see ``sync/budget.py`` / ``sync/budget_types.py``) and
+CHAOS-2754's normalized ``provider_usage`` actuals (``providers/usage.py``).
+No DB, no Celery -- these operate purely on the already-serialized dict
+shapes both sides emit, mirroring ``BudgetEstimate.to_dict()`` and
+``UsageRecorder.drain()``.
+
+Integration-level coverage (full ``run_sync_unit`` success path, the
+underestimation warning log end-to-end, and the result-stamp/admin-passthrough
+contract) lives in ``tests/test_sync_units.py``.
+"""
+
+from __future__ import annotations
+
+import copy
+import logging
+from datetime import datetime, timezone
+
+from dev_health_ops.workers.sync_units import (
+    _attach_budget_comparison,
+    _comparison_budget_key,
+    _join_budget_estimates_with_actuals,
+)
+
+
+def _estimate(
+    *,
+    route_family: str,
+    dimension: str,
+    estimated_units: int,
+    provider: str = "github",
+    org_id: str = "org-1",
+    host: str = "api.github.com",
+    credential_fingerprint: str = "fp-1",
+    confidence: str = "medium",
+) -> dict:
+    """Shape of ``BudgetEstimate.to_dict()`` (sync/budget_types.py)."""
+
+    return {
+        "bucket": {
+            "provider": provider,
+            "org_id": org_id,
+            "host": host,
+            "credential_fingerprint": credential_fingerprint,
+            "dimension": dimension,
+        },
+        "estimated_units": estimated_units,
+        "confidence": confidence,
+        "route_family": route_family,
+        "notes": [],
+    }
+
+
+def _actual(
+    *,
+    route_family: str,
+    dimension: str,
+    request_count: int,
+    transport: str = "rest",
+) -> dict:
+    """Shape of one ``UsageRecorder.drain()`` entry (providers/usage.py)."""
+
+    return {
+        "transport": transport,
+        "route_family": route_family,
+        "dimension": dimension,
+        "request_count": request_count,
+        "example_operation": "GET /example",
+    }
+
+
+_OVERFLOW_MARKER = {
+    "transport": "summary",
+    "route_family": "overflow",
+    "dimension": "summary",
+    "dropped_operation_count": 3,
+}
+
+
+def test_budget_comparison_attached_per_route_family():
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=2),
+        _estimate(
+            route_family="pr_social", dimension="graphql_cost", estimated_units=4
+        ),
+    ]
+    provider_usage = [
+        _actual(route_family="git", dimension="rest_core", request_count=5),
+        _actual(
+            route_family="pr_social",
+            dimension="graphql_cost",
+            request_count=1,
+            transport="graphql",
+        ),
+    ]
+
+    comparisons = _join_budget_estimates_with_actuals(budget_audit, provider_usage)
+
+    by_family = {row["route_family"]: row for row in comparisons}
+    assert set(by_family) == {"git", "pr_social"}
+
+    git_row = by_family["git"]
+    assert git_row["dimension"] == "rest_core"
+    assert git_row["estimated_units"] == 2
+    assert git_row["actual_requests"] == 5
+    assert git_row["ratio"] == 2.5
+    assert git_row["underestimated"] is True
+    assert git_row["incomplete"] is False
+    assert git_row["budget_key"] == _comparison_budget_key(
+        git_row["bucket"], route_family="git"
+    )
+
+    social_row = by_family["pr_social"]
+    assert social_row["estimated_units"] == 4
+    assert social_row["actual_requests"] == 1
+    assert social_row["ratio"] == 0.25
+    assert social_row["underestimated"] is False
+    assert social_row["incomplete"] is False
+
+
+def test_no_actuals_no_false_signal():
+    """A unit with estimates but no drained actuals for a family (code
+    datasets, LaunchDarkly's unwired families) must produce NO row -- never a
+    fabricated 100% over-estimation."""
+
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=2),
+    ]
+
+    assert _join_budget_estimates_with_actuals(budget_audit, []) == []
+    # Actuals present, but only for an unrelated family -- still no row for
+    # "git" (no cross-family fallback / guessing).
+    unrelated_actuals = [
+        _actual(route_family="flags", dimension="rest_core", request_count=9)
+    ]
+    assert _join_budget_estimates_with_actuals(budget_audit, unrelated_actuals) == []
+
+
+def test_overflow_marks_comparison_incomplete():
+    """The recorder's 50-key overflow marker means dropped operations could
+    belong to ANY route_family (the recorder never learns which family a
+    dropped operation would have joined), so every row for the unit is
+    incomplete and a ratio <= 1 must not be read as a confirmed
+    over-estimation."""
+
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=10),
+    ]
+    provider_usage = [
+        _actual(route_family="git", dimension="rest_core", request_count=3),
+        _OVERFLOW_MARKER,
+    ]
+
+    comparisons = _join_budget_estimates_with_actuals(budget_audit, provider_usage)
+
+    assert len(comparisons) == 1
+    row = comparisons[0]
+    assert row["actual_requests"] == 3
+    assert row["estimated_units"] == 10
+    assert row["incomplete"] is True
+    # Looks over-estimated on the visible numbers, but callers must treat that
+    # as unproven while incomplete -- the flag itself is that signal.
+    assert row["underestimated"] is False
+
+
+def test_overflow_does_not_suppress_a_real_underestimation_signal():
+    """Even when capped, a visible actual that already exceeds the estimate
+    is still a valid underestimation signal: the true (uncapped) actual can
+    only be larger, never smaller."""
+
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=2),
+    ]
+    provider_usage = [
+        _actual(route_family="git", dimension="rest_core", request_count=5),
+        _OVERFLOW_MARKER,
+    ]
+
+    comparisons = _join_budget_estimates_with_actuals(budget_audit, provider_usage)
+
+    assert len(comparisons) == 1
+    row = comparisons[0]
+    assert row["underestimated"] is True
+    assert row["incomplete"] is True
+
+
+def test_estimates_never_mutated_by_comparison():
+    """No auto-tuning regression guard: joining estimates to actuals must
+    never mutate either input (CHAOS-2759 is OBSERVE-ONLY)."""
+
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=2),
+    ]
+    provider_usage = [
+        _actual(route_family="git", dimension="rest_core", request_count=5),
+    ]
+    budget_audit_before = copy.deepcopy(budget_audit)
+    provider_usage_before = copy.deepcopy(provider_usage)
+
+    comparisons = _join_budget_estimates_with_actuals(budget_audit, provider_usage)
+
+    assert budget_audit == budget_audit_before
+    assert provider_usage == provider_usage_before
+    assert comparisons  # sanity: the join actually produced a row
+
+    # The row's bucket is a defensive copy, not the same object -- mutating
+    # the comparison output must never leak back into the estimate it was
+    # built from.
+    comparisons[0]["bucket"]["provider"] = "mutated"
+    assert budget_audit[0]["bucket"]["provider"] == "github"
+
+
+def test_attach_budget_comparison_is_noop_without_budget_audit():
+    result = {
+        "ok": True,
+        "observations": {
+            "provider_usage": [
+                _actual(route_family="git", dimension="rest_core", request_count=5)
+            ]
+        },
+    }
+
+    attached = _attach_budget_comparison(
+        result, None, log_ctx={}, computed_at=datetime.now(timezone.utc)
+    )
+
+    assert attached is result
+    assert "budget_comparison" not in attached["observations"]
+
+
+def test_attach_budget_comparison_is_noop_without_provider_usage():
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=2),
+    ]
+    result = {"ok": True, "observations": {}}
+
+    attached = _attach_budget_comparison(
+        result, budget_audit, log_ctx={}, computed_at=datetime.now(timezone.utc)
+    )
+
+    assert attached is result
+    assert "budget_comparison" not in attached["observations"]
+
+
+def test_attach_budget_comparison_logs_underestimated_warning(caplog):
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=2),
+    ]
+    result = {
+        "ok": True,
+        "observations": {
+            "provider_usage": [
+                _actual(route_family="git", dimension="rest_core", request_count=9)
+            ]
+        },
+    }
+    log_ctx = {
+        "sync_run_id": "run-1",
+        "unit_id": "unit-1",
+        "source_id": "src-1",
+        "dataset_key": "commits",
+        "provider": "github",
+        "cost_class": "medium",
+    }
+    computed_at = datetime.now(timezone.utc)
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.workers.sync_units"):
+        attached = _attach_budget_comparison(
+            result, budget_audit, log_ctx=log_ctx, computed_at=computed_at
+        )
+
+    comparison = attached["observations"]["budget_comparison"][0]
+    assert comparison["underestimated"] is True
+    assert (
+        attached["observations"]["budget_comparison_computed_at"]
+        == computed_at.isoformat()
+    )
+
+    warning_records = [
+        r for r in caplog.records if r.message == "run_sync_unit.budget_underestimated"
+    ]
+    assert len(warning_records) == 1
+    record = warning_records[0]
+    # Same structured-field vocabulary BudgetGuard's admission logs use
+    # (bucket, budget_key, estimated_units, route_family -- budget_guard.py
+    # `_observe_estimate`), so operators can correlate a calibration warning
+    # with the run's actual admission decision.
+    assert record.route_family == "git"
+    assert record.dimension == "rest_core"
+    assert record.estimated_units == 2
+    assert record.actual_requests == 9
+    assert record.budget_key == "github:org-1:api.github.com:fp-1:rest_core:git"
+    assert record.bucket["dimension"] == "rest_core"
+    assert record.sync_run_id == "run-1"
+    assert record.unit_id == "unit-1"
+
+
+def test_attach_budget_comparison_does_not_log_for_over_estimated_rows(caplog):
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=10),
+    ]
+    result = {
+        "ok": True,
+        "observations": {
+            "provider_usage": [
+                _actual(route_family="git", dimension="rest_core", request_count=1)
+            ]
+        },
+    }
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.workers.sync_units"):
+        attached = _attach_budget_comparison(
+            result,
+            budget_audit,
+            log_ctx={},
+            computed_at=datetime.now(timezone.utc),
+        )
+
+    assert attached["observations"]["budget_comparison"][0]["underestimated"] is False
+    assert not [
+        r for r in caplog.records if r.message == "run_sync_unit.budget_underestimated"
+    ]

--- a/tests/test_budget_calibration.py
+++ b/tests/test_budget_calibration.py
@@ -84,24 +84,17 @@ _OVERFLOW_MARKER = {
 def test_budget_comparison_attached_per_route_family():
     budget_audit = [
         _estimate(route_family="git", dimension="rest_core", estimated_units=2),
-        _estimate(
-            route_family="pr_social", dimension="graphql_cost", estimated_units=4
-        ),
+        _estimate(route_family="jql", dimension="search", estimated_units=4),
     ]
     provider_usage = [
         _actual(route_family="git", dimension="rest_core", request_count=5),
-        _actual(
-            route_family="pr_social",
-            dimension="graphql_cost",
-            request_count=1,
-            transport="graphql",
-        ),
+        _actual(route_family="jql", dimension="search", request_count=1),
     ]
 
     comparisons = _join_budget_estimates_with_actuals(budget_audit, provider_usage)
 
     by_family = {row["route_family"]: row for row in comparisons}
-    assert set(by_family) == {"git", "pr_social"}
+    assert set(by_family) == {"git", "jql"}
 
     git_row = by_family["git"]
     assert git_row["dimension"] == "rest_core"
@@ -109,35 +102,139 @@ def test_budget_comparison_attached_per_route_family():
     assert git_row["actual_requests"] == 5
     assert git_row["ratio"] == 2.5
     assert git_row["underestimated"] is True
+    assert git_row["underestimation_assessable"] is True
+    assert git_row["underestimation_assessable_reason"] is None
+    assert git_row["unbudgeted_actual"] is False
     assert git_row["incomplete"] is False
     assert git_row["budget_key"] == _comparison_budget_key(
         git_row["bucket"], route_family="git"
     )
 
-    social_row = by_family["pr_social"]
-    assert social_row["estimated_units"] == 4
-    assert social_row["actual_requests"] == 1
-    assert social_row["ratio"] == 0.25
-    assert social_row["underestimated"] is False
-    assert social_row["incomplete"] is False
+    # "search" is also request-count-comparable (Jira JQL listing pagination).
+    jql_row = by_family["jql"]
+    assert jql_row["estimated_units"] == 4
+    assert jql_row["actual_requests"] == 1
+    assert jql_row["ratio"] == 0.25
+    assert jql_row["underestimated"] is False
+    assert jql_row["underestimation_assessable"] is True
+    assert jql_row["unbudgeted_actual"] is False
+    assert jql_row["incomplete"] is False
+
+
+def test_non_assessable_dimension_does_not_claim_underestimation():
+    """graphql_cost (query-cost/complexity points) and other abstract-unit
+    dimensions must never produce ``underestimated: True`` from a raw
+    request-count comparison -- the estimator's units there aren't a 1:1
+    request count, so a magnitude comparison would invent a conversion it
+    never made (CHAOS-2759 adversarial review finding)."""
+
+    budget_audit = [
+        _estimate(
+            route_family="pr_social", dimension="graphql_cost", estimated_units=4
+        ),
+    ]
+    provider_usage = [
+        _actual(
+            route_family="pr_social",
+            dimension="graphql_cost",
+            request_count=9,
+            transport="graphql",
+        ),
+    ]
+
+    comparisons = _join_budget_estimates_with_actuals(budget_audit, provider_usage)
+
+    assert len(comparisons) == 1
+    row = comparisons[0]
+    assert row["actual_requests"] == 9
+    assert row["estimated_units"] == 4
+    assert row["ratio"] is None
+    assert row["underestimated"] is False
+    assert row["underestimation_assessable"] is False
+    assert row["underestimation_assessable_reason"] is not None
+    assert row["unbudgeted_actual"] is False
 
 
 def test_no_actuals_no_false_signal():
-    """A unit with estimates but no drained actuals for a family (code
-    datasets, LaunchDarkly's unwired families) must produce NO row -- never a
-    fabricated 100% over-estimation."""
+    """A unit with estimates but no drained actuals at all produces no rows
+    -- never a fabricated 100% over-estimation for the estimated side."""
 
     budget_audit = [
         _estimate(route_family="git", dimension="rest_core", estimated_units=2),
     ]
 
     assert _join_budget_estimates_with_actuals(budget_audit, []) == []
-    # Actuals present, but only for an unrelated family -- still no row for
-    # "git" (no cross-family fallback / guessing).
-    unrelated_actuals = [
-        _actual(route_family="flags", dimension="rest_core", request_count=9)
+
+
+def test_unbudgeted_actual_family_is_surfaced_not_dropped():
+    """Actual traffic for a route_family/dimension with NO matching estimate
+    at all must be surfaced as an explicit unbudgeted_actual row -- never
+    silently dropped. This is the highest-value calibration signal: real
+    provider calls against zero admitted budget (CHAOS-2759 adversarial
+    review finding)."""
+
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=2),
     ]
-    assert _join_budget_estimates_with_actuals(budget_audit, unrelated_actuals) == []
+    unrelated_actuals = [
+        _actual(route_family="flags", dimension="search", request_count=9)
+    ]
+
+    comparisons = _join_budget_estimates_with_actuals(budget_audit, unrelated_actuals)
+
+    assert len(comparisons) == 1
+    row = comparisons[0]
+    assert row["route_family"] == "flags"
+    assert row["dimension"] == "search"
+    assert row["estimated_units"] == 0
+    assert row["actual_requests"] == 9
+    assert row["ratio"] is None
+    assert row["unbudgeted_actual"] is True
+    # A zero baseline is never a unit-conversion problem, so this is always
+    # assessable -- unlike a nonzero abstract estimate.
+    assert row["underestimated"] is True
+    assert row["underestimation_assessable"] is True
+    assert row["underestimation_assessable_reason"] is None
+    # The bucket is a shell borrowed from a sibling estimate in the same
+    # unit (same provider/org/host/credential), dimension overridden to
+    # match the actual observation.
+    assert row["bucket"]["provider"] == "github"
+    assert row["bucket"]["org_id"] == "org-1"
+    assert row["bucket"]["dimension"] == "search"
+    assert row["budget_key"] == "github:org-1:api.github.com:fp-1:search:flags"
+
+
+def test_unclassified_family_actuals_surface_as_unbudgeted():
+    """The shared recorder's ``unclassified`` fallback (unresolved
+    operations, see ``providers/usage.py`` ``OperationResolver.resolve``) has
+    no estimator model by construction -- it must still surface as an
+    unbudgeted row, regardless of which dimension the unresolved transport
+    defaulted to."""
+
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=2),
+    ]
+    provider_usage = [
+        _actual(route_family="unclassified", dimension="rest_core", request_count=3),
+        _actual(
+            route_family="unclassified",
+            dimension="graphql_cost",
+            request_count=7,
+            transport="graphql",
+        ),
+    ]
+
+    comparisons = _join_budget_estimates_with_actuals(budget_audit, provider_usage)
+    by_dimension = {row["dimension"]: row for row in comparisons}
+
+    assert set(by_dimension) == {"rest_core", "graphql_cost"}
+    for row in by_dimension.values():
+        assert row["route_family"] == "unclassified"
+        assert row["estimated_units"] == 0
+        assert row["unbudgeted_actual"] is True
+        assert row["underestimated"] is True
+        assert row["underestimation_assessable"] is True
+        assert row["underestimation_assessable_reason"] is None
 
 
 def test_overflow_marks_comparison_incomplete():
@@ -297,6 +394,74 @@ def test_attach_budget_comparison_logs_underestimated_warning(caplog):
     assert record.bucket["dimension"] == "rest_core"
     assert record.sync_run_id == "run-1"
     assert record.unit_id == "unit-1"
+    assert record.reason == "underestimated"
+
+
+def test_attach_budget_comparison_logs_unbudgeted_reason(caplog):
+    """The warning's ``reason`` field distinguishes a genuine underestimation
+    (nonzero estimate exceeded) from unbudgeted actual traffic (zero
+    estimate, some real usage) -- both fire the same event name so existing
+    alerting still catches them, but operators can tell them apart."""
+
+    budget_audit = [
+        _estimate(route_family="git", dimension="rest_core", estimated_units=2),
+    ]
+    result = {
+        "ok": True,
+        "observations": {
+            "provider_usage": [
+                _actual(route_family="flags", dimension="rest_core", request_count=4)
+            ]
+        },
+    }
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.workers.sync_units"):
+        _attach_budget_comparison(
+            result, budget_audit, log_ctx={}, computed_at=datetime.now(timezone.utc)
+        )
+
+    warning_records = [
+        r for r in caplog.records if r.message == "run_sync_unit.budget_underestimated"
+    ]
+    assert len(warning_records) == 1
+    assert warning_records[0].reason == "unbudgeted_actual"
+    assert warning_records[0].route_family == "flags"
+
+
+def test_attach_budget_comparison_does_not_warn_for_non_assessable_dimension(caplog):
+    """graphql_cost actual_requests exceeding estimated_units must NOT log
+    the underestimation warning -- the comparison isn't unit-comparable."""
+
+    budget_audit = [
+        _estimate(
+            route_family="pr_social", dimension="graphql_cost", estimated_units=4
+        ),
+    ]
+    result = {
+        "ok": True,
+        "observations": {
+            "provider_usage": [
+                _actual(
+                    route_family="pr_social",
+                    dimension="graphql_cost",
+                    request_count=9,
+                    transport="graphql",
+                )
+            ]
+        },
+    }
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.workers.sync_units"):
+        attached = _attach_budget_comparison(
+            result, budget_audit, log_ctx={}, computed_at=datetime.now(timezone.utc)
+        )
+
+    row = attached["observations"]["budget_comparison"][0]
+    assert row["underestimated"] is False
+    assert row["underestimation_assessable"] is False
+    assert not [
+        r for r in caplog.records if r.message == "run_sync_unit.budget_underestimated"
+    ]
 
 
 def test_attach_budget_comparison_does_not_log_for_over_estimated_rows(caplog):

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -646,6 +646,126 @@ def test_run_sync_unit_success_logs_budget_underestimated_warning(
     assert record.unit_id == str(unit.id)
     assert record.bucket["provider"] == "github"
     assert record.budget_key.endswith(":rest_core:git")
+    assert record.reason == "underestimated"
+
+
+def test_run_sync_unit_success_surfaces_unbudgeted_actual_route_family(
+    db_session, monkeypatch, caplog
+):
+    """CHAOS-2759 adversarial review fix: actual traffic on a route_family
+    with NO matching budget estimate (e.g. the shared recorder's
+    'unclassified' fallback for an operation that couldn't be resolved to any
+    family) must surface as an explicit unbudgeted_actual row and a
+    budget_underestimated warning with reason=unbudgeted_actual -- never be
+    silently dropped."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)  # provider="github", dataset_key="commits"
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {
+            "ok": True,
+            "observations": {
+                "provider_usage": [
+                    {
+                        "transport": "rest",
+                        "route_family": "unclassified",
+                        "dimension": "rest_core",
+                        "request_count": 6,
+                    }
+                ]
+            },
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.workers.sync_units"):
+        result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    db_session.refresh(unit)
+    observations = unit.result["observations"]
+    comparisons = observations["budget_comparison"]
+    unclassified_row = next(
+        row for row in comparisons if row["route_family"] == "unclassified"
+    )
+    assert unclassified_row["estimated_units"] == 0
+    assert unclassified_row["actual_requests"] == 6
+    assert unclassified_row["unbudgeted_actual"] is True
+    assert unclassified_row["underestimated"] is True
+    assert unclassified_row["underestimation_assessable"] is True
+
+    warnings = [
+        r for r in caplog.records if r.message == "run_sync_unit.budget_underestimated"
+    ]
+    unbudgeted_warnings = [w for w in warnings if w.route_family == "unclassified"]
+    assert len(unbudgeted_warnings) == 1
+    assert unbudgeted_warnings[0].reason == "unbudgeted_actual"
+
+
+def test_run_sync_unit_success_does_not_warn_for_non_assessable_dimension(
+    db_session, monkeypatch, caplog
+):
+    """CHAOS-2759 adversarial review fix: a graphql_cost route_family
+    (query-cost/complexity points, not a request count) with actual_requests
+    far exceeding estimated_units must NOT log budget_underestimated -- the
+    comparison isn't unit-comparable."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    # "prs" estimates REST_CORE "prs", GRAPHQL_COST "pr_social", and
+    # SECONDARY_ABUSE_RISK "pr_social" (providers/github/budget.py) -- all
+    # unconditional, no processor_flags needed.
+    run, unit = _seed_run(db_session, dataset_key="prs")
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {
+            "ok": True,
+            "observations": {
+                "provider_usage": [
+                    {
+                        "transport": "graphql",
+                        "route_family": "pr_social",
+                        "dimension": "graphql_cost",
+                        "request_count": 999,
+                    }
+                ]
+            },
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.workers.sync_units"):
+        result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    db_session.refresh(unit)
+    comparisons = unit.result["observations"]["budget_comparison"]
+    pr_social_row = next(
+        row for row in comparisons if row["route_family"] == "pr_social"
+    )
+    assert pr_social_row["actual_requests"] == 999
+    assert pr_social_row["underestimated"] is False
+    assert pr_social_row["underestimation_assessable"] is False
+    assert pr_social_row["underestimation_assessable_reason"] is not None
+    assert not [
+        r for r in caplog.records if r.message == "run_sync_unit.budget_underestimated"
+    ]
 
 
 def test_run_sync_unit_budget_comparison_never_mutates_estimate(

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -501,6 +501,278 @@ def test_run_sync_unit_success_attaches_linear_budget_estimate(db_session, monke
     }
 
 
+def test_run_sync_unit_success_attaches_budget_comparison_per_route_family(
+    db_session, monkeypatch
+):
+    """CHAOS-2759: a success result carries budget_comparison rows joining
+    the run-time estimate to CHAOS-2754's normalized provider_usage actuals
+    for every route_family/dimension present in both."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)  # provider="github", dataset_key="commits"
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {
+            "ok": True,
+            "observations": {
+                "provider_usage": [
+                    {
+                        "transport": "rest",
+                        "route_family": "git",
+                        "dimension": "rest_core",
+                        "request_count": 5,
+                    }
+                ]
+            },
+        },
+    )
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    db_session.refresh(unit)
+    observations = unit.result["observations"]
+    # "commits" dataset estimate: route_family="git", dimension="rest_core",
+    # estimated_units=2 (providers/github/budget.py _scaled_units(2, 1)).
+    budget_estimate = observations["budget_estimate"]
+    assert budget_estimate[0]["route_family"] == "git"
+    assert budget_estimate[0]["estimated_units"] == 2
+
+    comparisons = observations["budget_comparison"]
+    assert len(comparisons) == 1
+    row = comparisons[0]
+    assert row["route_family"] == "git"
+    assert row["dimension"] == "rest_core"
+    assert row["estimated_units"] == 2
+    assert row["actual_requests"] == 5
+    assert row["ratio"] == 2.5
+    assert row["underestimated"] is True
+    assert row["incomplete"] is False
+    assert "budget_comparison_computed_at" in observations
+
+
+def test_run_sync_unit_success_omits_budget_comparison_without_actuals(
+    db_session, monkeypatch
+):
+    """CHAOS-2759: a dataset with a budget estimate but no drained actuals
+    this run must not produce a comparison row -- never a fake 100%
+    over-estimation."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {"ok": True, "observations": {}},
+    )
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    db_session.refresh(unit)
+    observations = unit.result["observations"]
+    assert "budget_estimate" in observations
+    assert "budget_comparison" not in observations
+
+
+def test_run_sync_unit_success_logs_budget_underestimated_warning(
+    db_session, monkeypatch, caplog
+):
+    """CHAOS-2759: an underestimated route_family/dimension logs
+    run_sync_unit.budget_underestimated using BudgetGuard's structured field
+    vocabulary (bucket, budget_key, estimated_units, route_family) so
+    operators can correlate a calibration warning with the run's admission
+    decision."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {
+            "ok": True,
+            "observations": {
+                "provider_usage": [
+                    {
+                        "transport": "rest",
+                        "route_family": "git",
+                        "dimension": "rest_core",
+                        "request_count": 50,
+                    }
+                ]
+            },
+        },
+    )
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.workers.sync_units"):
+        result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    warnings = [
+        r for r in caplog.records if r.message == "run_sync_unit.budget_underestimated"
+    ]
+    assert len(warnings) == 1
+    record = warnings[0]
+    assert record.route_family == "git"
+    assert record.dimension == "rest_core"
+    assert record.estimated_units == 2
+    assert record.actual_requests == 50
+    assert record.sync_run_id == str(run.id)
+    assert record.unit_id == str(unit.id)
+    assert record.bucket["provider"] == "github"
+    assert record.budget_key.endswith(":rest_core:git")
+
+
+def test_run_sync_unit_budget_comparison_never_mutates_estimate(
+    db_session, monkeypatch
+):
+    """No auto-tuning regression guard (CHAOS-2759): computing a
+    budget_comparison must never re-estimate or alter what
+    estimate_provider_budget produced. The persisted budget_estimate
+    observation is byte-identical to the (spied) live estimator output, and
+    the estimator is invoked exactly once -- the comparison never triggers a
+    second estimation pass or touches SYNC_BUDGET_* consumption (that lives
+    entirely in dispatch_sync_run/BudgetGuard, never called from
+    run_sync_unit)."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers import sync_units as sync_units_module
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    calls = []
+    real_estimate_provider_budget = sync_units_module.estimate_provider_budget
+
+    def spy_estimate_provider_budget(ctx):
+        estimates = real_estimate_provider_budget(ctx)
+        calls.append(estimates)
+        return estimates
+
+    monkeypatch.setattr(
+        sync_units_module, "estimate_provider_budget", spy_estimate_provider_budget
+    )
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {
+            "ok": True,
+            "observations": {
+                "provider_usage": [
+                    {
+                        "transport": "rest",
+                        "route_family": "git",
+                        "dimension": "rest_core",
+                        "request_count": 999,
+                    }
+                ]
+            },
+        },
+    )
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    assert len(calls) == 1, "comparison must not trigger a second estimation call"
+    live_estimate = [estimate.to_dict() for estimate in calls[0]]
+
+    db_session.refresh(unit)
+    observations = unit.result["observations"]
+    assert observations["budget_estimate"] == live_estimate
+    comparison = observations["budget_comparison"][0]
+    assert comparison["underestimated"] is True
+    assert comparison["estimated_units"] == live_estimate[0]["estimated_units"]
+    assert comparison["bucket"] == live_estimate[0]["bucket"]
+
+
+def test_run_sync_unit_budget_comparison_survives_result_stamp_and_admin_passthrough(
+    db_session, monkeypatch
+):
+    """CHAOS-2759: budget_comparison must survive the terminal SUCCESS UPDATE
+    (re-read from the DB, not just the in-memory result dict) and pass
+    through the admin API's result field untouched -- without perturbing the
+    promoted linear_page_count/linear_batch_count fields or error_category."""
+    from dev_health_ops.api.admin.routers.integrations import _unit_to_response
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {
+            "ok": True,
+            "observations": {
+                "provider_usage": [
+                    {
+                        "transport": "rest",
+                        "route_family": "git",
+                        "dimension": "rest_core",
+                        "request_count": 7,
+                    }
+                ]
+            },
+        },
+    )
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+    assert result["status"] == "success"
+
+    # Raw UPDATE used synchronize_session=False -- refresh proves this
+    # actually persisted through the terminal SUCCESS stamp, not merely the
+    # in-memory result dict built inside run_sync_unit.
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.SUCCESS.value
+    persisted_comparison = unit.result["observations"]["budget_comparison"]
+    assert persisted_comparison[0]["route_family"] == "git"
+
+    response = _unit_to_response(unit)
+    response_result = response.result
+    assert response_result is not None
+    assert response_result["observations"]["budget_comparison"] == persisted_comparison
+    assert response.linear_page_count is None
+    assert response.linear_batch_count is None
+    assert response.error_category is None
+
+
 def test_run_sync_unit_success_survives_finalize_enqueue_failure(
     db_session, monkeypatch
 ):


### PR DESCRIPTION
## Problem

Sync budget estimates (`estimate_provider_budget`) are static and never checked against reality. CHAOS-2754 landed a shared, route-family-keyed actuals recorder (`provider_usage`), but nothing joins it back to the estimate that admitted the unit, so underestimation is invisible to operators.

## Fix

- Added a pure join, `_join_budget_estimates_with_actuals` (+ `_attach_budget_comparison`, `_comparison_budget_key`) in `workers/sync_units.py`, run inside `run_sync_unit`'s success path. It joins the unit's run-time budget audit to the CHAOS-2754 `provider_usage` actuals per `(route_family, dimension)` and attaches the rows as `result['observations']['budget_comparison']`, each `{route_family, dimension, estimated_units, actual_requests, ratio, underestimated, incomplete, bucket, budget_key}`.
- Reports both numbers **raw** — `estimated_units` are abstract reservation units (docs/ops/deployment-guide.md), never converted against `actual_requests`.
- No row is emitted for a family with an estimate but no drained actuals (code datasets, unwired LaunchDarkly families) — never a fabricated 100% over-estimation.
- When CHAOS-2754's recorder hit its 50-key overflow cap, every row for that unit is marked `incomplete` (dropped operations can't be attributed to a specific family), suppressing any over-estimation conclusion — underestimation remains valid even then, since a capped actual that already exceeds the estimate only understates the true overage.
- Each underestimated row logs `run_sync_unit.budget_underestimated`, reusing BudgetGuard's own structured field vocabulary (`bucket`, `budget_key`, `estimated_units`, `route_family`) so operators can correlate a calibration warning with the run's actual admission decision.
- **Observe-only, no auto-tuning**: the join never re-estimates or mutates the estimator's output, and never touches `SYNC_BUDGET_*` consumption. v1 compares against the **run-time** budget audit (not admit-time stamping); a `budget_comparison_computed_at` timestamp and doc caveat record the possible admit-vs-execution drift for env-flag-dependent estimators (e.g. Jira). Persisting the admit-time estimate for a drift-free comparison is a deliberately deferred follow-up.
- Appended a "Actual-vs-estimated calibration" section to `docs/providers/rate-limit-policy.md`, updated the `Known gaps`/`Target contracts` entries for CHAOS-2759 accordingly.

## Tests

- `tests/test_budget_calibration.py` (new, pure-function level): join per route_family/dimension, no-actuals-no-row, overflow marks `incomplete` (and doesn't suppress a real underestimation signal), never-mutated invariant, `_attach_budget_comparison` no-ops and warning-log wiring.
- `tests/test_sync_units.py` (new, integration level via `run_sync_unit`): comparison attached on success, omitted without actuals, structured underestimation warning end-to-end, an estimator-untouched regression guard (spies `estimate_provider_budget`, asserts single call + byte-identical `budget_estimate` observation), and comparison survives the terminal `SUCCESS` UPDATE + admin API `result` passthrough without perturbing `linear_page_count`/`linear_batch_count`/`error_category`.
- Full local gate (`ci/local_validate.sh`, isolated scratch ClickHouse db): lint, mypy, full unit suite (6206 passed), and the live-ClickHouse argMax proof all green.

Part of CHAOS-2742
Fixes CHAOS-2759
https://linear.app/fullchaos/issue/CHAOS-2759