### PR TITLE
feat(external-ingest): batch status store + rejected-record diagnostics (CHAOS-2694)

### DIFF
--- a/docs/architecture/external-ingest-status-store.md
+++ b/docs/architecture/external-ingest-status-store.md
@@ -1,0 +1,222 @@
+# External-ingest status store (CHAOS-2694)
+
+Part of the [customer-push ingestion epic](adr-003-external-ingest-rest-boundary.md)
+(CHAOS-2690). This doc records the durable status-store decisions for
+answering "what happened to ingestion batch X" -- the DDL, the direct-SQL
+access pattern, the state machine, bounded-rejection diagnostics, and the
+retention policy.
+
+## Postgres, not ClickHouse
+
+`external_ingest_batches` / `external_ingest_rejections` /
+`external_ingest_batch_payloads` are Postgres tables, not ClickHouse, for the
+same reason as `provider_rate_limit_observations` (migration 0031) and
+`external_ingest_sources` / `external_ingest_tokens` (migration 0032): this
+is transactional state that must support a **strongly-consistent
+read-after-write** status immediately after `202 Accepted` (`dev-hops push
+batch --poll`, CHAOS-2700), and it joins the ingest-token/source-registration
+model (CHAOS-2696) in the same database. ClickHouse's async merge semantics
+on `ReplacingMergeTree` would make "poll immediately after accept" flaky, and
+there is no transactional join between a separate analytics cluster and the
+auth tables consulted on every request.
+
+## Direct SQL, not ORM CRUD
+
+The core implementation plan mandates direct SQL for API persistence/status
+queries, which diverges from the house convention of using the ORM for
+`session.add()`/`session.query()` elsewhere. This is resolved by keeping a
+declarative `Base` model (`ExternalIngestBatch`, `ExternalIngestRejection`,
+`ExternalIngestBatchPayload` in `src/dev_health_ops/models/external_ingest.py`)
+purely as the schema-of-record for Alembic and for
+`Base.metadata.create_all()` in sqlite-backed unit tests -- but all reads and
+writes in `src/dev_health_ops/api/external_ingest/status.py` go through
+`session.execute(text(...), params)`. This mirrors the established pattern in
+`api/billing/reconciliation_service.py` and `api/billing/refund_service.py`.
+
+Consequences of dialect-portable SQL (no `RETURNING`, no `ON CONFLICT`, no
+Postgres-only functions -- there is no live-Postgres pytest tier, only
+sqlite-in-memory unit tests plus a manual live-verification runbook, see
+"Live verification" below):
+
+- `ingestion_id`/rejection `id` values are generated in Python
+  (`uuid.uuid4()`) and always bound as `str(...)`, never raw `uuid.UUID`
+  objects, matching the `refund_service.py` precedent (`text()` binds get no
+  column-type-aware processing, and asyncpg's UUID codec accepts plain
+  strings).
+- Idempotency-key collisions are detected by catching `IntegrityError` on the
+  unique constraint (via a `session.begin_nested()` SAVEPOINT so the
+  caller's outer transaction survives the violation), not `ON CONFLICT`.
+- `created_at`/`updated_at`/`completed_at` are always passed as explicit
+  Python `datetime` bind params -- **never** relied upon via the migration's
+  `server_default=sa.text("now()")`, which is a safety net for manual `psql`
+  inserts only, not something the status.py write paths use.
+- `error_summary`/`record_counts` (JSON columns) are serialized with
+  `json.dumps(...)` before binding and parsed with `json.loads(...)` on read
+  -- neither SQLAlchemy's `text()` nor asyncpg apply JSON (de)serialization
+  to untyped raw-SQL parameters.
+
+## State machine
+
+```
+accepted -> (stream_unavailable) -> processing -> completed | partial | failed
+```
+
+- `accepted`: row committed (server default), enqueued or about to be.
+- `stream_unavailable`: row committed but the stream enqueue failed (client
+  got a `503`; retryable). `mark_stream_unavailable()` performs this
+  transition; callers MUST commit this write **before** raising the 503
+  ("commit-before-raise") so a resubmission has durable state to act on.
+- `processing`: the worker has picked up the batch.
+- Terminal: `completed` (0 rejected), `partial` (some rejected), `failed` (0
+  accepted, given a non-empty batch). Derived by
+  `terminal_status_for(items_received, items_accepted, items_rejected)`
+  (`models/external_ingest.py`), a pure function with no DB dependency.
+
+`mark_processing()`/`mark_stream_unavailable()` are idempotent no-op UPDATEs
+guarded by a `WHERE status = '<expected-from-status>'` predicate (never a DB
+`CHECK` constraint -- this matches the `SyncRunStatus`/
+`SyncComputeCheckpointStatus` precedent of a Python-enum-validated `Text`
+column). `complete_batch()` is stricter (adversarial-review finding): it only
+accepts a batch currently in `processing` -- calling it against `accepted` or
+`stream_unavailable` raises `ValueError` rather than silently completing an
+unprocessed or never-enqueued batch, and the caller-supplied
+`items_accepted`/`items_rejected` must be non-negative and sum to the batch's
+recorded `items_received`, also raising otherwise. Once a batch is already
+terminal, `complete_batch()` is a pure no-op: the (expected-identical)
+inputs are discarded and the already-persisted row is returned unchanged --
+this is what makes redelivered stream entries (at-least-once delivery) safe
+to reprocess without regressing a terminal status or double counting rejection
+rows -- see "Idempotency" below.
+
+`attempts` (default 1) tracks accept-attempt count for CHAOS-2695's
+same-key+hash resubmission policy (stale-accepted/`failed` -> fresh accept,
+same `ingestion_id`, `attempts += 1`); this issue only hosts the column, the
+increment logic belongs to CHAOS-2695's router rewire.
+
+### Concurrency safety (adversarial-review finding)
+
+`complete_batch()`'s status/counter write is an atomic compare-and-swap --
+`UPDATE ... WHERE status = 'processing'` -- not a check-then-write. If two
+callers race to complete the same batch, the row lock the UPDATE takes
+serializes them: only the caller whose UPDATE actually matched a row (checked
+via `rowcount`) proceeds to insert rejection rows; the loser re-reads and
+returns whatever the winner persisted, discarding its own outcome entirely.
+The documented deployment topology (single `worker-external-ingest` replica
+at concurrency=1, plus the consumer's own idempotent-skip guard -- master-spec
+CC11) shouldn't produce concurrent calls for the same `ingestion_id` in
+practice, but this primitive's correctness doesn't rely on that discipline
+holding -- the DB-level guarantee holds regardless. The `(ingestion_id,
+record_index)` unique index on `external_ingest_rejections` is a second,
+DB-enforced backstop against ever double-inserting a rejection row.
+
+## Bounded rejection diagnostics
+
+`MAX_STORED_REJECTIONS_PER_BATCH = 1000` (batch limits are capped at 1000
+records -- master-spec CC3 -- so this stores *all* rejections in the worst
+case; the cap is kept anyway as a safety bound). `complete_batch()`:
+
+1. Stores up to the cap as individual `external_ingest_rejections` rows
+   (`record_index`, `record_kind`, `external_id`, `code`, `message`, `path`).
+2. Always records the **true** total on the batch row
+   (`items_rejected`) and in `error_summary`, even when the stored rows are
+   truncated:
+
+   ```json
+   {
+     "total_rejected": 4213,
+     "stored_rejections": 1000,
+     "truncated": true,
+     "top_codes": [{"code": "missing_external_id", "count": 3980}, ...]
+   }
+   ```
+
+   The true magnitude of a failure is never hidden by the storage cap.
+3. Is idempotent under worker redelivery: once a batch is already in a
+   terminal status, a second `complete_batch()` call with the same inputs
+   skips re-inserting rejection rows (no duplicates) but still re-runs the
+   status/count UPDATE (a no-op given identical inputs).
+
+## FK cascade divergence from `provider_rate_limit_observations`
+
+`external_ingest_rejections.ingestion_id` **is** a foreign key to
+`external_ingest_batches.ingestion_id` with `ON DELETE CASCADE` -- a
+deliberate divergence from the FK-less `provider_rate_limit_observations`
+precedent. Rejection rows have no independent existence or retention
+requirement apart from their parent batch (unlike a rate-limit observation,
+which must outlive a pruned `sync_run`); a single prune sweep on
+`external_ingest_batches` is therefore sufficient to clean both tables.
+
+`external_ingest_batch_payloads` (CHAOS-2693's transient raw-payload table,
+hosted in this migration per the fixed migration chain, CC19) has **no** FK
+to `external_ingest_batches`: it is written before the batch row exists in
+CHAOS-2695's accept sequence and deleted independently by the worker on
+terminal status (or swept as an orphan by CHAOS-2693's own prune task after
+`EXTERNAL_INGEST_PAYLOAD_MAX_AGE_HOURS`), so its lifecycle is not tied to the
+batch row's lifecycle.
+
+## Retention
+
+`EXTERNAL_INGEST_STATUS_RETENTION_DAYS = 90` (env-tunable), beat-scheduled at
+`crontab(hour=5, minute=15)` on the existing `sync` queue (immediately after
+`prune-rate-limit-observations` at 05:00; no new Celery queue).
+`workers/external_ingest_reconciler.py::prune_external_ingest_batches`
+deletes batches (cascading to rejections) whose `created_at` is older than
+the window **and** whose `status` is one of `completed`/`partial`/`failed`,
+in bounded chunks of 500 rows (each chunk committed independently, per an
+adversarial-review finding -- a single unbounded `DELETE` against a large
+backlog, e.g. the first run after months of accumulation, risks one
+long-running transaction). It never deletes a batch still
+`accepted`/`processing`/`stream_unavailable`, even past retention -- a stuck
+batch past retention is a bug signal that should stay visible, not silently
+disappear. This is a **deliberate, pinned design decision** (master-spec
+CC13), not a gap: an adversarial review flagged "non-terminal rows accumulate
+unbounded" as a concern, but the brief and master-spec explicitly scope a
+defense-in-depth reconciler for never-resubmitted stale batches as a
+**separate, filed follow-up issue**, out of v1 -- auto-expiring or archiving
+stuck rows here would contradict the "stay visible as a bug signal" intent.
+90 days (vs. the 14-day rate-limit-observation precedent) reflects that this
+is customer-support/audit-facing operational history, closer in spirit to
+audit logs than to transient rate-limit telemetry.
+
+This task is retention-only. It never re-enqueues or resurrects stuck
+batches.
+
+## Endpoints
+
+`src/dev_health_ops/api/external_ingest/status.py` defines its own
+`APIRouter` (`status_router`), mounted directly in `api/main.py` -- it does
+**not** append to CHAOS-2691's `router.py`/`schemas.py`, keeping wave-2 files
+disjoint from CHAOS-2692 (schema registry) and CHAOS-2712 (real auth). Its
+response Pydantic models (camelCase, matching the data-plane wire
+convention) live locally in `status.py`.
+
+- `GET /api/v1/external-ingest/batches` -- paginated/filterable list
+  (`sourceSystem`, `sourceInstance`, `status`, `createdAfter`,
+  `createdBefore`), `ingest:status` scope, `INGEST_READ_LIMIT` (120/min,
+  token-keyed).
+- `GET /api/v1/external-ingest/batches/{ingestion_id}` -- single-batch status
+  + paginated rejected-record diagnostics (`errorLimit`/`errorOffset`), same
+  scope/rate limit. Tenant isolation returns `404 not_found` for both
+  "does not exist" and "exists but belongs to a different org" -- never a
+  `403` (a token from one org must not be able to confirm the existence of
+  another org's ingestion IDs).
+- `/api/v1/admin/customer-push/sources/{id}/batches`,
+  `/api/v1/admin/customer-push/batches/{ingestion_id}`,
+  `/api/v1/admin/customer-push/schemas*` -- admin-plane read proxies over the
+  same store (session-JWT + `require_admin`, house `HTTPException`/snake_case
+  conventions -- deliberately a second, distinct surface convention from the
+  data-plane's `ExternalIngestError`/camelCase envelope).
+
+Neither surface exposes a `recompute_status` block in this issue's wave --
+CHAOS-2699 (wave 3, migration 0034) extends `BatchStatusResponse`/
+`AdminBatchResponse` with that block once the recompute-status columns land
+(master-spec CC21); this is a deliberate, pinned cross-wave file touch.
+
+## Live verification
+
+There is no live-Postgres pytest tier in this repo (only sqlite-in-memory
+unit tests and a `clickhouse` marker exist). Live-Postgres verification for
+this store is a manual runbook step: apply migration 0033 to a scratch
+Postgres database, confirm the three tables/indexes/FK via `psql \d`, and
+exercise `status.py`'s functions directly via a one-off script before/after
+CHAOS-2691's router and CHAOS-2696's auth land.

--- a/src/dev_health_ops/alembic/versions/0033_add_external_ingest_status_store.py
+++ b/src/dev_health_ops/alembic/versions/0033_add_external_ingest_status_store.py
@@ -1,0 +1,200 @@
+"""Add external_ingest_batches, external_ingest_rejections, and
+external_ingest_batch_payloads (CHAOS-2694).
+
+Durable Postgres status store for customer-push ingestion batches
+(CHAOS-2690). Postgres, not ClickHouse -- deliberately, mirroring the
+provider_rate_limit_observations precedent (0031): transactional, joins the
+ingest-token/source-registration model (CHAOS-2696) in the same database, and
+must support a strongly-consistent read-after-write status for CLI polling
+(dev-hops push batch --poll, CHAOS-2700) immediately after 202 Accepted.
+
+Unlike provider_rate_limit_observations, external_ingest_rejections IS a
+child of external_ingest_batches (FK, ON DELETE CASCADE): rejection rows have
+no independent retention requirement, so a single prune sweep on the parent
+table is sufficient (see workers/external_ingest_reconciler.py).
+
+external_ingest_batch_payloads is CHAOS-2693's transient raw-payload table --
+hosted here (DDL + declarative model) so wave 3 (2693) needs no migration of
+its own; 2693 owns the payload_store.py accessors and orphan-prune sweep.
+
+Retry-safe / guarded per the 0025/0020/0031/0032 create-if-missing convention.
+
+Revision ID: 0033
+Revises: 0032
+Create Date: 2026-07-02 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0033"
+down_revision: str | None = "0032"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_BATCHES_TABLE = "external_ingest_batches"
+_REJECTIONS_TABLE = "external_ingest_rejections"
+_PAYLOADS_TABLE = "external_ingest_batch_payloads"
+
+_IDEM_INDEX = "uq_external_ingest_batches_idem"
+_ORG_STATUS_INDEX = "ix_external_ingest_batches_org_status"
+_ORG_CREATED_INDEX = "ix_external_ingest_batches_org_created"
+_ORG_SOURCE_INDEX = "ix_external_ingest_batches_org_source"
+_REJ_ORDER_INDEX = "uq_external_ingest_rejections_ingestion_order"
+_REJ_ORG_INDEX = "ix_external_ingest_rejections_org_id"
+_PAYLOADS_ORG_INDEX = "ix_external_ingest_batch_payloads_org_id"
+
+
+def upgrade() -> None:
+    if not _table_exists(_BATCHES_TABLE):
+        op.create_table(
+            _BATCHES_TABLE,
+            sa.Column("ingestion_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("org_id", sa.Text(), nullable=False),
+            sa.Column("idempotency_key", sa.Text(), nullable=False),
+            sa.Column("payload_hash", sa.Text(), nullable=False),
+            sa.Column("source_system", sa.Text(), nullable=False),
+            sa.Column("source_instance", sa.Text(), nullable=False),
+            sa.Column("producer", sa.Text(), nullable=True),
+            sa.Column("producer_version", sa.Text(), nullable=True),
+            sa.Column("schema_version", sa.Text(), nullable=False),
+            sa.Column("window_started_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("window_ended_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("status", sa.Text(), nullable=False, server_default="accepted"),
+            sa.Column("attempts", sa.Integer(), nullable=False, server_default="1"),
+            sa.Column(
+                "items_received", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "items_accepted", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column(
+                "items_rejected", sa.Integer(), nullable=False, server_default="0"
+            ),
+            sa.Column("record_counts", sa.JSON(), nullable=True),
+            sa.Column("error_summary", sa.JSON(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column(
+                "updated_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.PrimaryKeyConstraint("ingestion_id"),
+        )
+    _create_index_if_missing(_ORG_STATUS_INDEX, _BATCHES_TABLE, ["org_id", "status"])
+    _create_index_if_missing(
+        _ORG_CREATED_INDEX, _BATCHES_TABLE, ["org_id", "created_at"]
+    )
+    _create_index_if_missing(
+        _ORG_SOURCE_INDEX,
+        _BATCHES_TABLE,
+        ["org_id", "source_system", "source_instance"],
+    )
+    _create_unique_index_if_missing(
+        _IDEM_INDEX,
+        _BATCHES_TABLE,
+        ["org_id", "source_system", "source_instance", "idempotency_key"],
+    )
+
+    if not _table_exists(_REJECTIONS_TABLE):
+        op.create_table(
+            _REJECTIONS_TABLE,
+            sa.Column("id", UUID(as_uuid=True), nullable=False),
+            sa.Column("org_id", sa.Text(), nullable=False),
+            sa.Column(
+                "ingestion_id",
+                UUID(as_uuid=True),
+                sa.ForeignKey(
+                    f"{_BATCHES_TABLE}.ingestion_id",
+                    ondelete="CASCADE",
+                    name="fk_external_ingest_rejections_ingestion_id",
+                ),
+                nullable=False,
+            ),
+            sa.Column("record_index", sa.Integer(), nullable=False),
+            sa.Column("record_kind", sa.Text(), nullable=False),
+            sa.Column("external_id", sa.Text(), nullable=True),
+            sa.Column("code", sa.Text(), nullable=False),
+            sa.Column("message", sa.Text(), nullable=False),
+            sa.Column("path", sa.Text(), nullable=True),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    # UNIQUE, not just an ordering index (adversarial-review defense-in-depth):
+    # a single position in a customer's submitted batch is rejected at most
+    # once, so this also acts as a DB-level backstop against complete_batch()
+    # ever double-inserting diagnostics for the same record.
+    _create_unique_index_if_missing(
+        _REJ_ORDER_INDEX, _REJECTIONS_TABLE, ["ingestion_id", "record_index"]
+    )
+    _create_index_if_missing(_REJ_ORG_INDEX, _REJECTIONS_TABLE, ["org_id"])
+
+    if not _table_exists(_PAYLOADS_TABLE):
+        op.create_table(
+            _PAYLOADS_TABLE,
+            sa.Column("ingestion_id", UUID(as_uuid=True), nullable=False),
+            sa.Column("org_id", sa.Text(), nullable=False),
+            sa.Column("schema_version", sa.Text(), nullable=False),
+            sa.Column("payload_json", sa.LargeBinary(), nullable=False),
+            sa.Column("byte_size", sa.Integer(), nullable=False),
+            sa.Column(
+                "created_at",
+                sa.DateTime(timezone=True),
+                nullable=False,
+                server_default=sa.text("now()"),
+            ),
+            sa.PrimaryKeyConstraint("ingestion_id"),
+        )
+    _create_index_if_missing(_PAYLOADS_ORG_INDEX, _PAYLOADS_TABLE, ["org_id"])
+
+
+def downgrade() -> None:
+    if _table_exists(_PAYLOADS_TABLE):
+        op.drop_table(_PAYLOADS_TABLE)
+    if _table_exists(_REJECTIONS_TABLE):
+        op.drop_table(_REJECTIONS_TABLE)
+    if _table_exists(_BATCHES_TABLE):
+        op.drop_table(_BATCHES_TABLE)
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    return table_name in sa.inspect(bind).get_table_names()
+
+
+def _create_index_if_missing(
+    index_name: str, table_name: str, columns: list[str]
+) -> None:
+    bind = op.get_bind()
+    existing = {ix["name"] for ix in sa.inspect(bind).get_indexes(table_name)}
+    if index_name not in existing:
+        op.create_index(index_name, table_name, columns)
+
+
+def _create_unique_index_if_missing(
+    index_name: str, table_name: str, columns: list[str]
+) -> None:
+    bind = op.get_bind()
+    existing = {ix["name"] for ix in sa.inspect(bind).get_indexes(table_name)}
+    if index_name not in existing:
+        op.create_index(index_name, table_name, columns, unique=True)

--- a/src/dev_health_ops/api/admin/routers/customer_push.py
+++ b/src/dev_health_ops/api/admin/routers/customer_push.py
@@ -9,23 +9,36 @@ See docs/architecture/customer-push-authz.md for the one-active-owner
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from datetime import datetime, timezone
 from typing import Any
 
-from fastapi import APIRouter, Depends, HTTPException, Request
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.admin.middleware import get_admin_user
 from dev_health_ops.api.admin.schemas.customer_push import (
+    AdminBatchListItemResponse,
+    AdminBatchListResponse,
+    AdminBatchResponse,
+    AdminRejectedRecordResponse,
     IngestSourceCreate,
     IngestSourcePatch,
     IngestSourceResponse,
     IngestTokenCreate,
     IngestTokenCreateResponse,
     IngestTokenResponse,
+)
+from dev_health_ops.api.external_ingest import status as ingest_status
+from dev_health_ops.api.external_ingest.schemas import (
+    MAX_BODY_BYTES_DEFAULT,
+    MAX_RECORDS_DEFAULT,
+    RECORD_KIND_MODELS,
+    SCHEMA_VERSION,
+    BatchEnvelope,
 )
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.utils.audit import emit_audit_log
@@ -652,3 +665,197 @@ async def revoke_token(
         await session.commit()
 
     return _token_to_response(token)
+
+
+# ---------------------------------------------------------------------------
+# Batches (CHAOS-2694) -- admin-plane read proxies over the CHAOS-2694
+# status.py store (same tables the token-authed data-plane GET
+# /api/v1/external-ingest/batches* endpoints read). Session-JWT +
+# require_admin (already applied at the parent router level, CC25) rather
+# than an ingest token.
+# ---------------------------------------------------------------------------
+
+
+def _batch_to_admin_list_item(
+    batch: ingest_status.BatchRow,
+) -> AdminBatchListItemResponse:
+    return AdminBatchListItemResponse(
+        ingestion_id=str(batch.ingestion_id),
+        status=batch.status,
+        source_system=batch.source_system,
+        source_instance=batch.source_instance,
+        producer=batch.producer,
+        items_received=batch.items_received,
+        items_accepted=batch.items_accepted,
+        items_rejected=batch.items_rejected,
+        created_at=batch.created_at,
+        completed_at=batch.completed_at,
+    )
+
+
+async def _batch_to_admin_response(
+    session: AsyncSession,
+    batch: ingest_status.BatchRow,
+    *,
+    org_id: str,
+    rejected_records_limit: int,
+    rejected_records_offset: int,
+) -> AdminBatchResponse:
+    errors, errors_total = await ingest_status.list_rejections(
+        session,
+        org_id=org_id,
+        ingestion_id=batch.ingestion_id,
+        limit=rejected_records_limit,
+        offset=rejected_records_offset,
+    )
+    return AdminBatchResponse(
+        ingestion_id=str(batch.ingestion_id),
+        org_id=batch.org_id,
+        status=batch.status,
+        attempts=batch.attempts,
+        source_system=batch.source_system,
+        source_instance=batch.source_instance,
+        producer=batch.producer,
+        producer_version=batch.producer_version,
+        schema_version=batch.schema_version,
+        window_started_at=batch.window_started_at,
+        window_ended_at=batch.window_ended_at,
+        items_received=batch.items_received,
+        items_accepted=batch.items_accepted,
+        items_rejected=batch.items_rejected,
+        record_counts=batch.record_counts,
+        error_summary=batch.error_summary,
+        created_at=batch.created_at,
+        updated_at=batch.updated_at,
+        completed_at=batch.completed_at,
+        rejected_records=[
+            AdminRejectedRecordResponse(
+                index=e.record_index,
+                kind=e.record_kind,
+                external_id=e.external_id,
+                code=e.code,
+                message=e.message,
+                path=e.path,
+            )
+            for e in errors
+        ],
+        rejected_records_total=errors_total,
+        rejected_records_limit=rejected_records_limit,
+        rejected_records_offset=rejected_records_offset,
+    )
+
+
+@router.get(
+    "/customer-push/sources/{source_id}/batches",
+    response_model=AdminBatchListResponse,
+)
+async def list_source_batches(
+    source_id: str,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+    status_filter: str | None = Query(default=None, alias="status"),
+    producer: str | None = Query(default=None),
+    from_: datetime | None = Query(default=None, alias="from"),
+    to: datetime | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=200),
+    offset: int = Query(default=0, ge=0),
+) -> AdminBatchListResponse:
+    org_id = current_user.org_id
+    source = await _get_org_source(session, org_id, source_id)
+    rows, total = await ingest_status.list_batches(
+        session,
+        org_id=org_id,
+        source_system=source.system,
+        source_instance=source.instance,
+        status=status_filter,
+        producer=producer,
+        created_after=from_,
+        created_before=to,
+        limit=limit,
+        offset=offset,
+    )
+    return AdminBatchListResponse(
+        items=[_batch_to_admin_list_item(row) for row in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@router.get("/customer-push/batches/{ingestion_id}", response_model=AdminBatchResponse)
+async def get_batch_detail(
+    ingestion_id: str,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+    rejected_records_limit: int = Query(default=50, ge=1, le=200),
+    rejected_records_offset: int = Query(default=0, ge=0),
+) -> AdminBatchResponse:
+    org_id = current_user.org_id
+    try:
+        parsed_id = uuid.UUID(ingestion_id)
+    except ValueError:
+        raise HTTPException(status_code=404, detail="Batch not found")
+    batch = await ingest_status.get_batch(
+        session, org_id=org_id, ingestion_id=parsed_id
+    )
+    if batch is None:
+        raise HTTPException(status_code=404, detail="Batch not found")
+    return await _batch_to_admin_response(
+        session,
+        batch,
+        org_id=org_id,
+        rejected_records_limit=rejected_records_limit,
+        rejected_records_offset=rejected_records_offset,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schemas passthrough (CHAOS-2694) -- thin proxy over the same
+# schemas.py-derived payload the data-plane GET /schemas* endpoints return
+# (router.py owns those; not modified here). CHAOS-2692's schema registry
+# will eventually be the shared source for this once it lands.
+# ---------------------------------------------------------------------------
+
+
+def _external_ingest_limits() -> dict[str, int]:
+    return {
+        "maxRecordsPerBatch": int(
+            os.environ.get("EXTERNAL_INGEST_MAX_RECORDS", str(MAX_RECORDS_DEFAULT))
+        ),
+        "maxBodyBytes": int(
+            os.environ.get(
+                "EXTERNAL_INGEST_MAX_BODY_BYTES", str(MAX_BODY_BYTES_DEFAULT)
+            )
+        ),
+    }
+
+
+@router.get("/customer-push/schemas")
+async def admin_list_schemas(
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> dict[str, Any]:
+    return {
+        "schemaVersions": [SCHEMA_VERSION],
+        "recordKinds": sorted(RECORD_KIND_MODELS),
+        "limits": _external_ingest_limits(),
+    }
+
+
+@router.get("/customer-push/schemas/{schema_version}")
+async def admin_get_schema(
+    schema_version: str,
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> dict[str, Any]:
+    if schema_version != SCHEMA_VERSION:
+        raise HTTPException(
+            status_code=404, detail=f"Unknown schema version: {schema_version!r}"
+        )
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "envelope": BatchEnvelope.model_json_schema(by_alias=True),
+        "recordKinds": {
+            kind: model.model_json_schema(by_alias=True)
+            for kind, model in RECORD_KIND_MODELS.items()
+        },
+        "limits": _external_ingest_limits(),
+    }

--- a/src/dev_health_ops/api/admin/schemas/customer_push.py
+++ b/src/dev_health_ops/api/admin/schemas/customer_push.py
@@ -142,3 +142,67 @@ class IngestTokenResponse(BaseModel):
     created_at: datetime
 
     model_config = ConfigDict(from_attributes=True)
+
+
+# ---------------------------------------------------------------------------
+# Batches (CHAOS-2694) -- admin-plane read proxies over the same status.py
+# store the data-plane GET /api/v1/external-ingest/batches* endpoints use.
+# snake_case (admin convention), NOT the data-plane's camelCase. Deliberately
+# does NOT surface recompute_status in v1 (CHAOS-2699 adds that in wave 3,
+# master-spec CC21).
+# ---------------------------------------------------------------------------
+
+
+class AdminRejectedRecordResponse(BaseModel):
+    index: int
+    kind: str
+    external_id: str | None
+    code: str
+    message: str
+    path: str | None
+
+
+class AdminBatchResponse(BaseModel):
+    ingestion_id: str
+    org_id: str
+    status: str
+    attempts: int
+    source_system: str
+    source_instance: str
+    producer: str | None
+    producer_version: str | None
+    schema_version: str
+    window_started_at: datetime | None
+    window_ended_at: datetime | None
+    items_received: int
+    items_accepted: int
+    items_rejected: int
+    record_counts: dict | None
+    error_summary: dict | None
+    created_at: datetime
+    updated_at: datetime
+    completed_at: datetime | None
+    rejected_records: list[AdminRejectedRecordResponse]
+    rejected_records_total: int
+    rejected_records_limit: int
+    rejected_records_offset: int
+
+
+class AdminBatchListItemResponse(BaseModel):
+    ingestion_id: str
+    status: str
+    source_system: str
+    source_instance: str
+    producer: str | None
+    items_received: int
+    items_accepted: int
+    items_rejected: int
+    created_at: datetime
+    completed_at: datetime | None
+
+
+class AdminBatchListResponse(BaseModel):
+    items: list[AdminBatchListItemResponse]
+    total: int
+    limit: int
+    offset: int

--- a/src/dev_health_ops/api/external_ingest/status.py
+++ b/src/dev_health_ops/api/external_ingest/status.py
@@ -1,0 +1,876 @@
+"""Ingest batch status store + data-plane GET endpoints (CHAOS-2694).
+
+Direct-SQL read/write layer other external-ingest sub-issues call into
+(CHAOS-2691's ``POST /batches``, CHAOS-2695's idempotency/conflict policy,
+CHAOS-2697's worker) plus this issue's own GET endpoints. Defines its OWN
+``APIRouter`` (``status_router``), mounted directly in ``api/main.py`` -- it
+does NOT append to CHAOS-2691's ``router.py``/``schemas.py`` (deliberate,
+keeps wave-2 files disjoint from CHAOS-2692/2712; see
+``docs/architecture/external-ingest-status-store.md``).
+
+All reads/writes go through ``session.execute(text(...), params)`` -- no
+``session.add()``/ORM query paths -- per the plan's "use direct SQL for API
+persistence" mandate (``dev_health_ops.models.external_ingest`` holds the
+declarative classes purely as the Alembic/sqlite-test schema-of-record). SQL
+is dialect-portable (no ``RETURNING``/``ON CONFLICT``): UUIDs are bound as
+``str(...)`` and JSON columns as ``json.dumps(...)``/``json.loads(...)``
+manually (neither SQLAlchemy's ``text()`` nor asyncpg apply column-type-aware
+bind/result processing to untyped raw-SQL parameters), matching the
+``api/billing/reconciliation_service.py``/``refund_service.py`` precedent.
+
+CHAOS-2699 (wave 3) extends ``BatchStatusResponse``/``get_batch_status`` with
+a ``recompute_status`` block -- deliberately NOT present in this file yet
+(master-spec CC21); the response model's trailing comment marks the seam.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Annotated, Any
+
+from fastapi import APIRouter, Depends, Query, Request
+from pydantic import BaseModel, ConfigDict, Field
+from sqlalchemy import text
+from sqlalchemy.engine import RowMapping
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.dependencies import get_postgres_session_dep
+from dev_health_ops.api.middleware.rate_limit import (
+    INGEST_READ_LIMIT,
+    get_ingest_token_key,
+    limiter,
+)
+from dev_health_ops.models.external_ingest import (
+    MAX_STORED_REJECTIONS_PER_BATCH,
+    TERMINAL_STATUSES,
+    BatchStatus,
+    terminal_status_for,
+)
+
+from .auth import IngestAuthContext, require_ingest_scope
+from .errors import ExternalIngestError
+
+__all__ = [
+    "BatchRow",
+    "RejectedRecord",
+    "RejectionRow",
+    "DuplicateIdempotencyKeyError",
+    "find_existing_batch",
+    "create_batch",
+    "mark_processing",
+    "mark_stream_unavailable",
+    "complete_batch",
+    "get_batch",
+    "list_batches",
+    "list_rejections",
+    "status_router",
+]
+
+_BATCHES_TABLE = "external_ingest_batches"
+_REJECTIONS_TABLE = "external_ingest_rejections"
+_TERMINAL_STATUS_VALUES = {s.value for s in TERMINAL_STATUSES}
+
+
+class DuplicateIdempotencyKeyError(Exception):
+    """Unique-constraint collision on (org_id, source_system, source_instance,
+    idempotency_key). Raised by ``create_batch()`` when a concurrent insert
+    wins the race after the caller's own ``find_existing_batch()`` pre-check
+    missed it. Callers (CHAOS-2691/2695) should catch this, re-run
+    ``find_existing_batch()``, and apply the same-hash-200 /
+    different-hash-409 policy.
+    """
+
+    def __init__(
+        self,
+        org_id: str,
+        source_system: str,
+        source_instance: str,
+        idempotency_key: str,
+    ) -> None:
+        super().__init__(
+            f"duplicate idempotency key for org={org_id!r} "
+            f"source={source_system}/{source_instance} key={idempotency_key!r}"
+        )
+        self.org_id = org_id
+        self.source_system = source_system
+        self.source_instance = source_instance
+        self.idempotency_key = idempotency_key
+
+
+@dataclass(frozen=True)
+class BatchRow:
+    ingestion_id: uuid.UUID
+    org_id: str
+    idempotency_key: str
+    payload_hash: str
+    source_system: str
+    source_instance: str
+    producer: str | None
+    producer_version: str | None
+    schema_version: str
+    window_started_at: datetime | None
+    window_ended_at: datetime | None
+    status: str
+    attempts: int
+    items_received: int
+    items_accepted: int
+    items_rejected: int
+    record_counts: dict[str, Any] | None
+    error_summary: dict[str, Any] | None
+    created_at: datetime
+    updated_at: datetime
+    completed_at: datetime | None
+
+
+@dataclass(frozen=True)
+class RejectedRecord:
+    """Input shape the worker (CHAOS-2697/2698) passes to ``complete_batch()``."""
+
+    record_index: int
+    record_kind: str
+    external_id: str | None
+    code: str
+    message: str
+    path: str | None
+
+
+@dataclass(frozen=True)
+class RejectionRow(RejectedRecord):
+    id: uuid.UUID
+    created_at: datetime
+
+
+# ---------------------------------------------------------------------------
+# Row <-> Python value marshaling helpers (dialect-portable raw-SQL bind/read)
+# ---------------------------------------------------------------------------
+
+
+def _parse_uuid(value: Any) -> uuid.UUID:
+    return value if isinstance(value, uuid.UUID) else uuid.UUID(str(value))
+
+
+def _parse_dt_required(value: Any) -> datetime:
+    dt = value if isinstance(value, datetime) else datetime.fromisoformat(str(value))
+    return dt if dt.tzinfo is not None else dt.replace(tzinfo=timezone.utc)
+
+
+def _parse_dt(value: Any) -> datetime | None:
+    return None if value is None else _parse_dt_required(value)
+
+
+def _parse_json(value: Any) -> dict[str, Any] | None:
+    if value is None:
+        return None
+    if isinstance(value, dict):
+        return value
+    return dict(json.loads(value))
+
+
+def _row_to_batch(m: RowMapping) -> BatchRow:
+    return BatchRow(
+        ingestion_id=_parse_uuid(m["ingestion_id"]),
+        org_id=m["org_id"],
+        idempotency_key=m["idempotency_key"],
+        payload_hash=m["payload_hash"],
+        source_system=m["source_system"],
+        source_instance=m["source_instance"],
+        producer=m["producer"],
+        producer_version=m["producer_version"],
+        schema_version=m["schema_version"],
+        window_started_at=_parse_dt(m["window_started_at"]),
+        window_ended_at=_parse_dt(m["window_ended_at"]),
+        status=m["status"],
+        attempts=int(m["attempts"]),
+        items_received=int(m["items_received"]),
+        items_accepted=int(m["items_accepted"]),
+        items_rejected=int(m["items_rejected"]),
+        record_counts=_parse_json(m["record_counts"]),
+        error_summary=_parse_json(m["error_summary"]),
+        created_at=_parse_dt_required(m["created_at"]),
+        updated_at=_parse_dt_required(m["updated_at"]),
+        completed_at=_parse_dt(m["completed_at"]),
+    )
+
+
+def _row_to_rejection(m: RowMapping) -> RejectionRow:
+    return RejectionRow(
+        record_index=int(m["record_index"]),
+        record_kind=m["record_kind"],
+        external_id=m["external_id"],
+        code=m["code"],
+        message=m["message"],
+        path=m["path"],
+        id=_parse_uuid(m["id"]),
+        created_at=_parse_dt_required(m["created_at"]),
+    )
+
+
+def _build_error_summary(
+    total_rejected: int, stored: list[RejectedRecord], truncated: bool
+) -> dict[str, Any] | None:
+    if total_rejected == 0:
+        return None
+    counts: dict[str, int] = {}
+    for rejection in stored:
+        counts[rejection.code] = counts.get(rejection.code, 0) + 1
+    top_codes = sorted(counts.items(), key=lambda kv: kv[1], reverse=True)
+    return {
+        "total_rejected": total_rejected,
+        "stored_rejections": len(stored),
+        "truncated": truncated,
+        "top_codes": [{"code": code, "count": count} for code, count in top_codes],
+    }
+
+
+# ---------------------------------------------------------------------------
+# CRUD / state machine
+# ---------------------------------------------------------------------------
+
+
+async def find_existing_batch(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    source_system: str,
+    source_instance: str,
+    idempotency_key: str,
+) -> BatchRow | None:
+    """Idempotency-key lookup. Consumed by CHAOS-2695's conflict policy
+    BEFORE calling ``create_batch()`` -- this is the primary dedupe path; the
+    unique constraint + ``DuplicateIdempotencyKeyError`` is the race-safety
+    backstop, not the primary mechanism."""
+    result = await session.execute(
+        text(
+            f"SELECT * FROM {_BATCHES_TABLE} WHERE org_id = :org_id "
+            "AND source_system = :source_system AND source_instance = :source_instance "
+            "AND idempotency_key = :idempotency_key"
+        ),
+        {
+            "org_id": org_id,
+            "source_system": source_system,
+            "source_instance": source_instance,
+            "idempotency_key": idempotency_key,
+        },
+    )
+    row = result.mappings().first()
+    return _row_to_batch(row) if row is not None else None
+
+
+async def create_batch(
+    session: AsyncSession,
+    *,
+    ingestion_id: uuid.UUID,
+    org_id: str,
+    idempotency_key: str,
+    payload_hash: str,
+    source_system: str,
+    source_instance: str,
+    producer: str | None,
+    producer_version: str | None,
+    schema_version: str,
+    window_started_at: datetime | None,
+    window_ended_at: datetime | None,
+    items_received: int,
+) -> BatchRow:
+    """INSERT a new ``status='accepted'`` row. Caller (CHAOS-2691's
+    ``POST /batches`` handler, after CHAOS-2693's stream enqueue has already
+    SUCCEEDED -- never write a status row for a batch that failed to enqueue
+    durably) must have already called ``find_existing_batch()`` for the
+    idempotency pre-check. Raises ``DuplicateIdempotencyKeyError`` on a
+    concurrent-insert race. Does NOT commit -- caller commits once the
+    accept sequence's other writes (e.g. the payload row) also succeed."""
+    now = datetime.now(timezone.utc)
+    params: dict[str, Any] = {
+        "ingestion_id": str(ingestion_id),
+        "org_id": org_id,
+        "idempotency_key": idempotency_key,
+        "payload_hash": payload_hash,
+        "source_system": source_system,
+        "source_instance": source_instance,
+        "producer": producer,
+        "producer_version": producer_version,
+        "schema_version": schema_version,
+        "window_started_at": window_started_at,
+        "window_ended_at": window_ended_at,
+        "status": BatchStatus.ACCEPTED.value,
+        "attempts": 1,
+        "items_received": items_received,
+        "items_accepted": 0,
+        "items_rejected": 0,
+        "record_counts": None,
+        "error_summary": None,
+        "created_at": now,
+        "updated_at": now,
+        "completed_at": None,
+    }
+    insert_sql = text(
+        f"""
+        INSERT INTO {_BATCHES_TABLE} (
+            ingestion_id, org_id, idempotency_key, payload_hash, source_system,
+            source_instance, producer, producer_version, schema_version,
+            window_started_at, window_ended_at, status, attempts,
+            items_received, items_accepted, items_rejected, record_counts,
+            error_summary, created_at, updated_at, completed_at
+        ) VALUES (
+            :ingestion_id, :org_id, :idempotency_key, :payload_hash, :source_system,
+            :source_instance, :producer, :producer_version, :schema_version,
+            :window_started_at, :window_ended_at, :status, :attempts,
+            :items_received, :items_accepted, :items_rejected, :record_counts,
+            :error_summary, :created_at, :updated_at, :completed_at
+        )
+        """
+    )
+    try:
+        async with session.begin_nested():
+            await session.execute(insert_sql, params)
+    except IntegrityError as exc:
+        raise DuplicateIdempotencyKeyError(
+            org_id=org_id,
+            source_system=source_system,
+            source_instance=source_instance,
+            idempotency_key=idempotency_key,
+        ) from exc
+
+    return BatchRow(
+        ingestion_id=ingestion_id,
+        org_id=org_id,
+        idempotency_key=idempotency_key,
+        payload_hash=payload_hash,
+        source_system=source_system,
+        source_instance=source_instance,
+        producer=producer,
+        producer_version=producer_version,
+        schema_version=schema_version,
+        window_started_at=window_started_at,
+        window_ended_at=window_ended_at,
+        status=BatchStatus.ACCEPTED.value,
+        attempts=1,
+        items_received=items_received,
+        items_accepted=0,
+        items_rejected=0,
+        record_counts=None,
+        error_summary=None,
+        created_at=now,
+        updated_at=now,
+        completed_at=None,
+    )
+
+
+async def _transition_status(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    ingestion_id: uuid.UUID,
+    from_status: BatchStatus,
+    to_status: BatchStatus,
+) -> None:
+    now = datetime.now(timezone.utc)
+    await session.execute(
+        text(
+            f"UPDATE {_BATCHES_TABLE} SET status = :new_status, updated_at = :updated_at "
+            "WHERE org_id = :org_id AND ingestion_id = :ingestion_id AND status = :old_status"
+        ),
+        {
+            "new_status": to_status.value,
+            "updated_at": now,
+            "org_id": org_id,
+            "ingestion_id": str(ingestion_id),
+            "old_status": from_status.value,
+        },
+    )
+
+
+async def mark_processing(
+    session: AsyncSession, *, org_id: str, ingestion_id: uuid.UUID
+) -> None:
+    """``accepted -> processing``. Idempotent: a no-op UPDATE (``WHERE
+    status = 'accepted'``) if already processing/terminal, so redelivered
+    stream entries (at-least-once) never regress a terminal status back to
+    processing."""
+    await _transition_status(
+        session,
+        org_id=org_id,
+        ingestion_id=ingestion_id,
+        from_status=BatchStatus.ACCEPTED,
+        to_status=BatchStatus.PROCESSING,
+    )
+
+
+async def mark_stream_unavailable(
+    session: AsyncSession, *, org_id: str, ingestion_id: uuid.UUID
+) -> None:
+    """``accepted -> stream_unavailable`` (master-spec CC12/CC22): the
+    Postgres commit for the accept row succeeded but the stream enqueue
+    failed. Callers MUST commit this write before raising the 503 to the
+    client ("commit-before-raise") -- a rolled-back status row would leave
+    the client's 503 with no corresponding durable state to resubmit
+    against."""
+    await _transition_status(
+        session,
+        org_id=org_id,
+        ingestion_id=ingestion_id,
+        from_status=BatchStatus.ACCEPTED,
+        to_status=BatchStatus.STREAM_UNAVAILABLE,
+    )
+
+
+async def complete_batch(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    ingestion_id: uuid.UUID,
+    items_accepted: int,
+    items_rejected: int,
+    rejections: list[RejectedRecord],
+) -> BatchRow:
+    """``processing -> {completed, partial, failed}`` (derived from counts,
+    see ``terminal_status_for``). Idempotent: if called twice for the same
+    ``ingestion_id`` (worker redelivery) once the batch is already terminal,
+    this is a pure no-op -- the second call's (expected-identical) inputs are
+    discarded and the already-persisted row is returned unchanged. Only a
+    batch currently ``processing`` may transition to a terminal status
+    (adversarial review: completing directly from ``accepted``/
+    ``stream_unavailable`` would let an unprocessed or never-enqueued batch
+    masquerade as successfully completed) -- raises ``ValueError`` for any
+    other non-terminal starting state, and for counters that are negative or
+    don't sum to the batch's recorded ``items_received``.
+
+    Concurrency (adversarial review): the status/counter UPDATE is an atomic
+    compare-and-swap (``WHERE status = 'processing'``), not a check-then-write
+    -- if two callers race to complete the same batch, the DB row lock the
+    UPDATE takes serializes them, and only the winner (the one whose UPDATE
+    actually matched a row) proceeds to insert rejection rows; the loser
+    re-reads and returns whatever the winner persisted. This is what makes it
+    safe even though the documented deployment topology (single
+    ``worker-external-ingest`` replica at concurrency=1, consumer-level
+    idempotent-skip guard -- master-spec CC11) shouldn't produce concurrent
+    calls in practice; the DB-level guarantee doesn't rely on that discipline
+    holding. Diagnostics and the terminal status/counters land in the same
+    UPDATE/INSERT sequence inside one uncommitted transaction, so a caller
+    that commits afterward never exposes a terminal status without its
+    rejection rows already durable, and the ``(ingestion_id, record_index)``
+    unique index is a second, DB-enforced backstop against ever
+    double-inserting a rejection row."""
+    current = await get_batch(session, org_id=org_id, ingestion_id=ingestion_id)
+    if current is None:
+        raise ValueError(f"external ingest batch not found: {ingestion_id}")
+
+    if current.status in _TERMINAL_STATUS_VALUES:
+        return current
+
+    if current.status != BatchStatus.PROCESSING.value:
+        raise ValueError(
+            f"cannot complete external ingest batch {ingestion_id}: "
+            f"status is {current.status!r}, expected {BatchStatus.PROCESSING.value!r}"
+        )
+    if items_accepted < 0 or items_rejected < 0:
+        raise ValueError("items_accepted/items_rejected must be non-negative")
+    if items_accepted + items_rejected != current.items_received:
+        raise ValueError(
+            f"items_accepted ({items_accepted}) + items_rejected "
+            f"({items_rejected}) must equal items_received "
+            f"({current.items_received})"
+        )
+
+    new_status = terminal_status_for(
+        current.items_received, items_accepted, items_rejected
+    )
+    now = datetime.now(timezone.utc)
+    stored = rejections[:MAX_STORED_REJECTIONS_PER_BATCH]
+    truncated = len(rejections) > MAX_STORED_REJECTIONS_PER_BATCH
+    error_summary = _build_error_summary(items_rejected, stored, truncated)
+
+    cas_result = await session.execute(
+        text(
+            f"""
+            UPDATE {_BATCHES_TABLE}
+            SET status = :status, items_accepted = :items_accepted,
+                items_rejected = :items_rejected, error_summary = :error_summary,
+                completed_at = :completed_at, updated_at = :updated_at
+            WHERE org_id = :org_id AND ingestion_id = :ingestion_id
+                AND status = :expected_status
+            """
+        ),
+        {
+            "status": new_status.value,
+            "items_accepted": items_accepted,
+            "items_rejected": items_rejected,
+            "error_summary": (
+                json.dumps(error_summary) if error_summary is not None else None
+            ),
+            "completed_at": now,
+            "updated_at": now,
+            "org_id": org_id,
+            "ingestion_id": str(ingestion_id),
+            "expected_status": BatchStatus.PROCESSING.value,
+        },
+    )
+    if int(getattr(cas_result, "rowcount", 0) or 0) != 1:
+        # Lost the race: a concurrent completion (or some other transition)
+        # already moved this row out of 'processing' between our read above
+        # and this UPDATE. Never insert our own rejection rows in that case
+        # -- return whatever the winner actually persisted.
+        refreshed = await get_batch(session, org_id=org_id, ingestion_id=ingestion_id)
+        assert refreshed is not None
+        return refreshed
+
+    if stored:
+        insert_sql = text(
+            f"""
+            INSERT INTO {_REJECTIONS_TABLE} (
+                id, org_id, ingestion_id, record_index, record_kind,
+                external_id, code, message, path, created_at
+            ) VALUES (
+                :id, :org_id, :ingestion_id, :record_index, :record_kind,
+                :external_id, :code, :message, :path, :created_at
+            )
+            """
+        )
+        for rejection in stored:
+            await session.execute(
+                insert_sql,
+                {
+                    "id": str(uuid.uuid4()),
+                    "org_id": org_id,
+                    "ingestion_id": str(ingestion_id),
+                    "record_index": rejection.record_index,
+                    "record_kind": rejection.record_kind,
+                    "external_id": rejection.external_id,
+                    "code": rejection.code,
+                    "message": rejection.message,
+                    "path": rejection.path,
+                    "created_at": now,
+                },
+            )
+
+    updated = await get_batch(session, org_id=org_id, ingestion_id=ingestion_id)
+    assert updated is not None
+    return updated
+
+
+async def get_batch(
+    session: AsyncSession, *, org_id: str, ingestion_id: uuid.UUID
+) -> BatchRow | None:
+    """Tenant-scoped single lookup. Returns ``None`` (never raises) for both
+    "does not exist" and "exists but belongs to a different org" -- callers
+    MUST turn both into an identical 404, never a 403 (avoid leaking
+    cross-org existence)."""
+    result = await session.execute(
+        text(
+            f"SELECT * FROM {_BATCHES_TABLE} "
+            "WHERE org_id = :org_id AND ingestion_id = :ingestion_id"
+        ),
+        {"org_id": org_id, "ingestion_id": str(ingestion_id)},
+    )
+    row = result.mappings().first()
+    return _row_to_batch(row) if row is not None else None
+
+
+async def list_batches(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    source_system: str | None = None,
+    source_instance: str | None = None,
+    status: str | None = None,
+    producer: str | None = None,
+    created_after: datetime | None = None,
+    created_before: datetime | None = None,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[BatchRow], int]:
+    """Returns ``(page, total_count)``. Ordered by ``created_at DESC,
+    ingestion_id DESC`` -- the ``ingestion_id`` tiebreaker keeps pagination
+    stable across requests since ``created_at`` alone is not unique.
+    ``producer`` is an admin-proxy-only filter (master-spec CC25); the
+    data-plane list endpoint does not expose it."""
+    where = ["org_id = :org_id"]
+    params: dict[str, Any] = {"org_id": org_id}
+    if source_system is not None:
+        where.append("source_system = :source_system")
+        params["source_system"] = source_system
+    if source_instance is not None:
+        where.append("source_instance = :source_instance")
+        params["source_instance"] = source_instance
+    if status is not None:
+        where.append("status = :status")
+        params["status"] = status
+    if producer is not None:
+        where.append("producer = :producer")
+        params["producer"] = producer
+    if created_after is not None:
+        where.append("created_at >= :created_after")
+        params["created_after"] = created_after
+    if created_before is not None:
+        where.append("created_at <= :created_before")
+        params["created_before"] = created_before
+    where_clause = " AND ".join(where)
+
+    count_result = await session.execute(
+        text(f"SELECT COUNT(*) AS total FROM {_BATCHES_TABLE} WHERE {where_clause}"),
+        params,
+    )
+    total = int(count_result.scalar_one())
+
+    page_params = dict(params)
+    page_params["limit"] = limit
+    page_params["offset"] = offset
+    rows_result = await session.execute(
+        text(
+            f"SELECT * FROM {_BATCHES_TABLE} WHERE {where_clause} "
+            # ingestion_id tiebreaker: created_at alone is not unique, so a
+            # plain ORDER BY created_at DESC leaves ties free to reorder
+            # between requests -- adversarial-review finding -- which can
+            # duplicate or skip rows across pages under concurrent inserts.
+            "ORDER BY created_at DESC, ingestion_id DESC LIMIT :limit OFFSET :offset"
+        ),
+        page_params,
+    )
+    rows = [_row_to_batch(m) for m in rows_result.mappings().all()]
+    return rows, total
+
+
+async def list_rejections(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    ingestion_id: uuid.UUID,
+    limit: int = 50,
+    offset: int = 0,
+) -> tuple[list[RejectionRow], int]:
+    """Returns ``(page, total_stored_count)`` ordered by ``record_index
+    ASC``. ``total_stored_count`` is capped at
+    ``MAX_STORED_REJECTIONS_PER_BATCH`` -- for the TRUE total_rejected count
+    (which may exceed what's stored), read ``BatchRow.items_rejected`` /
+    ``error_summary['total_rejected']`` instead. ``org_id``-scoped even
+    though the caller has typically already tenant-checked the parent batch
+    (defense in depth: no rejection query in this module is ever
+    org-unscoped)."""
+    params = {"org_id": org_id, "ingestion_id": str(ingestion_id)}
+    count_result = await session.execute(
+        text(
+            f"SELECT COUNT(*) AS total FROM {_REJECTIONS_TABLE} "
+            "WHERE org_id = :org_id AND ingestion_id = :ingestion_id"
+        ),
+        params,
+    )
+    total = int(count_result.scalar_one())
+
+    page_params: dict[str, Any] = dict(params)
+    page_params["limit"] = limit
+    page_params["offset"] = offset
+    rows_result = await session.execute(
+        text(
+            f"SELECT * FROM {_REJECTIONS_TABLE} "
+            "WHERE org_id = :org_id AND ingestion_id = :ingestion_id "
+            "ORDER BY record_index ASC LIMIT :limit OFFSET :offset"
+        ),
+        page_params,
+    )
+    rows = [_row_to_rejection(m) for m in rows_result.mappings().all()]
+    return rows, total
+
+
+# ---------------------------------------------------------------------------
+# Data-plane response models (camelCase, local to this file -- CHAOS-2694
+# does not append to CHAOS-2691's schemas.py; see module docstring)
+# ---------------------------------------------------------------------------
+
+
+class SourceRef(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    system: str
+    instance: str
+
+
+class WindowRef(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    started_at: datetime | None = Field(default=None, alias="startedAt")
+    ended_at: datetime | None = Field(default=None, alias="endedAt")
+
+
+class RejectedRecordResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    index: int
+    kind: str
+    external_id: str | None = Field(default=None, alias="externalId")
+    code: str
+    message: str
+    path: str | None = None
+
+
+class BatchStatusResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    ingestion_id: uuid.UUID = Field(alias="ingestionId")
+    status: str
+    attempts: int
+    items_received: int = Field(alias="itemsReceived")
+    items_accepted: int = Field(alias="itemsAccepted")
+    items_rejected: int = Field(alias="itemsRejected")
+    source: SourceRef
+    window: WindowRef
+    producer: str | None = None
+    producer_version: str | None = Field(default=None, alias="producerVersion")
+    created_at: datetime = Field(alias="createdAt")
+    updated_at: datetime = Field(alias="updatedAt")
+    completed_at: datetime | None = Field(default=None, alias="completedAt")
+    error_summary: dict[str, Any] | None = Field(default=None, alias="errorSummary")
+    errors: list[RejectedRecordResponse]
+    errors_total: int = Field(alias="errorsTotal")
+    errors_limit: int = Field(alias="errorsLimit")
+    errors_offset: int = Field(alias="errorsOffset")
+    # NOTE(CHAOS-2699, master-spec CC21): a `recompute_status` block is added
+    # here in wave 3, once migration 0034 lands. Deliberately absent in v1.
+
+
+class BatchListItemResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    ingestion_id: uuid.UUID = Field(alias="ingestionId")
+    status: str
+    items_received: int = Field(alias="itemsReceived")
+    items_accepted: int = Field(alias="itemsAccepted")
+    items_rejected: int = Field(alias="itemsRejected")
+    source: SourceRef
+    window: WindowRef
+    producer: str | None = None
+    created_at: datetime = Field(alias="createdAt")
+    completed_at: datetime | None = Field(default=None, alias="completedAt")
+
+
+class BatchListResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    items: list[BatchListItemResponse]
+    total: int
+    limit: int
+    offset: int
+
+
+def _batch_to_list_item(row: BatchRow) -> BatchListItemResponse:
+    return BatchListItemResponse(
+        ingestion_id=row.ingestion_id,
+        status=row.status,
+        items_received=row.items_received,
+        items_accepted=row.items_accepted,
+        items_rejected=row.items_rejected,
+        source=SourceRef(system=row.source_system, instance=row.source_instance),
+        window=WindowRef(
+            started_at=row.window_started_at, ended_at=row.window_ended_at
+        ),
+        producer=row.producer,
+        created_at=row.created_at,
+        completed_at=row.completed_at,
+    )
+
+
+def _batch_to_status_response(
+    row: BatchRow,
+    errors: list[RejectionRow],
+    errors_total: int,
+    errors_limit: int,
+    errors_offset: int,
+) -> BatchStatusResponse:
+    return BatchStatusResponse(
+        ingestion_id=row.ingestion_id,
+        status=row.status,
+        attempts=row.attempts,
+        items_received=row.items_received,
+        items_accepted=row.items_accepted,
+        items_rejected=row.items_rejected,
+        source=SourceRef(system=row.source_system, instance=row.source_instance),
+        window=WindowRef(
+            started_at=row.window_started_at, ended_at=row.window_ended_at
+        ),
+        producer=row.producer,
+        producer_version=row.producer_version,
+        created_at=row.created_at,
+        updated_at=row.updated_at,
+        completed_at=row.completed_at,
+        error_summary=row.error_summary,
+        errors=[
+            RejectedRecordResponse(
+                index=e.record_index,
+                kind=e.record_kind,
+                external_id=e.external_id,
+                code=e.code,
+                message=e.message,
+                path=e.path,
+            )
+            for e in errors
+        ],
+        errors_total=errors_total,
+        errors_limit=errors_limit,
+        errors_offset=errors_offset,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Router (mounted directly in api/main.py, not via CHAOS-2691's router.py)
+# ---------------------------------------------------------------------------
+
+status_router = APIRouter(prefix="/api/v1/external-ingest", tags=["external-ingest"])
+
+# Bound once at import time (matches router.py's convention) so tests can
+# target this exact object via app.dependency_overrides.
+_require_ingest_status = require_ingest_scope("ingest:status")
+
+
+@status_router.get("/batches", response_model=BatchListResponse)
+@limiter.limit(INGEST_READ_LIMIT, key_func=get_ingest_token_key)
+async def list_batch_statuses(
+    request: Request,
+    session: Annotated[AsyncSession, Depends(get_postgres_session_dep)],
+    ctx: Annotated[IngestAuthContext, Depends(_require_ingest_status)],
+    source_system: Annotated[str | None, Query(alias="sourceSystem")] = None,
+    source_instance: Annotated[str | None, Query(alias="sourceInstance")] = None,
+    status_filter: Annotated[str | None, Query(alias="status")] = None,
+    created_after: Annotated[datetime | None, Query(alias="createdAfter")] = None,
+    created_before: Annotated[datetime | None, Query(alias="createdBefore")] = None,
+    limit: Annotated[int, Query(ge=1, le=200)] = 50,
+    offset: Annotated[int, Query(ge=0)] = 0,
+) -> BatchListResponse:
+    rows, total = await list_batches(
+        session,
+        org_id=ctx.org_id,
+        source_system=source_system,
+        source_instance=source_instance,
+        status=status_filter,
+        created_after=created_after,
+        created_before=created_before,
+        limit=limit,
+        offset=offset,
+    )
+    return BatchListResponse(
+        items=[_batch_to_list_item(row) for row in rows],
+        total=total,
+        limit=limit,
+        offset=offset,
+    )
+
+
+@status_router.get("/batches/{ingestion_id}", response_model=BatchStatusResponse)
+@limiter.limit(INGEST_READ_LIMIT, key_func=get_ingest_token_key)
+async def get_batch_status(
+    ingestion_id: uuid.UUID,
+    request: Request,
+    session: Annotated[AsyncSession, Depends(get_postgres_session_dep)],
+    ctx: Annotated[IngestAuthContext, Depends(_require_ingest_status)],
+    error_limit: Annotated[int, Query(ge=1, le=200, alias="errorLimit")] = 50,
+    error_offset: Annotated[int, Query(ge=0, alias="errorOffset")] = 0,
+) -> BatchStatusResponse:
+    batch = await get_batch(session, org_id=ctx.org_id, ingestion_id=ingestion_id)
+    if batch is None:
+        raise ExternalIngestError(404, "not_found", "ingestion batch not found")
+    errors, errors_total = await list_rejections(
+        session,
+        org_id=ctx.org_id,
+        ingestion_id=ingestion_id,
+        limit=error_limit,
+        offset=error_offset,
+    )
+    return _batch_to_status_response(
+        batch, errors, errors_total, error_limit, error_offset
+    )

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -26,6 +26,9 @@ from dev_health_ops.api.external_ingest import router as external_ingest_router
 from dev_health_ops.api.external_ingest.errors import (
     register_external_ingest_error_handlers,
 )
+from dev_health_ops.api.external_ingest.status import (
+    status_router as external_ingest_status_router,
+)
 from dev_health_ops.api.middleware.rate_limit import limiter
 from dev_health_ops.api.product_telemetry import router as product_telemetry_router
 from dev_health_ops.api.telemetry.router import router as telemetry_router
@@ -211,6 +214,7 @@ app.include_router(telemetry_router)
 app.include_router(product_telemetry_router)
 app.include_router(ingest_router)
 app.include_router(external_ingest_router)
+app.include_router(external_ingest_status_router)
 app.include_router(orgs_router)
 
 register_observability(app)

--- a/src/dev_health_ops/models/__init__.py
+++ b/src/dev_health_ops/models/__init__.py
@@ -19,6 +19,14 @@ from .checkpoints import (
     SyncComputeCheckpointStatus,
     SyncComputeType,
 )
+from .external_ingest import (
+    MAX_STORED_REJECTIONS_PER_BATCH,
+    TERMINAL_STATUSES,
+    BatchStatus,
+    ExternalIngestBatch,
+    ExternalIngestBatchPayload,
+    ExternalIngestRejection,
+)
 from .git import Base, GitBlame, GitBlameMixin, GitCommit, GitCommitStat, GitFile, Repo
 from .impersonation import ImpersonationSession
 from .ingest_auth import (
@@ -116,7 +124,11 @@ __all__ = [
     "BillingInterval",
     "BillingPlan",
     "BillingPrice",
+    "BatchStatus",
     "CheckpointStatus",
+    "ExternalIngestBatch",
+    "ExternalIngestBatchPayload",
+    "ExternalIngestRejection",
     "FeatureCategory",
     "FeatureBundle",
     "PlanFeatureBundle",
@@ -149,6 +161,7 @@ __all__ = [
     "JobRunStatus",
     "JobStatus",
     "LoginAttempt",
+    "MAX_STORED_REJECTIONS_PER_BATCH",
     "MemberRole",
     "Membership",
     "MetricCheckpoint",
@@ -190,6 +203,7 @@ __all__ = [
     "SyncRunUnit",
     "SyncRunUnitStatus",
     "SyncWatermark",
+    "TERMINAL_STATUSES",
     "TIER_LIMITS",
     "User",
     "JiraProjectOpsTeamLink",

--- a/src/dev_health_ops/models/external_ingest.py
+++ b/src/dev_health_ops/models/external_ingest.py
@@ -1,0 +1,217 @@
+"""External customer-push ingestion status store (CHAOS-2690 / CHAOS-2694).
+
+These declarative classes exist ONLY as the schema-of-record for Alembic and
+for ``Base.metadata.create_all()`` in sqlite-backed unit tests. All actual
+reads/writes go through parameterized ``text()`` SQL in
+``dev_health_ops.api.external_ingest.status`` -- per the plan's "use direct
+SQL for API persistence, avoid ORM-only paths" directive. Do not add
+``session.add()``/``session.query()`` call sites against ``ExternalIngestBatch``
+/``ExternalIngestRejection``; extend ``status.py`` instead.
+
+Postgres, not ClickHouse: transactional, joins the ingest-token/source model
+(CHAOS-2696) in the same database, and must support strongly-consistent
+read-after-write for CLI polling (``dev-hops push batch --poll``) immediately
+after 202 Accepted -- ClickHouse's async merge semantics on ReplacingMergeTree
+would make "poll immediately after accept" flaky.
+
+``ExternalIngestBatchPayload`` is CHAOS-2693's transient raw-payload table --
+hosted here (DDL/model) so wave 3 needs no migration of its own; 2693 owns the
+``payload_store.py`` accessors and the orphan-prune sweep for this table. It
+has no FK to ``external_ingest_batches``: it is written before the batch row
+exists (payload row lands first in CHAOS-2695's accept sequence) and deleted
+independently by the worker on terminal status, per master-spec CC9/CC22.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+from enum import Enum
+
+from sqlalchemy import (
+    JSON,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    LargeBinary,
+    Text,
+    UniqueConstraint,
+)
+from sqlalchemy.orm import Mapped, mapped_column
+
+from dev_health_ops.models.git import GUID, Base
+
+
+class BatchStatus(str, Enum):
+    ACCEPTED = "accepted"
+    STREAM_UNAVAILABLE = "stream_unavailable"
+    PROCESSING = "processing"
+    COMPLETED = "completed"
+    PARTIAL = "partial"
+    FAILED = "failed"
+
+
+#: Master-spec CC12: terminal outcomes. ``accepted``/``stream_unavailable``
+#: are non-terminal (retryable); ``processing`` is non-terminal/in-flight.
+TERMINAL_STATUSES = frozenset(
+    {BatchStatus.COMPLETED, BatchStatus.PARTIAL, BatchStatus.FAILED}
+)
+
+#: Cap on stored per-record rejection diagnostics for a single batch (brief
+#: Design Decision 4/9). ``items_rejected``/``error_summary.total_rejected``
+#: on the batch row always reflect the TRUE total even beyond this cap.
+MAX_STORED_REJECTIONS_PER_BATCH = 1000
+
+
+class ExternalIngestBatch(Base):
+    __tablename__ = "external_ingest_batches"
+
+    ingestion_id: Mapped[uuid.UUID] = mapped_column(
+        GUID, primary_key=True, default=uuid.uuid4
+    )
+    org_id: Mapped[str] = mapped_column(Text, nullable=False)
+    idempotency_key: Mapped[str] = mapped_column(Text, nullable=False)
+    payload_hash: Mapped[str] = mapped_column(Text, nullable=False)
+    source_system: Mapped[str] = mapped_column(Text, nullable=False)
+    source_instance: Mapped[str] = mapped_column(Text, nullable=False)
+    producer: Mapped[str | None] = mapped_column(Text, nullable=True)
+    producer_version: Mapped[str | None] = mapped_column(Text, nullable=True)
+    schema_version: Mapped[str] = mapped_column(Text, nullable=False)
+    window_started_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    window_ended_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    status: Mapped[str] = mapped_column(
+        Text, nullable=False, default=BatchStatus.ACCEPTED.value
+    )
+    attempts: Mapped[int] = mapped_column(Integer, nullable=False, default=1)
+    items_received: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    items_accepted: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    items_rejected: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    # Per-record-kind counts (e.g. {"pull_request.v1": 12, ...}) for
+    # Screen 6/detail. NOT populated by CHAOS-2694 v1 write paths (no caller
+    # exists yet -- CHAOS-2697's worker is the eventual writer); the column
+    # exists now so the migration doesn't need to change later.
+    record_counts: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    error_summary: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "org_id",
+            "source_system",
+            "source_instance",
+            "idempotency_key",
+            name="uq_external_ingest_batches_idem",
+        ),
+        Index("ix_external_ingest_batches_org_status", "org_id", "status"),
+        Index("ix_external_ingest_batches_org_created", "org_id", "created_at"),
+        Index(
+            "ix_external_ingest_batches_org_source",
+            "org_id",
+            "source_system",
+            "source_instance",
+        ),
+    )
+
+
+class ExternalIngestRejection(Base):
+    __tablename__ = "external_ingest_rejections"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False)
+    ingestion_id: Mapped[uuid.UUID] = mapped_column(
+        GUID,
+        ForeignKey("external_ingest_batches.ingestion_id", ondelete="CASCADE"),
+        nullable=False,
+    )
+    record_index: Mapped[int] = mapped_column(Integer, nullable=False)
+    record_kind: Mapped[str] = mapped_column(Text, nullable=False)
+    external_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    code: Mapped[str] = mapped_column(Text, nullable=False)
+    message: Mapped[str] = mapped_column(Text, nullable=False)
+    path: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        # Unique, not just an ordering index: a single position in a
+        # customer's submitted batch is rejected at most once, so this also
+        # backstops complete_batch() against ever double-inserting
+        # diagnostics for the same record.
+        Index(
+            "uq_external_ingest_rejections_ingestion_order",
+            "ingestion_id",
+            "record_index",
+            unique=True,
+        ),
+        Index("ix_external_ingest_rejections_org_id", "org_id"),
+    )
+
+
+class ExternalIngestBatchPayload(Base):
+    """Transient raw-batch-JSON store (CHAOS-2693's ``payload_store.py``
+    accessors; DDL/model hosted here per master-spec CC19)."""
+
+    __tablename__ = "external_ingest_batch_payloads"
+
+    ingestion_id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False)
+    schema_version: Mapped[str] = mapped_column(Text, nullable=False)
+    payload_json: Mapped[bytes] = mapped_column(LargeBinary, nullable=False)
+    byte_size: Mapped[int] = mapped_column(Integer, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (Index("ix_external_ingest_batch_payloads_org_id", "org_id"),)
+
+
+def terminal_status_for(
+    items_received: int, items_accepted: int, items_rejected: int
+) -> BatchStatus:
+    """Pure terminal-status derivation (brief Design Decision 5).
+
+    ``completed`` iff nothing was rejected; ``failed`` iff nothing was
+    accepted (and the batch was non-empty); else ``partial``.
+    """
+    assert items_received > 0, (
+        "empty batches must be rejected by CHAOS-2691 schema validation "
+        "before reaching the status store"
+    )
+    if items_rejected == 0:
+        return BatchStatus.COMPLETED
+    if items_accepted == 0:
+        return BatchStatus.FAILED
+    return BatchStatus.PARTIAL
+
+
+__all__ = [
+    "MAX_STORED_REJECTIONS_PER_BATCH",
+    "TERMINAL_STATUSES",
+    "BatchStatus",
+    "ExternalIngestBatch",
+    "ExternalIngestBatchPayload",
+    "ExternalIngestRejection",
+    "terminal_status_for",
+]

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -224,6 +224,15 @@ beat_schedule = {
         "schedule": crontab(hour=5, minute=0),
         "options": {"queue": "sync"},
     },
+    # Retention for the external-ingest status store (CHAOS-2694). Env-tunable
+    # via EXTERNAL_INGEST_STATUS_RETENTION_DAYS (default 90, see
+    # workers/external_ingest_reconciler.py). Scheduled immediately after
+    # prune-rate-limit-observations (5:00), clear of the other nightly jobs.
+    "prune-external-ingest-batches": {
+        "task": "dev_health_ops.workers.tasks.prune_external_ingest_batches",
+        "schedule": crontab(hour=5, minute=15),
+        "options": {"queue": "sync"},
+    },
 }
 
 # Result settings

--- a/src/dev_health_ops/workers/external_ingest_reconciler.py
+++ b/src/dev_health_ops/workers/external_ingest_reconciler.py
@@ -1,0 +1,87 @@
+"""Retention pruning for the external-ingest status store (CHAOS-2694).
+
+Deletes ``external_ingest_batches`` rows (and cascade-deletes their
+``external_ingest_rejections`` via ``ON DELETE CASCADE``) older than the
+retention window. Beat-scheduled (``workers/config.py``), env-tunable via
+``EXTERNAL_INGEST_STATUS_RETENTION_DAYS`` (default 90 -- this is
+customer-support/audit-facing operational history, closer in spirit to audit
+logs than to the 14-day ``provider_rate_limit_observations`` telemetry
+precedent it otherwise mirrors).
+
+Retention-only: this task never re-enqueues or resurrects stuck batches (a
+batch left in ``accepted``/``processing``/``stream_unavailable`` past
+retention is a bug signal that should stay visible, never silently pruned --
+see the ``status IN (...)`` guard below; this is a deliberate, pinned
+master-spec decision -- CC13 -- not an oversight, and a defense-in-depth
+reconciler for never-resubmitted stale batches is a separate, filed
+follow-up issue). Deletes in bounded chunks, committing each one, so a large
+backlog (e.g. the first run after months of accumulation) never holds one
+huge long-running transaction (adversarial-review finding).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from sqlalchemy import text
+
+from dev_health_ops.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_RETENTION_DAYS = 90
+_DELETE_CHUNK_SIZE = 500
+
+_DELETE_CHUNK_SQL = text(
+    """
+    DELETE FROM external_ingest_batches WHERE ingestion_id IN (
+        SELECT ingestion_id FROM external_ingest_batches
+        WHERE created_at < :cutoff AND status IN ('completed', 'partial', 'failed')
+        LIMIT :chunk_size
+    )
+    """
+)
+
+
+def _retention_days() -> int:
+    raw = os.getenv("EXTERNAL_INGEST_STATUS_RETENTION_DAYS")
+    if not raw:
+        return _DEFAULT_RETENTION_DAYS
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return _DEFAULT_RETENTION_DAYS
+
+
+@celery_app.task(
+    queue="sync",
+    name="dev_health_ops.workers.tasks.prune_external_ingest_batches",
+)
+def prune_external_ingest_batches(retention_days: int | None = None) -> dict[str, Any]:
+    from dev_health_ops.db import get_postgres_session_sync
+
+    days = retention_days if retention_days is not None else _retention_days()
+    cutoff = datetime.now(timezone.utc) - timedelta(days=max(0, int(days)))
+    deleted = 0
+    with get_postgres_session_sync() as session:
+        while True:
+            result: Any = session.execute(
+                _DELETE_CHUNK_SQL,
+                {"cutoff": cutoff, "chunk_size": _DELETE_CHUNK_SIZE},
+            )
+            chunk_deleted = int(getattr(result, "rowcount", 0) or 0)
+            deleted += chunk_deleted
+            session.commit()
+            if chunk_deleted < _DELETE_CHUNK_SIZE:
+                break
+    logger.info(
+        "prune_external_ingest_batches.completed",
+        extra={"deleted": deleted, "retention_days": days},
+    )
+    return {"status": "completed", "deleted": deleted, "retention_days": days}
+
+
+__all__ = ["prune_external_ingest_batches"]

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -1,3 +1,6 @@
+from dev_health_ops.workers.external_ingest_reconciler import (
+    prune_external_ingest_batches,
+)
 from dev_health_ops.workers.metrics_tasks import (
     dispatch_daily_metrics_partitioned,
     dispatch_release_impact,
@@ -70,6 +73,7 @@ __all__ = [
     "monitor_queue_depths",
     "phone_home_heartbeat",
     "process_webhook_event",
+    "prune_external_ingest_batches",
     "prune_rate_limit_observations",
     "reconcile_sync_dispatch",
     "dispatch_membership_backfill",

--- a/tests/api/admin/test_customer_push_batches.py
+++ b/tests/api/admin/test_customer_push_batches.py
@@ -1,0 +1,294 @@
+"""Tests for the CHAOS-2694 admin-plane batch/schema read proxies under
+``/api/v1/admin/customer-push/*``.
+
+Follows tests/api/admin/test_customer_push.py's direct-app fixture style.
+Seeds ``external_ingest_batches``/``rejections`` via status.py directly (not
+via HTTP -- the POST accept path is out of scope for this issue) alongside an
+``IngestSource`` row for the source-scoped list endpoint.
+"""
+
+from __future__ import annotations
+
+import importlib
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.external_ingest import status as status_mod
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.models.external_ingest import (
+    ExternalIngestBatch,
+    ExternalIngestRejection,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.ingest_auth import IngestSource
+from dev_health_ops.models.users import Organization, User
+from tests._helpers import tables_of
+
+admin_router_module = importlib.import_module("dev_health_ops.api.admin")
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+_TABLES = tables_of(
+    User,
+    Organization,
+    IngestSource,
+    ExternalIngestBatch,
+    ExternalIngestRejection,
+)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "customer_push_batches.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def seeded_state(session_maker):
+    org_id = uuid.uuid4()
+    user_id = uuid.uuid4()
+    org = Organization(id=org_id, slug="test-org", name="Test Org", tier="pro")
+    user = User(id=user_id, email="admin@example.com", is_active=True)
+    source = IngestSource(
+        id=uuid.uuid4(),
+        org_id=str(org_id),
+        system="github",
+        instance="acme/api",
+        mode="customer_push",
+        enabled=True,
+    )
+
+    async with session_maker() as session:
+        session.add_all([org, user, source])
+        await session.commit()
+
+    return {"org_id": str(org_id), "user_id": str(user_id), "source_id": str(source.id)}
+
+
+@pytest_asyncio.fixture
+async def client(session_maker, seeded_state):
+    app = FastAPI()
+    app.include_router(admin_router_module.router)
+
+    admin_user = AuthenticatedUser(
+        user_id=seeded_state["user_id"],
+        email="admin@example.com",
+        org_id=seeded_state["org_id"],
+        role="owner",
+        is_superuser=False,
+    )
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[auth_router_module.get_current_user] = lambda: admin_user
+    app.dependency_overrides[admin_router_module.get_session] = _session_override
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        yield ac, seeded_state
+
+    app.dependency_overrides.clear()
+
+
+async def _seed_batch(
+    session_maker,
+    *,
+    org_id: str,
+    idempotency_key: str = "key-1",
+    source_system: str = "github",
+    source_instance: str = "acme/api",
+    producer: str | None = "dev-hops-cli",
+    items_received: int = 3,
+    complete: bool = True,
+    rejections: list[status_mod.RejectedRecord] | None = None,
+) -> uuid.UUID:
+    async with session_maker() as session:
+        batch = await status_mod.create_batch(
+            session,
+            ingestion_id=uuid.uuid4(),
+            org_id=org_id,
+            idempotency_key=idempotency_key,
+            payload_hash="hash-1",
+            source_system=source_system,
+            source_instance=source_instance,
+            producer=producer,
+            producer_version="0.1.0",
+            schema_version="external-ingest.v1",
+            window_started_at=None,
+            window_ended_at=None,
+            items_received=items_received,
+        )
+        await session.commit()
+        if complete:
+            await status_mod.mark_processing(
+                session, org_id=org_id, ingestion_id=batch.ingestion_id
+            )
+            rejections = rejections or []
+            await status_mod.complete_batch(
+                session,
+                org_id=org_id,
+                ingestion_id=batch.ingestion_id,
+                items_accepted=items_received - len(rejections),
+                items_rejected=len(rejections),
+                rejections=rejections,
+            )
+            await session.commit()
+        return batch.ingestion_id
+
+
+# ---------------------------------------------------------------------------
+# GET /customer-push/sources/{source_id}/batches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_source_batches_filters_by_status_and_producer(
+    client, session_maker
+):
+    async_client, seeded_state = client
+    org_id = seeded_state["org_id"]
+    completed_id = await _seed_batch(
+        session_maker, org_id=org_id, idempotency_key="k1", producer="dev-hops-cli"
+    )
+    await _seed_batch(
+        session_maker,
+        org_id=org_id,
+        idempotency_key="k2",
+        producer="other-producer",
+        complete=False,
+    )
+
+    resp = await async_client.get(
+        f"/api/v1/admin/customer-push/sources/{seeded_state['source_id']}/batches",
+        params={"status": "completed"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["ingestion_id"] == str(completed_id)
+
+    resp = await async_client.get(
+        f"/api/v1/admin/customer-push/sources/{seeded_state['source_id']}/batches",
+        params={"producer": "other-producer"},
+    )
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["producer"] == "other-producer"
+
+
+@pytest.mark.asyncio
+async def test_list_source_batches_unknown_source_404s(client):
+    async_client, _ = client
+    resp = await async_client.get(
+        f"/api/v1/admin/customer-push/sources/{uuid.uuid4()}/batches"
+    )
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /customer-push/batches/{ingestion_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_includes_rejected_records_and_record_counts(
+    client, session_maker
+):
+    async_client, seeded_state = client
+    org_id = seeded_state["org_id"]
+    rejections = [
+        status_mod.RejectedRecord(
+            0, "commit.v1", "c0", "missing_required_field", "boom", "hash"
+        ),
+    ]
+    ingestion_id = await _seed_batch(
+        session_maker, org_id=org_id, items_received=2, rejections=rejections
+    )
+
+    resp = await async_client.get(f"/api/v1/admin/customer-push/batches/{ingestion_id}")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ingestion_id"] == str(ingestion_id)
+    assert body["status"] == "partial"
+    assert body["record_counts"] is None  # not populated by any v1 writer
+    assert "recompute_status" not in body  # CC21: added by CHAOS-2699 in wave 3
+    assert body["rejected_records_total"] == 1
+    assert body["rejected_records"][0] == {
+        "index": 0,
+        "kind": "commit.v1",
+        "external_id": "c0",
+        "code": "missing_required_field",
+        "message": "boom",
+        "path": "hash",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_nonexistent_and_malformed_both_404(client):
+    async_client, _ = client
+    resp_missing = await async_client.get(
+        f"/api/v1/admin/customer-push/batches/{uuid.uuid4()}"
+    )
+    resp_malformed = await async_client.get(
+        "/api/v1/admin/customer-push/batches/not-a-uuid"
+    )
+
+    assert resp_missing.status_code == 404
+    assert resp_malformed.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_cross_org_404s(client, session_maker):
+    async_client, _ = client
+    ingestion_id = await _seed_batch(session_maker, org_id=str(uuid.uuid4()))
+
+    resp = await async_client.get(f"/api/v1/admin/customer-push/batches/{ingestion_id}")
+
+    assert resp.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# GET /customer-push/schemas*
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_admin_list_schemas_passthrough(client):
+    async_client, _ = client
+    resp = await async_client.get("/api/v1/admin/customer-push/schemas")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["schemaVersions"] == ["external-ingest.v1"]
+    assert "commit.v1" in body["recordKinds"]
+    assert set(body["limits"]) == {"maxRecordsPerBatch", "maxBodyBytes"}
+
+
+@pytest.mark.asyncio
+async def test_admin_get_schema_unknown_version_404s(client):
+    async_client, _ = client
+    resp = await async_client.get(
+        "/api/v1/admin/customer-push/schemas/external-ingest.v99"
+    )
+    assert resp.status_code == 404

--- a/tests/test_external_ingest_status.py
+++ b/tests/test_external_ingest_status.py
@@ -1,0 +1,719 @@
+"""Unit tests for the external-ingest status store (CHAOS-2694).
+
+sqlite-in-memory (aiosqlite), no live Postgres -- mirrors the
+tests/test_rate_limit_observations.py / tests/api/admin/test_customer_push.py
+convention. Exercises status.py's CRUD/state-machine functions directly
+(never via HTTP -- see tests/test_external_ingest_status_api.py for the GET
+endpoint layer).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.external_ingest import status
+from dev_health_ops.models.external_ingest import (
+    MAX_STORED_REJECTIONS_PER_BATCH,
+    BatchStatus,
+    ExternalIngestBatch,
+    ExternalIngestRejection,
+    terminal_status_for,
+)
+from dev_health_ops.models.git import Base
+from tests._helpers import tables_of
+
+_TABLES = tables_of(ExternalIngestBatch, ExternalIngestRejection)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "external-ingest-status.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def session(session_maker):
+    async with session_maker() as s:
+        yield s
+
+
+ORG_A = "org-a"
+ORG_B = "org-b"
+SYSTEM = "github"
+INSTANCE = "acme/api"
+
+
+async def _create(
+    session: AsyncSession,
+    *,
+    org_id: str = ORG_A,
+    idempotency_key: str = "key-1",
+    payload_hash: str = "hash-1",
+    source_system: str = SYSTEM,
+    source_instance: str = INSTANCE,
+    items_received: int = 3,
+    ingestion_id: uuid.UUID | None = None,
+) -> status.BatchRow:
+    return await status.create_batch(
+        session,
+        ingestion_id=ingestion_id or uuid.uuid4(),
+        org_id=org_id,
+        idempotency_key=idempotency_key,
+        payload_hash=payload_hash,
+        source_system=source_system,
+        source_instance=source_instance,
+        producer="dev-hops-cli",
+        producer_version="0.1.0",
+        schema_version="external-ingest.v1",
+        window_started_at=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        window_ended_at=datetime(2026, 6, 2, tzinfo=timezone.utc),
+        items_received=items_received,
+    )
+
+
+# ---------------------------------------------------------------------------
+# create_batch / find_existing_batch
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_batch_inserts_accepted_row(session):
+    batch = await _create(session, payload_hash="deadbeef")
+    await session.commit()
+
+    assert batch.status == BatchStatus.ACCEPTED.value
+    assert batch.items_received == 3
+    assert batch.items_accepted == 0
+    assert batch.items_rejected == 0
+    assert batch.payload_hash == "deadbeef"
+    assert batch.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_find_existing_batch_none_for_fresh_key(session):
+    result = await status.find_existing_batch(
+        session,
+        org_id=ORG_A,
+        source_system=SYSTEM,
+        source_instance=INSTANCE,
+        idempotency_key="never-seen",
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_find_existing_batch_returns_known_key(session):
+    created = await _create(session, idempotency_key="key-known")
+    await session.commit()
+
+    found = await status.find_existing_batch(
+        session,
+        org_id=ORG_A,
+        source_system=SYSTEM,
+        source_instance=INSTANCE,
+        idempotency_key="key-known",
+    )
+    assert found is not None
+    assert found.ingestion_id == created.ingestion_id
+
+
+@pytest.mark.asyncio
+async def test_create_batch_duplicate_idempotency_key_raises(session):
+    await _create(session, idempotency_key="dupe-key")
+    await session.commit()
+
+    with pytest.raises(status.DuplicateIdempotencyKeyError):
+        await _create(session, idempotency_key="dupe-key")
+
+
+# ---------------------------------------------------------------------------
+# mark_processing / mark_stream_unavailable
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_mark_processing_transitions_accepted_to_processing(session):
+    batch = await _create(session)
+    await session.commit()
+
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+    await session.commit()
+
+    updated = await status.get_batch(
+        session, org_id=ORG_A, ingestion_id=batch.ingestion_id
+    )
+    assert updated is not None
+    assert updated.status == BatchStatus.PROCESSING.value
+
+
+@pytest.mark.asyncio
+async def test_mark_processing_is_noop_when_already_processing(session):
+    batch = await _create(session)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+    await session.commit()
+
+    # Second call: WHERE status='accepted' matches nothing -- no exception,
+    # no regression of an already-processing (or terminal) status.
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+    await session.commit()
+
+    updated = await status.get_batch(
+        session, org_id=ORG_A, ingestion_id=batch.ingestion_id
+    )
+    assert updated is not None
+    assert updated.status == BatchStatus.PROCESSING.value
+
+
+@pytest.mark.asyncio
+async def test_mark_stream_unavailable_transitions_accepted(session):
+    batch = await _create(session)
+    await session.commit()
+
+    await status.mark_stream_unavailable(
+        session, org_id=ORG_A, ingestion_id=batch.ingestion_id
+    )
+    await session.commit()
+
+    updated = await status.get_batch(
+        session, org_id=ORG_A, ingestion_id=batch.ingestion_id
+    )
+    assert updated is not None
+    assert updated.status == BatchStatus.STREAM_UNAVAILABLE.value
+
+
+# ---------------------------------------------------------------------------
+# complete_batch / terminal-status derivation
+# ---------------------------------------------------------------------------
+
+
+def test_terminal_status_for_boundary_table():
+    assert terminal_status_for(3, 3, 0) == BatchStatus.COMPLETED
+    assert terminal_status_for(3, 0, 3) == BatchStatus.FAILED
+    assert terminal_status_for(3, 1, 2) == BatchStatus.PARTIAL
+    with pytest.raises(AssertionError):
+        terminal_status_for(0, 0, 0)
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_all_accepted_is_completed(session):
+    batch = await _create(session, items_received=2)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+
+    result = await status.complete_batch(
+        session,
+        org_id=ORG_A,
+        ingestion_id=batch.ingestion_id,
+        items_accepted=2,
+        items_rejected=0,
+        rejections=[],
+    )
+    await session.commit()
+
+    assert result.status == BatchStatus.COMPLETED.value
+    assert result.completed_at is not None
+    assert result.error_summary is None
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_zero_accepted_is_failed(session):
+    batch = await _create(session, items_received=2)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+
+    rejections = [
+        status.RejectedRecord(
+            0, "commit.v1", "c1", "missing_required_field", "boom", "hash"
+        ),
+        status.RejectedRecord(
+            1, "commit.v1", "c2", "missing_required_field", "boom", "hash"
+        ),
+    ]
+    result = await status.complete_batch(
+        session,
+        org_id=ORG_A,
+        ingestion_id=batch.ingestion_id,
+        items_accepted=0,
+        items_rejected=2,
+        rejections=rejections,
+    )
+    await session.commit()
+
+    assert result.status == BatchStatus.FAILED.value
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_mixed_is_partial(session):
+    batch = await _create(session, items_received=3)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+
+    rejections = [
+        status.RejectedRecord(
+            1, "commit.v1", "c2", "missing_required_field", "boom", "hash"
+        ),
+    ]
+    result = await status.complete_batch(
+        session,
+        org_id=ORG_A,
+        ingestion_id=batch.ingestion_id,
+        items_accepted=2,
+        items_rejected=1,
+        rejections=rejections,
+    )
+    await session.commit()
+
+    assert result.status == BatchStatus.PARTIAL.value
+    assert result.error_summary is not None
+    assert result.error_summary["total_rejected"] == 1
+    assert result.error_summary["stored_rejections"] == 1
+    assert result.error_summary["truncated"] is False
+    assert result.error_summary["top_codes"] == [
+        {"code": "missing_required_field", "count": 1}
+    ]
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_truncates_stored_rejections_at_cap(session):
+    batch = await _create(session, items_received=MAX_STORED_REJECTIONS_PER_BATCH + 5)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+
+    total_rejected = MAX_STORED_REJECTIONS_PER_BATCH + 5
+    rejections = [
+        status.RejectedRecord(
+            i, "commit.v1", f"c{i}", "missing_required_field", "boom", None
+        )
+        for i in range(total_rejected)
+    ]
+    result = await status.complete_batch(
+        session,
+        org_id=ORG_A,
+        ingestion_id=batch.ingestion_id,
+        items_accepted=0,
+        items_rejected=total_rejected,
+        rejections=rejections,
+    )
+    await session.commit()
+
+    assert result.error_summary is not None
+    assert result.error_summary["total_rejected"] == total_rejected
+    assert result.error_summary["stored_rejections"] == MAX_STORED_REJECTIONS_PER_BATCH
+    assert result.error_summary["truncated"] is True
+
+    stored_rows, stored_total = await status.list_rejections(
+        session,
+        org_id=ORG_A,
+        ingestion_id=batch.ingestion_id,
+        limit=MAX_STORED_REJECTIONS_PER_BATCH,
+        offset=0,
+    )
+    assert stored_total == MAX_STORED_REJECTIONS_PER_BATCH
+    assert len(stored_rows) == MAX_STORED_REJECTIONS_PER_BATCH
+    # items_rejected on the batch row always reflects the TRUE total.
+    assert result.items_rejected == total_rejected
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_idempotent_under_redelivery(session):
+    batch = await _create(session, items_received=3)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+
+    rejections = [
+        status.RejectedRecord(
+            1, "commit.v1", "c2", "missing_required_field", "boom", "hash"
+        ),
+    ]
+    first = await status.complete_batch(
+        session,
+        org_id=ORG_A,
+        ingestion_id=batch.ingestion_id,
+        items_accepted=2,
+        items_rejected=1,
+        rejections=rejections,
+    )
+    await session.commit()
+
+    second = await status.complete_batch(
+        session,
+        org_id=ORG_A,
+        ingestion_id=batch.ingestion_id,
+        items_accepted=2,
+        items_rejected=1,
+        rejections=rejections,
+    )
+    await session.commit()
+
+    assert second.status == first.status == BatchStatus.PARTIAL.value
+    assert second.items_accepted == 2
+    assert second.items_rejected == 1
+
+    _, total_stored = await status.list_rejections(
+        session, org_id=ORG_A, ingestion_id=batch.ingestion_id, limit=10, offset=0
+    )
+    # No duplicate rows from the redelivered call.
+    assert total_stored == 1
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_missing_batch_raises(session):
+    with pytest.raises(ValueError):
+        await status.complete_batch(
+            session,
+            org_id=ORG_A,
+            ingestion_id=uuid.uuid4(),
+            items_accepted=1,
+            items_rejected=0,
+            rejections=[],
+        )
+
+
+# ---------------------------------------------------------------------------
+# complete_batch state/counter invariants (adversarial-review findings)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_rejects_accepted_batch(session):
+    # Never processed (no mark_processing call) -- must not be completable
+    # directly from 'accepted'.
+    batch = await _create(session, items_received=2)
+    await session.commit()
+
+    with pytest.raises(ValueError):
+        await status.complete_batch(
+            session,
+            org_id=ORG_A,
+            ingestion_id=batch.ingestion_id,
+            items_accepted=2,
+            items_rejected=0,
+            rejections=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_rejects_stream_unavailable_batch(session):
+    batch = await _create(session, items_received=2)
+    await session.commit()
+    await status.mark_stream_unavailable(
+        session, org_id=ORG_A, ingestion_id=batch.ingestion_id
+    )
+    await session.commit()
+
+    with pytest.raises(ValueError):
+        await status.complete_batch(
+            session,
+            org_id=ORG_A,
+            ingestion_id=batch.ingestion_id,
+            items_accepted=2,
+            items_rejected=0,
+            rejections=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_rejects_negative_counters(session):
+    batch = await _create(session, items_received=2)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+
+    with pytest.raises(ValueError):
+        await status.complete_batch(
+            session,
+            org_id=ORG_A,
+            ingestion_id=batch.ingestion_id,
+            items_accepted=-1,
+            items_rejected=3,
+            rejections=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_rejects_counter_sum_mismatch(session):
+    batch = await _create(session, items_received=2)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+
+    with pytest.raises(ValueError):
+        await status.complete_batch(
+            session,
+            org_id=ORG_A,
+            ingestion_id=batch.ingestion_id,
+            items_accepted=2,
+            items_rejected=2,  # sums to 4, but items_received is 2
+            rejections=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_rejects_zero_and_zero_when_received_nonzero(session):
+    batch = await _create(session, items_received=2)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+
+    with pytest.raises(ValueError):
+        await status.complete_batch(
+            session,
+            org_id=ORG_A,
+            ingestion_id=batch.ingestion_id,
+            items_accepted=0,
+            items_rejected=0,
+            rejections=[],
+        )
+
+
+@pytest.mark.asyncio
+async def test_complete_batch_cas_loses_race_to_concurrent_completion(session):
+    """Adversarial-review regression: simulates a second worker completing
+    the same batch between this call's initial read and its CAS UPDATE (the
+    exact window a check-then-write implementation would race on). The
+    losing call must not persist its own outcome or insert its own rejection
+    rows -- it must return whatever the concurrent winner actually wrote."""
+    batch = await _create(session, items_received=2)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+    await session.commit()
+
+    real_execute = session.execute
+    raced = {"done": False}
+
+    async def racing_execute(clause, params=None, *args, **kwargs):
+        sql_text = getattr(clause, "text", "")
+        if not raced["done"] and "SET status = :status" in sql_text:
+            raced["done"] = True
+            # A concurrent worker wins the race first, with a DIFFERENT
+            # outcome than the call under test is about to attempt.
+            await real_execute(
+                text(
+                    "UPDATE external_ingest_batches SET status = 'completed', "
+                    "items_accepted = 2, items_rejected = 0, updated_at = updated_at "
+                    "WHERE ingestion_id = :id"
+                ),
+                {"id": str(batch.ingestion_id)},
+            )
+        if params is None:
+            return await real_execute(clause, *args, **kwargs)
+        return await real_execute(clause, params, *args, **kwargs)
+
+    session.execute = racing_execute
+    try:
+        result = await status.complete_batch(
+            session,
+            org_id=ORG_A,
+            ingestion_id=batch.ingestion_id,
+            items_accepted=1,
+            items_rejected=1,
+            rejections=[
+                status.RejectedRecord(1, "commit.v1", "c1", "code", "msg", None)
+            ],
+        )
+    finally:
+        session.execute = real_execute
+
+    # The losing call's own outcome must NOT win -- the concurrently
+    # committed state (from the "other worker") is what's returned.
+    assert result.status == "completed"
+    assert result.items_accepted == 2
+    assert result.items_rejected == 0
+
+    rows, total = await status.list_rejections(
+        session, org_id=ORG_A, ingestion_id=batch.ingestion_id, limit=10, offset=0
+    )
+    assert total == 0
+
+
+# ---------------------------------------------------------------------------
+# get_batch tenant isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_batch_cross_org_returns_none(session):
+    batch = await _create(session, org_id=ORG_A)
+    await session.commit()
+
+    result = await status.get_batch(
+        session, org_id=ORG_B, ingestion_id=batch.ingestion_id
+    )
+    assert result is None
+
+    nonexistent = await status.get_batch(
+        session, org_id=ORG_A, ingestion_id=uuid.uuid4()
+    )
+    assert nonexistent is None
+
+
+# ---------------------------------------------------------------------------
+# list_batches
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_batches_filters_and_orders(session):
+    b1 = await _create(session, idempotency_key="k1", source_system="github")
+    await session.commit()
+    b2 = await _create(session, idempotency_key="k2", source_system="gitlab")
+    await session.commit()
+    b3 = await _create(session, idempotency_key="k3", source_system="github")
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=b3.ingestion_id)
+    await session.commit()
+
+    github_rows, github_total = await status.list_batches(
+        session, org_id=ORG_A, source_system="github", limit=50, offset=0
+    )
+    assert github_total == 2
+    assert {r.ingestion_id for r in github_rows} == {b1.ingestion_id, b3.ingestion_id}
+    # created_at DESC -- b3 created after b1.
+    assert github_rows[0].ingestion_id == b3.ingestion_id
+
+    processing_rows, processing_total = await status.list_batches(
+        session, org_id=ORG_A, status="processing", limit=50, offset=0
+    )
+    assert processing_total == 1
+    assert processing_rows[0].ingestion_id == b3.ingestion_id
+
+    gitlab_rows, gitlab_total = await status.list_batches(
+        session,
+        org_id=ORG_A,
+        source_instance=INSTANCE,
+        source_system="gitlab",
+        limit=50,
+        offset=0,
+    )
+    assert gitlab_total == 1
+    assert gitlab_rows[0].ingestion_id == b2.ingestion_id
+
+
+@pytest.mark.asyncio
+async def test_list_batches_respects_limit_offset(session):
+    for i in range(5):
+        await _create(session, idempotency_key=f"page-key-{i}")
+        await session.commit()
+
+    page1, total = await status.list_batches(session, org_id=ORG_A, limit=2, offset=0)
+    page2, _ = await status.list_batches(session, org_id=ORG_A, limit=2, offset=2)
+
+    assert total == 5
+    assert len(page1) == 2
+    assert len(page2) == 2
+    assert {r.ingestion_id for r in page1}.isdisjoint({r.ingestion_id for r in page2})
+
+
+@pytest.mark.asyncio
+async def test_list_batches_pagination_stable_across_tied_created_at(session):
+    # Adversarial-review regression: created_at alone is not unique (e.g.
+    # concurrent inserts within the same tick), so pagination must break
+    # ties on a second, unique column (ingestion_id) to avoid duplicating or
+    # skipping rows across page boundaries.
+    tied_at = datetime(2026, 6, 1, tzinfo=timezone.utc)
+    ids = sorted(uuid.uuid4() for _ in range(4))
+    for i, ingestion_id in enumerate(ids):
+        session.add(
+            ExternalIngestBatch(
+                ingestion_id=ingestion_id,
+                org_id=ORG_A,
+                idempotency_key=f"tied-{i}",
+                payload_hash="hash",
+                source_system=SYSTEM,
+                source_instance=INSTANCE,
+                schema_version="external-ingest.v1",
+                status=BatchStatus.ACCEPTED.value,
+                items_received=1,
+                created_at=tied_at,
+                updated_at=tied_at,
+            )
+        )
+    await session.commit()
+
+    seen: list[uuid.UUID] = []
+    for offset in range(0, 4, 2):
+        page, total = await status.list_batches(
+            session, org_id=ORG_A, limit=2, offset=offset
+        )
+        assert total == 4
+        seen.extend(r.ingestion_id for r in page)
+
+    # Every seeded id appears exactly once across all pages (no duplicates,
+    # no gaps) and in descending-ingestion_id tiebreak order.
+    assert seen == list(reversed(ids))
+
+
+@pytest.mark.asyncio
+async def test_list_batches_created_after_before(session):
+    old = await _create(session, idempotency_key="old-key")
+    await session.commit()
+    new = await _create(session, idempotency_key="new-key")
+    await session.commit()
+
+    cutoff = old.created_at + timedelta(microseconds=1)
+    rows, total = await status.list_batches(
+        session, org_id=ORG_A, created_after=cutoff, limit=50, offset=0
+    )
+    assert total == 1
+    assert rows[0].ingestion_id == new.ingestion_id
+
+    rows, total = await status.list_batches(
+        session, org_id=ORG_A, created_before=cutoff, limit=50, offset=0
+    )
+    assert total == 1
+    assert rows[0].ingestion_id == old.ingestion_id
+
+
+# ---------------------------------------------------------------------------
+# list_rejections
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_rejections_orders_by_record_index_and_paginates(session):
+    batch = await _create(session, items_received=3)
+    await session.commit()
+    await status.mark_processing(session, org_id=ORG_A, ingestion_id=batch.ingestion_id)
+
+    rejections = [
+        status.RejectedRecord(2, "commit.v1", "c2", "code-c", "msg", None),
+        status.RejectedRecord(0, "commit.v1", "c0", "code-a", "msg", None),
+        status.RejectedRecord(1, "commit.v1", "c1", "code-b", "msg", None),
+    ]
+    await status.complete_batch(
+        session,
+        org_id=ORG_A,
+        ingestion_id=batch.ingestion_id,
+        items_accepted=0,
+        items_rejected=3,
+        rejections=rejections,
+    )
+    await session.commit()
+
+    all_rows, total = await status.list_rejections(
+        session, org_id=ORG_A, ingestion_id=batch.ingestion_id, limit=50, offset=0
+    )
+    assert total == 3
+    assert [r.record_index for r in all_rows] == [0, 1, 2]
+
+    page, _ = await status.list_rejections(
+        session, org_id=ORG_A, ingestion_id=batch.ingestion_id, limit=1, offset=1
+    )
+    assert len(page) == 1
+    assert page[0].record_index == 1

--- a/tests/test_external_ingest_status_api.py
+++ b/tests/test_external_ingest_status_api.py
@@ -1,0 +1,281 @@
+"""API tests for the CHAOS-2694 status-store GET endpoints.
+
+Follows tests/api/test_external_ingest_router.py's fixture pattern: override
+the bound per-scope dependency object (not the ``require_ingest_scope``
+factory -- FastAPI's dependency_overrides matches by the exact callable
+passed to ``Depends()``) plus the Postgres session dependency, against an
+aiosqlite in-memory DB seeded directly via status.py (never via HTTP -- the
+POST accept path is out of scope for this issue).
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.external_ingest import status as status_mod
+from dev_health_ops.api.external_ingest.auth import IngestAuthContext
+from dev_health_ops.api.main import app
+from dev_health_ops.models.external_ingest import (
+    ExternalIngestBatch,
+    ExternalIngestRejection,
+)
+from dev_health_ops.models.git import Base
+from tests._helpers import tables_of
+
+BASE = "/api/v1/external-ingest"
+ORG_A = "test-org"
+ORG_B = "other-org"
+
+_TABLES = tables_of(ExternalIngestBatch, ExternalIngestRejection)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    db_path = tmp_path / "external-ingest-status-api.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(session_maker):
+    ctx = IngestAuthContext(org_id=ORG_A, scopes={"ingest:status"})
+
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+
+    app.dependency_overrides[status_mod._require_ingest_status] = lambda: ctx
+    app.dependency_overrides[status_mod.get_postgres_session_dep] = _session_override
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    try:
+        async with AsyncClient(transport=transport, base_url="http://test") as c:
+            yield c, session_maker
+    finally:
+        app.dependency_overrides.pop(status_mod._require_ingest_status, None)
+        app.dependency_overrides.pop(status_mod.get_postgres_session_dep, None)
+
+
+async def _seed_batch(
+    session_maker,
+    *,
+    org_id: str = ORG_A,
+    idempotency_key: str = "key-1",
+    source_system: str = "github",
+    source_instance: str = "acme/api",
+    items_received: int = 3,
+    complete: bool = True,
+    rejections: list[status_mod.RejectedRecord] | None = None,
+    items_accepted: int = 2,
+    items_rejected: int = 1,
+) -> uuid.UUID:
+    async with session_maker() as session:
+        batch = await status_mod.create_batch(
+            session,
+            ingestion_id=uuid.uuid4(),
+            org_id=org_id,
+            idempotency_key=idempotency_key,
+            payload_hash="hash-1",
+            source_system=source_system,
+            source_instance=source_instance,
+            producer="dev-hops-cli",
+            producer_version="0.1.0",
+            schema_version="external-ingest.v1",
+            window_started_at=None,
+            window_ended_at=None,
+            items_received=items_received,
+        )
+        await session.commit()
+        if complete:
+            await status_mod.mark_processing(
+                session, org_id=org_id, ingestion_id=batch.ingestion_id
+            )
+            await status_mod.complete_batch(
+                session,
+                org_id=org_id,
+                ingestion_id=batch.ingestion_id,
+                items_accepted=items_accepted,
+                items_rejected=items_rejected,
+                rejections=rejections or [],
+            )
+            await session.commit()
+        return batch.ingestion_id
+
+
+# ---------------------------------------------------------------------------
+# GET /batches/{ingestion_id}
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_happy_path(client):
+    async_client, session_maker = client
+    rejections = [
+        status_mod.RejectedRecord(
+            0, "commit.v1", "c0", "missing_required_field", "boom", "hash"
+        ),
+        status_mod.RejectedRecord(
+            1, "commit.v1", "c1", "invalid_literal", "bad", "state"
+        ),
+        status_mod.RejectedRecord(
+            2, "commit.v1", "c2", "invalid_literal", "bad", "state"
+        ),
+    ]
+    ingestion_id = await _seed_batch(
+        session_maker,
+        items_received=5,
+        items_accepted=2,
+        items_rejected=3,
+        rejections=rejections,
+    )
+
+    resp = await async_client.get(f"{BASE}/batches/{ingestion_id}")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["ingestionId"] == str(ingestion_id)
+    assert body["status"] == "partial"
+    assert body["itemsReceived"] == 5
+    assert body["itemsAccepted"] == 2
+    assert body["itemsRejected"] == 3
+    assert body["source"] == {"system": "github", "instance": "acme/api"}
+    assert body["producer"] == "dev-hops-cli"
+    assert body["producerVersion"] == "0.1.0"
+    assert body["errorsTotal"] == 3
+    assert body["errorsLimit"] == 50
+    assert body["errorsOffset"] == 0
+    assert len(body["errors"]) == 3
+    assert body["errors"][0] == {
+        "index": 0,
+        "kind": "commit.v1",
+        "externalId": "c0",
+        "code": "missing_required_field",
+        "message": "boom",
+        "path": "hash",
+    }
+    assert body["errorSummary"]["total_rejected"] == 3
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_pagination(client):
+    async_client, session_maker = client
+    rejections = [
+        status_mod.RejectedRecord(i, "commit.v1", f"c{i}", "code", "msg", None)
+        for i in range(3)
+    ]
+    ingestion_id = await _seed_batch(
+        session_maker,
+        items_received=3,
+        items_accepted=0,
+        items_rejected=3,
+        rejections=rejections,
+    )
+
+    resp = await async_client.get(
+        f"{BASE}/batches/{ingestion_id}", params={"errorLimit": 1, "errorOffset": 1}
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["errorsTotal"] == 3
+    assert body["errorsLimit"] == 1
+    assert body["errorsOffset"] == 1
+    assert len(body["errors"]) == 1
+    assert body["errors"][0]["index"] == 1
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_nonexistent_returns_404(client):
+    async_client, _ = client
+    resp = await async_client.get(f"{BASE}/batches/{uuid.uuid4()}")
+
+    assert resp.status_code == 404
+    assert resp.json()["error"]["code"] == "not_found"
+
+
+@pytest.mark.asyncio
+async def test_get_batch_detail_cross_org_returns_identical_404(client):
+    async_client, session_maker = client
+    ingestion_id = await _seed_batch(session_maker, org_id=ORG_B)
+
+    resp = await async_client.get(f"{BASE}/batches/{ingestion_id}")
+    nonexistent_resp = await async_client.get(f"{BASE}/batches/{uuid.uuid4()}")
+
+    assert resp.status_code == 404
+    assert resp.json() == nonexistent_resp.json()
+
+
+# ---------------------------------------------------------------------------
+# GET /batches (list)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_list_batches_filters_by_status_and_source(client):
+    async_client, session_maker = client
+    completed_id = await _seed_batch(
+        session_maker,
+        idempotency_key="k1",
+        source_system="github",
+        complete=True,
+        items_accepted=3,
+        items_rejected=0,
+    )
+    accepted_id = await _seed_batch(
+        session_maker, idempotency_key="k2", source_system="gitlab", complete=False
+    )
+
+    resp = await async_client.get(f"{BASE}/batches", params={"status": "completed"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["ingestionId"] == str(completed_id)
+
+    resp = await async_client.get(f"{BASE}/batches", params={"sourceSystem": "gitlab"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["total"] == 1
+    assert body["items"][0]["ingestionId"] == str(accepted_id)
+
+
+@pytest.mark.asyncio
+async def test_list_batches_pagination_total_independent_of_limit(client):
+    async_client, session_maker = client
+    for i in range(5):
+        await _seed_batch(session_maker, idempotency_key=f"page-{i}", complete=False)
+
+    resp = await async_client.get(f"{BASE}/batches", params={"limit": 2, "offset": 0})
+    body = resp.json()
+
+    assert body["total"] == 5
+    assert len(body["items"]) == 2
+    assert body["limit"] == 2
+    assert body["offset"] == 0
+
+
+@pytest.mark.asyncio
+async def test_list_batches_only_returns_requesting_org(client):
+    async_client, session_maker = client
+    await _seed_batch(session_maker, org_id=ORG_A, idempotency_key="mine")
+    await _seed_batch(session_maker, org_id=ORG_B, idempotency_key="theirs")
+
+    resp = await async_client.get(f"{BASE}/batches")
+    body = resp.json()
+
+    assert body["total"] == 1

--- a/tests/test_external_ingest_status_migration.py
+++ b/tests/test_external_ingest_status_migration.py
@@ -1,0 +1,162 @@
+"""Migration 0033 (external_ingest_batches/rejections/batch_payloads) tests.
+
+Follows the idempotent-upgrade/downgrade harness established for migration
+0031 (tests/test_rate_limit_observations.py::test_migration_0031_idempotent_upgrade)
+and migration 0032 (tests/test_migration_0032_customer_push_ingest_auth.py).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+
+def _load_migration_0033():
+    return importlib.import_module(
+        "dev_health_ops.alembic.versions.0033_add_external_ingest_status_store"
+    )
+
+
+def test_migration_0033_idempotent_upgrade_downgrade():
+    migration = _load_migration_0033()
+    assert migration.revision == "0033"
+    assert migration.down_revision == "0032"
+
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                table_names = inspector.get_table_names()
+                assert "external_ingest_batches" in table_names
+                assert "external_ingest_rejections" in table_names
+                assert "external_ingest_batch_payloads" in table_names
+
+                batch_columns = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_batches")
+                }
+                assert batch_columns == {
+                    "ingestion_id",
+                    "org_id",
+                    "idempotency_key",
+                    "payload_hash",
+                    "source_system",
+                    "source_instance",
+                    "producer",
+                    "producer_version",
+                    "schema_version",
+                    "window_started_at",
+                    "window_ended_at",
+                    "status",
+                    "attempts",
+                    "items_received",
+                    "items_accepted",
+                    "items_rejected",
+                    "record_counts",
+                    "error_summary",
+                    "created_at",
+                    "updated_at",
+                    "completed_at",
+                }
+
+                rejection_columns = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_rejections")
+                }
+                assert rejection_columns == {
+                    "id",
+                    "org_id",
+                    "ingestion_id",
+                    "record_index",
+                    "record_kind",
+                    "external_id",
+                    "code",
+                    "message",
+                    "path",
+                    "created_at",
+                }
+
+                payload_columns = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_batch_payloads")
+                }
+                assert payload_columns == {
+                    "ingestion_id",
+                    "org_id",
+                    "schema_version",
+                    "payload_json",
+                    "byte_size",
+                    "created_at",
+                }
+
+                batch_index_names = {
+                    ix["name"]
+                    for ix in inspector.get_indexes("external_ingest_batches")
+                }
+                assert "uq_external_ingest_batches_idem" in batch_index_names
+                assert "ix_external_ingest_batches_org_status" in batch_index_names
+                assert "ix_external_ingest_batches_org_created" in batch_index_names
+                assert "ix_external_ingest_batches_org_source" in batch_index_names
+
+                rejection_indexes = inspector.get_indexes("external_ingest_rejections")
+                rejection_index_names = {ix["name"] for ix in rejection_indexes}
+                assert (
+                    "uq_external_ingest_rejections_ingestion_order"
+                    in rejection_index_names
+                )
+                assert "ix_external_ingest_rejections_org_id" in rejection_index_names
+                order_index = next(
+                    ix
+                    for ix in rejection_indexes
+                    if ix["name"] == "uq_external_ingest_rejections_ingestion_order"
+                )
+                assert bool(order_index["unique"])
+
+                payload_index_names = {
+                    ix["name"]
+                    for ix in inspector.get_indexes("external_ingest_batch_payloads")
+                }
+                assert "ix_external_ingest_batch_payloads_org_id" in payload_index_names
+
+                fks = inspector.get_foreign_keys("external_ingest_rejections")
+                assert len(fks) == 1
+                assert fks[0]["referred_table"] == "external_ingest_batches"
+                assert fks[0]["options"].get("ondelete") == "CASCADE"
+
+                # Re-running upgrade() must be a no-op (guarded create-if-missing).
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert inspector.get_table_names().count("external_ingest_batches") == 1
+                assert (
+                    inspector.get_table_names().count("external_ingest_rejections") == 1
+                )
+                assert (
+                    inspector.get_table_names().count("external_ingest_batch_payloads")
+                    == 1
+                )
+
+                migration.downgrade()
+                inspector = sa.inspect(conn)
+                remaining = inspector.get_table_names()
+                assert "external_ingest_batch_payloads" not in remaining
+                assert "external_ingest_rejections" not in remaining
+                assert "external_ingest_batches" not in remaining
+
+                # downgrade() on already-absent tables is also a no-op.
+                migration.downgrade()
+
+                # And upgrade() works again from a clean slate.
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert "external_ingest_batches" in inspector.get_table_names()
+                assert "external_ingest_rejections" in inspector.get_table_names()
+                assert "external_ingest_batch_payloads" in inspector.get_table_names()
+    finally:
+        engine.dispose()

--- a/tests/test_external_ingest_status_reconciler.py
+++ b/tests/test_external_ingest_status_reconciler.py
@@ -1,0 +1,222 @@
+"""Tests for the external-ingest status store retention prune task
+(CHAOS-2694). Sync sqlite-in-memory, mirroring
+tests/test_rate_limit_observations.py's prune-task harness (reuses its
+``_patch_db_session``/``_fake_session_ctx`` helpers)."""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from sqlalchemy import create_engine, event
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.external_ingest import (
+    BatchStatus,
+    ExternalIngestBatch,
+    ExternalIngestRejection,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.workers.external_ingest_reconciler import (
+    _DELETE_CHUNK_SIZE,
+    prune_external_ingest_batches,
+)
+from tests._helpers import tables_of
+from tests.test_sync_units import _patch_db_session
+
+_TABLES = tables_of(ExternalIngestBatch)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine, tables=_TABLES)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+@pytest.fixture
+def db_session_with_fk_enforcement():
+    """Separate engine with ``PRAGMA foreign_keys=ON`` (off by default on
+    sqlite) so cascade-delete behavior is actually exercised, not just
+    declared in the schema."""
+    engine = create_engine("sqlite:///:memory:")
+
+    @event.listens_for(engine, "connect")
+    def _enable_fk(dbapi_connection, _record):
+        dbapi_connection.execute("PRAGMA foreign_keys=ON")
+
+    Base.metadata.create_all(
+        engine, tables=tables_of(ExternalIngestBatch, ExternalIngestRejection)
+    )
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
+
+
+def _make_batch(**overrides):
+    defaults = dict(
+        ingestion_id=uuid.uuid4(),
+        org_id="org-a",
+        idempotency_key=str(uuid.uuid4()),
+        payload_hash="hash",
+        source_system="github",
+        source_instance="acme/api",
+        schema_version="external-ingest.v1",
+        status=BatchStatus.COMPLETED.value,
+        items_received=1,
+        items_accepted=1,
+        items_rejected=0,
+    )
+    defaults.update(overrides)
+    return ExternalIngestBatch(**defaults)
+
+
+def test_prune_deletes_only_expired_terminal_batches(db_session, monkeypatch):
+    now = datetime.now(timezone.utc)
+    expired_completed = _make_batch(
+        status=BatchStatus.COMPLETED.value, created_at=now - timedelta(days=100)
+    )
+    expired_partial = _make_batch(
+        status=BatchStatus.PARTIAL.value, created_at=now - timedelta(days=100)
+    )
+    expired_failed = _make_batch(
+        status=BatchStatus.FAILED.value, created_at=now - timedelta(days=100)
+    )
+    fresh_completed = _make_batch(
+        status=BatchStatus.COMPLETED.value, created_at=now - timedelta(days=1)
+    )
+    db_session.add_all(
+        [expired_completed, expired_partial, expired_failed, fresh_completed]
+    )
+    db_session.commit()
+
+    _patch_db_session(monkeypatch, db_session)
+
+    result = getattr(prune_external_ingest_batches, "run")(retention_days=90)
+
+    assert result["status"] == "completed"
+    assert result["deleted"] == 3
+    assert result["retention_days"] == 90
+    remaining_ids = {
+        row.ingestion_id for row in db_session.query(ExternalIngestBatch).all()
+    }
+    assert remaining_ids == {fresh_completed.ingestion_id}
+
+
+def test_prune_never_deletes_non_terminal_batches_regardless_of_age(
+    db_session, monkeypatch
+):
+    now = datetime.now(timezone.utc)
+    stuck_accepted = _make_batch(
+        status=BatchStatus.ACCEPTED.value, created_at=now - timedelta(days=365)
+    )
+    stuck_processing = _make_batch(
+        status=BatchStatus.PROCESSING.value, created_at=now - timedelta(days=365)
+    )
+    stuck_stream_unavailable = _make_batch(
+        status=BatchStatus.STREAM_UNAVAILABLE.value,
+        created_at=now - timedelta(days=365),
+    )
+    db_session.add_all([stuck_accepted, stuck_processing, stuck_stream_unavailable])
+    db_session.commit()
+
+    _patch_db_session(monkeypatch, db_session)
+
+    result = getattr(prune_external_ingest_batches, "run")(retention_days=1)
+
+    assert result["deleted"] == 0
+    assert db_session.query(ExternalIngestBatch).count() == 3
+
+
+def test_prune_honors_env_var_when_no_explicit_override(db_session, monkeypatch):
+    now = datetime.now(timezone.utc)
+    three_days_old = _make_batch(
+        status=BatchStatus.COMPLETED.value, created_at=now - timedelta(days=3)
+    )
+    one_hour_old = _make_batch(
+        status=BatchStatus.COMPLETED.value, created_at=now - timedelta(hours=1)
+    )
+    db_session.add_all([three_days_old, one_hour_old])
+    db_session.commit()
+
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("EXTERNAL_INGEST_STATUS_RETENTION_DAYS", "1")
+
+    result = getattr(prune_external_ingest_batches, "run")()
+
+    assert result["deleted"] == 1
+    assert result["retention_days"] == 1
+    remaining = {
+        row.ingestion_id for row in db_session.query(ExternalIngestBatch).all()
+    }
+    assert remaining == {one_hour_old.ingestion_id}
+
+
+def test_prune_deletes_in_bounded_chunks_across_multiple_iterations(
+    db_session, monkeypatch
+):
+    # Seed more rows than one chunk to exercise the loop's multi-iteration
+    # path (adversarial-review finding: a single unbounded DELETE risks one
+    # huge long-running transaction against a large backlog).
+    now = datetime.now(timezone.utc)
+    total_rows = _DELETE_CHUNK_SIZE + 3
+    for _ in range(total_rows):
+        db_session.add(
+            _make_batch(
+                status=BatchStatus.COMPLETED.value, created_at=now - timedelta(days=100)
+            )
+        )
+    db_session.commit()
+
+    commit_calls = {"count": 0}
+    real_commit = db_session.commit
+
+    def counting_commit():
+        commit_calls["count"] += 1
+        return real_commit()
+
+    monkeypatch.setattr(db_session, "commit", counting_commit)
+    _patch_db_session(monkeypatch, db_session)
+
+    result = getattr(prune_external_ingest_batches, "run")(retention_days=1)
+
+    assert result["deleted"] == total_rows
+    assert db_session.query(ExternalIngestBatch).count() == 0
+    # More than one chunk was needed, so more than one commit happened
+    # (each chunk commits independently rather than one giant transaction).
+    assert commit_calls["count"] >= 2
+
+
+def test_prune_cascades_to_rejections_with_fk_enforcement(
+    db_session_with_fk_enforcement, monkeypatch
+):
+    session = db_session_with_fk_enforcement
+    now = datetime.now(timezone.utc)
+    batch = _make_batch(
+        status=BatchStatus.PARTIAL.value, created_at=now - timedelta(days=100)
+    )
+    session.add(batch)
+    session.commit()
+    session.add(
+        ExternalIngestRejection(
+            id=uuid.uuid4(),
+            org_id=batch.org_id,
+            ingestion_id=batch.ingestion_id,
+            record_index=0,
+            record_kind="commit.v1",
+            code="code",
+            message="msg",
+        )
+    )
+    session.commit()
+
+    _patch_db_session(monkeypatch, session)
+
+    result = getattr(prune_external_ingest_batches, "run")(retention_days=1)
+
+    assert result["deleted"] == 1
+    assert session.query(ExternalIngestBatch).count() == 0
+    assert session.query(ExternalIngestRejection).count() == 0


### PR DESCRIPTION
## Summary

Durable Postgres status store for customer-push ingestion batches (CHAOS-2690 wave 2). Owns "what happened to ingestion batch X":

- **Migration `0033`** (chained after `0032`): `external_ingest_batches` (incl. `payload_hash`, `attempts`, `record_counts`), `external_ingest_rejections` (FK `ON DELETE CASCADE`, unique `(ingestion_id, record_index)`), and `external_ingest_batch_payloads` (CHAOS-2693's transient payload table, hosted here per the fixed migration chain).
- **`api/external_ingest/status.py`**: direct-SQL (no ORM CRUD) read/write layer — `find_existing_batch`, `create_batch`, `mark_processing`, `mark_stream_unavailable`, `complete_batch`, `get_batch`, `list_batches`, `list_rejections` — plus its own `APIRouter` (`status_router`, mounted directly in `main.py`, not via `router.py`).
- **Data plane**: `GET /api/v1/external-ingest/batches` (filters + pagination) and `GET /api/v1/external-ingest/batches/{ingestion_id}` (detail + paginated rejected-record diagnostics), `ingest:status` scope, 120/min token-keyed rate limit, tenant isolation returns identical 404 for nonexistent vs. cross-org.
- **Admin plane**: read proxies appended to `api/admin/routers/customer_push.py` — `GET .../sources/{id}/batches`, `GET .../batches/{ingestion_id}`, `GET .../schemas*`.
- **Retention**: `workers/external_ingest_reconciler.py::prune_external_ingest_batches`, beat-scheduled daily, deletes terminal batches past `EXTERNAL_INGEST_STATUS_RETENTION_DAYS` (default 90) in bounded 500-row chunks. Never prunes `accepted`/`processing`/`stream_unavailable` rows (intentional — a stuck batch past retention should stay visible, per master-spec CC13).
- **Architecture doc**: `docs/architecture/external-ingest-status-store.md`.

### Adversarial review (3 rounds, all fixes verified)

- **[high]** `complete_batch()` originally allowed completing directly from `accepted`/`stream_unavailable` with no counter validation. Fixed: only `processing` batches may transition to terminal, counters must be non-negative and sum to `items_received`, and the status/counter UPDATE is now an atomic `WHERE status = 'processing'` compare-and-swap (not check-then-write) so concurrent completions can't duplicate diagnostics or clobber a terminal outcome — backstopped by a new unique `(ingestion_id, record_index)` index. Covered by a dedicated concurrency-simulation regression test.
- **[medium]** `list_batches()` ordered only by `created_at DESC` (non-unique, unstable pagination under ties). Fixed: `ORDER BY created_at DESC, ingestion_id DESC`, with a regression test seeding tied timestamps across pages.
- **[medium]** Prune task did a single unbounded `DELETE`. Fixed: bounded 500-row chunks, each committed independently.
- Refuted: "non-terminal rows are pruned unbounded forever" — this is intentional per master-spec CC13 (a filed follow-up issue owns stale-batch reconciliation), documented explicitly in the architecture doc.

Final codex verdict: **approve**, no material findings.

## Test plan

- [x] `ci/local_validate.sh` (full env-isolated gate) green — ruff, mypy, full unit suite (6353+ passed), live-ClickHouse argMax proof.
- [x] Migration 0033 idempotent upgrade/downgrade (sqlite unit test) + live scratch-Postgres proof: upgrade → `\d` verified tables/indexes/FK → downgrade -1 → re-upgrade → clean.
- [x] `status.py` exercised directly against live Postgres (create → mark_processing → complete_batch → get_batch → list_rejections) — UUID/datetime/JSON raw-SQL binding all verified working end-to-end.
- [x] Live HTTP verification via uvicorn + `EXTERNAL_INGEST_INSECURE_AUTH=1` against the scratch DB: detail happy path, pagination, 404 (nonexistent + cross-org, byte-identical bodies), list with status/org filters, list pagination.
- [x] Prune task live-verified: backdated row deleted, rejection row cascade-deleted.
- [x] 51 new tests across 5 files (status CRUD/state-machine, migration, API, admin proxy, reconciler), all passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)