### PR TITLE
feat(external-ingest): provider-neutral sink writes + source_id provenance (CHAOS-2698)

### DIFF
--- a/docs/architecture/external-ingest-sink-writes.md
+++ b/docs/architecture/external-ingest-sink-writes.md
@@ -1,0 +1,375 @@
+# External-ingest sink writes (CHAOS-2698)
+
+Part of the [customer-push ingestion epic](adr-003-external-ingest-rest-boundary.md)
+(CHAOS-2690). This doc records the sink-write-layer decisions (D1-D8): given a
+schema-validated, kind-normalized batch (CHAOS-2697's worker output), how
+`external_ingest/sinks.py::write_batch()` stamps provenance and writes each of
+the 9 v1 record kinds through the **existing** ClickHouse sink methods
+(`storage/clickhouse.py::ClickHouseStore`,
+`metrics/sinks/clickhouse::ClickHouseMetricsSink`), preserving current
+append/ReplacingMergeTree-dedup semantics.
+
+Module map: `external_ingest/ids.py` (server-side ID derivation),
+`external_ingest/types.py` (`NormalizedBatch` / `SinkWriteResult` /
+`SinkWriteError` / `AffectedScope`), `external_ingest/sinks.py`
+(`write_batch()` and the per-kind row builders).
+
+## D1 — Provenance column, not a `provider` value
+
+A new nullable `source_id UUID` column (migration
+`065_external_ingest_source_id.sql`) was added to the 9 tables this layer
+writes: `repos`, `git_commits`, `git_pull_requests`,
+`git_pull_request_reviews`, `teams`, `identities`, `work_items`,
+`work_item_transitions`, `work_item_dependencies`. Every row this layer
+writes stamps `source_id` to the resolved `external_ingest_sources.id`
+(CHAOS-2696, Postgres migration 0032); every native-sync row leaves it
+`NULL`. `repos.provider` / `teams.provider` / `work_items.provider` keep
+meaning "which upstream system" (github/gitlab/jira/linear/custom) —
+overloading them with `"customer_push"` would flip provider on an RMT
+replace and break every provider-branching reader (master-spec CC8; this
+was an explicitly refuted design from an earlier draft). `Repo.provider`
+gains `"custom"` as a legal value for custom-system repos; readers must
+tolerate it (covered by `test_repository_round_trip_and_repo_identity_handoff`
+—no crash on a `provider="custom"` row, though no reader-side assertion was
+added since no existing reader branches on `provider` in a way that would
+reject an unrecognized value).
+
+Two of the 9 tables required more than an additive `ALTER TABLE` on the
+Python side, because their sink methods extract rows by an **explicit
+column-name list**, not by forwarding arbitrary dict/dataclass keys:
+`storage/clickhouse.py`'s `insert_repo` / `insert_git_commit_data` /
+`insert_git_pull_requests` / `insert_git_pull_request_reviews` /
+`insert_teams` / `insert_identities`, and
+`metrics/sinks/clickhouse/work_graph.py`'s `write_work_items` /
+`write_work_item_transitions` / `write_work_item_dependencies`, all needed a
+one-line `"source_id"` addition to their column list (plus the
+dict/attribute extraction line). `write_work_item_dependencies` also needed
+a new `source_id: uuid.UUID | None = None` field on the
+`WorkItemDependency` frozen dataclass (`models/work_items.py`), because that
+one method routes through `_ClickHouseSinkBase._insert_rows`, which builds
+rows via `dataclasses.asdict()` — dict rows are not accepted there, unlike
+the other two work-item-family methods. All of these are additive,
+backward-compatible one-liners; no existing call site changed behavior
+(proven live: `test_native_sync_repo_write_leaves_source_id_null`).
+
+## D2 — `repository.v1` repo UUID must match native sync exactly
+
+`external_ingest/ids.py::derive_repo_uuid(system, instance, external_id)`
+calls `get_repo_uuid_from_repo()` (`models/git.py:72`) with the **same
+string shape** native sync uses for github/gitlab: the provider full name
+(`owner/repo` / `group/subgroup/project`), unchanged — verified against
+`processors/github.py:1574` (`repo=repo_info.full_name`) and
+`processors/gitlab.py:1815/2096` (`repo=full_name` /
+`project_info.full_name`). `get_repo_uuid_from_repo` lower-cases its input,
+so `Owner/Repo` and `owner/repo` derive the identical UUID — proven live by
+`test_repository_round_trip_and_repo_identity_handoff`, which also proves
+the actual identity-continuity property this exists for: a repo UUID
+derived from a pushed `repository.v1` record equals
+`get_repo_uuid_from_repo()` called directly, i.e. what a native
+`fullchaos_sync` GitHub processor would derive for "the same" repo. For
+`system == "custom"` (no matching real provider), the seed is
+`f"custom:{instance}:{external_id}"` instead — a distinct hash-input
+namespace with no collision risk against real-provider UUIDs
+(`test_derive_repo_uuid_custom_system_uses_distinct_namespace`).
+
+`derive_repo_uuid` inherits `get_repo_uuid_from_repo`'s `REPO_UUID`
+environment-variable override (returns that UUID for *every* call,
+regardless of input, when set) — this is existing native-sync behavior,
+not something this layer introduces or should special-case; a
+worker-external-ingest deployment must simply never set `REPO_UUID` (it is
+a single-repo CLI/local-dev override, not meant for a long-running
+process).
+
+## D3 — `work_item_id` / dependency IDs must match native sync's ID-space
+
+`external_ingest/ids.py::derive_work_item_id(system, instance, external_key,
+work_item_type)` reproduces the verified formats: `jira:{key}`,
+`linear:{id}`, `gh:{repo}#{n}` / `ghpr:{repo}#{n}` (`work_item_type ==
+"pr"`), `gitlab:{repo}#{iid}` / `gitlab:{repo}!{iid}`
+(`work_item_type == "merge_request"`), `custom:{instance}:{key}` — see
+`providers/github/normalize.py:108`, `providers/gitlab/normalize.py:57,216`,
+`providers/jira/normalize.py:271`, `providers/linear/normalize.py:213`.
+Table-driven proof: `test_derive_work_item_id_matches_native_sync_formats`.
+Neither `instance` (the repo full name) nor `external_key` is lower-cased —
+matching native sync exactly, which means (as with D2's env-var caveat) two
+pushes disagreeing only in `repositoryExternalId` casing derive the *same*
+repo UUID but *different* `work_item_id` strings; this is inherited
+native-sync behavior, not a new defect.
+
+`instance` is the repo full name for `system in {"github", "gitlab"}`
+(taken from the per-record `repositoryExternalId` when present, else the
+batch's `source_instance`) and unused for `jira`/`linear`.
+`work_item_dependency.v1` has no `provider`/`system` field of its own (only
+`sourceExternalKey`/`targetExternalKey` + optional per-side
+`workItemType`), so `_build_dependency()` derives both ends from the
+**batch's** `source_system`/`source_instance` — sound because a batch is
+scoped to exactly one source instance (master-spec CC5).
+
+Server-side derivation is explicitly bounded to the primary work-item
+identifier and the dependency source/target keys (the frozen contract's
+`externalKey`/`sourceExternalKey`/`targetExternalKey` fields). `parentId` /
+`epicId` / `sprintId` on `WorkItemV1` are passed through **verbatim** as the
+customer supplied them, with no namespaced-ID derivation attempted — native
+sync does derive these (e.g. `jira:{parent_key}`), but the wire schema
+gives no signal about which system a `parentId`/`epicId` string belongs to
+beyond "presumably the same system as the work item", and getting this
+wrong silently would be worse than a known, documented pass-through gap.
+Flagged as a v1 limitation, consistent with the brief's risk #6
+(`project_key`/`project_id` mapping quality is customer-payload-dependent,
+"not fixable at the sink layer").
+
+## D4 — Identity resolution: `resolve_identity()` for work items, raw for git
+
+`write_batch()` calls `metrics.identity.resolve_identity(system, {...})` on
+every work-item-family assignee/reporter/actor string, mirroring native
+connector behavior so cross-provider identity rollups stay consistent
+regardless of ingestion path. Customer payloads supply one opaque string
+per person (`WorkItemV1.assignees: list[str]`,
+`WorkItemV1.reporter: str | None`) rather than native connectors'
+structured `{email, username, account_id, display_name}` — `sinks.py`'s
+`_resolve_customer_identity()` is a documented heuristic: the raw string is
+always passed as both `username` and `display_name`, and additionally as
+`email` when it contains `"@"` (since `resolve_identity` prioritizes email
+when present). Git-family (`commit.v1`/`pull_request.v1`/`review.v1`)
+`author_name`/`author_email`/`reviewer` fields are passed through **raw**,
+unresolved — matching native sync exactly (`GitCommit` /
+`GitPullRequest` / `GitPullRequestReview` have no identity-resolved field).
+`identity.v1` records populate `insert_identities` purely as a directory
+side-effect; they do not feed `resolve_identity`'s static YAML alias map.
+
+## D5 — `identity.v1` / `team.v1` stay dict-shaped
+
+`NormalizedBatch.identities` / `.teams` are plain `dict`s. `_build_identity_row`
+/ `_build_team_row` accept CHAOS-2697 handing either the wire-schema's
+snake_case field names (`IdentityV1`/`TeamV1`) or fields already shaped to
+`insert_identities`/`insert_teams`'s row contract — `provider_identities` in
+particular is accepted as either a `dict[str, list[str]]` (json-encoded
+here) or an already-JSON-encoded string, so this layer is tolerant of
+either upstream choice per the brief's "this layer accepts either" clause.
+
+## D6 — Two client lifecycles per invocation, only when needed
+
+One async `ClickHouseStore` (via `create_store(dsn, "clickhouse")`) handles
+`repository`/`commit`/`pull_request`/`review`/`team`/`identity`; one sync
+`ClickHouseMetricsSink` (via `create_sink(dsn)`, run off the event loop with
+`asyncio.to_thread`) handles the work-item family. Both are constructed at
+most once per kind-family per `write_batch()` call — **not** once per
+record. One deliberate deviation from the brief's skeleton: the async store
+is only opened when at least one of `repositories`/`commits`/
+`pull_requests`/`reviews`/`teams`/`identities` is non-empty
+(`_maybe_store()`), so a pure work-item batch (a jira/linear-only push) does
+not pay for an unused ClickHouse connection. The three work-item-family
+writes (`write_work_items`/`write_work_item_transitions`/
+`write_work_item_dependencies`) each get their **own** `create_sink()` /
+`asyncio.to_thread` call rather than being bundled into one thread hop —
+this trades a little connection overhead for the partial-batch-resilience
+property below (each kind's failure is independent).
+
+`org_id` stamping differs by client, per the recon: `ClickHouseStore.
+_insert_rows` auto-injects `self.org_id` into any row missing it, so it is
+still explicitly set on every row this layer builds (never relying on that
+fallback); `ClickHouseMetricsSink.write_work_items`/
+`write_work_item_transitions` read `org_id` **directly off each record**
+with **no fallback** (`item["org_id"] if is_dict else item.org_id` — a
+`KeyError`/`AttributeError` otherwise), so `sinks.py` stamps `org_id`
+explicitly on every work-item-family row it builds
+(`test_write_batch_stamps_org_id_on_work_item_family_rows`).
+`write_work_item_dependencies` (the one work-item method that goes through
+`_insert_rows`/`asdict`) *does* have a `self.org_id` fallback, but this
+layer sets `org_id` on the `WorkItemDependency` instance directly anyway,
+for consistency.
+
+`work_items.repo_id` is non-nullable in the sink's row builder (defaults to
+`uuid.UUID(int=0)` when the row's `repo_id` key/attribute is falsy —
+`work_graph.py:652`). For jira/linear work items (no repo association) this
+layer passes `repo_id=None` explicitly (not omitting the key) so that
+fallback fires, per the brief's explicit instruction not to invent a
+different sentinel.
+
+## D7 — Re-push is "just write it again" (with one live-verified nuance)
+
+All 9 tables are `ReplacingMergeTree`, so `write_batch()` does not
+implement upsert/read-before-write logic: re-normalize, re-derive the same
+deterministic IDs (D2/D3), stamp a fresh `last_synced` (server `now()` for
+every kind except identities/teams — see D8), and call the same sink method
+again. Verified live for every kind
+(`test_*_round_trip` re-push assertions) — the newer write always wins
+after a `FINAL` read.
+
+`work_item_transitions` needed a closer look because its `ORDER BY`
+includes `occurred_at` — verified live (`SHOW CREATE TABLE
+work_item_transitions`): `ReplacingMergeTree(last_synced) ORDER BY (org_id,
+repo_id, work_item_id, occurred_at)`. Re-pushing the *same* transition
+(identical `occurred_at`, only `last_synced` differs — e.g. a corrected
+`actor`/status for an already-recorded event) is a genuine `ORDER BY`-key
+collision: a plain `SELECT ... FINAL` already collapses it to 1 row,
+without needing `idempotency.py`'s `semantic_deduped_subquery()` — verified
+live in `test_work_item_transition_semantic_dedup`, which also verifies
+the sharper hazard the brief calls out: a **non-`FINAL`** `SELECT *`
+genuinely returns 2 physical rows until a merge (or `FINAL`) runs, so any
+downstream reader of this table that skips `FINAL` (or the semantic
+subquery) can double-count. `WORK_ITEM_TRANSITION_SEMANTIC_COLUMNS`
+(`idempotency.py`) is a strict superset of the table's physical `ORDER BY`
+tuple (it additionally includes `provider`/`from_status`/`to_status`/
+`from_status_raw`/`to_status_raw`/`actor`), which is why it agrees with
+`FINAL` for this same-`occurred_at` case; it does **not** independently
+solve the "customer retry regenerates a slightly different `occurred_at`
+for what's semantically the same event" case that motivated the module
+(since `occurred_at` is itself part of the semantic tuple, two rows
+differing only in `occurred_at` remain two distinct semantic groups too).
+This is pre-existing `idempotency.py` design, out of this issue's scope to
+change — noted here for whoever next touches read-time transition
+de-duplication.
+
+## D8 — `identities`/`teams` `updated_at`: customer timestamp, clamped
+
+`identities`/`teams` are `ReplacingMergeTree(updated_at)` — the caller
+supplies the version column, so `write_identity()`/`write_team()` pass
+`record.updated_at` through **verbatim**
+(`test_identity_and_team_updated_at_pass_through_verbatim`), never
+overwriting it with `now()` (unlike every other timestamp in this module,
+which is always server-`now()` — a receive-time marker, not payload
+content). The one exception (CC24, post-critique): a customer `updatedAt`
+more than `UPDATED_AT_CLAMP_SKEW` (5 minutes) in the future is replaced
+with server `now()` and recorded as a `SinkWriteResult.warnings` entry
+(`code="updated_at_clamped"`), not a rejection — this prevents a
+buggy/malicious `updatedAt=2100-01-01` from permanently pinning an RMT row
+against every future correction, since no legitimate future write could
+ever out-version it otherwise. Verified live
+(`test_identity_updated_at_future_clamp_loses_to_later_legitimate_write`):
+the clamped row loses to a subsequent, normal-timestamped push. `warnings`
+is an additive field on `SinkWriteResult` beyond the interface brief's
+original sketch (`counts_written`/`errors`/`affected_scope` only) —
+CHAOS-2694 may ignore it; it exists because a clamp is neither a
+write-time failure (`errors`) nor silent.
+
+## Two non-nullable-column fixes found by the live tests
+
+Two `CommitV1`/`WorkItemV1` fields are optional on the wire but map to
+**non-nullable** `DateTime64` columns (verified via `DESCRIBE TABLE`):
+`git_commits.committer_when` and `work_items.updated_at`. Writing `NULL`
+there is not a ClickHouse constraint violation — clickhouse-connect's
+driver raises an `AttributeError` client-side while serializing the
+column (`'NoneType' object has no attribute 'timestamp'`), which
+`write_batch()` correctly catches and reports as a `clickhouse_insert_
+failed` `SinkWriteError`... but silently failing the whole `commit`/
+`work_item` kind for every payload that omits an optional field is not
+acceptable. `sinks.py` defaults `committer_when` to `author_when` (git's
+own convention: an unamended commit's committer date equals its author
+date) and `updated_at` to `created_at` (mirrors `WorkItem`'s dataclass
+default of never being `None`) when the customer payload omits them.
+
+## Adversarial-review findings (Codex, applied to trust boundary)
+
+The wire schema (`api/external_ingest/schemas.py`) is deliberately
+permissive about what a customer can send — this layer's job is to trust
+that input for shape, but not for the invariants native sync gets for free
+by construction. Two findings from the pre-merge adversarial review target
+exactly that gap:
+
+- **`native_team_key` forgery (fixed).** `_build_work_item_row` originally
+  passed a customer's `nativeTeamKey` through unconditionally. Team
+  attribution's precedence chain
+  (`docs/architecture/team-attribution.md` §0, AGENTS.md) treats any
+  non-empty `work_items.native_team_key` as a top-precedence NATIVE fact —
+  native sync only ever populates it for Linear
+  (`WorkItem.native_team_key` docstring: "None for GitHub/GitLab ... and
+  Jira"). A schema-valid github/gitlab/jira `work_item.v1` payload setting
+  `nativeTeamKey` could therefore forge rank-0 team ownership that bypasses
+  project/member/repo attribution entirely — a real corruption vector
+  since customer payloads are untrusted in a way native provider API
+  responses are not. Fixed: `native_team_key` is now dropped (forced
+  `None`) for every `system` except `"linear"`, regardless of what the
+  payload contains. Covered by
+  `test_native_team_key_dropped_for_non_linear_work_items` (parametrized
+  over github/gitlab/jira) and
+  `test_native_team_key_preserved_for_linear_work_items`.
+
+  A second review pass caught that the first fix's `system` gate fell back
+  to the **untrusted per-record** `provider` field
+  (`get("provider") or batch.source_system`) — exactly as spoofable as
+  `nativeTeamKey` itself. A github-scoped batch could smuggle a row
+  claiming `"provider": "linear"` and still preserve a forged key.
+
+  A third pass went further: nulling `native_team_key` alone was treating
+  the symptom, not the cause — `_build_work_item_row`/`_build_transition_row`
+  still derived `system` (and therefore `work_item_id`, `repo_id`, the
+  stored `provider` column, project scope, and identity resolution) from
+  that same untrusted per-record `provider`. A github-scoped batch with a
+  spoofed `provider="linear"` row would still persist as a genuine Linear
+  work item — `provider="linear"`, `work_item_id="linear:<key>"` — landing
+  in and potentially colliding with real Linear data, even with
+  `native_team_key` correctly dropped. Fixed at the root: `system` is now
+  **always** `batch.source_system` for `_build_work_item_row` and
+  `_build_transition_row` (`_build_dependency` already worked this way) —
+  never the per-record `provider` — since a batch is authenticated/
+  registered for exactly one system (CHAOS-2696) and there is no legitimate
+  case for a batch to contain another system's work items. The record's own
+  `provider`, when present and disagreeing with `batch.source_system`, only
+  produces a `record_provider_mismatch` warning (`_check_provider_scope()`)
+  — the same assert-but-not-reject posture as the git-family instance-scope
+  check above, never used for derivation. Covered by
+  `test_work_item_spoofed_provider_cannot_escape_batch_namespace`, which
+  asserts the row lands under the batch's own namespace
+  (`provider="github"`, `work_item_id="gh:...#42"`) with the mismatch
+  surfaced as a warning, not silently accepted as `provider="linear"`.
+
+- **Git repo-identity handoff trusts an unenforced customer string
+  (mitigated, not rejected).** D2's identity-continuity guarantee depends
+  on a git-family record's repo identifier equaling `source.instance`
+  (master-spec CC6). This layer derives IDs from the record's own string
+  without checking that invariant — by explicit epic-wide design (the
+  reconciliation header on brief-2698-sinks.md, item 6: "Kind×system
+  matrix (CC6) is enforced upstream in 2697's validate step; sinks may
+  assert-but-not-reject"), full rejection is CHAOS-2697's job, not this
+  layer's. A record that ships with a URL, a renamed/differently-cased
+  string, or any other value that doesn't match `source.instance` would
+  previously derive a repo UUID / `work_item_id` silently disjoint from
+  what native sync (or a correctly-scoped push) would derive for the same
+  logical repo — forking `customer_push` and `fullchaos_sync` history for
+  what should be one repo, with no visible signal. Mitigated (not
+  rejected, honoring the "assert-but-not-reject" contract):
+  `_check_instance_scope()` now flags every repository/commit/
+  pull_request/review/work_item record whose repo identifier disagrees
+  with `batch.source_instance` as a `record_outside_source_instance`
+  `SinkWriteResult.warnings` entry — the record is still written (this
+  layer doesn't invent an authority to reject that CC6 explicitly assigns
+  elsewhere), but the drift is now surfaced for CHAOS-2694's diagnostics
+  instead of silently forking identity. Covered by
+  `test_repository_external_id_mismatch_flagged_as_warning_not_rejected`
+  and `test_pull_request_matching_source_instance_has_no_warning`.
+
+- **Future-`updatedAt` clamp can still let a bad row outrank a truthful
+  older retry (evaluated, not changed — refuted as a fix target).** The
+  review correctly observes that a clamped row's `updated_at` (server
+  `now()` at the moment of the bad ingest) can still beat a subsequent
+  *legitimate* correction whose real source `updatedAt` predates that
+  ingest moment (e.g. a backfill/retry carrying an older, truthful
+  timestamp). That is a genuine residual risk — but master-spec CC24 is an
+  explicitly RATIFIED, epic-wide decision that this exact tradeoff is
+  intentional: "customer `updatedAt` used as the RMT version column
+  (identities/teams) is clamped ... values more than 5 minutes in the
+  future are replaced with server now() and recorded as a per-record
+  WARNING diagnostic (**not a rejection**)" (master-spec CC24, also stated
+  in the brief-2698-sinks.md reconciliation header). Rejecting a
+  future-dated write, as the review recommends, is the alternative CC24's
+  synthesizer explicitly considered and declined in favor of the clamp —
+  changing that here would silently re-litigate a cross-cutting epic
+  decision from a single sub-issue. Not implemented; the residual risk is
+  documented above (D8) rather than silently accepted.
+
+## Test plan
+
+- `tests/external_ingest/test_sinks_unit.py` — mocked `create_store`/
+  `create_sink`, no live DB: D2 case-insensitivity, D6 org_id stamping,
+  D3 table-driven ID-format proof, D8 pass-through + clamp, partial-batch
+  resilience on a mid-batch exception, `AffectedScope` aggregation, and the
+  two adversarial-review regressions above (`native_team_key` scoping,
+  `record_outside_source_instance` warnings).
+- `tests/external_ingest/test_sinks_clickhouse.py` (`@pytest.mark.
+  clickhouse`) — one round-trip test per record kind against an isolated
+  scratch database, plus the D2 repo-identity handoff, the D7
+  `work_item_transitions` FINAL-vs-semantic-dedup proof, the D8 clamp
+  live proof, and a backward-compatibility proof that a native-sync-style
+  `insert_repo()` call with no `source_id` still succeeds with
+  `source_id IS NULL`.

--- a/src/dev_health_ops/external_ingest/ids.py
+++ b/src/dev_health_ops/external_ingest/ids.py
@@ -1,0 +1,89 @@
+"""Server-side identity derivation for external-ingest records (CHAOS-2698).
+
+Two deterministic ID spaces this module owns, per master-spec CC4/CC7:
+
+- ``derive_repo_uuid`` — the ClickHouse ``repos.id`` UUID. MUST match what
+  native sync derives for the "same" repo (``get_repo_uuid_from_repo``,
+  ``models/git.py:72``) so a repo dedupes identically whether it arrived via
+  ``fullchaos_sync`` or ``customer_push`` — this is the one-active-owner
+  handoff's data-layer linchpin (brief-2698-sinks.md D2).
+- ``derive_work_item_id`` — the namespaced ``work_items.work_item_id`` string
+  every downstream query already assumes (``jira:ABC-123``,
+  ``gh:owner/repo#123``, ``ghpr:owner/repo#123``, ``gitlab:group/project#456``,
+  ``gitlab:group/project!456``, ``linear:CHAOS-123``). Verified against
+  ``providers/github/normalize.py:108``, ``providers/gitlab/normalize.py:57,216``,
+  ``providers/jira/normalize.py:271``, ``providers/linear/normalize.py:213``
+  (brief-2698-sinks.md D3). Customers send provider-native keys
+  (``WorkItemV1.external_key``) — never the namespaced ID (master-spec CC7).
+
+Neither function normalizes case beyond what the underlying primitive already
+does: ``get_repo_uuid_from_repo`` lower-cases its seed (so repo UUIDs are
+case-insensitive), but ``derive_work_item_id`` does NOT lower-case ``instance``
+or ``external_key`` — this matches native sync's ``work_item_id`` construction
+exactly (it never lower-cases either), which means two pushes that disagree
+only in ``repositoryExternalId`` casing produce the same repo UUID but
+different ``work_item_id`` strings. That is a pre-existing native-sync
+behavior, not something this module introduces or fixes.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+from dev_health_ops.models.git import get_repo_uuid_from_repo
+
+__all__ = ["derive_repo_uuid", "derive_work_item_id"]
+
+
+def derive_repo_uuid(system: str, instance: str, external_id: str) -> uuid.UUID:
+    """Derive the ClickHouse ``repos.id`` UUID for a pushed repository.
+
+    ``system in {"github", "gitlab"}``: seed is ``external_id`` (the provider
+    full name, e.g. ``owner/repo`` / ``group/subgroup/project`` — must equal
+    ``instance`` per master-spec CC6), fed unchanged into
+    ``get_repo_uuid_from_repo`` exactly as native sync does.
+
+    ``system == "custom"``: no real-provider namespace to align with, so the
+    seed is ``f"custom:{instance}:{external_id}"`` (brief-2698-sinks.md D2) —
+    a distinct namespace with no collision risk against real-provider UUIDs.
+    """
+    seed = external_id if system != "custom" else f"custom:{instance}:{external_id}"
+    return get_repo_uuid_from_repo(seed)
+
+
+def derive_work_item_id(
+    system: str,
+    instance: str | None,
+    external_key: str,
+    work_item_type: str | None = None,
+) -> str:
+    """Derive the namespaced ``work_items.work_item_id`` string.
+
+    ``instance`` is the repo full name (``owner/repo`` / ``group/project``)
+    for ``system in {"github", "gitlab"}`` — ignored for jira/linear, where
+    the provider-native key alone (``external_key``) is already globally
+    unique within the org's Jira/Linear namespace.
+
+    ``work_item_type`` disambiguates the issue vs. pr/merge_request
+    namespace for github/gitlab (``"pr"`` -> ``ghpr:``, ``"merge_request"``
+    -> ``gitlab:...!...``); any other value (including ``None``, the
+    schema's documented default) is treated as a plain issue.
+    """
+    if system == "jira":
+        return f"jira:{external_key}"
+    if system == "linear":
+        return f"linear:{external_key}"
+    if system == "github":
+        repo = instance or ""
+        if work_item_type == "pr":
+            return f"ghpr:{repo}#{external_key}"
+        return f"gh:{repo}#{external_key}"
+    if system == "gitlab":
+        repo = instance or ""
+        if work_item_type == "merge_request":
+            return f"gitlab:{repo}!{external_key}"
+        return f"gitlab:{repo}#{external_key}"
+    # system == "custom": CC6 excludes the work_item family for custom
+    # sources in v1, but ids.py stays provider-neutral / defensive here
+    # rather than raising, matching D2's custom repo-UUID fallback shape.
+    return f"custom:{instance}:{external_key}"

--- a/src/dev_health_ops/external_ingest/sinks.py
+++ b/src/dev_health_ops/external_ingest/sinks.py
@@ -1,0 +1,926 @@
+"""External-ingest sink-write layer (CHAOS-2698).
+
+Given a schema-validated, kind-normalized ``NormalizedBatch`` (CHAOS-2697's
+worker output), stamp ``org_id``/``source_id`` provenance and write each of
+the 9 v1 record kinds through the **existing** ClickHouse sink methods,
+preserving current append/ReplacingMergeTree-dedup semantics. See
+``ops/docs/architecture/external-ingest-sink-writes.md`` for design
+decisions D1-D8 this module implements.
+
+Two client lifecycles per invocation (D6):
+  - one async ``ClickHouseStore`` for repository/pull_request/review/commit/
+    team/identity (git-family + org-scoped kinds);
+  - one sync ``ClickHouseMetricsSink`` for the work-item family
+    (work_item/work_item_transition/work_item_dependency), run off the event
+    loop via ``asyncio.to_thread`` per kind so one kind's ClickHouse error
+    doesn't block the others (partial-batch resilience).
+
+Identity resolution (D4): work-item assignee/reporter/actor strings go
+through ``resolve_identity()`` (mirrors native connector behavior so
+cross-provider identity rollups stay consistent regardless of ingestion
+path); git-family author/reviewer strings are passed through **raw** exactly
+as native sync stores them.
+
+``identities``/``teams``'s ``updated_at`` is the customer-supplied RMT
+version column, passed through verbatim except for the CC24 future-timestamp
+clamp: values more than ``UPDATED_AT_CLAMP_SKEW`` in the future are replaced
+with server ``now()`` and recorded as a ``SinkWriteResult.warnings`` entry
+(not a rejection) so a buggy/malicious ``updatedAt=2100-01-01`` cannot
+permanently pin an RMT row against all future corrections. Every other
+timestamp in this module (``last_synced``, git-family ``last_synced``) is
+always server ``now()`` — a receive-time marker, not payload content.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from typing import Any, cast
+
+from dev_health_ops.metrics.identity import resolve_identity
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.metrics.sinks.factory import create_sink
+from dev_health_ops.models.work_items import WorkItemDependency
+from dev_health_ops.storage import create_store
+
+from .ids import derive_repo_uuid, derive_work_item_id
+from .types import AffectedScope, NormalizedBatch, SinkWriteError, SinkWriteResult
+
+logger = logging.getLogger(__name__)
+
+__all__ = ["write_batch"]
+
+# CC24: customer `updatedAt` more than this far in the future is clamped to
+# server now() (identities/teams RMT-version-column poisoning defense).
+UPDATED_AT_CLAMP_SKEW = timedelta(minutes=5)
+
+_GIT_SYSTEMS = {"github", "gitlab"}
+
+# WorkItemV1.type -> derive_work_item_id's work_item_type disambiguator.
+_WORK_ITEM_TYPE_FOR_ID = {"pr": "pr", "merge_request": "merge_request"}
+
+
+def _getter(record: Any):
+    if isinstance(record, dict):
+        return record.get
+
+    def _get(key: str, default: Any = None) -> Any:
+        return getattr(record, key, default)
+
+    return _get
+
+
+def _coerce_datetime(value: Any) -> datetime | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        dt = value
+    else:
+        dt = datetime.fromisoformat(str(value).replace("Z", "+00:00"))
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _original_index(batch: NormalizedBatch, kind: str, position: int) -> int:
+    indices = batch.record_index_by_kind.get(kind)
+    if indices and position < len(indices):
+        return indices[position]
+    return position
+
+
+def _track_scope_timestamp(scope: AffectedScope, value: Any) -> None:
+    dt = _coerce_datetime(value)
+    if dt is None:
+        return
+    if scope.min_timestamp is None or dt < scope.min_timestamp:
+        scope.min_timestamp = dt
+    if scope.max_timestamp is None or dt > scope.max_timestamp:
+        scope.max_timestamp = dt
+
+
+def _resolve_customer_identity(system: str, raw: str | None) -> str | None:
+    """D4: resolve a work-item-family raw assignee/reporter/actor string.
+
+    Customer payloads supply one opaque string per person (unlike native
+    connectors' structured email/username/account_id/display_name), so this
+    is a best-effort heuristic: treat it as ``email`` when it looks like one
+    (``resolve_identity`` prioritizes email), else as ``username`` +
+    ``display_name`` so alias-map / provider-qualified-username resolution
+    still applies.
+    """
+    if not raw:
+        return None
+    fields: dict[str, str] = {"username": raw, "display_name": raw}
+    if "@" in raw:
+        fields["email"] = raw
+    return resolve_identity(system, fields)
+
+
+def _clamp_updated_at(
+    value: Any, *, now: datetime | None = None
+) -> tuple[datetime, bool]:
+    now = now or datetime.now(timezone.utc)
+    dt = _coerce_datetime(value) or now
+    if dt > now + UPDATED_AT_CLAMP_SKEW:
+        return now, True
+    return dt, False
+
+
+# system values for which CC6 requires a git-family record's repo identifier
+# to equal the batch's source.instance (custom included -- master-spec CC6:
+# "For github/gitlab/custom, every git-family record's repositoryExternalId
+# MUST equal source.instance").
+_INSTANCE_SCOPED_SYSTEMS = {"github", "gitlab", "custom"}
+
+
+def _check_instance_scope(
+    *,
+    kind: str,
+    system: str,
+    repo_identifier: str,
+    batch: NormalizedBatch,
+    index: int,
+    warnings: list[SinkWriteError],
+) -> None:
+    """CC6 says kind x system / instance-match enforcement is the worker's
+    (CHAOS-2697) job and this layer "may assert-but-not-reject" -- this is
+    that assertion. A record whose repo identifier disagrees with the
+    batch's source.instance still gets written (D2/D3 IDs are derived from
+    the record's own string, not silently coerced to source_instance), but
+    is flagged: it derives a DIFFERENT repo UUID / work_item_id namespace
+    than a native-sync write for the "real" repo would, which forks the
+    identity-continuity guarantee the whole sink layer exists to protect.
+    """
+    if system not in _INSTANCE_SCOPED_SYSTEMS:
+        return
+    if repo_identifier == batch.source_instance:
+        return
+    warnings.append(
+        SinkWriteError(
+            record_index=index,
+            kind=kind,
+            external_id=repo_identifier,
+            code="record_outside_source_instance",
+            message=(
+                f"{kind}.v1 repository identifier {repo_identifier!r} does not "
+                f"match this batch's source.instance {batch.source_instance!r} "
+                "(master-spec CC6) -- record was still written using its own "
+                "identifier, which derives a different repo UUID/work_item_id "
+                "namespace than a native-sync write for the intended repo."
+            ),
+        )
+    )
+
+
+def _check_provider_scope(
+    *,
+    kind: str,
+    record_provider: str | None,
+    batch: NormalizedBatch,
+    index: int,
+    warnings: list[SinkWriteError],
+) -> None:
+    """A per-record ``provider`` field is exactly as spoofable as any other
+    payload content — round-3 codex adversarial review: trusting it for ID/
+    namespace derivation would let a github-authenticated batch (one
+    ``source_id``/``source_system`` CHAOS-2696 actually registered) write
+    rows claiming ``provider="linear"``, landing in the ``linear:``
+    work_item_id namespace and inheriting Linear-only trust (native_team_key)
+    despite never having been authenticated as a Linear source. Callers must
+    use ``batch.source_system`` — never this field — for derivation/storage;
+    this only records the disagreement as a diagnostic warning.
+    """
+    if not record_provider or record_provider == batch.source_system:
+        return
+    warnings.append(
+        SinkWriteError(
+            record_index=index,
+            kind=kind,
+            external_id=None,
+            code="record_provider_mismatch",
+            message=(
+                f"{kind}.v1 provider {record_provider!r} does not match this "
+                f"batch's source.system {batch.source_system!r} -- the record "
+                f"was written under source.system's namespace "
+                f"({batch.source_system!r}), not the claimed provider, to "
+                "prevent cross-namespace pollution."
+            ),
+        )
+    )
+
+
+# ---------------------------------------------------------------------------
+# Row builders — one per record kind. Each returns the shape the target sink
+# method expects; this function is the single translation point between the
+# wire-schema field names (api/external_ingest/schemas.py) and each sink's
+# row contract (brief-2698-sinks.md: "this layer's write_batch() should be
+# the single translation point").
+# ---------------------------------------------------------------------------
+
+
+def _build_repo_object(
+    record: dict[str, Any], batch: NormalizedBatch
+) -> SimpleNamespace:
+    get = record.get
+    system = str(get("source_system") or batch.source_system)
+    external_id = str(get("external_id") or "")
+    repo_id = derive_repo_uuid(system, batch.source_instance, external_id)
+    return SimpleNamespace(
+        id=repo_id,
+        repo=external_id,
+        ref=get("default_ref"),
+        created_at=None,
+        settings=get("settings") or {},
+        tags=get("tags") or [],
+        provider=system,
+        source_id=batch.source_id,
+    )
+
+
+def _build_commit_row(record: dict[str, Any], batch: NormalizedBatch) -> dict[str, Any]:
+    get = record.get
+    repo_full_name = str(get("repository_external_id") or "")
+    author_when = _coerce_datetime(get("author_when"))
+    return {
+        "repo_id": derive_repo_uuid(
+            batch.source_system, batch.source_instance, repo_full_name
+        ),
+        "hash": get("hash"),
+        "message": get("message"),
+        "author_name": get("author_name"),
+        "author_email": get("author_email"),
+        "author_when": author_when,
+        "committer_name": get("committer_name"),
+        "committer_email": get("committer_email"),
+        # git_commits.committer_when is non-nullable — CommitV1.committerWhen
+        # is optional on the wire, so fall back to author_when (matches git's
+        # own default: an unamended commit's committer date == author date).
+        "committer_when": _coerce_datetime(get("committer_when")) or author_when,
+        "parents": get("parents") if get("parents") is not None else 1,
+        "source_id": batch.source_id,
+    }
+
+
+def _build_pr_row(record: dict[str, Any], batch: NormalizedBatch) -> dict[str, Any]:
+    get = record.get
+    repo_full_name = str(get("repository_external_id") or "")
+    return {
+        "repo_id": derive_repo_uuid(
+            batch.source_system, batch.source_instance, repo_full_name
+        ),
+        "number": get("number"),
+        "title": get("title"),
+        "body": get("body"),
+        "state": get("state"),
+        "author_name": get("author_name"),
+        "author_email": get("author_email"),
+        "created_at": _coerce_datetime(get("created_at")),
+        "merged_at": _coerce_datetime(get("merged_at")),
+        "closed_at": _coerce_datetime(get("closed_at")),
+        "head_branch": get("head_branch"),
+        "base_branch": get("base_branch"),
+        "additions": get("additions"),
+        "deletions": get("deletions"),
+        "changed_files": get("changed_files"),
+        "first_review_at": _coerce_datetime(get("first_review_at")),
+        "first_comment_at": _coerce_datetime(get("first_comment_at")),
+        "changes_requested_count": get("changes_requested_count") or 0,
+        "reviews_count": get("reviews_count") or 0,
+        "comments_count": get("comments_count") or 0,
+        "source_id": batch.source_id,
+    }
+
+
+def _build_review_row(record: dict[str, Any], batch: NormalizedBatch) -> dict[str, Any]:
+    get = record.get
+    repo_full_name = str(get("repository_external_id") or "")
+    return {
+        "repo_id": derive_repo_uuid(
+            batch.source_system, batch.source_instance, repo_full_name
+        ),
+        "number": get("pull_request_number"),
+        "review_id": get("review_id"),
+        "reviewer": get("reviewer"),
+        "state": get("state"),
+        "submitted_at": _coerce_datetime(get("submitted_at")),
+        "source_id": batch.source_id,
+    }
+
+
+def _coerce_provider_identities(value: Any) -> str:
+    if isinstance(value, str):
+        return value
+    return json.dumps(value or {})
+
+
+def _build_identity_row(
+    record: dict[str, Any],
+    batch: NormalizedBatch,
+    *,
+    index: int,
+    warnings: list[SinkWriteError],
+) -> dict[str, Any]:
+    get = record.get
+    canonical_id = str(get("canonical_id") or "")
+    updated_at, clamped = _clamp_updated_at(get("updated_at"))
+    if clamped:
+        warnings.append(
+            SinkWriteError(
+                record_index=index,
+                kind="identity",
+                external_id=canonical_id,
+                code="updated_at_clamped",
+                message=(
+                    "identity.v1 updatedAt more than "
+                    f"{int(UPDATED_AT_CLAMP_SKEW.total_seconds() // 60)} minutes in the "
+                    "future; clamped to server now()"
+                ),
+            )
+        )
+    return {
+        "canonical_id": canonical_id,
+        "org_id": batch.org_id,
+        "identity_uuid": get("identity_uuid"),
+        "display_name": get("display_name"),
+        "email": get("email"),
+        "provider_identities": _coerce_provider_identities(get("provider_identities")),
+        "team_ids": get("team_ids") or [],
+        "is_active": int(bool(get("is_active", True))),
+        "updated_at": updated_at,
+        "source_id": batch.source_id,
+    }
+
+
+def _build_team_row(
+    record: dict[str, Any],
+    batch: NormalizedBatch,
+    *,
+    index: int,
+    warnings: list[SinkWriteError],
+) -> dict[str, Any]:
+    get = record.get
+    team_id = str(get("id") or "")
+    updated_at, clamped = _clamp_updated_at(get("updated_at"))
+    if clamped:
+        warnings.append(
+            SinkWriteError(
+                record_index=index,
+                kind="team",
+                external_id=team_id,
+                code="updated_at_clamped",
+                message=(
+                    "team.v1 updatedAt more than "
+                    f"{int(UPDATED_AT_CLAMP_SKEW.total_seconds() // 60)} minutes in the "
+                    "future; clamped to server now()"
+                ),
+            )
+        )
+    return {
+        "id": team_id,
+        "team_uuid": get("team_uuid"),
+        "name": get("name"),
+        "description": get("description"),
+        "members": get("members") or [],
+        "project_keys": get("project_keys") or [],
+        "repo_patterns": get("repo_patterns") or [],
+        "is_active": int(bool(get("is_active", True))),
+        "updated_at": updated_at,
+        "org_id": batch.org_id,
+        "provider": get("provider") or batch.source_system,
+        "native_team_key": get("native_team_key"),
+        "parent_team_id": get("parent_team_id"),
+        "source_id": batch.source_id,
+    }
+
+
+def _project_scope(
+    system: str, get: Any, repository_external_id: str | None
+) -> tuple[str | None, str | None, str | None]:
+    """Returns (project_key, project_id, project_name) per D-table convention."""
+    if system == "jira":
+        return get("project_key"), None, None
+    if system in _GIT_SYSTEMS:
+        return None, repository_external_id, None
+    if system == "linear":
+        project_id = get("project_id") or get("project_name") or get("native_team_key")
+        return None, project_id, get("project_name")
+    # custom
+    return get("project_key"), None, None
+
+
+def _build_work_item_row(
+    record: Any,
+    batch: NormalizedBatch,
+    *,
+    index: int,
+    warnings: list[SinkWriteError],
+) -> dict[str, Any]:
+    get = _getter(record)
+    # Trust boundary (round-3 codex adversarial review): `system` MUST be
+    # batch.source_system, never the customer-supplied per-record
+    # `provider` field. A batch is authenticated/registered for exactly one
+    # system (CHAOS-2696) — trusting a spoofed `provider` here would let a
+    # github-scoped batch write a row claiming `provider="linear"`,
+    # landing in the `linear:` work_item_id namespace (polluting/colliding
+    # with real Linear pushes) and inheriting Linear-only trust
+    # (native_team_key) despite never being authenticated as a Linear
+    # source. The record's own provider, if present and different, only
+    # produces the diagnostic warning below; it is never used for
+    # derivation, storage, or namespace selection.
+    _check_provider_scope(
+        kind="work_item",
+        record_provider=get("provider"),
+        batch=batch,
+        index=index,
+        warnings=warnings,
+    )
+    system = batch.source_system
+    repository_external_id = get("repository_external_id")
+    if repository_external_id:
+        _check_instance_scope(
+            kind="work_item",
+            system=system,
+            repo_identifier=str(repository_external_id),
+            batch=batch,
+            index=index,
+            warnings=warnings,
+        )
+    instance = repository_external_id or (
+        batch.source_instance if system in _GIT_SYSTEMS else None
+    )
+    raw_type = str(get("type") or "unknown")
+    work_item_type = _WORK_ITEM_TYPE_FOR_ID.get(raw_type, "issue")
+    external_key = str(get("external_key"))
+    work_item_id = derive_work_item_id(system, instance, external_key, work_item_type)
+    repo_id = (
+        derive_repo_uuid(system, batch.source_instance, instance)
+        if system in _GIT_SYSTEMS and instance
+        else None
+    )
+    project_key, project_id, project_name = _project_scope(
+        system, get, repository_external_id
+    )
+
+    return {
+        "repo_id": repo_id,
+        "work_item_id": work_item_id,
+        "provider": system,
+        "title": str(get("title") or ""),
+        "type": raw_type,
+        "status": str(get("status") or "unknown"),
+        "status_raw": get("status_raw"),
+        "project_key": project_key,
+        "project_id": project_id,
+        # Team-attribution precedence (docs/architecture/team-attribution.md
+        # §0, AGENTS.md) treats any non-empty work_items.native_team_key as a
+        # top-precedence NATIVE fact -- native sync only ever populates it
+        # for Linear (WorkItem.native_team_key docstring: "None for
+        # GitHub/GitLab ... and Jira"). `system` is now always
+        # batch.source_system (see trust-boundary note above), so this
+        # check is no longer independently spoofable via a forged
+        # per-record `provider`.
+        "native_team_key": get("native_team_key") if system == "linear" else None,
+        "project_name": project_name,
+        "assignees": [
+            identity
+            for identity in (
+                _resolve_customer_identity(system, a) for a in (get("assignees") or [])
+            )
+            if identity
+        ],
+        "reporter": _resolve_customer_identity(system, get("reporter")),
+        "created_at": (created_at := _coerce_datetime(get("created_at"))),
+        # work_items.updated_at is non-nullable — WorkItemV1.updatedAt is
+        # optional on the wire, so fall back to created_at when absent
+        # (mirrors WorkItem's dataclass default of never being None).
+        "updated_at": _coerce_datetime(get("updated_at")) or created_at,
+        "started_at": _coerce_datetime(get("started_at")),
+        "completed_at": _coerce_datetime(get("completed_at")),
+        "closed_at": _coerce_datetime(get("closed_at")),
+        "labels": get("labels") or [],
+        "story_points": get("story_points"),
+        "sprint_id": get("sprint_id"),
+        "sprint_name": get("sprint_name"),
+        "parent_id": get("parent_id"),
+        "epic_id": get("epic_id"),
+        "url": get("url"),
+        "org_id": batch.org_id,
+        "source_id": batch.source_id,
+    }
+
+
+def _build_transition_row(
+    record: Any,
+    batch: NormalizedBatch,
+    *,
+    index: int,
+    warnings: list[SinkWriteError],
+) -> dict[str, Any]:
+    get = _getter(record)
+    # Trust boundary — see _build_work_item_row: system is always
+    # batch.source_system, never the spoofable per-record `provider`.
+    _check_provider_scope(
+        kind="work_item_transition",
+        record_provider=get("provider"),
+        batch=batch,
+        index=index,
+        warnings=warnings,
+    )
+    system = batch.source_system
+    instance = batch.source_instance if system in _GIT_SYSTEMS else None
+    external_key = str(get("external_key"))
+    work_item_type = get("work_item_type")
+    work_item_id = derive_work_item_id(system, instance, external_key, work_item_type)
+    repo_id = (
+        derive_repo_uuid(
+            system, batch.source_instance, instance or batch.source_instance
+        )
+        if system in _GIT_SYSTEMS
+        else None
+    )
+    return {
+        "repo_id": repo_id,
+        "work_item_id": work_item_id,
+        "occurred_at": _coerce_datetime(get("occurred_at")),
+        "from_status": get("from_status"),
+        "to_status": get("to_status"),
+        "from_status_raw": get("from_status_raw"),
+        "to_status_raw": get("to_status_raw"),
+        "actor": _resolve_customer_identity(system, get("actor")),
+        "org_id": batch.org_id,
+        "source_id": batch.source_id,
+    }
+
+
+def _build_dependency(record: Any, batch: NormalizedBatch) -> WorkItemDependency:
+    get = _getter(record)
+    system = batch.source_system
+    instance = batch.source_instance if system in _GIT_SYSTEMS else None
+    source_key = str(get("source_external_key"))
+    target_key = str(get("target_external_key"))
+    source_work_item_id = derive_work_item_id(
+        system, instance, source_key, get("source_work_item_type")
+    )
+    target_work_item_id = derive_work_item_id(
+        system, instance, target_key, get("target_work_item_type")
+    )
+    return WorkItemDependency(
+        source_work_item_id=source_work_item_id,
+        target_work_item_id=target_work_item_id,
+        relationship_type=str(get("relationship_type")),
+        relationship_type_raw=str(get("relationship_type_raw") or ""),
+        last_synced=datetime.now(timezone.utc),
+        org_id=batch.org_id,
+        source_id=batch.source_id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# write_batch
+# ---------------------------------------------------------------------------
+
+
+@asynccontextmanager
+async def _maybe_store(
+    clickhouse_dsn: str, org_id: str, needed: bool
+) -> AsyncIterator[Any]:
+    """Only open a ClickHouseStore connection when a git-family/team/identity
+    kind is actually present — avoids a wasted connection for pure work-item
+    (jira/linear-only) batches.
+
+    Yields ``None`` when not needed; callers only dereference the yielded
+    value inside the same ``if batch.<kind>:`` guards that determined
+    ``needed`` in the first place, so ``None`` is never actually touched —
+    typed as plain ``Any`` (not ``Any | None``) so mypy doesn't demand a
+    redundant None-check at every call site.
+    """
+    if not needed:
+        yield None
+        return
+    store = create_store(clickhouse_dsn, "clickhouse")
+    store.org_id = org_id
+    async with store:
+        yield store
+
+
+def _open_metrics_sink(clickhouse_dsn: str, org_id: str) -> ClickHouseMetricsSink:
+    """``create_sink()`` is typed to return the abstract ``BaseMetricsSink``;
+    narrow to the concrete class this module actually needs (org_id
+    attribute, work-item-family write methods with the loose row-dict
+    signatures ``WorkGraphMixin`` implements, not the ABC's stricter typed
+    ``Sequence[WorkItem]`` declarations). ``create_sink`` always returns
+    ``ClickHouseMetricsSink`` for a clickhouse DSN — a type-checker-only
+    ``cast``, not a runtime ``isinstance`` check, deliberately: unit tests
+    patch ``create_sink`` with a duck-typed fake, which is not (and should
+    not need to be) a ``ClickHouseMetricsSink`` subclass."""
+    sink = cast(ClickHouseMetricsSink, create_sink(clickhouse_dsn))
+    sink.org_id = org_id
+    return sink
+
+
+async def write_batch(
+    batch: NormalizedBatch, *, clickhouse_dsn: str
+) -> SinkWriteResult:
+    errors: list[SinkWriteError] = []
+    warnings: list[SinkWriteError] = []
+    counts: dict[str, int] = {}
+    scope = AffectedScope(
+        org_id=batch.org_id,
+        source_systems={batch.source_system},
+        source_instances={batch.source_instance},
+    )
+
+    needs_async_store = bool(
+        batch.repositories
+        or batch.commits
+        or batch.pull_requests
+        or batch.reviews
+        or batch.teams
+        or batch.identities
+    )
+
+    async with _maybe_store(clickhouse_dsn, batch.org_id, needs_async_store) as store:
+        if batch.repositories:
+            try:
+                for i, r in enumerate(batch.repositories):
+                    _check_instance_scope(
+                        kind="repository",
+                        system=str(r.get("source_system") or batch.source_system),
+                        repo_identifier=str(r.get("external_id") or ""),
+                        batch=batch,
+                        index=_original_index(batch, "repository", i),
+                        warnings=warnings,
+                    )
+                repo_objs = [_build_repo_object(r, batch) for r in batch.repositories]
+                for repo_obj in repo_objs:
+                    await store.insert_repo(repo_obj)
+                    scope.repo_ids.add(repo_obj.id)
+                counts["repository"] = len(batch.repositories)
+                scope.record_kinds.add("repository")
+            except Exception as exc:  # noqa: BLE001 - one failed kind must not sink the batch
+                logger.exception("write_batch: repository sink write failed")
+                errors.append(
+                    SinkWriteError(
+                        record_index=-1,
+                        kind="repository",
+                        external_id=None,
+                        code="clickhouse_insert_failed",
+                        message=str(exc),
+                    )
+                )
+
+        if batch.commits:
+            try:
+                for i, r in enumerate(batch.commits):
+                    _check_instance_scope(
+                        kind="commit",
+                        system=batch.source_system,
+                        repo_identifier=str(r.get("repository_external_id") or ""),
+                        batch=batch,
+                        index=_original_index(batch, "commit", i),
+                        warnings=warnings,
+                    )
+                rows = [_build_commit_row(r, batch) for r in batch.commits]
+                await store.insert_git_commit_data(rows)
+                counts["commit"] = len(batch.commits)
+                scope.record_kinds.add("commit")
+                for row in rows:
+                    scope.repo_ids.add(row["repo_id"])
+                    _track_scope_timestamp(scope, row.get("author_when"))
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("write_batch: commit sink write failed")
+                errors.append(
+                    SinkWriteError(
+                        record_index=-1,
+                        kind="commit",
+                        external_id=None,
+                        code="clickhouse_insert_failed",
+                        message=str(exc),
+                    )
+                )
+
+        if batch.pull_requests:
+            try:
+                for i, r in enumerate(batch.pull_requests):
+                    _check_instance_scope(
+                        kind="pull_request",
+                        system=batch.source_system,
+                        repo_identifier=str(r.get("repository_external_id") or ""),
+                        batch=batch,
+                        index=_original_index(batch, "pull_request", i),
+                        warnings=warnings,
+                    )
+                rows = [_build_pr_row(r, batch) for r in batch.pull_requests]
+                await store.insert_git_pull_requests(rows)
+                counts["pull_request"] = len(batch.pull_requests)
+                scope.record_kinds.add("pull_request")
+                for row in rows:
+                    scope.repo_ids.add(row["repo_id"])
+                    _track_scope_timestamp(scope, row.get("created_at"))
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("write_batch: pull_request sink write failed")
+                errors.append(
+                    SinkWriteError(
+                        record_index=-1,
+                        kind="pull_request",
+                        external_id=None,
+                        code="clickhouse_insert_failed",
+                        message=str(exc),
+                    )
+                )
+
+        if batch.reviews:
+            try:
+                for i, r in enumerate(batch.reviews):
+                    _check_instance_scope(
+                        kind="review",
+                        system=batch.source_system,
+                        repo_identifier=str(r.get("repository_external_id") or ""),
+                        batch=batch,
+                        index=_original_index(batch, "review", i),
+                        warnings=warnings,
+                    )
+                rows = [_build_review_row(r, batch) for r in batch.reviews]
+                await store.insert_git_pull_request_reviews(rows)
+                counts["review"] = len(batch.reviews)
+                scope.record_kinds.add("review")
+                for row in rows:
+                    scope.repo_ids.add(row["repo_id"])
+                    _track_scope_timestamp(scope, row.get("submitted_at"))
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("write_batch: review sink write failed")
+                errors.append(
+                    SinkWriteError(
+                        record_index=-1,
+                        kind="review",
+                        external_id=None,
+                        code="clickhouse_insert_failed",
+                        message=str(exc),
+                    )
+                )
+
+        if batch.teams:
+            try:
+                rows = [
+                    _build_team_row(
+                        r,
+                        batch,
+                        index=_original_index(batch, "team", i),
+                        warnings=warnings,
+                    )
+                    for i, r in enumerate(batch.teams)
+                ]
+                await store.insert_teams(rows)
+                counts["team"] = len(batch.teams)
+                scope.record_kinds.add("team")
+                for row in rows:
+                    scope.team_ids.add(row["id"])
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("write_batch: team sink write failed")
+                errors.append(
+                    SinkWriteError(
+                        record_index=-1,
+                        kind="team",
+                        external_id=None,
+                        code="clickhouse_insert_failed",
+                        message=str(exc),
+                    )
+                )
+
+        if batch.identities:
+            try:
+                rows = [
+                    _build_identity_row(
+                        r,
+                        batch,
+                        index=_original_index(batch, "identity", i),
+                        warnings=warnings,
+                    )
+                    for i, r in enumerate(batch.identities)
+                ]
+                await store.insert_identities(rows)
+                counts["identity"] = len(batch.identities)
+                scope.record_kinds.add("identity")
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("write_batch: identity sink write failed")
+                errors.append(
+                    SinkWriteError(
+                        record_index=-1,
+                        kind="identity",
+                        external_id=None,
+                        code="clickhouse_insert_failed",
+                        message=str(exc),
+                    )
+                )
+
+    if batch.work_items:
+        try:
+            rows = [
+                _build_work_item_row(
+                    r,
+                    batch,
+                    index=_original_index(batch, "work_item", i),
+                    warnings=warnings,
+                )
+                for i, r in enumerate(batch.work_items)
+            ]
+            sink = _open_metrics_sink(clickhouse_dsn, batch.org_id)
+            try:
+                await asyncio.to_thread(sink.write_work_items, rows)
+            finally:
+                sink.close()
+            counts["work_item"] = len(batch.work_items)
+            scope.record_kinds.add("work_item")
+            for row in rows:
+                if row["repo_id"] is not None:
+                    scope.repo_ids.add(row["repo_id"])
+                scope.work_item_ids.add(row["work_item_id"])
+                _track_scope_timestamp(
+                    scope, row.get("updated_at") or row.get("created_at")
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("write_batch: work_item sink write failed")
+            errors.append(
+                SinkWriteError(
+                    record_index=-1,
+                    kind="work_item",
+                    external_id=None,
+                    code="clickhouse_insert_failed",
+                    message=str(exc),
+                )
+            )
+
+    if batch.work_item_transitions:
+        try:
+            rows = [
+                _build_transition_row(
+                    r,
+                    batch,
+                    index=_original_index(batch, "work_item_transition", i),
+                    warnings=warnings,
+                )
+                for i, r in enumerate(batch.work_item_transitions)
+            ]
+            sink = _open_metrics_sink(clickhouse_dsn, batch.org_id)
+            try:
+                await asyncio.to_thread(sink.write_work_item_transitions, rows)
+            finally:
+                sink.close()
+            counts["work_item_transition"] = len(batch.work_item_transitions)
+            scope.record_kinds.add("work_item_transition")
+            for row in rows:
+                if row["repo_id"] is not None:
+                    scope.repo_ids.add(row["repo_id"])
+                scope.work_item_ids.add(row["work_item_id"])
+                _track_scope_timestamp(scope, row.get("occurred_at"))
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("write_batch: work_item_transition sink write failed")
+            errors.append(
+                SinkWriteError(
+                    record_index=-1,
+                    kind="work_item_transition",
+                    external_id=None,
+                    code="clickhouse_insert_failed",
+                    message=str(exc),
+                )
+            )
+
+    if batch.work_item_dependencies:
+        try:
+            deps = [_build_dependency(r, batch) for r in batch.work_item_dependencies]
+            sink = _open_metrics_sink(clickhouse_dsn, batch.org_id)
+            try:
+                await asyncio.to_thread(sink.write_work_item_dependencies, deps)
+            finally:
+                sink.close()
+            counts["work_item_dependency"] = len(batch.work_item_dependencies)
+            scope.record_kinds.add("work_item_dependency")
+            for dep in deps:
+                scope.work_item_ids.add(dep.source_work_item_id)
+                scope.work_item_ids.add(dep.target_work_item_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("write_batch: work_item_dependency sink write failed")
+            errors.append(
+                SinkWriteError(
+                    record_index=-1,
+                    kind="work_item_dependency",
+                    external_id=None,
+                    code="clickhouse_insert_failed",
+                    message=str(exc),
+                )
+            )
+
+    return SinkWriteResult(
+        ingestion_id=batch.ingestion_id,
+        org_id=batch.org_id,
+        counts_written=counts,
+        errors=errors,
+        warnings=warnings,
+        affected_scope=scope,
+    )

--- a/src/dev_health_ops/external_ingest/types.py
+++ b/src/dev_health_ops/external_ingest/types.py
@@ -1,0 +1,112 @@
+"""Sink-write layer data contracts (CHAOS-2698).
+
+``NormalizedBatch`` is the interface CHAOS-2697's worker normalization hands
+to ``sinks.write_batch()``; ``SinkWriteResult``/``SinkWriteError``/
+``AffectedScope`` are what this layer hands back to CHAOS-2694 (status/error
+persistence) and CHAOS-2699 (bounded recompute). CHAOS-2699 does NOT import
+these types — its planner takes primitives (org_id, repo_ids, etc.) directly;
+CHAOS-2697 maps ``AffectedScope`` to those kwargs at the call site
+(master-spec CC21).
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+__all__ = [
+    "NormalizedBatch",
+    "SinkWriteError",
+    "AffectedScope",
+    "SinkWriteResult",
+]
+
+
+@dataclass
+class NormalizedBatch:
+    """Schema-validated, kind-normalized records ready for sink writes.
+
+    ``repositories``/``pull_requests``/``reviews``/``commits``/``identities``/
+    ``teams`` are plain dicts keyed by the same snake_case field names as
+    their ``api/external_ingest/schemas.py`` pydantic model (``RepositoryV1``,
+    ``PullRequestV1``, ``ReviewV1``, ``CommitV1``, ``IdentityV1``, ``TeamV1``).
+    ``work_items``/``work_item_transitions``/``work_item_dependencies`` accept
+    either the corresponding pydantic model instance (``WorkItemV1`` etc.) or
+    an equivalent dict — ``sinks.py`` duck-types both via attribute-or-key
+    lookup, so CHAOS-2697 may emit whichever shape is more convenient.
+    """
+
+    org_id: str
+    source_id: uuid.UUID
+    source_system: str  # "github" | "gitlab" | "jira" | "linear" | "custom"
+    source_instance: (
+        str  # e.g. "acme/api" (github/gitlab), "ABC" (jira), "CHAOS" (linear)
+    )
+    ingestion_id: uuid.UUID
+    repositories: list[dict[str, Any]] = field(default_factory=list)
+    identities: list[dict[str, Any]] = field(default_factory=list)
+    teams: list[dict[str, Any]] = field(default_factory=list)
+    work_items: list[Any] = field(default_factory=list)
+    work_item_transitions: list[Any] = field(default_factory=list)
+    work_item_dependencies: list[Any] = field(default_factory=list)
+    pull_requests: list[dict[str, Any]] = field(default_factory=list)
+    reviews: list[dict[str, Any]] = field(default_factory=list)
+    commits: list[dict[str, Any]] = field(default_factory=list)
+    # Per-kind list of the record's original index in the accepted envelope's
+    # `records` array, for error/warning correlation back to CHAOS-2694's
+    # rejection diagnostics. Falls back to in-batch position when absent or
+    # a kind's list is shorter than its record list.
+    record_index_by_kind: dict[str, list[int]] = field(default_factory=dict)
+
+
+@dataclass
+class SinkWriteError:
+    """A write-time failure or non-rejecting warning for one kind's write.
+
+    ``record_index`` is the record's original position in the envelope's
+    ``records`` array when known, else ``-1`` for batch-level (whole sink
+    method call) failures — sink methods write a kind in one batched call, so
+    a ClickHouse error there fails every record of that kind in this batch
+    (brief-2698-sinks.md: batch-call granularity, not per-record).
+    """
+
+    record_index: int
+    kind: str
+    external_id: str | None
+    code: str  # e.g. "clickhouse_insert_failed", "updated_at_clamped"
+    message: str
+
+
+@dataclass
+class AffectedScope:
+    """What this batch touched, for CHAOS-2699's bounded recompute planner."""
+
+    org_id: str
+    source_systems: set[str] = field(default_factory=set)
+    source_instances: set[str] = field(default_factory=set)
+    repo_ids: set[uuid.UUID] = field(default_factory=set)
+    team_ids: set[str] = field(default_factory=set)
+    work_item_ids: set[str] = field(default_factory=set)
+    min_timestamp: datetime | None = None
+    max_timestamp: datetime | None = None
+    record_kinds: set[str] = field(default_factory=set)
+
+
+@dataclass
+class SinkWriteResult:
+    """Machine-readable summary of one ``write_batch()`` call."""
+
+    ingestion_id: uuid.UUID
+    org_id: str
+    counts_written: dict[str, int] = field(default_factory=dict)
+    # Write-time failures only (validation already happened upstream).
+    errors: list[SinkWriteError] = field(default_factory=list)
+    # Non-rejecting diagnostics — currently only the D8/CC24 updatedAt clamp.
+    # Additive vs. the interface brief's original sketch (counts/errors/
+    # affected_scope only); CHAOS-2694 may ignore this field.
+    warnings: list[SinkWriteError] = field(default_factory=list)
+    affected_scope: AffectedScope = field(
+        default_factory=lambda: AffectedScope(org_id="")
+    )

--- a/src/dev_health_ops/metrics/sinks/clickhouse/work_graph.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/work_graph.py
@@ -342,6 +342,7 @@ class WorkGraphMixin(_ClickHouseSinkBase):
                 "relationship_type_raw",
                 "last_synced",
                 "org_id",
+                "source_id",
             ],
             rows,
         )
@@ -678,6 +679,9 @@ class WorkGraphMixin(_ClickHouseSinkBase):
                     "url": str(get("url") or ""),
                     "last_synced": _dt_to_clickhouse_datetime(synced_at),
                     "org_id": item["org_id"] if is_dict else item.org_id,
+                    # Nullable(UUID) — NULL for native sync, stamped by
+                    # external-ingest sink writes (CHAOS-2698 D1).
+                    "source_id": get("source_id"),
                 }
             )
 
@@ -709,6 +713,7 @@ class WorkGraphMixin(_ClickHouseSinkBase):
             "url",
             "last_synced",
             "org_id",
+            "source_id",
         ]
         for chunk in _chunked(rows, DEFAULT_BATCH_SIZE):
             matrix = [[row[col] for col in column_names] for row in chunk]
@@ -752,6 +757,9 @@ class WorkGraphMixin(_ClickHouseSinkBase):
                     "actor": str(get("actor") or ""),
                     "last_synced": _dt_to_clickhouse_datetime(synced_at),
                     "org_id": item["org_id"] if is_dict else item.org_id,
+                    # Nullable(UUID) — NULL for native sync, stamped by
+                    # external-ingest sink writes (CHAOS-2698 D1).
+                    "source_id": get("source_id"),
                 }
             )
 
@@ -766,6 +774,7 @@ class WorkGraphMixin(_ClickHouseSinkBase):
             "actor",
             "last_synced",
             "org_id",
+            "source_id",
         ]
         for chunk in _chunked(rows, DEFAULT_BATCH_SIZE):
             matrix = [[row[col] for col in column_names] for row in chunk]

--- a/src/dev_health_ops/migrations/clickhouse/065_external_ingest_source_id.sql
+++ b/src/dev_health_ops/migrations/clickhouse/065_external_ingest_source_id.sql
@@ -1,0 +1,14 @@
+-- Migration 065: add source_id provenance column to the 9 external-ingest
+-- record-kind tables (CHAOS-2698). NULL for every existing native-sync row.
+-- Set to the resolved customer-push source's UUID (external_ingest_sources.id,
+-- CHAOS-2696 Postgres migration 0032) by the external-ingest sink-write layer.
+-- Not part of any ORDER BY key -- purely a queryable attribution column.
+ALTER TABLE repos                    ADD COLUMN IF NOT EXISTS source_id Nullable(UUID) DEFAULT NULL;
+ALTER TABLE git_commits               ADD COLUMN IF NOT EXISTS source_id Nullable(UUID) DEFAULT NULL;
+ALTER TABLE git_pull_requests         ADD COLUMN IF NOT EXISTS source_id Nullable(UUID) DEFAULT NULL;
+ALTER TABLE git_pull_request_reviews  ADD COLUMN IF NOT EXISTS source_id Nullable(UUID) DEFAULT NULL;
+ALTER TABLE teams                     ADD COLUMN IF NOT EXISTS source_id Nullable(UUID) DEFAULT NULL;
+ALTER TABLE identities                ADD COLUMN IF NOT EXISTS source_id Nullable(UUID) DEFAULT NULL;
+ALTER TABLE work_items                ADD COLUMN IF NOT EXISTS source_id Nullable(UUID) DEFAULT NULL;
+ALTER TABLE work_item_transitions     ADD COLUMN IF NOT EXISTS source_id Nullable(UUID) DEFAULT NULL;
+ALTER TABLE work_item_dependencies    ADD COLUMN IF NOT EXISTS source_id Nullable(UUID) DEFAULT NULL;

--- a/src/dev_health_ops/models/work_items.py
+++ b/src/dev_health_ops/models/work_items.py
@@ -146,6 +146,9 @@ class WorkItemDependency:
     relationship_type_raw: str
     last_synced: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     org_id: str = ""
+    # Nullable — NULL for native sync, stamped by external-ingest sink writes
+    # (CHAOS-2698 D1).
+    source_id: uuid.UUID | None = None
 
 
 @dataclass(frozen=True)

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -86,6 +86,15 @@ class ClickHouseStore:
         return uuid.UUID(str(value))
 
     @staticmethod
+    def _normalize_uuid_or_none(value: Any) -> uuid.UUID | None:
+        """Nullable-UUID variant of ``_normalize_uuid`` (CHAOS-2698 source_id)."""
+        if value is None:
+            return None
+        if isinstance(value, uuid.UUID):
+            return value
+        return uuid.UUID(str(value))
+
+    @staticmethod
     def _normalize_datetime(value: Any) -> Any:
         if value is None:
             return None
@@ -283,6 +292,9 @@ class ClickHouseStore:
             "tags": self._json_or_none(getattr(repo, "tags", None)),
             "provider": getattr(repo, "provider", None) or "unknown",
             "last_synced": synced_at,
+            # Nullable(UUID) — NULL for native sync, stamped by external-ingest
+            # sink writes (CHAOS-2698 D1).
+            "source_id": self._normalize_uuid_or_none(getattr(repo, "source_id", None)),
         }
         await self._insert_rows(
             "repos",
@@ -295,6 +307,7 @@ class ClickHouseStore:
                 "tags",
                 "provider",
                 "last_synced",
+                "source_id",
             ],
             [row],
         )
@@ -648,6 +661,9 @@ class ClickHouseStore:
                         "last_synced": self._normalize_datetime(
                             item.get("last_synced") or synced_at_default
                         ),
+                        "source_id": self._normalize_uuid_or_none(
+                            item.get("source_id")
+                        ),
                     }
                 )
             else:
@@ -666,6 +682,9 @@ class ClickHouseStore:
                         "last_synced": self._normalize_datetime(
                             getattr(item, "last_synced", None) or synced_at_default
                         ),
+                        "source_id": self._normalize_uuid_or_none(
+                            getattr(item, "source_id", None)
+                        ),
                     }
                 )
 
@@ -683,6 +702,7 @@ class ClickHouseStore:
                 "committer_when",
                 "parents",
                 "last_synced",
+                "source_id",
             ],
             rows,
         )
@@ -838,6 +858,9 @@ class ClickHouseStore:
                         "last_synced": self._normalize_datetime(
                             item.get("last_synced") or synced_at_default
                         ),
+                        "source_id": self._normalize_uuid_or_none(
+                            item.get("source_id")
+                        ),
                     }
                 )
             else:
@@ -872,6 +895,9 @@ class ClickHouseStore:
                         "last_synced": self._normalize_datetime(
                             getattr(item, "last_synced", None) or synced_at_default
                         ),
+                        "source_id": self._normalize_uuid_or_none(
+                            getattr(item, "source_id", None)
+                        ),
                     }
                 )
 
@@ -899,6 +925,7 @@ class ClickHouseStore:
                 "reviews_count",
                 "comments_count",
                 "last_synced",
+                "source_id",
             ],
             rows,
         )
@@ -925,6 +952,9 @@ class ClickHouseStore:
                         "last_synced": self._normalize_datetime(
                             item.get("last_synced") or synced_at_default
                         ),
+                        "source_id": self._normalize_uuid_or_none(
+                            item.get("source_id")
+                        ),
                     }
                 )
             else:
@@ -939,6 +969,9 @@ class ClickHouseStore:
                         "last_synced": self._normalize_datetime(
                             getattr(item, "last_synced", None) or synced_at_default
                         ),
+                        "source_id": self._normalize_uuid_or_none(
+                            getattr(item, "source_id", None)
+                        ),
                     }
                 )
 
@@ -952,6 +985,7 @@ class ClickHouseStore:
                 "state",
                 "submitted_at",
                 "last_synced",
+                "source_id",
             ],
             rows,
         )
@@ -1552,6 +1586,9 @@ class ClickHouseStore:
                         "provider": str(item.get("provider") or ""),
                         "native_team_key": item.get("native_team_key"),
                         "parent_team_id": item.get("parent_team_id"),
+                        "source_id": self._normalize_uuid_or_none(
+                            item.get("source_id")
+                        ),
                     }
                 )
             else:
@@ -1571,6 +1608,9 @@ class ClickHouseStore:
                         "provider": str(getattr(item, "provider", "") or ""),
                         "native_team_key": getattr(item, "native_team_key", None),
                         "parent_team_id": getattr(item, "parent_team_id", None),
+                        "source_id": self._normalize_uuid_or_none(
+                            getattr(item, "source_id", None)
+                        ),
                     }
                 )
 
@@ -1591,6 +1631,7 @@ class ClickHouseStore:
                 "provider",
                 "native_team_key",
                 "parent_team_id",
+                "source_id",
             ],
             rows,
         )
@@ -1630,6 +1671,7 @@ class ClickHouseStore:
                     "is_active": int(get("is_active", 1) or 0),
                     "updated_at": self._normalize_datetime(get("updated_at"))
                     or synced_at,
+                    "source_id": self._normalize_uuid_or_none(get("source_id")),
                 }
             )
         await self._insert_rows(
@@ -1644,6 +1686,7 @@ class ClickHouseStore:
                 "team_ids",
                 "is_active",
                 "updated_at",
+                "source_id",
             ],
             rows,
         )

--- a/tests/external_ingest/test_sinks_clickhouse.py
+++ b/tests/external_ingest/test_sinks_clickhouse.py
@@ -1,0 +1,663 @@
+"""Live-ClickHouse round-trip tests for external_ingest.sinks.write_batch
+(CHAOS-2698, master-spec CC24: "Live-CH round-trip tests for all 9 kinds
+are OWNED BY 2698").
+
+For each of the 9 v1 record kinds: write one record via ``write_batch()``,
+read back with ``FINAL``, assert ``org_id``/``source_id``/provider
+attribution, then re-push an updated record and prove the RMT dedup/version
+semantics (D7) — plus the D2 repo-identity handoff proof and the D7/D8
+special cases called out in the brief.
+
+Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``. Point
+``CLICKHOUSE_URI`` at an ISOLATED scratch database — never ``default``
+(house rule, AGENTS.md "Safety rule (NON-NEGOTIABLE)").
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dev_health_ops.external_ingest.ids import derive_repo_uuid
+from dev_health_ops.external_ingest.sinks import write_batch
+from dev_health_ops.external_ingest.types import NormalizedBatch
+from dev_health_ops.metrics.sinks.clickhouse.idempotency import (
+    WORK_ITEM_TRANSITION_SEMANTIC_COLUMNS,
+    semantic_deduped_subquery,
+)
+from dev_health_ops.models.git import get_repo_uuid_from_repo
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.asyncio,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/ci_local_validate_2698)",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def dsn() -> str:
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    return CLICKHOUSE_URI
+
+
+@pytest.fixture(scope="module")
+def raw_client(dsn: str):
+    import clickhouse_connect
+
+    client = clickhouse_connect.get_client(dsn=dsn)
+    # Apply pending migrations (including 065) regardless of
+    # AUTO_RUN_MIGRATIONS — the column under test is a migration.
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    ClickHouseMetricsSink(dsn).ensure_schema(force=True)
+    yield client
+    client.close()
+
+
+def _org() -> str:
+    return f"test-chaos-2698-{uuid.uuid4()}"
+
+
+def _final_rows(raw_client, table: str, where: str, params: dict) -> list[tuple]:
+    raw_client.command(f"OPTIMIZE TABLE {table} FINAL")
+    result = raw_client.query(
+        f"SELECT * FROM {table} FINAL WHERE {where}", parameters=params
+    )
+    return list(result.result_rows or [])
+
+
+def _col_index(raw_client, table: str, where: str, params: dict, column: str):
+    result = raw_client.query(
+        f"SELECT {column} FROM {table} FINAL WHERE {where}", parameters=params
+    )
+    return list(result.result_rows or [])
+
+
+@pytest.fixture()
+def source_id() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+async def test_repository_round_trip_and_repo_identity_handoff(
+    raw_client, dsn, source_id
+):
+    org_id = _org()
+    repo_name = f"acme/api-{uuid.uuid4().hex[:8]}"
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        repositories=[
+            {
+                "external_id": repo_name,
+                "source_system": "github",
+                "tags": [],
+                "settings": {},
+            }
+        ],
+    )
+    result = await write_batch(batch, clickhouse_dsn=dsn)
+    assert not result.errors
+    assert result.counts_written["repository"] == 1
+
+    rows = _final_rows(
+        raw_client, "repos", "org_id = {org_id:String}", {"org_id": org_id}
+    )
+    assert len(rows) == 1
+
+    # D2 identity-continuity proof: the pushed repo's UUID equals what a
+    # native-sync-style GitHub processor would derive for the "same" repo.
+    result_ids = _col_index(
+        raw_client,
+        "repos",
+        "org_id = {org_id:String}",
+        {"org_id": org_id},
+        "id, source_id",
+    )
+    repo_uuid, stamped_source_id = result_ids[0]
+    assert str(repo_uuid) == str(derive_repo_uuid("github", repo_name, repo_name))
+    assert str(repo_uuid) == str(get_repo_uuid_from_repo(repo_name))
+    assert str(stamped_source_id) == str(source_id)
+
+    # Re-push with a different default_ref — RMT full-replace on newer last_synced.
+    batch2 = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        repositories=[
+            {
+                "external_id": repo_name,
+                "source_system": "github",
+                "default_ref": "develop",
+                "tags": [],
+                "settings": {},
+            }
+        ],
+    )
+    await write_batch(batch2, clickhouse_dsn=dsn)
+    rows2 = _final_rows(
+        raw_client, "repos", "org_id = {org_id:String}", {"org_id": org_id}
+    )
+    assert len(rows2) == 1
+    ref_rows = _col_index(
+        raw_client, "repos", "org_id = {org_id:String}", {"org_id": org_id}, "ref"
+    )
+    assert ref_rows[0][0] == "develop"
+
+
+async def test_native_sync_repo_write_leaves_source_id_null(raw_client, dsn):
+    """Backward-compat proof (brief risk #2): a native-sync-style insert_repo
+    call with no source_id set still succeeds and yields source_id IS NULL."""
+    from dev_health_ops.storage import create_store
+
+    org_id = _org()
+    repo_name = f"native/{uuid.uuid4().hex[:8]}"
+    store = create_store(dsn, "clickhouse")
+    store.org_id = org_id
+    async with store:
+        from dev_health_ops.models.git import Repo
+
+        repo = Repo(repo=repo_name, provider="github")
+        await store.insert_repo(repo)
+
+    rows = _col_index(
+        raw_client, "repos", "org_id = {org_id:String}", {"org_id": org_id}, "source_id"
+    )
+    assert rows[0][0] is None
+
+
+async def test_commit_round_trip(raw_client, dsn, source_id):
+    org_id = _org()
+    repo_name = f"acme/api-{uuid.uuid4().hex[:8]}"
+    commit_hash = uuid.uuid4().hex + uuid.uuid4().hex[:8]
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        commits=[
+            {
+                "repository_external_id": repo_name,
+                "hash": commit_hash,
+                "author_name": "Alice",
+                "author_email": "alice@example.com",
+                "author_when": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    result = await write_batch(batch, clickhouse_dsn=dsn)
+    assert not result.errors
+    rows = _final_rows(
+        raw_client, "git_commits", "hash = {hash:String}", {"hash": commit_hash}
+    )
+    assert len(rows) == 1
+
+    # Re-push with a changed message.
+    batch2 = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        commits=[
+            {
+                "repository_external_id": repo_name,
+                "hash": commit_hash,
+                "message": "updated message",
+                "author_name": "Alice",
+                "author_email": "alice@example.com",
+                "author_when": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    await write_batch(batch2, clickhouse_dsn=dsn)
+    rows2 = _col_index(
+        raw_client,
+        "git_commits",
+        "hash = {hash:String}",
+        {"hash": commit_hash},
+        "message, source_id",
+    )
+    assert len(rows2) == 1
+    assert rows2[0][0] == "updated message"
+    assert str(rows2[0][1]) == str(source_id)
+
+
+async def test_pull_request_round_trip(raw_client, dsn, source_id):
+    org_id = _org()
+    repo_name = f"acme/api-{uuid.uuid4().hex[:8]}"
+    number = 101
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        pull_requests=[
+            {
+                "repository_external_id": repo_name,
+                "number": number,
+                "state": "open",
+                "title": "Add feature",
+                "created_at": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    result = await write_batch(batch, clickhouse_dsn=dsn)
+    assert not result.errors
+    repo_id = derive_repo_uuid("github", repo_name, repo_name)
+    rows = _final_rows(
+        raw_client,
+        "git_pull_requests",
+        "repo_id = {repo_id:UUID} AND number = {number:UInt32}",
+        {"repo_id": str(repo_id), "number": number},
+    )
+    assert len(rows) == 1
+
+    batch2 = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        pull_requests=[
+            {
+                "repository_external_id": repo_name,
+                "number": number,
+                "state": "merged",
+                "title": "Add feature",
+                "created_at": datetime.now(timezone.utc),
+                "merged_at": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    await write_batch(batch2, clickhouse_dsn=dsn)
+    rows2 = _col_index(
+        raw_client,
+        "git_pull_requests",
+        "repo_id = {repo_id:UUID} AND number = {number:UInt32}",
+        {"repo_id": str(repo_id), "number": number},
+        "state",
+    )
+    assert len(rows2) == 1
+    assert rows2[0][0] == "merged"
+
+
+async def test_review_round_trip(raw_client, dsn, source_id):
+    org_id = _org()
+    repo_name = f"acme/api-{uuid.uuid4().hex[:8]}"
+    review_id = str(uuid.uuid4())
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        reviews=[
+            {
+                "repository_external_id": repo_name,
+                "pull_request_number": 5,
+                "review_id": review_id,
+                "reviewer": "bob",
+                "state": "APPROVED",
+                "submitted_at": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    result = await write_batch(batch, clickhouse_dsn=dsn)
+    assert not result.errors
+    rows = _final_rows(
+        raw_client,
+        "git_pull_request_reviews",
+        "review_id = {review_id:String}",
+        {"review_id": review_id},
+    )
+    assert len(rows) == 1
+
+    batch2 = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        reviews=[
+            {
+                "repository_external_id": repo_name,
+                "pull_request_number": 5,
+                "review_id": review_id,
+                "reviewer": "bob",
+                "state": "CHANGES_REQUESTED",
+                "submitted_at": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    await write_batch(batch2, clickhouse_dsn=dsn)
+    rows2 = _col_index(
+        raw_client,
+        "git_pull_request_reviews",
+        "review_id = {review_id:String}",
+        {"review_id": review_id},
+        "state",
+    )
+    assert len(rows2) == 1
+    assert rows2[0][0] == "CHANGES_REQUESTED"
+
+
+async def test_team_round_trip_and_updated_at_passthrough(raw_client, dsn, source_id):
+    org_id = _org()
+    team_id = f"team-{uuid.uuid4().hex[:8]}"
+    ts = datetime.now(timezone.utc) - timedelta(days=1)
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="linear",
+        source_instance="CHAOS",
+        ingestion_id=uuid.uuid4(),
+        teams=[{"id": team_id, "name": "Team One", "updated_at": ts}],
+    )
+    result = await write_batch(batch, clickhouse_dsn=dsn)
+    assert not result.errors
+    assert not result.warnings
+    rows = _col_index(
+        raw_client,
+        "teams",
+        "id = {id:String} AND org_id = {org_id:String}",
+        {"id": team_id, "org_id": org_id},
+        "name, source_id",
+    )
+    assert len(rows) == 1
+    assert rows[0][0] == "Team One"
+    assert str(rows[0][1]) == str(source_id)
+
+    # Re-push with an OLDER updated_at than the current row — must NOT win.
+    stale_ts = ts - timedelta(days=5)
+    batch_stale = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="linear",
+        source_instance="CHAOS",
+        ingestion_id=uuid.uuid4(),
+        teams=[{"id": team_id, "name": "Stale Name", "updated_at": stale_ts}],
+    )
+    await write_batch(batch_stale, clickhouse_dsn=dsn)
+    rows2 = _col_index(
+        raw_client,
+        "teams",
+        "id = {id:String} AND org_id = {org_id:String}",
+        {"id": team_id, "org_id": org_id},
+        "name",
+    )
+    assert rows2[0][0] == "Team One"
+
+
+async def test_identity_updated_at_future_clamp_loses_to_later_legitimate_write(
+    raw_client, dsn, source_id
+):
+    org_id = _org()
+    canonical_id = f"user-{uuid.uuid4().hex[:8]}"
+    far_future = datetime.now(timezone.utc) + timedelta(days=3650)
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="jira",
+        source_instance="ABC",
+        ingestion_id=uuid.uuid4(),
+        identities=[
+            {
+                "canonical_id": canonical_id,
+                "display_name": "Malicious Future",
+                "updated_at": far_future,
+                "provider_identities": {},
+                "team_ids": [],
+                "is_active": True,
+            }
+        ],
+    )
+    result = await write_batch(batch, clickhouse_dsn=dsn)
+    assert len(result.warnings) == 1
+    assert result.warnings[0].code == "updated_at_clamped"
+
+    rows = _col_index(
+        raw_client,
+        "identities",
+        "canonical_id = {cid:String} AND org_id = {org_id:String}",
+        {"cid": canonical_id, "org_id": org_id},
+        "updated_at",
+    )
+    # clickhouse-connect returns naive datetimes (server is UTC); compare
+    # naive-to-naive rather than assume tzinfo round-trips.
+    clamped_updated_at = rows[0][0]
+    assert clamped_updated_at < far_future.replace(tzinfo=None)
+
+    # A later legitimate push (server "now" at push time, guaranteed >= the
+    # clamped value since it happens strictly after) must win.
+    batch2 = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="jira",
+        source_instance="ABC",
+        ingestion_id=uuid.uuid4(),
+        identities=[
+            {
+                "canonical_id": canonical_id,
+                "display_name": "Legit Correction",
+                "updated_at": datetime.now(timezone.utc) + timedelta(seconds=1),
+                "provider_identities": {},
+                "team_ids": [],
+                "is_active": True,
+            }
+        ],
+    )
+    await write_batch(batch2, clickhouse_dsn=dsn)
+    rows2 = _col_index(
+        raw_client,
+        "identities",
+        "canonical_id = {cid:String} AND org_id = {org_id:String}",
+        {"cid": canonical_id, "org_id": org_id},
+        "display_name",
+    )
+    assert rows2[0][0] == "Legit Correction"
+
+
+async def test_work_item_round_trip(raw_client, dsn, source_id):
+    org_id = _org()
+    repo_name = f"acme/api-{uuid.uuid4().hex[:8]}"
+    external_key = "77"
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        work_items=[
+            {
+                "external_key": external_key,
+                "provider": "github",
+                "title": "Investigate flaky test",
+                "type": "issue",
+                "status": "todo",
+                "repository_external_id": repo_name,
+                "created_at": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    result = await write_batch(batch, clickhouse_dsn=dsn)
+    assert not result.errors
+    expected_id = f"gh:{repo_name}#{external_key}"
+    rows = _col_index(
+        raw_client,
+        "work_items",
+        "work_item_id = {wid:String} AND org_id = {org_id:String}",
+        {"wid": expected_id, "org_id": org_id},
+        "status, source_id",
+    )
+    assert len(rows) == 1
+    assert rows[0][0] == "todo"
+    assert str(rows[0][1]) == str(source_id)
+
+    batch2 = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        work_items=[
+            {
+                "external_key": external_key,
+                "provider": "github",
+                "title": "Investigate flaky test",
+                "type": "issue",
+                "status": "done",
+                "repository_external_id": repo_name,
+                "created_at": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    await write_batch(batch2, clickhouse_dsn=dsn)
+    rows2 = _col_index(
+        raw_client,
+        "work_items",
+        "work_item_id = {wid:String} AND org_id = {org_id:String}",
+        {"wid": expected_id, "org_id": org_id},
+        "status",
+    )
+    assert len(rows2) == 1
+    assert rows2[0][0] == "done"
+
+
+async def test_work_item_transition_semantic_dedup(raw_client, dsn, source_id):
+    """D7 proof, corrected against the live engine.
+
+    ``work_item_transitions`` is ``ReplacingMergeTree(last_synced) ORDER BY
+    (org_id, repo_id, work_item_id, occurred_at)`` (verified via
+    ``SHOW CREATE TABLE``) — and ``WORK_ITEM_TRANSITION_SEMANTIC_COLUMNS``
+    (idempotency.py) is a *superset* of that ORDER BY tuple. So re-pushing
+    the exact same transition (same ``occurred_at``, same everything else,
+    only ``last_synced`` differs — the brief's "corrected actor/status,
+    same occurred_at" scenario) is a genuine ORDER BY-key collision:
+    ``SELECT ... FINAL`` alone already collapses it to 1 row, matching
+    ``semantic_deduped_subquery``'s result — no extra dedup step is needed
+    for this case. What *does* need ``FINAL`` (or the semantic subquery) is
+    that the two inserts physically land as two separate, unmerged parts
+    until a merge/FINAL runs — a bare ``SELECT *`` with no ``FINAL``
+    genuinely returns 2 rows, which is the "must not assume writes alone
+    guarantee uniqueness" hazard D7 calls out.
+    """
+    org_id = _org()
+    repo_name = f"acme/api-{uuid.uuid4().hex[:8]}"
+    external_key = "88"
+    occurred_at = datetime.now(timezone.utc)
+
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        work_item_transitions=[
+            {
+                "external_key": external_key,
+                "provider": "github",
+                "occurred_at": occurred_at,
+                "from_status": "todo",
+                "to_status": "in_progress",
+            }
+        ],
+    )
+    result = await write_batch(batch, clickhouse_dsn=dsn)
+    assert not result.errors
+
+    # Re-push the identical semantic transition (same occurred_at) — a
+    # corrected resubmission, distinct only in last_synced.
+    batch2 = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="github",
+        source_instance=repo_name,
+        ingestion_id=uuid.uuid4(),
+        work_item_transitions=[
+            {
+                "external_key": external_key,
+                "provider": "github",
+                "occurred_at": occurred_at,
+                "from_status": "todo",
+                "to_status": "in_progress",
+            }
+        ],
+    )
+    await write_batch(batch2, clickhouse_dsn=dsn)
+
+    expected_id = f"gh:{repo_name}#{external_key}"
+    where = "work_item_id = {wid:String} AND org_id = {org_id:String}"
+    params = {"wid": expected_id, "org_id": org_id}
+
+    raw_no_final = raw_client.query(
+        f"SELECT count() FROM work_item_transitions WHERE {where}", parameters=params
+    )
+    assert raw_no_final.result_rows[0][0] == 2, (
+        "both physical inserts should be visible before a merge/FINAL runs"
+    )
+
+    raw_final = raw_client.query(
+        f"SELECT count() FROM work_item_transitions FINAL WHERE {where}",
+        parameters=params,
+    )
+    assert raw_final.result_rows[0][0] == 1, (
+        "RMT FINAL alone must collapse a same-occurred_at resubmission (D7)"
+    )
+
+    deduped_sql = semantic_deduped_subquery(
+        "work_item_transitions", WORK_ITEM_TRANSITION_SEMANTIC_COLUMNS
+    )
+    deduped_rows = raw_client.query(
+        f"SELECT count() FROM {deduped_sql} WHERE {where}", parameters=params
+    )
+    assert deduped_rows.result_rows[0][0] == 1
+
+
+async def test_work_item_dependency_round_trip(raw_client, dsn, source_id):
+    org_id = _org()
+    source_key = f"ABC-{uuid.uuid4().hex[:6]}"
+    target_key = f"ABC-{uuid.uuid4().hex[:6]}"
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system="jira",
+        source_instance="ABC",
+        ingestion_id=uuid.uuid4(),
+        work_item_dependencies=[
+            {
+                "source_external_key": source_key,
+                "target_external_key": target_key,
+                "relationship_type": "blocks",
+            }
+        ],
+    )
+    result = await write_batch(batch, clickhouse_dsn=dsn)
+    assert not result.errors
+    src_id = f"jira:{source_key}"
+    tgt_id = f"jira:{target_key}"
+    rows = _col_index(
+        raw_client,
+        "work_item_dependencies",
+        "source_work_item_id = {sid:String} AND target_work_item_id = {tid:String} "
+        "AND org_id = {org_id:String}",
+        {"sid": src_id, "tid": tgt_id, "org_id": org_id},
+        "relationship_type, source_id",
+    )
+    assert len(rows) == 1
+    assert rows[0][0] == "blocks"
+    assert str(rows[0][1]) == str(source_id)

--- a/tests/external_ingest/test_sinks_unit.py
+++ b/tests/external_ingest/test_sinks_unit.py
@@ -1,0 +1,525 @@
+"""Unit tests for external_ingest.sinks.write_batch (CHAOS-2698).
+
+Pure Python + mocked clients — no live ClickHouse. Live round-trip proofs
+(RMT dedup, FINAL reads, the D2 repo-identity handoff) live in
+``test_sinks_clickhouse.py`` (``@pytest.mark.clickhouse``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from dev_health_ops.external_ingest.ids import derive_repo_uuid, derive_work_item_id
+from dev_health_ops.external_ingest.sinks import write_batch
+from dev_health_ops.external_ingest.types import NormalizedBatch
+from dev_health_ops.models.git import get_repo_uuid_from_repo
+
+
+class FakeStore:
+    """Fakes the async ClickHouseStore surface write_batch() uses."""
+
+    def __init__(self) -> None:
+        self.org_id: str | None = None
+        self.insert_repo = AsyncMock()
+        self.insert_git_commit_data = AsyncMock()
+        self.insert_git_pull_requests = AsyncMock()
+        self.insert_git_pull_request_reviews = AsyncMock()
+        self.insert_teams = AsyncMock()
+        self.insert_identities = AsyncMock()
+
+    async def __aenter__(self) -> FakeStore:
+        return self
+
+    async def __aexit__(self, *exc_info: object) -> None:
+        return None
+
+
+class FakeSink:
+    """Fakes the sync ClickHouseMetricsSink surface write_batch() uses."""
+
+    def __init__(self) -> None:
+        self.org_id: str | None = None
+        self.write_work_items = MagicMock()
+        self.write_work_item_transitions = MagicMock()
+        self.write_work_item_dependencies = MagicMock()
+        self.close = MagicMock()
+
+
+def _awaited_args(mock: AsyncMock) -> tuple:
+    """``AsyncMock.await_args`` is typed ``Optional`` — narrow it for the
+    unpacking call sites below (a mock that was never awaited is a real
+    test bug, not a case to silently tolerate)."""
+    assert mock.await_args is not None
+    return mock.await_args
+
+
+def _base_batch(**overrides: object) -> NormalizedBatch:
+    defaults: dict[str, object] = dict(
+        org_id="org-1",
+        source_id=uuid.uuid4(),
+        source_system="github",
+        source_instance="acme/api",
+        ingestion_id=uuid.uuid4(),
+    )
+    defaults.update(overrides)
+    return NormalizedBatch(**defaults)  # type: ignore[arg-type]
+
+
+@pytest.mark.asyncio
+async def test_write_batch_repo_uuid_matches_native_sync_case_insensitively() -> None:
+    batch = _base_batch(
+        repositories=[
+            {
+                "external_id": "Owner/Repo",
+                "source_system": "github",
+                "default_ref": "main",
+                "tags": [],
+                "settings": {},
+            }
+        ],
+    )
+    fake_store = FakeStore()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_store", return_value=fake_store
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    fake_store.insert_repo.assert_awaited_once()
+    (repo_obj,), _kwargs = _awaited_args(fake_store.insert_repo)
+    assert repo_obj.id == get_repo_uuid_from_repo("owner/repo")
+    assert result.counts_written["repository"] == 1
+    assert repo_obj.id in result.affected_scope.repo_ids
+
+
+@pytest.mark.asyncio
+async def test_write_batch_stamps_org_id_on_work_item_family_rows() -> None:
+    batch = _base_batch(
+        work_items=[
+            {
+                "external_key": "42",
+                "provider": "github",
+                "title": "Fix bug",
+                "type": "issue",
+                "status": "todo",
+                "repository_external_id": "acme/api",
+                "created_at": datetime.now(timezone.utc),
+            }
+        ],
+        work_item_transitions=[
+            {
+                "external_key": "42",
+                "provider": "github",
+                "occurred_at": datetime.now(timezone.utc),
+                "from_status": "todo",
+                "to_status": "in_progress",
+            }
+        ],
+    )
+    fake_sink = FakeSink()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_sink", return_value=fake_sink
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    fake_sink.write_work_items.assert_called_once()
+    (work_item_rows,), _ = fake_sink.write_work_items.call_args
+    assert work_item_rows[0]["org_id"] == "org-1"
+    assert work_item_rows[0]["work_item_id"] == "gh:acme/api#42"
+
+    fake_sink.write_work_item_transitions.assert_called_once()
+    (transition_rows,), _ = fake_sink.write_work_item_transitions.call_args
+    assert transition_rows[0]["org_id"] == "org-1"
+    assert result.counts_written["work_item"] == 1
+    assert result.counts_written["work_item_transition"] == 1
+
+
+@pytest.mark.asyncio
+async def test_write_batch_dependency_uses_dataclass_row_with_org_and_source_id() -> (
+    None
+):
+    batch = _base_batch(
+        source_system="jira",
+        source_instance="ABC",
+        work_item_dependencies=[
+            {
+                "source_external_key": "ABC-1",
+                "target_external_key": "ABC-2",
+                "relationship_type": "blocks",
+            }
+        ],
+    )
+    fake_sink = FakeSink()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_sink", return_value=fake_sink
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    fake_sink.write_work_item_dependencies.assert_called_once()
+    (deps,), _ = fake_sink.write_work_item_dependencies.call_args
+    assert deps[0].source_work_item_id == "jira:ABC-1"
+    assert deps[0].target_work_item_id == "jira:ABC-2"
+    assert deps[0].org_id == "org-1"
+    assert deps[0].source_id == batch.source_id
+    assert result.counts_written["work_item_dependency"] == 1
+
+
+@pytest.mark.asyncio
+async def test_identity_and_team_updated_at_pass_through_verbatim() -> None:
+    ts = datetime.now(timezone.utc) - timedelta(days=3)
+    batch = _base_batch(
+        identities=[
+            {
+                "canonical_id": "u1",
+                "updated_at": ts,
+                "provider_identities": {},
+                "team_ids": [],
+                "is_active": True,
+            }
+        ],
+        teams=[
+            {
+                "id": "t1",
+                "name": "Team One",
+                "updated_at": ts,
+            }
+        ],
+    )
+    fake_store = FakeStore()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_store", return_value=fake_store
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    (identity_rows,), _ = _awaited_args(fake_store.insert_identities)
+    assert identity_rows[0]["updated_at"] == ts
+    (team_rows,), _ = _awaited_args(fake_store.insert_teams)
+    assert team_rows[0]["updated_at"] == ts
+    assert not result.warnings
+
+
+@pytest.mark.asyncio
+async def test_identity_updated_at_future_is_clamped_with_warning() -> None:
+    future = datetime.now(timezone.utc) + timedelta(hours=1)
+    batch = _base_batch(
+        identities=[
+            {
+                "canonical_id": "u1",
+                "updated_at": future,
+                "provider_identities": {},
+                "team_ids": [],
+                "is_active": True,
+            }
+        ],
+    )
+    fake_store = FakeStore()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_store", return_value=fake_store
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    (identity_rows,), _ = _awaited_args(fake_store.insert_identities)
+    assert identity_rows[0]["updated_at"] < future
+    assert len(result.warnings) == 1
+    assert result.warnings[0].code == "updated_at_clamped"
+    assert result.warnings[0].kind == "identity"
+
+
+@pytest.mark.asyncio
+async def test_identity_updated_at_within_skew_is_not_clamped() -> None:
+    near_future = datetime.now(timezone.utc) + timedelta(minutes=2)
+    batch = _base_batch(
+        identities=[
+            {
+                "canonical_id": "u1",
+                "updated_at": near_future,
+                "provider_identities": {},
+                "team_ids": [],
+                "is_active": True,
+            }
+        ],
+    )
+    fake_store = FakeStore()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_store", return_value=fake_store
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    (identity_rows,), _ = _awaited_args(fake_store.insert_identities)
+    assert identity_rows[0]["updated_at"] == near_future
+    assert not result.warnings
+
+
+@pytest.mark.asyncio
+async def test_one_failed_kind_does_not_block_other_kinds() -> None:
+    batch = _base_batch(
+        pull_requests=[
+            {
+                "repository_external_id": "acme/api",
+                "number": 1,
+                "state": "open",
+                "created_at": datetime.now(timezone.utc),
+            }
+        ],
+        commits=[
+            {
+                "repository_external_id": "acme/api",
+                "hash": "a" * 40,
+                "author_when": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    fake_store = FakeStore()
+    fake_store.insert_git_pull_requests.side_effect = RuntimeError("boom")
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_store", return_value=fake_store
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    assert result.counts_written.get("pull_request") is None
+    assert any(
+        e.kind == "pull_request" and e.code == "clickhouse_insert_failed"
+        for e in result.errors
+    )
+    fake_store.insert_git_commit_data.assert_awaited_once()
+    assert result.counts_written["commit"] == 1
+
+
+@pytest.mark.asyncio
+async def test_affected_scope_aggregates_across_mixed_batch() -> None:
+    batch = _base_batch(
+        repositories=[{"external_id": "acme/api", "source_system": "github"}],
+        pull_requests=[
+            {
+                "repository_external_id": "acme/api",
+                "number": 7,
+                "state": "open",
+                "created_at": datetime.now(timezone.utc),
+            }
+        ],
+        work_items=[
+            {
+                "external_key": "42",
+                "provider": "github",
+                "title": "Fix bug",
+                "type": "issue",
+                "status": "todo",
+                "repository_external_id": "acme/api",
+                "created_at": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    fake_store = FakeStore()
+    fake_sink = FakeSink()
+    with (
+        patch(
+            "dev_health_ops.external_ingest.sinks.create_store", return_value=fake_store
+        ),
+        patch(
+            "dev_health_ops.external_ingest.sinks.create_sink", return_value=fake_sink
+        ),
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    scope = result.affected_scope
+    assert scope.record_kinds == {"repository", "pull_request", "work_item"}
+    expected_repo_id = derive_repo_uuid("github", "acme/api", "acme/api")
+    assert scope.repo_ids == {expected_repo_id}
+    assert scope.work_item_ids == {"gh:acme/api#42"}
+    assert scope.org_id == "org-1"
+    assert scope.source_systems == {"github"}
+    assert scope.source_instances == {"acme/api"}
+
+
+@pytest.mark.parametrize(
+    "system,instance,external_key,work_item_type,expected",
+    [
+        ("github", "owner/repo", "42", None, "gh:owner/repo#42"),
+        ("github", "owner/repo", "42", "pr", "ghpr:owner/repo#42"),
+        ("gitlab", "group/project", "7", None, "gitlab:group/project#7"),
+        ("gitlab", "group/project", "7", "merge_request", "gitlab:group/project!7"),
+        ("jira", None, "ABC-123", None, "jira:ABC-123"),
+        ("linear", None, "CHAOS-1", None, "linear:CHAOS-1"),
+        ("custom", "my-instance", "ext-1", None, "custom:my-instance:ext-1"),
+    ],
+)
+def test_derive_work_item_id_matches_native_sync_formats(
+    system: str,
+    instance: str | None,
+    external_key: str,
+    work_item_type: str | None,
+    expected: str,
+) -> None:
+    assert (
+        derive_work_item_id(system, instance, external_key, work_item_type) == expected
+    )
+
+
+def test_derive_repo_uuid_custom_system_uses_distinct_namespace() -> None:
+    real = derive_repo_uuid("github", "acme/api", "acme/api")
+    custom = derive_repo_uuid("custom", "acme/api", "acme/api")
+    assert real != custom
+    assert custom == get_repo_uuid_from_repo("custom:acme/api:acme/api")
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("system", ["github", "gitlab", "jira"])
+async def test_native_team_key_dropped_for_non_linear_work_items(system: str) -> None:
+    """Codex adversarial review (CHAOS-2698): a non-Linear work_item.v1
+    payload must not be able to forge a top-precedence native_team_key —
+    native sync only ever populates it for Linear (WorkItem.native_team_key
+    docstring: "None for GitHub/GitLab ... and Jira"). ``work_item.v1``'s
+    ``provider`` field only allows jira/github/gitlab/linear (CC6 excludes
+    a "custom" work-item provider), so those are the three non-Linear
+    cases to prove."""
+    batch = _base_batch(
+        source_system=system,
+        source_instance="ABC" if system == "jira" else "acme/api",
+        work_items=[
+            {
+                "external_key": "42",
+                "provider": system,
+                "title": "Attribution forgery attempt",
+                "type": "issue",
+                "status": "todo",
+                "native_team_key": "FORGED-TEAM",
+                "repository_external_id": "acme/api"
+                if system in ("github", "gitlab")
+                else None,
+            }
+        ],
+    )
+    fake_sink = FakeSink()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_sink", return_value=fake_sink
+    ):
+        await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    (rows,), _ = fake_sink.write_work_items.call_args
+    assert rows[0]["native_team_key"] is None
+
+
+@pytest.mark.asyncio
+async def test_native_team_key_preserved_for_linear_work_items() -> None:
+    batch = _base_batch(
+        source_system="linear",
+        source_instance="CHAOS",
+        work_items=[
+            {
+                "external_key": "42",
+                "provider": "linear",
+                "title": "Legit Linear item",
+                "type": "issue",
+                "status": "todo",
+                "native_team_key": "CHAOS",
+            }
+        ],
+    )
+    fake_sink = FakeSink()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_sink", return_value=fake_sink
+    ):
+        await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    (rows,), _ = fake_sink.write_work_items.call_args
+    assert rows[0]["native_team_key"] == "CHAOS"
+
+
+@pytest.mark.asyncio
+async def test_work_item_spoofed_provider_cannot_escape_batch_namespace() -> None:
+    """Codex adversarial review, rounds 2-3 (CHAOS-2698): a github-scoped
+    batch smuggling a row claiming ``provider: "linear"`` must not just lose
+    ``native_team_key`` (round 2's fix) — the record must land under the
+    batch's OWN provider/work_item_id namespace, not "linear:...", since
+    trusting the spoofed value for derivation would let a github source
+    pollute/collide with real Linear data (round 3's finding). A
+    ``record_provider_mismatch`` warning surfaces the discrepancy instead of
+    silently swallowing it."""
+    batch = _base_batch(
+        source_system="github",
+        source_instance="acme/api",
+        work_items=[
+            {
+                "external_key": "42",
+                "provider": "linear",
+                "title": "Spoofed provider forgery attempt",
+                "type": "issue",
+                "status": "todo",
+                "native_team_key": "FORGED-TEAM",
+                "repository_external_id": "acme/api",
+            }
+        ],
+    )
+    fake_sink = FakeSink()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_sink", return_value=fake_sink
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    (rows,), _ = fake_sink.write_work_items.call_args
+    assert rows[0]["native_team_key"] is None
+    assert rows[0]["provider"] == "github"
+    assert rows[0]["work_item_id"] == "gh:acme/api#42"
+    assert any(
+        w.code == "record_provider_mismatch" and w.kind == "work_item"
+        for w in result.warnings
+    )
+
+
+@pytest.mark.asyncio
+async def test_repository_external_id_mismatch_flagged_as_warning_not_rejected() -> (
+    None
+):
+    """Codex adversarial review (CHAOS-2698): CC6 says instance-match
+    rejection is CHAOS-2697's job and this layer "may assert-but-not-
+    reject" — proves the assertion surfaces in warnings while the record
+    still gets written (the layer trusts its documented input contract but
+    makes drift from it visible)."""
+    batch = _base_batch(
+        source_system="github",
+        source_instance="acme/real-repo",
+        repositories=[
+            {
+                "external_id": "acme/different-repo",
+                "source_system": "github",
+            }
+        ],
+    )
+    fake_store = FakeStore()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_store", return_value=fake_store
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    fake_store.insert_repo.assert_awaited_once()
+    assert result.counts_written["repository"] == 1
+    assert any(
+        w.code == "record_outside_source_instance" and w.kind == "repository"
+        for w in result.warnings
+    )
+
+
+@pytest.mark.asyncio
+async def test_pull_request_matching_source_instance_has_no_warning() -> None:
+    batch = _base_batch(
+        source_system="github",
+        source_instance="acme/api",
+        pull_requests=[
+            {
+                "repository_external_id": "acme/api",
+                "number": 1,
+                "state": "open",
+                "created_at": datetime.now(timezone.utc),
+            }
+        ],
+    )
+    fake_store = FakeStore()
+    with patch(
+        "dev_health_ops.external_ingest.sinks.create_store", return_value=fake_store
+    ):
+        result = await write_batch(batch, clickhouse_dsn="clickhouse://x/y")
+
+    assert not result.warnings


### PR DESCRIPTION
## Summary

Implements the sink-write layer for the customer-push ingestion epic (CHAOS-2690): given a schema-validated, kind-normalized batch, stamp `org_id`/`source_id` provenance and write each of the 9 v1 record kinds through the **existing** ClickHouse sink methods, preserving current append/RMT-dedup semantics.

- `external_ingest/ids.py` — `derive_repo_uuid()` / `derive_work_item_id()`, replicating native sync's ID derivation exactly (verified against `providers/{github,gitlab,jira,linear}/normalize.py` and `models/git.py:get_repo_uuid_from_repo`).
- `external_ingest/types.py` — `NormalizedBatch` / `SinkWriteResult` / `SinkWriteError` / `AffectedScope`.
- `external_ingest/sinks.py` — `write_batch(batch, *, clickhouse_dsn)`, the single translation point from wire-schema field names to each sink method's row contract.
- `migrations/clickhouse/065_external_ingest_source_id.sql` — nullable `source_id UUID` provenance column on all 9 target tables (NULL for native sync).
- One-line additive `source_id` column support in `storage/clickhouse.py` and `metrics/sinks/clickhouse/work_graph.py`'s existing sink methods, plus a new `source_id` field on `WorkItemDependency`.
- `docs/architecture/external-ingest-sink-writes.md` — design decisions D1-D8 and the adversarial-review trust-boundary findings/fixes below.

## Adversarial review (3 rounds via Codex, converged per team-lead guidance)

- **[high, fixed]** `native_team_key` forgery — a non-Linear `work_item.v1` payload could set `nativeTeamKey` and forge top-precedence native team attribution. Now dropped for every system except Linear.
- **[high, fixed]** Root cause of the above: `system` (used for ID derivation, `repo_id`, stored `provider`, project scope, identity resolution) was derived from the untrusted per-record `provider` field. A github-scoped batch could spoof `provider="linear"` and land in the Linear namespace. Fixed: `system` is now always `batch.source_system` for work-item-family rows — never the payload — with a `record_provider_mismatch` warning surfaced (not rejected) when they disagree.
- **[high, mitigated]** Git repo-identity handoff trusted an unenforced customer string (repo UUID/work_item_id namespace could fork from native sync if `repositoryExternalId != source.instance`). Per master-spec CC6, rejection is CHAOS-2697's job; this layer now flags the drift as a `record_outside_source_instance` warning instead of silently forking identity.
- **[medium, refuted with evidence]** Future-`updatedAt` clamp can theoretically let a bad row outrank a truthful older retry. This is the explicitly RATIFIED master-spec CC24 tradeoff ("clamped ... not a rejection") — not re-litigated here; documented as an accepted residual risk.

## Test plan

- [x] `tests/external_ingest/test_sinks_unit.py` — 23 mocked unit tests (D2 case-insensitivity, D6 org_id stamping, D3 ID-format table, D8 clamp, partial-batch resilience, and regression tests for all 3 adversarial-review fixes)
- [x] `tests/external_ingest/test_sinks_clickhouse.py` (`@pytest.mark.clickhouse`) — 10 live round-trip tests, one per kind + D2 repo-identity handoff + D7 FINAL-vs-semantic-dedup proof + D8 live clamp proof + native-sync backward-compat proof
- [x] `SCRATCH_DB=ci_local_validate_2698 bash ci/local_validate.sh` — GATE PASSED (6473 unit tests, mypy clean, live-CH argMax proof)
- [x] Live verification against isolated `ci_2698_live` scratch DB: wrote one record of each of the 9 kinds via `write_batch()`, verified via `clickhouse-client` — correct `org_id`/`source_id`/`provider` attribution on every table, RMT convergence on re-push (work_item status `todo` → `done`), the clamp firing on a far-future `updatedAt`, and a native-sync-style `insert_repo()` call converging to the **same** UUID + single row (source_id correctly clears back to NULL when the native write wins). Scratch DB dropped after.

MUST NOT touched (respected): `api/external_ingest/*`, `workers/*`, compose, alembic migrations, CH `default`, PG `devhealth`, other worktrees.