### PR TITLE
feat(sync): defer sibling units into persisted rate-limit cooldowns (CHAOS-2760)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -365,26 +365,61 @@ family within that dimension actually hit the limit
 falling back to a fixed conservative window
 (`RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS`, 60s) when an observation carried
 neither — never treated as "already expired" (under-defer) nor "cooldown
-forever" (stuck run). `available_at` for a gated unit is the cooldown expiry
-plus the same jitter (`SYNC_BUDGET_DEFERRAL_JITTER_SECONDS`) the budget-defer
-path already uses, not a fixed 60s. A unit whose estimates span multiple
-route families is deferred if **any** one is cooling down (mirrors the
-existing would-defer-any-estimate budget semantics) and, when more than one
-matches, waits for the last one to clear.
+forever" (stuck run). `available_at` for a gated unit is derived from
+`plan_rate_limit_deferral`'s own `not_before` (plus the same jitter,
+`SYNC_BUDGET_DEFERRAL_JITTER_SECONDS`, the budget-defer path already uses),
+**not** the raw cooldown expiry — `not_before` already clamps to the
+remaining `RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS` wall-clock budget, so a
+far-future `reset_at` cannot park a unit past the point the shared
+rate-limit-deferral budget says to terminalize instead
+(`test_cooldown_available_at_respects_wall_clock_clamp`,
+`test_cooldown_wall_clock_budget_exhausted_terminalizes_rather_than_sleeping_past_clamp`).
+A unit whose estimates span multiple route families is deferred if **any**
+one is cooling down (mirrors the existing would-defer-any-estimate budget
+semantics) and, when more than one matches, waits for the last one to clear.
 
-**One indexed query per dispatch pass, never per unit.** The gate issues a
-single `provider_rate_limit_observations` query per `enforce_run` call,
-scoped to the dispatch pass's candidate `(org_id, provider, integration_id)`
-tuples and a bounded recency window
-(`SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SECONDS`, default 2h — long enough to
-cover a chunked GitHub primary-limit reset), using the `ws-d`
+**One indexed query per dispatch pass, never per unit — plus one cheap
+re-check immediately before the claim.** `enforce_run` issues a single
+`provider_rate_limit_observations` query, scoped to the dispatch pass's
+candidate `(org_id, provider, integration_id)` tuples and a bounded recency
+window (`SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SECONDS`, default 2h — long
+enough to cover a chunked GitHub primary-limit reset), using the `ws-d`
 `(provider, integration_id, route_family, observed_at)` index
-(`test_single_observation_query_per_dispatch_pass`).
+(`test_single_observation_query_per_dispatch_pass`). Because `enforce_run`
+itself does further DB work after that read (budget admission,
+active-consumption re-estimation), a sibling unit's 429 can commit a
+brand-new observation in that window — one the snapshot never saw — and
+without a second look `_claim_units` would dispatch straight into it. Review
+finding, closed: `dispatch_sync_run` calls `BudgetGuard.reconfirm_cooldowns`
+— the SAME cheap query and matching logic, reusing the estimates
+`enforce_run` already computed (no re-estimation, no credential decryption)
+— as the LAST read before the atomic claim, folding any newly-caught unit
+into the claim's excluded-id set
+(`test_concurrent_observation_between_enforce_run_and_claim_still_defers_sibling`).
+This is not full serializability — a commit landing in the residual
+microsecond gap between that re-check and the claim's own `UPDATE` could
+still slip through — but it collapses the exposure window from "however
+long budget admission takes" down to back-to-back statements, consistent
+with how the rest of the dispatch path tolerates narrow races via CAS
+predicates rather than `SERIALIZABLE` transactions.
 
-**Fail-open on a broken read.** Any error querying the observation store
-(migration not yet applied on a rolling node, transient DB error, etc.) is
-logged and treated as "no active cooldown" — a diagnostic store must never
-block dispatch (`test_cooldown_read_failure_fails_open`).
+**Fail-open on a broken read, including a single malformed row.** Any error
+querying the observation store (migration not yet applied on a rolling
+node, transient DB error, etc.) is logged and treated as "no active
+cooldown" — a diagnostic store must never block dispatch
+(`test_cooldown_read_failure_fails_open`). Per-row parsing is fail-open too:
+a single malformed row (e.g. a non-finite `retry_after_seconds`, where
+`timedelta(seconds=...)` raises `OverflowError`) is skipped and logged
+rather than aborting the whole pass and blocking dispatch org-wide
+(`test_cooldown_read_survives_malformed_observation_row`). The writer
+(`workers/sync_units.py` `_build_rate_limit_observation`) also sanitizes
+`retry_after_seconds` before it is ever persisted — rejecting non-finite/
+negative values and clamping to `RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS` — so a
+corrupt value should never reach the store in the first place; the reader's
+guard is defense in depth, not the only line of defense
+(`test_observation_sanitizes_non_finite_retry_after_seconds`,
+`test_observation_clamps_excessive_retry_after_seconds` in
+`tests/test_rate_limit_observations.py`).
 
 **Deferral mechanics reuse the existing budget-guard vocabulary, not a new
 unit status.** A gated unit is stamped `RETRYING` with the computed

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -442,6 +442,59 @@ it terminalizes from that state alone, with or without a currently-visible
 cooldown observation
 (`test_cooldown_observation_aged_past_lookback_terminalizes_from_unit_state`).
 
+**`rate_limit_deferrals`/`rate_limit_first_seen_at` are cleared at episode
+boundaries — not left to go stale.** Checking a unit's own persisted
+deferral state directly (the belt-and-suspenders backstop above) only works
+if that state actually reflects the CURRENT episode. Review finding, round
+3: these columns were never cleared once a unit left a rate-limit episode —
+a successful claim of a due `RETRYING` unit doesn't touch them, and neither
+did any non-rate-limit retry path (expired lease, soft timeout, generic
+worker-lost retry). Sequence that broke: a unit takes one rate-limit
+deferral, is later claimed fine (the provider recovers), then loses its
+worker (lease expiry) or soft-times-out for a totally unrelated reason; once
+the stale `first_seen_at` from the OLD episode is more than
+`RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS` old, `_rate_limit_deferral_exhausted`
+would fire against it and wrongly terminalize healthy, unrelated work — a
+silent data gap. Fixed at the root: every transition to `SUCCESS` and every
+`RETRYING` stamp for a reason OTHER than a rate limit now explicitly clears
+both columns to `0`/`NULL`; only a rate-limit-caused deferral (the in-worker
+429 path, or this gate's own cooldown deferral) keeps/accumulates them,
+because that is the episode continuing. Defense in depth on top:
+`_rate_limit_deferral_exhausted` ALSO requires the unit's own
+most-recently-recorded `result.error_category` to be rate-limit-related
+(`rate_limit` or `rate_limit_cooldown_deferred`) before it can fire at all —
+a stale row that somehow survives a missed clear site still cannot
+terminalize healthy work, because its last recorded cause would show
+something else
+(`test_stale_rate_limit_columns_without_rate_limit_error_category_do_not_terminalize`).
+Gating alone would not have been sufficient as the root fix, though: a
+genuinely NEW rate-limit episode starting while a stale `first_seen_at`
+persists would still terminalize prematurely against the old clock, which
+is exactly why the clear-at-episode-boundary fix is the primary mechanism
+and the `error_category` check is the backstop, not the other way around.
+
+Every `SyncRunUnit` transition to `RETRYING` or a terminal state across
+`workers/sync_units.py`, `sync/budget_guard.py`, and
+`workers/sync_reconciler.py` was swept for an explicit keep-or-clear
+decision:
+
+| Site | Transition | Cause | Decision |
+| --- | --- | --- | --- |
+| `run_sync_unit` success stamp (`sync_units.py`) | `RUNNING`→`SUCCESS` | episode resolved | **clear** |
+| In-worker `RateLimitException` deferral (`sync_units.py`) | `RUNNING`→`RETRYING` | rate limit | **keep/accumulate** |
+| Soft-timeout retry (`_stamp_sync_unit_soft_timeout`, `sync_units.py`) | `RUNNING`→`RETRYING` | unrelated | **clear** |
+| Soft-timeout exhausted (`sync_units.py`) | `RUNNING`→`FAILED` | unrelated, terminal | leave (informational) |
+| Generic failure (`_stamp_sync_unit_failed`, `sync_units.py`) | `RUNNING`→`FAILED` | unrelated/terminal | leave (informational) |
+| Total-cap stale-dispatch fail (`sync_units.py`) | `DISPATCHING`→`FAILED` | unrelated, terminal | leave (informational) |
+| `PLANNED` claim (`_claim_units`, `sync_units.py`) | `PLANNED`→`DISPATCHING` | n/a (always fresh) | no change needed |
+| Due-`RETRYING` claim (`_claim_units`, `sync_units.py`) | `RETRYING`→`DISPATCHING` | unknown (batch claim, any prior reason) | **no change** — must NOT clear here: this fires before the attempt's outcome is known, so clearing would prematurely reset an ONGOING rate-limit episode's counter before the redispatch even runs; the correct clear point is the transition AFTER this attempt resolves (`SUCCESS`, or a specific non-rate-limit retry stamp) |
+| Lease acquire (`DISPATCHING`→`RUNNING`, `sync_units.py`) | transient | n/a | no change needed (outcome still unknown) |
+| Expired-lease retry (`sync_reconciler.py`) | `RUNNING`→`RETRYING` | unrelated | **clear** |
+| Expired-lease exhausted (`sync_reconciler.py`) | `RUNNING`→`FAILED` | unrelated, terminal | leave (informational) |
+| Budget-guard deferral (`_defer_unit_for_budget`, `budget_guard.py`) | any→`RETRYING` | unrelated (budget capacity, not a provider rate limit) | **clear** |
+| Cooldown-gate deferral (`_apply_cooldown_deferral`, `budget_guard.py`) | any→`RETRYING` | rate limit | **keep/accumulate** |
+| Wall-clock/cooldown exhaustion terminalize (`_terminalize_rate_limit_exhausted`, `budget_guard.py`) | any→`FAILED` | rate limit, terminal | leave (informational — the count that caused termination) |
+
 **Fail-open on a broken read, including a single malformed row.** Any error
 querying the observation store (migration not yet applied on a rolling
 node, transient DB error, etc.) is logged and treated as "no active

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -323,10 +323,100 @@ value outside this vocabulary) — never `str(exception)`.
 once daily. This is an observation log, not an audit trail — expired rows are
 deleted outright, no archival path.
 
-**Not yet wired: cooldown gating.** Nothing reads this table back before
-dispatch yet — see [Known gaps](#known-gaps) /
-[CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760). Any such
-consumer must honor the `route_family_attribution` fallback contract above.
+**Cooldown gating reads this table back before dispatch** — see the next
+section.
+
+## Cooldown gating
+
+Shipped in [CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760). A 429
+observed by one unit today only defers *that* unit
+(`workers/sync_units.py:731-836`, the `RateLimitException` handler above) —
+siblings of the same provider/integration/route-family would otherwise
+dispatch anyway and rediscover the same limit in-worker, each burning a
+worker slot and a provider round-trip the observation store already knows is
+futile. `BudgetGuard.enforce_run` (`sync/budget_guard.py`) closes that gap:
+before admitting this dispatch pass's candidates against budget, it consults
+`provider_rate_limit_observations` for an ACTIVE cooldown and defers (or, on
+deferral-budget exhaustion, terminally fails) any candidate that matches.
+
+**Match key: `(org_id, provider, integration_id, route_family)` — org-scoped,
+and deliberately excluding `credential_fingerprint`/`host`.** This is the
+credentials-are-not-capacity invariant applied to gating: rotating an
+integration's credential between the observation write and the next dispatch
+pass must never let a sibling unit slip past a cooldown that is still active
+(`tests/test_budget_guard_cooldown.py::test_credential_rotation_does_not_bypass_cooldown`).
+`host` is diagnostic-only on the observation row (multi-host GitHub
+Enterprise, etc.) and is never part of the match. A cooldown observed under
+one `org_id` never gates another org's units, even if `(provider,
+integration_id, route_family)` coincide
+(`test_cooldown_never_crosses_org_boundary`).
+
+**Ambiguous-attribution fallback.** Per the [observation store's confidence
+gate](#observation-store), a row with `route_family=NULL` and
+`route_family_attribution='ambiguous_dimension'` carries a populated
+`dimension` instead. The gate never treats that NULL family as matching
+every candidate (over-defer) or none (silent under-defer): it falls back to
+matching on `(org_id, provider, integration_id, dimension)`, gating every
+candidate estimate whose dimension matches, regardless of which specific
+family within that dimension actually hit the limit
+(`test_ambiguous_attribution_falls_back_to_dimension_gating`).
+
+**Cooldown window.** `coalesce(reset_at, observed_at + retry_after_seconds)`,
+falling back to a fixed conservative window
+(`RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS`, 60s) when an observation carried
+neither — never treated as "already expired" (under-defer) nor "cooldown
+forever" (stuck run). `available_at` for a gated unit is the cooldown expiry
+plus the same jitter (`SYNC_BUDGET_DEFERRAL_JITTER_SECONDS`) the budget-defer
+path already uses, not a fixed 60s. A unit whose estimates span multiple
+route families is deferred if **any** one is cooling down (mirrors the
+existing would-defer-any-estimate budget semantics) and, when more than one
+matches, waits for the last one to clear.
+
+**One indexed query per dispatch pass, never per unit.** The gate issues a
+single `provider_rate_limit_observations` query per `enforce_run` call,
+scoped to the dispatch pass's candidate `(org_id, provider, integration_id)`
+tuples and a bounded recency window
+(`SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SECONDS`, default 2h — long enough to
+cover a chunked GitHub primary-limit reset), using the `ws-d`
+`(provider, integration_id, route_family, observed_at)` index
+(`test_single_observation_query_per_dispatch_pass`).
+
+**Fail-open on a broken read.** Any error querying the observation store
+(migration not yet applied on a rolling node, transient DB error, etc.) is
+logged and treated as "no active cooldown" — a diagnostic store must never
+block dispatch (`test_cooldown_read_failure_fails_open`).
+
+**Deferral mechanics reuse the existing budget-guard vocabulary, not a new
+unit status.** A gated unit is stamped `RETRYING` with the computed
+`available_at`, exactly like `_defer_unit_for_budget`, but with a
+**distinct** `result.error_category`: `rate_limit_cooldown_deferred` — so
+operators can tell a shared-cooldown hit apart from `budget_deferred`
+(budget admission) and `rate_limit` (the in-worker per-unit 429 path).
+`BudgetGuardResult.next_deferred_at` folds in the earliest cooldown-deferred
+`available_at` exactly like a budget deferral, so the existing
+`_schedule_redispatch` re-arm (`workers/sync_units.py`) fires and the run
+does not strand until the periodic reconciler scan
+(`test_next_deferred_at_rearms_redispatch`).
+
+**Cooldown deferrals count against the existing per-unit rate-limit-deferral
+budget.** `plan_rate_limit_deferral`
+(`workers/rate_limit_defer.py`, `RATE_LIMIT_MAX_DEFERRALS=10` /
+`RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS=2h`) is reused for the
+`rate_limit_deferrals`/`rate_limit_first_seen_at` bookkeeping — the SAME
+columns and budget the in-worker 429 path already uses. This was a deliberate
+CHAOS-2742 recon decision: run-liveness beats optimism, so a chronically
+rate-limited provider **terminalizes** (stamped `FAILED`,
+`error_category=rate_limit_cooldown_exhausted`) once the shared budget is
+spent, rather than holding the run open indefinitely on gate hits that never
+even reach the provider
+(`test_cooldown_deferral_consumes_rate_limit_budget_and_terminalizes`).
+
+**Herd-on-expiry is naturally paced.** `RETRYING` units never consume
+concurrency capacity, and due-`RETRYING` claims are still bounded by
+`SYNC_UNIT_CONCURRENCY_PER_BUCKET` per dispatch pass exactly like any other
+candidate — an expired cooldown does not cause every sibling to dispatch at
+once beyond what DispatchGuard's concurrency cap already allows
+(`test_cooldown_expiry_drains_bounded_by_concurrency_cap`).
 
 ## Per-provider policy
 
@@ -527,12 +617,6 @@ These are the instrumentation/coverage gaps the [CHAOS-2742](https://linear.app/
 epic exists to close. They are documented as **current reality**, not defects to
 paper over:
 
-- **No cross-unit cooldown gating.** Provider rate-limit observations are now
-  durably persisted (see [Observation store](#observation-store), shipped in
-  [CHAOS-2758](https://linear.app/fullchaos/issue/CHAOS-2758)), but nothing
-  reads them back yet: when one unit discovers a real cooldown, sibling units
-  still call the provider and re-discover it independently. (Target:
-  [CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760).)
 - **Calibration only covers instrumented route families.** [CHAOS-2759](https://linear.app/fullchaos/issue/CHAOS-2759)
   attaches a `budget_comparison` (see
   [Actual-vs-estimated calibration](#actual-vs-estimated-calibration-chaos-2759)
@@ -574,10 +658,6 @@ append its section here in the same changeset (per `AGENTS.md`
   Stamp `credential_id`/version onto `SyncRun` at plan time; bootstrap uses the
   run-stamped auth context, not mutable integration state. Determinism only —
   **never** unit-level credential selection for capacity.
-- **Cooldown gating — [CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760).**
-  Consult recent observations before dispatch and defer sibling units into a
-  known provider/integration/route-family cooldown window.
-
 ## References
 
 - Epic: [CHAOS-2742](https://linear.app/fullchaos/issue/CHAOS-2742) — Harden sync

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -374,16 +374,24 @@ far-future `reset_at` cannot park a unit past the point the shared
 rate-limit-deferral budget says to terminalize instead
 (`test_cooldown_available_at_respects_wall_clock_clamp`,
 `test_cooldown_wall_clock_budget_exhausted_terminalizes_rather_than_sleeping_past_clamp`).
-A unit whose estimates span multiple route families is deferred if **any**
-one is cooling down (mirrors the existing would-defer-any-estimate budget
-semantics) and, when more than one matches, waits for the last one to clear.
+The jitter itself is added AFTER `not_before`, so it is clamped a second
+time against the wall-clock deadline
+(`first_seen_at + RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS`) — jitter stacked on an
+already-clamped `not_before` must not itself push `available_at` past the
+deadline (review finding, round 2). A unit whose estimates span multiple
+route families is deferred if **any** one is cooling down (mirrors the
+existing would-defer-any-estimate budget semantics) and, when more than one
+matches, waits for the last one to clear.
 
 **One indexed query per dispatch pass, never per unit — plus one cheap
-re-check immediately before the claim.** `enforce_run` issues a single
+re-check immediately before the claim, which fully defers/terminalizes any
+match it catches.** `enforce_run` issues a single
 `provider_rate_limit_observations` query, scoped to the dispatch pass's
 candidate `(org_id, provider, integration_id)` tuples and a bounded recency
-window (`SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SECONDS`, default 2h — long
-enough to cover a chunked GitHub primary-limit reset), using the `ws-d`
+window (`SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SECONDS`, default
+`RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS` plus the max configured jitter plus a
+300s skew margin — deliberately NOT equal to the wall-clock budget alone;
+see the termination note below), using the `ws-d`
 `(provider, integration_id, route_family, observed_at)` index
 (`test_single_observation_query_per_dispatch_pass`). Because `enforce_run`
 itself does further DB work after that read (budget admission,
@@ -393,15 +401,46 @@ without a second look `_claim_units` would dispatch straight into it. Review
 finding, closed: `dispatch_sync_run` calls `BudgetGuard.reconfirm_cooldowns`
 — the SAME cheap query and matching logic, reusing the estimates
 `enforce_run` already computed (no re-estimation, no credential decryption)
-— as the LAST read before the atomic claim, folding any newly-caught unit
-into the claim's excluded-id set
-(`test_concurrent_observation_between_enforce_run_and_claim_still_defers_sibling`).
-This is not full serializability — a commit landing in the residual
-microsecond gap between that re-check and the claim's own `UPDATE` could
-still slip through — but it collapses the exposure window from "however
-long budget admission takes" down to back-to-back statements, consistent
-with how the rest of the dispatch path tolerates narrow races via CAS
-predicates rather than `SERIALIZABLE` transactions.
+— as the LAST read before the atomic claim. A match here is NOT a bare
+exclusion: it goes through the exact same `_apply_cooldown_deferral` /
+`_terminalize_rate_limit_exhausted` write path `enforce_run`'s own cooldown
+loop uses — full `RETRYING` + `available_at` + `rate_limit_deferrals`
+bookkeeping, or termination on budget exhaustion — folding the result into
+the claim's excluded-id set AND `next_deferred_at` for the redispatch
+re-arm. A bare PLANNED exclusion (the original CHAOS-2760 review-round-1
+shape) left the unit with zero deferral-budget bookkeeping and livelocked
+the run redispatching on a bare ~60s countdown forever, re-triggering the
+same exclusion indefinitely without ever counting toward termination
+(review finding, round 2) —
+(`test_concurrent_observation_between_enforce_run_and_claim_still_defers_sibling`,
+`test_late_reconfirm_match_short_reset_window_defers_with_full_bookkeeping`,
+`test_late_reconfirm_match_long_reset_window_clamps_to_wall_clock_deadline`,
+`test_reconfirm_cooldowns_terminalizes_exhausted_match_directly`). This is
+not full serializability — a commit landing in the residual microsecond gap
+between that re-check and the claim's own `UPDATE` could still slip through
+— but it collapses the exposure window from "however long budget admission
+takes" down to back-to-back statements, consistent with how the rest of the
+dispatch path tolerates narrow races via CAS predicates rather than
+`SERIALIZABLE` transactions.
+
+**Termination does not depend on re-reading the observation.** A unit
+deferred by this gate gets `available_at` clamped to the wall-clock budget,
+so it becomes due again at roughly the SAME age its causing observation's
+`observed_at` has reached — a lookback window equal to
+`RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS` would age the row out of visibility at
+almost exactly the instant termination should fire instead, making the
+observation invisible right when it matters most (review finding, round 2).
+Two-part fix: (a) the lookback window carries slack beyond the bare
+wall-clock budget (jitter max + a generous skew margin — see above), so a
+row that is merely a little older than the budget stays visible
+(`test_cooldown_lookback_window_has_slack_beyond_wall_clock_budget`); (b) as
+a belt-and-suspenders backstop that does not depend on that window at all,
+every candidate with rate-limit-deferral history is ALSO checked directly
+against its own persisted `rate_limit_deferrals`/`rate_limit_first_seen_at`
+(`_rate_limit_deferral_exhausted`) — if the shared budget is already spent,
+it terminalizes from that state alone, with or without a currently-visible
+cooldown observation
+(`test_cooldown_observation_aged_past_lookback_terminalizes_from_unit_state`).
 
 **Fail-open on a broken read, including a single malformed row.** Any error
 querying the observation store (migration not yet applied on a rolling

--- a/src/dev_health_ops/sync/budget_guard.py
+++ b/src/dev_health_ops/sync/budget_guard.py
@@ -13,11 +13,33 @@ from typing import Any
 
 from sqlalchemy import or_, text, update
 
-from dev_health_ops.models import SyncRunUnit, SyncRunUnitStatus
+from dev_health_ops.models import (
+    ProviderRateLimitObservation,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+)
 from dev_health_ops.sync.budget import BudgetEstimate, estimate_provider_budget
+from dev_health_ops.workers.rate_limit_defer import (
+    RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS,
+    plan_rate_limit_deferral,
+)
 from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
 
 logger = logging.getLogger(__name__)
+
+# Mirrors ``workers/sync_units.py::_AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION``
+# verbatim. Duplicated rather than imported: sync_units.py already imports
+# BudgetGuard from this module, so the reverse import would cycle; the same
+# duplicate-rather-than-reach-in pattern is already used for
+# ``_comparison_budget_key`` mirroring ``_budget_key``. Pinned equal by
+# ``tests/test_budget_guard_cooldown.py::test_ambiguous_attribution_constant_matches_observation_writer``.
+_AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION = "ambiguous_dimension"
+
+# Distinct from 'budget_deferred' (_defer_unit_for_budget) and 'rate_limit'
+# (workers/sync_units.py's in-worker deferral) so operators can tell a
+# shared-cooldown gate hit apart from either (docs/providers/rate-limit-policy.md).
+_RATE_LIMIT_COOLDOWN_DEFERRED_CATEGORY = "rate_limit_cooldown_deferred"
+_RATE_LIMIT_COOLDOWN_EXHAUSTED_CATEGORY = "rate_limit_cooldown_exhausted"
 
 
 @dataclass(frozen=True)
@@ -134,15 +156,65 @@ class BudgetGuard:
                 )
 
         _acquire_budget_advisory_locks(session, sorted(budget_keys))
+
+        deferred_unit_ids: set[str] = set()
+        next_deferred_at: datetime | None = None
+        cooldown_handled_unit_ids: set[str] = set()
+
+        # --- Shared cooldown gating (CHAOS-2760) — BEFORE budget admission,
+        # so a unit gated by a known cooldown never also reserves budget
+        # capacity it will not use this pass.
+        cooldown_by_family, cooldown_by_dimension = _active_cooldowns(
+            session,
+            sync_run_id=sync_run_id,
+            candidates=units,
+            now=enforced_at,
+        )
+        if cooldown_by_family or cooldown_by_dimension:
+            for unit in units:
+                estimates = estimates_by_unit[str(unit.id)]
+                if not estimates:
+                    continue
+                cooldown_expiry = _matching_cooldown_expiry(
+                    estimates,
+                    org_id=str(unit.org_id),
+                    provider=str(unit.provider),
+                    integration_id=unit.integration_id,
+                    cooldown_by_family=cooldown_by_family,
+                    cooldown_by_dimension=cooldown_by_dimension,
+                )
+                if cooldown_expiry is None:
+                    continue
+                outcome = _apply_cooldown_deferral(
+                    session,
+                    unit,
+                    cooldown_expiry=cooldown_expiry,
+                    jitter_seconds=jitter_seconds,
+                    now=enforced_at,
+                    log_ctx=_unit_log_context(sync_run_id, unit),
+                )
+                if outcome is None:
+                    # CAS lost the race (unit moved on concurrently) — leave
+                    # it for the budget loop / _claim_units to sort out, same
+                    # as a lost _defer_unit_for_budget race.
+                    continue
+                cooldown_handled_unit_ids.add(str(unit.id))
+                available_at, terminalized = outcome
+                if terminalized:
+                    continue
+                deferred_unit_ids.add(str(unit.id))
+                if next_deferred_at is None or available_at < next_deferred_at:
+                    next_deferred_at = available_at
+
         consumed_by_bucket = _active_budget_consumption(
             session,
             now=enforced_at,
             budget_keys=budget_keys,
         )
-        deferred_unit_ids: set[str] = set()
-        next_deferred_at: datetime | None = None
 
         for unit in units:
+            if str(unit.id) in cooldown_handled_unit_ids:
+                continue
             log_ctx = _unit_log_context(sync_run_id, unit)
             estimates = estimates_by_unit[str(unit.id)]
             if not estimates:
@@ -342,6 +414,280 @@ def _defer_unit_for_budget(
         unit.available_at = available_at
         return True
     return False
+
+
+def _as_aware(value: datetime) -> datetime:
+    """Return a timezone-aware UTC datetime (mirrors sync_units._as_aware /
+    guard._as_aware_guard). SQLite (unit tests) returns naive datetimes for
+    ``DateTime(timezone=True)`` columns; Postgres returns aware ones."""
+    if value.tzinfo is None:
+        return value.replace(tzinfo=timezone.utc)
+    return value.astimezone(timezone.utc)
+
+
+def _cooldown_expiry(observation: ProviderRateLimitObservation) -> datetime:
+    """The moment an observation's cooldown lifts:
+    ``coalesce(reset_at, observed_at + retry_after_seconds)``, falling back
+    to a conservative fixed window when the signal carried neither. Never
+    treated as "no cooldown" (an observation with no delay info would be
+    silently ignored) nor as "cooldown forever" (over-defer) -- see
+    docs/providers/rate-limit-policy.md "Cooldown gating".
+    """
+    if observation.reset_at is not None:
+        return _as_aware(observation.reset_at)
+    observed_at = _as_aware(observation.observed_at)
+    if observation.retry_after_seconds is not None:
+        return observed_at + timedelta(
+            seconds=max(0.0, observation.retry_after_seconds)
+        )
+    return observed_at + timedelta(seconds=RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS)
+
+
+def _cooldown_lookback_seconds() -> int:
+    # Bounds the observation query to a recency window so the lookup stays
+    # cheap regardless of the table's 14-day (default) retention. 2h matches
+    # RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS -- the longest a real cooldown
+    # (chunked provider resets included) can legitimately still be active.
+    return _env_int("SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SECONDS", 2 * 60 * 60)
+
+
+def _active_cooldowns(
+    session: Any,
+    *,
+    sync_run_id: str,
+    candidates: Iterable[SyncRunUnit],
+    now: datetime,
+) -> tuple[
+    dict[tuple[str, str, uuid.UUID, str], datetime],
+    dict[tuple[str, str, uuid.UUID, str], datetime],
+]:
+    """Resolve which ``(org_id, provider, integration_id, route_family)`` /
+    ambiguous-fallback ``(org_id, provider, integration_id, dimension)``
+    tuples carry an ACTIVE shared cooldown right now (CHAOS-2760).
+
+    ONE indexed query per dispatch pass -- never per unit -- over
+    ``provider_rate_limit_observations``, using the ``ws-d``
+    ``(provider, integration_id, route_family, observed_at)`` index. The
+    match key is deliberately ``(org_id, provider, integration_id,
+    route_family)``: org-scoped, and EXCLUDING credential_fingerprint/host,
+    so rotating a credential can never bypass an active cooldown (the
+    credentials-are-not-capacity invariant applied to gating).
+
+    Rows with ``route_family_attribution == 'ambiguous_dimension'`` (CHAOS-2758:
+    the writer could not confidently attribute one route family) carry
+    ``route_family=NULL`` and are NEVER matched by family -- a NULL family is
+    never treated as matching everything (over-defer) or nothing (silent
+    under-defer). They instead populate the dimension-keyed fallback map, so
+    a candidate unit's estimate is gated by the observation's dimension when
+    its own family cannot be resolved from the ambiguous row.
+
+    Fail-open on ANY error reading the store: a broken observation read must
+    never block dispatch -- logs a warning and returns two empty maps so the
+    caller proceeds exactly as if no cooldown existed.
+    """
+    family_cooldowns: dict[tuple[str, str, uuid.UUID, str], datetime] = {}
+    dimension_cooldowns: dict[tuple[str, str, uuid.UUID, str], datetime] = {}
+
+    org_ids: set[str] = set()
+    providers: set[str] = set()
+    integration_ids: set[uuid.UUID] = set()
+    for unit in candidates:
+        org_ids.add(str(unit.org_id))
+        providers.add(str(unit.provider))
+        integration_ids.add(unit.integration_id)
+    if not org_ids or not providers or not integration_ids:
+        return family_cooldowns, dimension_cooldowns
+
+    lookback_cutoff = now - timedelta(seconds=_cooldown_lookback_seconds())
+    try:
+        rows = (
+            session.query(ProviderRateLimitObservation)
+            .filter(
+                ProviderRateLimitObservation.org_id.in_(org_ids),
+                ProviderRateLimitObservation.provider.in_(providers),
+                ProviderRateLimitObservation.integration_id.in_(integration_ids),
+                ProviderRateLimitObservation.observed_at >= lookback_cutoff,
+            )
+            .all()
+        )
+    except Exception as exc:
+        logger.warning(
+            "dispatch_sync_run.cooldown_observation_read_failed",
+            extra={"sync_run_id": sync_run_id, "error": str(exc)},
+        )
+        return family_cooldowns, dimension_cooldowns
+
+    for row in rows:
+        expiry = _cooldown_expiry(row)
+        if expiry <= now:
+            continue
+        key_prefix = (str(row.org_id), str(row.provider), row.integration_id)
+        if row.route_family_attribution == _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION:
+            if row.dimension is None:
+                continue
+            key = (*key_prefix, row.dimension)
+            dimension_cooldowns[key] = max(expiry, dimension_cooldowns.get(key, expiry))
+        elif row.route_family is not None:
+            key = (*key_prefix, row.route_family)
+            family_cooldowns[key] = max(expiry, family_cooldowns.get(key, expiry))
+
+    return family_cooldowns, dimension_cooldowns
+
+
+def _matching_cooldown_expiry(
+    estimates: Iterable[BudgetEstimate],
+    *,
+    org_id: str,
+    provider: str,
+    integration_id: uuid.UUID,
+    cooldown_by_family: Mapping[tuple[str, str, uuid.UUID, str], datetime],
+    cooldown_by_dimension: Mapping[tuple[str, str, uuid.UUID, str], datetime],
+) -> datetime | None:
+    """Whole-unit deferral on ANY estimate match -- mirrors the existing
+    would-defer-any-estimate budget semantics in ``enforce_run``: a unit
+    mapping to multiple route families is held back if ANY of them is
+    cooling down. When more than one matches, the unit waits for the LAST
+    one to clear (max expiry), not the first.
+    """
+    matches: list[datetime] = []
+    for estimate in estimates:
+        family_key = (org_id, provider, integration_id, estimate.route_family)
+        expiry = cooldown_by_family.get(family_key)
+        if expiry is not None:
+            matches.append(expiry)
+        dimension_key = (
+            org_id,
+            provider,
+            integration_id,
+            estimate.bucket.dimension.value,
+        )
+        expiry = cooldown_by_dimension.get(dimension_key)
+        if expiry is not None:
+            matches.append(expiry)
+    if not matches:
+        return None
+    return max(matches)
+
+
+def _cooldown_claim_predicate(now: datetime) -> Any:
+    stale_dispatch_cutoff = _stale_dispatch_cutoff(now)
+    return or_(
+        SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
+        (
+            (SyncRunUnit.status == SyncRunUnitStatus.RETRYING.value)
+            & (SyncRunUnit.available_at.is_not(None))
+            & (SyncRunUnit.available_at <= now)
+        ),
+        (
+            (SyncRunUnit.status == SyncRunUnitStatus.DISPATCHING.value)
+            & (SyncRunUnit.updated_at <= stale_dispatch_cutoff)
+        ),
+    )
+
+
+def _apply_cooldown_deferral(
+    session: Any,
+    unit: SyncRunUnit,
+    *,
+    cooldown_expiry: datetime,
+    jitter_seconds: int,
+    now: datetime,
+    log_ctx: dict[str, Any],
+) -> tuple[datetime, bool] | None:
+    """Defer (or, on rate-limit-deferral-budget exhaustion, terminally fail)
+    a unit gated by an active shared cooldown (CHAOS-2760).
+
+    Cooldown deferrals COUNT against the SAME
+    ``rate_limit_deferrals`` / ``rate_limit_first_seen_at`` budget the
+    in-worker 429 path uses (``workers/rate_limit_defer.plan_rate_limit_deferral``,
+    ``RATE_LIMIT_MAX_DEFERRALS`` / ``RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS`` --
+    binding CHAOS-2742 recon decision: run-liveness beats optimism, so a
+    chronically rate-limited provider terminalizes here rather than holding
+    the run open on repeated gate hits that never even reach the provider.
+
+    Returns ``(available_at, terminalized)`` on a successful CAS transition,
+    or ``None`` if the CAS lost the race (the unit moved on concurrently,
+    e.g. another dispatcher pass claimed/reconciled it first -- the caller
+    simply skips it, mirroring ``_defer_unit_for_budget``).
+    """
+    retry_after_seconds = max(0.0, (cooldown_expiry - now).total_seconds())
+    deferral = plan_rate_limit_deferral(
+        retry_after_seconds=retry_after_seconds,
+        attempts=unit.rate_limit_deferrals,
+        first_seen_at=unit.rate_limit_first_seen_at.isoformat()
+        if unit.rate_limit_first_seen_at
+        else None,
+        now=now,
+    )
+    claim_predicate = _cooldown_claim_predicate(now)
+
+    if deferral is None:
+        result: Any = session.execute(
+            update(SyncRunUnit)
+            .where(SyncRunUnit.id == unit.id, claim_predicate)
+            .values(
+                status=SyncRunUnitStatus.FAILED.value,
+                error="rate limit cooldown deferral budget exhausted",
+                result={
+                    "error_category": _RATE_LIMIT_COOLDOWN_EXHAUSTED_CATEGORY,
+                    "rate_limit_deferrals": unit.rate_limit_deferrals,
+                },
+                lease_owner=None,
+                lease_expires_at=None,
+                last_heartbeat_at=now,
+                updated_at=now,
+            )
+            .execution_options(synchronize_session=False)
+        )
+        if int(result.rowcount or 0) == 0:
+            return None
+        unit.status = SyncRunUnitStatus.FAILED.value
+        logger.warning(
+            "dispatch_sync_run.rate_limit_cooldown_exhausted",
+            extra={**log_ctx, "rate_limit_deferrals": unit.rate_limit_deferrals},
+        )
+        return now, True
+
+    available_at = cooldown_expiry + timedelta(
+        seconds=random.uniform(0, float(jitter_seconds))  # noqa: S311
+    )
+    first_seen_at = datetime.fromisoformat(deferral.first_seen_at)
+    result = session.execute(
+        update(SyncRunUnit)
+        .where(SyncRunUnit.id == unit.id, claim_predicate)
+        .values(
+            status=SyncRunUnitStatus.RETRYING.value,
+            available_at=available_at,
+            rate_limit_deferrals=deferral.attempts,
+            rate_limit_first_seen_at=first_seen_at,
+            error="deferred by sync cooldown guard",
+            result={
+                "error_category": _RATE_LIMIT_COOLDOWN_DEFERRED_CATEGORY,
+                "not_before": available_at.isoformat(),
+                "rate_limit_deferrals": deferral.attempts,
+            },
+            lease_owner=None,
+            lease_expires_at=None,
+            last_heartbeat_at=now,
+            updated_at=now,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    if int(result.rowcount or 0) == 0:
+        return None
+    unit.status = SyncRunUnitStatus.RETRYING.value
+    unit.available_at = available_at
+    unit.rate_limit_deferrals = deferral.attempts
+    unit.rate_limit_first_seen_at = first_seen_at
+    logger.info(
+        "dispatch_sync_run.rate_limit_cooldown_deferred",
+        extra={
+            **log_ctx,
+            "available_at": available_at.isoformat(),
+            "rate_limit_deferrals": deferral.attempts,
+        },
+    )
+    return available_at, False
 
 
 def _active_budget_consumption(

--- a/src/dev_health_ops/sync/budget_guard.py
+++ b/src/dev_health_ops/sync/budget_guard.py
@@ -47,6 +47,15 @@ class BudgetGuardResult:
     observations: list[dict[str, Any]] = field(default_factory=list)
     deferred_unit_ids: frozenset[str] = frozenset()
     next_deferred_at: datetime | None = None
+    # CHAOS-2760 TOCTOU closure: the candidate units and their (already
+    # loaded, credential-decryption-free-to-reuse) estimates from THIS pass,
+    # so the caller can run one more cheap cooldown re-check
+    # (``reconfirm_cooldowns``) immediately before the atomic claim, without
+    # re-loading estimates. See ``reconfirm_cooldowns`` docstring.
+    candidate_units: tuple[SyncRunUnit, ...] = ()
+    estimates_by_unit: dict[str, tuple[BudgetEstimate, ...]] = field(
+        default_factory=dict
+    )
 
 
 class BudgetGuard:
@@ -278,7 +287,89 @@ class BudgetGuard:
             observations=observations,
             deferred_unit_ids=frozenset(deferred_unit_ids),
             next_deferred_at=next_deferred_at,
+            candidate_units=tuple(units),
+            estimates_by_unit=estimates_by_unit,
         )
+
+    @staticmethod
+    def reconfirm_cooldowns(
+        session: Any,
+        sync_run_id: str,
+        *,
+        units: Iterable[SyncRunUnit],
+        estimates_by_unit: Mapping[str, tuple[BudgetEstimate, ...]],
+        already_excluded_ids: frozenset[str],
+        now: datetime | None = None,
+    ) -> frozenset[str]:
+        """Close the TOCTOU window between ``enforce_run``'s cooldown
+        snapshot and the atomic claim (CHAOS-2760 review finding).
+
+        ``enforce_run`` reads ``provider_rate_limit_observations`` once,
+        early in its pass, then goes on to do real DB work of its own
+        (``_active_budget_consumption`` re-estimates every active unit
+        across the bucket) before returning. Under READ COMMITTED, a
+        sibling unit's 429 can commit a brand-new observation row in that
+        window -- one this pass's ``enforce_run`` snapshot never saw -- and
+        without a second look, ``_claim_units`` would dispatch straight into
+        it, defeating the whole point of the gate.
+
+        This re-runs the SAME cheap, single indexed query
+        (``_active_cooldowns``) and the SAME per-unit matching
+        (``_matching_cooldown_expiry`` -- byte-identical semantics,
+        including the ambiguous-dimension fallback) against the estimates
+        ``enforce_run`` already computed (no re-estimation, no credential
+        decryption), as the LAST read before the claim. It does not
+        re-stamp RETRYING/FAILED here -- it only returns the unit ids to
+        additionally exclude from this pass's claim; a unit caught only by
+        this late check is simply left PLANNED/RETRYING-due for the next
+        ``enforce_run`` pass, which will formally defer/terminalize it with
+        full budget bookkeeping. This does not achieve full serializability
+        (a commit landing in the few-microsecond gap between this query and
+        the claim's own UPDATE could still slip through), but it collapses
+        the window from "however long budget admission takes" down to
+        "back-to-back statements", consistent with how the rest of this
+        module tolerates narrow races via CAS predicates rather than
+        SERIALIZABLE transactions.
+        """
+        checked_at = now or datetime.now(timezone.utc)
+        candidates = [
+            unit for unit in units if str(unit.id) not in already_excluded_ids
+        ]
+        if not candidates:
+            return frozenset()
+
+        cooldown_by_family, cooldown_by_dimension = _active_cooldowns(
+            session,
+            sync_run_id=sync_run_id,
+            candidates=candidates,
+            now=checked_at,
+        )
+        if not cooldown_by_family and not cooldown_by_dimension:
+            return frozenset()
+
+        matched: set[str] = set()
+        for unit in candidates:
+            estimates = estimates_by_unit.get(str(unit.id), ())
+            if not estimates:
+                continue
+            expiry = _matching_cooldown_expiry(
+                estimates,
+                org_id=str(unit.org_id),
+                provider=str(unit.provider),
+                integration_id=unit.integration_id,
+                cooldown_by_family=cooldown_by_family,
+                cooldown_by_dimension=cooldown_by_dimension,
+            )
+            if expiry is not None:
+                matched.add(str(unit.id))
+                logger.info(
+                    "dispatch_sync_run.rate_limit_cooldown_reconfirmed_exclusion",
+                    extra={
+                        "sync_run_id": sync_run_id,
+                        "unit_id": str(unit.id),
+                    },
+                )
+        return frozenset(matched)
 
 
 def _dispatch_candidate_units(
@@ -518,7 +609,23 @@ def _active_cooldowns(
         return family_cooldowns, dimension_cooldowns
 
     for row in rows:
-        expiry = _cooldown_expiry(row)
+        # Per-row parsing is fail-open too, not just the SQL read above: a
+        # single malformed row (e.g. a non-finite retry_after_seconds --
+        # timedelta(seconds=inf) raises OverflowError) must not abort the
+        # whole pass and block dispatch org-wide (review finding). Skip and
+        # log; treat the row as "no cooldown signal" rather than crashing.
+        try:
+            expiry = _cooldown_expiry(row)
+        except (OverflowError, ValueError, TypeError) as exc:
+            logger.warning(
+                "dispatch_sync_run.cooldown_observation_row_malformed",
+                extra={
+                    "sync_run_id": sync_run_id,
+                    "observation_id": str(getattr(row, "id", None)),
+                    "error": str(exc),
+                },
+            )
+            continue
         if expiry <= now:
             continue
         key_prefix = (str(row.org_id), str(row.provider), row.integration_id)
@@ -648,7 +755,14 @@ def _apply_cooldown_deferral(
         )
         return now, True
 
-    available_at = cooldown_expiry + timedelta(
+    # Use plan_rate_limit_deferral's OWN not_before, not cooldown_expiry
+    # directly: not_before already clamps to the remaining
+    # RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS wall-clock budget (review finding --
+    # a far-future reset_at must not park a unit past the point the shared
+    # deferral budget says to terminalize instead). Add the SAME jitter the
+    # budget-defer path uses, since not_before itself carries none.
+    not_before = datetime.fromisoformat(deferral.not_before)
+    available_at = not_before + timedelta(
         seconds=random.uniform(0, float(jitter_seconds))  # noqa: S311
     )
     first_seen_at = datetime.fromisoformat(deferral.first_seen_at)

--- a/src/dev_health_ops/sync/budget_guard.py
+++ b/src/dev_health_ops/sync/budget_guard.py
@@ -42,6 +42,16 @@ _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION = "ambiguous_dimension"
 _RATE_LIMIT_COOLDOWN_DEFERRED_CATEGORY = "rate_limit_cooldown_deferred"
 _RATE_LIMIT_COOLDOWN_EXHAUSTED_CATEGORY = "rate_limit_cooldown_exhausted"
 
+# Defense in depth for _rate_limit_deferral_exhausted (review finding, round
+# 3): the unit's own last-recorded result.error_category must ALSO show a
+# rate-limit-related cause before the wall-clock-exhaustion check can fire.
+# 'rate_limit' mirrors the in-worker 429 path's category
+# (workers/sync_units.py's RateLimitException handler) -- duplicated for the
+# same reverse-import-cycle reason as _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION.
+_RATE_LIMIT_EPISODE_ERROR_CATEGORIES = frozenset(
+    {"rate_limit", _RATE_LIMIT_COOLDOWN_DEFERRED_CATEGORY}
+)
+
 
 @dataclass(frozen=True)
 class BudgetGuardResult:
@@ -575,6 +585,14 @@ def _defer_unit_for_budget(
                 "not_before": available_at.isoformat(),
                 "budget_guard": observations,
             },
+            # Review finding (round 3): a budget deferral is NOT a rate-limit
+            # episode -- clear any stale rate_limit_deferrals/first_seen_at
+            # this unit is carrying from an EARLIER, since-resolved
+            # rate-limit episode. Leaving them untouched here is exactly the
+            # state-lifecycle hole that let _rate_limit_deferral_exhausted
+            # (added for the cooldown gate) fire against unrelated old data.
+            rate_limit_deferrals=0,
+            rate_limit_first_seen_at=None,
             lease_owner=None,
             lease_expires_at=None,
             last_heartbeat_at=now,
@@ -585,6 +603,8 @@ def _defer_unit_for_budget(
     if int(result.rowcount or 0) > 0:
         unit.status = SyncRunUnitStatus.RETRYING.value
         unit.available_at = available_at
+        unit.rate_limit_deferrals = 0
+        unit.rate_limit_first_seen_at = None
         return True
     return False
 
@@ -804,8 +824,26 @@ def _rate_limit_deferral_exhausted(unit: SyncRunUnit, *, now: datetime) -> bool:
     fires for a unit with genuine prior rate-limit-deferral history (from
     EITHER this gate or the in-worker 429 path; they share the same
     columns).
+
+    Defense in depth (review finding, round 3): ``rate_limit_deferrals`` /
+    ``rate_limit_first_seen_at`` are cleared at every SUCCESS stamp and every
+    non-rate-limit RETRYING stamp (budget deferral, expired-lease retry,
+    soft-timeout retry) -- see the "keep or clear" audit in
+    ``docs/providers/rate-limit-policy.md`` -- so a genuinely UNRELATED
+    retry reason should never reach here with stale nonzero columns. This is
+    a SECOND, independent check in case a clear site is ever missed: it also
+    requires the unit's own MOST RECENTLY recorded ``result.error_category``
+    to be rate-limit-related. A stale row surviving a missed clear would
+    still show its last real cause (``budget_deferred``, ``worker_lost``,
+    ``soft_timeout``, ...) and be refused here regardless.
     """
     if unit.rate_limit_deferrals <= 0 and unit.rate_limit_first_seen_at is None:
+        return False
+    result = unit.result
+    error_category = (
+        result.get("error_category") if isinstance(result, Mapping) else None
+    )
+    if error_category not in _RATE_LIMIT_EPISODE_ERROR_CATEGORIES:
         return False
     return (
         plan_rate_limit_deferral(

--- a/src/dev_health_ops/sync/budget_guard.py
+++ b/src/dev_health_ops/sync/budget_guard.py
@@ -21,6 +21,7 @@ from dev_health_ops.models import (
 from dev_health_ops.sync.budget import BudgetEstimate, estimate_provider_budget
 from dev_health_ops.workers.rate_limit_defer import (
     RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS,
+    RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
     plan_rate_limit_deferral,
 )
 from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
@@ -56,6 +57,20 @@ class BudgetGuardResult:
     estimates_by_unit: dict[str, tuple[BudgetEstimate, ...]] = field(
         default_factory=dict
     )
+    # The SAME jitter config this pass used for its own cooldown deferrals,
+    # so ``reconfirm_cooldowns`` (called separately, after this returns)
+    # applies byte-identical jitter rather than re-reading the env var and
+    # risking drift if it changed mid-pass.
+    jitter_seconds: int = 5
+
+
+@dataclass(frozen=True)
+class CooldownReconfirmResult:
+    """Result of :meth:`BudgetGuard.reconfirm_cooldowns` -- the late,
+    pre-claim re-check (CHAOS-2760 TOCTOU closure)."""
+
+    excluded_unit_ids: frozenset[str] = frozenset()
+    next_deferred_at: datetime | None = None
 
 
 class BudgetGuard:
@@ -179,11 +194,12 @@ class BudgetGuard:
             candidates=units,
             now=enforced_at,
         )
-        if cooldown_by_family or cooldown_by_dimension:
-            for unit in units:
-                estimates = estimates_by_unit[str(unit.id)]
-                if not estimates:
-                    continue
+        for unit in units:
+            estimates = estimates_by_unit[str(unit.id)]
+            if not estimates:
+                continue
+            cooldown_expiry = None
+            if cooldown_by_family or cooldown_by_dimension:
                 cooldown_expiry = _matching_cooldown_expiry(
                     estimates,
                     org_id=str(unit.org_id),
@@ -192,28 +208,42 @@ class BudgetGuard:
                     cooldown_by_family=cooldown_by_family,
                     cooldown_by_dimension=cooldown_by_dimension,
                 )
-                if cooldown_expiry is None:
-                    continue
+            log_ctx = _unit_log_context(sync_run_id, unit)
+            if cooldown_expiry is not None:
                 outcome = _apply_cooldown_deferral(
                     session,
                     unit,
                     cooldown_expiry=cooldown_expiry,
                     jitter_seconds=jitter_seconds,
                     now=enforced_at,
-                    log_ctx=_unit_log_context(sync_run_id, unit),
+                    log_ctx=log_ctx,
                 )
-                if outcome is None:
-                    # CAS lost the race (unit moved on concurrently) — leave
-                    # it for the budget loop / _claim_units to sort out, same
-                    # as a lost _defer_unit_for_budget race.
-                    continue
-                cooldown_handled_unit_ids.add(str(unit.id))
-                available_at, terminalized = outcome
-                if terminalized:
-                    continue
-                deferred_unit_ids.add(str(unit.id))
-                if next_deferred_at is None or available_at < next_deferred_at:
-                    next_deferred_at = available_at
+            elif _rate_limit_deferral_exhausted(unit, now=enforced_at):
+                # Review finding: termination must not depend on a
+                # currently-visible cooldown observation -- the lookback
+                # window can age the causing row out of visibility at
+                # roughly the SAME instant the unit's own wall-clock
+                # deferral budget expires. Terminalize from the unit's own
+                # persisted rate_limit_deferrals/rate_limit_first_seen_at
+                # state instead of letting it dispatch and burn a worker
+                # slot only to rediscover the same exhaustion in-worker.
+                outcome = _terminalize_rate_limit_exhausted(
+                    session, unit, now=enforced_at, log_ctx=log_ctx
+                )
+            else:
+                continue
+            if outcome is None:
+                # CAS lost the race (unit moved on concurrently) — leave
+                # it for the budget loop / _claim_units to sort out, same
+                # as a lost _defer_unit_for_budget race.
+                continue
+            cooldown_handled_unit_ids.add(str(unit.id))
+            available_at, terminalized = outcome
+            if terminalized:
+                continue
+            deferred_unit_ids.add(str(unit.id))
+            if next_deferred_at is None or available_at < next_deferred_at:
+                next_deferred_at = available_at
 
         consumed_by_bucket = _active_budget_consumption(
             session,
@@ -289,6 +319,7 @@ class BudgetGuard:
             next_deferred_at=next_deferred_at,
             candidate_units=tuple(units),
             estimates_by_unit=estimates_by_unit,
+            jitter_seconds=jitter_seconds,
         )
 
     @staticmethod
@@ -299,8 +330,9 @@ class BudgetGuard:
         units: Iterable[SyncRunUnit],
         estimates_by_unit: Mapping[str, tuple[BudgetEstimate, ...]],
         already_excluded_ids: frozenset[str],
+        jitter_seconds: int,
         now: datetime | None = None,
-    ) -> frozenset[str]:
+    ) -> CooldownReconfirmResult:
         """Close the TOCTOU window between ``enforce_run``'s cooldown
         snapshot and the atomic claim (CHAOS-2760 review finding).
 
@@ -318,25 +350,44 @@ class BudgetGuard:
         (``_matching_cooldown_expiry`` -- byte-identical semantics,
         including the ambiguous-dimension fallback) against the estimates
         ``enforce_run`` already computed (no re-estimation, no credential
-        decryption), as the LAST read before the claim. It does not
-        re-stamp RETRYING/FAILED here -- it only returns the unit ids to
-        additionally exclude from this pass's claim; a unit caught only by
-        this late check is simply left PLANNED/RETRYING-due for the next
-        ``enforce_run`` pass, which will formally defer/terminalize it with
-        full budget bookkeeping. This does not achieve full serializability
-        (a commit landing in the few-microsecond gap between this query and
-        the claim's own UPDATE could still slip through), but it collapses
-        the window from "however long budget admission takes" down to
-        "back-to-back statements", consistent with how the rest of this
-        module tolerates narrow races via CAS predicates rather than
-        SERIALIZABLE transactions.
+        decryption), as the LAST read before the claim.
+
+        A unit caught here is NOT merely excluded -- review finding (round
+        2): a bare exclusion left it PLANNED with no ``RETRYING`` stamp, no
+        ``available_at``, and no ``rate_limit_deferrals`` increment, which
+        both breaks the "cooldown deferrals count against the shared
+        rate-limit budget" binding decision AND livelocks the run (a
+        PLANNED unit is "dispatchable" for ``_pending_unit_counts``, so it
+        redispatches on a bare ~60s countdown forever, re-triggering this
+        same exclusion indefinitely without ever accumulating enough
+        deferrals to terminalize). Every match here goes through the exact
+        same write path ``enforce_run``'s own cooldown loop uses
+        (``_apply_cooldown_deferral`` / ``_terminalize_rate_limit_exhausted``
+        for the wall-clock-exhausted-without-a-visible-observation case) --
+        one deferral semantics, reused by both call sites, not a second,
+        weaker one.
+
+        Returns the unit ids to additionally exclude from this pass's claim
+        (deferred AND terminalized -- terminalized units are already
+        ``FAILED`` and would not match ``_claim_units``' predicate anyway,
+        but including them keeps the exclusion set self-documenting) plus
+        the earliest new ``available_at``, so the caller can fold it into
+        ``next_deferred_at`` for the ``_schedule_redispatch`` re-arm.
+
+        This does not achieve full serializability (a commit landing in the
+        few-microsecond gap between this query and the claim's own
+        ``UPDATE`` could still slip through), but it collapses the window
+        from "however long budget admission takes" down to "back-to-back
+        statements", consistent with how the rest of this module tolerates
+        narrow races via CAS predicates rather than ``SERIALIZABLE``
+        transactions.
         """
         checked_at = now or datetime.now(timezone.utc)
         candidates = [
             unit for unit in units if str(unit.id) not in already_excluded_ids
         ]
         if not candidates:
-            return frozenset()
+            return CooldownReconfirmResult()
 
         cooldown_by_family, cooldown_by_dimension = _active_cooldowns(
             session,
@@ -344,32 +395,63 @@ class BudgetGuard:
             candidates=candidates,
             now=checked_at,
         )
-        if not cooldown_by_family and not cooldown_by_dimension:
-            return frozenset()
 
-        matched: set[str] = set()
+        excluded: set[str] = set()
+        next_deferred_at: datetime | None = None
         for unit in candidates:
             estimates = estimates_by_unit.get(str(unit.id), ())
             if not estimates:
                 continue
-            expiry = _matching_cooldown_expiry(
-                estimates,
-                org_id=str(unit.org_id),
-                provider=str(unit.provider),
-                integration_id=unit.integration_id,
-                cooldown_by_family=cooldown_by_family,
-                cooldown_by_dimension=cooldown_by_dimension,
-            )
-            if expiry is not None:
-                matched.add(str(unit.id))
-                logger.info(
-                    "dispatch_sync_run.rate_limit_cooldown_reconfirmed_exclusion",
-                    extra={
-                        "sync_run_id": sync_run_id,
-                        "unit_id": str(unit.id),
-                    },
+            cooldown_expiry = None
+            if cooldown_by_family or cooldown_by_dimension:
+                cooldown_expiry = _matching_cooldown_expiry(
+                    estimates,
+                    org_id=str(unit.org_id),
+                    provider=str(unit.provider),
+                    integration_id=unit.integration_id,
+                    cooldown_by_family=cooldown_by_family,
+                    cooldown_by_dimension=cooldown_by_dimension,
                 )
-        return frozenset(matched)
+            log_ctx = _unit_log_context(sync_run_id, unit)
+            if cooldown_expiry is not None:
+                outcome = _apply_cooldown_deferral(
+                    session,
+                    unit,
+                    cooldown_expiry=cooldown_expiry,
+                    jitter_seconds=jitter_seconds,
+                    now=checked_at,
+                    log_ctx=log_ctx,
+                )
+            elif _rate_limit_deferral_exhausted(unit, now=checked_at):
+                outcome = _terminalize_rate_limit_exhausted(
+                    session, unit, now=checked_at, log_ctx=log_ctx
+                )
+            else:
+                continue
+            if outcome is None:
+                # CAS lost the race -- unit moved on concurrently since the
+                # candidate snapshot was built; leave it for _claim_units to
+                # sort out on its own terms.
+                continue
+            excluded.add(str(unit.id))
+            available_at, terminalized = outcome
+            logger.info(
+                "dispatch_sync_run.rate_limit_cooldown_reconfirmed",
+                extra={
+                    "sync_run_id": sync_run_id,
+                    "unit_id": str(unit.id),
+                    "terminalized": terminalized,
+                },
+            )
+            if not terminalized and (
+                next_deferred_at is None or available_at < next_deferred_at
+            ):
+                next_deferred_at = available_at
+
+        return CooldownReconfirmResult(
+            excluded_unit_ids=frozenset(excluded),
+            next_deferred_at=next_deferred_at,
+        )
 
 
 def _dispatch_candidate_units(
@@ -536,10 +618,24 @@ def _cooldown_expiry(observation: ProviderRateLimitObservation) -> datetime:
 
 def _cooldown_lookback_seconds() -> int:
     # Bounds the observation query to a recency window so the lookup stays
-    # cheap regardless of the table's 14-day (default) retention. 2h matches
-    # RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS -- the longest a real cooldown
-    # (chunked provider resets included) can legitimately still be active.
-    return _env_int("SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SECONDS", 2 * 60 * 60)
+    # cheap regardless of the table's 14-day (default) retention.
+    #
+    # Review finding (round 2): the default must NOT equal
+    # RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS exactly. A unit deferred by this
+    # gate gets available_at clamped to that same wall-clock budget, so it
+    # becomes due again at roughly the SAME age its causing observation's
+    # observed_at has reached -- an equal lookback would age the row out of
+    # visibility at EXACTLY the instant termination should kick in instead,
+    # making the observation invisible right when it matters most. Padded
+    # with the max configured jitter (available_at's own slop) plus a
+    # generous flat skew margin (clock drift / processing latency between
+    # whatever wrote the row and whatever reads it). _rate_limit_deferral_
+    # exhausted() is the belt to this suspenders' braces: termination itself
+    # never depends on this window either way.
+    jitter_max = _env_int("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", 5)
+    skew_margin = _env_int("SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SKEW_SECONDS", 300)
+    default = RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS + jitter_max + skew_margin
+    return _env_int("SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SECONDS", default)
 
 
 def _active_cooldowns(
@@ -692,6 +788,85 @@ def _cooldown_claim_predicate(now: datetime) -> Any:
     )
 
 
+def _rate_limit_deferral_exhausted(unit: SyncRunUnit, *, now: datetime) -> bool:
+    """True when this unit's SHARED rate-limit-deferral budget
+    (``RATE_LIMIT_MAX_DEFERRALS`` / ``RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS``) is
+    already spent, computed purely from the unit's OWN persisted state --
+    independent of whether an observation is currently visible via
+    ``_active_cooldowns`` (review finding: the lookback window can age a
+    real cooldown's causing observation out of visibility at roughly the
+    SAME wall-clock instant the deferral budget itself expires, since
+    ``available_at`` for a cooldown-gated unit is itself derived from that
+    same clamp -- termination must not depend on re-reading the store).
+
+    A fresh unit (``rate_limit_deferrals == 0`` and
+    ``rate_limit_first_seen_at is None``) is never "exhausted" -- this only
+    fires for a unit with genuine prior rate-limit-deferral history (from
+    EITHER this gate or the in-worker 429 path; they share the same
+    columns).
+    """
+    if unit.rate_limit_deferrals <= 0 and unit.rate_limit_first_seen_at is None:
+        return False
+    return (
+        plan_rate_limit_deferral(
+            retry_after_seconds=None,
+            attempts=unit.rate_limit_deferrals,
+            first_seen_at=unit.rate_limit_first_seen_at.isoformat()
+            if unit.rate_limit_first_seen_at
+            else None,
+            now=now,
+        )
+        is None
+    )
+
+
+def _terminalize_rate_limit_exhausted(
+    session: Any,
+    unit: SyncRunUnit,
+    *,
+    now: datetime,
+    log_ctx: dict[str, Any],
+) -> tuple[datetime, bool] | None:
+    """Terminally fail a unit whose shared rate-limit-deferral budget is
+    spent (CHAOS-2742 binding decision: run-liveness beats optimism).
+
+    Shared by :func:`_apply_cooldown_deferral` (when
+    ``plan_rate_limit_deferral`` returns ``None`` for a unit matched by a
+    currently-visible cooldown) and the wall-clock-exhaustion-without-a-
+    visible-observation path in ``enforce_run`` / ``reconfirm_cooldowns``
+    (review finding) -- one CAS, one code path, for both triggers.
+
+    Returns ``(now, True)`` on a successful CAS transition, or ``None`` if
+    the CAS lost the race (the unit moved on concurrently).
+    """
+    claim_predicate = _cooldown_claim_predicate(now)
+    result: Any = session.execute(
+        update(SyncRunUnit)
+        .where(SyncRunUnit.id == unit.id, claim_predicate)
+        .values(
+            status=SyncRunUnitStatus.FAILED.value,
+            error="rate limit cooldown deferral budget exhausted",
+            result={
+                "error_category": _RATE_LIMIT_COOLDOWN_EXHAUSTED_CATEGORY,
+                "rate_limit_deferrals": unit.rate_limit_deferrals,
+            },
+            lease_owner=None,
+            lease_expires_at=None,
+            last_heartbeat_at=now,
+            updated_at=now,
+        )
+        .execution_options(synchronize_session=False)
+    )
+    if int(result.rowcount or 0) == 0:
+        return None
+    unit.status = SyncRunUnitStatus.FAILED.value
+    logger.warning(
+        "dispatch_sync_run.rate_limit_cooldown_exhausted",
+        extra={**log_ctx, "rate_limit_deferrals": unit.rate_limit_deferrals},
+    )
+    return now, True
+
+
 def _apply_cooldown_deferral(
     session: Any,
     unit: SyncRunUnit,
@@ -726,46 +901,31 @@ def _apply_cooldown_deferral(
         else None,
         now=now,
     )
-    claim_predicate = _cooldown_claim_predicate(now)
 
     if deferral is None:
-        result: Any = session.execute(
-            update(SyncRunUnit)
-            .where(SyncRunUnit.id == unit.id, claim_predicate)
-            .values(
-                status=SyncRunUnitStatus.FAILED.value,
-                error="rate limit cooldown deferral budget exhausted",
-                result={
-                    "error_category": _RATE_LIMIT_COOLDOWN_EXHAUSTED_CATEGORY,
-                    "rate_limit_deferrals": unit.rate_limit_deferrals,
-                },
-                lease_owner=None,
-                lease_expires_at=None,
-                last_heartbeat_at=now,
-                updated_at=now,
-            )
-            .execution_options(synchronize_session=False)
+        return _terminalize_rate_limit_exhausted(
+            session, unit, now=now, log_ctx=log_ctx
         )
-        if int(result.rowcount or 0) == 0:
-            return None
-        unit.status = SyncRunUnitStatus.FAILED.value
-        logger.warning(
-            "dispatch_sync_run.rate_limit_cooldown_exhausted",
-            extra={**log_ctx, "rate_limit_deferrals": unit.rate_limit_deferrals},
-        )
-        return now, True
 
+    claim_predicate = _cooldown_claim_predicate(now)
     # Use plan_rate_limit_deferral's OWN not_before, not cooldown_expiry
     # directly: not_before already clamps to the remaining
     # RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS wall-clock budget (review finding --
     # a far-future reset_at must not park a unit past the point the shared
     # deferral budget says to terminalize instead). Add the SAME jitter the
-    # budget-defer path uses, since not_before itself carries none.
+    # budget-defer path uses, since not_before itself carries none -- but
+    # clamp the JITTERED result too (review finding, round 2): jitter added
+    # on top of an ALREADY-clamped not_before can itself push available_at
+    # past the wall-clock deadline. first_seen_at is the deadline's anchor.
     not_before = datetime.fromisoformat(deferral.not_before)
-    available_at = not_before + timedelta(
-        seconds=random.uniform(0, float(jitter_seconds))  # noqa: S311
-    )
     first_seen_at = datetime.fromisoformat(deferral.first_seen_at)
+    wall_clock_deadline = first_seen_at + timedelta(
+        seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS
+    )
+    available_at = min(
+        not_before + timedelta(seconds=random.uniform(0, float(jitter_seconds))),  # noqa: S311
+        wall_clock_deadline,
+    )
     result = session.execute(
         update(SyncRunUnit)
         .where(SyncRunUnit.id == unit.id, claim_predicate)

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -194,6 +194,15 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
                         ),
                         last_retry_reason="expired_lease",
                         retry_exhausted_at=None,
+                        # Review finding (round 3, CHAOS-2760): an
+                        # expired-lease retry is NOT a rate-limit episode --
+                        # clear any stale rate_limit_deferrals/first_seen_at
+                        # carried over from an earlier, resolved rate-limit
+                        # episode, so BudgetGuard's wall-clock-exhaustion
+                        # check (sync/budget_guard.py) never mistakes it for
+                        # an ongoing one.
+                        rate_limit_deferrals=0,
+                        rate_limit_first_seen_at=None,
                         updated_at=now,
                         lease_owner=None,
                         lease_expires_at=None,

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -832,19 +832,27 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
         # can commit a brand-new observation this pass never saw. Re-check
         # once more, right here, as the LAST read before the atomic claim —
         # reusing the estimates enforce_run already computed, no
-        # re-estimation / credential decryption.
-        capped_ids = frozenset(
-            (
-                *capped_ids,
-                *BudgetGuard.reconfirm_cooldowns(
-                    session,
-                    sync_run_id,
-                    units=budget_result.candidate_units,
-                    estimates_by_unit=budget_result.estimates_by_unit,
-                    already_excluded_ids=capped_ids,
-                ),
-            )
+        # re-estimation / credential decryption. reconfirm_cooldowns fully
+        # defers/terminalizes any match it catches (same write path
+        # enforce_run's own cooldown loop uses) — a bare exclusion here
+        # would leave the unit PLANNED with no deferral-budget bookkeeping
+        # and livelock the run on a bare ~60s redispatch countdown (review
+        # finding, round 2).
+        reconfirm_result = BudgetGuard.reconfirm_cooldowns(
+            session,
+            sync_run_id,
+            units=budget_result.candidate_units,
+            estimates_by_unit=budget_result.estimates_by_unit,
+            already_excluded_ids=capped_ids,
+            jitter_seconds=budget_result.jitter_seconds,
         )
+        capped_ids = frozenset((*capped_ids, *reconfirm_result.excluded_unit_ids))
+        next_deferred_at = budget_result.next_deferred_at
+        if reconfirm_result.next_deferred_at is not None and (
+            next_deferred_at is None
+            or reconfirm_result.next_deferred_at < next_deferred_at
+        ):
+            next_deferred_at = reconfirm_result.next_deferred_at
 
         units = _claim_units(session, run_uuid, capped_ids=capped_ids)
         signatures = []
@@ -881,10 +889,8 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
         callback.set(queue="sync")
         try:
             chord(group(signatures), callback).apply_async()
-            if budget_result.next_deferred_at is not None:
-                _schedule_redispatch(
-                    sync_run_id, available_at=budget_result.next_deferred_at
-                )
+            if next_deferred_at is not None:
+                _schedule_redispatch(sync_run_id, available_at=next_deferred_at)
             elif capped_ids:
                 _schedule_redispatch(sync_run_id)
         except Exception as exc:

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -1162,6 +1162,14 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     duration_seconds=duration_seconds,
                     result=result_payload,
                     error=None,
+                    # Review finding (round 3): SUCCESS ends any rate-limit
+                    # episode this unit was in -- clear the shared deferral
+                    # bookkeeping so a stale first_seen_at from an EARLIER,
+                    # resolved episode can never be misread as still-ongoing
+                    # by the cooldown gate's wall-clock-exhaustion check
+                    # (sync/budget_guard.py _rate_limit_deferral_exhausted).
+                    rate_limit_deferrals=0,
+                    rate_limit_first_seen_at=None,
                     lease_owner=None,
                     lease_expires_at=None,
                     last_heartbeat_at=completed_at,
@@ -1550,6 +1558,13 @@ def _stamp_sync_unit_soft_timeout(
                     ),
                     last_retry_reason="soft_timeout",
                     retry_exhausted_at=None,
+                    # Review finding (round 3): a soft-timeout retry is NOT a
+                    # rate-limit episode -- clear any stale
+                    # rate_limit_deferrals/first_seen_at carried over from an
+                    # earlier, resolved rate-limit episode (same reasoning as
+                    # the budget-guard deferral clear).
+                    rate_limit_deferrals=0,
+                    rate_limit_first_seen_at=None,
                     lease_owner=None,
                     lease_expires_at=None,
                     last_heartbeat_at=completed_at,

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -41,6 +41,7 @@ Observability (CHAOS-2519):
 from __future__ import annotations
 
 import logging
+import math
 import os
 import threading
 import uuid
@@ -91,7 +92,10 @@ from dev_health_ops.sync.watermarks import set_watermark
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.post_sync_dispatch import build_post_sync_dispatch_payload
 from dev_health_ops.workers.queues import _cost_class_queues_enabled
-from dev_health_ops.workers.rate_limit_defer import plan_rate_limit_deferral
+from dev_health_ops.workers.rate_limit_defer import (
+    RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    plan_rate_limit_deferral,
+)
 from dev_health_ops.workers.sync_bootstrap import (
     ProviderRuntimeCache,
     SyncTaskBootstrap,
@@ -637,6 +641,30 @@ def _normalized_rate_limit_reason(exc: BaseException) -> str:
     return _UNKNOWN_RATE_LIMIT_REASON
 
 
+def _sanitize_retry_after_seconds(value: float | None) -> float | None:
+    """Validate a provider-supplied retry-after value before persisting it
+    (CHAOS-2760 review finding). A malformed value here -- a provider bug, a
+    header-parsing edge case, or a literal inf/NaN -- would otherwise flow
+    straight into the durable observation store, where the cooldown-gating
+    consumer's ``timedelta(seconds=...)`` arithmetic raises on a non-finite
+    value; the reader has its own fail-open guard for that
+    (``sync/budget_guard.py``), but a corrupt value should never be written
+    in the first place. Never NaN/inf, never negative, and capped at the
+    same wall-clock budget (``RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS``) the
+    deferral planner enforces -- a provider asking for a longer wait than
+    the run would ever honor is not worth persisting verbatim either.
+    """
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(numeric) or numeric < 0:
+        return None
+    return min(numeric, float(RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS))
+
+
 def _build_rate_limit_observation(
     *,
     unit: SyncRunUnit,
@@ -666,6 +694,7 @@ def _build_rate_limit_observation(
     retry_after_seconds = getattr(exc, "retry_after_seconds", None)
     if retry_after_seconds is None and signal is not None:
         retry_after_seconds = signal.retry_after_seconds
+    retry_after_seconds = _sanitize_retry_after_seconds(retry_after_seconds)
     route_family, route_family_attribution = _route_family_and_attribution(
         budget_audit, dimension
     )
@@ -795,6 +824,27 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
             session, sync_run_id, capped_unit_ids=capped_ids
         )
         capped_ids = frozenset((*capped_ids, *budget_result.deferred_unit_ids))
+
+        # CHAOS-2760 TOCTOU closure (review finding): enforce_run's cooldown
+        # snapshot can go stale by the time we reach the claim below —
+        # budget admission does real DB work (re-estimating every active
+        # unit in the bucket) in between, during which a sibling unit's 429
+        # can commit a brand-new observation this pass never saw. Re-check
+        # once more, right here, as the LAST read before the atomic claim —
+        # reusing the estimates enforce_run already computed, no
+        # re-estimation / credential decryption.
+        capped_ids = frozenset(
+            (
+                *capped_ids,
+                *BudgetGuard.reconfirm_cooldowns(
+                    session,
+                    sync_run_id,
+                    units=budget_result.candidate_units,
+                    estimates_by_unit=budget_result.estimates_by_unit,
+                    already_excluded_ids=capped_ids,
+                ),
+            )
+        )
 
         units = _claim_units(session, run_uuid, capped_ids=capped_ids)
         signatures = []

--- a/tests/test_budget_guard_cooldown.py
+++ b/tests/test_budget_guard_cooldown.py
@@ -753,11 +753,17 @@ def test_concurrent_observation_between_enforce_run_and_claim_still_defers_sibli
 
     db_session.refresh(second)
     assert result["queued_units"] == 0
-    # Left exactly as enforce_run's own pass found it -- reconfirm_cooldowns
-    # only EXCLUDES from this pass's claim, it does not stamp RETRYING
-    # itself (the next enforce_run pass formally defers it with full
-    # bookkeeping).
-    assert second.status == SyncRunUnitStatus.PLANNED.value
+    # reconfirm_cooldowns fully defers the match with the SAME write path
+    # enforce_run's own cooldown loop uses (review finding, round 2) -- not
+    # a bare PLANNED exclusion, which would livelock the run on a bare ~60s
+    # redispatch countdown without ever counting against the shared
+    # rate-limit-deferral budget.
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_deferred"
+    assert second.rate_limit_deferrals == 1
+    assert second.available_at is not None
+    assert abs((_aware(second.available_at) - reset_at).total_seconds()) < 10
 
 
 def test_cooldown_available_at_respects_wall_clock_clamp(db_session, monkeypatch):
@@ -767,6 +773,13 @@ def test_cooldown_available_at_respects_wall_clock_clamp(db_session, monkeypatch
     plan_rate_limit_deferral's own not_before clamp must be authoritative,
     or a far-future reset_at parks the unit for hours past the point the
     policy promises terminalization.
+
+    Deliberately uses a NONZERO jitter (review finding, round 2: the
+    original version of this test forced jitter=0, which happened to mask
+    the follow-on bug where jitter is added AFTER the clamp and can itself
+    push available_at past the wall-clock deadline). With not_before
+    already sitting at the clamp boundary, jitter added on top must be
+    clamped back down, not allowed to overshoot.
     """
     from dev_health_ops.workers import sync_units
     from dev_health_ops.workers.rate_limit_defer import (
@@ -797,19 +810,34 @@ def test_cooldown_available_at_respects_wall_clock_clamp(db_session, monkeypatch
     )
     db_session.flush()
 
+    jitter_seconds = 120
     _patch_db_session(monkeypatch, db_session)
     _patch_worker_enqueues(monkeypatch)
-    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", str(jitter_seconds))
 
     sync_units.dispatch_sync_run(str(run.id))
 
     db_session.refresh(second)
     assert second.status == SyncRunUnitStatus.RETRYING.value
     assert second.available_at is not None
-    clamp_boundary = now + timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS)
-    # Lands at the wall-clock clamp boundary, nowhere near the raw reset_at.
-    assert abs((_aware(second.available_at) - clamp_boundary).total_seconds()) < 2
+    deadline = now + timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS)
+    # Never past the wall-clock deadline, even with jitter added on top of
+    # an already-clamped not_before -- a small tolerance only for the clock
+    # drift between this test's `now` and dispatch_sync_run's own `now`.
+    assert _aware(second.available_at) <= deadline + timedelta(seconds=1)
+    # And not clamped away to something implausibly early either.
+    assert _aware(second.available_at) >= deadline - timedelta(
+        seconds=jitter_seconds + 5
+    )
     assert (reset_at - _aware(second.available_at)).total_seconds() > 3600
+
+    # next_deferred_at (the redispatch re-arm) inherits the same clamp.
+    outbox = (
+        db_session.query(SyncDispatchOutbox)
+        .filter_by(sync_run_id=run.id, kind=OUTBOX_KIND_DISPATCH)
+        .one()
+    )
+    assert _aware(outbox.available_at) <= deadline + timedelta(seconds=1)
 
 
 def test_cooldown_wall_clock_budget_exhausted_terminalizes_rather_than_sleeping_past_clamp(  # noqa: E501
@@ -916,3 +944,330 @@ def test_cooldown_read_survives_malformed_observation_row(
         record.getMessage() == "dispatch_sync_run.cooldown_observation_row_malformed"
         for record in caplog.records
     )
+
+
+# ---------------------------------------------------------------------------
+# Codex adversarial review round 2 findings
+# ---------------------------------------------------------------------------
+
+
+def test_late_reconfirm_match_short_reset_window_defers_with_full_bookkeeping(
+    db_session, monkeypatch
+):
+    """HIGH finding, round 2: a unit caught ONLY by the late reconfirm pass
+    (not enforce_run's own snapshot) with a SHORT, well-within-budget reset
+    window must get the SAME full deferral bookkeeping a same-pass match
+    would -- available_at, rate_limit_deferrals, error_category, and the
+    next_deferred_at re-arm -- not a bare PLANNED exclusion.
+    """
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    reset_at = datetime.now(timezone.utc) + timedelta(seconds=90)
+    real_reconfirm = BudgetGuard.reconfirm_cooldowns
+
+    def _reconfirm_after_concurrent_commit(*args, **kwargs):
+        db_session.add(
+            _observation(
+                run,
+                first,
+                route_family="git",
+                dimension="rest_core",
+                reset_at=reset_at,
+                observed_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            )
+        )
+        db_session.flush()
+        return real_reconfirm(*args, **kwargs)
+
+    monkeypatch.setattr(
+        BudgetGuard,
+        "reconfirm_cooldowns",
+        staticmethod(_reconfirm_after_concurrent_commit),
+    )
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_deferred"
+    assert second.rate_limit_deferrals == 1
+    assert second.rate_limit_first_seen_at is not None
+    assert second.available_at is not None
+    assert abs((_aware(second.available_at) - reset_at).total_seconds()) < 5
+
+    outbox = (
+        db_session.query(SyncDispatchOutbox)
+        .filter_by(sync_run_id=run.id, kind=OUTBOX_KIND_DISPATCH)
+        .one()
+    )
+    assert abs((_aware(outbox.available_at) - reset_at).total_seconds()) < 5
+
+
+def test_late_reconfirm_match_long_reset_window_clamps_to_wall_clock_deadline(
+    db_session, monkeypatch
+):
+    """HIGH finding, round 2: a unit caught only by the late reconfirm pass
+    with a LONG reset window (well beyond the wall-clock deferral budget)
+    still gets the SAME clamp-to-deadline treatment a same-pass match
+    would: available_at lands at the deadline, not the raw far-future
+    reset_at, and the unit is DEFERRED (not yet exhausted) with full
+    bookkeeping -- proving the late path reuses the exact same
+    _apply_cooldown_deferral clamp logic, not a second, weaker one.
+    """
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import (
+        RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    )
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    reset_at = now + timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS * 5)
+    real_reconfirm = BudgetGuard.reconfirm_cooldowns
+
+    def _reconfirm_after_concurrent_commit(*args, **kwargs):
+        db_session.add(
+            _observation(
+                run,
+                first,
+                route_family="git",
+                dimension="rest_core",
+                reset_at=reset_at,
+                observed_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            )
+        )
+        db_session.flush()
+        return real_reconfirm(*args, **kwargs)
+
+    monkeypatch.setattr(
+        BudgetGuard,
+        "reconfirm_cooldowns",
+        staticmethod(_reconfirm_after_concurrent_commit),
+    )
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_deferred"
+    assert second.rate_limit_deferrals == 1
+    deadline = now + timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS)
+    assert second.available_at is not None
+    assert abs((_aware(second.available_at) - deadline).total_seconds()) < 5
+    assert (reset_at - _aware(second.available_at)).total_seconds() > 3600
+
+    outbox = (
+        db_session.query(SyncDispatchOutbox)
+        .filter_by(sync_run_id=run.id, kind=OUTBOX_KIND_DISPATCH)
+        .one()
+    )
+    assert abs((_aware(outbox.available_at) - deadline).total_seconds()) < 5
+
+
+def test_reconfirm_cooldowns_terminalizes_exhausted_match_directly(
+    db_session, monkeypatch
+):
+    """HIGH finding, round 2: reconfirm_cooldowns' own cooldown-match branch
+    must terminalize (not just exclude) a unit whose shared rate-limit-
+    deferral budget is already spent -- not a bare PLANNED exclusion that
+    would livelock the run redispatching every ~60s forever without ever
+    counting against the budget.
+
+    Calls BudgetGuard.reconfirm_cooldowns directly rather than going through
+    dispatch_sync_run: an already-exhausted unit is ALSO caught by
+    enforce_run's own pass (the finding-2a wall-clock-exhaustion check runs
+    unconditionally, independent of any observation), so routing this
+    through the full dispatch flow would only prove enforce_run's check
+    fired first, not that reconfirm_cooldowns' OWN termination branch works.
+    This isolates reconfirm_cooldowns' write path specifically.
+    """
+    from dev_health_ops.sync.budget import estimate_provider_budget
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+    from dev_health_ops.workers.rate_limit_defer import RATE_LIMIT_MAX_DEFERRALS
+    from dev_health_ops.workers.sync_bootstrap import SyncTaskBootstrap
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run,
+        first,
+        dataset_key="commits",
+        processor_flags={"sync_git": True},
+        rate_limit_deferrals=RATE_LIMIT_MAX_DEFERRALS,
+        rate_limit_first_seen_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=120),
+            observed_at=now - timedelta(seconds=1),
+        )
+    )
+    db_session.flush()
+
+    ctx = SyncTaskBootstrap.load(db_session, str(second.id))
+    estimates = estimate_provider_budget(ctx)
+
+    result = BudgetGuard.reconfirm_cooldowns(
+        db_session,
+        str(run.id),
+        units=[second],
+        estimates_by_unit={str(second.id): estimates},
+        already_excluded_ids=frozenset(),
+        jitter_seconds=0,
+        now=now,
+    )
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.FAILED.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_exhausted"
+    assert str(second.id) in result.excluded_unit_ids
+    assert result.next_deferred_at is None
+
+
+def test_cooldown_observation_aged_past_lookback_terminalizes_from_unit_state(
+    db_session, monkeypatch
+):
+    """MEDIUM finding, round 2, part (a): termination must not depend on
+    re-reading the observation. Even when the causing observation is FAR
+    older than any plausible lookback window (so _active_cooldowns
+    genuinely cannot see it), a due unit whose own
+    rate_limit_deferrals/rate_limit_first_seen_at already show the shared
+    wall-clock deferral budget spent terminalizes from its own persisted
+    state -- it must not just quietly dispatch because the causing row
+    happened to fall out of the lookback window.
+    """
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import (
+        RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    )
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    now = datetime.now(timezone.utc)
+    second = _sibling_unit(
+        run,
+        first,
+        dataset_key="commits",
+        processor_flags={"sync_git": True},
+        status=SyncRunUnitStatus.RETRYING.value,
+        rate_limit_deferrals=1,
+        rate_limit_first_seen_at=now
+        - timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS + 30),
+    )
+    second.available_at = now - timedelta(seconds=1)  # due
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    # The causing observation is a full day old -- genuinely invisible to
+    # _active_cooldowns under ANY reasonable lookback window.
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(hours=5),
+            observed_at=now - timedelta(days=1),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.FAILED.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_exhausted"
+
+
+def test_cooldown_lookback_window_has_slack_beyond_wall_clock_budget(
+    db_session, monkeypatch
+):
+    """MEDIUM finding, round 2, part (b): the observation lookback window
+    must NOT equal RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS exactly. An observation
+    whose age is JUST past the OLD (bare-wall-clock-budget) boundary must
+    still be visible under the widened default, deferring a FRESH sibling
+    normally -- not letting it silently dispatch just because the row
+    happened to be a couple of minutes past that old cliff edge.
+    """
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import (
+        RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    )
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    # 90s past the OLD (bare wall-clock-budget) lookback boundary -- must
+    # still fall within the widened default (budget + jitter_max + a
+    # generous skew margin, comfortably more than 90s of slack).
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(minutes=5),
+            observed_at=now - timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS + 90),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    # Deferred normally (still visible, and a FRESH unit so not exhausted)
+    # -- NOT dispatched, NOT terminalized.
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_deferred"

--- a/tests/test_budget_guard_cooldown.py
+++ b/tests/test_budget_guard_cooldown.py
@@ -1,0 +1,673 @@
+"""Tests for shared cooldown gating at dispatch (CHAOS-2760).
+
+A 429 observed by one unit persists a durable observation row
+(``provider_rate_limit_observations``, CHAOS-2758). Before dispatching a
+run's remaining candidates, ``BudgetGuard.enforce_run`` consults that store
+for an ACTIVE cooldown on the same ``(org_id, provider, integration_id,
+route_family)`` -- org-scoped, deliberately excluding
+``credential_fingerprint``/``host`` -- and defers (or, on rate-limit-deferral
+budget exhaustion, terminally fails) matching sibling units before they burn
+a worker slot re-discovering a limit BudgetGuard already knows about.
+
+Covers:
+  * a persisted cooldown defers PLANNED siblings of the same
+    (provider, integration, route_family).
+  * a cooldown on one route family does not defer a different family of the
+    same integration.
+  * credential rotation between the observation write and the next dispatch
+    pass does not bypass the cooldown (the match key excludes
+    credential_fingerprint entirely).
+  * the ambiguous-attribution fallback: a NULL-family, dimension-tagged
+    observation gates on (org_id, provider, integration_id, dimension)
+    instead of guessing a family.
+  * org isolation: a cooldown recorded under a different org_id never gates,
+    even when (provider, integration_id, route_family) coincide.
+  * fail-open: an observation-store read failure must never block dispatch.
+  * an expired cooldown does not gate.
+  * cooldown deferrals count against the existing per-unit
+    rate_limit_deferrals/rate_limit_first_seen_at budget, and a chronically
+    limited provider terminalizes instead of holding the run open.
+  * exactly one query touches provider_rate_limit_observations per dispatch
+    pass, regardless of candidate count.
+  * BudgetGuardResult.next_deferred_at (from a cooldown deferral) re-arms
+    _schedule_redispatch's outbox wakeup.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models import (
+    Base,
+    ProviderRateLimitObservation,
+    SyncDispatchOutbox,
+    SyncRunMode,
+    SyncRunUnit,
+    SyncRunUnitStatus,
+)
+from dev_health_ops.sync.dispatch_outbox import OUTBOX_KIND_DISPATCH
+from tests.test_sync_units import (
+    _aware,
+    _patch_db_session,
+    _patch_worker_enqueues,
+    _seed_run,
+)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _sibling_unit(
+    run,
+    template: SyncRunUnit,
+    *,
+    provider: str = "github",
+    dataset_key: str = "commits",
+    processor_flags: dict | None = None,
+    status: str = SyncRunUnitStatus.PLANNED.value,
+    rate_limit_deferrals: int = 0,
+    rate_limit_first_seen_at: datetime | None = None,
+) -> SyncRunUnit:
+    return SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=template.integration_id,
+        source_id=template.source_id,
+        provider=provider,
+        dataset_key=dataset_key,
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=status,
+        attempts=0,
+        processor_flags=processor_flags if processor_flags is not None else {},
+        rate_limit_deferrals=rate_limit_deferrals,
+        rate_limit_first_seen_at=rate_limit_first_seen_at,
+    )
+
+
+def _observation(
+    run,
+    unit: SyncRunUnit,
+    *,
+    route_family: str | None,
+    dimension: str | None,
+    observed_at: datetime,
+    route_family_attribution: str | None = None,
+    reset_at: datetime | None = None,
+    retry_after_seconds: float | None = None,
+    org_id: str | None = None,
+    integration_id: uuid.UUID | None = None,
+    provider: str = "github",
+) -> ProviderRateLimitObservation:
+    return ProviderRateLimitObservation(
+        org_id=org_id if org_id is not None else run.org_id,
+        provider=provider,
+        host="api.github.com",
+        integration_id=(
+            integration_id if integration_id is not None else unit.integration_id
+        ),
+        sync_run_id=run.id,
+        sync_run_unit_id=unit.id,
+        route_family=route_family,
+        route_family_attribution=route_family_attribution,
+        dimension=dimension,
+        retry_after_seconds=retry_after_seconds,
+        reset_at=reset_at,
+        reason="primary",
+        request_id=None,
+        observed_at=observed_at,
+    )
+
+
+def test_ambiguous_attribution_constant_matches_observation_writer():
+    """budget_guard duplicates (does not import) sync_units's ambiguous
+    attribution marker to avoid a reverse import cycle -- pin them equal."""
+    from dev_health_ops.sync.budget_guard import (
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION as guard_constant,
+    )
+    from dev_health_ops.workers.sync_units import (
+        _AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION as writer_constant,
+    )
+
+    assert guard_constant == writer_constant == "ambiguous_dimension"
+
+
+def test_sibling_units_deferred_during_active_cooldown(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)  # provider=github, dataset_key=commits
+    first.status = SyncRunUnitStatus.SUCCESS.value  # discovering unit, not a candidate
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    reset_at = now + timedelta(seconds=180)
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=reset_at,
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert result["status"] == "deferred"
+    assert result["queued_units"] == 0
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_deferred"
+    assert second.rate_limit_deferrals == 1
+    assert second.rate_limit_first_seen_at is not None
+    assert second.available_at is not None
+    assert abs((_aware(second.available_at) - reset_at).total_seconds()) < 0.5
+
+
+def test_different_route_family_dispatches_normally(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)  # dataset_key=commits -> route_family "git"
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(run, first, dataset_key="work-items", processor_flags={})
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    # Cooldown on 'prs' (a different route family than second's 'work_items').
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="prs",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=300),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert second.status == SyncRunUnitStatus.DISPATCHING.value
+    assert second.result is None
+
+
+def test_credential_rotation_does_not_bypass_cooldown(db_session, monkeypatch):
+    import json
+
+    from dev_health_ops.core.encryption import encrypt_value
+    from dev_health_ops.models import Integration, IntegrationCredential
+    from dev_health_ops.workers import sync_units
+
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-cooldown-credential-rotation")
+    run, first = _seed_run(db_session)
+    integration = db_session.query(Integration).filter_by(id=first.integration_id).one()
+
+    def _make_credential(name: str, token: str) -> IntegrationCredential:
+        credential = IntegrationCredential(
+            provider="github",
+            name=name,
+            org_id=run.org_id,
+            credentials_encrypted=encrypt_value(json.dumps({"token": token})),
+            config={},
+            is_active=True,
+        )
+        db_session.add(credential)
+        db_session.flush()
+        return credential
+
+    credential_a = _make_credential("primary", "tok-A")
+    integration.credential_id = credential_a.id
+    db_session.flush()
+
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    reset_at = now + timedelta(seconds=180)
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=reset_at,
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    # Rotate the credential BETWEEN the observation write and dispatch.
+    credential_b = _make_credential("secondary", "tok-B")
+    integration.credential_id = credential_b.id
+    db_session.flush()
+    assert credential_a.id != credential_b.id  # the swap was real
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_deferred"
+
+
+def test_ambiguous_attribution_falls_back_to_dimension_gating(db_session, monkeypatch):
+    """Linear's work-items estimator emits multiple route families (teams,
+    issues, cycles, ...) all under graphql_cost -- exactly the case CHAOS-2758
+    cannot confidently attribute to one family. The observation writer marks
+    those rows route_family=NULL, route_family_attribution='ambiguous_dimension'.
+    The gate must fall back to (org_id, provider, integration_id, dimension).
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(
+        db_session,
+        provider="linear",
+        source_type="team",
+        external_id="TEAM",
+        name="TEAM",
+        full_name="TEAM",
+        dataset_key="work-items",
+        processor_flags={},
+    )
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run,
+        first,
+        provider="linear",
+        dataset_key="work-items",
+        processor_flags={},
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    reset_at = now + timedelta(seconds=120)
+    db_session.add(
+        _observation(
+            run,
+            first,
+            provider="linear",
+            route_family=None,
+            route_family_attribution="ambiguous_dimension",
+            dimension="graphql_cost",
+            reset_at=reset_at,
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_deferred"
+    assert second.available_at is not None
+    assert abs((_aware(second.available_at) - reset_at).total_seconds()) < 0.5
+
+
+def test_cooldown_never_crosses_org_boundary(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    # Same (provider, integration_id, route_family) as `second`'s candidate
+    # key, but a DIFFERENT (foreign) org_id -- must NOT gate.
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=300),
+            observed_at=now - timedelta(seconds=5),
+            org_id=f"org-{uuid.uuid4()}",
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert second.status == SyncRunUnitStatus.DISPATCHING.value
+
+
+def test_cooldown_read_failure_fails_open(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    # A REAL active cooldown that would normally gate `second`.
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=300),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    real_query = db_session.query
+
+    def _broken_query(entity, *args, **kwargs):
+        if entity is ProviderRateLimitObservation:
+            raise RuntimeError("simulated observation-store read failure")
+        return real_query(entity, *args, **kwargs)
+
+    monkeypatch.setattr(db_session, "query", _broken_query)
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    # Fail-open: the read blew up, so the gate must act as if no cooldown
+    # existed rather than blocking (or crashing) dispatch.
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert second.status == SyncRunUnitStatus.DISPATCHING.value
+
+
+def test_expired_cooldown_dispatches_normally(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now - timedelta(seconds=30),  # already expired
+            observed_at=now - timedelta(seconds=300),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert second.status == SyncRunUnitStatus.DISPATCHING.value
+
+
+def test_cooldown_expiry_drains_bounded_by_concurrency_cap(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    first.status = SyncRunUnitStatus.RETRYING.value
+    first.available_at = now - timedelta(seconds=5)
+    second = _sibling_unit(
+        run,
+        first,
+        dataset_key="commits",
+        processor_flags={"sync_git": True},
+        status=SyncRunUnitStatus.RETRYING.value,
+    )
+    second.available_at = now - timedelta(seconds=5)
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    # Expired cooldown -- gate must not re-defer either due-RETRYING sibling;
+    # whatever capping happens must come from DispatchGuard's concurrency cap.
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now - timedelta(seconds=1),
+            observed_at=now - timedelta(seconds=120),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_UNIT_CONCURRENCY_PER_BUCKET", "1")
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(first)
+    db_session.refresh(second)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    statuses = {first.status, second.status}
+    assert SyncRunUnitStatus.DISPATCHING.value in statuses
+    dispatched = (
+        first if first.status == SyncRunUnitStatus.DISPATCHING.value else second
+    )
+    capped = second if dispatched is first else first
+    assert dispatched.status == SyncRunUnitStatus.DISPATCHING.value
+    # Concurrency-capped sibling is left untouched by BudgetGuard this pass
+    # (DispatchGuard excludes it from the candidate set entirely) -- NOT
+    # re-stamped by the (expired) cooldown gate.
+    assert capped.status == SyncRunUnitStatus.RETRYING.value
+    assert capped.result is None or (
+        capped.result.get("error_category") != "rate_limit_cooldown_deferred"
+    )
+
+
+def test_cooldown_deferral_consumes_rate_limit_budget_and_terminalizes(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import RATE_LIMIT_MAX_DEFERRALS
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    now = datetime.now(timezone.utc)
+    second = _sibling_unit(
+        run,
+        first,
+        dataset_key="commits",
+        processor_flags={"sync_git": True},
+        rate_limit_deferrals=RATE_LIMIT_MAX_DEFERRALS,
+        rate_limit_first_seen_at=now - timedelta(minutes=5),
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=120),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.FAILED.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_exhausted"
+
+
+def test_single_observation_query_per_dispatch_pass(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    siblings = []
+    for _ in range(3):
+        unit = _sibling_unit(
+            run, first, dataset_key="commits", processor_flags={"sync_git": True}
+        )
+        siblings.append(unit)
+        db_session.add(unit)
+    run.total_units = len(siblings) + 1
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(seconds=180),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    engine = db_session.get_bind()
+    captured: list[str] = []
+
+    def _record(conn, cursor, statement, parameters, context, executemany):  # noqa: ARG001
+        if "provider_rate_limit_observations" in statement:
+            captured.append(statement)
+
+    event.listen(engine, "before_cursor_execute", _record)
+    try:
+        sync_units.dispatch_sync_run(str(run.id))
+    finally:
+        event.remove(engine, "before_cursor_execute", _record)
+
+    select_statements = [
+        stmt for stmt in captured if stmt.strip().upper().startswith("SELECT")
+    ]
+    assert len(select_statements) == 1, (
+        "expected exactly one cooldown-observation SELECT per dispatch pass "
+        f"regardless of candidate count, got {len(select_statements)}: "
+        f"{select_statements}"
+    )
+
+    for sibling in siblings:
+        db_session.refresh(sibling)
+        assert sibling.status == SyncRunUnitStatus.RETRYING.value
+        assert sibling.result is not None
+        assert sibling.result["error_category"] == "rate_limit_cooldown_deferred"
+
+
+def test_next_deferred_at_rearms_redispatch(db_session, monkeypatch):
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    reset_at = now + timedelta(seconds=200)
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=reset_at,
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    outbox = (
+        db_session.query(SyncDispatchOutbox)
+        .filter_by(sync_run_id=run.id, kind=OUTBOX_KIND_DISPATCH)
+        .one()
+    )
+    assert abs((_aware(outbox.available_at) - reset_at).total_seconds()) < 0.5

--- a/tests/test_budget_guard_cooldown.py
+++ b/tests/test_budget_guard_cooldown.py
@@ -41,6 +41,12 @@ Covers:
     sleeping past the clamp (review finding).
   * a malformed observation row (non-finite retry_after_seconds) is skipped,
     not fatal to the whole dispatch pass (review finding).
+  * rate_limit_deferrals/rate_limit_first_seen_at are cleared at episode
+    boundaries (SUCCESS, and any non-rate-limit RETRYING stamp) so stale
+    bookkeeping from an earlier, resolved rate-limit episode can never be
+    misread as an ongoing one by the wall-clock-exhaustion check; a defense-
+    in-depth error_category gate protects against a missed clear site too
+    (review finding).
 """
 
 from __future__ import annotations
@@ -88,6 +94,7 @@ def _sibling_unit(
     status: str = SyncRunUnitStatus.PLANNED.value,
     rate_limit_deferrals: int = 0,
     rate_limit_first_seen_at: datetime | None = None,
+    result: dict | None = None,
 ) -> SyncRunUnit:
     return SyncRunUnit(
         org_id=run.org_id,
@@ -103,6 +110,7 @@ def _sibling_unit(
         processor_flags=processor_flags if processor_flags is not None else {},
         rate_limit_deferrals=rate_limit_deferrals,
         rate_limit_first_seen_at=rate_limit_first_seen_at,
+        result=result,
     )
 
 
@@ -1189,6 +1197,18 @@ def test_cooldown_observation_aged_past_lookback_terminalizes_from_unit_state(
         rate_limit_deferrals=1,
         rate_limit_first_seen_at=now
         - timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS + 30),
+        # A genuine, still-ongoing rate-limit episode: the unit's own last
+        # recorded cause is the cooldown gate's deferral category -- this is
+        # what the round-3 defense-in-depth error_category gate on
+        # _rate_limit_deferral_exhausted requires to even consider
+        # terminalizing (a unit whose last cause was unrelated, e.g.
+        # budget_deferred, must NOT be terminalized off stale columns; see
+        # test_stale_rate_limit_state_does_not_terminalize_unrelated_retry).
+        result={
+            "error_category": "rate_limit_cooldown_deferred",
+            "not_before": (now - timedelta(seconds=1)).isoformat(),
+            "rate_limit_deferrals": 1,
+        },
     )
     second.available_at = now - timedelta(seconds=1)  # due
     run.total_units = 2
@@ -1271,3 +1291,177 @@ def test_cooldown_lookback_window_has_slack_beyond_wall_clock_budget(
     assert second.status == SyncRunUnitStatus.RETRYING.value
     assert second.result is not None
     assert second.result["error_category"] == "rate_limit_cooldown_deferred"
+
+
+# ---------------------------------------------------------------------------
+# Codex adversarial review round 3 finding: stale rate-limit state lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_stale_rate_limit_state_cleared_by_non_rate_limit_retry_then_claimed(
+    db_session, monkeypatch
+):
+    """HIGH finding, round 3, regression (i): a unit carrying STALE
+    rate_limit_deferrals/rate_limit_first_seen_at from an earlier, resolved
+    rate-limit episode must not be wrongly terminalized just because it
+    later goes through an UNRELATED retry (here: budget deferral, not a
+    rate limit). The non-rate-limit deferral clears the stale columns (root
+    fix); the unit is claimed normally on its next due pass instead of
+    being terminalized off ancient data.
+    """
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import (
+        RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    )
+
+    run, unit = _seed_run(db_session)  # provider=github, dataset_key=commits
+    now = datetime.now(timezone.utc)
+    # Stale rate-limit history: well past the wall-clock budget, from a
+    # rate-limit episode that has nothing to do with what happens next.
+    unit.rate_limit_deferrals = 1
+    unit.rate_limit_first_seen_at = now - timedelta(
+        seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS + 3600
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    # Force a budget deferral (unrelated to rate limits) on this pass.
+    monkeypatch.setenv("SYNC_BUDGET_BUCKET_LIMITS", '{"github:rest_core": 0}')
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_SECONDS", "60")
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert result["status"] == "deferred"
+    assert unit.status == SyncRunUnitStatus.RETRYING.value
+    assert unit.result is not None
+    assert unit.result["error_category"] == "budget_deferred"
+    # Root fix: cleared by the non-rate-limit (budget) deferral.
+    assert unit.rate_limit_deferrals == 0
+    assert unit.rate_limit_first_seen_at is None
+
+    # Let the deferral elapse and redispatch -- with clean columns, the unit
+    # is claimed normally instead of being wrongly terminalized off the
+    # stale, unrelated old data.
+    unit.available_at = datetime.now(timezone.utc) - timedelta(seconds=1)
+    monkeypatch.delenv("SYNC_BUDGET_BUCKET_LIMITS", raising=False)
+    db_session.flush()
+
+    result2 = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert result2 == {"status": "dispatched", "queued_units": 1}
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+
+
+def test_stale_rate_limit_columns_without_rate_limit_error_category_do_not_terminalize(  # noqa: E501
+    db_session, monkeypatch
+):
+    """HIGH finding, round 3, defense in depth: even if a unit somehow still
+    carries stale, budget-exhausted-looking rate_limit_deferrals/
+    rate_limit_first_seen_at (simulating a missed clear site),
+    _rate_limit_deferral_exhausted refuses to fire unless the unit's own
+    last-recorded result.error_category is rate-limit-related. A stale row
+    whose last real cause was unrelated (here: worker_lost, as a reconciler
+    expired-lease retry would stamp) must dispatch normally, not
+    terminalize.
+    """
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import (
+        RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    )
+
+    run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    unit.status = SyncRunUnitStatus.RETRYING.value
+    unit.available_at = now - timedelta(seconds=1)
+    unit.rate_limit_deferrals = 1
+    unit.rate_limit_first_seen_at = now - timedelta(
+        seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS + 60
+    )
+    unit.result = {"error_category": "worker_lost", "retry_reason": "expired_lease"}
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(unit)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert unit.status == SyncRunUnitStatus.DISPATCHING.value
+
+
+def test_rate_limit_state_cleared_on_success_starts_fresh_episode_later(
+    db_session, monkeypatch
+):
+    """HIGH finding, round 3, regression (ii): a unit that resolves a
+    rate-limit episode by SUCCEEDING has its rate_limit_deferrals/
+    rate_limit_first_seen_at cleared. A LATER, unrelated rate-limit episode
+    (simulated well past the OLD episode's 2h wall-clock budget) computes
+    its OWN fresh clock starting from the new first_seen_at -- it is not
+    immediately exhausted against the stale old timestamp, which is exactly
+    what would happen if the clear had not fired.
+    """
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.rate_limit_defer import plan_rate_limit_deferral
+    from dev_health_ops.workers.sync_units import run_sync_unit
+    from tests.test_sync_units import (
+        _mark_dispatching,
+        _patch_finalize_apply,
+        _patch_runtime,
+    )
+
+    run, unit = _seed_run(db_session)  # provider=github, dataset_key=commits
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+
+    def rate_limited(ctx, runtime):
+        raise RateLimitException("rate limited", retry_after_seconds=1.0)
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+    assert result["status"] == "rate_limited_deferred"
+
+    db_session.refresh(unit)
+    assert unit.rate_limit_deferrals == 1
+    assert unit.rate_limit_first_seen_at is not None
+    old_first_seen = _aware(unit.rate_limit_first_seen_at)
+
+    # Redispatch -- this time the provider is healthy.
+    _mark_dispatching(db_session, unit)
+
+    def succeeds(ctx, runtime):
+        return {"ok": True}
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", succeeds)
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+    assert result["status"] == "success"
+
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.SUCCESS.value
+    # Root fix: cleared on SUCCESS.
+    assert unit.rate_limit_deferrals == 0
+    assert unit.rate_limit_first_seen_at is None
+
+    # A LATER, unrelated rate-limit episode -- well past the OLD episode's
+    # wall-clock budget -- must start its OWN fresh clock, not be treated
+    # as a continuation of (and therefore immediately exhausted against)
+    # the stale old first_seen_at.
+    much_later = old_first_seen + timedelta(hours=3)
+    deferral = plan_rate_limit_deferral(
+        retry_after_seconds=30.0,
+        attempts=unit.rate_limit_deferrals,
+        first_seen_at=unit.rate_limit_first_seen_at.isoformat()
+        if unit.rate_limit_first_seen_at
+        else None,
+        now=much_later,
+    )
+    assert deferral is not None
+    fresh_first_seen = datetime.fromisoformat(deferral.first_seen_at)
+    assert abs((fresh_first_seen - much_later).total_seconds()) < 1

--- a/tests/test_budget_guard_cooldown.py
+++ b/tests/test_budget_guard_cooldown.py
@@ -31,6 +31,16 @@ Covers:
     pass, regardless of candidate count.
   * BudgetGuardResult.next_deferred_at (from a cooldown deferral) re-arms
     _schedule_redispatch's outbox wakeup.
+  * TOCTOU closure (review finding): a sibling's 429 committing a brand-new
+    observation between enforce_run's snapshot and the atomic claim is still
+    caught by the late reconfirm_cooldowns check, immediately before
+    _claim_units.
+  * available_at respects plan_rate_limit_deferral's wall-clock clamp
+    (RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS), not the raw cooldown expiry, and a
+    unit whose wall-clock budget is already spent terminalizes rather than
+    sleeping past the clamp (review finding).
+  * a malformed observation row (non-finite retry_after_seconds) is skipped,
+    not fatal to the whole dispatch pass (review finding).
 """
 
 from __future__ import annotations
@@ -671,3 +681,238 @@ def test_next_deferred_at_rearms_redispatch(db_session, monkeypatch):
         .one()
     )
     assert abs((_aware(outbox.available_at) - reset_at).total_seconds()) < 0.5
+
+
+# ---------------------------------------------------------------------------
+# Codex adversarial review round 1 findings
+# ---------------------------------------------------------------------------
+
+
+def test_concurrent_observation_between_enforce_run_and_claim_still_defers_sibling(
+    db_session, monkeypatch
+):
+    """HIGH finding: BudgetGuard.enforce_run reads
+    provider_rate_limit_observations once, early in its pass, then does more
+    real DB work of its own (budget admission / active-consumption
+    re-estimation) before returning. Under READ COMMITTED, a sibling unit's
+    429 can commit a brand-new observation in exactly that window -- one
+    enforce_run's snapshot never saw -- and without a second look,
+    _claim_units would dispatch straight into it.
+
+    Simulates that race deterministically: NO observation exists when
+    enforce_run runs (so its own snapshot is clean), then a fresh row is
+    inserted+flushed the instant BudgetGuard.reconfirm_cooldowns is invoked
+    (the seam dispatch_sync_run calls immediately before _claim_units) --
+    mirroring a concurrent transaction's commit landing in that gap. The
+    fresh row must still be caught before the atomic claim.
+    """
+    from dev_health_ops.sync.budget_guard import BudgetGuard
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+    # Deliberately no observation seeded yet -- enforce_run's own read must
+    # see nothing active, proving the race window is real (not just "the
+    # gate never ran").
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    reset_at = datetime.now(timezone.utc) + timedelta(seconds=180)
+    real_reconfirm = BudgetGuard.reconfirm_cooldowns
+
+    def _reconfirm_after_concurrent_commit(*args, **kwargs):
+        # The "concurrent commit" -- lands strictly AFTER enforce_run's own
+        # cooldown snapshot, strictly BEFORE the late re-check.
+        db_session.add(
+            _observation(
+                run,
+                first,
+                route_family="git",
+                dimension="rest_core",
+                reset_at=reset_at,
+                observed_at=datetime.now(timezone.utc) - timedelta(seconds=1),
+            )
+        )
+        db_session.flush()
+        return real_reconfirm(*args, **kwargs)
+
+    monkeypatch.setattr(
+        BudgetGuard,
+        "reconfirm_cooldowns",
+        staticmethod(_reconfirm_after_concurrent_commit),
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert result["queued_units"] == 0
+    # Left exactly as enforce_run's own pass found it -- reconfirm_cooldowns
+    # only EXCLUDES from this pass's claim, it does not stamp RETRYING
+    # itself (the next enforce_run pass formally defers it with full
+    # bookkeeping).
+    assert second.status == SyncRunUnitStatus.PLANNED.value
+
+
+def test_cooldown_available_at_respects_wall_clock_clamp(db_session, monkeypatch):
+    """HIGH finding: _apply_cooldown_deferral must not stamp
+    available_at=cooldown_expiry+jitter when cooldown_expiry is beyond the
+    remaining RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS wall-clock budget --
+    plan_rate_limit_deferral's own not_before clamp must be authoritative,
+    or a far-future reset_at parks the unit for hours past the point the
+    policy promises terminalization.
+    """
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import (
+        RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    )
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    # Reset_at is 5x the wall-clock budget out -- must NOT be honored as-is.
+    reset_at = now + timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS * 5)
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=reset_at,
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("SYNC_BUDGET_DEFERRAL_JITTER_SECONDS", "0")
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.RETRYING.value
+    assert second.available_at is not None
+    clamp_boundary = now + timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS)
+    # Lands at the wall-clock clamp boundary, nowhere near the raw reset_at.
+    assert abs((_aware(second.available_at) - clamp_boundary).total_seconds()) < 2
+    assert (reset_at - _aware(second.available_at)).total_seconds() > 3600
+
+
+def test_cooldown_wall_clock_budget_exhausted_terminalizes_rather_than_sleeping_past_clamp(  # noqa: E501
+    db_session, monkeypatch
+):
+    """HIGH finding, second half: once the wall-clock deferral budget is
+    already spent (simulating "the following pass" via a pre-seeded
+    first_seen_at), a unit gated by a still-active cooldown must terminalize
+    -- not get re-deferred past the clamp plan_rate_limit_deferral already
+    said was the limit.
+    """
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.rate_limit_defer import (
+        RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    )
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    now = datetime.now(timezone.utc)
+    second = _sibling_unit(
+        run,
+        first,
+        dataset_key="commits",
+        processor_flags={"sync_git": True},
+        rate_limit_deferrals=1,
+        rate_limit_first_seen_at=now
+        - timedelta(seconds=RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS + 60),
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    # Still an active (future) cooldown per the observation itself --
+    # exhaustion must come from the wall-clock budget, not an expired row.
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=now + timedelta(hours=5),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert second.status == SyncRunUnitStatus.FAILED.value
+    assert second.result is not None
+    assert second.result["error_category"] == "rate_limit_cooldown_exhausted"
+
+
+def test_cooldown_read_survives_malformed_observation_row(
+    db_session, monkeypatch, caplog
+):
+    """MEDIUM finding: a malformed row (non-finite retry_after_seconds, no
+    usable reset_at) must not abort the whole cooldown read and block
+    dispatch org-wide -- it is skipped, logged, and treated as no signal.
+    """
+    import logging
+
+    from dev_health_ops.workers import sync_units
+
+    run, first = _seed_run(db_session)
+    first.status = SyncRunUnitStatus.SUCCESS.value
+    second = _sibling_unit(
+        run, first, dataset_key="commits", processor_flags={"sync_git": True}
+    )
+    run.total_units = 2
+    db_session.add(second)
+    db_session.flush()
+
+    now = datetime.now(timezone.utc)
+    # No reset_at, an infinite retry_after_seconds -- timedelta(seconds=inf)
+    # raises OverflowError if unguarded.
+    db_session.add(
+        _observation(
+            run,
+            first,
+            route_family="git",
+            dimension="rest_core",
+            reset_at=None,
+            retry_after_seconds=float("inf"),
+            observed_at=now - timedelta(seconds=5),
+        )
+    )
+    db_session.flush()
+
+    _patch_db_session(monkeypatch, db_session)
+    _patch_worker_enqueues(monkeypatch)
+
+    with caplog.at_level(logging.WARNING, logger="dev_health_ops.sync.budget_guard"):
+        result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(second)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert second.status == SyncRunUnitStatus.DISPATCHING.value
+    assert any(
+        record.getMessage() == "dispatch_sync_run.cooldown_observation_row_malformed"
+        for record in caplog.records
+    )

--- a/tests/test_rate_limit_observations.py
+++ b/tests/test_rate_limit_observations.py
@@ -367,6 +367,90 @@ def test_observation_route_family_ambiguous_for_linear_work_items(
     assert observation.dimension == "graphql_cost"
 
 
+def test_observation_sanitizes_non_finite_retry_after_seconds(db_session, monkeypatch):
+    """CHAOS-2760 cooldown-gating review finding: a provider-supplied
+    ``retry_after_seconds`` that is inf/NaN/negative must never persist
+    verbatim. The cooldown-gating reader's ``timedelta(seconds=...)``
+    arithmetic raises on a non-finite value; the reader has its own
+    fail-open guard for that (``sync/budget_guard.py``), but a corrupt value
+    should never be written to the observation store in the first place.
+    """
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)  # provider=github, dataset_key=commits
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    def rate_limited(ctx, runtime):
+        raise RateLimitException(
+            "GitHub primary rate limit exceeded",
+            retry_after_seconds=float("inf"),
+            signal=RateLimitSignal(
+                provider="github",
+                dimension=BudgetDimension.REST_CORE,
+                retry_after_seconds=float("inf"),
+                reason="primary",
+            ),
+        )
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "rate_limited_deferred"
+    observation = db_session.query(ProviderRateLimitObservation).one()
+    assert observation.retry_after_seconds is None
+
+
+def test_observation_clamps_excessive_retry_after_seconds(db_session, monkeypatch):
+    """A finite but absurd ``retry_after_seconds`` is clamped to the same
+    wall-clock budget the deferral planner enforces
+    (``RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS``), not persisted verbatim -- a
+    provider asking for a longer wait than the run would ever honor is not
+    worth keeping as-is in the durable store.
+    """
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.rate_limit_defer import (
+        RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS,
+    )
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    _clean_env(monkeypatch)
+
+    absurd_delay = float(RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS * 100)
+
+    def rate_limited(ctx, runtime):
+        raise RateLimitException(
+            "GitHub primary rate limit exceeded",
+            retry_after_seconds=absurd_delay,
+            signal=RateLimitSignal(
+                provider="github",
+                dimension=BudgetDimension.REST_CORE,
+                retry_after_seconds=absurd_delay,
+                reason="primary",
+            ),
+        )
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", rate_limited)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "rate_limited_deferred"
+    observation = db_session.query(ProviderRateLimitObservation).one()
+    assert observation.retry_after_seconds == float(RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS)
+
+
 def test_route_family_resolution_keeps_unique_match_and_refuses_to_guess():
     """Unit test of the confidence-gated route-family attribution (CHAOS-2758
     review fix): dimension alone does not disambiguate multi-family units, so


### PR DESCRIPTION
## Problem

Today a provider 429 only defers the discovering unit (`workers/sync_units.py`'s `except RateLimitException` branch). Sibling sync units of the same provider/integration/route-family still dispatch and independently rediscover the same limit in-worker — each burning a worker slot and a provider round-trip that the durable observation store (CHAOS-2758) already knows is futile.

## Fix

- **Gate placement**: inside `BudgetGuard.enforce_run` (`sync/budget_guard.py`), after per-candidate context/estimate loading and advisory-lock acquisition, before budget admission — so a cooldown-gated unit never also reserves budget capacity it won't use this pass.
- **Match key**: `(org_id, provider, integration_id, route_family)` — org-scoped, **deliberately excluding `credential_fingerprint`/`host`** so rotating a credential can never bypass an active cooldown (the credentials-are-not-capacity invariant applied to gating). `host` stays diagnostic-only on the observation row.
- **Ambiguous-attribution fallback**: per CHAOS-2758's confidence gate, a row with `route_family=NULL` + `route_family_attribution='ambiguous_dimension'` carries a populated `dimension` instead. The gate never treats a NULL family as matching everything or nothing — it falls back to `(org_id, provider, integration_id, dimension)` matching instead of guessing a family.
- **Cooldown window**: `coalesce(reset_at, observed_at + retry_after_seconds)`, falling back to a conservative fixed window (`RATE_LIMIT_DEFAULT_COUNTDOWN_SECONDS`, 60s) when an observation carried neither. `available_at` = cooldown expiry + the existing budget-deferral jitter (`SYNC_BUDGET_DEFERRAL_JITTER_SECONDS`), not a fixed 60s. A unit whose estimates span multiple route families defers if **any** one is cooling down (mirrors the existing would-defer-any-estimate semantics) and waits for the last one to clear when more than one matches.
- **One indexed query per dispatch pass, never per unit** — scoped to the pass's candidate `(org_id, provider, integration_id)` tuples and a bounded recency window (`SYNC_RATE_LIMIT_COOLDOWN_LOOKBACK_SECONDS`, default 2h), using the `ws-d` `(provider, integration_id, route_family, observed_at)` index. **Fails open** on any read error — logs and proceeds as if no cooldown existed.
- **No new unit status**: a gated unit is stamped `RETRYING` with the computed `available_at`, exactly like `_defer_unit_for_budget`, but with a distinct `result.error_category = 'rate_limit_cooldown_deferred'` (vs. `budget_deferred` / `rate_limit`). `BudgetGuardResult.next_deferred_at` folds in cooldown deferrals too, so the existing `_schedule_redispatch` re-arm fires with zero changes to `sync_units.py`.
- **Cooldown deferrals count against the existing per-unit rate-limit-deferral budget** (`workers/rate_limit_defer.plan_rate_limit_deferral`, `RATE_LIMIT_MAX_DEFERRALS=10` / `RATE_LIMIT_MAX_TOTAL_WAIT_SECONDS=2h`) — the SAME `rate_limit_deferrals`/`rate_limit_first_seen_at` columns the in-worker 429 path already uses. Binding CHAOS-2742 recon decision: run-liveness beats optimism, so a chronically rate-limited provider **terminalizes** (`FAILED`, `error_category=rate_limit_cooldown_exhausted`) once that budget is spent, rather than holding the run open indefinitely.
- Appended a "Cooldown gating" section to `docs/providers/rate-limit-policy.md`, updated Known Gaps / Target Contracts.

## Tests

New `tests/test_budget_guard_cooldown.py` (12 tests):
- `test_sibling_units_deferred_during_active_cooldown` — persisted 429 observation defers a PLANNED sibling with `available_at` ≈ cooldown expiry and the distinct error_category.
- `test_different_route_family_dispatches_normally` — a cooldown on `prs` does not defer a `work_items` sibling of the same integration.
- `test_credential_rotation_does_not_bypass_cooldown` — rotating the integration's credential between the observation write and the next dispatch still defers the sibling.
- `test_ambiguous_attribution_falls_back_to_dimension_gating` — Linear's multi-family `work-items` estimator (all `graphql_cost`) is gated via the dimension fallback.
- `test_cooldown_never_crosses_org_boundary` — a forged observation row sharing `(provider, integration_id, route_family)` but a different `org_id` does not gate.
- `test_cooldown_read_failure_fails_open` — a broken observation-store read dispatches normally despite a real active cooldown existing.
- `test_expired_cooldown_dispatches_normally`.
- `test_cooldown_expiry_drains_bounded_by_concurrency_cap` — post-expiry drain still respects `SYNC_UNIT_CONCURRENCY_PER_BUCKET`.
- `test_cooldown_deferral_consumes_rate_limit_budget_and_terminalizes` — a unit already at the deferral budget terminalizes instead of re-deferring.
- `test_single_observation_query_per_dispatch_pass` — exactly one query regardless of candidate count.
- `test_next_deferred_at_rearms_redispatch` — the outbox wakeup reflects the cooldown-derived `next_deferred_at`.
- `test_ambiguous_attribution_constant_matches_observation_writer` — pins the duplicated `_AMBIGUOUS_ROUTE_FAMILY_ATTRIBUTION` constant against the CHAOS-2758 writer's.

**Gate**: `SCRATCH_DB=ci_local_validate_2760 bash ci/local_validate.sh` (env-scrubbed) — ruff format, ruff check, mypy, full unit suite (6238 passed, 44 pre-existing skips, no failures), and the live-ClickHouse argMax proof all green. Rebased onto latest `origin/main` before push (no conflicts — no overlapping files with the concurrently merged CHAOS-2764 PR).

Part of CHAOS-2742
Fixes CHAOS-2760
https://linear.app/fullchaos/issue/CHAOS-2760