### PR TITLE
fix(investment): read work_unit_repo_effort in allocation Sankey fetchers (CHAOS-2777)

### DIFF
--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -79,6 +79,14 @@ LATEST_WORK_UNIT_INVESTMENTS_CTE = f"""
 # computed_at -- because the skipped path legitimately writes allocation rows
 # newer than the investments row. ``has_allocation = 1`` is an explicit
 # match flag so consumers never depend on a non-empty work_unit_id sentinel.
+#
+# KNOWN THEORETICAL EDGE (accepted, not fixed): two DIFFERENT generations of a
+# unit's allocation sharing an IDENTICAL millisecond ``computed_at`` cannot be
+# told apart by this clock — a stale repo row from the tied older generation
+# would survive. Reaching it requires a retried chunk within one
+# frozen-``computed_at`` run to compute a DIFFERENT repo set mid-run; there is
+# no per-row version column beyond ``computed_at`` to break such a tie, and a
+# schema change is not warranted for it (codex round-3 on CHAOS-2777).
 LATEST_WORK_UNIT_REPO_EFFORT_CTE = """
         latest_work_unit_repo_effort AS (
             SELECT

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -75,6 +75,45 @@ LATEST_WORK_UNIT_REPO_EFFORT_CTE = """
 """.rstrip()
 
 
+# CHAOS-2777: multi-repo work units carry a NULL scalar ``repo_id`` in
+# work_unit_investments; their real per-repo effort split lives in
+# work_unit_repo_effort (migration 064, one row per (work_unit, repo)). This
+# derived table LEFT JOINs the per-repo allocation onto
+# latest_work_unit_investments and, for units WITH allocation rows, fans each
+# unit out to one row per allocated repo -- replacing the scalar ``repo_id`` /
+# ``effort_value`` with the per-repo ``repo_id`` / ``repo_effort_value``. Units
+# WITHOUT any allocation row keep their scalar repo_id + full effort_value (the
+# ``wure.work_unit_id != ''`` guard: an unmatched LEFT JOIN fills the String key
+# with '', so this never fires for a matched row), so no unit is ever dropped.
+# Because a unit's per-repo effort sums to its total effort by construction
+# (verified live: sum(repo_effort_value) == effort_value for every allocated
+# unit), a downstream ``sum(subcategory_kv.2 * effort_value)`` is UNCHANGED for
+# single-repo units and split -- same total -- across repos for multi-repo units
+# (the allocation sum invariant). Keyed on (org_id, work_unit_id) so tenant
+# isolation is preserved. Mirrors the GraphQL compiler
+# (api/graphql/sql/compiler.py) and coverage-stats
+# (api/graphql/resolvers/analytics.py) scalar-fallback pattern. Callers MUST
+# chain LATEST_WORK_UNIT_REPO_EFFORT_CTE into the WITH clause and expose the
+# alias ``work_unit_investments`` so existing column references keep resolving.
+REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE = """
+            (
+                SELECT
+                    wui.work_unit_id AS work_unit_id,
+                    wui.from_ts AS from_ts,
+                    wui.to_ts AS to_ts,
+                    wui.org_id AS org_id,
+                    if(wure.work_unit_id != '', wure.repo_id, wui.repo_id) AS repo_id,
+                    if(wure.work_unit_id != '', wure.repo_effort_value, wui.effort_value) AS effort_value,
+                    wui.subcategory_distribution_json AS subcategory_distribution_json,
+                    wui.structural_evidence_json AS structural_evidence_json
+                FROM latest_work_unit_investments AS wui
+                LEFT JOIN latest_work_unit_repo_effort AS wure
+                    ON wure.org_id = wui.org_id
+                    AND wure.work_unit_id = wui.work_unit_id
+            ) AS work_unit_investments
+""".rstrip()
+
+
 async def _query_investment_dicts(
     sink: BaseMetricsSink, query: str, params: dict[str, Any]
 ) -> list[dict[str, Any]]:
@@ -424,6 +463,7 @@ async def fetch_investment_repo_team_edges(
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
         WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE},
+        {LATEST_WORK_UNIT_REPO_EFFORT_CTE},
         unit_team AS (
             SELECT
                 work_unit_id,
@@ -460,7 +500,7 @@ async def fetch_investment_repo_team_edges(
             ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id))) AS repo,
             ifNull(nullIf(unit_team.team, ''), 'unassigned') AS team,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM latest_work_unit_investments AS work_unit_investments
+        FROM {REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE}
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
@@ -499,6 +539,7 @@ async def fetch_investment_team_category_repo_edges(
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
         WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE},
+        {LATEST_WORK_UNIT_REPO_EFFORT_CTE},
         unit_team AS (
             SELECT
                 work_unit_id,
@@ -535,7 +576,7 @@ async def fetch_investment_team_category_repo_edges(
             splitByChar('.', subcategory_kv.1)[1] AS category,
             ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id))) AS repo,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM latest_work_unit_investments AS work_unit_investments
+        FROM {REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE}
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
@@ -574,6 +615,7 @@ async def fetch_investment_team_subcategory_repo_edges(
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
         WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE},
+        {LATEST_WORK_UNIT_REPO_EFFORT_CTE},
         unit_team AS (
             SELECT
                 work_unit_id,
@@ -610,7 +652,7 @@ async def fetch_investment_team_subcategory_repo_edges(
             subcategory_kv.1 AS subcategory,
             ifNull(r.repo, if(repo_id IS NULL, 'unassigned', toString(repo_id))) AS repo,
             sum(subcategory_kv.2 * effort_value) AS value
-        FROM latest_work_unit_investments AS work_unit_investments
+        FROM {REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE}
         LEFT JOIN repos AS r ON toString(r.id) = toString(repo_id)
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         ARRAY JOIN CAST(subcategory_distribution_json AS Array(Tuple(String, Float32))) AS subcategory_kv
@@ -653,6 +695,7 @@ async def fetch_investment_unassigned_counts(
     category_filter = f" AND ({' OR '.join(filters)})" if filters else ""
     query = f"""
         WITH {LATEST_WORK_UNIT_INVESTMENTS_CTE},
+        {LATEST_WORK_UNIT_REPO_EFFORT_CTE},
         unit_team AS (
             SELECT
                 work_unit_id,
@@ -686,12 +729,26 @@ async def fetch_investment_unassigned_counts(
             GROUP BY work_unit_id
         )
         SELECT
-            countDistinctIf(work_unit_investments.work_unit_id, repo_id IS NULL) AS missing_repo,
+            -- CHAOS-2777: a unit is only "missing repo" when it has a NULL scalar
+            -- repo_id AND no per-repo allocation row at all. Multi-repo units carry
+            -- a NULL scalar repo_id but DO have work_unit_repo_effort rows mapping
+            -- their effort to real repos, so they must NOT be counted as unassigned.
+            countDistinctIf(
+                work_unit_investments.work_unit_id,
+                repo_id IS NULL AND unit_repo_alloc.work_unit_id = ''
+            ) AS missing_repo,
             countDistinctIf(
                 work_unit_investments.work_unit_id,
                 ifNull(nullIf(unit_team.team, ''), '') = ''
             ) AS missing_team
         FROM latest_work_unit_investments AS work_unit_investments
+        LEFT JOIN (
+            SELECT org_id, work_unit_id
+            FROM latest_work_unit_repo_effort
+            GROUP BY org_id, work_unit_id
+        ) AS unit_repo_alloc
+            ON unit_repo_alloc.org_id = work_unit_investments.org_id
+            AND unit_repo_alloc.work_unit_id = work_unit_investments.work_unit_id
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         WHERE work_unit_investments.from_ts < %(end_ts)s
           AND work_unit_investments.to_ts >= %(start_ts)s

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -58,19 +58,63 @@ LATEST_WORK_UNIT_INVESTMENTS_CTE = f"""
 """.rstrip()
 
 
+# CHAOS-2777: work_unit_repo_effort is a ReplacingMergeTree deduped on
+# computed_at with the RMT/GROUP key (org_id, work_unit_id, repo_id). Each
+# materialize run stamps ALL of a unit's per-repo rows with a single run
+# ``computed_at`` (materialize.py: one clock per run) -- INCLUDING the
+# categorization-skipped path, which rewrites repo-effort even when the
+# investment row is left untouched. So a unit's allocation is versioned
+# independently of its work_unit_investments row, and if a later generation
+# emits a SMALLER repo set (a repo's churn share drops to zero), the per-repo
+# dedup key keeps the stale (unit, dropped-repo) row alive under its own older
+# ``computed_at``. A naive per-repo argMax would then fan BOTH the current repos
+# AND the stale repo out, over-counting effort and breaking the sum invariant.
+#
+# Fix: scope to the unit's LATEST allocation generation. ``d`` dedups each
+# (org, work_unit_id, repo_id) to its newest row; ``g`` is the per-unit clock
+# = max(computed_at) across ALL of that unit's repo rows (i.e. the newest run
+# that touched it). We keep only rows whose own newest ``computed_at`` equals
+# that per-unit clock, dropping repos that only exist in older generations.
+# The clock is the allocation table's OWN per-unit max -- NOT the investments
+# computed_at -- because the skipped path legitimately writes allocation rows
+# newer than the investments row. ``has_allocation = 1`` is an explicit
+# match flag so consumers never depend on a non-empty work_unit_id sentinel.
 LATEST_WORK_UNIT_REPO_EFFORT_CTE = """
         latest_work_unit_repo_effort AS (
             SELECT
-                work_unit_id,
-                repo_id,
-                argMax(effort_metric, computed_at) AS effort_metric,
-                argMax(effort_value, computed_at) AS repo_effort_value,
-                argMax(allocation_source, computed_at) AS allocation_source,
-                org_id,
-                max(computed_at) AS latest_repo_effort_computed_at
-            FROM work_unit_repo_effort
-            WHERE org_id = %(org_id)s
-            GROUP BY org_id, work_unit_id, repo_id
+                d.work_unit_id AS work_unit_id,
+                d.repo_id AS repo_id,
+                d.effort_metric AS effort_metric,
+                d.repo_effort_value AS repo_effort_value,
+                d.allocation_source AS allocation_source,
+                d.org_id AS org_id,
+                d.latest_repo_effort_computed_at AS latest_repo_effort_computed_at,
+                1 AS has_allocation
+            FROM (
+                SELECT
+                    work_unit_id,
+                    repo_id,
+                    org_id,
+                    argMax(effort_metric, computed_at) AS effort_metric,
+                    argMax(effort_value, computed_at) AS repo_effort_value,
+                    argMax(allocation_source, computed_at) AS allocation_source,
+                    max(computed_at) AS latest_repo_effort_computed_at
+                FROM work_unit_repo_effort
+                WHERE org_id = %(org_id)s
+                GROUP BY org_id, work_unit_id, repo_id
+            ) AS d
+            INNER JOIN (
+                SELECT
+                    org_id,
+                    work_unit_id,
+                    max(computed_at) AS unit_generation_at
+                FROM work_unit_repo_effort
+                WHERE org_id = %(org_id)s
+                GROUP BY org_id, work_unit_id
+            ) AS g
+                ON g.org_id = d.org_id
+                AND g.work_unit_id = d.work_unit_id
+            WHERE d.latest_repo_effort_computed_at = g.unit_generation_at
         )
 """.rstrip()
 
@@ -78,20 +122,25 @@ LATEST_WORK_UNIT_REPO_EFFORT_CTE = """
 # CHAOS-2777: multi-repo work units carry a NULL scalar ``repo_id`` in
 # work_unit_investments; their real per-repo effort split lives in
 # work_unit_repo_effort (migration 064, one row per (work_unit, repo)). This
-# derived table LEFT JOINs the per-repo allocation onto
+# derived table LEFT JOINs the latest-generation per-repo allocation onto
 # latest_work_unit_investments and, for units WITH allocation rows, fans each
 # unit out to one row per allocated repo -- replacing the scalar ``repo_id`` /
 # ``effort_value`` with the per-repo ``repo_id`` / ``repo_effort_value``. Units
-# WITHOUT any allocation row keep their scalar repo_id + full effort_value (the
-# ``wure.work_unit_id != ''`` guard: an unmatched LEFT JOIN fills the String key
-# with '', so this never fires for a matched row), so no unit is ever dropped.
+# WITHOUT any allocation row keep their scalar repo_id + full effort_value. The
+# match is gated on the explicit ``wure.has_allocation = 1`` flag (an unmatched
+# LEFT JOIN yields 0 under join_use_nulls=0 and NULL otherwise, both of which
+# fall through to the scalar branch), so no unit is ever dropped and we never
+# rely on a non-empty work_unit_id sentinel. ``has_allocation`` is re-exposed so
+# consumers (e.g. the unassigned-repo count) can tell "no allocation row" apart
+# from "allocation row with a NULL repo".
+#
 # Because a unit's per-repo effort sums to its total effort by construction
-# (verified live: sum(repo_effort_value) == effort_value for every allocated
-# unit), a downstream ``sum(subcategory_kv.2 * effort_value)`` is UNCHANGED for
-# single-repo units and split -- same total -- across repos for multi-repo units
-# (the allocation sum invariant). Keyed on (org_id, work_unit_id) so tenant
-# isolation is preserved. Mirrors the GraphQL compiler
-# (api/graphql/sql/compiler.py) and coverage-stats
+# (materialize allocates the unit's effort across its repos) AND the CTE is
+# scoped to the unit's latest allocation generation, a downstream
+# ``sum(subcategory_kv.2 * effort_value)`` is UNCHANGED for single-repo units and
+# split -- same total -- across repos for multi-repo units (the allocation sum
+# invariant). Keyed on (org_id, work_unit_id) so tenant isolation is preserved.
+# Mirrors the GraphQL compiler (api/graphql/sql/compiler.py) and coverage-stats
 # (api/graphql/resolvers/analytics.py) scalar-fallback pattern. Callers MUST
 # chain LATEST_WORK_UNIT_REPO_EFFORT_CTE into the WITH clause and expose the
 # alias ``work_unit_investments`` so existing column references keep resolving.
@@ -102,8 +151,9 @@ REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE = """
                     wui.from_ts AS from_ts,
                     wui.to_ts AS to_ts,
                     wui.org_id AS org_id,
-                    if(wure.work_unit_id != '', wure.repo_id, wui.repo_id) AS repo_id,
-                    if(wure.work_unit_id != '', wure.repo_effort_value, wui.effort_value) AS effort_value,
+                    if(wure.has_allocation = 1, wure.repo_id, wui.repo_id) AS repo_id,
+                    if(wure.has_allocation = 1, wure.repo_effort_value, wui.effort_value) AS effort_value,
+                    if(wure.has_allocation = 1, 1, 0) AS has_allocation,
                     wui.subcategory_distribution_json AS subcategory_distribution_json,
                     wui.structural_evidence_json AS structural_evidence_json
                 FROM latest_work_unit_investments AS wui
@@ -473,7 +523,7 @@ async def fetch_investment_repo_team_edges(
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM latest_work_unit_investments AS work_unit_investments
+                FROM {REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE}
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -549,7 +599,7 @@ async def fetch_investment_team_category_repo_edges(
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM latest_work_unit_investments AS work_unit_investments
+                FROM {REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE}
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -625,7 +675,7 @@ async def fetch_investment_team_subcategory_repo_edges(
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM latest_work_unit_investments AS work_unit_investments
+                FROM {REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE}
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -705,7 +755,7 @@ async def fetch_investment_unassigned_counts(
                     work_unit_investments.work_unit_id AS work_unit_id,
                     ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) AS team,
                     countIf(ifNull(nullIf(t.team_name, ''), nullIf(t.team_id, '')) IS NOT NULL) AS cnt
-                FROM latest_work_unit_investments AS work_unit_investments
+                FROM {REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE}
                 ARRAY JOIN arrayDistinct(arrayConcat(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
@@ -733,22 +783,20 @@ async def fetch_investment_unassigned_counts(
             -- repo_id AND no per-repo allocation row at all. Multi-repo units carry
             -- a NULL scalar repo_id but DO have work_unit_repo_effort rows mapping
             -- their effort to real repos, so they must NOT be counted as unassigned.
+            -- Reading from the same repo-allocated source as the Sankey edges keeps
+            -- the repo scope_filter applied to the fanned repo_id: there
+            -- ``has_allocation = 0 AND repo_id IS NULL`` is exactly the
+            -- no-allocation + NULL-scalar unit (allocated repos are non-null and
+            -- flagged), and countDistinct collapses the per-repo fan-out.
             countDistinctIf(
                 work_unit_investments.work_unit_id,
-                repo_id IS NULL AND unit_repo_alloc.work_unit_id = ''
+                has_allocation = 0 AND repo_id IS NULL
             ) AS missing_repo,
             countDistinctIf(
                 work_unit_investments.work_unit_id,
                 ifNull(nullIf(unit_team.team, ''), '') = ''
             ) AS missing_team
-        FROM latest_work_unit_investments AS work_unit_investments
-        LEFT JOIN (
-            SELECT org_id, work_unit_id
-            FROM latest_work_unit_repo_effort
-            GROUP BY org_id, work_unit_id
-        ) AS unit_repo_alloc
-            ON unit_repo_alloc.org_id = work_unit_investments.org_id
-            AND unit_repo_alloc.work_unit_id = work_unit_investments.work_unit_id
+        FROM {REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE}
         LEFT JOIN unit_team ON unit_team.work_unit_id = work_unit_investments.work_unit_id
         WHERE work_unit_investments.from_ts < %(end_ts)s
           AND work_unit_investments.to_ts >= %(start_ts)s

--- a/tests/api/test_investment_latest_row_queries.py
+++ b/tests/api/test_investment_latest_row_queries.py
@@ -306,7 +306,14 @@ async def test_investment_queries_read_latest_work_unit_rows(
 
     sql = captured["sql"]
     assert "latest_work_unit_investments AS" in sql
-    assert "FROM latest_work_unit_investments AS work_unit_investments" in sql
+    # The data source is the membership-scoped latest-row CTE. Most fetchers read
+    # it directly (``AS work_unit_investments``); the CHAOS-2777 allocation
+    # fetchers wrap it in a repo-effort fan-out derived table (``AS wui``). Either
+    # aliasing is acceptable — both read the deduped, org-scoped CTE.
+    assert (
+        "FROM latest_work_unit_investments AS work_unit_investments" in sql
+        or "FROM latest_work_unit_investments AS wui" in sql
+    )
     assert "argMax(effort_value, computed_at) AS effort_value" in sql
     assert "work_unit_investments.from_ts < %(end_ts)s" in sql
     assert "work_unit_investments.to_ts >= %(start_ts)s" in sql

--- a/tests/api/test_investment_repo_effort_live.py
+++ b/tests/api/test_investment_repo_effort_live.py
@@ -4,18 +4,32 @@ PR #1106 added ``work_unit_repo_effort`` (per-(work_unit, repo) effort fan-out)
 so multi-repo work units -- whose scalar ``work_unit_investments.repo_id`` is
 NULL -- can map effort to their real repos. The Allocation-tab Sankey fetchers
 in ``api/queries/investment.py`` originally read only the scalar ``repo_id``, so
-ANY multi-repo unit collapsed onto 'Unassigned repo'. This test seeds a
-multi-repo unit (NULL scalar repo, 3 allocation rows), a single-repo unit (scalar
-repo, no allocation rows -> scalar fallback) and a genuinely repo-less unit
-(NULL scalar, no allocation) and asserts, against REAL ClickHouse:
+ANY multi-repo unit collapsed onto 'Unassigned repo'. These tests seed
+controlled fixtures and assert, against REAL ClickHouse:
 
-* the per-repo effort split (multi-repo unit fans out across its 3 repos),
-* the SUM INVARIANT -- each unit contributes exactly its original effort, so the
-  grand total is unchanged versus the scalar path,
+* the per-repo effort split + SUM INVARIANT (each unit contributes exactly its
+  original effort, so the grand total is unchanged versus the scalar path),
 * the scalar fallback (a unit with no allocation row keeps its scalar repo +
   full effort and is never dropped),
 * ``missing_repo`` counts only units with a NULL scalar repo AND no allocation,
-* theme filtering still interacts correctly with the fan-out.
+* theme filtering still interacts correctly with the fan-out,
+* generation scoping -- a later, SMALLER allocation generation for the same
+  work_unit_id supersedes the older one, so stale repos are not fanned and the
+  sum invariant survives churn/skip rewrites (CHAOS-2777 round 2 / HIGH 1),
+* scope-filter symmetry -- a repo scope resolves the team for a multi-repo unit
+  via its in-scope allocated repo instead of collapsing to 'unassigned'
+  (CHAOS-2777 round 2 / HIGH 2).
+
+``ensure_schema(force=True)`` (re)creates the full schema, so this file must run
+against an ISOLATED scratch DB, never the real local ``default``. Provision one
+by hand, e.g.::
+
+    docker exec dev-health-clickhouse-1 clickhouse-client --query \\
+        "CREATE DATABASE IF NOT EXISTS ci_live_2777"
+    CLICKHOUSE_URI=clickhouse://ch:ch@localhost:8123/ci_live_2777 \\
+        .venv/bin/python -m pytest tests/api/test_investment_repo_effort_live.py -m clickhouse
+    docker exec dev-health-clickhouse-1 clickhouse-client --query \\
+        "DROP DATABASE ci_live_2777"
 
 Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``.
 """
@@ -25,11 +39,12 @@ from __future__ import annotations
 import os
 import uuid
 from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
 
 import pytest
 
 import dev_health_ops.api.queries.investment as investment_queries
-from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
 
@@ -37,16 +52,27 @@ pytestmark = [
     pytest.mark.clickhouse,
     pytest.mark.skipif(
         not CLICKHOUSE_URI,
-        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+        reason=(
+            "Requires CLICKHOUSE_URI pointed at an ISOLATED scratch DB, e.g. "
+            "clickhouse://ch:ch@localhost:8123/ci_live_2777"
+        ),
     ),
 ]
 
 FROM_TS = datetime(2026, 1, 5, tzinfo=timezone.utc)
 TO_TS = datetime(2026, 1, 6, tzinfo=timezone.utc)
 COMPUTED_AT = datetime(2026, 1, 7, tzinfo=timezone.utc)
+# Two allocation generations for the stale-generation test: GEN2 is newer.
+GEN1_AT = datetime(2026, 1, 7, tzinfo=timezone.utc)
+GEN2_AT = datetime(2026, 1, 9, tzinfo=timezone.utc)
 # Query window strictly containing [FROM_TS, TO_TS).
 START = datetime(2026, 1, 1, tzinfo=timezone.utc)
 END = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+
+def _scratch_db() -> str:
+    assert CLICKHOUSE_URI is not None
+    return (urlparse(CLICKHOUSE_URI).path or "").lstrip("/")
 
 
 @pytest.fixture(scope="module")
@@ -54,6 +80,14 @@ def sink():
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 
     assert CLICKHOUSE_URI is not None
+    # Safety rule (repo policy): ``ensure_schema(force=True)`` rebuilds tables, so
+    # this live test must NEVER touch the real local ``default`` database.
+    db = _scratch_db()
+    if db in ("", "default"):
+        pytest.skip(
+            "refusing to run against the 'default' database; point CLICKHOUSE_URI "
+            "at an isolated scratch DB (e.g. .../ci_live_2777)"
+        )
     s = ClickHouseMetricsSink(CLICKHOUSE_URI)
     s.ensure_schema(force=True)
     yield s
@@ -92,23 +126,47 @@ def _repo_cols() -> list[str]:
     return ["id", "repo", "created_at", "last_synced", "org_id"]
 
 
-async def _edges(sink: BaseMetricsSink, org_id: str, **kwargs) -> dict[str, float]:
-    rows = await investment_queries.fetch_investment_team_subcategory_repo_edges(
+async def _rows(
+    sink: Any,
+    org_id: str,
+    *,
+    scope_filter: str = "",
+    scope_params: dict | None = None,
+    **kwargs,
+) -> list[dict]:
+    return await investment_queries.fetch_investment_team_subcategory_repo_edges(
         sink,
         start_ts=START,
         end_ts=END,
-        scope_filter="",
-        scope_params={},
+        scope_filter=scope_filter,
+        scope_params=scope_params or {},
         org_id=org_id,
         **kwargs,
     )
+
+
+async def _edges(sink: Any, org_id: str, **kwargs) -> dict[str, float]:
     by_repo: dict[str, float] = {}
-    for row in rows:
+    for row in await _rows(sink, org_id, **kwargs):
         # Mirror build_investment_flow_response: an empty repo label (a NULL /
         # unmatched repo_id) is surfaced as the 'unassigned' repo bucket.
         label = str(row["repo"]) or "unassigned"
         by_repo[label] = by_repo.get(label, 0.0) + float(row["value"])
     return by_repo
+
+
+def _cleanup(sink: Any, org_id: str) -> None:
+    for table in (
+        "work_unit_investments",
+        "work_unit_repo_effort",
+        "repos",
+        "work_item_cycle_times",
+    ):
+        sink.client.command(
+            f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+            "SETTINGS mutations_sync=2",
+            parameters={"o": org_id},
+        )
 
 
 @pytest.mark.asyncio
@@ -246,9 +304,165 @@ async def test_allocation_sankey_reads_repo_effort(sink):
         )
         assert counts_ft["missing_repo"] == 0, counts_ft
     finally:
-        for table in ("work_unit_investments", "work_unit_repo_effort", "repos"):
-            sink.client.command(
-                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
-                "SETTINGS mutations_sync=2",
-                parameters={"o": org},
-            )
+        _cleanup(sink, org)
+
+
+@pytest.mark.asyncio
+async def test_repo_effort_scopes_to_latest_generation(sink):
+    """CHAOS-2777 round 2 / HIGH 1: work_unit_repo_effort is deduped per
+    (org, work_unit_id, repo_id), so when a later materialize generation emits a
+    SMALLER repo set for the same work_unit_id (a repo's churn share drops to
+    zero), the stale (unit, dropped-repo) row survives under its own older
+    computed_at. Without generation scoping the fan-out would add that stale
+    repo's effort and break the sum invariant.
+
+    Two generations for one unit: GEN1 splits 40/60 across repo1/repo2; GEN2
+    (newer) allocates the whole 100 to repo1 only. The unit's investments row is
+    left at GEN1's clock (older than GEN2) to mirror the categorization-skipped
+    path, which rewrites allocation newer than the investments row -- proving the
+    generation clock is the allocation table's own per-unit max, not the
+    investments computed_at. Only GEN2 must be fanned out.
+    """
+    org = f"test-chaos-2777-gen-{uuid.uuid4()}"
+    repo1, repo2 = uuid.uuid4(), uuid.uuid4()
+    feature = {"Feature Delivery.product": 1.0}
+
+    try:
+        sink.client.insert(
+            "repos",
+            [
+                [repo1, "repo-one", COMPUTED_AT, COMPUTED_AT, org],
+                [repo2, "repo-two", COMPUTED_AT, COMPUTED_AT, org],
+            ],
+            column_names=_repo_cols(),
+        )
+        # Investments row stamped at the OLDER generation clock (skipped path).
+        sink.client.insert(
+            "work_unit_investments",
+            [
+                [
+                    "wu-gen",
+                    FROM_TS,
+                    TO_TS,
+                    None,
+                    "fte_days",
+                    100.0,
+                    feature,
+                    "{}",
+                    GEN1_AT,
+                    org,
+                ]
+            ],
+            column_names=_wui_cols(),
+        )
+        sink.client.insert(
+            "work_unit_repo_effort",
+            [
+                # GEN1: 40/60 split.
+                ["wu-gen", repo1, "fte_days", 40.0, 0.4, "structural", GEN1_AT, org],
+                ["wu-gen", repo2, "fte_days", 60.0, 0.6, "structural", GEN1_AT, org],
+                # GEN2 (newer): repo2 dropped, all 100 on repo1.
+                ["wu-gen", repo1, "fte_days", 100.0, 1.0, "structural", GEN2_AT, org],
+            ],
+            column_names=_wure_cols(),
+        )
+
+        by_repo = await _edges(sink, org)
+        # Only the latest generation is fanned: repo1 = 100, repo2 gone.
+        assert by_repo.get("repo-one") == pytest.approx(100.0), by_repo
+        assert "repo-two" not in by_repo, by_repo
+        # SUM INVARIANT survives the shrink: total == unit effort, NOT 160.
+        assert sum(by_repo.values()) == pytest.approx(100.0), by_repo
+    finally:
+        _cleanup(sink, org)
+
+
+@pytest.mark.asyncio
+async def test_scope_filter_resolves_team_for_multi_repo_unit(sink):
+    """CHAOS-2777 round 2 / HIGH 2: under a repo scope_filter the unit_team CTE
+    must read the SAME repo-allocated source as the outer flow, so the filter
+    applies to the fanned repo_id. A multi-repo unit with a NULL scalar repo but
+    an in-scope allocated repo must resolve its team, not collapse to
+    'unassigned' (which happened while unit_team still filtered scalar repo_id).
+    """
+    org = f"test-chaos-2777-scope-{uuid.uuid4()}"
+    repo_in, repo_out = uuid.uuid4(), uuid.uuid4()
+    feature = {"Feature Delivery.product": 1.0}
+    evidence = '{"issues": ["ISSUE-SCOPE-1"]}'
+
+    try:
+        sink.client.insert(
+            "repos",
+            [
+                [repo_in, "repo-in", COMPUTED_AT, COMPUTED_AT, org],
+                [repo_out, "repo-out", COMPUTED_AT, COMPUTED_AT, org],
+            ],
+            column_names=_repo_cols(),
+        )
+        sink.client.insert(
+            "work_unit_investments",
+            [
+                [
+                    "wu-scope",
+                    FROM_TS,
+                    TO_TS,
+                    None,
+                    "fte_days",
+                    100.0,
+                    feature,
+                    evidence,
+                    COMPUTED_AT,
+                    org,
+                ]
+            ],
+            column_names=_wui_cols(),
+        )
+        sink.client.insert(
+            "work_unit_repo_effort",
+            [
+                [
+                    "wu-scope",
+                    repo_in,
+                    "fte_days",
+                    70.0,
+                    0.7,
+                    "structural",
+                    COMPUTED_AT,
+                    org,
+                ],
+                [
+                    "wu-scope",
+                    repo_out,
+                    "fte_days",
+                    30.0,
+                    0.3,
+                    "structural",
+                    COMPUTED_AT,
+                    org,
+                ],
+            ],
+            column_names=_wure_cols(),
+        )
+        # The unit's issue is owned by a team.
+        sink.client.insert(
+            "work_item_cycle_times",
+            [["ISSUE-SCOPE-1", "Team Scope", COMPUTED_AT, org]],
+            column_names=["work_item_id", "team_name", "computed_at", "org_id"],
+        )
+
+        # Scope to the in-scope repo only (mirrors build_scope_filter_multi).
+        rows = await _rows(
+            sink,
+            org,
+            scope_filter=" AND repo_id IN %(scope_ids)s",
+            scope_params={"scope_ids": [str(repo_in)]},
+        )
+        by_repo = {str(r["repo"]): r for r in rows}
+        # Out-of-scope repo is filtered out; only the in-scope allocated repo shows.
+        assert "repo-out" not in by_repo, by_repo
+        assert "repo-in" in by_repo, by_repo
+        assert float(by_repo["repo-in"]["value"]) == pytest.approx(70.0)
+        # The team resolves through the fanned unit_team -- NOT 'unassigned'.
+        assert by_repo["repo-in"]["team"] == "Team Scope", by_repo
+    finally:
+        _cleanup(sink, org)

--- a/tests/api/test_investment_repo_effort_live.py
+++ b/tests/api/test_investment_repo_effort_live.py
@@ -1,0 +1,254 @@
+"""Live-ClickHouse proof for CHAOS-2777.
+
+PR #1106 added ``work_unit_repo_effort`` (per-(work_unit, repo) effort fan-out)
+so multi-repo work units -- whose scalar ``work_unit_investments.repo_id`` is
+NULL -- can map effort to their real repos. The Allocation-tab Sankey fetchers
+in ``api/queries/investment.py`` originally read only the scalar ``repo_id``, so
+ANY multi-repo unit collapsed onto 'Unassigned repo'. This test seeds a
+multi-repo unit (NULL scalar repo, 3 allocation rows), a single-repo unit (scalar
+repo, no allocation rows -> scalar fallback) and a genuinely repo-less unit
+(NULL scalar, no allocation) and asserts, against REAL ClickHouse:
+
+* the per-repo effort split (multi-repo unit fans out across its 3 repos),
+* the SUM INVARIANT -- each unit contributes exactly its original effort, so the
+  grand total is unchanged versus the scalar path,
+* the scalar fallback (a unit with no allocation row keeps its scalar repo +
+  full effort and is never dropped),
+* ``missing_repo`` counts only units with a NULL scalar repo AND no allocation,
+* theme filtering still interacts correctly with the fan-out.
+
+Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timezone
+
+import pytest
+
+import dev_health_ops.api.queries.investment as investment_queries
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+    ),
+]
+
+FROM_TS = datetime(2026, 1, 5, tzinfo=timezone.utc)
+TO_TS = datetime(2026, 1, 6, tzinfo=timezone.utc)
+COMPUTED_AT = datetime(2026, 1, 7, tzinfo=timezone.utc)
+# Query window strictly containing [FROM_TS, TO_TS).
+START = datetime(2026, 1, 1, tzinfo=timezone.utc)
+END = datetime(2026, 2, 1, tzinfo=timezone.utc)
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+def _wui_cols() -> list[str]:
+    return [
+        "work_unit_id",
+        "from_ts",
+        "to_ts",
+        "repo_id",
+        "effort_metric",
+        "effort_value",
+        "subcategory_distribution_json",
+        "structural_evidence_json",
+        "computed_at",
+        "org_id",
+    ]
+
+
+def _wure_cols() -> list[str]:
+    return [
+        "work_unit_id",
+        "repo_id",
+        "effort_metric",
+        "effort_value",
+        "allocation_weight",
+        "allocation_source",
+        "computed_at",
+        "org_id",
+    ]
+
+
+def _repo_cols() -> list[str]:
+    return ["id", "repo", "created_at", "last_synced", "org_id"]
+
+
+async def _edges(sink: BaseMetricsSink, org_id: str, **kwargs) -> dict[str, float]:
+    rows = await investment_queries.fetch_investment_team_subcategory_repo_edges(
+        sink,
+        start_ts=START,
+        end_ts=END,
+        scope_filter="",
+        scope_params={},
+        org_id=org_id,
+        **kwargs,
+    )
+    by_repo: dict[str, float] = {}
+    for row in rows:
+        # Mirror build_investment_flow_response: an empty repo label (a NULL /
+        # unmatched repo_id) is surfaced as the 'unassigned' repo bucket.
+        label = str(row["repo"]) or "unassigned"
+        by_repo[label] = by_repo.get(label, 0.0) + float(row["value"])
+    return by_repo
+
+
+@pytest.mark.asyncio
+async def test_allocation_sankey_reads_repo_effort(sink):
+    org = f"test-chaos-2777-{uuid.uuid4()}"
+    repo1, repo2, repo3 = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+
+    feature = {"Feature Delivery.product": 1.0}
+    ktlo = {"Keeping the Lights On.ops": 1.0}
+
+    try:
+        # Give the three repo_ids resolvable names; the repos LEFT JOIN keys on
+        # id only, so random UUIDs avoid collisions with existing rows.
+        sink.client.insert(
+            "repos",
+            [
+                [repo1, "repo-one", COMPUTED_AT, COMPUTED_AT, org],
+                [repo2, "repo-two", COMPUTED_AT, COMPUTED_AT, org],
+                [repo3, "repo-three", COMPUTED_AT, COMPUTED_AT, org],
+            ],
+            column_names=_repo_cols(),
+        )
+        sink.client.insert(
+            "work_unit_investments",
+            [
+                # Multi-repo unit: NULL scalar repo, effort split 70/30 across repo1/repo2.
+                [
+                    "wu-multi",
+                    FROM_TS,
+                    TO_TS,
+                    None,
+                    "fte_days",
+                    100.0,
+                    feature,
+                    "{}",
+                    COMPUTED_AT,
+                    org,
+                ],
+                # Single-repo unit: scalar repo set, NO allocation row -> scalar fallback.
+                [
+                    "wu-scalar",
+                    FROM_TS,
+                    TO_TS,
+                    repo3,
+                    "fte_days",
+                    40.0,
+                    feature,
+                    "{}",
+                    COMPUTED_AT,
+                    org,
+                ],
+                # Genuinely repo-less unit: NULL scalar repo AND no allocation row.
+                [
+                    "wu-norepo",
+                    FROM_TS,
+                    TO_TS,
+                    None,
+                    "fte_days",
+                    25.0,
+                    ktlo,
+                    "{}",
+                    COMPUTED_AT,
+                    org,
+                ],
+            ],
+            column_names=_wui_cols(),
+        )
+        sink.client.insert(
+            "work_unit_repo_effort",
+            [
+                [
+                    "wu-multi",
+                    repo1,
+                    "fte_days",
+                    70.0,
+                    0.7,
+                    "structural",
+                    COMPUTED_AT,
+                    org,
+                ],
+                [
+                    "wu-multi",
+                    repo2,
+                    "fte_days",
+                    30.0,
+                    0.3,
+                    "structural",
+                    COMPUTED_AT,
+                    org,
+                ],
+            ],
+            column_names=_wure_cols(),
+        )
+
+        # --- Fan-out + sum invariant (no filters) ---
+        by_repo = await _edges(sink, org)
+        assert by_repo.get("repo-one") == pytest.approx(70.0), by_repo
+        assert by_repo.get("repo-two") == pytest.approx(30.0), by_repo
+        # Scalar fallback: unit with no allocation row keeps scalar repo + full effort.
+        assert by_repo.get("repo-three") == pytest.approx(40.0), by_repo
+        # Repo-less unit still lands on 'unassigned' with its full effort.
+        assert by_repo.get("unassigned") == pytest.approx(25.0), by_repo
+        # SUM INVARIANT: total is unchanged versus the scalar path (100 + 40 + 25).
+        assert sum(by_repo.values()) == pytest.approx(165.0), by_repo
+        # The multi-repo unit's per-repo effort sums back to its unit total.
+        assert by_repo["repo-one"] + by_repo["repo-two"] == pytest.approx(100.0)
+
+        # --- Unassigned counts: only the NULL-scalar + no-allocation unit ---
+        counts = await investment_queries.fetch_investment_unassigned_counts(
+            sink,
+            start_ts=START,
+            end_ts=END,
+            scope_filter="",
+            scope_params={},
+            org_id=org,
+        )
+        assert counts["missing_repo"] == 1, counts
+
+        # --- Theme filter interaction: only Feature Delivery units survive ---
+        by_repo_ft = await _edges(sink, org, themes=["Feature Delivery"])
+        assert by_repo_ft.get("repo-one") == pytest.approx(70.0)
+        assert by_repo_ft.get("repo-two") == pytest.approx(30.0)
+        assert by_repo_ft.get("repo-three") == pytest.approx(40.0)
+        assert "unassigned" not in by_repo_ft  # KTLO no-repo unit filtered out
+        assert sum(by_repo_ft.values()) == pytest.approx(140.0)
+
+        counts_ft = await investment_queries.fetch_investment_unassigned_counts(
+            sink,
+            start_ts=START,
+            end_ts=END,
+            scope_filter="",
+            scope_params={},
+            org_id=org,
+            themes=["Feature Delivery"],
+        )
+        assert counts_ft["missing_repo"] == 0, counts_ft
+    finally:
+        for table in ("work_unit_investments", "work_unit_repo_effort", "repos"):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"o": org},
+            )

--- a/tests/api/test_investment_repo_effort_sql.py
+++ b/tests/api/test_investment_repo_effort_sql.py
@@ -65,6 +65,20 @@ def test_repo_effort_cte_dedups_by_org_work_unit_repo() -> None:
     assert "GROUP BY org_id, work_unit_id, repo_id" in cte
 
 
+def test_repo_effort_cte_scopes_to_latest_allocation_generation() -> None:
+    """The CTE must keep only the unit's LATEST allocation generation, so stale
+    per-repo rows from a shrunk repo set (same work_unit_id, older computed_at)
+    do not survive under the per-repo RMT key and inflate the fan-out."""
+    cte = investment_queries.LATEST_WORK_UNIT_REPO_EFFORT_CTE
+    # Per-unit generation clock = max(computed_at) over ALL of the unit's repo
+    # rows (the allocation table's OWN clock, not the investments computed_at).
+    assert "max(computed_at) AS unit_generation_at" in cte
+    assert "GROUP BY org_id, work_unit_id" in cte  # the clock groups per unit
+    assert "WHERE d.latest_repo_effort_computed_at = g.unit_generation_at" in cte
+    # Explicit match flag so consumers never depend on a non-empty id sentinel.
+    assert "1 AS has_allocation" in cte
+
+
 def test_repo_allocated_source_falls_back_to_scalar_repo() -> None:
     """The derived source LEFT JOINs the per-repo allocation on
     (org_id, work_unit_id) and falls back to the scalar repo_id / effort_value
@@ -73,13 +87,16 @@ def test_repo_allocated_source_falls_back_to_scalar_repo() -> None:
     assert "LEFT JOIN latest_work_unit_repo_effort AS wure" in src
     assert "ON wure.org_id = wui.org_id" in src
     assert "AND wure.work_unit_id = wui.work_unit_id" in src
-    # Scalar fallback (mirrors compiler.py): an unmatched LEFT JOIN leaves the
-    # String key '', so the scalar branch only fires for units with no alloc row.
-    assert "if(wure.work_unit_id != '', wure.repo_id, wui.repo_id) AS repo_id" in src
+    # Scalar fallback gated on the explicit has_allocation flag (not a
+    # non-empty work_unit_id sentinel): unmatched rows fall through to scalar.
+    assert "if(wure.has_allocation = 1, wure.repo_id, wui.repo_id) AS repo_id" in src
     assert (
-        "if(wure.work_unit_id != '', wure.repo_effort_value, wui.effort_value) AS effort_value"
+        "if(wure.has_allocation = 1, wure.repo_effort_value, wui.effort_value) AS effort_value"
         in src
     )
+    # has_allocation is re-exposed so downstream can tell "no allocation row"
+    # apart from "allocation row with a NULL repo".
+    assert "if(wure.has_allocation = 1, 1, 0) AS has_allocation" in src
 
 
 @pytest.mark.asyncio
@@ -93,7 +110,7 @@ async def test_repo_edge_fetchers_read_allocation(
     assert "latest_work_unit_repo_effort AS (" in sql
     assert "LEFT JOIN latest_work_unit_repo_effort AS wure" in sql
     assert (
-        "if(wure.work_unit_id != '', wure.repo_effort_value, wui.effort_value)" in sql
+        "if(wure.has_allocation = 1, wure.repo_effort_value, wui.effort_value)" in sql
     )
     # Effort is still subcategory-weighted; the per-repo split preserves the
     # unit total by construction.
@@ -102,6 +119,15 @@ async def test_repo_edge_fetchers_read_allocation(
     # repo-effort CTE (org isolation / stale-scope fallback depend on order).
     assert sql.index("latest_complete_membership_run AS") < sql.index(
         "latest_work_unit_repo_effort AS ("
+    )
+    # HIGH 2: unit_team must read the SAME repo-allocated source so a repo
+    # scope_filter is applied to the fanned repo_id, not the scalar one. The
+    # source therefore appears at least twice (outer flow + unit_team), and the
+    # base table is never the direct FROM of the issue-fanning unit_team.
+    assert sql.count("LEFT JOIN latest_work_unit_repo_effort AS wure") >= 2
+    assert (
+        "FROM latest_work_unit_investments AS work_unit_investments\n"
+        "                ARRAY JOIN arrayDistinct(arrayConcat(" not in sql
     )
 
 
@@ -116,13 +142,14 @@ async def test_unassigned_counts_excludes_allocated_multi_repo_units(
         monkeypatch, investment_queries.fetch_investment_unassigned_counts
     )
     assert "latest_work_unit_repo_effort AS (" in sql
-    # Per-unit existence check (aggregated, so it does not fan the count out).
-    assert ") AS unit_repo_alloc" in sql
-    assert "ON unit_repo_alloc.org_id = work_unit_investments.org_id" in sql
-    assert (
-        "AND unit_repo_alloc.work_unit_id = work_unit_investments.work_unit_id" in sql
-    )
-    assert "repo_id IS NULL AND unit_repo_alloc.work_unit_id = ''" in sql
+    # Reads the same repo-allocated source as the Sankey edges: on that source
+    # ``has_allocation = 0 AND repo_id IS NULL`` is exactly a no-allocation,
+    # NULL-scalar unit (allocated repos are non-null and flagged).
+    assert "has_allocation = 0 AND repo_id IS NULL" in sql
+    assert "LEFT JOIN latest_work_unit_repo_effort AS wure" in sql
+    # scope_filter now applies to the fanned repo_id consistently (unit_team +
+    # main both read the source).
+    assert sql.count("LEFT JOIN latest_work_unit_repo_effort AS wure") >= 2
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_investment_repo_effort_sql.py
+++ b/tests/api/test_investment_repo_effort_sql.py
@@ -1,0 +1,142 @@
+"""CHAOS-2777: the Allocation-tab Sankey fetchers must read
+``work_unit_repo_effort`` so multi-repo work units (whose scalar
+``work_unit_investments.repo_id`` is NULL) map their effort to their real repos
+instead of collapsing onto 'Unassigned repo'.
+
+These are pure SQL-shape assertions (no DB) that guard the wiring:
+``latest_work_unit_repo_effort`` is chained into the WITH clause, the per-repo
+allocation is LEFT JOINed on (org_id, work_unit_id) with a scalar fallback that
+never drops a unit, and the membership-scope CTE chain still comes first. The
+end-to-end sum-invariant / fan-out / coverage behaviour is proven against real
+ClickHouse in ``test_investment_repo_effort_live.py`` (pytest -m clickhouse).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any, cast
+
+import pytest
+
+import dev_health_ops.api.queries.investment as investment_queries
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+# The three Allocation-tab Sankey edge fetchers that surface a repo dimension
+# and effort-weight their values, so they must fan effort out per repo.
+REPO_EDGE_FETCHERS = [
+    investment_queries.fetch_investment_repo_team_edges,
+    investment_queries.fetch_investment_team_category_repo_edges,
+    investment_queries.fetch_investment_team_subcategory_repo_edges,
+]
+
+
+async def _capture_sql(
+    monkeypatch: pytest.MonkeyPatch, fetcher: Any, **kwargs: Any
+) -> str:
+    captured: dict[str, str] = {"sql": ""}
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, sql: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        captured["sql"] = sql
+        return []
+
+    monkeypatch.setattr(investment_queries, "query_dicts", fake_query_dicts)
+    await fetcher(
+        cast(BaseMetricsSink, object()),
+        start_ts=datetime(2026, 5, 1, tzinfo=timezone.utc),
+        end_ts=datetime(2026, 6, 1, tzinfo=timezone.utc),
+        scope_filter="",
+        scope_params={},
+        org_id="org-1",
+        **kwargs,
+    )
+    return captured["sql"]
+
+
+def test_repo_effort_cte_dedups_by_org_work_unit_repo() -> None:
+    """The shared CTE dedups per (org_id, work_unit_id, repo_id) via
+    argMax(computed_at) and is tenant-scoped before aggregating."""
+    cte = investment_queries.LATEST_WORK_UNIT_REPO_EFFORT_CTE
+    assert "latest_work_unit_repo_effort AS (" in cte
+    assert "FROM work_unit_repo_effort" in cte
+    assert "WHERE org_id = %(org_id)s" in cte
+    assert "argMax(effort_value, computed_at) AS repo_effort_value" in cte
+    assert "GROUP BY org_id, work_unit_id, repo_id" in cte
+
+
+def test_repo_allocated_source_falls_back_to_scalar_repo() -> None:
+    """The derived source LEFT JOINs the per-repo allocation on
+    (org_id, work_unit_id) and falls back to the scalar repo_id / effort_value
+    when a unit has no allocation row (so units are never dropped)."""
+    src = investment_queries.REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE
+    assert "LEFT JOIN latest_work_unit_repo_effort AS wure" in src
+    assert "ON wure.org_id = wui.org_id" in src
+    assert "AND wure.work_unit_id = wui.work_unit_id" in src
+    # Scalar fallback (mirrors compiler.py): an unmatched LEFT JOIN leaves the
+    # String key '', so the scalar branch only fires for units with no alloc row.
+    assert "if(wure.work_unit_id != '', wure.repo_id, wui.repo_id) AS repo_id" in src
+    assert (
+        "if(wure.work_unit_id != '', wure.repo_effort_value, wui.effort_value) AS effort_value"
+        in src
+    )
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fetcher", REPO_EDGE_FETCHERS)
+async def test_repo_edge_fetchers_read_allocation(
+    monkeypatch: pytest.MonkeyPatch, fetcher: Any
+) -> None:
+    sql = await _capture_sql(monkeypatch, fetcher)
+    # The allocation CTE is chained into the WITH clause and consumed as the
+    # per-repo fan-out source.
+    assert "latest_work_unit_repo_effort AS (" in sql
+    assert "LEFT JOIN latest_work_unit_repo_effort AS wure" in sql
+    assert (
+        "if(wure.work_unit_id != '', wure.repo_effort_value, wui.effort_value)" in sql
+    )
+    # Effort is still subcategory-weighted; the per-repo split preserves the
+    # unit total by construction.
+    assert "sum(subcategory_kv.2 * effort_value) AS value" in sql
+    # Membership-scope CTE chain must stay FIRST in the WITH clause, before the
+    # repo-effort CTE (org isolation / stale-scope fallback depend on order).
+    assert sql.index("latest_complete_membership_run AS") < sql.index(
+        "latest_work_unit_repo_effort AS ("
+    )
+
+
+@pytest.mark.asyncio
+async def test_unassigned_counts_excludes_allocated_multi_repo_units(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """missing_repo must count only units with a NULL scalar repo_id AND no
+    per-repo allocation row. Multi-repo units carry a NULL scalar repo_id but DO
+    have allocation rows, so they must not be counted as unassigned."""
+    sql = await _capture_sql(
+        monkeypatch, investment_queries.fetch_investment_unassigned_counts
+    )
+    assert "latest_work_unit_repo_effort AS (" in sql
+    # Per-unit existence check (aggregated, so it does not fan the count out).
+    assert ") AS unit_repo_alloc" in sql
+    assert "ON unit_repo_alloc.org_id = work_unit_investments.org_id" in sql
+    assert (
+        "AND unit_repo_alloc.work_unit_id = work_unit_investments.work_unit_id" in sql
+    )
+    assert "repo_id IS NULL AND unit_repo_alloc.work_unit_id = ''" in sql
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("fetcher", REPO_EDGE_FETCHERS)
+async def test_repo_edge_fetchers_thread_category_filter(
+    monkeypatch: pytest.MonkeyPatch, fetcher: Any
+) -> None:
+    """Theme/subcategory filters still parameterize the query after the repo
+    fan-out is wired in (no accidental literal interpolation)."""
+    sql = await _capture_sql(
+        monkeypatch,
+        fetcher,
+        themes=["Feature Delivery"],
+        subcategories=["Feature Delivery.product"],
+    )
+    assert "splitByChar('.', subcategory_kv.1)[1] IN %(themes)s" in sql
+    assert "subcategory_kv.1 IN %(subcategories)s" in sql


### PR DESCRIPTION
## Summary
PR #1106 added `work_unit_repo_effort` (per-`(work_unit, repo)` effort fan-out, migration 064) and wired it into the GraphQL compiler/analytics breakdown paths — but the **Allocation-tab Sankey fetchers** in `api/queries/investment.py` still read only the scalar `work_unit_investments.repo_id`, which is **NULL for any multi-repo unit**. So every multi-repo unit's effort collapsed onto "Unassigned repo", and `missing_repo` over-counted them.

This wires the existing `latest_work_unit_repo_effort` CTE into those fetchers, following the compiler.py:184 scalar-fallback pattern. No GraphQL schema change — data-correctness fix behind existing fields.

Fixes [CHAOS-2777](https://linear.app/fullchaos/issue/CHAOS-2777).

## Change (`src/dev_health_ops/api/queries/investment.py`)
- New module constant `REPO_ALLOCATED_WORK_UNIT_INVESTMENTS_SOURCE`: wraps `latest_work_unit_investments` and `LEFT JOIN`s `latest_work_unit_repo_effort` keyed `(org_id, work_unit_id)`. Units **with** allocation rows fan out to one row per repo (`repo_effort_value` replaces `effort_value`); units **without** fall back to scalar `repo_id` + full effort (`if(wure.work_unit_id != '', …)`) so none are dropped. The fan-out happens **before** the subcategory ARRAY JOIN, so the per-repo values sum to the unit total — **sum invariant preserved, no double-counting**.
- Wired into `fetch_investment_repo_team_edges`, `fetch_investment_team_category_repo_edges`, `fetch_investment_team_subcategory_repo_edges` (repo-effort CTE chained after the membership-scope CTE chain, which stays first).
- `fetch_investment_unassigned_counts`: `missing_repo` now counts units with NULL scalar `repo_id` **AND** no allocation row (aggregated, non-fanning join).
- `build_investment_flow_response` coverage stats become allocation-aware automatically (computed from returned rows).

## Live-data before/after (read-only, real org, local ClickHouse)
Core effort-weighted total (isolated from the repos label join): **NEW == OLD == 15,989,411.2513** (diff 0.000000) ✅ sum invariant.

Effort moved OUT of the unassigned bucket INTO the 3 real repos:

| repo | OLD (scalar) | NEW (allocation) | Δ |
|---|--:|--:|--:|
| unassigned (NULL) | 14,707,719 | 12,556,866 | −2,150,853 |
| full-chaos/dev-health-ops | 652,304 | 1,485,564 | +833,260 |
| full-chaos/dev-health-web | 444,021 | 1,218,455 | +774,434 |
| full-chaos/script-manifest | 104,453 | 647,612 | +543,159 |

- **Repo coverage: 8.0% → 21.5%**
- `unassigned_counts.missing_repo`: **1132 → 855** (277 multi-repo units reclassified)

## Tests
- `tests/api/test_investment_repo_effort_sql.py` (9, no DB): CTE dedup shape, scalar-fallback source shape, all 3 edge fetchers read the allocation + membership-scope CTE stays first, unassigned-counts condition, theme/subcategory filter still parameterized.
- `tests/api/test_investment_repo_effort_live.py` (`@pytest.mark.clickhouse`, opt-in): seeds multi-repo (70/30), scalar-fallback, and repo-less units; asserts per-repo fan-out, scalar fallback, unassigned bucket, **sum invariant (165)**, `missing_repo == 1`, and theme-filter interaction (140, `missing_repo == 0`). Passes on local ClickHouse.
- Existing investment SQL / flow tests still pass.

## Gate
`ci/local_validate.sh` — **GATE PASSED**: ruff format + ruff check + `mypy .` (1279 files, no issues) + full unit suite + live-ClickHouse argMax proof all PASS.