### PR TITLE
fix(api): filter developer options to email values (CHAOS-2746)

### DIFF
--- a/docs/api/team-catalog-source-of-truth.md
+++ b/docs/api/team-catalog-source-of-truth.md
@@ -88,6 +88,13 @@ Python-side `UNION ALL` across `teams FINAL`, `user_metrics_daily`, and
 the GraphQL surface and should be converged onto the same shared helper
 in a follow-up. New consumers should use the GraphQL `catalog` field.
 
+Developer values from this endpoint are intentionally limited to
+email-shaped `user_metrics_daily.author_email` values. The underlying
+metrics table can contain fallback identities such as provider handles
+or display names for issue-only contributors, but `who.developers` is an
+exact git author-email filter and the picker must not offer identities
+that cannot match that predicate.
+
 ## Files
 
 - `src/dev_health_ops/api/graphql/sql/templates.py` : `catalog_values_team_template()`

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -96,7 +96,10 @@ For PRs with `merged_at` on day **D**:
 
 ### Daily user metrics (`user_metrics_daily`)
 
-Keyed by `(repo_id, author_email, day)` where `author_email` falls back to `author_name` when email is missing.
+Keyed by `(repo_id, author_email, day)` where `author_email` falls back to
+`author_name` when email is missing. API filter pickers expose only email-shaped
+values from this column for developer filters, because `who.developers` matches
+git author email exactly.
 
 - Commits: counts, LOC added/deleted, distinct files changed (union across the day), large commits, avg commit size
 - PRs: authored (created that day), merged (merged that day), avg/p50/p75/p90 PR cycle hours (for PRs merged that day)

--- a/src/dev_health_ops/api/graphql/sql/filter_translation.py
+++ b/src/dev_health_ops/api/graphql/sql/filter_translation.py
@@ -28,7 +28,7 @@ if TYPE_CHECKING:
 # stale bookmarked URLs created before the email-only picker contract; keep
 # those values loadable and let the author_email predicate honestly match no
 # rows instead of rejecting the page load.
-_EMAIL_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
+_EMAIL_PATTERN = re.compile(r"^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$")
 
 
 def _validate_developer_emails(values: list[str], field: str) -> None:

--- a/src/dev_health_ops/api/graphql/sql/filter_translation.py
+++ b/src/dev_health_ops/api/graphql/sql/filter_translation.py
@@ -23,13 +23,11 @@ if TYPE_CHECKING:
 # CHAOS-2385/CHAOS-2492: author_email is the only identity column any
 # developer/author predicate can ever match (git_commits, git_pull_requests,
 # user_metrics_daily, commit_metrics; /api/v1/filters/options populates the
-# quick-filter picker with exactly this column). GraphQL input, URL-decoded
-# REST query params, and the advanced WhoSection UI (web repo) can all pass
-# arbitrary free-form strings (e.g. a raw "alice, bob" string instead of a
-# properly split array) -- silently building a predicate against a
-# non-email value would just match nothing and look like an unrelated bug
-# rather than a bad-input error. Validate format before ANY of who.developers
-# / scope.level=developer becomes a predicate (or a rejection).
+# quick-filter picker with exactly this column). scope.level=developer is a
+# first-class scoped query and stays strict. who.developers may arrive from
+# stale bookmarked URLs created before the email-only picker contract; keep
+# those values loadable and let the author_email predicate honestly match no
+# rows instead of rejecting the page load.
 _EMAIL_PATTERN = re.compile(r"^[^\s@]+@[^\s@]+\.[^\s@]+$")
 
 
@@ -246,8 +244,12 @@ def translate_filters(
 
     # Who filter - developers
     if filters.who is not None and filters.who.developers:
-        _validate_developer_emails(filters.who.developers, field="who")
         if use_investment:
+            # CHAOS-2746: stale URLs may still carry historical non-email
+            # developer tokens. Preserve them in the author_email predicate so
+            # the request loads as an honest-empty result instead of a
+            # validation error; new picker/free-form UI values are filtered to
+            # email-shaped values before they reach this layer.
             # CHAOS-2492: same hasAny() array-membership predicate as above.
             clauses.append(" AND hasAny(au.author_emails, %(developer_ids)s)")
             params["developer_ids"] = filters.who.developers

--- a/src/dev_health_ops/api/queries/filters.py
+++ b/src/dev_health_ops/api/queries/filters.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 import asyncio
+import re
 from typing import Any
 
 from dev_health_ops.investment_taxonomy import SUBCATEGORIES, THEMES
 
 from .client import query_dicts
+
+_EMAIL_VALUE_RE = re.compile(r"^[^\s@<>]+@[^\s@<>]+\.[^\s@<>]+$")
+
+
+def _is_email_value(value: str) -> bool:
+    return bool(_EMAIL_VALUE_RE.match(value))
 
 
 async def fetch_filter_options(
@@ -105,7 +112,11 @@ async def fetch_filter_options(
 
     options["teams"] = [row["value"] for row in team_rows if row.get("value")]
     options["repos"] = [row["value"] for row in repo_rows if row.get("value")]
-    options["developers"] = [row["value"] for row in dev_rows if row.get("value")]
+    options["developers"] = [
+        row["value"]
+        for row in dev_rows
+        if row.get("value") and _is_email_value(row["value"])
+    ]
     options["work_category"] = sorted(THEMES) + sorted(SUBCATEGORIES)
     options["issue_type"] = [row["value"] for row in issue_rows if row.get("value")]
     options["flow_stage"] = [row["value"] for row in stage_rows if row.get("value")]

--- a/tests/api/queries/test_filters.py
+++ b/tests/api/queries/test_filters.py
@@ -1,0 +1,45 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.queries import filters
+
+
+@pytest.mark.asyncio
+async def test_fetch_filter_options_only_returns_email_shaped_developers(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    async def fake_query_dicts(
+        _client: object,
+        query: str,
+        _params: dict[str, Any],
+    ) -> list[dict[str, str]]:
+        if "FROM teams" in query:
+            return [{"value": "team-a"}]
+        if "FROM repos" in query:
+            return [{"value": "org/repo"}]
+        if "author_email" in query:
+            return [
+                {"value": "alice@example.com"},
+                {"value": "bot@users.noreply.github.com"},
+                {"value": "github:octocat"},
+                {"value": "Alice Smith"},
+                {"value": "Alice <alice@example.com>"},
+                {"value": ""},
+            ]
+        if "issue_type_norm" in query:
+            return [{"value": "bug"}]
+        if "work_item_state_durations_daily" in query:
+            return [{"value": "review"}]
+        raise AssertionError(f"unexpected query: {query}")
+
+    monkeypatch.setattr(filters, "query_dicts", fake_query_dicts)
+
+    options = await filters.fetch_filter_options(object(), org_id="org-1")
+
+    assert options["developers"] == [
+        "alice@example.com",
+        "bot@users.noreply.github.com",
+    ]

--- a/tests/graphql/test_filters.py
+++ b/tests/graphql/test_filters.py
@@ -246,6 +246,31 @@ class TestFilterTranslation:
         assert exc_info.value.field == "scope"
         assert "email" in str(exc_info.value).lower()
 
+    def test_scope_filter_developer_rejects_angle_bracket_email_values(self):
+        """CHAOS-2746: the GraphQL _EMAIL_PATTERN previously lacked the
+        <> exclusion present in the REST picker regex (_EMAIL_VALUE_RE in
+        api/queries/filters.py), so a raw GraphQL request could sneak
+        'alice@example.com>' past strict scope.level=developer validation
+        even though the picker/REST/web stack would never emit or accept
+        such a value. Pins the stricter, REST-aligned shape."""
+        filters = FilterInput(
+            scope=ScopeFilterInput(
+                level=ScopeLevelInput.DEVELOPER, ids=["alice@example.com>"]
+            )
+        )
+        request = TimeseriesRequest(
+            dimension="team",
+            measure="count",
+            interval="day",
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 1, 7),
+        )
+
+        with pytest.raises(ValidationError) as exc_info:
+            compile_timeseries(request, org_id="org1", filters=filters)
+        assert exc_info.value.field == "scope"
+        assert "email" in str(exc_info.value).lower()
+
     def test_scope_filter_developer_uses_hasany_for_investment_query(self):
         """CHAOS-2492: scope.level=developer on an investment query resolves
         via the au join's hasAny(author_emails) predicate."""

--- a/tests/graphql/test_filters.py
+++ b/tests/graphql/test_filters.py
@@ -205,26 +205,25 @@ class TestFilterTranslation:
             compile_timeseries(request, org_id="org1", filters=filters)
         assert exc_info.value.field == "scope"
 
-    def test_who_filter_rejects_non_email_values(self):
-        """CHAOS-2385: who.developers values must look like email
-        addresses -- GraphQL input, URL-decoded REST query params, and the
-        advanced WhoSection UI (web repo) can all pass arbitrary free-form
-        strings (e.g. a raw "alice, bob" string instead of a properly split
-        array). Validate format before it ever reaches a predicate (or the
-        "not yet supported" rejection above)."""
+    def test_who_filter_preserves_stale_non_email_values_for_investment_query(self):
+        """CHAOS-2746: stale bookmarked URLs can still carry historical
+        non-email developer tokens. The advanced picker no longer offers or
+        adds those values, but old URLs should compile to an honest-empty
+        author_email predicate instead of rejecting page load."""
         filters = FilterInput(who=WhoFilterInput(developers=["alice, bob"]))
-        request = TimeseriesRequest(
-            dimension="team",
+        request = BreakdownRequest(
+            dimension="theme",
             measure="count",
-            interval="day",
             start_date=date(2025, 1, 1),
             end_date=date(2025, 1, 7),
+            use_investment=True,
         )
 
-        with pytest.raises(ValidationError) as exc_info:
-            compile_timeseries(request, org_id="org1", filters=filters)
-        assert exc_info.value.field == "who"
-        assert "email" in str(exc_info.value).lower()
+        sql, params = compile_breakdown(request, org_id="org1", filters=filters)
+
+        assert "work_unit_authors" in sql
+        assert "hasAny(au.author_emails, %(developer_ids)s)" in sql
+        assert params["developer_ids"] == ["alice, bob"]
 
     def test_scope_filter_developer_rejects_non_email_values(self):
         """CHAOS-2385: scope.level=developer ids must look like email


### PR DESCRIPTION
## Summary
- Filters `/api/v1/filters/options` developer values to email-shaped author emails.
- Preserves stale non-email `who.developers` values on investment GraphQL queries as honest-empty predicates.
- Keeps `scope.level=developer` strict and documents the developer-email filter contract.

Linear: CHAOS-2746
Related web PR: https://github.com/full-chaos/dev-health-web/pull/735

## Validation
- `python -m pytest tests/api/queries/test_filters.py tests/graphql/test_filters.py -q`
- `python -m ruff check src/dev_health_ops/api/queries/filters.py src/dev_health_ops/api/graphql/sql/filter_translation.py tests/api/queries/test_filters.py tests/graphql/test_filters.py`
- `python -m mypy src/dev_health_ops/api/queries/filters.py src/dev_health_ops/api/graphql/sql/filter_translation.py tests/api/queries/test_filters.py tests/graphql/test_filters.py`
- `python -m ruff format --check src/dev_health_ops/api/queries/filters.py src/dev_health_ops/api/graphql/sql/filter_translation.py tests/api/queries/test_filters.py tests/graphql/test_filters.py`
- `git diff --check`

## Notes
- `bash ci/local_validate.sh` could not run in this worktree because `.venv/bin/python` is missing.
- SCREENSHOT-WAIVER: backend/docs-only PR; rendered UI evidence is attached to the paired web PR.
