### PR TITLE
fix(investment): emit stale-scope telemetry for breakdown reads (CHAOS-2765)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -451,6 +451,13 @@ async def _execute_breakdown_query(
 
     sql, params = compile_breakdown(request, org_id, timeout, filters=filters)
 
+    # CHAOS-2765: breakdown reads compile the CHAOS-2764 membership-scoped
+    # work-unit CTE just like timeseries/coverage/sankey, so the stale-scope
+    # counter must cover this surface too. Mirror _execute_timeseries_query:
+    # emit before execution when the investment (scoped) path is active. The
+    # recorder is internally fail-open, so it never blocks the read.
+    if use_investment:
+        await record_stale_investment_membership_scope(client, org_id=org_id)
     rows = await query_dicts(client, sql, params)
 
     # Resolve repo/team dimension keys to human display names server-side so the

--- a/tests/graphql/test_resolvers.py
+++ b/tests/graphql/test_resolvers.py
@@ -402,3 +402,120 @@ class TestResolveAnalytics:
         assert null_item.value == 0.0  # NULL → 0.0
         normal_item = next(i for i in result.items if i.key == "api-gateway")
         assert normal_item.value == 7.2
+
+    @pytest.mark.asyncio
+    async def test_breakdown_emits_stale_scope_telemetry_when_investment(
+        self, monkeypatch
+    ):
+        """CHAOS-2765: investment breakdown reads compile the membership-scoped
+        CTE, so they must emit the stale-scope counter before execution — parity
+        with timeseries/coverage/sankey."""
+        from datetime import date as date_
+
+        from dev_health_ops.api.graphql.models.inputs import (
+            BreakdownRequestInput,
+            DateRangeInput,
+            DimensionInput,
+            MeasureInput,
+        )
+        from dev_health_ops.api.graphql.resolvers.analytics import (
+            _execute_breakdown_query,
+        )
+
+        recorded: list[str] = []
+
+        async def fake_record(_client, *, org_id):
+            recorded.append(org_id)
+
+        async def fake_query_dicts(_client, _sql, _params):
+            # Assert telemetry fires BEFORE execution, not after.
+            assert recorded == ["org-x"]
+            return [{"dimension_value": "Feature Work", "value": 42.0}]
+
+        def fake_compile_bd(_request, _org_id, _timeout, filters=None):
+            return "SELECT 1", {}
+
+        monkeypatch.setattr(
+            "dev_health_ops.api.graphql.resolvers.analytics."
+            "record_stale_investment_membership_scope",
+            fake_record,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.api.queries.client.query_dicts",
+            fake_query_dicts,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.api.graphql.resolvers.analytics.compile_breakdown",
+            fake_compile_bd,
+        )
+
+        bd_req = BreakdownRequestInput(
+            dimension=DimensionInput.THEME,
+            measure=MeasureInput.COUNT,
+            date_range=DateRangeInput(
+                start_date=date_(2025, 6, 1),
+                end_date=date_(2025, 6, 7),
+            ),
+        )
+        result = await _execute_breakdown_query(
+            MockClient(), bd_req, "org-x", 30, True, None
+        )
+        assert recorded == ["org-x"]
+        assert len(result.items) == 1
+
+    @pytest.mark.asyncio
+    async def test_breakdown_skips_stale_scope_telemetry_when_not_investment(
+        self, monkeypatch
+    ):
+        """CHAOS-2765: non-investment breakdowns don't compile the scoped CTE,
+        so they must NOT emit the stale-scope counter (would over-count)."""
+        from datetime import date as date_
+
+        from dev_health_ops.api.graphql.models.inputs import (
+            BreakdownRequestInput,
+            DateRangeInput,
+            DimensionInput,
+            MeasureInput,
+        )
+        from dev_health_ops.api.graphql.resolvers.analytics import (
+            _execute_breakdown_query,
+        )
+
+        recorded: list[str] = []
+
+        async def fake_record(_client, *, org_id):
+            recorded.append(org_id)
+
+        async def fake_query_dicts(_client, _sql, _params):
+            return [{"dimension_value": "team-a", "value": 3.0}]
+
+        def fake_compile_bd(_request, _org_id, _timeout, filters=None):
+            return "SELECT 1", {}
+
+        monkeypatch.setattr(
+            "dev_health_ops.api.graphql.resolvers.analytics."
+            "record_stale_investment_membership_scope",
+            fake_record,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.api.queries.client.query_dicts",
+            fake_query_dicts,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.api.graphql.resolvers.analytics.compile_breakdown",
+            fake_compile_bd,
+        )
+
+        bd_req = BreakdownRequestInput(
+            dimension=DimensionInput.TEAM,
+            measure=MeasureInput.COUNT,
+            date_range=DateRangeInput(
+                start_date=date_(2025, 6, 1),
+                end_date=date_(2025, 6, 7),
+            ),
+        )
+        result = await _execute_breakdown_query(
+            MockClient(), bd_req, "org-x", 30, False, None
+        )
+        assert recorded == []
+        assert len(result.items) == 1


### PR DESCRIPTION
## What

Investment **breakdown** (treemap) reads compile the CHAOS-2764 membership-scoped work-unit CTE just like the timeseries / coverage / sankey / home / detail surfaces, but `_execute_breakdown_query` never called `record_stale_investment_membership_scope` before execution. So when a breakdown was served on a **stale membership marker** (investments written after the latest complete membership run → fail-open unscoped fallback), the `investment_membership_scope_stale` counter did **not** fire for that surface. The telemetry under-represented which read surfaces were degraded.

This closes the last gap so the stale-scope counter represents *every* investment read surface.

## Change

`_execute_breakdown_query` now mirrors `_execute_timeseries_query` exactly: emit the recorder when `use_investment` is set, **after** `compile_breakdown` and **before** `query_dicts`.

Why the `if use_investment:` guard is precise (not just consistent): on the `resolve_analytics` path, `use_investment` is `bool(batch.use_investment)` — a concrete bool forwarded to `compile_breakdown` as `force_investment`. `_get_context_params` therefore never falls into its `auto_use_investment` branch, so the flag *is* the compiler's routing decision. The guard fires exactly when the scoped CTE is compiled. The recorder is internally fail-open (try/except), so it can never block or fail the read.

## Tests

- `test_breakdown_emits_stale_scope_telemetry_when_investment` — emits, and asserts it fires **before** execution.
- `test_breakdown_skips_stale_scope_telemetry_when_not_investment` — must not emit (guards against over-counting the non-investment path).

## Validation

- `bash ci/local_validate.sh`: ruff format/check ✔, mypy ✔ (1270 files), unit suite **6206 passed** incl. the 2 new tests.
- Two independent Codex reviews (rescue + adversarial) → **APPROVE, zero findings**.

> Note: the gate also surfaced **16 pre-existing failures in `tests/api/admin/test_credential_repos.py`** (an `owner="full-"` trailing-hyphen input now 400s instead of enumerating). Confirmed failing identically on clean `origin/main` (HEAD `f69e2a7de`), so **unrelated to this PR** — filing separately.

Closes CHAOS-2765.