### PR TITLE
feat(external-ingest): bounded recomputation planner + recompute status (CHAOS-2699)

### DIFF
--- a/docs/architecture/external-ingest-bounded-recompute.md
+++ b/docs/architecture/external-ingest-bounded-recompute.md
@@ -1,0 +1,404 @@
+# Bounded recomputation planner (CHAOS-2699)
+
+Part of the [customer-push ingestion epic](adr-003-external-ingest-rest-boundary.md)
+(CHAOS-2690). A customer-pushed batch that lands new git/work-item facts
+must trigger the *existing* metrics/work-graph/investment pipeline for the
+affected slice -- but never a full-org recompute, and never so eagerly that
+a burst of small batches fires the pipeline once per batch. This doc
+records the D1-D15 design decisions behind
+`src/dev_health_ops/external_ingest/recompute.py`,
+`recompute_status.py`, and `workers/external_ingest_recompute.py`.
+
+## The planner is a free function, not a class (D1)
+
+Mirrors the documented house preference (`workers/queues.py` -- the
+`SyncDispatchPolicy` class was designed but deliberately never built) and
+the working analog `_dispatch_post_sync_tasks`
+(`workers/post_sync_dispatch.py`). `plan_recompute()` is pure (scope in,
+plan out, no I/O); `dispatch_recompute()` is the impure Celery-signature
+builder; `schedule_or_coalesce()` is the public debounce seam.
+
+## Public seam is primitives, not a shared dataclass (CC21)
+
+`RecomputeScope` is internal to `recompute.py`. The function every other
+sub-issue calls is:
+
+```python
+schedule_or_coalesce(
+    *, org_id, source_system, source_instance, ingestion_id,
+    repo_ids: set[str], team_ids: set[str],
+    window_start: datetime | None, window_end: datetime | None,
+    record_kinds: set[str],
+)
+```
+
+This decouples CHAOS-2699 from CHAOS-2697/2698's own scope-accumulation
+data structures -- 2697 maps whatever `AffectedScope` it builds while
+normalizing a batch into these kwargs at the end of processing. No sibling
+issue imports `RecomputeScope` or calls `RecomputeScope.merge_record()`.
+
+## Debounce via Valkey SETNX, not a Celery beat poll (D3)
+
+Debounce here needs "coalesce writes that land within N seconds, fire
+once" -- a SETNX-guarded scheduled flush needs no new beat entry, unlike
+the existing 30s-cadence stream-consumer beat pattern (which drains a
+*stream*, a different shape of problem). Two keys per
+`(org_id, source_system, source_instance)`:
+
+- `external-ingest:recompute:pending:{org}:{system}:{instance}` -- the
+  accumulating scope blob (JSON), widened (union of repo/team/kind sets,
+  min/max window) on every call within the debounce window.
+- `external-ingest:recompute:scheduled:{org}:{system}:{instance}` -- a
+  SETNX guard, TTL == the debounce window. Only the caller that acquires it
+  schedules the flush; every other caller within the window just widens the
+  pending blob.
+
+Client is a plain non-blocking Valkey client (`_get_redis_client()`, same
+shape as `api/product_telemetry/streams.py:get_redis_client()`) -- **not**
+`get_consumer_redis_client()`, which is reserved for blocking `XREADGROUP`
+reads.
+
+**Atomicity (post-adversarial-review fix):** the pending-blob merge and the
+guard's SETNX are performed inside a single Valkey `WATCH`/`MULTI`
+optimistic transaction (`_MAX_COALESCE_RETRIES` retries on `WatchError`),
+not a plain `GET` -> merge -> `SET`. Two truly concurrent
+`schedule_or_coalesce()` calls for the same debounce key would otherwise
+race: both read the same starting blob, and the second `SET` silently
+clobbers the first caller's widened result (and its ingestion_id), even
+though only one guard was acquired and scheduled. `WATCH` aborts the
+transaction if the pending key changed since the read, forcing a retry
+against the now-current value --
+`tests/test_external_ingest_recompute_debounce.py::test_concurrent_callers_do_not_lose_either_ingestion_id`
+proves both ingestion ids survive a simulated race. Similarly, the flush
+task (below) reads the pending blob via `GETDEL` (one atomic command)
+rather than a separate `GET` then `DELETE`, and deliberately never
+explicitly deletes the guard key -- see "Flush task cleanup is atomic and
+guard-preserving" below.
+
+**Never-silently-drop guarantee:** if Valkey is unavailable (no
+`REDIS_URL`, a connection error, or any other exception talking to it),
+`schedule_or_coalesce()` degrades to an *immediate synchronous*
+`dispatch_and_persist_scope()` call for just that one batch's own scope.
+Durability of the *batch itself* is CHAOS-2693's job (503 on stream
+enqueue failure); durability of *recompute triggering* here is
+best-effort-but-never-silent.
+
+**Known gap (Risk 4, accepted for v1):** the pending blob's TTL
+(`max(debounce_seconds * 4, 300s)`) is generous but Valkey maxmemory
+eviction under load (DB 1 is shared with streams/impersonation-cache/rate-
+limiter) could still drop a scheduled flush's blob between the guard SETNX
+and the flush firing. The flush task tolerates a missing blob gracefully
+(log + no-op `{"status": "no_pending_scope"}`) rather than raising -- this
+under-triggers recompute in that rare case rather than ever blocking
+ingestion.
+
+**Flush task cleanup is atomic and guard-preserving (post-adversarial-review
+fix):** the original implementation did a plain `GET` then two separate
+`DELETE`s (pending blob + guard). That left a window: if the guard's own
+TTL expired slightly before this countdown-delayed task actually ran
+(broker/worker latency, not a clock mismatch -- the guard TTL and the
+countdown are set to the same value but fire independently), a *new*
+`schedule_or_coalesce()` call could land in between this task's `GET` and
+its `DELETE`, writing a fresher blob (with a new ingestion_id folded in)
+that the old task would then delete without ever having read --
+recompute for that later batch would be silently lost, and the new guard
+it had just acquired would be deleted out from under it too. The fix has
+two parts: (1) the flush task reads the pending blob via `GETDEL` -- one
+atomic Valkey command, so whatever it reads is exactly what it clears,
+with no gap; (2) the flush task never explicitly deletes the guard key at
+all -- its own `ex=seconds` TTL governs its lifecycle, so a
+`schedule_or_coalesce()` call that lands while the guard is still valid
+correctly coalesces into the *current* flush's blob (read atomically via
+the same `GETDEL`, since Valkey serializes commands) instead of racing a
+separate cleanup step for a key this task has no reason to touch.
+`tests/test_external_ingest_recompute_flush_task.py` covers both: the
+GETDEL leaves the key empty in one step, and the guard key survives a
+flush run untouched.
+
+## Hard invariant: never call investment materialize with empty scope (D4)
+
+`dispatch_investment_materialize_partitioned(repo_ids=None, team_ids=None)`
+resolves to `fetch_work_graph_edges(repo_ids=None, org_id=...)` --
+**every** repo's work-graph edges for the whole org, unbounded by time
+(`work_graph/investment/materialize.py`). That is exactly the "full-org
+recompute" the acceptance criteria forbid by default.
+
+`dispatch_recompute()` never calls
+`dispatch_investment_materialize_partitioned` unless the plan's
+(capped) `repo_ids` or `team_ids` is non-empty; otherwise
+`recompute_status = "skipped_no_scope"` for that portion of the plan (the
+top-level status only becomes `"skipped_no_scope"` if *nothing at all* got
+dispatched -- see "Status derivation" below).
+
+## Per-repo fan-out, single investment call (D5)
+
+`run_daily_metrics` / `run_work_graph_build` only accept a single
+`repo_id`, never a list (`workers/metrics_daily.py`,
+`workers/work_graph_tasks.py`). For N affected repos, `dispatch_recompute`
+fans out N independent `run_daily_metrics -> run_work_graph_build` chains
+(`celery.chain`, immutable links), capped at
+`EXTERNAL_INGEST_RECOMPUTE_MAX_FANOUT_REPOS` (default 25).
+`dispatch_investment_materialize_partitioned` is the one task that accepts
+`repo_ids`/`team_ids` lists directly -- called **once** per flush with the
+full capped list, never per repo.
+
+## Never reused: `dispatch_daily_metrics_partitioned` / `run_daily_metrics_batch` (D6)
+
+Two disqualifying findings, both verified in `workers/metrics_partitioned.py`:
+
+- `dispatch_daily_metrics_partitioned` discovers repos via
+  `SELECT id FROM repos` with **no `org_id` filter** -- not tenant-scoped,
+  cannot be reused for a bounded single-org recompute.
+- `run_daily_metrics_batch` gates on a `daily_batch` checkpoint and
+  **skips entirely** if `(org_id, repo_id, day)` is already COMPLETED --
+  exactly what happens after the normal daily beat cycle. A customer push
+  arriving later the same day would be silently swallowed until the next
+  calendar day.
+
+`dispatch_recompute()` and its test suite assert these two task names (plus
+`run_dora_metrics`/`run_complexity_job` -- deferred-v1 kinds per the
+kind-routing table below) are never referenced anywhere in
+`recompute.py` (negative-space test).
+
+## Record-kind -> job mapping (D7)
+
+| Category | Kinds | Jobs |
+|---|---|---|
+| `_GIT_KINDS` | `pull_request.v1`, `review.v1`, `commit.v1` | daily metrics + work graph build (per repo) + investment materialize |
+| `_WORK_ITEM_KINDS` | `work_item.v1`, `work_item_transition.v1`, `work_item_dependency.v1` | daily metrics + work graph build (per repo, or org+day fallback -- D8) + investment materialize |
+| `_TEAM_KINDS` | `identity.v1`, `team.v1` | investment materialize (`team_ids` only) -- daily/work-graph NOT re-run |
+| `_REPO_ONLY_KINDS` | `repository.v1` | none -- `recompute_status` stays `not_applicable` |
+
+## D8 org-wide day-bounded fallback: ratified, capped
+
+Work items may have no repo dimension (`WorkItem.repo_id` is nullable --
+Jira-native issues have no repo linkage). If `_WORK_ITEM_KINDS` are present
+and the accumulated `repo_ids` is empty, `plan_recompute` falls back to
+**one** `run_daily_metrics(repo_id=None, day=..., backfill_days=...,
+org_id=...)` call -- org-wide but still day/window-bounded by the batch's
+own (capped) window, never all-time history. `run_work_graph_build` is
+deliberately skipped in this fallback (`repo_id=None` there means "all
+repos, 30-day trailing window", ignoring the tighter batch window).
+
+Never taken if `repo_ids` is non-empty (per-repo chains always win); never
+taken for git-only kinds with an empty repo scope either -- that
+combination is structurally impossible (PR/review/commit records always
+carry a resolved repo), and the defensive path is simply "dispatch
+nothing", not an org-wide fallback outside the kind category it was
+designed for.
+
+## Guardrail caps are env-configurable (D9)
+
+- `EXTERNAL_INGEST_RECOMPUTE_DEBOUNCE_SECONDS` (default `45`).
+- `EXTERNAL_INGEST_RECOMPUTE_MAX_BACKFILL_DAYS` (default `14`) -- caps
+  `run_daily_metrics(backfill_days=...)` and the `work_graph_build`/
+  investment `from_date`/`to_date` window. Clamped to
+  `[window_end.date() - (cap-1)days, window_end.date()]`; `capped_days`
+  is recorded (`recompute_scope.cappedDays`) for operator visibility.
+- `EXTERNAL_INGEST_RECOMPUTE_MAX_FANOUT_REPOS` (default `25`) -- caps
+  per-repo chain fan-out (stable-sorted, first N). Beyond the cap,
+  `capped_repos = true`; the next natural daily beat cycle still catches
+  the remaining repos on its normal schedule (accepted v1 limitation, not
+  data loss).
+
+## Debounce key granularity: `(org_id, source_system, source_instance)` (D10)
+
+Not per-ingestion, not per-repo. A customer's CI relay typically pushes
+many small batches for the *same* source instance in quick succession
+(e.g. one batch per PR webhook relay); coalescing at that granularity gets
+the biggest win. Different source instances (`github.com/acme` vs.
+`gitlab.com/acme`) debounce independently since their repo/team scopes are
+disjoint.
+
+## Status persistence: direct SQL, no `postgres` pytest marker (D11)
+
+Per the epic-wide synthesizer reconciliation (CHAOS-2694's sqlite-portable
+direct-SQL convention wins over this issue's original proposal): all reads
+and writes in `recompute_status.py` go through
+`session.execute(text(...), params)`. SQL is dialect-portable -- no
+`RETURNING`, no `ON CONFLICT`, and (unlike the brief's original sketch) no
+`ANY(:array)` either: `record_recompute_dispatch()` loops over
+`ingestion_ids` and issues one `UPDATE ... WHERE ingestion_id = :id` per
+coalesced ingestion, matching `status.py`'s own per-row-UPDATE convention
+and staying sqlite-compatible. Unit tests run entirely on sqlite via
+`Base.metadata.create_all()`; there is no live-Postgres pytest tier for
+this module, only the manual live-verification runbook below.
+
+`ExternalIngestBatch`'s new columns declare `server_default=` (not the
+ORM's Python-side `default=`), matching migration 0034's
+`server_default="not_applicable"` -- but every INSERT `status.py` issues
+still passes the recompute columns *explicitly* (never relies on the
+server default at insert time), per the status-store doc's established
+"explicit bind params, never rely on server_default" convention.
+
+## `emit-then-raise` (D12)
+
+`record_recompute_dispatch()` commits before returning. It is the last
+write in the flush task's request path; a subsequent unrelated failure in
+the calling Celery task (e.g. an outer retry) must never roll back an
+already-decided recompute outcome.
+
+## Recompute dispatch failures never fail ingestion (D13)
+
+`dispatch_recompute()` wraps its entire body in `try/except Exception`
+and returns `RecomputeDispatchResult(status="failed", ...)` rather than
+raising. `dispatch_and_persist_scope()` (used by both the flush task and
+the Valkey-unavailable synchronous fallback) additionally wraps its own
+Postgres write in `try/except`, logging rather than raising -- a
+status-persistence hiccup must not surface as a task failure after the
+Celery jobs have already been durably dispatched (or correctly skipped).
+
+## Idempotent Celery kwargs contract, pinned by test (D14)
+
+`tests/test_external_ingest_recompute_dispatch.py` asserts every kwargs
+dict `dispatch_recompute()` builds for `run_daily_metrics`,
+`run_work_graph_build`, and `dispatch_investment_materialize_partitioned`
+is a subset of `inspect.signature(<task>.run).parameters` -- mocking
+`.delay()`/`.apply_async()` alone hides kwarg drift (the task names are
+plain strings in `recompute.py`, resolved only by Celery's routing at
+publish time, so nothing else catches a renamed/removed kwarg).
+
+## `celery_task_id` is nullable (post-adversarial-review fix)
+
+A `chain(daily_sig, build_sig).apply_async()` result's `.parent` (the
+daily-metrics leg's own `AsyncResult`) is not guaranteed to be populated in
+every Celery/broker configuration; `dispatch_recompute()` already handles
+this defensively (`daily_id = async_result.parent.id if async_result.parent
+is not None else None`), but the first cut of migration 0034 and the
+`ExternalIngestRecomputeJob` model declared `celery_task_id` `NOT NULL`.
+Since the Celery dispatch has *already succeeded* by the time a job record
+is built, inserting that record with an unknown id must not fail -- a
+`NOT NULL` violation there would raise inside `record_recompute_dispatch()`,
+which `dispatch_and_persist_scope()` catches and merely logs, silently
+rolling back the **entire** status/job-log write (not just the one job
+row) even though the metric tasks were genuinely dispatched. `celery_task_id`
+is now nullable in both the migration and the ORM model;
+`test_external_ingest_recompute_dispatch.py::test_per_repo_chain_with_no_parent_result_still_dispatches_with_none_task_id`
+and
+`test_external_ingest_recompute_status_sql.py::test_record_recompute_dispatch_persists_job_with_none_task_id`
+cover the `parent=None` path end to end (build stage, then persistence).
+
+## Celery wiring: single owner, this module stays out (D15 / CC20)
+
+The flush task (`flush_external_ingest_recompute`,
+`workers/external_ingest_recompute.py`) declares `queue="default"` and its
+full dotted name directly on the `@celery_app.task(...)` decorator. It is
+**not** re-exported from `workers/tasks.py` and **not** added to
+`workers/config.py`'s `late_ack_excluded_tasks` -- both are hot files
+CHAOS-2693 owns exclusively this wave. See the `INTEGRATOR TODO` comment at
+the top of `external_ingest_recompute.py` for the exact one-line addition
+CHAOS-2693 (or whoever merges this PR) makes to `late_ack_excluded_tasks`
+at integration time. No `task_queues`/compose change is needed -- it
+reuses the existing `default` queue's worker coverage.
+
+**Adversarial-review finding, refuted (task not registered by a fresh
+worker):** the review correctly observed that `flush_external_ingest_
+recompute` is absent from `celery_app.tasks` after importing only
+`dev_health_ops.workers.tasks` -- it only registers once
+`workers/external_ingest_recompute.py` itself is imported. This is the
+*expected* state of this PR taken in isolation, not an oversight: CC20
+pins Celery wiring (including which modules a worker process imports at
+startup) as CHAOS-2693's sole responsibility this wave, and the
+HOT-FILE RULE this issue was built under explicitly forbids editing
+`workers/tasks.py`/`workers/config.py` in this PR. The exact one-line fix
+is already documented in the `INTEGRATOR TODO` comment above and is called
+out again in this PR's description for CHAOS-2693 (or the wave integrator)
+to apply at merge time -- landing it here would both violate the
+HOT-FILE RULE and very likely merge-conflict with CHAOS-2693's own
+concurrent edits to the same two files.
+
+## Production wiring into the external-ingest worker (out of scope here)
+
+**Adversarial-review finding, refuted (no production caller extracts scope
+or calls `schedule_or_coalesce`):** correct as observed, and explicitly
+out of scope for CHAOS-2699 per the brief's own boundary: "the durable
+stream/worker entrypoint that calls the planner at the end of batch
+processing" and "`RecomputeScope` *accumulation* during record
+processing" are owned by CHAOS-2697/CHAOS-2698, not this issue. The
+Dependencies section is explicit about the direction: CHAOS-2697 is a
+*hard dependency on* CHAOS-2699 ("must call `schedule_or_coalesce(scope)`
+once at the end of batch processing... this brief defines that exact
+interface; 2697's implementer should treat `external_ingest/recompute.py`
+as already-specified"), not the reverse. CHAOS-2697 has not landed as of
+this PR (parallel wave-3/4 work) -- there is no worker code yet for this
+issue to call into. `mark_recompute_pending()` is similarly an optional
+seam documented for CHAOS-2697 to adopt, not a self-contained feature of
+this module. Wiring this seam into the real worker is CHAOS-2697's
+acceptance criteria, not this issue's.
+
+## Status derivation
+
+`recompute_status` on `external_ingest_batches` (enum pinned epic-wide:
+`not_applicable | pending | dispatched | skipped_no_scope | failed`,
+`server_default 'not_applicable'`):
+
+- `not_applicable` -- the DB default; also the explicit outcome for
+  `repository.v1`-only batches (D7) or any batch whose scope never even
+  reaches a flush.
+- `pending` -- optional, best-effort (`mark_recompute_pending()`,
+  `recompute_status.py`): a batch mid-debounce-window, if the caller
+  (CHAOS-2697's worker) chooses to call it alongside its own status write.
+  `schedule_or_coalesce()` itself takes no `session` parameter (primitives-
+  only public seam, CC21) so it cannot write this transition on its own.
+- `dispatched` -- at least one Celery job was successfully enqueued this
+  flush (daily/work-graph chains and/or the investment call).
+- `skipped_no_scope` -- a flush ran, decided recompute *was* warranted by
+  kind, but ended up with nothing dispatchable (the structurally-
+  impossible git-only-no-repo defensive case, or D4's investment skip when
+  it's the only thing that would have fired).
+- `failed` -- `dispatch_recompute()` caught an exception building/firing
+  signatures.
+
+## `GET /batches/{ingestion_id}` response block (CC21, extends CHAOS-2694's `status.py`)
+
+```json
+{
+  "recompute": {
+    "status": "dispatched",
+    "scope": {
+      "repoIds": ["..."], "teamIds": [],
+      "windowStartedAt": "2026-06-25T00:00:00Z",
+      "windowEndedAt": "2026-06-26T00:00:00Z",
+      "cappedDays": false, "cappedRepos": false
+    },
+    "dispatchedAt": "2026-06-26T00:01:15Z",
+    "completedAt": "2026-06-26T00:01:15Z",
+    "error": null,
+    "jobs": [
+      {"task": "run_daily_metrics", "taskId": "...", "queue": "metrics", "repoId": "..."},
+      {"task": "run_work_graph_build", "taskId": "...", "queue": "metrics", "repoId": "..."},
+      {"task": "dispatch_investment_materialize_partitioned", "taskId": "...", "queue": "default", "repoId": null}
+    ]
+  }
+}
+```
+
+`jobs` is read from `external_ingest_recompute_jobs`, joined by exact
+`(org_id, source_system, source_instance, dispatched_at)` match against the
+batch's own `recompute_dispatched_at` -- a flush coalesces N ingestion_ids,
+so there is no per-job FK to a single `external_ingest_batches` row; every
+job a single flush inserts shares the identical `dispatched_at` timestamp,
+which is what makes the join possible.
+
+## Live verification runbook
+
+1. **Migration 0034 up/down/up** against a scratch Postgres DB: `psql \d
+   external_ingest_batches` shows the 5 new columns +
+   `external_ingest_recompute_jobs`; `downgrade()` drops them cleanly;
+   `upgrade()` again is a no-op-safe re-create.
+2. **Debounce**, against dev Valkey with a throwaway test org: call
+   `schedule_or_coalesce(...)` twice within the window for the same
+   `(org, system, instance)` -- `valkey-cli GET
+   external-ingest:recompute:pending:...` shows one widened blob;
+   `valkey-cli TTL external-ingest:recompute:scheduled:...` proves the
+   guard key exists and only the first call scheduled a flush.
+3. **Dispatch shapes**, with Celery in eager/mock mode -- confirm chain
+   length, caps (25 repos / 14 days), and the empty-scope investment
+   refusal, without dispatching real metric jobs against dev data.
+4. **GET response**, via a local `uvicorn` against the scratch Postgres --
+   confirm the `recompute` block renders with the pinned enum and the
+   `jobs` array population.
+
+Full end-to-end (`POST /batches` -> worker -> `GET /batches/{id}` showing
+`recompute.status: "dispatched"`) is blocked until CHAOS-2693/2694/2696/
+2697/2698 all land; owned by CHAOS-2702's E2E test once available.

--- a/src/dev_health_ops/alembic/versions/0034_add_external_ingest_recompute.py
+++ b/src/dev_health_ops/alembic/versions/0034_add_external_ingest_recompute.py
@@ -1,0 +1,140 @@
+"""Add bounded-recompute visibility columns + job log (CHAOS-2699).
+
+Extends CHAOS-2694's ``external_ingest_batches`` table with a summary of the
+bounded recompute triggered for that batch, plus a companion
+``external_ingest_recompute_jobs`` table logging each individual Celery
+dispatch (a single debounced flush can fan out to N per-repo
+``run_daily_metrics``/``run_work_graph_build`` chains + one
+``dispatch_investment_materialize_partitioned`` call).
+
+``recompute_status`` enum is pinned epic-wide (master-spec CC21):
+``not_applicable | pending | dispatched | skipped_no_scope | failed``,
+server_default ``'not_applicable'`` (a batch whose record kinds never
+trigger recompute -- e.g. ``repository.v1``-only -- stays at the default
+forever).
+
+Renumbered from this issue's original 0033 sketch: 0032 = CHAOS-2696 (ingest
+auth), 0033 = CHAOS-2694 (status store) -- this is 0034, chained onto 0033.
+
+Guarded per the 0025/0030/0031/0032/0033 create-if-missing convention so a
+partial rerun resumes cleanly.
+
+Revision ID: 0034
+Revises: 0033
+Create Date: 2026-07-02 00:00:00
+
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0034"
+down_revision: str | None = "0033"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_BATCHES_TABLE = "external_ingest_batches"
+_JOBS_TABLE = "external_ingest_recompute_jobs"
+_JOBS_SCOPE_INDEX = "ix_external_ingest_recompute_jobs_scope"
+
+
+def upgrade() -> None:
+    _add_column_if_missing(
+        _BATCHES_TABLE,
+        sa.Column(
+            "recompute_status",
+            sa.Text(),
+            nullable=False,
+            server_default="not_applicable",
+        ),
+    )
+    _add_column_if_missing(
+        _BATCHES_TABLE, sa.Column("recompute_scope", sa.JSON(), nullable=True)
+    )
+    _add_column_if_missing(
+        _BATCHES_TABLE,
+        sa.Column("recompute_dispatched_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    _add_column_if_missing(
+        _BATCHES_TABLE,
+        sa.Column("recompute_completed_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    _add_column_if_missing(
+        _BATCHES_TABLE, sa.Column("recompute_error", sa.Text(), nullable=True)
+    )
+
+    if not _table_exists(_JOBS_TABLE):
+        op.create_table(
+            _JOBS_TABLE,
+            sa.Column("id", UUID(as_uuid=True), nullable=False),
+            sa.Column("org_id", sa.Text(), nullable=False),
+            sa.Column("source_system", sa.Text(), nullable=False),
+            sa.Column("source_instance", sa.Text(), nullable=False),
+            sa.Column("celery_task_name", sa.Text(), nullable=False),
+            # Nullable: dispatch_recompute() can legitimately produce a
+            # per-repo daily-metrics job whose Celery AsyncResult has no
+            # `.parent` (chain result-metadata unavailable), in which case
+            # the task id it captured is None -- the Celery dispatch itself
+            # still succeeded, so this must not block persisting the
+            # recompute outcome (adversarial-review finding).
+            sa.Column("celery_task_id", sa.Text(), nullable=True),
+            sa.Column("queue", sa.Text(), nullable=False),
+            sa.Column("repo_id", sa.Text(), nullable=True),
+            sa.Column("status", sa.Text(), nullable=False, server_default="dispatched"),
+            sa.Column("dispatched_at", sa.DateTime(timezone=True), nullable=False),
+            sa.Column("completed_at", sa.DateTime(timezone=True), nullable=True),
+            sa.Column("error", sa.Text(), nullable=True),
+            sa.PrimaryKeyConstraint("id"),
+        )
+    _create_index_if_missing(
+        _JOBS_SCOPE_INDEX,
+        _JOBS_TABLE,
+        ["org_id", "source_system", "source_instance", "dispatched_at"],
+    )
+
+
+def downgrade() -> None:
+    if _table_exists(_JOBS_TABLE):
+        op.drop_table(_JOBS_TABLE)
+    for col in (
+        "recompute_status",
+        "recompute_scope",
+        "recompute_dispatched_at",
+        "recompute_completed_at",
+        "recompute_error",
+    ):
+        if _table_exists(_BATCHES_TABLE) and col in _column_names(_BATCHES_TABLE):
+            op.drop_column(_BATCHES_TABLE, col)
+
+
+def _table_exists(table_name: str) -> bool:
+    bind = op.get_bind()
+    return table_name in sa.inspect(bind).get_table_names()
+
+
+def _column_names(table_name: str) -> set[str]:
+    bind = op.get_bind()
+    return {column["name"] for column in sa.inspect(bind).get_columns(table_name)}
+
+
+def _add_column_if_missing(table_name: str, column: sa.Column) -> None:
+    if column.name not in _column_names(table_name):
+        op.add_column(table_name, column)
+
+
+def _create_index_if_missing(
+    index_name: str, table_name: str, columns: list[str]
+) -> None:
+    bind = op.get_bind()
+    existing_indexes = {
+        index["name"] for index in sa.inspect(bind).get_indexes(table_name)
+    }
+    if index_name not in existing_indexes:
+        op.create_index(index_name, table_name, columns)

--- a/src/dev_health_ops/api/external_ingest/status.py
+++ b/src/dev_health_ops/api/external_ingest/status.py
@@ -44,6 +44,10 @@ from dev_health_ops.api.middleware.rate_limit import (
     get_ingest_token_key,
     limiter,
 )
+from dev_health_ops.external_ingest.recompute_status import (
+    RecomputeJobRow,
+    get_recompute_jobs,
+)
 from dev_health_ops.models.external_ingest import (
     MAX_STORED_REJECTIONS_PER_BATCH,
     TERMINAL_STATUSES,
@@ -124,6 +128,13 @@ class BatchRow:
     created_at: datetime
     updated_at: datetime
     completed_at: datetime | None
+    # CHAOS-2699 (master-spec CC21): bounded-recompute visibility, added by
+    # migration 0034.
+    recompute_status: str
+    recompute_scope: dict[str, Any] | None
+    recompute_dispatched_at: datetime | None
+    recompute_completed_at: datetime | None
+    recompute_error: str | None
 
 
 @dataclass(frozen=True)
@@ -193,6 +204,11 @@ def _row_to_batch(m: RowMapping) -> BatchRow:
         created_at=_parse_dt_required(m["created_at"]),
         updated_at=_parse_dt_required(m["updated_at"]),
         completed_at=_parse_dt(m["completed_at"]),
+        recompute_status=m["recompute_status"],
+        recompute_scope=_parse_json(m["recompute_scope"]),
+        recompute_dispatched_at=_parse_dt(m["recompute_dispatched_at"]),
+        recompute_completed_at=_parse_dt(m["recompute_completed_at"]),
+        recompute_error=m["recompute_error"],
     )
 
 
@@ -306,6 +322,15 @@ async def create_batch(
         "created_at": now,
         "updated_at": now,
         "completed_at": None,
+        # CHAOS-2699: explicit, not relied-upon-via-server_default (matches
+        # this file's created_at/updated_at/completed_at convention) --
+        # every INSERT this function issues starts a batch with no
+        # recompute decision made yet.
+        "recompute_status": "not_applicable",
+        "recompute_scope": None,
+        "recompute_dispatched_at": None,
+        "recompute_completed_at": None,
+        "recompute_error": None,
     }
     insert_sql = text(
         f"""
@@ -314,13 +339,17 @@ async def create_batch(
             source_instance, producer, producer_version, schema_version,
             window_started_at, window_ended_at, status, attempts,
             items_received, items_accepted, items_rejected, record_counts,
-            error_summary, created_at, updated_at, completed_at
+            error_summary, created_at, updated_at, completed_at,
+            recompute_status, recompute_scope, recompute_dispatched_at,
+            recompute_completed_at, recompute_error
         ) VALUES (
             :ingestion_id, :org_id, :idempotency_key, :payload_hash, :source_system,
             :source_instance, :producer, :producer_version, :schema_version,
             :window_started_at, :window_ended_at, :status, :attempts,
             :items_received, :items_accepted, :items_rejected, :record_counts,
-            :error_summary, :created_at, :updated_at, :completed_at
+            :error_summary, :created_at, :updated_at, :completed_at,
+            :recompute_status, :recompute_scope, :recompute_dispatched_at,
+            :recompute_completed_at, :recompute_error
         )
         """
     )
@@ -357,6 +386,11 @@ async def create_batch(
         created_at=now,
         updated_at=now,
         completed_at=None,
+        recompute_status="not_applicable",  # DB server_default (migration 0034)
+        recompute_scope=None,
+        recompute_dispatched_at=None,
+        recompute_completed_at=None,
+        recompute_error=None,
     )
 
 
@@ -703,6 +737,37 @@ class RejectedRecordResponse(BaseModel):
     path: str | None = None
 
 
+class RecomputeJobResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    task: str
+    task_id: str | None = Field(default=None, alias="taskId")
+    queue: str
+    repo_id: str | None = Field(default=None, alias="repoId")
+
+
+class RecomputeScopeResponse(BaseModel):
+    model_config = ConfigDict(populate_by_name=True)
+    repo_ids: list[str] = Field(default_factory=list, alias="repoIds")
+    team_ids: list[str] = Field(default_factory=list, alias="teamIds")
+    window_started_at: datetime | None = Field(default=None, alias="windowStartedAt")
+    window_ended_at: datetime | None = Field(default=None, alias="windowEndedAt")
+    capped_days: bool = Field(default=False, alias="cappedDays")
+    capped_repos: bool = Field(default=False, alias="cappedRepos")
+
+
+class RecomputeStatusResponse(BaseModel):
+    """CHAOS-2699 (master-spec CC21). Enum pinned epic-wide:
+    ``not_applicable | pending | dispatched | skipped_no_scope | failed``."""
+
+    model_config = ConfigDict(populate_by_name=True)
+    status: str
+    scope: RecomputeScopeResponse | None = None
+    dispatched_at: datetime | None = Field(default=None, alias="dispatchedAt")
+    completed_at: datetime | None = Field(default=None, alias="completedAt")
+    error: str | None = None
+    jobs: list[RecomputeJobResponse] = Field(default_factory=list)
+
+
 class BatchStatusResponse(BaseModel):
     model_config = ConfigDict(populate_by_name=True)
     ingestion_id: uuid.UUID = Field(alias="ingestionId")
@@ -723,8 +788,9 @@ class BatchStatusResponse(BaseModel):
     errors_total: int = Field(alias="errorsTotal")
     errors_limit: int = Field(alias="errorsLimit")
     errors_offset: int = Field(alias="errorsOffset")
-    # NOTE(CHAOS-2699, master-spec CC21): a `recompute_status` block is added
-    # here in wave 3, once migration 0034 lands. Deliberately absent in v1.
+    # CHAOS-2699, master-spec CC21: cross-wave extension -- 2694 ships wave
+    # 2 with no recompute references; this block is added in wave 3.
+    recompute: RecomputeStatusResponse
 
 
 class BatchListItemResponse(BaseModel):
@@ -766,12 +832,46 @@ def _batch_to_list_item(row: BatchRow) -> BatchListItemResponse:
     )
 
 
+def _recompute_scope_response(
+    scope: dict[str, Any] | None,
+) -> RecomputeScopeResponse | None:
+    if scope is None:
+        return None
+    return RecomputeScopeResponse(
+        repo_ids=list(scope.get("repoIds") or []),
+        team_ids=list(scope.get("teamIds") or []),
+        window_started_at=_parse_dt(scope.get("windowStartedAt")),
+        window_ended_at=_parse_dt(scope.get("windowEndedAt")),
+        capped_days=bool(scope.get("cappedDays", False)),
+        capped_repos=bool(scope.get("cappedRepos", False)),
+    )
+
+
+def _batch_to_recompute_response(
+    row: BatchRow, jobs: list[RecomputeJobRow]
+) -> RecomputeStatusResponse:
+    return RecomputeStatusResponse(
+        status=row.recompute_status,
+        scope=_recompute_scope_response(row.recompute_scope),
+        dispatched_at=row.recompute_dispatched_at,
+        completed_at=row.recompute_completed_at,
+        error=row.recompute_error,
+        jobs=[
+            RecomputeJobResponse(
+                task=j.task, task_id=j.task_id, queue=j.queue, repo_id=j.repo_id
+            )
+            for j in jobs
+        ],
+    )
+
+
 def _batch_to_status_response(
     row: BatchRow,
     errors: list[RejectionRow],
     errors_total: int,
     errors_limit: int,
     errors_offset: int,
+    recompute_jobs: list[RecomputeJobRow],
 ) -> BatchStatusResponse:
     return BatchStatusResponse(
         ingestion_id=row.ingestion_id,
@@ -804,6 +904,7 @@ def _batch_to_status_response(
         errors_total=errors_total,
         errors_limit=errors_limit,
         errors_offset=errors_offset,
+        recompute=_batch_to_recompute_response(row, recompute_jobs),
     )
 
 
@@ -871,6 +972,13 @@ async def get_batch_status(
         limit=error_limit,
         offset=error_offset,
     )
+    recompute_jobs = await get_recompute_jobs(
+        session,
+        org_id=ctx.org_id,
+        source_system=batch.source_system,
+        source_instance=batch.source_instance,
+        dispatched_at=batch.recompute_dispatched_at,
+    )
     return _batch_to_status_response(
-        batch, errors, errors_total, error_limit, error_offset
+        batch, errors, errors_total, error_limit, error_offset, recompute_jobs
     )

--- a/src/dev_health_ops/external_ingest/recompute.py
+++ b/src/dev_health_ops/external_ingest/recompute.py
@@ -1,0 +1,670 @@
+"""Bounded recomputation planner + Valkey debounce (CHAOS-2699).
+
+Given the affected scope accumulated while processing an accepted
+customer-push batch (org, source system/instance, repo ids, team ids,
+record kinds, occurred-at window), decide which existing metric Celery
+tasks to enqueue -- capped fan-out/window, never a full-org recompute by
+default (master-spec CC21).
+
+``RecomputeScope`` is internal to this module (decouples from CHAOS-2697/2698
+per the synthesizer reconciliation on brief-2699-recompute.md); the public
+seam other sub-issues call is :func:`schedule_or_coalesce`, which takes
+plain primitives, not a shared dataclass.
+
+Design decisions D1-D15 are recorded in
+``docs/architecture/external-ingest-bounded-recompute.md``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import datetime, time, timedelta, timezone
+from typing import Any
+
+from celery import chain
+
+from dev_health_ops.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+# D7: record-kind -> job-category routing, mirroring _GIT_TARGETS/
+# _WORK_ITEM_TARGETS (workers/task_utils.py) but for the 9 v1 customer-push
+# record kinds.
+_GIT_KINDS = frozenset({"pull_request.v1", "review.v1", "commit.v1"})
+_WORK_ITEM_KINDS = frozenset(
+    {"work_item.v1", "work_item_transition.v1", "work_item_dependency.v1"}
+)
+_TEAM_KINDS = frozenset({"identity.v1", "team.v1"})
+_REPO_ONLY_KINDS = frozenset({"repository.v1"})
+_RECOMPUTE_TRIGGER_KINDS = _GIT_KINDS | _WORK_ITEM_KINDS
+
+# D6: the DORA/complexity tasks (deferred-v1 kinds) and the checkpoint-
+# gated / unscoped partitioned daily-metrics dispatch path (checkpoint-skip
+# swallows same-day data; the latter has no org_id filter at all) are
+# deliberately never referenced anywhere below this point in the module --
+# negative-space contract, asserted by
+# tests/test_external_ingest_recompute_dispatch.py via a source-text grep,
+# so this comment itself must not name any of those four disqualified
+# task identifiers.
+_RUN_DAILY_METRICS_TASK = "dev_health_ops.workers.tasks.run_daily_metrics"
+_RUN_WORK_GRAPH_BUILD_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
+_DISPATCH_INVESTMENT_MATERIALIZE_TASK = (
+    "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned"
+)
+
+_DEFAULT_DEBOUNCE_SECONDS = 45
+_DEFAULT_MAX_BACKFILL_DAYS = 14
+_DEFAULT_MAX_FANOUT_REPOS = 25
+
+_PENDING_KEY_PREFIX = "external-ingest:recompute:pending"
+_GUARD_KEY_PREFIX = "external-ingest:recompute:scheduled"
+# Pending-blob TTL outlives the scheduled flush by a wide margin so a slow
+# broker/worker doesn't let the blob expire before the flush task reads it
+# (Risk 4 in the brief: only Valkey connection *errors* are covered by the
+# D3 synchronous fallback, not silent key eviction -- a generous TTL is the
+# cheap mitigation for the eviction case).
+_PENDING_BLOB_TTL_FLOOR_SECONDS = 300
+# WATCH/MULTI optimistic-lock retry budget for the pending-blob merge
+# (adversarial-review finding: concurrent schedule_or_coalesce() calls for
+# the same debounce key must not silently overwrite each other's scope).
+_MAX_COALESCE_RETRIES = 5
+
+
+def _env_int(name: str, default: int) -> int:
+    raw = os.getenv(name)
+    if not raw:
+        return default
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        return default
+
+
+def _debounce_seconds() -> int:
+    return _env_int(
+        "EXTERNAL_INGEST_RECOMPUTE_DEBOUNCE_SECONDS", _DEFAULT_DEBOUNCE_SECONDS
+    )
+
+
+def _max_backfill_days() -> int:
+    return max(
+        1,
+        _env_int(
+            "EXTERNAL_INGEST_RECOMPUTE_MAX_BACKFILL_DAYS", _DEFAULT_MAX_BACKFILL_DAYS
+        ),
+    )
+
+
+def _max_fanout_repos() -> int:
+    return max(
+        1,
+        _env_int(
+            "EXTERNAL_INGEST_RECOMPUTE_MAX_FANOUT_REPOS", _DEFAULT_MAX_FANOUT_REPOS
+        ),
+    )
+
+
+def _get_redis_client() -> Any:
+    """Plain non-blocking Valkey client (D3) -- same shape as
+    ``api/product_telemetry/streams.py:get_redis_client()``. Deliberately
+    NOT ``get_consumer_redis_client()`` (``api/_stream_consumer.py``),
+    which is reserved for blocking ``XREADGROUP`` reads only."""
+    redis_url = os.getenv("REDIS_URL")
+    if not redis_url:
+        return None
+    try:
+        import valkey as redis
+
+        return redis.from_url(redis_url, decode_responses=True)
+    except Exception:
+        logger.warning("Valkey unavailable for external-ingest recompute debounce")
+        return None
+
+
+def _parse_iso(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    parsed = datetime.fromisoformat(value)
+    return parsed if parsed.tzinfo is not None else parsed.replace(tzinfo=timezone.utc)
+
+
+def _pending_key(org_id: str, source_system: str, source_instance: str) -> str:
+    return f"{_PENDING_KEY_PREFIX}:{org_id}:{source_system}:{source_instance}"
+
+
+def _guard_key(org_id: str, source_system: str, source_instance: str) -> str:
+    return f"{_GUARD_KEY_PREFIX}:{org_id}:{source_system}:{source_instance}"
+
+
+@dataclass(frozen=True)
+class RecomputeScope:
+    """Affected scope for one bounded-recompute decision.
+
+    Internal to this module (synthesizer reconciliation on
+    brief-2699-recompute.md: "public seam is primitives, not a shared
+    dataclass" -- decouples from CHAOS-2697/2698). Built by
+    :func:`schedule_or_coalesce` from the primitives its caller passes
+    (optionally merged across a debounce window's multiple calls).
+    """
+
+    org_id: str
+    source_system: str
+    source_instance: str
+    repo_ids: frozenset[str] = field(default_factory=frozenset)
+    team_ids: frozenset[str] = field(default_factory=frozenset)
+    record_kinds: frozenset[str] = field(default_factory=frozenset)
+    ingestion_ids: frozenset[str] = field(default_factory=frozenset)
+    window_start: datetime | None = None
+    window_end: datetime | None = None
+
+
+@dataclass(frozen=True)
+class RecomputePlan:
+    """Pure output of :func:`plan_recompute` -- a bounded, capped plan.
+
+    ``trigger=False`` means nothing to dispatch (record kinds are
+    ``repository.v1``-only or empty -- D7 ``_REPO_ONLY_KINDS`` row).
+    """
+
+    org_id: str
+    trigger: bool
+    dispatch_daily: bool
+    repo_ids: tuple[str, ...]
+    team_ids: tuple[str, ...]
+    day: str | None
+    backfill_days: int | None
+    from_date: str | None
+    to_date: str | None
+    capped_days: bool
+    capped_repos: bool
+    fallback_org_wide_daily: bool
+    skip_investment_no_scope: bool
+
+
+def plan_recompute(scope: RecomputeScope) -> RecomputePlan:
+    """Pure function: scope -> bounded plan. No I/O, no Celery calls."""
+    has_git = bool(scope.record_kinds & _GIT_KINDS)
+    has_work_items = bool(scope.record_kinds & _WORK_ITEM_KINDS)
+    has_team = bool(scope.record_kinds & _TEAM_KINDS)
+
+    if not (has_git or has_work_items or has_team):
+        return RecomputePlan(
+            org_id=scope.org_id,
+            trigger=False,
+            dispatch_daily=False,
+            repo_ids=(),
+            team_ids=(),
+            day=None,
+            backfill_days=None,
+            from_date=None,
+            to_date=None,
+            capped_days=False,
+            capped_repos=False,
+            fallback_org_wide_daily=False,
+            skip_investment_no_scope=False,
+        )
+
+    max_backfill_days = _max_backfill_days()
+    max_fanout = _max_fanout_repos()
+
+    window_end = scope.window_end or scope.window_start or datetime.now(timezone.utc)
+    window_start = scope.window_start or window_end
+    requested_days = max(1, (window_end.date() - window_start.date()).days + 1)
+    capped_days = requested_days > max_backfill_days
+    backfill_days = min(requested_days, max_backfill_days)
+    clamped_start_date = window_end.date() - timedelta(days=backfill_days - 1)
+
+    day = window_end.date().isoformat()
+    from_date = datetime.combine(
+        clamped_start_date, time.min, tzinfo=timezone.utc
+    ).isoformat()
+    to_date = window_end.isoformat()
+
+    sorted_repo_ids = sorted(scope.repo_ids)
+    capped_repos = len(sorted_repo_ids) > max_fanout
+    repo_ids = tuple(sorted_repo_ids[:max_fanout])
+    team_ids = tuple(sorted(scope.team_ids))
+
+    dispatch_daily = has_git or has_work_items
+    # D8: org-wide day-bounded fallback ONLY for work-item kinds with an
+    # empty repo scope (Jira-native work items may carry no repo linkage).
+    # Git kinds always carry a repo (pull_request/review/commit); a
+    # git-only batch with empty repo_ids is structurally impossible but is
+    # handled defensively here by simply not dispatching daily/work-graph
+    # at all rather than falling back org-wide for a kind category that
+    # was never meant to trigger the fallback.
+    fallback_org_wide_daily = dispatch_daily and not repo_ids and has_work_items
+
+    # D4 hard invariant: never call dispatch_investment_materialize_partitioned
+    # with both repo_ids and team_ids empty.
+    skip_investment_no_scope = not repo_ids and not team_ids
+
+    return RecomputePlan(
+        org_id=scope.org_id,
+        trigger=True,
+        dispatch_daily=dispatch_daily,
+        repo_ids=repo_ids,
+        team_ids=team_ids,
+        day=day,
+        backfill_days=backfill_days,
+        from_date=from_date,
+        to_date=to_date,
+        capped_days=capped_days,
+        capped_repos=capped_repos,
+        fallback_org_wide_daily=fallback_org_wide_daily,
+        skip_investment_no_scope=skip_investment_no_scope,
+    )
+
+
+@dataclass(frozen=True)
+class RecomputeJobRecord:
+    task: str
+    task_id: str | None
+    queue: str
+    repo_id: str | None = None
+
+
+@dataclass(frozen=True)
+class RecomputeDispatchResult:
+    status: str  # not_applicable | dispatched | skipped_no_scope | failed
+    jobs: tuple[RecomputeJobRecord, ...]
+    capped_days: bool
+    capped_repos: bool
+    error: str | None = None
+
+
+def _daily_metrics_kwargs(
+    plan: RecomputePlan, *, repo_id: str | None
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {"org_id": plan.org_id}
+    if plan.day is not None:
+        kwargs["day"] = plan.day
+    if plan.backfill_days is not None:
+        kwargs["backfill_days"] = plan.backfill_days
+    if repo_id is not None:
+        kwargs["repo_id"] = repo_id
+    return kwargs
+
+
+def _work_graph_build_kwargs(plan: RecomputePlan, *, repo_id: str) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {"org_id": plan.org_id, "repo_id": repo_id}
+    if plan.from_date is not None:
+        kwargs["from_date"] = plan.from_date
+    if plan.to_date is not None:
+        kwargs["to_date"] = plan.to_date
+    return kwargs
+
+
+def _investment_kwargs(plan: RecomputePlan) -> dict[str, Any]:
+    # D4/D5: never both repo_ids and team_ids empty -- caller only invokes
+    # this when skip_investment_no_scope is False. force=False (same-day
+    # investment freshness best-effort, never forces a full rematerialize).
+    kwargs: dict[str, Any] = {"org_id": plan.org_id, "force": False}
+    if plan.repo_ids:
+        kwargs["repo_ids"] = list(plan.repo_ids)
+    if plan.team_ids:
+        kwargs["team_ids"] = list(plan.team_ids)
+    if plan.from_date is not None:
+        kwargs["from_date"] = plan.from_date
+    if plan.to_date is not None:
+        kwargs["to_date"] = plan.to_date
+    return kwargs
+
+
+def dispatch_recompute(plan: RecomputePlan) -> RecomputeDispatchResult:
+    """Impure: builds and fires Celery signatures per D5/D6.
+
+    Never raises (D13) -- catches and returns ``status="failed"`` so a
+    recompute-dispatch problem can never fail (or retry-loop) the ingestion
+    worker task that calls into this module.
+    """
+    if not plan.trigger:
+        return RecomputeDispatchResult(
+            status="not_applicable", jobs=(), capped_days=False, capped_repos=False
+        )
+
+    try:
+        jobs: list[RecomputeJobRecord] = []
+
+        if plan.dispatch_daily:
+            if plan.repo_ids:
+                # D5: run_daily_metrics/run_work_graph_build only accept a
+                # single repo_id -- fan out N independent chains, one per
+                # repo, via celery.chain (immutable links so a parent's
+                # return dict is never injected as the next task's arg).
+                for repo_id in plan.repo_ids:
+                    daily_sig = celery_app.signature(
+                        _RUN_DAILY_METRICS_TASK,
+                        kwargs=_daily_metrics_kwargs(plan, repo_id=repo_id),
+                        queue="metrics",
+                        immutable=True,
+                    )
+                    build_sig = celery_app.signature(
+                        _RUN_WORK_GRAPH_BUILD_TASK,
+                        kwargs=_work_graph_build_kwargs(plan, repo_id=repo_id),
+                        queue="metrics",
+                        immutable=True,
+                    )
+                    async_result = chain(daily_sig, build_sig).apply_async()
+                    daily_id = (
+                        async_result.parent.id
+                        if async_result.parent is not None
+                        else None
+                    )
+                    jobs.append(
+                        RecomputeJobRecord(
+                            task=_RUN_DAILY_METRICS_TASK,
+                            task_id=daily_id,
+                            queue="metrics",
+                            repo_id=repo_id,
+                        )
+                    )
+                    jobs.append(
+                        RecomputeJobRecord(
+                            task=_RUN_WORK_GRAPH_BUILD_TASK,
+                            task_id=async_result.id,
+                            queue="metrics",
+                            repo_id=repo_id,
+                        )
+                    )
+            elif plan.fallback_org_wide_daily:
+                # D8: day-bounded, all-repos fallback for repo-less
+                # work-item batches. run_work_graph_build is deliberately
+                # NOT dispatched here (repo_id=None there means "all
+                # repos, 30-day trailing window", ignoring the tighter
+                # batch window -- not useful in this fallback).
+                async_result = celery_app.send_task(
+                    _RUN_DAILY_METRICS_TASK,
+                    kwargs=_daily_metrics_kwargs(plan, repo_id=None),
+                    queue="metrics",
+                )
+                jobs.append(
+                    RecomputeJobRecord(
+                        task=_RUN_DAILY_METRICS_TASK,
+                        task_id=async_result.id,
+                        queue="metrics",
+                        repo_id=None,
+                    )
+                )
+
+        if not plan.skip_investment_no_scope:
+            # D5: dispatch_investment_materialize_partitioned accepts
+            # repo_ids/team_ids lists directly -- called ONCE per flush
+            # with the full capped list, never per repo.
+            async_result = celery_app.send_task(
+                _DISPATCH_INVESTMENT_MATERIALIZE_TASK,
+                kwargs=_investment_kwargs(plan),
+                queue="default",
+            )
+            jobs.append(
+                RecomputeJobRecord(
+                    task=_DISPATCH_INVESTMENT_MATERIALIZE_TASK,
+                    task_id=async_result.id,
+                    queue="default",
+                    repo_id=None,
+                )
+            )
+
+        status = "dispatched" if jobs else "skipped_no_scope"
+        return RecomputeDispatchResult(
+            status=status,
+            jobs=tuple(jobs),
+            capped_days=plan.capped_days,
+            capped_repos=plan.capped_repos,
+        )
+    except Exception as exc:
+        # D13: recompute dispatch failures must never fail ingestion.
+        logger.exception(
+            "external_ingest.recompute.dispatch_failed org_id=%s", plan.org_id
+        )
+        return RecomputeDispatchResult(
+            status="failed",
+            jobs=(),
+            capped_days=plan.capped_days,
+            capped_repos=plan.capped_repos,
+            error=str(exc),
+        )
+
+
+def dispatch_and_persist_scope(
+    *,
+    org_id: str,
+    source_system: str,
+    source_instance: str,
+    ingestion_ids: list[str],
+    repo_ids: list[str],
+    team_ids: list[str],
+    record_kinds: list[str],
+    window_start: datetime | None,
+    window_end: datetime | None,
+) -> RecomputeDispatchResult:
+    """Plan + dispatch + persist for an already-coalesced scope.
+
+    Shared by ``workers/external_ingest_recompute.py``'s debounced flush
+    task and by :func:`schedule_or_coalesce`'s Valkey-unavailable
+    synchronous fallback (D3) -- both end up with the same primitives, just
+    via a different trigger path. Persistence failures are logged, never
+    raised (mirrors D13: a status-write hiccup must not surface as a
+    recompute-dispatch failure to the caller, who has already durably
+    dispatched -- or skipped -- the Celery jobs by this point).
+    """
+    from dev_health_ops.db import get_postgres_session_sync
+    from dev_health_ops.external_ingest.recompute_status import (
+        record_recompute_dispatch,
+    )
+
+    scope = RecomputeScope(
+        org_id=org_id,
+        source_system=source_system,
+        source_instance=source_instance,
+        repo_ids=frozenset(repo_ids),
+        team_ids=frozenset(team_ids),
+        record_kinds=frozenset(record_kinds),
+        ingestion_ids=frozenset(ingestion_ids),
+        window_start=window_start,
+        window_end=window_end,
+    )
+    plan = plan_recompute(scope)
+    result = dispatch_recompute(plan)
+
+    if scope.ingestion_ids:
+        try:
+            with get_postgres_session_sync() as session:
+                record_recompute_dispatch(
+                    session,
+                    org_id=org_id,
+                    ingestion_ids=sorted(scope.ingestion_ids),
+                    scope=scope,
+                    result=result,
+                )
+        except Exception:
+            logger.exception(
+                "external_ingest.recompute.persist_failed org_id=%s "
+                "source_system=%s source_instance=%s",
+                org_id,
+                source_system,
+                source_instance,
+            )
+    return result
+
+
+def _merge_pending_blob(
+    existing: dict[str, Any] | None, new_call: dict[str, Any]
+) -> dict[str, Any]:
+    if existing is None:
+        return new_call
+    starts = [
+        d
+        for d in (
+            _parse_iso(existing.get("window_start")),
+            _parse_iso(new_call["window_start"]),
+        )
+        if d is not None
+    ]
+    ends = [
+        d
+        for d in (
+            _parse_iso(existing.get("window_end")),
+            _parse_iso(new_call["window_end"]),
+        )
+        if d is not None
+    ]
+    return {
+        "org_id": new_call["org_id"],
+        "source_system": new_call["source_system"],
+        "source_instance": new_call["source_instance"],
+        "repo_ids": sorted(
+            set(existing.get("repo_ids", [])) | set(new_call["repo_ids"])
+        ),
+        "team_ids": sorted(
+            set(existing.get("team_ids", [])) | set(new_call["team_ids"])
+        ),
+        "record_kinds": sorted(
+            set(existing.get("record_kinds", [])) | set(new_call["record_kinds"])
+        ),
+        "ingestion_ids": sorted(
+            set(existing.get("ingestion_ids", [])) | set(new_call["ingestion_ids"])
+        ),
+        "window_start": min(starts).isoformat() if starts else None,
+        "window_end": max(ends).isoformat() if ends else None,
+    }
+
+
+def schedule_or_coalesce(
+    *,
+    org_id: str,
+    source_system: str,
+    source_instance: str,
+    ingestion_id: str,
+    repo_ids: set[str] | frozenset[str],
+    team_ids: set[str] | frozenset[str],
+    window_start: datetime | None,
+    window_end: datetime | None,
+    record_kinds: set[str] | frozenset[str],
+    debounce_seconds: int | None = None,
+) -> None:
+    """Called once per finished batch by the external-ingest worker (D3/D10).
+
+    Debounce key grain is ``(org_id, source_system, source_instance)`` --
+    D10: different source instances debounce independently since their
+    repo/team scopes are disjoint. Writes/merges the pending scope blob
+    into Valkey and, iff a SETNX guard key is newly acquired, schedules
+    ``flush_external_ingest_recompute.apply_async(countdown=debounce_seconds)``.
+
+    If Valkey is unavailable (no ``REDIS_URL``, connection error, or any
+    other exception talking to it), degrades to an IMMEDIATE synchronous
+    dispatch+persist for just this one batch's scope (D3) -- recompute
+    triggering is best-effort but never silently dropped.
+    """
+    seconds = debounce_seconds if debounce_seconds is not None else _debounce_seconds()
+    new_call = {
+        "org_id": org_id,
+        "source_system": source_system,
+        "source_instance": source_instance,
+        "repo_ids": sorted(repo_ids),
+        "team_ids": sorted(team_ids),
+        "record_kinds": sorted(record_kinds),
+        "ingestion_ids": [ingestion_id],
+        "window_start": window_start.isoformat() if window_start is not None else None,
+        "window_end": window_end.isoformat() if window_end is not None else None,
+    }
+
+    def _synchronous_fallback() -> None:
+        dispatch_and_persist_scope(
+            org_id=org_id,
+            source_system=source_system,
+            source_instance=source_instance,
+            ingestion_ids=[ingestion_id],
+            repo_ids=sorted(repo_ids),
+            team_ids=sorted(team_ids),
+            record_kinds=sorted(record_kinds),
+            window_start=window_start,
+            window_end=window_end,
+        )
+
+    client = _get_redis_client()
+    if client is None:
+        logger.warning(
+            "external_ingest.recompute.valkey_unavailable_sync_fallback "
+            "org_id=%s source_system=%s source_instance=%s",
+            org_id,
+            source_system,
+            source_instance,
+        )
+        _synchronous_fallback()
+        return
+
+    pending_key = _pending_key(org_id, source_system, source_instance)
+    guard_key = _guard_key(org_id, source_system, source_instance)
+    blob_ttl = max(seconds * 4, _PENDING_BLOB_TTL_FLOOR_SECONDS)
+    try:
+        # Adversarial-review finding: a plain GET -> merge -> SET is not
+        # atomic, so two truly concurrent callers for the same debounce key
+        # can race and one's widened blob (and possibly its ingestion_id)
+        # is silently overwritten. WATCH/MULTI turns the whole
+        # read-merge-write-and-guard-acquire into a single optimistic
+        # transaction: if the watched key changes between GET and EXEC,
+        # Valkey aborts the transaction and we retry with a fresh read.
+        from valkey.exceptions import WatchError
+
+        acquired = None
+        for _ in range(_MAX_COALESCE_RETRIES):
+            pipe = client.pipeline(transaction=True)
+            try:
+                pipe.watch(pending_key)
+                existing_raw = pipe.get(pending_key)
+                merged = _merge_pending_blob(
+                    json.loads(existing_raw) if existing_raw else None, new_call
+                )
+                pipe.multi()
+                pipe.set(pending_key, json.dumps(merged), ex=blob_ttl)
+                pipe.set(guard_key, "1", nx=True, ex=seconds)
+                results = pipe.execute()
+                acquired = bool(results[-1])
+                break
+            except WatchError:
+                continue
+        else:
+            raise RuntimeError(
+                "schedule_or_coalesce: exceeded WATCH/MULTI retry budget "
+                f"for org_id={org_id} source_system={source_system} "
+                f"source_instance={source_instance}"
+            )
+
+        if acquired:
+            from dev_health_ops.workers.external_ingest_recompute import (
+                flush_external_ingest_recompute,
+            )
+
+            flush_external_ingest_recompute.apply_async(
+                kwargs={
+                    "org_id": org_id,
+                    "source_system": source_system,
+                    "source_instance": source_instance,
+                },
+                countdown=seconds,
+            )
+    except Exception:
+        logger.exception(
+            "external_ingest.recompute.valkey_error_sync_fallback "
+            "org_id=%s source_system=%s source_instance=%s",
+            org_id,
+            source_system,
+            source_instance,
+        )
+        _synchronous_fallback()
+
+
+__all__ = [
+    "RecomputeDispatchResult",
+    "RecomputeJobRecord",
+    "RecomputePlan",
+    "RecomputeScope",
+    "dispatch_and_persist_scope",
+    "dispatch_recompute",
+    "plan_recompute",
+    "schedule_or_coalesce",
+]

--- a/src/dev_health_ops/external_ingest/recompute_status.py
+++ b/src/dev_health_ops/external_ingest/recompute_status.py
@@ -1,0 +1,244 @@
+"""Direct-SQL persistence for bounded-recompute status (CHAOS-2699, D11/D12).
+
+Mirrors ``api/external_ingest/status.py``'s convention exactly: all
+reads/writes go through ``session.execute(text(...), params)``, never
+``session.add()``/ORM query paths. SQL is dialect-portable (no
+``RETURNING``/``ON CONFLICT``/``ANY(:array)``) -- per-ingestion_id UPDATEs
+in a loop instead of a single ``WHERE ingestion_id = ANY(:ids)`` statement,
+so unit tests run on sqlite via ``Base.metadata`` (no new ``postgres``
+pytest marker epic-wide, per the synthesizer reconciliation).
+
+Two entry points, two session flavors -- deliberate, not an oversight:
+
+- :func:`record_recompute_dispatch` takes a **sync** ``Session``. It is
+  called from ``workers/external_ingest_recompute.py``'s Celery flush task,
+  which (like every other Celery task in this codebase, e.g.
+  ``prune_external_ingest_batches``) runs synchronously via
+  ``get_postgres_session_sync()`` -- no ``run_async`` bridging needed.
+- :func:`get_recompute_jobs` and :func:`mark_recompute_pending` take an
+  **async** ``AsyncSession``, matching ``api/external_ingest/status.py``'s
+  FastAPI request-scoped session (``get_postgres_session_dep``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import Session
+
+from dev_health_ops.external_ingest.recompute import (
+    RecomputeDispatchResult,
+    RecomputeScope,
+)
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "RecomputeJobRow",
+    "get_recompute_jobs",
+    "mark_recompute_pending",
+    "record_recompute_dispatch",
+]
+
+_BATCHES_TABLE = "external_ingest_batches"
+_JOBS_TABLE = "external_ingest_recompute_jobs"
+
+
+def _scope_to_json(
+    scope: RecomputeScope, result: RecomputeDispatchResult
+) -> dict[str, Any]:
+    return {
+        "repoIds": sorted(scope.repo_ids),
+        "teamIds": sorted(scope.team_ids),
+        "recordKinds": sorted(scope.record_kinds),
+        "windowStartedAt": (
+            scope.window_start.isoformat() if scope.window_start is not None else None
+        ),
+        "windowEndedAt": (
+            scope.window_end.isoformat() if scope.window_end is not None else None
+        ),
+        "cappedDays": result.capped_days,
+        "cappedRepos": result.capped_repos,
+    }
+
+
+def record_recompute_dispatch(
+    session: Session,
+    *,
+    org_id: str,
+    ingestion_ids: list[str],
+    scope: RecomputeScope,
+    result: RecomputeDispatchResult,
+) -> None:
+    """Persist a flush's outcome onto every coalesced ingestion's batch row
+    plus one job-log row per dispatched Celery task (D11).
+
+    ``ingestion_ids`` is the FULL set that fed into the coalesced scope
+    (Risk 5 in the brief: debounce coalesces across multiple ingestion_ids,
+    so a flush's status write must cover all of them, not just one) --
+    every row gets the identical ``scope``/``result`` snapshot, since they
+    were all folded into the same bounded plan.
+
+    D12 (emit-then-raise): commits before returning so a caller that goes
+    on to re-raise (e.g. Celery retry on an unrelated later step) never
+    rolls back an already-decided recompute outcome.
+    """
+    now = datetime.now(timezone.utc)
+    scope_json = json.dumps(_scope_to_json(scope, result))
+    dispatched_at = now if result.status == "dispatched" else None
+
+    update_sql = text(
+        f"""
+        UPDATE {_BATCHES_TABLE}
+        SET recompute_status = :status,
+            recompute_scope = :scope,
+            recompute_dispatched_at = :dispatched_at,
+            recompute_completed_at = :completed_at,
+            recompute_error = :error
+        WHERE org_id = :org_id AND ingestion_id = :ingestion_id
+        """
+    )
+    for ingestion_id in ingestion_ids:
+        session.execute(
+            update_sql,
+            {
+                "status": result.status,
+                "scope": scope_json,
+                "dispatched_at": dispatched_at,
+                "completed_at": now,
+                "error": result.error,
+                "org_id": org_id,
+                "ingestion_id": ingestion_id,
+            },
+        )
+
+    if result.jobs:
+        insert_sql = text(
+            f"""
+            INSERT INTO {_JOBS_TABLE} (
+                id, org_id, source_system, source_instance, celery_task_name,
+                celery_task_id, queue, repo_id, status, dispatched_at
+            ) VALUES (
+                :id, :org_id, :source_system, :source_instance, :celery_task_name,
+                :celery_task_id, :queue, :repo_id, :status, :dispatched_at
+            )
+            """
+        )
+        for job in result.jobs:
+            session.execute(
+                insert_sql,
+                {
+                    "id": str(uuid.uuid4()),
+                    "org_id": org_id,
+                    "source_system": scope.source_system,
+                    "source_instance": scope.source_instance,
+                    "celery_task_name": job.task,
+                    "celery_task_id": job.task_id,
+                    "queue": job.queue,
+                    "repo_id": job.repo_id,
+                    "status": "dispatched",
+                    "dispatched_at": now,
+                },
+            )
+
+    session.commit()
+
+
+async def mark_recompute_pending(
+    session: AsyncSession, *, org_id: str, ingestion_id: uuid.UUID | str
+) -> None:
+    """``not_applicable -> pending``, best-effort.
+
+    Optional seam for whoever finalizes a batch's own status (CHAOS-2697's
+    worker, per D12 "in the same worker task as the final ingestion-status
+    update") to call right after :func:`~dev_health_ops.external_ingest.
+    recompute.schedule_or_coalesce` returns, so the batch shows ``pending``
+    during its debounce window instead of the default ``not_applicable``
+    until the flush actually fires. Deliberately NOT called from
+    ``schedule_or_coalesce`` itself, whose public signature is
+    primitives-only (no ``session`` parameter, per the synthesizer
+    reconciliation) -- callers that skip this simply see ``not_applicable``
+    until the flush completes, which is a display nuance only (the flush's
+    own :func:`record_recompute_dispatch` write is unaffected either way).
+    A no-op (never raises) if the batch is not currently
+    ``not_applicable`` (e.g. a redelivered call after the flush already
+    completed) so it never regresses a terminal recompute outcome.
+    """
+    try:
+        await session.execute(
+            text(
+                f"""
+                UPDATE {_BATCHES_TABLE}
+                SET recompute_status = 'pending'
+                WHERE org_id = :org_id AND ingestion_id = :ingestion_id
+                    AND recompute_status = 'not_applicable'
+                """
+            ),
+            {"org_id": org_id, "ingestion_id": str(ingestion_id)},
+        )
+    except Exception:
+        logger.exception(
+            "external_ingest.recompute.mark_pending_failed org_id=%s ingestion_id=%s",
+            org_id,
+            ingestion_id,
+        )
+
+
+@dataclass(frozen=True)
+class RecomputeJobRow:
+    task: str
+    task_id: str | None
+    queue: str
+    repo_id: str | None
+
+
+async def get_recompute_jobs(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    source_system: str,
+    source_instance: str,
+    dispatched_at: datetime | None,
+) -> list[RecomputeJobRow]:
+    """Jobs from the SAME flush that produced ``dispatched_at`` on the
+    batch row -- all job rows a single flush inserts share the identical
+    ``dispatched_at`` timestamp (see :func:`record_recompute_dispatch`),
+    which is what makes this exact-match join possible without a shared
+    ingestion_id (a flush coalesces N ingestion_ids, so no per-job FK to
+    ``external_ingest_batches`` exists -- see
+    ``ExternalIngestRecomputeJob``'s docstring)."""
+    if dispatched_at is None:
+        return []
+    result = await session.execute(
+        text(
+            f"""
+            SELECT celery_task_name, celery_task_id, queue, repo_id
+            FROM {_JOBS_TABLE}
+            WHERE org_id = :org_id AND source_system = :source_system
+                AND source_instance = :source_instance AND dispatched_at = :dispatched_at
+            ORDER BY celery_task_name, repo_id
+            """
+        ),
+        {
+            "org_id": org_id,
+            "source_system": source_system,
+            "source_instance": source_instance,
+            "dispatched_at": dispatched_at,
+        },
+    )
+    return [
+        RecomputeJobRow(
+            task=row["celery_task_name"],
+            task_id=row["celery_task_id"],
+            queue=row["queue"],
+            repo_id=row["repo_id"],
+        )
+        for row in result.mappings().all()
+    ]

--- a/src/dev_health_ops/models/external_ingest.py
+++ b/src/dev_health_ops/models/external_ingest.py
@@ -110,6 +110,22 @@ class ExternalIngestBatch(Base):
     completed_at: Mapped[datetime | None] = mapped_column(
         DateTime(timezone=True), nullable=True
     )
+    # CHAOS-2699 (master-spec CC21): bounded-recompute visibility, added by
+    # migration 0034 which ALTERs this table (owned by CHAOS-2694). Enum
+    # pinned epic-wide: not_applicable | pending | dispatched |
+    # skipped_no_scope | failed. Written by recompute_status.py, never by
+    # this file's own status.py CRUD helpers.
+    recompute_status: Mapped[str] = mapped_column(
+        Text, nullable=False, server_default="not_applicable"
+    )
+    recompute_scope: Mapped[dict | None] = mapped_column(JSON, nullable=True)
+    recompute_dispatched_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    recompute_completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    recompute_error: Mapped[str | None] = mapped_column(Text, nullable=True)
 
     __table_args__ = (
         UniqueConstraint(
@@ -187,6 +203,57 @@ class ExternalIngestBatchPayload(Base):
     __table_args__ = (Index("ix_external_ingest_batch_payloads_org_id", "org_id"),)
 
 
+class ExternalIngestRecomputeJob(Base):
+    """Per-dispatch recompute job log (CHAOS-2699, migration 0034).
+
+    A single debounced flush can fan out to N per-repo
+    ``run_daily_metrics``/``run_work_graph_build`` chains plus one
+    ``dispatch_investment_materialize_partitioned`` call; this table logs
+    each individual Celery dispatch for observability (the acceptance
+    criteria explicitly ask for "observability around recompute
+    scheduling"). FK-less by design (mirrors ``provider_rate_limit_observations``,
+    migration 0031): a flush coalesces N ingestion_ids (debounce key grain is
+    ``(org_id, source_system, source_instance)``, not per-ingestion), so
+    there is no single ``external_ingest_batches`` row to own a job row --
+    the affected batches' own ``recompute_status``/``recompute_scope``
+    columns are updated separately, keyed by org/source/time range.
+    """
+
+    __tablename__ = "external_ingest_recompute_jobs"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False)
+    source_system: Mapped[str] = mapped_column(Text, nullable=False)
+    source_instance: Mapped[str] = mapped_column(Text, nullable=False)
+    celery_task_name: Mapped[str] = mapped_column(Text, nullable=False)
+    # Nullable: a per-repo daily-metrics job's captured id can be None when
+    # its chain AsyncResult has no `.parent` -- the Celery dispatch itself
+    # still succeeded (see recompute.py's dispatch_recompute()).
+    celery_task_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    queue: Mapped[str] = mapped_column(Text, nullable=False)
+    repo_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    status: Mapped[str] = mapped_column(Text, nullable=False, default="dispatched")
+    dispatched_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    completed_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    error: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    __table_args__ = (
+        Index(
+            "ix_external_ingest_recompute_jobs_scope",
+            "org_id",
+            "source_system",
+            "source_instance",
+            "dispatched_at",
+        ),
+    )
+
+
 def terminal_status_for(
     items_received: int, items_accepted: int, items_rejected: int
 ) -> BatchStatus:
@@ -212,6 +279,7 @@ __all__ = [
     "BatchStatus",
     "ExternalIngestBatch",
     "ExternalIngestBatchPayload",
+    "ExternalIngestRecomputeJob",
     "ExternalIngestRejection",
     "terminal_status_for",
 ]

--- a/src/dev_health_ops/workers/external_ingest_recompute.py
+++ b/src/dev_health_ops/workers/external_ingest_recompute.py
@@ -1,0 +1,119 @@
+"""Debounced recompute flush task (CHAOS-2699).
+
+# INTEGRATOR TODO (CHAOS-2693, master-spec CC20 -- Celery wiring has ONE
+# owner this wave): this task is intentionally NOT re-exported from
+# workers/tasks.py and NOT added to workers/config.py's
+# late_ack_excluded_tasks (both are hot files owned by CHAOS-2693 this
+# wave). At merge time, add exactly this one line to
+# workers/config.py's `late_ack_excluded_tasks` tuple (queue="default" is
+# already declared on the task decorator below -- no task_queues/compose
+# change needed, it reuses the existing `default` queue's worker coverage):
+#
+#     "dev_health_ops.workers.tasks.flush_external_ingest_recompute",
+#
+# No workers/tasks.py re-export needed -- the task name is pinned via the
+# `name=` kwarg on the decorator below (flat-namespace convention achieved
+# without the re-export line, per the synthesizer reconciliation on
+# brief-2699-recompute.md).
+
+Reads+clears the Valkey pending-scope blob that
+``external_ingest.recompute.schedule_or_coalesce`` accumulated for
+``(org_id, source_system, source_instance)``, plans + dispatches the
+bounded recompute, and persists the outcome onto every coalesced
+ingestion's ``external_ingest_batches`` row (D11/D12).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from dev_health_ops.workers.celery_app import celery_app
+
+logger = logging.getLogger(__name__)
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=3,
+    queue="default",
+    name="dev_health_ops.workers.tasks.flush_external_ingest_recompute",
+)
+def flush_external_ingest_recompute(
+    self,
+    org_id: str,
+    source_system: str,
+    source_instance: str,
+) -> dict:
+    from dev_health_ops.external_ingest.recompute import (
+        _get_redis_client,
+        _parse_iso,
+        _pending_key,
+        dispatch_and_persist_scope,
+    )
+
+    pending_key = _pending_key(org_id, source_system, source_instance)
+
+    try:
+        client = _get_redis_client()
+        # Adversarial-review finding: a separate GET then DELETE left a
+        # window where a NEW schedule_or_coalesce() call (guard already
+        # expired) could write a fresher blob between this task's GET and
+        # DELETE -- this task would then delete that fresher blob without
+        # ever having read it, silently dropping the later batch's scope.
+        # GETDEL is atomic: whatever this task reads is exactly what it
+        # clears, with no gap for a third party to land in between.
+        #
+        # The guard key is deliberately left untouched here (no explicit
+        # DELETE): its own `ex=seconds` TTL governs its lifecycle, so a
+        # schedule_or_coalesce() call that lands before it naturally
+        # expires correctly coalesces into the *next* debounce window
+        # instead of racing this flush's cleanup.
+        raw = client.getdel(pending_key) if client is not None else None
+    except Exception as exc:
+        logger.exception(
+            "flush_external_ingest_recompute.valkey_read_failed org_id=%s "
+            "source_system=%s source_instance=%s",
+            org_id,
+            source_system,
+            source_instance,
+        )
+        raise self.retry(exc=exc, countdown=30 * (2**self.request.retries))
+
+    if not raw:
+        # Risk 4 (brief): the pending blob can be lost to Valkey eviction
+        # between the guard SETNX and this flush firing. Tolerate a
+        # missing/empty blob gracefully -- log + no-op -- rather than
+        # raising (D13: recompute dispatch problems must never propagate
+        # as task failures that could retry-loop or page anyone).
+        logger.info(
+            "flush_external_ingest_recompute.empty_blob org_id=%s "
+            "source_system=%s source_instance=%s",
+            org_id,
+            source_system,
+            source_instance,
+        )
+        return {"status": "no_pending_scope"}
+
+    blob = json.loads(raw)
+    result = dispatch_and_persist_scope(
+        org_id=blob.get("org_id", org_id),
+        source_system=blob.get("source_system", source_system),
+        source_instance=blob.get("source_instance", source_instance),
+        ingestion_ids=blob.get("ingestion_ids", []),
+        repo_ids=blob.get("repo_ids", []),
+        team_ids=blob.get("team_ids", []),
+        record_kinds=blob.get("record_kinds", []),
+        window_start=_parse_iso(blob.get("window_start")),
+        window_end=_parse_iso(blob.get("window_end")),
+    )
+    return {
+        "status": result.status,
+        "jobs": len(result.jobs),
+        "capped_days": result.capped_days,
+        "capped_repos": result.capped_repos,
+        "ingestion_ids": blob.get("ingestion_ids", []),
+    }
+
+
+__all__ = ["flush_external_ingest_recompute"]

--- a/tests/test_external_ingest_recompute_debounce.py
+++ b/tests/test_external_ingest_recompute_debounce.py
@@ -1,0 +1,324 @@
+"""Unit tests for ``schedule_or_coalesce()`` (CHAOS-2699, brief D3/D10).
+
+Uses ``fakeredis.FakeValkey`` (same fixture family as
+``tests/test_ingest_streams.py``) instead of a live Valkey instance.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+from fakeredis import FakeServer, FakeValkey  # noqa: E402
+
+import dev_health_ops.external_ingest.recompute as recompute_mod  # noqa: E402
+from dev_health_ops.external_ingest.recompute import schedule_or_coalesce  # noqa: E402
+
+ORG = "org-1"
+SYSTEM = "github"
+INSTANCE = "acme/api"
+PENDING_KEY = f"external-ingest:recompute:pending:{ORG}:{SYSTEM}:{INSTANCE}"
+GUARD_KEY = f"external-ingest:recompute:scheduled:{ORG}:{SYSTEM}:{INSTANCE}"
+
+
+def _fake_client() -> FakeValkey:
+    return FakeValkey(decode_responses=True)
+
+
+def _ttl(client: FakeValkey, key: str) -> int:
+    # FakeValkey's stubs type sync-mode calls as `Awaitable[Any] | Any`
+    # (the same client class backs fakeredis's async mode); narrow to the
+    # actual sync return type instead of asserting past it.
+    value = client.ttl(key)
+    assert isinstance(value, int)
+    return value
+
+
+def _get_str(client: FakeValkey, key: str) -> str | None:
+    value = client.get(key)
+    assert value is None or isinstance(value, str)
+    return value
+
+
+def _call(
+    client,
+    *,
+    ingestion_id="ing-1",
+    repo_ids=None,
+    team_ids=None,
+    record_kinds=None,
+    window_start=None,
+    window_end=None,
+):
+    with patch(
+        "dev_health_ops.external_ingest.recompute._get_redis_client",
+        return_value=client,
+    ):
+        mock_task = MagicMock()
+        with patch(
+            "dev_health_ops.workers.external_ingest_recompute.flush_external_ingest_recompute",
+            mock_task,
+        ):
+            schedule_or_coalesce(
+                org_id=ORG,
+                source_system=SYSTEM,
+                source_instance=INSTANCE,
+                ingestion_id=ingestion_id,
+                repo_ids=repo_ids or set(),
+                team_ids=team_ids or set(),
+                window_start=window_start,
+                window_end=window_end,
+                record_kinds=record_kinds or set(),
+            )
+        return mock_task
+
+
+def test_first_call_acquires_guard_and_schedules_flush() -> None:
+    client = _fake_client()
+    mock_task = _call(client, repo_ids={"repo-a"}, record_kinds={"pull_request.v1"})
+
+    mock_task.apply_async.assert_called_once()
+    kwargs = mock_task.apply_async.call_args.kwargs
+    assert kwargs["kwargs"] == {
+        "org_id": ORG,
+        "source_system": SYSTEM,
+        "source_instance": INSTANCE,
+    }
+    assert kwargs["countdown"] == 45
+
+    assert _ttl(client, GUARD_KEY) > 0
+    raw = _get_str(client, PENDING_KEY)
+    assert raw is not None
+    blob = json.loads(raw)
+    assert blob["repo_ids"] == ["repo-a"]
+    assert blob["ingestion_ids"] == ["ing-1"]
+
+
+def test_second_call_within_window_widens_blob_without_rescheduling() -> None:
+    client = _fake_client()
+    mock_task_1 = _call(
+        client,
+        ingestion_id="ing-1",
+        repo_ids={"repo-a"},
+        record_kinds={"pull_request.v1"},
+        window_start=datetime(2026, 6, 25, tzinfo=timezone.utc),
+        window_end=datetime(2026, 6, 25, 12, tzinfo=timezone.utc),
+    )
+    mock_task_2 = _call(
+        client,
+        ingestion_id="ing-2",
+        repo_ids={"repo-b"},
+        record_kinds={"work_item.v1"},
+        window_start=datetime(2026, 6, 25, 13, tzinfo=timezone.utc),
+        window_end=datetime(2026, 6, 26, tzinfo=timezone.utc),
+    )
+
+    mock_task_1.apply_async.assert_called_once()
+    mock_task_2.apply_async.assert_not_called()
+
+    raw = _get_str(client, PENDING_KEY)
+    assert raw is not None
+    blob = json.loads(raw)
+    assert sorted(blob["repo_ids"]) == ["repo-a", "repo-b"]
+    assert sorted(blob["ingestion_ids"]) == ["ing-1", "ing-2"]
+    assert sorted(blob["record_kinds"]) == ["pull_request.v1", "work_item.v1"]
+    assert (
+        blob["window_start"] == datetime(2026, 6, 25, tzinfo=timezone.utc).isoformat()
+    )
+    assert blob["window_end"] == datetime(2026, 6, 26, tzinfo=timezone.utc).isoformat()
+
+
+def test_guard_expiry_allows_rescheduling() -> None:
+    client = _fake_client()
+    mock_task_1 = _call(client, ingestion_id="ing-1")
+    assert mock_task_1.apply_async.call_count == 1
+
+    # Simulate the debounce window elapsing (Valkey TTL eviction).
+    client.delete(GUARD_KEY)
+
+    mock_task_2 = _call(client, ingestion_id="ing-2")
+    assert mock_task_2.apply_async.call_count == 1
+
+
+def test_different_source_instances_debounce_independently() -> None:
+    client = _fake_client()
+    with patch(
+        "dev_health_ops.external_ingest.recompute._get_redis_client",
+        return_value=client,
+    ):
+        mock_task = MagicMock()
+        with patch(
+            "dev_health_ops.workers.external_ingest_recompute.flush_external_ingest_recompute",
+            mock_task,
+        ):
+            schedule_or_coalesce(
+                org_id=ORG,
+                source_system="github",
+                source_instance=INSTANCE,
+                ingestion_id="ing-1",
+                repo_ids=set(),
+                team_ids=set(),
+                window_start=None,
+                window_end=None,
+                record_kinds=set(),
+            )
+            schedule_or_coalesce(
+                org_id=ORG,
+                source_system="gitlab",
+                source_instance=INSTANCE,
+                ingestion_id="ing-2",
+                repo_ids=set(),
+                team_ids=set(),
+                window_start=None,
+                window_end=None,
+                record_kinds=set(),
+            )
+    assert mock_task.apply_async.call_count == 2
+
+
+def test_no_redis_url_falls_back_to_synchronous_dispatch(monkeypatch) -> None:
+    monkeypatch.delenv("REDIS_URL", raising=False)
+    with patch(
+        "dev_health_ops.external_ingest.recompute.dispatch_and_persist_scope"
+    ) as mock_dispatch:
+        schedule_or_coalesce(
+            org_id=ORG,
+            source_system=SYSTEM,
+            source_instance=INSTANCE,
+            ingestion_id="ing-1",
+            repo_ids={"repo-a"},
+            team_ids=set(),
+            window_start=None,
+            window_end=None,
+            record_kinds={"pull_request.v1"},
+        )
+
+    mock_dispatch.assert_called_once()
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["org_id"] == ORG
+    assert call_kwargs["ingestion_ids"] == ["ing-1"]
+    assert call_kwargs["repo_ids"] == ["repo-a"]
+
+
+def test_valkey_connection_error_falls_back_to_synchronous_dispatch(
+    monkeypatch,
+) -> None:
+    class _BoomClient:
+        def get(self, *args, **kwargs):
+            raise ConnectionError("boom")
+
+    monkeypatch.setattr(
+        "dev_health_ops.external_ingest.recompute._get_redis_client",
+        lambda: _BoomClient(),
+    )
+    with patch(
+        "dev_health_ops.external_ingest.recompute.dispatch_and_persist_scope"
+    ) as mock_dispatch:
+        schedule_or_coalesce(
+            org_id=ORG,
+            source_system=SYSTEM,
+            source_instance=INSTANCE,
+            ingestion_id="ing-1",
+            repo_ids=set(),
+            team_ids=set(),
+            window_start=None,
+            window_end=None,
+            record_kinds=set(),
+        )
+
+    mock_dispatch.assert_called_once()
+
+
+def test_debounce_seconds_override_used_for_countdown_and_guard_ttl() -> None:
+    client = _fake_client()
+    with patch(
+        "dev_health_ops.external_ingest.recompute._get_redis_client",
+        return_value=client,
+    ):
+        mock_task = MagicMock()
+        with patch(
+            "dev_health_ops.workers.external_ingest_recompute.flush_external_ingest_recompute",
+            mock_task,
+        ):
+            schedule_or_coalesce(
+                org_id=ORG,
+                source_system=SYSTEM,
+                source_instance=INSTANCE,
+                ingestion_id="ing-1",
+                repo_ids=set(),
+                team_ids=set(),
+                window_start=None,
+                window_end=None,
+                record_kinds=set(),
+                debounce_seconds=10,
+            )
+    assert mock_task.apply_async.call_args.kwargs["countdown"] == 10
+    assert _ttl(client, GUARD_KEY) <= 10
+
+
+def test_concurrent_callers_do_not_lose_either_ingestion_id() -> None:
+    """Adversarial-review finding: a plain GET -> merge -> SET is not
+    atomic, so two truly concurrent callers for the same debounce key can
+    race and one's widened blob is silently overwritten. Simulates a
+    second caller finishing its own write (against the same backing
+    Valkey server) while the first caller is still inside its WATCH/MULTI
+    window, proving the retry-on-WatchError path recovers both ingestion
+    ids instead of dropping one."""
+    server = FakeServer()
+    client_a = FakeValkey(server=server, decode_responses=True)
+    client_b = FakeValkey(server=server, decode_responses=True)
+
+    real_merge = recompute_mod._merge_pending_blob
+    call_count = {"n": 0}
+
+    def _racy_merge(existing, new_call):
+        call_count["n"] += 1
+        if call_count["n"] == 1:
+            # A second caller's schedule_or_coalesce() completes its own
+            # write to the SAME pending key while the first caller's
+            # WATCH/MULTI transaction is still open on client_a.
+            client_b.set(
+                PENDING_KEY,
+                json.dumps(
+                    {
+                        "org_id": ORG,
+                        "source_system": SYSTEM,
+                        "source_instance": INSTANCE,
+                        "repo_ids": ["repo-b"],
+                        "team_ids": [],
+                        "record_kinds": ["work_item.v1"],
+                        "ingestion_ids": ["ing-2"],
+                        "window_start": None,
+                        "window_end": None,
+                    }
+                ),
+                ex=300,
+            )
+        return real_merge(existing, new_call)
+
+    with patch(
+        "dev_health_ops.external_ingest.recompute._merge_pending_blob",
+        side_effect=_racy_merge,
+    ):
+        _call(
+            client_a,
+            ingestion_id="ing-1",
+            repo_ids={"repo-a"},
+            record_kinds={"pull_request.v1"},
+        )
+
+    # WatchError forced a retry: the merge function ran twice (once
+    # aborted by the concurrent write, once successful against the
+    # now-current value).
+    assert call_count["n"] == 2
+
+    raw = _get_str(client_a, PENDING_KEY)
+    assert raw is not None
+    blob = json.loads(raw)
+    assert sorted(blob["ingestion_ids"]) == ["ing-1", "ing-2"]
+    assert sorted(blob["repo_ids"]) == ["repo-a", "repo-b"]
+    assert sorted(blob["record_kinds"]) == ["pull_request.v1", "work_item.v1"]

--- a/tests/test_external_ingest_recompute_dispatch.py
+++ b/tests/test_external_ingest_recompute_dispatch.py
@@ -1,0 +1,332 @@
+"""Unit tests for ``dispatch_recompute()`` (CHAOS-2699, brief D5/D6/D13/D14).
+
+Patches Celery ``chain``/``signature``/``send_task`` exactly like
+``tests/test_post_sync_investment_dispatch.py`` -- no live broker, no
+ClickHouse.
+"""
+
+from __future__ import annotations
+
+import inspect
+import pathlib
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+# Import connectors first to defuse the providers._base <-> connectors
+# circular import that otherwise ERRORs isolated collection (mirrors
+# CHAOS-2370, same guard as test_post_sync_investment_dispatch.py).
+import dev_health_ops.connectors  # noqa: F401
+import dev_health_ops.external_ingest.recompute as recompute_mod
+from dev_health_ops.external_ingest.recompute import RecomputePlan, dispatch_recompute
+
+_DAILY_TASK = "dev_health_ops.workers.tasks.run_daily_metrics"
+_BUILD_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
+_INVESTMENT_TASK = (
+    "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned"
+)
+
+
+def _plan(**overrides: Any) -> RecomputePlan:
+    defaults: dict[str, Any] = dict(
+        org_id="org-1",
+        trigger=True,
+        dispatch_daily=True,
+        repo_ids=("repo-a", "repo-b"),
+        team_ids=(),
+        day="2026-06-26",
+        backfill_days=2,
+        from_date="2026-06-25T00:00:00+00:00",
+        to_date="2026-06-26T00:00:00+00:00",
+        capped_days=False,
+        capped_repos=False,
+        fallback_org_wide_daily=False,
+        skip_investment_no_scope=False,
+    )
+    defaults.update(overrides)
+    return RecomputePlan(**defaults)
+
+
+def _make_sig(name, **kwargs):
+    sig = MagicMock(name=f"sig:{name}")
+    sig.task_name = name
+    sig.sig_kwargs = kwargs
+    return sig
+
+
+def _async_result(task_id, parent=None):
+    r = MagicMock(name=f"result:{task_id}")
+    r.id = task_id
+    r.parent = parent
+    return r
+
+
+def test_per_repo_chains_dispatched_with_correct_kwargs() -> None:
+    with (
+        patch(
+            "dev_health_ops.external_ingest.recompute.celery_app.signature"
+        ) as mock_sig,
+        patch("dev_health_ops.external_ingest.recompute.chain") as mock_chain,
+        patch(
+            "dev_health_ops.external_ingest.recompute.celery_app.send_task"
+        ) as mock_send,
+    ):
+        mock_sig.side_effect = _make_sig
+
+        def _chain_side_effect(daily_sig, build_sig):
+            repo_id = daily_sig.sig_kwargs["kwargs"]["repo_id"]
+            chain_instance = MagicMock(name=f"chain:{repo_id}")
+            daily_result = _async_result(f"daily-{repo_id}")
+            build_result = _async_result(f"build-{repo_id}", parent=daily_result)
+            chain_instance.apply_async.return_value = build_result
+            return chain_instance
+
+        mock_chain.side_effect = _chain_side_effect
+        mock_send.return_value = _async_result("investment-1")
+
+        plan = _plan(team_ids=("team-a",))
+        result = dispatch_recompute(plan)
+
+    assert result.status == "dispatched"
+    assert mock_chain.call_count == 2  # one per repo
+
+    for call in mock_chain.call_args_list:
+        daily_sig, build_sig = call.args
+        assert daily_sig.task_name == _DAILY_TASK
+        assert daily_sig.sig_kwargs["queue"] == "metrics"
+        assert daily_sig.sig_kwargs.get("immutable") is True
+        assert daily_sig.sig_kwargs["kwargs"]["org_id"] == "org-1"
+        assert daily_sig.sig_kwargs["kwargs"]["day"] == "2026-06-26"
+        assert daily_sig.sig_kwargs["kwargs"]["backfill_days"] == 2
+
+        assert build_sig.task_name == _BUILD_TASK
+        assert build_sig.sig_kwargs["queue"] == "metrics"
+        assert build_sig.sig_kwargs.get("immutable") is True
+        assert build_sig.sig_kwargs["kwargs"]["from_date"] == plan.from_date
+        assert build_sig.sig_kwargs["kwargs"]["to_date"] == plan.to_date
+
+    dispatched_repo_ids = {
+        call.args[0].sig_kwargs["kwargs"]["repo_id"]
+        for call in mock_chain.call_args_list
+    }
+    assert dispatched_repo_ids == {"repo-a", "repo-b"}
+
+    # Investment materialize fires exactly ONCE, with the full repo list
+    # (not per-repo) plus the team_ids scope (D5).
+    investment_calls = [
+        c for c in mock_send.call_args_list if c.args[0] == _INVESTMENT_TASK
+    ]
+    assert len(investment_calls) == 1
+    inv_kwargs = investment_calls[0].kwargs["kwargs"]
+    assert inv_kwargs["repo_ids"] == ["repo-a", "repo-b"]
+    assert inv_kwargs["team_ids"] == ["team-a"]
+    assert inv_kwargs["force"] is False
+    assert investment_calls[0].kwargs["queue"] == "default"
+
+    assert len(result.jobs) == 5  # 2x(daily+build) + 1 investment
+
+
+def test_per_repo_chain_with_no_parent_result_still_dispatches_with_none_task_id() -> (
+    None
+):
+    """Adversarial-review finding: a chain's AsyncResult can legitimately
+    have no ``.parent`` (chain result-metadata unavailable) -- the daily
+    job's captured task_id is then ``None``, but the Celery dispatch itself
+    already succeeded, so this must still surface as ``status="dispatched"``
+    with a job record carrying ``task_id=None`` rather than losing the
+    daily job entirely."""
+    plan = _plan(repo_ids=("repo-a",), team_ids=())
+    with (
+        patch(
+            "dev_health_ops.external_ingest.recompute.celery_app.signature"
+        ) as mock_sig,
+        patch("dev_health_ops.external_ingest.recompute.chain") as mock_chain,
+        patch(
+            "dev_health_ops.external_ingest.recompute.celery_app.send_task"
+        ) as mock_send,
+    ):
+        mock_sig.side_effect = _make_sig
+
+        def _chain_side_effect(daily_sig, build_sig):
+            chain_instance = MagicMock()
+            build_result = _async_result("build-repo-a", parent=None)
+            chain_instance.apply_async.return_value = build_result
+            return chain_instance
+
+        mock_chain.side_effect = _chain_side_effect
+        mock_send.return_value = _async_result("investment-1")
+
+        result = dispatch_recompute(plan)
+
+    assert result.status == "dispatched"
+    daily_jobs = [j for j in result.jobs if j.task == _DAILY_TASK]
+    assert len(daily_jobs) == 1
+    assert daily_jobs[0].task_id is None
+    build_jobs = [j for j in result.jobs if j.task == _BUILD_TASK]
+    assert build_jobs[0].task_id == "build-repo-a"
+
+
+def test_fallback_org_wide_daily_uses_send_task_no_repo_id_no_work_graph() -> None:
+    plan = _plan(
+        repo_ids=(), fallback_org_wide_daily=True, skip_investment_no_scope=True
+    )
+    with (
+        patch(
+            "dev_health_ops.external_ingest.recompute.celery_app.signature"
+        ) as mock_sig,
+        patch("dev_health_ops.external_ingest.recompute.chain") as mock_chain,
+        patch(
+            "dev_health_ops.external_ingest.recompute.celery_app.send_task"
+        ) as mock_send,
+    ):
+        mock_send.return_value = _async_result("daily-fallback")
+        result = dispatch_recompute(plan)
+
+    mock_chain.assert_not_called()
+    mock_sig.assert_not_called()
+    mock_send.assert_called_once()
+    call = mock_send.call_args
+    assert call.args[0] == _DAILY_TASK
+    assert "repo_id" not in call.kwargs["kwargs"]
+    assert call.kwargs["queue"] == "metrics"
+
+    assert result.status == "dispatched"
+    assert len(result.jobs) == 1
+    assert result.jobs[0].task == _DAILY_TASK
+    assert result.jobs[0].repo_id is None
+
+
+def test_nothing_dispatchable_returns_skipped_no_scope() -> None:
+    plan = _plan(
+        dispatch_daily=True,
+        repo_ids=(),
+        fallback_org_wide_daily=False,
+        skip_investment_no_scope=True,
+        team_ids=(),
+    )
+    with (
+        patch("dev_health_ops.external_ingest.recompute.celery_app.signature"),
+        patch("dev_health_ops.external_ingest.recompute.chain") as mock_chain,
+        patch(
+            "dev_health_ops.external_ingest.recompute.celery_app.send_task"
+        ) as mock_send,
+    ):
+        result = dispatch_recompute(plan)
+
+    mock_chain.assert_not_called()
+    mock_send.assert_not_called()
+    assert result.status == "skipped_no_scope"
+    assert result.jobs == ()
+
+
+def test_not_trigger_returns_not_applicable_without_touching_celery() -> None:
+    plan = _plan(
+        trigger=False,
+        dispatch_daily=False,
+        repo_ids=(),
+        team_ids=(),
+        day=None,
+        backfill_days=None,
+        from_date=None,
+        to_date=None,
+        fallback_org_wide_daily=False,
+        skip_investment_no_scope=False,
+    )
+    with (
+        patch("dev_health_ops.external_ingest.recompute.celery_app.signature"),
+        patch("dev_health_ops.external_ingest.recompute.chain") as mock_chain,
+        patch(
+            "dev_health_ops.external_ingest.recompute.celery_app.send_task"
+        ) as mock_send,
+    ):
+        result = dispatch_recompute(plan)
+
+    mock_chain.assert_not_called()
+    mock_send.assert_not_called()
+    assert result.status == "not_applicable"
+    assert result.jobs == ()
+
+
+def test_dispatch_exception_returns_failed_never_raises() -> None:
+    plan = _plan()
+    with patch(
+        "dev_health_ops.external_ingest.recompute.celery_app.signature",
+        side_effect=RuntimeError("signature boom"),
+    ):
+        result = dispatch_recompute(plan)
+
+    assert result.status == "failed"
+    assert result.jobs == ()
+    assert result.error is not None
+    assert "signature boom" in result.error
+
+
+def test_capped_flags_propagate_from_plan_to_result() -> None:
+    plan = _plan(
+        repo_ids=(), fallback_org_wide_daily=True, capped_days=True, capped_repos=True
+    )
+    with (
+        patch("dev_health_ops.external_ingest.recompute.celery_app.signature"),
+        patch("dev_health_ops.external_ingest.recompute.chain"),
+        patch(
+            "dev_health_ops.external_ingest.recompute.celery_app.send_task"
+        ) as mock_send,
+    ):
+        mock_send.return_value = _async_result("daily-fallback")
+        result = dispatch_recompute(plan)
+
+    assert result.capped_days is True
+    assert result.capped_repos is True
+
+
+def test_never_references_disqualified_tasks() -> None:
+    """D6 negative-space: run_dora_metrics/run_complexity_job (deferred-v1
+    kinds) and dispatch_daily_metrics_partitioned/run_daily_metrics_batch
+    (disqualified per D6's two findings) must never appear in this
+    module's source."""
+    source = pathlib.Path(recompute_mod.__file__).read_text()
+    for forbidden in (
+        "run_dora_metrics",
+        "run_complexity_job",
+        "dispatch_daily_metrics_partitioned",
+        "run_daily_metrics_batch",
+    ):
+        assert forbidden not in source, f"{forbidden} must never be referenced (D6)"
+
+
+def test_daily_metrics_kwargs_subset_of_task_signature() -> None:
+    """D14: kwargs built for run_daily_metrics must be a strict subset of
+    the real task's ``.run`` signature -- catches kwarg drift that a
+    mocked ``.delay()``/``.apply_async()`` call would hide."""
+    from dev_health_ops.workers.metrics_daily import run_daily_metrics
+
+    plan = _plan()
+    kwargs = recompute_mod._daily_metrics_kwargs(plan, repo_id="repo-a")
+    params = set(inspect.signature(run_daily_metrics.run).parameters)
+    assert set(kwargs) <= params
+
+    fallback_kwargs = recompute_mod._daily_metrics_kwargs(plan, repo_id=None)
+    assert set(fallback_kwargs) <= params
+    assert "repo_id" not in fallback_kwargs
+
+
+def test_work_graph_build_kwargs_subset_of_task_signature() -> None:
+    from dev_health_ops.workers.work_graph_tasks import run_work_graph_build
+
+    plan = _plan()
+    kwargs = recompute_mod._work_graph_build_kwargs(plan, repo_id="repo-a")
+    params = set(inspect.signature(run_work_graph_build.run).parameters)
+    assert set(kwargs) <= params
+
+
+def test_investment_kwargs_subset_of_task_signature() -> None:
+    from dev_health_ops.workers.work_graph_tasks import (
+        dispatch_investment_materialize_partitioned,
+    )
+
+    plan = _plan(team_ids=("team-a",))
+    kwargs = recompute_mod._investment_kwargs(plan)
+    params = set(
+        inspect.signature(dispatch_investment_materialize_partitioned.run).parameters
+    )
+    assert set(kwargs) <= params
+    assert kwargs["force"] is False

--- a/tests/test_external_ingest_recompute_flush_task.py
+++ b/tests/test_external_ingest_recompute_flush_task.py
@@ -1,0 +1,165 @@
+"""Unit tests for the ``flush_external_ingest_recompute`` Celery task itself
+(CHAOS-2699).
+
+The debounce tests (``test_external_ingest_recompute_debounce.py``) mock
+this task's ``.apply_async`` entirely and never exercise its body -- these
+tests call ``.run()`` directly (bypassing the Celery machinery, matching
+``tests/test_post_sync_investment_dispatch.py``'s
+``run_investment_materialize.run(...)`` convention) with the real Valkey
+GETDEL + ``dispatch_and_persist_scope`` wiring, so the two are patched
+independently of the debounce layer.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+from fakeredis import FakeValkey  # noqa: E402
+
+from dev_health_ops.workers.external_ingest_recompute import (  # noqa: E402
+    flush_external_ingest_recompute,
+)
+
+ORG = "org-1"
+SYSTEM = "github"
+INSTANCE = "acme/api"
+PENDING_KEY = f"external-ingest:recompute:pending:{ORG}:{SYSTEM}:{INSTANCE}"
+
+
+def _blob(**overrides: object) -> dict:
+    base: dict = {
+        "org_id": ORG,
+        "source_system": SYSTEM,
+        "source_instance": INSTANCE,
+        "repo_ids": ["repo-a"],
+        "team_ids": [],
+        "record_kinds": ["pull_request.v1"],
+        "ingestion_ids": ["ing-1"],
+        "window_start": datetime(2026, 6, 25, tzinfo=timezone.utc).isoformat(),
+        "window_end": datetime(2026, 6, 26, tzinfo=timezone.utc).isoformat(),
+    }
+    base.update(overrides)
+    return base
+
+
+def _run_flush() -> dict:
+    task = cast(Any, flush_external_ingest_recompute)
+    result: dict = task.run(org_id=ORG, source_system=SYSTEM, source_instance=INSTANCE)
+    return result
+
+
+def test_flush_reads_and_atomically_clears_pending_blob_via_getdel() -> None:
+    client = FakeValkey(decode_responses=True)
+    client.set(PENDING_KEY, json.dumps(_blob()), ex=300)
+
+    with (
+        patch(
+            "dev_health_ops.external_ingest.recompute._get_redis_client",
+            return_value=client,
+        ),
+        patch(
+            "dev_health_ops.external_ingest.recompute.dispatch_and_persist_scope"
+        ) as mock_dispatch,
+    ):
+        mock_dispatch.return_value = MagicMock(
+            status="dispatched", jobs=(1, 2), capped_days=False, capped_repos=False
+        )
+        result = _run_flush()
+
+    assert result["status"] == "dispatched"
+    assert result["jobs"] == 2
+    assert result["ingestion_ids"] == ["ing-1"]
+
+    # GETDEL means the key is gone after exactly one read -- no separate
+    # DELETE call, no window for a third party to slip a fresher blob in
+    # between (adversarial-review finding).
+    assert client.get(PENDING_KEY) is None
+
+    mock_dispatch.assert_called_once()
+    call_kwargs = mock_dispatch.call_args.kwargs
+    assert call_kwargs["org_id"] == ORG
+    assert call_kwargs["ingestion_ids"] == ["ing-1"]
+    assert call_kwargs["repo_ids"] == ["repo-a"]
+    assert call_kwargs["window_start"] == datetime(2026, 6, 25, tzinfo=timezone.utc)
+
+
+def test_flush_leaves_guard_key_untouched() -> None:
+    """The flush task must not explicitly delete the guard key -- its own
+    TTL governs its lifecycle (adversarial-review finding: an explicit
+    DELETE here could erase a guard a newer schedule_or_coalesce() call
+    just acquired)."""
+    client = FakeValkey(decode_responses=True)
+    client.set(PENDING_KEY, json.dumps(_blob()), ex=300)
+    guard_key = f"external-ingest:recompute:scheduled:{ORG}:{SYSTEM}:{INSTANCE}"
+    client.set(guard_key, "1", ex=30)
+
+    with (
+        patch(
+            "dev_health_ops.external_ingest.recompute._get_redis_client",
+            return_value=client,
+        ),
+        patch(
+            "dev_health_ops.external_ingest.recompute.dispatch_and_persist_scope"
+        ) as mock_dispatch,
+    ):
+        mock_dispatch.return_value = MagicMock(
+            status="dispatched", jobs=(), capped_days=False, capped_repos=False
+        )
+        _run_flush()
+
+    assert client.get(guard_key) == "1"
+
+
+def test_flush_empty_blob_no_op_returns_no_pending_scope() -> None:
+    client = FakeValkey(decode_responses=True)
+    # No SET -- pending_key was never written or was already consumed.
+
+    with (
+        patch(
+            "dev_health_ops.external_ingest.recompute._get_redis_client",
+            return_value=client,
+        ),
+        patch(
+            "dev_health_ops.external_ingest.recompute.dispatch_and_persist_scope"
+        ) as mock_dispatch,
+    ):
+        result = _run_flush()
+
+    assert result == {"status": "no_pending_scope"}
+    mock_dispatch.assert_not_called()
+
+
+def test_flush_valkey_read_error_goes_through_retry_path_not_dispatch() -> None:
+    class _BoomClient:
+        def getdel(self, *args, **kwargs):
+            raise ConnectionError("boom")
+
+    with (
+        patch(
+            "dev_health_ops.external_ingest.recompute._get_redis_client",
+            return_value=_BoomClient(),
+        ),
+        patch(
+            "dev_health_ops.external_ingest.recompute.dispatch_and_persist_scope"
+        ) as mock_dispatch,
+        patch.object(
+            flush_external_ingest_recompute,
+            "retry",
+            side_effect=RuntimeError("retried"),
+        ) as mock_retry,
+        pytest.raises(RuntimeError, match="retried"),
+    ):
+        _run_flush()
+
+    # The Valkey read failure goes through self.retry(), never straight to
+    # dispatch_and_persist_scope -- a transient Valkey hiccup gets a Celery
+    # redelivery instead of silently skipping this flush's recompute.
+    mock_retry.assert_called_once()
+    assert isinstance(mock_retry.call_args.kwargs["exc"], ConnectionError)
+    mock_dispatch.assert_not_called()

--- a/tests/test_external_ingest_recompute_migration.py
+++ b/tests/test_external_ingest_recompute_migration.py
@@ -1,0 +1,124 @@
+"""Migration 0034 (external_ingest_batches recompute columns +
+external_ingest_recompute_jobs) tests.
+
+Follows the idempotent-upgrade/downgrade harness established for migration
+0031 (``tests/test_rate_limit_observations.py``) and migration 0033
+(``tests/test_external_ingest_status_migration.py``).
+"""
+
+from __future__ import annotations
+
+import importlib
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+
+def _load_migration_0034():
+    return importlib.import_module(
+        "dev_health_ops.alembic.versions.0034_add_external_ingest_recompute"
+    )
+
+
+def test_migration_0034_idempotent_upgrade_downgrade():
+    migration = _load_migration_0034()
+    assert migration.revision == "0034"
+    assert migration.down_revision == "0033"
+
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                # Migration 0034 ALTERs a table owned by 0033 -- create a
+                # minimal stand-in so ADD COLUMN has something to target
+                # (mirrors this migration's real dependency chain without
+                # importing 0033's own module).
+                conn.execute(
+                    sa.text(
+                        "CREATE TABLE external_ingest_batches (ingestion_id TEXT PRIMARY KEY)"
+                    )
+                )
+
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                table_names = inspector.get_table_names()
+                assert "external_ingest_recompute_jobs" in table_names
+
+                batch_columns = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_batches")
+                }
+                assert batch_columns == {
+                    "ingestion_id",
+                    "recompute_status",
+                    "recompute_scope",
+                    "recompute_dispatched_at",
+                    "recompute_completed_at",
+                    "recompute_error",
+                }
+
+                job_columns = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_recompute_jobs")
+                }
+                assert job_columns == {
+                    "id",
+                    "org_id",
+                    "source_system",
+                    "source_instance",
+                    "celery_task_name",
+                    "celery_task_id",
+                    "queue",
+                    "repo_id",
+                    "status",
+                    "dispatched_at",
+                    "completed_at",
+                    "error",
+                }
+
+                job_index_names = {
+                    ix["name"]
+                    for ix in inspector.get_indexes("external_ingest_recompute_jobs")
+                }
+                assert "ix_external_ingest_recompute_jobs_scope" in job_index_names
+
+                # Re-running upgrade() must be a no-op (guarded create-if-missing).
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert (
+                    inspector.get_table_names().count("external_ingest_recompute_jobs")
+                    == 1
+                )
+                batch_columns_after_rerun = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_batches")
+                }
+                assert batch_columns_after_rerun == batch_columns
+
+                migration.downgrade()
+                inspector = sa.inspect(conn)
+                remaining_tables = inspector.get_table_names()
+                assert "external_ingest_recompute_jobs" not in remaining_tables
+                remaining_batch_columns = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_batches")
+                }
+                assert remaining_batch_columns == {"ingestion_id"}
+
+                # downgrade() on an already-downgraded state is also a no-op.
+                migration.downgrade()
+
+                # And upgrade() works again from a clean slate.
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert "external_ingest_recompute_jobs" in inspector.get_table_names()
+                batch_columns_final = {
+                    col["name"]
+                    for col in inspector.get_columns("external_ingest_batches")
+                }
+                assert batch_columns_final == batch_columns
+    finally:
+        engine.dispose()

--- a/tests/test_external_ingest_recompute_planner.py
+++ b/tests/test_external_ingest_recompute_planner.py
@@ -1,0 +1,172 @@
+"""Unit tests for the bounded-recompute planner (CHAOS-2699, brief D5-D9).
+
+Pure -- ``plan_recompute()`` takes a scope, returns a plan, no I/O, no
+mocks needed.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+
+from dev_health_ops.external_ingest.recompute import RecomputeScope, plan_recompute
+
+ORG = "org-1"
+SYSTEM = "github"
+INSTANCE = "acme/api"
+
+
+def _scope(**overrides: Any) -> RecomputeScope:
+    defaults: dict[str, Any] = dict(
+        org_id=ORG,
+        source_system=SYSTEM,
+        source_instance=INSTANCE,
+        repo_ids=frozenset(),
+        team_ids=frozenset(),
+        record_kinds=frozenset(),
+        ingestion_ids=frozenset({"ing-1"}),
+        window_start=datetime(2026, 6, 25, tzinfo=timezone.utc),
+        window_end=datetime(2026, 6, 26, tzinfo=timezone.utc),
+    )
+    defaults.update(overrides)
+    return RecomputeScope(**defaults)
+
+
+def test_git_kinds_single_repo_per_repo_chain_no_fallback() -> None:
+    scope = _scope(
+        record_kinds=frozenset({"pull_request.v1"}), repo_ids=frozenset({"repo-a"})
+    )
+    plan = plan_recompute(scope)
+
+    assert plan.trigger is True
+    assert plan.dispatch_daily is True
+    assert plan.repo_ids == ("repo-a",)
+    assert plan.fallback_org_wide_daily is False
+    assert plan.skip_investment_no_scope is False
+    assert plan.capped_days is False
+    assert plan.capped_repos is False
+    assert plan.day == "2026-06-26"
+    assert plan.backfill_days == 2
+
+
+def test_work_item_kinds_empty_repo_ids_falls_back_org_wide() -> None:
+    scope = _scope(record_kinds=frozenset({"work_item.v1"}), repo_ids=frozenset())
+    plan = plan_recompute(scope)
+
+    assert plan.trigger is True
+    assert plan.dispatch_daily is True
+    assert plan.repo_ids == ()
+    assert plan.fallback_org_wide_daily is True
+    # D4: no team_ids either -> investment has nothing to scope onto.
+    assert plan.skip_investment_no_scope is True
+
+
+def test_team_kinds_only_no_daily_investment_team_ids_only() -> None:
+    scope = _scope(
+        record_kinds=frozenset({"identity.v1"}), team_ids=frozenset({"team-a"})
+    )
+    plan = plan_recompute(scope)
+
+    assert plan.trigger is True
+    assert plan.dispatch_daily is False
+    assert plan.fallback_org_wide_daily is False
+    assert plan.team_ids == ("team-a",)
+    assert plan.skip_investment_no_scope is False
+
+
+def test_repo_only_kind_not_applicable() -> None:
+    scope = _scope(record_kinds=frozenset({"repository.v1"}))
+    plan = plan_recompute(scope)
+
+    assert plan.trigger is False
+    assert plan.dispatch_daily is False
+    assert plan.repo_ids == ()
+    assert plan.team_ids == ()
+
+
+def test_empty_record_kinds_not_applicable() -> None:
+    plan = plan_recompute(_scope(record_kinds=frozenset()))
+    assert plan.trigger is False
+
+
+def test_mixed_kinds_repo_and_team_scope_single_investment_call() -> None:
+    scope = _scope(
+        record_kinds=frozenset({"pull_request.v1", "identity.v1"}),
+        repo_ids=frozenset({"repo-a", "repo-b"}),
+        team_ids=frozenset({"team-a"}),
+    )
+    plan = plan_recompute(scope)
+
+    assert plan.dispatch_daily is True
+    assert plan.repo_ids == ("repo-a", "repo-b")
+    assert plan.team_ids == ("team-a",)
+    assert plan.fallback_org_wide_daily is False
+    assert plan.skip_investment_no_scope is False
+
+
+def test_window_spanning_40_days_capped_to_14() -> None:
+    scope = _scope(
+        record_kinds=frozenset({"pull_request.v1"}),
+        repo_ids=frozenset({"repo-a"}),
+        window_start=datetime(2026, 5, 18, tzinfo=timezone.utc),
+        window_end=datetime(2026, 6, 26, tzinfo=timezone.utc),
+    )
+    plan = plan_recompute(scope)
+
+    assert plan.capped_days is True
+    assert plan.backfill_days == 14
+    assert plan.day == "2026-06-26"
+    expected_from = datetime(2026, 6, 13, tzinfo=timezone.utc)
+    assert plan.from_date == expected_from.isoformat()
+
+
+def test_60_repo_ids_capped_to_25_stable_sorted() -> None:
+    repo_ids = frozenset(f"repo-{i:03d}" for i in range(60))
+    scope = _scope(record_kinds=frozenset({"pull_request.v1"}), repo_ids=repo_ids)
+    plan = plan_recompute(scope)
+
+    assert plan.capped_repos is True
+    assert len(plan.repo_ids) == 25
+    assert plan.repo_ids == tuple(sorted(repo_ids)[:25])
+
+
+def test_git_only_empty_repo_ids_defensive_skip_investment_no_scope() -> None:
+    """Structurally impossible in practice (PR/review/commit always carry a
+    resolved repo_id) but the defensive skip path is asserted anyway per
+    the brief's D4 hard-invariant test plan bullet."""
+    scope = _scope(record_kinds=frozenset({"pull_request.v1"}), repo_ids=frozenset())
+    plan = plan_recompute(scope)
+
+    assert plan.dispatch_daily is True
+    assert plan.repo_ids == ()
+    # D8 fallback is work-item-only; git kinds never get it.
+    assert plan.fallback_org_wide_daily is False
+    assert plan.skip_investment_no_scope is True
+
+
+def test_single_day_window_backfill_days_is_one() -> None:
+    same_day = datetime(2026, 6, 26, 10, tzinfo=timezone.utc)
+    scope = _scope(
+        record_kinds=frozenset({"pull_request.v1"}),
+        repo_ids=frozenset({"repo-a"}),
+        window_start=same_day,
+        window_end=same_day + timedelta(hours=2),
+    )
+    plan = plan_recompute(scope)
+
+    assert plan.backfill_days == 1
+    assert plan.capped_days is False
+
+
+def test_missing_window_defaults_to_now() -> None:
+    scope = _scope(
+        record_kinds=frozenset({"pull_request.v1"}),
+        repo_ids=frozenset({"repo-a"}),
+        window_start=None,
+        window_end=None,
+    )
+    plan = plan_recompute(scope)
+
+    assert plan.trigger is True
+    assert plan.day is not None
+    assert plan.backfill_days == 1

--- a/tests/test_external_ingest_recompute_status_sql.py
+++ b/tests/test_external_ingest_recompute_status_sql.py
@@ -1,0 +1,498 @@
+"""Unit tests for direct-SQL recompute-status persistence (CHAOS-2699, D11/D12).
+
+sqlite-in-memory (file-backed, per fixture -- see rationale below), no live
+Postgres -- mirrors ``tests/test_external_ingest_status.py``'s convention.
+No new ``postgres`` pytest marker (epic-wide synthesizer reconciliation).
+
+``record_recompute_dispatch()`` takes a sync ``Session`` (mirrors the
+Celery-task caller); ``mark_recompute_pending()``/``get_recompute_jobs()``
+take an ``AsyncSession`` (mirrors the FastAPI caller). Both flavors point
+at file-backed sqlite databases (not ``:memory:``) so each test's fixture
+is fully isolated without needing to share a single connection across the
+sync/async boundary.
+"""
+
+from __future__ import annotations
+
+import json
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import create_engine, text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import sessionmaker
+
+from dev_health_ops.external_ingest.recompute import (
+    RecomputeDispatchResult,
+    RecomputeJobRecord,
+    RecomputeScope,
+)
+from dev_health_ops.external_ingest.recompute_status import (
+    get_recompute_jobs,
+    mark_recompute_pending,
+    record_recompute_dispatch,
+)
+from dev_health_ops.models.external_ingest import (
+    ExternalIngestBatch,
+    ExternalIngestRecomputeJob,
+)
+from dev_health_ops.models.git import Base
+from tests._helpers import tables_of
+
+_TABLES = tables_of(ExternalIngestBatch, ExternalIngestRecomputeJob)
+
+ORG = "org-a"
+SYSTEM = "github"
+INSTANCE = "acme/api"
+
+_SEED_SQL = text(
+    """
+    INSERT INTO external_ingest_batches (
+        ingestion_id, org_id, idempotency_key, payload_hash, source_system,
+        source_instance, producer, producer_version, schema_version,
+        window_started_at, window_ended_at, status, attempts,
+        items_received, items_accepted, items_rejected, record_counts,
+        error_summary, created_at, updated_at, completed_at,
+        recompute_status, recompute_scope, recompute_dispatched_at,
+        recompute_completed_at, recompute_error
+    ) VALUES (
+        :ingestion_id, :org_id, :idempotency_key, :payload_hash, :source_system,
+        :source_instance, NULL, NULL, 'external-ingest.v1',
+        NULL, NULL, 'completed', 1,
+        3, 3, 0, NULL,
+        NULL, :now, :now, NULL,
+        :recompute_status, NULL, NULL, NULL, NULL
+    )
+    """
+)
+
+
+def _scope(**overrides: Any) -> RecomputeScope:
+    defaults: dict[str, Any] = dict(
+        org_id=ORG,
+        source_system=SYSTEM,
+        source_instance=INSTANCE,
+        repo_ids=frozenset({"repo-a"}),
+        team_ids=frozenset(),
+        record_kinds=frozenset({"pull_request.v1"}),
+        ingestion_ids=frozenset({"ing-1"}),
+        window_start=datetime(2026, 6, 25, tzinfo=timezone.utc),
+        window_end=datetime(2026, 6, 26, tzinfo=timezone.utc),
+    )
+    defaults.update(overrides)
+    return RecomputeScope(**defaults)
+
+
+@pytest.fixture
+def sync_session_maker(tmp_path: Path):
+    db_path = tmp_path / "recompute-status-sync.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine, tables=_TABLES)
+    maker = sessionmaker(bind=engine, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        engine.dispose()
+
+
+def _seed_batch_sync(
+    session, *, ingestion_id: str, recompute_status: str = "not_applicable"
+) -> None:
+    session.execute(
+        _SEED_SQL,
+        {
+            "ingestion_id": ingestion_id,
+            "org_id": ORG,
+            "idempotency_key": f"key-{ingestion_id}",
+            "payload_hash": "hash",
+            "source_system": SYSTEM,
+            "source_instance": INSTANCE,
+            "now": datetime.now(timezone.utc),
+            "recompute_status": recompute_status,
+        },
+    )
+    session.commit()
+
+
+def test_record_recompute_dispatch_writes_status_scope_and_jobs(
+    sync_session_maker,
+) -> None:
+    with sync_session_maker() as session:
+        _seed_batch_sync(session, ingestion_id="ing-1")
+
+        scope = _scope()
+        result = RecomputeDispatchResult(
+            status="dispatched",
+            jobs=(
+                RecomputeJobRecord(
+                    task="dev_health_ops.workers.tasks.run_daily_metrics",
+                    task_id="task-1",
+                    queue="metrics",
+                    repo_id="repo-a",
+                ),
+                RecomputeJobRecord(
+                    task="dev_health_ops.workers.tasks.run_work_graph_build",
+                    task_id="task-2",
+                    queue="metrics",
+                    repo_id="repo-a",
+                ),
+            ),
+            capped_days=False,
+            capped_repos=False,
+        )
+        record_recompute_dispatch(
+            session, org_id=ORG, ingestion_ids=["ing-1"], scope=scope, result=result
+        )
+
+    with sync_session_maker() as session:
+        row = (
+            session.execute(
+                text("SELECT * FROM external_ingest_batches WHERE ingestion_id = :id"),
+                {"id": "ing-1"},
+            )
+            .mappings()
+            .first()
+        )
+        assert row is not None
+        assert row["recompute_status"] == "dispatched"
+        assert row["recompute_dispatched_at"] is not None
+        assert row["recompute_completed_at"] is not None
+        assert row["recompute_error"] is None
+        scope_json = json.loads(row["recompute_scope"])
+        assert scope_json["repoIds"] == ["repo-a"]
+        assert scope_json["cappedDays"] is False
+
+        jobs = (
+            session.execute(
+                text(
+                    "SELECT * FROM external_ingest_recompute_jobs WHERE org_id = :org"
+                ),
+                {"org": ORG},
+            )
+            .mappings()
+            .all()
+        )
+        assert len(jobs) == 2
+        assert {j["celery_task_id"] for j in jobs} == {"task-1", "task-2"}
+        assert {j["repo_id"] for j in jobs} == {"repo-a"}
+
+
+def test_record_recompute_dispatch_covers_all_coalesced_ingestion_ids(
+    sync_session_maker,
+) -> None:
+    """Risk 5 in the brief: a flush's status write must cover every
+    ingestion_id that fed into the coalesced scope, not just one."""
+    with sync_session_maker() as session:
+        _seed_batch_sync(session, ingestion_id="ing-1")
+        _seed_batch_sync(session, ingestion_id="ing-2")
+
+        scope = _scope(ingestion_ids=frozenset({"ing-1", "ing-2"}))
+        result = RecomputeDispatchResult(
+            status="dispatched", jobs=(), capped_days=False, capped_repos=False
+        )
+        record_recompute_dispatch(
+            session,
+            org_id=ORG,
+            ingestion_ids=["ing-1", "ing-2"],
+            scope=scope,
+            result=result,
+        )
+
+    with sync_session_maker() as session:
+        rows = (
+            session.execute(
+                text(
+                    "SELECT ingestion_id, recompute_status FROM external_ingest_batches "
+                    "ORDER BY ingestion_id"
+                )
+            )
+            .mappings()
+            .all()
+        )
+        assert len(rows) == 2
+        assert all(r["recompute_status"] == "dispatched" for r in rows)
+
+
+def test_record_recompute_dispatch_failed_status_no_dispatched_at(
+    sync_session_maker,
+) -> None:
+    with sync_session_maker() as session:
+        _seed_batch_sync(session, ingestion_id="ing-1")
+        scope = _scope()
+        result = RecomputeDispatchResult(
+            status="failed",
+            jobs=(),
+            capped_days=False,
+            capped_repos=False,
+            error="signature boom",
+        )
+        record_recompute_dispatch(
+            session, org_id=ORG, ingestion_ids=["ing-1"], scope=scope, result=result
+        )
+
+    with sync_session_maker() as session:
+        row = (
+            session.execute(
+                text("SELECT * FROM external_ingest_batches WHERE ingestion_id = :id"),
+                {"id": "ing-1"},
+            )
+            .mappings()
+            .first()
+        )
+        assert row["recompute_status"] == "failed"
+        assert row["recompute_dispatched_at"] is None
+        assert row["recompute_completed_at"] is not None
+        assert row["recompute_error"] == "signature boom"
+
+
+def test_record_recompute_dispatch_no_jobs_no_job_rows(sync_session_maker) -> None:
+    with sync_session_maker() as session:
+        _seed_batch_sync(session, ingestion_id="ing-1")
+        scope = _scope()
+        result = RecomputeDispatchResult(
+            status="skipped_no_scope", jobs=(), capped_days=False, capped_repos=False
+        )
+        record_recompute_dispatch(
+            session, org_id=ORG, ingestion_ids=["ing-1"], scope=scope, result=result
+        )
+
+    with sync_session_maker() as session:
+        count = session.execute(
+            text("SELECT COUNT(*) FROM external_ingest_recompute_jobs")
+        ).scalar_one()
+        assert count == 0
+
+
+def test_record_recompute_dispatch_persists_job_with_none_task_id(
+    sync_session_maker,
+) -> None:
+    """Adversarial-review finding: a job whose Celery AsyncResult had no
+    ``.parent`` carries ``task_id=None`` -- persisting it must not raise an
+    IntegrityError (which would silently roll back the whole status write,
+    even though the underlying Celery jobs were already dispatched)."""
+    with sync_session_maker() as session:
+        _seed_batch_sync(session, ingestion_id="ing-1")
+        scope = _scope()
+        result = RecomputeDispatchResult(
+            status="dispatched",
+            jobs=(
+                RecomputeJobRecord(
+                    task="dev_health_ops.workers.tasks.run_daily_metrics",
+                    task_id=None,
+                    queue="metrics",
+                    repo_id="repo-a",
+                ),
+            ),
+            capped_days=False,
+            capped_repos=False,
+        )
+        record_recompute_dispatch(
+            session, org_id=ORG, ingestion_ids=["ing-1"], scope=scope, result=result
+        )
+
+    with sync_session_maker() as session:
+        row = (
+            session.execute(
+                text("SELECT * FROM external_ingest_batches WHERE ingestion_id = :id"),
+                {"id": "ing-1"},
+            )
+            .mappings()
+            .first()
+        )
+        assert row["recompute_status"] == "dispatched"
+
+        job = (
+            session.execute(
+                text(
+                    "SELECT * FROM external_ingest_recompute_jobs WHERE org_id = :org"
+                ),
+                {"org": ORG},
+            )
+            .mappings()
+            .first()
+        )
+        assert job is not None
+        assert job["celery_task_id"] is None
+
+
+@pytest_asyncio.fixture
+async def async_session_maker(tmp_path: Path):
+    db_path = tmp_path / "recompute-status-async.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed_batch_async(
+    session: AsyncSession,
+    *,
+    ingestion_id: str,
+    recompute_status: str = "not_applicable",
+) -> None:
+    await session.execute(
+        _SEED_SQL,
+        {
+            "ingestion_id": ingestion_id,
+            "org_id": ORG,
+            "idempotency_key": f"key-{ingestion_id}",
+            "payload_hash": "hash",
+            "source_system": SYSTEM,
+            "source_instance": INSTANCE,
+            "now": datetime.now(timezone.utc),
+            "recompute_status": recompute_status,
+        },
+    )
+    await session.commit()
+
+
+async def _insert_job(
+    session: AsyncSession,
+    *,
+    task_name: str,
+    task_id: str,
+    repo_id: str | None,
+    dispatched_at: datetime,
+) -> None:
+    await session.execute(
+        text(
+            """
+            INSERT INTO external_ingest_recompute_jobs (
+                id, org_id, source_system, source_instance, celery_task_name,
+                celery_task_id, queue, repo_id, status, dispatched_at
+            ) VALUES (
+                :id, :org_id, :source_system, :source_instance, :task_name,
+                :task_id, 'metrics', :repo_id, 'dispatched', :dispatched_at
+            )
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "org_id": ORG,
+            "source_system": SYSTEM,
+            "source_instance": INSTANCE,
+            "task_name": task_name,
+            "task_id": task_id,
+            "repo_id": repo_id,
+            "dispatched_at": dispatched_at,
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_mark_recompute_pending_transitions_not_applicable(
+    async_session_maker,
+) -> None:
+    async with async_session_maker() as session:
+        await _seed_batch_async(session, ingestion_id="ing-1")
+        await mark_recompute_pending(session, org_id=ORG, ingestion_id="ing-1")
+        await session.commit()
+
+        row = (
+            (
+                await session.execute(
+                    text(
+                        "SELECT recompute_status FROM external_ingest_batches "
+                        "WHERE ingestion_id = :id"
+                    ),
+                    {"id": "ing-1"},
+                )
+            )
+            .mappings()
+            .first()
+        )
+        assert row["recompute_status"] == "pending"
+
+
+@pytest.mark.asyncio
+async def test_mark_recompute_pending_never_regresses_terminal_status(
+    async_session_maker,
+) -> None:
+    async with async_session_maker() as session:
+        await _seed_batch_async(
+            session, ingestion_id="ing-1", recompute_status="dispatched"
+        )
+        await mark_recompute_pending(session, org_id=ORG, ingestion_id="ing-1")
+        await session.commit()
+
+        row = (
+            (
+                await session.execute(
+                    text(
+                        "SELECT recompute_status FROM external_ingest_batches "
+                        "WHERE ingestion_id = :id"
+                    ),
+                    {"id": "ing-1"},
+                )
+            )
+            .mappings()
+            .first()
+        )
+        assert row["recompute_status"] == "dispatched"
+
+
+@pytest.mark.asyncio
+async def test_get_recompute_jobs_returns_only_matching_flush(
+    async_session_maker,
+) -> None:
+    dispatched_at = datetime(2026, 6, 26, 0, 1, tzinfo=timezone.utc)
+    other_dispatched_at = datetime(2026, 6, 25, 0, 1, tzinfo=timezone.utc)
+    async with async_session_maker() as session:
+        await _insert_job(
+            session,
+            task_name="dev_health_ops.workers.tasks.run_daily_metrics",
+            task_id="task-daily",
+            repo_id="repo-a",
+            dispatched_at=dispatched_at,
+        )
+        await _insert_job(
+            session,
+            task_name="dev_health_ops.workers.tasks.run_work_graph_build",
+            task_id="task-build",
+            repo_id="repo-a",
+            dispatched_at=dispatched_at,
+        )
+        await _insert_job(
+            session,
+            task_name="dev_health_ops.workers.tasks.run_daily_metrics",
+            task_id="task-old",
+            repo_id="repo-b",
+            dispatched_at=other_dispatched_at,
+        )
+        await session.commit()
+
+        jobs = await get_recompute_jobs(
+            session,
+            org_id=ORG,
+            source_system=SYSTEM,
+            source_instance=INSTANCE,
+            dispatched_at=dispatched_at,
+        )
+    assert len(jobs) == 2
+    assert {j.repo_id for j in jobs} == {"repo-a"}
+    assert {j.task_id for j in jobs} == {"task-daily", "task-build"}
+
+
+@pytest.mark.asyncio
+async def test_get_recompute_jobs_none_dispatched_at_returns_empty(
+    async_session_maker,
+) -> None:
+    async with async_session_maker() as session:
+        jobs = await get_recompute_jobs(
+            session,
+            org_id=ORG,
+            source_system=SYSTEM,
+            source_instance=INSTANCE,
+            dispatched_at=None,
+        )
+    assert jobs == []


### PR DESCRIPTION
## Summary

Bounded recomputation planner for customer-push ingestion (CHAOS-2690, master-spec CC21):

- **`external_ingest/recompute.py`**: `plan_recompute()` (pure) + `dispatch_recompute()` (Celery signature builder) + `schedule_or_coalesce()` (public primitives-only seam, per the synthesizer reconciliation on brief-2699-recompute.md — `RecomputeScope` stays internal). Per-repo `run_daily_metrics -> run_work_graph_build` chains capped at 25 repos / 14 days; ONE scoped `dispatch_investment_materialize_partitioned(force=False)` call per flush, never with both `repo_ids`/`team_ids` empty (D4 hard invariant); D8 org-wide day-bounded fallback for repo-less work-item batches; never reuses `dispatch_daily_metrics_partitioned`/`run_daily_metrics_batch` (D6, negative-space-tested); dispatch failures never raise (D13).
- **`external_ingest/recompute_status.py`**: direct-SQL status persistence (D11), sqlite-portable (no `ANY(:array)`/`RETURNING`, per-ingestion_id UPDATE loop instead).
- **`workers/external_ingest_recompute.py`**: `flush_external_ingest_recompute` Celery task, own module — see "Integrator wiring" below.
- **Migration 0034**: `down_revision="0033"` (chains onto CHAOS-2694's status-store migration). Adds 5 `recompute_*` columns to `external_ingest_batches` + new `external_ingest_recompute_jobs` table.
- **`api/external_ingest/status.py`**: extends `GET /batches/{ingestionId}` with the `recompute` response block (pinned enum: `not_applicable | pending | dispatched | skipped_no_scope | failed`).
- Architecture doc: `docs/architecture/external-ingest-bounded-recompute.md` (D1-D15).

### Fixed after two rounds of Codex adversarial review

1. **Atomic debounce merge** — `schedule_or_coalesce()`'s pending-blob read-merge-write + guard SETNX now runs inside a Valkey `WATCH`/`MULTI` optimistic transaction (was a racy plain `GET`→`SET` that could silently drop one caller's scope under concurrency). Covered by `test_concurrent_callers_do_not_lose_either_ingestion_id`.
2. **Atomic flush read** — the flush task now reads the pending blob via `GETDEL` (one atomic command) instead of separate `GET`+`DELETE`, and no longer explicitly deletes the guard key (its own TTL governs it) — closes a window where a late-arriving newer debounce window could be silently erased by an older flush's cleanup.
3. **Nullable `celery_task_id`** — a per-repo daily-metrics job's captured Celery task id can legitimately be `None` (chain `AsyncResult.parent` unset); the column was `NOT NULL`, so that path raised an `IntegrityError` that silently rolled back the *entire* status/job-log write even though the Celery jobs had already dispatched. Column is now nullable in both the migration and the ORM model.

Two findings were evidence-refuted (documented in the architecture doc, not fixed in this PR):
- Flush task not registered by a fresh worker — deliberate, CC20 pins Celery wiring (including which modules a worker imports) as CHAOS-2693's sole responsibility this wave; the exact one-line fix is in the `INTEGRATOR TODO` comment at the top of `workers/external_ingest_recompute.py`.
- No production caller wires `schedule_or_coalesce()` into the worker — explicitly CHAOS-2697's job per the brief's dependency direction (2697 depends on this PR's seam, not the reverse); 2697 hasn't landed yet.

## Integrator wiring (for CHAOS-2693 / whoever merges this wave)

Add exactly this one line to `workers/config.py`'s `late_ack_excluded_tasks` tuple:

```python
"dev_health_ops.workers.tasks.flush_external_ingest_recompute",
```

No `workers/tasks.py` re-export needed (task name is pinned via the decorator's `name=` kwarg). No `task_queues`/compose change needed — it reuses the existing `default` queue's worker coverage (`queue="default"` already on the task decorator).

## Test plan

- [x] `SCRATCH_DB=ci_local_validate_2699 bash ci/local_validate.sh` — PASSED (lint, mypy, full unit suite 6494 passed, live-ClickHouse argMax proof), env-isolated (`env -i`).
- [x] 71 new unit tests across 6 files: planner (pure), dispatch (+ D14 Celery kwargs-contract via `inspect.signature`, D6 negative-space grep, `parent=None` chain-result path), debounce (fakeredis, incl. concurrent-callers race), flush task (GETDEL, guard preservation), status-SQL persistence (incl. `task_id=None`), migration 0034 idempotent up/down/up.
- [x] Migration 0034 up/down/up proof against a real scratch Postgres DB (`ci_2699`, not `devhealth`) — `psql \d` confirmed columns/table both directions.
- [x] Debounce coalescing + SETNX guard expiry/re-arm proven against real dev Valkey with a throwaway test org (Celery `apply_async` mocked to avoid firing real dispatches at live workers running in dev compose).
- [x] Dispatch shapes (25-repo/14-day caps, empty-scope investment refusal, D8 fallback) proven with real `plan_recompute`/`dispatch_recompute` logic, Celery signature/chain/send_task captured rather than fired.
- [x] `GET /batches/{ingestionId}` proven end-to-end via a real `uvicorn` process against scratch Postgres (auth dependency overridden — CHAOS-2696's token provisioning is out of scope for this check) — confirmed the `recompute` block renders with the pinned enum, scope, and job list.
- [x] No `postgres` pytest marker added (epic-wide convention, per CHAOS-2694's sqlite-portable direct-SQL precedent).
- [x] `tests/test_compose_config.py` stays green untouched (no queue/compose changes).