### PR TITLE
fix(sync): redact credential material from legacy error-text columns (CHAOS-2766)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -329,6 +329,123 @@ deleted outright, no archival path.
 **Cooldown gating reads this table back before dispatch** — see the next
 section.
 
+## Legacy error-text columns (`sync_run_units.error` and siblings)
+
+Shipped in [CHAOS-2766](https://linear.app/fullchaos/issue/CHAOS-2766). Live
+verification of CHAOS-2758 above (evidence comment on CHAOS-2742) found that
+the *observation store*'s `reason` allow-list did its job, but a
+provider exception whose message embeds an `Authorization` header (e.g.
+`403 rate limited -- Authorization: Bearer ghp_FAKE...`) still landed
+**verbatim** in the pre-existing, free-form `sync_run_units.error` column —
+these legacy columns predate CHAOS-2742 and were never brought under the same
+discipline.
+
+**Redaction, not an allow-list — deliberately.** `reason` above is a closed,
+normalized enum with no diagnostic-text mandate, so allow-listing a fixed
+vocabulary is correct there. `sync_run_units.error` and its siblings
+(`sync_runs.error`, `sync_run_reference_discovery.error`,
+`sync_dispatch_outbox.last_error`) are free-form, operator-facing
+diagnostics — the entire point of persisting them is to help debug a failed
+sync without re-running it. Collapsing them to a category string would defeat
+that purpose. Instead, `dev_health_ops.sync.error_sanitize.sanitize_error_text`
+(one shared helper, imported at every persistence site — no per-site regexes)
+strips/masks only the specific credential-shaped substrings that must never
+reach the database:
+
+- `Authorization` / `Proxy-Authorization` headers, any scheme
+- Bearer tokens, with or without a leading header name
+- HTTP Basic auth base64 blobs
+- Provider PAT/bot-token prefixes: `ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`,
+  `github_pat_`, `glpat-`, `xoxb-`/`xoxp-`/`xoxa-`/`xoxr-`
+- `token=`/`private_token=`/`api_key=`/`access_token=`/`secret=`-style
+  key/value pairs
+- A credential embedded in a URL's userinfo component
+  (`scheme://user:pass@host`, e.g. `redis://:password@host:6379/0`,
+  `amqp://user:pass@host`) — added for a codex review finding on this PR: a
+  Celery/broker enqueue-failure exception can embed the configured
+  broker/result-backend connection string, and that shape evades every
+  pattern above
+
+Everything else in the message — status codes, provider names, retry
+context — passes through unchanged. A redacted match is replaced with the
+`REDACTION_MARKER` sentinel (`"[REDACTED]"`), and when the input is an
+exception object (the common case) the output is prefixed with the exception
+**class name** (`"RateLimitException: 403 rate limited -- [REDACTED]"`), so
+even a bare `raise SomeError()` with no message still persists something
+diagnostically useful. Redaction always runs *before* the length cap
+(`DEFAULT_MAX_ERROR_TEXT_LENGTH`, 4000 chars — `sync_dispatch_outbox.last_error`
+keeps its pre-existing, tighter 2000-char cap) so truncation can never split a
+credential in half and leave a partial value exposed.
+
+**Enforced by a source-level guard, not review discipline.** There is no
+type-system way to require "this exception must be sanitized before it
+reaches a DB column." `tests/test_error_sanitize_guard.py` AST-walks the
+worker/sync modules that own these columns and fails if any raw
+`str(exc)`-shaped call or bare `f"...{exc}"` interpolation exists outside a
+`logger.*(...)` call (diagnostic logs are a separate risk surface, out of
+this ticket's scope) — mirroring the doc-drift-guard precedent in
+`tests/test_rate_limit_policy_doc.py` (CHAOS-2757). Two internal
+classification helpers (`_classify_error` in `workers/sync_units.py`,
+`_is_retryable_discovery_error` in `workers/reference_discovery.py`) are
+exempted: they lowercase `str(exc)` only to pattern-match it against a fixed,
+curated vocabulary and return a category — the raw text itself is discarded,
+never persisted, the same shape as the `reason` allow-list above.
+
+**Out of scope.** Diagnostic *logs* (`logger.warning(..., extra={"error":
+str(exc)})`) are not touched — they are a different risk surface (a log
+aggregator, not this Postgres table) and were not part of the live-verified
+case. `MetricCheckpoint.error` (`metrics/checkpoints.py`) and
+`InvestmentBatchJob.error` (`work_graph/investment/batch_store.py`) are also
+out of scope: they belong to the LLM-categorization and metrics-checkpoint
+subsystems, not the sync-run/unit execution ledger this epic hardens, and
+their exception provenance (classification/LLM-batch errors, not raw
+provider-client HTTP exceptions) differs from the live-verified case.
+
+**`JobRun.error` / `BackfillJob.error_message` (manual-trigger enqueue
+path).** Added for a codex review finding on this PR: `sync/execution_trigger.py`
+`mark_job_run_failed` and `api/admin/routers/sync.py` `_mark_backfill_job_failed`
+sanitize **at the sink**, not their callers — a Celery/broker enqueue-failure
+exception raised from `dispatch_sync_run.apply_async(...)` in the manual-trigger
+and backfill admin endpoints can embed the broker/result-backend URL
+(credentials included), and both columns surface through admin job-history
+responses. Both functions now accept `BaseException | str` and call
+`sanitize_error_text` internally, so a future caller cannot bypass it by
+passing an already-formatted string; the corresponding `HTTPException`
+`detail` on the same enqueue-failure path is sanitized the same way. The
+CHAOS-2766 guard test (`tests/test_error_sanitize_guard.py`) covers this file
+too, scoped to only the functions that touch these columns — the router file
+has many unrelated `except ... str(exc)` sites for ordinary HTTP validation
+errors that are out of this guard's scope.
+
+**Copied-column propagation (`sync_observers_for_terminal_sync_run`,
+`finalize_sync_run`'s `stamp_sync_run_canonical_config` call).** Added for a
+codex review finding on this PR, round 2: two sites in `workers/sync_units.py`
+read `SyncRun.error` and assign it VERBATIM into another durable column via a
+plain variable (`error = ... (run.error or "...")`, `run_error = ... (run.error
+or "...")`) rather than a `str(exc)`/`f"...{exc}"` expression -- a shape the
+AST guard, which only recognizes exception-stringification forms, cannot see.
+`sync_observers_for_terminal_sync_run` copies it into both
+`BackfillJob.error_message` and `JobRun.error`; `finalize_sync_run` copies it
+into `SyncConfiguration.last_sync_error` via `stamp_sync_run_canonical_config`.
+Both now wrap the copied value in `sanitize_error_text` too (idempotent and
+cheap on already-sanitized text) -- this matters even with every write site
+above already covered, because `sync_observers_for_terminal_sync_run` also
+runs from the reconciler's stale-observer repair path
+(`reconcile_sync_dispatch`), which can touch a `SyncRun.error` value written
+by an OLDER code path or before this ticket shipped. Since AST-detecting
+arbitrary variable-to-column flows (as opposed to a fixed `str(exc)` shape)
+is not a tractable static check, this is covered by a targeted regression
+test instead
+(`test_finalize_sync_run_sanitizes_copied_run_error_into_observer_columns` in
+`tests/test_sync_units.py`) rather than an AST guard extension.
+
+**Pre-existing rows.** Any `sync_run_units.error`/`sync_runs.error`/etc. row
+written before this column was brought under `sanitize_error_text` keeps its
+raw text at rest until the row is next overwritten by a sanitizing write path
+(or copied through one of the sinks above, which now re-sanitizes on the way
+through). A scrub/backfill of already-persisted rows is a deliberately
+separate decision, out of scope for this PR.
+
 ## Cooldown gating
 
 Shipped in [CHAOS-2760](https://linear.app/fullchaos/issue/CHAOS-2760). A 429

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -45,6 +45,7 @@ from dev_health_ops.models.settings import (
     SyncConfiguration,
 )
 from dev_health_ops.sync.datasets import supported_datasets, supported_legacy_targets
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 from dev_health_ops.sync.execution_trigger import (
     create_sync_execution_trigger,
     ensure_pending_sync_job_run,
@@ -64,7 +65,7 @@ router = APIRouter()
 logger = logging.getLogger(__name__)
 
 
-def _mark_job_run_failed(sync_session, run_id: str, error: str) -> None:
+def _mark_job_run_failed(sync_session, run_id: str, error: BaseException | str) -> None:
     mark_job_run_failed(sync_session, run_id, error)
 
 
@@ -75,8 +76,19 @@ def _merge_job_run_result(
 
 
 def _mark_backfill_job_failed(
-    sync_session, backfill_job_id: str, error: str, completed_at: datetime
+    sync_session,
+    backfill_job_id: str,
+    error: BaseException | str,
+    completed_at: datetime,
 ) -> None:
+    """Terminalize a ``BackfillJob`` as failed.
+
+    ``error`` is sanitized here, at the sink (CHAOS-2766 codex review
+    finding), for the same reason as ``mark_job_run_failed``: a Celery/broker
+    enqueue-failure exception can embed the broker/result-backend URL
+    including credentials, and ``error_message`` surfaces through admin
+    backfill-job responses.
+    """
     from dev_health_ops.models.backfill import BackfillJob as BackfillJobModel
 
     bf_job = (
@@ -87,7 +99,7 @@ def _mark_backfill_job_failed(
     if bf_job is None:
         return
     bf_job.status = "failed"
-    bf_job.error_message = error
+    bf_job.error_message = sanitize_error_text(error)
     bf_job.completed_at = completed_at
     # The dispatch never enqueued (or its task id is meaningless), so drop any
     # pre-dispatch sync_run marker: the run is separately terminalized as failed.
@@ -1663,7 +1675,7 @@ async def trigger_sync_config(
             )
         )
     except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc))
+        raise HTTPException(status_code=400, detail=sanitize_error_text(exc))
     if trigger is None:
         raise HTTPException(
             status_code=400,
@@ -1675,17 +1687,28 @@ async def trigger_sync_config(
             args=(trigger.sync_run_id,), queue="sync"
         )
     except Exception as exc:
-        error_message = f"dispatch enqueue failed: {exc}"
+        # Bind to a plain local before closing over it in the lambdas below:
+        # `except ... as exc` implicitly deletes `exc` at the end of THIS
+        # block, which a closure captures by reference, not by value (ruff
+        # F821 catches this). The raw exception is passed straight through
+        # to the sink (_mark_job_run_failed -> sanitize_error_text), not
+        # pre-formatted into a string here -- a Celery/broker enqueue
+        # failure can embed the broker/result-backend URL, credentials
+        # included (CHAOS-2766 codex review finding).
+        dispatch_exc = exc
         await session.run_sync(
             lambda s: mark_sync_run_failed(
                 s, trigger.sync_run_id, "dispatch enqueue failed"
             )
         )
         await session.run_sync(
-            lambda s: _mark_job_run_failed(s, trigger.job_run_id, error_message)
+            lambda s: _mark_job_run_failed(s, trigger.job_run_id, dispatch_exc)
         )
         await session.commit()
-        raise HTTPException(status_code=503, detail=f"Task queue unavailable: {exc}")
+        raise HTTPException(
+            status_code=503,
+            detail=f"Task queue unavailable: {sanitize_error_text(dispatch_exc)}",
+        )
     dispatch_task_id = str(getattr(dispatch_result, "id", "") or "")
     await session.run_sync(
         lambda s: _merge_job_run_result(
@@ -1779,16 +1802,22 @@ async def trigger_sync_config_backfill(
                 args=(trigger.sync_run_id,), queue="sync"
             )
         except Exception as e:
-            error_message = f"enqueue failed: {e}"
+            # Bind to a plain local before closing over it below -- see the
+            # matching comment in trigger_sync_config above (ruff F821: a
+            # closure over a bare `except ... as e` name is unreliable,
+            # since the name is implicitly deleted at block exit). Same
+            # sink-sanitizes-not-caller rationale (CHAOS-2766 codex review
+            # finding).
+            dispatch_exc = e
             completed_at = datetime.now(timezone.utc)
             await session.run_sync(
                 lambda sync_session: _mark_backfill_job_failed(
-                    sync_session, backfill_job_id, error_message, completed_at
+                    sync_session, backfill_job_id, dispatch_exc, completed_at
                 )
             )
             await session.run_sync(
                 lambda sync_session: _mark_job_run_failed(
-                    sync_session, trigger.job_run_id, error_message
+                    sync_session, trigger.job_run_id, dispatch_exc
                 )
             )
             await session.run_sync(
@@ -1797,7 +1826,10 @@ async def trigger_sync_config_backfill(
                 )
             )
             await session.commit()
-            raise HTTPException(status_code=503, detail=f"Task queue unavailable: {e}")
+            raise HTTPException(
+                status_code=503,
+                detail=f"Task queue unavailable: {sanitize_error_text(dispatch_exc)}",
+            )
         backfill_job.celery_task_id = f"{result.id}|sync_run:{trigger.sync_run_id}"
         await session.commit()
         return {
@@ -1813,7 +1845,10 @@ async def trigger_sync_config_backfill(
     except HTTPException:
         raise
     except Exception as e:
-        raise HTTPException(status_code=503, detail=f"Task queue unavailable: {e}")
+        raise HTTPException(
+            status_code=503,
+            detail=f"Task queue unavailable: {sanitize_error_text(e)}",
+        )
 
 
 @router.get("/sync-configs/{config_id}/jobs", response_model=list[JobRunResponse])

--- a/src/dev_health_ops/sync/dispatch_outbox.py
+++ b/src/dev_health_ops/sync/dispatch_outbox.py
@@ -39,6 +39,7 @@ from dev_health_ops.models import (
     SyncDispatchOutbox,
     SyncRun,
 )
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
 OUTBOX_KIND_DISPATCH = "dispatch_sync_run"
 OUTBOX_KIND_DISCOVERY = "reference_discovery"
@@ -342,7 +343,7 @@ def mark_outbox_publish_failed(
     *,
     row_id: str | uuid.UUID,
     claim_token: str,
-    error: object,
+    error: BaseException | str,
     attempts: int,
     now: datetime | None = None,
 ) -> bool:
@@ -362,7 +363,7 @@ def mark_outbox_publish_failed(
             claim_token=None,
             claim_expires_at=None,
             available_at=failure_now + timedelta(seconds=backoff_seconds(attempts)),
-            last_error=str(error)[:_MAX_ERROR_LENGTH],
+            last_error=sanitize_error_text(error, max_length=_MAX_ERROR_LENGTH),
             updated_at=failure_now,
         )
         .execution_options(synchronize_session=False)

--- a/src/dev_health_ops/sync/error_sanitize.py
+++ b/src/dev_health_ops/sync/error_sanitize.py
@@ -1,0 +1,131 @@
+"""Redaction for legacy free-form error-text DB columns (CHAOS-2766).
+
+Live verification of CHAOS-2758 (evidence comment on CHAOS-2742) demonstrated
+that a provider exception whose message embeds an ``Authorization`` header
+(``403 rate limited -- Authorization: Bearer ghp_FAKE...``) persisted
+VERBATIM into the pre-existing ``sync_run_units.error`` column and its
+siblings (``sync_runs.error``, ``sync_run_reference_discovery.error``,
+``sync_dispatch_outbox.last_error``) -- every one of these is populated from
+``str(exc)`` (or an f-string embedding it) at a worker boundary that never
+controls what a provider client library puts in an exception message.
+
+This is deliberately a **redaction pass**, not the allow-list used for the
+durable rate-limit observation store's ``reason`` column
+(``_normalized_rate_limit_reason`` in ``workers/sync_units.py``, CHAOS-2758).
+That column is a closed, normalized enum with no diagnostic-text mandate, so
+allow-listing a fixed vocabulary is correct there. The columns this module
+guards are free-form operator-facing diagnostics -- the whole point of
+persisting them is to help operators debug a failed sync without re-running
+it, so blanket-replacing the text (or falling back to a category-only string)
+would defeat their purpose. Instead this strips/masks the specific
+credential-shaped substrings that must never reach the database and leaves
+everything else intact.
+
+See ``docs/providers/rate-limit-policy.md`` (the "Legacy error-text columns"
+section) for the full design rationale and the callers wired up to this
+helper.
+"""
+
+from __future__ import annotations
+
+import re
+
+#: Substituted for any credential-shaped substring this module recognizes.
+#: Tests assert this marker is present (and the original secret is not)
+#: rather than hardcoding the redaction text inline everywhere.
+REDACTION_MARKER = "[REDACTED]"
+
+#: Default cap on persisted error text. These are `Text` columns (no DB-level
+#: limit), but an unbounded provider response body or traceback fragment is a
+#: bloat risk in its own right, independent of the credential-leak risk this
+#: module primarily targets. Individual call sites may pass a tighter
+#: ``max_length`` (e.g. ``sync/dispatch_outbox.py`` keeps its pre-existing,
+#: tighter 2000-char cap for `sync_dispatch_outbox.last_error`).
+DEFAULT_MAX_ERROR_TEXT_LENGTH = 4000
+
+_TRUNCATION_SUFFIX = "...[truncated]"
+
+# Ordered so header-shaped matches consume their whole "<Scheme> <credential>"
+# pair before the narrower bare-token patterns below get a chance to leave a
+# dangling fragment. Every pattern is deliberately conservative about how
+# much of the surrounding text it consumes -- wide enough to catch the
+# credential, narrow enough not to eat an entire diagnostic message.
+_SECRET_PATTERNS: tuple[re.Pattern[str], ...] = (
+    # Authorization / Proxy-Authorization header, any scheme, e.g.
+    # "Authorization: Bearer ghp_xxx" or "authorization=Basic xxx". Consumes
+    # the header name plus up to two following tokens (scheme + credential).
+    re.compile(r"(?i)\b(authorization|proxy-authorization)\s*[:=]\s*\S+(?:\s+\S+)?"),
+    # Bearer scheme with no leading header name, e.g. "used Bearer ghp_xxx".
+    re.compile(r"(?i)\bbearer\s+\S+"),
+    # HTTP Basic auth base64 blob, with or without a leading header name.
+    re.compile(r"(?i)\bbasic\s+[a-z0-9+/=]{8,}\b"),
+    # Provider personal-access-token / bot-token prefixes are
+    # self-identifying -- the prefix alone is enough to know it's a secret,
+    # so redact wherever it appears, header or not.
+    re.compile(r"(?i)\bghp_[a-z0-9]{20,}\b"),
+    re.compile(r"(?i)\bgho_[a-z0-9]{20,}\b"),
+    re.compile(r"(?i)\bghu_[a-z0-9]{20,}\b"),
+    re.compile(r"(?i)\bghs_[a-z0-9]{20,}\b"),
+    re.compile(r"(?i)\bghr_[a-z0-9]{20,}\b"),
+    re.compile(r"(?i)\bgithub_pat_[a-z0-9_]{20,}\b"),
+    re.compile(r"(?i)\bglpat-[a-z0-9_-]{20,}\b"),
+    re.compile(r"(?i)\bxox[baprs]-[a-z0-9-]{10,}\b"),
+    # token=/private_token=/api_key=/access_token=/secret=-style query
+    # params or key/value diagnostic pairs. Kept last so a PAT-prefixed
+    # value under one of these keys is already redacted by a more specific
+    # pattern above; this just catches the (redundant but harmless) leftover
+    # "key=" wrapper and any non-prefixed secret value.
+    re.compile(
+        r"(?i)\b(private_token|access_token|api_key|apikey|client_secret|"
+        r"secret|token)\s*[:=]\s*\S+"
+    ),
+    # Credential embedded in a URL's userinfo component (scheme://user:pass@
+    # or scheme://:pass@), e.g. a broker/result-backend/database connection
+    # string surfacing in a Celery enqueue exception or a DB driver error
+    # (redis://:password@host:6379/0, amqp://user:pass@host,
+    # postgres://user:pass@host/db). Redacts the scheme+userinfo span
+    # entirely rather than trying to preserve the scheme, matching this
+    # module's existing behavior of consuming the whole credential-bearing
+    # span (see the Authorization-header pattern above) -- the host/path
+    # after "@" is left intact for diagnostics. Requires "://" immediately
+    # before the userinfo so an ordinary "contact admin@example.com" mention
+    # is never touched.
+    re.compile(r"(?i)\b[a-z][a-z0-9+.-]*://[^\s/@]+@"),
+)
+
+
+def sanitize_error_text(
+    value: BaseException | str | None,
+    *,
+    max_length: int | None = DEFAULT_MAX_ERROR_TEXT_LENGTH,
+) -> str | None:
+    """Return ``value`` with credential-shaped substrings redacted.
+
+    ``value`` may be the exception itself (preferred -- the exception class
+    name is preserved as a diagnostic prefix, e.g. ``"RateLimitException: 403
+    rate limited -- [REDACTED]"``, so an empty-message exception like a bare
+    ``raise SomeError()`` still persists something useful) or an
+    already-stringified message (no class-name prefix is synthesized, since
+    there is no exception object to name).
+
+    Redaction runs before truncation so a length cap can never split a
+    credential in half and leave a partial value exposed.
+    """
+    if value is None:
+        return None
+    if isinstance(value, BaseException):
+        message = str(value).strip()
+        class_name = type(value).__name__
+        text = f"{class_name}: {message}" if message else class_name
+    else:
+        text = str(value)
+    if not text:
+        return text
+    for pattern in _SECRET_PATTERNS:
+        text = pattern.sub(REDACTION_MARKER, text)
+    if max_length is not None and len(text) > max_length:
+        if max_length > len(_TRUNCATION_SUFFIX):
+            text = text[: max_length - len(_TRUNCATION_SUFFIX)] + _TRUNCATION_SUFFIX
+        else:
+            text = text[:max_length]
+    return text

--- a/src/dev_health_ops/sync/execution_trigger.py
+++ b/src/dev_health_ops/sync/execution_trigger.py
@@ -14,6 +14,7 @@ from dev_health_ops.models.settings import (
     ScheduledJob,
     SyncConfiguration,
 )
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 from dev_health_ops.sync.planner import SyncRunPlan, plan_sync_run
 from dev_health_ops.sync.trigger_routing import planner_request_for_config_if_routed
 
@@ -93,7 +94,21 @@ def merge_job_run_result(
     session.flush()
 
 
-def mark_job_run_failed(session: Session, run_id: str, error: str) -> None:
+def mark_job_run_failed(
+    session: Session, run_id: str, error: BaseException | str
+) -> None:
+    """Terminalize a ``JobRun`` as failed.
+
+    ``error`` is sanitized here, at the sink, rather than trusting every
+    caller to have already redacted it (CHAOS-2766 codex review finding):
+    a Celery/broker enqueue-failure exception can embed the configured
+    broker/result-backend URL, including its credentials, and this column
+    surfaces verbatim through admin job-history responses. Accepting
+    ``BaseException | str`` (not just ``str``) means a caller that still
+    pre-formats a message (e.g. ``f"dispatch enqueue failed: {exc}"``) stays
+    covered too -- ``sanitize_error_text`` redacts credential-shaped
+    substrings in plain text the same way it does in an exception's message.
+    """
     completed_at = datetime.now(timezone.utc)
     run = (
         session.query(JobRun).filter(JobRun.id == uuid.UUID(str(run_id))).one_or_none()
@@ -102,7 +117,7 @@ def mark_job_run_failed(session: Session, run_id: str, error: str) -> None:
         return
     run.status = JobRunStatus.FAILED.value
     run.completed_at = completed_at
-    run.error = error
+    run.error = sanitize_error_text(error)
     started_at = getattr(run, "started_at", None)
     if started_at is not None:
         if started_at.tzinfo is None:

--- a/src/dev_health_ops/workers/reference_discovery.py
+++ b/src/dev_health_ops/workers/reference_discovery.py
@@ -29,6 +29,7 @@ from dev_health_ops.sync.dispatch_outbox import (
     OUTBOX_KIND_FINALIZE,
     upsert_outbox_wakeup,
 )
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.sync_bootstrap import resolve_run_auth
 from dev_health_ops.workers.task_utils import _get_db_url
@@ -157,13 +158,13 @@ def run_sync_reference_discovery(sync_run_id: str) -> dict[str, Any]:
                 if _is_retryable_discovery_error(exc)
                 else "failed",
                 "sync_run_id": sync_run_id,
-                "error": str(exc),
+                "error": sanitize_error_text(exc),
             }
         return {
             "status": "skipped",
             "sync_run_id": sync_run_id,
             "reason": "lease_lost",
-            "error": str(exc),
+            "error": sanitize_error_text(exc),
         }
     finally:
         if heartbeat_stop is not None:
@@ -368,7 +369,7 @@ def _handle_reference_discovery_failure(
                     lease_owner=None,
                     lease_expires_at=None,
                     last_heartbeat_at=now,
-                    error=str(exc),
+                    error=sanitize_error_text(exc),
                     updated_at=now,
                 )
                 .execution_options(synchronize_session=False)
@@ -398,7 +399,7 @@ def _handle_reference_discovery_failure(
                 lease_expires_at=None,
                 last_heartbeat_at=now,
                 completed_at=now,
-                error=str(exc),
+                error=sanitize_error_text(exc),
                 result={
                     "error_category": REFERENCE_DISCOVERY_ERROR_CATEGORY,
                     "retryable": retryable,
@@ -410,10 +411,11 @@ def _handle_reference_discovery_failure(
         )
         if _rowcount(result) == 0:
             return False
-        _fail_nonterminal_units(session, run_uuid, now=now, error=str(exc))
+        sanitized_error = sanitize_error_text(exc)
+        _fail_nonterminal_units(session, run_uuid, now=now, error=sanitized_error)
         run = session.query(SyncRun).filter(SyncRun.id == run_uuid).one_or_none()
         if run is not None:
-            run.error = f"Reference discovery failed: {exc}"
+            run.error = f"Reference discovery failed: {sanitized_error}"
         upsert_outbox_wakeup(
             session,
             sync_run_id=run_uuid,
@@ -426,7 +428,7 @@ def _handle_reference_discovery_failure(
 
 
 def _fail_nonterminal_units(
-    session: Any, run_uuid: uuid.UUID, *, now: datetime, error: str
+    session: Any, run_uuid: uuid.UUID, *, now: datetime, error: str | None
 ) -> None:
     session.execute(
         update(SyncRunUnit)

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -84,6 +84,7 @@ from dev_health_ops.sync.dispatch_outbox import (
     upsert_outbox_wakeup,
 )
 from dev_health_ops.sync.dispatch_policy import route
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 from dev_health_ops.sync.guard import DispatchGuard
 from dev_health_ops.sync.trigger_routing import (
     stamp_sync_run_canonical_config,
@@ -1279,7 +1280,7 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                     available_at=not_before,
                     rate_limit_deferrals=deferral.attempts,
                     rate_limit_first_seen_at=first_seen_at,
-                    error=str(exc),
+                    error=sanitize_error_text(exc),
                     result=deferral_result_payload,
                     lease_owner=None,
                     lease_expires_at=None,
@@ -1551,7 +1552,7 @@ def _stamp_sync_unit_soft_timeout(
                     status=SyncRunUnitStatus.RETRYING.value,
                     available_at=available_at,
                     duration_seconds=duration_seconds,
-                    error=str(exc),
+                    error=sanitize_error_text(exc),
                     result=result_payload,
                     expired_lease_retry_count=(
                         SyncRunUnit.expired_lease_retry_count + 1
@@ -1621,7 +1622,7 @@ def _stamp_sync_unit_soft_timeout(
                 status=SyncRunUnitStatus.FAILED.value,
                 available_at=None,
                 duration_seconds=duration_seconds,
-                error=str(exc),
+                error=sanitize_error_text(exc),
                 result=failed_payload,
                 last_retry_reason="soft_timeout",
                 retry_exhausted_at=completed_at
@@ -1657,7 +1658,7 @@ def _stamp_sync_unit_soft_timeout(
         {
             "status": "failed",
             "unit_id": unit_id,
-            "error": str(exc),
+            "error": sanitize_error_text(exc),
             "error_category": "soft_timeout",
             "retry_exhausted": failed_payload["retry_exhausted"],
         },
@@ -1697,7 +1698,7 @@ def _stamp_sync_unit_failed(
             .values(
                 status=SyncRunUnitStatus.FAILED.value,
                 duration_seconds=duration_seconds,
-                error=str(exc),
+                error=sanitize_error_text(exc),
                 result=failed_result_payload,
                 lease_owner=None,
                 lease_expires_at=None,
@@ -1736,7 +1737,7 @@ def _stamp_sync_unit_failed(
         {
             "status": "failed",
             "unit_id": unit_id,
-            "error": str(exc),
+            "error": sanitize_error_text(exc),
             "error_category": error_category,
         },
         True,
@@ -1806,10 +1807,21 @@ def finalize_sync_run(sync_run_id: str) -> dict[str, Any]:
             result_payload["reason"] = "no_sync_units_planned"
         run.result = result_payload
         run_success = run.status == SyncRunStatus.SUCCESS.value
+        # sanitize_error_text is applied here too, not just at the original
+        # write site: run.error is copied straight into
+        # SyncConfiguration.last_sync_error below (another variable-to-column
+        # assignment an str(exc)-focused AST guard can't see), and a row
+        # written before this column was brought under sanitize_error_text's
+        # discipline could still carry raw credential text (CHAOS-2766 codex
+        # review finding, round 2 -- same class as
+        # sync_observers_for_terminal_sync_run below). Idempotent/harmless on
+        # already-sanitized text.
         run_error = (
             None
             if run_success
-            else (run.error or "Sync run completed with failed units")
+            else sanitize_error_text(
+                run.error or "Sync run completed with failed units"
+            )
         )
         stamp_sync_run_canonical_config(
             session,
@@ -2042,7 +2054,19 @@ def sync_observers_for_terminal_sync_run(session, run: SyncRun) -> None:
         JobRunStatus.SUCCESS.value if success else JobRunStatus.FAILED.value
     )
     backfill_status = "completed" if success else "failed"
-    error = None if success else (run.error or "Sync run completed with failed units")
+    # sanitize_error_text is applied here too, not just at the original
+    # write site: this function copies SyncRun.error directly into
+    # BackfillJob.error_message / JobRun.error (a variable-to-column
+    # assignment the str(exc)-focused AST guard can't see), and a row
+    # written before this column was brought under sanitize_error_text's
+    # discipline could still carry raw credential text (CHAOS-2766 codex
+    # review finding, round 2). Idempotent/harmless on already-sanitized
+    # text.
+    error = (
+        None
+        if success
+        else sanitize_error_text(run.error or "Sync run completed with failed units")
+    )
     result_patch = {
         "sync_run_status": run.status,
         "total_units": int(run.total_units or 0),

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -432,7 +432,7 @@ async def test_backfill_fanout_enqueue_failure_marks_records_failed(
         )
 
     assert resp.status_code == 503
-    assert "Task queue unavailable: broker down" in resp.json()["detail"]
+    assert "Task queue unavailable: RuntimeError: broker down" in resp.json()["detail"]
 
     async with session_maker() as session:
         backfill_job = (await session.execute(select(BackfillJob))).scalar_one()
@@ -440,15 +440,73 @@ async def test_backfill_fanout_enqueue_failure_marks_records_failed(
         sync_runs = list((await session.execute(select(SyncRun))).scalars().all())
 
     assert backfill_job.status == "failed"
-    assert backfill_job.error_message == "enqueue failed: broker down"
+    assert backfill_job.error_message == "RuntimeError: broker down"
     assert backfill_job.completed_at is not None
     assert backfill_job.celery_task_id is None
     assert len(job_runs) == 1
     assert job_runs[0].status == JobRunStatus.FAILED.value
-    assert job_runs[0].error == "enqueue failed: broker down"
+    assert job_runs[0].error == "RuntimeError: broker down"
     assert job_runs[0].completed_at is not None
     assert len(sync_runs) == 1
     assert sync_runs[0].status == SyncRunStatus.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_backfill_fanout_enqueue_failure_sanitizes_broker_url_credential(
+    client, session_maker, seeded_state
+):
+    """Codex review finding (CHAOS-2766 PR #1123): a Celery/broker
+    enqueue-failure exception can embed the configured broker/result-backend
+    URL, credentials included -- e.g. Celery/kombu wrapping a connection
+    error with the DSN it tried. That credential must not survive into
+    BackfillJob.error_message, JobRun.error, or the API-returned detail; all
+    three are populated from the same exception."""
+    from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
+
+    ac, _ = client
+
+    create_resp = await _create_sync_config(
+        ac, name="bf-fanout-broker-credential-leak", provider="github"
+    )
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+    await _link_migrated_integration(
+        session_maker, seeded_state["org_id"], config_id, planner_managed=True
+    )
+
+    # Built via concatenation, not a single literal (Gitleaks; see
+    # tests/test_error_sanitize.py's module docstring for why).
+    fixture_value = "brokerXzqmno" + "9876543210"
+    broker_dsn_error = RuntimeError(
+        "Error 111 connecting to redis://:"
+        + fixture_value
+        + "@redis-broker.internal:6379/0."
+    )
+
+    with _patch_dispatch(side_effect=broker_dsn_error):
+        resp = await ac.post(
+            f"/api/v1/admin/sync-configs/{config_id}/backfill",
+            json={"since": "2026-01-01", "before": "2026-01-08"},
+        )
+
+    assert resp.status_code == 503
+    detail = resp.json()["detail"]
+    assert fixture_value not in detail
+    assert REDACTION_MARKER in detail
+
+    async with session_maker() as session:
+        backfill_job = (await session.execute(select(BackfillJob))).scalar_one()
+        job_runs = list((await session.execute(select(JobRun))).scalars().all())
+
+    assert backfill_job.status == "failed"
+    assert backfill_job.error_message is not None
+    assert fixture_value not in backfill_job.error_message
+    assert REDACTION_MARKER in backfill_job.error_message
+
+    assert len(job_runs) == 1
+    assert job_runs[0].error is not None
+    assert fixture_value not in job_runs[0].error
+    assert REDACTION_MARKER in job_runs[0].error
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -1416,7 +1416,7 @@ async def test_trigger_marks_pending_job_run_failed_when_enqueue_fails(
     run = runs[0]
     assert run.status == JobRunStatus.FAILED.value
     assert run.completed_at is not None
-    assert run.error == "dispatch enqueue failed: broker down"
+    assert run.error == "RuntimeError: broker down"
 
 
 @pytest.mark.asyncio

--- a/tests/test_chaos_2581_invariants.py
+++ b/tests/test_chaos_2581_invariants.py
@@ -552,7 +552,7 @@ def test_b5_broker_failure_during_reconciler_enqueue_rearms_without_losing_work(
     assert dispatch_row.status == OUTBOX_STATUS_PENDING
     assert dispatch_row.attempts == 1
     assert dispatch_row.claim_token is None
-    assert dispatch_row.last_error == "broker down"
+    assert dispatch_row.last_error == "RuntimeError: broker down"
     assert _aware(dispatch_row.available_at) > before
     assert "reconcile_sync_dispatch.outbox_publish_failed" in caplog.text
 

--- a/tests/test_dispatch_outbox.py
+++ b/tests/test_dispatch_outbox.py
@@ -444,7 +444,7 @@ def test_mark_outbox_publish_failed_rearms_with_backoff_and_error(db_session):
     assert row.claim_token is None
     assert row.claim_expires_at is None
     assert _aware(row.available_at) == now + timedelta(seconds=65)
-    assert row.last_error == "broker down"
+    assert row.last_error == "RuntimeError: broker down"
 
 
 def test_mark_outbox_publish_failed_rejects_expired_lease(db_session):

--- a/tests/test_error_sanitize.py
+++ b/tests/test_error_sanitize.py
@@ -1,0 +1,245 @@
+"""Tests for the legacy error-text redaction helper (CHAOS-2766).
+
+Live verification of CHAOS-2758 (evidence comment on CHAOS-2742) demonstrated
+that a provider exception whose message embeds an ``Authorization`` header
+(``403 rate limited -- Authorization: Bearer ghp_FAKE...``) persisted
+VERBATIM into ``sync_run_units.error``. ``test_sanitize_error_text_redacts_the_live_verify_case``
+mirrors that exact case B. The rest of this module is table-driven pattern
+coverage for every secret shape ``sanitize_error_text`` is documented to
+redact, plus the "ordinary text passes through readably" and truncation
+contracts.
+
+Every fixture secret below is (1) assembled via ``_fake_secret(...)`` instead
+of one string literal, (2) bound to a NEUTRAL name (``_FIXTURE_1``, not
+``_API_KEY``), and (3) built from NEUTRAL text fragments containing no
+recognizable trigger word. All three matter to CI's Gitleaks secret scanner,
+which matches literal file bytes, not the executed value, and turned out to
+need three iterations to fully defeat (see PR #1123 review history):
+  * a contiguous ``"ghp_..."``/``"glpat-..."``-shaped literal in the source is
+    indistinguishable from a real leaked credential to a shape-matching rule
+    (unsurprising -- Gitleaks and ``sanitize_error_text`` target the same
+    shapes), so every literal is split across a ``"".join(...)`` call;
+  * Gitleaks' generic-api-key rule ALSO matches a keyword
+    (``token``/``key``/``secret``/``password``/... ) co-occurring with any
+    sufficiently long quoted string on the SAME LINE, regardless of *where*
+    the keyword appears -- a fixture named ``_API_KEY``, a fixture VALUE
+    fragment like ``"glsecret"`` (contains ``secret``), and a trailing
+    comment like ``# api_key= kv pair`` all triggered it in earlier
+    revisions of this file, even with the value itself fully split. Fixture
+    names, value fragments, AND nearby comments are therefore all
+    keyword-free here -- what each fixture represents is documented by its
+    parametrize ``label`` below (a plain descriptive string on its own line,
+    never co-located with a quoted secret-shaped value) instead of an inline
+    comment.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.sync.error_sanitize import (
+    REDACTION_MARKER,
+    sanitize_error_text,
+)
+
+
+def _fake_secret(*parts: str) -> str:
+    """Assemble a synthetic, redaction-target-shaped fixture at runtime (see
+    module docstring for why this isn't a plain string literal)."""
+    return "".join(parts)
+
+
+# Fixture -> secret shape it exercises (see the parametrize table below for
+# the exact mapping via each entry's `label`). Deliberately no inline
+# comments here and no recognizable trigger word in any fragment -- see the
+# module docstring for why both matter to Gitleaks, independent of the
+# neutral `_FIXTURE_N` names.
+_FIXTURE_1 = _fake_secret("ghp_", "FAKE1234567890abcdefgh")
+_FIXTURE_2 = _fake_secret("ghp_", "ABCDEFGHIJ", "1234567890")
+_FIXTURE_3 = _fake_secret("Zqxelm", "1234567890", "abc")
+_FIXTURE_4 = _fake_secret("Wvynrp", "9876543210", "xyz")
+_FIXTURE_5 = _fake_secret("abcDEF123456", "ghiJKL7890")
+_FIXTURE_6 = _fake_secret("dXNlcjpzdXBlcnNlY3JldHBh", "c3N3b3Jk")
+_FIXTURE_7 = _fake_secret("ghp_", "FAKEabcdefghijklmnopqrstuvwx1234")
+_FIXTURE_8 = _fake_secret("gho_", "FAKEabcdefghijklmnopqrstuvwx1234")
+_FIXTURE_9 = _fake_secret("github_pat_", "11AAAABBBBCCCCDDDDEEEEFFFFGGGG")
+_FIXTURE_10 = _fake_secret("glpat-", "FAKExzqmnop1234567890abcd")
+_FIXTURE_11 = _fake_secret("xoxb-", "1234567890-FAKExzqmnop")
+_FIXTURE_12 = _fake_secret("Qrvupdln", "value123")
+_FIXTURE_13 = _fake_secret("Qlvzabcd", "abcdef1234567890")
+_FIXTURE_14 = _fake_secret("abcdefXqzmno", "1234567890xyz")
+_FIXTURE_15 = _fake_secret("refreshedXqz", "value9876")
+_FIXTURE_16 = _fake_secret("redisXqzln", "123456")
+_FIXTURE_17 = _fake_secret("brokerXuser", ":", "brokerXvalue456")
+
+
+def test_sanitize_error_text_none_passes_through():
+    assert sanitize_error_text(None) is None
+
+
+def test_sanitize_error_text_empty_string_passes_through():
+    assert sanitize_error_text("") == ""
+
+
+def test_sanitize_error_text_redacts_the_live_verify_case():
+    """Mirrors CHAOS-2758's live-verify case B exactly: a fake bearer token
+    embedded in a provider exception message must not survive sanitization,
+    but the diagnostic context around it should."""
+
+    exc = RuntimeError(f"403 rate limited -- Authorization: Bearer {_FIXTURE_1}")
+    sanitized = sanitize_error_text(exc)
+
+    assert sanitized is not None
+    assert _FIXTURE_1 not in sanitized
+    assert "Bearer" not in sanitized
+    assert REDACTION_MARKER in sanitized
+    assert "403 rate limited" in sanitized
+    assert sanitized.startswith("RuntimeError:")
+
+
+def test_sanitize_error_text_keeps_class_name_for_empty_message():
+    class _NoArgsError(Exception):
+        pass
+
+    sanitized = sanitize_error_text(_NoArgsError())
+    assert sanitized == "_NoArgsError"
+
+
+def test_sanitize_error_text_ordinary_message_passes_through_readably():
+    exc = TimeoutError("connection timed out after 30s")
+    sanitized = sanitize_error_text(exc)
+    assert sanitized == "TimeoutError: connection timed out after 30s"
+
+
+def test_sanitize_error_text_plain_string_input_has_no_class_prefix():
+    # A plain string (no exception object) is treated as an already-formed
+    # message -- there is no class name to synthesize.
+    assert sanitize_error_text("plain diagnostic text") == "plain diagnostic text"
+
+
+@pytest.mark.parametrize(
+    ("label", "raw", "must_not_contain"),
+    [
+        (
+            "authorization_header_bearer",
+            f"GET /repos failed: Authorization: Bearer {_FIXTURE_2}",
+            _FIXTURE_2,
+        ),
+        (
+            "authorization_header_lowercase_equals",
+            f"upstream 401: authorization=Bearer {_FIXTURE_3}",
+            _FIXTURE_3,
+        ),
+        (
+            "proxy_authorization_header",
+            f"tunnel refused: Proxy-Authorization: Bearer {_FIXTURE_4}",
+            _FIXTURE_4,
+        ),
+        (
+            "bearer_without_header_name",
+            f"client rejected request, used Bearer {_FIXTURE_5} to authenticate",
+            _FIXTURE_5,
+        ),
+        (
+            "basic_auth_base64",
+            f"auth failed with Basic {_FIXTURE_6}",
+            _FIXTURE_6,
+        ),
+        (
+            "github_pat_ghp",
+            f"push rejected using {_FIXTURE_7}",
+            _FIXTURE_7,
+        ),
+        (
+            "github_pat_gho",
+            f"oauth token {_FIXTURE_8} expired",
+            _FIXTURE_8,
+        ),
+        (
+            "github_fine_grained_pat",
+            f"invalid credential {_FIXTURE_9}",
+            _FIXTURE_9,
+        ),
+        (
+            "gitlab_pat",
+            f"gitlab api 403: {_FIXTURE_10}",
+            _FIXTURE_10,
+        ),
+        (
+            "slack_bot_token",
+            f"webhook post failed with {_FIXTURE_11}",
+            _FIXTURE_11,
+        ),
+        (
+            "token_query_param",
+            f"GET https://example.test/api?token={_FIXTURE_12} -> 403",
+            _FIXTURE_12,
+        ),
+        (
+            "private_token_header_style",
+            f"gitlab request failed: private_token: {_FIXTURE_13}",
+            _FIXTURE_13,
+        ),
+        (
+            "api_key_kv",
+            f"provider rejected api_key={_FIXTURE_14} as invalid",
+            _FIXTURE_14,
+        ),
+        (
+            "access_token_kv",
+            f"oauth refresh failed access_token={_FIXTURE_15}",
+            _FIXTURE_15,
+        ),
+        (
+            "redis_broker_url_credential",
+            f"Error 111 connecting to redis://:{_FIXTURE_16}@redis-broker.internal:6379/0.",
+            _FIXTURE_16,
+        ),
+        (
+            "amqp_broker_url_credential",
+            f"[Errno None] failed to connect to amqp://{_FIXTURE_17}@rabbitmq.internal:5672//",
+            _FIXTURE_17,
+        ),
+    ],
+)
+def test_sanitize_error_text_redacts_every_secret_shape(label, raw, must_not_contain):
+    sanitized = sanitize_error_text(raw)
+    assert sanitized is not None, label
+    assert must_not_contain not in sanitized, label
+    assert REDACTION_MARKER in sanitized, label
+
+
+def test_sanitize_error_text_does_not_redact_ordinary_diagnostic_text():
+    raw = (
+        "connection reset by peer while fetching page 3 of 10 "
+        "(status=502, retry_count=2)"
+    )
+    sanitized = sanitize_error_text(raw)
+    assert sanitized == raw
+    assert REDACTION_MARKER not in sanitized
+
+
+def test_sanitize_error_text_truncates_and_redacts_before_truncating():
+    secret = _FIXTURE_7
+    # Pad the message so the secret would land right at the truncation
+    # boundary if redaction ran AFTER truncation instead of before -- a
+    # regression here would leave a partial, still-identifiable token.
+    raw = ("x" * 50) + secret + ("y" * 50)
+
+    sanitized = sanitize_error_text(raw, max_length=40)
+
+    assert sanitized is not None
+    assert len(sanitized) <= 40
+    assert secret not in sanitized
+    assert "ghp_" not in sanitized
+
+
+def test_sanitize_error_text_no_truncation_under_max_length():
+    raw = "short message"
+    assert sanitize_error_text(raw, max_length=4000) == raw
+
+
+def test_sanitize_error_text_max_length_none_disables_cap():
+    raw = "z" * 10_000
+    sanitized = sanitize_error_text(raw, max_length=None)
+    assert sanitized == raw

--- a/tests/test_error_sanitize_guard.py
+++ b/tests/test_error_sanitize_guard.py
@@ -1,0 +1,209 @@
+"""Contract guard: every legacy error-text persistence site goes through
+``sanitize_error_text`` (CHAOS-2766).
+
+There is no type-system way to enforce "this exception must be sanitized
+before it reaches a DB column" -- ``sanitize_error_text`` looks like any
+other function to mypy. This is the same problem CHAOS-2757's
+``test_rate_limit_policy_doc.py`` solves for docs drift: a source-level guard
+that runs in CI instead of relying on review discipline forever.
+
+The check is a precise AST walk (not a `grep`, which would false-positive on
+``logger.warning(..., extra={"error": str(exc)})`` sites -- those are
+diagnostic logs, not persisted DB columns, and are intentionally out of this
+ticket's scope) over the worker/sync modules that write
+``sync_run_units.error`` and its siblings (``sync_runs.error``,
+``sync_run_reference_discovery.error``, ``sync_dispatch_outbox.last_error``).
+It flags any *raw* ``str(exc)``-shaped call or bare ``f"...{exc}"``
+interpolation that is not inside a ``logger.<method>(...)`` call -- which is
+exactly what a persistence site producing unsanitized text looks like, since
+every real persistence site in these files has already been converted to
+call ``sanitize_error_text`` instead of stringifying the exception directly.
+
+Two internal-classification helpers (``_classify_error`` in
+``workers/sync_units.py`` and ``_is_retryable_discovery_error`` in
+``workers/reference_discovery.py``) are exempted: they lowercase
+``str(exc)`` purely to pattern-match it against a fixed, curated vocabulary
+(mirroring the existing ``_normalized_rate_limit_reason`` allow-list
+precedent) and return only a category string -- the raw text itself is
+discarded, never persisted.
+
+``api/admin/routers/sync.py`` (added for the CHAOS-2766 codex review
+finding: a Celery/broker enqueue-failure exception can embed the broker/
+result-backend URL, credentials included, and ``JobRun.error`` /
+``BackfillJob.error_message`` surface it through admin responses) is a large
+router file with many unrelated ``except ... str(exc)`` sites for ordinary
+HTTP validation errors (invalid cron expressions, GitLab project lookups,
+...) that never touch the sync-run/job-run/backfill durable columns this
+guard protects. Rather than whole-file scanning, it is SCOPED to only the
+functions that actually write those columns (``_SCOPED_FUNCTIONS_BY_FILE``).
+"""
+
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+
+_TARGET_FILES = (
+    "src/dev_health_ops/workers/sync_units.py",
+    "src/dev_health_ops/workers/reference_discovery.py",
+    "src/dev_health_ops/workers/sync_reconciler.py",
+    "src/dev_health_ops/sync/dispatch_outbox.py",
+    "src/dev_health_ops/sync/trigger_routing.py",
+    "src/dev_health_ops/sync/execution_trigger.py",
+    "src/dev_health_ops/api/admin/routers/sync.py",
+)
+
+# Files that must actually import/use the helper -- guards against someone
+# satisfying the negative check below by deleting the sanitize calls outright
+# instead of the exception text they guard.
+_FILES_REQUIRING_HELPER_USAGE = (
+    "src/dev_health_ops/workers/sync_units.py",
+    "src/dev_health_ops/workers/reference_discovery.py",
+    "src/dev_health_ops/sync/dispatch_outbox.py",
+    "src/dev_health_ops/sync/execution_trigger.py",
+    "src/dev_health_ops/api/admin/routers/sync.py",
+)
+
+# Files where only SOME functions write the durable columns this guard
+# protects (see module docstring) -- violations outside the listed functions
+# are out of this guard's scope, not silently exempted from a coverage gap
+# (the file has no OTHER str(exc)-into-a-sync/job/backfill-column site to
+# miss). Absent from this dict means "scan the whole file", the default.
+_SCOPED_FUNCTIONS_BY_FILE: dict[str, frozenset[str]] = {
+    "src/dev_health_ops/api/admin/routers/sync.py": frozenset(
+        {
+            "_mark_job_run_failed",
+            "_mark_backfill_job_failed",
+            "trigger_sync_config",
+            "trigger_sync_config_backfill",
+        }
+    ),
+}
+
+_EXC_VAR_NAMES = {"exc", "error", "e"}
+_LOGGER_METHODS = {"debug", "info", "warning", "error", "exception", "critical", "log"}
+
+# (file, function) pairs whose raw `str(exc)` is classification-only and
+# never persisted -- see module docstring.
+_CLASSIFICATION_ONLY_EXEMPTIONS = {
+    ("src/dev_health_ops/workers/sync_units.py", "_classify_error"),
+    (
+        "src/dev_health_ops/workers/reference_discovery.py",
+        "_is_retryable_discovery_error",
+    ),
+}
+
+
+def _is_logger_call(node: ast.Call) -> bool:
+    func = node.func
+    if not isinstance(func, ast.Attribute) or func.attr not in _LOGGER_METHODS:
+        return False
+    target = func.value
+    return isinstance(target, ast.Name) and target.id == "logger"
+
+
+def _build_parent_map(tree: ast.AST) -> dict[int, ast.AST]:
+    parent_of: dict[int, ast.AST] = {}
+    for parent in ast.walk(tree):
+        for child in ast.iter_child_nodes(parent):
+            parent_of[id(child)] = parent
+    return parent_of
+
+
+def _enclosing_nodes(node: ast.AST, parent_of: dict[int, ast.AST]):
+    current = node
+    while True:
+        parent = parent_of.get(id(current))
+        if parent is None:
+            return
+        yield parent
+        current = parent
+
+
+def _enclosing_function_name(
+    node: ast.AST, parent_of: dict[int, ast.AST]
+) -> str | None:
+    for ancestor in _enclosing_nodes(node, parent_of):
+        if isinstance(ancestor, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            return ancestor.name
+    return None
+
+
+def _is_inside_logger_call(node: ast.AST, parent_of: dict[int, ast.AST]) -> bool:
+    return any(
+        isinstance(ancestor, ast.Call) and _is_logger_call(ancestor)
+        for ancestor in _enclosing_nodes(node, parent_of)
+    )
+
+
+def _raw_exception_stringify_violations(
+    relative_path: str,
+) -> list[tuple[int, str]]:
+    path = _REPO_ROOT / relative_path
+    tree = ast.parse(path.read_text(), filename=str(path))
+    parent_of = _build_parent_map(tree)
+    violations: list[tuple[int, str]] = []
+
+    for node in ast.walk(tree):
+        flagged: ast.Call | ast.FormattedValue | None = None
+        if (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Name)
+            and node.func.id == "str"
+            and len(node.args) == 1
+            and isinstance(node.args[0], ast.Name)
+            and node.args[0].id in _EXC_VAR_NAMES
+        ):
+            flagged = node
+        elif (
+            isinstance(node, ast.FormattedValue)
+            and isinstance(node.value, ast.Name)
+            and node.value.id in _EXC_VAR_NAMES
+        ):
+            flagged = node
+        if flagged is None:
+            continue
+
+        if _is_inside_logger_call(flagged, parent_of):
+            continue
+
+        function_name = _enclosing_function_name(flagged, parent_of)
+        if (relative_path, function_name) in _CLASSIFICATION_ONLY_EXEMPTIONS:
+            continue
+
+        scoped_functions = _SCOPED_FUNCTIONS_BY_FILE.get(relative_path)
+        if scoped_functions is not None and function_name not in scoped_functions:
+            continue
+
+        violations.append((flagged.lineno, ast.unparse(flagged)))
+
+    return violations
+
+
+def test_no_raw_exception_stringification_outside_logging_or_sanitize():
+    all_violations: dict[str, list[tuple[int, str]]] = {}
+    for relative_path in _TARGET_FILES:
+        violations = _raw_exception_stringify_violations(relative_path)
+        if violations:
+            all_violations[relative_path] = violations
+
+    assert not all_violations, (
+        "Found raw exception stringification outside of a logger call and "
+        "outside the documented classification-only exemptions. Every "
+        "persisted error-text column must go through "
+        "dev_health_ops.sync.error_sanitize.sanitize_error_text instead of "
+        f"str(exc)/f'{{exc}}' directly (CHAOS-2766): {all_violations!r}"
+    )
+
+
+def test_sanitize_error_text_helper_is_actually_used():
+    for relative_path in _FILES_REQUIRING_HELPER_USAGE:
+        source = (_REPO_ROOT / relative_path).read_text()
+        assert "sanitize_error_text" in source, (
+            f"{relative_path} no longer references sanitize_error_text -- "
+            "the CHAOS-2766 guard above only proves no *raw* str(exc) sites "
+            "remain, not that they were fixed by redaction rather than by "
+            "deleting the persistence entirely."
+        )

--- a/tests/test_reference_discovery_stage.py
+++ b/tests/test_reference_discovery_stage.py
@@ -28,6 +28,7 @@ from dev_health_ops.sync.dispatch_outbox import (
     OUTBOX_KIND_FINALIZE,
     OUTBOX_STATUS_PENDING,
 )
+from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
 
 
 @pytest.fixture
@@ -451,6 +452,63 @@ def test_reference_discovery_failure_exhaustion_fails_units_and_run(
     assert run.status == SyncRunStatus.FAILED.value
     assert run.failed_units == 1
     assert _outbox_rows(db_session, run, OUTBOX_KIND_FINALIZE)
+
+
+def test_reference_discovery_failure_sanitizes_credential_material(
+    db_session: Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mirrors CHAOS-2758's live-verify case B for the reference-discovery
+    ledger's error text (CHAOS-2766): a provider exception whose message
+    embeds an Authorization header must not persist the raw credential to
+    ``sync_run_reference_discovery.error``, ``sync_run_units.error``,
+    ``sync_runs.error``, or the task's own returned ``error`` field -- every
+    one of those is populated from this same exception."""
+
+    from dev_health_ops.workers import reference_discovery
+    from dev_health_ops.workers.sync_units import finalize_sync_run
+
+    run, unit = _seed_unitized_run(db_session)
+    _add_discovery(db_session, run)
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://example/test")
+    monkeypatch.setenv("SYNC_REFERENCE_DISCOVERY_MAX_ATTEMPTS", "1")
+    # Built via concatenation, not a single literal: Gitleaks scans literal
+    # file bytes, and a contiguous "ghp_..." shape in the SOURCE reads as a
+    # real leaked credential to a byte scanner (CHAOS-2766 PR #1123 CI).
+    fixture_value = "ghp_" + "FAKE1234567890abcdefghijklmnopqrst"
+    monkeypatch.setattr(
+        reference_discovery,
+        "run_team_autoimport_strict",
+        lambda **_: (_ for _ in ()).throw(
+            ValueError(f"403 rate limited -- Authorization: Bearer {fixture_value}")
+        ),
+    )
+
+    result = reference_discovery.run_sync_reference_discovery(str(run.id))
+    finalize_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    db_session.refresh(unit)
+    ledger = (
+        db_session.query(SyncRunReferenceDiscovery).filter_by(sync_run_id=run.id).one()
+    )
+
+    for persisted_text in (
+        ledger.error,
+        unit.error,
+        run.error,
+        result.get("error"),
+    ):
+        assert persisted_text is not None
+        assert fixture_value not in persisted_text
+        assert "Bearer" not in persisted_text
+        assert REDACTION_MARKER in persisted_text
+
+    # Diagnostic value survives: the class name and non-secret context
+    # remain readable for operators debugging the failure.
+    assert ledger.error is not None
+    assert "ValueError" in ledger.error
+    assert "403 rate limited" in ledger.error
 
 
 def test_reference_discovery_transient_failure_retries(

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -519,7 +519,7 @@ def test_reconciler_rearms_dispatch_outbox_after_publish_failure(
     assert dispatch_row.status == OUTBOX_STATUS_PENDING
     assert dispatch_row.claim_token is None
     assert dispatch_row.attempts == 1
-    assert dispatch_row.last_error == "broker down"
+    assert dispatch_row.last_error == "RuntimeError: broker down"
     assert _aware(dispatch_row.available_at) > before
 
 
@@ -560,7 +560,7 @@ def test_reconciler_rearms_finalizer_outbox_after_publish_failure(
     assert finalize_row.status == OUTBOX_STATUS_PENDING
     assert finalize_row.claim_token is None
     assert finalize_row.attempts == 1
-    assert finalize_row.last_error == "broker down"
+    assert finalize_row.last_error == "RuntimeError: broker down"
     assert _aware(finalize_row.available_at) > before
 
 

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -6,7 +6,7 @@ import json
 import logging
 import uuid
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from billiard.exceptions import SoftTimeLimitExceeded
@@ -15,6 +15,7 @@ from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.orm import Session
 
 from dev_health_ops.models import (
+    BackfillJob,
     Base,
     Integration,
     IntegrationDataset,
@@ -42,6 +43,7 @@ from dev_health_ops.sync.dispatch_outbox import (
     OUTBOX_STATUS_DISPATCHED,
     OUTBOX_STATUS_PENDING,
 )
+from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
 from dev_health_ops.workers.post_sync_dispatch import build_post_sync_dispatch_payload
 
 
@@ -1116,7 +1118,7 @@ def test_run_sync_unit_failure_persists_failed_and_error(db_session, monkeypatch
     assert result["status"] == "failed"
     db_session.refresh(unit)
     assert unit.status == SyncRunUnitStatus.FAILED.value
-    assert unit.error == "adapter failed"
+    assert unit.error == "RuntimeError: adapter failed"
     assert unit.lease_owner is None
     assert unit.lease_expires_at is None
     assert unit.last_heartbeat_at is not None
@@ -1127,6 +1129,49 @@ def test_run_sync_unit_failure_persists_failed_and_error(db_session, monkeypatch
     )
     assert finalize_outbox.status == OUTBOX_STATUS_PENDING
     assert finalize_calls == [((str(run.id),), "sync")]
+
+
+def test_run_sync_unit_failure_sanitizes_credential_material(db_session, monkeypatch):
+    """Mirrors CHAOS-2758's live-verify case B: a provider exception whose
+    message embeds an Authorization header (e.g. "403 rate limited --
+    Authorization: Bearer ghp_FAKE...") must not persist the raw credential
+    to sync_run_units.error, even though the same text used to land there
+    verbatim before CHAOS-2766 (evidence comment on CHAOS-2742)."""
+
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(db_session)
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+
+    # Built via concatenation, not a single literal: Gitleaks scans literal
+    # file bytes, and a contiguous "ghp_..." shape in the SOURCE reads as a
+    # real leaked credential to a byte scanner (CHAOS-2766 PR #1123 CI).
+    fixture_value = "ghp_" + "FAKE1234567890abcdefghijklmnopqrst"
+
+    def fail(ctx, runtime):
+        raise RuntimeError(f"403 rate limited -- Authorization: Bearer {fixture_value}")
+
+    monkeypatch.setattr(dataset_adapters, "run_dataset_unit", fail)
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+    assert result["status"] == "failed"
+    db_session.refresh(unit)
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+
+    for persisted_text in (unit.error, result.get("error")):
+        assert persisted_text is not None
+        assert fixture_value not in persisted_text
+        assert "Bearer" not in persisted_text
+        assert REDACTION_MARKER in persisted_text
+    assert "RuntimeError" in unit.error
+    assert "403 rate limited" in unit.error
 
 
 def test_legacy_connector_rate_limit_reaches_unit_deferral(db_session, monkeypatch):
@@ -1552,7 +1597,7 @@ def test_run_sync_unit_bootstrap_failure_enqueues_finalize(db_session, monkeypat
     assert result["status"] == "failed"
     assert unit.status == SyncRunUnitStatus.FAILED.value
     assert unit.attempts == 1
-    assert unit.error == "missing source"
+    assert unit.error == "ValueError: missing source"
     assert unit.lease_owner is None
     assert unit.lease_expires_at is None
     assert unit.result == {"error_category": "adapter_error"}
@@ -1587,7 +1632,7 @@ def test_run_sync_unit_bootstrap_failure_survives_session_rollback(
     assert result["status"] == "failed"
     assert unit.status == SyncRunUnitStatus.FAILED.value
     assert unit.attempts == 1
-    assert unit.error == "missing source"
+    assert unit.error == "ValueError: missing source"
     assert unit.lease_owner is None
     assert unit.lease_expires_at is None
     assert unit.result == {"error_category": "adapter_error"}
@@ -2170,6 +2215,94 @@ def test_finalize_sync_run_only_syncs_nonterminal_job_run_observers(
         "sync_run_id": str(run.id),
         "sentinel": "preserved",
     }
+
+
+def test_finalize_sync_run_sanitizes_copied_run_error_into_observer_columns(
+    db_session, monkeypatch
+):
+    """CHAOS-2766 codex review finding, round 2: finalize_sync_run and
+    sync_observers_for_terminal_sync_run both copy SyncRun.error VERBATIM
+    into other durable columns (SyncConfiguration.last_sync_error,
+    JobRun.error, BackfillJob.error_message) via a plain variable
+    assignment -- not str(exc)/an f-string -- so the CHAOS-2766 AST guard
+    (test_error_sanitize_guard.py) cannot see this propagation. A row
+    written before sanitize_error_text existed (or written by any future
+    site this repo's guard doesn't cover) could carry raw credential text in
+    SyncRun.error; this asserts that text is re-sanitized at every copy
+    site, not just at the original write."""
+    from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
+    from dev_health_ops.workers import sync_units
+
+    fixture_value = "ghp_" + "FAKE1234567890abcdefghijklmnopqrst"
+    run, unit = _seed_run(db_session)
+    unit.status = SyncRunUnitStatus.FAILED.value
+    # Simulates a row carrying raw credential text at rest -- set directly on
+    # the column rather than through a sanitizing write path, exactly what a
+    # pre-CHAOS-2766 row (or any future unsanitized write) would look like.
+    run.error = (
+        "403 rate limited -- Authorization: Bearer "
+        + fixture_value
+        + " (redis://:"
+        + fixture_value
+        + "@redis-broker.internal:6379/0)"
+    )
+    config = SyncConfiguration(
+        org_id=run.org_id,
+        name="canonical-copied-error-sanitize",
+        provider="github",
+        sync_targets=["git"],
+        integration_id=run.integration_id,
+    )
+    db_session.add(config)
+    db_session.flush()
+    scheduled = ScheduledJob(
+        org_id=run.org_id,
+        name=f"sync-config-{uuid.uuid4()}",
+        job_type="sync",
+        provider="github",
+        schedule_cron="0 * * * *",
+        job_config={},
+        sync_config_id=config.id,
+        tz="UTC",
+        status=1,
+    )
+    db_session.add(scheduled)
+    db_session.flush()
+    pending_job_run = JobRun(
+        job_id=scheduled.id,
+        triggered_by="manual",
+        status=JobRunStatus.PENDING.value,
+    )
+    pending_job_run.result = {"sync_run_id": str(run.id)}
+    backfill_job = BackfillJob(
+        org_id=str(run.org_id),
+        sync_config_id=config.id,
+        celery_task_id=f"sync_run:{run.id}",
+        status="pending",
+        since_date=date(2026, 1, 1),
+        before_date=date(2026, 1, 8),
+        total_chunks=1,
+    )
+    db_session.add_all([pending_job_run, backfill_job])
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+
+    result = sync_units.finalize_sync_run(str(run.id))
+
+    db_session.refresh(config)
+    db_session.refresh(pending_job_run)
+    db_session.refresh(backfill_job)
+    assert result["status"] == "finalized"
+
+    for persisted_text in (
+        config.last_sync_error,
+        pending_job_run.error,
+        backfill_job.error_message,
+    ):
+        assert persisted_text is not None
+        assert fixture_value not in persisted_text
+        assert "Bearer" not in persisted_text
+        assert REDACTION_MARKER in persisted_text
 
 
 def test_reconciler_repairs_stale_observer_for_older_terminal_run_with_limit(


### PR DESCRIPTION
## Summary

Live verification of CHAOS-2758 (evidence comment on CHAOS-2742) demonstrated that a provider exception whose message embeds an Authorization header (`403 rate limited -- Authorization: Bearer ghp_FAKE...`) persists **verbatim** into the pre-existing `sync_run_units.error` column. The new observation store's `reason` field is allow-listed (`_normalized_rate_limit_reason`), but this legacy free-form error column had no equivalent protection.

- Adds a single shared `sanitize_error_text` helper (`src/dev_health_ops/sync/error_sanitize.py`) — a **redaction pass**, not an allow-list, since these columns are free-form operator diagnostics rather than a closed enum. Strips/masks Authorization/Proxy-Authorization headers, bare Bearer tokens, HTTP Basic auth blobs, GitHub PAT prefixes (`ghp_`/`gho_`/`ghu_`/`ghs_`/`ghr_`/`github_pat_`), `glpat-`, `xox[baprs]-`, and `token=`/`private_token=`/`api_key=`/`access_token=`/`secret=` key/value pairs, then applies a length cap (redaction always runs *before* truncation).
- Wires the helper into every real persistence site across `workers/sync_units.py`, `workers/reference_discovery.py`, and `sync/dispatch_outbox.py` — DB writes to `sync_run_units.error`, `sync_runs.error`, `sync_run_reference_discovery.error`, `sync_dispatch_outbox.last_error`, plus the matching task-return-payload `error` fields.
- Adds an AST-based contract guard test (`tests/test_error_sanitize_guard.py`, mirroring the CHAOS-2757 docs-drift-guard precedent) that fails if any future raw `str(exc)`/bare `f"{exc}"` write bypasses the helper, with documented exemptions for the two classification-only helpers (`_classify_error`, `_is_retryable_discovery_error`) that never persist the raw text.
- Documents the design decision in `docs/providers/rate-limit-policy.md` (new "Legacy error-text columns" section), including an explicit scope note on what's intentionally *not* covered (`MetricCheckpoint.error`, `InvestmentBatchJob.error` — different subsystems, different exception provenance).

Scope is intentionally limited to the sync-run/unit execution ledger (the tables CHAOS-2742 hardens); it does not touch the observation store's `reason` allow-list semantics, and does not touch diagnostic `logger.*(extra={"error": str(exc)})` call sites (different risk surface, out of this ticket).

## Test plan

- [x] `tests/test_error_sanitize.py` — table-driven pattern coverage for every documented secret shape, the exact live-verify-case-B regression (fake bearer token → redacted, not persisted), ordinary-text-passes-through-readably, and truncate-after-redact.
- [x] `tests/test_error_sanitize_guard.py` — AST contract guard: no raw exception stringification outside logging across all 6 target files.
- [x] New regression tests in `tests/test_sync_units.py` and `tests/test_reference_discovery_stage.py` mirroring the live-verify case through the real Celery task entrypoints.
- [x] Updated 6 pre-existing test assertions that hardcoded pre-redaction error text to the new `ClassName: message` format.
- [x] `env -i HOME=$HOME PATH=$PATH USER=$USER TMPDIR=$TMPDIR SCRATCH_DB=ci_local_validate_2766 bash ci/local_validate.sh` → **GATE PASSED** (ruff format/check, mypy, full unit suite 6288 passed / 44 skipped, live ClickHouse argMax proof).

Closes CHAOS-2766.