### PR TITLE
feat(external-ingest): REST contract, record schemas, validation endpoint (CHAOS-2691)

### DIFF
--- a/docs/architecture/adr-003-external-ingest-rest-boundary.md
+++ b/docs/architecture/adr-003-external-ingest-rest-boundary.md
@@ -1,0 +1,143 @@
+# ADR-003: External-ingest REST boundary, token scopes, and ownership model
+
+## Status
+
+Accepted. This is the CHAOS-2690 epic's backend ADR (flagged as unowned by
+the epic's cross-ticket recon). It covers decisions that span multiple
+sub-issues; the REST contract layer (this document's "REST, not GraphQL"
+section) ships in CHAOS-2691, while the token/ownership bodies described
+below ship in CHAOS-2696/2712/2695 — this ADR records the agreed model so
+those tickets implement against a fixed shape rather than re-deriving it.
+
+## Context
+
+CHAOS-2690 adds a customer-facing ingestion path: external customers push
+git/work-item data into FullChaos via HTTP instead of FullChaos's connectors
+pulling it. This needs (1) a stable public contract surface, (2) a
+credential/scope model distinct from session auth, and (3) a policy for what
+happens when a customer's pushed data would collide with FullChaos's own
+managed sync for the same repo/project/team.
+
+## Decision 1: REST, not GraphQL, for the data plane
+
+The ingestion endpoints (`/api/v1/external-ingest/*`) and their admin
+counterparts (`/api/v1/admin/customer-push/*`) are plain REST, snake_case on
+the admin side and camelCase on the data-plane wire contract — **no GraphQL
+mutations are added for this epic** (master-spec CC25).
+
+Rationale:
+
+- External customers integrate via CI scripts, cron jobs, and simple HTTP
+  clients (curl, a thin CLI) — a REST/JSON contract with a documented error
+  envelope is the lowest-friction integration surface for that audience,
+  matching how GitHub/Stripe/most ingestion-style APIs are consumed.
+- The existing GraphQL schema (`api/graphql/schema.py`) is primarily a
+  query surface for the web app's own read paths; the earlier "verified
+  query-only schema" claim in this ADR's early drafts was **incorrect** —
+  `api/graphql/schema.py:814` defines a `Mutation` root with five
+  saved-report mutations. The REST-only decision here is grounded in the
+  epic's own scope (a stable external contract, not another GraphQL
+  surface), not in an absent mutation root.
+- Precedent: the legacy `/api/v1/ingest` router and `api/product_telemetry/`
+  are both REST. External-ingest follows the same shape rather than
+  introducing a third pattern.
+
+The data plane and the admin plane deliberately use **two different
+response conventions** — the data plane's `{"error": {code, message,
+errors?}}` envelope (`api/external_ingest/errors.py`, CHAOS-2691 D3) versus
+the admin plane's house `HTTPException`/snake_case convention. This is not
+an oversight: the data plane is a documented public contract consumed by
+customer code; the admin plane is consumed by FullChaos's own web app and
+can evolve with the rest of the internal API.
+
+## Decision 2: Token scopes
+
+Three scopes: `schema:read`, `ingest:write`, `ingest:status`. `ingest:write`
+requires a source-bound token (a token minted against one registered
+`external_ingest_sources` row); `schema:read`/`ingest:status` do not.
+Provider-specific scopes are reserved but not implemented in v1 (no-op).
+
+`IngestAuthContext(org_id, scopes, token_id, source)` is the single shape
+threaded through every endpoint via `require_ingest_scope(scope)`
+(`api/external_ingest/auth.py`). CHAOS-2691 ships this dependency's
+signature and an **interim** body (see Decision 4); CHAOS-2696 mints real
+tokens (table `external_ingest_tokens`, format `fcpush_` +
+`secrets.token_urlsafe(32)`, sha256-hashed at rest); CHAOS-2712 swaps the
+dependency body to real resolution without changing the shape or any
+`Depends(...)` call site.
+
+## Decision 3: One-active-owner policy
+
+A customer should not be able to push data for a repo/project/team that
+FullChaos's own managed sync already owns — that would produce silently
+diverging or duplicated rows. The policy (master-spec CC5/CC14):
+
+- **Per-provider matching**, not bare `external_id` equality — verified in
+  code that a bare-equality check fails open for 3 of 4 providers (GitHub's
+  `integration_sources.external_id` is `owner/repo`; GitLab's is the
+  *numeric* project ID with the human-readable path living in
+  `full_name`/metadata; Jira matches on `project_id`/`project_key`/config
+  name; Linear matches on a team UUID or the literal `"linear"` org-wide
+  placeholder). Each provider gets its own matching rule (see
+  `sync/discovery.py:107,123,133` and `api/admin/routers/sync.py:535,775-820`
+  for the verified shapes).
+- **Registration-time resolution is stored**: matching runs once when a
+  customer registers a source; the matched row's id persists as
+  `external_ingest_sources.matched_integration_source_id`. If the match hits
+  an **enabled** managed source, registration is rejected
+  (`409 source_owned_by_fullchaos_sync`); if the match is disabled,
+  registration succeeds and the match is recorded.
+- **Accept-time re-check is authoritative**: every `POST /batches` re-checks
+  the stored match plus the two indexed exact matches, so a managed source
+  created or re-enabled *after* registration is still caught
+  (`403 source_owned_by_fullchaos_sync` via `resolve_effective_mode()`,
+  owned by CHAOS-2695's `ownership.py`).
+- Instance-level ownership is a **hard XOR** (a given repo/project/team is
+  owned by exactly one of {managed sync, customer push} at a time);
+  provider-level (e.g. "this org has GitHub sync enabled at all") is a
+  **soft warning** surfaced in the registration UX, not an enforcement gate.
+
+### Residual risk: Linear team-scoped ownership cannot be exactly resolved
+
+A managed Linear `IntegrationSource` stores a **team UUID**, not the
+human-readable team key (`CHAOS`) that `source.instance` uses for
+external-ingest. Equating the two requires a Linear API call this ingestion
+path does not make. The per-provider matching rule therefore falls back to
+`full_name`/`name` equality plus the org-wide `"linear"` placeholder rule
+(any enabled Linear source with `metadata_.org_wide_placeholder == true` or
+`external_id == 'linear'` owns **all** Linear instances for the org) — this
+is intentionally conservative (favors false-positive conflicts over
+false-negative silent divergence) but is not a byte-for-byte guarantee.
+**Operational guidance**: disable managed Linear sync for a team before
+enabling customer push for that same team's work items; do not rely on the
+matching rule alone to prevent a Linear collision.
+
+## Decision 4: Interim auth is a mechanically-gated stopgap, not a real credential system
+
+CHAOS-2691 ships `api/external_ingest/auth.py::require_ingest_scope` with a
+body that accepts **any** bearer token + `X-Org-Id` header combination —
+solely so the REST contract is end-to-end testable before CHAOS-2696/2712
+land real token issuance and validation. This is gated, not silently
+insecure:
+
+- The dependency **hard-fails `503 auth_not_configured`** unless the
+  deployment sets `EXTERNAL_INGEST_INSECURE_AUTH=1` — a flag intended only
+  for local compose/CI, never a deployed environment.
+- Every request accepted under the flag logs a WARNING naming the org_id,
+  so interim-mode traffic is visible in ops before CHAOS-2696/2712 land.
+- **CHAOS-2696/2712 landing (real DB-backed `IngestToken` validation) is a
+  hard pre-GA blocker** for this epic, not routine follow-up work. Merging
+  the `chaos-2690-external-ingest` integration branch to `main` remains
+  additionally gated on CHAOS-2712.
+
+## Consequences
+
+- Sibling tickets import fixed shapes from this ADR + CHAOS-2691's
+  `schemas.py`/`auth.py`/`errors.py` rather than re-deriving the contract,
+  keeping the epic's many parallel sub-issues from diverging.
+- The Linear residual risk above is a known, documented gap — not a defect
+  to silently patch over — until a future ticket adds a live Linear API
+  lookup to the matching rule (not scoped to CHAOS-2690 v1).
+- Interim auth is real, working code, not a mock — which is precisely why
+  it needs the mechanical off-switch: a working-but-insecure code path is
+  more dangerous than an obviously-fake one if a deploy gate slips.

--- a/docs/architecture/external-ingest-rest-contract.md
+++ b/docs/architecture/external-ingest-rest-contract.md
@@ -1,0 +1,207 @@
+# External-ingest REST contract (CHAOS-2691)
+
+Design decisions behind `src/dev_health_ops/api/external_ingest/` — the
+`/api/v1/external-ingest/*` REST contract, its 9 versioned record-kind
+schemas, and the two interim seams (`streams.py`, `auth.py`) later tickets
+harden. See [ADR-003](adr-003-external-ingest-rest-boundary.md) for the
+cross-epic REST-vs-GraphQL and ownership-model decisions this ticket does
+not own.
+
+## Idempotency-Key: body is canonical, header is an optional alias
+
+`BatchEnvelope.idempotencyKey` (body) is required and authoritative — it
+participates in the batch-identity tuple (`org_id + source_system +
+source_instance + idempotencyKey`) that later tickets use for
+replay/conflict detection, so it needs to live inside the payload a CLI can
+replay offline. The HTTP `Idempotency-Key` header is an optional
+Stripe-style alias for generic cURL/CI ergonomics; if both are present they
+must match, or the request is rejected with `400 idempotency_key_mismatch`.
+This ticket only implements the header/body consistency check — durable
+conflict detection (payload-hash comparison, 409 semantics) is CHAOS-2695.
+
+## 400 vs 422: the router parses the envelope itself
+
+The app-wide convention (`api/_errors.py`) maps FastAPI's automatic
+Pydantic-body validation failures to `422`. External-ingest's documented
+contract requires `400` for malformed envelopes. Rather than fight the
+app-wide convention, the endpoints take a raw `Request`, read bytes
+themselves (needed anyway for the body-size check below), and call
+`BatchEnvelope.model_validate_json(raw)` inside a try/except that maps
+`pydantic.ValidationError` to `ExternalIngestError(400, "invalid_envelope",
+...)`. Every other router in the app keeps the generic 422 convention
+untouched.
+
+## Error envelope: `{"error": {"code", "message", "errors"?}}`
+
+A dedicated shape (`api/external_ingest/errors.py::ExternalIngestError` +
+handler), not the app's `{"detail": ...}` convention — external-ingest
+responses are consumed by customer SDKs/CI scripts and need a stable,
+documented, machine-parseable contract distinct from the internal
+convention. Starlette dispatches exception handlers by exact type, so this
+handler wins over the app's generic `Exception` catch-all regardless of
+registration order. The canonical `code` vocabulary is pinned epic-wide
+(master-spec CC16); this ticket raises `invalid_envelope`,
+`unsupported_schema_version`, `unknown_record_kind`,
+`idempotency_key_mismatch`, `batch_too_large`, `payload_too_large`,
+`stream_unavailable`, `auth_not_configured`, `invalid_token`,
+`insufficient_scope` (dead code in interim auth), and `rate_limited` (429,
+wired via a path-prefix branch in the shared `api/_errors.py::_rate_limit_handler`
+rather than a second
+`RateLimitExceeded` handler registration). Auth failures use this envelope
+too (master-spec CC16 explicitly includes them) — a missing/malformed
+bearer token is `401 invalid_token`; a missing `X-Org-Id` header is
+`400 missing_org_header`, a code that exists **only** for this interim
+mechanism (the header itself disappears once CHAOS-2712 derives `org_id`
+from a validated token, so it is deliberately not in CC16's permanent
+vocabulary). A genuinely unexpected exception (not one of the deliberate
+`ExternalIngestError`s above) also gets this envelope — `api/_errors.py`'s
+shared generic handler branches on the `/api/v1/external-ingest` path
+prefix and returns `500 internal_error` with the same sanitized "Internal
+Server Error" message it uses app-wide, so customer SDKs never need a
+special-case parser for the one failure mode that would otherwise use the
+app's `{"detail": ...}` shape (adversarial-review finding). This does not
+change `ExternalIngestError`'s own handler winning by exact-type dispatch
+for every deliberate error above. The remaining codes (`source_not_registered`,
+`source_disabled`, `source_owned_by_fullchaos_sync`, `source_mismatch`,
+`not_found`, `idempotency_conflict`, `ingest_temporarily_unavailable`) are
+reserved for CHAOS-2694/2695/2696/2712.
+
+## Batch limits: 1000 records / 10 MB body, both env-overridable
+
+`EXTERNAL_INGEST_MAX_RECORDS` (default 1000) is checked against
+`len(envelope.records)` after parse (`400 batch_too_large` — a semantic
+limit, not a transport one). `EXTERNAL_INGEST_MAX_BODY_BYTES` (default
+10,000,000) is checked against `Content-Length` first (fast rejection) and
+against the actual streamed byte count if `Content-Length` is absent or the
+request is chunked (`413 payload_too_large`). `POST /validate` enforces the
+same two limits. `GET /schemas` exposes both as `limits.maxRecordsPerBatch`
+/ `limits.maxBodyBytes` so a CLI pre-check reads live server values instead
+of hardcoding them.
+
+## `/batches` checks envelope + kind allowlist only; `/validate` deep-validates eagerly
+
+`POST /batches` rejects the entire batch with `400` for: unsupported
+`schemaVersion`, any `records[i].kind` outside the 9 known kinds, or
+envelope-level shape errors. It does **not** reject the batch for a
+malformed individual record *payload* (e.g. a `pull_request.v1` missing
+`title`) — those are accepted into the stream and, once CHAOS-2694/2697
+land, surface as per-record rejections after the worker's full validation
+pass. This means a customer's momentary schema drift on a handful of
+records out of a large batch doesn't drop the rest.
+
+`POST /validate` performs the deep per-record check eagerly via
+`dev_health_ops.external_ingest.validate.validate_records` — the **single**
+owner of deep validation (master-spec CC17): CHAOS-2697's worker imports
+this function unchanged, so "the API's /validate and the durable worker
+agree on what's valid" holds by construction rather than by keeping two
+implementations in sync. `RecordEnvelope.payload` is typed as a plain
+`dict` at the envelope level (not a discriminated union) specifically so one
+malformed record's shape doesn't abort parsing the rest of the batch —
+per-record diagnostics need to report *which* record failed without
+throwing away the other 999.
+
+## `Repo.provider` stores the source system, not the ingestion mode
+
+`repository.v1.sourceSystem` is written directly into `Repo.provider`
+(`"github"`, `"gitlab"`, `"custom"`) by the CHAOS-2697/2698 worker — no new
+`"customer_push"` provider value is introduced. Ingestion-mode / ownership
+tracking lives exclusively in the CHAOS-2696 source-registration table
+(`external_ingest_sources`, keyed on `org_id, system, instance`), not
+overloaded onto `repos.provider`. Provenance (which specific registered
+source wrote a row) is a separate nullable `source_id` column added by
+CHAOS-2698's ClickHouse migration, not `provider` itself.
+
+## `repository.v1.externalId` is the provider full name, not a URL
+
+Verified in code (not assumed): `processors/github.py:1572` passes
+`repo=repo_info.full_name`, `processors/gitlab.py:1815` passes
+`path_with_namespace`, and `get_repo_uuid_from_repo()`
+(`models/git.py:72-93`) lowercases/strips whatever string it's given as the
+deterministic-UUID seed. So `externalId` for github/gitlab must be exactly
+the string FullChaos's own connector would have derived (`owner/repo` /
+`group/subgroup/project`) for identity continuity across a
+fullchaos_sync-to-customer_push handoff to work; for `system="custom"` the
+seed is `custom:{source.instance}:{externalId}` instead. This is a genuine,
+unenforced footgun: Pydantic validates string *shape*, not "is this the
+same string FullChaos's connector would derive" — a customer sending a
+differently-formatted identifier for the same logical repo silently creates
+a duplicate `repos` row instead of reconciling with the existing one.
+`repository.v1.externalId` must also equal `source.instance` for git
+systems (repo/project-grain sources, one batch per source instance).
+
+## `work_item.v1` takes `externalKey`, not a customer-supplied namespaced ID
+
+Customers send the provider-native key only (`ABC-123`, `CHAOS-123`, an
+issue/PR number) — never the internal namespaced `work_item_id`
+(`jira:ABC-123`, `gh:{repo}#{n}`, etc.), which CHAOS-2698's
+`external_ingest/ids.py` derives server-side. `WorkItemTransitionV1` and
+`WorkItemDependencyV1` mirror this with `externalKey`
+(`sourceExternalKey`/`targetExternalKey` for the dependency's two sides)
+plus an optional `workItemType` per side, since GitHub/GitLab need it to
+disambiguate an issue namespace from a PR/MR namespace sharing the same
+number.
+
+## `review.v1.state` is a validated allow-list, not a free string
+
+The internal `GitPullRequestReview.state` has no normalized enum — it's a
+raw provider string. External-ingest constrains the wire schema to
+`Literal["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED",
+"PENDING"]` instead, because a customer payload is untrusted input in a way
+a native sync provider's response is not; an unrecognized value is a loud
+`422`-shaped validation error, not a silent pass-through.
+
+## `extra="forbid"` on all 9 record models — and on the envelope/wrapper models too
+
+A deliberate deviation from most Pydantic models elsewhere in this
+codebase, which tend to be looser. This is a versioned, external,
+customer-SDK contract — a customer's field-name typo should be a loud
+validation error, not silently dropped data. If a future reviewer expects
+laxer validation (matching `product_telemetry`'s free-form `payload: dict`
+field), the strictness is intentional and load-bearing: CHAOS-2692's
+"schemas match API validation behavior" acceptance criterion depends on
+validation being meaningful.
+
+`SourceDescriptor`, `IngestWindow`, `RecordEnvelope`, and `BatchEnvelope`
+(the envelope/wrapper layer, as opposed to the 9 per-kind payload models)
+also carry `extra="forbid"` — an adversarial-review fix: strict payloads
+wrapped in a loose envelope would let a typo in `schemaVersion`'s sibling
+fields, `source`, `window`, or a record wrapper's own keys pass through
+silently while `/schemas` advertises exact-match validation. `POST
+/batches` and `POST /validate` both reject unknown fields anywhere in the
+envelope with `400 invalid_envelope` accordingly.
+
+## `streams.py` / `auth.py` are real interim implementations, not mocks
+
+`enqueue_batch()` is a real Valkey `XADD` writer that raises
+`StreamUnavailableError` on any failure — the router maps this to `503
+stream_unavailable`, never accept-and-warn (contrast the legacy
+`api/ingest/streams.py`, which accepts silently on Redis failure). Stream
+naming (`external-ingest:{org_id}:batches`, DLQ
+`external-ingest:{org_id}:dlq`) and the signature (including the
+`record_count`/`window_started_at`/`window_ended_at` pointer fields added
+per master-spec CC9) are a pinned contract CHAOS-2693 extends in place
+without changing.
+
+`require_ingest_scope()`'s interim body accepts any bearer token + valid
+`X-Org-Id` header **only** when `EXTERNAL_INGEST_INSECURE_AUTH=1` is set;
+otherwise it hard-fails `503 auth_not_configured`. See
+[ADR-003](adr-003-external-ingest-rest-boundary.md#decision-4-interim-auth-is-a-mechanically-gated-stopgap-not-a-real-credential-system)
+for the full rationale and the CHAOS-2696/2712 replacement plan — this is a
+release blocker for the epic, not a routine follow-up.
+
+Because interim auth does not validate the bearer value at all, keying the
+rate limiter on it would let a caller rotate arbitrary strings for a fresh
+60/minute bucket on every request (adversarial-review finding).
+`get_ingest_token_key` (`api/middleware/rate_limit.py`) checks
+`EXTERNAL_INGEST_INSECURE_AUTH` itself and keys on IP instead of the bearer
+digest whenever the flag is set — the only real, uncontrolled identity
+available until CHAOS-2696/2712 issue validated per-token credentials.
+
+## `GET /schemas` / `GET /schemas/{version}`: minimal, real, off the Pydantic models directly
+
+Both endpoints return live output from `BatchEnvelope.model_json_schema()`
+and each `RECORD_KIND_MODELS[kind].model_json_schema()` — no separate
+schema-registry module. CHAOS-2692 is additive polish (examples, ETag,
+versioned history) on top of this, importing `RECORD_KIND_MODELS` from this
+ticket's `schemas.py` rather than redeclaring the models, so the two
+tickets' schemas can never drift apart.

--- a/src/dev_health_ops/api/_errors.py
+++ b/src/dev_health_ops/api/_errors.py
@@ -15,6 +15,11 @@ from fastapi.exceptions import RequestValidationError
 from fastapi.responses import JSONResponse
 from slowapi.errors import RateLimitExceeded
 
+from .external_ingest.errors import (
+    EXTERNAL_INGEST_PATH_PREFIX,
+    external_ingest_error_body,
+)
+
 if TYPE_CHECKING:
     from fastapi import FastAPI
 
@@ -27,8 +32,21 @@ def _rate_limit_handler(request: Request, exc: Exception) -> JSONResponse:
     Any other exception type is re-raised so the framework can route it to the
     appropriate handler (this preserves the original semantics of the inline
     handler).
+
+    external-ingest routes get their own error envelope (master-spec CC16)
+    instead of the app-wide ``{"detail": ...}`` shape — branching on path
+    here avoids registering a second ``RateLimitExceeded`` handler (Starlette
+    only dispatches one per exception type) and avoids a second ``Limiter``
+    instance (master-spec CC15 requires reusing the shared singleton).
     """
     if isinstance(exc, RateLimitExceeded):
+        if request.url.path.startswith(EXTERNAL_INGEST_PATH_PREFIX):
+            return JSONResponse(
+                status_code=429,
+                content=external_ingest_error_body(
+                    "rate_limited", "Rate limit exceeded. Please try again later."
+                ),
+            )
         return JSONResponse(
             status_code=429,
             content={
@@ -69,6 +87,13 @@ async def _generic_exception_handler(request: Request, exc: Exception) -> JSONRe
 
     Logs the real exception with stack trace at ERROR level so operators can
     investigate via logs/Sentry, but never leaks internals to the client.
+
+    external-ingest routes get the customer-facing envelope here too
+    (adversarial-review finding): the documented contract is one stable
+    ``{"error": {...}}`` shape for every ``/api/v1/external-ingest/*``
+    response, including a genuinely unexpected 500 — not just the errors
+    ``ExternalIngestError`` raises deliberately. The message stays the same
+    generic, sanitized text; only the envelope shape changes.
     """
     logger.error(
         "Unhandled exception on %s %s",
@@ -76,6 +101,13 @@ async def _generic_exception_handler(request: Request, exc: Exception) -> JSONRe
         request.url.path,
         exc_info=exc,
     )
+    if request.url.path.startswith(EXTERNAL_INGEST_PATH_PREFIX):
+        return JSONResponse(
+            status_code=500,
+            content=external_ingest_error_body(
+                "internal_error", "Internal Server Error"
+            ),
+        )
     return JSONResponse(
         status_code=500,
         content={"detail": "Internal Server Error"},

--- a/src/dev_health_ops/api/external_ingest/__init__.py
+++ b/src/dev_health_ops/api/external_ingest/__init__.py
@@ -1,0 +1,3 @@
+from .router import router
+
+__all__ = ["router"]

--- a/src/dev_health_ops/api/external_ingest/auth.py
+++ b/src/dev_health_ops/api/external_ingest/auth.py
@@ -1,0 +1,101 @@
+"""Interim external-ingest auth dependency (CHAOS-2691 D7).
+
+INTEGRATION-BRANCH-ONLY: this module's body is intentionally permissive once
+``EXTERNAL_INGEST_INSECURE_AUTH=1`` is set (any bearer token + any
+``X-Org-Id`` is then accepted) because CHAOS-2691's own acceptance criteria
+never test 401/403 — only 202/400/413/openapi/tests-for-shapes. Merging the
+``chaos-2690-external-ingest`` integration branch to ``main`` is gated on
+CHAOS-2712 landing real DB-backed ``IngestToken`` validation.
+
+CHAOS-2696/CHAOS-2712 replace this function's body; the ``IngestAuthContext``
+shape and ``Depends(...)`` call sites in ``router.py`` must not change.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+
+from fastapi import Header
+
+from dev_health_ops.api.services.auth import set_current_org_id
+
+from .errors import ExternalIngestError
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class IngestAuthContext:
+    org_id: str
+    scopes: set[str] = field(default_factory=set)
+    token_id: str | None = None  # populated once CHAOS-2696 lands
+
+
+def require_ingest_scope(required_scope: str):
+    async def _dep(
+        authorization: str | None = Header(default=None),
+        x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
+    ) -> IngestAuthContext:
+        # Mechanical guard (master-spec CC14): the interim dependency refuses
+        # to run unless explicitly enabled for local/test use. Prevents the
+        # any-bearer+X-Org-Id path from ever working in a deployed
+        # environment (integration branches DO get deployed to shared envs;
+        # process gates slip). CHAOS-2712 deletes this flag together with
+        # the interim body.
+        if os.environ.get("EXTERNAL_INGEST_INSECURE_AUTH") != "1":
+            raise ExternalIngestError(
+                status_code=503,
+                code="auth_not_configured",
+                message="external-ingest auth is not configured on this deployment",
+            )
+        if not authorization or not authorization.lower().startswith("bearer "):
+            # Adversarial-review fix: use the external-ingest error envelope
+            # (master-spec CC16 explicitly includes auth failures), not a
+            # bare HTTPException — customer SDKs must not need special-case
+            # parsing for auth errors on a contract that advertises one
+            # stable {"error": {...}} shape.
+            raise ExternalIngestError(
+                status_code=401,
+                code="invalid_token",
+                message="Missing or malformed bearer token",
+            )
+        if not x_org_id:
+            # missing_org_header is interim-only: the X-Org-Id header itself
+            # disappears once CHAOS-2712 derives org_id from a validated
+            # token, so this code is not in master-spec CC16's permanent
+            # vocabulary.
+            raise ExternalIngestError(
+                status_code=400,
+                code="missing_org_header",
+                message="X-Org-Id header required",
+            )
+        # INTERIM (CHAOS-2691): token value is opaque and NOT validated
+        # against a DB-backed IngestToken/scope model yet. CHAOS-2696
+        # replaces this function body. Every interim-mode request is logged
+        # at WARNING so this is visible in ops before 2696 lands.
+        logger.warning(
+            "external-ingest interim auth: unvalidated token accepted for org_id=%s",
+            x_org_id,
+        )
+        ctx = IngestAuthContext(
+            org_id=x_org_id,
+            scopes={"ingest:write", "ingest:status", "schema:read"},
+        )
+        if required_scope not in ctx.scopes:
+            # Dead code in interim mode (all scopes are granted above) — the
+            # check is written now so the Depends() seam doesn't change
+            # shape once CHAOS-2696 grants real, narrower scopes.
+            raise ExternalIngestError(
+                status_code=403,
+                code="insufficient_scope",
+                message=f"Token is missing required scope: {required_scope}",
+            )
+        set_current_org_id(ctx.org_id)  # keep ClickHouse auto-scoping consistent
+        return ctx
+
+    return _dep
+
+
+__all__ = ["IngestAuthContext", "require_ingest_scope"]

--- a/src/dev_health_ops/api/external_ingest/errors.py
+++ b/src/dev_health_ops/api/external_ingest/errors.py
@@ -1,0 +1,83 @@
+"""Customer-facing error envelope for /api/v1/external-ingest/* (CHAOS-2691 D3).
+
+External-ingest responses are consumed by customer SDKs/CI scripts, not just
+the web app, so they need a stable, documented, machine-parseable error shape
+distinct from the app-wide ``{"detail": ...}`` convention (``api/_errors.py``),
+which is not a documented public contract.
+
+Canonical ``code`` vocabulary (master-spec CC16) is a fixed, cross-ticket set;
+this ticket raises a subset (see docs/architecture/adr-003-external-ingest-rest-boundary.md)
+and reserves the rest for sibling tickets (2694/2695/2696/2712/2699).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+from fastapi import Request
+from fastapi.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+#: Shared with api/_errors.py so the 429 handler can select this envelope
+#: shape for external-ingest routes without a second Limiter/exception
+#: handler registration (master-spec CC15).
+EXTERNAL_INGEST_PATH_PREFIX = "/api/v1/external-ingest"
+
+
+class ExternalIngestError(Exception):
+    def __init__(
+        self,
+        status_code: int,
+        code: str,
+        message: str,
+        *,
+        errors: list[dict] | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.status_code = status_code
+        self.code = code
+        self.message = message
+        self.errors = errors or []
+
+
+def external_ingest_error_body(
+    code: str, message: str, errors: list[dict] | None = None
+) -> dict:
+    body: dict = {"error": {"code": code, "message": message}}
+    if errors:
+        body["error"]["errors"] = errors
+    return body
+
+
+async def _external_ingest_error_handler(
+    request: Request, exc: Exception
+) -> JSONResponse:
+    if not isinstance(exc, ExternalIngestError):
+        # Defensive: should never happen since this handler is registered
+        # specifically for ExternalIngestError.
+        raise exc
+    return JSONResponse(
+        status_code=exc.status_code,
+        content=external_ingest_error_body(exc.code, exc.message, exc.errors),
+    )
+
+
+def register_external_ingest_error_handlers(app: FastAPI) -> None:
+    """Register the ExternalIngestError handler.
+
+    Starlette dispatches on exact exception type first, so this wins over
+    the generic ``Exception`` catch-all registered by
+    ``register_exception_handlers`` regardless of call order — safe to call
+    this anywhere after that registration in ``main.py``.
+    """
+    app.add_exception_handler(ExternalIngestError, _external_ingest_error_handler)
+
+
+__all__ = [
+    "EXTERNAL_INGEST_PATH_PREFIX",
+    "ExternalIngestError",
+    "external_ingest_error_body",
+    "register_external_ingest_error_handlers",
+]

--- a/src/dev_health_ops/api/external_ingest/router.py
+++ b/src/dev_health_ops/api/external_ingest/router.py
@@ -1,0 +1,249 @@
+"""External-ingest REST contract: 4 endpoints (CHAOS-2691).
+
+``POST /batches`` only checks envelope shape + the record-kind allowlist
+(400 on any unknown kind) — deep per-record validation happens eagerly in
+``POST /validate`` and durably in the CHAOS-2697 worker, so a customer's
+momentary schema drift on a handful of records doesn't drop an entire batch
+(see docs/architecture/external-ingest-rest-contract.md). ``GET /schemas*``
+is a minimal, real implementation straight off the Pydantic models in
+``schemas.py`` (brief D8) — CHAOS-2692 layers a registry/examples/ETag on
+top without redeclaring these models.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from uuid import uuid4
+
+from fastapi import APIRouter, Depends, Header, Request
+from pydantic import ValidationError
+
+from dev_health_ops.api.middleware.rate_limit import (
+    INGEST_BATCH_LIMIT,
+    INGEST_READ_LIMIT,
+    INGEST_VALIDATE_LIMIT,
+    get_ingest_token_key,
+    limiter,
+)
+from dev_health_ops.external_ingest.validate import validate_records
+
+from .auth import IngestAuthContext, require_ingest_scope
+from .errors import ExternalIngestError
+from .schemas import (
+    MAX_BODY_BYTES_DEFAULT,
+    MAX_RECORDS_DEFAULT,
+    RECORD_KIND_MODELS,
+    SCHEMA_VERSION,
+    BatchAcceptedResponse,
+    BatchEnvelope,
+    ValidationResponse,
+)
+from .streams import StreamUnavailableError, enqueue_batch
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v1/external-ingest", tags=["external-ingest"])
+
+# Bound once at import time (not called inline in each Depends(...)) so tests
+# can target these exact objects via app.dependency_overrides — overriding
+# the require_ingest_scope factory itself does not intercept already-bound
+# closures, since FastAPI matches overrides by the specific callable passed
+# to Depends().
+_require_schema_read = require_ingest_scope("schema:read")
+_require_ingest_write = require_ingest_scope("ingest:write")
+
+
+def _max_records() -> int:
+    return int(os.environ.get("EXTERNAL_INGEST_MAX_RECORDS", str(MAX_RECORDS_DEFAULT)))
+
+
+def _max_body_bytes() -> int:
+    return int(
+        os.environ.get("EXTERNAL_INGEST_MAX_BODY_BYTES", str(MAX_BODY_BYTES_DEFAULT))
+    )
+
+
+def _limits_payload() -> dict[str, int]:
+    return {"maxRecordsPerBatch": _max_records(), "maxBodyBytes": _max_body_bytes()}
+
+
+async def _read_body_enforcing_size_limit(request: Request) -> bytes:
+    """Read the raw request body, enforcing EXTERNAL_INGEST_MAX_BODY_BYTES.
+
+    Checks Content-Length first (reject fast) and falls back to counting
+    streamed bytes when Content-Length is absent/chunked (brief D4). Reading
+    raw bytes ourselves (rather than a typed Pydantic body param) is also
+    what lets ``_parse_envelope_or_400`` map malformed JSON to 400 instead of
+    FastAPI's app-wide RequestValidationError -> 422 convention (brief D2).
+    """
+    max_bytes = _max_body_bytes()
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            if int(content_length) > max_bytes:
+                raise ExternalIngestError(
+                    413, "payload_too_large", f"Request body exceeds {max_bytes} bytes"
+                )
+        except ValueError:
+            pass  # malformed Content-Length header: fall through to streamed count
+
+    body = bytearray()
+    async for chunk in request.stream():
+        body.extend(chunk)
+        if len(body) > max_bytes:
+            raise ExternalIngestError(
+                413, "payload_too_large", f"Request body exceeds {max_bytes} bytes"
+            )
+    return bytes(body)
+
+
+def _parse_envelope_or_400(raw: bytes) -> BatchEnvelope:
+    try:
+        return BatchEnvelope.model_validate_json(raw)
+    except ValidationError as exc:
+        raise ExternalIngestError(
+            400,
+            "invalid_envelope",
+            "Malformed batch envelope",
+            errors=[dict(e) for e in exc.errors()],
+        ) from exc
+
+
+def _check_idempotency_header_matches_body(
+    envelope: BatchEnvelope, header_value: str | None
+) -> None:
+    # Body idempotencyKey is canonical (brief D1); the header is an optional
+    # Stripe-style alias that must agree, kept for generic cURL/CI ergonomics.
+    if header_value is not None and header_value != envelope.idempotency_key:
+        raise ExternalIngestError(
+            400,
+            "idempotency_key_mismatch",
+            "Idempotency-Key header does not match body idempotencyKey",
+        )
+
+
+def _check_schema_version_or_400(envelope: BatchEnvelope) -> None:
+    if envelope.schema_version != SCHEMA_VERSION:
+        raise ExternalIngestError(
+            400,
+            "unsupported_schema_version",
+            f"Unsupported schemaVersion: {envelope.schema_version!r}",
+        )
+
+
+def _check_batch_size_or_400(envelope: BatchEnvelope) -> None:
+    max_records = _max_records()
+    if len(envelope.records) > max_records:
+        raise ExternalIngestError(
+            400,
+            "batch_too_large",
+            f"Batch has {len(envelope.records)} records; max is {max_records}",
+        )
+
+
+def _check_all_kinds_known_or_400(envelope: BatchEnvelope) -> None:
+    # /batches rejects the entire batch on any unsupported kind (no partial
+    # acceptance in v1); /validate instead reports per-record errors via
+    # validate_records (dev_health_ops.external_ingest.validate).
+    for index, record in enumerate(envelope.records):
+        if record.kind not in RECORD_KIND_MODELS:
+            raise ExternalIngestError(
+                400,
+                "unknown_record_kind",
+                f"Unknown record kind at index {index}: {record.kind!r}",
+            )
+
+
+@router.get("/schemas")
+@limiter.limit(INGEST_READ_LIMIT, key_func=get_ingest_token_key)
+async def list_schemas(request: Request) -> dict[str, object]:
+    return {
+        "schemaVersions": [SCHEMA_VERSION],
+        "recordKinds": sorted(RECORD_KIND_MODELS),
+        "limits": _limits_payload(),
+    }
+
+
+@router.get("/schemas/{schema_version}")
+@limiter.limit(INGEST_READ_LIMIT, key_func=get_ingest_token_key)
+async def get_schema(schema_version: str, request: Request) -> dict[str, object]:
+    if schema_version != SCHEMA_VERSION:
+        raise ExternalIngestError(
+            404,
+            "unsupported_schema_version",
+            f"Unknown schema version: {schema_version!r}",
+        )
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "envelope": BatchEnvelope.model_json_schema(by_alias=True),
+        "recordKinds": {
+            kind: model.model_json_schema(by_alias=True)
+            for kind, model in RECORD_KIND_MODELS.items()
+        },
+        "limits": _limits_payload(),
+    }
+
+
+@router.post("/validate", response_model=ValidationResponse)
+@limiter.limit(INGEST_VALIDATE_LIMIT, key_func=get_ingest_token_key)
+async def validate_batch(
+    request: Request,
+    ctx: IngestAuthContext = Depends(_require_schema_read),
+) -> ValidationResponse:
+    raw = await _read_body_enforcing_size_limit(request)
+    envelope = _parse_envelope_or_400(raw)
+    _check_schema_version_or_400(envelope)
+    _check_batch_size_or_400(envelope)
+    errors = validate_records(envelope.records)
+    rejected_indices = {item.index for item in errors}
+    return ValidationResponse(
+        valid=not errors,
+        items_accepted=len(envelope.records) - len(rejected_indices),
+        items_rejected=len(rejected_indices),
+        errors=errors,
+    )
+
+
+@router.post("/batches", response_model=BatchAcceptedResponse, status_code=202)
+@limiter.limit(INGEST_BATCH_LIMIT, key_func=get_ingest_token_key)
+async def accept_batch(
+    request: Request,
+    ctx: IngestAuthContext = Depends(_require_ingest_write),
+    idempotency_key_header: str | None = Header(default=None, alias="Idempotency-Key"),
+) -> BatchAcceptedResponse:
+    raw = await _read_body_enforcing_size_limit(request)
+    envelope = _parse_envelope_or_400(raw)
+    _check_idempotency_header_matches_body(envelope, idempotency_key_header)
+    _check_schema_version_or_400(envelope)
+    _check_all_kinds_known_or_400(envelope)
+    _check_batch_size_or_400(envelope)
+
+    ingestion_id = str(uuid4())
+    window = envelope.window
+    try:
+        stream = enqueue_batch(
+            org_id=ctx.org_id,
+            ingestion_id=ingestion_id,
+            source_system=envelope.source.system,
+            source_instance=envelope.source.instance,
+            schema_version=envelope.schema_version,
+            idempotency_key=envelope.idempotency_key,
+            payload_json=raw.decode("utf-8"),
+            record_count=len(envelope.records),
+            window_started_at=window.started_at if window else None,
+            window_ended_at=window.ended_at if window else None,
+        )
+    except StreamUnavailableError as exc:
+        raise ExternalIngestError(
+            503, "stream_unavailable", "Ingest stream unavailable"
+        ) from exc
+
+    return BatchAcceptedResponse(
+        ingestion_id=ingestion_id,
+        items_received=len(envelope.records),
+        stream=stream,
+    )
+
+
+__all__ = ["router"]

--- a/src/dev_health_ops/api/external_ingest/schemas.py
+++ b/src/dev_health_ops/api/external_ingest/schemas.py
@@ -1,0 +1,368 @@
+"""Pydantic v2 wire schemas for the external-ingest REST contract (CHAOS-2691).
+
+Frozen wire contract for CHAOS-2690's customer-push ingestion epic — sibling
+tickets (2692 schema registry, 2697 worker normalization, 2698 sinks, 2700
+CLI) import these models rather than re-declaring field sets. See
+``docs/architecture/external-ingest-rest-contract.md`` for the design
+decisions behind the shapes below (D1-D13) and
+``docs/architecture/adr-003-external-ingest-rest-boundary.md`` for the
+REST-boundary/ownership-model rationale.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Literal
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+
+SCHEMA_VERSION = "external-ingest.v1"
+MAX_RECORDS_DEFAULT = 1000
+MAX_BODY_BYTES_DEFAULT = 10_000_000
+
+_WORK_ITEM_STATUS = Literal[
+    "backlog",
+    "todo",
+    "in_progress",
+    "in_review",
+    "blocked",
+    "done",
+    "canceled",
+    "unknown",
+]
+_WORK_ITEM_TYPE = Literal["issue", "pr", "merge_request"]
+
+
+class SourceDescriptor(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    type: Literal["customer_push"] = "customer_push"
+    system: Literal["github", "gitlab", "jira", "linear", "custom"]
+    instance: str = Field(..., min_length=1, max_length=255)
+    producer: str | None = None
+    producer_version: str | None = Field(default=None, alias="producerVersion")
+
+
+class IngestWindow(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    started_at: datetime = Field(..., alias="startedAt")
+    ended_at: datetime = Field(..., alias="endedAt")
+
+    @field_validator("ended_at")
+    @classmethod
+    def _ended_after_started(cls, v: datetime, info) -> datetime:
+        started = info.data.get("started_at")
+        if started and v < started:
+            raise ValueError("window.endedAt must be >= window.startedAt")
+        return v
+
+
+class RecordEnvelope(BaseModel):
+    """Generic wrapper: kind + externalId (for error correlation) + payload.
+
+    ``payload`` is validated per-kind against ``RECORD_KIND_MODELS`` in
+    ``router.py``/``validate.py``, not here — a discriminated union at this
+    level would abort parsing the whole batch on one bad record (see
+    docs/architecture/external-ingest-rest-contract.md D-payload-shape).
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    kind: str
+    external_id: str = Field(..., alias="externalId", min_length=1, max_length=512)
+    payload: dict
+
+
+class BatchEnvelope(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    schema_version: str = Field(..., alias="schemaVersion")
+    idempotency_key: str = Field(
+        ..., alias="idempotencyKey", min_length=1, max_length=255
+    )
+    source: SourceDescriptor
+    window: IngestWindow | None = None
+    # min_length=1: empty batches are a 400 at parse time (master-spec CC3).
+    records: list[RecordEnvelope] = Field(..., min_length=1)
+
+
+# ---------------------------------------------------------------------------
+# Responses
+# ---------------------------------------------------------------------------
+
+
+class ValidationErrorItem(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    index: int
+    kind: str
+    code: str
+    message: str
+    path: str | None = None
+
+
+class ValidationResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    valid: bool
+    items_accepted: int = Field(..., alias="itemsAccepted")
+    items_rejected: int = Field(..., alias="itemsRejected")
+    errors: list[ValidationErrorItem] = Field(default_factory=list)
+
+
+class BatchAcceptedResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+
+    ingestion_id: str = Field(..., alias="ingestionId")
+    status: Literal["accepted"] = "accepted"
+    items_received: int = Field(..., alias="itemsReceived")
+    stream: str
+
+
+# ---------------------------------------------------------------------------
+# The 9 record-kind payload schemas
+#
+# All models: extra="forbid" — this is a versioned, external, customer-SDK
+# contract, not an internal analytics event. A customer typo should be a
+# loud validation error, not silently dropped data (deliberate deviation
+# from the rest of the codebase's looser Pydantic configs).
+# ---------------------------------------------------------------------------
+
+
+class RepositoryV1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    # externalId is the provider FULL NAME ("owner/repo" / "group/subgroup/
+    # project"), NOT a URL (master-spec CC4, verified against
+    # processors/github.py:1572 repo=repo_info.full_name and
+    # processors/gitlab.py:1815 path_with_namespace) — becomes Repo.repo AND
+    # the get_repo_uuid_from_repo() seed. Must equal source.instance for git
+    # systems. For system="custom": seed = f"custom:{instance}:{externalId}".
+    external_id: str = Field(..., alias="externalId", min_length=1, max_length=1024)
+    source_system: Literal["github", "gitlab", "custom"] = Field(
+        ..., alias="sourceSystem"
+    )
+    default_ref: str | None = Field(default=None, alias="defaultRef")
+    tags: list[str] = Field(default_factory=list, max_length=50)
+    settings: dict[str, str | int | float | bool] = Field(default_factory=dict)
+
+
+class IdentityV1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    canonical_id: str = Field(..., alias="canonicalId", min_length=1, max_length=255)
+    display_name: str | None = Field(default=None, alias="displayName")
+    email: str | None = None
+    provider_identities: dict[str, list[str]] = Field(
+        default_factory=dict, alias="providerIdentities"
+    )
+    team_ids: list[str] = Field(default_factory=list, alias="teamIds")
+    is_active: bool = Field(default=True, alias="isActive")
+    updated_at: datetime = Field(..., alias="updatedAt")
+
+
+class TeamV1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    id: str = Field(..., min_length=1, max_length=255)
+    name: str
+    description: str | None = None
+    members: list[str] = Field(default_factory=list)
+    project_keys: list[str] = Field(default_factory=list, alias="projectKeys")
+    repo_patterns: list[str] = Field(default_factory=list, alias="repoPatterns")
+    is_active: bool = Field(default=True, alias="isActive")
+    updated_at: datetime = Field(..., alias="updatedAt")
+    native_team_key: str | None = Field(default=None, alias="nativeTeamKey")
+    parent_team_id: str | None = Field(default=None, alias="parentTeamId")
+
+
+class WorkItemV1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    # Provider-NATIVE key ("ABC-123", "CHAOS-123", issue/PR number) — master-
+    # spec CC7. The namespaced work_item_id (jira:/linear:/gh:/ghpr:/
+    # gitlab:#/gitlab:!) is derived server-side in external_ingest/ids.py
+    # (CHAOS-2698); customers never send it.
+    external_key: str = Field(..., alias="externalKey", min_length=1, max_length=512)
+    provider: Literal["jira", "github", "gitlab", "linear"]
+    title: str
+    type: Literal[
+        "story",
+        "task",
+        "bug",
+        "epic",
+        "pr",
+        "merge_request",
+        "issue",
+        "incident",
+        "chore",
+        "unknown",
+    ] = "unknown"
+    status: _WORK_ITEM_STATUS
+    status_raw: str | None = Field(default=None, alias="statusRaw")
+    description: str | None = None
+    repository_external_id: str | None = Field(
+        default=None, alias="repositoryExternalId"
+    )
+    native_team_key: str | None = Field(default=None, alias="nativeTeamKey")
+    project_key: str | None = Field(default=None, alias="projectKey")
+    project_id: str | None = Field(default=None, alias="projectId")
+    project_name: str | None = Field(default=None, alias="projectName")
+    assignees: list[str] = Field(default_factory=list)
+    reporter: str | None = None
+    created_at: datetime = Field(..., alias="createdAt")
+    updated_at: datetime | None = Field(default=None, alias="updatedAt")
+    started_at: datetime | None = Field(default=None, alias="startedAt")
+    completed_at: datetime | None = Field(default=None, alias="completedAt")
+    closed_at: datetime | None = Field(default=None, alias="closedAt")
+    labels: list[str] = Field(default_factory=list)
+    story_points: float | None = Field(default=None, alias="storyPoints")
+    sprint_id: str | None = Field(default=None, alias="sprintId")
+    sprint_name: str | None = Field(default=None, alias="sprintName")
+    parent_id: str | None = Field(default=None, alias="parentId")
+    epic_id: str | None = Field(default=None, alias="epicId")
+    url: str | None = None
+    priority_raw: str | None = Field(default=None, alias="priorityRaw")
+    service_class: str | None = Field(default=None, alias="serviceClass")
+    due_at: datetime | None = Field(default=None, alias="dueAt")
+
+
+class WorkItemTransitionV1(BaseModel):
+    """Master-spec header item 2: takes ``externalKey`` (not the internal
+    namespaced ``work_item_id``) + optional ``workItemType`` to disambiguate
+    the issue vs. pr/merge_request namespace for github/gitlab.
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    external_key: str = Field(..., alias="externalKey", min_length=1, max_length=512)
+    provider: Literal["jira", "github", "gitlab", "linear"]
+    work_item_type: _WORK_ITEM_TYPE | None = Field(default=None, alias="workItemType")
+    occurred_at: datetime = Field(..., alias="occurredAt")
+    from_status_raw: str | None = Field(default=None, alias="fromStatusRaw")
+    to_status_raw: str | None = Field(default=None, alias="toStatusRaw")
+    from_status: _WORK_ITEM_STATUS = Field(..., alias="fromStatus")
+    to_status: _WORK_ITEM_STATUS = Field(..., alias="toStatus")
+    actor: str | None = None
+
+
+class WorkItemDependencyV1(BaseModel):
+    """Master-spec header item 2: source/target take ``externalKey`` pairs
+    (not internal namespaced work-item IDs) + optional per-side
+    ``workItemType`` since source and target may be different namespaces
+    (e.g. an issue blocked by a PR).
+    """
+
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    source_external_key: str = Field(
+        ..., alias="sourceExternalKey", min_length=1, max_length=512
+    )
+    source_work_item_type: _WORK_ITEM_TYPE | None = Field(
+        default=None, alias="sourceWorkItemType"
+    )
+    target_external_key: str = Field(
+        ..., alias="targetExternalKey", min_length=1, max_length=512
+    )
+    target_work_item_type: _WORK_ITEM_TYPE | None = Field(
+        default=None, alias="targetWorkItemType"
+    )
+    relationship_type: Literal[
+        "blocks", "blocked_by", "relates_to", "duplicates", "parent_of", "child_of"
+    ] = Field(..., alias="relationshipType")
+    relationship_type_raw: str | None = Field(default=None, alias="relationshipTypeRaw")
+
+
+class PullRequestV1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    repository_external_id: str = Field(..., alias="repositoryExternalId")
+    number: int = Field(..., ge=1)
+    title: str | None = None
+    body: str | None = None
+    state: Literal["open", "closed", "merged"]
+    author_name: str | None = Field(default=None, alias="authorName")
+    author_email: str | None = Field(default=None, alias="authorEmail")
+    created_at: datetime = Field(..., alias="createdAt")
+    merged_at: datetime | None = Field(default=None, alias="mergedAt")
+    closed_at: datetime | None = Field(default=None, alias="closedAt")
+    head_branch: str | None = Field(default=None, alias="headBranch")
+    base_branch: str | None = Field(default=None, alias="baseBranch")
+    additions: int | None = Field(default=None, ge=0)
+    deletions: int | None = Field(default=None, ge=0)
+    changed_files: int | None = Field(default=None, alias="changedFiles", ge=0)
+    first_review_at: datetime | None = Field(default=None, alias="firstReviewAt")
+    first_comment_at: datetime | None = Field(default=None, alias="firstCommentAt")
+    changes_requested_count: int | None = Field(
+        default=0, alias="changesRequestedCount", ge=0
+    )
+    reviews_count: int | None = Field(default=0, alias="reviewsCount", ge=0)
+    comments_count: int | None = Field(default=0, alias="commentsCount", ge=0)
+    url: str | None = None
+
+
+class ReviewV1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    repository_external_id: str = Field(..., alias="repositoryExternalId")
+    pull_request_number: int = Field(..., alias="pullRequestNumber", ge=1)
+    review_id: str = Field(..., alias="reviewId", min_length=1)
+    reviewer: str
+    # Validated free-string allow-list, not the internal untyped raw
+    # provider string (brief D12) — customer payloads are untrusted in a
+    # way native sync providers are not.
+    state: Literal["APPROVED", "CHANGES_REQUESTED", "COMMENTED", "DISMISSED", "PENDING"]
+    submitted_at: datetime = Field(..., alias="submittedAt")
+
+
+class CommitV1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    repository_external_id: str = Field(..., alias="repositoryExternalId")
+    hash: str = Field(..., min_length=7, max_length=64)
+    message: str | None = None
+    author_name: str | None = Field(default=None, alias="authorName")
+    author_email: str | None = Field(default=None, alias="authorEmail")
+    author_when: datetime = Field(..., alias="authorWhen")
+    committer_name: str | None = Field(default=None, alias="committerName")
+    committer_email: str | None = Field(default=None, alias="committerEmail")
+    committer_when: datetime | None = Field(default=None, alias="committerWhen")
+    parents: int = Field(default=1, ge=0)
+
+
+RECORD_KIND_MODELS: dict[str, type[BaseModel]] = {
+    "repository.v1": RepositoryV1,
+    "identity.v1": IdentityV1,
+    "team.v1": TeamV1,
+    "work_item.v1": WorkItemV1,
+    "work_item_transition.v1": WorkItemTransitionV1,
+    "work_item_dependency.v1": WorkItemDependencyV1,
+    "pull_request.v1": PullRequestV1,
+    "review.v1": ReviewV1,
+    "commit.v1": CommitV1,
+}
+
+
+__all__ = [
+    "SCHEMA_VERSION",
+    "MAX_RECORDS_DEFAULT",
+    "MAX_BODY_BYTES_DEFAULT",
+    "SourceDescriptor",
+    "IngestWindow",
+    "RecordEnvelope",
+    "BatchEnvelope",
+    "ValidationErrorItem",
+    "ValidationResponse",
+    "BatchAcceptedResponse",
+    "RepositoryV1",
+    "IdentityV1",
+    "TeamV1",
+    "WorkItemV1",
+    "WorkItemTransitionV1",
+    "WorkItemDependencyV1",
+    "PullRequestV1",
+    "ReviewV1",
+    "CommitV1",
+    "RECORD_KIND_MODELS",
+]

--- a/src/dev_health_ops/api/external_ingest/streams.py
+++ b/src/dev_health_ops/api/external_ingest/streams.py
@@ -1,0 +1,101 @@
+"""Interim durable-stream writer for external-ingest batches (CHAOS-2691 D6).
+
+Real, not mocked: raises ``StreamUnavailableError`` on any failure so the
+router can fail closed with a 503 — never accept-and-warn (contrast with
+``api/ingest/streams.py``'s legacy accept-and-warn behavior, which the epic
+explicitly rejects for the durability-focused external-ingest path).
+
+CHAOS-2693 hardens this into the full DLQ/consumer-group system and must
+preserve ``enqueue_batch()``'s signature and the stream-naming convention
+below without updating ``router.py``'s call site out from under it.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime
+
+logger = logging.getLogger(__name__)
+
+
+class StreamUnavailableError(Exception):
+    """Raised when the durable ingest stream cannot accept a write."""
+
+
+def stream_name(org_id: str) -> str:
+    return f"external-ingest:{org_id}:batches"
+
+
+def dlq_name(org_id: str) -> str:
+    return f"external-ingest:{org_id}:dlq"
+
+
+def get_redis_client():
+    redis_url = os.getenv("REDIS_URL")
+    if not redis_url:
+        return None
+    try:
+        import valkey as redis
+
+        return redis.from_url(redis_url, decode_responses=True)
+    except Exception:
+        logger.warning("Redis unavailable for external-ingest streams")
+        return None
+
+
+def enqueue_batch(
+    *,
+    org_id: str,
+    ingestion_id: str,
+    source_system: str,
+    source_instance: str,
+    schema_version: str,
+    idempotency_key: str,
+    payload_json: str,
+    record_count: int,
+    window_started_at: datetime | None = None,
+    window_ended_at: datetime | None = None,
+) -> str:
+    """Write one batch to the durable stream. Returns the stream key.
+
+    Raises StreamUnavailableError if Redis/Valkey is unavailable or the
+    write fails — CALLERS MUST map this to HTTP 503, never accept-and-warn.
+
+    ``record_count``/``window_started_at``/``window_ended_at`` are pointer
+    fields the CHAOS-2693 consumer/status-store need without deserializing
+    ``payload`` (master-spec CC9). Wave-1 interim: ``payload`` is still
+    XADD'd inline (nothing consumes it yet) — CHAOS-2693's PR drops that
+    param once the Postgres-backed payload store lands, updating this call
+    site as an approved, planned change.
+    """
+    client = get_redis_client()
+    if client is None:
+        raise StreamUnavailableError("Redis/Valkey unavailable")
+    stream = stream_name(org_id)
+    fields = {
+        "ingestion_id": ingestion_id,
+        "org_id": org_id,
+        "source_system": source_system,
+        "source_instance": source_instance,
+        "schema_version": schema_version,
+        "idempotency_key": idempotency_key,
+        "record_count": str(record_count),
+        "window_started_at": window_started_at.isoformat() if window_started_at else "",
+        "window_ended_at": window_ended_at.isoformat() if window_ended_at else "",
+        "payload": payload_json,
+    }
+    try:
+        client.xadd(stream, fields, maxlen=100000, approximate=True)
+    except Exception as exc:
+        raise StreamUnavailableError(str(exc)) from exc
+    return stream
+
+
+__all__ = [
+    "StreamUnavailableError",
+    "stream_name",
+    "dlq_name",
+    "get_redis_client",
+    "enqueue_batch",
+]

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -22,6 +22,10 @@ configure_logging()
 init_sentry()
 init_tracing()
 
+from dev_health_ops.api.external_ingest import router as external_ingest_router
+from dev_health_ops.api.external_ingest.errors import (
+    register_external_ingest_error_handlers,
+)
 from dev_health_ops.api.middleware.rate_limit import limiter
 from dev_health_ops.api.product_telemetry import router as product_telemetry_router
 from dev_health_ops.api.telemetry.router import router as telemetry_router
@@ -191,6 +195,7 @@ app = FastAPI(
 
 app.state.limiter = limiter
 register_exception_handlers(app)
+register_external_ingest_error_handlers(app)
 
 register_middleware(app)
 
@@ -205,6 +210,7 @@ app.include_router(licensing_router)
 app.include_router(telemetry_router)
 app.include_router(product_telemetry_router)
 app.include_router(ingest_router)
+app.include_router(external_ingest_router)
 app.include_router(orgs_router)
 
 register_observability(app)

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -29,6 +29,40 @@ AUTH_REFRESH_LIMIT = "10/15minutes"
 AUTH_VALIDATE_LIMIT = "30/15minutes"
 ADMIN_PASSWORD_LIMIT = "5/hour"
 
+# External-ingest (CHAOS-2690 epic, added by CHAOS-2691 per master-spec CC15):
+# shared limiter singleton, no second Limiter instance. INGEST_READ_LIMIT
+# applies to the public GET /schemas* endpoints (IP-keyed via
+# get_ingest_token_key's fallback) and to CHAOS-2694's GET /batches* (token-
+# keyed once real tokens exist).
+INGEST_BATCH_LIMIT = "60/minute"
+INGEST_VALIDATE_LIMIT = "60/minute"
+INGEST_READ_LIMIT = "120/minute"
+
+
+def get_ingest_token_key(request: Request) -> str:
+    """Rate-limit key for external-ingest endpoints: per-token, IP fallback.
+
+    Keys on a truncated hash of the bearer token (never the raw token, which
+    must not appear in limiter storage) so distinct ingest tokens get
+    independent buckets. Falls back to the forwarded IP for unauthenticated
+    requests (the public GET /schemas* endpoints) and, while
+    EXTERNAL_INGEST_INSECURE_AUTH=1's interim auth is active, for ALL
+    requests: interim auth does not validate the bearer value at all, so
+    keying on it would let a caller rotate arbitrary strings for a fresh
+    limiter bucket on every request (adversarial review finding) — IP is the
+    only real identity available until CHAOS-2696/2712 issue validated
+    per-token credentials; see brief-2691 Risks.
+    """
+    if os.environ.get("EXTERNAL_INGEST_INSECURE_AUTH") == "1":
+        return f"ingest-ip:{get_forwarded_ip(request)}"
+    auth_header = request.headers.get("authorization") or ""
+    if auth_header.lower().startswith("bearer "):
+        token = auth_header[7:].strip()
+        if token:
+            digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+            return f"ingest-token:{digest}"
+    return f"ingest-ip:{get_forwarded_ip(request)}"
+
 
 def _normalize_email(value: str | None) -> str:
     if not value:

--- a/src/dev_health_ops/external_ingest/__init__.py
+++ b/src/dev_health_ops/external_ingest/__init__.py
@@ -1,0 +1,9 @@
+"""External-ingest worker-facing package (CHAOS-2690 epic).
+
+Distinct from ``dev_health_ops.api.external_ingest`` (the HTTP layer):
+this package holds modules shared between the REST contract and the
+CHAOS-2693/2697 worker — starting with ``validate.py`` (CHAOS-2691), the
+single source of deep per-record validation. See master-spec.md's module
+map (docs/superpowers/plans/2026-07-01-chaos-2690-implementation/) for the
+full, cross-ticket ownership list of files that land here over the epic.
+"""

--- a/src/dev_health_ops/external_ingest/validate.py
+++ b/src/dev_health_ops/external_ingest/validate.py
@@ -1,0 +1,86 @@
+"""Deep per-record validation over external-ingest wire schemas (CHAOS-2691).
+
+Single owner (master-spec CC17): created COMPLETE here in wave 1, powers
+``POST /api/v1/external-ingest/validate``. CHAOS-2697's worker imports
+``validate_records`` UNCHANGED in wave 4 so the endpoint and the durable
+worker path can never diverge on what "valid" means.
+
+Shape-only: does not resolve cross-batch references (``repositoryExternalId``,
+``sourceExternalKey``/``targetExternalKey``, etc.) against ClickHouse — that
+requires a DB round-trip the request-validation path deliberately avoids.
+Kind×system-matrix / source-instance-scope enforcement (master-spec CC6) is
+also out of scope here — it needs org/source context this module doesn't
+have and is added by CHAOS-2695/2697's worker-side validation extension.
+"""
+
+from __future__ import annotations
+
+from pydantic import ValidationError
+
+from dev_health_ops.api.external_ingest.schemas import (
+    RECORD_KIND_MODELS,
+    RecordEnvelope,
+    ValidationErrorItem,
+)
+
+#: Pydantic error "type" -> our stable per-record rejection code vocabulary
+#: (master-spec CC16 lists missing_required_field/invalid_literal/unknown_kind
+#: as the canonical examples; anything else collapses to invalid_field).
+_MISSING_ERROR_TYPES = {"missing"}
+_LITERAL_ERROR_TYPES = {"literal_error", "enum"}
+
+
+def _error_code_for(pydantic_error_type: str) -> str:
+    if pydantic_error_type in _MISSING_ERROR_TYPES:
+        return "missing_required_field"
+    if pydantic_error_type in _LITERAL_ERROR_TYPES:
+        return "invalid_literal"
+    return "invalid_field"
+
+
+def _error_path(index: int, loc: tuple) -> str:
+    base = f"records[{index}].payload"
+    if not loc:
+        return base
+    return base + "." + ".".join(str(part) for part in loc)
+
+
+def validate_records(records: list[RecordEnvelope]) -> list[ValidationErrorItem]:
+    """Validate each record's payload against its kind's Pydantic model.
+
+    Returns one ``ValidationErrorItem`` per Pydantic field error found
+    (a single malformed record can produce multiple items). An unknown
+    ``kind`` produces exactly one ``unknown_kind`` item and skips payload
+    validation for that record (there is no model to validate against).
+    """
+    errors: list[ValidationErrorItem] = []
+    for index, record in enumerate(records):
+        model = RECORD_KIND_MODELS.get(record.kind)
+        if model is None:
+            errors.append(
+                ValidationErrorItem(
+                    index=index,
+                    kind=record.kind,
+                    code="unknown_kind",
+                    message=f"Unknown record kind: {record.kind!r}",
+                    path=f"records[{index}].kind",
+                )
+            )
+            continue
+        try:
+            model.model_validate(record.payload)
+        except ValidationError as exc:
+            for err in exc.errors():
+                errors.append(
+                    ValidationErrorItem(
+                        index=index,
+                        kind=record.kind,
+                        code=_error_code_for(err["type"]),
+                        message=err["msg"],
+                        path=_error_path(index, err["loc"]),
+                    )
+                )
+    return errors
+
+
+__all__ = ["validate_records"]

--- a/tests/api/test_external_ingest_router.py
+++ b/tests/api/test_external_ingest_router.py
@@ -1,0 +1,505 @@
+"""Tests for the external-ingest REST contract (CHAOS-2691).
+
+Covers the brief's test plan: envelope/kind/size validation (D2/D4), the D1
+idempotency header/body match, D6's fail-closed stream-unavailable mapping,
+D7's interim auth mechanical gate (master-spec CC14), and D8's schema
+discovery endpoints.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.external_ingest.auth import IngestAuthContext
+from dev_health_ops.api.external_ingest.schemas import (
+    RECORD_KIND_MODELS,
+    SCHEMA_VERSION,
+)
+from dev_health_ops.api.external_ingest.streams import StreamUnavailableError
+from dev_health_ops.api.main import app
+
+# __init__.py exports the APIRouter as "router", shadowing the module name —
+# force-load the actual module so we can reach its internals (the bound
+# per-scope dependency objects, enqueue_batch) the same way
+# tests/test_ingest_api.py reaches api.ingest.router's _persist_telemetry.
+importlib.import_module("dev_health_ops.api.external_ingest.router")
+router_mod = sys.modules["dev_health_ops.api.external_ingest.router"]
+
+BASE = "/api/v1/external-ingest"
+
+TEST_CTX = IngestAuthContext(
+    org_id="test-org", scopes={"ingest:write", "ingest:status", "schema:read"}
+)
+
+
+@pytest_asyncio.fixture
+async def client():
+    # Overriding require_ingest_scope (the factory) would not intercept
+    # anything: router.py binds each scope's closure once at import time via
+    # Depends(_require_schema_read)/Depends(_require_ingest_write), and
+    # FastAPI's dependency_overrides matches on that exact callable — not on
+    # the factory that produced it. Override the bound objects directly so
+    # unit tests never exercise D7's real (WARN-logging) interim auth body.
+    app.dependency_overrides[router_mod._require_schema_read] = lambda: TEST_CTX
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: TEST_CTX
+    # raise_app_exceptions=False: Starlette's ServerErrorMiddleware sends the
+    # sanitized 500 response *then* re-raises so ASGI-server-level logging
+    # still sees it; without this, httpx's ASGITransport re-raises instead of
+    # returning the response (matches tests/api/test_generic_exception_handler.py).
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield c
+    finally:
+        app.dependency_overrides.pop(router_mod._require_schema_read, None)
+        app.dependency_overrides.pop(router_mod._require_ingest_write, None)
+
+
+def _record(kind: str, external_id: str, payload: dict) -> dict:
+    return {"kind": kind, "externalId": external_id, "payload": payload}
+
+
+VALID_PAYLOADS: dict[str, dict] = {
+    "repository.v1": {"externalId": "acme/api", "sourceSystem": "github"},
+    "identity.v1": {"canonicalId": "user-1", "updatedAt": "2026-06-25T00:00:00Z"},
+    "team.v1": {
+        "id": "team-1",
+        "name": "Team One",
+        "updatedAt": "2026-06-25T00:00:00Z",
+    },
+    "work_item.v1": {
+        "externalKey": "ABC-123",
+        "provider": "jira",
+        "title": "Fix bug",
+        "status": "in_progress",
+        "createdAt": "2026-06-25T00:00:00Z",
+    },
+    "work_item_transition.v1": {
+        "externalKey": "ABC-123",
+        "provider": "jira",
+        "occurredAt": "2026-06-25T00:00:00Z",
+        "fromStatus": "todo",
+        "toStatus": "in_progress",
+    },
+    "work_item_dependency.v1": {
+        "sourceExternalKey": "ABC-123",
+        "targetExternalKey": "ABC-124",
+        "relationshipType": "blocks",
+    },
+    "pull_request.v1": {
+        "repositoryExternalId": "acme/api",
+        "number": 1,
+        "state": "open",
+        "createdAt": "2026-06-25T00:00:00Z",
+    },
+    "review.v1": {
+        "repositoryExternalId": "acme/api",
+        "pullRequestNumber": 1,
+        "reviewId": "rev-1",
+        "reviewer": "alice",
+        "state": "APPROVED",
+        "submittedAt": "2026-06-25T00:00:00Z",
+    },
+    "commit.v1": {
+        "repositoryExternalId": "acme/api",
+        "hash": "abc1234567",
+        "authorWhen": "2026-06-25T00:00:00Z",
+    },
+}
+
+
+def _envelope(records: list[dict], idempotency_key: str = "test-key-1") -> dict:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "idempotencyKey": idempotency_key,
+        "source": {"type": "customer_push", "system": "github", "instance": "acme/api"},
+        "records": records,
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /batches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_accept_minimal_valid_batch(client, monkeypatch):
+    calls = []
+
+    def fake_enqueue(**kwargs):
+        calls.append(kwargs)
+        return "external-ingest:test-org:batches"
+
+    monkeypatch.setattr(router_mod, "enqueue_batch", fake_enqueue)
+
+    envelope = _envelope([_record("commit.v1", "abc123", VALID_PAYLOADS["commit.v1"])])
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 202
+    body = resp.json()
+    assert body["status"] == "accepted"
+    assert body["itemsReceived"] == 1
+    assert "ingestionId" in body
+    assert body["stream"] == "external-ingest:test-org:batches"
+    assert len(calls) == 1
+    assert calls[0]["org_id"] == "test-org"
+    assert calls[0]["source_system"] == "github"
+    assert calls[0]["record_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_accept_batch_with_all_nine_kinds(client, monkeypatch):
+    monkeypatch.setattr(router_mod, "enqueue_batch", lambda **kwargs: "stream-x")
+    records = [
+        _record(kind, f"ext-{kind}", payload)
+        for kind, payload in VALID_PAYLOADS.items()
+    ]
+
+    resp = await client.post(f"{BASE}/batches", json=_envelope(records))
+
+    assert resp.status_code == 202
+    assert resp.json()["itemsReceived"] == len(VALID_PAYLOADS)
+
+
+@pytest.mark.asyncio
+async def test_missing_schema_version_returns_invalid_envelope(client):
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+    del envelope["schemaVersion"]
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_envelope"
+
+
+@pytest.mark.asyncio
+async def test_unsupported_schema_version_rejected(client):
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+    envelope["schemaVersion"] = "external-ingest.v2"
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "unsupported_schema_version"
+
+
+@pytest.mark.asyncio
+async def test_unknown_record_kind_rejected(client):
+    envelope = _envelope([_record("deployment.v1", "d1", {"status": "success"})])
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "unknown_record_kind"
+
+
+@pytest.mark.asyncio
+async def test_unknown_top_level_envelope_field_rejected(client):
+    # extra="forbid" on the wrapper models too (adversarial-review finding):
+    # a typo'd top-level field must be a loud 400, not silently ignored, on
+    # a versioned public contract advertised as matching /schemas exactly.
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+    envelope["unexpectedField"] = "typo"
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_envelope"
+
+
+@pytest.mark.asyncio
+async def test_unknown_source_field_rejected(client):
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+    envelope["source"]["unexpectedField"] = "typo"
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_envelope"
+
+
+@pytest.mark.asyncio
+async def test_unknown_record_wrapper_field_rejected(client):
+    record = _record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])
+    record["unexpectedField"] = "typo"
+
+    resp = await client.post(f"{BASE}/batches", json=_envelope([record]))
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_envelope"
+
+
+@pytest.mark.asyncio
+async def test_unknown_window_field_rejected(client):
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+    envelope["window"] = {
+        "startedAt": "2026-06-25T00:00:00Z",
+        "endedAt": "2026-06-26T00:00:00Z",
+        "unexpectedField": "typo",
+    }
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "invalid_envelope"
+
+
+@pytest.mark.asyncio
+async def test_batch_too_large_rejected(client):
+    # Payload contents are not deep-validated at /batches accept-time (only
+    # envelope shape + kind allowlist), so an empty payload dict is enough
+    # to exercise the record-count limit cheaply.
+    records = [_record("commit.v1", f"c{i}", {}) for i in range(1001)]
+
+    resp = await client.post(f"{BASE}/batches", json=_envelope(records))
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "batch_too_large"
+
+
+@pytest.mark.asyncio
+async def test_payload_too_large_rejected(client, monkeypatch):
+    # Shrink the limit rather than construct a literal ~10MB fixture body.
+    monkeypatch.setenv("EXTERNAL_INGEST_MAX_BODY_BYTES", "10")
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 413
+    assert resp.json()["error"]["code"] == "payload_too_large"
+
+
+@pytest.mark.asyncio
+async def test_idempotency_header_matching_body_is_accepted(client, monkeypatch):
+    monkeypatch.setattr(router_mod, "enqueue_batch", lambda **kwargs: "stream-x")
+    envelope = _envelope(
+        [_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])],
+        idempotency_key="key-1",
+    )
+
+    resp = await client.post(
+        f"{BASE}/batches", json=envelope, headers={"Idempotency-Key": "key-1"}
+    )
+
+    assert resp.status_code == 202
+
+
+@pytest.mark.asyncio
+async def test_idempotency_header_mismatch_rejected(client):
+    envelope = _envelope(
+        [_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])],
+        idempotency_key="key-1",
+    )
+
+    resp = await client.post(
+        f"{BASE}/batches", json=envelope, headers={"Idempotency-Key": "different-key"}
+    )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "idempotency_key_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_stream_unavailable_returns_503(client, monkeypatch):
+    def _raise(**kwargs):
+        raise StreamUnavailableError("boom")
+
+    monkeypatch.setattr(router_mod, "enqueue_batch", _raise)
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "stream_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_unexpected_exception_falls_through_to_generic_handler(
+    client, monkeypatch
+):
+    def _raise(**kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(router_mod, "enqueue_batch", _raise)
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 500
+    # ExternalIngestError's handler doesn't accidentally swallow an unrelated
+    # RuntimeError (Starlette dispatches by exact type), but the generic
+    # handler still returns the customer-facing envelope for this path
+    # (adversarial-review finding: one stable {"error": {...}} shape for
+    # every /api/v1/external-ingest/* response, even unexpected 500s).
+    assert resp.json() == {
+        "error": {"code": "internal_error", "message": "Internal Server Error"}
+    }
+
+
+# ---------------------------------------------------------------------------
+# POST /validate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_validate_reports_per_record_errors(client):
+    work_item_missing_title = {
+        k: v for k, v in VALID_PAYLOADS["work_item.v1"].items() if k != "title"
+    }
+    bad_pull_request = {**VALID_PAYLOADS["pull_request.v1"], "state": "bogus"}
+    records = [
+        _record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"]),
+        _record("work_item.v1", "w1", work_item_missing_title),
+        _record("team.v1", "t1", VALID_PAYLOADS["team.v1"]),
+        _record("pull_request.v1", "p1", bad_pull_request),
+        _record("identity.v1", "i1", VALID_PAYLOADS["identity.v1"]),
+    ]
+
+    resp = await client.post(f"{BASE}/validate", json=_envelope(records))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert body["itemsAccepted"] == 3
+    assert body["itemsRejected"] == 2
+    codes = {(err["index"], err["code"]) for err in body["errors"]}
+    assert (1, "missing_required_field") in codes
+    assert (3, "invalid_literal") in codes
+
+
+@pytest.mark.asyncio
+async def test_validate_fully_valid_batch(client):
+    records = [
+        _record(kind, f"ext-{kind}", payload)
+        for kind, payload in VALID_PAYLOADS.items()
+    ]
+
+    resp = await client.post(f"{BASE}/validate", json=_envelope(records))
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is True
+    assert body["itemsRejected"] == 0
+    assert body["itemsAccepted"] == len(records)
+
+
+# ---------------------------------------------------------------------------
+# GET /schemas, GET /schemas/{version}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_schemas_requires_no_auth(client):
+    resp = await client.get(f"{BASE}/schemas")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schemaVersions"] == [SCHEMA_VERSION]
+    assert body["recordKinds"] == sorted(RECORD_KIND_MODELS)
+    assert "limits" in body
+    assert set(body["limits"]) == {"maxRecordsPerBatch", "maxBodyBytes"}
+
+
+@pytest.mark.asyncio
+async def test_get_schema_returns_json_schema_per_kind(client):
+    resp = await client.get(f"{BASE}/schemas/{SCHEMA_VERSION}")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schemaVersion"] == SCHEMA_VERSION
+    assert set(body["recordKinds"]) == set(RECORD_KIND_MODELS)
+    commit_schema = body["recordKinds"]["commit.v1"]
+    assert "properties" in commit_schema
+    assert "properties" in body["envelope"]
+
+
+@pytest.mark.asyncio
+async def test_get_schema_unknown_version_returns_404(client):
+    resp = await client.get(f"{BASE}/schemas/external-ingest.v99")
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "unsupported_schema_version"
+
+
+# ---------------------------------------------------------------------------
+# Auth (D7 / master-spec CC14) — exercised WITHOUT the dependency override so
+# the real require_ingest_scope body actually runs.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_authorization_header_returns_401(monkeypatch):
+    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+        resp = await c.post(
+            f"{BASE}/batches", json=envelope, headers={"X-Org-Id": "org-1"}
+        )
+
+    assert resp.status_code == 401
+    # Auth failures must use the same customer-facing envelope as every other
+    # external-ingest error (master-spec CC16 explicitly includes auth
+    # failures) — a bare HTTPException {"detail": ...} would force customer
+    # SDKs to special-case parsing (adversarial-review finding).
+    assert resp.json()["error"]["code"] == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_missing_org_id_header_returns_400(monkeypatch):
+    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+        resp = await c.post(
+            f"{BASE}/batches",
+            json=envelope,
+            headers={"Authorization": "Bearer dev-token"},
+        )
+
+    assert resp.status_code == 400
+    assert resp.json()["error"]["code"] == "missing_org_header"
+
+
+@pytest.mark.asyncio
+async def test_interim_auth_hard_fails_without_insecure_flag(monkeypatch):
+    # CC14: mechanical guard — auth 503s unless EXTERNAL_INGEST_INSECURE_AUTH=1
+    # is explicitly set, regardless of otherwise-valid credentials.
+    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+        resp = await c.post(
+            f"{BASE}/batches",
+            json=envelope,
+            headers={"Authorization": "Bearer dev-token", "X-Org-Id": "org-1"},
+        )
+
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "auth_not_configured"
+
+
+# ---------------------------------------------------------------------------
+# OpenAPI + schema round-trip
+# ---------------------------------------------------------------------------
+
+
+def test_routes_appear_in_openapi_schema():
+    paths = app.openapi()["paths"]
+
+    assert f"{BASE}/batches" in paths
+    assert f"{BASE}/validate" in paths
+    assert f"{BASE}/schemas" in paths
+    assert f"{BASE}/schemas/{{schema_version}}" in paths
+
+
+def test_record_kind_models_produce_valid_json_schema():
+    for model in RECORD_KIND_MODELS.values():
+        schema = model.model_json_schema(by_alias=True)
+        assert isinstance(schema, dict)
+        assert "properties" in schema

--- a/tests/api/test_ingest_rate_limit_key.py
+++ b/tests/api/test_ingest_rate_limit_key.py
@@ -1,0 +1,91 @@
+"""Per-token rate-limit keying for external-ingest endpoints (CHAOS-2691).
+
+Regression coverage for an adversarial-review finding: while
+EXTERNAL_INGEST_INSECURE_AUTH=1's interim auth is active, the bearer value
+is not validated at all, so keying the limiter on it would let a caller
+rotate arbitrary bearer strings to get a fresh bucket on every request. In
+that mode the key must collapse to IP regardless of the bearer value.
+"""
+
+from __future__ import annotations
+
+import hashlib
+
+from fastapi import Request
+
+from dev_health_ops.api.middleware.rate_limit import get_ingest_token_key
+
+
+def _make_request(
+    authorization: str | None = None, client_host: str = "203.0.113.5"
+) -> Request:
+    headers = []
+    if authorization is not None:
+        headers.append((b"authorization", authorization.encode()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": "/api/v1/external-ingest/batches",
+        "headers": headers,
+        "client": (client_host, 12345),
+    }
+    return Request(scope)
+
+
+def test_distinct_bearer_tokens_get_distinct_buckets_outside_interim_auth(monkeypatch):
+    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
+    req_a = _make_request(authorization="Bearer token-a")
+    req_b = _make_request(authorization="Bearer token-b")
+    assert get_ingest_token_key(req_a) != get_ingest_token_key(req_b)
+
+
+def test_same_bearer_token_same_bucket_outside_interim_auth(monkeypatch):
+    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
+    assert get_ingest_token_key(
+        _make_request(authorization="Bearer token-a")
+    ) == get_ingest_token_key(_make_request(authorization="Bearer token-a"))
+
+
+def test_raw_token_never_appears_in_key(monkeypatch):
+    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
+    token = "super-secret-ingest-token"
+    key = get_ingest_token_key(_make_request(authorization=f"Bearer {token}"))
+    assert token not in key
+
+
+def test_rotating_bearer_tokens_cannot_bypass_the_limit_in_interim_auth_mode(
+    monkeypatch,
+):
+    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
+    req_a = _make_request(authorization="Bearer token-a", client_host="203.0.113.5")
+    req_b = _make_request(
+        authorization="Bearer token-b-rotated", client_host="203.0.113.5"
+    )
+    assert (
+        get_ingest_token_key(req_a)
+        == get_ingest_token_key(req_b)
+        == "ingest-ip:203.0.113.5"
+    )
+
+
+def test_interim_auth_mode_still_distinguishes_by_ip(monkeypatch):
+    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
+    req_a = _make_request(authorization="Bearer token-a", client_host="203.0.113.5")
+    req_b = _make_request(authorization="Bearer token-a", client_host="198.51.100.9")
+    assert get_ingest_token_key(req_a) != get_ingest_token_key(req_b)
+
+
+def test_missing_bearer_falls_back_to_ip(monkeypatch):
+    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
+    req = _make_request(authorization=None, client_host="203.0.113.5")
+    assert get_ingest_token_key(req) == "ingest-ip:203.0.113.5"
+
+
+def test_token_key_uses_sha256_digest_not_raw_prefix(monkeypatch):
+    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
+    token = "dev-token"
+    expected = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
+    assert (
+        get_ingest_token_key(_make_request(authorization=f"Bearer {token}"))
+        == f"ingest-token:{expected}"
+    )


### PR DESCRIPTION
## Summary

Implements the REST contract layer for CHAOS-2690's customer-push ingestion epic, per `docs/superpowers/plans/2026-07-01-chaos-2690-implementation/briefs/brief-2691-contract.md` and `master-spec.md`'s cross-cutting decisions:

- `/api/v1/external-ingest/` package: `POST /batches`, `POST /validate`, `GET /schemas`, `GET /schemas/{version}`.
- Pydantic v2 envelope + 9 versioned record-kind schemas (`schemas.py`), `extra="forbid"` on both the payload models **and** the envelope/wrapper models (`SourceDescriptor`, `IngestWindow`, `RecordEnvelope`, `BatchEnvelope`).
- Customer-facing `{"error": {"code", "message", "errors"?}}` envelope (`errors.py`), used for every `/api/v1/external-ingest/*` response including auth failures and unexpected 500s.
- Interim, mechanically-gated auth (`auth.py`, master-spec CC14): hard-fails `503 auth_not_configured` unless `EXTERNAL_INGEST_INSECURE_AUTH=1`; loud WARNING log per accepted request. Real DB-backed tokens land in CHAOS-2696/2712 — **documented as a hard pre-GA blocker** in `docs/architecture/adr-003-external-ingest-rest-boundary.md`.
- Real (non-mock) interim Valkey stream writer (`streams.py`) that fails closed with `503 stream_unavailable`, never accept-and-warn; hardened by CHAOS-2693 without changing the `enqueue_batch()` signature or stream-naming convention.
- `dev_health_ops.external_ingest.validate` (top-level package, sibling to `api/`, per master-spec's module map): single source of deep per-record validation, imported unchanged by CHAOS-2697's worker so `/validate` and the durable worker can never diverge on what "valid" means.
- Shared-limiter rate limiting (`api/middleware/rate_limit.py`, master-spec CC15): `INGEST_BATCH_LIMIT`/`INGEST_VALIDATE_LIMIT`/`INGEST_READ_LIMIT` + `get_ingest_token_key`, no second `Limiter` instance.
- `docs/architecture/adr-003-external-ingest-rest-boundary.md` (the epic's backend ADR — REST-vs-GraphQL, token scopes, one-active-owner model, Linear team-UUID↔team-key residual risk) and `docs/architecture/external-ingest-rest-contract.md` (this ticket's own D1–D13 decisions).

Deviations from the brief text (all resolved in favor of the authoritative `master-spec.md`, which the brief itself says wins on conflict):
- `repository.v1.externalId` = provider full name, not a URL (CC4).
- `WorkItemV1.externalKey` replaces the brief's `work_item_id`; `WorkItemTransitionV1`/`WorkItemDependencyV1` take `externalKey`(s) + optional `workItemType` (CC7) — the transition/dependency field renames were my own extrapolation of the header's "likewise take externalKey(s)" instruction since the brief's inline sketch code hadn't been updated to match; flagging for reviewer sign-off.
- `BatchEnvelope.records` has `min_length=1` (CC3).
- Rate limiting reuses the shared `limiter` singleton per CC15, not a second `Limiter` as the brief's own inline sketch shows.
- `dev_health_ops.external_ingest.validate.py` created complete in this ticket (CC17) — lives in the **top-level** `external_ingest` package (sibling to `api/`), not under `api/external_ingest/`, matching master-spec's module map even though the dispatch briefing paraphrased it as `api/external_ingest/validate.py`.

## Codex adversarial review (2 rounds, `--base origin/chaos-2690-external-ingest`)

**Round 1** — 2 high / 2 medium:
- [high] Interim auth flag enables arbitrary cross-tenant writes when `EXTERNAL_INGEST_INSECURE_AUTH=1` is set — **REFUTED**: this is exactly master-spec CC14's specified wave-1 behavior (mechanically gated by the flag, hard pre-GA blocker documented in adr-003 and PR description); "don't expose POST endpoints" contradicts the ticket's explicit charter to ship testable endpoints without waiting on CHAOS-2696/2712.
- [high] Rate limit bypassable via bearer-token rotation in interim mode — **FIXED**: `get_ingest_token_key` now keys on IP whenever `EXTERNAL_INGEST_INSECURE_AUTH=1` is active, since the bearer value isn't validated at all in that mode. Regression tests in `tests/api/test_ingest_rate_limit_key.py`.
- [medium] Auth errors (401/400) used the app-wide `{"detail": ...}` shape instead of the external-ingest envelope — **FIXED**: both now raise `ExternalIngestError` (`invalid_token`, `missing_org_header`).
- [medium] Envelope/wrapper models allowed unknown fields while payload models didn't — **FIXED**: `extra="forbid"` added to `SourceDescriptor`/`IngestWindow`/`RecordEnvelope`/`BatchEnvelope`, with new tests.

**Round 2** (after the round-1 fixes) — 2 high / 1 medium:
- [high] SlowAPI rate limits don't cover auth-dependency failures (401/400/503 resolve before the decorator's check runs) — **REFUTED**: verified this is a pre-existing, pervasive characteristic of this codebase's `@limiter.limit(...)` + `Depends(...)` pattern (e.g. `main.py`'s `filter_options`, `home_post`, `investment_post`, and 5+ other established routes all exhibit the same ordering), not something CHAOS-2691 introduced or can fix in isolation without redesigning app-wide rate limiting.
- [high] `/validate` bound to `schema:read` instead of `ingest:write` — **REFUTED**: master-spec CC17 explicitly pins `/validate` to `schema:read` (the brief's own prose and its own code sketch disagree with each other here; CC17 is authoritative and matches what's implemented). Also makes sense design-wise: `/validate` has no persistence side effects, so a broader read-only credential is appropriate.
- [medium] Unhandled exceptions on external-ingest routes fell through to the app-wide `{"detail": ...}` 500 shape — **FIXED**: `api/_errors.py`'s shared generic handler now branches on the `/api/v1/external-ingest` path prefix, returning `500 internal_error` in the same envelope (message text unchanged, "sanitized" intent from the brief's own test-19 acceptance criterion preserved).

## Gate

`ci/local_validate.sh` (via `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR"` to eliminate direnv-injected dev-app-config env leakage from the calling shell) — lint, mypy, ClickHouse migrate, full unit suite (6252+ passed, 0 failed), and the live argMax proof all green.

## Live verification

Ran the interim API (`uvicorn`, `EXTERNAL_INGEST_INSECURE_AUTH=1`) against the real shared dev-stack Postgres/ClickHouse/Valkey (read-only; no writes to `default`/`devhealth`):
- `GET /schemas`, `GET /schemas/external-ingest.v1` — 200, all 9 kinds present, `limits` field populated.
- `GET /schemas/unknown-version` — 404 `unsupported_schema_version`.
- Valid `POST /batches` (real org UUID) — 202, `ingestionId` present; confirmed via `valkey-cli XRANGE` that the batch was actually written to `external-ingest:{org_id}:batches` (not just a 202 lie).
- `POST /validate` with 1 valid + 1 multi-error record — 200, `itemsAccepted: 1`, `itemsRejected: 1`, correct per-field error codes/paths.
- `503 auth_not_configured` confirmed with the insecure-auth flag unset (otherwise-valid credentials).
- `413 payload_too_large` confirmed via a lowered `EXTERNAL_INGEST_MAX_BODY_BYTES`.
- `503 stream_unavailable` confirmed by unsetting `REDIS_URL` for the API process only (did **not** stop the shared `valkey` container, per the "must not stop shared docker containers" constraint).
- Post-fix spot check: `401 invalid_token` / `400 missing_org_header` now both return the external-ingest error envelope.

## Test plan

- [x] `tests/api/test_external_ingest_router.py` — 29 tests covering the brief's full test plan (valid/invalid envelopes, all 9 kinds, batch/body size limits, idempotency header match/mismatch, stream-unavailable→503, generic-exception passthrough, `/validate` per-record diagnostics, schema discovery, auth gate, OpenAPI registration, JSON-Schema round-trip) plus the round-1/round-2 codex regression coverage (envelope-strictness on wrapper fields, auth-envelope shape).
- [x] `tests/api/test_ingest_rate_limit_key.py` — 7 tests for the interim-mode rate-limit-key collapse fix.
- [x] Full `ci/local_validate.sh` gate green.