### PR TITLE
feat(providers): instrument LaunchDarkly actuals via canonical client (CHAOS-2761)

### DIFF
--- a/docs/architecture/launchdarkly-sync-budgeting.md
+++ b/docs/architecture/launchdarkly-sync-budgeting.md
@@ -2,9 +2,9 @@
 
 > See also: [Provider Rate-Limit Policy](../providers/rate-limit-policy.md) for
 > LaunchDarkly's quota dimensions, headers (`X-RateLimit-Route-Remaining`,
-> `Retry-After`), retry/deferral semantics, the frozen-connector caveat, and how
-> LD route families fit the cross-provider rate-limit and
-> credentials-are-not-capacity model.
+> `Retry-After`), retry/deferral semantics, the canonical-provider-migration
+> and actuals-instrumentation history, and how LD route families fit the
+> cross-provider rate-limit and credentials-are-not-capacity model.
 
 Status: implemented for CHAOS-2687 feature-flag sync budgeting. The
 `feature-flags` dataset now emits LaunchDarkly budget estimates through the
@@ -13,7 +13,7 @@ existing `SyncRunUnit` pipeline, and `estimate_provider_budget()` dispatches to
 
 ## Current provider status
 
-The canonical `src/dev_health_ops/providers/launchdarkly/` package is partial. It currently contains code-reference helpers, a code-reference client, and the LaunchDarkly budget estimator. Existing flag and audit-log fetches still live in the frozen legacy connector path and are called by the feature-flag worker through the `SyncRunUnit` dataset adapter path. Future provider work must move canonical raw fetch, pagination, retry, rate-limit handling, and normalization under `providers/launchdarkly/`; until then, do not add new code under `connectors/`.
+The canonical `src/dev_health_ops/providers/launchdarkly/` package is now complete for the `feature-flags` dataset (CHAOS-2761). It contains code-reference helpers, a code-reference client (`code_refs.py`), a flags/audit-log client (`client.py`, migrated off the frozen legacy connector), and the LaunchDarkly budget estimator (`budget.py`). All three currently-emitted route families (`flags`, `audit_log`, `code_refs`) record real per-request actuals through the shared CHAOS-2754 recorder, so LaunchDarkly units now produce a `budget_comparison`. The legacy connector (`connectors/launchdarkly.py`) is left in place, unused by the sync path, but still backs the admin credentials "test connection" endpoint (`api/admin/routers/credentials.py::_test_launchdarkly_connection`) — that path never flows through a `SyncRunUnit` or budget estimation, mirroring the same raw/legacy-client pattern already used there for Jira/Linear connectivity checks, so it carries no actuals-instrumentation gap. As with every canonical provider, do not add new code under `connectors/`.
 
 ## Estimator contract
 
@@ -71,9 +71,10 @@ CHAOS-2687 satisfies the budgeting gate for the existing `feature-flags` unit. B
 
 ## Follow-ups
 
-- Migrate the full LaunchDarkly provider off the frozen connector path.
 - Replace fixed request estimates with dynamic estimates driven by project, environment, flag, audit-log, and code-reference fanout.
 - Add GitLab feature-flag budgeting when GitLab feature-flag sync units are enabled.
+- Reserve budget for the `projects`, `segments`, and `members` route families once a client fetches them (currently modeled but not emitted or instrumented).
+- Feed the `X-RateLimit-Route-Remaining` low-budget warning into the deferral/cooldown machinery instead of only logging it (see [Provider Rate-Limit Policy — Known gaps](../providers/rate-limit-policy.md#known-gaps)).
 
 ## Initial operator defaults
 

--- a/docs/architecture/sync-usage-actuals.md
+++ b/docs/architecture/sync-usage-actuals.md
@@ -49,6 +49,7 @@ Drains emit two keys on `ProviderBatch.observations` / the unit-result
 | GitLab | REST | `GitLabProvider.ingest` **and** `metrics.work_items.fetch_gitlab_work_items` (the live worker path) |
 | Jira | REST | `JiraProvider.ingest` (legacy + atlassian paths) and the `job_work_items` client drain |
 | Linear | GraphQL | `LinearClient` per-POST counting (`X-RateLimit-Requests-*` capture) drained via `job_work_items` |
+| LaunchDarkly | REST | `_sync_launchdarkly_feature_flags` (CHAOS-2761): `LaunchDarklyClient` (flags, audit_log) + `LaunchDarklyCodeReferencesClient` (code_refs), both drained into `provider_usage` |
 
 Failure preservation: work-item clients are built per sync unit (unit-scoped,
 safe to instrument). `run_work_items_sync_job` accumulates observations
@@ -71,17 +72,23 @@ attribution would require richer operation labels at the client call sites.
 
 ## Out-of-scope actuals gaps (documented, not fixed here)
 
-1. **LaunchDarkly actuals.** LaunchDarkly flag/audit-log fetches still live in
-   the frozen `connectors/` path (see
-   [`launchdarkly-sync-budgeting.md`](launchdarkly-sync-budgeting.md)), which
-   forbids new code. No recorder is wired there. Actuals capture must wait for
-   the canonical-provider migration that moves LaunchDarkly raw fetch under
-   `providers/launchdarkly/`.
-2. **Code-dataset actuals.** The GitHub code datasets (`commits`, `files`,
-   `blame`, `cicd`, `tests`, `deployments`, `security`) run through
-   `processors/dataset_adapters._run_github_dataset`, which uses a shared/reused
-   store rather than an instrumented per-unit work client. Their budget families
-   (`git`, `commit_stats`, `files`, `blame`, `cicd`, `tests`, `deployments`,
-   `security`) are declared in the GitHub usage registry for coverage but carry
-   no operation markers. Instrumenting them needs a recorder threaded through
-   the dataset store and is deferred to a follow-up.
+1. **Code-dataset actuals.** The GitHub/GitLab code datasets (`commits`,
+   `files`, `blame`, `cicd`, `tests`, `deployments`, `security`) run through
+   `processors/dataset_adapters._run_github_dataset` / `_run_gitlab_dataset`,
+   which use a shared/reused store rather than an instrumented per-unit work
+   client — they still fetch through the frozen `connectors/github.py`
+   (PyGithub-based) / `connectors/gitlab.py` (python-gitlab-based) connectors.
+   Their budget families (`git`, `commit_stats`, `files`, `blame`, `cicd`,
+   `tests`, `deployments`, `security`) are declared in the GitHub/GitLab usage
+   registries for coverage but carry no operation markers. Instrumenting them
+   needs a canonical-provider migration off PyGithub/python-gitlab (much
+   larger than a follow-up-ticket-sized change — see [Provider Rate-Limit
+   Policy — Known gaps](../providers/rate-limit-policy.md#known-gaps)) and is
+   deferred to its own tracked effort.
+
+> **Resolved (CHAOS-2761):** LaunchDarkly flag/audit-log actuals — previously
+> gap #1 here, blocked on the frozen `connectors/launchdarkly.py` path — are
+> now instrumented. `flags`/`audit_log` moved to the canonical
+> `providers/launchdarkly/client.py::LaunchDarklyClient`, and the pre-existing
+> canonical `code_refs.py` client was wired to the same shared recorder. See
+> [LaunchDarkly sync budgeting](launchdarkly-sync-budgeting.md).

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -83,7 +83,8 @@ cooperating layers:
    | Jira client (JQL + enrichment) | 4 (`max_retries_429=3` → `+1` initial) | `providers/jira/client.py` |
    | Jira Atlassian REST compat | 5 (`RESTClient(max_retries=5)`) | `connectors/utils/rest.py` |
    | Linear | 5 (`DEFAULT_MAX_ATTEMPTS`) | `providers/linear/client.py` |
-   | LaunchDarkly | 5 (`max_retries=5`) | `connectors/launchdarkly.py` |
+   | LaunchDarkly (flags/audit_log) | 5 (`max_retries=5`) | `providers/launchdarkly/client.py` |
+   | LaunchDarkly (code_refs) | 5 (`max_retries=5`) | `providers/launchdarkly/code_refs.py` |
 
 2. **`RateLimitException` as the carrier.** When in-place retries are exhausted
    (or a 429/permission-vs-limit decision is made), the **canonical provider
@@ -173,7 +174,9 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
   `actual_requests`; the two are reported side by side, not blended into one
   number.
 - **A route_family/dimension with an estimate but no drained actuals this
-  run produces no row** (code datasets, an unwired LaunchDarkly family, …) —
+  run produces no row** (GitHub/GitLab code datasets still on the frozen
+  connector path, a `contents_blob`/`secondary_abuse_risk` dimension sharing
+  its single REST call with an already-recorded `rest_core` dimension, …) —
   never a fabricated 100% over-estimation.
 - **`unbudgeted_actual`** is the reverse case: actual traffic on a
   route_family/dimension with **no matching estimate at all**, including the
@@ -704,27 +707,46 @@ once beyond what DispatchGuard's concurrency cap already allows
   endpoint hard-caps pages at 20 entries. Code-reference reads carry a
   `secondary_abuse_risk` reservation in addition to `rest_core`.
 - **Headers.** `X-RateLimit-Route-Remaining` (per-route remaining budget) and
-  `Retry-After` on `429` (`connectors/launchdarkly.py`).
+  `Retry-After` on `429` (`providers/launchdarkly/client.py`,
+  `providers/launchdarkly/code_refs.py`).
 - **Retry semantics.** `429` and `5xx` are retried with exponential backoff
   (honoring `Retry-After`) up to `max_retries = 5`. On exhaustion the terminal
   type differs: a `429` raises `RateLimitException` (→ worker deferral) while a
-  `5xx` raises `APIException` (a normal failure, `connectors/launchdarkly.py`
-  `_raise_for_status`). A low `X-RateLimit-Route-Remaining` (< 5) is currently
-  only **logged as a warning**, not fed into the deferral/cooldown machinery —
-  see [Known gaps](#known-gaps).
+  `5xx` raises `APIException` (a normal failure, `providers/launchdarkly/
+  client.py` / `providers/launchdarkly/code_refs.py` `_raise_for_status`). A
+  low `X-RateLimit-Route-Remaining` (< 5) is currently only **logged as a
+  warning**, not fed into the deferral/cooldown machinery — see
+  [Known gaps](#known-gaps).
 - **Non-retryable auth cases.** `401` → `AuthenticationException`; `403` →
   `APIException` (forbidden). LaunchDarkly does **not** distinguish a
   permission-403 from a rate-limit case the way GitHub/GitLab do.
-- **Frozen path caveat.** Flag and audit-log fetches still live in the **frozen
-  legacy connector** (`connectors/launchdarkly.py`); only the code-reference
-  client, code-ref helpers, and the budget estimator are canonical under
-  `providers/launchdarkly/`. See
+- **Canonical provider migration complete (CHAOS-2761).** Flag and audit-log
+  fetches moved off the frozen legacy connector
+  (`connectors/launchdarkly.py`, left in place unused by the sync path — it
+  still backs the admin credentials "test connection" endpoint, which mirrors
+  the same raw/legacy-client pattern already used there for Jira/Linear
+  connectivity checks and carries no actuals-instrumentation gap) into
+  `providers/launchdarkly/client.py::LaunchDarklyClient`, mirroring the
+  request/retry semantics byte-for-byte (parity pinned by
+  `tests/test_rate_limit_signal.py::test_launchdarkly_403_is_authentication_error`).
+  Combined with the pre-existing canonical `providers/launchdarkly/code_refs.py`,
+  all of `providers/launchdarkly/` is now canonical. See
   [LaunchDarkly sync budgeting](../architecture/launchdarkly-sync-budgeting.md).
+- **Actuals instrumentation (CHAOS-2761).** All 3 currently-emitted route
+  families (`flags`, `audit_log`, `code_refs`) now record real per-request
+  counts through the shared CHAOS-2754 recorder
+  (`LAUNCHDARKLY_USAGE_RESOLVER` in `providers/launchdarkly/budget.py`), so
+  LaunchDarkly units produce a `budget_comparison` row like GitHub/GitLab/
+  Jira/Linear work-item units already did. `code_refs`' `secondary_abuse_risk`
+  reservation shares its single REST call with the `rest_core` reservation, so
+  only `rest_core` ever gets a live actual (same one-call/two-dimension shape
+  as GitHub's `commit_stats`/`files`/`blame` `contents_blob` entries).
 - **Documented vs. emitted families.** The estimator currently emits `flags`,
   `audit_log`, and `code_refs`. `projects`, `segments`, and `members` are
   **modeled route families** (`LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES` in
   `providers/launchdarkly/budget.py`) that the current `feature-flags` estimator
-  does not yet reserve; they are documented here for completeness.
+  does not yet reserve, and no client fetches yet; they are documented here for
+  completeness.
 
 #### Route families
 <!-- route-families:launchdarkly -->
@@ -760,11 +782,22 @@ paper over:
   `connectors.base.RateLimitException` (frozen legacy connectors) — and neither
   carries a normalized `route_family` / `dimension` / `reason` / `request_id`.
   (Target: [CHAOS-2753](https://linear.app/fullchaos/issue/CHAOS-2753).)
-- **Frozen `connectors/` path.** LaunchDarkly flag/audit-log fetches and several
-  GitHub/GitLab paths remain under the frozen `connectors/` tree. No new code may
-  be added there (see [`AGENTS.md`](../../AGENTS.md)); rate-limit/actuals
+- **Frozen `connectors/` path.** GitHub's `git`/`commit_stats`/`files`/`blame`/
+  `cicd`/`tests`/`deployments`/`security` route families and the equivalent
+  GitLab code-dataset paths remain under the frozen `connectors/` tree
+  (`connectors/github.py`'s PyGithub-based `GitHubConnector`, `connectors/
+  gitlab.py`'s python-gitlab-based `GitLabConnector`). No new code may be added
+  there (see [`AGENTS.md`](../../AGENTS.md)); rate-limit/actuals
   instrumentation for those datasets lands as the fetch moves to
-  `providers/<provider>/`.
+  `providers/github/` / `providers/gitlab/` — tracked as its own
+  canonical-provider-migration effort in
+  [CHAOS-XXXX](https://linear.app/fullchaos/issue/CHAOS-XXXX) (placeholder —
+  confirm issue number before merge), since it is a much larger migration
+  (~1400 lines per connector, off PyGithub/python-gitlab entirely) than a
+  follow-up-ticket-sized change. LaunchDarkly's equivalent gap (flag/audit-log
+  fetches on the frozen connector) was closed in
+  [CHAOS-2761](https://linear.app/fullchaos/issue/CHAOS-2761); see
+  [LaunchDarkly](#launchdarkly) above.
 
 ## Target contracts (CHAOS-2742)
 

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -791,11 +791,10 @@ paper over:
   instrumentation for those datasets lands as the fetch moves to
   `providers/github/` / `providers/gitlab/` — tracked as its own
   canonical-provider-migration effort in
-  [CHAOS-XXXX](https://linear.app/fullchaos/issue/CHAOS-XXXX) (placeholder —
-  confirm issue number before merge), since it is a much larger migration
-  (~1400 lines per connector, off PyGithub/python-gitlab entirely) than a
-  follow-up-ticket-sized change. LaunchDarkly's equivalent gap (flag/audit-log
-  fetches on the frozen connector) was closed in
+  [CHAOS-2773](https://linear.app/fullchaos/issue/CHAOS-2773), since it is a
+  much larger migration (~1400 lines per connector, off PyGithub/python-gitlab
+  entirely) than a follow-up-ticket-sized change. LaunchDarkly's equivalent
+  gap (flag/audit-log fetches on the frozen connector) was closed in
   [CHAOS-2761](https://linear.app/fullchaos/issue/CHAOS-2761); see
   [LaunchDarkly](#launchdarkly) above.
 

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -353,7 +353,7 @@ def _run_feature_flags_dataset(context: SyncTaskContext) -> dict[str, Any]:
             f"Unsupported feature-flags provider: provider={context.provider!r}"
         )
 
-    return {
+    dataset_result: dict[str, Any] = {
         "provider": context.provider,
         "dataset": context.dataset_key,
         "source": context.source_external_id,
@@ -365,6 +365,9 @@ def _run_feature_flags_dataset(context: SyncTaskContext) -> dict[str, Any]:
         if context.window_end is not None
         else None,
     }
+    if isinstance(result, dict) and isinstance(result.get("observations"), dict):
+        dataset_result["observations"] = result["observations"]
+    return dataset_result
 
 
 def run_dataset_unit(

--- a/src/dev_health_ops/providers/launchdarkly/__init__.py
+++ b/src/dev_health_ops/providers/launchdarkly/__init__.py
@@ -1,8 +1,12 @@
 from dev_health_ops.providers.launchdarkly.budget import (
     LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES,
     LAUNCHDARKLY_BUDGET_ROUTE_FAMILY_KEYS,
+    LAUNCHDARKLY_USAGE_RESOLVER,
+    LAUNCHDARKLY_USAGE_ROUTE_FAMILIES,
+    LAUNCHDARKLY_USAGE_ROUTE_FAMILY_KEYS,
     LaunchDarklyBudgetRouteFamily,
 )
+from dev_health_ops.providers.launchdarkly.client import LaunchDarklyClient
 from dev_health_ops.providers.launchdarkly.code_refs import (
     LD_CODE_REFERENCE_CONFIDENCE,
     LaunchDarklyCodeReference,
@@ -15,8 +19,12 @@ from dev_health_ops.providers.launchdarkly.code_refs import (
 __all__ = [
     "LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES",
     "LAUNCHDARKLY_BUDGET_ROUTE_FAMILY_KEYS",
+    "LAUNCHDARKLY_USAGE_RESOLVER",
+    "LAUNCHDARKLY_USAGE_ROUTE_FAMILIES",
+    "LAUNCHDARKLY_USAGE_ROUTE_FAMILY_KEYS",
     "LD_CODE_REFERENCE_CONFIDENCE",
     "LaunchDarklyBudgetRouteFamily",
+    "LaunchDarklyClient",
     "LaunchDarklyCodeReference",
     "LaunchDarklyCodeReferencesClient",
     "build_code_reference_links",

--- a/src/dev_health_ops/providers/launchdarkly/budget.py
+++ b/src/dev_health_ops/providers/launchdarkly/budget.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Mapping
 from dataclasses import dataclass
 from urllib.parse import urlparse
 
+from dev_health_ops.providers.usage import OperationResolver, UsageRouteFamily
 from dev_health_ops.sync.budget_types import (
     BudgetBucketKey,
     BudgetDimension,
@@ -234,3 +235,63 @@ def _safe_credential_scope(
     if base_url is not None:
         scope["base_url"] = base_url
     return scope
+
+
+# ---------------------------------------------------------------------------
+# Actuals recorder route-family registry (CHAOS-2754 / CHAOS-2761)
+# ---------------------------------------------------------------------------
+# Declares the full budget vocabulary the LaunchDarkly estimator(s) emit so
+# recorded actuals key by the same (route_family, dimension) an estimate is
+# keyed by. Unlike GitHub's registry, every family the *current*
+# feature-flags estimator emits (flags, audit_log, code_refs) now has a live,
+# instrumented call site: `providers/launchdarkly/client.py::LaunchDarklyClient`
+# (flags, audit_log) and `providers/launchdarkly/code_refs.py::
+# LaunchDarklyCodeReferencesClient` (code_refs) both record through this
+# resolver (CHAOS-2761 -- the "frozen connectors/ path" gap documented in
+# docs/providers/rate-limit-policy.md is closed for LaunchDarkly).
+#
+# `code_refs` reserves both `rest_core` and `secondary_abuse_risk` for the
+# SAME single REST call (see `LaunchDarklyBudgetEstimator.estimate` above); a
+# real REST response can only resolve to one dimension per the shared
+# resolver, so only the `rest_core` entry ever matches a live operation --
+# `secondary_abuse_risk` is declared with no markers purely for
+# estimator-coverage parity (mirrors GitHub's `commit_stats`/`files`/`blame`
+# `contents_blob` entries, which have the same one-call/two-dimension shape).
+#
+# `projects`, `segments`, and `members` are *modeled* route families
+# (`LAUNCHDARKLY_BUDGET_ROUTE_FAMILIES` above) the feature-flags estimator
+# does not yet reserve against and no client fetches yet; declared with no
+# markers so they never match a live operation, same as the estimator not
+# yet emitting them.
+LAUNCHDARKLY_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
+    UsageRouteFamily(
+        "flags",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("/flags/",),
+    ),
+    UsageRouteFamily(
+        "audit_log",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("/auditlog",),
+    ),
+    UsageRouteFamily(
+        "code_refs",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("/code-refs/",),
+    ),
+    UsageRouteFamily("code_refs", BudgetDimension.SECONDARY_ABUSE_RISK),
+    UsageRouteFamily("projects", BudgetDimension.REST_CORE),
+    UsageRouteFamily("segments", BudgetDimension.REST_CORE),
+    UsageRouteFamily("members", BudgetDimension.REST_CORE),
+)
+
+LAUNCHDARKLY_USAGE_ROUTE_FAMILY_KEYS = frozenset(
+    family.route_family for family in LAUNCHDARKLY_USAGE_ROUTE_FAMILIES
+)
+
+LAUNCHDARKLY_USAGE_RESOLVER = OperationResolver(
+    families=LAUNCHDARKLY_USAGE_ROUTE_FAMILIES,
+)

--- a/src/dev_health_ops/providers/launchdarkly/client.py
+++ b/src/dev_health_ops/providers/launchdarkly/client.py
@@ -1,0 +1,402 @@
+"""Canonical LaunchDarkly client for flags + audit-log fetches (CHAOS-2761).
+
+This is the ``providers/launchdarkly/`` migration target for the flag and
+audit-log fetch logic that historically lived in the frozen
+``connectors/launchdarkly.py`` (``LaunchDarklyConnector``). AGENTS.md bans new
+code under ``connectors/``, and actuals instrumentation requires a client that
+owns a ``UsageRecorder`` (CHAOS-2754) -- so this module ports the connector's
+request/retry/pagination logic verbatim (behavior parity: same retry
+semantics, same canonical ``dev_health_ops.exceptions.RateLimitException`` +
+``RateLimitSignal`` construction the legacy connector already used) and adds
+the recorder the frozen connector could never carry.
+
+``connectors/launchdarkly.py`` is left in place, unused by the sync path, but
+still imported by the admin credentials "test connection" endpoint
+(``api/admin/routers/credentials.py::_test_launchdarkly_connection``), which
+mirrors the same raw/legacy-client pattern already used there for Jira and
+Linear connectivity checks -- that path never flows through a sync unit or
+budget estimation, so it carries no actuals-instrumentation gap.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from dev_health_ops.api.utils.logging import sanitize_for_log
+from dev_health_ops.connectors.exceptions import (
+    APIException,
+    AuthenticationException,
+    RateLimitException,
+)
+from dev_health_ops.providers.usage import UsageRecorder
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
+
+logger = logging.getLogger(__name__)
+
+
+def _response_host(response: httpx.Response) -> str | None:
+    """Best-effort host for the responding LaunchDarkly instance."""
+    host = getattr(getattr(response, "url", None), "host", None)
+    return host if isinstance(host, str) and host else None
+
+
+_BASE_URL = "https://app.launchdarkly.com/api/v2"
+
+# LaunchDarkly hard-caps the audit-log `limit` at 20 entries per request; full
+# history is assembled by following the `_links.next` cursor across pages.
+_AUDIT_LOG_PAGE_SIZE = 20
+_API_V2_PREFIX = "/api/v2"
+
+# Response headers worth logging/recording to attribute a 429 or diagnose
+# throttling (never the token/Authorization header).
+_DIAGNOSTIC_HEADER_NAMES = (
+    "x-ratelimit-route-remaining",
+    "x-ratelimit-reset",
+    "retry-after",
+)
+
+
+def _diagnostic_headers(headers: object) -> dict[str, str]:
+    get_items = getattr(headers, "items", None)
+    if get_items is None:
+        return {}
+    lowered = {str(k).lower(): str(v) for k, v in get_items()}
+    return {name: lowered[name] for name in _DIAGNOSTIC_HEADER_NAMES if name in lowered}
+
+
+def _parse_rate_limit_remaining(response: httpx.Response) -> int | None:
+    """Extract remaining rate-limit budget from LD response headers."""
+    value = response.headers.get("X-RateLimit-Route-Remaining")
+    if value is None:
+        return None
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_retry_after(response: httpx.Response) -> float | None:
+    """Extract Retry-After seconds from a 429 response."""
+    value = response.headers.get("Retry-After")
+    if value is None:
+        return None
+    try:
+        return max(1.0, float(value))
+    except (TypeError, ValueError):
+        return None
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    """Translate HTTP error codes into connector exceptions.
+
+    Kept byte-for-byte in step with ``connectors.launchdarkly._raise_for_status``
+    and ``providers.launchdarkly.code_refs._raise_for_status`` (parity pinned by
+    ``tests/test_rate_limit_signal.py::test_launchdarkly_403_is_authentication_error``).
+    """
+    status = response.status_code
+    if status == 401:
+        raise AuthenticationException("LaunchDarkly authentication failed")
+    if status == 403:
+        # Permission/feature-disabled: non-retryable, matching the
+        # GitHub/GitLab convention where a permission 403 is an auth error
+        # rather than a retryable APIException.
+        raise AuthenticationException(f"LaunchDarkly forbidden: {response.text}")
+    if status == 429:
+        retry_after = _parse_retry_after(response)
+        raise RateLimitException(
+            "LaunchDarkly rate limit exceeded",
+            retry_after_seconds=retry_after,
+            signal=RateLimitSignal(
+                provider="launchdarkly",
+                host=_response_host(response),
+                dimension=BudgetDimension.REST_CORE,
+                retry_after_seconds=retry_after,
+                # LaunchDarkly reports its reset window as epoch MILLISECONDS.
+                reset_at=RateLimitSignal.reset_at_from_epoch_millis(
+                    response.headers.get("X-RateLimit-Reset")
+                ),
+                reason="primary",
+            ),
+        )
+    if status == 404:
+        raise APIException(f"LaunchDarkly resource not found: {response.url}")
+    if status >= 500:
+        raise APIException(f"LaunchDarkly server error: {status} - {response.text}")
+    if status >= 400:
+        raise APIException(f"LaunchDarkly API error: {status} - {response.text}")
+
+
+class LaunchDarklyClient:
+    """Async canonical client for the LaunchDarkly REST API v2 (flags + audit log).
+
+    :param api_key: LaunchDarkly API access token.
+    :param project_key: Default project key (can be overridden per call).
+    :param base_url: API base URL (override for testing / private instances).
+    :param timeout: Request timeout in seconds.
+    :param max_retries: Maximum retry attempts on 429 / 5xx errors.
+    """
+
+    def __init__(
+        self,
+        api_key: str,
+        project_key: str | None = None,
+        base_url: str = _BASE_URL,
+        timeout: int = 30,
+        max_retries: int = 5,
+    ) -> None:
+        self.api_key = api_key
+        self.default_project_key = project_key
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self._client: httpx.AsyncClient | None = None
+
+        # Deferred import mirrors providers/github/client.py + providers/jira/
+        # client.py: budget.py is the source of truth for the route-family
+        # vocabulary, imported lazily to avoid a module-load-order cycle.
+        from dev_health_ops.providers.launchdarkly.budget import (
+            LAUNCHDARKLY_USAGE_RESOLVER,
+        )
+
+        self._usage = UsageRecorder(resolver=LAUNCHDARKLY_USAGE_RESOLVER)
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers={
+                    "Authorization": self.api_key,
+                    "Content-Type": "application/json",
+                },
+                timeout=self.timeout,
+            )
+        return self._client
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        params: dict[str, Any] | None = None,
+    ) -> Any:
+        """Execute an HTTP request with retry on 429 / 5xx.
+
+        Every completed HTTP round trip -- including retried 429/5xx attempts
+        -- is recorded as one real request via ``_record_rest_usage`` (CHAOS-2754
+        contract: actuals are real request counts, never abstract units).
+        """
+        client = await self._get_client()
+        last_exc: Exception | None = None
+        delay = 1.0
+
+        for attempt in range(self.max_retries):
+            try:
+                response = await client.request(method, path, params=params)
+                self._record_rest_usage(
+                    f"{method} {path}",
+                    headers=response.headers,
+                    status=response.status_code,
+                )
+
+                remaining = _parse_rate_limit_remaining(response)
+                if remaining is not None and remaining < 5:
+                    logger.warning(
+                        "LaunchDarkly rate-limit budget low: %d remaining",
+                        remaining,
+                    )
+
+                if response.status_code == 429 or response.status_code >= 500:
+                    retry_after = _parse_retry_after(response) or delay
+                    if attempt < self.max_retries - 1:
+                        logger.warning(
+                            "LaunchDarkly %d on %s (attempt %d/%d), retrying in %.1fs",
+                            response.status_code,
+                            sanitize_for_log(path),
+                            attempt + 1,
+                            self.max_retries,
+                            retry_after,
+                        )
+                        await asyncio.sleep(retry_after)
+                        delay = min(delay * 2, 60.0)
+                        continue
+                    _raise_for_status(response)
+
+                _raise_for_status(response)
+                return response.json()
+
+            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                last_exc = exc
+                if attempt < self.max_retries - 1:
+                    logger.warning(
+                        "LaunchDarkly request to %s failed (attempt %d/%d): %s",
+                        sanitize_for_log(path),
+                        attempt + 1,
+                        self.max_retries,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 60.0)
+                    continue
+                raise APIException(f"LaunchDarkly request failed: {exc}") from exc
+
+        if last_exc:
+            raise APIException(
+                f"LaunchDarkly request failed after {self.max_retries} attempts"
+            ) from last_exc
+        raise APIException("LaunchDarkly request failed: unknown error")
+
+    # ------------------------------------------------------------------
+    # Usage recording (CHAOS-2754 / CHAOS-2761)
+    # ------------------------------------------------------------------
+
+    def _record_usage_observation(
+        self,
+        *,
+        transport: str,
+        operation: str,
+        headers: dict[str, str],
+        rate_limit: dict[str, Any],
+        status: int | None = None,
+    ) -> None:
+        # Aggregation/keying by route_family lives in the shared recorder
+        # (CHAOS-2754); this client only owns the header extraction below.
+        self._usage.record(
+            transport=transport,
+            operation=operation,
+            headers=headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
+
+    def _record_rest_usage(
+        self,
+        operation: str,
+        *,
+        headers: object | None = None,
+        status: int | None = None,
+    ) -> None:
+        safe_headers = _diagnostic_headers(headers or {})
+        rate_limit: dict[str, Any] = {}
+        remaining = safe_headers.get("x-ratelimit-route-remaining")
+        reset = safe_headers.get("x-ratelimit-reset")
+        retry_after = safe_headers.get("retry-after")
+        if remaining is not None:
+            rate_limit["remaining"] = remaining
+        if reset is not None:
+            rate_limit["reset"] = reset
+        if retry_after is not None:
+            rate_limit["retry_after"] = retry_after
+        self._record_usage_observation(
+            transport="rest",
+            operation=operation,
+            headers=safe_headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        return self._usage.drain()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def get_flags(self, project_key: str | None = None) -> list[dict]:
+        """Fetch all feature flags for a project, paginating through all pages.
+
+        :param project_key: LD project key; falls back to ``self.default_project_key``.
+        :returns: List of raw flag dicts from the LD API.
+        """
+        key = project_key or self.default_project_key
+        if not key:
+            raise ValueError(
+                "project_key is required (pass it or set default_project_key)"
+            )
+
+        all_items: list[dict] = []
+        offset = 0
+        limit = 50
+        while True:
+            data = await self._request(
+                "GET", f"/flags/{key}", params={"limit": limit, "offset": offset}
+            )
+            items = data.get("items", [])
+            all_items.extend(items)
+            total = data.get("totalCount", len(all_items))
+            if len(all_items) >= total or len(items) < limit:
+                break
+            offset += limit
+        logger.info(
+            "Fetched %d flags for project %s", len(all_items), sanitize_for_log(key)
+        )
+        return all_items
+
+    async def get_audit_log(
+        self,
+        since: datetime | None = None,
+        limit: int = 1000,
+    ) -> list[dict]:
+        """Fetch audit log entries, paginating to assemble full history.
+
+        LaunchDarkly caps the audit-log endpoint at 20 entries per request, so
+        this pages via the ``_links.next`` cursor until the log is exhausted or
+        ``limit`` total entries have been collected.
+
+        :param since: Only return entries occurring after this timestamp.
+        :param limit: Maximum total entries to return across all pages.
+        :returns: List of raw audit-log entry dicts.
+        """
+        max_total = max(0, int(limit))
+        if max_total == 0:
+            return []
+
+        params: dict[str, Any] = {"limit": _AUDIT_LOG_PAGE_SIZE}
+        if since is not None:
+            # LD expects epoch milliseconds for date filters.
+            params["after"] = int(since.timestamp() * 1000)
+
+        all_items: list[dict] = []
+        # Bound the page count defensively so a misbehaving cursor cannot loop
+        # forever; each page yields at most _AUDIT_LOG_PAGE_SIZE entries.
+        max_pages = max_total // _AUDIT_LOG_PAGE_SIZE + 2
+        data = await self._request("GET", "/auditlog", params=params)
+        for _ in range(max_pages):
+            items = data.get("items", [])
+            if not items:
+                break
+            all_items.extend(items)
+            if len(all_items) >= max_total:
+                break
+            href = ((data.get("_links") or {}).get("next") or {}).get("href")
+            if not href:
+                break
+            # base_url already includes /api/v2; strip that prefix so a relative
+            # next-href resolves against base_url without duplicating it.
+            if href.startswith("http"):
+                next_path = href
+            elif href.startswith(_API_V2_PREFIX):
+                next_path = href[len(_API_V2_PREFIX) :]
+            else:
+                next_path = href
+            data = await self._request("GET", next_path)
+
+        result = all_items[:max_total]
+        logger.info("Fetched %d audit log entries", len(result))
+        return result
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def __aenter__(self) -> LaunchDarklyClient:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()

--- a/src/dev_health_ops/providers/launchdarkly/code_refs.py
+++ b/src/dev_health_ops/providers/launchdarkly/code_refs.py
@@ -103,12 +103,19 @@ def _normalize_path(path: str, branch_name: str) -> str:
 
 
 def _raise_for_status(response: httpx.Response) -> None:
+    # Deferred import mirrors the budget-resolver imports below: avoids a
+    # module-load-order cycle with providers/launchdarkly/client.py (CHAOS-2761
+    # review finding -- share the canonical Retry-After parser instead of
+    # re-copying an unguarded `float(...)` that raises on an HTTP-date or
+    # malformed header, which would escape this function entirely and never
+    # produce a `RateLimitException` at all).
+    from dev_health_ops.providers.launchdarkly.client import _parse_retry_after
+
     status = response.status_code
     if status == 401:
         raise AuthenticationException("LaunchDarkly authentication failed")
     if status == 429:
-        retry_after_raw = response.headers.get("Retry-After")
-        retry_after = float(retry_after_raw) if retry_after_raw else None
+        retry_after = _parse_retry_after(response)
         raise RateLimitException(
             "LaunchDarkly rate limit exceeded",
             retry_after_seconds=retry_after,
@@ -182,6 +189,13 @@ class LaunchDarklyCodeReferencesClient:
         *,
         params: dict[str, Any] | None = None,
     ) -> Any:
+        # Shared with providers/launchdarkly/client.py (CHAOS-2761 review
+        # finding): a bare `float(retry_after)` raises ValueError on an
+        # HTTP-date or malformed Retry-After header, which would escape this
+        # retry loop entirely -- _parse_retry_after returns None instead, so
+        # the exponential-backoff `delay` fallback below always applies.
+        from dev_health_ops.providers.launchdarkly.client import _parse_retry_after
+
         client = await self._get_client()
         delay = 1.0
         last_exc: Exception | None = None
@@ -195,8 +209,7 @@ class LaunchDarklyCodeReferencesClient:
                 )
                 if response.status_code == 429 or response.status_code >= 500:
                     if attempt < self.max_retries - 1:
-                        retry_after = response.headers.get("Retry-After")
-                        wait_seconds = float(retry_after) if retry_after else delay
+                        wait_seconds = _parse_retry_after(response) or delay
                         logger.warning(
                             "LaunchDarkly %d on %s (attempt %d/%d), retrying in %.1fs",
                             response.status_code,

--- a/src/dev_health_ops/providers/launchdarkly/code_refs.py
+++ b/src/dev_health_ops/providers/launchdarkly/code_refs.py
@@ -17,6 +17,7 @@ from dev_health_ops.connectors.exceptions import (
     RateLimitException,
 )
 from dev_health_ops.metrics.schemas import FeatureFlagLinkRecord
+from dev_health_ops.providers.usage import UsageRecorder
 from dev_health_ops.sync.budget_types import BudgetDimension
 from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 from dev_health_ops.work_graph.ids import generate_feature_flag_id, generate_file_id
@@ -32,6 +33,21 @@ def _response_host(response: httpx.Response) -> str | None:
 
 _BASE_URL = "https://app.launchdarkly.com/api/v2"
 LD_CODE_REFERENCE_CONFIDENCE = 0.95
+
+# Response headers worth recording to diagnose throttling (never the token).
+_DIAGNOSTIC_HEADER_NAMES = (
+    "x-ratelimit-route-remaining",
+    "x-ratelimit-reset",
+    "retry-after",
+)
+
+
+def _diagnostic_headers(headers: object) -> dict[str, str]:
+    get_items = getattr(headers, "items", None)
+    if get_items is None:
+        return {}
+    lowered = {str(k).lower(): str(v) for k, v in get_items()}
+    return {name: lowered[name] for name in _DIAGNOSTIC_HEADER_NAMES if name in lowered}
 
 
 @dataclass(frozen=True)
@@ -141,6 +157,15 @@ class LaunchDarklyCodeReferencesClient:
         self.max_retries = max_retries
         self._client: httpx.AsyncClient | None = None
 
+        # Deferred import mirrors providers/github/client.py + providers/jira/
+        # client.py: budget.py is the source of truth for the route-family
+        # vocabulary, imported lazily to avoid a module-load-order cycle.
+        from dev_health_ops.providers.launchdarkly.budget import (
+            LAUNCHDARKLY_USAGE_RESOLVER,
+        )
+
+        self._usage = UsageRecorder(resolver=LAUNCHDARKLY_USAGE_RESOLVER)
+
     async def _get_client(self) -> httpx.AsyncClient:
         if self._client is None or self._client.is_closed:
             self._client = httpx.AsyncClient(
@@ -163,6 +188,11 @@ class LaunchDarklyCodeReferencesClient:
         for attempt in range(self.max_retries):
             try:
                 response = await client.request(method, path, params=params)
+                self._record_rest_usage(
+                    f"{method} {path}",
+                    headers=response.headers,
+                    status=response.status_code,
+                )
                 if response.status_code == 429 or response.status_code >= 500:
                     if attempt < self.max_retries - 1:
                         retry_after = response.headers.get("Retry-After")
@@ -190,6 +220,58 @@ class LaunchDarklyCodeReferencesClient:
                     f"LaunchDarkly code references request failed: {exc}"
                 ) from exc
         raise APIException("LaunchDarkly code references request failed") from last_exc
+
+    # ------------------------------------------------------------------
+    # Usage recording (CHAOS-2754 / CHAOS-2761)
+    # ------------------------------------------------------------------
+
+    def _record_usage_observation(
+        self,
+        *,
+        transport: str,
+        operation: str,
+        headers: dict[str, str],
+        rate_limit: dict[str, Any],
+        status: int | None = None,
+    ) -> None:
+        # Aggregation/keying by route_family lives in the shared recorder
+        # (CHAOS-2754); this client only owns the header extraction below.
+        self._usage.record(
+            transport=transport,
+            operation=operation,
+            headers=headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
+
+    def _record_rest_usage(
+        self,
+        operation: str,
+        *,
+        headers: object | None = None,
+        status: int | None = None,
+    ) -> None:
+        safe_headers = _diagnostic_headers(headers or {})
+        rate_limit: dict[str, Any] = {}
+        remaining = safe_headers.get("x-ratelimit-route-remaining")
+        reset = safe_headers.get("x-ratelimit-reset")
+        retry_after = safe_headers.get("retry-after")
+        if remaining is not None:
+            rate_limit["remaining"] = remaining
+        if reset is not None:
+            rate_limit["reset"] = reset
+        if retry_after is not None:
+            rate_limit["retry_after"] = retry_after
+        self._record_usage_observation(
+            transport="rest",
+            operation=operation,
+            headers=safe_headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        return self._usage.drain()
 
     async def list_default_branch_references(
         self,

--- a/src/dev_health_ops/workers/feature_flag_sync.py
+++ b/src/dev_health_ops/workers/feature_flag_sync.py
@@ -105,196 +105,214 @@ def _sync_launchdarkly_feature_flags(
     async def _run() -> dict[str, Any]:
         # Real per-request actuals drained through the shared CHAOS-2754
         # recorder for all 3 currently-emitted LaunchDarkly route families
-        # (flags, audit_log, code_refs) -- CHAOS-2761.
+        # (flags, audit_log, code_refs) -- CHAOS-2761. The whole body below is
+        # one big try/except (not just the fetch step) so a failure ANYWHERE
+        # downstream of the fetch -- code_refs, normalization, ClickHouse/
+        # WorkGraph writes -- still preserves whatever actuals were already
+        # recorded instead of silently dropping real request counts (review
+        # finding: the original narrow fetch-only try/except left every
+        # post-fetch failure path uncovered).
         provider_usage_observations: list[dict[str, Any]] = []
-
         connector: LaunchDarklyClient | None = None
+        code_refs_client: LaunchDarklyCodeReferencesClient | None = None
+
         try:
             async with LaunchDarklyClient(
                 api_key=api_key, project_key=project_key
             ) as connector:
                 raw_flags = await connector.get_flags(project_key)
                 raw_events = await connector.get_audit_log(since=since_dt, limit=1000)
+            provider_usage_observations.extend(drain_provider_usage(connector))
+
+            try:
+                async with LaunchDarklyCodeReferencesClient(
+                    api_key=api_key
+                ) as code_refs_client:
+                    raw_code_refs = (
+                        await code_refs_client.list_default_branch_references(
+                            project_key=project_key
+                        )
+                    )
+                code_references_error = None
+            except ConnectorException as exc:
+                logger.warning(
+                    "Skipping LaunchDarkly code references for project %s: %s",
+                    project_key,
+                    exc,
+                )
+                raw_code_refs = []
+                code_references_error = str(exc)
+            finally:
+                # Code references are best-effort (errors are swallowed
+                # above), but any requests that DID complete before the
+                # failure still count as real actuals -- drain regardless of
+                # outcome.
+                if code_refs_client is not None:
+                    provider_usage_observations.extend(
+                        drain_provider_usage(code_refs_client)
+                    )
+
+            flags = normalize_flags(raw_flags, org_id)
+            if environment:
+                flags = [
+                    flag.__class__(
+                        provider=flag.provider,
+                        flag_key=flag.flag_key,
+                        project_key=flag.project_key,
+                        repo_id=flag.repo_id,
+                        environment=environment,
+                        flag_type=flag.flag_type,
+                        created_at=flag.created_at,
+                        archived_at=flag.archived_at,
+                        last_synced=flag.last_synced,
+                        org_id=flag.org_id,
+                    )
+                    for flag in flags
+                ]
+            events = normalize_audit_events(raw_events, org_id)
+            if environment:
+                events = [
+                    event.__class__(
+                        event_type=event.event_type,
+                        flag_key=event.flag_key,
+                        environment=event.environment or environment,
+                        repo_id=event.repo_id,
+                        actor_type=event.actor_type,
+                        prev_state=event.prev_state,
+                        next_state=event.next_state,
+                        event_ts=event.event_ts,
+                        ingested_at=event.ingested_at,
+                        source_event_id=event.source_event_id,
+                        dedupe_key=event.dedupe_key,
+                        org_id=event.org_id,
+                    )
+                    for event in events
+                ]
+
+            sink = ClickHouseMetricsSink(db_url)
+            setattr(sink, "org_id", org_id)
+            builder = WorkGraphBuilder(BuildConfig(dsn=db_url, org_id=org_id))
+            try:
+                sink.write_feature_flags(flags)
+                sink.write_feature_flag_events(events)
+
+                repo_rows = sink.query_dicts(
+                    "SELECT id, repo FROM repos WHERE org_id = " + _ch_string(org_id),
+                    {},
+                )
+                repo_index = index_repo_rows(repo_rows)
+                repo_paths = {
+                    (str(repo_id), ref.file_path)
+                    for ref in raw_code_refs
+                    if (repo_id := resolve_repo_id(ref, repo_index)) is not None
+                }
+                pr_ids_by_repo_path = _load_pr_ids_by_repo_path(
+                    sink,
+                    org_id=org_id,
+                    repo_paths=repo_paths,
+                )
+                code_ref_links, code_ref_edges = build_code_reference_links(
+                    raw_code_refs,
+                    org_id=org_id,
+                    repo_index=repo_index,
+                    pr_ids_by_repo_path=pr_ids_by_repo_path,
+                )
+                sink.write_feature_flag_links(code_ref_links)
+                for edge in code_ref_edges:
+                    target_type = (
+                        NodeType.FILE if edge["target_type"] == "file" else NodeType.PR
+                    )
+                    builder.add_feature_flag_edge(
+                        flag_id=str(edge["flag_id"]),
+                        target_type=target_type,
+                        target_id=str(edge["target_id"]),
+                        edge_type=EdgeType.GUARDS,
+                        confidence=LD_CODE_REFERENCE_CONFIDENCE,
+                        evidence=str(edge["evidence"]),
+                        provenance=Provenance.NATIVE,
+                        repo_id=edge["repo_id"],
+                        provider="launchdarkly",
+                    )
+
+                latest_events: dict[str, Any] = {}
+                for event in events:
+                    existing = latest_events.get(event.flag_key)
+                    if existing is None or event.event_ts > existing.event_ts:
+                        latest_events[event.flag_key] = event
+
+                for flag in flags:
+                    builder.add_feature_flag_node(
+                        flag_key=flag.flag_key,
+                        provider=flag.provider,
+                        project_key=flag.project_key or project_key,
+                        repo_id=flag.repo_id,
+                        event_ts=flag.created_at,
+                    )
+                    latest_event = latest_events.get(flag.flag_key)
+                    if latest_event is None:
+                        continue
+                    flag_id = generate_feature_flag_id(
+                        org_id,
+                        flag.provider,
+                        flag.project_key or project_key,
+                        flag.flag_key,
+                    )
+                    builder.add_feature_flag_edge(
+                        flag_id=flag_id,
+                        target_type=NodeType.FEATURE_FLAG,
+                        target_id=flag_id,
+                        edge_type=EdgeType.CONFIG_CHANGED_BY,
+                        confidence=1.0,
+                        evidence=(
+                            f"{latest_event.event_ts.isoformat()}"
+                            f"|{latest_event.event_type}"
+                            f"|{latest_event.next_state or ''}"
+                        ),
+                        provenance=Provenance.NATIVE,
+                        provider=flag.provider,
+                        event_ts=latest_event.event_ts,
+                    )
+            finally:
+                builder.close()
+                sink.close()
+
+            result: dict[str, Any] = {
+                "flags_synced": len(flags),
+                "events_synced": len(events),
+                "code_references_synced": len(raw_code_refs),
+                "code_reference_links_synced": len(code_ref_links),
+                "code_reference_edges_synced": len(code_ref_edges),
+                "code_references_error": code_references_error,
+                "project_key": project_key,
+                "environment": environment or None,
+            }
+            if provider_usage_observations:
+                result["observations"] = {"provider_usage": provider_usage_observations}
+            return result
         except Exception as exc:
-            # Preserve actuals gathered before the raise (e.g. flags succeeded,
-            # audit_log then hit a rate limit) so the worker's deferral/failure
-            # stamp can still persist them (CHAOS-2754 contract, reused here
-            # verbatim -- `attach_work_item_partial_observations` is
-            # provider-neutral despite its name; `_merge_partial_observations_
-            # into_result` in workers/sync_units.py reads it regardless of
-            # dataset/provider).
+            # Preserve actuals gathered before the raise so the worker's
+            # deferral/failure stamp can still persist them (CHAOS-2754
+            # contract, reused here verbatim -- `attach_work_item_partial_
+            # observations` is provider-neutral despite its name;
+            # `_merge_partial_observations_into_result` in
+            # workers/sync_units.py reads it regardless of dataset/provider,
+            # and only ever ADDS an `observations` key -- it never touches
+            # `error_category` / `next_retry_at`). Draining an
+            # already-drained UsageRecorder is safe: `drain()` clears its
+            # internal state, so re-draining `connector` / `code_refs_client`
+            # here after an earlier successful drain returns `[]` and nothing
+            # is double-counted.
             if connector is not None:
                 provider_usage_observations.extend(drain_provider_usage(connector))
+            if code_refs_client is not None:
+                provider_usage_observations.extend(
+                    drain_provider_usage(code_refs_client)
+                )
             if provider_usage_observations:
                 attach_work_item_partial_observations(
                     exc, {"provider_usage": provider_usage_observations}
                 )
             raise
-        provider_usage_observations.extend(drain_provider_usage(connector))
-
-        code_refs_client: LaunchDarklyCodeReferencesClient | None = None
-        try:
-            async with LaunchDarklyCodeReferencesClient(
-                api_key=api_key
-            ) as code_refs_client:
-                raw_code_refs = await code_refs_client.list_default_branch_references(
-                    project_key=project_key
-                )
-            code_references_error = None
-        except ConnectorException as exc:
-            logger.warning(
-                "Skipping LaunchDarkly code references for project %s: %s",
-                project_key,
-                exc,
-            )
-            raw_code_refs = []
-            code_references_error = str(exc)
-        finally:
-            # Code references are best-effort (errors are swallowed above), but
-            # any requests that DID complete before the failure still count as
-            # real actuals -- drain regardless of outcome.
-            if code_refs_client is not None:
-                provider_usage_observations.extend(
-                    drain_provider_usage(code_refs_client)
-                )
-
-        flags = normalize_flags(raw_flags, org_id)
-        if environment:
-            flags = [
-                flag.__class__(
-                    provider=flag.provider,
-                    flag_key=flag.flag_key,
-                    project_key=flag.project_key,
-                    repo_id=flag.repo_id,
-                    environment=environment,
-                    flag_type=flag.flag_type,
-                    created_at=flag.created_at,
-                    archived_at=flag.archived_at,
-                    last_synced=flag.last_synced,
-                    org_id=flag.org_id,
-                )
-                for flag in flags
-            ]
-        events = normalize_audit_events(raw_events, org_id)
-        if environment:
-            events = [
-                event.__class__(
-                    event_type=event.event_type,
-                    flag_key=event.flag_key,
-                    environment=event.environment or environment,
-                    repo_id=event.repo_id,
-                    actor_type=event.actor_type,
-                    prev_state=event.prev_state,
-                    next_state=event.next_state,
-                    event_ts=event.event_ts,
-                    ingested_at=event.ingested_at,
-                    source_event_id=event.source_event_id,
-                    dedupe_key=event.dedupe_key,
-                    org_id=event.org_id,
-                )
-                for event in events
-            ]
-
-        sink = ClickHouseMetricsSink(db_url)
-        setattr(sink, "org_id", org_id)
-        builder = WorkGraphBuilder(BuildConfig(dsn=db_url, org_id=org_id))
-        try:
-            sink.write_feature_flags(flags)
-            sink.write_feature_flag_events(events)
-
-            repo_rows = sink.query_dicts(
-                "SELECT id, repo FROM repos WHERE org_id = " + _ch_string(org_id),
-                {},
-            )
-            repo_index = index_repo_rows(repo_rows)
-            repo_paths = {
-                (str(repo_id), ref.file_path)
-                for ref in raw_code_refs
-                if (repo_id := resolve_repo_id(ref, repo_index)) is not None
-            }
-            pr_ids_by_repo_path = _load_pr_ids_by_repo_path(
-                sink,
-                org_id=org_id,
-                repo_paths=repo_paths,
-            )
-            code_ref_links, code_ref_edges = build_code_reference_links(
-                raw_code_refs,
-                org_id=org_id,
-                repo_index=repo_index,
-                pr_ids_by_repo_path=pr_ids_by_repo_path,
-            )
-            sink.write_feature_flag_links(code_ref_links)
-            for edge in code_ref_edges:
-                target_type = (
-                    NodeType.FILE if edge["target_type"] == "file" else NodeType.PR
-                )
-                builder.add_feature_flag_edge(
-                    flag_id=str(edge["flag_id"]),
-                    target_type=target_type,
-                    target_id=str(edge["target_id"]),
-                    edge_type=EdgeType.GUARDS,
-                    confidence=LD_CODE_REFERENCE_CONFIDENCE,
-                    evidence=str(edge["evidence"]),
-                    provenance=Provenance.NATIVE,
-                    repo_id=edge["repo_id"],
-                    provider="launchdarkly",
-                )
-
-            latest_events: dict[str, Any] = {}
-            for event in events:
-                existing = latest_events.get(event.flag_key)
-                if existing is None or event.event_ts > existing.event_ts:
-                    latest_events[event.flag_key] = event
-
-            for flag in flags:
-                builder.add_feature_flag_node(
-                    flag_key=flag.flag_key,
-                    provider=flag.provider,
-                    project_key=flag.project_key or project_key,
-                    repo_id=flag.repo_id,
-                    event_ts=flag.created_at,
-                )
-                latest_event = latest_events.get(flag.flag_key)
-                if latest_event is None:
-                    continue
-                flag_id = generate_feature_flag_id(
-                    org_id,
-                    flag.provider,
-                    flag.project_key or project_key,
-                    flag.flag_key,
-                )
-                builder.add_feature_flag_edge(
-                    flag_id=flag_id,
-                    target_type=NodeType.FEATURE_FLAG,
-                    target_id=flag_id,
-                    edge_type=EdgeType.CONFIG_CHANGED_BY,
-                    confidence=1.0,
-                    evidence=(
-                        f"{latest_event.event_ts.isoformat()}"
-                        f"|{latest_event.event_type}"
-                        f"|{latest_event.next_state or ''}"
-                    ),
-                    provenance=Provenance.NATIVE,
-                    provider=flag.provider,
-                    event_ts=latest_event.event_ts,
-                )
-        finally:
-            builder.close()
-            sink.close()
-
-        result: dict[str, Any] = {
-            "flags_synced": len(flags),
-            "events_synced": len(events),
-            "code_references_synced": len(raw_code_refs),
-            "code_reference_links_synced": len(code_ref_links),
-            "code_reference_edges_synced": len(code_ref_edges),
-            "code_references_error": code_references_error,
-            "project_key": project_key,
-            "environment": environment or None,
-        }
-        if provider_usage_observations:
-            result["observations"] = {"provider_usage": provider_usage_observations}
-        return result
 
     return run_async(_run())
 

--- a/src/dev_health_ops/workers/feature_flag_sync.py
+++ b/src/dev_health_ops/workers/feature_flag_sync.py
@@ -65,12 +65,15 @@ def _sync_launchdarkly_feature_flags(
     since_dt: datetime | None,
 ) -> dict[str, Any]:
     from dev_health_ops.connectors.exceptions import ConnectorException
-    from dev_health_ops.connectors.launchdarkly import LaunchDarklyConnector
+    from dev_health_ops.metrics.job_work_items import (
+        attach_work_item_partial_observations,
+    )
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
     from dev_health_ops.processors.launchdarkly import (
         normalize_audit_events,
         normalize_flags,
     )
+    from dev_health_ops.providers.launchdarkly.client import LaunchDarklyClient
     from dev_health_ops.providers.launchdarkly.code_refs import (
         LD_CODE_REFERENCE_CONFIDENCE,
         LaunchDarklyCodeReferencesClient,
@@ -78,6 +81,7 @@ def _sync_launchdarkly_feature_flags(
         index_repo_rows,
         resolve_repo_id,
     )
+    from dev_health_ops.providers.usage import drain_provider_usage
     from dev_health_ops.work_graph.builder import BuildConfig, WorkGraphBuilder
     from dev_health_ops.work_graph.ids import generate_feature_flag_id
     from dev_health_ops.work_graph.models import EdgeType, NodeType, Provenance
@@ -99,14 +103,41 @@ def _sync_launchdarkly_feature_flags(
         )
 
     async def _run() -> dict[str, Any]:
-        async with LaunchDarklyConnector(
-            api_key=api_key, project_key=project_key
-        ) as connector:
-            raw_flags = await connector.get_flags(project_key)
-            raw_events = await connector.get_audit_log(since=since_dt, limit=1000)
+        # Real per-request actuals drained through the shared CHAOS-2754
+        # recorder for all 3 currently-emitted LaunchDarkly route families
+        # (flags, audit_log, code_refs) -- CHAOS-2761.
+        provider_usage_observations: list[dict[str, Any]] = []
+
+        connector: LaunchDarklyClient | None = None
         try:
-            async with LaunchDarklyCodeReferencesClient(api_key=api_key) as code_refs:
-                raw_code_refs = await code_refs.list_default_branch_references(
+            async with LaunchDarklyClient(
+                api_key=api_key, project_key=project_key
+            ) as connector:
+                raw_flags = await connector.get_flags(project_key)
+                raw_events = await connector.get_audit_log(since=since_dt, limit=1000)
+        except Exception as exc:
+            # Preserve actuals gathered before the raise (e.g. flags succeeded,
+            # audit_log then hit a rate limit) so the worker's deferral/failure
+            # stamp can still persist them (CHAOS-2754 contract, reused here
+            # verbatim -- `attach_work_item_partial_observations` is
+            # provider-neutral despite its name; `_merge_partial_observations_
+            # into_result` in workers/sync_units.py reads it regardless of
+            # dataset/provider).
+            if connector is not None:
+                provider_usage_observations.extend(drain_provider_usage(connector))
+            if provider_usage_observations:
+                attach_work_item_partial_observations(
+                    exc, {"provider_usage": provider_usage_observations}
+                )
+            raise
+        provider_usage_observations.extend(drain_provider_usage(connector))
+
+        code_refs_client: LaunchDarklyCodeReferencesClient | None = None
+        try:
+            async with LaunchDarklyCodeReferencesClient(
+                api_key=api_key
+            ) as code_refs_client:
+                raw_code_refs = await code_refs_client.list_default_branch_references(
                     project_key=project_key
                 )
             code_references_error = None
@@ -118,6 +149,14 @@ def _sync_launchdarkly_feature_flags(
             )
             raw_code_refs = []
             code_references_error = str(exc)
+        finally:
+            # Code references are best-effort (errors are swallowed above), but
+            # any requests that DID complete before the failure still count as
+            # real actuals -- drain regardless of outcome.
+            if code_refs_client is not None:
+                provider_usage_observations.extend(
+                    drain_provider_usage(code_refs_client)
+                )
 
         flags = normalize_flags(raw_flags, org_id)
         if environment:
@@ -243,7 +282,7 @@ def _sync_launchdarkly_feature_flags(
             builder.close()
             sink.close()
 
-        return {
+        result: dict[str, Any] = {
             "flags_synced": len(flags),
             "events_synced": len(events),
             "code_references_synced": len(raw_code_refs),
@@ -253,6 +292,9 @@ def _sync_launchdarkly_feature_flags(
             "project_key": project_key,
             "environment": environment or None,
         }
+        if provider_usage_observations:
+            result["observations"] = {"provider_usage": provider_usage_observations}
+        return result
 
     return run_async(_run())
 

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -363,6 +363,37 @@ def test_launchdarkly_feature_flags_route_to_existing_feature_flag_sync() -> Non
     assert result["feature_flags"] == {"flags_synced": 3}
 
 
+def test_launchdarkly_feature_flags_threads_usage_observations_to_result() -> None:
+    """CHAOS-2761: provider_usage actuals drained by LaunchDarklyClient /
+    LaunchDarklyCodeReferencesClient must reach the unit result's top-level
+    ``observations``, mirroring the work-items dataset passthrough, so
+    run_sync_unit's budget_comparison join can see them."""
+    ctx = _context(
+        provider="launchdarkly",
+        dataset_key="feature-flags",
+        source_external_id="proj",
+        credentials={"api_key": "ld-key"},
+    )
+    observations = {
+        "provider_usage": [
+            {
+                "transport": "rest",
+                "route_family": "flags",
+                "dimension": "rest_core",
+                "request_count": 1,
+            }
+        ]
+    }
+
+    with patch(
+        "dev_health_ops.workers.feature_flag_sync._sync_launchdarkly_feature_flags",
+        return_value={"flags_synced": 3, "observations": observations},
+    ):
+        result = run_dataset_unit(ctx, _runtime())
+
+    assert result["observations"] == observations
+
+
 def test_unsupported_provider_dataset_pair_raises_value_error() -> None:
     ctx = _context(provider="jira", dataset_key="commits", source_external_id="OPS")
 

--- a/tests/test_feature_flag_sync.py
+++ b/tests/test_feature_flag_sync.py
@@ -47,6 +47,7 @@ def _make_fake_client(
         def __init__(self, *, api_key: str, project_key: str | None = None) -> None:
             self.api_key = api_key
             self.project_key = project_key
+            self._drained = False
 
         async def __aenter__(self) -> _FakeClient:
             return self
@@ -69,6 +70,12 @@ def _make_fake_client(
             return events or []
 
         def drain_usage_observations(self) -> list[dict[str, Any]]:
+            # Mirrors UsageRecorder.drain() clearing its state: a second call
+            # after an earlier successful drain returns [] rather than
+            # re-emitting the same observations (double-counting).
+            if self._drained:
+                return []
+            self._drained = True
             return usage_observations
 
     return _FakeClient
@@ -85,6 +92,7 @@ def _make_fake_code_refs_client(
     class _FakeCodeRefsClient:
         def __init__(self, *, api_key: str) -> None:
             self.api_key = api_key
+            self._drained = False
 
         async def __aenter__(self) -> _FakeCodeRefsClient:
             return self
@@ -100,6 +108,12 @@ def _make_fake_code_refs_client(
             return refs or []
 
         def drain_usage_observations(self) -> list[dict[str, Any]]:
+            # Mirrors UsageRecorder.drain() clearing its state: a second call
+            # after an earlier successful drain returns [] rather than
+            # re-emitting the same observations (double-counting).
+            if self._drained:
+                return []
+            self._drained = True
             return usage_observations
 
     return _FakeCodeRefsClient
@@ -254,3 +268,54 @@ def test_code_references_failure_still_drains_its_own_usage(monkeypatch) -> None
 
     assert result["code_references_error"] is not None
     assert result["observations"]["provider_usage"] == flags_usage + code_refs_usage
+
+
+def test_sink_write_failure_preserves_all_actuals_gathered_so_far(monkeypatch) -> None:
+    """CHAOS-2761 review finding (HIGH): before the fix, only a raise DURING
+    the flags/audit_log fetch attached partial observations -- a failure
+    anywhere downstream (code_refs, normalization, ClickHouse/WorkGraph
+    writes) reached run_sync_unit bare, silently dropping real request counts
+    that had already been recorded and drained. Here the flags/audit_log AND
+    code_refs fetches both succeed (and drain usage) before a ClickHouse sink
+    write fails; both actuals must still survive on the raised exception."""
+    flags_usage = [
+        {
+            "transport": "rest",
+            "route_family": "flags",
+            "dimension": "rest_core",
+            "request_count": 1,
+        }
+    ]
+    code_refs_usage = [
+        {
+            "transport": "rest",
+            "route_family": "code_refs",
+            "dimension": "rest_core",
+            "request_count": 1,
+        }
+    ]
+    monkeypatch.setattr(_CLIENT_PATCH, _make_fake_client(flags_usage))
+    monkeypatch.setattr(_CODE_REFS_PATCH, _make_fake_code_refs_client(code_refs_usage))
+
+    sink = MagicMock()
+    sink.query_dicts.return_value = []
+    sink.write_feature_flags.side_effect = RuntimeError("clickhouse write failed")
+    sink_cls = MagicMock(return_value=sink)
+    builder_cls = MagicMock(return_value=MagicMock())
+
+    with patch(_SINK_PATCH, sink_cls), patch(_BUILDER_PATCH, builder_cls):
+        with pytest.raises(RuntimeError) as excinfo:
+            _sync_launchdarkly_feature_flags(
+                db_url="clickhouse://localhost/default",
+                org_id="org-1",
+                credentials=_credentials(),
+                sync_options={"project_key": "proj"},
+                since_dt=None,
+            )
+
+    observations = read_work_item_partial_observations(excinfo.value)
+    assert observations is not None
+    assert observations["provider_usage"] == flags_usage + code_refs_usage
+    # The finally block must still have closed the sink/builder even though
+    # the write raised.
+    sink.close.assert_called_once()

--- a/tests/test_feature_flag_sync.py
+++ b/tests/test_feature_flag_sync.py
@@ -1,0 +1,256 @@
+"""Tests for workers/feature_flag_sync.py's LaunchDarkly cutover (CHAOS-2761).
+
+``_sync_launchdarkly_feature_flags`` now fetches flags/audit-log through the
+canonical ``providers/launchdarkly/client.py::LaunchDarklyClient`` (not the
+frozen ``connectors/launchdarkly.py::LaunchDarklyConnector``), and drains real
+per-request actuals from both ``LaunchDarklyClient`` and
+``LaunchDarklyCodeReferencesClient`` into
+``result["observations"]["provider_usage"]``. This module tests that wiring
+at the seam (fake clients standing in for the real HTTP-backed ones -- the
+clients' own internal per-request counting is covered by
+tests/test_launchdarkly.py) with no network calls.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.metrics.job_work_items import read_work_item_partial_observations
+from dev_health_ops.workers.feature_flag_sync import _sync_launchdarkly_feature_flags
+
+_SINK_PATCH = "dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink"
+_BUILDER_PATCH = "dev_health_ops.work_graph.builder.WorkGraphBuilder"
+_CLIENT_PATCH = "dev_health_ops.providers.launchdarkly.client.LaunchDarklyClient"
+_CODE_REFS_PATCH = (
+    "dev_health_ops.providers.launchdarkly.code_refs.LaunchDarklyCodeReferencesClient"
+)
+
+
+def _credentials() -> dict[str, Any]:
+    return {"api_key": "ld-key", "project_key": "proj"}
+
+
+def _make_fake_client(
+    usage_observations: list[dict[str, Any]],
+    *,
+    flags: list[dict] | None = None,
+    events: list[dict] | None = None,
+    raise_on: str | None = None,
+):
+    """Build a fake stand-in for LaunchDarklyClient (flags + audit_log)."""
+
+    class _FakeClient:
+        def __init__(self, *, api_key: str, project_key: str | None = None) -> None:
+            self.api_key = api_key
+            self.project_key = project_key
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(self, *exc_info: object) -> None:
+            return None
+
+        async def get_flags(self, project_key: str | None = None) -> list[dict]:
+            if raise_on == "get_flags":
+                raise RateLimitException(
+                    "LaunchDarkly rate limit exceeded", retry_after_seconds=30
+                )
+            return flags or []
+
+        async def get_audit_log(self, since=None, limit: int = 1000) -> list[dict]:
+            if raise_on == "get_audit_log":
+                raise RateLimitException(
+                    "LaunchDarkly rate limit exceeded", retry_after_seconds=30
+                )
+            return events or []
+
+        def drain_usage_observations(self) -> list[dict[str, Any]]:
+            return usage_observations
+
+    return _FakeClient
+
+
+def _make_fake_code_refs_client(
+    usage_observations: list[dict[str, Any]],
+    *,
+    refs: list[Any] | None = None,
+    raise_exc: Exception | None = None,
+):
+    """Build a fake stand-in for LaunchDarklyCodeReferencesClient."""
+
+    class _FakeCodeRefsClient:
+        def __init__(self, *, api_key: str) -> None:
+            self.api_key = api_key
+
+        async def __aenter__(self) -> _FakeCodeRefsClient:
+            return self
+
+        async def __aexit__(self, *exc_info: object) -> None:
+            return None
+
+        async def list_default_branch_references(
+            self, *, project_key: str, flag_key: str | None = None
+        ) -> list[Any]:
+            if raise_exc is not None:
+                raise raise_exc
+            return refs or []
+
+        def drain_usage_observations(self) -> list[dict[str, Any]]:
+            return usage_observations
+
+    return _FakeCodeRefsClient
+
+
+def _stub_sink_and_builder():
+    """Patch the sink/graph-builder dependencies so the sync's persistence
+    step never touches a real ClickHouse instance."""
+    sink = MagicMock()
+    sink.query_dicts.return_value = []
+    sink_cls = MagicMock(return_value=sink)
+    builder_cls = MagicMock(return_value=MagicMock())
+    return patch(_SINK_PATCH, sink_cls), patch(_BUILDER_PATCH, builder_cls)
+
+
+def test_sync_uses_canonical_client_and_threads_provider_usage(monkeypatch) -> None:
+    """The 3 currently-emitted LD route families (flags, audit_log, code_refs)
+    all drain into result['observations']['provider_usage']."""
+    flags_usage = [
+        {
+            "transport": "rest",
+            "route_family": "flags",
+            "dimension": "rest_core",
+            "request_count": 1,
+        },
+        {
+            "transport": "rest",
+            "route_family": "audit_log",
+            "dimension": "rest_core",
+            "request_count": 1,
+        },
+    ]
+    code_refs_usage = [
+        {
+            "transport": "rest",
+            "route_family": "code_refs",
+            "dimension": "rest_core",
+            "request_count": 1,
+        }
+    ]
+
+    monkeypatch.setattr(_CLIENT_PATCH, _make_fake_client(flags_usage))
+    monkeypatch.setattr(_CODE_REFS_PATCH, _make_fake_code_refs_client(code_refs_usage))
+
+    sink_patch, builder_patch = _stub_sink_and_builder()
+    with sink_patch, builder_patch:
+        result = _sync_launchdarkly_feature_flags(
+            db_url="clickhouse://localhost/default",
+            org_id="org-1",
+            credentials=_credentials(),
+            sync_options={"project_key": "proj"},
+            since_dt=None,
+        )
+
+    assert result["observations"]["provider_usage"] == flags_usage + code_refs_usage
+
+
+def test_sync_omits_observations_key_when_nothing_drained(monkeypatch) -> None:
+    """No fabricated empty observations dict when both clients drain nothing."""
+    monkeypatch.setattr(_CLIENT_PATCH, _make_fake_client([]))
+    monkeypatch.setattr(_CODE_REFS_PATCH, _make_fake_code_refs_client([]))
+
+    sink_patch, builder_patch = _stub_sink_and_builder()
+    with sink_patch, builder_patch:
+        result = _sync_launchdarkly_feature_flags(
+            db_url="clickhouse://localhost/default",
+            org_id="org-1",
+            credentials=_credentials(),
+            sync_options={"project_key": "proj"},
+            since_dt=None,
+        )
+
+    assert "observations" not in result
+
+
+def test_rate_limit_during_audit_log_preserves_partial_flags_usage(
+    monkeypatch,
+) -> None:
+    """CHAOS-2754 contract, reused verbatim for LaunchDarkly: a mid-sync
+    RateLimitException still carries whatever actuals were recorded before the
+    raise (here, the flags fetch succeeded before audit_log hit a limit), so
+    the worker deferral path can persist them without ever calling the
+    provider again."""
+    flags_usage = [
+        {
+            "transport": "rest",
+            "route_family": "flags",
+            "dimension": "rest_core",
+            "request_count": 1,
+        }
+    ]
+    monkeypatch.setattr(
+        _CLIENT_PATCH,
+        _make_fake_client(flags_usage, raise_on="get_audit_log"),
+    )
+
+    with pytest.raises(RateLimitException) as excinfo:
+        _sync_launchdarkly_feature_flags(
+            db_url="clickhouse://localhost/default",
+            org_id="org-1",
+            credentials=_credentials(),
+            sync_options={"project_key": "proj"},
+            since_dt=None,
+        )
+
+    observations = read_work_item_partial_observations(excinfo.value)
+    assert observations is not None
+    assert observations["provider_usage"] == flags_usage
+
+
+def test_code_references_failure_still_drains_its_own_usage(monkeypatch) -> None:
+    """code_refs failures stay tolerated (existing behavior, unchanged), but
+    any requests that DID complete before the failure must still count as
+    real actuals rather than being silently discarded."""
+    from dev_health_ops.connectors.exceptions import APIException
+
+    flags_usage = [
+        {
+            "transport": "rest",
+            "route_family": "flags",
+            "dimension": "rest_core",
+            "request_count": 1,
+        }
+    ]
+    code_refs_usage = [
+        {
+            "transport": "rest",
+            "route_family": "code_refs",
+            "dimension": "rest_core",
+            "request_count": 1,
+        }
+    ]
+
+    monkeypatch.setattr(_CLIENT_PATCH, _make_fake_client(flags_usage))
+    monkeypatch.setattr(
+        _CODE_REFS_PATCH,
+        _make_fake_code_refs_client(
+            code_refs_usage,
+            raise_exc=APIException("LaunchDarkly code references server error: 500"),
+        ),
+    )
+
+    sink_patch, builder_patch = _stub_sink_and_builder()
+    with sink_patch, builder_patch:
+        result = _sync_launchdarkly_feature_flags(
+            db_url="clickhouse://localhost/default",
+            org_id="org-1",
+            credentials=_credentials(),
+            sync_options={"project_key": "proj"},
+            since_dt=None,
+        )
+
+    assert result["code_references_error"] is not None
+    assert result["observations"]["provider_usage"] == flags_usage + code_refs_usage

--- a/tests/test_launchdarkly.py
+++ b/tests/test_launchdarkly.py
@@ -34,6 +34,9 @@ from dev_health_ops.providers.launchdarkly.code_refs import (
     index_repo_rows,
     parse_code_reference_repositories,
 )
+from dev_health_ops.providers.launchdarkly.code_refs import (
+    _raise_for_status as _code_refs_raise_for_status,
+)
 from dev_health_ops.work_graph.ids import (
     generate_feature_flag_id,
     generate_file_id,
@@ -578,6 +581,100 @@ class TestLaunchDarklyCodeReferences:
             )
         ]
         assert edges[0]["repo_id"] == uuid.UUID(correct_repo_id)
+
+
+class TestLaunchDarklyCodeReferencesRetryAfterParsing:
+    """CHAOS-2761 review finding (MEDIUM): code_refs.py's ``_raise_for_status``
+    and its ``_request`` retry loop used a bare ``float(retry_after)``, which
+    raises ``ValueError`` on an HTTP-date, malformed, or empty Retry-After
+    header -- escaping BEFORE the canonical ``RateLimitException`` was ever
+    built, and (since ``feature_flag_sync`` only swallows ``ConnectorException``
+    for code_refs) failing the entire LaunchDarkly sync while bypassing the
+    worker's rate-limit deferral path entirely. Fixed by sharing
+    ``providers/launchdarkly/client.py``'s ``_parse_retry_after`` (returns
+    ``None`` on anything unparseable instead of raising)."""
+
+    @pytest.mark.parametrize(
+        "retry_after_header",
+        [
+            "7",  # numeric
+            "Wed, 21 Oct 2015 07:28:00 GMT",  # HTTP-date (valid per RFC 7231)
+            "not-a-number",  # garbage
+            "",  # empty string
+        ],
+    )
+    def test_raise_for_status_429_never_raises_value_error(
+        self, retry_after_header: str
+    ) -> None:
+        response = MagicMock()
+        response.status_code = 429
+        response.text = ""
+        response.url = None
+        response.headers = {
+            "Retry-After": retry_after_header,
+            "X-RateLimit-Reset": "0",
+        }
+
+        with pytest.raises(RootRateLimitException) as excinfo:
+            _code_refs_raise_for_status(response)
+
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.provider == "launchdarkly"
+        assert excinfo.value.signal.reason == "primary"
+
+    @pytest.mark.asyncio
+    async def test_request_retry_loop_falls_back_to_backoff_on_malformed_retry_after(
+        self,
+    ) -> None:
+        """A malformed Retry-After on a 429 must not raise ValueError mid-retry
+        -- it must fall back to the exponential-backoff delay and retry, same
+        as a missing header."""
+        throttled = MagicMock()
+        throttled.status_code = 429
+        throttled.headers = {"Retry-After": "not-a-number"}
+
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.headers = {}
+        ok.json.return_value = {"items": []}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=[throttled, ok])
+
+        client = LaunchDarklyCodeReferencesClient(api_key="key", max_retries=2)
+        client._client = mock_client
+
+        refs = await client.list_default_branch_references(project_key="web")
+
+        assert refs == []
+        assert mock_client.request.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_request_exhausted_retries_raise_canonical_rate_limit_exception(
+        self,
+    ) -> None:
+        """Every attempt throttled with a malformed Retry-After still ends in
+        the canonical RateLimitException (via _raise_for_status), never a bare
+        ValueError."""
+        throttled = MagicMock()
+        throttled.status_code = 429
+        throttled.text = ""
+        throttled.url = None
+        throttled.headers = {"Retry-After": "garbage", "X-RateLimit-Reset": "0"}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=throttled)
+
+        client = LaunchDarklyCodeReferencesClient(api_key="key", max_retries=1)
+        client._client = mock_client
+
+        with pytest.raises(RootRateLimitException) as excinfo:
+            await client.list_default_branch_references(project_key="web")
+
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.provider == "launchdarkly"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_launchdarkly.py
+++ b/tests/test_launchdarkly.py
@@ -18,12 +18,14 @@ from dev_health_ops.connectors.launchdarkly import (
     _parse_retry_after,
     _raise_for_status,
 )
+from dev_health_ops.exceptions import RateLimitException as RootRateLimitException
 from dev_health_ops.processors.launchdarkly import (
     _EVENT_KIND_MAP,
     _parse_iso,
     normalize_audit_events,
     normalize_flags,
 )
+from dev_health_ops.providers.launchdarkly.client import LaunchDarklyClient
 from dev_health_ops.providers.launchdarkly.code_refs import (
     LD_CODE_REFERENCE_CONFIDENCE,
     LaunchDarklyCodeReference,
@@ -249,6 +251,145 @@ class TestLaunchDarklyConnector:
             assert conn.api_key == "key"
 
 
+class TestLaunchDarklyClientUsageRecording:
+    """CHAOS-2761: providers/launchdarkly/client.py is the canonical migration
+    target for the frozen connector's flag/audit-log fetch logic. It must
+    record REAL per-request counts (not abstract per-call units -- the
+    codex-flagged CHAOS-2759 contract) through the shared CHAOS-2754 recorder,
+    while keeping identical retry/429 behavior to the connector it replaces.
+    """
+
+    @pytest.fixture
+    def client(self):
+        return LaunchDarklyClient(api_key="test-api-key", project_key="default")
+
+    @pytest.mark.asyncio
+    async def test_get_flags_records_one_request_per_page(self, client):
+        mock_response = MagicMock()
+        mock_response.status_code = 200
+        mock_response.headers = {"X-RateLimit-Route-Remaining": "100"}
+        mock_response.json.return_value = {
+            "totalCount": 2,
+            "items": [
+                {"key": "flag-1", "name": "Flag One", "kind": "boolean"},
+                {"key": "flag-2", "name": "Flag Two", "kind": "multivariate"},
+            ],
+        }
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=mock_response)
+        client._client = mock_client
+
+        flags = await client.get_flags()
+
+        assert len(flags) == 2
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "flags"
+        assert observations[0]["dimension"] == "rest_core"
+        assert observations[0]["request_count"] == 1
+        assert observations[0]["rate_limit"]["remaining"] == "100"
+
+    @pytest.mark.asyncio
+    async def test_get_audit_log_pagination_counts_each_page_as_a_real_request(
+        self, client
+    ):
+        # Mirrors TestLaunchDarklyConnector.test_get_audit_log_paginates_via_
+        # next_link: 3 pages -> 3 real HTTP requests, all keyed under the SAME
+        # audit_log route family (never one "logical fetch" unit).
+        def _page(items: list[dict], next_href: str | None = None) -> MagicMock:
+            resp = MagicMock()
+            resp.status_code = 200
+            resp.headers = {}
+            body: dict[str, object] = {"items": items}
+            if next_href is not None:
+                body["_links"] = {"next": {"href": next_href}}
+            resp.json.return_value = body
+            return resp
+
+        page1 = _page(
+            [{"_id": f"a{i}"} for i in range(20)],
+            "/api/v2/auditlog?limit=20&before=2000",
+        )
+        page2 = _page(
+            [{"_id": f"b{i}"} for i in range(20)],
+            "/api/v2/auditlog?limit=20&before=1000",
+        )
+        page3 = _page([{"_id": f"c{i}"} for i in range(5)])
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=[page1, page2, page3])
+        client._client = mock_client
+
+        events = await client.get_audit_log(limit=1000)
+
+        assert len(events) == 45
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "audit_log"
+        assert observations[0]["request_count"] == 3, (
+            "three real HTTP requests were made (one per page); this must "
+            "reflect a REAL request count, not an abstract per-call unit"
+        )
+
+    @pytest.mark.asyncio
+    async def test_retried_429_counts_every_attempt_as_a_real_request(self, client):
+        throttled = MagicMock()
+        throttled.status_code = 429
+        throttled.headers = {"Retry-After": "0"}
+        throttled.text = ""
+
+        ok = MagicMock()
+        ok.status_code = 200
+        ok.headers = {}
+        ok.json.return_value = {"totalCount": 0, "items": []}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=[throttled, ok])
+        client._client = mock_client
+
+        await client.get_flags()
+
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["request_count"] == 2, (
+            "the retried 429 attempt AND the eventual success are both real "
+            "requests against the provider -- neither is free"
+        )
+        assert observations[0]["latest_status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_exception_carries_canonical_signal(self, client):
+        # CHAOS-2761 requirement: the same canonical exception + RateLimitSignal
+        # the frozen connector already raised (CHAOS-2753 normalization) --
+        # this is a migration, not a new signal shape.
+        throttled = MagicMock()
+        throttled.status_code = 429
+        throttled.headers = {"Retry-After": "7", "X-RateLimit-Reset": "0"}
+        throttled.text = ""
+        throttled.url = None
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=throttled)
+        client._client = mock_client
+        client.max_retries = 1
+
+        with pytest.raises(RootRateLimitException) as excinfo:
+            await client.get_flags()
+
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.provider == "launchdarkly"
+        assert excinfo.value.signal.reason == "primary"
+        assert excinfo.value.retry_after_seconds == 7.0
+        # Exactly one real request was recorded before giving up.
+        observations = client.drain_usage_observations()
+        assert observations[0]["request_count"] == 1
+
+
 class TestLaunchDarklyCodeReferences:
     @pytest.mark.asyncio
     async def test_list_default_branch_references_uses_project_filter(self):
@@ -272,6 +413,31 @@ class TestLaunchDarklyCodeReferences:
             "/code-refs/repositories",
             params={"withReferencesForDefaultBranch": "1", "projKey": "web"},
         )
+
+    @pytest.mark.asyncio
+    async def test_list_default_branch_references_records_usage(self):
+        """CHAOS-2761: code_refs was already canonical but never wired to the
+        shared CHAOS-2754 recorder -- close that gap."""
+        response = MagicMock()
+        response.status_code = 200
+        response.headers = {"X-RateLimit-Route-Remaining": "50"}
+        response.json.return_value = {"items": []}
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=response)
+
+        client = LaunchDarklyCodeReferencesClient(api_key="key")
+        client._client = mock_client
+
+        await client.list_default_branch_references(project_key="web")
+
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "code_refs"
+        assert observations[0]["dimension"] == "rest_core"
+        assert observations[0]["request_count"] == 1
+        assert observations[0]["rate_limit"]["remaining"] == "50"
 
     def test_parse_code_reference_repositories_flattens_hunks(self):
         refs = parse_code_reference_repositories(

--- a/tests/test_provider_usage.py
+++ b/tests/test_provider_usage.py
@@ -23,6 +23,11 @@ from dev_health_ops.providers.jira.budget import (
     JIRA_USAGE_ROUTE_FAMILY_KEYS,
     JiraBudgetEstimator,
 )
+from dev_health_ops.providers.launchdarkly.budget import (
+    LAUNCHDARKLY_USAGE_RESOLVER,
+    LAUNCHDARKLY_USAGE_ROUTE_FAMILY_KEYS,
+    LaunchDarklyBudgetEstimator,
+)
 from dev_health_ops.providers.linear.budget import (
     LINEAR_USAGE_RESOLVER,
     LINEAR_USAGE_ROUTE_FAMILY_KEYS,
@@ -145,6 +150,23 @@ def test_jira_resolver_maps_rest_paths_to_estimator_families() -> None:
         )
 
 
+def test_launchdarkly_resolver_maps_operations_to_estimator_families() -> None:
+    cases = {
+        "GET /flags/default": ("flags", BudgetDimension.REST_CORE),
+        "GET /auditlog": ("audit_log", BudgetDimension.REST_CORE),
+        # Cursor-paginated audit-log pages carry the stripped /api/v2 href
+        # (querystring included) as their operation label; the marker must
+        # still match.
+        "GET /auditlog?limit=20&before=1000": ("audit_log", BudgetDimension.REST_CORE),
+        "GET /code-refs/repositories": ("code_refs", BudgetDimension.REST_CORE),
+    }
+    for operation, expected in cases.items():
+        assert (
+            LAUNCHDARKLY_USAGE_RESOLVER.resolve(transport="rest", operation=operation)
+            == expected
+        ), operation
+
+
 def test_gitlab_resolver_distinguishes_project_metadata_from_iterators() -> None:
     assert GITLAB_USAGE_RESOLVER.resolve(
         transport="rest", operation="GET /projects/:id"
@@ -190,6 +212,11 @@ def test_operation_route_family_mapping_covers_estimator_families() -> None:
         ("gitlab", GitLabBudgetEstimator(), GITLAB_USAGE_ROUTE_FAMILY_KEYS),
         ("jira", JiraBudgetEstimator(), JIRA_USAGE_ROUTE_FAMILY_KEYS),
         ("linear", LinearBudgetEstimator(), LINEAR_USAGE_ROUTE_FAMILY_KEYS),
+        (
+            "launchdarkly",
+            LaunchDarklyBudgetEstimator(),
+            LAUNCHDARKLY_USAGE_ROUTE_FAMILY_KEYS,
+        ),
     ]
     for provider, estimator, registry_keys in providers:
         emitted: set[str] = set()

--- a/tests/test_rate_limit_signal.py
+++ b/tests/test_rate_limit_signal.py
@@ -438,7 +438,7 @@ def test_reference_discovery_honors_retry_after() -> None:
 
 
 # ---------------------------------------------------------------------------
-# LaunchDarkly 403 -> AuthenticationException (both LD client modules)
+# LaunchDarkly 403 -> AuthenticationException (all three LD client modules)
 # ---------------------------------------------------------------------------
 
 
@@ -446,18 +446,27 @@ def test_launchdarkly_403_is_authentication_error() -> None:
     from dev_health_ops.connectors.launchdarkly import (
         _raise_for_status as connector_raise,
     )
+    from dev_health_ops.providers.launchdarkly.client import (
+        _raise_for_status as client_raise,
+    )
     from dev_health_ops.providers.launchdarkly.code_refs import (
         _raise_for_status as code_refs_raise,
     )
+
+    # CHAOS-2761: providers/launchdarkly/client.py is the canonical migration
+    # target for connectors/launchdarkly.py's flag/audit-log fetch logic --
+    # behavior parity means all three raise sites (legacy connector, the new
+    # canonical client, and the pre-existing canonical code-refs client)
+    # classify identically.
+    raise_sites = (connector_raise, client_raise, code_refs_raise)
 
     forbidden = cast(
         httpx.Response,
         SimpleNamespace(status_code=403, text="forbidden", headers={}, url=None),
     )
-    with pytest.raises(AuthenticationException):
-        connector_raise(forbidden)
-    with pytest.raises(AuthenticationException):
-        code_refs_raise(forbidden)
+    for raise_site in raise_sites:
+        with pytest.raises(AuthenticationException):
+            raise_site(forbidden)
 
     # 429 still yields a retryable RateLimitException carrying a signal.
     throttled = cast(
@@ -469,11 +478,12 @@ def test_launchdarkly_403_is_authentication_error() -> None:
             url=None,
         ),
     )
-    with pytest.raises(RootRateLimitException) as excinfo:
-        connector_raise(throttled)
-    assert excinfo.value.signal is not None
-    assert excinfo.value.signal.provider == "launchdarkly"
-    assert excinfo.value.signal.reason == "primary"
-    assert excinfo.value.signal.dimension is BudgetDimension.REST_CORE
-    assert excinfo.value.signal.retry_after_seconds == 7.0
-    assert excinfo.value.signal.reset_at == _EPOCH_UTC
+    for raise_site in raise_sites:
+        with pytest.raises(RootRateLimitException) as excinfo:
+            raise_site(throttled)
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.provider == "launchdarkly"
+        assert excinfo.value.signal.reason == "primary"
+        assert excinfo.value.signal.dimension is BudgetDimension.REST_CORE
+        assert excinfo.value.signal.retry_after_seconds == 7.0
+        assert excinfo.value.signal.reset_at == _EPOCH_UTC

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -450,6 +450,82 @@ def test_run_sync_unit_success_attaches_launchdarkly_budget_estimate(
     assert finalize_calls == [((str(run.id),), "sync")]
 
 
+def test_run_sync_unit_success_attaches_launchdarkly_budget_comparison(
+    db_session, monkeypatch
+):
+    """CHAOS-2761: LaunchDarklyClient / LaunchDarklyCodeReferencesClient now
+    drain real request counts through the shared CHAOS-2754 recorder for all
+    3 currently-emitted LD route families, so a run's provider_usage actuals
+    join against the LaunchDarklyBudgetEstimator estimate exactly like
+    GitHub's CHAOS-2759 calibration already does."""
+    from dev_health_ops.processors import dataset_adapters
+    from dev_health_ops.workers.sync_units import run_sync_unit
+
+    run, unit = _seed_run(
+        db_session,
+        provider="launchdarkly",
+        source_type="project",
+        external_id="project:default",
+        name="default",
+        full_name="LaunchDarkly/default",
+        dataset_key="feature-flags",
+        processor_flags={"sync_feature_flags": True},
+    )
+    _mark_dispatching(db_session, unit)
+    _patch_db_session(monkeypatch, db_session)
+    _patch_runtime(monkeypatch)
+    _patch_finalize_apply(monkeypatch)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URL", raising=False)
+    monkeypatch.setattr(
+        dataset_adapters,
+        "run_dataset_unit",
+        lambda ctx, runtime: {
+            "ok": True,
+            "observations": {
+                "provider_usage": [
+                    {
+                        "transport": "rest",
+                        "route_family": "flags",
+                        "dimension": "rest_core",
+                        "request_count": 3,
+                    },
+                    {
+                        "transport": "rest",
+                        "route_family": "audit_log",
+                        "dimension": "rest_core",
+                        "request_count": 1,
+                    },
+                    {
+                        "transport": "rest",
+                        "route_family": "code_refs",
+                        "dimension": "rest_core",
+                        "request_count": 1,
+                    },
+                ]
+            },
+        },
+    )
+
+    result = getattr(run_sync_unit, "run")(str(unit.id))
+
+    assert result["status"] == "success"
+    db_session.refresh(unit)
+    observations = unit.result["observations"]
+    comparisons = {
+        row["route_family"]: row for row in observations["budget_comparison"]
+    }
+    assert set(comparisons) == {"flags", "audit_log", "code_refs"}
+    assert comparisons["flags"]["actual_requests"] == 3
+    assert comparisons["audit_log"]["actual_requests"] == 1
+    assert comparisons["code_refs"]["actual_requests"] == 1
+    # code_refs' estimated_units=1 (LaunchDarklyBudgetEstimator, 1 REST_CORE
+    # estimate) vs. 1 actual request -> not underestimated.
+    assert comparisons["code_refs"]["underestimated"] is False
+    assert "budget_comparison_computed_at" in observations
+
+
 def test_run_sync_unit_success_attaches_linear_budget_estimate(db_session, monkeypatch):
     from dev_health_ops.processors import dataset_adapters
     from dev_health_ops.workers.sync_units import run_sync_unit


### PR DESCRIPTION
## Summary

CHAOS-2754 unified GitHub/GitLab/Jira/Linear actuals capture behind a shared usage recorder with route-family keying; CHAOS-2759 joins those actuals against budget estimates into `budget_comparison`. LaunchDarkly had no actuals instrumentation at all: `flags`/`audit_log` fetches lived in the frozen `connectors/launchdarkly.py` (hard-banned for new code), so LD units produced budget estimates but never a `budget_comparison`.

This PR closes that gap for LaunchDarkly:

- **New `providers/launchdarkly/client.py::LaunchDarklyClient`** — a behavior-parity migration of `connectors/launchdarkly.py`'s flag/audit-log fetch logic (same retry/429/5xx semantics, same canonical `RateLimitException` + `RateLimitSignal` construction — LD's legacy connector was already on the canonical exception hierarchy per CHAOS-2753, so this is a pure code-location migration, not a new signal shape) into the canonical `providers/launchdarkly/` package, now wired to the CHAOS-2754 shared `UsageRecorder`.
- **`providers/launchdarkly/code_refs.py::LaunchDarklyCodeReferencesClient`** — was already canonical but never wired to the recorder; now it is.
- **`providers/launchdarkly/budget.py`** — new `LAUNCHDARKLY_USAGE_ROUTE_FAMILIES` / `LAUNCHDARKLY_USAGE_RESOLVER` registry (mirrors GitHub/Jira's pattern), mapping real HTTP operations to the same `flags`/`audit_log`/`code_refs` route families the estimator already emits.
- **`workers/feature_flag_sync.py`** — `_sync_launchdarkly_feature_flags` now uses `LaunchDarklyClient` instead of the frozen connector, drains both clients' usage into `result.observations.provider_usage`, and preserves partial actuals on a mid-sync `RateLimitException` via the existing (reused verbatim) `attach_work_item_partial_observations` / `read_work_item_partial_observations` contract.
- **`processors/dataset_adapters.py`** — `_run_feature_flags_dataset` now threads `observations` through to the unit result, mirroring the existing work-items dataset passthrough.
- `connectors/launchdarkly.py` is left in place, unused by the sync path — it still backs the admin credentials "test connection" endpoint (`_test_launchdarkly_connection`), which mirrors the same raw/legacy-client pattern already used there for Jira/Linear connectivity checks and carries no actuals-instrumentation gap (verified: no other caller of the frozen connector exists).

**Result:** all 3 currently-emitted LaunchDarkly route families (`flags`, `audit_log`, `code_refs`) now drain real per-request actuals, so LaunchDarkly `feature-flags` units produce a `budget_comparison` the same way GitHub/GitLab/Jira/Linear work-item units already do.

**Out of scope (flagged to reviewer, not attempted here):** the GitHub/GitLab "code-dataset" actuals gap (`commits`/`files`/`blame`/`cicd`/`tests`/`deployments`/`security`) is a much larger canonical-provider migration — those datasets are fetched via the frozen, PyGithub/python-gitlab-based `connectors/github.py` (~1400 lines) / `connectors/gitlab.py` (~1400 lines), and instrumenting them requires migrating those connectors off PyGithub/python-gitlab entirely, not a follow-up-ticket-sized change. Docs updated to reflect the split; a separate Linear issue for that migration is being filed (placeholder `CHAOS-XXXX` in `docs/providers/rate-limit-policy.md` — will update once the issue number is confirmed).

Linear: CHAOS-2761

## Test plan

- [x] New/updated tests, all passing:
  - `tests/test_launchdarkly.py` — `LaunchDarklyClient` + `LaunchDarklyCodeReferencesClient` real per-request usage recording (including retried-429 counting as 2 real requests, not 1) and canonical `RateLimitSignal` parity
  - `tests/test_rate_limit_signal.py` — 3-way `_raise_for_status` parity (legacy connector / new canonical client / code_refs client)
  - `tests/test_provider_usage.py` — LaunchDarkly added to the estimator-coverage contract test; new resolver-mapping test
  - `tests/test_feature_flag_sync.py` (new) — cutover to `LaunchDarklyClient` verified with fake clients (no network), observations threading, partial-actuals-on-RateLimitException preservation, code-refs-failure-still-drains-its-own-usage
  - `tests/test_dataset_adapters.py` — observations passthrough for the `feature-flags` dataset
  - `tests/test_sync_units.py` — end-to-end `budget_comparison` for an LD unit through `run_sync_unit`
- [x] `docs/providers/rate-limit-policy.md` and `docs/architecture/{launchdarkly-sync-budgeting,sync-usage-actuals}.md` updated in the same changeset
- [x] Gate: `env -i HOME=$HOME PATH=$PATH USER=$USER TMPDIR=$TMPDIR SCRATCH_DB=ci_local_validate_2761 bash ci/local_validate.sh` → **GATE PASSED** (6272 passed, 44 skipped, lint/mypy/full unit suite/live-ClickHouse argMax proof all green)
- [x] Rebased on latest `origin/main` before push (no drift — branch was already at tip)
- [x] No `uv.lock` changes, no provider network calls in tests