### PR TITLE
fix(sync): run membership projection after windowed post-sync materialize (CHAOS-2776)

### DIFF
--- a/docs/architecture/investment-data-model.md
+++ b/docs/architecture/investment-data-model.md
@@ -117,6 +117,55 @@ before ClickHouse has compacted older ReplacingMergeTree versions.
 
 ---
 
+## Membership projection & completion marker — write side (CHAOS-2433 / CHAOS-2776)
+
+The read-side scope guard above arms only when the latest complete
+`work_unit_membership_runs` marker is **at least as recent as** every
+`work_unit_investments` row. That marker is published exclusively by the no-LLM
+**membership projection** (`work_graph.investment.backfill.backfill_memberships`),
+which runs in three places:
+
+- **post-sync** (the fresh-data path): `run_work_graph_build` →
+  `dispatch_investment_materialize_partitioned` (LLM materialize, chunked chord)
+  → its finalizer runs the projection.
+- **daily floor cadence** (03:30 UTC): `dispatch_membership_backfill` fans out a
+  cheap `build → project` chain per active org.
+- **operator CLI**: `dev-hops investment materialize` runs the projection inline
+  after a successful materialize.
+
+**The projection is full-coverage by construction.** It iterates the *entire*
+current work graph and projects membership from the latest persisted investments
+per unit (`argMax(computed_at)`), so its coverage is **independent of any
+materialize window**. A `--from`/`--to`/`--window-days` bound only limits which
+WorkUnits receive *new* LLM investment rows; it does **not** limit which units the
+projection republishes. The marker is stamped with the run's **completion time**
+(`now()` at marker write, not run start) so overlapping runs resolve by which
+finished last.
+
+**Publish gate = SCOPE, not window (CHAOS-2776).** Whether a run publishes the
+org-wide marker is decided solely by whether it is **repo/team-scoped**:
+
+| Run shape | Publishes org-wide marker? | Why |
+| --------- | -------------------------- | --- |
+| Org-wide, no window | ✅ | Full coverage. |
+| Org-wide, windowed (`--from`/`--to`, or the post-sync sync window) | ✅ | Projection coverage is window-independent, so it is still full-coverage. |
+| Repo- or team-scoped | ❌ | A scoped projection covers only in-scope units; publishing it as the org's latest marker would blank every other repo for unscoped reads. Scoped runs rely on the daily org-wide projection to republish. |
+
+**CHAOS-2776 bug & fix.** Previously both the Celery finalizer
+(`finalize_investment_materialize_partitioned` via
+`dispatch_investment_materialize_partitioned`) and the CLI *also* skipped the
+projection for **windowed** runs. But the post-sync dispatcher *always* forwards
+the sync window as `from_date`/`to_date`, so the finalizer **never** projected
+after a post-sync materialize. The marker then lagged the freshly-written
+investments, the read guard fell back to `unscoped_fallback` (emitting
+`investment_membership_scope_stale`), and stale work-unit generations flooded the
+Investment charts until the next daily 03:30 projection — which the next sync
+immediately re-disarmed. The fix gates the projection on **scope only**
+(`not (repo_ids or team_ids)`), so windowed org-wide runs project and re-arm the
+guard on every sync.
+
+---
+
 ## Related
 
 - [Investment Categorization Pipeline](investment-categorization-pipeline.md) — how rows are produced

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -1053,7 +1053,8 @@ Materialize WorkUnit investment categorization (theme/subcategory distributions 
 # Full org materialization (publishes coverage marker)
 dev-hops investment materialize --db "$CLICKHOUSE_URI" --org "$ORG_ID"
 
-# Date-windowed refresh (does NOT publish org-wide coverage marker)
+# Date-windowed refresh (unscoped → still publishes the org-wide coverage
+# marker via the full-coverage membership projection; CHAOS-2776)
 dev-hops investment materialize --window-days 30 --llm-provider none
 ```
 
@@ -1062,8 +1063,8 @@ dev-hops investment materialize --window-days 30 --llm-provider none
 |--------|-------------|
 | `--db` | ClickHouse connection string (default: `CLICKHOUSE_URI`) |
 | `--from` / `--to` | Date range (`--from` defaults to `--window-days` before `--to`; `--to` defaults to now) |
-| `--window-days` | Window size when `--from` is not set (default: 30). Marks the run as date-windowed: refreshes investments only, no org-wide coverage marker |
-| `--repo-id` / `--team-id` | Filter to specific repos/teams |
+| `--window-days` | Window size when `--from` is not set (default: 30). Windowing does NOT suppress the org-wide membership marker — the post-run projection is full-coverage by construction (CHAOS-2776) |
+| `--repo-id` / `--team-id` | Filter to specific repos/teams. Scoped runs skip the membership projection and publish no org-wide marker |
 | `-l, --llm-provider` | LLM provider (`auto`, `openai`, `anthropic`, `local`, `mock`, `none`). Use `none` for distributions without explanations |
 | `-m, --model` | LLM model name (overrides provider default) |
 | `--persist-evidence-snippets` / `--no-persist-evidence-snippets` | Persist or skip extractive evidence quotes |

--- a/docs/ops/investment-materialization.md
+++ b/docs/ops/investment-materialization.md
@@ -156,7 +156,7 @@ successful materialize. The projection is full-coverage by construction, so an
 **unscoped** run publishes a full-coverage org-wide membership marker **even when
 windowed** (CHAOS-2776); only `--repo-id`/`--team-id` scoping suppresses the
 org-wide marker. See
-[Investment Data Model → Membership projection & completion marker](../architecture/investment-data-model.md#membership-projection--completion-marker--write-side-chaos-2433--chaos-2776).
+[Investment Data Model → Membership projection & completion marker](../architecture/investment-data-model.md#membership-projection-completion-marker-write-side-chaos-2433-chaos-2776).
 
 ### Output
 

--- a/docs/ops/investment-materialization.md
+++ b/docs/ops/investment-materialization.md
@@ -151,6 +151,13 @@ but they do **not** bound how components are **formed** — components are built
 full edge set first, then filtered. See the
 [pipeline doc](../architecture/investment-categorization-pipeline.md#step-1-form-the-workunit).
 
+They likewise do **not** bound the **membership projection** that runs after a
+successful materialize. The projection is full-coverage by construction, so an
+**unscoped** run publishes a full-coverage org-wide membership marker **even when
+windowed** (CHAOS-2776); only `--repo-id`/`--team-id` scoping suppresses the
+org-wide marker. See
+[Investment Data Model → Membership projection & completion marker](../architecture/investment-data-model.md#membership-projection--completion-marker--write-side-chaos-2433--chaos-2776).
+
 ### Output
 
 On success the command logs `Components=… Records=… Quotes=…` and returns exit code `0`.

--- a/src/dev_health_ops/work_graph/runner.py
+++ b/src/dev_health_ops/work_graph/runner.py
@@ -259,15 +259,22 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
     # synchronously after a successful materialization (a direct call, not a
     # Celery dispatch, so the CLI is complete on return).
     #
-    # COVERAGE RULE (finding #2, unchanged): only an ORG-WIDE FULL-COVERAGE run may
-    # publish the org-wide marker. A repo/team-SCOPED OR date-WINDOWED manual
-    # materialize must NOT publish an org marker (it would blank out-of-scope /
-    # out-of-window components under the new latest marker). We detect a
-    # date-windowed run by whether the operator explicitly bounded the window via
-    # --from/--to/--window-days. Such scoped/windowed runs refresh investments
-    # only; the org-wide daily projection republishes the full-coverage marker.
-    explicitly_windowed = bool(ns.from_date or ns.to_date or ns.window_days)
-    is_full_org_wide = not repo_ids and not team_ids and not explicitly_windowed
+    # COVERAGE RULE (CHAOS-2433 finding #2, AMENDED by CHAOS-2776): the publish
+    # gate is SCOPE, not window. ``backfill_memberships`` is ALWAYS full-coverage
+    # BY CONSTRUCTION — it iterates the FULL current work graph and projects from
+    # the latest persisted investments per unit (argMax(computed_at)), regardless
+    # of the materialize window. --from/--to/--window-days only bound which units
+    # get NEW LLM investment rows; they do NOT bound projection coverage. So an
+    # UNSCOPED-but-WINDOWED materialize is safe to project: it republishes a
+    # full-coverage marker at >= the newest investment clock and re-arms the
+    # read-path stale-generation guard (CHAOS-2764). Previously we ALSO skipped
+    # the projection for windowed runs, which — mirroring the post-sync Celery bug
+    # this ticket fixes — left investments newer than the marker
+    # (scope_mode='unscoped_fallback') until the daily 03:30 org-wide projection.
+    # Only a repo/team-SCOPED run must NOT publish the org marker (a scoped
+    # projection covers only in-scope units and would blank other repos for
+    # unscoped reads); it relies on the org-wide daily projection to republish.
+    is_org_wide = not repo_ids and not team_ids
 
     logging.info(f"Materializing investments from {config.from_ts} to {config.to_ts}")
     try:
@@ -282,9 +289,11 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
         logging.error(f"Investment materialization failed: {e}")
         return 1
 
-    if is_full_org_wide:
+    if is_org_wide:
         # Publish a fresh full-coverage membership run + marker so theme filters
-        # read the new investments. The projection is no-LLM and synchronous.
+        # read the new investments. The projection is no-LLM and synchronous, and
+        # its coverage is independent of any --from/--to/--window-days on this run
+        # (CHAOS-2776).
         from dev_health_ops.work_graph.investment.backfill import (
             MembershipBackfillConfig,
             backfill_memberships,
@@ -310,12 +319,11 @@ def run_investment_materialization(ns: argparse.Namespace) -> int:
             return 1
     else:
         logging.info(
-            "Scoped/windowed materialization (repos=%s teams=%s windowed=%s) — "
-            "NOT publishing an org-wide membership marker; the org-wide daily "
-            "projection republishes full coverage (CHAOS-2433).",
+            "Scoped materialization (repos=%s teams=%s) — NOT publishing an "
+            "org-wide membership marker; the org-wide daily projection "
+            "republishes full coverage (CHAOS-2433/2776).",
             repo_ids or None,
             team_ids or None,
-            explicitly_windowed,
         )
 
     return 0
@@ -438,9 +446,11 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         type=int,
         default=None,
         help="Window size in days when --from is not set (default: 30). "
-        "Passing this (or --from/--to) marks the run as date-windowed, so it "
-        "refreshes investments only and does NOT publish an org-wide membership "
-        "marker (CHAOS-2433 coverage rule).",
+        "Bounds which WorkUnits get NEW LLM investment rows; it does NOT bound "
+        "membership-projection coverage, so an unscoped windowed run still "
+        "publishes a full-coverage org-wide membership marker (CHAOS-2776). "
+        "Only --repo-id/--team-id scoping suppresses the org-wide marker "
+        "(CHAOS-2433 coverage rule).",
     )
     investment_materialize.add_argument(
         "--repo-id",

--- a/src/dev_health_ops/workers/work_graph_tasks.py
+++ b/src/dev_health_ops/workers/work_graph_tasks.py
@@ -527,7 +527,32 @@ def dispatch_investment_materialize_partitioned(
     from dev_health_ops.work_graph.investment.queries import fetch_work_graph_edges
 
     # Hoisted to guarantee definite assignment on every return path (CodeQL).
-    run_membership = not (repo_ids or team_ids or from_date or to_date)
+    #
+    # CHAOS-2776: gate the finalizer's membership projection on SCOPE, not window.
+    # The finalizer runs ``backfill_memberships`` (see
+    # ``work_graph.investment.backfill`` module docstring for the CHAOS-2433
+    # run-marker protocol), which is ALWAYS full-coverage BY CONSTRUCTION: it
+    # iterates the FULL current work graph and projects from the latest persisted
+    # investments per unit (argMax(computed_at)), independent of any materialize
+    # window. ``from_date``/``to_date`` only bound which units get NEW LLM
+    # investment rows; they do NOT bound projection coverage. So running the
+    # projection after a WINDOWED org-wide materialize is safe and correct — it
+    # republishes a full-coverage org-wide completion marker at >= the newest
+    # investment clock, re-arming the read-path stale-generation guard
+    # (CHAOS-2764, api/queries/investment_membership_scope.py).
+    #
+    # The old ``... or from_date or to_date`` gate broke the post-sync path: the
+    # dispatcher (post_sync_dispatch.py) ALWAYS forwards the sync window as
+    # from_date/to_date, so the finalizer NEVER projected after a post-sync
+    # materialize. The guard then disarmed (investments newer than the marker,
+    # scope_mode='unscoped_fallback') until the next daily 03:30 org-wide
+    # projection — which the next sync immediately disarmed again, flooding the
+    # Investment charts with stale work-unit generations (~18x effort inflation).
+    #
+    # Only repo/team-SCOPED runs must still skip publishing the org-wide marker: a
+    # scoped projection would only cover in-scope units and blank every other
+    # repo's membership for unscoped reads.
+    run_membership = not (repo_ids or team_ids)
 
     # Resolve the component-size cap ONCE and freeze it for the whole
     # partitioned run: chunk workers rebuild the component list from a fresh

--- a/tests/api/test_investment_membership_scope_projection_live.py
+++ b/tests/api/test_investment_membership_scope_projection_live.py
@@ -1,0 +1,158 @@
+"""Live-ClickHouse integration for CHAOS-2776: the no-LLM membership projection
+re-arms the read-path stale-generation guard.
+
+Reproduces the CHAOS-2776 incident end-to-end against a real ClickHouse:
+
+  1. An OLD org-wide membership marker exists (completed at ``old_ts``).
+  2. A NEWER ``work_unit_investments`` row (computed at ``mid_ts`` > ``old_ts``)
+     makes the read-path scope state fall back to ``unscoped_fallback`` —
+     investments are newer than the latest marker, so scoped reads disarm and
+     stale work-unit generations flood the Investment charts (the ~18x effort
+     inflation observed in the incident).
+  3. Running ``backfill_memberships`` (the full-coverage projection the finalizer
+     now runs after a WINDOWED org-wide post-sync materialize — the fix) publishes
+     a FRESH org-wide marker stamped with the COMPLETION time (``now()`` >>
+     ``mid_ts``), so the scope state returns to ``scoped``.
+
+The projection's coverage is independent of any materialize window, which is why
+running it after a windowed org-wide materialize is safe and correct — the exact
+property the CHAOS-2776 gating change relies on.
+
+Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+from dev_health_ops.api.queries.investment_membership_scope import (
+    fetch_investment_membership_scope_state,
+)
+from dev_health_ops.work_graph.investment.backfill import (
+    MembershipBackfillConfig,
+    backfill_memberships,
+)
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+def _edge_cols() -> list[str]:
+    return [
+        "org_id",
+        "edge_id",
+        "source_type",
+        "source_id",
+        "target_type",
+        "target_id",
+        "edge_type",
+        "repo_id",
+        "provider",
+        "provenance",
+        "confidence",
+        "evidence",
+        "discovered_at",
+        "last_synced",
+        "event_ts",
+        "day",
+    ]
+
+
+def _membership_run_cols() -> list[str]:
+    return ["org_id", "run_id", "completed_at"]
+
+
+def _investment_cols() -> list[str]:
+    return ["org_id", "work_unit_id", "computed_at"]
+
+
+@pytest.mark.asyncio
+async def test_projection_after_windowed_materialize_restores_scoped_state(sink):
+    """After the projection runs, the scope state flips unscoped_fallback ->
+    scoped (CHAOS-2776)."""
+    org_id = f"test-chaos-2776-{uuid.uuid4()}"
+    node_id = f"ISSUE-{uuid.uuid4()}"
+    pr_id = f"PR-{uuid.uuid4()}"
+    edge_id = f"edge-{uuid.uuid4()}"
+    repo_uuid = str(uuid.uuid4())
+
+    old_marker_ts = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    # Investment newer than the OLD marker -> read path falls back to unscoped.
+    investment_ts = datetime(2026, 2, 1, tzinfo=timezone.utc)
+    old_run_id = uuid.uuid4().hex
+
+    # One edge => one current work-graph component => the projection has something
+    # to iterate and will publish an org-wide completion marker.
+    edge_rows = [
+        [
+            org_id,
+            edge_id,
+            "issue",
+            node_id,
+            "pr",
+            pr_id,
+            "implements",
+            repo_uuid,
+            "github",
+            "native",
+            1.0,
+            "",
+            investment_ts,
+            investment_ts,
+            investment_ts,
+            investment_ts.date(),
+        ]
+    ]
+    # A prior COMPLETE org-wide marker at old_marker_ts.
+    run_marker_rows = [[org_id, old_run_id, old_marker_ts]]
+    # A newer investments row -> latest_investment_computed_at > latest marker.
+    # Only org_id + computed_at feed the scope-state clock; the rest default.
+    investment_rows = [[org_id, f"U-{uuid.uuid4()}", investment_ts]]
+
+    sink.client.insert("work_graph_edges", edge_rows, column_names=_edge_cols())
+    sink.client.insert(
+        "work_unit_membership_runs",
+        run_marker_rows,
+        column_names=_membership_run_cols(),
+    )
+    sink.client.insert(
+        "work_unit_investments", investment_rows, column_names=_investment_cols()
+    )
+
+    # BEFORE the projection: investments are newer than the marker -> fallback.
+    before = await fetch_investment_membership_scope_state(sink, org_id=org_id)
+    assert before.scope_mode == "unscoped_fallback"
+    assert before.lag_seconds > 0
+
+    # Run the real no-LLM projection (org-wide: repo_ids=None). It publishes a
+    # fresh marker stamped at COMPLETION time (now() >> investment_ts).
+    assert CLICKHOUSE_URI is not None  # narrowed by pytestmark.skipif
+    backfill_memberships(
+        MembershipBackfillConfig(dsn=CLICKHOUSE_URI, org_id=org_id, repo_ids=None)
+    )
+
+    # AFTER the projection: the newest marker is >= the investment clock -> scoped.
+    after = await fetch_investment_membership_scope_state(sink, org_id=org_id)
+    assert after.scope_mode == "scoped"

--- a/tests/test_investment_materialize_partitioned.py
+++ b/tests/test_investment_materialize_partitioned.py
@@ -141,7 +141,15 @@ def test_dispatch_partitioned_materialize_uses_env_batch_defaults(monkeypatch) -
     assert chunk_kwargs["llm_batch_timeout_seconds"] == 123.0
 
 
-def test_dispatch_partitioned_materialize_skips_marker_for_windowed_run() -> None:
+def test_dispatch_partitioned_materialize_runs_marker_for_windowed_org_wide_run() -> (
+    None
+):
+    """CHAOS-2776: a WINDOWED but UNSCOPED run (org-wide, from/to only) must still
+    project membership in the finalizer. The projection is full-coverage by
+    construction (independent of the materialize window), so this republishes the
+    org-wide marker and re-arms the read-path stale-generation guard. This is the
+    post-sync path — the dispatcher always forwards the sync window — so before
+    the fix the projection never ran after a post-sync materialize."""
     with (
         patch(
             "dev_health_ops.metrics.sinks.factory.create_sink",
@@ -159,7 +167,7 @@ def test_dispatch_partitioned_materialize_skips_marker_for_windowed_run() -> Non
     ):
         mock_chord.return_value = MagicMock()
         task = cast(Any, dispatch_investment_materialize_partitioned)
-        task.run(
+        result = task.run(
             db_url="clickhouse://x",
             org_id="org-1",
             from_date="2026-01-01",
@@ -167,7 +175,77 @@ def test_dispatch_partitioned_materialize_skips_marker_for_windowed_run() -> Non
         )
 
     callback = mock_chord.call_args.args[1]
+    assert callback.sig_kwargs["kwargs"]["run_membership_backfill_after"] is True
+    assert result["membership_in_finalizer"] is True
+
+
+def test_dispatch_partitioned_materialize_skips_marker_for_repo_scoped_run() -> None:
+    """A repo-SCOPED run must NOT project the org-wide marker (it would only cover
+    in-scope units and blank other repos for unscoped reads)."""
+    with (
+        patch(
+            "dev_health_ops.metrics.sinks.factory.create_sink",
+            return_value=_FakeSink(),
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.queries.fetch_work_graph_edges",
+            return_value=[_edge(1)],
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.celery_app.signature",
+            side_effect=_signature_factory,
+        ),
+        patch("dev_health_ops.workers.work_graph_tasks.chord") as mock_chord,
+    ):
+        mock_chord.return_value = MagicMock()
+        task = cast(Any, dispatch_investment_materialize_partitioned)
+        result = task.run(
+            db_url="clickhouse://x",
+            org_id="org-1",
+            repo_ids=["repo-1"],
+            from_date="2026-01-01",
+            to_date="2026-01-02",
+        )
+
+    callback = mock_chord.call_args.args[1]
     assert callback.sig_kwargs["kwargs"]["run_membership_backfill_after"] is False
+    assert result["membership_in_finalizer"] is False
+
+
+def test_dispatch_partitioned_materialize_skips_marker_for_team_scoped_run() -> None:
+    """A team-SCOPED run must NOT project the org-wide marker."""
+    with (
+        patch(
+            "dev_health_ops.metrics.sinks.factory.create_sink",
+            return_value=_FakeSink(),
+        ),
+        # team_ids resolve to concrete repo_ids inside the materialize module; patch
+        # there because dispatch imports _resolve_repo_ids locally from that module.
+        patch(
+            "dev_health_ops.work_graph.investment.materialize._resolve_repo_ids",
+            return_value=["repo-1"],
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.queries.fetch_work_graph_edges",
+            return_value=[_edge(1)],
+        ),
+        patch(
+            "dev_health_ops.workers.work_graph_tasks.celery_app.signature",
+            side_effect=_signature_factory,
+        ),
+        patch("dev_health_ops.workers.work_graph_tasks.chord") as mock_chord,
+    ):
+        mock_chord.return_value = MagicMock()
+        task = cast(Any, dispatch_investment_materialize_partitioned)
+        result = task.run(
+            db_url="clickhouse://x",
+            org_id="org-1",
+            team_ids=["team-1"],
+        )
+
+    callback = mock_chord.call_args.args[1]
+    assert callback.sig_kwargs["kwargs"]["run_membership_backfill_after"] is False
+    assert result["membership_in_finalizer"] is False
 
 
 def test_materialize_chunk_checkpoint_skips_completed_chunk() -> None:
@@ -294,3 +372,24 @@ def test_finalize_aggregates_split_stats_by_max_not_sum() -> None:
     assert result["oversized_components"] == 2
     assert result["dropped_edges"] == 9
     assert result["dropped_nodes"] == 3
+||||||| 9deae3284
+
+
+def test_partitioned_finalizer_skips_membership_when_flag_false() -> None:
+    """A scoped run's finalizer (run_membership_backfill_after=False) aggregates
+    stats but must NOT project membership (no org-wide marker published)."""
+    with patch(
+        "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+    ) as backfill:
+        task = cast(Any, finalize_investment_materialize_partitioned)
+        result = task.run(
+            [{"stats": {"records": 2}}],
+            db_url="clickhouse://x",
+            org_id="org-1",
+            run_id="run-1",
+            run_membership_backfill_after=False,
+        )
+
+    assert result["records"] == 2
+    assert "membership" not in result
+    backfill.assert_not_called()

--- a/tests/test_investment_materialize_partitioned.py
+++ b/tests/test_investment_materialize_partitioned.py
@@ -372,7 +372,6 @@ def test_finalize_aggregates_split_stats_by_max_not_sum() -> None:
     assert result["oversized_components"] == 2
     assert result["dropped_edges"] == 9
     assert result["dropped_nodes"] == 3
-||||||| 9deae3284
 
 
 def test_partitioned_finalizer_skips_membership_when_flag_false() -> None:

--- a/tests/work_graph/test_runner.py
+++ b/tests/work_graph/test_runner.py
@@ -110,10 +110,12 @@ def test_verification_uses_builder_sink_client_when_builder_has_no_client():
 
 
 # ---------------------------------------------------------------------------
-# CHAOS-2433 round-4 finding #1: the CLI `investment materialize` entry point
-# must publish a full-coverage membership marker after an ORG-WIDE materialization
-# (the materializer writes investments only). Scoped/windowed manual runs must
-# NOT publish an org-wide marker.
+# CHAOS-2433 round-4 finding #1 (AMENDED by CHAOS-2776): the CLI `investment
+# materialize` entry point must publish a full-coverage membership marker after an
+# UNSCOPED materialization (the materializer writes investments only). The publish
+# gate is SCOPE, not window: because the no-LLM projection is full-coverage by
+# construction (independent of --from/--to/--window-days), an unscoped WINDOWED run
+# still publishes the org-wide marker. Only repo/team-SCOPED runs skip it.
 # ---------------------------------------------------------------------------
 
 
@@ -363,10 +365,12 @@ def test_cli_materialize_threads_allow_unscoped():
     backfill_mock.assert_not_called()
 
 
-def test_cli_date_windowed_materialize_skips_org_marker():
-    """An explicitly date-windowed manual materialize (--window-days / --from /
-    --to) refreshes investments only and does NOT publish an org-wide marker —
-    it could otherwise blank out-of-window components under the new marker."""
+def test_cli_date_windowed_org_wide_materialize_runs_org_marker():
+    """CHAOS-2776: an explicitly date-windowed BUT UNSCOPED manual materialize
+    (--window-days / --from / --to, no repo/team scope) STILL publishes a
+    full-coverage org-wide marker. The no-LLM projection iterates the full current
+    work graph independent of the materialize window, so it cannot publish partial
+    coverage — and running it re-arms the read-path stale-generation guard."""
     fake_materialize, materialize_mock, backfill_mock = (
         _patch_materialize_and_projection()
     )
@@ -383,6 +387,35 @@ def test_cli_date_windowed_materialize_skips_org_marker():
     ):
         # Explicit window via --window-days.
         rc = run_investment_materialization(_materialize_ns(window_days=7))
+
+    assert rc == 0
+    materialize_mock.assert_called_once()
+    backfill_mock.assert_called_once()
+    proj_config = backfill_mock.call_args.args[0]
+    assert proj_config.repo_ids is None  # org-wide projection
+    assert proj_config.is_org_wide is True
+
+
+def test_cli_date_windowed_repo_scoped_materialize_skips_org_marker():
+    """A date-windowed AND repo-scoped run still skips the org-wide marker — the
+    scope (not the window) is what suppresses publishing (CHAOS-2776)."""
+    fake_materialize, materialize_mock, backfill_mock = (
+        _patch_materialize_and_projection()
+    )
+
+    with (
+        patch(
+            "dev_health_ops.work_graph.runner.materialize_investments",
+            fake_materialize,
+        ),
+        patch(
+            "dev_health_ops.work_graph.investment.backfill.backfill_memberships",
+            backfill_mock,
+        ),
+    ):
+        rc = run_investment_materialization(
+            _materialize_ns(window_days=7, repo_id=["repo-uuid-1"])
+        )
 
     assert rc == 0
     materialize_mock.assert_called_once()


### PR DESCRIPTION
## Summary

The investment read path has a stale-generation guard (CHAOS-2764): reads are scoped to work units in the latest complete membership run, but only while `max(work_unit_investments.computed_at) <= latest work_unit_membership_runs marker`. When investments are newer than the marker, reads fall back to unscoped (`scope_mode='unscoped_fallback'`) and stale work-unit generations flood the Investment charts (observed ~18x effort inflation: 13.9M vs 761k effort; investments computed 12:19 vs marker 03:30).

## Root cause

`dispatch_investment_materialize_partitioned` gated the finalizer's membership projection on `not (repo_ids or team_ids or from_date or to_date)`. The post-sync dispatcher (`post_sync_dispatch.py`) **always** forwards the sync window as `from_date`/`to_date`, so the chord finalizer (`finalize_investment_materialize_partitioned`, `run_membership_backfill_after`) **never** ran the projection after a post-sync materialize. The guard then stayed disarmed until the daily 03:30 org-wide projection — which the next sync immediately re-disarmed.

The windowed-run exclusion conflated the **materialize window** with **projection coverage**. `backfill_memberships` is always full-coverage by construction: it iterates the full current work graph and projects from the latest persisted investments per unit (`argMax(computed_at)`), independent of any materialize window. Running it after a *windowed* org-wide materialize is safe and correct. Only repo/team-**scoped** runs must skip publishing the org-wide marker (a scoped projection would blank other repos for unscoped reads).

## Changes

- **`workers/work_graph_tasks.py`**: gate the finalizer projection on `not (repo_ids or team_ids)` — windowed org-wide runs now trigger the projection. Expanded the CHAOS-2433 comment to explain why windowed is safe and reference CHAOS-2776.
- **`work_graph/runner.py`** (CLI `dev-hops investment materialize`): mirror the fix — replaced `explicitly_windowed`/`is_full_org_wide` with scope-only `is_org_wide`; an unscoped windowed run now publishes the org-wide marker. Updated the comment block, the scoped-log message, and the `--window-days` help text.

## Protocol amendment (durable docs)

- **`docs/architecture/investment-data-model.md`**: added a "Membership projection & completion marker — write side (CHAOS-2433 / CHAOS-2776)" section documenting the full-coverage-by-construction invariant, the scope-not-window publish gate (with a run-shape table), and the CHAOS-2776 bug/fix.
- **`docs/ops/investment-materialization.md`**: note in "Time window behavior" that windowed unscoped runs still publish the org-wide marker; links to the new section.

## Tests

- Flipped `test_dispatch_partitioned_materialize_skips_marker_for_windowed_run` → `..._runs_marker_for_windowed_org_wide_run` (windowed org-wide now runs the projection; asserts `run_membership_backfill_after` / `membership_in_finalizer` True).
- Added dispatcher tests: repo-scoped and team-scoped windowed runs still skip the marker.
- Added `test_partitioned_finalizer_skips_membership_when_flag_false` (finalizer aggregates stats but does not project when the flag is False).
- CLI: flipped `test_cli_date_windowed_materialize_skips_org_marker` → `test_cli_date_windowed_org_wide_materialize_runs_org_marker`; added `test_cli_date_windowed_repo_scoped_materialize_skips_org_marker`.
- Added opt-in live integration test `tests/api/test_investment_membership_scope_projection_live.py` (`-m clickhouse`): seeds an old marker + newer investments (→ `unscoped_fallback`), runs the real `backfill_memberships`, and asserts the scope state returns to `scoped`.

## Validation

- `ci/local_validate.sh`: **GATE PASSED** — ruff format/check, mypy (no issues in 1278 files), CH scratch migrate, full unit suite (**6264 passed / 44 skipped**), argMax live-exec proof. Isolated scratch DB only; `default` untouched.

Fixes CHAOS-2776.