### PR TITLE
feat(external-ingest): schema discovery + JSON Schema export (CHAOS-2692)

### DIFF
--- a/docs/api/external-ingest/v1/schema.json
+++ b/docs/api/external-ingest/v1/schema.json
@@ -1,0 +1,1518 @@
+{
+  "$defs": {
+    "BatchEnvelope": {
+      "additionalProperties": false,
+      "properties": {
+        "idempotencyKey": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Idempotencykey",
+          "type": "string"
+        },
+        "records": {
+          "items": {
+            "$ref": "#/$defs/RecordEnvelope"
+          },
+          "minItems": 1,
+          "title": "Records",
+          "type": "array"
+        },
+        "schemaVersion": {
+          "const": "external-ingest.v1",
+          "title": "Schemaversion",
+          "type": "string"
+        },
+        "source": {
+          "$ref": "#/$defs/SourceDescriptor"
+        },
+        "window": {
+          "anyOf": [
+            {
+              "$ref": "#/$defs/IngestWindow"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null
+        }
+      },
+      "required": [
+        "schemaVersion",
+        "idempotencyKey",
+        "source",
+        "records"
+      ],
+      "title": "BatchEnvelope",
+      "type": "object"
+    },
+    "CommitV1": {
+      "additionalProperties": false,
+      "properties": {
+        "authorEmail": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authoremail"
+        },
+        "authorName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authorname"
+        },
+        "authorWhen": {
+          "format": "date-time",
+          "title": "Authorwhen",
+          "type": "string"
+        },
+        "committerEmail": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Committeremail"
+        },
+        "committerName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Committername"
+        },
+        "committerWhen": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Committerwhen"
+        },
+        "hash": {
+          "maxLength": 64,
+          "minLength": 7,
+          "title": "Hash",
+          "type": "string"
+        },
+        "message": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Message"
+        },
+        "parents": {
+          "default": 1,
+          "minimum": 0,
+          "title": "Parents",
+          "type": "integer"
+        },
+        "repositoryExternalId": {
+          "title": "Repositoryexternalid",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repositoryExternalId",
+        "hash",
+        "authorWhen"
+      ],
+      "title": "CommitV1",
+      "type": "object"
+    },
+    "IdentityV1": {
+      "additionalProperties": false,
+      "properties": {
+        "canonicalId": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Canonicalid",
+          "type": "string"
+        },
+        "displayName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Displayname"
+        },
+        "email": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Email"
+        },
+        "isActive": {
+          "default": true,
+          "title": "Isactive",
+          "type": "boolean"
+        },
+        "providerIdentities": {
+          "additionalProperties": {
+            "items": {
+              "type": "string"
+            },
+            "type": "array"
+          },
+          "title": "Provideridentities",
+          "type": "object"
+        },
+        "teamIds": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Teamids",
+          "type": "array"
+        },
+        "updatedAt": {
+          "format": "date-time",
+          "title": "Updatedat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "canonicalId",
+        "updatedAt"
+      ],
+      "title": "IdentityV1",
+      "type": "object"
+    },
+    "IngestWindow": {
+      "additionalProperties": false,
+      "properties": {
+        "endedAt": {
+          "format": "date-time",
+          "title": "Endedat",
+          "type": "string"
+        },
+        "startedAt": {
+          "format": "date-time",
+          "title": "Startedat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "startedAt",
+        "endedAt"
+      ],
+      "title": "IngestWindow",
+      "type": "object"
+    },
+    "PullRequestV1": {
+      "additionalProperties": false,
+      "properties": {
+        "additions": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Additions"
+        },
+        "authorEmail": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authoremail"
+        },
+        "authorName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authorname"
+        },
+        "baseBranch": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Basebranch"
+        },
+        "body": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Body"
+        },
+        "changedFiles": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Changedfiles"
+        },
+        "changesRequestedCount": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0,
+          "title": "Changesrequestedcount"
+        },
+        "closedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Closedat"
+        },
+        "commentsCount": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0,
+          "title": "Commentscount"
+        },
+        "createdAt": {
+          "format": "date-time",
+          "title": "Createdat",
+          "type": "string"
+        },
+        "deletions": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deletions"
+        },
+        "firstCommentAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Firstcommentat"
+        },
+        "firstReviewAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Firstreviewat"
+        },
+        "headBranch": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Headbranch"
+        },
+        "mergedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mergedat"
+        },
+        "number": {
+          "minimum": 1,
+          "title": "Number",
+          "type": "integer"
+        },
+        "repositoryExternalId": {
+          "title": "Repositoryexternalid",
+          "type": "string"
+        },
+        "reviewsCount": {
+          "anyOf": [
+            {
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": 0,
+          "title": "Reviewscount"
+        },
+        "state": {
+          "enum": [
+            "open",
+            "closed",
+            "merged"
+          ],
+          "title": "State",
+          "type": "string"
+        },
+        "title": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Title"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Url"
+        }
+      },
+      "required": [
+        "repositoryExternalId",
+        "number",
+        "state",
+        "createdAt"
+      ],
+      "title": "PullRequestV1",
+      "type": "object"
+    },
+    "RecordEnvelope": {
+      "additionalProperties": false,
+      "description": "Generic wrapper: kind + externalId (for error correlation) + payload.\n\n``payload`` is validated per-kind against ``RECORD_KIND_MODELS`` in\n``router.py``/``validate.py``, not here \u2014 a discriminated union at this\nlevel would abort parsing the whole batch on one bad record (see\ndocs/architecture/external-ingest-rest-contract.md D-payload-shape).",
+      "properties": {
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "kind": {
+          "enum": [
+            "commit.v1",
+            "identity.v1",
+            "pull_request.v1",
+            "repository.v1",
+            "review.v1",
+            "team.v1",
+            "work_item.v1",
+            "work_item_dependency.v1",
+            "work_item_transition.v1"
+          ],
+          "title": "Kind",
+          "type": "string"
+        },
+        "payload": {
+          "additionalProperties": true,
+          "title": "Payload",
+          "type": "object"
+        }
+      },
+      "required": [
+        "kind",
+        "externalId",
+        "payload"
+      ],
+      "title": "RecordEnvelope",
+      "type": "object"
+    },
+    "RepositoryV1": {
+      "additionalProperties": false,
+      "properties": {
+        "defaultRef": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Defaultref"
+        },
+        "externalId": {
+          "maxLength": 1024,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "settings": {
+          "additionalProperties": {
+            "anyOf": [
+              {
+                "type": "string"
+              },
+              {
+                "type": "integer"
+              },
+              {
+                "type": "number"
+              },
+              {
+                "type": "boolean"
+              }
+            ]
+          },
+          "title": "Settings",
+          "type": "object"
+        },
+        "sourceSystem": {
+          "enum": [
+            "github",
+            "gitlab",
+            "custom"
+          ],
+          "title": "Sourcesystem",
+          "type": "string"
+        },
+        "tags": {
+          "items": {
+            "type": "string"
+          },
+          "maxItems": 50,
+          "title": "Tags",
+          "type": "array"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceSystem"
+      ],
+      "title": "RepositoryV1",
+      "type": "object"
+    },
+    "ReviewV1": {
+      "additionalProperties": false,
+      "properties": {
+        "pullRequestNumber": {
+          "minimum": 1,
+          "title": "Pullrequestnumber",
+          "type": "integer"
+        },
+        "repositoryExternalId": {
+          "title": "Repositoryexternalid",
+          "type": "string"
+        },
+        "reviewId": {
+          "minLength": 1,
+          "title": "Reviewid",
+          "type": "string"
+        },
+        "reviewer": {
+          "title": "Reviewer",
+          "type": "string"
+        },
+        "state": {
+          "enum": [
+            "APPROVED",
+            "CHANGES_REQUESTED",
+            "COMMENTED",
+            "DISMISSED",
+            "PENDING"
+          ],
+          "title": "State",
+          "type": "string"
+        },
+        "submittedAt": {
+          "format": "date-time",
+          "title": "Submittedat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "repositoryExternalId",
+        "pullRequestNumber",
+        "reviewId",
+        "reviewer",
+        "state",
+        "submittedAt"
+      ],
+      "title": "ReviewV1",
+      "type": "object"
+    },
+    "SourceDescriptor": {
+      "additionalProperties": false,
+      "properties": {
+        "instance": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Instance",
+          "type": "string"
+        },
+        "producer": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Producer"
+        },
+        "producerVersion": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Producerversion"
+        },
+        "system": {
+          "enum": [
+            "github",
+            "gitlab",
+            "jira",
+            "linear",
+            "custom"
+          ],
+          "title": "System",
+          "type": "string"
+        },
+        "type": {
+          "const": "customer_push",
+          "default": "customer_push",
+          "title": "Type",
+          "type": "string"
+        }
+      },
+      "required": [
+        "system",
+        "instance"
+      ],
+      "title": "SourceDescriptor",
+      "type": "object"
+    },
+    "TeamV1": {
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "id": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Id",
+          "type": "string"
+        },
+        "isActive": {
+          "default": true,
+          "title": "Isactive",
+          "type": "boolean"
+        },
+        "members": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Members",
+          "type": "array"
+        },
+        "name": {
+          "title": "Name",
+          "type": "string"
+        },
+        "nativeTeamKey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Nativeteamkey"
+        },
+        "parentTeamId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parentteamid"
+        },
+        "projectKeys": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Projectkeys",
+          "type": "array"
+        },
+        "repoPatterns": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Repopatterns",
+          "type": "array"
+        },
+        "updatedAt": {
+          "format": "date-time",
+          "title": "Updatedat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "id",
+        "name",
+        "updatedAt"
+      ],
+      "title": "TeamV1",
+      "type": "object"
+    },
+    "WorkItemDependencyV1": {
+      "additionalProperties": false,
+      "description": "Master-spec header item 2: source/target take ``externalKey`` pairs\n(not internal namespaced work-item IDs) + optional per-side\n``workItemType`` since source and target may be different namespaces\n(e.g. an issue blocked by a PR).",
+      "properties": {
+        "relationshipType": {
+          "enum": [
+            "blocks",
+            "blocked_by",
+            "relates_to",
+            "duplicates",
+            "parent_of",
+            "child_of"
+          ],
+          "title": "Relationshiptype",
+          "type": "string"
+        },
+        "relationshipTypeRaw": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshiptyperaw"
+        },
+        "sourceExternalKey": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Sourceexternalkey",
+          "type": "string"
+        },
+        "sourceWorkItemType": {
+          "anyOf": [
+            {
+              "enum": [
+                "issue",
+                "pr",
+                "merge_request"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceworkitemtype"
+        },
+        "targetExternalKey": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Targetexternalkey",
+          "type": "string"
+        },
+        "targetWorkItemType": {
+          "anyOf": [
+            {
+              "enum": [
+                "issue",
+                "pr",
+                "merge_request"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Targetworkitemtype"
+        }
+      },
+      "required": [
+        "sourceExternalKey",
+        "targetExternalKey",
+        "relationshipType"
+      ],
+      "title": "WorkItemDependencyV1",
+      "type": "object"
+    },
+    "WorkItemTransitionV1": {
+      "additionalProperties": false,
+      "description": "Master-spec header item 2: takes ``externalKey`` (not the internal\nnamespaced ``work_item_id``) + optional ``workItemType`` to disambiguate\nthe issue vs. pr/merge_request namespace for github/gitlab.",
+      "properties": {
+        "actor": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Actor"
+        },
+        "externalKey": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalkey",
+          "type": "string"
+        },
+        "fromStatus": {
+          "enum": [
+            "backlog",
+            "todo",
+            "in_progress",
+            "in_review",
+            "blocked",
+            "done",
+            "canceled",
+            "unknown"
+          ],
+          "title": "Fromstatus",
+          "type": "string"
+        },
+        "fromStatusRaw": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Fromstatusraw"
+        },
+        "occurredAt": {
+          "format": "date-time",
+          "title": "Occurredat",
+          "type": "string"
+        },
+        "provider": {
+          "enum": [
+            "jira",
+            "github",
+            "gitlab",
+            "linear"
+          ],
+          "title": "Provider",
+          "type": "string"
+        },
+        "toStatus": {
+          "enum": [
+            "backlog",
+            "todo",
+            "in_progress",
+            "in_review",
+            "blocked",
+            "done",
+            "canceled",
+            "unknown"
+          ],
+          "title": "Tostatus",
+          "type": "string"
+        },
+        "toStatusRaw": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Tostatusraw"
+        },
+        "workItemType": {
+          "anyOf": [
+            {
+              "enum": [
+                "issue",
+                "pr",
+                "merge_request"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Workitemtype"
+        }
+      },
+      "required": [
+        "externalKey",
+        "provider",
+        "occurredAt",
+        "fromStatus",
+        "toStatus"
+      ],
+      "title": "WorkItemTransitionV1",
+      "type": "object"
+    },
+    "WorkItemV1": {
+      "additionalProperties": false,
+      "properties": {
+        "assignees": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Assignees",
+          "type": "array"
+        },
+        "closedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Closedat"
+        },
+        "completedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Completedat"
+        },
+        "createdAt": {
+          "format": "date-time",
+          "title": "Createdat",
+          "type": "string"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "dueAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Dueat"
+        },
+        "epicId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Epicid"
+        },
+        "externalKey": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalkey",
+          "type": "string"
+        },
+        "labels": {
+          "items": {
+            "type": "string"
+          },
+          "title": "Labels",
+          "type": "array"
+        },
+        "nativeTeamKey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Nativeteamkey"
+        },
+        "parentId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Parentid"
+        },
+        "priorityRaw": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Priorityraw"
+        },
+        "projectId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Projectid"
+        },
+        "projectKey": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Projectkey"
+        },
+        "projectName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Projectname"
+        },
+        "provider": {
+          "enum": [
+            "jira",
+            "github",
+            "gitlab",
+            "linear"
+          ],
+          "title": "Provider",
+          "type": "string"
+        },
+        "reporter": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Reporter"
+        },
+        "repositoryExternalId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repositoryexternalid"
+        },
+        "serviceClass": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Serviceclass"
+        },
+        "sprintId": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sprintid"
+        },
+        "sprintName": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sprintname"
+        },
+        "startedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Startedat"
+        },
+        "status": {
+          "enum": [
+            "backlog",
+            "todo",
+            "in_progress",
+            "in_review",
+            "blocked",
+            "done",
+            "canceled",
+            "unknown"
+          ],
+          "title": "Status",
+          "type": "string"
+        },
+        "statusRaw": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Statusraw"
+        },
+        "storyPoints": {
+          "anyOf": [
+            {
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Storypoints"
+        },
+        "title": {
+          "title": "Title",
+          "type": "string"
+        },
+        "type": {
+          "default": "unknown",
+          "enum": [
+            "story",
+            "task",
+            "bug",
+            "epic",
+            "pr",
+            "merge_request",
+            "issue",
+            "incident",
+            "chore",
+            "unknown"
+          ],
+          "title": "Type",
+          "type": "string"
+        },
+        "updatedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Updatedat"
+        },
+        "url": {
+          "anyOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Url"
+        }
+      },
+      "required": [
+        "externalKey",
+        "provider",
+        "title",
+        "status",
+        "createdAt"
+      ],
+      "title": "WorkItemV1",
+      "type": "object"
+    }
+  },
+  "$id": "https://api.fullchaos.dev/api/v1/external-ingest/schemas/external-ingest.v1",
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "description": "FullChaos external customer-push ingestion contract, v1. 'envelope' validates batch shape only \u2014 records[].payload is intentionally unconstrained there (see $defs.RecordEnvelope); validate each record's payload against recordKinds[kind].$ref for kind-specific field requirements (adversarial-review finding: envelope-only validation can pass a payload the server's POST /validate rejects).",
+  "envelope": {
+    "$ref": "#/$defs/BatchEnvelope"
+  },
+  "recordKinds": {
+    "commit.v1": {
+      "$ref": "#/$defs/CommitV1",
+      "examples": [
+        {
+          "authorEmail": "alice@acme.example",
+          "authorName": "Alice Doe",
+          "authorWhen": "2026-06-21T09:55:00Z",
+          "committerEmail": "alice@acme.example",
+          "committerName": "Alice Doe",
+          "committerWhen": "2026-06-21T09:55:00Z",
+          "hash": "9fceb02d0ae598e95dc970b74767f19372d61af8",
+          "message": "fix: resolve login redirect loop",
+          "parents": 1,
+          "repositoryExternalId": "acme/api"
+        }
+      ]
+    },
+    "identity.v1": {
+      "$ref": "#/$defs/IdentityV1",
+      "examples": [
+        {
+          "canonicalId": "acme-user-42",
+          "displayName": "Alice Doe",
+          "email": "alice@acme.example",
+          "isActive": true,
+          "providerIdentities": {
+            "github": [
+              "alicedoe"
+            ],
+            "jira": [
+              "alice.doe"
+            ]
+          },
+          "teamIds": [
+            "team-platform"
+          ],
+          "updatedAt": "2026-06-25T00:00:00Z"
+        }
+      ]
+    },
+    "pull_request.v1": {
+      "$ref": "#/$defs/PullRequestV1",
+      "examples": [
+        {
+          "additions": 42,
+          "authorEmail": "alice@acme.example",
+          "authorName": "Alice Doe",
+          "baseBranch": "main",
+          "changedFiles": 3,
+          "commentsCount": 4,
+          "createdAt": "2026-06-21T10:00:00Z",
+          "deletions": 10,
+          "headBranch": "fix/login-redirect",
+          "mergedAt": "2026-06-22T15:30:00Z",
+          "number": 482,
+          "repositoryExternalId": "acme/api",
+          "reviewsCount": 2,
+          "state": "merged",
+          "title": "Fix login redirect loop",
+          "url": "https://github.com/acme/api/pull/482"
+        }
+      ]
+    },
+    "repository.v1": {
+      "$ref": "#/$defs/RepositoryV1",
+      "examples": [
+        {
+          "defaultRef": "main",
+          "externalId": "acme/api",
+          "settings": {
+            "visibility": "private"
+          },
+          "sourceSystem": "github",
+          "tags": [
+            "backend",
+            "core"
+          ]
+        }
+      ]
+    },
+    "review.v1": {
+      "$ref": "#/$defs/ReviewV1",
+      "examples": [
+        {
+          "pullRequestNumber": 482,
+          "repositoryExternalId": "acme/api",
+          "reviewId": "rev-9001",
+          "reviewer": "bob@acme.example",
+          "state": "APPROVED",
+          "submittedAt": "2026-06-22T14:00:00Z"
+        }
+      ]
+    },
+    "team.v1": {
+      "$ref": "#/$defs/TeamV1",
+      "examples": [
+        {
+          "description": "Core platform engineering team",
+          "id": "team-platform",
+          "isActive": true,
+          "members": [
+            "acme-user-42"
+          ],
+          "name": "Platform",
+          "nativeTeamKey": "PLAT",
+          "projectKeys": [
+            "ABC"
+          ],
+          "repoPatterns": [
+            "acme/*"
+          ],
+          "updatedAt": "2026-06-25T00:00:00Z"
+        }
+      ]
+    },
+    "work_item.v1": {
+      "$ref": "#/$defs/WorkItemV1",
+      "examples": [
+        {
+          "assignees": [
+            "alice@acme.example"
+          ],
+          "createdAt": "2026-06-20T14:00:00Z",
+          "description": "Users are redirected in a loop after SSO login.",
+          "externalKey": "ABC-123",
+          "labels": [
+            "bug",
+            "auth"
+          ],
+          "priorityRaw": "High",
+          "projectKey": "ABC",
+          "projectName": "Acme Platform",
+          "provider": "jira",
+          "reporter": "bob@acme.example",
+          "startedAt": "2026-06-21T09:00:00Z",
+          "status": "in_progress",
+          "statusRaw": "In Progress",
+          "storyPoints": 3,
+          "title": "Fix login redirect loop",
+          "type": "bug",
+          "updatedAt": "2026-06-25T09:30:00Z",
+          "url": "https://acme.atlassian.net/browse/ABC-123"
+        }
+      ]
+    },
+    "work_item_dependency.v1": {
+      "$ref": "#/$defs/WorkItemDependencyV1",
+      "examples": [
+        {
+          "relationshipType": "blocks",
+          "relationshipTypeRaw": "blocks",
+          "sourceExternalKey": "ABC-123",
+          "targetExternalKey": "ABC-124"
+        }
+      ]
+    },
+    "work_item_transition.v1": {
+      "$ref": "#/$defs/WorkItemTransitionV1",
+      "examples": [
+        {
+          "actor": "alice@acme.example",
+          "externalKey": "ABC-123",
+          "fromStatus": "todo",
+          "fromStatusRaw": "To Do",
+          "occurredAt": "2026-06-21T09:00:00Z",
+          "provider": "jira",
+          "toStatus": "in_progress",
+          "toStatusRaw": "In Progress"
+        }
+      ]
+    }
+  },
+  "schemaVersion": "external-ingest.v1",
+  "title": "external-ingest.v1"
+}

--- a/docs/architecture/adr-005-external-ingest-schema-discovery.md
+++ b/docs/architecture/adr-005-external-ingest-schema-discovery.md
@@ -1,0 +1,222 @@
+# ADR-005: External-ingest schema discovery and JSON Schema export
+
+## Status
+
+Accepted.
+
+## Context
+
+CHAOS-2691 ships the frozen wire contract for `/api/v1/external-ingest/*` as
+Pydantic v2 models in `api/external_ingest/schemas.py` — the envelope
+(`BatchEnvelope`), its wrapper (`RecordEnvelope`), and the 9 record-kind
+payload models in `RECORD_KIND_MODELS`. Customers need a machine-readable,
+versioned way to discover that contract (`GET /schemas`, `GET
+/schemas/{schema_version}`) without hand-reading Python source, so their own
+CI pipelines and SDKs can validate payloads before pushing — and `dev-hops
+push validate`/`push sample` (CHAOS-2700) need the same generated shapes to
+work offline. This ADR records the generation, caching, and static-export
+decisions CHAOS-2692 makes on top of CHAOS-2691's models (mirroring
+`docs/architecture/adr-003-external-ingest-rest-boundary.md`'s "record
+decisions in-tree" convention).
+
+## Decision 1: JSON Schema is generated, never hand-written
+
+`schema_registry.py` builds the discovery bundle from
+`pydantic.json_schema.models_json_schema()` over `BatchEnvelope` plus all 9
+`RECORD_KIND_MODELS` values in one call, not per-model `model_json_schema()`
+calls stitched together by hand. Verified against the installed pydantic
+(2.13.4): the default `ref_template` already emits `#/$defs/{ModelName}`
+refs and the returned `$defs` are collision-free across all 10 models, so no
+`ref_template` override or manual `$ref` merging is needed. This is the same
+"single source of truth" property CC17 establishes for validation — the
+registry imports `RECORD_KIND_MODELS`/`BatchEnvelope` and never redeclares a
+field.
+
+## Decision 2: One bundled document per envelope version, `$ref`-based record index
+
+`GET /schemas/{schema_version}` returns one JSON Schema document containing:
+
+- `envelope`: `{"$ref": "#/$defs/BatchEnvelope"}`
+- `recordKinds`: a map of versioned kind (`"commit.v1"`, …) to
+  `{"$ref": "#/$defs/<Model>", "examples": [...]}`
+- `$defs`: every referenced model's schema, generated once by
+  `models_json_schema()`
+
+`schema_version` is the envelope-level API version (`external-ingest.v1`),
+not a per-record-kind version — bumping a single record kind's shape is
+expressed by renaming its Pydantic model / `kind` literal (`commit.v2`)
+while the bundle's `schema_version` stays `v1`; bumping the envelope shape
+itself requires a new `external-ingest.v2` bundle. `$ref`-based indexing
+(over inlining each record kind's full schema under `recordKinds`) lets a
+standard validator (ajv, the Python `jsonschema` package) resolve
+`$defs.CommitV1` directly from the one document — proven in this issue's
+live verification by validating each kind's example against
+`{**doc, "$ref": doc["recordKinds"][kind]["$ref"]}` with an independent
+`jsonschema` validator, not Pydantic itself.
+
+`GET /schemas/{schema_version}` does not support a `?kind=` narrowing query
+param in v1 — the full bundle (9 kinds) is small and standard `$ref`
+resolution already lets a customer validate a single record kind from it.
+
+## Decision 3: Compute once per process, ETag over canonical JSON
+
+`schema_registry._build_v1_bundle()` is `@lru_cache(maxsize=1)`'d and forced
+eagerly at `router.py` import time (a bare `get_bundle(SCHEMA_VERSION)`
+call, result discarded) — `models_json_schema()` reflection and example-file
+loading are non-trivial and deterministic per process, so a bad example
+fixture or a schema-generation regression fails app startup, not a
+customer's first request.
+
+`schema_registry.compute_etag(document) = sha256(json.dumps(document,
+sort_keys=True, separators=(",", ":")))`, wrapped in quotes.
+`SchemaBundle.etag` (computed once, cached with the rest of the bundle) is a
+*structural* hash over the schema shape alone — useful for content-addressing
+independent of runtime config. The **served** `ETag` header is a different,
+per-request value: `router.py` hashes the full response body actually
+returned (`{**bundle.document, "limits": _limits_payload()}`, live env-var
+values included) via that same `compute_etag()` helper. This distinction
+closes an adversarial-review finding in this issue's own review: an earlier
+draft hashed only `bundle.document` and appended live `limits` outside the
+hash, so a `maxRecordsPerBatch`/`maxBodyBytes` change (env var) could return
+a `304 Not Modified` for a response whose body had actually changed — an
+incorrect HTTP validator for the representation served. Hashing the whole
+body per request is cheap (a few KB, no re-reflection — `bundle.document` is
+still cache-built once) and keeps `If-None-Match` correct for the entire
+representation, not just the versioned-schema portion of it.
+
+`GET /schemas/{schema_version}` sets `ETag` and `Cache-Control: public,
+max-age=3600, must-revalidate`; a matching `If-None-Match` request returns
+`304` with only the `ETag` header (no body).
+
+No new caching middleware is added — no generic ETag/Cache-Control handling
+existed anywhere in the app before this issue, and schemas are the first
+genuinely cacheable, static-per-deploy REST resource; a narrow, local
+implementation in the two `GET /schemas*` handlers avoids scope-creeping a
+decision for every other route.
+
+## Decision 4: Discovery endpoints stay public; rate-limited against anonymous DoS by IP, never by an unvalidated bearer token
+
+Per CHAOS-2691's D2 (unchanged by this issue): `GET /schemas` and `GET
+/schemas/{schema_version}` are not gated behind `require_ingest_scope`.
+`schema:read` is reserved for a future per-org-customization state and is a
+no-op scope for these two routes. Both routes keep CHAOS-2691's
+`INGEST_READ_LIMIT` (`120/minute`) — public + ETag'd is still a
+registry-render per request, a cheap anonymous DoS surface without a
+limiter.
+
+They do **not**, however, reuse `rate_limit.get_ingest_token_key` as their
+limiter key function — a second adversarial-review finding in this issue's
+own review. `get_ingest_token_key` hashes any `Authorization: Bearer <value>`
+header into its own limiter bucket, which is the *correct* behavior for
+`POST /batches`/`POST /validate` once a bearer value has been checked against
+a real credential (CHAOS-2696/2712): distinct valid tokens should not share
+one global bucket. But `GET /schemas*` never validates the bearer value at
+all (that's the whole point of D2 — no auth dependency runs) — so keying on
+an unvalidated header lets a caller mint a fresh 120/minute allowance on
+every request just by rotating a random string, defeating the limiter
+entirely. `router.py` instead defines `_schema_discovery_rate_limit_key`, a
+small IP-only key function (`rate_limit.get_forwarded_ip`) scoped to just
+these two routes — the only identity that actually exists for an
+unauthenticated request. `POST /batches`/`POST /validate` are unaffected and
+keep `get_ingest_token_key`.
+
+## Decision 5: Static export checked into `docs/api/external-ingest/v1/`, enforced by a no-drift pytest
+
+`export_schemas.py` (`python3 -m
+dev_health_ops.api.external_ingest.export_schemas --out <path>`) mirrors
+`api/graphql/export_schema.py`'s shape (argparse, `--out`, stdout fallback)
+and serializes the same `schema_registry.get_bundle(...).document` used by
+the live endpoint (`json.dumps(..., indent=2, sort_keys=True)`), so the
+committed `docs/api/external-ingest/v1/schema.json` and the live response
+can never structurally diverge except by an unstaged regeneration.
+`tests/api/external_ingest/test_schema_export_no_drift.py` fails the gate
+(not a new CI workflow — the existing unit-test tier already runs it) if the
+committed file doesn't byte-match a fresh export, with a message telling the
+implementer the exact regeneration command.
+
+Rationale for checking in a static artifact instead of "customers just call
+the live endpoint": (a) customers/CI can vendor the file into their own repo
+for offline `ajv`/`jsonschema` validation without a live FullChaos
+dependency, (b) docs get a stable linkable artifact
+(`docs/examples/external-ingest/` in CHAOS-2701 links to it), (c) the
+no-drift test is cheap insurance against silent registry/docs skew at PR
+time, since generation is deterministic and fast.
+
+One deliberate deviation from the GraphQL precedent: `export_schemas.py`'s
+`main()` runs under `if __name__ == "__main__":` rather than unconditionally
+at module scope, so the no-drift test can `import render_schema_json`
+without argparse consuming pytest's own argv.
+
+## Decision 6: Canonical examples live under `api/external_ingest/examples/`, one JSON file per kind
+
+`api/external_ingest/examples/<kind>.json` (e.g. `commit.v1.json`) holds one
+realistic **payload-shaped** example per record kind — not a full
+`RecordEnvelope` wrapper — loaded via `importlib.resources` (so it works
+once packaged as a wheel, not just in a source checkout) and attached to
+each `recordKinds` entry's `"examples"` array in both the live bundle and
+the static export. This is CC18's single canonical fixture home for the
+whole epic: CHAOS-2700's `dev-hops push sample --kind` calls
+`schema_registry.load_example(kind)` directly rather than duplicating
+payloads; CHAOS-2701 copies these files to
+`docs/examples/external-ingest/` under its own byte-identity drift test;
+CHAOS-2702's e2e valid fixtures assert equality against this same package
+directory.
+
+## Decision 7: Post-generation tightening of two server-enforced literals (`schemaVersion`, `kind`)
+
+A second adversarial-review round found that `BatchEnvelope.schema_version`
+and `RecordEnvelope.kind` are typed as bare `str` in `schemas.py` (not
+`Literal`) — deliberately, so `POST /batches` can 400 with a precise
+`unsupported_schema_version`/`unknown_record_kind` message rather than
+FastAPI's generic 422 for a bad enum value. The side effect: the naively
+generated schema for those two fields was just `{"type": "string"}`, so a
+customer's offline validator could certify a batch with
+`schemaVersion: "external-ingest.v99"` or an invented `kind` that the live
+server actually rejects — the opposite of what a schema-discovery endpoint
+is for.
+
+`schema_registry._tighten_server_enforced_literals()` closes this by adding
+`const: SUPPORTED_SCHEMA_VERSIONS[0]` (or `enum` if a second version is ever
+added) to `$defs.BatchEnvelope.properties.schemaVersion`, and
+`enum: sorted(RECORD_KIND_MODELS)` to
+`$defs.RecordEnvelope.properties.kind`, as a post-processing step on the
+`models_json_schema()` output — **not** by hand-writing a schema (D5) or
+adding a `Literal` to the frozen `schemas.py` model (CC17, out of this
+issue's ownership). The values used are the same `SUPPORTED_SCHEMA_VERSIONS`
+tuple and `RECORD_KIND_MODELS` keys the registry already treats as its
+source of truth elsewhere (`list_versions()`, `iter_record_kinds()`), so
+this can't drift from the rest of the bundle. Regression tests
+(`test_schema_version_field_is_pinned_to_supported_versions`,
+`test_kind_field_is_pinned_to_known_record_kinds`) lock in the constraint.
+
+This is a narrower, lower-risk fix than the still-open Decision-6/Consequences
+gap below (`records[].payload` not being tied to `kind`): `schemaVersion`
+and `kind` are each a single scalar field with one server-enforced value
+set, so a `const`/`enum` addition is a faithful, mechanical tightening. Fully
+closing the payload-vs-kind gap would require a hand-built `oneOf`
+discriminated union the registry does not attempt, per Decision 6's
+rationale.
+
+## Consequences
+
+- Adding a 10th record kind or an `external-ingest.v2` envelope is additive:
+  extend `RECORD_KIND_MODELS`/`SUPPORTED_SCHEMA_VERSIONS` and drop in an
+  example file — no hand-written JSON Schema to keep in sync.
+- The registry has zero database/network dependency (pure Pydantic
+  reflection + packaged JSON files), so none of this issue's tests need a
+  `clickhouse`/`postgres` marker.
+- Validating a whole batch against just the top-level `envelope` ref cannot
+  catch a kind-specific violation (e.g. a `commit.v1` record with an empty
+  payload) — `RecordEnvelope.payload` is a bare, unconstrained object in
+  `schemas.py` (payload/kind are tied together only in Python validation
+  code — `router.py`'s kind allowlist and `validate.py` — not in the wire
+  model itself, and that model is frozen/owned by CHAOS-2691, not
+  redeclarable here per CC17). This is a real, deliberate fidelity gap
+  (adversarial-review finding), not a silent one: the bundle's top-level
+  `description` states it explicitly, and
+  `tests/api/external_ingest/test_schema_registry.py::
+  test_envelope_level_payload_is_documented_as_kind_unconstrained` locks it
+  in. Customers/CI needing kind-accurate validation must validate each
+  record's payload against `recordKinds[kind].$ref` (the documented,
+  D9-intended usage — `GET /schemas/{version}` deliberately returns per-kind
+  `$ref`s for exactly this reason), not the envelope alone.

--- a/src/dev_health_ops/api/external_ingest/examples/commit.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/commit.v1.json
@@ -1,0 +1,12 @@
+{
+  "repositoryExternalId": "acme/api",
+  "hash": "9fceb02d0ae598e95dc970b74767f19372d61af8",
+  "message": "fix: resolve login redirect loop",
+  "authorName": "Alice Doe",
+  "authorEmail": "alice@acme.example",
+  "authorWhen": "2026-06-21T09:55:00Z",
+  "committerName": "Alice Doe",
+  "committerEmail": "alice@acme.example",
+  "committerWhen": "2026-06-21T09:55:00Z",
+  "parents": 1
+}

--- a/src/dev_health_ops/api/external_ingest/examples/identity.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/identity.v1.json
@@ -1,0 +1,9 @@
+{
+  "canonicalId": "acme-user-42",
+  "displayName": "Alice Doe",
+  "email": "alice@acme.example",
+  "providerIdentities": {"github": ["alicedoe"], "jira": ["alice.doe"]},
+  "teamIds": ["team-platform"],
+  "isActive": true,
+  "updatedAt": "2026-06-25T00:00:00Z"
+}

--- a/src/dev_health_ops/api/external_ingest/examples/pull_request.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/pull_request.v1.json
@@ -1,0 +1,18 @@
+{
+  "repositoryExternalId": "acme/api",
+  "number": 482,
+  "title": "Fix login redirect loop",
+  "state": "merged",
+  "authorName": "Alice Doe",
+  "authorEmail": "alice@acme.example",
+  "createdAt": "2026-06-21T10:00:00Z",
+  "mergedAt": "2026-06-22T15:30:00Z",
+  "headBranch": "fix/login-redirect",
+  "baseBranch": "main",
+  "additions": 42,
+  "deletions": 10,
+  "changedFiles": 3,
+  "reviewsCount": 2,
+  "commentsCount": 4,
+  "url": "https://github.com/acme/api/pull/482"
+}

--- a/src/dev_health_ops/api/external_ingest/examples/repository.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/repository.v1.json
@@ -1,0 +1,7 @@
+{
+  "externalId": "acme/api",
+  "sourceSystem": "github",
+  "defaultRef": "main",
+  "tags": ["backend", "core"],
+  "settings": {"visibility": "private"}
+}

--- a/src/dev_health_ops/api/external_ingest/examples/review.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/review.v1.json
@@ -1,0 +1,8 @@
+{
+  "repositoryExternalId": "acme/api",
+  "pullRequestNumber": 482,
+  "reviewId": "rev-9001",
+  "reviewer": "bob@acme.example",
+  "state": "APPROVED",
+  "submittedAt": "2026-06-22T14:00:00Z"
+}

--- a/src/dev_health_ops/api/external_ingest/examples/team.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/team.v1.json
@@ -1,0 +1,11 @@
+{
+  "id": "team-platform",
+  "name": "Platform",
+  "description": "Core platform engineering team",
+  "members": ["acme-user-42"],
+  "projectKeys": ["ABC"],
+  "repoPatterns": ["acme/*"],
+  "isActive": true,
+  "updatedAt": "2026-06-25T00:00:00Z",
+  "nativeTeamKey": "PLAT"
+}

--- a/src/dev_health_ops/api/external_ingest/examples/work_item.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/work_item.v1.json
@@ -1,0 +1,20 @@
+{
+  "externalKey": "ABC-123",
+  "provider": "jira",
+  "title": "Fix login redirect loop",
+  "type": "bug",
+  "status": "in_progress",
+  "statusRaw": "In Progress",
+  "description": "Users are redirected in a loop after SSO login.",
+  "projectKey": "ABC",
+  "projectName": "Acme Platform",
+  "assignees": ["alice@acme.example"],
+  "reporter": "bob@acme.example",
+  "createdAt": "2026-06-20T14:00:00Z",
+  "updatedAt": "2026-06-25T09:30:00Z",
+  "startedAt": "2026-06-21T09:00:00Z",
+  "labels": ["bug", "auth"],
+  "storyPoints": 3,
+  "priorityRaw": "High",
+  "url": "https://acme.atlassian.net/browse/ABC-123"
+}

--- a/src/dev_health_ops/api/external_ingest/examples/work_item_dependency.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/work_item_dependency.v1.json
@@ -1,0 +1,6 @@
+{
+  "sourceExternalKey": "ABC-123",
+  "targetExternalKey": "ABC-124",
+  "relationshipType": "blocks",
+  "relationshipTypeRaw": "blocks"
+}

--- a/src/dev_health_ops/api/external_ingest/examples/work_item_transition.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/work_item_transition.v1.json
@@ -1,0 +1,10 @@
+{
+  "externalKey": "ABC-123",
+  "provider": "jira",
+  "occurredAt": "2026-06-21T09:00:00Z",
+  "fromStatus": "todo",
+  "toStatus": "in_progress",
+  "fromStatusRaw": "To Do",
+  "toStatusRaw": "In Progress",
+  "actor": "alice@acme.example"
+}

--- a/src/dev_health_ops/api/external_ingest/export_schemas.py
+++ b/src/dev_health_ops/api/external_ingest/export_schemas.py
@@ -1,0 +1,62 @@
+"""Export the external-ingest JSON Schema bundle as a static artifact.
+
+Usage:
+    python3 -m dev_health_ops.api.external_ingest.export_schemas [--out <path>]
+
+Mirrors ``api/graphql/export_schema.py``'s pattern (argparse, ``--out``,
+stdout fallback): lets customers/CI vendor a schema file for offline
+``ajv``/``jsonschema`` validation, gives docs a stable linkable artifact,
+and is compared byte-for-byte against the committed
+``docs/api/external-ingest/v1/schema.json`` by
+``tests/api/external_ingest/test_schema_export_no_drift.py`` at PR time
+(brief D7) — deliberately a pytest, not a new CI workflow.
+
+Deviation from the GraphQL precedent: ``main()`` runs under an
+``if __name__ == "__main__":`` guard rather than unconditionally at module
+scope, so ``render_schema_json`` can be imported (by the no-drift test)
+without triggering argparse against pytest's own argv.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+
+from .schema_registry import SUPPORTED_SCHEMA_VERSIONS, get_bundle
+
+DEFAULT_SCHEMA_VERSION = SUPPORTED_SCHEMA_VERSIONS[0]
+
+
+def render_schema_json(schema_version: str = DEFAULT_SCHEMA_VERSION) -> str:
+    bundle = get_bundle(schema_version)
+    if bundle is None:
+        raise KeyError(f"Unknown schema version: {schema_version!r}")
+    return json.dumps(bundle.document, indent=2, sort_keys=True) + "\n"
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Export the external-ingest JSON Schema bundle"
+    )
+    parser.add_argument(
+        "--out", metavar="PATH", help="Write JSON Schema to file instead of stdout"
+    )
+    parser.add_argument(
+        "--schema-version",
+        default=DEFAULT_SCHEMA_VERSION,
+        help=f"Schema version to export (default: {DEFAULT_SCHEMA_VERSION})",
+    )
+    args = parser.parse_args()
+
+    text = render_schema_json(args.schema_version)
+
+    if args.out:
+        with open(args.out, "w") as f:
+            f.write(text)
+    else:
+        sys.stdout.write(text)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/dev_health_ops/api/external_ingest/router.py
+++ b/src/dev_health_ops/api/external_ingest/router.py
@@ -5,9 +5,10 @@
 ``POST /validate`` and durably in the CHAOS-2697 worker, so a customer's
 momentary schema drift on a handful of records doesn't drop an entire batch
 (see docs/architecture/external-ingest-rest-contract.md). ``GET /schemas*``
-is a minimal, real implementation straight off the Pydantic models in
-``schemas.py`` (brief D8) — CHAOS-2692 layers a registry/examples/ETag on
-top without redeclaring these models.
+(CHAOS-2692) is generated from the same ``schemas.py`` Pydantic models via
+``schema_registry.py`` — a versioned bundle with ``$defs``, per-record-kind
+``$ref``s + examples, and an ETag; this module never redeclares those
+models. See docs/architecture/adr-005-external-ingest-schema-discovery.md.
 """
 
 from __future__ import annotations
@@ -16,13 +17,14 @@ import logging
 import os
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, Header, Request
+from fastapi import APIRouter, Depends, Header, Request, Response
 from pydantic import ValidationError
 
 from dev_health_ops.api.middleware.rate_limit import (
     INGEST_BATCH_LIMIT,
     INGEST_READ_LIMIT,
     INGEST_VALIDATE_LIMIT,
+    get_forwarded_ip,
     get_ingest_token_key,
     limiter,
 )
@@ -30,6 +32,7 @@ from dev_health_ops.external_ingest.validate import validate_records
 
 from .auth import IngestAuthContext, require_ingest_scope
 from .errors import ExternalIngestError
+from .schema_registry import compute_etag, get_bundle, list_versions
 from .schemas import (
     MAX_BODY_BYTES_DEFAULT,
     MAX_RECORDS_DEFAULT,
@@ -155,34 +158,67 @@ def _check_all_kinds_known_or_400(envelope: BatchEnvelope) -> None:
             )
 
 
+# Force schema generation (models_json_schema + example loading) to run at
+# import time, not lazily on a customer's first request — a bad example
+# fixture or a models_json_schema regression should fail app startup, not a
+# random GET (schema_registry D6).
+get_bundle(SCHEMA_VERSION)
+
+
+def _schema_discovery_rate_limit_key(request: Request) -> str:
+    """IP-only rate-limit key for the public GET /schemas* routes.
+
+    Deliberately does NOT reuse ``get_ingest_token_key``: that function
+    hashes any ``Authorization: Bearer <value>`` header into a distinct
+    limiter bucket, which is correct once a real bearer token is validated
+    (POST /batches, POST /validate) but wrong here — these two routes never
+    validate the bearer value at all (D2, public discovery), so a caller
+    could rotate an arbitrary string per request and get a fresh bucket
+    every time, defeating INGEST_READ_LIMIT (adversarial-review finding).
+    The forwarded IP is the only real identity available for an
+    unauthenticated route.
+    """
+    return f"ingest-ip:{get_forwarded_ip(request)}"
+
+
 @router.get("/schemas")
-@limiter.limit(INGEST_READ_LIMIT, key_func=get_ingest_token_key)
+@limiter.limit(INGEST_READ_LIMIT, key_func=_schema_discovery_rate_limit_key)
 async def list_schemas(request: Request) -> dict[str, object]:
     return {
-        "schemaVersions": [SCHEMA_VERSION],
+        "schemaVersions": [version["schemaVersion"] for version in list_versions()],
         "recordKinds": sorted(RECORD_KIND_MODELS),
         "limits": _limits_payload(),
     }
 
 
 @router.get("/schemas/{schema_version}")
-@limiter.limit(INGEST_READ_LIMIT, key_func=get_ingest_token_key)
-async def get_schema(schema_version: str, request: Request) -> dict[str, object]:
-    if schema_version != SCHEMA_VERSION:
+@limiter.limit(INGEST_READ_LIMIT, key_func=_schema_discovery_rate_limit_key)
+async def get_schema(
+    schema_version: str, request: Request, response: Response
+) -> dict[str, object]:
+    bundle = get_bundle(schema_version)
+    if bundle is None:
         raise ExternalIngestError(
             404,
             "unsupported_schema_version",
             f"Unknown schema version: {schema_version!r}",
         )
-    return {
-        "schemaVersion": SCHEMA_VERSION,
-        "envelope": BatchEnvelope.model_json_schema(by_alias=True),
-        "recordKinds": {
-            kind: model.model_json_schema(by_alias=True)
-            for kind, model in RECORD_KIND_MODELS.items()
-        },
-        "limits": _limits_payload(),
-    }
+
+    # ETag over the full served representation (schema + live limits), not
+    # just bundle.etag's schema-only hash — otherwise a limits change could
+    # be masked behind a 304 for a client holding the old ETag
+    # (adversarial-review finding; see schema_registry.compute_etag).
+    body = {**bundle.document, "limits": _limits_payload()}
+    etag = compute_etag(body)
+
+    if request.headers.get("if-none-match") == etag:
+        response.status_code = 304
+        response.headers["ETag"] = etag
+        return {}
+
+    response.headers["ETag"] = etag
+    response.headers["Cache-Control"] = "public, max-age=3600, must-revalidate"
+    return body
 
 
 @router.post("/validate", response_model=ValidationResponse)

--- a/src/dev_health_ops/api/external_ingest/schema_registry.py
+++ b/src/dev_health_ops/api/external_ingest/schema_registry.py
@@ -1,0 +1,181 @@
+"""Schema discovery registry for external-ingest (CHAOS-2692).
+
+Builds the versioned JSON Schema bundle documented by ``GET /schemas`` and
+``GET /schemas/{schema_version}`` once per process from CHAOS-2691's
+Pydantic models in ``schemas.py`` — the single source of truth (master-spec
+CC17). This module never redeclares or hand-writes a JSON Schema; it only
+generates one via ``pydantic.json_schema.models_json_schema()`` and wraps it
+with an ETag, a per-record-kind ``$ref`` index, and canonical examples
+(``examples/*.json``, CC18) for discovery/export/CLI consumers.
+
+See ``docs/architecture/adr-005-external-ingest-schema-discovery.md`` for
+the versioning/caching/static-export rationale.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+from pydantic import BaseModel
+from pydantic.json_schema import JsonSchemaMode, models_json_schema
+
+from . import schemas as s
+
+SUPPORTED_SCHEMA_VERSIONS: tuple[str, ...] = (s.SCHEMA_VERSION,)
+
+
+@dataclass(frozen=True)
+class SchemaBundle:
+    schema_version: str
+    document: dict[str, Any]  # full JSON Schema doc, incl. $defs — ETag'd
+    etag: str
+    record_kinds: tuple[str, ...]
+
+
+def compute_etag(document: dict[str, Any]) -> str:
+    """Quoted sha256 over the canonical (sorted, compact) JSON of ``document``.
+
+    Public so ``router.py`` can hash the *actual served representation*
+    (schema document + live ``limits``) per request for ``If-None-Match``
+    comparisons — not just the cached ``SchemaBundle.etag``, which only
+    covers the schema shape (adversarial-review finding: a 304 must be a
+    correct HTTP validator for the whole response body, not a subset of it,
+    or a client could cache stale ``limits`` under an unchanged ETag).
+    """
+    canonical = json.dumps(document, sort_keys=True, separators=(",", ":"))
+    digest = hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+    return f'"{digest}"'
+
+
+def _tighten_server_enforced_literals(definitions: dict[str, Any]) -> None:
+    """Add ``const``/``enum`` for two fields the server rejects on but whose
+    Pydantic type is a bare ``str`` (adversarial-review finding, round 2):
+    ``BatchEnvelope.schema_version`` and ``RecordEnvelope.kind`` are typed
+    ``str`` in ``schemas.py`` (not ``Literal``) so ``POST /batches`` can 400
+    with a precise ``unsupported_schema_version``/``unknown_record_kind``
+    message instead of FastAPI's generic 422 — but that means the
+    *generated* schema for those two fields was just ``{"type": "string"}``,
+    so a customer validating against it could certify a batch the server
+    actually rejects (e.g. ``schemaVersion: "external-ingest.v99"``).
+
+    This does not hand-write a schema (D5) or redeclare a model (CC17) — it
+    tightens two already-generated field schemas using data this registry
+    already owns (``SUPPORTED_SCHEMA_VERSIONS``, ``RECORD_KIND_MODELS``
+    keys), post-``models_json_schema()``, to match documented, tested server
+    behavior (``router.py``'s ``_check_schema_version_or_400`` /
+    ``_check_all_kinds_known_or_400``).
+    """
+    defs = definitions["$defs"]
+
+    schema_version_field = defs["BatchEnvelope"]["properties"]["schemaVersion"]
+    if len(SUPPORTED_SCHEMA_VERSIONS) == 1:
+        schema_version_field["const"] = SUPPORTED_SCHEMA_VERSIONS[0]
+    else:
+        schema_version_field["enum"] = list(SUPPORTED_SCHEMA_VERSIONS)
+
+    defs["RecordEnvelope"]["properties"]["kind"]["enum"] = sorted(s.RECORD_KIND_MODELS)
+
+
+def _load_example(kind: str) -> dict[str, Any]:
+    if kind not in s.RECORD_KIND_MODELS:
+        raise KeyError(f"Unknown record kind: {kind!r}")
+    data = (
+        resources.files("dev_health_ops.api.external_ingest.examples")
+        .joinpath(f"{kind}.json")
+        .read_text()
+    )
+    return json.loads(data)
+
+
+@lru_cache(maxsize=1)
+def _build_v1_bundle() -> SchemaBundle:
+    # models_json_schema (not per-model model_json_schema() stitched by
+    # hand) gives collision-free $defs across all models in one pass (D5) —
+    # verified against installed pydantic 2.13.4: default ref_template
+    # already produces "#/$defs/{model}" refs, so no override is needed.
+    mode: JsonSchemaMode = "validation"
+    models_and_modes: list[tuple[type[BaseModel], JsonSchemaMode]] = [
+        (s.BatchEnvelope, mode)
+    ] + [(model, mode) for model in s.RECORD_KIND_MODELS.values()]
+    refs, definitions = models_json_schema(models_and_modes)
+    _tighten_server_enforced_literals(definitions)
+
+    record_index: dict[str, Any] = {}
+    for kind, model in s.RECORD_KIND_MODELS.items():
+        ref = refs[(model, "validation")]
+        record_index[kind] = {**ref, "examples": [_load_example(kind)]}
+
+    document: dict[str, Any] = {
+        "$schema": "https://json-schema.org/draft/2020-12/schema",
+        "$id": (
+            "https://api.fullchaos.dev/api/v1/external-ingest/schemas/"
+            f"{s.SCHEMA_VERSION}"
+        ),
+        "schemaVersion": s.SCHEMA_VERSION,
+        "title": s.SCHEMA_VERSION,
+        "description": (
+            "FullChaos external customer-push ingestion contract, v1. "
+            "'envelope' validates batch shape only — records[].payload is "
+            "intentionally unconstrained there (see $defs.RecordEnvelope); "
+            "validate each record's payload against recordKinds[kind].$ref "
+            "for kind-specific field requirements (adversarial-review "
+            "finding: envelope-only validation can pass a payload the "
+            "server's POST /validate rejects)."
+        ),
+        "envelope": refs[(s.BatchEnvelope, "validation")],
+        "recordKinds": record_index,
+        **definitions,  # contributes "$defs": {...}
+    }
+
+    return SchemaBundle(
+        schema_version=s.SCHEMA_VERSION,
+        document=document,
+        # Structural ETag over the schema shape alone (stable across
+        # process restarts, independent of dict insertion order, D6) — the
+        # HTTP-served ETag used for If-None-Match is computed fresh per
+        # request in router.py over document + live limits (compute_etag()).
+        etag=compute_etag(document),
+        record_kinds=tuple(s.RECORD_KIND_MODELS),
+    )
+
+
+def get_bundle(schema_version: str) -> SchemaBundle | None:
+    if schema_version == s.SCHEMA_VERSION:
+        return _build_v1_bundle()
+    return None
+
+
+def list_versions() -> list[dict[str, Any]]:
+    bundle = _build_v1_bundle()
+    return [
+        {
+            "schemaVersion": bundle.schema_version,
+            "recordKinds": list(bundle.record_kinds),
+        }
+    ]
+
+
+def load_example(kind: str) -> dict[str, Any]:
+    """Public accessor for CHAOS-2700's ``dev-hops push sample --kind``."""
+    return _load_example(kind)
+
+
+def iter_record_kinds() -> list[tuple[str, type[BaseModel]]]:
+    """Public (kind, model) pairs — avoids importing the private dict."""
+    return list(s.RECORD_KIND_MODELS.items())
+
+
+__all__ = [
+    "SUPPORTED_SCHEMA_VERSIONS",
+    "SchemaBundle",
+    "compute_etag",
+    "get_bundle",
+    "list_versions",
+    "load_example",
+    "iter_record_kinds",
+]

--- a/tests/api/external_ingest/test_examples_validate.py
+++ b/tests/api/external_ingest/test_examples_validate.py
@@ -1,0 +1,28 @@
+"""Every canonical example validates against its record-kind model (CHAOS-2692).
+
+Directly satisfies the acceptance criterion "Examples pass validation" and
+automatically covers any record kind added later, since it's parametrized
+over the registry's ``iter_record_kinds()`` rather than a hardcoded list.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.api.external_ingest import schema_registry as registry
+
+_KIND_MODEL_PAIRS = registry.iter_record_kinds()
+
+
+@pytest.mark.parametrize(
+    "kind,model", _KIND_MODEL_PAIRS, ids=[kind for kind, _ in _KIND_MODEL_PAIRS]
+)
+def test_example_validates_against_its_model(kind, model):
+    example = registry.load_example(kind)
+
+    model.model_validate(example)  # raises on failure
+
+
+def test_every_record_kind_has_an_example():
+    for kind, _model in _KIND_MODEL_PAIRS:
+        assert registry.load_example(kind)

--- a/tests/api/external_ingest/test_schema_export_no_drift.py
+++ b/tests/api/external_ingest/test_schema_export_no_drift.py
@@ -1,0 +1,26 @@
+"""No-drift check: committed static export vs. a fresh in-memory render (CHAOS-2692).
+
+Imports the exact document-building/serialization function
+``export_schemas.py`` uses (does not shell out) — brief D7's no-drift test,
+run as part of the standing unit-test tier rather than a new CI workflow.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from dev_health_ops.api.external_ingest.export_schemas import render_schema_json
+
+_REPO_ROOT = Path(__file__).resolve().parents[3]
+_COMMITTED_PATH = _REPO_ROOT / "docs" / "api" / "external-ingest" / "v1" / "schema.json"
+
+
+def test_static_export_matches_committed_artifact():
+    generated = render_schema_json()
+    committed = _COMMITTED_PATH.read_text()
+
+    assert generated == committed, (
+        f"{_COMMITTED_PATH} is stale — run `python3 -m "
+        "dev_health_ops.api.external_ingest.export_schemas --out "
+        "docs/api/external-ingest/v1/schema.json` and commit the diff"
+    )

--- a/tests/api/external_ingest/test_schema_registry.py
+++ b/tests/api/external_ingest/test_schema_registry.py
@@ -1,0 +1,133 @@
+"""Unit tests for the schema discovery registry (CHAOS-2692).
+
+Pure-Python — the registry is computed from Pydantic classes plus packaged
+JSON fixtures, no ClickHouse/Postgres dependency (docs/superpowers/plans/
+2026-07-01-chaos-2690-implementation/briefs/brief-2692-schemas.md test
+plan).
+"""
+
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from dev_health_ops.api.external_ingest import schema_registry as registry
+from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION
+
+_ETAG_RE = re.compile(r'^"[0-9a-f]{64}"$')
+
+
+def test_get_bundle_returns_all_kinds_and_envelope_in_defs():
+    bundle = registry.get_bundle(SCHEMA_VERSION)
+
+    assert bundle is not None
+    assert bundle.schema_version == SCHEMA_VERSION
+    defs = bundle.document["$defs"]
+    assert "BatchEnvelope" in defs
+    for kind, model in registry.iter_record_kinds():
+        assert model.__name__ in defs, f"{kind} model missing from $defs"
+
+
+def test_get_bundle_unsupported_version_returns_none():
+    assert registry.get_bundle("external-ingest.v99") is None
+
+
+def test_list_versions_has_one_entry_with_all_nine_kinds_no_duplicates():
+    versions = registry.list_versions()
+
+    assert len(versions) == 1
+    entry = versions[0]
+    assert entry["schemaVersion"] == SCHEMA_VERSION
+    kinds = entry["recordKinds"]
+    assert len(kinds) == 9
+    assert len(set(kinds)) == len(kinds)
+
+
+def test_etag_is_stable_and_shaped_like_a_quoted_sha256():
+    bundle_a = registry.get_bundle(SCHEMA_VERSION)
+    bundle_b = registry.get_bundle(SCHEMA_VERSION)
+
+    assert bundle_a is not None
+    assert bundle_b is not None
+    assert bundle_a.etag == bundle_b.etag
+    assert _ETAG_RE.match(bundle_a.etag), bundle_a.etag
+
+
+def test_load_example_returns_dict_for_known_kind():
+    example = registry.load_example("commit.v1")
+
+    assert isinstance(example, dict)
+    assert example  # non-empty
+
+
+def test_load_example_unknown_kind_raises_key_error():
+    with pytest.raises(KeyError):
+        registry.load_example("nonexistent.v1")
+
+
+def test_envelope_level_payload_is_documented_as_kind_unconstrained():
+    # Adversarial-review finding: $defs.RecordEnvelope.payload is a bare
+    # object (no kind-conditional constraint is derivable from schemas.py's
+    # RecordEnvelope model — payload/kind are only tied together in Python
+    # validation code, not in the wire model). Validating a whole batch
+    # against just "envelope" can therefore pass a payload the server's
+    # POST /validate rejects; a customer must validate each record against
+    # recordKinds[kind].$ref instead. Lock in that this gap is documented in
+    # the bundle (not silently discoverable in prod), and that each
+    # record-kind schema DOES carry real field constraints (proving the
+    # per-record $ref workaround is actually meaningful).
+    bundle = registry.get_bundle(SCHEMA_VERSION)
+    assert bundle is not None
+
+    payload_schema = bundle.document["$defs"]["RecordEnvelope"]["properties"]["payload"]
+    assert "required" not in payload_schema  # unconstrained at envelope level
+    assert "recordKinds[kind]" in bundle.document["description"]
+
+    for _kind, model in registry.iter_record_kinds():
+        kind_schema = bundle.document["$defs"][model.__name__]
+        assert kind_schema.get("required"), (
+            f"{model.__name__} has no required fields — the per-record $ref "
+            "fidelity claim in the bundle description would be false"
+        )
+
+
+def test_schema_version_field_is_pinned_to_supported_versions():
+    # Adversarial-review finding (round 2): BatchEnvelope.schema_version is a
+    # bare `str` in the frozen schemas.py (the model can't be edited here to
+    # add a Literal — CC17), so the naive generated schema was just
+    # {"type": "string"} and a customer's offline validator would certify a
+    # batch with schemaVersion="external-ingest.v99" that the live server
+    # rejects with 400 unsupported_schema_version. The registry tightens
+    # this post-generation using SUPPORTED_SCHEMA_VERSIONS (data it already
+    # owns), not by hand-writing a schema.
+    bundle = registry.get_bundle(SCHEMA_VERSION)
+    assert bundle is not None
+
+    field = bundle.document["$defs"]["BatchEnvelope"]["properties"]["schemaVersion"]
+    assert field["const"] == SCHEMA_VERSION
+    assert "external-ingest.v99" != field["const"]
+
+
+def test_kind_field_is_pinned_to_known_record_kinds():
+    # Same fidelity gap as schema_version, for RecordEnvelope.kind: a
+    # customer validating a batch against just "envelope" should not be able
+    # to certify an unknown kind the server's unknown_record_kind 400 would
+    # reject.
+    bundle = registry.get_bundle(SCHEMA_VERSION)
+    assert bundle is not None
+
+    field = bundle.document["$defs"]["RecordEnvelope"]["properties"]["kind"]
+    expected = {kind for kind, _model in registry.iter_record_kinds()}
+    assert set(field["enum"]) == expected
+    assert "deployment.v1" not in field["enum"]
+
+
+def test_record_kind_entries_ref_into_defs_and_carry_one_example():
+    bundle = registry.get_bundle(SCHEMA_VERSION)
+
+    assert bundle is not None
+    for kind, model in registry.iter_record_kinds():
+        entry = bundle.document["recordKinds"][kind]
+        assert entry["$ref"] == f"#/$defs/{model.__name__}"
+        assert len(entry["examples"]) == 1

--- a/tests/api/external_ingest/test_schemas_api.py
+++ b/tests/api/external_ingest/test_schemas_api.py
@@ -1,0 +1,155 @@
+"""API tests for GET /schemas + GET /schemas/{schema_version} (CHAOS-2692).
+
+Uses the ASGITransport + AsyncClient pattern from
+tests/api/test_external_ingest_router.py / tests/test_ingest_api.py. These
+two routes take no auth dependency (D2) so, unlike that file's other tests,
+no dependency_overrides are needed here.
+"""
+
+from __future__ import annotations
+
+import importlib
+import re
+import sys
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.external_ingest.schemas import (
+    RECORD_KIND_MODELS,
+    SCHEMA_VERSION,
+)
+from dev_health_ops.api.main import app
+
+# See tests/api/test_external_ingest_router.py for why the module must be
+# force-loaded through sys.modules rather than imported via the package's
+# __init__ (which shadows the module name with the exported APIRouter).
+importlib.import_module("dev_health_ops.api.external_ingest.router")
+router_mod = sys.modules["dev_health_ops.api.external_ingest.router"]
+
+BASE = "/api/v1/external-ingest"
+_ETAG_RE = re.compile(r'^"[0-9a-f]{64}"$')
+
+
+@pytest_asyncio.fixture
+async def client():
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_list_schemas_no_auth_required(client):
+    resp = await client.get(f"{BASE}/schemas")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schemaVersions"] == [SCHEMA_VERSION]
+    assert body["recordKinds"] == sorted(RECORD_KIND_MODELS)
+    assert set(body["limits"]) == {"maxRecordsPerBatch", "maxBodyBytes"}
+
+
+@pytest.mark.asyncio
+async def test_get_schema_returns_bundled_json_schema_document(client):
+    resp = await client.get(f"{BASE}/schemas/{SCHEMA_VERSION}")
+
+    assert resp.status_code == 200
+    assert _ETAG_RE.match(resp.headers["etag"])
+    assert resp.headers["cache-control"] == "public, max-age=3600, must-revalidate"
+
+    body = resp.json()
+    assert body["schemaVersion"] == SCHEMA_VERSION
+    assert set(body["recordKinds"]) == set(RECORD_KIND_MODELS)
+    assert set(body["limits"]) == {"maxRecordsPerBatch", "maxBodyBytes"}
+
+    # recordKinds entries are $ref + examples into $defs (D5), not inlined
+    # per-kind schemas — resolve the $ref manually the way a customer's
+    # validator would.
+    commit_entry = body["recordKinds"]["commit.v1"]
+    assert commit_entry["$ref"] == "#/$defs/CommitV1"
+    assert len(commit_entry["examples"]) == 1
+    assert "properties" in body["$defs"]["CommitV1"]
+
+    assert body["envelope"] == {"$ref": "#/$defs/BatchEnvelope"}
+    assert "properties" in body["$defs"]["BatchEnvelope"]
+
+
+@pytest.mark.asyncio
+async def test_get_schema_etag_round_trip_returns_304(client):
+    first = await client.get(f"{BASE}/schemas/{SCHEMA_VERSION}")
+    etag = first.headers["etag"]
+
+    second = await client.get(
+        f"{BASE}/schemas/{SCHEMA_VERSION}", headers={"If-None-Match": etag}
+    )
+
+    assert second.status_code == 304
+    assert second.headers["etag"] == etag
+    assert second.content == b""
+
+
+@pytest.mark.asyncio
+async def test_get_schema_stale_if_none_match_returns_200(client):
+    resp = await client.get(
+        f"{BASE}/schemas/{SCHEMA_VERSION}",
+        headers={"If-None-Match": '"stale-etag-value"'},
+    )
+
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_get_schema_etag_changes_when_live_limits_change(client, monkeypatch):
+    # Adversarial-review regression: the served ETag must cover the full
+    # response body (schema + limits), not just the cached schema document —
+    # otherwise a client holding a stale ETag could get a 304 for a response
+    # whose limits actually changed.
+    first = await client.get(f"{BASE}/schemas/{SCHEMA_VERSION}")
+    etag = first.headers["etag"]
+    assert first.json()["limits"]["maxRecordsPerBatch"] != 7
+
+    monkeypatch.setenv("EXTERNAL_INGEST_MAX_RECORDS", "7")
+    second = await client.get(
+        f"{BASE}/schemas/{SCHEMA_VERSION}", headers={"If-None-Match": etag}
+    )
+
+    assert second.status_code == 200
+    assert second.json()["limits"]["maxRecordsPerBatch"] == 7
+    assert second.headers["etag"] != etag
+
+
+def test_schema_discovery_rate_limit_key_ignores_arbitrary_bearer_tokens():
+    # Adversarial-review regression: an unauthenticated caller must not be
+    # able to mint a fresh rate-limit bucket per request by rotating a
+    # bearer value the route never validates (D2, public discovery).
+    class _FakeRequest:
+        def __init__(self, headers):
+            self.headers = headers
+            self.client = None
+
+    no_auth = _FakeRequest({})
+    bearer_a = _FakeRequest({"authorization": "Bearer aaaaaaaaaaaaaaaa"})
+    bearer_b = _FakeRequest({"authorization": "Bearer bbbbbbbbbbbbbbbb"})
+
+    key_no_auth = router_mod._schema_discovery_rate_limit_key(no_auth)
+    key_bearer_a = router_mod._schema_discovery_rate_limit_key(bearer_a)
+    key_bearer_b = router_mod._schema_discovery_rate_limit_key(bearer_b)
+
+    assert key_no_auth == key_bearer_a == key_bearer_b
+    assert key_no_auth.startswith("ingest-ip:")
+
+
+@pytest.mark.asyncio
+async def test_get_schema_unknown_version_returns_404(client):
+    resp = await client.get(f"{BASE}/schemas/external-ingest.v99")
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "unsupported_schema_version"
+
+
+def test_schemas_routes_appear_in_openapi_schema():
+    paths = app.openapi()["paths"]
+
+    assert f"{BASE}/schemas" in paths
+    assert f"{BASE}/schemas/{{schema_version}}" in paths

--- a/tests/api/test_external_ingest_router.py
+++ b/tests/api/test_external_ingest_router.py
@@ -413,9 +413,14 @@ async def test_get_schema_returns_json_schema_per_kind(client):
     body = resp.json()
     assert body["schemaVersion"] == SCHEMA_VERSION
     assert set(body["recordKinds"]) == set(RECORD_KIND_MODELS)
+    # CHAOS-2692: recordKinds/envelope are $ref-indexed into $defs (built via
+    # pydantic's models_json_schema), not full inlined per-kind schemas — see
+    # tests/api/external_ingest/test_schemas_api.py for the full contract
+    # (ETag, examples, 304 round-trip).
     commit_schema = body["recordKinds"]["commit.v1"]
-    assert "properties" in commit_schema
-    assert "properties" in body["envelope"]
+    assert commit_schema["$ref"].startswith("#/$defs/")
+    assert "properties" in body["$defs"][commit_schema["$ref"].rsplit("/", 1)[-1]]
+    assert body["envelope"]["$ref"].startswith("#/$defs/")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Implements CHAOS-2692 (wave 2 of the CHAOS-2690 external customer-push ingestion epic): schema discovery and JSON Schema export for the frozen `external-ingest.v1` wire contract shipped by CHAOS-2691.

- **`schema_registry.py`**: builds a versioned JSON Schema bundle from CHAOS-2691's Pydantic models (`BatchEnvelope` + the 9 `RECORD_KIND_MODELS`) via `pydantic.json_schema.models_json_schema()` — never hand-written, never redeclared (CC17/D5). One document with `envelope`/`recordKinds` `$ref`s into a collision-free `$defs`, computed once per process (`@lru_cache`) and forced eagerly at router import time so a bad example or generation regression fails app startup, not a customer's first request.
- **`router.py`**: reworks `GET /schemas` + `GET /schemas/{schema_version}` to serve the registry's bundle, with ETag (`sha256` over the full served representation, not just the schema shape) and `If-None-Match` → `304`. Both routes stay public (D2) and rate-limited (`INGEST_READ_LIMIT`).
- **`examples/*.json`**: one canonical, realistic payload example per record kind — the epic's single fixture home (CC18), loaded via `importlib.resources`, attached to each `recordKinds` entry.
- **`export_schemas.py`**: static export mirroring `graphql/export_schema.py`'s pattern, checked into `docs/api/external-ingest/v1/schema.json`, enforced by a no-drift pytest.
- **`docs/architecture/adr-005-external-ingest-schema-discovery.md`**: records the versioning/caching/static-export decisions, including two adversarial-review rounds' findings and fixes (below).
- 21 new/updated tests across `tests/api/external_ingest/` + targeted updates to `tests/api/test_external_ingest_router.py` (schema response shape changed from inlined per-kind schemas to `$ref`-indexed).

## Adversarial review findings (2 rounds, all resolved)

1. **[HIGH]** `GET /schemas*`'s rate-limit key reused `get_ingest_token_key`, which hashes any `Authorization: Bearer <value>` header into its own bucket — but these routes never validate that header (public by design), so a caller could rotate a random bearer string per request to bypass `INGEST_READ_LIMIT` entirely. **Fixed**: a local IP-only key function scoped to just these two routes (no edit to `middleware/rate_limit.py`).
2. **[MEDIUM]** ETag was hashed over the schema document only; the dynamic `limits` field was appended outside the hash, so a `maxRecordsPerBatch`/`maxBodyBytes` env change could return a stale `304`. **Fixed**: the served ETag is now computed per-request over the full response body.
3. **[MEDIUM]** The exported envelope schema doesn't tie `records[].payload` to `kind` (that link is Python-only, in the frozen `RecordEnvelope` model) — a customer could validate a full batch against `envelope` alone and pass a payload the server's `/validate` rejects. **Addressed** via explicit documentation in the bundle's `description` + a locking regression test, per master-spec D9's already-scoped per-record-`$ref` validation path (a hand-rolled `oneOf`-by-kind schema would violate D5).
4. **[MEDIUM, round 2]** `schemaVersion`/`kind` are typed `str` (not `Literal`) in the frozen model, so the naive generated schema didn't constrain them — a customer could certify `schemaVersion: "external-ingest.v99"` or an unknown `kind` that the server rejects. **Fixed**: post-generation `const`/`enum` tightening in the registry, sourced from data it already owns (`SUPPORTED_SCHEMA_VERSIONS`, `RECORD_KIND_MODELS`), not hand-writing a schema.

## Test plan

- [x] `env -i ... SCRATCH_DB=ci_local_validate_2692 bash ci/local_validate.sh` — GATE PASSED (ruff format/check, mypy, full unit suite 6343 passed/44 skipped, live-ClickHouse argMax proof)
- [x] Codex adversarial review — 2 rounds, all findings resolved (see above)
- [x] Live verification (`uvicorn` on `127.0.0.1:8692`):
  - `GET /schemas` lists `external-ingest.v1` + all 9 record kinds + limits
  - `GET /schemas/external-ingest.v1` returns the bundled document with correct `ETag`/`Cache-Control` headers
  - `If-None-Match` round-trip → `304`; stale/unknown version → `404`
  - Restarting with a different `EXTERNAL_INGEST_MAX_RECORDS` confirms a stale client ETag no longer 304s (round-1 fix verified live)
  - Independent `jsonschema` validator (ephemeral install, not committed) cross-checked against `POST /validate`: all 9 examples validate; a known-bad `commit.v1` payload is rejected by both the per-kind `$ref` schema and `/validate` with matching diagnosis; an unsupported `schemaVersion`/unknown `kind` at the envelope level is now rejected by the independent validator (round-2 fix verified live)