### PR TITLE
feat(external-ingest): customer-push source registration + ingest tokens (CHAOS-2696)

### DIFF
--- a/docs/architecture/customer-push-authz.md
+++ b/docs/architecture/customer-push-authz.md
@@ -1,0 +1,231 @@
+# Customer-Push Source Registration & Ingest Token Authz (CHAOS-2696/2712)
+
+This document covers the authn/authz/credential-lifecycle boundary for the
+external customer-push ingestion API (epic CHAOS-2690): source registration,
+ingest tokens, and how ownership conflicts with FullChaos-managed sync are
+resolved. It does not cover the `POST /batches` business logic, the
+stream/worker, or normalization -- see
+`docs/superpowers/plans/2026-06-26-external-customer-push-ingestion-api.md`
+and the epic's master implementation spec for those.
+
+## Tables
+
+Two new Postgres tables, both org-scoped, not extensions of `integrations`/
+`integration_credentials`:
+
+- `external_ingest_sources` (model `IngestSource`, `models/ingest_auth.py`) --
+  one row per `(org_id, system, instance)`. `instance` is repo/project grain:
+  GitHub/GitLab repo full name (`acme/api`), Jira project key, Linear team
+  key, or a stable slug for `custom`.
+- `external_ingest_tokens` (model `IngestToken`) -- hashed bearer credentials
+  scoped to an org and optionally a single source.
+
+The `external_ingest_*` naming matches the sibling `external_ingest_batches`/
+`external_ingest_rejections`/`external_ingest_payloads` tables (CHAOS-2694)
+and deliberately avoids the legacy `/api/v1/ingest` router's vocabulary --
+the two systems are unrelated and must never be confused in `\dt` output or
+test-file listings.
+
+`IntegrationCredential` is reversibly Fernet-encrypted for *outbound*
+provider credentials FullChaos must decrypt to call GitHub/GitLab/Jira APIs.
+An ingest token is an *inbound* bearer secret FullChaos only ever compares,
+never recovers -- the wrong shape for that table, hence a parallel model.
+
+## Single registry for all three ownership modes
+
+`IngestSource.mode` is one of `fullchaos_sync | customer_push | disabled` --
+`IngestSource` is the single registry for all three states, not just
+customer-push rows, despite this issue's title. This is what makes the
+one-active-owner XOR check enforceable: two enabled rows can never exist for
+the same `(org_id, system, instance)` (enforced by a `UniqueConstraint`);
+`mode` is *mutated* via `PATCH`, never a second insert.
+
+## One-active-owner: per-provider ownership matching (CC5)
+
+Registration-time conflict detection runs when `mode=customer_push`. It
+checks the *instance-grain* managed catalog (`integration_sources`), **not**
+the *provider-grain* `Integration` table (which has no `instance` column --
+one row per `org_id + provider`).
+
+Per-provider matching, org- and provider-scoped. The provider comparison
+itself is case-insensitive (`lower(IntegrationSource.provider) == system` /
+`lower(Integration.provider) == system`): neither `IntegrationCreate` nor the
+sync-config creation paths enforce lowercase provider values, so a
+mixed-case managed row (`"GitHub"`) must still be found by a lowercase
+`system="github"` customer-push registration -- a bare `==` would silently
+let it through:
+
+| system | match condition |
+|---|---|
+| github | `external_id == instance` OR `full_name == instance` |
+| gitlab | `full_name == instance` OR `metadata_->>'path_with_namespace' == instance` OR `external_id == instance` (external_id is GitLab's *numeric* project_id, not a slug) |
+| jira | `external_id == instance` OR `full_name == instance` |
+| linear | `external_id == instance` OR `full_name == instance` OR `name == instance`; **plus** any enabled Linear `IntegrationSource` with `metadata_.org_wide_placeholder == true` (or `external_id == 'linear'`) owns **all** Linear instances for the org |
+| custom | never conflicts -- no managed equivalent |
+
+Matching is case- and whitespace-sensitive against the stored `instance`, so
+the admin API trims the submitted `instance` before both matching and
+persistence (and 422s on a blank/whitespace-only value) -- an un-trimmed
+`"acme/api "` must not create a distinct `(org_id, system, instance)` row
+that silently bypasses the 409 against the trimmed managed-source value.
+
+Outcome:
+
+- Matched row is **actively owned** -- i.e. `IntegrationSource.is_enabled`
+  AND its parent `Integration.is_active` are both true -- ->
+  `409 source_owned_by_fullchaos_sync`. Registration is rejected outright.
+  Both flags are required: a source row an operator never explicitly
+  disabled but whose parent `Integration` has since been deactivated no
+  longer counts as active ownership (nothing in this codebase cascades
+  `Integration.is_active=false` down to its `IntegrationSource.is_enabled`
+  rows, so the two must be checked independently, not just the source flag).
+- Matched row exists but is **not actively owned** (source disabled, or its
+  integration inactive) -> registration succeeds; the match's id is
+  persisted in `external_ingest_sources.matched_integration_source_id` so a
+  later accept-time check (owned by CHAOS-2695's `ownership.py`) can detect
+  if that managed source becomes actively owned again without a second
+  registration lookup.
+- No match -> registration succeeds, `matched_integration_source_id` is `NULL`.
+
+This check re-runs on `PATCH .../sources/{id}` whenever the patch results in
+the source becoming write-eligible (`mode=customer_push AND enabled=true`) --
+"creating/enabling" a customer-push row is the trigger, not just the initial
+`POST`. The admin-time check is best-effort UX; the **authoritative** guard is
+the accept-time re-check on every `POST /batches` (CHAOS-2695), which also
+catches a managed source created or re-enabled *after* registration.
+
+### Residual narrowing this overrules
+
+An earlier draft of this feature (Design Decision 8 in the original brief)
+proposed a **warn-only** stance for all managed-sync conflicts -- reasoning
+that `Integration` has no `instance` grain, so a hard block against "any
+active `Integration` row for this provider" would wrongly prevent mixed
+fleets (e.g. `github.com/acme/repo-a` on managed sync, `repo-b` on
+customer-push). That reasoning is still correct for the **provider-level**
+check, which stays a **non-blocking warning** (see below) -- but a
+post-critique review found the *instance-level* check itself was
+under-verified against three of four providers' actual `external_id`
+semantics (GitLab's is a numeric project_id, not a full-name slug; Jira and
+Linear fall back through `sync_options`/team-UUID paths that a bare
+`external_id ==` comparison misses entirely). With the corrected per-provider
+matching above, instance-level ownership can be resolved precisely, so the
+hard 409 is restored for that case. **This document's stated behavior (hard
+409 on an enabled instance-grain match) is authoritative; do not revert to
+warn-only.**
+
+## Provider-level non-blocking warning (surviving half of Decision 8)
+
+Independent of the instance-level check, registering/enabling a
+customer-push source also checks whether *any* enabled `Integration` row
+exists for the same `(org_id, provider)` -- regardless of instance. If one
+does, the response includes a `warnings: [...]` entry (not a 409):
+
+> "Managed sync is also configured for provider '{system}' in this
+> organization -- verify this is a different repository/workspace."
+
+This stays non-blocking because `Integration` has no `instance` grain --
+treating "managed sync exists anywhere for this provider" as a hard block
+would forbid the legitimate mixed-fleet case above.
+
+## Auth dependency does not reuse `OrgIdMiddleware`/`get_current_user`
+
+`OrgIdMiddleware` only understands user JWTs; for an `fcpush_...` bearer
+token, `AuthService.authenticate_access_token` safely returns `None` and the
+middleware takes its anonymous pass-through branch -- it does not set the
+`org_id` contextvar. The ingest-token auth dependency (`resolve_ingest_token`,
+owned by CHAOS-2712, wave 2) must independently call
+`set_current_org_id(token.org_id)` and reset it in a `finally`, mirroring the
+middleware's own token/reset pattern, so downstream org-scoped code sees the
+right org. This module (`models/ingest_auth.py`) only defines the
+token-hashing primitives (`generate_ingest_token`/`hash_ingest_token`); the
+dependency itself lands in `api/external_ingest/auth.py` in a later wave.
+
+## Audit scope: lifecycle always, ingest-auth outcomes only on failure
+
+Token/source lifecycle events (create/rotate/revoke/register/enable/disable)
+are audited unconditionally via `emit_audit_log` + the `AuditAction`/
+`AuditResourceType` enums (`INGEST_TOKEN_CREATED`/`_ROTATED`/`_REVOKED`,
+`INGEST_SOURCE_REGISTERED`/`_MODE_CHANGED`, resource types `INGEST_TOKEN`/
+`INGEST_SOURCE`). Ingest-auth *outcomes* (the data-plane dependency, wave 2+)
+are audited only on failure (401/403) plus the initial `POST /batches`
+accept -- not on every `GET /batches/{id}` poll, since CI/CD producers poll
+frequently and the ingestion status table is already the durable per-request
+record for successful reads. `AuditAction.INGEST_AUTH_FAILED` is reserved
+here for that later wave.
+
+**Commit-before-raise.** Every `emit_audit_log(...)` call in the admin CRUD
+router is followed by an explicit `await session.commit()` on its own line.
+`get_postgres_session`'s ambient commit only fires on a clean return --  it
+rolls back on *any* exception, including a deliberately-raised
+`HTTPException`, which would silently discard the just-added `AuditLog` row.
+This mirrors the confirmed pattern in `api/auth/routers/login.py`.
+
+## Token format, hashing, and lifecycle
+
+- Format: `fcpush_<43-char urlsafe-base64 secret>` (`secrets.token_urlsafe(32)`,
+  256 bits of entropy). The `fcpush_` prefix lets support/log/regex scanners
+  identify a leaked token (same reasoning as GitHub's `ghp_`/`github_pat_`)
+  and disambiguates from JWTs in the `Authorization: Bearer` header at a
+  glance.
+- Hash: `sha256(token).hexdigest()`, no per-token salt/pepper -- matching the
+  house convention (`RefreshToken`, `PasswordResetToken`, `OrgInvite`,
+  `EmailVerificationToken`). A high-entropy random secret makes a fast hash
+  safe here; this is not a password.
+- Display: the first 12 characters of the full token (including the
+  `fcpush_` marker) are stored in a plaintext `token_prefix` column for
+  UI/audit display. The full plaintext is returned exactly once, in the
+  create/rotate response body, and never stored or logged again.
+- Scopes: `schema:read`, `ingest:write`, `ingest:status`. `source_id` is
+  nullable on `IngestToken` -- `NULL` means "all sources in this org" and is
+  only legal when scopes are a subset of `{schema:read, ingest:status}`
+  (never `ingest:write`); enforced as a `400` at creation time in the admin
+  endpoint (`POST /customer-push/tokens`, the org-wide/unbound path) rather
+  than a many-to-many join table.
+- Rotation is a **hard, immediate cutover**, not a grace-window/
+  successor-token scheme (`RefreshToken`'s `successor_jti` exists to smooth
+  browser session races, which don't apply to an operator-triggered,
+  infrequent CI-secret rotation). `rotate` = one transaction: set
+  `revoked_at=now()` on the old row, insert a new row with the same
+  `org_id`/`source_id`/`scopes`, recompute `expires_at` from *now* + the
+  original TTL if the original had one (else `NULL`), return the new
+  plaintext token once. The old token is invalid immediately after commit.
+  Rotate (and revoke) fetch the target row with `SELECT ... FOR UPDATE`
+  (matching `RefreshToken`'s own rotation locking), so two concurrent rotate
+  requests for the same token can't both observe `revoked_at IS NULL` and
+  each mint a live successor -- the second waits for the first's commit and
+  then correctly 400s on "already revoked".
+
+## Reserved columns (must-not-foreclose CHAOS-2715)
+
+`external_ingest_sources.webhook_mode` (`disabled | customer_relay |
+fullchaos_hosted`, default `disabled`) and `webhook_secret_id` (nullable
+UUID) are added in migration `0032` now, ahead of CHAOS-2715's
+webhook-assisted ingestion work, so that feature doesn't need a follow-up
+migration to add columns to a table this feature already owns. v1 only
+accepts `disabled`/`customer_relay` at the admin API layer -- `fullchaos_hosted`
+400s (`webhook_secret_id` is unused until Option B webhook support lands).
+
+## Admin REST surface
+
+`/api/v1/admin/customer-push/*` (`api/admin/routers/customer_push.py`),
+included in the existing parent admin router
+(`APIRouter(prefix="/api/v1/admin", dependencies=[Depends(require_admin)])`)
+-- gated by `require_admin` (owner/admin/superuser) like every other admin
+router, no extra per-route dependency needed. snake_case field naming,
+matching every other admin Pydantic schema module -- a deliberate
+inconsistency versus the data-plane `external-ingest` batch envelope (which
+is camelCase); the two are different namespaces built by different
+sub-issues and are not reconciled.
+
+```
+POST   /api/v1/admin/customer-push/sources
+GET    /api/v1/admin/customer-push/sources
+GET    /api/v1/admin/customer-push/sources/{source_id}
+PATCH  /api/v1/admin/customer-push/sources/{source_id}
+GET    /api/v1/admin/customer-push/sources/{source_id}/tokens
+POST   /api/v1/admin/customer-push/sources/{source_id}/tokens
+GET    /api/v1/admin/customer-push/tokens
+POST   /api/v1/admin/customer-push/tokens                    # org-wide, unbound (no ingest:write)
+POST   /api/v1/admin/customer-push/tokens/{token_id}/rotate
+POST   /api/v1/admin/customer-push/tokens/{token_id}/revoke
+```

--- a/src/dev_health_ops/alembic/versions/0032_add_customer_push_ingest_auth.py
+++ b/src/dev_health_ops/alembic/versions/0032_add_customer_push_ingest_auth.py
@@ -1,0 +1,156 @@
+"""Add external_ingest_sources and external_ingest_tokens (CHAOS-2696/2712).
+
+Why Postgres, not ClickHouse: this is transactional config/authz state (source
+ownership + bearer-credential validity) consulted synchronously on every
+external-ingest request, mirroring ProviderRateLimitObservation's
+justification (migration 0031) -- ClickHouse is a separate analytics cluster
+with no transactional read path suitable for per-request auth checks.
+
+``webhook_mode``/``webhook_secret_id`` are reserved columns for CHAOS-2715
+(webhook-assisted ingestion)'s must-not-foreclose contract -- unused in v1,
+the admin API 400s on ``webhook_mode=fullchaos_hosted``.
+``matched_integration_source_id`` stores the managed ``integration_sources``
+row resolved by per-provider ownership matching at registration time
+(post-critique CC5; see docs/architecture/customer-push-authz.md).
+
+Guarded individually (create-if-missing / add-column-if-missing / per the
+0025/0031 convention) so a partially-applied run can be re-run safely.
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-07-01 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0032"
+down_revision: str | None = "0031"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_SOURCES_TABLE = "external_ingest_sources"
+_TOKENS_TABLE = "external_ingest_tokens"
+
+
+def upgrade() -> None:
+    if not _table_exists(_SOURCES_TABLE):
+        op.create_table(
+            _SOURCES_TABLE,
+            sa.Column("id", UUID(as_uuid=True), nullable=False),
+            sa.Column("org_id", sa.Text(), nullable=False),
+            sa.Column("system", sa.Text(), nullable=False),
+            sa.Column("instance", sa.Text(), nullable=False),
+            sa.Column("display_name", sa.Text(), nullable=True),
+            sa.Column("mode", sa.Text(), nullable=False, server_default="disabled"),
+            sa.Column(
+                "enabled", sa.Boolean(), nullable=False, server_default=sa.true()
+            ),
+            sa.Column(
+                "webhook_mode", sa.Text(), nullable=False, server_default="disabled"
+            ),
+            sa.Column("webhook_secret_id", UUID(as_uuid=True), nullable=True),
+            sa.Column(
+                "matched_integration_source_id", UUID(as_uuid=True), nullable=True
+            ),
+            sa.Column("created_by_user_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("updated_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "org_id",
+                "system",
+                "instance",
+                name="uq_external_ingest_sources_org_system_instance",
+            ),
+        )
+    _add_column_if_missing(
+        _SOURCES_TABLE,
+        sa.Column("webhook_mode", sa.Text(), nullable=False, server_default="disabled"),
+    )
+    _add_column_if_missing(
+        _SOURCES_TABLE,
+        sa.Column("webhook_secret_id", UUID(as_uuid=True), nullable=True),
+    )
+    _add_column_if_missing(
+        _SOURCES_TABLE,
+        sa.Column("matched_integration_source_id", UUID(as_uuid=True), nullable=True),
+    )
+    _create_index_if_missing(
+        "ix_external_ingest_sources_org_id", _SOURCES_TABLE, ["org_id"]
+    )
+
+    if not _table_exists(_TOKENS_TABLE):
+        op.create_table(
+            _TOKENS_TABLE,
+            sa.Column("id", UUID(as_uuid=True), nullable=False),
+            sa.Column("org_id", sa.Text(), nullable=False),
+            sa.Column(
+                "source_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey(f"{_SOURCES_TABLE}.id"),
+                nullable=True,
+            ),
+            sa.Column("name", sa.Text(), nullable=False),
+            sa.Column("token_hash", sa.Text(), nullable=False),
+            sa.Column("token_prefix", sa.Text(), nullable=False),
+            sa.Column("scopes", sa.JSON(), nullable=False),
+            sa.Column("created_by_user_id", UUID(as_uuid=True), nullable=True),
+            sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("last_used_ip", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint(
+                "token_hash", name="uq_external_ingest_tokens_token_hash"
+            ),
+        )
+    _create_index_if_missing(
+        "ix_external_ingest_tokens_org_id", _TOKENS_TABLE, ["org_id"]
+    )
+    _create_index_if_missing(
+        "ix_external_ingest_tokens_source_id", _TOKENS_TABLE, ["source_id"]
+    )
+    _create_index_if_missing(
+        "ix_external_ingest_tokens_org_active", _TOKENS_TABLE, ["org_id", "revoked_at"]
+    )
+
+
+def downgrade() -> None:
+    if _table_exists(_TOKENS_TABLE):
+        op.drop_table(_TOKENS_TABLE)
+    if _table_exists(_SOURCES_TABLE):
+        op.drop_table(_SOURCES_TABLE)
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    return table_name in sa.inspect(bind).get_table_names()
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    if column.name not in _column_names(table_name):
+        op.add_column(table_name, column)
+
+
+def _create_index_if_missing(
+    index_name: str, table_name: str, columns: list[str]
+) -> None:
+    bind = op.get_bind()
+    existing = {ix["name"] for ix in sa.inspect(bind).get_indexes(table_name)}
+    if index_name not in existing:
+        op.create_index(index_name, table_name, columns)

--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -6,6 +6,7 @@ from dev_health_ops.api.admin.middleware import require_admin
 
 from .routers import (
     credentials_router,
+    customer_push_router,
     features_router,
     get_clickhouse_store,
     get_session,
@@ -39,6 +40,7 @@ router = APIRouter(
 router.include_router(settings_router)
 router.include_router(setup_router)
 router.include_router(credentials_router)
+router.include_router(customer_push_router)
 router.include_router(sync_router)
 router.include_router(identities_router)
 router.include_router(teams_router)

--- a/src/dev_health_ops/api/admin/routers/__init__.py
+++ b/src/dev_health_ops/api/admin/routers/__init__.py
@@ -8,6 +8,7 @@ from .credentials import (
 from .credentials import (
     router as credentials_router,
 )
+from .customer_push import router as customer_push_router
 from .features import router as features_router
 from .github_app import router as github_app_router
 from .governance import router as governance_router
@@ -23,6 +24,7 @@ from .users import router as users_router
 
 __all__ = [
     "credentials_router",
+    "customer_push_router",
     "features_router",
     "get_clickhouse_store",
     "get_session",

--- a/src/dev_health_ops/api/admin/routers/customer_push.py
+++ b/src/dev_health_ops/api/admin/routers/customer_push.py
@@ -1,0 +1,654 @@
+"""Admin CRUD for customer-push source registration + ingest tokens (CHAOS-2696).
+
+See docs/architecture/customer-push-authz.md for the one-active-owner
+(per-provider matching) and token-scoping design. Endpoints live under
+``/api/v1/admin/customer-push/*``; the parent admin router already applies
+``Depends(require_admin)`` (see ``api/admin/router.py``).
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy import func, select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.admin.middleware import get_admin_user
+from dev_health_ops.api.admin.schemas.customer_push import (
+    IngestSourceCreate,
+    IngestSourcePatch,
+    IngestSourceResponse,
+    IngestTokenCreate,
+    IngestTokenCreateResponse,
+    IngestTokenResponse,
+)
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.utils.audit import emit_audit_log
+from dev_health_ops.models.audit import AuditAction, AuditResourceType
+from dev_health_ops.models.ingest_auth import (
+    TOKEN_PREFIX_DISPLAY_LENGTH,
+    IngestSource,
+    IngestSourceMode,
+    IngestToken,
+    IngestTokenScope,
+    generate_ingest_token,
+    hash_ingest_token,
+)
+from dev_health_ops.models.integrations import Integration, IntegrationSource
+
+from .common import get_session
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+_VALID_SYSTEMS = {"github", "gitlab", "jira", "linear", "custom"}
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _org_uuid(org_id: str) -> uuid.UUID:
+    return uuid.UUID(org_id)
+
+
+def _user_uuid(user_id: str | None) -> uuid.UUID | None:
+    return uuid.UUID(user_id) if user_id else None
+
+
+def _validate_system(system: str) -> str:
+    normalized = system.strip().lower()
+    if normalized not in _VALID_SYSTEMS:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Invalid system '{system}'; must be one of {sorted(_VALID_SYSTEMS)}",
+        )
+    return normalized
+
+
+def _validate_mode(mode: str) -> IngestSourceMode:
+    try:
+        return IngestSourceMode(mode)
+    except ValueError:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Invalid mode '{mode}'; must be one of "
+                f"{[m.value for m in IngestSourceMode]}"
+            ),
+        )
+
+
+def _source_to_response(
+    source: IngestSource, warnings: list[str] | None = None
+) -> IngestSourceResponse:
+    return IngestSourceResponse(
+        id=str(source.id),
+        org_id=source.org_id,
+        system=source.system,
+        instance=source.instance,
+        display_name=source.display_name,
+        mode=source.mode,
+        enabled=source.enabled,
+        webhook_mode=source.webhook_mode,
+        matched_integration_source_id=(
+            str(source.matched_integration_source_id)
+            if source.matched_integration_source_id is not None
+            else None
+        ),
+        created_at=source.created_at,
+        updated_at=source.updated_at,
+        warnings=warnings or [],
+    )
+
+
+def _token_to_response(token: IngestToken) -> IngestTokenResponse:
+    return IngestTokenResponse(
+        id=str(token.id),
+        org_id=token.org_id,
+        source_id=str(token.source_id) if token.source_id is not None else None,
+        name=token.name,
+        token_prefix=token.token_prefix,
+        scopes=list(token.scopes or []),
+        expires_at=token.expires_at,
+        revoked_at=token.revoked_at,
+        last_used_at=token.last_used_at,
+        created_at=token.created_at,
+    )
+
+
+async def _get_org_source(
+    session: AsyncSession, org_id: str, source_id: str
+) -> IngestSource:
+    try:
+        source_uuid = uuid.UUID(source_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Source not found")
+    result = await session.execute(
+        select(IngestSource).where(
+            IngestSource.id == source_uuid, IngestSource.org_id == org_id
+        )
+    )
+    source = result.scalar_one_or_none()
+    if source is None:
+        raise HTTPException(status_code=404, detail="Source not found")
+    return source
+
+
+async def _get_org_token(
+    session: AsyncSession, org_id: str, token_id: str, *, for_update: bool = False
+) -> IngestToken:
+    try:
+        token_uuid = uuid.UUID(token_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Token not found")
+    stmt = select(IngestToken).where(
+        IngestToken.id == token_uuid, IngestToken.org_id == org_id
+    )
+    if for_update:
+        # Serializes concurrent rotate/revoke on the same token (Postgres;
+        # no-op on SQLite, which lacks SELECT ... FOR UPDATE) so two
+        # concurrent rotations can't both observe revoked_at IS NULL and
+        # each mint a live successor token.
+        stmt = stmt.with_for_update()
+    result = await session.execute(stmt)
+    token = result.scalar_one_or_none()
+    if token is None:
+        raise HTTPException(status_code=404, detail="Token not found")
+    return token
+
+
+def _linear_is_org_wide_placeholder(source: IntegrationSource) -> bool:
+    metadata = source.metadata_ or {}
+    if metadata.get("org_wide_placeholder") is True:
+        return True
+    return (source.external_id or "").strip().lower() == "linear"
+
+
+def _matches_instance(system: str, instance: str, source: IntegrationSource) -> bool:
+    """CC5 per-provider matching (see docs/architecture/customer-push-authz.md)."""
+    if system in ("github", "jira"):
+        return instance in (source.external_id, source.full_name)
+    if system == "gitlab":
+        path_with_namespace = (source.metadata_ or {}).get("path_with_namespace")
+        return instance in (source.full_name, path_with_namespace, source.external_id)
+    if system == "linear":
+        if _linear_is_org_wide_placeholder(source):
+            return True
+        return instance in (source.external_id, source.full_name, source.name)
+    return False
+
+
+async def _resolve_ownership(
+    session: AsyncSession, org_id: str, system: str, instance: str
+) -> tuple[uuid.UUID | None, list[str]]:
+    """Run CC5 per-provider ownership matching against managed integration_sources.
+
+    Returns ``(matched_integration_source_id, warnings)``. Raises 409
+    ``source_owned_by_fullchaos_sync`` if a managed source matches this
+    instance AND is both source-``is_enabled`` and its parent ``Integration``
+    is ``is_active`` (post-critique CC5/CC14; overrules the brief body's
+    warn-only Decision 8) -- "one-active-owner": a source row left enabled
+    under a since-deactivated integration no longer counts as active
+    ownership. ``custom`` systems have no managed equivalent and never
+    conflict. A matched-but-not-actively-owned managed source is allowed to
+    register and its id is persisted for the accept-time re-check (owned by
+    CHAOS-2695). Independently, an active provider-level ``Integration`` row
+    for the same provider (any instance) produces a non-blocking warning --
+    the surviving half of Decision 8.
+    """
+    warnings: list[str] = []
+    matched_id: uuid.UUID | None = None
+
+    if system == "custom":
+        return matched_id, warnings
+
+    # func.lower(...) on both sides: nearby sync-creation paths (e.g.
+    # IntegrationCreate) don't enforce lowercase provider values, so a
+    # mixed-case managed row ("GitHub") must still be found and block a
+    # lowercase "github" customer-push registration -- a bare `==` here
+    # would silently bypass the one-active-owner 409.
+    candidate_rows = (
+        await session.execute(
+            select(IntegrationSource, Integration.is_active)
+            .join(Integration, IntegrationSource.integration_id == Integration.id)
+            .where(
+                IntegrationSource.org_id == org_id,
+                func.lower(IntegrationSource.provider) == system,
+            )
+        )
+    ).all()
+    matches = [
+        (source, integration_is_active)
+        for source, integration_is_active in candidate_rows
+        if _matches_instance(system, instance, source)
+    ]
+    enabled_match = next(
+        (
+            source
+            for source, integration_is_active in matches
+            if source.is_enabled and integration_is_active
+        ),
+        None,
+    )
+    if enabled_match is not None:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "source_owned_by_fullchaos_sync",
+                "message": (
+                    f"A managed {system} sync source already owns '{instance}' "
+                    "in this organization; disable it before enabling "
+                    "customer-push for the same instance."
+                ),
+            },
+        )
+    if matches:
+        matched_id = matches[0][0].id
+
+    integration_active = (
+        await session.execute(
+            select(Integration.id)
+            .where(
+                Integration.org_id == org_id,
+                func.lower(Integration.provider) == system,
+                Integration.is_active.is_(True),
+            )
+            .limit(1)
+        )
+    ).scalar_one_or_none()
+    if integration_active is not None:
+        warnings.append(
+            f"Managed sync is also configured for provider '{system}' in this "
+            "organization -- verify this is a different repository/workspace."
+        )
+
+    return matched_id, warnings
+
+
+async def _create_token(
+    session: AsyncSession,
+    request: Request,
+    current_user: AuthenticatedUser,
+    org_id: str,
+    source_id: uuid.UUID | None,
+    payload: IngestTokenCreate,
+) -> IngestTokenCreateResponse:
+    plaintext = generate_ingest_token()
+    token = IngestToken(
+        org_id=org_id,
+        source_id=source_id,
+        name=payload.name,
+        token_hash=hash_ingest_token(plaintext),
+        token_prefix=plaintext[:TOKEN_PREFIX_DISPLAY_LENGTH],
+        scopes=list(payload.scopes),
+        created_by_user_id=_user_uuid(current_user.user_id),
+        expires_at=payload.expires_at,
+    )
+    session.add(token)
+    await session.flush()
+
+    emit_audit_log(
+        session,
+        org_id=_org_uuid(org_id),
+        action=AuditAction.INGEST_TOKEN_CREATED,
+        resource_type=AuditResourceType.INGEST_TOKEN,
+        resource_id=str(token.id),
+        user_id=_user_uuid(current_user.user_id),
+        description=f"Created ingest token '{payload.name}'",
+        changes={
+            "name": payload.name,
+            "scopes": list(payload.scopes),
+            "source_id": str(source_id) if source_id else None,
+        },
+        request=request,
+    )
+    await session.commit()
+
+    return IngestTokenCreateResponse(
+        id=str(token.id),
+        org_id=org_id,
+        source_id=str(source_id) if source_id else None,
+        name=token.name,
+        token=plaintext,
+        token_prefix=token.token_prefix,
+        scopes=list(token.scopes),
+        expires_at=token.expires_at,
+        created_at=token.created_at,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+
+
+@router.post(
+    "/customer-push/sources", response_model=IngestSourceResponse, status_code=201
+)
+async def create_source(
+    payload: IngestSourceCreate,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> IngestSourceResponse:
+    org_id = current_user.org_id
+    system = _validate_system(payload.system)
+    mode = _validate_mode(payload.mode)
+
+    matched_id: uuid.UUID | None = None
+    warnings: list[str] = []
+    if mode == IngestSourceMode.CUSTOMER_PUSH:
+        matched_id, warnings = await _resolve_ownership(
+            session, org_id, system, payload.instance
+        )
+
+    source = IngestSource(
+        org_id=org_id,
+        system=system,
+        instance=payload.instance,
+        display_name=payload.display_name,
+        mode=mode.value,
+        enabled=True,
+        webhook_mode=payload.webhook_mode,
+        matched_integration_source_id=matched_id,
+        created_by_user_id=_user_uuid(current_user.user_id),
+    )
+    try:
+        async with session.begin_nested():
+            session.add(source)
+            await session.flush()
+    except IntegrityError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"A source is already registered for system='{system}' "
+                f"instance='{payload.instance}' in this organization"
+            ),
+        ) from exc
+
+    emit_audit_log(
+        session,
+        org_id=_org_uuid(org_id),
+        action=AuditAction.INGEST_SOURCE_REGISTERED,
+        resource_type=AuditResourceType.INGEST_SOURCE,
+        resource_id=str(source.id),
+        user_id=_user_uuid(current_user.user_id),
+        description=f"Registered customer-push source {system}/{payload.instance}",
+        changes={"system": system, "instance": payload.instance, "mode": mode.value},
+        request=request,
+    )
+    await session.commit()
+
+    return _source_to_response(source, warnings=warnings)
+
+
+@router.get("/customer-push/sources", response_model=list[IngestSourceResponse])
+async def list_sources(
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> list[IngestSourceResponse]:
+    result = await session.execute(
+        select(IngestSource)
+        .where(IngestSource.org_id == current_user.org_id)
+        .order_by(IngestSource.created_at.desc())
+    )
+    return [_source_to_response(s) for s in result.scalars().all()]
+
+
+@router.get("/customer-push/sources/{source_id}", response_model=IngestSourceResponse)
+async def get_source(
+    source_id: str,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> IngestSourceResponse:
+    source = await _get_org_source(session, current_user.org_id, source_id)
+    return _source_to_response(source)
+
+
+@router.patch("/customer-push/sources/{source_id}", response_model=IngestSourceResponse)
+async def patch_source(
+    source_id: str,
+    payload: IngestSourcePatch,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> IngestSourceResponse:
+    org_id = current_user.org_id
+    source = await _get_org_source(session, org_id, source_id)
+
+    changes: dict[str, Any] = {}
+    if payload.mode is not None:
+        new_mode = _validate_mode(payload.mode)
+        if new_mode.value != source.mode:
+            changes["mode"] = {"old": source.mode, "new": new_mode.value}
+        source.mode = new_mode.value
+    if payload.enabled is not None and payload.enabled != source.enabled:
+        changes["enabled"] = {"old": source.enabled, "new": payload.enabled}
+        source.enabled = payload.enabled
+    if payload.display_name is not None and payload.display_name != source.display_name:
+        changes["display_name"] = {
+            "old": source.display_name,
+            "new": payload.display_name,
+        }
+        source.display_name = payload.display_name
+    if payload.webhook_mode is not None and payload.webhook_mode != source.webhook_mode:
+        changes["webhook_mode"] = {
+            "old": source.webhook_mode,
+            "new": payload.webhook_mode,
+        }
+        source.webhook_mode = payload.webhook_mode
+
+    # Re-run the CC5 ownership check whenever this PATCH results in the
+    # source becoming write-eligible (mode=customer_push AND enabled=True) --
+    # "creating/enabling" per CC14 -- so a managed sync source created after
+    # the initial registration is still caught here (best-effort; the
+    # authoritative guard is the accept-time re-check owned by CHAOS-2695).
+    warnings: list[str] = []
+    if source.is_write_eligible() and ("mode" in changes or "enabled" in changes):
+        matched_id, warnings = await _resolve_ownership(
+            session, org_id, source.system, source.instance
+        )
+        source.matched_integration_source_id = matched_id
+
+    if changes:
+        emit_audit_log(
+            session,
+            org_id=_org_uuid(org_id),
+            action=AuditAction.INGEST_SOURCE_MODE_CHANGED,
+            resource_type=AuditResourceType.INGEST_SOURCE,
+            resource_id=str(source.id),
+            user_id=_user_uuid(current_user.user_id),
+            description=f"Updated customer-push source {source.system}/{source.instance}",
+            changes=changes,
+            request=request,
+        )
+        await session.commit()
+
+    return _source_to_response(source, warnings=warnings)
+
+
+# ---------------------------------------------------------------------------
+# Tokens
+# ---------------------------------------------------------------------------
+
+
+@router.get(
+    "/customer-push/sources/{source_id}/tokens",
+    response_model=list[IngestTokenResponse],
+)
+async def list_source_tokens(
+    source_id: str,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> list[IngestTokenResponse]:
+    org_id = current_user.org_id
+    source = await _get_org_source(session, org_id, source_id)
+    result = await session.execute(
+        select(IngestToken)
+        .where(IngestToken.org_id == org_id, IngestToken.source_id == source.id)
+        .order_by(IngestToken.created_at.desc())
+    )
+    return [_token_to_response(t) for t in result.scalars().all()]
+
+
+@router.post(
+    "/customer-push/sources/{source_id}/tokens",
+    response_model=IngestTokenCreateResponse,
+    status_code=201,
+)
+async def create_source_token(
+    source_id: str,
+    payload: IngestTokenCreate,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> IngestTokenCreateResponse:
+    org_id = current_user.org_id
+    source = await _get_org_source(session, org_id, source_id)
+    return await _create_token(
+        session, request, current_user, org_id, source.id, payload
+    )
+
+
+@router.get("/customer-push/tokens", response_model=list[IngestTokenResponse])
+async def list_org_tokens(
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> list[IngestTokenResponse]:
+    result = await session.execute(
+        select(IngestToken)
+        .where(IngestToken.org_id == current_user.org_id)
+        .order_by(IngestToken.created_at.desc())
+    )
+    return [_token_to_response(t) for t in result.scalars().all()]
+
+
+@router.post(
+    "/customer-push/tokens",
+    response_model=IngestTokenCreateResponse,
+    status_code=201,
+)
+async def create_org_token(
+    payload: IngestTokenCreate,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> IngestTokenCreateResponse:
+    """Create an org-wide (unbound) token -- never eligible for ingest:write
+    (Design Decision 7: NULL source_id is only legal for schema:read/
+    ingest:status)."""
+    if IngestTokenScope.INGEST_WRITE.value in payload.scopes:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "ingest:write requires a source-bound token; create it via "
+                "POST /customer-push/sources/{source_id}/tokens"
+            ),
+        )
+    return await _create_token(
+        session, request, current_user, current_user.org_id, None, payload
+    )
+
+
+@router.post(
+    "/customer-push/tokens/{token_id}/rotate",
+    response_model=IngestTokenCreateResponse,
+)
+async def rotate_token(
+    token_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> IngestTokenCreateResponse:
+    """Hard, immediate cutover (Design Decision 16) -- no grace window."""
+    org_id = current_user.org_id
+    old_token = await _get_org_token(session, org_id, token_id, for_update=True)
+    if old_token.revoked_at is not None:
+        raise HTTPException(status_code=400, detail="Token already revoked")
+
+    now = datetime.now(timezone.utc)
+    new_expires_at: datetime | None = None
+    if old_token.expires_at is not None:
+        original_ttl = old_token.expires_at - old_token.created_at
+        new_expires_at = now + original_ttl
+
+    old_token.revoked_at = now
+
+    plaintext = generate_ingest_token()
+    new_token = IngestToken(
+        org_id=org_id,
+        source_id=old_token.source_id,
+        name=old_token.name,
+        token_hash=hash_ingest_token(plaintext),
+        token_prefix=plaintext[:TOKEN_PREFIX_DISPLAY_LENGTH],
+        scopes=list(old_token.scopes or []),
+        created_by_user_id=_user_uuid(current_user.user_id),
+        expires_at=new_expires_at,
+    )
+    session.add(new_token)
+    await session.flush()
+
+    emit_audit_log(
+        session,
+        org_id=_org_uuid(org_id),
+        action=AuditAction.INGEST_TOKEN_ROTATED,
+        resource_type=AuditResourceType.INGEST_TOKEN,
+        resource_id=str(new_token.id),
+        user_id=_user_uuid(current_user.user_id),
+        description=f"Rotated ingest token '{old_token.name}'",
+        changes={
+            "old_token_id": str(old_token.id),
+            "new_token_id": str(new_token.id),
+        },
+        request=request,
+    )
+    await session.commit()
+
+    return IngestTokenCreateResponse(
+        id=str(new_token.id),
+        org_id=org_id,
+        source_id=str(new_token.source_id) if new_token.source_id else None,
+        name=new_token.name,
+        token=plaintext,
+        token_prefix=new_token.token_prefix,
+        scopes=list(new_token.scopes),
+        expires_at=new_token.expires_at,
+        created_at=new_token.created_at,
+    )
+
+
+@router.post(
+    "/customer-push/tokens/{token_id}/revoke",
+    response_model=IngestTokenResponse,
+)
+async def revoke_token(
+    token_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> IngestTokenResponse:
+    org_id = current_user.org_id
+    token = await _get_org_token(session, org_id, token_id, for_update=True)
+    if token.revoked_at is None:
+        token.revoked_at = datetime.now(timezone.utc)
+        emit_audit_log(
+            session,
+            org_id=_org_uuid(org_id),
+            action=AuditAction.INGEST_TOKEN_REVOKED,
+            resource_type=AuditResourceType.INGEST_TOKEN,
+            resource_id=str(token.id),
+            user_id=_user_uuid(current_user.user_id),
+            description=f"Revoked ingest token '{token.name}'",
+            request=request,
+        )
+        await session.commit()
+
+    return _token_to_response(token)

--- a/src/dev_health_ops/api/admin/schemas/customer_push.py
+++ b/src/dev_health_ops/api/admin/schemas/customer_push.py
@@ -1,0 +1,144 @@
+"""Pydantic schemas for the customer-push admin API (CHAOS-2696).
+
+snake_case field naming, matching every other admin schema module (see
+Design Decision 15 in docs/architecture/customer-push-authz.md) -- this is a
+deliberate divergence from the camelCase data-plane batch envelope.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+from dev_health_ops.models.ingest_auth import IngestTokenScope, IngestWebhookMode
+
+_VALID_ADMIN_WEBHOOK_MODES = {
+    IngestWebhookMode.DISABLED.value,
+    IngestWebhookMode.CUSTOMER_RELAY.value,
+}
+_VALID_SCOPES = {scope.value for scope in IngestTokenScope}
+
+
+def _validate_webhook_mode(value: str | None) -> str | None:
+    if value is None:
+        return value
+    if value not in _VALID_ADMIN_WEBHOOK_MODES:
+        raise ValueError(
+            "webhook_mode must be one of "
+            f"{sorted(_VALID_ADMIN_WEBHOOK_MODES)} (fullchaos_hosted is reserved, "
+            "not available in v1)"
+        )
+    return value
+
+
+# ---------------------------------------------------------------------------
+# Sources
+# ---------------------------------------------------------------------------
+
+
+class IngestSourceCreate(BaseModel):
+    system: str = Field(..., min_length=1)
+    instance: str = Field(..., min_length=1)
+    display_name: str | None = None
+    mode: str = "customer_push"
+    webhook_mode: str = "disabled"
+
+    @field_validator("instance")
+    @classmethod
+    def _check_instance(cls, value: str) -> str:
+        # Trim before storage/matching -- an un-normalized "acme/api " would
+        # both create a distinct (org_id, system, instance) row AND silently
+        # bypass the CC5 ownership match against the trimmed managed-source
+        # value, defeating the one-active-owner 409.
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("instance must not be blank")
+        return normalized
+
+    @field_validator("webhook_mode")
+    @classmethod
+    def _check_webhook_mode(cls, value: str) -> str:
+        result = _validate_webhook_mode(value)
+        assert result is not None
+        return result
+
+
+class IngestSourceResponse(BaseModel):
+    id: str
+    org_id: str
+    system: str
+    instance: str
+    display_name: str | None
+    mode: str
+    enabled: bool
+    webhook_mode: str
+    matched_integration_source_id: str | None
+    created_at: datetime
+    updated_at: datetime
+    # Decision 8 non-blocking managed-sync-conflict warning; empty on plain reads.
+    warnings: list[str] = []
+
+    model_config = ConfigDict(from_attributes=True)
+
+
+class IngestSourcePatch(BaseModel):
+    display_name: str | None = None
+    mode: str | None = None
+    enabled: bool | None = None
+    webhook_mode: str | None = None
+
+    @field_validator("webhook_mode")
+    @classmethod
+    def _check_webhook_mode(cls, value: str | None) -> str | None:
+        return _validate_webhook_mode(value)
+
+
+# ---------------------------------------------------------------------------
+# Tokens
+# ---------------------------------------------------------------------------
+
+
+class IngestTokenCreate(BaseModel):
+    name: str = Field(..., min_length=1)
+    scopes: list[str] = Field(..., min_length=1)
+    expires_at: datetime | None = None
+
+    @field_validator("scopes")
+    @classmethod
+    def _check_scopes(cls, value: list[str]) -> list[str]:
+        unknown = sorted(set(value) - _VALID_SCOPES)
+        if unknown:
+            raise ValueError(
+                f"Unknown scope(s) {unknown}; valid scopes are {sorted(_VALID_SCOPES)}"
+            )
+        return value
+
+
+class IngestTokenCreateResponse(BaseModel):
+    id: str
+    org_id: str
+    source_id: str | None
+    name: str
+    token: str  # PLAINTEXT -- present only in this one response, never again
+    token_prefix: str
+    scopes: list[str]
+    expires_at: datetime | None
+    created_at: datetime
+
+
+class IngestTokenResponse(BaseModel):
+    """List/detail view -- deliberately has no ``token`` field."""
+
+    id: str
+    org_id: str
+    source_id: str | None
+    name: str
+    token_prefix: str
+    scopes: list[str]
+    expires_at: datetime | None
+    revoked_at: datetime | None
+    last_used_at: datetime | None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/src/dev_health_ops/models/__init__.py
+++ b/src/dev_health_ops/models/__init__.py
@@ -21,6 +21,13 @@ from .checkpoints import (
 )
 from .git import Base, GitBlame, GitBlameMixin, GitCommit, GitCommitStat, GitFile, Repo
 from .impersonation import ImpersonationSession
+from .ingest_auth import (
+    IngestSource,
+    IngestSourceMode,
+    IngestToken,
+    IngestTokenScope,
+    IngestWebhookMode,
+)
 from .integrations import (
     Integration,
     IntegrationDataset,
@@ -122,6 +129,11 @@ __all__ = [
     "GitCommitStat",
     "GitFile",
     "GithubAppInstallation",
+    "IngestSource",
+    "IngestSourceMode",
+    "IngestToken",
+    "IngestTokenScope",
+    "IngestWebhookMode",
     "Integration",
     "IntegrationCredential",
     "IntegrationDataset",

--- a/src/dev_health_ops/models/audit.py
+++ b/src/dev_health_ops/models/audit.py
@@ -90,6 +90,14 @@ class AuditAction(str, Enum):
     IMPERSONATION_START = "impersonation_start"
     IMPERSONATION_STOP = "impersonation_stop"
 
+    # Customer-push ingest events (CHAOS-2696/2712)
+    INGEST_TOKEN_CREATED = "ingest_token_created"
+    INGEST_TOKEN_ROTATED = "ingest_token_rotated"
+    INGEST_TOKEN_REVOKED = "ingest_token_revoked"
+    INGEST_SOURCE_REGISTERED = "ingest_source_registered"
+    INGEST_SOURCE_MODE_CHANGED = "ingest_source_mode_changed"
+    INGEST_AUTH_FAILED = "ingest_auth_failed"
+
     # Settings events
     SETTINGS_UPDATED = "settings_updated"
     CREDENTIAL_CREATED = "credential_created"
@@ -122,6 +130,8 @@ class AuditResourceType(str, Enum):
     AUDIT_LOG = "audit_log"
     METRICS = "metrics"
     SESSION = "session"
+    INGEST_TOKEN = "ingest_token"
+    INGEST_SOURCE = "ingest_source"
     OTHER = "other"
 
 

--- a/src/dev_health_ops/models/ingest_auth.py
+++ b/src/dev_health_ops/models/ingest_auth.py
@@ -1,0 +1,181 @@
+"""Customer-push source registration and ingest-token models (CHAOS-2696/2712).
+
+See docs/architecture/customer-push-authz.md for the one-active-owner and
+token-scoping design rationale. Table names (``external_ingest_sources``/
+``external_ingest_tokens``) match the ``external_ingest_*`` feature family
+(batches/rejections/payloads) and intentionally avoid the legacy
+``/api/v1/ingest`` router's vocabulary.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+
+from sqlalchemy import (
+    JSON,
+    Boolean,
+    DateTime,
+    ForeignKey,
+    Index,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from dev_health_ops.models.git import GUID, Base
+
+TOKEN_PREFIX = "fcpush_"
+TOKEN_PREFIX_DISPLAY_LENGTH = 12
+
+
+class IngestSourceMode(str, Enum):
+    FULLCHAOS_SYNC = "fullchaos_sync"
+    CUSTOMER_PUSH = "customer_push"
+    DISABLED = "disabled"
+
+
+class IngestWebhookMode(str, Enum):
+    """Reserved for CHAOS-2715 (webhook-assisted ingestion).
+
+    v1 only supports ``disabled``/``customer_relay`` -- the admin API 400s on
+    ``fullchaos_hosted`` (must-not-foreclose contract, see 0032 migration).
+    """
+
+    DISABLED = "disabled"
+    CUSTOMER_RELAY = "customer_relay"
+    FULLCHAOS_HOSTED = "fullchaos_hosted"
+
+
+class IngestTokenScope(str, Enum):
+    SCHEMA_READ = "schema:read"
+    INGEST_WRITE = "ingest:write"
+    INGEST_STATUS = "ingest:status"
+
+
+def generate_ingest_token() -> str:
+    """Mint a new plaintext ingest token: ``fcpush_<43-char urlsafe secret>``.
+
+    256 bits of entropy (``secrets.token_urlsafe(32)``) makes a fast hash
+    function (see ``hash_ingest_token``) safe for this purpose -- this is a
+    high-entropy bearer secret, not a user password.
+    """
+    return f"{TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+
+
+def hash_ingest_token(token: str) -> str:
+    """sha256 digest, matching the house convention (RefreshToken,
+    PasswordResetToken, OrgInvite, EmailVerificationToken)."""
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class IngestSource(Base):
+    """One row per ``(org_id, system, instance)``.
+
+    Tracks which of ``fullchaos_sync | customer_push | disabled`` currently
+    owns that source instance -- the single registry the one-active-owner XOR
+    check is enforced against, not just customer-push rows (Design Decision 4).
+    """
+
+    __tablename__ = "external_ingest_sources"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    system: Mapped[str] = mapped_column(Text, nullable=False)
+    instance: Mapped[str] = mapped_column(Text, nullable=False)
+    display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
+    mode: Mapped[str] = mapped_column(
+        Text, nullable=False, default=IngestSourceMode.DISABLED.value
+    )
+    enabled: Mapped[bool] = mapped_column(Boolean, nullable=False, default=True)
+    webhook_mode: Mapped[str] = mapped_column(
+        Text, nullable=False, default=IngestWebhookMode.DISABLED.value
+    )
+    # Reserved, unused in v1 (CHAOS-2715 must-not-foreclose contract).
+    webhook_secret_id: Mapped[uuid.UUID | None] = mapped_column(GUID, nullable=True)
+    # CC5: the integration_sources.id resolved by per-provider matching at
+    # registration time (or the most recent enable/mode-change re-check).
+    # NULL means no managed source currently matches this instance.
+    matched_integration_source_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID, nullable=True
+    )
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(GUID, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+        onupdate=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "system",
+            "instance",
+            name="uq_external_ingest_sources_org_system_instance",
+        ),
+    )
+
+    def is_write_eligible(self) -> bool:
+        return self.enabled and self.mode == IngestSourceMode.CUSTOMER_PUSH.value
+
+
+class IngestToken(Base):
+    """Hashed bearer credential scoped to an org + optionally a single source."""
+
+    __tablename__ = "external_ingest_tokens"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    # NULL means "all sources in this org" -- only legal when scopes are a
+    # subset of {schema:read, ingest:status} (never ingest:write); enforced at
+    # creation time in the admin endpoint (Design Decision 7).
+    source_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID,
+        ForeignKey("external_ingest_sources.id"),
+        nullable=True,
+        index=True,
+    )
+    name: Mapped[str] = mapped_column(Text, nullable=False)
+    token_hash: Mapped[str] = mapped_column(
+        Text, nullable=False, unique=True, index=True
+    )
+    # First 12 chars of the full token (incl. the fcpush_ marker) for
+    # human-recognizable UI/audit display -- never the full plaintext secret.
+    token_prefix: Mapped[str] = mapped_column(Text, nullable=False)
+    scopes: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(GUID, nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_used_ip: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        Index("ix_external_ingest_tokens_org_active", "org_id", "revoked_at"),
+    )
+
+    def is_valid(self, now: datetime) -> bool:
+        if self.revoked_at is not None:
+            return False
+        if self.expires_at is not None and now > self.expires_at:
+            return False
+        return True

--- a/tests/api/admin/test_customer_push.py
+++ b/tests/api/admin/test_customer_push.py
@@ -1,0 +1,785 @@
+"""Tests for the customer-push admin API (CHAOS-2696).
+
+Covers source registration + per-provider ownership matching (CC5), token
+issue/rotate/revoke, and audit logging. Follows the direct-app fixture style
+established by tests/api/admin/test_integrations.py.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.audit import AuditLog
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.ingest_auth import IngestSource, IngestToken
+from dev_health_ops.models.integrations import Integration, IntegrationSource
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+admin_router_module = importlib.import_module("dev_health_ops.api.admin")
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    Integration,
+    IntegrationSource,
+    IngestSource,
+    IngestToken,
+    AuditLog,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "customer_push.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_state(session_maker):
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    org = Organization(id=org_id, slug="test-org", name="Test Org", tier="pro")
+    user = User(id=user_id, email="admin@example.com", is_active=True)
+
+    async with session_maker() as session:
+        session.add_all([org, user])
+        await session.commit()
+
+    return {"org_id": str(org_id), "user_id": str(user_id)}
+
+
+@pytest_asyncio.fixture
+async def client(session_maker, seeded_state):
+    app = FastAPI()
+    app.include_router(admin_router_module.router)
+
+    admin_user = AuthenticatedUser(
+        user_id=seeded_state["user_id"],
+        email="admin@example.com",
+        org_id=seeded_state["org_id"],
+        role="owner",
+        is_superuser=False,
+    )
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: admin_user
+    app.dependency_overrides[admin_router_module.get_session] = _session_override
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, seeded_state
+
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+async def _seed_integration_source(
+    session_maker,
+    org_id: str,
+    *,
+    provider: str,
+    external_id: str,
+    full_name: str,
+    name: str | None = None,
+    metadata_: dict | None = None,
+    is_enabled: bool = True,
+    integration_is_active: bool = True,
+) -> None:
+    integration_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add(
+            Integration(
+                id=integration_id,
+                org_id=org_id,
+                provider=provider,
+                name=f"{provider}-integration",
+                is_active=integration_is_active,
+            )
+        )
+        session.add(
+            IntegrationSource(
+                id=uuid.uuid4(),
+                org_id=org_id,
+                integration_id=integration_id,
+                provider=provider,
+                source_type="repository",
+                external_id=external_id,
+                name=name or full_name,
+                full_name=full_name,
+                metadata_=metadata_ or {},
+                is_enabled=is_enabled,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_active_integration(session_maker, org_id: str, provider: str) -> None:
+    async with session_maker() as session:
+        session.add(
+            Integration(
+                id=uuid.uuid4(),
+                org_id=org_id,
+                provider=provider,
+                name=f"{provider}-integration",
+                is_active=True,
+            )
+        )
+        await session.commit()
+
+
+async def _create_source(
+    ac, system: str = "github", instance: str = "acme/api", **extra
+):
+    payload = {"system": system, "instance": instance, **extra}
+    return await ac.post("/api/v1/admin/customer-push/sources", json=payload)
+
+
+async def _audit_actions(session_maker, org_id: str) -> list[str]:
+    async with session_maker() as session:
+        result = await session.execute(
+            select(AuditLog.action).where(AuditLog.org_id == uuid.UUID(org_id))
+        )
+        return [row[0] for row in result.all()]
+
+
+# ---------------------------------------------------------------------------
+# Source registration
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_source_defaults_to_customer_push_enabled(client):
+    ac, _ = client
+    resp = await _create_source(ac, system="github", instance="acme/api")
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["mode"] == "customer_push"
+    assert body["enabled"] is True
+    assert body["webhook_mode"] == "disabled"
+    assert body["matched_integration_source_id"] is None
+    assert body["warnings"] == []
+
+
+@pytest.mark.asyncio
+async def test_create_source_invalid_system_400(client):
+    ac, _ = client
+    resp = await _create_source(ac, system="bitbucket", instance="acme/api")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_source_invalid_mode_400(client):
+    ac, _ = client
+    resp = await _create_source(ac, mode="not_a_mode")
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_source_invalid_webhook_mode_422(client):
+    ac, _ = client
+    resp = await _create_source(ac, webhook_mode="fullchaos_hosted")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_source_duplicate_org_system_instance_409(client):
+    ac, _ = client
+    first = await _create_source(ac, system="github", instance="acme/api")
+    assert first.status_code == 201
+    second = await _create_source(ac, system="github", instance="acme/api")
+    assert second.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_list_sources_scoped_to_org(session_maker, client):
+    ac, state = client
+    await _create_source(ac, system="github", instance="acme/api")
+
+    other_org = uuid.uuid4()
+    async with session_maker() as session:
+        session.add(
+            IngestSource(
+                org_id=str(other_org),
+                system="github",
+                instance="other/repo",
+                mode="customer_push",
+                enabled=True,
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get("/api/v1/admin/customer-push/sources")
+    assert resp.status_code == 200
+    instances = [s["instance"] for s in resp.json()]
+    assert instances == ["acme/api"]
+
+
+@pytest.mark.asyncio
+async def test_get_source_not_found_404(client):
+    ac, _ = client
+    resp = await ac.get(f"/api/v1/admin/customer-push/sources/{uuid.uuid4()}")
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# CC5 per-provider ownership matching
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_github_enabled_managed_match_by_external_id_409(session_maker, client):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+    resp = await _create_source(ac, system="github", instance="acme/api")
+    assert resp.status_code == 409
+    assert resp.json()["detail"]["code"] == "source_owned_by_fullchaos_sync"
+
+
+@pytest.mark.asyncio
+async def test_github_disabled_managed_match_allows_and_stores_id(
+    session_maker, client
+):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+        is_enabled=False,
+    )
+    resp = await _create_source(ac, system="github", instance="acme/api")
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["matched_integration_source_id"] is not None
+
+
+@pytest.mark.asyncio
+async def test_gitlab_matches_numeric_external_id(session_maker, client):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="gitlab",
+        external_id="12345",
+        full_name="group/sub/project",
+        metadata_={"path_with_namespace": "group/sub/project"},
+    )
+    resp = await _create_source(ac, system="gitlab", instance="12345")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_gitlab_matches_path_with_namespace_metadata(session_maker, client):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="gitlab",
+        external_id="99999",
+        full_name="group/sub/project",
+        metadata_={"path_with_namespace": "group/sub/project"},
+    )
+    resp = await _create_source(ac, system="gitlab", instance="group/sub/project")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_gitlab_no_match_by_unrelated_instance_succeeds(session_maker, client):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="gitlab",
+        external_id="99999",
+        full_name="group/sub/project",
+        metadata_={"path_with_namespace": "group/sub/project"},
+    )
+    resp = await _create_source(ac, system="gitlab", instance="group/other-project")
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_jira_matches_external_id_or_full_name(session_maker, client):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="jira",
+        external_id="ABC",
+        full_name="ABC",
+    )
+    resp = await _create_source(ac, system="jira", instance="ABC")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_linear_matches_exact_instance(session_maker, client):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="linear",
+        external_id="team-uuid-123",
+        full_name="team-uuid-123",
+        name="CHAOS",
+    )
+    resp = await _create_source(ac, system="linear", instance="CHAOS")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_linear_org_wide_placeholder_owns_all_instances(session_maker, client):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="linear",
+        external_id="linear",
+        full_name="linear",
+        name="linear",
+        metadata_={"org_wide_placeholder": True},
+    )
+    resp = await _create_source(ac, system="linear", instance="ANY-TEAM")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_linear_org_wide_placeholder_via_external_id_literal(
+    session_maker, client
+):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="linear",
+        external_id="linear",
+        full_name="Linear Org Sync",
+        name="Linear Org Sync",
+    )
+    resp = await _create_source(ac, system="linear", instance="SOME-OTHER-TEAM")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_custom_system_never_conflicts(session_maker, client):
+    ac, state = client
+    # Seed a managed source that would match if this were treated as "github".
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+    resp = await _create_source(ac, system="custom", instance="acme/api")
+    assert resp.status_code == 201
+    assert resp.json()["matched_integration_source_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_mixed_case_managed_provider_still_hits_409(session_maker, client):
+    """Regression: nearby sync-creation paths don't enforce lowercase
+    Integration/IntegrationSource.provider values -- a mixed-case managed row
+    must still block a lowercase customer-push registration."""
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="GitHub",
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+    resp = await _create_source(ac, system="github", instance="acme/api")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_mixed_case_managed_provider_warns_not_409_when_different_instance(
+    session_maker, client
+):
+    ac, state = client
+    await _seed_active_integration(session_maker, state["org_id"], "GitHub")
+    resp = await _create_source(ac, system="github", instance="acme/repo-b")
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["warnings"]
+
+
+@pytest.mark.asyncio
+async def test_active_integration_different_instance_warns_not_409(
+    session_maker, client
+):
+    ac, state = client
+    await _seed_active_integration(session_maker, state["org_id"], "github")
+
+    resp = await _create_source(ac, system="github", instance="acme/repo-b")
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["warnings"]
+    assert "github" in body["warnings"][0]
+
+
+@pytest.mark.asyncio
+async def test_registering_disabled_mode_skips_ownership_check(session_maker, client):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+    resp = await _create_source(
+        ac, system="github", instance="acme/api", mode="disabled"
+    )
+    assert resp.status_code == 201
+
+
+@pytest.mark.asyncio
+async def test_instance_is_trimmed_before_persisting(client):
+    ac, _ = client
+    resp = await _create_source(ac, system="github", instance="  acme/api  ")
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["instance"] == "acme/api"
+
+
+@pytest.mark.asyncio
+async def test_blank_instance_rejected_422(client):
+    ac, _ = client
+    resp = await _create_source(ac, system="github", instance="   ")
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_whitespace_variant_instance_still_hits_409(session_maker, client):
+    """Regression: an un-trimmed instance must not bypass the CC5 match."""
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+    resp = await _create_source(ac, system="github", instance="  acme/api ")
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_inactive_integration_does_not_block_registration(session_maker, client):
+    """A source row left enabled under a deactivated Integration no longer
+    counts as active ownership -- registration succeeds (matched id still
+    recorded for bookkeeping), it does not 409."""
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+        is_enabled=True,
+        integration_is_active=False,
+    )
+    resp = await _create_source(ac, system="github", instance="acme/api")
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["matched_integration_source_id"] is not None
+
+
+# ---------------------------------------------------------------------------
+# PATCH re-check on enable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_patch_enabling_customer_push_reruns_ownership_check(
+    session_maker, client
+):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+    created = await _create_source(
+        ac, system="github", instance="acme/api", mode="disabled"
+    )
+    assert created.status_code == 201
+    source_id = created.json()["id"]
+
+    resp = await ac.patch(
+        f"/api/v1/admin/customer-push/sources/{source_id}",
+        json={"mode": "customer_push"},
+    )
+    assert resp.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_patch_updates_fields_and_audits(session_maker, client):
+    ac, state = client
+    created = await _create_source(ac, system="github", instance="acme/api")
+    source_id = created.json()["id"]
+
+    resp = await ac.patch(
+        f"/api/v1/admin/customer-push/sources/{source_id}",
+        json={"display_name": "Acme API", "enabled": False},
+    )
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["display_name"] == "Acme API"
+    assert body["enabled"] is False
+
+    actions = await _audit_actions(session_maker, state["org_id"])
+    assert actions.count("ingest_source_registered") == 1
+    assert actions.count("ingest_source_mode_changed") == 1
+
+
+@pytest.mark.asyncio
+async def test_patch_no_changes_emits_no_extra_audit_row(session_maker, client):
+    ac, state = client
+    created = await _create_source(ac, system="github", instance="acme/api")
+    source_id = created.json()["id"]
+
+    resp = await ac.patch(
+        f"/api/v1/admin/customer-push/sources/{source_id}",
+        json={"mode": "customer_push"},
+    )
+    assert resp.status_code == 200
+
+    actions = await _audit_actions(session_maker, state["org_id"])
+    assert actions.count("ingest_source_mode_changed") == 0
+
+
+# ---------------------------------------------------------------------------
+# Tokens
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_source_token_returns_plaintext_once(client):
+    ac, state = client
+    created = await _create_source(ac, system="github", instance="acme/api")
+    source_id = created.json()["id"]
+
+    resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/tokens",
+        json={"name": "ci-runner", "scopes": ["ingest:write", "ingest:status"]},
+    )
+    assert resp.status_code == 201, resp.text
+    body = resp.json()
+    assert body["token"].startswith("fcpush_")
+    assert body["token_prefix"] == body["token"][:12]
+    assert body["source_id"] == source_id
+
+    list_resp = await ac.get(f"/api/v1/admin/customer-push/sources/{source_id}/tokens")
+    assert list_resp.status_code == 200
+    listed = list_resp.json()
+    assert len(listed) == 1
+    assert "token" not in listed[0]
+    assert listed[0]["token_prefix"] == body["token_prefix"]
+
+    org_list_resp = await ac.get("/api/v1/admin/customer-push/tokens")
+    assert org_list_resp.status_code == 200
+    assert all("token" not in t for t in org_list_resp.json())
+
+
+@pytest.mark.asyncio
+async def test_create_source_token_rejects_unknown_scope(client):
+    ac, _ = client
+    created = await _create_source(ac, system="github", instance="acme/api")
+    source_id = created.json()["id"]
+
+    resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/tokens",
+        json={"name": "bad", "scopes": ["ingest:github"]},
+    )
+    assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_create_org_token_rejects_ingest_write_400(client):
+    ac, _ = client
+    resp = await ac.post(
+        "/api/v1/admin/customer-push/tokens",
+        json={"name": "org-wide", "scopes": ["ingest:write"]},
+    )
+    assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_create_org_token_allows_read_scopes(client):
+    ac, _ = client
+    resp = await ac.post(
+        "/api/v1/admin/customer-push/tokens",
+        json={"name": "org-wide", "scopes": ["schema:read", "ingest:status"]},
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["source_id"] is None
+
+
+@pytest.mark.asyncio
+async def test_rotate_token_invalidates_old_and_returns_new(session_maker, client):
+    ac, state = client
+    created = await _create_source(ac, system="github", instance="acme/api")
+    source_id = created.json()["id"]
+    token_resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/tokens",
+        json={"name": "ci-runner", "scopes": ["ingest:write"]},
+    )
+    old_token_id = token_resp.json()["id"]
+    old_plaintext = token_resp.json()["token"]
+
+    rotate_resp = await ac.post(
+        f"/api/v1/admin/customer-push/tokens/{old_token_id}/rotate"
+    )
+    assert rotate_resp.status_code == 200, rotate_resp.text
+    new_body = rotate_resp.json()
+    assert new_body["id"] != old_token_id
+    assert new_body["token"] != old_plaintext
+
+    async with session_maker() as session:
+        old_row = await session.get(IngestToken, uuid.UUID(old_token_id))
+        assert old_row.revoked_at is not None
+        new_row = await session.get(IngestToken, uuid.UUID(new_body["id"]))
+        assert new_row.revoked_at is None
+        assert new_row.source_id == old_row.source_id
+
+
+@pytest.mark.asyncio
+async def test_rotate_token_recomputes_expiry_from_original_ttl(session_maker, client):
+    ac, state = client
+    expires_at = datetime.now(timezone.utc) + timedelta(days=30)
+    token_resp = await ac.post(
+        "/api/v1/admin/customer-push/tokens",
+        json={
+            "name": "org-wide",
+            "scopes": ["schema:read"],
+            "expires_at": expires_at.isoformat(),
+        },
+    )
+    assert token_resp.status_code == 201, token_resp.text
+    old_token_id = token_resp.json()["id"]
+
+    rotate_resp = await ac.post(
+        f"/api/v1/admin/customer-push/tokens/{old_token_id}/rotate"
+    )
+    assert rotate_resp.status_code == 200, rotate_resp.text
+    new_expires_at = datetime.fromisoformat(rotate_resp.json()["expires_at"])
+
+    # Original TTL was ~30 days; the rotated token's expiry should be
+    # recomputed from *now* + that TTL, not copied verbatim (Design
+    # Decision 16) -- allow generous slack for test wall-clock time.
+    delta_days = (new_expires_at - datetime.now(timezone.utc)).total_seconds() / 86400
+    assert 29 < delta_days <= 30
+
+
+@pytest.mark.asyncio
+async def test_rotate_token_without_expiry_stays_unexpiring(client):
+    ac, _ = client
+    token_resp = await ac.post(
+        "/api/v1/admin/customer-push/tokens",
+        json={"name": "org-wide", "scopes": ["schema:read"]},
+    )
+    old_token_id = token_resp.json()["id"]
+
+    rotate_resp = await ac.post(
+        f"/api/v1/admin/customer-push/tokens/{old_token_id}/rotate"
+    )
+    assert rotate_resp.status_code == 200, rotate_resp.text
+    assert rotate_resp.json()["expires_at"] is None
+
+
+@pytest.mark.asyncio
+async def test_rotate_already_revoked_token_400(client):
+    ac, _ = client
+    token_resp = await ac.post(
+        "/api/v1/admin/customer-push/tokens",
+        json={"name": "org-wide", "scopes": ["schema:read"]},
+    )
+    token_id = token_resp.json()["id"]
+    revoke_resp = await ac.post(f"/api/v1/admin/customer-push/tokens/{token_id}/revoke")
+    assert revoke_resp.status_code == 200
+
+    rotate_resp = await ac.post(f"/api/v1/admin/customer-push/tokens/{token_id}/rotate")
+    assert rotate_resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_revoke_token_is_idempotent_and_audited_once(session_maker, client):
+    ac, state = client
+    token_resp = await ac.post(
+        "/api/v1/admin/customer-push/tokens",
+        json={"name": "org-wide", "scopes": ["schema:read"]},
+    )
+    token_id = token_resp.json()["id"]
+
+    first = await ac.post(f"/api/v1/admin/customer-push/tokens/{token_id}/revoke")
+    assert first.status_code == 200
+    assert first.json()["revoked_at"] is not None
+
+    second = await ac.post(f"/api/v1/admin/customer-push/tokens/{token_id}/revoke")
+    assert second.status_code == 200
+
+    actions = await _audit_actions(session_maker, state["org_id"])
+    assert actions.count("ingest_token_revoked") == 1
+
+
+@pytest.mark.asyncio
+async def test_full_lifecycle_produces_expected_audit_rows(session_maker, client):
+    ac, state = client
+    created = await _create_source(ac, system="github", instance="acme/api")
+    source_id = created.json()["id"]
+    token_resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/tokens",
+        json={"name": "ci-runner", "scopes": ["ingest:write"]},
+    )
+    token_id = token_resp.json()["id"]
+    await ac.post(f"/api/v1/admin/customer-push/tokens/{token_id}/rotate")
+
+    actions = await _audit_actions(session_maker, state["org_id"])
+    assert actions.count("ingest_source_registered") == 1
+    assert actions.count("ingest_token_created") == 1
+    assert actions.count("ingest_token_rotated") == 1

--- a/tests/models/test_ingest_auth.py
+++ b/tests/models/test_ingest_auth.py
@@ -1,0 +1,90 @@
+"""Unit tests for the customer-push ingest-auth models (CHAOS-2696)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dev_health_ops.models.ingest_auth import (
+    TOKEN_PREFIX,
+    IngestSource,
+    IngestSourceMode,
+    IngestToken,
+    hash_ingest_token,
+)
+from dev_health_ops.models.ingest_auth import generate_ingest_token as _generate_token
+
+NOW = datetime(2026, 7, 1, tzinfo=timezone.utc)
+
+
+def test_generate_ingest_token_has_expected_prefix_and_length():
+    token = _generate_token()
+    assert token.startswith(TOKEN_PREFIX)
+    # secrets.token_urlsafe(32) -> 43 chars, plus the "fcpush_" prefix.
+    assert len(token) == len(TOKEN_PREFIX) + 43
+
+
+def test_generate_ingest_token_is_random():
+    assert _generate_token() != _generate_token()
+
+
+def test_hash_ingest_token_round_trip_is_deterministic():
+    token = _generate_token()
+    assert hash_ingest_token(token) == hash_ingest_token(token)
+
+
+def test_hash_ingest_token_differs_for_different_tokens():
+    assert hash_ingest_token(_generate_token()) != hash_ingest_token(_generate_token())
+
+
+def test_hash_ingest_token_never_contains_the_raw_token():
+    token = _generate_token()
+    digest = hash_ingest_token(token)
+    assert token not in digest
+    assert len(digest) == 64  # sha256 hex digest
+
+
+@pytest.mark.parametrize(
+    "revoked_at, expires_at, expected",
+    [
+        (None, None, True),
+        (None, NOW + timedelta(hours=1), True),
+        (None, NOW - timedelta(hours=1), False),
+        (NOW - timedelta(minutes=1), None, False),
+        (NOW - timedelta(minutes=1), NOW + timedelta(hours=1), False),
+        (NOW - timedelta(minutes=1), NOW - timedelta(hours=1), False),
+    ],
+)
+def test_is_valid_matrix(revoked_at, expires_at, expected):
+    token = IngestToken(
+        org_id="org-1",
+        name="t",
+        token_hash="hash",
+        token_prefix="fcpush_abcd",
+        scopes=["schema:read"],
+        revoked_at=revoked_at,
+        expires_at=expires_at,
+    )
+    assert token.is_valid(NOW) is expected
+
+
+@pytest.mark.parametrize(
+    "mode, enabled, expected",
+    [
+        (IngestSourceMode.CUSTOMER_PUSH.value, True, True),
+        (IngestSourceMode.CUSTOMER_PUSH.value, False, False),
+        (IngestSourceMode.FULLCHAOS_SYNC.value, True, False),
+        (IngestSourceMode.DISABLED.value, True, False),
+        (IngestSourceMode.DISABLED.value, False, False),
+    ],
+)
+def test_is_write_eligible_matrix(mode, enabled, expected):
+    source = IngestSource(
+        org_id="org-1",
+        system="github",
+        instance="acme/api",
+        mode=mode,
+        enabled=enabled,
+    )
+    assert source.is_write_eligible() is expected

--- a/tests/test_migration_0032_customer_push_ingest_auth.py
+++ b/tests/test_migration_0032_customer_push_ingest_auth.py
@@ -1,0 +1,113 @@
+"""Migration 0032 (external_ingest_sources/external_ingest_tokens) tests.
+
+Follows the idempotent-upgrade/downgrade harness established for migration
+0031 (tests/test_rate_limit_observations.py::test_migration_0031_idempotent_upgrade).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+
+def _load_migration_0032():
+    return importlib.import_module(
+        "dev_health_ops.alembic.versions.0032_add_customer_push_ingest_auth"
+    )
+
+
+def test_migration_0032_idempotent_upgrade_downgrade():
+    migration = _load_migration_0032()
+    assert migration.revision == "0032"
+    assert migration.down_revision == "0031"
+
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                table_names = inspector.get_table_names()
+                assert "external_ingest_sources" in table_names
+                assert "external_ingest_tokens" in table_names
+
+                source_columns = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_sources")
+                }
+                assert source_columns == {
+                    "id",
+                    "org_id",
+                    "system",
+                    "instance",
+                    "display_name",
+                    "mode",
+                    "enabled",
+                    "webhook_mode",
+                    "webhook_secret_id",
+                    "matched_integration_source_id",
+                    "created_by_user_id",
+                    "created_at",
+                    "updated_at",
+                }
+
+                token_columns = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_tokens")
+                }
+                assert token_columns == {
+                    "id",
+                    "org_id",
+                    "source_id",
+                    "name",
+                    "token_hash",
+                    "token_prefix",
+                    "scopes",
+                    "created_by_user_id",
+                    "expires_at",
+                    "revoked_at",
+                    "last_used_at",
+                    "last_used_ip",
+                    "created_at",
+                }
+
+                source_index_names = {
+                    ix["name"]
+                    for ix in inspector.get_indexes("external_ingest_sources")
+                }
+                assert "ix_external_ingest_sources_org_id" in source_index_names
+
+                token_index_names = {
+                    ix["name"] for ix in inspector.get_indexes("external_ingest_tokens")
+                }
+                assert "ix_external_ingest_tokens_org_id" in token_index_names
+                assert "ix_external_ingest_tokens_source_id" in token_index_names
+                assert "ix_external_ingest_tokens_org_active" in token_index_names
+
+                # Re-running upgrade() must be a no-op (guarded create-if-missing).
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert inspector.get_table_names().count("external_ingest_sources") == 1
+                assert inspector.get_table_names().count("external_ingest_tokens") == 1
+
+                migration.downgrade()
+                inspector = sa.inspect(conn)
+                remaining = inspector.get_table_names()
+                assert "external_ingest_tokens" not in remaining
+                assert "external_ingest_sources" not in remaining
+
+                # downgrade() on already-absent tables is also a no-op.
+                migration.downgrade()
+
+                # And upgrade() works again from a clean slate.
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert "external_ingest_sources" in inspector.get_table_names()
+                assert "external_ingest_tokens" in inspector.get_table_names()
+    finally:
+        engine.dispose()


### PR DESCRIPTION
## Summary

Wave-1 foundation for the CHAOS-2690 external customer-push ingestion epic: source registration + ingest-token authz.

- `models/ingest_auth.py`: `IngestSource`/`IngestToken` models, `IngestSourceMode`/`IngestWebhookMode`/`IngestTokenScope` enums, `generate_ingest_token`/`hash_ingest_token` helpers (kept out of `api/external_ingest/auth.py` per master-spec CC14, avoiding a wave-1 file collision with CHAOS-2691).
- Migration `0032`: `external_ingest_sources` / `external_ingest_tokens` (table names per the brief's own reconciliation header + master-spec CC14), including the post-critique `matched_integration_source_id` column and CHAOS-2715's reserved `webhook_mode`/`webhook_secret_id` columns.
- `api/admin/routers/customer_push.py` + `schemas/customer_push.py`: full admin CRUD under `/api/v1/admin/customer-push/*` — source register/list/get/patch, source-bound + org-wide token issue, org-wide token list, rotate, revoke.
- One-active-owner registration conflicts resolved via CC5 per-provider matching against managed `integration_sources` (github `external_id`/`full_name`, gitlab `full_name`/`path_with_namespace`/numeric `external_id`, jira `external_id`/`full_name`, linear + org-wide placeholder rule). Hard `409 source_owned_by_fullchaos_sync` requires the match to be **actively owned** (`IntegrationSource.is_enabled` AND parent `Integration.is_active`); a non-blocking `warnings` field covers provider-level (any-instance) conflicts — the surviving half of the brief's Decision 8, overruled to a hard block at the instance grain per post-critique CC5/CC14.
- Token lifecycle matches the house `RefreshToken`/`PasswordResetToken` convention: `fcpush_` + `secrets.token_urlsafe(32)`, sha256-hashed, one-time plaintext display, 12-char `token_prefix` for UI. Rotation is a hard, immediate cutover under `SELECT ... FOR UPDATE`.
- `models/audit.py`: new `AuditAction`/`AuditResourceType` members; every lifecycle mutation emits an audit row with explicit commit-before-raise.
- `docs/architecture/customer-push-authz.md`: documents the one-active-owner design, the CC5 matching table, and the reserved-column contract for CHAOS-2715.

## Deviations from the brief (documented in `docs/architecture/customer-push-authz.md` and the report)

- Admin CRUD tests live at `tests/api/admin/test_customer_push.py` (matching AGENTS.md's stated convention and the `test_integrations.py` precedent), not `tests/api/external_ingest/*` — that tree belongs to CHAOS-2691/2712, out of this issue's scope.
- `schemas/__init__.py` is unmodified — verified `schemas/integrations.py` isn't re-exported there either; followed the same direct-import pattern.
- Added the `POST /customer-push/tokens` (org-wide, unbound) endpoint explicitly named in Design Decision 7 / the schema sketch, even though the brief's endpoint table omits it from the list.

## Codex adversarial review (2 rounds, 4 findings, all fixed)

1. **[high]** Un-trimmed `instance` (e.g. `"acme/api "`) bypassed the CC5 409 by creating a distinct row that didn't match the trimmed managed-source value. Fixed: `instance` is trimmed + blank-rejected at the schema layer.
2. **[high]** `rotate_token` had no row lock — concurrent rotations could both mint a live successor. Fixed: `SELECT ... FOR UPDATE` on rotate/revoke (matching `RefreshToken`'s own rotation precedent).
3. **[medium]** The hard 409 checked only `IntegrationSource.is_enabled`, not the parent `Integration.is_active`. Fixed: `_resolve_ownership` now requires both.
4. **[high]** Provider comparison was case-sensitive (`==`), so a mixed-case managed row (`"GitHub"`) could bypass the 409 against a lowercase `system="github"` registration. Fixed: `func.lower(...)` on both sides.

All four have regression tests.

## Gate

`SCRATCH_DB=ci_local_validate_2696 bash ci/local_validate.sh`, run 4x. ruff format/check ✔, mypy ✔, ClickHouse scratch-create/migrate ✔. Unit suite shows **14 pre-existing failures unrelated to this change** — confirmed via `git stash` A/B test against the unmodified `chaos-2690-external-ingest` base branch (identical failures reproduce with zero CHAOS-2696 code present), all in `test_register.py`/`test_credential_resolver.py`/`test_new_user_journey.py`/`test_cli_preflight.py`/`test_org_deletion.py` (license-key/env-config and secrets-in-logs concerns — nothing touching ingest auth or the audit enum). Flagging this to the epic owner as a pre-existing gate-health issue on the integration branch.

My own tests: 55 passing (`tests/api/admin/test_customer_push.py` + `tests/models/test_ingest_auth.py` + `tests/test_migration_0032_customer_push_ingest_auth.py`).

## Live verification

Migration proof against scratch Postgres `ci_2696` (never `devhealth`): `alembic upgrade head` from 0031 through 0032 clean, `dev-hops migrate postgres current` → `0032 (head)`, `psql \d` confirms all columns/constraints/indexes/FK exactly as designed, `downgrade -1` → tables dropped → re-`upgrade` → back to head. Scratch DB dropped on completion.

## Test plan

- [x] `ci/local_validate.sh` (lint, mypy, ClickHouse scratch provisioning) green
- [x] Unit suite green modulo pre-existing unrelated failures (documented above)
- [x] Migration up/down/up proof against scratch Postgres
- [x] 2-round Codex adversarial review, all findings fixed with regression tests