### PR TITLE
feat(sync): persist shared rate-limit observations to Postgres (CHAOS-2758)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -240,22 +240,30 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
 
 Shipped in [CHAOS-2758](https://linear.app/fullchaos/issue/CHAOS-2758). Every
 `RateLimitException` that defers a sync unit (the worker-level deferral path
-above) now writes one durable, normalized row to the
+above) now attempts one durable, normalized row into the
 `provider_rate_limit_observations` Postgres table, in the **same
-session/transaction** as the unit's `RETRYING` stamp
+session** as the unit's `RETRYING` stamp
 (`workers/sync_units.py`, the `except RateLimitException` branch of
-`run_sync_unit`) — the observation and the deferral commit together or not at
-all, so the table never holds an orphan row for a deferral that didn't
-actually happen.
+`run_sync_unit`), attempted only after the CAS confirming that stamp landed
+succeeds — so the write never fires for a deferral that didn't actually
+happen. The write itself is isolated in its own `SAVEPOINT`
+(`session.begin_nested()`), not folded into the outer transaction outright:
+the observation store is diagnostic, not load-bearing, so a DB-level failure
+persisting it (a rolling deploy where migration `0031` isn't applied to every
+node yet, schema drift, or any other insert-time error) rolls back only the
+observation attempt and is logged — it must never turn a recoverable
+rate-limit deferral into a lost/failed unit.
 
 **Schema:** `id`, `org_id` (indexed), `provider`, `host`, `integration_id`,
-`sync_run_id`, `sync_run_unit_id`, `route_family`, `dimension`,
-`retry_after_seconds`, `reset_at`, `reason`, `request_id`, `observed_at`, plus
-a composite index `(provider, integration_id, route_family, observed_at)` for
-the cooldown lookup a future consumer needs (migration `0031`,
-`models/rate_limit_observations.py`). Only normalized fields are persisted —
-**never raw provider headers** (leak/bloat risk); header capture stays
-best-effort and provider-local exactly as documented per-provider above.
+`sync_run_id`, `sync_run_unit_id`, `route_family`, `route_family_attribution`,
+`dimension`, `retry_after_seconds`, `reset_at`, `reason`, `request_id`,
+`observed_at`, plus a composite index `(provider, integration_id,
+route_family, observed_at)` for the cooldown lookup a future consumer needs
+(migration `0031`, `models/rate_limit_observations.py`). Only normalized
+fields are persisted — **never raw provider headers or exception text**
+(leak/bloat risk); header capture stays best-effort and provider-local
+exactly as documented per-provider above, and `reason` is one of a fixed,
+allow-listed category vocabulary (below), never free text.
 
 **Why Postgres, not ClickHouse.** This answers the open question the earlier
 CHAOS-2742 budget plan left unresolved ("no new persistence table unless
@@ -280,15 +288,34 @@ both before persisting: `integration_id` comes from the unit row already
 loaded for the deferral (`SyncRunUnit.integration_id` — never re-resolved from
 mutable `Integration` state), and `route_family` is picked from the
 `BudgetEstimate` list **already computed for this unit's dispatch** (never
-re-estimated — estimators require credential decryption). A unit's estimate
-can carry multiple `(route_family, dimension)` pairs (e.g. GitHub PR datasets
-emit `prs`/`rest_core` alongside `pr_social`/`graphql_cost` +
-`pr_social`/`secondary_abuse_risk`); rather than fan out one row per matched
-family, the observation writer picks a single **primary** family: it matches
-the signal's `dimension` (populated by the client at the classification site,
-i.e. which kind of call actually hit the limit) against the estimate list,
-falling back to the first-emitted estimate when the dimension is absent or
-unmatched (every provider estimator emits its dataset-primary family first).
+re-estimated — estimators require credential decryption).
+
+**Route-family attribution is confidence-gated, never guessed.** A unit's
+estimate can carry multiple `(route_family, dimension)` pairs, and dimension
+alone frequently does **not** disambiguate them: Linear's `work-items`
+estimator emits `teams`/`issues`/`cycles`/`comments`/`attachments`/`history`
+**all** under `graphql_cost`, and Jira's comment-bearing datasets can emit
+both `jira_issue_enrichment` and `jira_comments` under `rest_core`. The
+observation writer (`_route_family_and_attribution` in `workers/sync_units.py`)
+narrows the unit's estimates by the signal's `dimension` (which call kind
+actually hit the limit) and only commits to a `route_family` when the
+surviving candidates name exactly **one distinct** family — this also covers
+the common case of a single-estimate unit, and estimates that share one
+family across dimensions (e.g. GitHub's `commit_stats`). Whenever that check
+can't produce a unique family — no budget audit, no dimension match, or more
+than one distinct family — `route_family` is `NULL` and
+`route_family_attribution` is set to `ambiguous_dimension`; `dimension`
+itself is still populated. **The CHAOS-2760 cooldown-gating consumer must
+fall back to provider+integration+dimension gating whenever
+`route_family_attribution` is set**, rather than trusting a guessed family.
+
+**`reason` is a normalized category, never raw exception text.** Legacy
+no-signal raise sites build their message from the provider's raw response
+body, which can embed header/body-shaped diagnostic content; persisting that
+verbatim for the retention window would be a leak risk. `reason` is always
+one of a fixed vocabulary — `primary`, `secondary`, `permission` (reserved for
+a future classification site), `complexity`, or `unknown` (no signal, or a
+value outside this vocabulary) — never `str(exception)`.
 
 **Retention.** A beat-scheduled task (`prune_rate_limit_observations`,
 `workers/sync_reconciler.py`, `workers/config.py`) deletes rows older than
@@ -298,7 +325,8 @@ deleted outright, no archival path.
 
 **Not yet wired: cooldown gating.** Nothing reads this table back before
 dispatch yet — see [Known gaps](#known-gaps) /
-[CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760).
+[CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760). Any such
+consumer must honor the `route_family_attribution` fallback contract above.
 
 ## Per-provider policy
 

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -236,6 +236,70 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
   also out of scope — there's no bucket context to attribute even an
   unbudgeted row to.
 
+## Observation store
+
+Shipped in [CHAOS-2758](https://linear.app/fullchaos/issue/CHAOS-2758). Every
+`RateLimitException` that defers a sync unit (the worker-level deferral path
+above) now writes one durable, normalized row to the
+`provider_rate_limit_observations` Postgres table, in the **same
+session/transaction** as the unit's `RETRYING` stamp
+(`workers/sync_units.py`, the `except RateLimitException` branch of
+`run_sync_unit`) — the observation and the deferral commit together or not at
+all, so the table never holds an orphan row for a deferral that didn't
+actually happen.
+
+**Schema:** `id`, `org_id` (indexed), `provider`, `host`, `integration_id`,
+`sync_run_id`, `sync_run_unit_id`, `route_family`, `dimension`,
+`retry_after_seconds`, `reset_at`, `reason`, `request_id`, `observed_at`, plus
+a composite index `(provider, integration_id, route_family, observed_at)` for
+the cooldown lookup a future consumer needs (migration `0031`,
+`models/rate_limit_observations.py`). Only normalized fields are persisted —
+**never raw provider headers** (leak/bloat risk); header capture stays
+best-effort and provider-local exactly as documented per-provider above.
+
+**Why Postgres, not ClickHouse.** This answers the open question the earlier
+CHAOS-2742 budget plan left unresolved ("no new persistence table unless
+log/result metadata proves insufficient — durable store TBD"). Every store the
+dispatch path already consults transactionally is Postgres:
+`SyncDispatchOutbox` (`models/integrations.py`), the per-unit rate-limit
+deferral columns on `sync_run_units` (migration `0022`),
+`SyncComputeCheckpoint` (migration `0025`), and `BudgetGuard`'s own
+reservation runs inside a Postgres advisory-lock transaction
+(`sync/budget_guard.py`). The [cooldown-gating consumer](#known-gaps)
+(CHAOS-2760) needs to read recent observations from inside that same
+advisory-lock transaction — only Postgres supports that join here; ClickHouse
+is a separate analytics cluster with no transactional relationship to the
+dispatch guard. ClickHouse mirroring is deferred and would only be revisited
+if this table becomes an analytics source in its own right, not a dispatch
+input.
+
+**Enrichment (worker boundary, not the client).** Per the
+[`RateLimitSignal` contract](#how-rate-limits-are-handled), provider clients
+leave `integration_id`/`route_family` unset. The worker boundary enriches
+both before persisting: `integration_id` comes from the unit row already
+loaded for the deferral (`SyncRunUnit.integration_id` — never re-resolved from
+mutable `Integration` state), and `route_family` is picked from the
+`BudgetEstimate` list **already computed for this unit's dispatch** (never
+re-estimated — estimators require credential decryption). A unit's estimate
+can carry multiple `(route_family, dimension)` pairs (e.g. GitHub PR datasets
+emit `prs`/`rest_core` alongside `pr_social`/`graphql_cost` +
+`pr_social`/`secondary_abuse_risk`); rather than fan out one row per matched
+family, the observation writer picks a single **primary** family: it matches
+the signal's `dimension` (populated by the client at the classification site,
+i.e. which kind of call actually hit the limit) against the estimate list,
+falling back to the first-emitted estimate when the dimension is absent or
+unmatched (every provider estimator emits its dataset-primary family first).
+
+**Retention.** A beat-scheduled task (`prune_rate_limit_observations`,
+`workers/sync_reconciler.py`, `workers/config.py`) deletes rows older than
+`SYNC_RATE_LIMIT_OBSERVATION_RETENTION_DAYS` (default **14**, env-overridable)
+once daily. This is an observation log, not an audit trail — expired rows are
+deleted outright, no archival path.
+
+**Not yet wired: cooldown gating.** Nothing reads this table back before
+dispatch yet — see [Known gaps](#known-gaps) /
+[CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760).
+
 ## Per-provider policy
 
 ### GitHub
@@ -326,7 +390,12 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
   work-item **listing** goes through the separately-limited REST `search/jql`
   endpoint (`search` dimension), while enrichment (changelog/comments/sprints)
   uses `rest_core`. AGG GraphQL enrichment, when enabled, uses `graphql_cost`.
-- **Headers.** `Retry-After` on `429`.
+- **Headers.** `Retry-After` on `429` (authoritative delay). `X-RateLimit-Reset`
+  is also sent, but as an **ISO 8601 timestamp** (e.g. `2025-10-08T15:00:00Z`),
+  not epoch seconds/milliseconds like GitHub/GitLab/Linear — verified against
+  Atlassian's Cloud rate-limiting docs
+  (`developer.atlassian.com/cloud/jira/platform/rate-limiting/`) for CHAOS-2758
+  (previously unverified; `RateLimitSignal.reset_at_from_iso8601` parses it).
 - **Retry semantics.** On `429`, Jira retries **in place** honoring `Retry-After`
   (`providers/jira/client.py` `_request_json`, `max_retries_429=3` → 4 attempts),
   then raises `RateLimitException` when exhausted so the worker deferral path
@@ -430,12 +499,11 @@ These are the instrumentation/coverage gaps the [CHAOS-2742](https://linear.app/
 epic exists to close. They are documented as **current reality**, not defects to
 paper over:
 
-- **No shared, persisted rate-limit observations.** Provider 429s are handled
-  per-task; there is no durable store of `retry_after` / `reset_at` /
-  `route_family` observations that siblings can consult. (Target:
-  [CHAOS-2758](https://linear.app/fullchaos/issue/CHAOS-2758).)
-- **No cross-unit cooldown gating.** When one unit discovers a real cooldown,
-  sibling units still call the provider and re-discover it. (Target:
+- **No cross-unit cooldown gating.** Provider rate-limit observations are now
+  durably persisted (see [Observation store](#observation-store), shipped in
+  [CHAOS-2758](https://linear.app/fullchaos/issue/CHAOS-2758)), but nothing
+  reads them back yet: when one unit discovers a real cooldown, sibling units
+  still call the provider and re-discover it independently. (Target:
   [CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760).)
 - **Calibration only covers instrumented route families.** [CHAOS-2759](https://linear.app/fullchaos/issue/CHAOS-2759)
   attaches a `budget_comparison` (see
@@ -478,8 +546,6 @@ append its section here in the same changeset (per `AGENTS.md`
   Stamp `credential_id`/version onto `SyncRun` at plan time; bootstrap uses the
   run-stamped auth context, not mutable integration state. Determinism only —
   **never** unit-level credential selection for capacity.
-- **Observation store — [CHAOS-2758](https://linear.app/fullchaos/issue/CHAOS-2758).**
-  A durable Postgres table / event stream for provider rate-limit observations.
 - **Cooldown gating — [CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760).**
   Consult recent observations before dispatch and defer sibling units into a
   known provider/integration/route-family cooldown window.

--- a/src/dev_health_ops/alembic/versions/0031_add_provider_rate_limit_observations.py
+++ b/src/dev_health_ops/alembic/versions/0031_add_provider_rate_limit_observations.py
@@ -55,6 +55,7 @@ def upgrade() -> None:
             sa.Column("sync_run_id", UUID(as_uuid=True), nullable=False),
             sa.Column("sync_run_unit_id", UUID(as_uuid=True), nullable=False),
             sa.Column("route_family", sa.Text(), nullable=True),
+            sa.Column("route_family_attribution", sa.Text(), nullable=True),
             sa.Column("dimension", sa.Text(), nullable=True),
             sa.Column("retry_after_seconds", sa.Float(), nullable=True),
             sa.Column("reset_at", sa.DateTime(timezone=True), nullable=True),
@@ -63,6 +64,13 @@ def upgrade() -> None:
             sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
             sa.PrimaryKeyConstraint("id"),
         )
+    # Guarded individually (per revision 0022/0030 convention) so a rerun
+    # against a DB that already has the table -- but predates the
+    # route_family_attribution column added during review -- resumes cleanly
+    # instead of failing on a duplicate/missing column.
+    _add_column_if_missing(
+        _TABLE_NAME, sa.Column("route_family_attribution", sa.Text(), nullable=True)
+    )
     _create_index_if_missing(_ORG_INDEX_NAME, _TABLE_NAME, ["org_id"])
     _create_index_if_missing(
         _COOLDOWN_INDEX_NAME,
@@ -79,6 +87,16 @@ def downgrade() -> None:
 def _table_exists(table_name: str) -> bool:
     bind = op.get_bind()
     return table_name in sa.inspect(bind).get_table_names()
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    if column.name not in _column_names(table_name):
+        op.add_column(table_name, column)
 
 
 def _create_index_if_missing(

--- a/src/dev_health_ops/alembic/versions/0031_add_provider_rate_limit_observations.py
+++ b/src/dev_health_ops/alembic/versions/0031_add_provider_rate_limit_observations.py
@@ -1,0 +1,92 @@
+"""Add provider_rate_limit_observations table (CHAOS-2758).
+
+Durable, org-scoped store of provider rate-limit observations. Every
+``RateLimitException`` that defers a sync unit writes one normalized row here
+in the SAME transaction as the unit's RETRYING stamp
+(``workers/sync_units.py``), so a later consumer (cross-unit cooldown gating,
+CHAOS-2760) can consult recent provider/integration/route-family cooldowns.
+
+Postgres, not ClickHouse -- every durable store the dispatch path already
+consults is Postgres (``sync_dispatch_outbox`` 0020, the per-unit rate-limit
+deferral columns 0022, ``sync_compute_checkpoints`` 0025), and BudgetGuard's
+own reservation runs inside a Postgres advisory-lock transaction
+(``sync/budget_guard.py``). See
+``docs/providers/rate-limit-policy.md`` "Observation store" section.
+
+Retry safety: table + index creation are guarded (per the 0025 / 0020
+"create-if-missing" convention) so a rerun after a partial failure resumes
+instead of failing on "relation already exists".
+
+Revision ID: 0031
+Revises: 0030
+Create Date: 2026-07-01 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0031"
+down_revision: str | None = "0030"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_TABLE_NAME = "provider_rate_limit_observations"
+_COOLDOWN_INDEX_NAME = "ix_provider_rate_limit_observations_cooldown"
+_ORG_INDEX_NAME = "ix_provider_rate_limit_observations_org_id"
+
+
+def upgrade() -> None:
+    if not _table_exists(_TABLE_NAME):
+        op.create_table(
+            _TABLE_NAME,
+            sa.Column("id", UUID(as_uuid=True), nullable=False),
+            sa.Column("org_id", sa.Text(), nullable=False),
+            sa.Column("provider", sa.Text(), nullable=False),
+            sa.Column("host", sa.Text(), nullable=True),
+            sa.Column("integration_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("sync_run_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("sync_run_unit_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("route_family", sa.Text(), nullable=True),
+            sa.Column("dimension", sa.Text(), nullable=True),
+            sa.Column("retry_after_seconds", sa.Float(), nullable=True),
+            sa.Column("reset_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("reason", sa.Text(), nullable=True),
+            sa.Column("request_id", sa.Text(), nullable=True),
+            sa.Column("observed_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_if_missing(_ORG_INDEX_NAME, _TABLE_NAME, ["org_id"])
+    _create_index_if_missing(
+        _COOLDOWN_INDEX_NAME,
+        _TABLE_NAME,
+        ["provider", "integration_id", "route_family", "observed_at"],
+    )
+
+
+def downgrade() -> None:
+    if _table_exists(_TABLE_NAME):
+        op.drop_table(_TABLE_NAME)
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    return table_name in sa.inspect(bind).get_table_names()
+
+
+def _create_index_if_missing(
+    index_name: str, table_name: str, columns: list[str]
+) -> None:
+    bind = op.get_bind()
+    existing_indexes = {
+        index["name"] for index in sa.inspect(bind).get_indexes(table_name)
+    }
+    if index_name not in existing_indexes:
+        op.create_index(index_name, table_name, columns)

--- a/src/dev_health_ops/models/__init__.py
+++ b/src/dev_health_ops/models/__init__.py
@@ -51,6 +51,7 @@ from .licensing import (
     OrgLicense,
 )
 from .org_invite import OrgInvite
+from .rate_limit_observations import ProviderRateLimitObservation
 from .refresh_token import RefreshToken
 from .refunds import Refund, RefundStatus
 from .reports import (
@@ -145,6 +146,7 @@ __all__ = [
     "OrgIPAllowlist",
     "OrgLicense",
     "OrgRetentionPolicy",
+    "ProviderRateLimitObservation",
     "Refund",
     "RefundStatus",
     "RefreshToken",

--- a/src/dev_health_ops/models/rate_limit_observations.py
+++ b/src/dev_health_ops/models/rate_limit_observations.py
@@ -61,6 +61,15 @@ class ProviderRateLimitObservation(Base):
     sync_run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
     sync_run_unit_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
     route_family: Mapped[str | None] = mapped_column(Text, nullable=True)
+    # NULL exactly when route_family could not be confidently attributed --
+    # e.g. "ambiguous_dimension" when the signal's dimension matches more than
+    # one distinct route family for this unit (dimension alone does not
+    # disambiguate: Linear's work-items estimator emits teams/issues/cycles/
+    # comments/attachments/history all under graphql_cost). A future
+    # cooldown-gating consumer (CHAOS-2760) falls back to
+    # provider+integration+dimension gating whenever this is set, never a
+    # guessed family. See workers/sync_units.py:_route_family_and_attribution.
+    route_family_attribution: Mapped[str | None] = mapped_column(Text, nullable=True)
     dimension: Mapped[str | None] = mapped_column(Text, nullable=True)
     retry_after_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
     reset_at: Mapped[datetime | None] = mapped_column(

--- a/src/dev_health_ops/models/rate_limit_observations.py
+++ b/src/dev_health_ops/models/rate_limit_observations.py
@@ -1,0 +1,94 @@
+"""Durable rate-limit observation store (CHAOS-2742 / CHAOS-2758).
+
+Persists one normalized row per provider rate-limit event that defers a sync
+unit, so a later consumer (cross-unit cooldown gating, CHAOS-2760) can consult
+recent provider/integration/route-family cooldowns without re-discovering the
+limit against the provider itself.
+
+Postgres, not ClickHouse -- deliberately. Every durable store the dispatch
+path already consults is Postgres: ``SyncDispatchOutbox``
+(``models/integrations.py``), the per-unit rate-limit deferral columns on
+``sync_run_units`` (migration 0022), ``SyncComputeCheckpoint``
+(``models/checkpoints.py``), and ``BudgetGuard``'s reservation itself runs
+inside a Postgres advisory-lock transaction (``sync/budget_guard.py``). A
+future cooldown-gating consumer (CHAOS-2760) needs to read this table from
+inside that same advisory-lock transaction, which only Postgres supports here
+-- ClickHouse is a separate analytics cluster with no transactional join to
+the dispatch guard. See ``docs/providers/rate-limit-policy.md`` "Observation
+store" section for the full justification.
+
+Only normalized fields are persisted -- never raw provider headers (leak /
+bloat risk). Header capture stays best-effort and provider-local; this table
+never carries them.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import DateTime, Float, Index, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from dev_health_ops.models.git import GUID, Base
+
+
+class ProviderRateLimitObservation(Base):
+    """One row per rate-limit observation that deferred a sync unit.
+
+    Written atomically with the deferring unit's RETRYING stamp
+    (``workers/sync_units.py`` -- the ``except RateLimitException`` branch of
+    ``run_sync_unit``), in the same session/transaction: the observation and
+    the deferral must commit together or not at all, so this table never
+    holds an "orphan" row for a deferral that didn't actually happen (and vice
+    versa).
+
+    No foreign keys to ``sync_runs`` / ``sync_run_units`` / ``Integration``:
+    this is a durable, independently-retained observation log (see the
+    beat-scheduled prune task, ``workers/sync_reconciler.py``), not a
+    dependent child row -- it must survive its parent run/unit being pruned
+    or deleted, mirroring ``SyncRunUnit.integration_id`` (also FK-less, per
+    ``models/integrations.py``).
+    """
+
+    __tablename__ = "provider_rate_limit_observations"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    provider: Mapped[str] = mapped_column(Text, nullable=False)
+    host: Mapped[str | None] = mapped_column(Text, nullable=True)
+    integration_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    sync_run_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    sync_run_unit_id: Mapped[uuid.UUID] = mapped_column(GUID, nullable=False)
+    route_family: Mapped[str | None] = mapped_column(Text, nullable=True)
+    dimension: Mapped[str | None] = mapped_column(Text, nullable=True)
+    retry_after_seconds: Mapped[float | None] = mapped_column(Float, nullable=True)
+    reset_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    request_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    observed_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        # Cooldown lookup: "what's the most recent observation for this
+        # provider/integration/route-family" (CHAOS-2760 consumer).
+        Index(
+            "ix_provider_rate_limit_observations_cooldown",
+            "provider",
+            "integration_id",
+            "route_family",
+            "observed_at",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ProviderRateLimitObservation("
+            f"org={self.org_id!r}, provider={self.provider!r}, "
+            f"route_family={self.route_family!r}, observed_at={self.observed_at})>"
+        )

--- a/src/dev_health_ops/providers/jira/client.py
+++ b/src/dev_health_ops/providers/jira/client.py
@@ -192,7 +192,12 @@ class JiraClient:
                             host=urlparse(self.auth.base_url).hostname,
                             dimension=BudgetDimension.REST_CORE,
                             retry_after_seconds=retry_after,
-                            reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                            # Jira's X-RateLimit-Reset is an ISO 8601 timestamp
+                            # (Atlassian Cloud rate-limiting docs), not epoch
+                            # seconds like GitHub/GitLab -- CHAOS-2758 verified
+                            # this against the docs (see RateLimitSignal
+                            # docstring); Retry-After remains authoritative.
+                            reset_at=RateLimitSignal.reset_at_from_iso8601(
                                 resp.headers.get("X-RateLimit-Reset")
                             ),
                             reason="primary",

--- a/src/dev_health_ops/sync/rate_limit_signal.py
+++ b/src/dev_health_ops/sync/rate_limit_signal.py
@@ -77,6 +77,26 @@ class RateLimitSignal:
             return None
         return datetime.fromtimestamp(epoch_ms / 1000.0, tz=timezone.utc)
 
+    @staticmethod
+    def reset_at_from_iso8601(value: object) -> datetime | None:
+        """Build a UTC ``reset_at`` from an ISO 8601 timestamp string (Jira).
+
+        Verified against Atlassian's Jira Cloud rate-limiting docs
+        (developer.atlassian.com/cloud/jira/platform/rate-limiting/):
+        ``X-RateLimit-Reset`` is documented as "ISO 8601 timestamp when the
+        current window resets" (e.g. ``2025-10-08T15:00:00Z``) -- an absolute
+        UTC instant, NOT an epoch-seconds/-millis integer like GitHub/GitLab
+        (``Retry-After`` remains the authoritative delay for Jira; this is
+        only a supplementary hint, and parsing failures degrade to ``None``
+        gracefully rather than raising).
+        """
+        if not isinstance(value, str) or not value.strip():
+            return None
+        try:
+            return datetime.fromisoformat(value.strip().replace("Z", "+00:00"))
+        except ValueError:
+            return None
+
     def to_dict(self) -> dict[str, object | None]:
         return {
             "provider": self.provider,

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -214,6 +214,16 @@ beat_schedule = {
         "schedule": crontab(hour=3, minute=30),
         "options": {"queue": "default"},
     },
+    # Retention for the durable rate-limit observation store (CHAOS-2758).
+    # Env-tunable via SYNC_RATE_LIMIT_OBSERVATION_RETENTION_DAYS (default 14,
+    # see workers/sync_reconciler.py). Scheduled off-peak, clear of the other
+    # nightly jobs (1:00 metrics, 1:30 release-impact, 2:00 recommendations,
+    # 3:30 membership backfill).
+    "prune-rate-limit-observations": {
+        "task": "dev_health_ops.workers.tasks.prune_rate_limit_observations",
+        "schedule": crontab(hour=5, minute=0),
+        "options": {"queue": "sync"},
+    },
 }
 
 # Result settings

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -1,16 +1,18 @@
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any
 
-from sqlalchemy import select, update
+from sqlalchemy import delete, select, update
 
 from dev_health_ops.models import (
     BackfillJob,
     JobRun,
     JobRunStatus,
+    ProviderRateLimitObservation,
     SyncDispatchOutbox,
     SyncRun,
     SyncRunPostDispatch,
@@ -25,6 +27,63 @@ from dev_health_ops.workers.celery_app import celery_app
 logger = logging.getLogger(__name__)
 
 _WORKER_LOST_RETRY_EXHAUSTED_CATEGORY = "worker_lost_retry_exhausted"
+
+_DEFAULT_RATE_LIMIT_OBSERVATION_RETENTION_DAYS = 14
+
+
+def _rate_limit_observation_retention_days() -> int:
+    try:
+        days = int(
+            os.getenv(
+                "SYNC_RATE_LIMIT_OBSERVATION_RETENTION_DAYS",
+                str(_DEFAULT_RATE_LIMIT_OBSERVATION_RETENTION_DAYS),
+            )
+        )
+    except ValueError:
+        return _DEFAULT_RATE_LIMIT_OBSERVATION_RETENTION_DAYS
+    return max(0, days)
+
+
+@celery_app.task(
+    queue="sync",
+    name="dev_health_ops.workers.tasks.prune_rate_limit_observations",
+)
+def prune_rate_limit_observations(retention_days: int | None = None) -> dict[str, Any]:
+    """Delete durable rate-limit observations older than the retention window.
+
+    Beat-scheduled (``workers/config.py``), env-tunable via
+    ``SYNC_RATE_LIMIT_OBSERVATION_RETENTION_DAYS`` (default
+    :data:`_DEFAULT_RATE_LIMIT_OBSERVATION_RETENTION_DAYS`). This table has no
+    ClickHouse mirror or archival path (CHAOS-2758) -- expired rows are
+    deleted outright, matching the "observation, not audit log" scope agreed
+    for CHAOS-2742.
+    """
+    from dev_health_ops.db import get_postgres_session_sync
+
+    days = (
+        retention_days
+        if retention_days is not None
+        else _rate_limit_observation_retention_days()
+    )
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max(0, int(days)))
+    with get_postgres_session_sync() as session:
+        result: Any = session.execute(
+            delete(ProviderRateLimitObservation).where(
+                ProviderRateLimitObservation.observed_at < cutoff
+            )
+        )
+        deleted = int(getattr(result, "rowcount", 0) or 0)
+        session.flush()
+    logger.info(
+        "prune_rate_limit_observations.completed",
+        extra={
+            "deleted": deleted,
+            "retention_days": days,
+            "cutoff": cutoff.isoformat(),
+        },
+    )
+    return {"status": "completed", "deleted": deleted, "retention_days": days}
+
 
 # Relay contract (CHAOS-2581 / CHAOS-2596): dispatch_sync_run and
 # finalize_sync_run wakeups remain durable at-least-once because their consumers

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -599,8 +599,14 @@ def _route_family_and_attribution(
             and isinstance(entry.get("bucket"), Mapping)
             and entry["bucket"].get("dimension") == dimension
         ]
-        if dimension_matches:
-            candidates = dimension_matches
+        if not dimension_matches:
+            # The signal names a dimension the unit never budgeted (e.g. a
+            # secondary-abuse signal against a REST-only unit). Falling back
+            # to the full audit would confidently attribute a family whose
+            # dimension CONTRADICTS the signal — CHAOS-2760 must use the
+            # provider+integration+dimension fallback instead.
+            return None, _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION
+        candidates = dimension_matches
 
     route_families = {
         str(entry.get("route_family"))

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -538,41 +538,97 @@ def _merge_partial_observations_into_result(
     _promote_result_observation_fields(result)
 
 
-def _route_family_for_rate_limit(
+_AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION = "ambiguous_dimension"
+
+# Allow-listed, normalized rate-limit reason categories (CHAOS-2758 review):
+# the observation store must never persist raw exception text -- legacy
+# no-signal raise sites build messages from provider response bodies, which
+# can embed header/body-shaped diagnostic content. Every provider client's
+# ``RateLimitSignal.reason`` value is already drawn from this vocabulary
+# (`primary`/`secondary` for GitHub/GitLab/LaunchDarkly/Jira,
+# `complexity` for Linear); `permission` is reserved for a future
+# classification site. Anything else -- including no signal at all --
+# normalizes to `unknown`.
+_RATE_LIMIT_REASON_CATEGORIES = frozenset(
+    {"primary", "secondary", "permission", "complexity", "unknown"}
+)
+_UNKNOWN_RATE_LIMIT_REASON = "unknown"
+
+
+def _route_family_and_attribution(
     budget_audit: list[dict[str, Any]] | None, dimension: str | None
-) -> str | None:
+) -> tuple[str | None, str | None]:
     """Resolve the route family a rate-limit observation attributes to.
 
-    A unit's budget estimate can carry multiple (route_family, dimension)
-    pairs -- e.g. GitHub PR datasets emit ``prs``/``rest_core`` alongside
-    ``pr_social``/``graphql_cost`` and ``pr_social``/``secondary_abuse_risk``
-    (``providers/github/budget.py``). The rate-limit signal's ``dimension`` --
-    populated by the provider client at the classification site, i.e. which
-    kind of call actually hit the limit -- picks the matching estimate.
+    Returns ``(route_family, attribution)``. ``attribution`` is ``None`` when
+    ``route_family`` was confidently resolved, or
+    :data:`_AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION` when it could not be -- in
+    which case ``route_family`` is always ``None`` too. Never guesses: a
+    future cooldown-gating consumer (CHAOS-2760) falls back to
+    provider+integration+dimension gating whenever attribution is set,
+    documented in ``docs/providers/rate-limit-policy.md``.
 
-    One unit can therefore map to multiple route families; this picks the
-    single *primary* one rather than writing one row per matched family
-    (CHAOS-2758 decision). When the dimension is absent or matches nothing in
-    the audit, fall back to the first estimate: every provider estimator
-    emits its dataset-primary family first (see
-    ``providers/<provider>/budget.py``), so first-emitted approximates
-    "primary" for that fallback case.
+    A unit's budget estimate can carry multiple (route_family, dimension)
+    pairs, and **dimension alone does not disambiguate them**: e.g. Linear's
+    ``work-items`` estimator (``providers/linear/budget.py``) emits ``teams``,
+    ``issues``, ``cycles``, ``comments``, ``attachments``, and ``history`` --
+    all under ``graphql_cost`` -- and Jira's issue-comment datasets
+    (``providers/jira/budget.py``) can emit both ``jira_issue_enrichment`` and
+    ``jira_comments`` under ``rest_core``. Picking the first match in that
+    case would be a guess, not an attribution.
+
+    The rate-limit signal's ``dimension`` (populated by the provider client at
+    the classification site, i.e. which kind of call actually hit the limit)
+    narrows the candidate estimates when present. If the surviving candidate
+    set names exactly one **distinct** route family, that family is the
+    confident answer (this also covers the common single-estimate unit, e.g.
+    GitHub's ``commits`` dataset, and estimates that share one family across
+    multiple dimensions, e.g. GitHub's ``commit_stats``). Any other outcome --
+    no budget audit, no dimension match, or more than one distinct family --
+    is ambiguous and is NOT guessed at.
     """
     if not budget_audit:
-        return None
+        return None, _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION
+
+    candidates = budget_audit
     if dimension is not None:
-        for entry in budget_audit:
-            bucket = entry.get("bucket") if isinstance(entry, Mapping) else None
-            if isinstance(bucket, Mapping) and bucket.get("dimension") == dimension:
-                route_family = entry.get("route_family")
-                if route_family:
-                    return str(route_family)
-    first = budget_audit[0]
-    if isinstance(first, Mapping):
-        route_family = first.get("route_family")
-        if route_family:
-            return str(route_family)
-    return None
+        dimension_matches = [
+            entry
+            for entry in budget_audit
+            if isinstance(entry, Mapping)
+            and isinstance(entry.get("bucket"), Mapping)
+            and entry["bucket"].get("dimension") == dimension
+        ]
+        if dimension_matches:
+            candidates = dimension_matches
+
+    route_families = {
+        str(entry.get("route_family"))
+        for entry in candidates
+        if isinstance(entry, Mapping) and entry.get("route_family")
+    }
+    if len(route_families) == 1:
+        return next(iter(route_families)), None
+    return None, _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION
+
+
+def _normalized_rate_limit_reason(exc: BaseException) -> str:
+    """Return an allow-listed rate-limit reason category, never raw text.
+
+    ``signal.reason`` is already a short normalized category at every
+    provider classification site (see :data:`_RATE_LIMIT_REASON_CATEGORIES`),
+    but this defensively re-validates it rather than trusting it blindly, and
+    NEVER falls back to ``str(exc)``: legacy no-signal raise sites build their
+    message from the raw provider response body, which can embed
+    header/body-shaped diagnostic content this store must not retain for its
+    14-day (default) retention window.
+    """
+    signal = getattr(exc, "signal", None)
+    if signal is not None and signal.reason:
+        candidate = str(signal.reason).strip().lower()
+        if candidate in _RATE_LIMIT_REASON_CATEGORIES:
+            return candidate
+    return _UNKNOWN_RATE_LIMIT_REASON
 
 
 def _build_rate_limit_observation(
@@ -585,15 +641,15 @@ def _build_rate_limit_observation(
 ) -> ProviderRateLimitObservation:
     """Build the durable observation row for a rate-limit deferral (CHAOS-2758).
 
-    Only normalized fields are persisted -- never raw provider headers (leak /
-    bloat risk). ``integration_id``/``sync_run_id``/``sync_run_unit_id`` come
-    from the unit row already loaded in this task (never re-resolved from
-    mutable ``Integration`` state); ``route_family``/``dimension`` come from
-    the budget estimate ALREADY computed for this unit at dispatch time --
-    never re-estimated (estimators require credential decryption). The
-    ``RateLimitSignal`` (CHAOS-2753) may be absent on legacy-connector
-    exceptions raised without one; every field degrades gracefully to the
-    unit/exception context in that case.
+    Only normalized fields are persisted -- never raw provider headers or
+    exception text (leak / bloat risk). ``integration_id``/``sync_run_id``/
+    ``sync_run_unit_id`` come from the unit row already loaded in this task
+    (never re-resolved from mutable ``Integration`` state); ``route_family``/
+    ``dimension`` come from the budget estimate ALREADY computed for this
+    unit at dispatch time -- never re-estimated (estimators require
+    credential decryption). The ``RateLimitSignal`` (CHAOS-2753) may be absent
+    on legacy-connector exceptions raised without one; every field degrades
+    gracefully to the unit/exception context in that case.
     """
     signal = getattr(exc, "signal", None)
     dimension = (
@@ -604,11 +660,9 @@ def _build_rate_limit_observation(
     retry_after_seconds = getattr(exc, "retry_after_seconds", None)
     if retry_after_seconds is None and signal is not None:
         retry_after_seconds = signal.retry_after_seconds
-    reason = None
-    if signal is not None and signal.reason:
-        reason = signal.reason
-    if reason is None:
-        reason = str(exc) or None
+    route_family, route_family_attribution = _route_family_and_attribution(
+        budget_audit, dimension
+    )
     return ProviderRateLimitObservation(
         org_id=str(unit.org_id),
         provider=(
@@ -618,11 +672,12 @@ def _build_rate_limit_observation(
         integration_id=unit.integration_id,
         sync_run_id=unit.sync_run_id,
         sync_run_unit_id=unit.id,
-        route_family=_route_family_for_rate_limit(budget_audit, dimension),
+        route_family=route_family,
+        route_family_attribution=route_family_attribution,
         dimension=dimension,
         retry_after_seconds=retry_after_seconds,
         reset_at=signal.reset_at if signal is not None else None,
-        reason=reason,
+        reason=_normalized_rate_limit_reason(exc),
         request_id=signal.request_id if signal is not None else None,
         observed_at=observed_at,
     )
@@ -1169,20 +1224,38 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     "unit_id": unit_id,
                     "reason": "lease_lost",
                 }
-            # Durable observation store (CHAOS-2758): inserted only after the
-            # CAS above confirms the RETRYING stamp actually landed, and in
-            # the SAME session/transaction as that stamp, so the observation
-            # and the deferral commit together or not at all (never an
-            # orphan row for a deferral that didn't happen, and vice versa).
-            session.add(
-                _build_rate_limit_observation(
-                    unit=unit,
-                    provider=ctx.provider,
-                    exc=exc,
-                    budget_audit=budget_audit,
-                    observed_at=now,
+            # Durable observation store (CHAOS-2758): attempted only after the
+            # CAS above confirms the RETRYING stamp actually landed, so it
+            # never runs for a deferral that didn't happen. It is
+            # deliberately isolated in its own SAVEPOINT rather than sharing
+            # the outer transaction outright: the observation store is
+            # diagnostic, not load-bearing, and a DB-level failure writing it
+            # (e.g. migration 0031 not yet applied during a rolling deploy,
+            # or schema drift) must never roll back the RETRYING stamp / turn
+            # a recoverable rate-limit deferral into a lost unit. On success
+            # the two still commit together (nested.commit() only stages the
+            # savepoint into the still-open outer transaction); on failure
+            # only the observation attempt rolls back and is logged.
+            observation_nested = session.begin_nested()
+            try:
+                session.add(
+                    _build_rate_limit_observation(
+                        unit=unit,
+                        provider=ctx.provider,
+                        exc=exc,
+                        budget_audit=budget_audit,
+                        observed_at=now,
+                    )
                 )
-            )
+                session.flush()
+            except SQLAlchemyError as observation_exc:
+                observation_nested.rollback()
+                logger.warning(
+                    "run_sync_unit.rate_limit_observation_persist_failed",
+                    extra={**_log_ctx, "error": str(observation_exc)},
+                )
+            else:
+                observation_nested.commit()
             if sync_run_id is not None:
                 # Earlier-wins upsert (CHAOS-2647): we deliberately do NOT
                 # force-set available_at=not_before here. A revived past dispatch

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -59,6 +59,7 @@ from dev_health_ops.models import (
     BackfillJob,
     JobRun,
     JobRunStatus,
+    ProviderRateLimitObservation,
     SyncComputeCheckpoint,
     SyncComputeCheckpointStatus,
     SyncComputeType,
@@ -535,6 +536,96 @@ def _merge_partial_observations_into_result(
     merged.update(observations)
     result["observations"] = merged
     _promote_result_observation_fields(result)
+
+
+def _route_family_for_rate_limit(
+    budget_audit: list[dict[str, Any]] | None, dimension: str | None
+) -> str | None:
+    """Resolve the route family a rate-limit observation attributes to.
+
+    A unit's budget estimate can carry multiple (route_family, dimension)
+    pairs -- e.g. GitHub PR datasets emit ``prs``/``rest_core`` alongside
+    ``pr_social``/``graphql_cost`` and ``pr_social``/``secondary_abuse_risk``
+    (``providers/github/budget.py``). The rate-limit signal's ``dimension`` --
+    populated by the provider client at the classification site, i.e. which
+    kind of call actually hit the limit -- picks the matching estimate.
+
+    One unit can therefore map to multiple route families; this picks the
+    single *primary* one rather than writing one row per matched family
+    (CHAOS-2758 decision). When the dimension is absent or matches nothing in
+    the audit, fall back to the first estimate: every provider estimator
+    emits its dataset-primary family first (see
+    ``providers/<provider>/budget.py``), so first-emitted approximates
+    "primary" for that fallback case.
+    """
+    if not budget_audit:
+        return None
+    if dimension is not None:
+        for entry in budget_audit:
+            bucket = entry.get("bucket") if isinstance(entry, Mapping) else None
+            if isinstance(bucket, Mapping) and bucket.get("dimension") == dimension:
+                route_family = entry.get("route_family")
+                if route_family:
+                    return str(route_family)
+    first = budget_audit[0]
+    if isinstance(first, Mapping):
+        route_family = first.get("route_family")
+        if route_family:
+            return str(route_family)
+    return None
+
+
+def _build_rate_limit_observation(
+    *,
+    unit: SyncRunUnit,
+    provider: str,
+    exc: BaseException,
+    budget_audit: list[dict[str, Any]] | None,
+    observed_at: datetime,
+) -> ProviderRateLimitObservation:
+    """Build the durable observation row for a rate-limit deferral (CHAOS-2758).
+
+    Only normalized fields are persisted -- never raw provider headers (leak /
+    bloat risk). ``integration_id``/``sync_run_id``/``sync_run_unit_id`` come
+    from the unit row already loaded in this task (never re-resolved from
+    mutable ``Integration`` state); ``route_family``/``dimension`` come from
+    the budget estimate ALREADY computed for this unit at dispatch time --
+    never re-estimated (estimators require credential decryption). The
+    ``RateLimitSignal`` (CHAOS-2753) may be absent on legacy-connector
+    exceptions raised without one; every field degrades gracefully to the
+    unit/exception context in that case.
+    """
+    signal = getattr(exc, "signal", None)
+    dimension = (
+        signal.dimension.value
+        if signal is not None and signal.dimension is not None
+        else None
+    )
+    retry_after_seconds = getattr(exc, "retry_after_seconds", None)
+    if retry_after_seconds is None and signal is not None:
+        retry_after_seconds = signal.retry_after_seconds
+    reason = None
+    if signal is not None and signal.reason:
+        reason = signal.reason
+    if reason is None:
+        reason = str(exc) or None
+    return ProviderRateLimitObservation(
+        org_id=str(unit.org_id),
+        provider=(
+            signal.provider if signal is not None and signal.provider else provider
+        ),
+        host=signal.host if signal is not None else None,
+        integration_id=unit.integration_id,
+        sync_run_id=unit.sync_run_id,
+        sync_run_unit_id=unit.id,
+        route_family=_route_family_for_rate_limit(budget_audit, dimension),
+        dimension=dimension,
+        retry_after_seconds=retry_after_seconds,
+        reset_at=signal.reset_at if signal is not None else None,
+        reason=reason,
+        request_id=signal.request_id if signal is not None else None,
+        observed_at=observed_at,
+    )
 
 
 @celery_app.task(queue="sync", name="dev_health_ops.workers.tasks.dispatch_sync_run")
@@ -1078,6 +1169,20 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     "unit_id": unit_id,
                     "reason": "lease_lost",
                 }
+            # Durable observation store (CHAOS-2758): inserted only after the
+            # CAS above confirms the RETRYING stamp actually landed, and in
+            # the SAME session/transaction as that stamp, so the observation
+            # and the deferral commit together or not at all (never an
+            # orphan row for a deferral that didn't happen, and vice versa).
+            session.add(
+                _build_rate_limit_observation(
+                    unit=unit,
+                    provider=ctx.provider,
+                    exc=exc,
+                    budget_audit=budget_audit,
+                    observed_at=now,
+                )
+            )
             if sync_run_id is not None:
                 # Earlier-wins upsert (CHAOS-2647): we deliberately do NOT
                 # force-set available_at=not_before here. A revived past dispatch

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -17,7 +17,10 @@ from dev_health_ops.workers.recommendations_tasks import run_recommendations_job
 from dev_health_ops.workers.reference_discovery import run_sync_reference_discovery
 from dev_health_ops.workers.report_scheduler import dispatch_scheduled_reports
 from dev_health_ops.workers.report_task import execute_saved_report
-from dev_health_ops.workers.sync_reconciler import reconcile_sync_dispatch
+from dev_health_ops.workers.sync_reconciler import (
+    prune_rate_limit_observations,
+    reconcile_sync_dispatch,
+)
 from dev_health_ops.workers.sync_scheduler import dispatch_scheduled_syncs
 from dev_health_ops.workers.sync_units import (
     dispatch_sync_run,
@@ -67,6 +70,7 @@ __all__ = [
     "monitor_queue_depths",
     "phone_home_heartbeat",
     "process_webhook_event",
+    "prune_rate_limit_observations",
     "reconcile_sync_dispatch",
     "dispatch_membership_backfill",
     "run_capacity_forecast_job",

--- a/tests/providers/test_jira_client_ratelimit.py
+++ b/tests/providers/test_jira_client_ratelimit.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+from datetime import datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -15,10 +16,12 @@ from dev_health_ops.providers.jira.client import JiraAuth, JiraClient
 class _FakeJira429Response(requests.Response):
     """Minimal requests.Response subclass that simulates a 429 reply."""
 
-    def __init__(self) -> None:
+    def __init__(self, *, reset_at: str | None = None) -> None:
         super().__init__()
         self.status_code = 429
         self.headers["Retry-After"] = "2"
+        if reset_at is not None:
+            self.headers["X-RateLimit-Reset"] = reset_at
         self._content = b"rate limited"
 
     def raise_for_status(self) -> None:
@@ -84,7 +87,9 @@ def test_jira_search_page_persistent_429_exhausts_retries_and_raises(
     gate = MagicMock(spec=RateLimitGate)
     gate.penalize.return_value = 2.0
     client = _make_client(gate, max_retries_429=2)
-    mock_get = MagicMock(return_value=_FakeJira429Response())
+    mock_get = MagicMock(
+        return_value=_FakeJira429Response(reset_at="2025-10-08T15:00:00Z")
+    )
     monkeypatch.setattr(client.session, "get", mock_get)
 
     with pytest.raises(RateLimitException) as exc_info:
@@ -96,3 +101,10 @@ def test_jira_search_page_persistent_429_exhausts_retries_and_raises(
     assert gate.wait_sync.call_count == 3
     assert gate.penalize.call_count == 3
     gate.reset.assert_not_called()
+
+    # CHAOS-2758: X-RateLimit-Reset is an ISO 8601 timestamp for Jira (verified
+    # against Atlassian's Cloud rate-limiting docs), not epoch seconds -- the
+    # signal must parse it as such rather than silently degrading to None.
+    signal = exc_info.value.signal
+    assert signal is not None
+    assert signal.reset_at == datetime(2025, 10, 8, 15, 0, 0, tzinfo=timezone.utc)

--- a/tests/test_rate_limit_observations.py
+++ b/tests/test_rate_limit_observations.py
@@ -1,0 +1,497 @@
+"""Tests for the durable rate-limit observation store (CHAOS-2758).
+
+Covers:
+  * the observation row commits atomically with the unit's RETRYING stamp --
+    same session/transaction, never an orphan when the deferral CAS loses.
+  * integration_id / route_family / dimension enrichment from the unit row +
+    the budget estimate already computed for dispatch (never re-estimated).
+  * only normalized fields are persisted -- never raw headers/secrets.
+  * the ws-a exception-unification fix (CHAOS-2753) means
+    ``connectors.base.RateLimitException`` (no signal) also produces a row.
+  * the beat-scheduled retention prune task.
+  * migration 0031 is a guarded, retry-safe (idempotent) upgrade/downgrade.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import (
+    Base,
+    ProviderRateLimitObservation,
+    SyncRunUnitStatus,
+)
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
+from tests.test_sync_units import (
+    _mark_dispatching,
+    _patch_db_session,
+    _patch_finalize_apply,
+    _patch_runtime,
+    _seed_run,
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+
+def _aware(value: datetime) -> datetime:
+    """Normalize a datetime read back from SQLite (which drops tzinfo on
+    round-trip) to UTC-aware, for comparison against the tz-aware value that
+    was written."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+# ---------------------------------------------------------------------------
+# Atomic persistence with the RETRYING stamp
+# ---------------------------------------------------------------------------
+
+
+def test_observation_persisted_atomically_with_deferral(db_session, monkeypatch):
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)  # provider=github, dataset_key=commits
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    reset_at = datetime(2026, 7, 2, 0, 0, 0, tzinfo=timezone.utc)
+
+    def rate_limited(ctx, runtime):
+        raise RateLimitException(
+            "GitHub primary rate limit exceeded",
+            retry_after_seconds=45.0,
+            signal=RateLimitSignal(
+                provider="github",
+                host="api.github.com",
+                dimension=BudgetDimension.REST_CORE,
+                retry_after_seconds=45.0,
+                reset_at=reset_at,
+                reason="primary",
+                request_id="req-123",
+            ),
+        )
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    assert result["status"] == "rate_limited_deferred"
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+
+    observations = db_session.query(ProviderRateLimitObservation).all()
+    assert len(observations) == 1
+    observation = observations[0]
+    assert observation.org_id == unit.org_id
+    assert observation.provider == "github"
+    assert observation.host == "api.github.com"
+    assert observation.integration_id == unit.integration_id
+    assert observation.sync_run_id == run.id
+    assert observation.sync_run_unit_id == unit.id
+    assert observation.route_family == "git"  # github "commits" estimator family
+    assert observation.dimension == "rest_core"
+    assert observation.retry_after_seconds == 45.0
+    assert _aware(observation.reset_at) == reset_at
+    assert observation.reason == "primary"
+    assert observation.request_id == "req-123"
+    assert observation.observed_at is not None
+
+
+def test_observation_not_orphaned_when_deferral_cas_loses_lease(
+    db_session, monkeypatch
+):
+    """A CAS loss on the RETRYING stamp must leave no orphan observation row.
+
+    The observation insert is deliberately placed AFTER the deferral CAS
+    rowcount check in ``run_sync_unit`` so the two either commit together or
+    neither does. Mirrors the established
+    ``test_run_sync_unit_lost_lease_before_work_item_sink_aborts_without_finalize``
+    pattern: steal the lease via the SAME shared session mid-flight (rather
+    than a second engine/session), so the CAS predicate's ``lease_owner``
+    match fails without detaching the ``unit`` ORM object the deferral branch
+    still reads (``rate_limit_deferrals`` / ``rate_limit_first_seen_at``).
+    """
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    def rate_limited(ctx, runtime):
+        # Simulate another worker stealing the lease while this task is
+        # mid-flight, so the deferral CAS below (which matches on the
+        # original lease_owner) affects zero rows.
+        db_session.refresh(unit)
+        unit.lease_owner = "other-worker"
+        db_session.flush()
+        raise RateLimitException(
+            "GitHub primary rate limit exceeded", retry_after_seconds=30.0
+        )
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result == {
+        "status": "skipped",
+        "unit_id": str(unit.id),
+        "reason": "lease_lost",
+    }
+    assert db_session.query(ProviderRateLimitObservation).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Enrichment: integration_id from the unit row, route_family/dimension from
+# the pre-computed budget audit (never re-estimated).
+# ---------------------------------------------------------------------------
+
+
+def test_observation_enriched_with_integration_and_route_family(
+    db_session, monkeypatch
+):
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    # "prs" emits three estimates: prs/rest_core, pr_social/graphql_cost,
+    # pr_social/secondary_abuse_risk -- a real multi-route-family unit.
+    run, unit = _seed_run(db_session, dataset_key="prs")
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    estimate_calls = []
+    real_estimate = sync_units.estimate_provider_budget
+
+    def counting_estimate(ctx):
+        estimate_calls.append(ctx)
+        return real_estimate(ctx)
+
+    monkeypatch.setattr(sync_units, "estimate_provider_budget", counting_estimate)
+
+    def rate_limited(ctx, runtime):
+        raise RateLimitException(
+            "GitHub GraphQL secondary rate limit",
+            retry_after_seconds=60.0,
+            signal=RateLimitSignal(
+                provider="github",
+                dimension=BudgetDimension.GRAPHQL_COST,
+                retry_after_seconds=60.0,
+                reason="secondary",
+            ),
+        )
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "rate_limited_deferred"
+    # The estimate was computed exactly once (at dispatch, for the started_at
+    # audit) -- the exception branch reuses it, it never re-estimates
+    # (estimators require credential decryption).
+    assert len(estimate_calls) == 1
+
+    observation = db_session.query(ProviderRateLimitObservation).one()
+    assert observation.integration_id == unit.integration_id
+    assert observation.route_family == "pr_social"
+    assert observation.dimension == "graphql_cost"
+
+
+def test_route_family_resolution_falls_back_to_primary_estimate():
+    """Unit test of the pick-one-primary-family decision (CHAOS-2758).
+
+    When the signal's dimension is absent or matches nothing in the budget
+    audit, the first-emitted estimate (each provider estimator emits its
+    dataset-primary family first) is used as the fallback "primary".
+    """
+    from dev_health_ops.workers.sync_units import _route_family_for_rate_limit
+
+    budget_audit = [
+        {"bucket": {"dimension": "rest_core"}, "route_family": "prs"},
+        {"bucket": {"dimension": "graphql_cost"}, "route_family": "pr_social"},
+        {"bucket": {"dimension": "secondary_abuse_risk"}, "route_family": "pr_social"},
+    ]
+
+    assert (
+        _route_family_for_rate_limit(budget_audit, "secondary_abuse_risk")
+        == "pr_social"
+    )
+    assert _route_family_for_rate_limit(budget_audit, "rest_core") == "prs"
+    # No match / no signal dimension -> first-emitted (documented "primary").
+    assert _route_family_for_rate_limit(budget_audit, None) == "prs"
+    assert _route_family_for_rate_limit(budget_audit, "search") == "prs"
+    assert _route_family_for_rate_limit(None, "rest_core") is None
+    assert _route_family_for_rate_limit([], "rest_core") is None
+
+
+# ---------------------------------------------------------------------------
+# No raw headers / secrets ever persisted
+# ---------------------------------------------------------------------------
+
+
+def test_observation_contains_no_raw_headers_or_secrets(db_session, monkeypatch):
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    class _ExceptionWithRawHeaders(RateLimitException):
+        """Simulates a provider client that stashed raw headers on the
+        exception for its own in-place retry logic -- the observation writer
+        must never read or persist them."""
+
+        def __init__(self) -> None:
+            super().__init__(
+                "rate limited",
+                retry_after_seconds=15.0,
+                signal=RateLimitSignal(
+                    provider="github",
+                    dimension=BudgetDimension.REST_CORE,
+                    retry_after_seconds=15.0,
+                    reason="primary",
+                ),
+            )
+            self.raw_headers = {
+                "Authorization": "Bearer super-secret-token",
+                "X-RateLimit-Remaining": "0",
+            }
+
+    def rate_limited(ctx, runtime):
+        raise _ExceptionWithRawHeaders()
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    getattr(run_sync_unit, "run")(str(unit.id))
+
+    observation = db_session.query(ProviderRateLimitObservation).one()
+    mapper = sa.inspect(ProviderRateLimitObservation)
+    persisted_columns = {col.key for col in mapper.columns}
+    # Only the normalized schema fields exist on the row -- no headers column,
+    # no raw dict anywhere in the mapped state.
+    assert "raw_headers" not in persisted_columns
+    assert "headers" not in persisted_columns
+    for column_name in persisted_columns:
+        value = getattr(observation, column_name)
+        if isinstance(value, str):
+            assert "super-secret-token" not in value
+            assert "Authorization" not in value
+
+
+# ---------------------------------------------------------------------------
+# Legacy connector exceptions (post CHAOS-2753 unification) also persist
+# ---------------------------------------------------------------------------
+
+
+def test_legacy_connector_exception_also_persists_observation(db_session, monkeypatch):
+    from dev_health_ops.connectors.base import (
+        RateLimitException as LegacyRateLimitException,
+    )
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    def rate_limited(ctx, runtime):
+        # No `signal=` -- matches the real legacy connectors (connectors/
+        # github.py, connectors/gitlab.py) at call sites that predate ws-a
+        # signal population, and any that still omit one.
+        raise LegacyRateLimitException(
+            "GitLab rate limited (HTTP 429)", retry_after_seconds=30.0
+        )
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "rate_limited_deferred"
+    observation = db_session.query(ProviderRateLimitObservation).one()
+    assert observation.org_id == unit.org_id
+    assert observation.provider == "github"  # falls back to ctx.provider
+    assert observation.integration_id == unit.integration_id
+    assert observation.sync_run_unit_id == unit.id
+    assert observation.retry_after_seconds == 30.0
+    assert observation.dimension is None  # no signal -> no client-known dimension
+    assert observation.route_family == "git"  # falls back to first estimate
+    assert observation.reason == "GitLab rate limited (HTTP 429)"
+    assert observation.host is None
+    assert observation.request_id is None
+
+
+# ---------------------------------------------------------------------------
+# Retention prune task
+# ---------------------------------------------------------------------------
+
+
+def _make_observation(**overrides):
+    defaults = dict(
+        org_id=str(uuid.uuid4()),
+        provider="github",
+        host="api.github.com",
+        integration_id=uuid.uuid4(),
+        sync_run_id=uuid.uuid4(),
+        sync_run_unit_id=uuid.uuid4(),
+        route_family="git",
+        dimension="rest_core",
+        retry_after_seconds=30.0,
+        reason="primary",
+        observed_at=datetime.now(timezone.utc),
+    )
+    defaults.update(overrides)
+    return ProviderRateLimitObservation(**defaults)
+
+
+def test_prune_task_deletes_expired_rows_only(db_session, monkeypatch):
+    from dev_health_ops.workers.sync_reconciler import prune_rate_limit_observations
+
+    now = datetime.now(timezone.utc)
+    expired = _make_observation(observed_at=now - timedelta(days=20))
+    borderline_fresh = _make_observation(observed_at=now - timedelta(days=1))
+    fresh = _make_observation(observed_at=now - timedelta(hours=1))
+    db_session.add_all([expired, borderline_fresh, fresh])
+    db_session.commit()
+
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("SYNC_RATE_LIMIT_OBSERVATION_RETENTION_DAYS", "14")
+
+    result = getattr(prune_rate_limit_observations, "run")()
+
+    assert result["status"] == "completed"
+    assert result["deleted"] == 1
+    assert result["retention_days"] == 14
+    remaining_ids = {
+        row.id for row in db_session.query(ProviderRateLimitObservation).all()
+    }
+    assert remaining_ids == {borderline_fresh.id, fresh.id}
+
+
+def test_prune_task_honors_explicit_retention_days_override(db_session, monkeypatch):
+    from dev_health_ops.workers.sync_reconciler import prune_rate_limit_observations
+
+    now = datetime.now(timezone.utc)
+    three_days_old = _make_observation(observed_at=now - timedelta(days=3))
+    one_hour_old = _make_observation(observed_at=now - timedelta(hours=1))
+    db_session.add_all([three_days_old, one_hour_old])
+    db_session.commit()
+
+    _patch_db_session(monkeypatch, db_session)
+    # Env default (14) would keep both; an explicit override prunes tighter.
+    monkeypatch.delenv("SYNC_RATE_LIMIT_OBSERVATION_RETENTION_DAYS", raising=False)
+
+    result = getattr(prune_rate_limit_observations, "run")(retention_days=1)
+
+    assert result["deleted"] == 1
+    remaining_ids = {
+        row.id for row in db_session.query(ProviderRateLimitObservation).all()
+    }
+    assert remaining_ids == {one_hour_old.id}
+
+
+# ---------------------------------------------------------------------------
+# Migration 0031: guarded, retry-safe (idempotent) upgrade
+# ---------------------------------------------------------------------------
+
+
+def _load_migration_0031():
+    return importlib.import_module(
+        "dev_health_ops.alembic.versions.0031_add_provider_rate_limit_observations"
+    )
+
+
+def test_migration_0031_idempotent_upgrade():
+    migration = _load_migration_0031()
+    assert migration.revision == "0031"
+    assert migration.down_revision == "0030"
+
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(conn)
+            # Operations.context() installs the module-global `alembic.op`
+            # proxy (the same `from alembic import op` the migration file
+            # imports) for the duration of the block -- the documented way to
+            # unit-test an individual migration's upgrade()/downgrade().
+            with Operations.context(ctx):
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert "provider_rate_limit_observations" in inspector.get_table_names()
+                index_names = {
+                    ix["name"]
+                    for ix in inspector.get_indexes("provider_rate_limit_observations")
+                }
+                assert "ix_provider_rate_limit_observations_cooldown" in index_names
+                assert "ix_provider_rate_limit_observations_org_id" in index_names
+
+                # Re-running upgrade() must be a no-op, not an error (guarded
+                # create-if-missing, per the 0020/0025 convention).
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert (
+                    inspector.get_table_names().count(
+                        "provider_rate_limit_observations"
+                    )
+                    == 1
+                )
+
+                migration.downgrade()
+                inspector = sa.inspect(conn)
+                assert (
+                    "provider_rate_limit_observations"
+                    not in inspector.get_table_names()
+                )
+
+                # downgrade() on an already-absent table is also a no-op.
+                migration.downgrade()
+
+                # And upgrade() works again from a clean slate.
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert "provider_rate_limit_observations" in inspector.get_table_names()
+    finally:
+        engine.dispose()

--- a/tests/test_rate_limit_observations.py
+++ b/tests/test_rate_limit_observations.py
@@ -391,9 +391,24 @@ def test_route_family_resolution_keeps_unique_match_and_refuses_to_guess():
         "prs",
         None,
     )
-    # A dimension that matches nothing falls back to the full candidate set --
-    # still ambiguous here since it names two distinct families.
+    # A dimension that matches NOTHING in the audit is ambiguous by
+    # definition -- the signal names traffic the unit never budgeted, so a
+    # family pick would contradict the signal's own dimension.
     assert _route_family_and_attribution(github_prs_audit, "search") == (
+        None,
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+    )
+    # Regression (codex re-pass finding): the dimension-miss rule must hold
+    # even for SINGLE-family audits. A REST-only GitHub "commits" unit hit by
+    # a secondary-abuse signal must not be recorded as a trusted 'git'
+    # observation -- CHAOS-2760 falls back to provider+integration+dimension.
+    github_commits_audit = [
+        {"bucket": {"dimension": "rest_core"}, "route_family": "git"},
+        {"bucket": {"dimension": "contents_blob"}, "route_family": "git"},
+    ]
+    assert _route_family_and_attribution(
+        github_commits_audit, "secondary_abuse_risk"
+    ) == (
         None,
         _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
     )

--- a/tests/test_rate_limit_observations.py
+++ b/tests/test_rate_limit_observations.py
@@ -1,11 +1,15 @@
 """Tests for the durable rate-limit observation store (CHAOS-2758).
 
 Covers:
-  * the observation row commits atomically with the unit's RETRYING stamp --
-    same session/transaction, never an orphan when the deferral CAS loses.
+  * the observation write is attempted only after the RETRYING CAS succeeds,
+    and is best-effort/non-blocking (its own SAVEPOINT): a DB-level failure
+    persisting it must never roll back the deferral or block dispatch.
   * integration_id / route_family / dimension enrichment from the unit row +
-    the budget estimate already computed for dispatch (never re-estimated).
-  * only normalized fields are persisted -- never raw headers/secrets.
+    the budget estimate already computed for dispatch (never re-estimated),
+    with route-family attribution confidence-gated (never guessed when
+    dimension alone cannot disambiguate multiple candidate families).
+  * only normalized fields are persisted -- never raw headers, secrets, or
+    raw exception text (``reason`` is an allow-listed category).
   * the ws-a exception-unification fix (CHAOS-2753) means
     ``connectors.base.RateLimitException`` (no signal) also produces a row.
   * the beat-scheduled retention prune task.
@@ -23,14 +27,17 @@ import sqlalchemy as sa
 from alembic.migration import MigrationContext
 from alembic.operations import Operations
 from sqlalchemy import create_engine
+from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from dev_health_ops.models import (
     Base,
     ProviderRateLimitObservation,
+    SyncDispatchOutbox,
     SyncRunUnitStatus,
 )
 from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.dispatch_outbox import OUTBOX_KIND_DISPATCH
 from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 from tests.test_sync_units import (
     _mark_dispatching,
@@ -117,6 +124,7 @@ def test_observation_persisted_atomically_with_deferral(db_session, monkeypatch)
     assert observation.sync_run_id == run.id
     assert observation.sync_run_unit_id == unit.id
     assert observation.route_family == "git"  # github "commits" estimator family
+    assert observation.route_family_attribution is None  # confidently attributed
     assert observation.dimension == "rest_core"
     assert observation.retry_after_seconds == 45.0
     assert _aware(observation.reset_at) == reset_at
@@ -170,6 +178,72 @@ def test_observation_not_orphaned_when_deferral_cas_loses_lease(
         "unit_id": str(unit.id),
         "reason": "lease_lost",
     }
+    assert db_session.query(ProviderRateLimitObservation).count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Best-effort, non-blocking persistence (HIGH finding, CHAOS-2758 review)
+# ---------------------------------------------------------------------------
+
+
+def test_observation_persist_failure_does_not_block_deferral(db_session, monkeypatch):
+    """A DB-level failure writing the observation (e.g. migration 0031 not
+    yet applied to every node during a rolling deploy, or schema drift) must
+    NOT roll back the RETRYING stamp or the dispatch wakeup -- the
+    observation store is diagnostic, not load-bearing.
+
+    Forces the flush the observation-persistence SAVEPOINT performs to raise
+    a real ``SQLAlchemyError`` (rather than just making the builder function
+    raise), so this exercises the actual ``session.begin_nested()`` /
+    rollback path, not merely a Python-level guard.
+    """
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    real_flush = db_session.flush
+
+    def guarded_flush(*args, **kwargs):
+        # Only the observation-persistence SAVEPOINT flushes while a nested
+        # transaction is active; every other flush in run_sync_unit (the
+        # RETRYING CAS, the outbox wakeup) happens outside one.
+        if db_session.in_nested_transaction():
+            raise SQLAlchemyError(
+                'relation "provider_rate_limit_observations" does not exist'
+            )
+        return real_flush(*args, **kwargs)
+
+    monkeypatch.setattr(db_session, "flush", guarded_flush)
+
+    def rate_limited(ctx, runtime):
+        raise RateLimitException(
+            "GitHub primary rate limit exceeded", retry_after_seconds=30.0
+        )
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    db_session.refresh(unit)
+    # The deferral itself must succeed exactly as if the observation write
+    # had never been attempted.
+    assert result["status"] == "rate_limited_deferred"
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+    assert unit.rate_limit_deferrals == 1
+    dispatch_wakeup = (
+        db_session.query(SyncDispatchOutbox)
+        .filter_by(sync_run_id=run.id, kind=OUTBOX_KIND_DISPATCH)
+        .one()
+    )
+    assert dispatch_wakeup is not None
+    # No observation row -- the SAVEPOINT rolled back the failed insert.
     assert db_session.query(ProviderRateLimitObservation).count() == 0
 
 
@@ -230,34 +304,164 @@ def test_observation_enriched_with_integration_and_route_family(
     observation = db_session.query(ProviderRateLimitObservation).one()
     assert observation.integration_id == unit.integration_id
     assert observation.route_family == "pr_social"
+    assert observation.route_family_attribution is None  # unique dimension match
     assert observation.dimension == "graphql_cost"
 
 
-def test_route_family_resolution_falls_back_to_primary_estimate():
-    """Unit test of the pick-one-primary-family decision (CHAOS-2758).
+def test_observation_route_family_ambiguous_for_linear_work_items(
+    db_session, monkeypatch
+):
+    """End-to-end regression for the false-precision fix (CHAOS-2758 review).
 
-    When the signal's dimension is absent or matches nothing in the budget
-    audit, the first-emitted estimate (each provider estimator emits its
-    dataset-primary family first) is used as the fallback "primary".
+    Linear's ``work-items`` unit estimates teams/issues/cycles/comments/
+    attachments/history ALL under ``graphql_cost`` -- a rate limit tagged
+    ``graphql_cost`` cannot disambiguate which one actually failed, so the
+    observation must record ``route_family=NULL`` +
+    ``route_family_attribution="ambiguous_dimension"`` rather than guessing
+    the first-listed family. ``dimension`` itself is still populated so a
+    cooldown-gating consumer can fall back to provider+integration+dimension.
     """
-    from dev_health_ops.workers.sync_units import _route_family_for_rate_limit
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import (
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+        run_sync_unit,
+    )
 
-    budget_audit = [
+    run, unit = _seed_run(
+        db_session,
+        provider="linear",
+        source_type="team",
+        external_id="TEAM",
+        name="TEAM",
+        full_name="TEAM",
+        dataset_key="work-items",
+        processor_flags={},
+    )
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    def rate_limited(ctx, runtime):
+        raise RateLimitException(
+            "Linear rate limited",
+            retry_after_seconds=20.0,
+            signal=RateLimitSignal(
+                provider="linear",
+                dimension=BudgetDimension.GRAPHQL_COST,
+                retry_after_seconds=20.0,
+                reason="primary",
+            ),
+        )
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "rate_limited_deferred"
+    observation = db_session.query(ProviderRateLimitObservation).one()
+    assert observation.route_family is None
+    assert observation.route_family_attribution == _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION
+    assert observation.dimension == "graphql_cost"
+
+
+def test_route_family_resolution_keeps_unique_match_and_refuses_to_guess():
+    """Unit test of the confidence-gated route-family attribution (CHAOS-2758
+    review fix): dimension alone does not disambiguate multi-family units, so
+    a match is only trusted when it names exactly one distinct family.
+    """
+    from dev_health_ops.workers.sync_units import (
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+        _route_family_and_attribution,
+    )
+
+    # GitHub "prs": dimension is unique per family here.
+    github_prs_audit = [
         {"bucket": {"dimension": "rest_core"}, "route_family": "prs"},
         {"bucket": {"dimension": "graphql_cost"}, "route_family": "pr_social"},
         {"bucket": {"dimension": "secondary_abuse_risk"}, "route_family": "pr_social"},
     ]
-
-    assert (
-        _route_family_for_rate_limit(budget_audit, "secondary_abuse_risk")
-        == "pr_social"
+    assert _route_family_and_attribution(github_prs_audit, "secondary_abuse_risk") == (
+        "pr_social",
+        None,
     )
-    assert _route_family_for_rate_limit(budget_audit, "rest_core") == "prs"
-    # No match / no signal dimension -> first-emitted (documented "primary").
-    assert _route_family_for_rate_limit(budget_audit, None) == "prs"
-    assert _route_family_for_rate_limit(budget_audit, "search") == "prs"
-    assert _route_family_for_rate_limit(None, "rest_core") is None
-    assert _route_family_for_rate_limit([], "rest_core") is None
+    assert _route_family_and_attribution(github_prs_audit, "rest_core") == (
+        "prs",
+        None,
+    )
+    # A dimension that matches nothing falls back to the full candidate set --
+    # still ambiguous here since it names two distinct families.
+    assert _route_family_and_attribution(github_prs_audit, "search") == (
+        None,
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+    )
+    # No dimension at all -> same full-candidate-set ambiguity.
+    assert _route_family_and_attribution(github_prs_audit, None) == (
+        None,
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+    )
+
+    # GitHub "commit_stats": two dimensions, but they share ONE family --
+    # still confidently attributable even without a dimension match.
+    github_commit_stats_audit = [
+        {"bucket": {"dimension": "rest_core"}, "route_family": "commit_stats"},
+        {"bucket": {"dimension": "contents_blob"}, "route_family": "commit_stats"},
+    ]
+    assert _route_family_and_attribution(github_commit_stats_audit, None) == (
+        "commit_stats",
+        None,
+    )
+    assert _route_family_and_attribution(
+        github_commit_stats_audit, "contents_blob"
+    ) == ("commit_stats", None)
+
+    # Linear "work-items": teams/issues/cycles/comments/attachments/history are
+    # ALL graphql_cost -- dimension is genuinely uninformative here. Must NOT
+    # guess a family.
+    linear_work_items_audit = [
+        {"bucket": {"dimension": "graphql_cost"}, "route_family": "teams"},
+        {"bucket": {"dimension": "graphql_cost"}, "route_family": "issues"},
+        {"bucket": {"dimension": "graphql_cost"}, "route_family": "cycles"},
+        {"bucket": {"dimension": "graphql_cost"}, "route_family": "comments"},
+        {"bucket": {"dimension": "graphql_cost"}, "route_family": "attachments"},
+        {"bucket": {"dimension": "graphql_cost"}, "route_family": "history"},
+    ]
+    assert _route_family_and_attribution(linear_work_items_audit, "graphql_cost") == (
+        None,
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+    )
+    assert _route_family_and_attribution(linear_work_items_audit, None) == (
+        None,
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+    )
+
+    # Jira comments dataset: jira_issue_enrichment + jira_comments both
+    # rest_core -- ambiguous under that dimension.
+    jira_comments_audit = [
+        {"bucket": {"dimension": "search"}, "route_family": "jira_jql"},
+        {"bucket": {"dimension": "rest_core"}, "route_family": "jira_issue_enrichment"},
+        {"bucket": {"dimension": "rest_core"}, "route_family": "jira_comments"},
+    ]
+    assert _route_family_and_attribution(jira_comments_audit, "search") == (
+        "jira_jql",
+        None,
+    )
+    assert _route_family_and_attribution(jira_comments_audit, "rest_core") == (
+        None,
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+    )
+
+    # No budget audit at all -> ambiguous, never a guess.
+    assert _route_family_and_attribution(None, "rest_core") == (
+        None,
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+    )
+    assert _route_family_and_attribution([], "rest_core") == (
+        None,
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -319,6 +523,54 @@ def test_observation_contains_no_raw_headers_or_secrets(db_session, monkeypatch)
             assert "Authorization" not in value
 
 
+def test_observation_no_signal_reason_never_persists_raw_exception_text(
+    db_session, monkeypatch
+):
+    """Regression for the MEDIUM finding (CHAOS-2758 review): a no-signal
+    exception's message can embed a provider's raw response body (legacy
+    connectors build their message from ``response.text``). ``reason`` must
+    normalize to the fixed ``unknown`` category, never ``str(exc)``.
+    """
+    from dev_health_ops.connectors.base import (
+        RateLimitException as LegacyRateLimitException,
+    )
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    secret_bearing_body = (
+        'Rate limited: {"message": "API rate limit exceeded", '
+        '"token": "ghp_SUPERSECRETTOKEN1234567890", '
+        '"Authorization": "Bearer super-secret-token"}'
+    )
+
+    def rate_limited(ctx, runtime):
+        # No `signal=` -- the message embeds header/body-shaped content, as a
+        # real legacy no-signal raise site's `str(response_body)` would.
+        raise LegacyRateLimitException(secret_bearing_body, retry_after_seconds=5.0)
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    getattr(run_sync_unit, "run")(str(unit.id))
+
+    observation = db_session.query(ProviderRateLimitObservation).one()
+    assert observation.reason == "unknown"
+    mapper = sa.inspect(ProviderRateLimitObservation)
+    for column_name in {col.key for col in mapper.columns}:
+        value = getattr(observation, column_name)
+        if isinstance(value, str):
+            assert "SUPERSECRETTOKEN" not in value
+            assert "super-secret-token" not in value
+            assert "Authorization" not in value
+            assert "API rate limit exceeded" not in value
+
+
 # ---------------------------------------------------------------------------
 # Legacy connector exceptions (post CHAOS-2753 unification) also persist
 # ---------------------------------------------------------------------------
@@ -358,8 +610,14 @@ def test_legacy_connector_exception_also_persists_observation(db_session, monkey
     assert observation.sync_run_unit_id == unit.id
     assert observation.retry_after_seconds == 30.0
     assert observation.dimension is None  # no signal -> no client-known dimension
-    assert observation.route_family == "git"  # falls back to first estimate
-    assert observation.reason == "GitLab rate limited (HTTP 429)"
+    # Single-estimate unit ("commits" -> "git" only) is still confidently
+    # attributable even with no dimension signal at all.
+    assert observation.route_family == "git"
+    assert observation.route_family_attribution is None
+    # No signal -> normalized to the "unknown" reason category, NEVER the raw
+    # exception message (which for a real legacy connector could embed the
+    # provider's raw response body).
+    assert observation.reason == "unknown"
     assert observation.host is None
     assert observation.request_id is None
 
@@ -461,6 +719,11 @@ def test_migration_0031_idempotent_upgrade():
                 migration.upgrade()
                 inspector = sa.inspect(conn)
                 assert "provider_rate_limit_observations" in inspector.get_table_names()
+                column_names = {
+                    col["name"]
+                    for col in inspector.get_columns("provider_rate_limit_observations")
+                }
+                assert "route_family_attribution" in column_names
                 index_names = {
                     ix["name"]
                     for ix in inspector.get_indexes("provider_rate_limit_observations")

--- a/tests/test_rate_limit_signal.py
+++ b/tests/test_rate_limit_signal.py
@@ -119,6 +119,28 @@ def test_signal_reset_at_normalized_to_utc() -> None:
     assert naive.reset_at.tzinfo is timezone.utc
 
 
+def test_signal_reset_at_from_iso8601_for_jira() -> None:
+    # Jira's X-RateLimit-Reset is an ISO 8601 timestamp (Atlassian Cloud
+    # rate-limiting docs), not epoch seconds/millis like GitHub/GitLab/Linear
+    # (CHAOS-2758 verification of the previously-unverified epoch unit).
+    sig = RateLimitSignal(
+        provider="jira",
+        reset_at=RateLimitSignal.reset_at_from_iso8601("2025-10-08T15:00:00Z"),
+    )
+    assert sig.reset_at == datetime(2025, 10, 8, 15, 0, 0, tzinfo=timezone.utc)
+
+    # An explicit offset is honored and normalized to UTC.
+    offset = RateLimitSignal.reset_at_from_iso8601("2025-10-08T16:00:00+01:00")
+    assert offset == datetime(2025, 10, 8, 15, 0, 0, tzinfo=timezone.utc)
+
+    # Absent / malformed / wrong-type values degrade to None (Retry-After
+    # stays authoritative regardless).
+    assert RateLimitSignal.reset_at_from_iso8601(None) is None
+    assert RateLimitSignal.reset_at_from_iso8601("") is None
+    assert RateLimitSignal.reset_at_from_iso8601("not-a-timestamp") is None
+    assert RateLimitSignal.reset_at_from_iso8601(1_700_000_000) is None
+
+
 def test_legacy_connector_rate_limit_subclasses_root() -> None:
     """The class-split bug fix: base.RateLimitException IS-A root RateLimitException."""
     from dev_health_ops.connectors.base import (


### PR DESCRIPTION
## Problem

Provider 429s are handled per-task with no durable, queryable record: `retry_after`/`reset_at`/`route_family` observations vanish once a unit's deferral completes, so sibling units (and any future cross-unit cooldown consumer) have nothing to consult. This was the last open "durable store" question the CHAOS-2742 budget plan left unresolved.

## Fix

- **Alembic `0031`** (chained on `0030`, retry-safe guarded create-if-missing per the `0020`/`0022`/`0025` convention): new `provider_rate_limit_observations` table — `org_id` (indexed), `provider`, `host`, `integration_id`, `sync_run_id`, `sync_run_unit_id`, `route_family`, `dimension`, `retry_after_seconds`, `reset_at`, `reason`, `request_id`, `observed_at`, plus a composite `(provider, integration_id, route_family, observed_at)` index for the cooldown lookup. New ORM model in `models/rate_limit_observations.py`.
- **Postgres, not ClickHouse** — deliberate, and documented in `docs/providers/rate-limit-policy.md`: every store the dispatch path already consults transactionally is Postgres (`SyncDispatchOutbox`, the per-unit deferral columns, `SyncComputeCheckpoint`), and `BudgetGuard`'s own reservation runs inside a Postgres advisory-lock transaction (`sync/budget_guard.py:136`) that a future cooldown-gating consumer (CHAOS-2760) needs to join.
- **Single write site**: `workers/sync_units.py`'s `except RateLimitException` branch in `run_sync_unit`. The observation is inserted in the **same session/transaction** as the unit's `RETRYING` stamp, and only *after* the CAS confirming that stamp landed — so the observation and the deferral commit together or not at all (verified: a CAS loss leaves zero orphan rows).
- **Worker-boundary enrichment, not the client**: `integration_id` comes from the already-loaded unit row (never re-resolved from mutable `Integration` state); `route_family`/`dimension` come from the `BudgetEstimate` list already computed for this unit's dispatch (never re-estimated — estimators require credential decryption). A unit can map to multiple route families (e.g. GitHub PR datasets emit `prs` + `pr_social` estimates); rather than fan out one row per family, the writer picks a single **primary** family by matching the signal's `dimension`, falling back to the first-emitted estimate (documented decision).
- Only normalized fields are ever persisted — never raw provider headers.
- **Retention**: beat-scheduled `prune_rate_limit_observations` task (`workers/sync_reconciler.py`, wired in `workers/config.py`), deletes rows older than `SYNC_RATE_LIMIT_OBSERVATION_RETENTION_DAYS` (default 14, env-overridable).
- **Inherited verification (deferred from the #1111 review)**: Jira's `X-RateLimit-Reset` epoch unit was unverified. Confirmed against Atlassian's Cloud rate-limiting docs — it's an **ISO 8601 timestamp**, not epoch seconds. The prior `reset_at_from_epoch_seconds` parse always silently degraded to `None` for Jira. Added `RateLimitSignal.reset_at_from_iso8601` and switched the Jira client to it (`Retry-After` remains authoritative either way, so this was a graceful-degradation gap, not a functional regression).
- Doc: appended the "Observation store" section to `docs/providers/rate-limit-policy.md`, updated Known Gaps / Target Contracts for CHAOS-2758.

## Tests

- `tests/test_rate_limit_observations.py` (new): atomic persistence with the RETRYING stamp; no orphan row when the deferral CAS loses the lease; integration_id/route_family/dimension enrichment (incl. the multi-route-family primary-pick decision, unit-tested directly); no raw headers/secrets ever persisted; legacy `connectors.base.RateLimitException` (no signal) also produces a row; retention prune task (default window + explicit override); migration `0031` idempotent upgrade/downgrade (guarded retry-safety).
- `tests/test_rate_limit_signal.py`: `reset_at_from_iso8601` parsing (Z-suffix, explicit offset, malformed/wrong-type → `None`).
- `tests/providers/test_jira_client_ratelimit.py`: a live 429 response with `X-RateLimit-Reset` now parses correctly into `reset_at`.

**Gate**: `ci/local_validate.sh` (isolated scratch DB) — ruff format, ruff check, mypy, full unit suite (6202 passed), and the live-ClickHouse argMax proof all green.

Part of CHAOS-2742
Fixes CHAOS-2758
https://linear.app/fullchaos/issue/CHAOS-2758