### PR TITLE
fix(work-graph): exclude heuristic edges + cap component size in investment work units (CHAOS-2775)

### DIFF
--- a/src/dev_health_ops/work_graph/investment/backfill.py
+++ b/src/dev_health_ops/work_graph/investment/backfill.py
@@ -75,6 +75,10 @@ from dev_health_ops.metrics.schemas import (
 )
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 from dev_health_ops.metrics.sinks.factory import create_sink
+from dev_health_ops.work_graph.investment.components import (
+    ComponentBuildStats,
+    build_components,
+)
 from dev_health_ops.work_graph.investment.membership import (
     NodeKey,
     build_membership_records,
@@ -108,39 +112,21 @@ class MembershipBackfillConfig:
 
 def _build_components_for_backfill(
     edges: list[dict[str, Any]],
+    *,
+    stats: ComponentBuildStats | None = None,
 ) -> list[list[NodeKey]]:
     """Connected-component node lists from work_graph_edges.
 
-    Mirrors ``materialize._build_components`` (same union-find over
-    source/target endpoints) but returns only the per-component node lists — the
-    backfill does not need the component edges. Kept local to avoid importing the
-    heavy ``materialize`` module (and its LLM provider deps) into the worker.
+    Delegates to the SHARED ``components.build_components`` (the exact same
+    grouping + CHAOS-2775 oversized-component split the LLM materializer uses)
+    and drops the per-component edge bundles the backfill does not need. Sharing
+    the implementation is REQUIRED for correctness: ``work_unit_id`` is a hash of
+    a component's node set, so if this path grouped nodes even slightly
+    differently from the materializer the projected membership would target
+    non-existent unit ids. ``components`` is intentionally lightweight (no LLM
+    provider deps), so importing it into the worker is cheap.
     """
-    adjacency: dict[NodeKey, list[NodeKey]] = {}
-    for edge in edges:
-        source = (str(edge.get("source_type")), str(edge.get("source_id")))
-        target = (str(edge.get("target_type")), str(edge.get("target_id")))
-        adjacency.setdefault(source, []).append(target)
-        adjacency.setdefault(target, []).append(source)
-
-    visited: set[NodeKey] = set()
-    components: list[list[NodeKey]] = []
-    for node in adjacency:
-        if node in visited:
-            continue
-        stack = [node]
-        visited.add(node)
-        component_nodes: list[NodeKey] = []
-        while stack:
-            current = stack.pop()
-            component_nodes.append(current)
-            for neighbor in adjacency.get(current, []):
-                if neighbor in visited:
-                    continue
-                visited.add(neighbor)
-                stack.append(neighbor)
-        components.append(component_nodes)
-    return components
+    return [nodes for nodes, _edges in build_components(edges, stats=stats)]
 
 
 def _fetch_latest_distributions(
@@ -206,7 +192,8 @@ def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
         sink.ensure_schema()
 
         edges = fetch_work_graph_edges(sink, repo_ids=config.repo_ids, org_id=org_id)
-        components = _build_components_for_backfill(edges)
+        component_stats = ComponentBuildStats()
+        components = _build_components_for_backfill(edges, stats=component_stats)
         if not components:
             logger.info(
                 "Membership backfill: no work graph components for org=%s", org_id
@@ -216,6 +203,7 @@ def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
                 "matched": 0,
                 "skipped": 0,
                 "memberships": 0,
+                **component_stats.as_dict(),
             }
 
         # Map each current work_unit_id -> its node list.
@@ -375,6 +363,7 @@ def backfill_memberships(config: MembershipBackfillConfig) -> dict[str, int]:
             "matched": matched,
             "skipped": skipped,
             "memberships": len(membership_records),
+            **component_stats.as_dict(),
         }
     finally:
         sink.close()

--- a/src/dev_health_ops/work_graph/investment/components.py
+++ b/src/dev_health_ops/work_graph/investment/components.py
@@ -1,0 +1,344 @@
+"""Shared connected-component builder for investment work units (CHAOS-2775).
+
+Both the LLM materializer (``materialize._build_components``) and the no-LLM
+membership backfill (``backfill._build_components_for_backfill``) MUST derive
+IDENTICAL connected components from the SAME ``work_graph_edges``. The
+``work_unit_id`` is a hash of a component's node set (``utils.work_unit_id``) and
+the backfill projects membership onto those hashes, so any divergence in how the
+two paths group nodes silently breaks membership scoping. This module is the
+single source of truth for that grouping — including the oversized-component
+split — so the two callers cannot drift.
+
+Two safety nets guard against the "one giant work unit" pathology (CHAOS-2775):
+
+1. Heuristic edges are excluded upstream at the ``fetch_work_graph_edges`` choke
+   point (see ``queries.py``); they never reach this builder for unit grouping.
+2. Any connected component larger than ``max_component_nodes`` is deterministically
+   split here rather than materialized as a single unit:
+     a. Drop the component's lowest-confidence edges (ordered by
+        ``(confidence, edge_id)`` for determinism) until every resulting fragment
+        fits. Edges tied at the component's MAX confidence are never dropped in
+        this phase.
+     b. If a fragment still exceeds the cap using only max-confidence edges,
+        remove the highest-degree hub node(s) (tie-broken by node id) until it
+        fits. A removed hub is dropped from every output fragment.
+   Nothing is silently truncated: counts of oversized components, dropped edges,
+   and dropped nodes are accumulated into a :class:`ComponentBuildStats`.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from dev_health_ops.work_graph.investment.constants import (
+    resolve_max_component_nodes,
+)
+
+logger = logging.getLogger(__name__)
+
+NodeKey = tuple[str, str]
+Edge = dict[str, object]
+Component = tuple[list[NodeKey], list[Edge]]
+
+
+@dataclass
+class ComponentBuildStats:
+    """Accounting for the oversized-component split (CHAOS-2775).
+
+    Exposed in the run stats of both the materializer and the membership
+    backfill so an oversized-graph split is observable, never silent.
+    """
+
+    oversized_components: int = 0
+    dropped_edges: int = 0
+    dropped_nodes: int = 0
+
+    def as_dict(self) -> dict[str, int]:
+        return {
+            "oversized_components": self.oversized_components,
+            "dropped_edges": self.dropped_edges,
+            "dropped_nodes": self.dropped_nodes,
+        }
+
+
+def _edge_endpoints(edge: Edge) -> tuple[NodeKey, NodeKey]:
+    source = (str(edge.get("source_type")), str(edge.get("source_id")))
+    target = (str(edge.get("target_type")), str(edge.get("target_id")))
+    return source, target
+
+
+def _edge_confidence(edge: Edge) -> float:
+    value = edge.get("confidence")
+    if isinstance(value, bool):
+        return 0.0
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return 0.0
+    return 0.0
+
+
+def _edge_id(edge: Edge) -> str:
+    return str(edge.get("edge_id") or "")
+
+
+def _connected_components(
+    nodes: Iterable[NodeKey],
+    edges: Iterable[Edge],
+) -> list[list[NodeKey]]:
+    """Connected components over ``nodes`` using only ``edges`` whose BOTH
+    endpoints are in ``nodes``.
+
+    Grouping is content-based (union-find), so the node SET of each component is
+    independent of input iteration order — the property the ``work_unit_id`` hash
+    relies on. Node order WITHIN a component is irrelevant because
+    ``work_unit_id`` sorts its tokens.
+    """
+    node_set = set(nodes)
+    parent: dict[NodeKey, NodeKey] = {node: node for node in node_set}
+
+    def find(node: NodeKey) -> NodeKey:
+        root = node
+        while parent[root] != root:
+            root = parent[root]
+        while parent[node] != root:
+            parent[node], node = root, parent[node]
+        return root
+
+    for edge in edges:
+        source, target = _edge_endpoints(edge)
+        if source in node_set and target in node_set:
+            root_a, root_b = find(source), find(target)
+            if root_a != root_b:
+                parent[root_b] = root_a
+
+    groups: dict[NodeKey, list[NodeKey]] = {}
+    for node in node_set:
+        groups.setdefault(find(node), []).append(node)
+    return list(groups.values())
+
+
+def _discover_components(edges: list[Edge]) -> list[Component]:
+    """Raw connected components with their deduped edge bundles.
+
+    This is the historical ``materialize._build_components`` traversal, preserved
+    verbatim so that for graphs WITHOUT any oversized component the output
+    (including component order and per-component edge lists) is byte-identical to
+    the pre-CHAOS-2775 behavior.
+    """
+    adjacency: dict[NodeKey, list[NodeKey]] = {}
+    edges_by_node: dict[NodeKey, list[Edge]] = {}
+
+    for edge in edges:
+        source, target = _edge_endpoints(edge)
+        adjacency.setdefault(source, []).append(target)
+        adjacency.setdefault(target, []).append(source)
+        edges_by_node.setdefault(source, []).append(edge)
+        edges_by_node.setdefault(target, []).append(edge)
+
+    visited: set[NodeKey] = set()
+    components: list[Component] = []
+
+    for node in adjacency:
+        if node in visited:
+            continue
+        stack = [node]
+        visited.add(node)
+        component_nodes: list[NodeKey] = []
+        component_edges: dict[str, Edge] = {}
+        while stack:
+            current = stack.pop()
+            component_nodes.append(current)
+            for edge in edges_by_node.get(current, []):
+                edge_id = _edge_id(edge)
+                if edge_id and edge_id not in component_edges:
+                    component_edges[edge_id] = edge
+            for neighbor in adjacency.get(current, []):
+                if neighbor in visited:
+                    continue
+                visited.add(neighbor)
+                stack.append(neighbor)
+        components.append((component_nodes, list(component_edges.values())))
+    return components
+
+
+def _degrees(edges: Iterable[Edge], within: set[NodeKey]) -> dict[NodeKey, int]:
+    degree: dict[NodeKey, int] = {node: 0 for node in within}
+    for edge in edges:
+        source, target = _edge_endpoints(edge)
+        if source in within and target in within:
+            degree[source] += 1
+            degree[target] += 1
+    return degree
+
+
+def _remove_hubs(
+    nodes: set[NodeKey],
+    edges: list[Edge],
+    max_nodes: int,
+    stats: ComponentBuildStats | None,
+) -> list[list[NodeKey]]:
+    """Drop highest-degree hub nodes until every fragment fits ``max_nodes``.
+
+    Deterministic: among the nodes of every still-oversized fragment, the node
+    with the highest degree is removed (ties broken by the smallest node id). A
+    removed node is dropped entirely — it is excluded from all output fragments
+    and its incident edges disappear with it. Terminates because every iteration
+    shrinks the active node set.
+    """
+    active = set(nodes)
+    while True:
+        active_edges = [
+            edge
+            for edge in edges
+            if _edge_endpoints(edge)[0] in active and _edge_endpoints(edge)[1] in active
+        ]
+        fragments = _connected_components(active, active_edges)
+        oversized_nodes: set[NodeKey] = set()
+        for fragment in fragments:
+            if len(fragment) > max_nodes:
+                oversized_nodes.update(fragment)
+        if not oversized_nodes:
+            return fragments
+        degree = _degrees(active_edges, oversized_nodes)
+        max_degree = max(degree.get(node, 0) for node in oversized_nodes)
+        hub = min(node for node in oversized_nodes if degree.get(node, 0) == max_degree)
+        active.discard(hub)
+        if stats is not None:
+            stats.dropped_nodes += 1
+        logger.warning(
+            "Investment component split: dropped hub node %s (degree %d) to "
+            "enforce max_component_nodes=%d",
+            hub,
+            max_degree,
+            max_nodes,
+        )
+
+
+def _split_oversized_component(
+    nodes: list[NodeKey],
+    edges: list[Edge],
+    max_nodes: int,
+    stats: ComponentBuildStats | None,
+) -> list[Component]:
+    """Split one oversized component into fragments that each fit ``max_nodes``.
+
+    Edge-drop phase (deterministic): edges below the component's max confidence
+    are dropped in ``(confidence, edge_id)`` order; we binary-search the smallest
+    prefix of that ordering whose removal makes every fragment fit (fragment size
+    is monotonically non-increasing as more edges are dropped). Whatever the edge
+    phase cannot resolve — a fragment held together purely by max-confidence
+    edges — is handed to :func:`_remove_hubs`.
+    """
+    node_set = set(nodes)
+    if edges:
+        max_confidence = max(_edge_confidence(edge) for edge in edges)
+    else:
+        max_confidence = 0.0
+
+    protected_edges = [
+        edge for edge in edges if _edge_confidence(edge) >= max_confidence
+    ]
+    droppable_edges = sorted(
+        (edge for edge in edges if _edge_confidence(edge) < max_confidence),
+        key=lambda edge: (_edge_confidence(edge), _edge_id(edge)),
+    )
+
+    def fits(drop_count: int) -> bool:
+        kept = protected_edges + droppable_edges[drop_count:]
+        return all(
+            len(fragment) <= max_nodes
+            for fragment in _connected_components(node_set, kept)
+        )
+
+    lo, hi = 0, len(droppable_edges)
+    while lo < hi:
+        mid = (lo + hi) // 2
+        if fits(mid):
+            hi = mid
+        else:
+            lo = mid + 1
+    drop_count = lo
+
+    if stats is not None:
+        stats.dropped_edges += drop_count
+    if drop_count:
+        logger.warning(
+            "Investment component split: dropped %d lowest-confidence edge(s) "
+            "to enforce max_component_nodes=%d",
+            drop_count,
+            max_nodes,
+        )
+
+    kept_edges = protected_edges + droppable_edges[drop_count:]
+    fragments = _connected_components(node_set, kept_edges)
+
+    fragment_node_lists: list[list[NodeKey]] = []
+    for fragment in fragments:
+        if len(fragment) <= max_nodes:
+            fragment_node_lists.append(fragment)
+        else:
+            fragment_node_lists.extend(
+                _remove_hubs(set(fragment), kept_edges, max_nodes, stats)
+            )
+
+    result: list[Component] = []
+    for fragment_nodes in fragment_node_lists:
+        fragment_set = set(fragment_nodes)
+        fragment_edges = [
+            edge
+            for edge in kept_edges
+            if _edge_endpoints(edge)[0] in fragment_set
+            and _edge_endpoints(edge)[1] in fragment_set
+        ]
+        result.append((fragment_nodes, fragment_edges))
+
+    # Deterministic fragment order, independent of set-iteration order: sort by
+    # the fragment's sorted node tuple.
+    result.sort(key=lambda component: sorted(component[0]))
+    return result
+
+
+def build_components(
+    edges: list[Edge],
+    *,
+    max_component_nodes: int | None = None,
+    stats: ComponentBuildStats | None = None,
+) -> list[Component]:
+    """Build investment work-unit components from ``work_graph_edges`` rows.
+
+    Returns ``(node_list, edge_list)`` per component. Components exceeding
+    ``max_component_nodes`` (defaulting to
+    :func:`constants.resolve_max_component_nodes`, env-overridable via
+    ``INVESTMENT_MAX_COMPONENT_NODES``) are deterministically split; the split's
+    drop counts are accumulated into ``stats`` when provided.
+
+    This is the SINGLE implementation shared by the materializer and the
+    membership backfill so their component sets — and therefore ``work_unit_id``
+    hashes — stay identical for identical edge input.
+    """
+    cap = resolve_max_component_nodes(max_component_nodes)
+
+    result: list[Component] = []
+    for component_nodes, component_edges in _discover_components(edges):
+        unit_nodes = list(dict.fromkeys(component_nodes))
+        if len(unit_nodes) <= cap:
+            result.append((unit_nodes, component_edges))
+            continue
+        if stats is not None:
+            stats.oversized_components += 1
+        logger.warning(
+            "Investment component with %d nodes exceeds max_component_nodes=%d; "
+            "splitting deterministically (CHAOS-2775)",
+            len(unit_nodes),
+            cap,
+        )
+        result.extend(
+            _split_oversized_component(unit_nodes, component_edges, cap, stats)
+        )
+    return result

--- a/src/dev_health_ops/work_graph/investment/constants.py
+++ b/src/dev_health_ops/work_graph/investment/constants.py
@@ -13,6 +13,16 @@ MIN_EVIDENCE_CHARS = 300
 # (e.g. a changelog PR) can percolate thousands of issues/PRs/commits into one
 # component that dominates the Investment allocation chart. Env-overridable via
 # ``INVESTMENT_MAX_COMPONENT_NODES``.
+#
+# OPERATIONAL INVARIANT: work_unit_id is a hash of component membership, so the
+# cap must resolve identically for the LLM materialize run and the LATER no-LLM
+# membership projection (backfill.py) that projects from its investments — set
+# INVESTMENT_MAX_COMPONENT_NODES identically on every worker/beat/CLI host (or
+# nowhere). Within one partitioned run the dispatcher freezes the resolved cap
+# into every chunk, but the projection is a separate process invocation and
+# re-resolves from env; a divergent value there re-splits differently, computes
+# different work_unit_ids, and silently skips those units' membership
+# (tracked as follow-up CHAOS-2779).
 INVESTMENT_MAX_COMPONENT_NODES = 150
 
 

--- a/src/dev_health_ops/work_graph/investment/constants.py
+++ b/src/dev_health_ops/work_graph/investment/constants.py
@@ -1,6 +1,38 @@
 """Shared constants for investment materialization and validation."""
 
+from __future__ import annotations
+
+import os
+
 MIN_EVIDENCE_CHARS = 300
+
+# Maximum node count for a single investment work-unit component (CHAOS-2775).
+# Connected components of ``work_graph_edges`` larger than this are
+# deterministically split (see ``components.build_components``) rather than
+# materialized as one giant unit. Without this cap a single densely-linked hub
+# (e.g. a changelog PR) can percolate thousands of issues/PRs/commits into one
+# component that dominates the Investment allocation chart. Env-overridable via
+# ``INVESTMENT_MAX_COMPONENT_NODES``.
+INVESTMENT_MAX_COMPONENT_NODES = 150
+
+
+def resolve_max_component_nodes(value: int | None = None) -> int:
+    """Resolve the max component node cap (explicit arg > env > default).
+
+    Falls back to :data:`INVESTMENT_MAX_COMPONENT_NODES` for a missing,
+    unparseable, or non-positive value.
+    """
+    if value is not None:
+        return value if value >= 1 else INVESTMENT_MAX_COMPONENT_NODES
+    raw = os.getenv("INVESTMENT_MAX_COMPONENT_NODES")
+    if raw is None:
+        return INVESTMENT_MAX_COMPONENT_NODES
+    try:
+        parsed = int(raw)
+    except (TypeError, ValueError):
+        return INVESTMENT_MAX_COMPONENT_NODES
+    return parsed if parsed >= 1 else INVESTMENT_MAX_COMPONENT_NODES
+
 
 # Minimum category weight for a node to be recorded as a member of that
 # theme/subcategory in work_unit_membership (CHAOS-2430). Multi-membership: a

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -58,6 +58,10 @@ from dev_health_ops.work_graph.investment.categorize import (
     categorize_text_bundle_completion,
     fallback_outcome,
 )
+from dev_health_ops.work_graph.investment.components import (
+    ComponentBuildStats,
+    build_components,
+)
 from dev_health_ops.work_graph.investment.constants import (
     MEMBERSHIP_WEIGHT_THRESHOLD,
     MIN_EVIDENCE_CHARS,
@@ -786,42 +790,18 @@ class MaterializeConfig:
 
 def _build_components(
     edges: list[dict[str, object]],
+    *,
+    stats: ComponentBuildStats | None = None,
 ) -> list[tuple[list[NodeKey], list[dict[str, object]]]]:
-    adjacency: dict[NodeKey, list[NodeKey]] = {}
-    edges_by_node: dict[NodeKey, list[dict[str, object]]] = {}
+    """Connected-component work units, with the CHAOS-2775 oversized-component
+    split applied.
 
-    for edge in edges:
-        source = (str(edge.get("source_type")), str(edge.get("source_id")))
-        target = (str(edge.get("target_type")), str(edge.get("target_id")))
-        adjacency.setdefault(source, []).append(target)
-        adjacency.setdefault(target, []).append(source)
-        edges_by_node.setdefault(source, []).append(edge)
-        edges_by_node.setdefault(target, []).append(edge)
-
-    visited: set[NodeKey] = set()
-    components: list[tuple[list[NodeKey], list[dict[str, object]]]] = []
-
-    for node in adjacency:
-        if node in visited:
-            continue
-        stack = [node]
-        visited.add(node)
-        component_nodes: list[NodeKey] = []
-        component_edges: dict[str, dict[str, object]] = {}
-        while stack:
-            current = stack.pop()
-            component_nodes.append(current)
-            for edge in edges_by_node.get(current, []):
-                edge_id = str(edge.get("edge_id") or "")
-                if edge_id and edge_id not in component_edges:
-                    component_edges[edge_id] = edge
-            for neighbor in adjacency.get(current, []):
-                if neighbor in visited:
-                    continue
-                visited.add(neighbor)
-                stack.append(neighbor)
-        components.append((component_nodes, list(component_edges.values())))
-    return components
+    Thin adapter over the SHARED ``components.build_components`` so the
+    materializer, the dispatch enumerator (``workers.work_graph_tasks``), and the
+    membership backfill all group nodes identically — a divergence would break
+    ``work_unit_id`` hashing across the LLM and no-LLM paths.
+    """
+    return build_components(edges, stats=stats)
 
 
 def _flatten_nodes(
@@ -1109,13 +1089,19 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
         edges = fetch_work_graph_edges(
             sink, repo_ids=repo_ids, org_id=config.org_id or ""
         )
-        components = _build_components(edges)
+        component_stats = ComponentBuildStats()
+        components = _build_components(edges, stats=component_stats)
         total_components = len(components)
         if not components:
             logger.info(
                 "No work graph components found for investment materialization."
             )
-            return {"components": 0, "records": 0, "quotes": 0}
+            return {
+                "components": 0,
+                "records": 0,
+                "quotes": 0,
+                **component_stats.as_dict(),
+            }
         if config.component_indexes is not None:
             wanted_indexes = set(config.component_indexes)
             components = [
@@ -1709,6 +1695,7 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             "llm_output_tokens": llm_output_tokens,
             "llm_failures": sum(llm_failure_counts.values()),
             "llm_failure_counts": dict(llm_failure_counts),
+            **component_stats.as_dict(),
         }
     finally:
         sink.close()

--- a/src/dev_health_ops/work_graph/investment/materialize.py
+++ b/src/dev_health_ops/work_graph/investment/materialize.py
@@ -774,6 +774,13 @@ class MaterializeConfig:
     llm_batch_min_items: int = 25
     llm_batch_poll_interval_seconds: float = 30.0
     llm_batch_timeout_seconds: float = 3000.0
+    # Frozen component-size cap for partitioned runs: the dispatcher resolves
+    # the cap ONCE and passes it to every chunk so dispatcher and chunk workers
+    # can never disagree via divergent INVESTMENT_MAX_COMPONENT_NODES env
+    # (component_indexes are positional — a cap mismatch would re-split
+    # differently and index N would name a different work unit). None = resolve
+    # from env/default locally (single-process runs).
+    max_component_nodes: int | None = None
 
     def __post_init__(self) -> None:
         if self.llm_batch_mode not in _LLM_BATCH_MODES:
@@ -792,6 +799,7 @@ def _build_components(
     edges: list[dict[str, object]],
     *,
     stats: ComponentBuildStats | None = None,
+    max_component_nodes: int | None = None,
 ) -> list[tuple[list[NodeKey], list[dict[str, object]]]]:
     """Connected-component work units, with the CHAOS-2775 oversized-component
     split applied.
@@ -801,7 +809,7 @@ def _build_components(
     membership backfill all group nodes identically — a divergence would break
     ``work_unit_id`` hashing across the LLM and no-LLM paths.
     """
-    return build_components(edges, stats=stats)
+    return build_components(edges, stats=stats, max_component_nodes=max_component_nodes)
 
 
 def _flatten_nodes(
@@ -1090,7 +1098,11 @@ async def materialize_investments(config: MaterializeConfig) -> dict[str, Any]:
             sink, repo_ids=repo_ids, org_id=config.org_id or ""
         )
         component_stats = ComponentBuildStats()
-        components = _build_components(edges, stats=component_stats)
+        components = _build_components(
+            edges,
+            stats=component_stats,
+            max_component_nodes=config.max_component_nodes,
+        )
         total_components = len(components)
         if not components:
             logger.info(

--- a/src/dev_health_ops/work_graph/investment/queries.py
+++ b/src/dev_health_ops/work_graph/investment/queries.py
@@ -32,6 +32,23 @@ def fetch_work_graph_edges(
     choke point shared by the materializer, the dispatch enumerator, and the
     membership backfill, so the default-on filter keeps all three consistent
     without any call-site changes.
+
+    Two invariants both the heuristic filter and partitioned dispatch rely on:
+
+    - DEDUP BEFORE FILTER: ``work_graph_edges`` is a ReplacingMergeTree keyed by
+      (org_id, source_type, source_id, edge_type, target_type, target_id) and a
+      raw read can return stale pre-merge versions of an edge. Provenance is NOT
+      part of that identity (a heuristic link can later be re-emitted as
+      native), so rows are argMax-collapsed by ``last_synced`` per identity and
+      the heuristic filter applies to the LATEST provenance via HAVING —
+      otherwise a stale row could resurrect an excluded edge (or keep an edge
+      excluded that is now native) depending on merge timing.
+    - DETERMINISTIC ORDER: partitioned materialization dispatches numeric
+      ``component_indexes`` and each chunk worker re-fetches and rebuilds the
+      component list. Component discovery order follows edge row order, so this
+      query ORDERs BY the full identity key — without it, ClickHouse physical
+      row order could differ between dispatcher and chunk workers and index N
+      would name a different component (skipped / double-categorized units).
     """
     conditions: list[str] = []
     params: dict[str, Any] = {}
@@ -42,26 +59,35 @@ def fetch_work_graph_edges(
     if org_id:
         params["org_id"] = org_id
         conditions.append("org_id = %(org_id)s")
-    if exclude_heuristic:
-        # Parameterized (no value interpolation): exclude rule-inferred edges.
-        params["heuristic_provenance"] = "heuristic"
-        conditions.append("provenance != %(heuristic_provenance)s")
     where_sql = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    having_sql = ""
+    if exclude_heuristic:
+        # Parameterized (no value interpolation): exclude rule-inferred edges,
+        # judged on the deduplicated (latest) provenance. HAVING must reference
+        # the SELECT alias, NOT repeat argMax(provenance, ...): the alias
+        # shadows the raw column and re-aggregating it raises
+        # ILLEGAL_AGGREGATION (184) — same ClickHouse trap documented on
+        # LATEST_WORK_UNIT_INVESTMENTS_CTE (api/queries/investment.py).
+        params["heuristic_provenance"] = "heuristic"
+        having_sql = "HAVING provenance != %(heuristic_provenance)s"
     query = f"""
         SELECT
-            edge_id,
+            any(edge_id) AS edge_id,
             source_type,
             source_id,
             target_type,
             target_id,
             edge_type,
-            toString(repo_id) AS repo_id,
-            provider,
-            provenance,
-            confidence,
-            evidence
+            toString(argMax(repo_id, last_synced)) AS repo_id,
+            argMax(provider, last_synced) AS provider,
+            argMax(provenance, last_synced) AS provenance,
+            argMax(confidence, last_synced) AS confidence,
+            argMax(evidence, last_synced) AS evidence
         FROM work_graph_edges
         {where_sql}
+        GROUP BY org_id, source_type, source_id, edge_type, target_type, target_id
+        {having_sql}
+        ORDER BY org_id, source_type, source_id, edge_type, target_type, target_id
     """
     return query_dicts(sink, query, params)
 

--- a/src/dev_health_ops/work_graph/investment/queries.py
+++ b/src/dev_health_ops/work_graph/investment/queries.py
@@ -20,19 +20,33 @@ def fetch_work_graph_edges(
     *,
     repo_ids: list[str] | None = None,
     org_id: str = "",
+    exclude_heuristic: bool = True,
 ) -> list[dict[str, Any]]:
+    """Fetch work-graph edges for investment work-unit component building.
+
+    ``exclude_heuristic`` (default ON, CHAOS-2775) drops ``provenance='heuristic'``
+    edges — low-confidence, rule-inferred links (e.g. same repo + time window)
+    that percolate thousands of unrelated issues/PRs/commits into a single giant
+    "work unit". Heuristic edges remain in ``work_graph_edges`` for display and
+    other consumers; only work-unit grouping excludes them. This is the single
+    choke point shared by the materializer, the dispatch enumerator, and the
+    membership backfill, so the default-on filter keeps all three consistent
+    without any call-site changes.
+    """
+    conditions: list[str] = []
     params: dict[str, Any] = {}
-    where_sql = ""
     if repo_ids:
         params["repo_ids"] = repo_ids
-        where_sql = "WHERE repo_id IN %(repo_ids)s"
+        conditions.append("repo_id IN %(repo_ids)s")
     # Optional org_id filtering
     if org_id:
         params["org_id"] = org_id
-        if where_sql:
-            where_sql += " AND org_id = %(org_id)s"
-        else:
-            where_sql = "WHERE org_id = %(org_id)s"
+        conditions.append("org_id = %(org_id)s")
+    if exclude_heuristic:
+        # Parameterized (no value interpolation): exclude rule-inferred edges.
+        params["heuristic_provenance"] = "heuristic"
+        conditions.append("provenance != %(heuristic_provenance)s")
+    where_sql = f"WHERE {' AND '.join(conditions)}" if conditions else ""
     query = f"""
         SELECT
             edge_id,

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -293,6 +293,7 @@ def run_investment_materialize_chunk(
     llm_batch_min_items: int | None = None,
     llm_batch_poll_interval_seconds: float | None = None,
     llm_batch_timeout_seconds: float | None = None,
+    max_component_nodes: int | None = None,
 ) -> dict:
     from dev_health_ops.db import get_postgres_session_sync
     from dev_health_ops.llm import LLMAuthError, LLMError, resolve_provider_name
@@ -382,6 +383,10 @@ def run_investment_materialize_chunk(
             llm_batch_timeout_seconds=resolve_llm_batch_timeout_seconds(
                 llm_batch_timeout_seconds
             ),
+            # Frozen by the dispatcher: chunk workers must split components with
+            # the SAME cap the dispatcher enumerated with, or component_indexes
+            # would name different work units (CHAOS-2775 codex round 2).
+            max_component_nodes=max_component_nodes,
         )
         stats = run_async(materialize_investments(config))
 
@@ -435,6 +440,9 @@ def finalize_investment_materialize_partitioned(
         "llm_output_tokens": 0,
         "llm_failures": 0,
         "llm_failure_counts": {},
+        "oversized_components": 0,
+        "dropped_edges": 0,
+        "dropped_nodes": 0,
     }
     try:
         for result in chunk_results or []:
@@ -449,6 +457,13 @@ def finalize_investment_materialize_partitioned(
                 "llm_failures",
             ):
                 totals[key] += int(stats.get(key, 0) or 0)
+            # Split stats are aggregated by MAX, not summed: every chunk
+            # rebuilds the FULL component list (then materializes only its
+            # component_indexes slice), so each chunk reports the same
+            # graph-wide split counters — summing would multiply them by the
+            # chunk count (CHAOS-2775 codex round 2).
+            for key in ("oversized_components", "dropped_edges", "dropped_nodes"):
+                totals[key] = max(totals[key], int(stats.get(key, 0) or 0))
             for failure_class, count in dict(
                 stats.get("llm_failure_counts", {})
             ).items():
@@ -498,6 +513,9 @@ def dispatch_investment_materialize_partitioned(
     llm_batch_timeout_seconds: float | None = None,
 ) -> dict:
     from dev_health_ops.metrics.sinks.factory import create_sink
+    from dev_health_ops.work_graph.investment.constants import (
+        resolve_max_component_nodes,
+    )
     from dev_health_ops.work_graph.investment.materialize import (
         _build_components,
         _resolve_repo_ids,
@@ -511,6 +529,14 @@ def dispatch_investment_materialize_partitioned(
     # Hoisted to guarantee definite assignment on every return path (CodeQL).
     run_membership = not (repo_ids or team_ids or from_date or to_date)
 
+    # Resolve the component-size cap ONCE and freeze it for the whole
+    # partitioned run: chunk workers rebuild the component list from a fresh
+    # fetch, and component_indexes are positional — if a chunk worker resolved
+    # a different INVESTMENT_MAX_COMPONENT_NODES from its own env, the split
+    # would differ and index N would name a different work unit
+    # (CHAOS-2775 codex round 2).
+    frozen_max_component_nodes = resolve_max_component_nodes()
+
     db_url = db_url or _get_db_url()
     sink = create_sink(db_url)
     try:
@@ -521,7 +547,9 @@ def dispatch_investment_materialize_partitioned(
         edges = fetch_work_graph_edges(
             sink, repo_ids=resolved_repo_ids, org_id=org_id or ""
         )
-        components = _build_components(edges)
+        components = _build_components(
+            edges, max_component_nodes=frozen_max_component_nodes
+        )
     finally:
         sink.close()
 
@@ -564,6 +592,7 @@ def dispatch_investment_materialize_partitioned(
             "computed_at": computed_at,
             "component_indexes": chunk_indexes,
             "chunk_index": chunk_index,
+            "max_component_nodes": frozen_max_component_nodes,
         }
         if allow_unscoped:
             chunk_kwargs["allow_unscoped"] = True

--- a/tests/test_investment_materialize_partitioned.py
+++ b/tests/test_investment_materialize_partitioned.py
@@ -230,3 +230,67 @@ def test_partitioned_finalizer_aggregates_and_runs_membership_once() -> None:
     assert result["llm_failure_counts"] == {"rate_limit": 1}
     assert result["membership"] == {"memberships": 4}
     backfill.assert_called_once()
+
+
+def test_dispatch_freezes_max_component_nodes_into_chunks(monkeypatch) -> None:
+    """CHAOS-2775 codex round 2 (HIGH): the dispatcher resolves the component
+    size cap ONCE and passes it to every chunk. component_indexes are
+    positional over a re-built component list, so a chunk worker resolving a
+    different INVESTMENT_MAX_COMPONENT_NODES from its own env would split
+    differently and index N would name a different work unit."""
+    monkeypatch.setenv("INVESTMENT_MAX_COMPONENT_NODES", "7")
+    with (
+        patch(
+            "dev_health_ops.metrics.sinks.factory.create_sink",
+            return_value=_FakeSink(),
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.queries.fetch_work_graph_edges",
+            return_value=[_edge(1), _edge(2), _edge(3)],
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.celery_app.signature",
+            side_effect=_signature_factory,
+        ),
+        patch("dev_health_ops.workers.work_graph_tasks.chord") as mock_chord,
+    ):
+        mock_chord.return_value = MagicMock()
+        task = cast(Any, dispatch_investment_materialize_partitioned)
+        task.run(db_url="clickhouse://x", org_id="org-1", chunk_size=2)
+
+    header, _callback = mock_chord.call_args.args
+    for sig in header:
+        assert sig.sig_kwargs["kwargs"]["max_component_nodes"] == 7
+
+
+def test_finalize_aggregates_split_stats_by_max_not_sum() -> None:
+    """CHAOS-2775 codex round 2 (LOW): every chunk rebuilds the FULL component
+    list, so each reports the same graph-wide split counters — the finalizer
+    must aggregate them by MAX (summing would multiply by the chunk count)."""
+    chunk_stats = {
+        "records": 1,
+        "quotes": 0,
+        "skipped_existing": 0,
+        "llm_calls": 0,
+        "llm_input_tokens": 0,
+        "llm_output_tokens": 0,
+        "llm_failures": 0,
+        "llm_failure_counts": {},
+        "oversized_components": 2,
+        "dropped_edges": 9,
+        "dropped_nodes": 3,
+    }
+    task = cast(Any, finalize_investment_materialize_partitioned)
+    result = task.run(
+        [{"stats": dict(chunk_stats)}, {"stats": dict(chunk_stats)}],
+        db_url="clickhouse://x",
+        org_id="org-1",
+        run_id="run-1",
+        run_membership_backfill_after=False,
+    )
+
+    # Summable counters still sum; split counters do not.
+    assert result["records"] == 2
+    assert result["oversized_components"] == 2
+    assert result["dropped_edges"] == 9
+    assert result["dropped_nodes"] == 3

--- a/tests/test_membership_backfill.py
+++ b/tests/test_membership_backfill.py
@@ -271,6 +271,9 @@ def test_backfill_empty_graph_is_clean_noop() -> None:
         "matched": 0,
         "skipped": 0,
         "memberships": 0,
+        "oversized_components": 0,
+        "dropped_edges": 0,
+        "dropped_nodes": 0,
     }
     assert sink.written == []
     assert sink.run_markers == []

--- a/tests/work_graph/test_investment_components.py
+++ b/tests/work_graph/test_investment_components.py
@@ -1,0 +1,324 @@
+"""Tests for the shared investment work-unit component builder (CHAOS-2775).
+
+Covers the two safety nets that stop a single densely-linked hub from
+percolating thousands of unrelated nodes into one giant "work unit":
+
+1. Heuristic edges are excluded at the ``fetch_work_graph_edges`` choke point.
+2. Oversized connected components are deterministically split (drop lowest-
+   confidence edges, then remove highest-degree hubs) and never materialized as
+   a single unit.
+
+Also proves the materializer and the no-LLM membership backfill derive
+IDENTICAL components (→ identical ``work_unit_id`` hashes) from the same edges,
+which is required for membership scoping to line up across the two paths.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+from dev_health_ops.work_graph.investment import queries as q
+from dev_health_ops.work_graph.investment.backfill import (
+    _build_components_for_backfill,
+)
+from dev_health_ops.work_graph.investment.components import (
+    ComponentBuildStats,
+    build_components,
+)
+from dev_health_ops.work_graph.investment.constants import (
+    INVESTMENT_MAX_COMPONENT_NODES,
+    resolve_max_component_nodes,
+)
+from dev_health_ops.work_graph.investment.materialize import _build_components
+from dev_health_ops.work_graph.investment.utils import work_unit_id
+
+
+def _edge(
+    src_type: str,
+    src_id: str,
+    tgt_type: str,
+    tgt_id: str,
+    *,
+    provenance: str = "native",
+    confidence: float = 1.0,
+    edge_id: str | None = None,
+) -> dict[str, Any]:
+    return {
+        "edge_id": edge_id or f"{src_type}:{src_id}->{tgt_type}:{tgt_id}",
+        "source_type": src_type,
+        "source_id": src_id,
+        "target_type": tgt_type,
+        "target_id": tgt_id,
+        "edge_type": "relates",
+        "provenance": provenance,
+        "confidence": confidence,
+    }
+
+
+def _component_node_sets(
+    components: list[tuple[list[tuple[str, str]], list[dict[str, Any]]]],
+) -> list[frozenset[tuple[str, str]]]:
+    return [frozenset(nodes) for nodes, _edges in components]
+
+
+def _max_component_size(
+    components: list[tuple[list[tuple[str, str]], list[dict[str, Any]]]],
+) -> int:
+    return max((len(nodes) for nodes, _edges in components), default=0)
+
+
+# ---------------------------------------------------------------------------
+# (d) Heuristic edges excluded from fetch; native edges kept.
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_excludes_heuristic_by_default(monkeypatch):
+    """The fetch choke point drops provenance='heuristic' rows by default and
+    keeps native/explicit_text rows — with the filter PARAMETERIZED, never
+    interpolated."""
+    db_rows = [
+        {"edge_id": "e1", "provenance": "heuristic"},
+        {"edge_id": "e2", "provenance": "native"},
+        {"edge_id": "e3", "provenance": "explicit_text"},
+    ]
+    captured: dict[str, Any] = {}
+
+    def fake_query_dicts(_sink, query, params):
+        captured["query"] = query
+        captured["params"] = params
+        # Emulate ClickHouse honoring the parameterized predicate.
+        rows = db_rows
+        if "heuristic_provenance" in params:
+            rows = [
+                r for r in rows if r["provenance"] != params["heuristic_provenance"]
+            ]
+        return rows
+
+    monkeypatch.setattr(q, "query_dicts", fake_query_dicts)
+    sink = cast(BaseMetricsSink, object())
+
+    rows = q.fetch_work_graph_edges(sink)
+
+    kept = {r["provenance"] for r in rows}
+    assert kept == {"native", "explicit_text"}
+    # Parameterized: the placeholder is in the SQL, the value lives in params.
+    assert "provenance != %(heuristic_provenance)s" in captured["query"]
+    assert captured["params"]["heuristic_provenance"] == "heuristic"
+    # No value interpolation: the literal string is not spliced into the SQL.
+    assert "'heuristic'" not in captured["query"]
+
+
+def test_fetch_keeps_heuristic_when_disabled(monkeypatch):
+    """exclude_heuristic=False restores the pre-CHAOS-2775 behavior (all rows,
+    no provenance predicate)."""
+    db_rows = [
+        {"edge_id": "e1", "provenance": "heuristic"},
+        {"edge_id": "e2", "provenance": "native"},
+    ]
+    captured: dict[str, Any] = {}
+
+    def fake_query_dicts(_sink, query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return db_rows
+
+    monkeypatch.setattr(q, "query_dicts", fake_query_dicts)
+    sink = cast(BaseMetricsSink, object())
+
+    rows = q.fetch_work_graph_edges(sink, exclude_heuristic=False)
+
+    assert len(rows) == 2
+    assert "provenance !=" not in captured["query"]
+    assert "heuristic_provenance" not in captured["params"]
+
+
+# ---------------------------------------------------------------------------
+# (a) Percolation regression: a dense blob glued ONLY by heuristic edges must
+#     NOT survive as a giant work unit once fetch strips heuristic edges.
+# ---------------------------------------------------------------------------
+
+
+def test_percolation_glued_only_by_heuristic_edges_does_not_form_giant_unit(
+    monkeypatch,
+):
+    # 60-node star glued exclusively by heuristic edges (the time_window_7d
+    # pathology), plus two genuine native components.
+    hub = ("pr", "changelog-pr")
+    heuristic_edges = [
+        _edge(
+            "pr",
+            "changelog-pr",
+            "issue",
+            f"H-{i}",
+            provenance="heuristic",
+            confidence=0.3,
+            edge_id=f"heur-{i}",
+        )
+        for i in range(60)
+    ]
+    native_edges = [
+        _edge("issue", "N-1", "pr", "NP-1"),
+        _edge("pr", "NP-1", "commit", "NC-1"),
+        _edge("issue", "N-2", "commit", "NC-2"),
+    ]
+    db_rows = heuristic_edges + native_edges
+
+    def fake_query_dicts(_sink, query, params):
+        rows = db_rows
+        if "heuristic_provenance" in params:
+            rows = [
+                r for r in rows if r.get("provenance") != params["heuristic_provenance"]
+            ]
+        return rows
+
+    monkeypatch.setattr(q, "query_dicts", fake_query_dicts)
+    sink = cast(BaseMetricsSink, object())
+
+    edges = q.fetch_work_graph_edges(sink)
+    components = build_components(edges)
+
+    # The heuristic-glued blob is gone; the changelog hub isn't in any unit.
+    node_sets = _component_node_sets(components)
+    assert all(hub not in ns for ns in node_sets)
+    # Only the small native components remain — no giant unit.
+    assert _max_component_size(components) <= 3
+    assert not any(("issue", "H-0") in ns for ns in node_sets)
+
+
+# ---------------------------------------------------------------------------
+# (b) Size-cap split determinism.
+# ---------------------------------------------------------------------------
+
+
+def test_size_cap_splits_on_low_confidence_bridge_deterministically():
+    # Two 4-node native paths joined by a single low-confidence bridge; cap 5.
+    x_path = [
+        _edge("issue", "x0", "pr", "x1"),
+        _edge("pr", "x1", "commit", "x2"),
+        _edge("commit", "x2", "issue", "x3"),
+    ]
+    y_path = [
+        _edge("issue", "y0", "pr", "y1"),
+        _edge("pr", "y1", "commit", "y2"),
+        _edge("commit", "y2", "issue", "y3"),
+    ]
+    bridge = _edge(
+        "issue", "x0", "issue", "y0", provenance="explicit_text", confidence=0.3
+    )
+    edges = x_path + y_path + [bridge]
+
+    stats1 = ComponentBuildStats()
+    first = build_components(edges, max_component_nodes=5, stats=stats1)
+    stats2 = ComponentBuildStats()
+    second = build_components(edges, max_component_nodes=5, stats=stats2)
+
+    # Deterministic: identical fragments (same order, same node sets) both runs.
+    assert _component_node_sets(first) == _component_node_sets(second)
+    # Split into exactly the two 4-node clusters; low-conf bridge dropped.
+    assert sorted(len(nodes) for nodes, _e in first) == [4, 4]
+    assert stats1.oversized_components == 1
+    assert stats1.dropped_edges == 1
+    assert stats1.dropped_nodes == 0
+    assert stats1.as_dict() == stats2.as_dict()
+
+
+def test_size_cap_removes_hub_when_only_max_confidence_edges_remain():
+    # A star: one hub with 20 native (max-confidence) spokes. No low-confidence
+    # edge exists to drop, so the split must remove the hub node.
+    edges = [_edge("pr", "hub", "issue", f"L-{i}") for i in range(20)]
+
+    stats1 = ComponentBuildStats()
+    first = build_components(edges, max_component_nodes=5, stats=stats1)
+    stats2 = ComponentBuildStats()
+    second = build_components(edges, max_component_nodes=5, stats=stats2)
+
+    assert _component_node_sets(first) == _component_node_sets(second)
+    assert stats1.oversized_components == 1
+    assert stats1.dropped_edges == 0
+    assert stats1.dropped_nodes == 1
+    # Hub removed → every spoke is isolated → no surviving component.
+    assert all(("pr", "hub") not in frozenset(nodes) for nodes, _e in first)
+    assert _max_component_size(first) <= 5
+    assert stats1.as_dict() == stats2.as_dict()
+
+
+def test_size_cap_splits_long_chain_by_removing_hubs_until_it_fits():
+    # A 30-node native chain, cap 8: no droppable edges (all conf 1.0), so the
+    # chain is split by removing highest-degree nodes until fragments fit.
+    nodes = [("issue", f"c{i}") for i in range(30)]
+    edges = [
+        _edge(nodes[i][0], nodes[i][1], nodes[i + 1][0], nodes[i + 1][1])
+        for i in range(len(nodes) - 1)
+    ]
+
+    stats = ComponentBuildStats()
+    components = build_components(edges, max_component_nodes=8, stats=stats)
+
+    assert _max_component_size(components) <= 8
+    assert stats.oversized_components == 1
+    assert stats.dropped_nodes >= 1
+    # Re-running yields identical fragments.
+    again = build_components(edges, max_component_nodes=8)
+    assert _component_node_sets(components) == _component_node_sets(again)
+
+
+# ---------------------------------------------------------------------------
+# (c) Hash consistency: materializer vs backfill produce identical work units.
+# ---------------------------------------------------------------------------
+
+
+def test_materialize_and_backfill_produce_identical_work_unit_ids():
+    # Mixed graph of several small components at the default cap (no split): the
+    # two production entry points must agree on the derived work_unit_ids.
+    cluster_a = [
+        _edge("issue", "a0", "pr", "a1"),
+        _edge("pr", "a1", "commit", "a2"),
+    ]
+    cluster_b = [
+        _edge("issue", "b0", "pr", "b1"),
+        _edge("issue", "a0", "issue", "b0", provenance="explicit_text", confidence=0.2),
+    ]
+    small = [_edge("issue", "z0", "pr", "z1")]
+    edges = cluster_a + cluster_b + small
+
+    mat = _build_components(edges)
+    back = _build_components_for_backfill(edges)
+
+    mat_ids = {work_unit_id(nodes) for nodes, _edges in mat}
+    back_ids = {work_unit_id(nodes) for nodes in back}
+    assert mat_ids == back_ids
+    # Sanity: both derived the same number of units.
+    assert len(mat) == len(back)
+
+
+def test_materialize_and_backfill_identical_when_component_is_split(monkeypatch):
+    # Force a small cap via env so the star is oversized and split; both paths
+    # must still agree on the resulting unit ids.
+    monkeypatch.setenv("INVESTMENT_MAX_COMPONENT_NODES", "5")
+    edges = [_edge("pr", "hub", "issue", f"S-{i}") for i in range(20)] + [
+        _edge("issue", "p0", "pr", "p1"),
+        _edge("pr", "p1", "commit", "p2"),
+    ]
+
+    mat = _build_components(edges)
+    back = _build_components_for_backfill(edges)
+
+    assert {work_unit_id(n) for n, _e in mat} == {work_unit_id(n) for n in back}
+
+
+# ---------------------------------------------------------------------------
+# Constant / resolver behavior.
+# ---------------------------------------------------------------------------
+
+
+def test_resolve_max_component_nodes_precedence(monkeypatch):
+    assert resolve_max_component_nodes(42) == 42
+    monkeypatch.delenv("INVESTMENT_MAX_COMPONENT_NODES", raising=False)
+    assert resolve_max_component_nodes() == INVESTMENT_MAX_COMPONENT_NODES
+    monkeypatch.setenv("INVESTMENT_MAX_COMPONENT_NODES", "77")
+    assert resolve_max_component_nodes() == 77
+    monkeypatch.setenv("INVESTMENT_MAX_COMPONENT_NODES", "not-an-int")
+    assert resolve_max_component_nodes() == INVESTMENT_MAX_COMPONENT_NODES
+    monkeypatch.setenv("INVESTMENT_MAX_COMPONENT_NODES", "0")
+    assert resolve_max_component_nodes() == INVESTMENT_MAX_COMPONENT_NODES

--- a/tests/work_graph/test_investment_components.py
+++ b/tests/work_graph/test_investment_components.py
@@ -322,3 +322,41 @@ def test_resolve_max_component_nodes_precedence(monkeypatch):
     assert resolve_max_component_nodes() == INVESTMENT_MAX_COMPONENT_NODES
     monkeypatch.setenv("INVESTMENT_MAX_COMPONENT_NODES", "0")
     assert resolve_max_component_nodes() == INVESTMENT_MAX_COMPONENT_NODES
+
+
+def test_fetch_dedups_rmt_versions_and_orders_deterministically(monkeypatch):
+    """CHAOS-2775 codex round 2 (MEDIUM + HIGH): the fetch must
+
+    1. argMax-collapse ReplacingMergeTree row versions per edge identity and
+       judge the heuristic filter on the LATEST provenance (a stale pre-merge
+       row must not resurrect an excluded edge), and
+    2. ORDER BY the full identity key so component discovery order — and with
+       it the positional component_indexes used by partitioned dispatch — is
+       identical across dispatcher and chunk workers.
+
+    The HAVING clause must reference the SELECT alias, NOT repeat
+    argMax(provenance, ...): the alias shadows the raw column and
+    re-aggregating raises ILLEGAL_AGGREGATION (184) on ClickHouse 26.x — the
+    same trap documented on LATEST_WORK_UNIT_INVESTMENTS_CTE.
+    """
+    captured: dict[str, Any] = {}
+
+    def fake_query_dicts(_sink, query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(q, "query_dicts", fake_query_dicts)
+    sink = cast(BaseMetricsSink, object())
+
+    q.fetch_work_graph_edges(sink, org_id="org-1")
+
+    query = captured["query"]
+    identity = "org_id, source_type, source_id, edge_type, target_type, target_id"
+    assert f"GROUP BY {identity}" in query
+    assert f"ORDER BY {identity}" in query
+    assert "argMax(provenance, last_synced) AS provenance" in query
+    assert "argMax(confidence, last_synced) AS confidence" in query
+    # Alias (not aggregate) in HAVING — ILLEGAL_AGGREGATION regression guard.
+    assert "HAVING provenance != %(heuristic_provenance)s" in query
+    assert "HAVING argMax" not in query

--- a/tests/work_graph/test_investment_materialize.py
+++ b/tests/work_graph/test_investment_materialize.py
@@ -1478,7 +1478,14 @@ async def test_materialize_passes_configured_llm_credentials(monkeypatch):
 
     stats = await materialize_investments(config)
 
-    assert stats == {"components": 0, "records": 0, "quotes": 0}
+    assert stats == {
+        "components": 0,
+        "records": 0,
+        "quotes": 0,
+        "oversized_components": 0,
+        "dropped_edges": 0,
+        "dropped_nodes": 0,
+    }
     assert captured == {
         "name": "openai",
         "model": "gpt-4o-mini",


### PR DESCRIPTION
## Problem (CHAOS-2775)

Investment work units are connected components of `work_graph_edges`. Two
pathologies let a single densely-linked hub percolate thousands of unrelated
nodes into **one giant work unit** that dominated ~92% of the Investment
allocation chart (a ~700k-churn, `repo_id` NULL "issue" unit):

1. **Heuristic edges were included.** `fetch_work_graph_edges` pulled EVERY
   edge, including `provenance='heuristic'` — rule-inferred `time_window_7d`
   `relates` edges emitted at `builder.py:1360` (confidence 0.3). On org
   `70d529e0` that is **5298 heuristic edges** (avg conf 0.43) gluing ~2559
   issues + 658 PRs + 590 commits into one component.
2. **No component size cap.** Even after excluding heuristic edges, a
   high-degree native/explicit_text hub (a changelog PR at degree ~74 on real
   data) can still form an oversized unit.

## Fix

- **Exclude heuristic edges at the choke point.** `fetch_work_graph_edges` gains
  `exclude_heuristic=True` (default-on), a **parameterized** predicate
  (`provenance != %(heuristic_provenance)s`, no value interpolation). Heuristic
  edges remain in the table for display / other consumers; only work-unit
  grouping excludes them. Default-on keeps the materializer, the dispatch
  enumerator (`work_graph_tasks`), and the membership backfill consistent with
  **no call-site changes** (backward-compatible signature).
- **Single shared component builder.** New
  `work_graph/investment/components.build_components()` is the one source of
  truth for connected-component grouping + oversized-component splitting. Both
  `materialize._build_components` and `backfill._build_components_for_backfill`
  now delegate to it, so their `work_unit_id` hashes **cannot drift** (membership
  scoping depends on identical hashes across the LLM and no-LLM paths).
- **Deterministic size cap.** Components larger than
  `INVESTMENT_MAX_COMPONENT_NODES` (new constant, default **150**,
  env-overridable via `INVESTMENT_MAX_COMPONENT_NODES`) are split:
  1. drop lowest-confidence edges ordered by `(confidence, edge_id)` until every
     fragment fits (binary search on the drop prefix; edges tied at the
     component's max confidence are never dropped here);
  2. if a fragment is still too big using only max-confidence edges, remove the
     highest-degree hub node(s), tie-broken by node id, until it fits.
  Counts are surfaced in the run stats dict (`oversized_components`,
  `dropped_edges`, `dropped_nodes`) and logged — **no silent truncation**.

## Tests (`tests/work_graph/test_investment_components.py`)

- **Percolation regression:** a 60-node blob glued only by heuristic edges forms
  no giant unit once fetch strips heuristic edges.
- **Split determinism:** identical fragments across two runs for both the
  low-confidence-bridge drop and the max-confidence hub-removal paths (+ a
  30-node chain).
- **Hash consistency:** `materialize` vs `backfill` produce identical
  `work_unit_id` sets, including under a forced (`INVESTMENT_MAX_COMPONENT_NODES=5`)
  split.
- **Fetch filter:** heuristic excluded by default (parameterized), native /
  explicit_text kept; `exclude_heuristic=False` restores prior behavior.
- Constant/resolver precedence (arg > env > default; rejects non-positive /
  unparseable).

## Validation

- `ci/local_validate.sh`: **GATE PASSED** — ruff format/check, mypy, full unit
  suite (**6269 passed, 44 skipped**), live-ClickHouse argMax proof.
- `mypy --install-types --non-interactive .`: clean (1279 files).

Closes CHAOS-2775.
