### PR TITLE
fix(sync): drop legacy SyncConfiguration.credential_id auth surface (CHAOS-2762)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -25,6 +25,20 @@ The concrete shape that enforces this today:
   `workers/sync_bootstrap.py`. There is no credential pool, no round-robin, and
   no unit-level credential selection. A sync unit uses exactly the integration's
   one active credential (or the env fallback when `credential_id is None`).
+- **Exactly one place a credential attaches to sync work.**
+  `SyncConfiguration` (the admin API's sync-config row) used to carry its own
+  `credential_id` column — a second, *unfrozen* copy of the same selection,
+  writable independently of `Integration.credential_id` and never read by
+  planning, budgeting, or auth resolution. It was removed
+  ([CHAOS-2762](https://linear.app/fullchaos/issue/CHAOS-2762)); the admin API
+  still accepts/returns `credential_id` on sync-config payloads, but it is now
+  resolved live from the linked `Integration.credential_id` on every read (see
+  `api/admin/routers/sync.py`), so it can never drift from the surface auth
+  resolution actually uses. **`SyncConfigResponse.credential_id` is a
+  compatibility read-through alias, not a design target** — it exists only
+  because the web admin UI still reads a sync config's credential off the
+  sync-config response. It is a candidate for removal once web reads
+  credentials at the `Integration` level directly instead.
 - **Runtime cache is credential-scoped for isolation, not capacity.** The
   provider runtime reuse cache keys on
   `RuntimeCacheKey(org_id, integration_id, credential_id, credential_fingerprint,

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -58,9 +58,15 @@ The concrete shape that enforces this today:
   credential identity/version onto a `SyncRun` at plan time (so a mid-run
   credential edit cannot produce a mixed-auth run) is a *determinism* mechanism.
   It selects **one** auth context for the whole run and must never be used to
-  pick different credentials per unit for throughput. **Target contract, landing
-  in [CHAOS-2755](https://linear.app/fullchaos/issue/CHAOS-2755):** the `SyncRun`
-  model does not yet carry a credential stamp column.
+  pick different credentials per unit for throughput. **Shipped**
+  ([CHAOS-2755](https://linear.app/fullchaos/issue/CHAOS-2755), migration
+  `0030`): `sync_runs` carries `credential_id` / `credential_fingerprint` /
+  `auth_source`, stamped once at plan time by `sync/planner.py`'s
+  `_resolve_credential_stamp` and never re-resolved mid-run —
+  `workers/sync_bootstrap.py` reads the frozen stamp, falling back to the
+  mutable `Integration.credential_id` path only for legacy/in-flight-at-deploy
+  runs whose stamp is `NULL`. Enforced by `tests/test_sync_run_auth_freeze.py`
+  and `tests/test_sync_planner.py`.
 
 **Out of scope, permanently:** credential pools, credential round-robin,
 unit-level credential assignment for throughput, and any UI/API language
@@ -825,12 +831,7 @@ append its section here in the same changeset (per `AGENTS.md`
   and the deferral machinery consumes, preserving GitHub's
   primary/secondary/permission distinction and extending comparable handling to
   Linear, Jira, GitLab, and LaunchDarkly.
-- **Shared actuals recorder — [CHAOS-2754](https://linear.app/fullchaos/issue/CHAOS-2754).**
-  A shared usage recorder with route-family keying and GitLab/Jira/Linear drains.
-- **Run-auth freeze — [CHAOS-2755](https://linear.app/fullchaos/issue/CHAOS-2755).**
-  Stamp `credential_id`/version onto `SyncRun` at plan time; bootstrap uses the
-  run-stamped auth context, not mutable integration state. Determinism only —
-  **never** unit-level credential selection for capacity.
+
 ## References
 
 - Epic: [CHAOS-2742](https://linear.app/fullchaos/issue/CHAOS-2742) — Harden sync

--- a/src/dev_health_ops/alembic/versions/0032_drop_sync_config_credential_id.py
+++ b/src/dev_health_ops/alembic/versions/0032_drop_sync_config_credential_id.py
@@ -20,11 +20,12 @@ Data note: the column's values are redundant with (and, for planner-managed
 configs, always assigned from) ``Integration.credential_id`` via each config's
 ``integration_id`` FK, so no backfill/migration of live data is needed before
 dropping it. The downgrade recreates the column (nullable, FK'd back to
-``integration_credentials``) but does **not** repopulate historical values --
-this is a deliberate, documented lossy downgrade of a column that was already
-provably redundant; the current mapping can be reconstructed post-downgrade
-via ``UPDATE sync_configurations sc SET credential_id = i.credential_id FROM
-integrations i WHERE i.id = sc.integration_id`` if ever needed.
+``integration_credentials``) and repopulates it from each config's linked
+``Integration.credential_id`` (a correlated-subquery ``UPDATE``, run BEFORE
+the FK is re-added so a stale/dangling ``integration_id`` can't violate it) --
+old code reading the restored column sees the same value the sanctioned
+surface would have resolved, rather than every row silently going NULL and
+widening any code still reading the legacy column (codex review, CHAOS-2762).
 
 Revision ID: 0032
 Revises: 0031
@@ -63,6 +64,7 @@ def downgrade() -> None:
         _TABLE,
         sa.Column(_COLUMN, UUID(as_uuid=True), nullable=True),
     )
+    _repopulate_from_linked_integration()
     existing_fks = {fk["name"] for fk in _foreign_keys(_TABLE)}
     fk_name = f"fk_{_TABLE}_{_COLUMN}_{_TARGET_TABLE}"
     if fk_name not in existing_fks and _COLUMN not in {
@@ -76,6 +78,36 @@ def downgrade() -> None:
             ["id"],
             ondelete="SET NULL",
         )
+
+
+def _repopulate_from_linked_integration() -> None:
+    """Backfill the recreated column from each config's linked Integration.
+
+    Codex review (CHAOS-2762 finding #2): a bare re-add left every row NULL on
+    rollback, silently changing behavior for anything still reading the
+    legacy column (e.g. a not-yet-rolled-back-deploy's ``workers
+    /team_drift_sync.py``) even though the true, current mapping is fully
+    recoverable from ``Integration.credential_id``. Runs BEFORE the FK is
+    re-added, so a stale/dangling ``integration_id`` (no matching
+    ``integrations`` row) cannot violate the new constraint -- such rows
+    simply keep ``credential_id IS NULL``, matching "no linked integration"
+    semantics.
+
+    A correlated subquery (not ``UPDATE ... FROM``) so this runs unchanged on
+    SQLite (used to unit-test this migration) and Postgres alike.
+    """
+    op.execute(
+        sa.text(
+            f"UPDATE {_TABLE} "
+            f"SET {_COLUMN} = ("
+            f"    SELECT credential_id FROM integrations "
+            f"    WHERE integrations.id = {_TABLE}.integration_id"
+            f") "
+            f"WHERE integration_id IN ("
+            f"    SELECT id FROM integrations WHERE credential_id IS NOT NULL"
+            f")"
+        )
+    )
 
 
 def _add_column_if_missing(table_name: str, column: sa.Column) -> None:

--- a/src/dev_health_ops/alembic/versions/0032_drop_sync_config_credential_id.py
+++ b/src/dev_health_ops/alembic/versions/0032_drop_sync_config_credential_id.py
@@ -1,0 +1,116 @@
+"""Drop the legacy sync_configurations.credential_id auth surface (CHAOS-2762).
+
+``SyncConfiguration.credential_id`` predates run-level credential stamping
+(CHAOS-2755, ``0030``) and was always a second, *unfrozen* copy of the
+credential selection: ``api/admin/routers/sync.py``'s planner-managed create
+path wrote the same value to both ``Integration.credential_id`` (the
+sanctioned surface ``resolve_run_auth``/``plan_sync_run`` actually reads) and
+this column. Nothing in the auth-resolution path (``sync/planner.py``,
+``workers/sync_bootstrap.py``) has ever read ``sync_configurations
+.credential_id`` -- only the admin API preflight/response-building code did,
+and that has been repointed to resolve through the linked ``Integration`` row
+instead (``SyncConfiguration.integration_id -> Integration.credential_id``).
+
+Dropping this column removes a second, unfrozen path by which a credential
+could appear to attach to sync work, leaving exactly one (``Integration``,
+frozen onto ``sync_runs`` at plan time). This does not touch dispatch
+capacity: the column was never read by planning, budgeting, or dispatch.
+
+Data note: the column's values are redundant with (and, for planner-managed
+configs, always assigned from) ``Integration.credential_id`` via each config's
+``integration_id`` FK, so no backfill/migration of live data is needed before
+dropping it. The downgrade recreates the column (nullable, FK'd back to
+``integration_credentials``) but does **not** repopulate historical values --
+this is a deliberate, documented lossy downgrade of a column that was already
+provably redundant; the current mapping can be reconstructed post-downgrade
+via ``UPDATE sync_configurations sc SET credential_id = i.credential_id FROM
+integrations i WHERE i.id = sc.integration_id`` if ever needed.
+
+Revision ID: 0032
+Revises: 0031
+Create Date: 2026-07-02 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any, cast
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0032"
+down_revision: str | None = "0031"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_TABLE = "sync_configurations"
+_COLUMN = "credential_id"
+_TARGET_TABLE = "integration_credentials"
+
+
+def upgrade() -> None:
+    _drop_foreign_key_on_column(_TABLE, _COLUMN)
+    _drop_column_if_present(_TABLE, _COLUMN)
+
+
+def downgrade() -> None:
+    _add_column_if_missing(
+        _TABLE,
+        sa.Column(_COLUMN, UUID(as_uuid=True), nullable=True),
+    )
+    existing_fks = {fk["name"] for fk in _foreign_keys(_TABLE)}
+    fk_name = f"fk_{_TABLE}_{_COLUMN}_{_TARGET_TABLE}"
+    if fk_name not in existing_fks and _COLUMN not in {
+        col for fk in _foreign_keys(_TABLE) for col in fk.get("constrained_columns", [])
+    }:
+        op.create_foreign_key(
+            fk_name,
+            _TABLE,
+            _TARGET_TABLE,
+            [_COLUMN],
+            ["id"],
+            ondelete="SET NULL",
+        )
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    if column.name not in _column_names(table_name):
+        op.add_column(table_name, column)
+
+
+def _drop_column_if_present(table_name: str, column_name: str) -> None:
+    if column_name in _column_names(table_name):
+        op.drop_column(table_name, column_name)
+
+
+def _drop_foreign_key_on_column(table_name: str, column_name: str) -> None:
+    for fk in _foreign_keys(table_name):
+        if column_name in fk.get("constrained_columns", []):
+            fk_name = fk.get("name")
+            if fk_name:
+                op.drop_constraint(fk_name, table_name, type_="foreignkey")
+
+
+def _foreign_keys(table_name: str) -> list[dict[str, Any]]:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return []
+    # SQLAlchemy types this as list[ReflectedForeignKeyConstraint] (a TypedDict);
+    # widen to list[dict[str, Any]] for the plain-dict access below (fk["name"],
+    # fk.get("constrained_columns")) -- structurally a dict, just not
+    # list-invariance-compatible without the cast.
+    return cast(list[dict[str, Any]], inspector.get_foreign_keys(table_name))
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    if table_name not in inspector.get_table_names():
+        return set()
+    return {column["name"] for column in inspector.get_columns(table_name)}

--- a/src/dev_health_ops/alembic/versions/0032_drop_sync_config_credential_id.py
+++ b/src/dev_health_ops/alembic/versions/0032_drop_sync_config_credential_id.py
@@ -93,20 +93,37 @@ def _repopulate_from_linked_integration() -> None:
     simply keep ``credential_id IS NULL``, matching "no linked integration"
     semantics.
 
-    A correlated subquery (not ``UPDATE ... FROM``) so this runs unchanged on
-    SQLite (used to unit-test this migration) and Postgres alike.
+    Built as a SQLAlchemy Core expression via lightweight ``sa.table()``/
+    ``sa.column()`` proxies (the documented pattern for data migrations that
+    can't import the real ORM models) rather than an interpolated SQL string,
+    so a static SQL-injection scanner has no string-built query to flag --
+    ``_TABLE``/``_COLUMN`` are module constants, not user input, but this
+    avoids the pattern entirely instead of suppressing the finding. A
+    correlated scalar subquery (not ``UPDATE ... FROM``) so this compiles
+    identically on SQLite (used to unit-test this migration) and Postgres.
     """
+    sync_configurations = sa.table(
+        _TABLE,
+        sa.column("integration_id"),
+        sa.column(_COLUMN),
+    )
+    integrations = sa.table(
+        "integrations",
+        sa.column("id"),
+        sa.column("credential_id"),
+    )
+    linked_credential = (
+        sa.select(integrations.c.credential_id)
+        .where(integrations.c.id == sync_configurations.c.integration_id)
+        .scalar_subquery()
+    )
+    linked_integration_ids = sa.select(integrations.c.id).where(
+        integrations.c.credential_id.is_not(None)
+    )
     op.execute(
-        sa.text(
-            f"UPDATE {_TABLE} "
-            f"SET {_COLUMN} = ("
-            f"    SELECT credential_id FROM integrations "
-            f"    WHERE integrations.id = {_TABLE}.integration_id"
-            f") "
-            f"WHERE integration_id IN ("
-            f"    SELECT id FROM integrations WHERE credential_id IS NOT NULL"
-            f")"
-        )
+        sa.update(sync_configurations)
+        .where(sync_configurations.c.integration_id.in_(linked_integration_ids))
+        .values({_COLUMN: linked_credential})
     )
 
 

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -95,28 +95,35 @@ def _mark_backfill_job_failed(
     sync_session.flush()
 
 
-def _sync_config_integration_credential_id(sync_session, config) -> uuid.UUID | None:
+def _sync_config_integration_credential_id(
+    sync_session, config, org_id: str
+) -> uuid.UUID | None:
     """Resolve the credential a config's LINKED integration actually uses.
 
     ``SyncConfiguration`` carries no credential of its own (CHAOS-2762) --
     ``Integration.credential_id`` (reached via ``config.integration_id``) is
     the single sanctioned surface. Returns ``None`` when the config has no
     linked integration (a pre-planner legacy row; the trigger/backfill
-    endpoints already reject those with "no linked integration" downstream).
+    endpoints already reject those with "no linked integration" downstream)
+    OR when the linked integration does not belong to ``org_id``: an
+    out-of-org ``integration_id`` (corrupt data / manual tampering) must never
+    leak another org's credential, so it is treated as no-credential -- the
+    same org-scoping ``sync/planner.py``'s ``_load_integration`` enforces.
     """
     integration_id = getattr(config, "integration_id", None)
     if integration_id is None:
         return None
     integration = (
         sync_session.query(Integration)
-        .filter(Integration.id == integration_id)
+        .filter(Integration.id == integration_id, Integration.org_id == org_id)
         .one_or_none()
     )
     return getattr(integration, "credential_id", None) if integration else None
 
 
 def _preflight_planner_credential(sync_session, config) -> None:
-    credential_id = _sync_config_integration_credential_id(sync_session, config)
+    org_id = str(getattr(config, "org_id"))
+    credential_id = _sync_config_integration_credential_id(sync_session, config, org_id)
     if credential_id is None:
         return
     from dev_health_ops.models.settings import IntegrationCredential
@@ -125,7 +132,7 @@ def _preflight_planner_credential(sync_session, config) -> None:
         sync_session.query(IntegrationCredential)
         .filter(
             IntegrationCredential.id == credential_id,
-            IntegrationCredential.org_id == getattr(config, "org_id"),
+            IntegrationCredential.org_id == org_id,
         )
         .one_or_none()
     )
@@ -211,31 +218,38 @@ class _MutableSyncConfiguration(Protocol):
 
 
 async def _integration_credential_id_for_config(
-    session: AsyncSession, config: object
+    session: AsyncSession, config: object, org_id: str
 ) -> uuid.UUID | None:
     """Async counterpart of ``_sync_config_integration_credential_id``.
 
     Resolves the ``credential_id`` of a config's linked ``Integration`` --
     the single sanctioned surface (CHAOS-2762) -- for building API responses.
+    Scoped to ``org_id`` so an out-of-org ``integration_id`` (corrupt data)
+    can never leak another org's credential UUID into this response; treated
+    as no-credential, same as the planner's org-scoped integration lookup.
     """
     integration_id = getattr(config, "integration_id", None)
     if integration_id is None:
         return None
     result = await session.execute(
-        select(Integration.credential_id).where(Integration.id == integration_id)
+        select(Integration.credential_id).where(
+            Integration.id == integration_id, Integration.org_id == org_id
+        )
     )
     return result.scalar_one_or_none()
 
 
 async def _integration_credential_ids_for_configs(
-    session: AsyncSession, configs: Sequence[object]
+    session: AsyncSession, configs: Sequence[object], org_id: str
 ) -> dict[str, uuid.UUID | None]:
     """Batch variant of ``_integration_credential_id_for_config`` for list responses.
 
     ONE query for the whole page via ``Integration.id.in_(...)`` -- callers
     must use this (not a per-row ``_integration_credential_id_for_config``
     call in a loop) when building a list response, or credential resolution
-    becomes an N+1 over ``Integration``.
+    becomes an N+1 over ``Integration``. Also scoped to ``org_id`` (see
+    ``_integration_credential_id_for_config``) so an out-of-org
+    ``integration_id`` never leaks another org's credential.
     """
     integration_ids = {
         getattr(config, "integration_id")
@@ -246,7 +260,7 @@ async def _integration_credential_ids_for_configs(
         return {}
     result = await session.execute(
         select(Integration.id, Integration.credential_id).where(
-            Integration.id.in_(integration_ids)
+            Integration.org_id == org_id, Integration.id.in_(integration_ids)
         )
     )
     return {
@@ -763,7 +777,7 @@ async def _replace_planner_repository_selection(
     mutable_config.sync_options = sync_options
 
     existing_credential_id = await _integration_credential_id_for_config(
-        session, config
+        session, config, org_id
     )
     batch_payload = SyncConfigBatchCreate(
         name=str(getattr(config, "name")),
@@ -1039,7 +1053,7 @@ async def list_sync_configs(
         children_counts = {str(pid): cnt for pid, cnt in rows}
 
     credential_ids_by_integration = await _integration_credential_ids_for_configs(
-        session, configs
+        session, configs, org_id
     )
 
     results = []
@@ -1478,7 +1492,7 @@ async def get_sync_config(
     config = await svc.get_by_id(config_id)
     if config is None:
         raise HTTPException(status_code=404, detail="Sync configuration not found")
-    credential_id = await _integration_credential_id_for_config(session, config)
+    credential_id = await _integration_credential_id_for_config(session, config, org_id)
     return _sync_config_to_response(config, credential_id=credential_id)
 
 
@@ -1656,7 +1670,9 @@ async def update_sync_config(
                 await _upsert_scheduled_job(session, child, org_id)
             await session.flush()
 
-    credential_id = await _integration_credential_id_for_config(session, updated)
+    credential_id = await _integration_credential_id_for_config(
+        session, updated, org_id
+    )
     return _sync_config_to_response(updated, credential_id=credential_id)
 
 

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -95,8 +95,28 @@ def _mark_backfill_job_failed(
     sync_session.flush()
 
 
+def _sync_config_integration_credential_id(sync_session, config) -> uuid.UUID | None:
+    """Resolve the credential a config's LINKED integration actually uses.
+
+    ``SyncConfiguration`` carries no credential of its own (CHAOS-2762) --
+    ``Integration.credential_id`` (reached via ``config.integration_id``) is
+    the single sanctioned surface. Returns ``None`` when the config has no
+    linked integration (a pre-planner legacy row; the trigger/backfill
+    endpoints already reject those with "no linked integration" downstream).
+    """
+    integration_id = getattr(config, "integration_id", None)
+    if integration_id is None:
+        return None
+    integration = (
+        sync_session.query(Integration)
+        .filter(Integration.id == integration_id)
+        .one_or_none()
+    )
+    return getattr(integration, "credential_id", None) if integration else None
+
+
 def _preflight_planner_credential(sync_session, config) -> None:
-    credential_id = getattr(config, "credential_id", None)
+    credential_id = _sync_config_integration_credential_id(sync_session, config)
     if credential_id is None:
         return
     from dev_health_ops.models.settings import IntegrationCredential
@@ -190,20 +210,63 @@ class _MutableSyncConfiguration(Protocol):
     is_active: bool
 
 
+async def _integration_credential_id_for_config(
+    session: AsyncSession, config: object
+) -> uuid.UUID | None:
+    """Async counterpart of ``_sync_config_integration_credential_id``.
+
+    Resolves the ``credential_id`` of a config's linked ``Integration`` --
+    the single sanctioned surface (CHAOS-2762) -- for building API responses.
+    """
+    integration_id = getattr(config, "integration_id", None)
+    if integration_id is None:
+        return None
+    result = await session.execute(
+        select(Integration.credential_id).where(Integration.id == integration_id)
+    )
+    return result.scalar_one_or_none()
+
+
+async def _integration_credential_ids_for_configs(
+    session: AsyncSession, configs: Sequence[object]
+) -> dict[str, uuid.UUID | None]:
+    """Batch variant of ``_integration_credential_id_for_config`` for list responses.
+
+    ONE query for the whole page via ``Integration.id.in_(...)`` -- callers
+    must use this (not a per-row ``_integration_credential_id_for_config``
+    call in a loop) when building a list response, or credential resolution
+    becomes an N+1 over ``Integration``.
+    """
+    integration_ids = {
+        getattr(config, "integration_id")
+        for config in configs
+        if getattr(config, "integration_id", None) is not None
+    }
+    if not integration_ids:
+        return {}
+    result = await session.execute(
+        select(Integration.id, Integration.credential_id).where(
+            Integration.id.in_(integration_ids)
+        )
+    )
+    return {
+        str(integration_id): credential_id
+        for integration_id, credential_id in result.all()
+    }
+
+
 def _sync_config_to_response(
     config: object,
     children_count: int | None = None,
+    *,
+    credential_id: uuid.UUID | str | None = None,
 ) -> SyncConfigResponse:
     return SyncConfigResponse.model_validate(
         {
             "id": str(getattr(config, "id")),
             "name": getattr(config, "name"),
             "provider": getattr(config, "provider"),
-            "credential_id": (
-                str(getattr(config, "credential_id"))
-                if getattr(config, "credential_id") is not None
-                else None
-            ),
+            "credential_id": str(credential_id) if credential_id is not None else None,
             "sync_targets": list(getattr(config, "sync_targets") or []),
             "sync_options": dict(getattr(config, "sync_options") or {}),
             "is_active": getattr(config, "is_active"),
@@ -699,11 +762,14 @@ async def _replace_planner_repository_selection(
     mutable_config = cast(_MutableSyncConfiguration, config)
     mutable_config.sync_options = sync_options
 
+    existing_credential_id = await _integration_credential_id_for_config(
+        session, config
+    )
     batch_payload = SyncConfigBatchCreate(
         name=str(getattr(config, "name")),
         provider=str(getattr(config, "provider")),
-        credential_id=str(getattr(config, "credential_id"))
-        if getattr(config, "credential_id", None)
+        credential_id=str(existing_credential_id)
+        if existing_credential_id is not None
         else None,
         sync_targets=list(getattr(config, "sync_targets") or []),
         sync_options=sync_options,
@@ -841,6 +907,10 @@ async def _create_planner_managed_config(
     the scheduled-job anchor. There is no bare ``SyncConfiguration`` insert path
     anywhere, so a config can never be created unlinked from its integration and
     the planner can always route it.
+
+    The credential is stamped ONLY on ``Integration.credential_id`` (CHAOS-2762):
+    ``SyncConfiguration`` carries no credential column of its own, so there is
+    exactly one place a credential attaches to sync work.
     """
     credential_uuid = uuid.UUID(credential_id) if credential_id else None
     integration = Integration(
@@ -860,7 +930,6 @@ async def _create_planner_managed_config(
         name=name,
         provider=provider,
         org_id=org_id,
-        credential_id=credential_uuid,
         sync_targets=sync_targets,
         sync_options=parent_options,
         is_active=True,
@@ -969,10 +1038,22 @@ async def list_sync_configs(
         rows = (await session.execute(stmt)).all()
         children_counts = {str(pid): cnt for pid, cnt in rows}
 
+    credential_ids_by_integration = await _integration_credential_ids_for_configs(
+        session, configs
+    )
+
     results = []
     for c in configs:
         cc = children_counts.get(str(getattr(c, "id")))
-        results.append(_sync_config_to_response(c, children_count=cc))
+        integration_id = getattr(c, "integration_id", None)
+        credential_id = (
+            credential_ids_by_integration.get(str(integration_id))
+            if integration_id is not None
+            else None
+        )
+        results.append(
+            _sync_config_to_response(c, children_count=cc, credential_id=credential_id)
+        )
     return results
 
 
@@ -1235,7 +1316,9 @@ async def batch_create_sync_configs(
     )
 
     return SyncConfigBatchResponse(
-        parent=_sync_config_to_response(parent, children_count=0),
+        parent=_sync_config_to_response(
+            parent, children_count=0, credential_id=integration.credential_id
+        ),
         children=[],
         total_created=0,
     )
@@ -1382,7 +1465,7 @@ async def create_sync_config(
         timezone=payload.timezone,
         build_source_rows=_build_sources,
     )
-    return _sync_config_to_response(config)
+    return _sync_config_to_response(config, credential_id=integration.credential_id)
 
 
 @router.get("/sync-configs/{config_id}", response_model=SyncConfigResponse)
@@ -1395,7 +1478,8 @@ async def get_sync_config(
     config = await svc.get_by_id(config_id)
     if config is None:
         raise HTTPException(status_code=404, detail="Sync configuration not found")
-    return _sync_config_to_response(config)
+    credential_id = await _integration_credential_id_for_config(session, config)
+    return _sync_config_to_response(config, credential_id=credential_id)
 
 
 @router.get(
@@ -1572,7 +1656,8 @@ async def update_sync_config(
                 await _upsert_scheduled_job(session, child, org_id)
             await session.flush()
 
-    return _sync_config_to_response(updated)
+    credential_id = await _integration_credential_id_for_config(session, updated)
+    return _sync_config_to_response(updated, credential_id=credential_id)
 
 
 @router.delete("/sync-configs/{config_id}", status_code=204)

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -109,6 +109,9 @@ class SyncConfigResponse(BaseModel):
     id: str
     name: str
     provider: str
+    # CHAOS-2762: SyncConfiguration stores no credential of its own -- this is
+    # resolved live from the linked Integration.credential_id (the single
+    # sanctioned surface) each time a response is built, never a stored mirror.
     credential_id: str | None
     sync_targets: list[str]
     sync_options: dict[str, Any]
@@ -127,6 +130,8 @@ class SyncConfigResponse(BaseModel):
 class SyncConfigCreate(BaseModel):
     name: str = Field(..., min_length=1)
     provider: str = Field(..., min_length=1)
+    # CHAOS-2762: write-only input -- seeds the created Integration's
+    # credential_id. SyncConfiguration itself stores no credential column.
     credential_id: str | None = None
     sync_targets: list[str] = Field(default_factory=list)
     sync_options: dict[str, Any] = Field(default_factory=dict)
@@ -140,6 +145,8 @@ class SyncConfigBatchCreate(BaseModel):
 
     name: str = Field(..., min_length=1)
     provider: str = Field(..., min_length=1)
+    # CHAOS-2762: write-only input -- seeds the created Integration's
+    # credential_id. SyncConfiguration itself stores no credential column.
     credential_id: str | None = None
     sync_targets: list[str] = Field(default_factory=list)
     sync_options: dict[str, Any] = Field(default_factory=dict)

--- a/src/dev_health_ops/api/services/configuration/sync_configuration.py
+++ b/src/dev_health_ops/api/services/configuration/sync_configuration.py
@@ -1,7 +1,8 @@
 """Sync configuration service.
 
-Manages provider sync configuration rows (cron-like sync target lists,
-sync options, credential association).
+Manages provider sync configuration rows (cron-like sync target lists, sync
+options). Credential association lives on the linked ``Integration``
+(``integration_id``), not here -- see CHAOS-2762.
 """
 
 from __future__ import annotations

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -247,7 +247,14 @@ class SyncConfiguration(Base):
     """Configuration for data sync jobs.
 
     Defines what to sync (repos, projects, teams) and how (filters, options).
-    Links to IntegrationCredential for authentication.
+
+    Authentication is NOT configured here. ``credential_id`` was removed
+    (CHAOS-2762): it was a second, unfrozen mirror of ``Integration
+    .credential_id`` that the auth-resolution path (``sync/planner.py``,
+    ``workers/sync_bootstrap.py``) never read. The sanctioned surface is
+    ``Integration.credential_id``, reached via this config's
+    ``integration_id`` FK and frozen onto ``sync_runs`` at plan time
+    (CHAOS-2755's ``resolve_run_auth``).
     """
 
     __tablename__ = "sync_configurations"
@@ -260,15 +267,6 @@ class SyncConfiguration(Base):
         Text, nullable=False, comment="Display name for this sync config"
     )
     provider: Mapped[str] = mapped_column(Text, nullable=False, index=True)
-
-    credential_id: Mapped[uuid.UUID | None] = mapped_column(
-        GUID,
-        ForeignKey("integration_credentials.id", ondelete="SET NULL"),
-        nullable=True,
-    )
-    credential: Mapped[IntegrationCredential | None] = relationship(
-        "IntegrationCredential"
-    )
 
     sync_targets: Mapped[list[str]] = mapped_column(
         JSON,
@@ -356,7 +354,6 @@ class SyncConfiguration(Base):
         name: str,
         provider: str,
         org_id: str | None = None,
-        credential_id: uuid.UUID | None = None,
         sync_targets: list[str] | None = None,
         sync_options: dict[str, Any] | None = None,
         is_active: bool = True,
@@ -369,7 +366,6 @@ class SyncConfiguration(Base):
         self.org_id = org_id or ""
         self.name = name
         self.provider = provider
-        self.credential_id = credential_id
         self.sync_targets = sync_targets or []
         self.sync_options = sync_options or {}
         self.is_active = is_active

--- a/src/dev_health_ops/workers/team_drift_sync.py
+++ b/src/dev_health_ops/workers/team_drift_sync.py
@@ -105,28 +105,54 @@ def _configured_provider_syncs(org_id: str) -> list[_DriftSyncConfig]:
         for row in rows:
             provider = str(row.provider or "").strip().lower()
             credential = None
+            credential_missing = False
             # CHAOS-2762: SyncConfiguration carries no credential of its own --
             # resolve through the linked Integration (the single sanctioned
             # surface reached via integration_id), never a per-row column.
-            credential_id = None
+            # Mirrors sync/planner.py's _resolve_credential_stamp exactly:
+            # Integration.credential_id NULL -> env auth (below); non-NULL ->
+            # the credential MUST be an active, same-org, same-provider row or
+            # this config fails closed rather than silently falling back to
+            # env auth. Falling back on a missing/inactive credential would
+            # let this worker authenticate where the planner would reject
+            # outright -- a capacity increase through this second surface,
+            # exactly what the epic invariant forbids.
             if row.integration_id is not None:
                 integration = (
                     session.query(Integration)
-                    .filter(Integration.id == row.integration_id)
-                    .one_or_none()
-                )
-                credential_id = (
-                    integration.credential_id if integration is not None else None
-                )
-            if credential_id is not None:
-                credential = (
-                    session.query(IntegrationCredential)
                     .filter(
-                        IntegrationCredential.id == credential_id,
-                        IntegrationCredential.org_id == org_id,
+                        Integration.id == row.integration_id,
+                        Integration.org_id == org_id,
                     )
                     .one_or_none()
                 )
+                if integration is None:
+                    # Dangling / out-of-org integration_id -- fail closed.
+                    credential_missing = True
+                elif integration.credential_id is not None:
+                    credential = (
+                        session.query(IntegrationCredential)
+                        .filter(
+                            IntegrationCredential.id == integration.credential_id,
+                            IntegrationCredential.org_id == org_id,
+                            IntegrationCredential.provider == provider,
+                            IntegrationCredential.is_active.is_(True),
+                        )
+                        .one_or_none()
+                    )
+                    if credential is None:
+                        credential_missing = True
+            if credential_missing:
+                logger.warning(
+                    "Skipping team drift sync for provider=%s org_id=%s config=%s: "
+                    "linked Integration's credential is missing, inactive, or "
+                    "provider-mismatched -- failing closed (CHAOS-2762 planner "
+                    "parity) rather than falling back to environment auth",
+                    provider,
+                    org_id,
+                    row.name,
+                )
+                continue
             credentials = (
                 _credential_mapping(credential)
                 if credential is not None

--- a/src/dev_health_ops/workers/team_drift_sync.py
+++ b/src/dev_health_ops/workers/team_drift_sync.py
@@ -21,12 +21,61 @@ class _DriftSyncConfig:
     name: str
 
 
+@dataclass(frozen=True)
+class _SkippedConfig:
+    """A ``SyncConfiguration`` dropped by the fail-closed auth check (CHAOS-2762).
+
+    Distinct from the per-provider ``"skipped"`` results ``_discover_*``
+    return (missing credentials fields, unsupported provider, a discovery
+    exception): those configs at least got as far as attempting discovery.
+    A ``_SkippedConfig`` never gets that far -- it never becomes a
+    ``_DriftSyncConfig`` at all, so without this record it would be
+    invisible in ``provider_results`` and the task result would look like a
+    clean, complete success even if EVERY configured provider was skipped
+    (e.g. a fleet-wide credential deactivation/deletion).
+    """
+
+    config_id: str
+    provider: str
+    reason: str
+
+
+@dataclass(frozen=True)
+class _ConfiguredProviderSyncs:
+    configs: list[_DriftSyncConfig]
+    skipped: list[_SkippedConfig]
+
+
+# _SkippedConfig.reason values -- stable strings, safe to alert/dashboard on.
+_SKIP_REASON_INTEGRATION_NOT_FOUND = "integration_not_found_or_cross_org"
+_SKIP_REASON_CREDENTIAL_NOT_FOUND = "credential_not_found_or_cross_org"
+_SKIP_REASON_CREDENTIAL_PROVIDER_MISMATCH = "credential_provider_mismatch"
+_SKIP_REASON_CREDENTIAL_INACTIVE = "credential_inactive"
+
+
 @celery_app.task(queue="sync", name="sync_team_drift")
 def sync_team_drift(org_id: str) -> dict[str, Any]:
     return asyncio.run(_sync_team_drift_async(org_id=str(org_id)))
 
 
 async def _sync_team_drift_async(org_id: str) -> dict[str, Any]:
+    """Run team-drift discovery for every configured provider in ``org_id``.
+
+    Auth semantics (CHAOS-2762): a config whose linked ``Integration``
+    credential is missing, inactive, or provider-mismatched is dropped
+    entirely (fail closed, planner parity -- see ``_configured_provider_syncs``)
+    rather than falling back to environment auth. Dropped configs are
+    reported in the result's ``configs_skipped`` (one entry per config, with
+    its ``reason``) alongside ``configs_skipped_count``, and a single
+    WARNING aggregate line is logged whenever the list is non-empty.
+
+    ``status`` stays ``"success"`` even when every configured provider was
+    skipped this way: a fail-closed skip is policy (a credential the planner
+    itself would reject), not a task error, so it must never retry/alert as
+    one. The result is still fully observable through ``configs_skipped`` --
+    the whole point of this shape is that a fleet-wide credential outage is
+    visible in the task result, not just grep-able from worker logs.
+    """
     from dev_health_ops.api.services.configuration.clickhouse_team_drift_projector import (
         project_team_rows_with_store,
     )
@@ -37,7 +86,9 @@ async def _sync_team_drift_async(org_id: str) -> dict[str, Any]:
     )
 
     db_url = _validate_worker_clickhouse_uri(_get_db_url())
-    configs = _configured_provider_syncs(org_id)
+    resolved = _configured_provider_syncs(org_id)
+    configs = resolved.configs
+    configs_skipped = resolved.skipped
     provider_results: list[dict[str, Any]] = []
     team_rows_by_provider: dict[str, list[dict[str, Any]]] = {}
     discovered_at_by_provider: dict[str, datetime] = {}
@@ -67,6 +118,20 @@ async def _sync_team_drift_async(org_id: str) -> dict[str, Any]:
                 discovered_at=discovered_at_by_provider[provider],
                 resolve_missing_provider_changes=complete_by_provider[provider],
             )
+
+    if configs_skipped:
+        logger.warning(
+            "Team drift sync for org_id=%s skipped %d of %d configured "
+            "provider config(s) due to fail-closed credential checks "
+            "(CHAOS-2762 planner parity): %s",
+            org_id,
+            len(configs_skipped),
+            len(configs) + len(configs_skipped),
+            ", ".join(
+                f"{s.provider}/{s.config_id}:{s.reason}" for s in configs_skipped
+            ),
+        )
+
     return {
         "status": "success",
         "org_id": org_id,
@@ -75,10 +140,15 @@ async def _sync_team_drift_async(org_id: str) -> dict[str, Any]:
         "teams_discovered": sum(
             int(row.get("teams_discovered", 0)) for row in provider_results
         ),
+        "configs_skipped": [
+            {"config_id": s.config_id, "provider": s.provider, "reason": s.reason}
+            for s in configs_skipped
+        ],
+        "configs_skipped_count": len(configs_skipped),
     }
 
 
-def _configured_provider_syncs(org_id: str) -> list[_DriftSyncConfig]:
+def _configured_provider_syncs(org_id: str) -> _ConfiguredProviderSyncs:
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.models import (
         Integration,
@@ -91,6 +161,7 @@ def _configured_provider_syncs(org_id: str) -> list[_DriftSyncConfig]:
     )
 
     configs: list[_DriftSyncConfig] = []
+    skipped: list[_SkippedConfig] = []
     with get_postgres_session_sync() as session:
         rows = (
             session.query(SyncConfiguration)
@@ -105,7 +176,7 @@ def _configured_provider_syncs(org_id: str) -> list[_DriftSyncConfig]:
         for row in rows:
             provider = str(row.provider or "").strip().lower()
             credential = None
-            credential_missing = False
+            skip_reason: str | None = None
             # CHAOS-2762: SyncConfiguration carries no credential of its own --
             # resolve through the linked Integration (the single sanctioned
             # surface reached via integration_id), never a per-row column.
@@ -128,29 +199,38 @@ def _configured_provider_syncs(org_id: str) -> list[_DriftSyncConfig]:
                 )
                 if integration is None:
                     # Dangling / out-of-org integration_id -- fail closed.
-                    credential_missing = True
+                    skip_reason = _SKIP_REASON_INTEGRATION_NOT_FOUND
                 elif integration.credential_id is not None:
-                    credential = (
+                    credential_row = (
                         session.query(IntegrationCredential)
                         .filter(
                             IntegrationCredential.id == integration.credential_id,
                             IntegrationCredential.org_id == org_id,
-                            IntegrationCredential.provider == provider,
-                            IntegrationCredential.is_active.is_(True),
                         )
                         .one_or_none()
                     )
-                    if credential is None:
-                        credential_missing = True
-            if credential_missing:
+                    if credential_row is None:
+                        skip_reason = _SKIP_REASON_CREDENTIAL_NOT_FOUND
+                    elif str(credential_row.provider or "").strip().lower() != provider:
+                        skip_reason = _SKIP_REASON_CREDENTIAL_PROVIDER_MISMATCH
+                    elif not bool(credential_row.is_active):
+                        skip_reason = _SKIP_REASON_CREDENTIAL_INACTIVE
+                    else:
+                        credential = credential_row
+            if skip_reason is not None:
                 logger.warning(
                     "Skipping team drift sync for provider=%s org_id=%s config=%s: "
-                    "linked Integration's credential is missing, inactive, or "
-                    "provider-mismatched -- failing closed (CHAOS-2762 planner "
-                    "parity) rather than falling back to environment auth",
+                    "%s -- failing closed (CHAOS-2762 planner parity) rather than "
+                    "falling back to environment auth",
                     provider,
                     org_id,
                     row.name,
+                    skip_reason,
+                )
+                skipped.append(
+                    _SkippedConfig(
+                        config_id=str(row.id), provider=provider, reason=skip_reason
+                    )
                 )
                 continue
             credentials = (
@@ -166,7 +246,7 @@ def _configured_provider_syncs(org_id: str) -> list[_DriftSyncConfig]:
                     name=str(row.name or provider),
                 )
             )
-    return configs
+    return _ConfiguredProviderSyncs(configs=configs, skipped=skipped)
 
 
 async def _discover_provider_team_rows(

--- a/src/dev_health_ops/workers/team_drift_sync.py
+++ b/src/dev_health_ops/workers/team_drift_sync.py
@@ -80,7 +80,11 @@ async def _sync_team_drift_async(org_id: str) -> dict[str, Any]:
 
 def _configured_provider_syncs(org_id: str) -> list[_DriftSyncConfig]:
     from dev_health_ops.db import get_postgres_session_sync
-    from dev_health_ops.models import IntegrationCredential, SyncConfiguration
+    from dev_health_ops.models import (
+        Integration,
+        IntegrationCredential,
+        SyncConfiguration,
+    )
     from dev_health_ops.workers.task_utils import (
         _credential_mapping,
         _resolve_env_credentials,
@@ -101,11 +105,24 @@ def _configured_provider_syncs(org_id: str) -> list[_DriftSyncConfig]:
         for row in rows:
             provider = str(row.provider or "").strip().lower()
             credential = None
-            if row.credential_id is not None:
+            # CHAOS-2762: SyncConfiguration carries no credential of its own --
+            # resolve through the linked Integration (the single sanctioned
+            # surface reached via integration_id), never a per-row column.
+            credential_id = None
+            if row.integration_id is not None:
+                integration = (
+                    session.query(Integration)
+                    .filter(Integration.id == row.integration_id)
+                    .one_or_none()
+                )
+                credential_id = (
+                    integration.credential_id if integration is not None else None
+                )
+            if credential_id is not None:
                 credential = (
                     session.query(IntegrationCredential)
                     .filter(
-                        IntegrationCredential.id == row.credential_id,
+                        IntegrationCredential.id == credential_id,
                         IntegrationCredential.org_id == org_id,
                     )
                     .one_or_none()

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -851,6 +851,72 @@ async def test_sync_configs_sharing_integration_read_consistent_credential_id(
 
 
 @pytest.mark.asyncio
+async def test_sync_config_credential_id_is_null_for_out_of_org_integration_link(
+    client, session_maker
+):
+    """CHAOS-2762 regression (codex finding #3): a ``SyncConfiguration`` whose
+    ``integration_id`` points at an ``Integration`` belonging to a DIFFERENT
+    org (corrupt data / manual tampering -- there is no org constraint on
+    that FK) must never leak that other org's ``credential_id`` into this
+    org's API response. The read-through helpers are org-scoped, so an
+    out-of-org link resolves to null exactly like "no linked integration"
+    rather than exposing another tenant's credential UUID.
+    """
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+    other_org_id = str(uuid.uuid4())
+
+    async with session_maker() as session:
+        other_org_credential = IntegrationCredential(
+            provider="github",
+            name="other-org-cred",
+            org_id=other_org_id,
+            credentials_encrypted="enc-other-org",
+            is_active=True,
+        )
+        session.add(other_org_credential)
+        await session.flush()
+
+        other_org_integration = Integration(
+            org_id=other_org_id,
+            provider="github",
+            name="other-org-integration",
+            config={},
+            is_active=True,
+        )
+        other_org_integration.credential_id = other_org_credential.id
+        session.add(other_org_integration)
+        await session.flush()
+
+        # Corrupt/tampered link: a config that belongs to THIS org but whose
+        # integration_id points at ANOTHER org's Integration.
+        config = SyncConfiguration(
+            org_id=org_id,
+            name="cross-org-link",
+            provider="github",
+            sync_targets=["git"],
+            sync_options={},
+            integration_id=other_org_integration.id,
+        )
+        session.add(config)
+        await session.commit()
+        config_id = str(config.id)
+
+    get_resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}")
+    assert get_resp.status_code == 200
+    assert get_resp.json()["credential_id"] is None, (
+        "an out-of-org integration_id must never leak another org's credential_id"
+    )
+
+    list_resp = await ac.get("/api/v1/admin/sync-configs")
+    assert list_resp.status_code == 200
+    [listed] = [c for c in list_resp.json() if c["id"] == config_id]
+    assert listed["credential_id"] is None, (
+        "the list endpoint's batched read-through must be org-scoped too"
+    )
+
+
+@pytest.mark.asyncio
 async def test_update_sync_config_changes_is_active(client):
     ac, _ = client
 

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -679,6 +679,178 @@ async def test_get_sync_config_nonexistent_returns_404(client):
 
 
 @pytest.mark.asyncio
+async def test_sync_config_credential_id_reflects_linked_integration(
+    client, session_maker
+):
+    """CHAOS-2762 regression: ``SyncConfiguration`` stores no credential of
+    its own -- the API's ``credential_id`` is derived live from the linked
+    ``Integration`` (the single sanctioned surface), so it can never carry a
+    second, unfrozen copy that drifts from what auth resolution actually uses.
+    """
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    async with session_maker() as session:
+        cred_a = IntegrationCredential(
+            provider="github",
+            name="cred-a",
+            org_id=org_id,
+            credentials_encrypted="enc-a",
+            is_active=True,
+        )
+        cred_b = IntegrationCredential(
+            provider="github",
+            name="cred-b",
+            org_id=org_id,
+            credentials_encrypted="enc-b",
+            is_active=True,
+        )
+        session.add_all([cred_a, cred_b])
+        await session.commit()
+        cred_a_id, cred_b_id = str(cred_a.id), str(cred_b.id)
+
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "credential-mirror-test",
+            "provider": "github",
+            "credential_id": cred_a_id,
+            "sync_targets": [],
+            "sync_options": {"all_repos": True},
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    created = create_resp.json()
+    assert created["credential_id"] == cred_a_id
+    config_id = created["id"]
+
+    async with session_maker() as session:
+        config = (
+            await session.execute(
+                select(SyncConfiguration).where(
+                    SyncConfiguration.id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+        # The legacy column is gone: the model no longer even exposes it.
+        assert not hasattr(config, "credential_id")
+
+        integration = (
+            await session.execute(
+                select(Integration).where(Integration.id == config.integration_id)
+            )
+        ).scalar_one()
+        assert integration.credential_id == uuid.UUID(cred_a_id)
+
+        # Rotate the credential on the Integration directly -- the same
+        # surface an admin PATCH /integrations/{id} would touch.
+        integration.credential_id = uuid.UUID(cred_b_id)
+        await session.commit()
+
+    get_resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}")
+    assert get_resp.status_code == 200
+    # No stale mirror to go out of sync: the response tracks the rotation.
+    assert get_resp.json()["credential_id"] == cred_b_id
+
+    list_resp = await ac.get("/api/v1/admin/sync-configs")
+    assert list_resp.status_code == 200
+    [listed] = [c for c in list_resp.json() if c["id"] == config_id]
+    assert listed["credential_id"] == cred_b_id
+
+
+@pytest.mark.asyncio
+async def test_sync_configs_sharing_integration_read_consistent_credential_id(
+    client, session_maker
+):
+    """CHAOS-2762 regression: configs sharing one ``integration_id`` (a
+    planner-managed parent plus a pre-planner legacy child, both still linked
+    to the same ``Integration`` per the ``0016``/``0023`` migration links)
+    must report the SAME ``credential_id`` -- and stay consistent after a
+    rotation -- because both now derive it from the one shared ``Integration``
+    row instead of each carrying its own, independently-writable copy.
+    """
+    ac, seeded_state = client
+    org_id = seeded_state["org_id"]
+
+    async with session_maker() as session:
+        cred_a = IntegrationCredential(
+            provider="github",
+            name="cred-a",
+            org_id=org_id,
+            credentials_encrypted="enc-a",
+            is_active=True,
+        )
+        cred_b = IntegrationCredential(
+            provider="github",
+            name="cred-b",
+            org_id=org_id,
+            credentials_encrypted="enc-b",
+            is_active=True,
+        )
+        session.add_all([cred_a, cred_b])
+        await session.commit()
+        cred_a_id, cred_b_id = str(cred_a.id), str(cred_b.id)
+
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "shared-integration-parent",
+            "provider": "github",
+            "credential_id": cred_a_id,
+            "sync_targets": [],
+            "sync_options": {"all_repos": True},
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    parent_id = create_resp.json()["id"]
+
+    async with session_maker() as session:
+        parent = (
+            await session.execute(
+                select(SyncConfiguration).where(
+                    SyncConfiguration.id == uuid.UUID(parent_id)
+                )
+            )
+        ).scalar_one()
+        integration_id = parent.integration_id
+
+        # A pre-planner legacy child sharing the parent's Integration (see
+        # migrations 0016/0023): its OWN row never carried credential_id
+        # independently even before this change -- children were created
+        # without one -- so this pins that both rows read the parent
+        # Integration's credential consistently, not just the parent alone.
+        child = SyncConfiguration(
+            org_id=org_id,
+            name="shared-integration-child",
+            provider="github",
+            sync_targets=["git"],
+            sync_options={},
+            parent_id=parent.id,
+            integration_id=integration_id,
+        )
+        session.add(child)
+        await session.commit()
+        child_id = str(child.id)
+
+    for config_id in (parent_id, child_id):
+        resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}")
+        assert resp.status_code == 200
+        assert resp.json()["credential_id"] == cred_a_id
+
+    async with session_maker() as session:
+        integration = await session.get(Integration, integration_id)
+        integration.credential_id = uuid.UUID(cred_b_id)
+        await session.commit()
+
+    for config_id in (parent_id, child_id):
+        resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}")
+        assert resp.status_code == 200
+        assert resp.json()["credential_id"] == cred_b_id, (
+            f"config {config_id} did not observe the rotated credential"
+        )
+
+
+@pytest.mark.asyncio
 async def test_update_sync_config_changes_is_active(client):
     ac, _ = client
 

--- a/tests/test_credential_capacity_invariants.py
+++ b/tests/test_credential_capacity_invariants.py
@@ -24,6 +24,7 @@ credential selection (forbidden).
 from __future__ import annotations
 
 import dataclasses
+import importlib
 import json
 import uuid
 from collections.abc import Iterator
@@ -31,6 +32,9 @@ from datetime import datetime, timezone
 from typing import Any
 
 import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
@@ -542,3 +546,140 @@ def test_credential_rotation_never_increases_admitted_capacity(
         "rotation admitted every candidate — in-flight consumption stopped "
         "gating after the fingerprint changed"
     )
+
+
+# ---------------------------------------------------------------------------
+# Migration 0032: downgrade repopulates credential_id (codex finding #2)
+# ---------------------------------------------------------------------------
+
+
+def _load_migration_0032():
+    return importlib.import_module(
+        "dev_health_ops.alembic.versions.0032_drop_sync_config_credential_id"
+    )
+
+
+def test_migration_0032_downgrade_repopulates_credential_id_from_integration():
+    """The recreated column must be repopulated from each config's linked
+    ``Integration.credential_id``, not left NULL.
+
+    A bare rollback that only re-adds the column (no data) would silently
+    change behavior for anything still reading it post-downgrade -- the same
+    class of surprise this migration exists to remove going the other
+    direction. Runs the real migration module's ``upgrade()`` against a live
+    schema (the documented way to unit-test one migration in isolation -- see
+    ``test_migration_0031_idempotent_upgrade``), then the real
+    column-add-and-repopulate helpers ``downgrade()`` itself calls, using a
+    correlated-subquery ``UPDATE`` that behaves the same on this test's
+    SQLite engine as it will on Postgres.
+    """
+    migration = _load_migration_0032()
+    assert migration.revision == "0032"
+    assert migration.down_revision == "0031"
+
+    metadata = sa.MetaData()
+    sa.Table(
+        "integration_credentials",
+        metadata,
+        sa.Column("id", sa.String, primary_key=True),
+    )
+    integrations = sa.Table(
+        "integrations",
+        metadata,
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column("credential_id", sa.String, nullable=True),
+    )
+    sync_configurations = sa.Table(
+        "sync_configurations",
+        metadata,
+        sa.Column("id", sa.String, primary_key=True),
+        sa.Column("integration_id", sa.String, nullable=True),
+        sa.Column("credential_id", sa.String, nullable=True),
+    )
+
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as conn:
+            metadata.create_all(conn)
+
+            linked_integration_id = "integration-with-credential"
+            env_auth_integration_id = "integration-env-auth"
+            credential_id = "credential-a"
+
+            conn.execute(
+                integrations.insert(),
+                [
+                    {"id": linked_integration_id, "credential_id": credential_id},
+                    {"id": env_auth_integration_id, "credential_id": None},
+                ],
+            )
+            conn.execute(
+                sync_configurations.insert(),
+                [
+                    {
+                        "id": "config-linked",
+                        "integration_id": linked_integration_id,
+                        "credential_id": None,
+                    },
+                    {
+                        "id": "config-env-auth",
+                        "integration_id": env_auth_integration_id,
+                        "credential_id": None,
+                    },
+                    {
+                        "id": "config-unlinked",
+                        "integration_id": None,
+                        "credential_id": None,
+                    },
+                ],
+            )
+            conn.commit()
+
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                # Simulate the pre-0032 state (column present) by upgrading
+                # first (drops it), so there is something real to restore --
+                # exactly the rollback path this test pins.
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert "credential_id" not in {
+                    col["name"] for col in inspector.get_columns("sync_configurations")
+                }
+
+                # Exercise downgrade()'s column-add + repopulation directly
+                # rather than the full public function: its third step
+                # (re-adding the FK to integration_credentials) requires
+                # ALTER-ADD-CONSTRAINT support SQLite's Alembic dialect does
+                # not have without batch mode (a driver limitation unrelated
+                # to this migration's logic). That FK step was hand-verified
+                # against a real Postgres round-trip during CHAOS-2762
+                # review; what's being pinned HERE -- and what codex flagged
+                # -- is specifically that the column comes back populated,
+                # not empty.
+                migration._add_column_if_missing(
+                    migration._TABLE,
+                    sa.Column(migration._COLUMN, sa.String, nullable=True),
+                )
+                migration._repopulate_from_linked_integration()
+                inspector = sa.inspect(conn)
+                assert "credential_id" in {
+                    col["name"] for col in inspector.get_columns("sync_configurations")
+                }
+
+            rows = {
+                row.id: row.credential_id
+                for row in conn.execute(sa.select(sync_configurations))
+            }
+            assert rows["config-linked"] == credential_id, (
+                "downgrade must repopulate credential_id from the linked "
+                "Integration's credential_id, not leave it NULL"
+            )
+            assert rows["config-env-auth"] is None, (
+                "an Integration with credential_id NULL (env auth) must "
+                "repopulate as NULL, not invent a value"
+            )
+            assert rows["config-unlinked"] is None, (
+                "a config with no linked integration at all must stay NULL"
+            )
+    finally:
+        engine.dispose()

--- a/tests/test_credential_capacity_invariants.py
+++ b/tests/test_credential_capacity_invariants.py
@@ -28,6 +28,7 @@ import json
 import uuid
 from collections.abc import Iterator
 from datetime import datetime, timezone
+from typing import Any
 
 import pytest
 from sqlalchemy import create_engine
@@ -331,16 +332,19 @@ def test_sync_configuration_has_no_credential_column() -> None:
         "Integration.credential_id is the only sanctioned surface"
     )
 
+    # Built as a dict and unpacked (not passed as a literal keyword) so this
+    # deliberately-invalid call isn't statically bindable to the constructor
+    # signature -- both mypy (call-arg) and CodeQL
+    # (py/call/wrong-named-class-argument) would otherwise flag the literal
+    # form as a static error, which is exactly the point being proven, just
+    # asserted at runtime instead.
+    legacy_write_kwargs: dict[str, Any] = {
+        "name": "legacy-write-attempt",
+        "provider": "github",
+        "credential_id": uuid.uuid4(),
+    }
     with pytest.raises(TypeError):
-        # Deliberately passing a removed constructor kwarg -- mypy also
-        # rejects this call statically (call-arg), which is the same
-        # regression from the other direction; silence it here rather than
-        # weaken the constructor's signature to humor a test.
-        SyncConfiguration(  # type: ignore[call-arg]
-            name="legacy-write-attempt",
-            provider="github",
-            credential_id=uuid.uuid4(),
-        )
+        SyncConfiguration(**legacy_write_kwargs)
 
 
 # --- Behavior guards ----------------------------------------------------------

--- a/tests/test_credential_capacity_invariants.py
+++ b/tests/test_credential_capacity_invariants.py
@@ -310,6 +310,39 @@ def test_sync_run_unit_model_has_no_credential_column() -> None:
     )
 
 
+def test_sync_configuration_has_no_credential_column() -> None:
+    """CHAOS-2762: ``SyncConfiguration`` carries no credential of its own.
+
+    Before this change, ``SyncConfiguration.credential_id`` was a second,
+    *unfrozen* mirror of ``Integration.credential_id`` -- writable and
+    readable independently of the run-auth freeze CHAOS-2755 stamps onto
+    ``sync_runs`` at plan time, even though nothing in the auth-resolution
+    path (``sync/planner.py``, ``workers/sync_bootstrap.py``) ever read it.
+    ``Integration.credential_id`` (reached via ``SyncConfiguration
+    .integration_id``) is now the only surface a credential attaches to sync
+    work through. Both the mapped table and the constructor must reject the
+    legacy field so it cannot silently come back.
+    """
+    from dev_health_ops.models.settings import SyncConfiguration
+
+    column_names = {column.name for column in SyncConfiguration.__table__.columns}
+    assert "credential_id" not in column_names, (
+        "SyncConfiguration must carry no credential_id column (CHAOS-2762): "
+        "Integration.credential_id is the only sanctioned surface"
+    )
+
+    with pytest.raises(TypeError):
+        # Deliberately passing a removed constructor kwarg -- mypy also
+        # rejects this call statically (call-arg), which is the same
+        # regression from the other direction; silence it here rather than
+        # weaken the constructor's signature to humor a test.
+        SyncConfiguration(  # type: ignore[call-arg]
+            name="legacy-write-attempt",
+            provider="github",
+            credential_id=uuid.uuid4(),
+        )
+
+
 # --- Behavior guards ----------------------------------------------------------
 
 

--- a/tests/workers/test_team_drift_sync.py
+++ b/tests/workers/test_team_drift_sync.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import json
+import uuid
 from contextlib import contextmanager
 
 from sqlalchemy import create_engine
@@ -127,3 +128,232 @@ def test_configured_provider_syncs_falls_back_to_env_without_linked_integration(
 
     assert len(configs) == 1
     assert configs[0].credentials.get("token") == "tok-env-fallback"
+
+
+def test_configured_provider_syncs_fails_closed_when_credential_inactive(
+    monkeypatch,
+) -> None:
+    """CHAOS-2762 planner-parity regression (codex finding #1): an inactive
+    credential must fail closed (the config is dropped), never silently fall
+    back to env auth. ``sync/planner.py``'s ``_resolve_credential_stamp``
+    raises on an inactive credential rather than treating it as absent --
+    falling back here would let this worker authenticate where the planner
+    would reject outright.
+    """
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-team-drift-sync-secret")
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-env-must-not-be-used")
+    import dev_health_ops.db as db
+    from dev_health_ops.workers import team_drift_sync
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            credential = IntegrationCredential(
+                provider="github",
+                name="inactive-cred",
+                org_id=_ORG,
+                credentials_encrypted=encrypt_value(
+                    json.dumps({"token": "tok-inactive"})
+                ),
+                config={},
+                is_active=False,
+            )
+            session.add(credential)
+            session.flush()
+
+            integration = Integration(
+                org_id=_ORG,
+                provider="github",
+                name="gh-integration",
+                config={},
+                is_active=True,
+            )
+            integration.credential_id = credential.id
+            session.add(integration)
+            session.flush()
+
+            config = SyncConfiguration(
+                name="drift-config",
+                provider="github",
+                org_id=_ORG,
+                sync_targets=["git"],
+                sync_options={"owner": "acme"},
+                integration_id=integration.id,
+            )
+            session.add(config)
+            session.commit()
+
+            monkeypatch.setattr(
+                db, "get_postgres_session_sync", lambda: _session_ctx(session)
+            )
+
+            configs = team_drift_sync._configured_provider_syncs(_ORG)
+    finally:
+        engine.dispose()
+
+    assert configs == []
+
+
+def test_configured_provider_syncs_fails_closed_when_credential_missing(
+    monkeypatch,
+) -> None:
+    """CHAOS-2762 planner-parity regression (codex finding #1): a stamped
+    ``credential_id`` with no matching row must fail closed, matching the
+    planner's "Credential not found" fail-fast rather than falling back to
+    env auth.
+    """
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-env-must-not-be-used")
+    import dev_health_ops.db as db
+    from dev_health_ops.workers import team_drift_sync
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            integration = Integration(
+                org_id=_ORG,
+                provider="github",
+                name="gh-integration",
+                config={},
+                is_active=True,
+            )
+            # Points at a credential that was never created (deleted, or a
+            # stale/corrupt reference) -- the FK is deliberately unenforced.
+            integration.credential_id = uuid.uuid4()
+            session.add(integration)
+            session.flush()
+
+            config = SyncConfiguration(
+                name="drift-config",
+                provider="github",
+                org_id=_ORG,
+                sync_targets=["git"],
+                sync_options={"owner": "acme"},
+                integration_id=integration.id,
+            )
+            session.add(config)
+            session.commit()
+
+            monkeypatch.setattr(
+                db, "get_postgres_session_sync", lambda: _session_ctx(session)
+            )
+
+            configs = team_drift_sync._configured_provider_syncs(_ORG)
+    finally:
+        engine.dispose()
+
+    assert configs == []
+
+
+def test_configured_provider_syncs_fails_closed_when_credential_cross_org(
+    monkeypatch,
+) -> None:
+    """CHAOS-2762 planner-parity regression (codex finding #1, cross-org
+    case): a credential that exists but belongs to a DIFFERENT org must never
+    be used, and must not silently fall back to env auth either -- mirrors
+    the planner's org-scoped credential lookup
+    (``IntegrationCredential.org_id == integration.org_id``).
+    """
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-team-drift-sync-secret")
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-env-must-not-be-used")
+    import dev_health_ops.db as db
+    from dev_health_ops.workers import team_drift_sync
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            other_org_credential = IntegrationCredential(
+                provider="github",
+                name="other-org-cred",
+                org_id="other-org",
+                credentials_encrypted=encrypt_value(
+                    json.dumps({"token": "tok-other-org"})
+                ),
+                config={},
+                is_active=True,
+            )
+            session.add(other_org_credential)
+            session.flush()
+
+            integration = Integration(
+                org_id=_ORG,
+                provider="github",
+                name="gh-integration",
+                config={},
+                is_active=True,
+            )
+            integration.credential_id = other_org_credential.id
+            session.add(integration)
+            session.flush()
+
+            config = SyncConfiguration(
+                name="drift-config",
+                provider="github",
+                org_id=_ORG,
+                sync_targets=["git"],
+                sync_options={"owner": "acme"},
+                integration_id=integration.id,
+            )
+            session.add(config)
+            session.commit()
+
+            monkeypatch.setattr(
+                db, "get_postgres_session_sync", lambda: _session_ctx(session)
+            )
+
+            configs = team_drift_sync._configured_provider_syncs(_ORG)
+    finally:
+        engine.dispose()
+
+    assert configs == []
+
+
+def test_configured_provider_syncs_fails_closed_when_integration_cross_org(
+    monkeypatch,
+) -> None:
+    """CHAOS-2762 planner-parity regression (codex finding #1, cross-org
+    case): a ``SyncConfiguration.integration_id`` pointing at an ``Integration``
+    belonging to a DIFFERENT org (corrupt data / manual tampering) must never
+    resolve a credential -- it fails closed rather than falling back to env
+    auth, matching the planner's org-scoped ``_load_integration``.
+    """
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-env-must-not-be-used")
+    import dev_health_ops.db as db
+    from dev_health_ops.workers import team_drift_sync
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            other_org_integration = Integration(
+                org_id="other-org",
+                provider="github",
+                name="other-org-integration",
+                config={},
+                is_active=True,
+            )
+            session.add(other_org_integration)
+            session.flush()
+
+            config = SyncConfiguration(
+                name="drift-config",
+                provider="github",
+                org_id=_ORG,
+                sync_targets=["git"],
+                sync_options={"owner": "acme"},
+                integration_id=other_org_integration.id,
+            )
+            session.add(config)
+            session.commit()
+
+            monkeypatch.setattr(
+                db, "get_postgres_session_sync", lambda: _session_ctx(session)
+            )
+
+            configs = team_drift_sync._configured_provider_syncs(_ORG)
+    finally:
+        engine.dispose()
+
+    assert configs == []

--- a/tests/workers/test_team_drift_sync.py
+++ b/tests/workers/test_team_drift_sync.py
@@ -1,6 +1,17 @@
 from __future__ import annotations
 
+import json
+from contextlib import contextmanager
+
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.core.encryption import encrypt_value
+from dev_health_ops.models import Base, Integration
+from dev_health_ops.models.settings import IntegrationCredential, SyncConfiguration
 from dev_health_ops.workers.team_drift_sync import _provider_scan_complete
+
+_ORG = "team-drift-sync-org"
 
 
 def test_provider_scan_complete_accepts_plain_success() -> None:
@@ -11,3 +22,108 @@ def test_provider_scan_complete_rejects_truncated_or_warning_results() -> None:
     assert not _provider_scan_complete({"status": "success", "complete": False})
     assert not _provider_scan_complete({"status": "success", "warnings": ["bounded"]})
     assert not _provider_scan_complete({"status": "skipped"})
+
+
+@contextmanager
+def _session_ctx(session):
+    yield session
+    session.commit()
+
+
+def test_configured_provider_syncs_resolves_credential_via_linked_integration(
+    monkeypatch,
+) -> None:
+    """CHAOS-2762 regression: drift sync must authenticate off the linked
+    ``Integration``'s credential (the sanctioned surface reached via
+    ``SyncConfiguration.integration_id``) -- ``SyncConfiguration`` carries no
+    credential column of its own to read instead.
+    """
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-team-drift-sync-secret")
+    import dev_health_ops.db as db
+    from dev_health_ops.workers import team_drift_sync
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            credential = IntegrationCredential(
+                provider="github",
+                name="drift-cred",
+                org_id=_ORG,
+                credentials_encrypted=encrypt_value(json.dumps({"token": "tok-drift"})),
+                config={},
+                is_active=True,
+            )
+            session.add(credential)
+            session.flush()
+
+            integration = Integration(
+                org_id=_ORG,
+                provider="github",
+                name="gh-integration",
+                config={},
+                is_active=True,
+            )
+            integration.credential_id = credential.id
+            session.add(integration)
+            session.flush()
+
+            config = SyncConfiguration(
+                name="drift-config",
+                provider="github",
+                org_id=_ORG,
+                sync_targets=["git"],
+                sync_options={"owner": "acme"},
+                integration_id=integration.id,
+            )
+            session.add(config)
+            session.commit()
+
+            monkeypatch.setattr(
+                db, "get_postgres_session_sync", lambda: _session_ctx(session)
+            )
+
+            configs = team_drift_sync._configured_provider_syncs(_ORG)
+    finally:
+        engine.dispose()
+
+    assert len(configs) == 1
+    assert configs[0].provider == "github"
+    assert configs[0].credentials.get("token") == "tok-drift"
+
+
+def test_configured_provider_syncs_falls_back_to_env_without_linked_integration(
+    monkeypatch,
+) -> None:
+    """A config with no linked integration (legacy, pre-planner row) falls
+    back to env credentials rather than erroring -- same behavior as before
+    CHAOS-2762, just resolved through Integration instead of a stale column.
+    """
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-env-fallback")
+    import dev_health_ops.db as db
+    from dev_health_ops.workers import team_drift_sync
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            config = SyncConfiguration(
+                name="legacy-config",
+                provider="github",
+                org_id=_ORG,
+                sync_targets=["git"],
+                sync_options={"owner": "acme"},
+            )
+            session.add(config)
+            session.commit()
+
+            monkeypatch.setattr(
+                db, "get_postgres_session_sync", lambda: _session_ctx(session)
+            )
+
+            configs = team_drift_sync._configured_provider_syncs(_ORG)
+    finally:
+        engine.dispose()
+
+    assert len(configs) == 1
+    assert configs[0].credentials.get("token") == "tok-env-fallback"

--- a/tests/workers/test_team_drift_sync.py
+++ b/tests/workers/test_team_drift_sync.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import uuid
 from contextlib import contextmanager
@@ -84,13 +85,14 @@ def test_configured_provider_syncs_resolves_credential_via_linked_integration(
                 db, "get_postgres_session_sync", lambda: _session_ctx(session)
             )
 
-            configs = team_drift_sync._configured_provider_syncs(_ORG)
+            result = team_drift_sync._configured_provider_syncs(_ORG)
     finally:
         engine.dispose()
 
-    assert len(configs) == 1
-    assert configs[0].provider == "github"
-    assert configs[0].credentials.get("token") == "tok-drift"
+    assert result.skipped == []
+    assert len(result.configs) == 1
+    assert result.configs[0].provider == "github"
+    assert result.configs[0].credentials.get("token") == "tok-drift"
 
 
 def test_configured_provider_syncs_falls_back_to_env_without_linked_integration(
@@ -122,12 +124,13 @@ def test_configured_provider_syncs_falls_back_to_env_without_linked_integration(
                 db, "get_postgres_session_sync", lambda: _session_ctx(session)
             )
 
-            configs = team_drift_sync._configured_provider_syncs(_ORG)
+            result = team_drift_sync._configured_provider_syncs(_ORG)
     finally:
         engine.dispose()
 
-    assert len(configs) == 1
-    assert configs[0].credentials.get("token") == "tok-env-fallback"
+    assert result.skipped == []
+    assert len(result.configs) == 1
+    assert result.configs[0].credentials.get("token") == "tok-env-fallback"
 
 
 def test_configured_provider_syncs_fails_closed_when_credential_inactive(
@@ -188,11 +191,14 @@ def test_configured_provider_syncs_fails_closed_when_credential_inactive(
                 db, "get_postgres_session_sync", lambda: _session_ctx(session)
             )
 
-            configs = team_drift_sync._configured_provider_syncs(_ORG)
+            result = team_drift_sync._configured_provider_syncs(_ORG)
     finally:
         engine.dispose()
 
-    assert configs == []
+    assert result.configs == []
+    assert len(result.skipped) == 1
+    assert result.skipped[0].provider == "github"
+    assert result.skipped[0].reason == team_drift_sync._SKIP_REASON_CREDENTIAL_INACTIVE
 
 
 def test_configured_provider_syncs_fails_closed_when_credential_missing(
@@ -220,7 +226,8 @@ def test_configured_provider_syncs_fails_closed_when_credential_missing(
             )
             # Points at a credential that was never created (deleted, or a
             # stale/corrupt reference) -- the FK is deliberately unenforced.
-            integration.credential_id = uuid.uuid4()
+            missing_credential_id = uuid.uuid4()
+            integration.credential_id = missing_credential_id
             session.add(integration)
             session.flush()
 
@@ -239,11 +246,13 @@ def test_configured_provider_syncs_fails_closed_when_credential_missing(
                 db, "get_postgres_session_sync", lambda: _session_ctx(session)
             )
 
-            configs = team_drift_sync._configured_provider_syncs(_ORG)
+            result = team_drift_sync._configured_provider_syncs(_ORG)
     finally:
         engine.dispose()
 
-    assert configs == []
+    assert result.configs == []
+    assert len(result.skipped) == 1
+    assert result.skipped[0].reason == team_drift_sync._SKIP_REASON_CREDENTIAL_NOT_FOUND
 
 
 def test_configured_provider_syncs_fails_closed_when_credential_cross_org(
@@ -303,11 +312,13 @@ def test_configured_provider_syncs_fails_closed_when_credential_cross_org(
                 db, "get_postgres_session_sync", lambda: _session_ctx(session)
             )
 
-            configs = team_drift_sync._configured_provider_syncs(_ORG)
+            result = team_drift_sync._configured_provider_syncs(_ORG)
     finally:
         engine.dispose()
 
-    assert configs == []
+    assert result.configs == []
+    assert len(result.skipped) == 1
+    assert result.skipped[0].reason == team_drift_sync._SKIP_REASON_CREDENTIAL_NOT_FOUND
 
 
 def test_configured_provider_syncs_fails_closed_when_integration_cross_org(
@@ -352,8 +363,199 @@ def test_configured_provider_syncs_fails_closed_when_integration_cross_org(
                 db, "get_postgres_session_sync", lambda: _session_ctx(session)
             )
 
-            configs = team_drift_sync._configured_provider_syncs(_ORG)
+            result = team_drift_sync._configured_provider_syncs(_ORG)
     finally:
         engine.dispose()
 
-    assert configs == []
+    assert result.configs == []
+    assert len(result.skipped) == 1
+    assert (
+        result.skipped[0].reason == team_drift_sync._SKIP_REASON_INTEGRATION_NOT_FOUND
+    )
+
+
+def test_configured_provider_syncs_fails_closed_when_credential_provider_mismatch(
+    monkeypatch,
+) -> None:
+    """CHAOS-2762 planner-parity regression (codex finding #1): a credential
+    that exists, is active, and belongs to the SAME org but was provisioned
+    for a DIFFERENT provider must never be used for this config's provider --
+    it fails closed with a distinct, specific reason rather than silently
+    substituting env auth.
+    """
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-team-drift-sync-secret")
+    monkeypatch.setenv("GITHUB_TOKEN", "tok-env-must-not-be-used")
+    import dev_health_ops.db as db
+    from dev_health_ops.workers import team_drift_sync
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    try:
+        with Session(engine) as session:
+            gitlab_credential = IntegrationCredential(
+                provider="gitlab",
+                name="gitlab-cred",
+                org_id=_ORG,
+                credentials_encrypted=encrypt_value(
+                    json.dumps({"token": "tok-gitlab"})
+                ),
+                config={},
+                is_active=True,
+            )
+            session.add(gitlab_credential)
+            session.flush()
+
+            # An Integration whose provider is "github" but whose stamped
+            # credential_id points at a "gitlab" credential -- a data
+            # inconsistency that should never actually arise, but the check
+            # must catch it rather than trust the linkage blindly.
+            integration = Integration(
+                org_id=_ORG,
+                provider="github",
+                name="gh-integration",
+                config={},
+                is_active=True,
+            )
+            integration.credential_id = gitlab_credential.id
+            session.add(integration)
+            session.flush()
+
+            config = SyncConfiguration(
+                name="drift-config",
+                provider="github",
+                org_id=_ORG,
+                sync_targets=["git"],
+                sync_options={"owner": "acme"},
+                integration_id=integration.id,
+            )
+            session.add(config)
+            session.commit()
+
+            monkeypatch.setattr(
+                db, "get_postgres_session_sync", lambda: _session_ctx(session)
+            )
+
+            result = team_drift_sync._configured_provider_syncs(_ORG)
+    finally:
+        engine.dispose()
+
+    assert result.configs == []
+    assert len(result.skipped) == 1
+    assert (
+        result.skipped[0].reason
+        == team_drift_sync._SKIP_REASON_CREDENTIAL_PROVIDER_MISMATCH
+    )
+
+
+def test_sync_team_drift_async_surfaces_all_skipped_configs_in_result(
+    monkeypatch,
+) -> None:
+    """Codex re-pass regression: when EVERY configured provider is skipped by
+    the fail-closed auth check, the task result must show it.
+
+    Before this fix, ``_sync_team_drift_async`` returned
+    ``status: "success"`` with ``providers_attempted: 0`` and nothing else --
+    a fleet-wide credential outage (every config's linked credential
+    deactivated/deleted) would read as a clean, complete success unless
+    someone thought to grep worker logs. ``configs_skipped`` /
+    ``configs_skipped_count`` now make that outage visible in the result
+    itself, and a WARNING aggregate line is logged.
+
+    Isolates the aggregation/surfacing logic in ``_sync_team_drift_async``
+    from the DB-query logic in ``_configured_provider_syncs`` (covered by the
+    tests above) by monkeypatching the latter directly, and fakes
+    ``ClickHouseStore`` so no real ClickHouse connection is needed -- with
+    zero configs, ``project_team_rows_with_store`` is never called anyway.
+    """
+    import dev_health_ops.storage.clickhouse as clickhouse_module
+    from dev_health_ops.workers import team_drift_sync
+
+    monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://test:9000/test")
+
+    skipped = [
+        team_drift_sync._SkippedConfig(
+            config_id="config-1",
+            provider="github",
+            reason=team_drift_sync._SKIP_REASON_CREDENTIAL_INACTIVE,
+        ),
+        team_drift_sync._SkippedConfig(
+            config_id="config-2",
+            provider="gitlab",
+            reason=team_drift_sync._SKIP_REASON_CREDENTIAL_NOT_FOUND,
+        ),
+    ]
+    monkeypatch.setattr(
+        team_drift_sync,
+        "_configured_provider_syncs",
+        lambda org_id: team_drift_sync._ConfiguredProviderSyncs(
+            configs=[], skipped=skipped
+        ),
+    )
+
+    class _FakeClickHouseStore:
+        def __init__(self, conn_string, settings=None):
+            self.conn_string = conn_string
+            self.org_id: str | None = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(clickhouse_module, "ClickHouseStore", _FakeClickHouseStore)
+
+    result = asyncio.run(team_drift_sync._sync_team_drift_async(org_id="org-x"))
+
+    assert result["status"] == "success"
+    assert result["providers_attempted"] == 0
+    assert result["configs_skipped_count"] == 2
+    assert result["configs_skipped"] == [
+        {
+            "config_id": "config-1",
+            "provider": "github",
+            "reason": "credential_inactive",
+        },
+        {
+            "config_id": "config-2",
+            "provider": "gitlab",
+            "reason": "credential_not_found_or_cross_org",
+        },
+    ]
+
+
+def test_sync_team_drift_async_configs_skipped_empty_when_nothing_skipped(
+    monkeypatch,
+) -> None:
+    """``configs_skipped`` is always present (an empty list, not a missing
+    key) when nothing was skipped, so callers can rely on the key existing
+    unconditionally.
+    """
+    import dev_health_ops.storage.clickhouse as clickhouse_module
+    from dev_health_ops.workers import team_drift_sync
+
+    monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://test:9000/test")
+
+    monkeypatch.setattr(
+        team_drift_sync,
+        "_configured_provider_syncs",
+        lambda org_id: team_drift_sync._ConfiguredProviderSyncs(configs=[], skipped=[]),
+    )
+
+    class _FakeClickHouseStore:
+        def __init__(self, conn_string, settings=None):
+            self.org_id: str | None = None
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+    monkeypatch.setattr(clickhouse_module, "ClickHouseStore", _FakeClickHouseStore)
+
+    result = asyncio.run(team_drift_sync._sync_team_drift_async(org_id="org-x"))
+
+    assert result["status"] == "success"
+    assert result["configs_skipped"] == []
+    assert result["configs_skipped_count"] == 0


### PR DESCRIPTION
## Summary

Removes the legacy, unfrozen `SyncConfiguration.credential_id` auth surface that predates run-level credential stamping (CHAOS-2755 / #1109). There is now exactly one place a credential attaches to sync work: `Integration.credential_id`, frozen onto `sync_runs` at plan time by `resolve_run_auth`.

- `SyncConfiguration.credential_id` was a second, independently-writable mirror of `Integration.credential_id`, dual-written at create time by the planner-managed config path (`api/admin/routers/sync.py`) but **never read** by auth resolution (`sync/planner.py`, `workers/sync_bootstrap.py`).
- Dropped the column/model field (migration `0032`, FK + column, reversible downgrade documented as lossy-but-redundant since the data was never independently meaningful).
- The admin API keeps its `credential_id` request/response fields on sync-config payloads (web has live readers/writers — `SyncConfigForm.tsx`, `ProviderCredentialsList.tsx`, the sync-config detail page), but the response value is now resolved **live** through the linked `Integration` via `integration_id` instead of a stored mirror. This also fixes a real staleness bug: previously, rotating a credential via `PATCH /integrations/{id}` would not propagate to the `SyncConfiguration` mirror, so the admin UI could show a stale credential after rotation.
- Found and migrated a third reader via mypy (missed in the initial `rg` inventory): `workers/team_drift_sync.py`'s `_configured_provider_syncs`, which resolved auth for the `sync_team_drift` Celery task straight off the legacy column.
- Invariant tests (`tests/test_credential_capacity_invariants.py`) updated coherently — added a regression proving the model/table no longer carries the column, without touching the existing run-level allowlist (which only ever covered `sync_runs`/`sync_run_units`, not `SyncConfiguration`).
- Documented the removal + the read-through-alias status in `docs/providers/rate-limit-policy.md` (flagged as a compatibility shim and a candidate for future removal once web reads credentials at the `Integration` level directly).

Product invariant (credentials are not capacity) is untouched: this field was never read by planning, budgeting, or dispatch.

## Test plan

- [x] `tests/test_credential_capacity_invariants.py` — new regression: `SyncConfiguration` has no `credential_id` column/constructor kwarg.
- [x] `tests/api/admin/test_sync_configs.py` — new regressions: response `credential_id` reflects the linked `Integration` live (including after a rotation), and configs sharing one `Integration` (parent + legacy child) read a consistent value.
- [x] `tests/workers/test_team_drift_sync.py` — new regressions: drift sync resolves credentials via the linked `Integration`, with the pre-planner env-fallback path pinned.
- [x] Migration `0032` round-tripped by hand against a scratch Postgres db (upgrade → downgrade → upgrade), confirming column/FK drop and restore.
- [x] Full local gate: `ci/local_validate.sh` (lint, mypy, full unit suite — 6265 passed, 0 failed — and the live-ClickHouse argMax proof) — **GATE PASSED**.

Linked: [CHAOS-2762](https://linear.app/fullchaos/issue/CHAOS-2762)