### PR TITLE
feat(external-ingest): real ingest-token auth + credential lifecycle (CHAOS-2712)

### DIFF
--- a/docs/architecture/adr-003-external-ingest-rest-boundary.md
+++ b/docs/architecture/adr-003-external-ingest-rest-boundary.md
@@ -114,21 +114,30 @@ matching rule alone to prevent a Linear collision.
 
 ## Decision 4: Interim auth is a mechanically-gated stopgap, not a real credential system
 
-CHAOS-2691 ships `api/external_ingest/auth.py::require_ingest_scope` with a
-body that accepts **any** bearer token + `X-Org-Id` header combination —
-solely so the REST contract is end-to-end testable before CHAOS-2696/2712
-land real token issuance and validation. This is gated, not silently
-insecure:
+**RESOLVED by CHAOS-2712** — `require_ingest_scope` now resolves real,
+DB-backed `IngestToken` rows (sha256-hashed `fcpush_` bearer tokens against
+`external_ingest_tokens`); the `EXTERNAL_INGEST_INSECURE_AUTH` flag and the
+`X-Org-Id` header path described below no longer exist in any form. This
+section is kept as the historical record of the interim state CHAOS-2691
+shipped and the release-blocker rationale that gated it; see
+[docs/architecture/customer-push-authz.md](customer-push-authz.md) for the
+real auth model.
 
-- The dependency **hard-fails `503 auth_not_configured`** unless the
-  deployment sets `EXTERNAL_INGEST_INSECURE_AUTH=1` — a flag intended only
+CHAOS-2691 originally shipped `api/external_ingest/auth.py::require_ingest_scope`
+with a body that accepted **any** bearer token + `X-Org-Id` header
+combination — solely so the REST contract was end-to-end testable before
+CHAOS-2696/2712 landed real token issuance and validation. This was gated,
+not silently insecure:
+
+- The dependency **hard-failed `503 auth_not_configured`** unless the
+  deployment set `EXTERNAL_INGEST_INSECURE_AUTH=1` — a flag intended only
   for local compose/CI, never a deployed environment.
-- Every request accepted under the flag logs a WARNING naming the org_id,
-  so interim-mode traffic is visible in ops before CHAOS-2696/2712 land.
-- **CHAOS-2696/2712 landing (real DB-backed `IngestToken` validation) is a
+- Every request accepted under the flag logged a WARNING naming the org_id,
+  so interim-mode traffic was visible in ops before CHAOS-2696/2712 landed.
+- **CHAOS-2696/2712 landing (real DB-backed `IngestToken` validation) was a
   hard pre-GA blocker** for this epic, not routine follow-up work. Merging
-  the `chaos-2690-external-ingest` integration branch to `main` remains
-  additionally gated on CHAOS-2712.
+  the `chaos-2690-external-ingest` integration branch to `main` was
+  additionally gated on CHAOS-2712 — now satisfied.
 
 ## Consequences
 

--- a/docs/architecture/customer-push-authz.md
+++ b/docs/architecture/customer-push-authz.md
@@ -201,9 +201,84 @@ This mirrors the confirmed pattern in `api/auth/routers/login.py`.
 fullchaos_hosted`, default `disabled`) and `webhook_secret_id` (nullable
 UUID) are added in migration `0032` now, ahead of CHAOS-2715's
 webhook-assisted ingestion work, so that feature doesn't need a follow-up
-migration to add columns to a table this feature already owns. v1 only
-accepts `disabled`/`customer_relay` at the admin API layer -- `fullchaos_hosted`
-400s (`webhook_secret_id` is unused until Option B webhook support lands).
+migration to add columns to a table this feature already owns.
+
+Two-layer contract (adr-004's must-not-foreclose section, implemented by
+CHAOS-2712): the admin Pydantic schemas (`IngestSourceCreate`/
+`IngestSourcePatch` in `api/admin/schemas/customer_push.py`) accept the
+*full* 3-value enum -- a request body containing `fullchaos_hosted` passes
+schema validation, no `422` -- so the field never needs a breaking schema
+change to add real support for it later. The admin router
+(`_reject_fullchaos_hosted_webhook_mode` in
+`api/admin/routers/customer_push.py`) is the layer that actually rejects it,
+with a `400`, before it is persisted or acted on. Do not collapse this back
+to a 2-value schema enum (`webhook_secret_id` stays unused until Option B
+webhook support lands).
+
+## Data-plane enforcement added by CHAOS-2712 (auth.py real body)
+
+Two checks closing gaps an adversarial review found in the initial
+`require_ingest_scope` implementation, beyond token validity/scope:
+
+- **Source binding (`require_matching_source`,
+  `api/external_ingest/auth.py`)**: `require_ingest_scope` resolves before
+  the request body is available, so it cannot itself compare a
+  source-bound token's `IngestSource` against the batch envelope's declared
+  `source.system`/`source.instance`. `POST /batches`
+  (`api/external_ingest/router.py::accept_batch`) calls
+  `require_matching_source(ctx, envelope.source.system,
+  envelope.source.instance)` explicitly, right after envelope parsing and
+  before `enqueue_batch`. Without this, a source-bound `ingest:write` token
+  could push data for a *different* source instance in the same org --
+  `ctx.org_id` alone does not prevent that. Mismatch -> `403
+  source_mismatch`; source resolved but disabled or not `customer_push` ->
+  `403 source_disabled`; an unbound (org-wide) token presented against a
+  write endpoint is treated the same as a mismatch (token-creation time
+  already forbids `ingest:write` on an unbound token, Design Decision 7 --
+  this is defense-in-depth, not the primary enforcement point).
+- **Pre-auth, IP-keyed throttles (two layers)**: the router's existing
+  per-token rate limit (`@limiter.limit(..., key_func=get_ingest_token_key)`)
+  never sees a request that fails inside `require_ingest_scope` -- FastAPI
+  resolves a route's `Depends()` before the `@limiter.limit(...)` decorator
+  body runs, so an auth failure raises and aborts the request before the
+  decorated endpoint (and its rate check) is ever reached. Without a
+  separate guard, missing/unknown/revoked/expired-token and wrong-scope
+  requests from one IP were completely unthrottled, each still paying for a
+  DB hash lookup and a failure-audit write. `require_ingest_scope` now calls
+  into the shared `limiter` backend directly, via two independent buckets
+  (`api/middleware/rate_limit.py`):
+  1. **`INGEST_AUTH_ATTEMPT_IP_LIMIT = "100/minute"`** -- an atomic,
+     unconditional ceiling consumed via `hit()` as the *first* thing the
+     dependency does, before the token-hash DB lookup and before any
+     `await`. This is the actual DB/app-load protection: a synchronous
+     `hit()` call with no `await` inside it cannot be interleaved with
+     other concurrently-scheduled requests in the same asyncio event loop,
+     so it closes a race a `test()`-then-`hit()` split cannot -- the DB
+     lookup between those two calls is itself an `await` point, so a burst
+     of *concurrent* invalid-token requests could previously all observe
+     the bucket as available and all reach Postgres before any of them
+     were counted (2nd-round adversarial-review finding). Applies to every
+     attempt regardless of outcome, and is deliberately generous so
+     legitimate high-volume traffic sharing an IP (e.g. several CI runners
+     behind one NAT gateway, each with its own valid token) stays well
+     under it in practice.
+  2. **`INGEST_AUTH_FAILURE_IP_LIMIT = "30/minute"`** -- a stricter,
+     failure-only signal layered *behind* the attempt ceiling above. A
+     read-only `test()` rejects with `429 rate_limited` if the IP is
+     already over budget; each failure branch then calls `hit()` to
+     consume from it. A request that succeeds never consumes it. Its own
+     `test()`-then-`hit()` gap is no longer a DB-load concern (bucket 1
+     already bounds that unconditionally); this bucket exists purely to
+     penalize repeated *wrong credentials* specifically, independent of
+     raw request volume.
+
+`get_ingest_token_key` (`api/middleware/rate_limit.py`, the *post-auth*
+per-token key func used by the route decorators) keys on
+`request.state.ingest_token_id`, set only once `require_ingest_scope`
+resolves a token successfully -- never on raw bearer text, which would let
+a caller rotate arbitrary strings to mint a fresh bucket on every request.
+Requests without a validated token (including the public `GET /schemas*`
+endpoints, which carry no auth dependency at all) always key on IP.
 
 ## Admin REST surface
 

--- a/docs/architecture/external-ingest-rest-contract.md
+++ b/docs/architecture/external-ingest-rest-contract.md
@@ -182,20 +182,23 @@ naming (`external-ingest:{org_id}:batches`, DLQ
 per master-spec CC9) are a pinned contract CHAOS-2693 extends in place
 without changing.
 
-`require_ingest_scope()`'s interim body accepts any bearer token + valid
-`X-Org-Id` header **only** when `EXTERNAL_INGEST_INSECURE_AUTH=1` is set;
-otherwise it hard-fails `503 auth_not_configured`. See
+**Updated by CHAOS-2712**: `require_ingest_scope()`'s body now resolves a
+real, DB-backed `IngestToken` row (sha256-hashed `fcpush_` bearer against
+`external_ingest_tokens`) — the `EXTERNAL_INGEST_INSECURE_AUTH` flag and
+`X-Org-Id` header path described in this section's original (CHAOS-2691
+interim) form are deleted entirely. See
 [ADR-003](adr-003-external-ingest-rest-boundary.md#decision-4-interim-auth-is-a-mechanically-gated-stopgap-not-a-real-credential-system)
-for the full rationale and the CHAOS-2696/2712 replacement plan — this is a
-release blocker for the epic, not a routine follow-up.
+for the interim-era history and
+[docs/architecture/customer-push-authz.md](customer-push-authz.md) for the
+real auth/token model.
 
-Because interim auth does not validate the bearer value at all, keying the
-rate limiter on it would let a caller rotate arbitrary strings for a fresh
-60/minute bucket on every request (adversarial-review finding).
-`get_ingest_token_key` (`api/middleware/rate_limit.py`) checks
-`EXTERNAL_INGEST_INSECURE_AUTH` itself and keys on IP instead of the bearer
-digest whenever the flag is set — the only real, uncontrolled identity
-available until CHAOS-2696/2712 issue validated per-token credentials.
+`get_ingest_token_key` (`api/middleware/rate_limit.py`) now keys the
+limiter on `request.state.ingest_token_id` — set by `require_ingest_scope`
+only once a bearer has been resolved against a real token row — falling
+back to IP for public/unauthenticated requests. This closes the
+adversarial-review finding against the old interim design (keying on a hash
+of the raw, unvalidated bearer text would have let a caller rotate
+arbitrary strings for a fresh 60/minute bucket on every request).
 
 ## `GET /schemas` / `GET /schemas/{version}`: minimal, real, off the Pydantic models directly
 

--- a/src/dev_health_ops/api/admin/routers/customer_push.py
+++ b/src/dev_health_ops/api/admin/routers/customer_push.py
@@ -36,6 +36,7 @@ from dev_health_ops.models.ingest_auth import (
     IngestSourceMode,
     IngestToken,
     IngestTokenScope,
+    IngestWebhookMode,
     generate_ingest_token,
     hash_ingest_token,
 )
@@ -83,6 +84,23 @@ def _validate_mode(mode: str) -> IngestSourceMode:
                 f"Invalid mode '{mode}'; must be one of "
                 f"{[m.value for m in IngestSourceMode]}"
             ),
+        )
+
+
+def _reject_fullchaos_hosted_webhook_mode(webhook_mode: str) -> None:
+    """Router business-logic layer of adr-004's two-layer webhookMode contract.
+
+    The Pydantic schema (``api/admin/schemas/customer_push.py``) accepts the
+    full 3-value enum -- including ``fullchaos_hosted`` -- so a request body
+    containing it passes schema validation (no 422); this is what actually
+    rejects it, with a 400, before it is persisted or acted on (Option B /
+    FullChaos-hosted webhooks are not built yet, see
+    docs/architecture/adr-004-webhook-assisted-customer-push-ingestion.md).
+    """
+    if webhook_mode == IngestWebhookMode.FULLCHAOS_HOSTED.value:
+        raise HTTPException(
+            status_code=400,
+            detail="fullchaos_hosted webhook mode is not available yet",
         )
 
 
@@ -342,6 +360,7 @@ async def create_source(
     org_id = current_user.org_id
     system = _validate_system(payload.system)
     mode = _validate_mode(payload.mode)
+    _reject_fullchaos_hosted_webhook_mode(payload.webhook_mode)
 
     matched_id: uuid.UUID | None = None
     warnings: list[str] = []
@@ -440,6 +459,7 @@ async def patch_source(
         }
         source.display_name = payload.display_name
     if payload.webhook_mode is not None and payload.webhook_mode != source.webhook_mode:
+        _reject_fullchaos_hosted_webhook_mode(payload.webhook_mode)
         changes["webhook_mode"] = {
             "old": source.webhook_mode,
             "new": payload.webhook_mode,

--- a/src/dev_health_ops/api/admin/schemas/customer_push.py
+++ b/src/dev_health_ops/api/admin/schemas/customer_push.py
@@ -13,22 +13,25 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from dev_health_ops.models.ingest_auth import IngestTokenScope, IngestWebhookMode
 
-_VALID_ADMIN_WEBHOOK_MODES = {
-    IngestWebhookMode.DISABLED.value,
-    IngestWebhookMode.CUSTOMER_RELAY.value,
-}
+_ALL_WEBHOOK_MODES = {mode.value for mode in IngestWebhookMode}
 _VALID_SCOPES = {scope.value for scope in IngestTokenScope}
 
 
 def _validate_webhook_mode(value: str | None) -> str | None:
+    """Schema/type-layer check ONLY -- accepts the full 3-value enum.
+
+    adr-004's must-not-foreclose contract is a deliberate two-layer design:
+    the Pydantic type here must accept ``fullchaos_hosted`` (no 422) so the
+    field never needs a breaking schema change to add it back later; the
+    admin router's business-logic layer (``_reject_fullchaos_hosted_webhook_mode``
+    in ``api/admin/routers/customer_push.py``) is what actually 400s that
+    value before it's persisted or acted on. Do not narrow this to the
+    2-value v1-supported subset.
+    """
     if value is None:
         return value
-    if value not in _VALID_ADMIN_WEBHOOK_MODES:
-        raise ValueError(
-            "webhook_mode must be one of "
-            f"{sorted(_VALID_ADMIN_WEBHOOK_MODES)} (fullchaos_hosted is reserved, "
-            "not available in v1)"
-        )
+    if value not in _ALL_WEBHOOK_MODES:
+        raise ValueError(f"webhook_mode must be one of {sorted(_ALL_WEBHOOK_MODES)}")
     return value
 
 

--- a/src/dev_health_ops/api/external_ingest/auth.py
+++ b/src/dev_health_ops/api/external_ingest/auth.py
@@ -1,101 +1,361 @@
-"""Interim external-ingest auth dependency (CHAOS-2691 D7).
+"""Real external-ingest auth dependency (CHAOS-2696/2712, master-spec CC14).
 
-INTEGRATION-BRANCH-ONLY: this module's body is intentionally permissive once
-``EXTERNAL_INGEST_INSECURE_AUTH=1`` is set (any bearer token + any
-``X-Org-Id`` is then accepted) because CHAOS-2691's own acceptance criteria
-never test 401/403 — only 202/400/413/openapi/tests-for-shapes. Merging the
-``chaos-2690-external-ingest`` integration branch to ``main`` is gated on
-CHAOS-2712 landing real DB-backed ``IngestToken`` validation.
+Resolves an ``fcpush_`` bearer token against ``external_ingest_tokens``
+(``sha256``, matching the house convention -- see
+``docs/architecture/customer-push-authz.md``), independently sets the
+``org_id`` contextvar (``OrgIdMiddleware`` only understands user JWTs and
+takes its anonymous pass-through branch for an ``fcpush_...`` bearer, so it
+never sets the contextvar for us), and is the single place 401/403 semantics
+for CHAOS-2690's data-plane endpoints are decided.
 
-CHAOS-2696/CHAOS-2712 replace this function's body; the ``IngestAuthContext``
-shape and ``Depends(...)`` call sites in ``router.py`` must not change.
+Deletes CHAOS-2691's interim, flag-gated body (``EXTERNAL_INGEST_INSECURE_AUTH``
++ the ``X-Org-Id`` header path) entirely -- this ticket is the hard pre-GA
+blocker for the ``chaos-2690-external-ingest`` integration branch
+(master-spec CC14 / reconciliation delta A5). The ``IngestAuthContext`` shape
+and ``Depends(...)`` call sites in ``router.py`` are unchanged: both bound
+scope dependencies (``_require_schema_read``/``_require_ingest_write``) still
+resolve to ``require_ingest_scope(scope)``.
 """
 
 from __future__ import annotations
 
 import logging
-import os
-from dataclasses import dataclass, field
+import uuid
+from collections.abc import AsyncGenerator
+from dataclasses import dataclass
+from datetime import datetime, timezone
 
-from fastapi import Header
+from fastapi import Depends, Request
+from limits import parse as parse_rate_limit
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from dev_health_ops.api.services.auth import set_current_org_id
+from dev_health_ops.api.dependencies import get_postgres_session_dep
+from dev_health_ops.api.middleware.rate_limit import (
+    INGEST_AUTH_ATTEMPT_IP_LIMIT,
+    INGEST_AUTH_FAILURE_IP_LIMIT,
+    get_forwarded_ip,
+    limiter,
+)
+from dev_health_ops.api.services.auth import _current_org_id, set_current_org_id
+from dev_health_ops.api.utils.audit import emit_audit_log
+from dev_health_ops.db import get_postgres_session
+from dev_health_ops.models.audit import AuditAction, AuditResourceType
+from dev_health_ops.models.ingest_auth import (
+    TOKEN_PREFIX,
+    IngestSource,
+    IngestToken,
+    hash_ingest_token,
+)
 
 from .errors import ExternalIngestError
 
 logger = logging.getLogger(__name__)
 
+_AUTH_ATTEMPT_LIMIT_ITEM = parse_rate_limit(INGEST_AUTH_ATTEMPT_IP_LIMIT)
+_AUTH_FAILURE_LIMIT_ITEM = parse_rate_limit(INGEST_AUTH_FAILURE_IP_LIMIT)
 
-@dataclass
+
+@dataclass(frozen=True)
 class IngestAuthContext:
+    """Resolved identity for an authenticated ``/api/v1/external-ingest/*`` request.
+
+    Shape pinned epic-wide (master-spec CC14). ``source`` is ``None`` for
+    org-wide tokens -- legal only when scopes are a subset of
+    ``{schema:read, ingest:status}`` (never ``ingest:write``), enforced at
+    token-creation time (Design Decision 7,
+    docs/architecture/customer-push-authz.md), not re-validated here.
+    """
+
     org_id: str
-    scopes: set[str] = field(default_factory=set)
-    token_id: str | None = None  # populated once CHAOS-2696 lands
+    scopes: frozenset[str]
+    token_id: str | None = None
+    source: IngestSource | None = None
 
 
-def require_ingest_scope(required_scope: str):
-    async def _dep(
-        authorization: str | None = Header(default=None),
-        x_org_id: str | None = Header(default=None, alias="X-Org-Id"),
-    ) -> IngestAuthContext:
-        # Mechanical guard (master-spec CC14): the interim dependency refuses
-        # to run unless explicitly enabled for local/test use. Prevents the
-        # any-bearer+X-Org-Id path from ever working in a deployed
-        # environment (integration branches DO get deployed to shared envs;
-        # process gates slip). CHAOS-2712 deletes this flag together with
-        # the interim body.
-        if os.environ.get("EXTERNAL_INGEST_INSECURE_AUTH") != "1":
-            raise ExternalIngestError(
-                status_code=503,
-                code="auth_not_configured",
-                message="external-ingest auth is not configured on this deployment",
-            )
-        if not authorization or not authorization.lower().startswith("bearer "):
-            # Adversarial-review fix: use the external-ingest error envelope
-            # (master-spec CC16 explicitly includes auth failures), not a
-            # bare HTTPException — customer SDKs must not need special-case
-            # parsing for auth errors on a contract that advertises one
-            # stable {"error": {...}} shape.
-            raise ExternalIngestError(
-                status_code=401,
-                code="invalid_token",
-                message="Missing or malformed bearer token",
-            )
-        if not x_org_id:
-            # missing_org_header is interim-only: the X-Org-Id header itself
-            # disappears once CHAOS-2712 derives org_id from a validated
-            # token, so this code is not in master-spec CC16's permanent
-            # vocabulary.
-            raise ExternalIngestError(
-                status_code=400,
-                code="missing_org_header",
-                message="X-Org-Id header required",
-            )
-        # INTERIM (CHAOS-2691): token value is opaque and NOT validated
-        # against a DB-backed IngestToken/scope model yet. CHAOS-2696
-        # replaces this function body. Every interim-mode request is logged
-        # at WARNING so this is visible in ops before 2696 lands.
+def _extract_bearer(request: Request) -> str | None:
+    header = request.headers.get("authorization")
+    if not header or not header.lower().startswith("bearer "):
+        return None
+    token = header[7:].strip()
+    return token or None
+
+
+async def _emit_failure_audit(
+    db: AsyncSession,
+    request: Request,
+    *,
+    org_id: str | None,
+    token_id: str | None,
+    reason: str,
+) -> None:
+    """Commit-before-raise (docs/architecture/customer-push-authz.md).
+
+    Every caller does ``await _emit_failure_audit(...)`` immediately
+    followed by ``raise ExternalIngestError(...)`` on its own line --
+    ``get_postgres_session``'s ambient commit only fires on a clean
+    dependency return and rolls back on *any* exception, including a
+    deliberately-raised one, which would otherwise silently discard the
+    ``INGEST_AUTH_FAILED`` row this function exists to persist (mirrors the
+    confirmed live fix pattern in ``api/auth/routers/login.py``).
+
+    ``org_id`` is unknown for a header that never resolved to a token row
+    (missing/malformed bearer, unrecognized hash) -- ``AuditLog.org_id`` is a
+    required FK to ``organizations.id`` with nothing valid to attach to, so
+    those cases log at WARNING only and are never written to Postgres.
+    """
+    if org_id is None:
         logger.warning(
-            "external-ingest interim auth: unvalidated token accepted for org_id=%s",
-            x_org_id,
+            "external-ingest auth failure (no org resolved): path=%s reason=%s",
+            request.url.path,
+            reason,
         )
-        ctx = IngestAuthContext(
-            org_id=x_org_id,
-            scopes={"ingest:write", "ingest:status", "schema:read"},
+        return
+    try:
+        emit_audit_log(
+            db,
+            org_id=uuid.UUID(org_id),
+            action=AuditAction.INGEST_AUTH_FAILED,
+            resource_type=AuditResourceType.INGEST_TOKEN,
+            resource_id=token_id or "unknown",
+            description=f"Ingest auth failed on {request.url.path}: {reason}",
+            request=request,
+            status="failure",
+            error_message=reason,
         )
-        if required_scope not in ctx.scopes:
-            # Dead code in interim mode (all scopes are granted above) — the
-            # check is written now so the Depends() seam doesn't change
-            # shape once CHAOS-2696 grants real, narrower scopes.
-            raise ExternalIngestError(
-                status_code=403,
-                code="insufficient_scope",
-                message=f"Token is missing required scope: {required_scope}",
+        await db.commit()
+    except Exception:
+        logger.exception("Failed to persist ingest auth failure audit log (non-fatal)")
+
+
+def _auth_attempt_ip_key(request: Request) -> str:
+    return f"external-ingest-auth-attempt:{get_forwarded_ip(request)}"
+
+
+def _auth_failure_ip_key(request: Request) -> str:
+    return f"external-ingest-auth-fail:{get_forwarded_ip(request)}"
+
+
+def _reserve_auth_attempt_or_429(request: Request) -> None:
+    """Atomic, unconditional per-IP ceiling on ingest-auth attempts.
+
+    Must be the first thing ``require_ingest_scope``'s dependency does --
+    before ``_extract_bearer``, before the token-hash DB lookup, before any
+    ``await``. Consumed via ``hit()`` (not ``test()``), which makes this
+    atomic with respect to other concurrently-scheduled requests in the same
+    asyncio event loop: a synchronous call with no ``await`` inside it
+    cannot be interleaved with another coroutine's execution. A
+    ``test()``-then-``hit()`` split (as used by
+    ``_reject_if_already_ip_throttled`` below) is *not* atomic here, because
+    the token-hash DB lookup sits between the two calls and is itself an
+    ``await`` point -- a burst of concurrent invalid-token requests can all
+    observe the bucket as available and all reach Postgres before any of
+    them are counted (2nd-round adversarial-review finding). This bucket is
+    the actual DB/app-load protection; see ``INGEST_AUTH_ATTEMPT_IP_LIMIT``'s
+    comment (``api/middleware/rate_limit.py``) for why it's generous and
+    applies to every attempt regardless of outcome.
+    """
+    rate_limiter = getattr(limiter, "limiter", None)
+    if rate_limiter is None:  # _NoOpLimiter (tests / slowapi unavailable)
+        return
+    if not rate_limiter.hit(_AUTH_ATTEMPT_LIMIT_ITEM, _auth_attempt_ip_key(request)):
+        raise ExternalIngestError(
+            429, "rate_limited", "Too many authentication attempts"
+        )
+
+
+def _reject_if_already_ip_throttled(request: Request) -> None:
+    """Stricter, failure-only signal layered behind the attempt ceiling
+    above -- penalizes repeated *wrong credentials* specifically, not just
+    request volume. Its own ``test()``-then-``hit()`` gap is no longer a
+    DB-load concern (``_reserve_auth_attempt_or_429`` already bounds that
+    unconditionally, atomically, before this ever runs); it exists purely
+    as an independent signal. Read-only ``test()`` here (never consumes) so
+    a request that's about to succeed never pays for this at all -- only
+    ``_record_auth_failure_hit`` (called on the failure paths below)
+    consumes from the bucket.
+    """
+    rate_limiter = getattr(limiter, "limiter", None)
+    if rate_limiter is None:  # _NoOpLimiter (tests / slowapi unavailable)
+        return
+    if not rate_limiter.test(_AUTH_FAILURE_LIMIT_ITEM, _auth_failure_ip_key(request)):
+        raise ExternalIngestError(
+            429, "rate_limited", "Too many failed authentication attempts"
+        )
+
+
+def _record_auth_failure_hit(request: Request) -> None:
+    rate_limiter = getattr(limiter, "limiter", None)
+    if rate_limiter is None:
+        return
+    rate_limiter.hit(_AUTH_FAILURE_LIMIT_ITEM, _auth_failure_ip_key(request))
+
+
+async def _bump_last_used(token_id: uuid.UUID, ip: str | None) -> None:
+    """Best-effort, isolated from the request's main session (Design
+    Decision 11, docs/architecture/customer-push-authz.md).
+
+    A later exception raised downstream of this dependency (e.g. the route
+    handler's own business logic, which may use its own separate DB session)
+    must not roll this back -- "was this token used, even for a rejected
+    request" must survive regardless of what happens after ``yield``.
+    Awaited synchronously rather than fired via ``asyncio.create_task`` so
+    callers (including tests) observe the update deterministically instead
+    of racing a detached background task in a short-lived event loop.
+    """
+    try:
+        async with get_postgres_session() as session:
+            token = await session.get(IngestToken, token_id)
+            if token is not None:
+                token.last_used_at = datetime.now(timezone.utc)
+                token.last_used_ip = ip
+            await session.commit()
+    except Exception:
+        logger.exception("Failed to record ingest token last_used_at (non-fatal)")
+
+
+def require_ingest_scope(scope: str):
+    """Single dependency factory for CHAOS-2690's data-plane scope checks.
+
+    Bound once per required scope at router import time (see
+    ``api/external_ingest/router.py``'s ``_require_schema_read``/
+    ``_require_ingest_write``) -- ``Depends()`` matches
+    ``app.dependency_overrides`` by the exact bound callable produced here,
+    not by this factory, so unit tests override the bound objects directly.
+    """
+
+    async def _dep(
+        request: Request,
+        db: AsyncSession = Depends(get_postgres_session_dep),
+    ) -> AsyncGenerator[IngestAuthContext, None]:
+        _reserve_auth_attempt_or_429(request)
+        _reject_if_already_ip_throttled(request)
+
+        raw = _extract_bearer(request)
+        if raw is None or not raw.startswith(TOKEN_PREFIX):
+            _record_auth_failure_hit(request)
+            await _emit_failure_audit(
+                db,
+                request,
+                org_id=None,
+                token_id=None,
+                reason="missing_or_malformed_bearer",
             )
-        set_current_org_id(ctx.org_id)  # keep ClickHouse auto-scoping consistent
-        return ctx
+            raise ExternalIngestError(
+                401, "invalid_token", "Missing or invalid ingest token"
+            )
+
+        token_hash = hash_ingest_token(raw)
+        result = await db.execute(
+            select(IngestToken).where(IngestToken.token_hash == token_hash)
+        )
+        token = result.scalar_one_or_none()
+        if token is None:
+            _record_auth_failure_hit(request)
+            await _emit_failure_audit(
+                db, request, org_id=None, token_id=None, reason="unknown_token"
+            )
+            raise ExternalIngestError(
+                401, "invalid_token", "Missing or invalid ingest token"
+            )
+
+        now = datetime.now(timezone.utc)
+        if not token.is_valid(now):
+            reason = "revoked" if token.revoked_at is not None else "expired"
+            _record_auth_failure_hit(request)
+            await _emit_failure_audit(
+                db,
+                request,
+                org_id=token.org_id,
+                token_id=str(token.id),
+                reason=reason,
+            )
+            raise ExternalIngestError(
+                401, "invalid_token", "Missing or invalid ingest token"
+            )
+
+        source: IngestSource | None = None
+        if token.source_id is not None:
+            source = await db.get(IngestSource, token.source_id)
+
+        # Token is confirmed present + valid -- record usage regardless of
+        # whether the scope check below ultimately passes (Design Decision 11).
+        client_ip = request.client.host if request.client else None
+        await _bump_last_used(token.id, client_ip)
+
+        scopes = frozenset(token.scopes or [])
+        if scope not in scopes:
+            _record_auth_failure_hit(request)
+            await _emit_failure_audit(
+                db,
+                request,
+                org_id=token.org_id,
+                token_id=str(token.id),
+                reason=f"insufficient_scope:{scope}",
+            )
+            raise ExternalIngestError(
+                403,
+                "insufficient_scope",
+                f"Token is missing required scope: {scope}",
+            )
+
+        ctx = IngestAuthContext(
+            org_id=token.org_id,
+            scopes=scopes,
+            token_id=str(token.id),
+            source=source,
+        )
+        # Diagnostics + the rate-limit key func (get_ingest_token_key) key on
+        # this once it's been validated here -- never on raw bearer text
+        # (adversarial-review finding: an unvalidated raw-text hash lets a
+        # caller rotate arbitrary strings to mint a fresh limiter bucket
+        # every request).
+        request.state.ingest_token_id = ctx.token_id
+        org_token = set_current_org_id(
+            ctx.org_id
+        )  # OrgIdMiddleware doesn't do this for an fcpush_ bearer (Decision 9)
+        try:
+            yield ctx
+        finally:
+            _current_org_id.reset(org_token)
 
     return _dep
 
 
-__all__ = ["IngestAuthContext", "require_ingest_scope"]
+def require_matching_source(
+    ctx: IngestAuthContext, system: str, instance: str
+) -> IngestSource:
+    """Enforce that a write request's declared source matches the token's
+    bound source (Design Decision 7 / master-spec CC16 ``source_mismatch``).
+
+    ``require_ingest_scope`` resolves before the request body is available,
+    so it cannot check the payload's ``source.system``/``source.instance``
+    itself -- call this from the route handler, after parsing the envelope
+    (adversarial-review finding: without this check, any source-bound
+    ``ingest:write`` token could push data for a *different* source
+    instance in the same org, since only ``ctx.org_id`` was previously
+    checked).
+
+    An org-wide (unbound) token -- ``ctx.source is None`` -- can only ever
+    reach here via ``ingest:write`` if the source-binding invariant enforced
+    at token-creation time (Design Decision 7: ``ingest:write`` requires a
+    non-null ``source_id``) was somehow bypassed; treat that defensively as
+    a mismatch, not a pass-through.
+    """
+    source = ctx.source
+    if source is None or source.system != system or source.instance != instance:
+        raise ExternalIngestError(
+            403,
+            "source_mismatch",
+            "Payload source does not match the token's bound source",
+        )
+    if not source.is_write_eligible():
+        raise ExternalIngestError(
+            403,
+            "source_disabled",
+            "Source is disabled or not in customer_push mode",
+        )
+    return source
+
+
+__all__ = ["IngestAuthContext", "require_ingest_scope", "require_matching_source"]

--- a/src/dev_health_ops/api/external_ingest/router.py
+++ b/src/dev_health_ops/api/external_ingest/router.py
@@ -28,7 +28,7 @@ from dev_health_ops.api.middleware.rate_limit import (
 )
 from dev_health_ops.external_ingest.validate import validate_records
 
-from .auth import IngestAuthContext, require_ingest_scope
+from .auth import IngestAuthContext, require_ingest_scope, require_matching_source
 from .errors import ExternalIngestError
 from .schemas import (
     MAX_BODY_BYTES_DEFAULT,
@@ -218,6 +218,12 @@ async def accept_batch(
     _check_schema_version_or_400(envelope)
     _check_all_kinds_known_or_400(envelope)
     _check_batch_size_or_400(envelope)
+    # Adversarial-review fix: require_ingest_scope resolves before the body
+    # is parsed, so it can't check payload source vs. token-bound source
+    # itself -- a source-bound ingest:write token must not be able to push
+    # data for a different source instance in the same org (CC16
+    # source_mismatch / source_disabled).
+    require_matching_source(ctx, envelope.source.system, envelope.source.instance)
 
     ingestion_id = str(uuid4())
     window = envelope.window

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -38,29 +38,59 @@ INGEST_BATCH_LIMIT = "60/minute"
 INGEST_VALIDATE_LIMIT = "60/minute"
 INGEST_READ_LIMIT = "120/minute"
 
+# CHAOS-2712 (adversarial-review finding): the post-auth, per-token buckets
+# above never see a request that fails auth -- FastAPI resolves Depends()
+# (require_ingest_scope) before slowapi's @limiter.limit(...) decorator body
+# runs, so a request that 401s/403s inside the auth dependency never reaches
+# the decorated route at all. Without a separate guard, token-guessing /
+# revoked-token / wrong-scope floods from one IP are completely unthrottled.
+# require_ingest_scope (api/external_ingest/auth.py) applies two IP-keyed
+# limits itself, directly against the shared `limiter` backend below:
+#
+# INGEST_AUTH_ATTEMPT_IP_LIMIT: an atomic, unconditional ceiling on ingest-auth
+# attempts (success AND failure), consumed via hit() BEFORE any DB work --
+# this is what actually bounds worst-case DB/app load per IP under a
+# concurrent flood (a test()-then-hit() split is not atomic: the DB lookup
+# between the two calls is an await point, so a burst of concurrent
+# requests can all observe spare capacity and all reach Postgres before any
+# of them are counted -- 2nd-round adversarial-review finding). Deliberately
+# generous so legitimate high-volume traffic sharing an IP (e.g. several CI
+# runners behind one NAT gateway, each with its own valid token) stays well
+# under it in practice.
+INGEST_AUTH_ATTEMPT_IP_LIMIT = "100/minute"
+#
+# INGEST_AUTH_FAILURE_IP_LIMIT: a stricter, failure-only signal layered
+# behind the attempt ceiling above -- a client whose requests all succeed
+# never touches it. Its own test()-then-hit() gap is no longer a DB-load
+# concern (the attempt ceiling already bounds that unconditionally); it
+# exists purely to penalize repeated *wrong credentials* specifically.
+INGEST_AUTH_FAILURE_IP_LIMIT = "30/minute"
+
 
 def get_ingest_token_key(request: Request) -> str:
-    """Rate-limit key for external-ingest endpoints: per-token, IP fallback.
+    """Rate-limit key for external-ingest endpoints: per-VALIDATED-token, IP fallback.
 
-    Keys on a truncated hash of the bearer token (never the raw token, which
-    must not appear in limiter storage) so distinct ingest tokens get
-    independent buckets. Falls back to the forwarded IP for unauthenticated
-    requests (the public GET /schemas* endpoints) and, while
-    EXTERNAL_INGEST_INSECURE_AUTH=1's interim auth is active, for ALL
-    requests: interim auth does not validate the bearer value at all, so
-    keying on it would let a caller rotate arbitrary strings for a fresh
-    limiter bucket on every request (adversarial review finding) — IP is the
-    only real identity available until CHAOS-2696/2712 issue validated
-    per-token credentials; see brief-2691 Risks.
+    Keys on a truncated hash of ``request.state.ingest_token_id`` -- set by
+    ``require_ingest_scope`` (``api/external_ingest/auth.py``, CHAOS-2712)
+    only once a bearer token has been resolved against a real, DB-backed
+    ``IngestToken`` row -- never on the raw, unvalidated bearer text. FastAPI
+    resolves a route's ``Depends()`` (including the auth dependency) before
+    slowapi's ``@limiter.limit(...)`` decorator body runs, so by the time
+    this key_func executes for an authenticated route, auth has already
+    succeeded (and set ``request.state.ingest_token_id``) or the request has
+    already been aborted with a 401/403 and never reaches here. Keying on raw
+    bearer text instead would let a caller rotate arbitrary strings to mint a
+    fresh limiter bucket on every request for any route this key_func is
+    applied to without a preceding auth dependency -- concretely the public
+    GET /schemas* endpoints, which carry no auth dependency at all and so
+    would see attacker-controlled ``Authorization`` headers directly
+    (adversarial-review finding). Those, and any other request without a
+    validated token, always key on IP.
     """
-    if os.environ.get("EXTERNAL_INGEST_INSECURE_AUTH") == "1":
-        return f"ingest-ip:{get_forwarded_ip(request)}"
-    auth_header = request.headers.get("authorization") or ""
-    if auth_header.lower().startswith("bearer "):
-        token = auth_header[7:].strip()
-        if token:
-            digest = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
-            return f"ingest-token:{digest}"
+    token_id = getattr(request.state, "ingest_token_id", None)
+    if token_id:
+        digest = hashlib.sha256(str(token_id).encode("utf-8")).hexdigest()[:16]
+        return f"ingest-token:{digest}"
     return f"ingest-ip:{get_forwarded_ip(request)}"
 
 

--- a/src/dev_health_ops/models/ingest_auth.py
+++ b/src/dev_health_ops/models/ingest_auth.py
@@ -176,6 +176,15 @@ class IngestToken(Base):
     def is_valid(self, now: datetime) -> bool:
         if self.revoked_at is not None:
             return False
-        if self.expires_at is not None and now > self.expires_at:
-            return False
+        if self.expires_at is not None:
+            expires_at = self.expires_at
+            if expires_at.tzinfo is None:
+                # SQLite (test fixtures, per AGENTS.md) round-trips
+                # DateTime(timezone=True) values as naive; Postgres (prod)
+                # preserves tzinfo. Values are always written as UTC (see
+                # generate_ingest_token/rotate call sites), so a naive value
+                # read back is UTC, never local time.
+                expires_at = expires_at.replace(tzinfo=timezone.utc)
+            if now > expires_at:
+                return False
         return True

--- a/tests/api/admin/test_customer_push.py
+++ b/tests/api/admin/test_customer_push.py
@@ -212,10 +212,35 @@ async def test_create_source_invalid_mode_400(client):
 
 
 @pytest.mark.asyncio
-async def test_create_source_invalid_webhook_mode_422(client):
+async def test_create_source_fullchaos_hosted_webhook_mode_rejected_400(client):
+    # adr-004 two-layer contract: the schema TYPE accepts fullchaos_hosted
+    # (no 422 -- see test_create_source_fullchaos_hosted_webhook_mode_passes_schema_validation
+    # below), but the router's business-logic layer 400s it before persisting.
     ac, _ = client
     resp = await _create_source(ac, webhook_mode="fullchaos_hosted")
+    assert resp.status_code == 400
+    assert "fullchaos_hosted" in resp.json()["detail"]
+
+
+@pytest.mark.asyncio
+async def test_create_source_unknown_webhook_mode_422(client):
+    ac, _ = client
+    resp = await _create_source(ac, webhook_mode="not_a_real_mode")
     assert resp.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_patch_source_fullchaos_hosted_webhook_mode_rejected_400(client):
+    ac, _ = client
+    created = await _create_source(ac, system="github", instance="acme/api")
+    source_id = created.json()["id"]
+
+    resp = await ac.patch(
+        f"/api/v1/admin/customer-push/sources/{source_id}",
+        json={"webhook_mode": "fullchaos_hosted"},
+    )
+    assert resp.status_code == 400
+    assert "fullchaos_hosted" in resp.json()["detail"]
 
 
 @pytest.mark.asyncio

--- a/tests/api/external_ingest/test_auth.py
+++ b/tests/api/external_ingest/test_auth.py
@@ -1,0 +1,742 @@
+"""Tests for the real, DB-backed external-ingest auth dependency (CHAOS-2712).
+
+Two layers, mirroring tests/api/webhooks/test_auth.py's direct-dependency-
+function-call style plus a small end-to-end slice through the real router:
+
+1. Direct calls into ``require_ingest_scope(scope)``'s returned dependency
+   (an async-generator FastAPI dependency -- driven here the same way
+   FastAPI itself drives it: ``await agen.__anext__()`` to reach the
+   yielded ``IngestAuthContext``, ``await agen.aclose()`` to run its
+   ``finally`` teardown). This lets tests assert precisely on ctx fields,
+   audit-row persistence, and last_used bookkeeping without needing HTTP.
+2. A handful of end-to-end ``httpx`` calls against a standalone app mounting
+   the real ``external_ingest`` router, proving the full stack (error
+   envelope shape, status codes) wires together correctly.
+
+Covers master-spec CC14's 401/403 contract, the commit-before-raise audit
+trap (docs/architecture/customer-push-authz.md), Design Decision 11's
+last-used isolation, and regression coverage for the deleted
+``EXTERNAL_INGEST_INSECURE_AUTH`` flag / ``X-Org-Id`` header path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import importlib
+import sys
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI, Request
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.external_ingest import auth as auth_module
+from dev_health_ops.api.external_ingest.errors import (
+    ExternalIngestError,
+    register_external_ingest_error_handlers,
+)
+from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION
+from dev_health_ops.api.middleware import rate_limit as rate_limit_module
+from dev_health_ops.api.services.auth import get_current_org_id
+from dev_health_ops.models.audit import AuditAction, AuditLog
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.ingest_auth import (
+    IngestSource,
+    IngestSourceMode,
+    IngestToken,
+    generate_ingest_token,
+    hash_ingest_token,
+)
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+# __init__.py exports the APIRouter as "router", shadowing the module name --
+# force-load the actual module (mirrors tests/api/test_external_ingest_router.py).
+importlib.import_module("dev_health_ops.api.external_ingest.router")
+router_module = sys.modules["dev_health_ops.api.external_ingest.router"]
+
+BASE = "/api/v1/external-ingest"
+
+_TABLES = tables_of(Organization, User, IngestSource, IngestToken, AuditLog)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "external_ingest_auth.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture(autouse=True)
+def _patch_isolated_session(monkeypatch, session_maker):
+    """Point auth.py's isolated-session writes (the last_used bump, called
+    via ``get_postgres_session()`` rather than FastAPI's ``Depends()``) at
+    this test's own sqlite engine -- otherwise it would try to reach the
+    real (unconfigured) Postgres engine from db.py."""
+
+    @asynccontextmanager
+    async def _fake_get_postgres_session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(auth_module, "get_postgres_session", _fake_get_postgres_session)
+
+
+@pytest.fixture(autouse=True)
+def _reset_ingest_auth_failure_limiter():
+    """The shared ``limiter`` singleton (api/middleware/rate_limit.py) uses
+    process-global in-memory storage -- without a reset, the new
+    INGEST_AUTH_FAILURE_IP_LIMIT bucket (CHAOS-2712 adversarial-review fix)
+    would accumulate hits across every failure-path test in this module that
+    shares the default ``_make_request`` client_host, risking order-dependent
+    429s in tests that don't intend to exercise the throttle itself."""
+    reset = getattr(rate_limit_module.limiter, "reset", None)
+    if reset is not None:
+        try:
+            reset()
+        except Exception:
+            pass
+    yield
+
+
+@pytest_asyncio.fixture
+async def org_id(session_maker) -> str:
+    oid = uuid.uuid4()
+    async with session_maker() as session:
+        session.add(Organization(id=oid, slug="test-org", name="Test Org", tier="pro"))
+        await session.commit()
+    return str(oid)
+
+
+@pytest_asyncio.fixture
+async def http_client(session_maker):
+    """Standalone app mounting only the real external-ingest router, with
+    ``get_postgres_session_dep`` (the Depends()-injected session used for
+    token/source lookups and commit-before-raise audit writes) overridden to
+    the same test engine. No dependency_overrides for auth itself -- the
+    real ``require_ingest_scope`` body runs end-to-end."""
+    app = FastAPI()
+    app.include_router(router_module.router)
+    register_external_ingest_error_handlers(app)
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+
+    app.dependency_overrides[auth_module.get_postgres_session_dep] = _session_override
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        yield client
+    app.dependency_overrides.clear()
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_request(
+    *,
+    authorization: str | None = None,
+    client_host: str = "203.0.113.5",
+    path: str = f"{BASE}/validate",
+) -> Request:
+    headers = []
+    if authorization is not None:
+        headers.append((b"authorization", authorization.encode()))
+    scope = {
+        "type": "http",
+        "method": "POST",
+        "path": path,
+        "headers": headers,
+        "client": (client_host, 12345),
+    }
+    return Request(scope)
+
+
+async def _create_token(
+    session_maker,
+    org_id: str,
+    *,
+    scopes: list[str],
+    source_id: uuid.UUID | None = None,
+    revoked: bool = False,
+    expired: bool = False,
+) -> tuple[str, IngestToken]:
+    plaintext = generate_ingest_token()
+    now = datetime.now(timezone.utc)
+    token = IngestToken(
+        org_id=org_id,
+        source_id=source_id,
+        name="test-token",
+        token_hash=hash_ingest_token(plaintext),
+        token_prefix=plaintext[:12],
+        scopes=scopes,
+        revoked_at=(now - timedelta(minutes=1)) if revoked else None,
+        expires_at=(now - timedelta(minutes=1)) if expired else None,
+    )
+    async with session_maker() as session:
+        session.add(token)
+        await session.commit()
+    return plaintext, token
+
+
+def _minimal_envelope() -> dict:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "idempotencyKey": "test-key-1",
+        "source": {
+            "type": "customer_push",
+            "system": "github",
+            "instance": "acme/api",
+        },
+        "records": [{"kind": "commit.v1", "externalId": "c1", "payload": {}}],
+    }
+
+
+async def _audit_rows(session_maker, org_id: str) -> list[AuditLog]:
+    async with session_maker() as session:
+        result = await session.execute(
+            select(AuditLog).where(AuditLog.org_id == uuid.UUID(org_id))
+        )
+        return list(result.scalars().all())
+
+
+# ---------------------------------------------------------------------------
+# Direct dependency-level tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_authorization_header_401(session_maker):
+    dep = auth_module.require_ingest_scope("schema:read")
+    request = _make_request(authorization=None)
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        with pytest.raises(ExternalIngestError) as exc_info:
+            await agen.__anext__()
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.code == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_malformed_bearer_prefix_401(session_maker):
+    dep = auth_module.require_ingest_scope("schema:read")
+    request = _make_request(authorization="Bearer not-an-fcpush-token")
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        with pytest.raises(ExternalIngestError) as exc_info:
+            await agen.__anext__()
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.code == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_unknown_token_hash_401(session_maker):
+    dep = auth_module.require_ingest_scope("schema:read")
+    request = _make_request(
+        authorization=f"Bearer {auth_module.TOKEN_PREFIX}does-not-exist-in-db"
+    )
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        with pytest.raises(ExternalIngestError) as exc_info:
+            await agen.__anext__()
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.code == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_unknown_token_hash_does_not_persist_audit_row(session_maker, org_id):
+    # No org is resolvable for a hash that matches no row -- nothing valid
+    # to attach an AuditLog FK to, so this must not crash and must not write.
+    dep = auth_module.require_ingest_scope("schema:read")
+    request = _make_request(
+        authorization=f"Bearer {auth_module.TOKEN_PREFIX}does-not-exist-in-db"
+    )
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        with pytest.raises(ExternalIngestError):
+            await agen.__anext__()
+    assert await _audit_rows(session_maker, org_id) == []
+
+
+@pytest.mark.asyncio
+async def test_revoked_token_401_and_audit_row_survives_the_raise(
+    session_maker, org_id
+):
+    plaintext, token = await _create_token(
+        session_maker, org_id, scopes=["schema:read"], revoked=True
+    )
+    dep = auth_module.require_ingest_scope("schema:read")
+    request = _make_request(authorization=f"Bearer {plaintext}")
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        with pytest.raises(ExternalIngestError) as exc_info:
+            await agen.__anext__()
+    assert exc_info.value.status_code == 401
+    assert exc_info.value.code == "invalid_token"
+
+    # Regression (commit-before-raise, docs/architecture/customer-push-authz.md):
+    # the audit row must persist even though this same request raised
+    # immediately afterward on the same session.
+    rows = await _audit_rows(session_maker, org_id)
+    assert len(rows) == 1
+    assert rows[0].action == AuditAction.INGEST_AUTH_FAILED.value
+    assert rows[0].status == "failure"
+    assert rows[0].resource_id == str(token.id)
+
+
+@pytest.mark.asyncio
+async def test_expired_token_401_and_audit_row_survives_the_raise(
+    session_maker, org_id
+):
+    plaintext, token = await _create_token(
+        session_maker, org_id, scopes=["schema:read"], expired=True
+    )
+    dep = auth_module.require_ingest_scope("schema:read")
+    request = _make_request(authorization=f"Bearer {plaintext}")
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        with pytest.raises(ExternalIngestError) as exc_info:
+            await agen.__anext__()
+    assert exc_info.value.status_code == 401
+
+    rows = await _audit_rows(session_maker, org_id)
+    assert len(rows) == 1
+    assert rows[0].resource_id == str(token.id)
+
+
+@pytest.mark.asyncio
+async def test_insufficient_scope_403_and_audit_row_survives_the_raise(
+    session_maker, org_id
+):
+    plaintext, token = await _create_token(
+        session_maker, org_id, scopes=["schema:read"]
+    )
+    dep = auth_module.require_ingest_scope("ingest:write")
+    request = _make_request(authorization=f"Bearer {plaintext}")
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        with pytest.raises(ExternalIngestError) as exc_info:
+            await agen.__anext__()
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.code == "insufficient_scope"
+
+    rows = await _audit_rows(session_maker, org_id)
+    assert len(rows) == 1
+    assert rows[0].action == AuditAction.INGEST_AUTH_FAILED.value
+    assert rows[0].resource_id == str(token.id)
+
+    # Design Decision 11: last_used is bumped on ANY presented valid token,
+    # even one that ultimately fails its scope check.
+    async with session_maker() as session:
+        refreshed = await session.get(IngestToken, token.id)
+    assert refreshed.last_used_at is not None
+
+
+@pytest.mark.asyncio
+async def test_valid_token_yields_ctx_and_resets_org_contextvar(session_maker, org_id):
+    plaintext, token = await _create_token(
+        session_maker, org_id, scopes=["schema:read", "ingest:status"]
+    )
+    dep = auth_module.require_ingest_scope("schema:read")
+    request = _make_request(authorization=f"Bearer {plaintext}")
+    before = get_current_org_id()
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        ctx = await agen.__anext__()
+        assert ctx.org_id == org_id
+        assert ctx.scopes == frozenset({"schema:read", "ingest:status"})
+        assert ctx.token_id == str(token.id)
+        assert ctx.source is None
+        assert get_current_org_id() == org_id
+        assert request.state.ingest_token_id == str(token.id)
+        await agen.aclose()
+    assert get_current_org_id() == before
+
+    # last_used_at/last_used_ip recorded via the isolated session.
+    async with session_maker() as session:
+        refreshed = await session.get(IngestToken, token.id)
+    assert refreshed.last_used_at is not None
+    assert refreshed.last_used_ip == "203.0.113.5"
+
+
+@pytest.mark.asyncio
+async def test_valid_token_with_bound_source_resolves_ctx_source(session_maker, org_id):
+    source_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add(
+            IngestSource(
+                id=source_id,
+                org_id=org_id,
+                system="github",
+                instance="acme/api",
+                mode=IngestSourceMode.CUSTOMER_PUSH.value,
+                enabled=True,
+            )
+        )
+        await session.commit()
+
+    plaintext, _token = await _create_token(
+        session_maker, org_id, scopes=["ingest:write"], source_id=source_id
+    )
+    dep = auth_module.require_ingest_scope("ingest:write")
+    request = _make_request(authorization=f"Bearer {plaintext}")
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        ctx = await agen.__anext__()
+        assert ctx.source is not None
+        assert ctx.source.id == source_id
+        assert ctx.source.instance == "acme/api"
+        await agen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_two_tokens_resolve_to_their_own_distinct_orgs(session_maker):
+    org_a = str(uuid.uuid4())
+    org_b = str(uuid.uuid4())
+    async with session_maker() as session:
+        session.add_all(
+            [
+                Organization(
+                    id=uuid.UUID(org_a), slug="org-a", name="Org A", tier="pro"
+                ),
+                Organization(
+                    id=uuid.UUID(org_b), slug="org-b", name="Org B", tier="pro"
+                ),
+            ]
+        )
+        await session.commit()
+
+    plaintext_a, _ = await _create_token(session_maker, org_a, scopes=["schema:read"])
+    plaintext_b, _ = await _create_token(session_maker, org_b, scopes=["schema:read"])
+
+    dep = auth_module.require_ingest_scope("schema:read")
+    async with session_maker() as db:
+        agen_a = dep(
+            request=_make_request(authorization=f"Bearer {plaintext_a}"), db=db
+        )
+        ctx_a = await agen_a.__anext__()
+        await agen_a.aclose()
+    async with session_maker() as db:
+        agen_b = dep(
+            request=_make_request(authorization=f"Bearer {plaintext_b}"), db=db
+        )
+        ctx_b = await agen_b.__anext__()
+        await agen_b.aclose()
+
+    assert ctx_a.org_id == org_a
+    assert ctx_b.org_id == org_b
+    assert ctx_a.org_id != ctx_b.org_id
+
+
+@pytest.mark.asyncio
+async def test_revoked_after_first_use_fails_immediately_next_request(
+    session_maker, org_id
+):
+    """No caching beyond a single request (team-lead scope item 5): a token
+    valid on request 1 must fail on request 2 the instant it's revoked."""
+    plaintext, token = await _create_token(
+        session_maker, org_id, scopes=["schema:read"]
+    )
+    dep = auth_module.require_ingest_scope("schema:read")
+
+    async with session_maker() as db:
+        agen = dep(request=_make_request(authorization=f"Bearer {plaintext}"), db=db)
+        ctx = await agen.__anext__()
+        assert ctx.org_id == org_id
+        await agen.aclose()
+
+    async with session_maker() as session:
+        row = await session.get(IngestToken, token.id)
+        row.revoked_at = datetime.now(timezone.utc)
+        await session.commit()
+
+    async with session_maker() as db:
+        agen = dep(request=_make_request(authorization=f"Bearer {plaintext}"), db=db)
+        with pytest.raises(ExternalIngestError) as exc_info:
+            await agen.__anext__()
+    assert exc_info.value.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_insecure_auth_env_flag_no_longer_has_any_effect(
+    session_maker, monkeypatch
+):
+    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
+    dep = auth_module.require_ingest_scope("schema:read")
+    request = _make_request(authorization="Bearer totally-not-fcpush-prefixed")
+    async with session_maker() as db:
+        agen = dep(request=request, db=db)
+        with pytest.raises(ExternalIngestError) as exc_info:
+            await agen.__anext__()
+    assert exc_info.value.status_code == 401
+
+
+# ---------------------------------------------------------------------------
+# Pre-auth IP throttle (CHAOS-2712 adversarial-review fix)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_repeated_auth_failures_from_same_ip_eventually_rate_limited(
+    session_maker,
+):
+    # A distinct IP, unbound to any other test's usage of the shared limiter.
+    ip = "198.51.100.42"
+    dep = auth_module.require_ingest_scope("schema:read")
+    limit = int(rate_limit_module.INGEST_AUTH_FAILURE_IP_LIMIT.split("/")[0])
+
+    async def _one_failed_attempt():
+        request = _make_request(authorization="Bearer not-fcpush", client_host=ip)
+        async with session_maker() as db:
+            agen = dep(request=request, db=db)
+            with pytest.raises(ExternalIngestError) as exc_info:
+                await agen.__anext__()
+            return exc_info.value
+
+    for _ in range(limit):
+        err = await _one_failed_attempt()
+        assert err.status_code == 401
+
+    # One more over the limit -- rate limited before it even reaches the
+    # token-hash DB lookup, regardless of what the bearer value is.
+    err = await _one_failed_attempt()
+    assert err.status_code == 429
+    assert err.code == "rate_limited"
+
+
+@pytest.mark.asyncio
+async def test_successful_auth_never_consumes_the_failure_limiter_bucket(
+    session_maker, org_id
+):
+    # A token that succeeds every time must never trip the failure-only
+    # throttle, however many times it's presented from the same IP.
+    ip = "198.51.100.43"
+    plaintext, _token = await _create_token(
+        session_maker, org_id, scopes=["schema:read"]
+    )
+    dep = auth_module.require_ingest_scope("schema:read")
+    limit = int(rate_limit_module.INGEST_AUTH_FAILURE_IP_LIMIT.split("/")[0])
+
+    for _ in range(limit + 5):
+        request = _make_request(authorization=f"Bearer {plaintext}", client_host=ip)
+        async with session_maker() as db:
+            agen = dep(request=request, db=db)
+            ctx = await agen.__anext__()
+            assert ctx.org_id == org_id
+            await agen.aclose()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_unknown_token_floods_are_bounded_by_attempt_limiter(
+    session_maker,
+):
+    """2nd-round adversarial-review regression: a test()-then-hit() split
+    is not atomic (the token-hash DB lookup between the two calls is itself
+    an await point), so a burst of CONCURRENT invalid-token requests from
+    one IP could previously all observe spare capacity and all reach
+    Postgres before any of them were counted.
+    ``_reserve_auth_attempt_or_429`` fixes this by consuming atomically via
+    hit() before any DB work -- this test proves the number of DB lookups
+    actually performed under a concurrent flood is bounded by the attempt
+    ceiling, not merely the eventual (post-hoc) 429 count."""
+    ip = "198.51.100.44"
+    dep = auth_module.require_ingest_scope("schema:read")
+    attempt_limit = int(rate_limit_module.INGEST_AUTH_ATTEMPT_IP_LIMIT.split("/")[0])
+    overflow = 10
+
+    lookup_count = 0
+    real_execute = AsyncSession.execute
+
+    async def _counting_execute(self, *args, **kwargs):
+        nonlocal lookup_count
+        lookup_count += 1
+        return await real_execute(self, *args, **kwargs)
+
+    async def _one_attempt(index: int):
+        request = _make_request(
+            authorization=f"Bearer {auth_module.TOKEN_PREFIX}nonexistent-{index}",
+            client_host=ip,
+        )
+        async with session_maker() as db:
+            db.execute = _counting_execute.__get__(db, AsyncSession)
+            agen = dep(request=request, db=db)
+            with pytest.raises(ExternalIngestError) as exc_info:
+                await agen.__anext__()
+            return exc_info.value.status_code
+
+    results = await asyncio.gather(
+        *[_one_attempt(i) for i in range(attempt_limit + overflow)]
+    )
+
+    assert results.count(429) == overflow
+    assert results.count(401) == attempt_limit
+    # The regression proof: every allowed-through request performs exactly
+    # one DB lookup, and the reservation caps how many are ever allowed
+    # through -- concurrency cannot inflate this beyond the ceiling.
+    assert lookup_count == attempt_limit
+
+
+# ---------------------------------------------------------------------------
+# Source binding (CHAOS-2712 adversarial-review fix: require_matching_source)
+# ---------------------------------------------------------------------------
+
+
+def test_require_matching_source_passes_for_matching_write_eligible_source():
+    source = IngestSource(
+        org_id="org-1",
+        system="github",
+        instance="acme/api",
+        mode=IngestSourceMode.CUSTOMER_PUSH.value,
+        enabled=True,
+    )
+    ctx = auth_module.IngestAuthContext(
+        org_id="org-1", scopes=frozenset({"ingest:write"}), source=source
+    )
+    assert auth_module.require_matching_source(ctx, "github", "acme/api") is source
+
+
+def test_require_matching_source_rejects_mismatched_instance():
+    source = IngestSource(
+        org_id="org-1",
+        system="github",
+        instance="acme/api",
+        mode=IngestSourceMode.CUSTOMER_PUSH.value,
+        enabled=True,
+    )
+    ctx = auth_module.IngestAuthContext(
+        org_id="org-1", scopes=frozenset({"ingest:write"}), source=source
+    )
+    with pytest.raises(ExternalIngestError) as exc_info:
+        auth_module.require_matching_source(ctx, "github", "other/repo")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.code == "source_mismatch"
+
+
+def test_require_matching_source_rejects_unbound_token():
+    ctx = auth_module.IngestAuthContext(
+        org_id="org-1", scopes=frozenset({"ingest:write"}), source=None
+    )
+    with pytest.raises(ExternalIngestError) as exc_info:
+        auth_module.require_matching_source(ctx, "github", "acme/api")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.code == "source_mismatch"
+
+
+def test_require_matching_source_rejects_disabled_source():
+    source = IngestSource(
+        org_id="org-1",
+        system="github",
+        instance="acme/api",
+        mode=IngestSourceMode.CUSTOMER_PUSH.value,
+        enabled=False,
+    )
+    ctx = auth_module.IngestAuthContext(
+        org_id="org-1", scopes=frozenset({"ingest:write"}), source=source
+    )
+    with pytest.raises(ExternalIngestError) as exc_info:
+        auth_module.require_matching_source(ctx, "github", "acme/api")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.code == "source_disabled"
+
+
+def test_require_matching_source_rejects_non_customer_push_mode():
+    source = IngestSource(
+        org_id="org-1",
+        system="github",
+        instance="acme/api",
+        mode=IngestSourceMode.FULLCHAOS_SYNC.value,
+        enabled=True,
+    )
+    ctx = auth_module.IngestAuthContext(
+        org_id="org-1", scopes=frozenset({"ingest:write"}), source=source
+    )
+    with pytest.raises(ExternalIngestError) as exc_info:
+        auth_module.require_matching_source(ctx, "github", "acme/api")
+    assert exc_info.value.status_code == 403
+    assert exc_info.value.code == "source_disabled"
+
+
+# ---------------------------------------------------------------------------
+# End-to-end (real router, real auth dependency, no auth override)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_e2e_missing_authorization_header_401_envelope(http_client):
+    resp = await http_client.post(f"{BASE}/validate", json=_minimal_envelope())
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_e2e_unknown_token_401_envelope(http_client):
+    resp = await http_client.post(
+        f"{BASE}/validate",
+        json=_minimal_envelope(),
+        headers={"Authorization": f"Bearer {auth_module.TOKEN_PREFIX}nope"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_token"
+
+
+@pytest.mark.asyncio
+async def test_e2e_valid_token_wrong_scope_403_envelope(
+    session_maker, org_id, http_client
+):
+    plaintext, _ = await _create_token(session_maker, org_id, scopes=["ingest:status"])
+    resp = await http_client.post(
+        f"{BASE}/validate",
+        json=_minimal_envelope(),
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "insufficient_scope"
+
+
+@pytest.mark.asyncio
+async def test_e2e_valid_token_with_scope_reaches_route_handler(
+    session_maker, org_id, http_client
+):
+    plaintext, _ = await _create_token(session_maker, org_id, scopes=["schema:read"])
+    resp = await http_client.post(
+        f"{BASE}/validate",
+        json=_minimal_envelope(),
+        headers={"Authorization": f"Bearer {plaintext}"},
+    )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_e2e_insecure_auth_flag_and_x_org_id_header_have_no_effect(
+    http_client, monkeypatch
+):
+    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
+    resp = await http_client.post(
+        f"{BASE}/validate",
+        json=_minimal_envelope(),
+        headers={"Authorization": "Bearer dev-token", "X-Org-Id": "org-1"},
+    )
+    assert resp.status_code == 401
+    assert resp.json()["error"]["code"] == "invalid_token"

--- a/tests/api/test_external_ingest_router.py
+++ b/tests/api/test_external_ingest_router.py
@@ -2,8 +2,11 @@
 
 Covers the brief's test plan: envelope/kind/size validation (D2/D4), the D1
 idempotency header/body match, D6's fail-closed stream-unavailable mapping,
-D7's interim auth mechanical gate (master-spec CC14), and D8's schema
-discovery endpoints.
+and D8's schema discovery endpoints. Auth (`require_ingest_scope`'s real,
+DB-backed body -- CHAOS-2712) is exercised end-to-end in
+tests/api/external_ingest/test_auth.py; this file overrides the bound scope
+dependencies for every test below so router-contract tests don't need a
+database.
 """
 
 from __future__ import annotations
@@ -22,6 +25,7 @@ from dev_health_ops.api.external_ingest.schemas import (
 )
 from dev_health_ops.api.external_ingest.streams import StreamUnavailableError
 from dev_health_ops.api.main import app
+from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
 
 # __init__.py exports the APIRouter as "router", shadowing the module name —
 # force-load the actual module so we can reach its internals (the bound
@@ -32,8 +36,22 @@ router_mod = sys.modules["dev_health_ops.api.external_ingest.router"]
 
 BASE = "/api/v1/external-ingest"
 
+# Matches the (system, instance) every _envelope() below declares -- accept_batch
+# now enforces require_matching_source (CHAOS-2712 adversarial-review fix), so
+# the write-scoped test context needs a bound, write-eligible source or every
+# POST /batches test would 403 source_mismatch.
+_TEST_SOURCE = IngestSource(
+    org_id="test-org",
+    system="github",
+    instance="acme/api",
+    mode=IngestSourceMode.CUSTOMER_PUSH.value,
+    enabled=True,
+)
+
 TEST_CTX = IngestAuthContext(
-    org_id="test-org", scopes={"ingest:write", "ingest:status", "schema:read"}
+    org_id="test-org",
+    scopes=frozenset({"ingest:write", "ingest:status", "schema:read"}),
+    source=_TEST_SOURCE,
 )
 
 
@@ -427,61 +445,73 @@ async def test_get_schema_unknown_version_returns_404(client):
 
 
 # ---------------------------------------------------------------------------
-# Auth (D7 / master-spec CC14) — exercised WITHOUT the dependency override so
-# the real require_ingest_scope body actually runs.
+# Source binding (CHAOS-2712 adversarial-review fix: require_matching_source)
 # ---------------------------------------------------------------------------
 
 
 @pytest.mark.asyncio
-async def test_missing_authorization_header_returns_401(monkeypatch):
-    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
+async def test_batch_for_mismatched_source_rejected_403(client, monkeypatch):
+    monkeypatch.setattr(router_mod, "enqueue_batch", lambda **kwargs: "stream-x")
+    mismatched_ctx = IngestAuthContext(
+        org_id="test-org",
+        scopes=frozenset({"ingest:write"}),
+        source=IngestSource(
+            org_id="test-org",
+            system="github",
+            instance="other/repo",  # envelope declares acme/api -- CHAOS-2712 default
+            mode=IngestSourceMode.CUSTOMER_PUSH.value,
+            enabled=True,
+        ),
+    )
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: mismatched_ctx
+    try:
         envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
-        resp = await c.post(
-            f"{BASE}/batches", json=envelope, headers={"X-Org-Id": "org-1"}
-        )
+        resp = await client.post(f"{BASE}/batches", json=envelope)
+    finally:
+        app.dependency_overrides[router_mod._require_ingest_write] = lambda: TEST_CTX
 
-    assert resp.status_code == 401
-    # Auth failures must use the same customer-facing envelope as every other
-    # external-ingest error (master-spec CC16 explicitly includes auth
-    # failures) — a bare HTTPException {"detail": ...} would force customer
-    # SDKs to special-case parsing (adversarial-review finding).
-    assert resp.json()["error"]["code"] == "invalid_token"
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "source_mismatch"
 
 
 @pytest.mark.asyncio
-async def test_missing_org_id_header_returns_400(monkeypatch):
-    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
+async def test_batch_for_unbound_write_token_rejected_403(client):
+    unbound_ctx = IngestAuthContext(
+        org_id="test-org", scopes=frozenset({"ingest:write"}), source=None
+    )
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: unbound_ctx
+    try:
         envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
-        resp = await c.post(
-            f"{BASE}/batches",
-            json=envelope,
-            headers={"Authorization": "Bearer dev-token"},
-        )
+        resp = await client.post(f"{BASE}/batches", json=envelope)
+    finally:
+        app.dependency_overrides[router_mod._require_ingest_write] = lambda: TEST_CTX
 
-    assert resp.status_code == 400
-    assert resp.json()["error"]["code"] == "missing_org_header"
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "source_mismatch"
 
 
 @pytest.mark.asyncio
-async def test_interim_auth_hard_fails_without_insecure_flag(monkeypatch):
-    # CC14: mechanical guard — auth 503s unless EXTERNAL_INGEST_INSECURE_AUTH=1
-    # is explicitly set, regardless of otherwise-valid credentials.
-    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
-    transport = ASGITransport(app=app)
-    async with AsyncClient(transport=transport, base_url="http://test") as c:
+async def test_batch_for_disabled_source_rejected_403(client):
+    disabled_ctx = IngestAuthContext(
+        org_id="test-org",
+        scopes=frozenset({"ingest:write"}),
+        source=IngestSource(
+            org_id="test-org",
+            system="github",
+            instance="acme/api",
+            mode=IngestSourceMode.CUSTOMER_PUSH.value,
+            enabled=False,
+        ),
+    )
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: disabled_ctx
+    try:
         envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
-        resp = await c.post(
-            f"{BASE}/batches",
-            json=envelope,
-            headers={"Authorization": "Bearer dev-token", "X-Org-Id": "org-1"},
-        )
+        resp = await client.post(f"{BASE}/batches", json=envelope)
+    finally:
+        app.dependency_overrides[router_mod._require_ingest_write] = lambda: TEST_CTX
 
-    assert resp.status_code == 503
-    assert resp.json()["error"]["code"] == "auth_not_configured"
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "source_disabled"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_ingest_rate_limit_key.py
+++ b/tests/api/test_ingest_rate_limit_key.py
@@ -1,10 +1,14 @@
-"""Per-token rate-limit keying for external-ingest endpoints (CHAOS-2691).
+"""Per-token rate-limit keying for external-ingest endpoints (CHAOS-2691/2712).
 
-Regression coverage for an adversarial-review finding: while
-EXTERNAL_INGEST_INSECURE_AUTH=1's interim auth is active, the bearer value
-is not validated at all, so keying the limiter on it would let a caller
-rotate arbitrary bearer strings to get a fresh bucket on every request. In
-that mode the key must collapse to IP regardless of the bearer value.
+CHAOS-2712 replaced raw-bearer-text hashing with keying on
+``request.state.ingest_token_id`` -- set by ``require_ingest_scope``
+(``api/external_ingest/auth.py``) only once a bearer has been resolved
+against a real, DB-backed ``IngestToken`` row. Regression coverage for an
+adversarial-review finding: an unauthenticated request (no auth dependency
+ran, so no validated token id) must not be able to mint a fresh limiter
+bucket per request by rotating an arbitrary/garbage ``Authorization: Bearer``
+header -- it must collapse to the IP-based key regardless of what that
+header contains.
 """
 
 from __future__ import annotations
@@ -17,7 +21,9 @@ from dev_health_ops.api.middleware.rate_limit import get_ingest_token_key
 
 
 def _make_request(
-    authorization: str | None = None, client_host: str = "203.0.113.5"
+    authorization: str | None = None,
+    client_host: str = "203.0.113.5",
+    ingest_token_id: str | None = None,
 ) -> Request:
     headers = []
     if authorization is not None:
@@ -29,63 +35,63 @@ def _make_request(
         "headers": headers,
         "client": (client_host, 12345),
     }
-    return Request(scope)
+    request = Request(scope)
+    if ingest_token_id is not None:
+        request.state.ingest_token_id = ingest_token_id
+    return request
 
 
-def test_distinct_bearer_tokens_get_distinct_buckets_outside_interim_auth(monkeypatch):
-    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
-    req_a = _make_request(authorization="Bearer token-a")
-    req_b = _make_request(authorization="Bearer token-b")
+def test_distinct_validated_token_ids_get_distinct_buckets():
+    req_a = _make_request(ingest_token_id="token-id-a")
+    req_b = _make_request(ingest_token_id="token-id-b")
     assert get_ingest_token_key(req_a) != get_ingest_token_key(req_b)
 
 
-def test_same_bearer_token_same_bucket_outside_interim_auth(monkeypatch):
-    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
+def test_same_validated_token_id_same_bucket():
     assert get_ingest_token_key(
-        _make_request(authorization="Bearer token-a")
-    ) == get_ingest_token_key(_make_request(authorization="Bearer token-a"))
+        _make_request(ingest_token_id="token-id-a")
+    ) == get_ingest_token_key(_make_request(ingest_token_id="token-id-a"))
 
 
-def test_raw_token_never_appears_in_key(monkeypatch):
-    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
-    token = "super-secret-ingest-token"
-    key = get_ingest_token_key(_make_request(authorization=f"Bearer {token}"))
-    assert token not in key
+def test_validated_token_id_never_appears_in_key():
+    token_id = "11111111-2222-3333-4444-555555555555"
+    key = get_ingest_token_key(_make_request(ingest_token_id=token_id))
+    assert token_id not in key
+    assert key.startswith("ingest-token:")
 
 
-def test_rotating_bearer_tokens_cannot_bypass_the_limit_in_interim_auth_mode(
-    monkeypatch,
-):
-    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
-    req_a = _make_request(authorization="Bearer token-a", client_host="203.0.113.5")
-    req_b = _make_request(
-        authorization="Bearer token-b-rotated", client_host="203.0.113.5"
-    )
-    assert (
-        get_ingest_token_key(req_a)
-        == get_ingest_token_key(req_b)
-        == "ingest-ip:203.0.113.5"
+def test_token_key_uses_sha256_digest_of_token_id():
+    token_id = "11111111-2222-3333-4444-555555555555"
+    expected = hashlib.sha256(token_id.encode("utf-8")).hexdigest()[:16]
+    assert get_ingest_token_key(_make_request(ingest_token_id=token_id)) == (
+        f"ingest-token:{expected}"
     )
 
 
-def test_interim_auth_mode_still_distinguishes_by_ip(monkeypatch):
-    monkeypatch.setenv("EXTERNAL_INGEST_INSECURE_AUTH", "1")
-    req_a = _make_request(authorization="Bearer token-a", client_host="203.0.113.5")
-    req_b = _make_request(authorization="Bearer token-a", client_host="198.51.100.9")
-    assert get_ingest_token_key(req_a) != get_ingest_token_key(req_b)
+def test_no_validated_token_id_falls_back_to_ip_regardless_of_bearer_header():
+    req = _make_request(authorization="Bearer some-unvalidated-string")
+    assert get_ingest_token_key(req) == "ingest-ip:203.0.113.5"
 
 
-def test_missing_bearer_falls_back_to_ip(monkeypatch):
-    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
+def test_rotating_unvalidated_bearer_strings_cannot_mint_fresh_buckets():
+    """Regression (adversarial review): without a preceding auth dependency
+    (e.g. the public GET /schemas* endpoints), an attacker can send any
+    Authorization header they like. It must never influence the limiter key
+    -- only request.state.ingest_token_id (set post-validation) may."""
+    same_ip_requests = [
+        _make_request(authorization=f"Bearer rotated-{i}", client_host="203.0.113.5")
+        for i in range(5)
+    ]
+    keys = {get_ingest_token_key(req) for req in same_ip_requests}
+    assert keys == {"ingest-ip:203.0.113.5"}
+
+
+def test_missing_bearer_and_missing_token_id_falls_back_to_ip():
     req = _make_request(authorization=None, client_host="203.0.113.5")
     assert get_ingest_token_key(req) == "ingest-ip:203.0.113.5"
 
 
-def test_token_key_uses_sha256_digest_not_raw_prefix(monkeypatch):
-    monkeypatch.delenv("EXTERNAL_INGEST_INSECURE_AUTH", raising=False)
-    token = "dev-token"
-    expected = hashlib.sha256(token.encode("utf-8")).hexdigest()[:16]
-    assert (
-        get_ingest_token_key(_make_request(authorization=f"Bearer {token}"))
-        == f"ingest-token:{expected}"
-    )
+def test_distinct_ips_without_validated_token_get_distinct_buckets():
+    req_a = _make_request(client_host="203.0.113.5")
+    req_b = _make_request(client_host="198.51.100.9")
+    assert get_ingest_token_key(req_a) != get_ingest_token_key(req_b)


### PR DESCRIPTION
## Summary

Replaces CHAOS-2691's interim, flag-gated `require_ingest_scope` body with real, DB-backed `IngestToken` authorization (master-spec CC14 — the epic's hard pre-GA blocker).

- Resolves `fcpush_` bearer tokens via `sha256` against `external_ingest_tokens`, builds `IngestAuthContext(org_id, scopes, token_id, source)`.
- 401 `invalid_token` on missing/malformed/unknown/revoked/expired; 403 `insufficient_scope` on missing scope.
- Last-used tracking (`last_used_at`/`last_used_ip`) in an isolated Postgres session, decoupled from the request's own session, so it survives regardless of what happens downstream.
- Ingest-auth failures are audited (`INGEST_AUTH_FAILED`) with commit-before-raise discipline — a regression test proves the audit row survives the 401/403 it documents.
- **Deletes `EXTERNAL_INGEST_INSECURE_AUTH` and the `X-Org-Id` header path entirely.**
- Fixes the admin `webhookMode` two-layer contract (adr-004): schema accepts the full 3-value enum (no 422 on `fullchaos_hosted`); router rejects it with 400 before persisting.

### Adversarial-review fixes (2 rounds, both closed)

1. **[high] Cross-source write hole**: `POST /batches` never checked a source-bound `ingest:write` token's source against the payload's declared source — only `org_id` was checked. Added `require_matching_source` (called from `router.py::accept_batch` after envelope parsing, since the auth dependency resolves before the body is available) → 403 `source_mismatch`/`source_disabled`.
2. **[medium→high] Unthrottled auth-failure floods**: FastAPI resolves `Depends()` (the auth dependency) before the route's `@limiter.limit(...)` decorator body runs, so a 401/403 never reaches the existing per-token limiter. Added a two-layer IP-keyed throttle in `auth.py`: an atomic `hit()`-based attempt ceiling (`INGEST_AUTH_ATTEMPT_IP_LIMIT=100/minute`, consumed before any DB work — closes a TOCTOU race the first-pass `test()`-then-`hit()` design had, since the DB lookup between those two calls is itself an `await` point) plus a stricter `test()`/`hit()` failure-only bucket (`INGEST_AUTH_FAILURE_IP_LIMIT=30/minute`) layered behind it.

Both fixes were verified with a live server + real minted tokens, and a concurrency regression test (`asyncio.gather` of 110 concurrent invalid-token requests) proves the number of DB lookups actually performed is bounded exactly at the attempt ceiling.

## Test plan

- [x] `tests/api/external_ingest/test_auth.py` (new): direct-dependency-style unit tests (401/403 matrix, audit persistence, last-used bump, org isolation, no-caching-on-revoke) + a handful of end-to-end httpx tests through the real router + the two-round adversarial-review regressions (source binding, concurrent-flood throttle).
- [x] `tests/api/test_ingest_rate_limit_key.py`: rewritten for the new validated-token-id keying (was raw-bearer-text hashing).
- [x] `tests/api/test_external_ingest_router.py`: removed obsolete interim-auth tests; added source-binding coverage; `TEST_CTX` updated to the final `IngestAuthContext` shape.
- [x] `tests/api/admin/test_customer_push.py`: fixed a pre-existing test asserting the *wrong* (422) behavior for `webhookMode=fullchaos_hosted`; added coverage for the corrected 400 two-layer behavior.
- [x] `env -i ... SCRATCH_DB=ci_local_validate_2712 bash ci/local_validate.sh` — green (lint, mypy, full unit suite 6348 tests, live-ClickHouse argMax proof).
- [x] Codex adversarial review — 2 rounds, both findings fixed and re-verified.
- [x] Live verification against a scratch Postgres DB + real minted `fcpush_` tokens: schema:read/ingest:write success paths, 401 matrix (missing/unknown/revoked/expired), 403 matrix (insufficient_scope, source_mismatch), audit-row persistence via `psql`, `last_used_at` tracking, revoke-takes-effect-on-next-request (no caching), `EXTERNAL_INGEST_INSECURE_AUTH=1` confirmed to have zero effect even when explicitly set on the server, and a live concurrent-burst curl flood confirming the atomic throttle.

Docs updated in the same changeset: `docs/architecture/customer-push-authz.md` (new sections on source binding + the two-layer throttle), `docs/architecture/adr-003-external-ingest-rest-boundary.md` and `docs/architecture/external-ingest-rest-contract.md` (marked the interim-auth sections resolved).