### PR TITLE
fix(investment): scope investment reads to fresh membership runs (CHAOS-2764)

### DIFF
--- a/docs/architecture/investment-data-model.md
+++ b/docs/architecture/investment-data-model.md
@@ -21,7 +21,7 @@ One row per WorkUnit per materialization run. Created in
 
 | Column | Type | Notes |
 | ------ | ---- | ----- |
-| `work_unit_id` | `String` | Stable SHA-256 of the component's sorted nodes |
+| `work_unit_id` | `String` | SHA-256 of the component's sorted nodes for that materialization run |
 | `work_unit_type` | `Nullable(String)` | Label (added in 019) |
 | `work_unit_name` | `Nullable(String)` | Label (added in 019) |
 | `from_ts` / `to_ts` | `DateTime64(3,'UTC')` | Component time bounds (min/max node times) |
@@ -99,12 +99,18 @@ for all new work.
 The three canonical investment tables (`work_unit_investments`, `work_unit_investment_quotes`, `investment_explanations`) use `ENGINE = ReplacingMergeTree(computed_at)`. ClickHouse replaces rows
 with the same sort key **eventually**, during background merges — not immediately.
 
-- `work_unit_investments` is `ORDER BY (work_unit_id)`, so re-materializing a WorkUnit
-  produces a new row that *eventually* replaces the old one.
+- `work_unit_investments` is `ORDER BY (work_unit_id)`, so re-materializing an identical
+  component produces a new row that *eventually* replaces the old one. If the component's
+  node set changes, its hash changes and the old row is not superseded by ClickHouse merges.
 - The investment API does not rely on background merge timing. Read queries first select
   the latest physical row per `work_unit_id` with an explicit `argMax(..., computed_at)`
-  latest-row subquery, then apply the normal `org_id`, time-window, scope, and category
-  filters before effort-weighted aggregation.
+  latest-row subquery. When the latest complete `work_unit_membership` projection is at
+  least as recent as every `work_unit_investments` row, the API scopes reads to that
+  projection's distinct `work_unit_id` set before aggregation. If no complete marker exists,
+  or any investment row is newer than the marker, reads fail open to the historical unscoped
+  behavior and emit `investment_membership_scope_stale` for stale-marker fallbacks. A complete
+  marker with zero matching membership rows is treated as an empty canonical set, not a
+  fallback.
 
 This means user-visible investment totals use latest-row-by-`computed_at` semantics even
 before ClickHouse has compacted older ReplacingMergeTree versions.

--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -15,6 +15,9 @@ from dev_health_ops.api.queries.investment import (
     LATEST_WORK_UNIT_REPO_EFFORT_CTE,
     fetch_investment_quality_stats,
 )
+from dev_health_ops.api.queries.investment_membership_scope import (
+    record_stale_investment_membership_scope,
+)
 
 from ..authz import require_org_id
 from ..context import GraphQLContext
@@ -350,6 +353,8 @@ async def _execute_timeseries_query(
 
     sql, params = compile_timeseries(request, org_id, timeout, filters=filters)
 
+    if use_investment:
+        await record_stale_investment_membership_scope(client, org_id=org_id)
     rows = await query_dicts(client, sql, params)
     grouped: dict[str, list[TimeseriesBucket]] = {}
 
@@ -807,6 +812,10 @@ async def resolve_analytics(
                 cov_params.update(coverage_filter_params)
 
                 try:
+                    if request.use_investment:
+                        await record_stale_investment_membership_scope(
+                            client, org_id=org_id
+                        )
                     c_rows = await query_dicts(client, coverage_sql, cov_params)
                     if c_rows:
                         total = float(c_rows[0].get("total", 0))

--- a/src/dev_health_ops/api/graphql/resolvers/home.py
+++ b/src/dev_health_ops/api/graphql/resolvers/home.py
@@ -34,6 +34,10 @@ async def resolve_home(
         raise RuntimeError("Database client not available")
 
     from dev_health_ops.api.queries.client import query_dicts
+    from dev_health_ops.api.queries.investment import LATEST_WORK_UNIT_INVESTMENTS_CTE
+    from dev_health_ops.api.queries.investment_membership_scope import (
+        record_stale_investment_membership_scope,
+    )
     from dev_health_ops.api.queries.metrics import (
         _INVESTMENT_THEME_LABELS,
         canonical_investment_theme_sql,
@@ -56,13 +60,14 @@ async def resolve_home(
         last_ingested = freshness_rows[0]["last_ingested_at"]
 
     # Get metric deltas (comparing current period to previous)
-    deltas_sql = """
+    deltas_sql = f"""
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}
         SELECT
             'throughput' as metric,
             'Throughput' as label,
             count(DISTINCT work_unit_id) as value,
             'units' as unit
-        FROM work_unit_investments
+        FROM latest_work_unit_investments AS work_unit_investments
         WHERE from_ts >= today() - 30
         AND from_ts < today()
         AND org_id = %(org_id)s
@@ -71,12 +76,13 @@ async def resolve_home(
             'pr_rework_ratio' as metric,
             'PR Rework Ratio' as label,
             SUM(pr_rework_ratio * prs_merged) / NULLIF(SUM(prs_merged), 0) * 100.0 as value,
-            '%' as unit
+            '%%' as unit
         FROM repo_metrics_daily
         WHERE day >= today() - 30
         AND day < today()
         AND org_id = %(org_id)s
     """
+    await record_stale_investment_membership_scope(client, org_id=context.org_id)
     delta_rows = await query_dicts(client, deltas_sql, {"org_id": context.org_id})
 
     canonical_theme_expr = canonical_investment_theme_sql("investment_area")

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -6,6 +6,11 @@ from typing import Any
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
+from .investment_membership_scope import (
+    INVESTMENT_MEMBERSHIP_SCOPE_CTES,
+    INVESTMENT_MEMBERSHIP_SCOPE_FILTER,
+    record_stale_investment_membership_scope,
+)
 
 # NOTE: This CTE MUST stay tenant-scoped. The ReplacingMergeTree dedup key for
 # work_unit_investments is (org_id, work_unit_id) (migration 027), so org_id is
@@ -15,7 +20,8 @@ from .client import query_dicts
 # `WHERE org_id = %(org_id)s` drops the losing tenant's data entirely
 # (cross-org leak / undercount — CHAOS-2374). Every consumer of this CTE already
 # supplies the `org_id` query param.
-LATEST_WORK_UNIT_INVESTMENTS_CTE = """
+LATEST_WORK_UNIT_INVESTMENTS_CTE = f"""
+{INVESTMENT_MEMBERSHIP_SCOPE_CTES},
         latest_work_unit_investments AS (
             SELECT
                 work_unit_id,
@@ -46,6 +52,7 @@ LATEST_WORK_UNIT_INVESTMENTS_CTE = """
                 max(computed_at) AS latest_computed_at
             FROM work_unit_investments
             WHERE org_id = %(org_id)s
+{INVESTMENT_MEMBERSHIP_SCOPE_FILTER}
             GROUP BY org_id, work_unit_id
         )
 """.rstrip()
@@ -66,6 +73,15 @@ LATEST_WORK_UNIT_REPO_EFFORT_CTE = """
             GROUP BY org_id, work_unit_id, repo_id
         )
 """.rstrip()
+
+
+async def _query_investment_dicts(
+    sink: BaseMetricsSink, query: str, params: dict[str, Any]
+) -> list[dict[str, Any]]:
+    org_id = str(params.get("org_id") or "")
+    if org_id:
+        await record_stale_investment_membership_scope(sink, org_id=org_id)
+    return await query_dicts(sink, query, params)
 
 
 # CHAOS-2492: work_unit_investments carries NO author/developer column at all
@@ -181,7 +197,7 @@ async def fetch_investment_breakdown(
         GROUP BY subcategory, theme
         ORDER BY value DESC
     """
-    return await query_dicts(sink, query, params)
+    return await _query_investment_dicts(sink, query, params)
 
 
 async def fetch_mock_fixture_investment_row_count(
@@ -226,7 +242,7 @@ async def fetch_mock_fixture_investment_row_count(
         {scope_filter}
         {category_filter}
     """
-    rows = await query_dicts(sink, query, params)
+    rows = await _query_investment_dicts(sink, query, params)
     if not rows:
         return 0
     return int(rows[0].get("count") or 0)
@@ -266,7 +282,7 @@ async def fetch_investment_edges(
         GROUP BY source, target
         ORDER BY value DESC
     """
-    return await query_dicts(sink, query, params)
+    return await _query_investment_dicts(sink, query, params)
 
 
 async def fetch_investment_subcategory_edges(
@@ -308,7 +324,7 @@ async def fetch_investment_subcategory_edges(
         GROUP BY source, target
         ORDER BY value DESC
     """
-    return await query_dicts(sink, query, params)
+    return await _query_investment_dicts(sink, query, params)
 
 
 async def fetch_investment_team_edges(
@@ -381,7 +397,7 @@ async def fetch_investment_team_edges(
         GROUP BY source, target
         ORDER BY value DESC
     """
-    return await query_dicts(sink, query, params)
+    return await _query_investment_dicts(sink, query, params)
 
 
 async def fetch_investment_repo_team_edges(
@@ -456,7 +472,7 @@ async def fetch_investment_repo_team_edges(
         GROUP BY subcategory, repo, team
         ORDER BY value DESC
     """
-    return await query_dicts(sink, query, params)
+    return await _query_investment_dicts(sink, query, params)
 
 
 async def fetch_investment_team_category_repo_edges(
@@ -531,7 +547,7 @@ async def fetch_investment_team_category_repo_edges(
         GROUP BY team, category, repo
         ORDER BY value DESC
     """
-    return await query_dicts(sink, query, params)
+    return await _query_investment_dicts(sink, query, params)
 
 
 async def fetch_investment_team_subcategory_repo_edges(
@@ -606,7 +622,7 @@ async def fetch_investment_team_subcategory_repo_edges(
         GROUP BY team, subcategory, repo
         ORDER BY value DESC
     """
-    return await query_dicts(sink, query, params)
+    return await _query_investment_dicts(sink, query, params)
 
 
 async def fetch_investment_unassigned_counts(
@@ -683,7 +699,7 @@ async def fetch_investment_unassigned_counts(
         {scope_filter}
         {category_filter}
     """
-    rows = await query_dicts(sink, query, params)
+    rows = await _query_investment_dicts(sink, query, params)
     if not rows:
         return {"missing_team": 0, "missing_repo": 0}
     row = rows[0]
@@ -739,7 +755,7 @@ async def fetch_investment_sunburst(
         ORDER BY value DESC
         LIMIT %(limit)s
     """
-    return await query_dicts(sink, query, params)
+    return await _query_investment_dicts(sink, query, params)
 
 
 async def fetch_investment_quality_stats(
@@ -835,7 +851,7 @@ async def fetch_investment_quality_stats(
         {team_filter}
         {category_filter}
     """
-    rows = await query_dicts(sink, query, params)
+    rows = await _query_investment_dicts(sink, query, params)
     if not rows:
         return {}
     return dict(rows[0])

--- a/src/dev_health_ops/api/queries/investment_membership_scope.py
+++ b/src/dev_health_ops/api/queries/investment_membership_scope.py
@@ -1,0 +1,155 @@
+from __future__ import annotations
+
+import logging
+from typing import Any, Literal, NamedTuple, cast
+
+from dev_health_ops.api.graphql.resolvers._membership_run_scope import (
+    LEGACY_NODE_MAX_JOIN,
+    RUN_SCOPE_PREDICATE,
+)
+from dev_health_ops.metrics.prometheus import record_investment_membership_scope_stale
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+from .client import query_dicts
+
+logger = logging.getLogger(__name__)
+
+ScopeMode = Literal["scoped", "unscoped_no_marker", "unscoped_fallback"]
+
+
+class InvestmentMembershipScopeState(NamedTuple):
+    scope_mode: ScopeMode
+    lag_seconds: int
+
+
+INVESTMENT_MEMBERSHIP_SCOPE_STATE_CTES = """
+        latest_complete_membership_run AS (
+            SELECT
+                argMax(run_id, completed_at) AS latest_run_id,
+                max(completed_at) AS latest_run_completed_at,
+                count() AS marker_count
+            FROM work_unit_membership_runs
+            WHERE org_id = %(org_id)s
+        ),
+        latest_investment_clock AS (
+            SELECT max(computed_at) AS latest_investment_computed_at
+            FROM work_unit_investments
+            WHERE org_id = %(org_id)s
+        ),
+        investment_membership_scope_state AS (
+            SELECT
+                if(
+                    marker_count > 0
+                    AND latest_run_id != ''
+                    AND (
+                        latest_investment_computed_at IS NULL
+                        OR latest_investment_computed_at <= latest_run_completed_at
+                    ),
+                    1,
+                    0
+                ) AS scope_enabled,
+                multiIf(
+                    marker_count = 0 OR latest_run_id = '', 'unscoped_no_marker',
+                    latest_investment_computed_at IS NOT NULL
+                    AND latest_investment_computed_at > latest_run_completed_at,
+                    'unscoped_fallback',
+                    'scoped'
+                ) AS scope_mode,
+                greatest(
+                    0,
+                    if(
+                        latest_investment_computed_at IS NULL,
+                        0,
+                        dateDiff('second', latest_run_completed_at, latest_investment_computed_at)
+                    )
+                ) AS lag_seconds
+            FROM latest_complete_membership_run
+            CROSS JOIN latest_investment_clock
+        )
+""".rstrip()
+
+INVESTMENT_MEMBERSHIP_SCOPED_WORK_UNITS_CTE = f"""
+        membership_scoped_work_unit_ids AS (
+            SELECT DISTINCT m.work_unit_id AS work_unit_id
+            FROM work_unit_membership AS m
+            INNER JOIN latest_complete_membership_run AS latest_run ON 1 = 1
+            {LEGACY_NODE_MAX_JOIN}
+            WHERE m.org_id = %(org_id)s
+              AND latest_run.latest_run_id != ''
+              AND ({RUN_SCOPE_PREDICATE})
+        )
+""".rstrip()
+
+INVESTMENT_MEMBERSHIP_SCOPE_CTES = f"""
+{INVESTMENT_MEMBERSHIP_SCOPE_STATE_CTES},
+{INVESTMENT_MEMBERSHIP_SCOPED_WORK_UNITS_CTE}
+""".rstrip()
+
+INVESTMENT_MEMBERSHIP_SCOPE_FILTER = """
+              AND (
+                  (SELECT scope_enabled FROM investment_membership_scope_state) = 0
+                  OR work_unit_id IN (
+                      SELECT work_unit_id FROM membership_scoped_work_unit_ids
+                  )
+              )
+""".rstrip()
+
+
+async def fetch_investment_membership_scope_state(
+    sink: BaseMetricsSink,
+    *,
+    org_id: str,
+) -> InvestmentMembershipScopeState:
+    query = f"""
+        WITH {INVESTMENT_MEMBERSHIP_SCOPE_STATE_CTES}
+        SELECT scope_mode, lag_seconds
+        FROM investment_membership_scope_state
+    """
+    rows = await query_dicts(sink, query, {"org_id": org_id})
+    if not rows:
+        return InvestmentMembershipScopeState("unscoped_no_marker", 0)
+    row = rows[0]
+    mode = str(row.get("scope_mode") or "unscoped_no_marker")
+    if mode not in {"scoped", "unscoped_no_marker", "unscoped_fallback"}:
+        mode = "unscoped_no_marker"
+    return InvestmentMembershipScopeState(
+        cast(ScopeMode, mode), int(float(row.get("lag_seconds") or 0))
+    )
+
+
+async def record_stale_investment_membership_scope(
+    sink: BaseMetricsSink,
+    *,
+    org_id: str,
+) -> None:
+    try:
+        state = await fetch_investment_membership_scope_state(sink, org_id=org_id)
+    except Exception as exc:
+        logger.debug("investment membership scope metric skipped: %s", exc)
+        return
+    if state.scope_mode != "unscoped_fallback":
+        return
+    record_investment_membership_scope_stale(
+        lag_seconds=state.lag_seconds,
+        scope_mode=state.scope_mode,
+    )
+    logger.warning(
+        "investment membership scope stale for org %s; falling back unscoped "
+        "(lag_seconds=%s)",
+        org_id,
+        state.lag_seconds,
+    )
+
+
+def extract_scope_state_from_rows(
+    rows: list[dict[str, Any]],
+) -> InvestmentMembershipScopeState:
+    if not rows:
+        return InvestmentMembershipScopeState("unscoped_no_marker", 0)
+    row = rows[0]
+    mode = str(row.get("scope_mode") or "unscoped_no_marker")
+    if mode not in {"scoped", "unscoped_no_marker", "unscoped_fallback"}:
+        mode = "unscoped_no_marker"
+    return InvestmentMembershipScopeState(
+        cast(ScopeMode, mode), int(float(row.get("lag_seconds") or 0))
+    )

--- a/src/dev_health_ops/api/queries/sankey.py
+++ b/src/dev_health_ops/api/queries/sankey.py
@@ -7,6 +7,7 @@ from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
 from .investment import LATEST_WORK_UNIT_INVESTMENTS_CTE
+from .investment_membership_scope import record_stale_investment_membership_scope
 
 
 async def fetch_investment_flow_items(
@@ -38,6 +39,7 @@ async def fetch_investment_flow_items(
     params = {"start_ts": start_ts, "end_ts": end_ts, "limit": limit}
     params.update(scope_params)
     params["org_id"] = org_id
+    await record_stale_investment_membership_scope(sink, org_id=org_id)
     return await query_dicts(sink, query, params)
 
 

--- a/src/dev_health_ops/api/queries/work_unit_investments.py
+++ b/src/dev_health_ops/api/queries/work_unit_investments.py
@@ -7,6 +7,8 @@ from typing import Any, TypeVar
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
+from .investment import LATEST_WORK_UNIT_INVESTMENTS_CTE
+from .investment_membership_scope import record_stale_investment_membership_scope
 
 _LOOKUP_CHUNK_SIZE = 250
 T = TypeVar("T")
@@ -36,43 +38,44 @@ async def fetch_work_unit_investments(
     # ClickHouse may prefer alias over column names in WHERE; always qualify columns
     # to avoid accidentally referencing argMax(...) aliases.
     filters: list[str] = [
-        "work_unit_investments.from_ts < {end_ts:DateTime}",
-        "work_unit_investments.to_ts >= {start_ts:DateTime}",
-        "work_unit_investments.org_id = {org_id:String}",
+        "work_unit_investments.from_ts < %(end_ts)s",
+        "work_unit_investments.to_ts >= %(start_ts)s",
+        "work_unit_investments.org_id = %(org_id)s",
     ]
     if repo_ids:
-        filters.append("work_unit_investments.repo_id IN {repo_ids:Array(String)}")
+        filters.append("work_unit_investments.repo_id IN %(repo_ids)s")
         params["repo_ids"] = repo_ids
     if work_unit_id:
-        filters.append("work_unit_investments.work_unit_id = {work_unit_id:String}")
+        filters.append("work_unit_investments.work_unit_id = %(work_unit_id)s")
         params["work_unit_id"] = work_unit_id
     where_sql = " AND ".join(filters)
     query = f"""
+        WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE}
         SELECT
             work_unit_id,
-            argMax(work_unit_type, work_unit_investments.computed_at) AS work_unit_type,
-            argMax(work_unit_name, work_unit_investments.computed_at) AS work_unit_name,
-            argMax(from_ts, work_unit_investments.computed_at) AS from_ts,
-            argMax(to_ts, work_unit_investments.computed_at) AS to_ts,
-            argMax(repo_id, work_unit_investments.computed_at) AS repo_id,
-            argMax(provider, work_unit_investments.computed_at) AS provider,
-            argMax(effort_metric, work_unit_investments.computed_at) AS effort_metric,
-            argMax(effort_value, work_unit_investments.computed_at) AS effort_value,
-            argMax(theme_distribution_json, work_unit_investments.computed_at) AS theme_distribution_json,
-            argMax(subcategory_distribution_json, work_unit_investments.computed_at) AS subcategory_distribution_json,
-            argMax(structural_evidence_json, work_unit_investments.computed_at) AS structural_evidence_json,
-            argMax(evidence_quality, work_unit_investments.computed_at) AS evidence_quality,
-            argMax(evidence_quality_band, work_unit_investments.computed_at) AS evidence_quality_band,
-            argMax(categorization_status, work_unit_investments.computed_at) AS categorization_status,
-            argMax(categorization_model_version, work_unit_investments.computed_at) AS categorization_model_version,
-            argMax(categorization_run_id, work_unit_investments.computed_at) AS categorization_run_id,
-            max(work_unit_investments.computed_at) AS computed_at
-        FROM work_unit_investments
+            work_unit_type,
+            work_unit_name,
+            from_ts,
+            to_ts,
+            repo_id,
+            provider,
+            effort_metric,
+            effort_value,
+            theme_distribution_json,
+            subcategory_distribution_json,
+            structural_evidence_json,
+            evidence_quality,
+            evidence_quality_band,
+            categorization_status,
+            categorization_model_version,
+            categorization_run_id,
+            latest_computed_at AS computed_at
+        FROM latest_work_unit_investments AS work_unit_investments
         WHERE {where_sql}
-        GROUP BY org_id, work_unit_id
         ORDER BY effort_value DESC, work_unit_id ASC
-        LIMIT {{limit:UInt32}}
+        LIMIT %(limit)s
     """
+    await record_stale_investment_membership_scope(sink, org_id=org_id)
     return await query_dicts(sink, query, params)
 
 

--- a/src/dev_health_ops/metrics/prometheus.py
+++ b/src/dev_health_ops/metrics/prometheus.py
@@ -27,13 +27,15 @@ from __future__ import annotations
 import time
 from collections.abc import Generator
 from contextlib import contextmanager
+from importlib import import_module
+from typing import Any
 
 try:
-    from prometheus_client import Counter, Gauge, Histogram
-
-    _PROMETHEUS_AVAILABLE = True
+    _prometheus_client_module: Any = import_module("prometheus_client")
 except ImportError:
-    _PROMETHEUS_AVAILABLE = False
+    _prometheus_client_module = None
+
+_PROMETHEUS_AVAILABLE = _prometheus_client_module is not None
 
 
 def _noop_counter(*args, **kwargs):
@@ -72,16 +74,18 @@ def _noop_gauge(*args, **kwargs):
 
 
 if _PROMETHEUS_AVAILABLE:
+    assert _prometheus_client_module is not None
+
     # ---------------------------------------------------------------------------
     # Celery metrics
     # ---------------------------------------------------------------------------
-    CELERY_TASKS_TOTAL = Counter(
+    CELERY_TASKS_TOTAL = _prometheus_client_module.Counter(
         "devhealth_celery_tasks_total",
         "Total number of Celery task executions",
         ["task_name", "state"],
     )
 
-    CELERY_TASK_DURATION_SECONDS = Histogram(
+    CELERY_TASK_DURATION_SECONDS = _prometheus_client_module.Histogram(
         "devhealth_celery_task_duration_seconds",
         "Celery task execution duration in seconds",
         ["task_name"],
@@ -91,14 +95,14 @@ if _PROMETHEUS_AVAILABLE:
     # ---------------------------------------------------------------------------
     # ClickHouse metrics
     # ---------------------------------------------------------------------------
-    CLICKHOUSE_QUERY_DURATION_SECONDS = Histogram(
+    CLICKHOUSE_QUERY_DURATION_SECONDS = _prometheus_client_module.Histogram(
         "devhealth_clickhouse_query_duration_seconds",
         "ClickHouse query latency in seconds",
         ["query_type"],
         buckets=(0.01, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
     )
 
-    CLICKHOUSE_QUERIES_TOTAL = Counter(
+    CLICKHOUSE_QUERIES_TOTAL = _prometheus_client_module.Counter(
         "devhealth_clickhouse_queries_total",
         "Total ClickHouse queries executed",
         ["query_type", "status"],
@@ -107,19 +111,19 @@ if _PROMETHEUS_AVAILABLE:
     # ---------------------------------------------------------------------------
     # LLM metrics
     # ---------------------------------------------------------------------------
-    LLM_REQUESTS_TOTAL = Counter(
+    LLM_REQUESTS_TOTAL = _prometheus_client_module.Counter(
         "devhealth_llm_requests_total",
         "Total LLM API requests",
         ["provider", "model", "status"],
     )
 
-    LLM_TOKENS_TOTAL = Counter(
+    LLM_TOKENS_TOTAL = _prometheus_client_module.Counter(
         "devhealth_llm_tokens_total",
         "Total LLM tokens consumed",
         ["provider", "model", "token_type"],
     )
 
-    LLM_REQUEST_DURATION_SECONDS = Histogram(
+    LLM_REQUEST_DURATION_SECONDS = _prometheus_client_module.Histogram(
         "devhealth_llm_request_duration_seconds",
         "LLM API request latency in seconds",
         ["provider", "model"],
@@ -129,16 +133,28 @@ if _PROMETHEUS_AVAILABLE:
     # ---------------------------------------------------------------------------
     # GitHub API metrics
     # ---------------------------------------------------------------------------
-    GITHUB_API_REQUESTS_TOTAL = Counter(
+    GITHUB_API_REQUESTS_TOTAL = _prometheus_client_module.Counter(
         "devhealth_github_api_requests_total",
         "Total GitHub API requests by endpoint and status code",
         ["endpoint", "status_code"],
     )
 
-    GITHUB_RATE_LIMIT_REMAINING = Gauge(
+    GITHUB_RATE_LIMIT_REMAINING = _prometheus_client_module.Gauge(
         "devhealth_github_rate_limit_remaining",
         "GitHub API rate limit remaining calls by resource type",
         ["resource"],
+    )
+
+    INVESTMENT_MEMBERSHIP_SCOPE_STALE_TOTAL = _prometheus_client_module.Counter(
+        "devhealth_investment_membership_scope_stale_total",
+        "Investment reads that fell back to unscoped results due to stale membership projection",
+        ["scope_mode"],
+    )
+
+    INVESTMENT_MEMBERSHIP_SCOPE_LAG_SECONDS = _prometheus_client_module.Gauge(
+        "devhealth_investment_membership_scope_lag_seconds",
+        "Lag between latest work_unit_investments row and latest membership run when stale",
+        ["scope_mode"],
     )
 
 else:
@@ -152,6 +168,8 @@ else:
     LLM_REQUEST_DURATION_SECONDS = _noop_histogram()
     GITHUB_API_REQUESTS_TOTAL = _noop_counter()
     GITHUB_RATE_LIMIT_REMAINING = _noop_gauge()
+    INVESTMENT_MEMBERSHIP_SCOPE_STALE_TOTAL = _noop_counter()
+    INVESTMENT_MEMBERSHIP_SCOPE_LAG_SECONDS = _noop_gauge()
 
 
 # ---------------------------------------------------------------------------
@@ -199,6 +217,15 @@ def record_github_api_request(endpoint: str, status_code: str) -> None:
 def record_github_rate_limit(resource: str, remaining: int) -> None:
     """Update the GitHub rate limit remaining gauge for a resource type."""
     GITHUB_RATE_LIMIT_REMAINING.labels(resource=resource).set(remaining)
+
+
+def record_investment_membership_scope_stale(
+    *, lag_seconds: int, scope_mode: str
+) -> None:
+    INVESTMENT_MEMBERSHIP_SCOPE_STALE_TOTAL.labels(scope_mode=scope_mode).inc()
+    INVESTMENT_MEMBERSHIP_SCOPE_LAG_SECONDS.labels(scope_mode=scope_mode).set(
+        lag_seconds
+    )
 
 
 @contextmanager

--- a/tests/api/graphql/test_home_resolver_investment_scope.py
+++ b/tests/api/graphql/test_home_resolver_investment_scope.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from dev_health_ops.api.graphql.resolvers.home import resolve_home
+
+
+@pytest.mark.asyncio
+async def test_home_throughput_uses_scoped_latest_work_units(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[str] = []
+
+    async def fake_query_dicts(_client: object, query: str, _params: dict[str, Any]):
+        captured.append(query)
+        if "devhealth_investment_metrics_daily" in query:
+            return []
+        if "latest_work_unit_investments" in query:
+            return [
+                {
+                    "metric": "throughput",
+                    "label": "Throughput",
+                    "value": 1,
+                    "unit": "units",
+                },
+                {
+                    "metric": "pr_rework_ratio",
+                    "label": "PR Rework Ratio",
+                    "value": 0,
+                    "unit": "%",
+                },
+            ]
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts",
+        fake_query_dicts,
+    )
+
+    context = SimpleNamespace(client=object(), org_id="org-1")
+    await resolve_home(context)  # type: ignore[arg-type]
+
+    deltas_sql = captured[1]
+    assert "latest_complete_membership_run AS" in deltas_sql
+    assert "latest_work_unit_investments AS" in deltas_sql
+    assert "membership_scoped_work_unit_ids AS" in deltas_sql
+    assert "FROM latest_work_unit_investments AS work_unit_investments" in deltas_sql
+    assert "FROM work_unit_investments" in deltas_sql

--- a/tests/api/test_investment_latest_row_queries.py
+++ b/tests/api/test_investment_latest_row_queries.py
@@ -21,6 +21,19 @@ def _window() -> tuple[datetime, datetime]:
     )
 
 
+def _assert_membership_scope_sql(sql: str) -> None:
+    assert "latest_complete_membership_run AS" in sql
+    assert "investment_membership_scope_state AS" in sql
+    assert "membership_scoped_work_unit_ids AS" in sql
+    assert "argMax(run_id, completed_at) AS latest_run_id" in sql
+    assert "latest_run.latest_run_id != ''" in sql
+    assert "m.run_id = latest_run.latest_run_id" in sql
+    assert "max(computed_at) AS legacy_max_computed_at" in sql
+    assert "m.computed_at = lnm.legacy_max_computed_at" in sql
+    assert "SELECT DISTINCT m.work_unit_id AS work_unit_id" in sql
+    assert "(SELECT scope_enabled FROM investment_membership_scope_state) = 0" in sql
+
+
 def test_latest_row_cte_does_not_shadow_argmax_ordering_column() -> None:
     """Regression: the aggregate in the latest-row CTE must NOT be aliased to
     ``computed_at``.
@@ -38,6 +51,7 @@ def test_latest_row_cte_does_not_shadow_argmax_ordering_column() -> None:
     assert "argMax(effort_value, computed_at)" in cte  # ordering column is used
     assert "max(computed_at) AS computed_at" not in cte  # the shadowing alias
     assert "max(computed_at) AS latest_computed_at" in cte
+    _assert_membership_scope_sql(cte)
 
 
 def test_work_unit_authors_cte_scopes_dedup_by_org() -> None:
@@ -301,6 +315,7 @@ async def test_investment_queries_read_latest_work_unit_rows(
     # applied before aggregation and the dedup key must include org_id.
     assert "WHERE org_id = %(org_id)s" in sql
     assert "GROUP BY org_id, work_unit_id" in sql
+    _assert_membership_scope_sql(sql)
 
 
 @pytest.mark.asyncio
@@ -332,6 +347,7 @@ async def test_sankey_flow_items_read_latest_work_unit_rows(
     assert (
         "FROM latest_work_unit_investments AS work_unit_investments" in captured["sql"]
     )
+    _assert_membership_scope_sql(captured["sql"])
 
 
 def test_investment_timeseries_compiler_reads_latest_work_unit_rows() -> None:
@@ -350,3 +366,4 @@ def test_investment_timeseries_compiler_reads_latest_work_unit_rows() -> None:
     assert "latest_work_unit_investments AS" in sql
     assert "FROM latest_work_unit_investments AS work_unit_investments" in sql
     assert "work_unit_investments.org_id = %(org_id)s" in sql
+    _assert_membership_scope_sql(sql)

--- a/tests/api/test_investment_membership_scope.py
+++ b/tests/api/test_investment_membership_scope.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+import dev_health_ops.api.queries.investment_membership_scope as scope
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+
+def test_extract_scope_state_accepts_stale_fallback() -> None:
+    state = scope.extract_scope_state_from_rows(
+        [{"scope_mode": "unscoped_fallback", "lag_seconds": 3660}]
+    )
+
+    assert state.scope_mode == "unscoped_fallback"
+    assert state.lag_seconds == 3660
+
+
+def test_extract_scope_state_defaults_unknown_mode_to_no_marker() -> None:
+    state = scope.extract_scope_state_from_rows(
+        [{"scope_mode": "unexpected", "lag_seconds": 5}]
+    )
+
+    assert state.scope_mode == "unscoped_no_marker"
+    assert state.lag_seconds == 5
+
+
+def test_scope_state_uses_strict_membership_freshness_boundary() -> None:
+    sql = scope.INVESTMENT_MEMBERSHIP_SCOPE_STATE_CTES
+
+    assert "latest_investment_computed_at <= latest_run_completed_at" in sql
+    assert "latest_investment_computed_at > latest_run_completed_at" in sql
+    assert "INTERVAL" not in sql
+
+
+@pytest.mark.asyncio
+async def test_record_stale_investment_membership_scope_emits_metric(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[int, str]] = []
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, query: str, params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        assert "investment_membership_scope_state AS" in query
+        assert params["org_id"] == "org-1"
+        return [{"scope_mode": "unscoped_fallback", "lag_seconds": 42}]
+
+    def fake_record(*, lag_seconds: int, scope_mode: str) -> None:
+        captured.append((lag_seconds, scope_mode))
+
+    monkeypatch.setattr(scope, "query_dicts", fake_query_dicts)
+    monkeypatch.setattr(scope, "record_investment_membership_scope_stale", fake_record)
+
+    await scope.record_stale_investment_membership_scope(
+        cast(BaseMetricsSink, object()), org_id="org-1"
+    )
+
+    assert captured == [(42, "unscoped_fallback")]
+
+
+@pytest.mark.asyncio
+async def test_record_stale_investment_membership_scope_skips_fresh_scope(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: list[tuple[int, str]] = []
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, _query: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        return [{"scope_mode": "scoped", "lag_seconds": 0}]
+
+    def fake_record(*, lag_seconds: int, scope_mode: str) -> None:
+        captured.append((lag_seconds, scope_mode))
+
+    monkeypatch.setattr(scope, "query_dicts", fake_query_dicts)
+    monkeypatch.setattr(scope, "record_investment_membership_scope_stale", fake_record)
+
+    await scope.record_stale_investment_membership_scope(
+        cast(BaseMetricsSink, object()), org_id="org-1"
+    )
+
+    assert captured == []

--- a/tests/api/test_work_unit_investments_query.py
+++ b/tests/api/test_work_unit_investments_query.py
@@ -37,11 +37,13 @@ async def test_work_unit_investments_query_qualifies_columns(monkeypatch):
 
     assert "work_unit_investments.from_ts" in captured["query"]
     assert "work_unit_investments.to_ts" in captured["query"]
-    assert "{start_ts:DateTime}" in captured["query"]
-    assert "{end_ts:DateTime}" in captured["query"]
-    assert "%(start_ts)s" not in captured["query"]
-    assert "%(end_ts)s" not in captured["query"]
-    assert "argMax(from_ts, work_unit_investments.computed_at)" in captured["query"]
+    assert "%(start_ts)s" in captured["query"]
+    assert "%(end_ts)s" in captured["query"]
+    assert "{start_ts:DateTime}" not in captured["query"]
+    assert "{end_ts:DateTime}" not in captured["query"]
+    assert "latest_work_unit_investments AS" in captured["query"]
+    assert "membership_scoped_work_unit_ids AS" in captured["query"]
+    assert "latest_computed_at AS computed_at" in captured["query"]
     assert "argMax(computed_at, computed_at)" not in captured["query"]
     assert "ORDER BY effort_value DESC, work_unit_id ASC" in captured["query"]
 


### PR DESCRIPTION
## Summary
- Scope canonical work_unit_investments reads to the latest fresh complete work_unit_membership run.
- Fail open for no-marker and stale-marker cases; preserve complete-empty membership as an empty canonical set.
- Add stale-scope Prometheus telemetry, query-shape coverage, GraphQL home throughput coverage, and investment data model docs.

## Validation
- bash ci/local_validate.sh: PASS (6198 passed, 44 skipped)
- Focused pytest for investment membership scope/query surfaces: PASS (25 passed)
- Pre-push hooks: ruff format check, ruff check, mypy PASS
- Manual investment query-surface driver: PASS
- Final QA review: PASS, no blockers
- Final Oracle review: PASS, no correctness blockers

## Follow-up
- CHAOS-2765 tracks optional stale-scope telemetry coverage for compiled breakdown reads.

SCREENSHOT-WAIVER: backend/API-only ClickHouse query behavior change; no rendered UI changed.

Linear: CHAOS-2764