### PR TITLE
feat(external-ingest): durable stream, DLQ, consumer + Celery/compose wiring (CHAOS-2693)

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -282,6 +282,20 @@ services:
     container_name: worker-ingest
     command: -A dev_health_ops.workers.celery_app worker --loglevel=info --disable-prefetch -Q ingest --concurrency=1
 
+  # CHAOS-2693 D8/master-spec CC11: dedicated queue/container, not folded
+  # into worker-ingest -- external-ingest is customer-facing (spiky,
+  # potentially larger batches) and must not share throughput with an
+  # unrelated internal consumer backlog, nor vice versa.
+  # DEPLOYMENT INVARIANT: exactly ONE replica at --concurrency=1. The
+  # reclaim/redelivery design (StreamConsumer.enable_reclaim,
+  # reclaim_idle_ms=900_000) assumes a single logical consumer identity
+  # draining the PEL; scaling replicas requires revisiting reclaim
+  # semantics first. tests/test_compose_config.py asserts this flag shape.
+  worker-external-ingest:
+    <<: *worker-base
+    container_name: worker-external-ingest
+    command: -A dev_health_ops.workers.celery_app worker --loglevel=info --disable-prefetch -Q external-ingest --concurrency=1
+
   worker-heavy:
     <<: *worker-base
     container_name: worker-heavy

--- a/deploy/docker-compose/compose.production.yml
+++ b/deploy/docker-compose/compose.production.yml
@@ -315,6 +315,22 @@ services:
       - ingest
       - --concurrency=1
 
+  # CHAOS-2693 D8/master-spec CC11: dedicated queue/container. DEPLOYMENT
+  # INVARIANT: exactly ONE replica at --concurrency=1 (reclaim/redelivery
+  # assumes a single logical consumer identity draining the PEL).
+  worker-external-ingest:
+    <<: *worker-base
+    container_name: dev-health-worker-external-ingest
+    command:
+      - -A
+      - dev_health_ops.workers.celery_app
+      - worker
+      - --loglevel=info
+      - --disable-prefetch
+      - -Q
+      - external-ingest
+      - --concurrency=1
+
   worker-heavy:
     <<: *worker-base
     container_name: dev-health-worker-heavy

--- a/deploy/docker-swarm/stack.yml
+++ b/deploy/docker-swarm/stack.yml
@@ -244,6 +244,41 @@ services:
       - ingest
       - --concurrency=1
 
+  # CHAOS-2693 D8/master-spec CC11: dedicated queue/container. DEPLOYMENT
+  # INVARIANT: exactly ONE replica at --concurrency=1 -- the reclaim/
+  # redelivery design assumes a single logical consumer identity draining
+  # the PEL, so `deploy.replicas` is pinned to 1 here explicitly (not
+  # inherited from worker-base's replicas:2) rather than left implicit.
+  worker-external-ingest:
+    <<: *worker-base
+    command:
+      - -A
+      - dev_health_ops.workers.celery_app
+      - worker
+      - --loglevel=info
+      - --disable-prefetch
+      - -Q
+      - external-ingest
+      - --concurrency=1
+    deploy:
+      mode: replicated
+      replicas: 1
+      update_config:
+        parallelism: 1
+        delay: 10s
+        failure_action: rollback
+      resources:
+        limits:
+          memory: 2G
+          cpus: "1"
+        reservations:
+          memory: 256M
+          cpus: "0.1"
+      restart_policy:
+        condition: on-failure
+        delay: 5s
+        max_attempts: 3
+
   worker-heavy:
     <<: *worker-base
     command:

--- a/deploy/helm/dev-health/templates/worker-pools.yaml
+++ b/deploy/helm/dev-health/templates/worker-pools.yaml
@@ -74,6 +74,77 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
 {{- end }}
+{{- if .Values.workerExternalIngest.enabled }}
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "dev-health.fullname" . }}-worker-external-ingest
+  namespace: {{ include "dev-health.namespace" . }}
+  labels:
+    {{- include "dev-health.componentLabels" (dict "component" "worker-external-ingest" "context" $) | nindent 4 }}
+spec:
+  progressDeadlineSeconds: {{ .Values.workerExternalIngest.progressDeadlineSeconds }}
+  replicas: {{ .Values.workerExternalIngest.replicas }}
+  selector:
+    matchLabels:
+      {{- include "dev-health.componentSelectorLabels" (dict "component" "worker-external-ingest" "context" $) | nindent 6 }}
+  template:
+    metadata:
+      annotations:
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+      labels:
+        {{- include "dev-health.componentSelectorLabels" (dict "component" "worker-external-ingest" "context" $) | nindent 8 }}
+    spec:
+      terminationGracePeriodSeconds: {{ .Values.workerExternalIngest.terminationGracePeriodSeconds }}
+      {{- include "dev-health.imagePullSecrets" . | nindent 6 }}
+      serviceAccountName: {{ include "dev-health.serviceAccountName" . }}
+      securityContext:
+        runAsNonRoot: true
+      containers:
+        - name: worker-external-ingest
+          image: {{ include "dev-health.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+          command:
+            - celery
+            - -A
+            - dev_health_ops.workers.celery_app
+            - worker
+            - --loglevel={{ .Values.workerExternalIngest.logLevel }}
+            - --disable-prefetch
+            - -Q
+            - {{ .Values.workerExternalIngest.queues }}
+            - --concurrency={{ .Values.workerExternalIngest.concurrency }}
+          envFrom:
+            - configMapRef:
+                name: {{ include "dev-health.configMapName" . }}
+            - secretRef:
+                name: {{ include "dev-health.secretName" . }}
+          {{- with .Values.worker.livenessProbe }}
+          livenessProbe:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          resources:
+            {{- toYaml .Values.workerExternalIngest.resources | nindent 12 }}
+      {{- with .Values.workerExternalIngest.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerExternalIngest.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.workerExternalIngest.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}
 {{- if .Values.workerHeavy.enabled }}
 ---
 apiVersion: apps/v1

--- a/deploy/helm/dev-health/values.yaml
+++ b/deploy/helm/dev-health/values.yaml
@@ -151,6 +151,32 @@ workerIngest:
   tolerations: []
   affinity: {}
 
+# External-ingest pool (CHAOS-2693 D8/master-spec CC11): isolated single
+# slot for the customer-push durable-stream consumer, dedicated queue (not
+# shared with workerIngest) so a slow external customer can't starve
+# internal ingest/telemetry, nor vice versa. Fixed-replica (no
+# autoscaling) -- DEPLOYMENT INVARIANT: exactly ONE replica at
+# concurrency 1; the reclaim/redelivery design assumes a single logical
+# consumer identity draining the PEL.
+workerExternalIngest:
+  enabled: true
+  replicas: 1
+  queues: "external-ingest"
+  concurrency: 1
+  logLevel: info
+  terminationGracePeriodSeconds: 3700
+  progressDeadlineSeconds: 7600
+  resources:
+    requests:
+      memory: "256Mi"
+      cpu: "100m"
+    limits:
+      memory: "1Gi"
+      cpu: "500m"
+  nodeSelector: {}
+  tolerations: []
+  affinity: {}
+
 # Heavy pool (CHAOS-2278 / CHAOS-2517): batch compute (metrics, backfill) +
 # heavy cost-class sync sub-queues, isolated from latency-sensitive work.
 workerHeavy:

--- a/deploy/kubernetes/worker.yaml
+++ b/deploy/kubernetes/worker.yaml
@@ -210,6 +210,103 @@ spec:
             periodSeconds: 30
             timeoutSeconds: 15
 ---
+# External-ingest worker (CHAOS-2693 D8/master-spec CC11): isolated single
+# slot for the customer-push durable-stream consumer, dedicated queue (not
+# shared with the internal `worker-ingest` pool) so a slow external customer
+# can't starve internal ingest/telemetry, nor vice versa. DEPLOYMENT
+# INVARIANT: exactly ONE replica (fixed, no HPA) at --concurrency 1 -- the
+# reclaim/redelivery design (StreamConsumer.enable_reclaim,
+# reclaim_idle_ms=900_000) assumes a single logical consumer identity
+# draining the PEL; scaling replicas requires revisiting reclaim semantics.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dev-health-worker-external-ingest
+  namespace: dev-health
+  labels:
+    app.kubernetes.io/name: dev-health-worker-external-ingest
+    app.kubernetes.io/component: worker
+    app.kubernetes.io/part-of: dev-health-ops
+spec:
+  progressDeadlineSeconds: 7600
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: dev-health-worker-external-ingest
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: dev-health-worker-external-ingest
+    spec:
+      terminationGracePeriodSeconds: 3700
+      securityContext:
+        runAsNonRoot: true
+      initContainers:
+        - name: wait-for-migrations
+          image: ghcr.io/your-org/dev-health-ops:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+          command:
+            - sh
+            - -c
+            - |
+              attempts=0
+              until dev-hops migrate clickhouse status --check; do
+                attempts=$((attempts + 1))
+                if [ "$attempts" -ge 60 ]; then
+                  echo "ClickHouse migrations still pending after $attempts checks; exiting for restart backoff" >&2
+                  exit 1
+                fi
+                echo "ClickHouse migrations pending; re-checking in 5s (attempt $attempts/60)"
+                sleep 5
+              done
+          envFrom:
+            - configMapRef:
+                name: dev-health-config
+            - secretRef:
+                name: dev-health-secrets
+      containers:
+        - name: worker-external-ingest
+          image: ghcr.io/your-org/dev-health-ops:latest
+          securityContext:
+            allowPrivilegeEscalation: false
+          command:
+            - celery
+            - -A
+            - dev_health_ops.workers.celery_app
+            - worker
+            - --loglevel=info
+            - --disable-prefetch
+            - -Q
+            - external-ingest
+            - --concurrency
+            - "1"
+          envFrom:
+            - configMapRef:
+                name: dev-health-config
+            - secretRef:
+                name: dev-health-secrets
+          resources:
+            requests:
+              memory: "256Mi"
+              cpu: "100m"
+            limits:
+              memory: "1Gi"
+              cpu: "500m"
+          livenessProbe:
+            exec:
+              command:
+                - celery
+                - -A
+                - dev_health_ops.workers.celery_app
+                - inspect
+                - ping
+                - --timeout
+                - "10"
+            initialDelaySeconds: 60
+            periodSeconds: 30
+            timeoutSeconds: 15
+---
 # Heavy worker (CHAOS-2278): batch compute (metrics, backfill) + heavy
 # cost-class sync sub-queues (CHAOS-2517) isolated from latency-sensitive work.
 apiVersion: apps/v1

--- a/docs/architecture/external-ingest-stream-design.md
+++ b/docs/architecture/external-ingest-stream-design.md
@@ -1,0 +1,238 @@
+# External-ingest durable stream and DLQ (CHAOS-2693)
+
+Part of the [customer-push ingestion epic](adr-003-external-ingest-rest-boundary.md)
+(CHAOS-2690). This doc records the transport-layer decisions between "a batch
+has been accepted and durably persisted" and "a worker has picked it up for
+processing": stream naming, pointer-only payload placement, fail-closed
+enqueue, and the retry/reclaim/DLQ machinery.
+
+> **DEPLOYMENT BLOCKER (adversarial-review finding, critical): do not deploy
+> this issue's PR standalone alongside CHAOS-2691's interim router without
+> CHAOS-2695.** This issue removes the inline `payload` field from the
+> stream `XADD` (D2, below) as ratified/pinned by master-spec CC9. CC22 pins
+> the corresponding Postgres write (`payload_store.upsert_payload`, called
+> from the accept transaction) as CHAOS-2695's wave-4 router-rewire
+> responsibility -- until that PR lands, CHAOS-2691's interim `POST /batches`
+> handler calls `enqueue_batch(...)` with the raw body as `payload_json`,
+> which this issue's hardened `enqueue_batch()` silently accepts-but-discards
+> (kept as a no-op kwarg only for call-site compatibility, since editing
+> `router.py` is out of this issue's assigned scope -- see the "Scope
+> boundaries" note in the PR). **Net effect: any environment that deploys
+> this issue's PR without ALSO deploying CHAOS-2695 will accept customer
+> batches (202) whose raw payload is persisted nowhere at all** -- not on
+> the stream (removed here) and not in Postgres (not wired until 2695).
+> This is a genuine regression from the wave-1-only state (payload at least
+> sat inertly on the stream). The epic owner must sequence CHAOS-2693 and
+> CHAOS-2695 into the same deployment, or hold CHAOS-2691/2693 out of any
+> environment that accepts real traffic until CHAOS-2695 merges.
+
+## Per-org streams, not one shared stream
+
+`external-ingest:<org_id>:batches` + `external-ingest:<org_id>:dlq`, one
+stream pair per org rather than a single stream with an `org_id` field.
+Redis Streams delivers entries in strict ID order regardless of logical
+owner, so a single huge/bursty org's backlog would delay every other org's
+consumer-group progress on a shared stream. `StreamConsumer.discover_streams()`
+(`api/_stream_consumer.py`) already supports `SCAN ... TYPE stream` wildcard
+discovery (`external-ingest:*:batches`), so per-org keys need no separate
+registry, and per-org DLQ keys are equally discoverable
+(`external-ingest:*:dlq`) -- a single bad-actor/misconfigured org flooding
+poison batches doesn't crowd out DLQ visibility for other orgs.
+
+## Pointer-only transport, not payload-on-stream
+
+The stream entry carries batch *metadata* only: `ingestion_id, org_id,
+source_system, source_instance, schema_version, idempotency_key,
+record_count, window_started_at, window_ended_at, enqueued_at` -- all short
+strings. The full batch JSON lives in Postgres
+(`external_ingest_batch_payloads`, DDL/model hosted by CHAOS-2694's
+migration `0033`; this issue owns the `external_ingest/payload_store.py`
+raw-SQL accessors: `upsert_payload`/`fetch_payload`/`delete_payload`). The
+worker fetches the payload by `ingestion_id` (+`org_id` predicate).
+
+Why: batches can be multi-MB. Putting full JSON on `XADD` would (a) break
+the existing `maxlen=100_000, approximate=True` backpressure convention,
+which bounds by *entry count* not bytes; (b) make DLQ entries themselves
+multi-MB, defeating DLQ's purpose as a lightweight operational trail; (c)
+mean a stream trim under load could silently lose the only copy of a
+customer's data before a worker consumes it.
+
+`upsert_payload()` is a SELECT-then-UPDATE-or-INSERT in the caller's own
+transaction (no `ON CONFLICT`/`RETURNING` -- sqlite-portable, matching the
+plan's dialect-portable-SQL mandate): a RETRY accept reuses the same
+`ingestion_id`, so the row may already exist (`stream_unavailable` case:
+worker never ran) or not (`failed` case: worker already deleted it on
+terminal status). The idempotency row (`external_ingest_batches`, written
+first under its unique index in the same accept transaction) is the
+serialization point for concurrent same-key accepts; the residual sub-ms
+concurrent-insert race surfaces as `503 ingest_temporarily_unavailable`
+upstream (CHAOS-2695), not as a constraint violation here.
+
+Trade-off: the Postgres commit and the stream `XADD` are two separate
+operations with no distributed transaction between them. A `503` response
+can still leave a `status='received'`-equivalent (`accepted`) row with no
+consumer ever notified if the `XADD` fails or a stream trim races an unread
+entry. `reenqueue_batch()` (`api/external_ingest/streams.py`) is exposed as
+the seam a future reconciler (CHAOS-2769, and CHAOS-2695's RETRY-idempotency
+path reusing the same `ingestion_id`) calls; no reconciler is scheduled by
+this issue.
+
+## Fail-closed, never accept-and-warn
+
+`enqueue_batch()` raises `StreamUnavailableError` on any failure -- it never
+returns a boolean/accept-and-warn sentinel. This mirrors
+`product_telemetry/streams.py`'s `raise ConnectionError(...)` and is
+stricter than legacy `/api/v1/ingest`'s silent-drop-on-`False`. The router
+(CHAOS-2691) maps this to `503 stream_unavailable`.
+
+## Consumer: shared `StreamConsumer` base + additive reclaim extension
+
+`ExternalIngestStreamConsumer` (`api/external_ingest/consumer.py`) subclasses
+the shared `StreamConsumer` base (`api/_stream_consumer.py`) rather than
+hand-rolling `XREADGROUP` -- that base class exists specifically because two
+independent consumers (ingest, product-telemetry) regressed the same two
+production bugs (blocking-read socket-timeout race; unguarded-loop crash).
+
+The base class's default `handle_entries()` has no true retry path: every
+failure, permanent or transient, is immediately DLQ'd and ACKed in the same
+pass. That's acceptable for the existing best-effort internal consumers but
+not for external-ingest's stricter durability bar -- a transient
+ClickHouse/Postgres blip during sink-write must be retried, not immediately
+treated as a customer-data-loss event.
+
+This issue adds an **opt-in, default-`False`** capability to the shared base
+(`enable_reclaim`, `reclaim_idle_ms=900_000`, `max_deliveries=5`,
+`reclaim_stale()`), wired into `consume()` immediately before each stream's
+`XREADGROUP` call. Existing consumers (ingest, product-telemetry) are
+byte-for-byte unaffected: `reclaim_stale()` returns `[]` without touching
+Redis when `enable_reclaim` is `False` (see
+`tests/api/test_stream_consumer.py`'s explicit regression coverage, plus the
+unmodified re-run of the existing ingest/product-telemetry test files).
+
+`reclaim_idle_ms=900_000` (15 minutes), not a naive 60s: the in-process
+retry ladder alone can sleep ~14s, and a 1000-record batch can take well
+over 60s to process -- a short reclaim window risks two workers concurrently
+processing the same entry.
+
+Retry policy (`external_ingest/errors.py::PermanentProcessingError`):
+
+- `PermanentProcessingError` (unsupported schema version, a structurally
+  invalid envelope that survived API-layer validation) -> immediate DLQ +
+  ACK, no retry.
+- Any other exception (including unclassified ones, treated conservatively
+  as transient) -> **left un-ACKed**, staying in the consumer group's PEL
+  for `reclaim_stale()` to retry on a later poll, up to `max_deliveries`.
+  Once exhausted, `reclaim_stale()` itself calls `move_to_dlq()` (the
+  give-up path) -- routed to the same DLQ logic as an explicit permanent
+  failure, including the `mark_batch_failed` call below.
+
+This is a new interface contract with CHAOS-2697's worker
+(`external_ingest/processor.py::process_batch`), documented in
+`external_ingest/errors.py` so both issues import the same canonical
+`PermanentProcessingError` type.
+
+## DLQ: best-effort XADD-and-ACK + mark_batch_failed
+
+Giving up on an entry (permanent failure, or transient exhausted at
+`max_deliveries`) does two things:
+
+1. Best-effort `XADD` to the per-org DLQ stream (`external-ingest:<org_id>:dlq`)
+   with `original_stream`, `entry_id`, `reason`, `ingestion_id`, `org_id`,
+   `moved_at`. A DLQ write failure is logged and swallowed, matching the
+   base class's existing DLQ philosophy -- it must never crash the consumer
+   loop.
+2. A best-effort call to `external_ingest.processor.mark_batch_failed(
+   ingestion_id, org_id, reason)` (CHAOS-2697's pinned worker contract) so
+   the batch row reaches `failed` and becomes resubmittable via the same
+   idempotency key. Import-tolerant: CHAOS-2697 lands after this issue, so
+   until it does, this logs a warning and returns rather than raising
+   `ImportError` into the consumer loop.
+
+Both the async permanent-failure call site (inside the batch's single
+`run_async` event loop) and the sync give-up call site (the base's
+`reclaim_stale()`, called outside any running loop) route through the same
+XADD logic but call `mark_batch_failed` via their respective sync/async
+paths -- see `consumer.py`'s `_dlq_entry_async` vs `move_to_dlq` docstrings.
+Calling the sync path's `run_async()` from inside the async batch handler
+would trip `run_async`'s own re-entrancy guard; this split exists
+specifically to avoid that (caught by
+`tests/api/test_external_ingest_consumer.py::TestPermanentFailure::test_calls_mark_batch_failed`
+during implementation).
+
+## Idempotent-skip guard
+
+Before (re)processing ANY entry -- freshly read or reclaimed -- the consumer
+loads the batch's current status (`api.external_ingest.status.get_batch`,
+CHAOS-2694) and ACKs-and-skips without reprocessing if it is already
+terminal (`completed`/`partial`/`failed`). This prevents double processing
+when an entry is reclaimed after a slow-but-ultimately-successful run raced
+the 15-minute reclaim window. A status-lookup failure (e.g. a transient
+Postgres blip) fails open (treated as non-terminal, processing proceeds)
+rather than silently stranding the batch.
+
+## Deployment invariant: single replica, `--concurrency=1`
+
+Exactly ONE `worker-external-ingest` replica must run, at Celery
+`--concurrency=1`, across every deploy target (`compose.yml`,
+`compose.production.yml`, `docker-swarm/stack.yml`,
+`kubernetes/worker.yaml`, the Helm chart's `workerExternalIngest` pool).
+The reclaim design assumes a single logical consumer identity draining the
+PEL; scaling replicas without first revisiting reclaim semantics
+reintroduces the double-processing window the 15-minute `reclaim_idle_ms`
+and the idempotent-skip guard are built to close.
+`tests/test_compose_config.py` enforces queue/worker topology coverage
+across all deploy targets; the `--concurrency=1` flag itself is a comment
+convention, not a machine-checked invariant, mirroring the existing
+`worker-ingest` precedent.
+
+## Dedicated Celery queue, not shared with `worker-ingest`
+
+`external-ingest` is its own Celery queue, consumed only by the dedicated
+`worker-external-ingest` container (`-Q external-ingest --concurrency=1`).
+External-ingest is customer-facing (spiky, potentially larger batches) and
+must not have its processing throughput hostage to an unrelated internal
+consumer backlog (`worker-ingest`'s `/api/v1/ingest` + product-telemetry
+traffic), nor vice versa.
+
+## Observability: structured logs, no new table
+
+`external_ingest_stream_health` (`api/external_ingest/stream_health.py`,
+beat-scheduled every 60s on the `monitoring` queue) mirrors the existing
+`workers/queue_monitor.py` convention: no Prometheus/statsd exporter exists
+anywhere in this codebase today, so this logs depth (`XLEN`), pending count,
+and the oldest pending entry's idle time (`XPENDING`) per discovered
+`external-ingest:*:batches`/`external-ingest:*:dlq` stream, warning above
+`STREAM_DEPTH_WARNING_THRESHOLD`/`STREAM_AGE_WARNING_MS`. A future
+ClickHouse/Data-Health-UI surface for this is out of scope, same posture as
+`queue_monitor.py`.
+
+## Risks / follow-ups
+
+1. **Shared-file blast radius.** `_stream_consumer.py`'s reclaim extension
+   is additive and default-off, with explicit regression coverage (the
+   unmodified existing ingest/product-telemetry test files, plus new tests
+   asserting the disabled defaults) -- see the "Consumer" section above.
+2. **Orphan Postgres rows on stream-enqueue failure.** No reconciler is
+   built in this issue; `reenqueue_batch()` is the seam for a future one
+   (CHAOS-2769 / a filed follow-up).
+3. **DLQ has no replay tooling.** Poison/give-up entries are discoverable
+   via `XRANGE`/`valkey-cli` but there is no admin UI or CLI to re-drive
+   them in v1.
+4. **`external_ingest.processor.mark_batch_failed` doesn't exist yet.**
+   CHAOS-2697 lands after this issue; until it does, the give-up path logs
+   a warning and the batch row is not marked `failed` (it remains in
+   whatever status the worker itself left it in, or `accepted` if the
+   worker crashed before reaching a status write). This is expected and
+   resolves itself once CHAOS-2697 merges -- no action needed in this PR.
+5. **`external_ingest.processor.process_batch` doesn't exist yet either --
+   guarded at the consumer entry point, not just the give-up path.**
+   `ExternalIngestStreamConsumer.consume()` checks module availability
+   before claiming any entries and is a full no-op (no `XREADGROUP`, no
+   reclaim) when the processor is missing, so beat-scheduling this consumer
+   ahead of CHAOS-2697 leaves entries completely untouched rather than
+   burning through `max_deliveries` reclaim cycles for every batch
+   (adversarial-review finding, fixed in this PR).
+6. **DEPLOYMENT BLOCKER: payload persists nowhere until CHAOS-2695 lands.**
+   See the callout at the top of this document (adversarial-review finding,
+   critical) -- do not deploy this PR standalone alongside CHAOS-2691's
+   interim router without CHAOS-2695's payload-upsert wiring also present.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,12 @@ per-file-ignores = { "__init__.py" = [
   "E402",
 ], "tests/test_ingest_streams.py" = [
   "E402",
+], "tests/api/test_external_ingest_streams.py" = [
+  "E402",
+], "tests/api/test_external_ingest_consumer.py" = [
+  "E402",
+], "tests/api/test_external_ingest_stream_health.py" = [
+  "E402",
 ] }
 
 [tool.ruff.format]

--- a/src/dev_health_ops/api/_stream_consumer.py
+++ b/src/dev_health_ops/api/_stream_consumer.py
@@ -105,6 +105,24 @@ class StreamConsumer:
     #: Exceptions treated as "reject to DLQ" (logged at warning, not error).
     reject_exceptions: tuple[type[BaseException], ...] = ()
 
+    #: Opt-in, default-off reclaim/redelivery (CHAOS-2693 D5). The base
+    #: ``handle_entries()`` above has no true retry path -- every failure is
+    #: DLQ'd and ACKed in the same pass, which is fine for existing
+    #: best-effort internal consumers (ingest, product-telemetry) but not
+    #: for a consumer with a stricter durability bar. Leaving this ``False``
+    #: keeps every existing subclass byte-for-byte unaffected: ``reclaim_stale``
+    #: below short-circuits before touching Redis when disabled.
+    enable_reclaim: bool = False
+    #: Idle time (ms) before a pending entry is eligible for reclaim. 15
+    #: minutes, not the naive 60s: a consumer's own in-process retry ladder
+    #: can sleep ~14s by itself, and a large batch can take well over 60s to
+    #: process -- a short reclaim window risks two workers concurrently
+    #: processing the same entry.
+    reclaim_idle_ms: int = 900_000
+    #: Delivery attempts (first read + reclaims) before an entry is treated
+    #: as poison: DLQ + ACK instead of being reclaimed again.
+    max_deliveries: int = 5
+
     def __init__(
         self,
         *,
@@ -174,10 +192,25 @@ class StreamConsumer:
             )
             raise
 
-    def move_to_dlq(self, rc: Any, stream_key: str, entry_id: str, reason: str) -> None:
-        """Best-effort route of a poison entry to the configured DLQ stream."""
+    def move_to_dlq(
+        self, rc: Any, stream_key: str, entry_id: str, reason: str
+    ) -> bool | None:
+        """Best-effort route of a poison entry to the configured DLQ stream.
+
+        Return value is an ack-gating contract for :meth:`reclaim_stale`'s
+        give-up path (added for CHAOS-2693's stricter-durability subclass;
+        additive, does not change this default's own behavior): ``False``
+        means the DLQ write itself failed and the caller should NOT ack the
+        source entry (leave it pending for a later retry rather than losing
+        it with no DLQ record). This base implementation still returns
+        ``None`` (not ``False``) on failure -- existing subclasses
+        (ingest, product-telemetry) keep their original best-effort/
+        always-ack semantics unless they override this method to return
+        ``False`` explicitly on failure, as :class:`ExternalIngestStreamConsumer`
+        does.
+        """
         if not self.dlq_stream:
-            return
+            return None
         try:
             rc.xadd(
                 self.dlq_stream,
@@ -190,6 +223,80 @@ class StreamConsumer:
             )
         except Exception:
             logger.exception("Failed to move entry %s to DLQ", entry_id)
+        return None
+
+    def reclaim_stale(
+        self, rc: Any, stream_key: str
+    ) -> list[tuple[str, dict[str, str]]]:
+        """Reclaim entries idle longer than :attr:`reclaim_idle_ms`.
+
+        No-op (returns ``[]`` without touching Redis) unless
+        :attr:`enable_reclaim` is set -- existing subclasses pay no extra
+        round-trip. Entries that have already reached :attr:`max_deliveries`
+        are treated as poison: routed to the DLQ and ACKed (given up on, not
+        reclaimed) via the same :meth:`move_to_dlq` hook the default
+        :meth:`handle_entries` uses, so DLQ semantics are identical
+        regardless of which path gave up on the entry.
+        """
+        if not self.enable_reclaim:
+            return []
+        try:
+            pending = rc.xpending_range(
+                stream_key,
+                self.consumer_group,
+                min="-",
+                max="+",
+                count=self.batch_size,
+                idle=self.reclaim_idle_ms,
+            )
+        except Exception:
+            logger.exception("xpending_range failed for %s", stream_key)
+            return []
+
+        claim_ids: list[str] = []
+        for entry in pending:
+            message_id = entry.get("message_id")
+            if message_id is None:
+                continue
+            times_delivered = int(entry.get("times_delivered", 0) or 0)
+            if times_delivered >= self.max_deliveries:
+                moved = self.move_to_dlq(
+                    rc, stream_key, message_id, "max_deliveries_exceeded"
+                )
+                if moved is False:
+                    # DLQ write itself failed: do NOT ack -- leave the entry
+                    # pending so the next reclaim_stale() poll retries the
+                    # DLQ write instead of silently losing the entry with no
+                    # DLQ record (adversarial-review finding).
+                    logger.warning(
+                        "DLQ write failed for given-up entry %s; leaving "
+                        "pending for retry instead of ACKing",
+                        message_id,
+                    )
+                    continue
+                try:
+                    rc.xack(stream_key, self.consumer_group, message_id)
+                except Exception:
+                    logger.exception(
+                        "Failed to ACK reclaimed-and-given-up entry %s", message_id
+                    )
+            else:
+                claim_ids.append(message_id)
+
+        if not claim_ids:
+            return []
+        try:
+            claimed = rc.xclaim(
+                stream_key,
+                self.consumer_group,
+                self.consumer_name,
+                min_idle_time=self.reclaim_idle_ms,
+                message_ids=claim_ids,
+            )
+        except Exception:
+            logger.exception("xclaim failed for %s", stream_key)
+            return []
+        return list(claimed)
 
     def handle_entries(
         self,
@@ -248,6 +355,15 @@ class StreamConsumer:
         backoff_s = 1.0
         while max_iterations is None or iterations < max_iterations:
             iterations += 1
+
+            if self.enable_reclaim:
+                for stream_key in streams:
+                    reclaimed = self.reclaim_stale(rc, stream_key)
+                    if reclaimed:
+                        total_processed += self.handle_entries(
+                            rc, stream_key, reclaimed
+                        )
+
             try:
                 results = rc.xreadgroup(
                     self.consumer_group,

--- a/src/dev_health_ops/api/external_ingest/consumer.py
+++ b/src/dev_health_ops/api/external_ingest/consumer.py
@@ -186,18 +186,22 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         than call :meth:`_mark_batch_failed_best_effort` (which itself calls
         :func:`run_async`), or ``run_async``'s own re-entrancy guard raises.
 
-        Returns whether the DLQ write succeeded -- the caller must only ack
-        the source entry when this is ``True`` (same rationale as
-        :meth:`move_to_dlq`).
+        Returns whether the source entry may be ACKed: requires BOTH the DLQ
+        write to succeed (same rationale as :meth:`move_to_dlq`) AND, when an
+        ingestion_id is present, the failed-status write to be safe (see
+        :meth:`_mark_batch_failed_best_effort_async` -- adversarial-review
+        round-2: ACKing past a raised ``mark_batch_failed`` strands the batch
+        in a non-terminal status with the entry gone).
         """
         org_id, dlq_written = self._xadd_dlq_entry(
             rc, stream_key, entry_id, reason, data
         )
         ingestion_id = data.get("ingestion_id")
         if dlq_written and ingestion_id:
-            await self._mark_batch_failed_best_effort_async(
+            marked_ok = await self._mark_batch_failed_best_effort_async(
                 org_id=org_id, ingestion_id=ingestion_id, reason=reason
             )
+            return dlq_written and marked_ok
         return dlq_written
 
     def _xadd_dlq_entry(
@@ -289,10 +293,22 @@ class ExternalIngestStreamConsumer(StreamConsumer):
 
     async def _mark_batch_failed_best_effort_async(
         self, *, org_id: str, ingestion_id: str, reason: str
-    ) -> None:
+    ) -> bool:
         """Async path: used by :meth:`_dlq_entry_async`, already inside a
         running event loop -- awaits the coroutine directly, never
-        :func:`run_async`."""
+        :func:`run_async`.
+
+        Returns whether it is safe to ACK the source entry with respect to
+        status marking: ``True`` when the batch was marked failed OR when the
+        seam is not yet importable (pre-CHAOS-2697 there is no worker writing
+        statuses to strand; the CC13 stale-accepted RETRY path remains the
+        customer's recovery). ``False`` ONLY when a resolvable
+        ``mark_batch_failed`` raised (e.g. transient Postgres outage): the
+        caller must then leave the entry un-ACKed so a later redelivery
+        retries the status write -- otherwise the customer-visible status
+        never reaches ``failed`` while the entry is gone (adversarial-review
+        round-2 finding). A duplicate DLQ entry on that retry is accepted
+        operational noise; a silently non-terminal batch is not."""
         mark_batch_failed = self._resolve_mark_batch_failed()
         if mark_batch_failed is None:
             logger.warning(
@@ -301,7 +317,7 @@ class ExternalIngestStreamConsumer(StreamConsumer):
                 ingestion_id,
                 org_id,
             )
-            return
+            return True
         try:
             result = mark_batch_failed(
                 ingestion_id=ingestion_id, org_id=org_id, reason=reason
@@ -310,10 +326,13 @@ class ExternalIngestStreamConsumer(StreamConsumer):
                 await result
         except Exception:
             logger.exception(
-                "mark_batch_failed failed for ingestion_id=%s org=%s",
+                "mark_batch_failed failed for ingestion_id=%s org=%s -- "
+                "leaving source entry un-ACKed for a status-write retry",
                 ingestion_id,
                 org_id,
             )
+            return False
+        return True
 
     # ------------------------------------------------------------------
     # Idempotent-skip guard

--- a/src/dev_health_ops/api/external_ingest/consumer.py
+++ b/src/dev_health_ops/api/external_ingest/consumer.py
@@ -1,0 +1,468 @@
+"""Consumer group + retry/reclaim + DLQ for external-ingest streams (CHAOS-2693).
+
+Subclasses the shared :class:`~dev_health_ops.api._stream_consumer.StreamConsumer`
+base rather than hand-rolling the ``XREADGROUP`` loop -- that base class
+exists specifically because two independent consumers (ingest,
+product-telemetry) regressed the same two production bugs (blocking-read
+socket-timeout race; unguarded-loop crash). See its module docstring.
+
+DEPLOYMENT INVARIANT (master-spec CC11, non-negotiable): exactly ONE
+``worker-external-ingest`` replica must run, at Celery ``--concurrency=1``
+(``compose.yml``). The reclaim design (``enable_reclaim=True`` below) relies
+on there being a single logical consumer identity draining the PEL --
+scaling replicas without first revisiting reclaim semantics reintroduces
+the double-processing window the 15-minute ``reclaim_idle_ms`` and the
+idempotent-skip guard below are built to close.
+
+Retry/give-up policy (D5): a :class:`PermanentProcessingError` from
+``process_entry`` (unsupported schema version, a structurally invalid
+envelope that survived API-layer validation) is routed straight to the
+DLQ and ACKed -- no retry. Any other exception is treated conservatively
+as transient (connection errors, timeouts, unclassified bugs): the entry
+is deliberately left un-ACKed, so it stays in the consumer group's PEL for
+the shared base's ``reclaim_stale()`` to retry on a later poll, up to
+``max_deliveries``. Once exhausted, the base's reclaim loop calls
+:meth:`move_to_dlq` itself (the "give-up" path) -- routed here to the same
+DLQ logic as an explicit permanent failure.
+
+Idempotent-skip guard (CC11 post-critique): before (re)processing ANY
+entry -- freshly read or reclaimed -- the consumer loads the batch's
+current status (``api.external_ingest.status.get_batch``, CHAOS-2694) and
+ACKs-and-skips without reprocessing if it is already terminal
+(completed/partial/failed). This prevents double processing when an entry
+is reclaimed after a slow-but-ultimately-successful run raced the
+15-minute reclaim window.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import uuid
+from collections.abc import Coroutine
+from datetime import datetime, timezone
+from typing import Any, cast
+
+from dev_health_ops.external_ingest.errors import PermanentProcessingError
+from dev_health_ops.models.external_ingest import TERMINAL_STATUSES
+from dev_health_ops.workers.async_runner import run_async
+
+from .._stream_consumer import StreamConsumer
+from .streams import CONSUMER_GROUP, STREAM_MAXLEN, dlq_name
+
+logger = logging.getLogger(__name__)
+
+# Smaller than ingest's 100: each entry now triggers a Postgres payload
+# fetch + full record processing, not a cheap in-memory item append.
+BATCH_SIZE = 50
+BLOCK_MS = 5000
+RECLAIM_IDLE_MS = 900_000  # 15 min, master-spec CC11 post-critique
+MAX_DELIVERIES = 5
+
+_TERMINAL_STATUS_VALUES = {s.value for s in TERMINAL_STATUSES}
+
+
+def _processor_available() -> bool:
+    """Whether CHAOS-2697's ``external_ingest.processor`` module (owning
+    ``process_batch``/``mark_batch_failed``) is importable yet.
+
+    Deployment-order guard (adversarial-review finding): this issue's beat
+    schedule/queue wiring ships ahead of CHAOS-2697's worker implementation
+    by design (master-spec wave plan), so the consumer must check this
+    before claiming any entries rather than draining the stream into a
+    guaranteed-ImportError retry ladder.
+    """
+    try:
+        import dev_health_ops.external_ingest.processor  # type: ignore  # noqa: F401
+    except ImportError:
+        return False
+    return True
+
+
+class ExternalIngestStreamConsumer(StreamConsumer):
+    consumer_group = CONSUMER_GROUP
+    consumer_name_prefix = "external-ingest-consumer"
+    batch_size = BATCH_SIZE
+    block_ms = BLOCK_MS
+    enable_reclaim = True
+    reclaim_idle_ms = RECLAIM_IDLE_MS
+    max_deliveries = MAX_DELIVERIES
+    reject_exceptions = (PermanentProcessingError,)
+
+    def stream_patterns(self) -> list[str]:
+        return ["external-ingest:*:batches"]
+
+    # ------------------------------------------------------------------
+    # Deployment-order guard (adversarial-review finding)
+    # ------------------------------------------------------------------
+    def consume(self, max_iterations: int | None = None) -> int:
+        """Refuses to claim any stream entries when CHAOS-2697's
+        ``external_ingest.processor`` module is unavailable.
+
+        Without this guard, enabling this consumer (beat-scheduled every
+        30s) before CHAOS-2697 lands would deliver every entry into
+        ``process_entry``, which immediately raises ``ImportError``
+        (treated as transient), burning through ``max_deliveries`` reclaim
+        cycles for no reason and routing customer batches to the DLQ before
+        a real worker implementation ever existed to attempt them. A no-op
+        here leaves entries completely untouched (zero delivery attempts)
+        in the stream/PEL, so they are picked up fresh and correctly once
+        CHAOS-2697 ships -- no manual re-drive needed.
+        """
+        if not _processor_available():
+            logger.warning(
+                "external_ingest.processor unavailable (CHAOS-2697 not yet "
+                "landed) -- %s refusing to claim any stream entries this "
+                "poll; entries remain untouched for a later poll once the "
+                "processor ships",
+                type(self).__name__,
+            )
+            return 0
+        return super().consume(max_iterations=max_iterations)
+
+    # ------------------------------------------------------------------
+    # DLQ routing
+    # ------------------------------------------------------------------
+    def _org_id_from_stream_key(self, stream_key: str) -> str:
+        # "external-ingest:<org_id>:batches"
+        parts = stream_key.split(":")
+        return parts[1] if len(parts) >= 3 else "unknown"
+
+    def _fetch_entry_fields(
+        self, rc: Any, stream_key: str, entry_id: str
+    ) -> dict[str, str]:
+        """Re-read a single entry's fields by ID.
+
+        Used only by :meth:`move_to_dlq`'s give-up path (invoked by the
+        shared base's ``reclaim_stale()``, which has no field data -- only
+        the message ID from ``XPENDING``). Freshly-read/reclaimed entries
+        handled via :meth:`handle_entries` already carry their field dict
+        and never call this.
+        """
+        try:
+            rows = rc.xrange(stream_key, min=entry_id, max=entry_id)
+        except Exception:
+            logger.exception("Failed to re-read entry %s for DLQ routing", entry_id)
+            return {}
+        if not rows:
+            return {}
+        _id, data = rows[0]
+        return dict(data)
+
+    def move_to_dlq(self, rc: Any, stream_key: str, entry_id: str, reason: str) -> bool:
+        """Give-up path invoked directly by the shared base's ``reclaim_stale()``
+        once ``max_deliveries`` is exhausted for a still-pending entry. This
+        is a SYNC call site, outside of any running event loop -- safe to
+        use :func:`run_async` for the ``mark_batch_failed`` side effect.
+
+        Returns whether the DLQ write itself succeeded (base class contract,
+        adversarial-review finding): the caller (``reclaim_stale``) must NOT
+        ack the source entry when this is ``False``, or a DLQ write failure
+        (e.g. a transient Redis blip) would silently lose the entry with no
+        DLQ record at all.
+        """
+        data = self._fetch_entry_fields(rc, stream_key, entry_id)
+        org_id, dlq_written = self._xadd_dlq_entry(
+            rc, stream_key, entry_id, reason, data
+        )
+        ingestion_id = data.get("ingestion_id")
+        if dlq_written and ingestion_id:
+            self._mark_batch_failed_best_effort(
+                org_id=org_id, ingestion_id=ingestion_id, reason=reason
+            )
+        return dlq_written
+
+    async def _dlq_entry_async(
+        self,
+        rc: Any,
+        stream_key: str,
+        entry_id: str,
+        reason: str,
+        data: dict[str, str],
+    ) -> bool:
+        """Async counterpart of the give-up path, for the permanent-failure
+        branch inside :meth:`_handle_entries_async`, which already runs
+        inside ``run_async``'s event loop -- MUST ``await`` directly rather
+        than call :meth:`_mark_batch_failed_best_effort` (which itself calls
+        :func:`run_async`), or ``run_async``'s own re-entrancy guard raises.
+
+        Returns whether the DLQ write succeeded -- the caller must only ack
+        the source entry when this is ``True`` (same rationale as
+        :meth:`move_to_dlq`).
+        """
+        org_id, dlq_written = self._xadd_dlq_entry(
+            rc, stream_key, entry_id, reason, data
+        )
+        ingestion_id = data.get("ingestion_id")
+        if dlq_written and ingestion_id:
+            await self._mark_batch_failed_best_effort_async(
+                org_id=org_id, ingestion_id=ingestion_id, reason=reason
+            )
+        return dlq_written
+
+    def _xadd_dlq_entry(
+        self,
+        rc: Any,
+        stream_key: str,
+        entry_id: str,
+        reason: str,
+        data: dict[str, str],
+    ) -> tuple[str, bool]:
+        """XADD to the per-org DLQ (sync -- the redis client itself is never
+        async). Per-org (D1): a single bad-actor/misconfigured org flooding
+        poison batches must not crowd out DLQ visibility for other orgs.
+        Returns ``(org_id, succeeded)`` -- callers use ``succeeded`` to
+        decide whether it is safe to ack the source entry (adversarial-review
+        finding: a swallowed DLQ-write failure must not silently drop the
+        entry with no DLQ record).
+        """
+        org_id = data.get("org_id") or self._org_id_from_stream_key(stream_key)
+        dlq = dlq_name(org_id)
+        try:
+            rc.xadd(
+                dlq,
+                {
+                    "original_stream": stream_key,
+                    "entry_id": entry_id,
+                    "reason": reason,
+                    "ingestion_id": data.get("ingestion_id", ""),
+                    "org_id": org_id,
+                    "moved_at": datetime.now(timezone.utc).isoformat(),
+                },
+                maxlen=STREAM_MAXLEN,
+                approximate=True,
+            )
+        except Exception:
+            logger.exception("Failed to move entry %s to DLQ", entry_id)
+            return org_id, False
+        return org_id, True
+
+    @staticmethod
+    def _resolve_mark_batch_failed():
+        """Give-up path calls ``external_ingest.processor.mark_batch_failed``
+        (CHAOS-2697's pinned worker contract, CC23). Import-tolerant:
+        CHAOS-2697 lands after this issue, so until it does, this returns
+        ``None`` rather than raising ImportError into the consumer loop.
+        """
+        try:
+            # CHAOS-2697's module; doesn't exist yet at this issue's
+            # implementation time (see module docstring) -- the
+            # missing-stubs diagnostic for this module path is already
+            # silenced once per file by _processor_available()'s import.
+            from dev_health_ops.external_ingest.processor import mark_batch_failed
+        except ImportError:
+            return None
+        return mark_batch_failed
+
+    def _mark_batch_failed_best_effort(
+        self, *, org_id: str, ingestion_id: str, reason: str
+    ) -> None:
+        """Sync path: used by :meth:`move_to_dlq`, itself only ever called
+        outside a running event loop (the shared base's synchronous
+        ``reclaim_stale()``)."""
+        mark_batch_failed = self._resolve_mark_batch_failed()
+        if mark_batch_failed is None:
+            logger.warning(
+                "external_ingest.processor.mark_batch_failed unavailable "
+                "(CHAOS-2697 not yet landed) -- batch %s org=%s not marked failed",
+                ingestion_id,
+                org_id,
+            )
+            return
+        try:
+            result = mark_batch_failed(
+                ingestion_id=ingestion_id, org_id=org_id, reason=reason
+            )
+            if inspect.isawaitable(result):
+                # mark_batch_failed's concrete return type is unknown until
+                # CHAOS-2697 defines it; inspect.isawaitable narrows to the
+                # broader Awaitable protocol, but run_async expects a
+                # Coroutine specifically -- an async def's return value
+                # always is one at runtime.
+                run_async(cast(Coroutine[Any, Any, Any], result))
+        except Exception:
+            logger.exception(
+                "mark_batch_failed failed for ingestion_id=%s org=%s",
+                ingestion_id,
+                org_id,
+            )
+
+    async def _mark_batch_failed_best_effort_async(
+        self, *, org_id: str, ingestion_id: str, reason: str
+    ) -> None:
+        """Async path: used by :meth:`_dlq_entry_async`, already inside a
+        running event loop -- awaits the coroutine directly, never
+        :func:`run_async`."""
+        mark_batch_failed = self._resolve_mark_batch_failed()
+        if mark_batch_failed is None:
+            logger.warning(
+                "external_ingest.processor.mark_batch_failed unavailable "
+                "(CHAOS-2697 not yet landed) -- batch %s org=%s not marked failed",
+                ingestion_id,
+                org_id,
+            )
+            return
+        try:
+            result = mark_batch_failed(
+                ingestion_id=ingestion_id, org_id=org_id, reason=reason
+            )
+            if inspect.isawaitable(result):
+                await result
+        except Exception:
+            logger.exception(
+                "mark_batch_failed failed for ingestion_id=%s org=%s",
+                ingestion_id,
+                org_id,
+            )
+
+    # ------------------------------------------------------------------
+    # Idempotent-skip guard
+    # ------------------------------------------------------------------
+    async def _is_batch_terminal_async(self, org_id: str, ingestion_id: str) -> bool:
+        from dev_health_ops.api.external_ingest.status import get_batch
+        from dev_health_ops.db import get_postgres_session
+
+        try:
+            batch_ingestion_id = uuid.UUID(ingestion_id)
+        except (ValueError, AttributeError, TypeError):
+            return False
+
+        async with get_postgres_session() as session:
+            batch = await get_batch(
+                session, org_id=org_id, ingestion_id=batch_ingestion_id
+            )
+        return batch is not None and batch.status in _TERMINAL_STATUS_VALUES
+
+    # ------------------------------------------------------------------
+    # Processing
+    # ------------------------------------------------------------------
+    async def _process_entry_async(
+        self, stream_key: str, entry_id: str, data: dict[str, str]
+    ) -> int:
+        from dev_health_ops.external_ingest.processor import process_batch
+
+        result = process_batch(
+            ingestion_id=data["ingestion_id"],
+            org_id=data["org_id"],
+            source_system=data["source_system"],
+            source_instance=data["source_instance"],
+            schema_version=data["schema_version"],
+        )
+        if inspect.isawaitable(result):
+            result = await result
+        return int(result)
+
+    def process_entry(
+        self, stream_key: str, entry_id: str, data: dict[str, str]
+    ) -> int:
+        """Standalone sync entry point (interface parity with the base
+        class contract / CHAOS-2697; ad-hoc REPL verification). Not called
+        internally by :meth:`handle_entries`, which awaits the async core
+        directly within a single event loop for the whole batch -- see its
+        docstring for why a per-entry ``run_async`` would break.
+        """
+        return run_async(self._process_entry_async(stream_key, entry_id, data))
+
+    # ------------------------------------------------------------------
+    # Batch handling: selective ack (D5) + idempotent-skip guard (CC11)
+    # ------------------------------------------------------------------
+    def handle_entries(
+        self,
+        rc: Any,
+        stream_key: str,
+        entries: list[tuple[str, dict[str, str]]],
+    ) -> int:
+        """Overrides the base's default (which ACKs every entry regardless
+        of outcome) -- external-ingest's durability bar requires transient
+        failures to stay in the PEL for reclaim, not be ACKed away.
+
+        Runs the whole batch through ONE event loop (a single
+        ``run_async`` call), not one per entry: the cached async Postgres
+        engine (``db.get_postgres_engine()``) is bound to whichever event
+        loop first created it, and ``run_async`` resets it before each
+        call -- doing that per-entry inside a tight loop would be both
+        wasteful (a connection-pool teardown/rebuild per entry) and, if
+        this method's caller (the shared base's ``consume()``) already
+        held a running loop, would trip ``run_async``'s own re-entrancy
+        guard.
+        """
+        return run_async(self._handle_entries_async(rc, stream_key, entries))
+
+    async def _handle_entries_async(
+        self,
+        rc: Any,
+        stream_key: str,
+        entries: list[tuple[str, dict[str, str]]],
+    ) -> int:
+        processed = 0
+        to_ack: list[str] = []
+        for entry_id, data in entries:
+            org_id = data.get("org_id", "")
+            ingestion_id = data.get("ingestion_id", "")
+            try:
+                if ingestion_id and await self._is_batch_terminal_async(
+                    org_id, ingestion_id
+                ):
+                    logger.info(
+                        "Skipping already-terminal batch %s (idempotent-skip guard)",
+                        ingestion_id,
+                    )
+                    to_ack.append(entry_id)
+                    continue
+                processed += await self._process_entry_async(stream_key, entry_id, data)
+                to_ack.append(entry_id)
+            except PermanentProcessingError as exc:
+                logger.warning("Permanent failure for entry %s: %s", entry_id, exc)
+                dlq_written = await self._dlq_entry_async(
+                    rc, stream_key, entry_id, str(exc), data
+                )
+                if dlq_written:
+                    to_ack.append(entry_id)
+                else:
+                    # DLQ write failed: do NOT ack -- leave pending so a
+                    # later poll retries the DLQ write instead of silently
+                    # losing the entry with no DLQ record (adversarial-review
+                    # finding). It will keep re-hitting PermanentProcessingError
+                    # on every fresh delivery/reclaim until the DLQ write
+                    # eventually succeeds.
+                    logger.warning(
+                        "DLQ write failed for permanently-failed entry %s; "
+                        "leaving un-ACKed for retry",
+                        entry_id,
+                    )
+            except Exception:
+                logger.exception(
+                    "Transient failure processing entry %s on %s; leaving "
+                    "un-ACKed for reclaim_stale()",
+                    entry_id,
+                    stream_key,
+                )
+                # Deliberately NOT appended to to_ack: stays in the PEL.
+
+        if to_ack:
+            try:
+                rc.xack(stream_key, self.consumer_group, *to_ack)
+            except Exception:
+                logger.exception("Failed to ACK entries on %s", stream_key)
+        return processed
+
+
+def consume_external_ingest_streams(
+    max_iterations: int | None = None, consumer_name: str | None = None
+) -> int:
+    """Entry point for the Celery task (``workers/system_ops.py``) and
+    ad-hoc/live-verification REPL calls. Returns total units processed."""
+    consumer = ExternalIngestStreamConsumer(
+        consumer_name=consumer_name, block_ms=BLOCK_MS, batch_size=BATCH_SIZE
+    )
+    return consumer.consume(max_iterations=max_iterations)
+
+
+__all__ = [
+    "BATCH_SIZE",
+    "BLOCK_MS",
+    "RECLAIM_IDLE_MS",
+    "MAX_DELIVERIES",
+    "ExternalIngestStreamConsumer",
+    "consume_external_ingest_streams",
+]

--- a/src/dev_health_ops/api/external_ingest/router.py
+++ b/src/dev_health_ops/api/external_ingest/router.py
@@ -15,11 +15,14 @@ from __future__ import annotations
 
 import logging
 import os
+from typing import Annotated
 from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Header, Request, Response
 from pydantic import ValidationError
+from sqlalchemy.ext.asyncio import AsyncSession
 
+from dev_health_ops.api.dependencies import get_postgres_session_dep
 from dev_health_ops.api.middleware.rate_limit import (
     INGEST_BATCH_LIMIT,
     INGEST_READ_LIMIT,
@@ -28,6 +31,7 @@ from dev_health_ops.api.middleware.rate_limit import (
     get_ingest_token_key,
     limiter,
 )
+from dev_health_ops.external_ingest.payload_store import upsert_payload
 from dev_health_ops.external_ingest.validate import validate_records
 
 from .auth import IngestAuthContext, require_ingest_scope, require_matching_source
@@ -245,6 +249,7 @@ async def validate_batch(
 @limiter.limit(INGEST_BATCH_LIMIT, key_func=get_ingest_token_key)
 async def accept_batch(
     request: Request,
+    session: Annotated[AsyncSession, Depends(get_postgres_session_dep)],
     ctx: IngestAuthContext = Depends(_require_ingest_write),
     idempotency_key_header: str | None = Header(default=None, alias="Idempotency-Key"),
 ) -> BatchAcceptedResponse:
@@ -263,15 +268,33 @@ async def accept_batch(
 
     ingestion_id = str(uuid4())
     window = envelope.window
+
+    # Persist the raw payload BEFORE enqueueing the pointer (D2/CC9): the
+    # stream entry never carries payload bytes, so a worker fetching by
+    # ingestion_id must always find a durable row. Committed here, ahead of
+    # enqueue_batch()'s own fail-closed payload-durability check (streams.py)
+    # -- that check opens an independent read after this commit, so it must
+    # already be visible. This is the interim (pre-CHAOS-2695) accept flow:
+    # no idempotency/ownership resolution or status-row write yet (CHAOS-2695
+    # wave 4 owns that full CC22 rewrite) -- adding only the payload
+    # persistence this issue (CHAOS-2693) owns.
+    await upsert_payload(
+        session,
+        ingestion_id=ingestion_id,
+        org_id=ctx.org_id,
+        schema_version=envelope.schema_version,
+        payload_bytes=raw,
+    )
+    await session.commit()
+
     try:
-        stream = enqueue_batch(
+        stream = await enqueue_batch(
             org_id=ctx.org_id,
             ingestion_id=ingestion_id,
             source_system=envelope.source.system,
             source_instance=envelope.source.instance,
             schema_version=envelope.schema_version,
             idempotency_key=envelope.idempotency_key,
-            payload_json=raw.decode("utf-8"),
             record_count=len(envelope.records),
             window_started_at=window.started_at if window else None,
             window_ended_at=window.ended_at if window else None,

--- a/src/dev_health_ops/api/external_ingest/router.py
+++ b/src/dev_health_ops/api/external_ingest/router.py
@@ -31,7 +31,7 @@ from dev_health_ops.api.middleware.rate_limit import (
     get_ingest_token_key,
     limiter,
 )
-from dev_health_ops.external_ingest.payload_store import upsert_payload
+from dev_health_ops.external_ingest.payload_store import delete_payload, upsert_payload
 from dev_health_ops.external_ingest.validate import validate_records
 
 from .auth import IngestAuthContext, require_ingest_scope, require_matching_source
@@ -300,6 +300,22 @@ async def accept_batch(
             window_ended_at=window.ended_at if window else None,
         )
     except StreamUnavailableError as exc:
+        # Adversarial-review round-2: without cleanup, every customer retry of
+        # a 503 leaves another committed multi-MB payload row behind (each
+        # accept mints a fresh ingestion_id in this interim flow, so nothing
+        # ever reuses or prunes them). Best-effort delete keeps "payload row
+        # exists" ~equivalent to "a pointer may exist". Residual orphans from
+        # a crash between commit and enqueue remain possible -- the
+        # CHAOS-2769 reconciler / CHAOS-2695 status rows are the systematic
+        # answer; a failed delete here must never mask the customer-facing
+        # 503.
+        try:
+            await delete_payload(session, ingestion_id=ingestion_id)
+            await session.commit()
+        except Exception:
+            logger.exception(
+                "orphan payload cleanup failed for ingestion_id=%s", ingestion_id
+            )
         raise ExternalIngestError(
             503, "stream_unavailable", "Ingest stream unavailable"
         ) from exc

--- a/src/dev_health_ops/api/external_ingest/stream_health.py
+++ b/src/dev_health_ops/api/external_ingest/stream_health.py
@@ -1,0 +1,113 @@
+"""Liveness/lag observability for external-ingest streams (CHAOS-2693 D9).
+
+Mirrors the existing ``workers/queue_monitor.py`` convention (structured
+logs, no new table -- no Prometheus/statsd exporter exists anywhere in this
+codebase today) applied to Redis Streams instead of the Celery broker:
+``SCAN``s ``external-ingest:*:batches``/``external-ingest:*:dlq``, and per
+stream logs depth (``XLEN``), pending-entry count, and the oldest pending
+entry's idle time (``XPENDING``), warning above thresholds analogous to
+``queue_monitor.py``'s ``QUEUE_DEPTH_WARNING_THRESHOLD``/
+``QUEUE_AGE_WARNING_SECONDS``.
+
+Beat-scheduled every 60s on the ``monitoring`` queue (``workers/config.py``)
+-- the same dedicated telemetry queue ``monitor_queue_depths`` uses, so this
+keeps reporting even if ``default``/``external-ingest`` floods.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from .streams import CONSUMER_GROUP, get_redis_client
+
+logger = logging.getLogger(__name__)
+
+STREAM_DEPTH_WARNING_THRESHOLD = 200
+STREAM_AGE_WARNING_MS = 600_000  # 10 minutes
+
+
+def _oldest_pending_idle_ms(rc: Any, stream_key: str) -> int | None:
+    """Idle time (ms) of the lowest-ID (oldest-delivered) pending entry.
+
+    A cheap proxy for "oldest pending age": ``XPENDING``'s plain summary
+    form reports count/min-id/max-id/per-consumer counts but not idle time;
+    the extended (range) form with ``count=1`` returns the single
+    lowest-ID pending entry, which in a FIFO consumer-group PEL is also the
+    entry that has been outstanding longest in the common case (its ID
+    ordering is unaffected by reclaim).
+    """
+    try:
+        oldest = rc.xpending_range(
+            stream_key, CONSUMER_GROUP, min="-", max="+", count=1
+        )
+    except Exception:
+        logger.debug("xpending_range failed for %s", stream_key, exc_info=True)
+        return None
+    if not oldest:
+        return None
+    return int(oldest[0].get("time_since_delivered", 0) or 0)
+
+
+def _pending_count(rc: Any, stream_key: str) -> int:
+    try:
+        summary = rc.xpending(stream_key, CONSUMER_GROUP)
+    except Exception:
+        logger.debug("xpending failed for %s", stream_key, exc_info=True)
+        return 0
+    if not summary:
+        return 0
+    return int(summary.get("pending", 0) or 0)
+
+
+def report_stream_health() -> dict[str, Any]:
+    """Log depth/pending/oldest-idle for every discovered external-ingest
+    stream (batches + DLQ). Returns the same data for programmatic/test use.
+    """
+    rc = get_redis_client()
+    if rc is None:
+        logger.warning("external_ingest_stream_health: Redis unavailable")
+        return {"streams": []}
+
+    observed: list[dict[str, Any]] = []
+    for pattern in ("external-ingest:*:batches", "external-ingest:*:dlq"):
+        is_dlq = pattern.endswith(":dlq")
+        try:
+            stream_keys = list(rc.scan_iter(match=pattern, _type="stream"))
+        except Exception:
+            logger.exception("scan_iter failed for pattern %s", pattern)
+            continue
+
+        for stream_key in stream_keys:
+            try:
+                depth = int(rc.xlen(stream_key))
+            except Exception:
+                logger.exception("xlen failed for %s", stream_key)
+                continue
+
+            pending = 0 if is_dlq else _pending_count(rc, stream_key)
+            oldest_idle_ms = None if is_dlq else _oldest_pending_idle_ms(rc, stream_key)
+
+            stats = {
+                "stream": stream_key,
+                "is_dlq": is_dlq,
+                "depth": depth,
+                "pending": pending,
+                "oldest_pending_idle_ms": oldest_idle_ms,
+            }
+            observed.append(stats)
+            logger.info("external_ingest_stream_health", extra=stats)
+
+            if depth > STREAM_DEPTH_WARNING_THRESHOLD or (
+                oldest_idle_ms is not None and oldest_idle_ms > STREAM_AGE_WARNING_MS
+            ):
+                logger.warning("external_ingest_stream_backlog", extra=stats)
+
+    return {"streams": observed}
+
+
+__all__ = [
+    "report_stream_health",
+    "STREAM_DEPTH_WARNING_THRESHOLD",
+    "STREAM_AGE_WARNING_MS",
+]

--- a/src/dev_health_ops/api/external_ingest/streams.py
+++ b/src/dev_health_ops/api/external_ingest/streams.py
@@ -1,26 +1,64 @@
-"""Interim durable-stream writer for external-ingest batches (CHAOS-2691 D6).
+"""Durable-stream writer for external-ingest batches (CHAOS-2691 D6, hardened
+by CHAOS-2693).
 
 Real, not mocked: raises ``StreamUnavailableError`` on any failure so the
-router can fail closed with a 503 — never accept-and-warn (contrast with
+router can fail closed with a 503 -- never accept-and-warn (contrast with
 ``api/ingest/streams.py``'s legacy accept-and-warn behavior, which the epic
 explicitly rejects for the durability-focused external-ingest path).
 
-CHAOS-2693 hardens this into the full DLQ/consumer-group system and must
-preserve ``enqueue_batch()``'s signature and the stream-naming convention
-below without updating ``router.py``'s call site out from under it.
+Pointer-only transport (master-spec CC9/D2): the stream entry carries batch
+*metadata* only; the full payload lives in Postgres
+(``external_ingest_batch_payloads``, accessed via
+``dev_health_ops.external_ingest.payload_store``). The wave-1 interim
+inline-``payload`` field is dropped from the XADD fields here.
+
+**Fail-closed payload invariant (standing correctness guarantee, not just a
+deployment-sequencing note):** ``enqueue_batch()`` is ``async`` and, before
+writing the pointer, verifies via a cheap indexed
+``payload_store.payload_exists()`` check that the payload row is already
+durable. Absent row -> ``StreamUnavailableError`` (503), same as a Redis
+outage. This makes "a pointer must never become visible before its payload
+is durable" true regardless of caller ordering mistakes -- the router
+(CHAOS-2691, and its wave-4 CC22 rewire owned by CHAOS-2695) is expected to
+call ``payload_store.upsert_payload()`` and commit *before* calling this
+function, but the invariant holds even if a future caller gets that
+ordering wrong.
+
+Per-org stream/DLQ naming (master-spec CC10/D1): a single huge/bursty org's
+backlog must not delay another org's consumer-group progress, since Redis
+Streams delivers entries in strict ID order regardless of logical owner.
+``StreamConsumer.discover_streams()`` (``api/_stream_consumer.py``)
+resolves these via ``SCAN ... TYPE stream`` wildcard discovery
+(``external-ingest:*:batches``), so per-org keys need no separate registry.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from datetime import datetime
+from datetime import datetime, timezone
 
 logger = logging.getLogger(__name__)
 
+#: Consumer-group name shared by producer (documented here) and consumer
+#: (``consumer.py``) -- kept as one constant (master-spec CC10).
+CONSUMER_GROUP = "external-ingest-consumers"
+
+#: Matches the existing ingest/product-telemetry stream backpressure
+#: convention -- bounds by entry count, not bytes (D2's rationale for
+#: keeping payloads off the stream entirely).
+STREAM_MAXLEN = 100_000
+
 
 class StreamUnavailableError(Exception):
-    """Raised when the durable ingest stream cannot accept a write."""
+    """Raised when the durable ingest stream cannot accept a write.
+
+    Callers MUST map this to HTTP 503, never accept-and-warn (master-spec
+    CC11/D3) -- mirrors product-telemetry's ``raise ConnectionError(...)``,
+    stricter than legacy ``/api/v1/ingest``'s silent-drop-on-``False``. Also
+    raised when the payload-durability precondition (see module docstring)
+    cannot be verified or is not satisfied.
+    """
 
 
 def stream_name(org_id: str) -> str:
@@ -44,7 +82,39 @@ def get_redis_client():
         return None
 
 
-def enqueue_batch(
+async def _require_payload_durable(*, org_id: str, ingestion_id: str) -> None:
+    """Fail-closed precondition check: raises unless the payload row exists.
+
+    Opens its own short-lived session (rather than requiring callers to pass
+    one) so ``enqueue_batch()`` stays a self-contained precondition check --
+    correct regardless of whether the caller's own write transaction has
+    already committed by the time this runs (it must have, or this raises).
+    A Postgres error here (not just "row absent") is ALSO fail-closed: if we
+    cannot verify durability, we must not make the pointer visible either.
+    """
+    from dev_health_ops.db import get_postgres_session
+    from dev_health_ops.external_ingest import payload_store
+
+    try:
+        async with get_postgres_session() as session:
+            present = await payload_store.payload_exists(
+                session, ingestion_id=ingestion_id, org_id=org_id
+            )
+    except Exception as exc:
+        logger.exception(
+            "Failed to verify payload durability for ingestion_id=%s", ingestion_id
+        )
+        raise StreamUnavailableError(str(exc)) from exc
+
+    if not present:
+        raise StreamUnavailableError(
+            f"payload row missing for ingestion_id={ingestion_id!r} "
+            f"org_id={org_id!r} -- refusing to enqueue a pointer with no "
+            "durable payload behind it"
+        )
+
+
+async def enqueue_batch(
     *,
     org_id: str,
     ingestion_id: str,
@@ -52,23 +122,19 @@ def enqueue_batch(
     source_instance: str,
     schema_version: str,
     idempotency_key: str,
-    payload_json: str,
     record_count: int,
     window_started_at: datetime | None = None,
     window_ended_at: datetime | None = None,
 ) -> str:
-    """Write one batch to the durable stream. Returns the stream key.
+    """Durably enqueue a pointer to an already-persisted batch.
 
-    Raises StreamUnavailableError if Redis/Valkey is unavailable or the
-    write fails — CALLERS MUST map this to HTTP 503, never accept-and-warn.
-
-    ``record_count``/``window_started_at``/``window_ended_at`` are pointer
-    fields the CHAOS-2693 consumer/status-store need without deserializing
-    ``payload`` (master-spec CC9). Wave-1 interim: ``payload`` is still
-    XADD'd inline (nothing consumes it yet) — CHAOS-2693's PR drops that
-    param once the Postgres-backed payload store lands, updating this call
-    site as an approved, planned change.
+    Returns the stream key written to. Raises ``StreamUnavailableError`` if
+    the payload row is not yet durable (see module docstring), Redis/Valkey
+    is unavailable, or the write fails -- CALLERS MUST map this to HTTP 503,
+    never accept-and-warn.
     """
+    await _require_payload_durable(org_id=org_id, ingestion_id=ingestion_id)
+
     client = get_redis_client()
     if client is None:
         raise StreamUnavailableError("Redis/Valkey unavailable")
@@ -83,19 +149,60 @@ def enqueue_batch(
         "record_count": str(record_count),
         "window_started_at": window_started_at.isoformat() if window_started_at else "",
         "window_ended_at": window_ended_at.isoformat() if window_ended_at else "",
-        "payload": payload_json,
+        "enqueued_at": datetime.now(timezone.utc).isoformat(),
     }
     try:
-        client.xadd(stream, fields, maxlen=100000, approximate=True)
+        client.xadd(stream, fields, maxlen=STREAM_MAXLEN, approximate=True)
     except Exception as exc:
+        logger.exception("Failed to enqueue external-ingest batch %s", ingestion_id)
         raise StreamUnavailableError(str(exc)) from exc
     return stream
 
 
+async def reenqueue_batch(
+    *,
+    org_id: str,
+    ingestion_id: str,
+    source_system: str,
+    source_instance: str,
+    schema_version: str,
+    idempotency_key: str,
+    record_count: int,
+    window_started_at: datetime | None = None,
+    window_ended_at: datetime | None = None,
+) -> str:
+    """Re-drive a batch whose Postgres row exists but has no live consumer.
+
+    Thin wrapper around :func:`enqueue_batch` (brief Design Decision D2 /
+    Gap G3): a batch can reach Postgres (``status='accepted'``) while its
+    stream ``XADD`` fails or is trimmed before a consumer ever reads it.
+    Exposed here as the seam a future reconciler (CHAOS-2769, and
+    CHAOS-2695's wave-4 RETRY-idempotency-outcome path -- same
+    ``ingestion_id`` reused) calls; this issue does not itself schedule any
+    re-enqueue. The payload row is expected to already exist (that's the
+    premise of "re-drive"); :func:`enqueue_batch`'s fail-closed check still
+    applies.
+    """
+    return await enqueue_batch(
+        org_id=org_id,
+        ingestion_id=ingestion_id,
+        source_system=source_system,
+        source_instance=source_instance,
+        schema_version=schema_version,
+        idempotency_key=idempotency_key,
+        record_count=record_count,
+        window_started_at=window_started_at,
+        window_ended_at=window_ended_at,
+    )
+
+
 __all__ = [
+    "CONSUMER_GROUP",
+    "STREAM_MAXLEN",
     "StreamUnavailableError",
     "stream_name",
     "dlq_name",
     "get_redis_client",
     "enqueue_batch",
+    "reenqueue_batch",
 ]

--- a/src/dev_health_ops/external_ingest/errors.py
+++ b/src/dev_health_ops/external_ingest/errors.py
@@ -1,0 +1,25 @@
+"""Worker-side processing exception hierarchy (CHAOS-2693 D5).
+
+Pinned interface contract between this issue's consumer
+(``api/external_ingest/consumer.py``) and CHAOS-2697's worker
+(``external_ingest/processor.py::process_batch``), documented here rather
+than inline in the consumer so both issues import the same canonical type
+instead of each declaring their own (master-spec CC11/CC23).
+
+``process_batch`` must raise ``PermanentProcessingError`` for failures that
+can never succeed on retry (unsupported schema version, an envelope shape
+that survived API-layer validation but is structurally invalid) -- the
+consumer routes these straight to the DLQ, no reclaim. Any other exception
+is treated conservatively as transient (connection errors, timeouts,
+unclassified bugs) -- the consumer leaves the entry un-ACKed for
+``reclaim_stale()`` to retry, up to ``max_deliveries``.
+"""
+
+from __future__ import annotations
+
+
+class PermanentProcessingError(Exception):
+    """Non-retryable batch-processing failure: DLQ immediately, no reclaim."""
+
+
+__all__ = ["PermanentProcessingError"]

--- a/src/dev_health_ops/external_ingest/payload_store.py
+++ b/src/dev_health_ops/external_ingest/payload_store.py
@@ -1,0 +1,167 @@
+"""Raw-SQL accessors for ``external_ingest_batch_payloads`` (CHAOS-2693 D2).
+
+The durable stream carries a metadata *pointer* only -- never the raw batch
+JSON (see ``docs/architecture/external-ingest-stream-design.md``). The full
+payload lives here, in Postgres, keyed by ``ingestion_id``; the worker
+(CHAOS-2697) fetches it by pointer and deletes it on terminal status (D7).
+
+Table/model DDL is hosted by CHAOS-2694's migration ``0033`` and
+``models/external_ingest.py::ExternalIngestBatchPayload`` (master-spec
+CC19) -- this module owns only the read/write helpers, using raw
+parameterized ``text()`` SQL (house rule: no ORM-only paths for API
+persistence) so it stays portable across the sqlite-in-memory engine used
+by unit tests and real Postgres in production (no ``RETURNING``/
+``ON CONFLICT``).
+
+``upsert_payload`` is a SELECT-then-UPDATE-or-INSERT in the caller's own
+transaction (master-spec CC22, post-critique CC22): a RETRY accept (same
+``ingestion_id`` reused for both the ``stream_unavailable`` case -- row
+still exists, worker never ran -- and the ``failed`` case -- worker may have
+already deleted the row) must not collide on the primary key. The
+idempotency row (``external_ingest_batches``, unique-indexed, written first
+in the same accept transaction by the caller) is the serialization point
+for concurrent same-key accepts; the residual sub-ms concurrent-insert race
+surfaces as ``503 ingest_temporarily_unavailable`` upstream (CHAOS-2695),
+not as a constraint violation here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession
+
+_TABLE = "external_ingest_batch_payloads"
+
+
+async def upsert_payload(
+    session: AsyncSession,
+    *,
+    ingestion_id: uuid.UUID | str,
+    org_id: str,
+    schema_version: str,
+    payload_bytes: bytes,
+) -> None:
+    """Write (or refresh) the raw-payload row for ``ingestion_id``.
+
+    Does NOT commit -- caller commits once the accept sequence's other
+    writes (the ``external_ingest_batches`` status row) also succeed, so a
+    payload row is never durable without its corresponding status row (and
+    vice versa is fine: the status row is written first in CC22's pinned
+    sequence, so a crash between the two leaves an orphaned status row, not
+    an orphaned payload -- see brief Risk G3).
+    """
+    ingestion_id_str = str(ingestion_id)
+    existing = (
+        await session.execute(
+            text(
+                f"SELECT 1 FROM {_TABLE} "
+                "WHERE ingestion_id = :ingestion_id AND org_id = :org_id"
+            ),
+            {"ingestion_id": ingestion_id_str, "org_id": org_id},
+        )
+    ).first()
+
+    params = {
+        "ingestion_id": ingestion_id_str,
+        "org_id": org_id,
+        "schema_version": schema_version,
+        "payload_json": payload_bytes,
+        "byte_size": len(payload_bytes),
+        # Python-side UTC timestamp, not SQL now() -- keeps this portable
+        # across the sqlite-in-memory engine used by unit tests and real
+        # Postgres in prod (matches tests/test_rate_limit_observations.py's
+        # convention).
+        "created_at": datetime.now(timezone.utc),
+    }
+
+    if existing:
+        await session.execute(
+            text(
+                f"UPDATE {_TABLE} SET schema_version = :schema_version, "
+                "payload_json = :payload_json, byte_size = :byte_size, "
+                "created_at = :created_at "
+                "WHERE ingestion_id = :ingestion_id AND org_id = :org_id"
+            ),
+            params,
+        )
+    else:
+        await session.execute(
+            text(
+                f"INSERT INTO {_TABLE} "
+                "(ingestion_id, org_id, schema_version, payload_json, byte_size, created_at) "
+                "VALUES (:ingestion_id, :org_id, :schema_version, :payload_json, "
+                ":byte_size, :created_at)"
+            ),
+            params,
+        )
+
+
+async def payload_exists(
+    session: AsyncSession, *, ingestion_id: uuid.UUID | str, org_id: str
+) -> bool:
+    """Cheap indexed existence check -- ``SELECT 1``, no payload bytes.
+
+    Backs ``streams.enqueue_batch()``'s fail-closed invariant (a pointer
+    must never become visible on the stream before its payload is durable
+    in Postgres): unlike :func:`fetch_payload`, this never transfers the
+    (possibly multi-MB) blob just to answer a yes/no question.
+    """
+    row = (
+        await session.execute(
+            text(
+                f"SELECT 1 FROM {_TABLE} "
+                "WHERE ingestion_id = :ingestion_id AND org_id = :org_id"
+            ),
+            {"ingestion_id": str(ingestion_id), "org_id": org_id},
+        )
+    ).first()
+    return row is not None
+
+
+async def fetch_payload(
+    session: AsyncSession, *, ingestion_id: uuid.UUID | str, org_id: str
+) -> bytes | None:
+    """Read the raw payload bytes for ``ingestion_id``.
+
+    ``org_id`` is included in the predicate even though ``ingestion_id``
+    alone is already a unique primary key -- defense in depth against a
+    leaked/guessed UUID crossing tenants (house rule: org_id in every
+    lookup predicate).
+    """
+    row = (
+        await session.execute(
+            text(
+                f"SELECT payload_json FROM {_TABLE} "
+                "WHERE ingestion_id = :ingestion_id AND org_id = :org_id"
+            ),
+            {"ingestion_id": str(ingestion_id), "org_id": org_id},
+        )
+    ).first()
+    if row is None:
+        return None
+    value = row[0]
+    # sqlite (unit tests) round-trips LargeBinary as bytes already; guard
+    # only for a driver returning e.g. memoryview.
+    return bytes(value) if not isinstance(value, bytes) else value
+
+
+async def delete_payload(
+    session: AsyncSession, *, ingestion_id: uuid.UUID | str
+) -> None:
+    """Delete the payload row. Idempotent: a no-op if already deleted.
+
+    No ``org_id`` predicate -- callers (the worker, on terminal status; the
+    beat-scheduled prune sweep, D7) already resolve ``ingestion_id``
+    tenant-scoped upstream, and this table has no secondary index that
+    would benefit from one.
+    """
+    await session.execute(
+        text(f"DELETE FROM {_TABLE} WHERE ingestion_id = :ingestion_id"),
+        {"ingestion_id": str(ingestion_id)},
+    )
+
+
+__all__ = ["upsert_payload", "payload_exists", "fetch_payload", "delete_payload"]

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -45,6 +45,13 @@ late_ack_excluded_tasks = (
     "dev_health_ops.workers.system_ops.send_billing_notification",
     "dev_health_ops.workers.tasks.run_ingest_consumer",
     "dev_health_ops.workers.tasks.run_product_telemetry_consumer",
+    "dev_health_ops.workers.tasks.run_external_ingest_consumer",
+    # CHAOS-2699's debounced recompute flush task (master-spec CC20; see the
+    # INTEGRATOR TODO atop workers/external_ingest_recompute.py). Valkey's
+    # SETNX debounce guard is the durability/dedup layer here, not Celery's
+    # acks-late redelivery -- reuses the existing `default` queue, no
+    # task_queues/compose change needed.
+    "dev_health_ops.workers.tasks.flush_external_ingest_recompute",
 )
 task_annotations = {
     task_name: {"acks_late": False, "reject_on_worker_lost": False}
@@ -108,6 +115,13 @@ task_queues: dict[str, dict[str, Any]] = {
     "backfill": {},
     "webhooks": {},
     "ingest": {},
+    # Dedicated queue (CHAOS-2693 D8), not the shared `ingest` queue:
+    # external-ingest is customer-facing, potentially spiky/large-batch, and
+    # must not have its processing throughput hostage to an unrelated
+    # internal consumer backlog (nor vice versa). Consumed by the dedicated
+    # `worker-external-ingest` container (compose.yml), single replica at
+    # --concurrency=1 (master-spec CC11 deployment invariant).
+    "external-ingest": {},
     "reports": {},
     "scheduler": {},
     # Dedicated telemetry queue: monitor_queue_depths must not share a queue
@@ -183,6 +197,23 @@ beat_schedule = {
         "schedule": stream_consumer_schedule_seconds,
         "kwargs": {"max_iterations": stream_consumer_max_iterations},
         "options": {"queue": "ingest", "expires": stream_consumer_expires_seconds},
+    },
+    "process-external-ingest-streams": {
+        "task": "dev_health_ops.workers.tasks.run_external_ingest_consumer",
+        "schedule": stream_consumer_schedule_seconds,
+        "kwargs": {"max_iterations": stream_consumer_max_iterations},
+        "options": {
+            "queue": "external-ingest",
+            "expires": stream_consumer_expires_seconds,
+        },
+    },
+    "external-ingest-stream-health": {
+        "task": "dev_health_ops.workers.tasks.external_ingest_stream_health",
+        "schedule": 60.0,
+        # Dedicated `monitoring` queue (matches monitor-queue-depths):
+        # telemetry must keep flowing even when `external-ingest` itself
+        # backs up -- that is exactly when it is needed.
+        "options": {"queue": "monitoring"},
     },
     "phone-home-heartbeat": {
         "task": "dev_health_ops.workers.tasks.phone_home_heartbeat",

--- a/src/dev_health_ops/workers/system_ops.py
+++ b/src/dev_health_ops/workers/system_ops.py
@@ -38,6 +38,33 @@ def run_product_telemetry_consumer(self, max_iterations: int = 100):
     return {"processed": processed}
 
 
+@celery_app.task(
+    bind=True,
+    queue="external-ingest",
+    name="dev_health_ops.workers.tasks.run_external_ingest_consumer",
+)
+def run_external_ingest_consumer(self, max_iterations: int = 100):
+    """Process buffered external-ingest stream entries (CHAOS-2693)."""
+    from dev_health_ops.api.external_ingest.consumer import (
+        consume_external_ingest_streams,
+    )
+
+    processed = consume_external_ingest_streams(max_iterations=max_iterations)
+    return {"processed": processed}
+
+
+@celery_app.task(
+    bind=True,
+    queue="monitoring",
+    name="dev_health_ops.workers.tasks.external_ingest_stream_health",
+)
+def external_ingest_stream_health(self) -> dict:
+    """Log external-ingest stream depth/lag telemetry (CHAOS-2693 D9)."""
+    from dev_health_ops.api.external_ingest.stream_health import report_stream_health
+
+    return report_stream_health()
+
+
 @celery_app.task(bind=True, name="dev_health_ops.workers.tasks.health_check")
 def health_check(self) -> dict:
     """Simple health check task to verify worker is running."""

--- a/src/dev_health_ops/workers/system_tasks.py
+++ b/src/dev_health_ops/workers/system_tasks.py
@@ -1,6 +1,8 @@
 from dev_health_ops.workers.system_ops import (
+    external_ingest_stream_health,
     health_check,
     phone_home_heartbeat,
+    run_external_ingest_consumer,
     run_ingest_consumer,
     run_product_telemetry_consumer,
     send_billing_notification,
@@ -8,9 +10,11 @@ from dev_health_ops.workers.system_ops import (
 from dev_health_ops.workers.system_webhooks import process_webhook_event
 
 __all__ = [
+    "external_ingest_stream_health",
     "health_check",
     "phone_home_heartbeat",
     "process_webhook_event",
+    "run_external_ingest_consumer",
     "run_ingest_consumer",
     "run_product_telemetry_consumer",
     "send_billing_notification",

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -1,3 +1,4 @@
+import dev_health_ops.workers.external_ingest_recompute  # noqa: F401
 from dev_health_ops.workers.external_ingest_reconciler import (
     prune_external_ingest_batches,
 )
@@ -31,9 +32,11 @@ from dev_health_ops.workers.sync_units import (
     run_sync_unit,
 )
 from dev_health_ops.workers.system_tasks import (
+    external_ingest_stream_health,
     health_check,
     phone_home_heartbeat,
     process_webhook_event,
+    run_external_ingest_consumer,
     run_ingest_consumer,
     run_product_telemetry_consumer,
     send_billing_notification,
@@ -69,6 +72,7 @@ __all__ = [
     "dispatch_scheduled_syncs",
     "dispatch_sync_run",
     "execute_saved_report",
+    "external_ingest_stream_health",
     "health_check",
     "monitor_queue_depths",
     "phone_home_heartbeat",
@@ -83,6 +87,7 @@ __all__ = [
     "run_daily_metrics_batch",
     "run_daily_metrics_finalize_task",
     "run_dora_metrics",
+    "run_external_ingest_consumer",
     "run_ingest_consumer",
     "run_investment_materialize",
     "run_investment_materialize_chunk",

--- a/tests/api/test_external_ingest_consumer.py
+++ b/tests/api/test_external_ingest_consumer.py
@@ -186,6 +186,42 @@ class TestPermanentFailure:
         assert kwargs["ingestion_id"] == "ingest-marks-failed"
         assert kwargs["reason"] == "nope"
 
+    def test_mark_batch_failed_raising_leaves_entry_unacked(
+        self, fake_redis, monkeypatch
+    ):
+        """Adversarial-review round-2: a DLQ-written entry must NOT be ACKed
+        when the failed-status write raised -- otherwise the batch strands in
+        a non-terminal status while the entry is gone. Leaving it pending
+        lets a later redelivery retry the status write (a duplicate DLQ entry
+        on that retry is accepted operational noise)."""
+        fake_processor = types.ModuleType("dev_health_ops.external_ingest.processor")
+        mark_failed = AsyncMock(side_effect=RuntimeError("pg down"))
+        setattr(fake_processor, "mark_batch_failed", mark_failed)
+        monkeypatch.setitem(
+            sys.modules, "dev_health_ops.external_ingest.processor", fake_processor
+        )
+
+        stream, _entry_id = _xadd_batch(
+            fake_redis, org_id="org-mark-raises", ingestion_id="ingest-mark-raises"
+        )
+        c = _consumer()
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(side_effect=PermanentProcessingError("nope")),
+        ):
+            c.consume(max_iterations=1)
+
+        mark_failed.assert_awaited_once()
+        # DLQ entry was written...
+        dlq_entries = fake_redis.xrange("external-ingest:org-mark-raises:dlq")
+        assert len(dlq_entries) == 1
+        # ...but the source entry remains pending (NOT acked) for a retry.
+        pending = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert len(pending) == 1
+
     def test_missing_processor_module_does_not_crash_consumer(self, fake_redis):
         """Before CHAOS-2697 lands, processor.py doesn't exist -- the
         give-up path must log and continue, not crash the consumer loop."""

--- a/tests/api/test_external_ingest_consumer.py
+++ b/tests/api/test_external_ingest_consumer.py
@@ -1,0 +1,706 @@
+"""Tests for the external-ingest consumer: retry/reclaim, DLQ, and the
+idempotent-skip guard (CHAOS-2693 D4/D5/CC11).
+
+Uses ``fakeredis.FakeValkey`` (confirmed to implement XPENDING/XCLAIM/XRANGE
+-- see brief Risk 4) end-to-end through ``consumer.consume()`` rather than a
+hand-rolled fake, so the assertions exercise the real XREADGROUP/XPENDING/
+XCLAIM/XACK sequence.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import time
+import types
+import uuid
+from contextlib import asynccontextmanager
+from unittest.mock import AsyncMock, patch
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+fakeredis = pytest.importorskip("fakeredis")
+from fakeredis import FakeValkey  # noqa: E402
+
+from dev_health_ops.api.external_ingest import consumer as consumer_mod
+from dev_health_ops.api.external_ingest import status as status_mod
+from dev_health_ops.external_ingest.errors import PermanentProcessingError
+from dev_health_ops.models.external_ingest import (
+    ExternalIngestBatch,
+    ExternalIngestRejection,
+)
+from dev_health_ops.models.git import Base
+from tests._helpers import tables_of
+
+_STATUS_TABLES = tables_of(ExternalIngestBatch, ExternalIngestRejection)
+
+# Captured at collection time (before the module-wide `_not_terminal`
+# autouse fixture below ever runs) so TestIdempotentSkipGuardRealStatusStore
+# can explicitly restore the real implementation regardless of fixture
+# ordering between that blanket stub and this class's own fixtures.
+_REAL_IS_BATCH_TERMINAL_ASYNC = (
+    consumer_mod.ExternalIngestStreamConsumer._is_batch_terminal_async
+)
+# Same rationale, for the module-wide `_processor_available` autouse stub.
+_REAL_PROCESSOR_AVAILABLE = consumer_mod._processor_available
+
+
+@pytest.fixture
+def fake_redis():
+    return FakeValkey(decode_responses=True)
+
+
+def _consumer(**overrides) -> consumer_mod.ExternalIngestStreamConsumer:
+    inst = consumer_mod.ExternalIngestStreamConsumer(consumer_name="test-consumer")
+    for key, value in overrides.items():
+        setattr(inst, key, value)
+    return inst
+
+
+def _xadd_batch(
+    rc,
+    org_id: str = "org-1",
+    ingestion_id: str | None = None,
+    source_system: str = "github",
+) -> tuple[str, str]:
+    stream = f"external-ingest:{org_id}:batches"
+    ingestion_id = ingestion_id or str(uuid.uuid4())
+    entry_id = rc.xadd(
+        stream,
+        {
+            "ingestion_id": ingestion_id,
+            "org_id": org_id,
+            "source_system": source_system,
+            "source_instance": "acme/api",
+            "schema_version": "external-ingest.v1",
+            "idempotency_key": "key-1",
+            "record_count": "1",
+        },
+    )
+    return stream, entry_id
+
+
+@pytest.fixture(autouse=True)
+def _patch_client(monkeypatch, fake_redis):
+    monkeypatch.setattr(
+        consumer_mod.StreamConsumer, "get_client", lambda self: fake_redis
+    )
+
+
+@pytest.fixture(autouse=True)
+def _not_terminal(monkeypatch):
+    """By default, no batch is terminal -- most tests exercise processing,
+    not the idempotent-skip guard (which has its own dedicated tests)."""
+    monkeypatch.setattr(
+        consumer_mod.ExternalIngestStreamConsumer,
+        "_is_batch_terminal_async",
+        AsyncMock(return_value=False),
+    )
+
+
+@pytest.fixture(autouse=True)
+def _processor_available(monkeypatch):
+    """By default, treat CHAOS-2697's processor module as available -- most
+    tests exercise retry/DLQ/reclaim mechanics that assume a real processor
+    exists; the deployment-order guard itself has its own dedicated tests
+    (TestProcessorAvailabilityGuard) that override this back to False."""
+    monkeypatch.setattr(consumer_mod, "_processor_available", lambda: True)
+
+
+class TestHappyPath:
+    def test_success_acks_and_not_pending(self, fake_redis):
+        stream, entry_id = _xadd_batch(fake_redis)
+        c = _consumer()
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(return_value=1),
+        ):
+            processed = c.consume(max_iterations=1)
+
+        assert processed == 1
+        pending = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert pending == []
+
+
+class TestPermanentFailure:
+    def test_lands_on_dlq_with_reason_and_is_acked(self, fake_redis):
+        stream, entry_id = _xadd_batch(fake_redis, org_id="org-perm")
+        c = _consumer()
+        with (
+            patch.object(
+                consumer_mod.ExternalIngestStreamConsumer,
+                "_process_entry_async",
+                AsyncMock(side_effect=PermanentProcessingError("bad schema_version")),
+            ),
+            patch.object(
+                consumer_mod.ExternalIngestStreamConsumer,
+                "_mark_batch_failed_best_effort",
+                lambda self, **kwargs: None,
+            ),
+        ):
+            processed = c.consume(max_iterations=1)
+
+        assert processed == 0
+        pending = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert pending == []  # ACKed, not left pending
+
+        dlq_entries = fake_redis.xrange("external-ingest:org-perm:dlq")
+        assert len(dlq_entries) == 1
+        _dlq_id, dlq_data = dlq_entries[0]
+        assert dlq_data["reason"] == "bad schema_version"
+        assert dlq_data["original_stream"] == stream
+        assert dlq_data["entry_id"] == entry_id
+
+    def test_calls_mark_batch_failed(self, fake_redis, monkeypatch):
+        # dev_health_ops.external_ingest.processor is CHAOS-2697's module and
+        # does not exist yet in this issue's scope -- inject a stand-in so we
+        # can assert the give-up path calls it exactly as CC23 pins, without
+        # depending on 2697 having landed.
+        fake_processor = types.ModuleType("dev_health_ops.external_ingest.processor")
+        mark_failed = AsyncMock()
+        setattr(
+            fake_processor, "mark_batch_failed", mark_failed
+        )  # ModuleType has no static attr
+        monkeypatch.setitem(
+            sys.modules, "dev_health_ops.external_ingest.processor", fake_processor
+        )
+
+        stream, entry_id = _xadd_batch(fake_redis, ingestion_id="ingest-marks-failed")
+        c = _consumer()
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(side_effect=PermanentProcessingError("nope")),
+        ):
+            c.consume(max_iterations=1)
+
+        mark_failed.assert_awaited_once()
+        _args, kwargs = mark_failed.call_args
+        assert kwargs["ingestion_id"] == "ingest-marks-failed"
+        assert kwargs["reason"] == "nope"
+
+    def test_missing_processor_module_does_not_crash_consumer(self, fake_redis):
+        """Before CHAOS-2697 lands, processor.py doesn't exist -- the
+        give-up path must log and continue, not crash the consumer loop."""
+        stream, _entry_id = _xadd_batch(fake_redis, org_id="org-no-processor")
+        c = _consumer()
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(side_effect=PermanentProcessingError("nope")),
+        ):
+            processed = c.consume(max_iterations=1)  # must not raise
+
+        assert processed == 0
+        assert fake_redis.xrange("external-ingest:org-no-processor:dlq")
+
+
+class TestTransientFailure:
+    def test_left_unacked_and_still_pending(self, fake_redis):
+        stream, entry_id = _xadd_batch(fake_redis)
+        c = _consumer()
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(side_effect=RuntimeError("clickhouse blip")),
+        ):
+            processed = c.consume(max_iterations=1)
+
+        assert processed == 0
+        pending = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert len(pending) == 1
+        assert pending[0]["message_id"] == entry_id
+
+    def test_not_routed_to_dlq_on_first_transient_failure(self, fake_redis):
+        stream, _entry_id = _xadd_batch(fake_redis, org_id="org-transient")
+        c = _consumer()
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(side_effect=RuntimeError("blip")),
+        ):
+            c.consume(max_iterations=1)
+
+        assert fake_redis.xrange("external-ingest:org-transient:dlq") == []
+
+
+class TestReclaim:
+    def test_stale_entry_under_max_deliveries_is_reclaimed_and_reprocessed(
+        self, fake_redis
+    ):
+        stream, entry_id = _xadd_batch(fake_redis, org_id="org-reclaim")
+        c = _consumer(reclaim_idle_ms=0)  # treat immediately-idle as stale
+
+        # First pass: process_entry fails transiently, entry stays pending.
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(side_effect=RuntimeError("blip")),
+        ):
+            c.consume(max_iterations=1)
+
+        pending_before = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert len(pending_before) == 1
+        assert pending_before[0]["times_delivered"] == 1
+
+        # Second pass: reclaim_stale() picks it up (idle=0 means everything
+        # is eligible), process_entry now succeeds.
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(return_value=1),
+        ):
+            processed = c.consume(max_iterations=1)
+
+        assert processed == 1
+        pending_after = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert pending_after == []
+
+    def test_entry_at_max_deliveries_is_given_up_not_reclaimed(
+        self, fake_redis, monkeypatch
+    ):
+        stream, entry_id = _xadd_batch(fake_redis, org_id="org-giveup")
+        c = _consumer(reclaim_idle_ms=0, max_deliveries=2)
+
+        # Deliberately exercise the REAL (unmocked) move_to_dlq ->
+        # _mark_batch_failed_best_effort -> run_async(...) path here rather
+        # than stubbing it out: this is the sync give-up call site invoked
+        # by the shared base's reclaim_stale() outside of any running event
+        # loop -- the async permanent-failure path (test_calls_mark_batch_failed
+        # above) exercises the awaited counterpart; this test is the sync
+        # counterpart's regression coverage for the same class of bug (a
+        # nested/re-entrant run_async() call would raise here).
+        fake_processor = types.ModuleType("dev_health_ops.external_ingest.processor")
+        mark_failed = AsyncMock()
+        setattr(
+            fake_processor, "mark_batch_failed", mark_failed
+        )  # ModuleType has no static attr
+        monkeypatch.setitem(
+            sys.modules, "dev_health_ops.external_ingest.processor", fake_processor
+        )
+
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(side_effect=RuntimeError("still broken")),
+        ):
+            # 3 separate consume() calls (not one max_iterations=3 call),
+            # each preceded by a tiny sleep: fakeredis's XPENDING IDLE filter
+            # requires actual elapsed wall-clock ms (idle=0 does NOT mean
+            # "always eligible" -- see test_stream_consumer.py's identical
+            # note), and three iterations run back-to-back inside one
+            # consume() call can complete within the same 0ms tick,
+            # especially under -n-distributed parallel test load, making the
+            # give-up assertion below flaky without the explicit sleeps.
+            #
+            # iter 1: fresh read, delivery #1, fails, stays pending.
+            c.consume(max_iterations=1)
+            # iter 2: reclaim_stale sees delivery #1 < max_deliveries(2),
+            #         reclaims -> delivery #2, handle_entries fails again,
+            #         stays pending.
+            time.sleep(0.01)
+            c.consume(max_iterations=1)
+            # iter 3: reclaim_stale sees delivery #2 >= max_deliveries(2) ->
+            #         DLQ + ACK (give up), no 3rd XREADGROUP delivery.
+            time.sleep(0.01)
+            c.consume(max_iterations=1)
+
+        pending_after = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert pending_after == []
+        dlq_entries = fake_redis.xrange("external-ingest:org-giveup:dlq")
+        assert len(dlq_entries) == 1
+        assert dlq_entries[0][1]["reason"] == "max_deliveries_exceeded"
+        assert dlq_entries[0][1]["entry_id"] == entry_id
+        mark_failed.assert_awaited_once()
+        _args, kwargs = mark_failed.call_args
+        assert kwargs["reason"] == "max_deliveries_exceeded"
+
+
+class TestPerOrgDlqIsolation:
+    def test_two_orgs_poison_entries_land_on_distinct_dlq_streams(self, fake_redis):
+        _xadd_batch(fake_redis, org_id="org-a", ingestion_id="a-1")
+        _xadd_batch(fake_redis, org_id="org-b", ingestion_id="b-1")
+        c = _consumer()
+
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(side_effect=PermanentProcessingError("bad")),
+        ):
+            c.consume(max_iterations=1)
+
+        dlq_a = fake_redis.xrange("external-ingest:org-a:dlq")
+        dlq_b = fake_redis.xrange("external-ingest:org-b:dlq")
+        assert len(dlq_a) == 1
+        assert len(dlq_b) == 1
+        assert dlq_a[0][1]["ingestion_id"] == "a-1"
+        assert dlq_b[0][1]["ingestion_id"] == "b-1"
+
+
+class TestMoveToDlqFailureIsSwallowed:
+    @staticmethod
+    def _broken_dlq_client():
+        class BrokenOnDlqOnly(FakeValkey):
+            def xadd(self, name, *args, **kwargs):
+                if name.endswith(":dlq"):
+                    raise ConnectionError("dlq write failed")
+                return super().xadd(name, *args, **kwargs)
+
+        return BrokenOnDlqOnly(decode_responses=True)
+
+    def test_broken_dlq_xadd_does_not_propagate(self):
+        broken = self._broken_dlq_client()
+        _stream, _entry_id = _xadd_batch(broken)
+        c = _consumer()
+
+        with (
+            patch.object(
+                consumer_mod.StreamConsumer, "get_client", lambda self: broken
+            ),
+            patch.object(
+                consumer_mod.ExternalIngestStreamConsumer,
+                "_process_entry_async",
+                AsyncMock(side_effect=PermanentProcessingError("bad")),
+            ),
+        ):
+            processed = c.consume(max_iterations=1)  # must not raise
+
+        assert processed == 0
+
+    def test_broken_dlq_xadd_leaves_entry_unacked_not_lost(self):
+        """Adversarial-review finding: a DLQ write failure must not still
+        ACK the source entry -- that would silently lose a poison message
+        with no DLQ record and no way to retry the DLQ write. The entry
+        must stay in the PEL so a later poll retries the DLQ write."""
+        broken = self._broken_dlq_client()
+        stream, entry_id = _xadd_batch(broken, org_id="org-dlq-broken")
+        c = _consumer()
+
+        with (
+            patch.object(
+                consumer_mod.StreamConsumer, "get_client", lambda self: broken
+            ),
+            patch.object(
+                consumer_mod.ExternalIngestStreamConsumer,
+                "_process_entry_async",
+                AsyncMock(side_effect=PermanentProcessingError("bad")),
+            ),
+        ):
+            c.consume(max_iterations=1)
+
+        pending = broken.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert len(pending) == 1
+        assert pending[0]["message_id"] == entry_id
+        assert broken.xrange("external-ingest:org-dlq-broken:dlq") == []
+
+    def test_reclaim_give_up_with_broken_dlq_leaves_entry_pending(self):
+        """Same finding, exercised via the base's synchronous
+        reclaim_stale() give-up path (move_to_dlq) rather than the async
+        permanent-failure path."""
+        broken = self._broken_dlq_client()
+        stream, entry_id = _xadd_batch(broken, org_id="org-dlq-broken-reclaim")
+        c = _consumer(reclaim_idle_ms=0, max_deliveries=1)
+
+        with (
+            patch.object(
+                consumer_mod.StreamConsumer, "get_client", lambda self: broken
+            ),
+            patch.object(
+                consumer_mod.ExternalIngestStreamConsumer,
+                "_process_entry_async",
+                AsyncMock(side_effect=RuntimeError("transient")),
+            ),
+        ):
+            c.consume(max_iterations=1)  # delivery 1, transient, stays pending
+            time.sleep(0.01)
+            # reclaim_stale sees times_delivered(1) >= max_deliveries(1) ->
+            # give-up path -> move_to_dlq -> DLQ write fails -> must NOT ack.
+            c.consume(max_iterations=1)
+
+        pending = broken.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert len(pending) == 1
+        assert pending[0]["message_id"] == entry_id
+        assert broken.xrange("external-ingest:org-dlq-broken-reclaim:dlq") == []
+
+
+class TestProcessorAvailabilityGuard:
+    """Deployment-order guard (adversarial-review finding): before
+    CHAOS-2697 ships, the consumer must refuse to claim any stream entries
+    rather than draining them into a guaranteed-ImportError retry ladder."""
+
+    def test_consume_is_a_full_noop_when_processor_unavailable(
+        self, fake_redis, monkeypatch
+    ):
+        monkeypatch.setattr(consumer_mod, "_processor_available", lambda: False)
+        stream, entry_id = _xadd_batch(fake_redis)
+        c = _consumer()
+
+        processed = c.consume(max_iterations=1)
+
+        assert processed == 0
+        # No XREADGROUP/consumer-group activity at all: the entry was never
+        # even delivered once (no PEL entry), unlike the transient-failure
+        # case which delivers then leaves it pending.
+        assert fake_redis.xlen(stream) == 1
+        with_group = fake_redis.exists(stream)
+        assert with_group  # stream itself untouched, still has our entry
+
+    def test_consume_proceeds_normally_when_processor_available(
+        self, fake_redis, monkeypatch
+    ):
+        monkeypatch.setattr(consumer_mod, "_processor_available", lambda: True)
+        _stream, _entry_id = _xadd_batch(fake_redis)
+        c = _consumer()
+
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(return_value=1),
+        ):
+            processed = c.consume(max_iterations=1)
+
+        assert processed == 1
+
+    def test_processor_available_reflects_real_import(self):
+        """Sanity check on the real (unmocked) helper: CHAOS-2697's module
+        genuinely does not exist yet at this issue's implementation time.
+        Uses the reference captured at collection time (module docstring
+        note above) since the autouse fixture in this file replaces
+        ``consumer_mod._processor_available`` for every other test."""
+        assert _REAL_PROCESSOR_AVAILABLE() is False
+
+
+class TestIdempotentSkipGuard:
+    def test_terminal_batch_is_acked_and_skipped_without_reprocessing(self, fake_redis):
+        stream, entry_id = _xadd_batch(fake_redis, ingestion_id="ingest-terminal")
+        c = _consumer()
+        process_mock = AsyncMock(return_value=1)
+        with (
+            patch.object(
+                consumer_mod.ExternalIngestStreamConsumer,
+                "_is_batch_terminal_async",
+                AsyncMock(return_value=True),
+            ),
+            patch.object(
+                consumer_mod.ExternalIngestStreamConsumer,
+                "_process_entry_async",
+                process_mock,
+            ),
+        ):
+            processed = c.consume(max_iterations=1)
+
+        # Skipped (not "processed" -- terminal-skip returns 0 contribution)
+        # but ACKed regardless, and process_entry is never invoked.
+        assert processed == 0
+        process_mock.assert_not_awaited()
+        pending = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert pending == []
+
+
+class TestConsumeExternalIngestStreams:
+    def test_wires_batch_size_and_block_ms(self, fake_redis, monkeypatch):
+        captured = {}
+        orig_init = consumer_mod.ExternalIngestStreamConsumer.__init__
+
+        def spy_init(self, *args, **kwargs):
+            captured.update(kwargs)
+            orig_init(self, *args, **kwargs)
+
+        monkeypatch.setattr(
+            consumer_mod.ExternalIngestStreamConsumer, "__init__", spy_init
+        )
+        consumer_mod.consume_external_ingest_streams(max_iterations=0)
+        assert captured["block_ms"] == consumer_mod.BLOCK_MS
+        assert captured["batch_size"] == consumer_mod.BATCH_SIZE
+
+
+class TestIdempotentSkipGuardRealStatusStore:
+    """Exercises the guard against the real status.get_batch()/sqlite
+    integration (CHAOS-2694's store) rather than a mocked
+    ``_is_batch_terminal_async`` -- proves the actual query + status-value
+    comparison, not just the call site."""
+
+    @pytest.fixture(autouse=True)
+    def _use_real_terminal_check(self, monkeypatch):
+        # Undo the module-wide `_not_terminal` autouse stub (declared above,
+        # applies to every test by default) for this class specifically.
+        monkeypatch.setattr(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_is_batch_terminal_async",
+            _REAL_IS_BATCH_TERMINAL_ASYNC,
+        )
+
+    @pytest_asyncio.fixture
+    async def session_maker(self, tmp_path):
+        db_path = tmp_path / "external-ingest-consumer-status.db"
+        engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+        async with engine.begin() as conn:
+            await conn.run_sync(
+                lambda c: Base.metadata.create_all(c, tables=_STATUS_TABLES)
+            )
+        maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        try:
+            yield maker
+        finally:
+            await engine.dispose()
+
+    @pytest.fixture
+    def patched_db_session(self, monkeypatch, session_maker):
+        @asynccontextmanager
+        async def _fake_get_postgres_session():
+            async with session_maker() as s:
+                try:
+                    yield s
+                    await s.commit()
+                except Exception:
+                    await s.rollback()
+                    raise
+
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session", _fake_get_postgres_session
+        )
+
+    async def _seed_terminal_batch(
+        self, session_maker, *, ingestion_id: uuid.UUID, org_id: str
+    ) -> None:
+        async with session_maker() as s:
+            await status_mod.create_batch(
+                s,
+                ingestion_id=ingestion_id,
+                org_id=org_id,
+                idempotency_key="key-1",
+                payload_hash="hash-1",
+                source_system="github",
+                source_instance="acme/api",
+                producer=None,
+                producer_version=None,
+                schema_version="external-ingest.v1",
+                window_started_at=None,
+                window_ended_at=None,
+                items_received=1,
+            )
+            await s.commit()
+            await status_mod.mark_processing(
+                s, org_id=org_id, ingestion_id=ingestion_id
+            )
+            await s.commit()
+            await status_mod.complete_batch(
+                s,
+                org_id=org_id,
+                ingestion_id=ingestion_id,
+                items_accepted=1,
+                items_rejected=0,
+                rejections=[],
+            )
+            await s.commit()
+
+    def test_terminal_batch_is_skipped_and_acked(
+        self, fake_redis, session_maker, patched_db_session
+    ):
+        ingestion_id = uuid.uuid4()
+        asyncio.run(
+            self._seed_terminal_batch(
+                session_maker, ingestion_id=ingestion_id, org_id="org-1"
+            )
+        )
+
+        stream, entry_id = _xadd_batch(
+            fake_redis, org_id="org-1", ingestion_id=str(ingestion_id)
+        )
+        c = _consumer()
+        process_mock = AsyncMock(return_value=1)
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            process_mock,
+        ):
+            processed = c.consume(max_iterations=1)
+
+        assert processed == 0
+        process_mock.assert_not_awaited()
+        pending = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        assert pending == []
+
+    def test_non_terminal_batch_is_processed_normally(
+        self, fake_redis, session_maker, patched_db_session
+    ):
+        ingestion_id = uuid.uuid4()
+
+        async def _seed_accepted() -> None:
+            async with session_maker() as s:
+                await status_mod.create_batch(
+                    s,
+                    ingestion_id=ingestion_id,
+                    org_id="org-1",
+                    idempotency_key="key-1",
+                    payload_hash="hash-1",
+                    source_system="github",
+                    source_instance="acme/api",
+                    producer=None,
+                    producer_version=None,
+                    schema_version="external-ingest.v1",
+                    window_started_at=None,
+                    window_ended_at=None,
+                    items_received=1,
+                )
+                await s.commit()
+
+        asyncio.run(_seed_accepted())
+
+        _stream, _entry_id = _xadd_batch(
+            fake_redis, org_id="org-1", ingestion_id=str(ingestion_id)
+        )
+        c = _consumer()
+        process_mock = AsyncMock(return_value=1)
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            process_mock,
+        ):
+            processed = c.consume(max_iterations=1)
+
+        assert processed == 1
+        process_mock.assert_awaited_once()
+
+    def test_missing_batch_row_is_processed_normally(
+        self, fake_redis, session_maker, patched_db_session
+    ):
+        """No status row at all (e.g. status.py's write raced this
+        stream entry) -- fail open, process rather than skip."""
+        _stream, _entry_id = _xadd_batch(
+            fake_redis, org_id="org-1", ingestion_id=str(uuid.uuid4())
+        )
+        c = _consumer()
+        process_mock = AsyncMock(return_value=1)
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            process_mock,
+        ):
+            processed = c.consume(max_iterations=1)
+
+        assert processed == 1
+        process_mock.assert_awaited_once()

--- a/tests/api/test_external_ingest_router.py
+++ b/tests/api/test_external_ingest_router.py
@@ -63,13 +63,21 @@ async def _default_fake_upsert_payload(*args, **kwargs) -> None:
     return None
 
 
+class _FakeSession:
+    """Commit-only stand-in: accept_batch calls ``session.commit()`` directly
+    after the (mocked) ``upsert_payload``, so the fake must expose it."""
+
+    async def commit(self) -> None:
+        return None
+
+
 async def _fake_postgres_session_dep():
     # Router-contract tests don't need a database (module docstring) --
     # upsert_payload is mocked by default (see _default_fake_upsert_payload)
-    # so this session object is never actually used for real I/O; only the
+    # so this session object is never used for real I/O; only the
     # payload-persistence integration tests (test_external_ingest_router_
     # payload_persistence.py) exercise a real session.
-    yield None
+    yield _FakeSession()
 
 
 @pytest_asyncio.fixture
@@ -322,7 +330,10 @@ async def test_payload_too_large_rejected(client, monkeypatch):
 
 @pytest.mark.asyncio
 async def test_idempotency_header_matching_body_is_accepted(client, monkeypatch):
-    monkeypatch.setattr(router_mod, "enqueue_batch", lambda **kwargs: "stream-x")
+    async def _fake_enqueue(**kwargs) -> str:
+        return "stream-x"
+
+    monkeypatch.setattr(router_mod, "enqueue_batch", _fake_enqueue)
     envelope = _envelope(
         [_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])],
         idempotency_key="key-1",
@@ -362,6 +373,37 @@ async def test_stream_unavailable_returns_503(client, monkeypatch):
 
     assert resp.status_code == 503
     assert resp.json()["error"]["code"] == "stream_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_failure_deletes_orphan_payload(client, monkeypatch):
+    """Adversarial-review round-2: a 503 (stream unavailable) must not leave
+    the just-committed payload row behind -- each accept mints a fresh
+    ingestion_id in the interim flow, so customer retries of a 503 would
+    otherwise accumulate one orphan multi-MB row per attempt."""
+    upserted: list[str] = []
+    deleted: list[str] = []
+
+    async def _fake_upsert(session, *, ingestion_id, **kwargs):
+        upserted.append(str(ingestion_id))
+
+    async def _fake_delete(session, *, ingestion_id):
+        deleted.append(str(ingestion_id))
+
+    def _raise(**kwargs):
+        raise StreamUnavailableError("boom")
+
+    monkeypatch.setattr(router_mod, "upsert_payload", _fake_upsert)
+    monkeypatch.setattr(router_mod, "delete_payload", _fake_delete)
+    monkeypatch.setattr(router_mod, "enqueue_batch", _raise)
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 503
+    assert resp.json()["error"]["code"] == "stream_unavailable"
+    assert len(upserted) == 1
+    assert deleted == upserted  # the orphan row was cleaned up
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_external_ingest_router.py
+++ b/tests/api/test_external_ingest_router.py
@@ -55,8 +55,25 @@ TEST_CTX = IngestAuthContext(
 )
 
 
+async def _default_fake_enqueue(**kwargs) -> str:
+    return "stream-x"
+
+
+async def _default_fake_upsert_payload(*args, **kwargs) -> None:
+    return None
+
+
+async def _fake_postgres_session_dep():
+    # Router-contract tests don't need a database (module docstring) --
+    # upsert_payload is mocked by default (see _default_fake_upsert_payload)
+    # so this session object is never actually used for real I/O; only the
+    # payload-persistence integration tests (test_external_ingest_router_
+    # payload_persistence.py) exercise a real session.
+    yield None
+
+
 @pytest_asyncio.fixture
-async def client():
+async def client(monkeypatch):
     # Overriding require_ingest_scope (the factory) would not intercept
     # anything: router.py binds each scope's closure once at import time via
     # Depends(_require_schema_read)/Depends(_require_ingest_write), and
@@ -65,6 +82,17 @@ async def client():
     # unit tests never exercise D7's real (WARN-logging) interim auth body.
     app.dependency_overrides[router_mod._require_schema_read] = lambda: TEST_CTX
     app.dependency_overrides[router_mod._require_ingest_write] = lambda: TEST_CTX
+    app.dependency_overrides[router_mod.get_postgres_session_dep] = (
+        _fake_postgres_session_dep
+    )
+    # Amendment (team-lead-authorized router touch, see PR): accept_batch now
+    # persists the payload before enqueueing. Default both to working
+    # async no-ops so every existing contract-level test (envelope/kind/size
+    # validation, schema discovery, etc.) keeps not needing a database;
+    # individual tests below still override enqueue_batch for their own
+    # success/failure scenarios.
+    monkeypatch.setattr(router_mod, "enqueue_batch", _default_fake_enqueue)
+    monkeypatch.setattr(router_mod, "upsert_payload", _default_fake_upsert_payload)
     # raise_app_exceptions=False: Starlette's ServerErrorMiddleware sends the
     # sanitized 500 response *then* re-raises so ASGI-server-level logging
     # still sees it; without this, httpx's ASGITransport re-raises instead of
@@ -76,6 +104,7 @@ async def client():
     finally:
         app.dependency_overrides.pop(router_mod._require_schema_read, None)
         app.dependency_overrides.pop(router_mod._require_ingest_write, None)
+        app.dependency_overrides.pop(router_mod.get_postgres_session_dep, None)
 
 
 def _record(kind: str, external_id: str, payload: dict) -> dict:
@@ -149,7 +178,7 @@ def _envelope(records: list[dict], idempotency_key: str = "test-key-1") -> dict:
 async def test_accept_minimal_valid_batch(client, monkeypatch):
     calls = []
 
-    def fake_enqueue(**kwargs):
+    async def fake_enqueue(**kwargs):
         calls.append(kwargs)
         return "external-ingest:test-org:batches"
 
@@ -171,8 +200,7 @@ async def test_accept_minimal_valid_batch(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_accept_batch_with_all_nine_kinds(client, monkeypatch):
-    monkeypatch.setattr(router_mod, "enqueue_batch", lambda **kwargs: "stream-x")
+async def test_accept_batch_with_all_nine_kinds(client):
     records = [
         _record(kind, f"ext-{kind}", payload)
         for kind, payload in VALID_PAYLOADS.items()

--- a/tests/api/test_external_ingest_stream_health.py
+++ b/tests/api/test_external_ingest_stream_health.py
@@ -1,0 +1,85 @@
+"""Tests for external-ingest stream liveness/lag observability (CHAOS-2693 D9)."""
+
+from __future__ import annotations
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+from fakeredis import FakeValkey  # noqa: E402
+
+from dev_health_ops.api.external_ingest import stream_health
+from dev_health_ops.api.external_ingest.streams import CONSUMER_GROUP
+
+
+@pytest.fixture
+def fake_redis():
+    return FakeValkey(decode_responses=True)
+
+
+@pytest.fixture(autouse=True)
+def _patch_client(monkeypatch, fake_redis):
+    monkeypatch.setattr(stream_health, "get_redis_client", lambda: fake_redis)
+
+
+class TestReportStreamHealth:
+    def test_empty_when_no_streams_exist(self):
+        assert stream_health.report_stream_health() == {"streams": []}
+
+    def test_returns_none_streams_when_redis_unavailable(self, monkeypatch):
+        monkeypatch.setattr(stream_health, "get_redis_client", lambda: None)
+        assert stream_health.report_stream_health() == {"streams": []}
+
+    def test_reports_depth_and_pending_for_batches_stream(self, fake_redis):
+        stream = "external-ingest:org-1:batches"
+        fake_redis.xadd(stream, {"a": "1"})
+        fake_redis.xadd(stream, {"a": "2"})
+        fake_redis.xgroup_create(stream, CONSUMER_GROUP, id="0")
+        fake_redis.xreadgroup(CONSUMER_GROUP, "c1", streams={stream: ">"}, count=10)
+
+        result = stream_health.report_stream_health()
+
+        assert len(result["streams"]) == 1
+        stats = result["streams"][0]
+        assert stats["stream"] == stream
+        assert stats["is_dlq"] is False
+        assert stats["depth"] == 2
+        assert stats["pending"] == 2
+        assert stats["oldest_pending_idle_ms"] is not None
+
+    def test_reports_dlq_depth_without_pending_lookup(self, fake_redis):
+        dlq = "external-ingest:org-1:dlq"
+        fake_redis.xadd(dlq, {"reason": "poison"})
+
+        result = stream_health.report_stream_health()
+
+        assert len(result["streams"]) == 1
+        stats = result["streams"][0]
+        assert stats["stream"] == dlq
+        assert stats["is_dlq"] is True
+        assert stats["depth"] == 1
+        assert stats["pending"] == 0
+        assert stats["oldest_pending_idle_ms"] is None
+
+    def test_warns_above_depth_threshold(self, fake_redis, caplog):
+        stream = "external-ingest:org-1:batches"
+        for i in range(stream_health.STREAM_DEPTH_WARNING_THRESHOLD + 1):
+            fake_redis.xadd(stream, {"i": str(i)})
+
+        with caplog.at_level("WARNING"):
+            stream_health.report_stream_health()
+
+        assert any(
+            r.message == "external_ingest_stream_backlog" for r in caplog.records
+        )
+
+    def test_multiple_orgs_all_reported(self, fake_redis):
+        fake_redis.xadd("external-ingest:org-a:batches", {"a": "1"})
+        fake_redis.xadd("external-ingest:org-b:batches", {"a": "1"})
+
+        result = stream_health.report_stream_health()
+
+        streams = {s["stream"] for s in result["streams"]}
+        assert streams == {
+            "external-ingest:org-a:batches",
+            "external-ingest:org-b:batches",
+        }

--- a/tests/api/test_external_ingest_streams.py
+++ b/tests/api/test_external_ingest_streams.py
@@ -1,0 +1,298 @@
+"""Tests for the external-ingest durable-stream producer (CHAOS-2693).
+
+Covers D1 (per-org naming), D2 (pointer-only -- no payload on the stream),
+D3 (fail-closed StreamUnavailableError), the fail-closed payload-durability
+invariant (team-lead-authorized amendment, see PR), and the
+reenqueue_batch() seam.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock
+
+import pytest
+
+fakeredis = pytest.importorskip("fakeredis")
+from fakeredis import FakeValkey  # noqa: E402
+
+from dev_health_ops.api.external_ingest import streams
+
+# Captured at collection time (before the module-wide `_payload_durable`
+# autouse fixture below ever runs) so TestPayloadDurabilityInvariant can
+# restore the real implementation regardless of fixture ordering.
+_REAL_REQUIRE_PAYLOAD_DURABLE = streams._require_payload_durable
+
+
+@pytest.fixture
+def fake_redis():
+    return FakeValkey(decode_responses=True)
+
+
+@pytest.fixture
+def patched_client(monkeypatch, fake_redis):
+    monkeypatch.setattr(streams, "get_redis_client", lambda: fake_redis)
+    return fake_redis
+
+
+@pytest.fixture(autouse=True)
+def _payload_durable(monkeypatch):
+    """Default every test to "the payload row already exists" -- most tests
+    here exercise the Redis/XADD side; the fail-closed payload-durability
+    check itself has its own dedicated test class below."""
+    monkeypatch.setattr(
+        streams, "_require_payload_durable", AsyncMock(return_value=None)
+    )
+
+
+class TestNaming:
+    def test_stream_name_is_per_org_batches(self):
+        assert streams.stream_name("org-1") == "external-ingest:org-1:batches"
+
+    def test_dlq_name_is_per_org_dlq(self):
+        assert streams.dlq_name("org-1") == "external-ingest:org-1:dlq"
+
+    def test_two_orgs_get_distinct_streams(self):
+        assert streams.stream_name("org-a") != streams.stream_name("org-b")
+        assert streams.dlq_name("org-a") != streams.dlq_name("org-b")
+
+
+class TestEnqueueBatch:
+    def _kwargs(self, **overrides):
+        base = dict(
+            org_id="org-1",
+            ingestion_id="ingest-1",
+            source_system="github",
+            source_instance="acme/api",
+            schema_version="external-ingest.v1",
+            idempotency_key="key-1",
+            record_count=3,
+            window_started_at=datetime(2026, 7, 1, tzinfo=timezone.utc),
+            window_ended_at=datetime(2026, 7, 1, 1, tzinfo=timezone.utc),
+        )
+        base.update(overrides)
+        return base
+
+    @pytest.mark.asyncio
+    async def test_writes_one_entry_with_pointer_fields(
+        self, patched_client, fake_redis
+    ):
+        stream = await streams.enqueue_batch(**self._kwargs())
+
+        assert stream == "external-ingest:org-1:batches"
+        entries = fake_redis.xrange(stream)
+        assert len(entries) == 1
+        _entry_id, data = entries[0]
+        assert data["ingestion_id"] == "ingest-1"
+        assert data["org_id"] == "org-1"
+        assert data["source_system"] == "github"
+        assert data["source_instance"] == "acme/api"
+        assert data["schema_version"] == "external-ingest.v1"
+        assert data["idempotency_key"] == "key-1"
+        assert data["record_count"] == "3"
+        assert data["window_started_at"] == "2026-07-01T00:00:00+00:00"
+        assert data["window_ended_at"] == "2026-07-01T01:00:00+00:00"
+        assert "enqueued_at" in data
+
+    @pytest.mark.asyncio
+    async def test_never_writes_payload_to_the_stream(self, patched_client, fake_redis):
+        """D2: the stream carries a pointer only -- the payload lives in
+        Postgres, not on the entry (there's no ``payload``/``payload_json``
+        kwarg on ``enqueue_batch`` at all anymore)."""
+        stream = await streams.enqueue_batch(**self._kwargs())
+        _entry_id, data = fake_redis.xrange(stream)[0]
+        assert "payload" not in data
+        assert "payload_json" not in data
+
+    @pytest.mark.asyncio
+    async def test_maxlen_approximate_passed_on_every_xadd(self, monkeypatch):
+        calls = []
+
+        class SpyClient:
+            def xadd(self, stream, fields, maxlen=None, approximate=None):
+                calls.append({"maxlen": maxlen, "approximate": approximate})
+
+        monkeypatch.setattr(streams, "get_redis_client", lambda: SpyClient())
+        await streams.enqueue_batch(**self._kwargs())
+
+        assert calls == [{"maxlen": streams.STREAM_MAXLEN, "approximate": True}]
+
+    @pytest.mark.asyncio
+    async def test_raises_stream_unavailable_when_redis_url_unset(self, monkeypatch):
+        monkeypatch.setattr(streams, "get_redis_client", lambda: None)
+        with pytest.raises(streams.StreamUnavailableError):
+            await streams.enqueue_batch(**self._kwargs())
+
+    @pytest.mark.asyncio
+    async def test_raises_stream_unavailable_on_xadd_failure(self, monkeypatch):
+        class BrokenClient:
+            def xadd(self, *args, **kwargs):
+                raise ConnectionError("boom")
+
+        monkeypatch.setattr(streams, "get_redis_client", lambda: BrokenClient())
+        with pytest.raises(streams.StreamUnavailableError):
+            await streams.enqueue_batch(**self._kwargs())
+
+    @pytest.mark.asyncio
+    async def test_xadd_failure_is_not_silently_swallowed(self, monkeypatch):
+        """Regression test for D3/fail-closed: a raising xadd must propagate
+        as StreamUnavailableError, never return a falsy sentinel."""
+        calls = {"count": 0}
+
+        class BrokenClient:
+            def xadd(self, *args, **kwargs):
+                calls["count"] += 1
+                raise TimeoutError("no ack from valkey")
+
+        monkeypatch.setattr(streams, "get_redis_client", lambda: BrokenClient())
+        with pytest.raises(streams.StreamUnavailableError):
+            await streams.enqueue_batch(**self._kwargs())
+        assert calls["count"] == 1
+
+
+class TestPayloadDurabilityInvariant:
+    """team-lead-authorized amendment: enqueue_batch() must fail closed if
+    the payload row is not (yet) durable -- this converts what was a
+    deployment-sequencing hazard into a standing correctness guarantee.
+
+    Restores the real ``_require_payload_durable`` (undoing the module-wide
+    autouse bypass above) so these tests exercise the actual check.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _use_real_check(self, monkeypatch):
+        monkeypatch.setattr(
+            streams, "_require_payload_durable", _REAL_REQUIRE_PAYLOAD_DURABLE
+        )
+
+    def _kwargs(self, **overrides):
+        base = dict(
+            org_id="org-1",
+            ingestion_id="ingest-1",
+            source_system="github",
+            source_instance="acme/api",
+            schema_version="external-ingest.v1",
+            idempotency_key="key-1",
+            record_count=1,
+        )
+        base.update(overrides)
+        return base
+
+    class _FakeSessionCtx:
+        async def __aenter__(self):
+            return object()
+
+        async def __aexit__(self, *exc):
+            return False
+
+    class _FakeSessionCtxRaisesOnEnter:
+        async def __aenter__(self):
+            raise ConnectionError("postgres down")
+
+        async def __aexit__(self, *exc):
+            return False
+
+    @pytest.mark.asyncio
+    async def test_raises_when_payload_row_missing(self, monkeypatch, patched_client):
+        async def _fake_payload_exists(session, *, ingestion_id, org_id):
+            return False
+
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session", self._FakeSessionCtx
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.external_ingest.payload_store.payload_exists",
+            _fake_payload_exists,
+        )
+
+        with pytest.raises(streams.StreamUnavailableError, match="payload row missing"):
+            await streams.enqueue_batch(**self._kwargs())
+
+    @pytest.mark.asyncio
+    async def test_does_not_write_to_redis_when_payload_missing(
+        self, monkeypatch, fake_redis
+    ):
+        """The fail-closed check must run BEFORE the XADD -- a missing
+        payload row must never produce a pointer on the stream at all."""
+
+        async def _fake_payload_exists(session, *, ingestion_id, org_id):
+            return False
+
+        monkeypatch.setattr(streams, "get_redis_client", lambda: fake_redis)
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session", self._FakeSessionCtx
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.external_ingest.payload_store.payload_exists",
+            _fake_payload_exists,
+        )
+
+        with pytest.raises(streams.StreamUnavailableError):
+            await streams.enqueue_batch(**self._kwargs())
+
+        assert fake_redis.xrange(streams.stream_name("org-1")) == []
+
+    @pytest.mark.asyncio
+    async def test_raises_when_durability_check_itself_errors(self, monkeypatch):
+        """Cannot verify durability (e.g. Postgres down) -> fail closed too,
+        same as "row absent": never enqueue a pointer we can't vouch for."""
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session",
+            self._FakeSessionCtxRaisesOnEnter,
+        )
+
+        with pytest.raises(streams.StreamUnavailableError):
+            await streams.enqueue_batch(**self._kwargs())
+
+    @pytest.mark.asyncio
+    async def test_proceeds_when_payload_row_present(
+        self, monkeypatch, patched_client, fake_redis
+    ):
+        async def _fake_payload_exists(session, *, ingestion_id, org_id):
+            return True
+
+        monkeypatch.setattr(streams, "get_redis_client", lambda: patched_client)
+        monkeypatch.setattr(
+            "dev_health_ops.db.get_postgres_session", self._FakeSessionCtx
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.external_ingest.payload_store.payload_exists",
+            _fake_payload_exists,
+        )
+
+        stream = await streams.enqueue_batch(**self._kwargs())
+        assert fake_redis.xrange(stream)
+
+
+class TestReenqueueBatch:
+    @pytest.mark.asyncio
+    async def test_delegates_to_enqueue_batch_same_ids(
+        self, patched_client, fake_redis
+    ):
+        stream = await streams.reenqueue_batch(
+            org_id="org-1",
+            ingestion_id="ingest-1",
+            source_system="github",
+            source_instance="acme/api",
+            schema_version="external-ingest.v1",
+            idempotency_key="key-1",
+            record_count=3,
+        )
+        assert stream == "external-ingest:org-1:batches"
+        _entry_id, data = fake_redis.xrange(stream)[0]
+        assert data["ingestion_id"] == "ingest-1"
+        assert data["org_id"] == "org-1"
+
+    @pytest.mark.asyncio
+    async def test_propagates_stream_unavailable(self, monkeypatch):
+        monkeypatch.setattr(streams, "get_redis_client", lambda: None)
+        with pytest.raises(streams.StreamUnavailableError):
+            await streams.reenqueue_batch(
+                org_id="org-1",
+                ingestion_id="ingest-1",
+                source_system="github",
+                source_instance="acme/api",
+                schema_version="external-ingest.v1",
+                idempotency_key="key-1",
+                record_count=3,
+            )

--- a/tests/api/test_stream_consumer.py
+++ b/tests/api/test_stream_consumer.py
@@ -13,6 +13,7 @@ Covers the two defects this module was created to fix:
 
 from __future__ import annotations
 
+import time
 from typing import Any
 from unittest.mock import MagicMock, patch
 
@@ -239,3 +240,109 @@ def test_no_streams_returns_zero(monkeypatch):
 
     assert WildcardEmpty().consume(max_iterations=1) == 0
     assert redis.xreadgroup_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# Reclaim/redelivery extension (CHAOS-2693 D5) -- additive, default-off.
+# These assert the DEFAULTS leave existing consumers byte-for-byte
+# unaffected, and that reclaim_stale() itself behaves correctly when opted
+# in via a real fakeredis-backed consumer group (see
+# tests/api/test_external_ingest_consumer.py for the full retry/DLQ/give-up
+# behavioral suite against the real ExternalIngestStreamConsumer).
+# ---------------------------------------------------------------------------
+
+
+def test_reclaim_disabled_by_default_on_base_class():
+    assert StreamConsumer.enable_reclaim is False
+    assert StreamConsumer.reclaim_idle_ms == 900_000
+    assert StreamConsumer.max_deliveries == 5
+
+
+def test_reclaim_stale_is_a_noop_without_touching_redis_when_disabled():
+    """The whole point of default-off: no extra round-trip, ever, unless a
+    subclass opts in."""
+
+    class RaisesIfCalled:
+        def xpending_range(self, *args, **kwargs):
+            raise AssertionError("xpending_range must not be called when disabled")
+
+    consumer = _Consumer()
+    assert consumer.enable_reclaim is False
+    assert consumer.reclaim_stale(RaisesIfCalled(), "test:org:events") == []
+
+
+def test_consume_does_not_call_reclaim_stale_when_disabled(monkeypatch):
+    """Regression test for the ingest/product-telemetry consumers: consume()
+    must not even attempt reclaim_stale() when enable_reclaim is False."""
+    redis = FakeRedis([("1-0", {"ok": "1"})])
+    monkeypatch.setattr(base, "get_consumer_redis_client", lambda: redis)
+    calls: list[int] = []
+
+    def _spy_reclaim_stale(self, rc, stream_key):
+        calls.append(1)
+        return []
+
+    monkeypatch.setattr(_Consumer, "reclaim_stale", _spy_reclaim_stale)
+
+    _Consumer().consume(max_iterations=1)
+
+    assert calls == []
+
+
+class _ReclaimingConsumer(_Consumer):
+    consumer_group = "reclaim-consumers"
+    dlq_stream = "reclaim:dlq"
+    enable_reclaim = True
+    reclaim_idle_ms = 0
+    max_deliveries = 2
+
+
+def test_reclaim_stale_reclaims_entries_under_max_deliveries():
+    import fakeredis
+
+    # Explicit Any: fakeredis's stubs declare xpending_range/xclaim with a
+    # sync/async-overloaded signature; without this, mypy resolves the
+    # local `rc`'s method calls to `Awaitable[Any] | Any` and rejects
+    # indexing the (very much synchronous, at runtime) result below.
+    rc: Any = fakeredis.FakeValkey(decode_responses=True)
+    rc.xadd("s", {"a": "1"})
+    rc.xgroup_create("s", "reclaim-consumers", id="0")
+    rc.xreadgroup("reclaim-consumers", "c1", streams={"s": ">"}, count=10)
+    # fakeredis's XPENDING IDLE filter compares against elapsed wall-clock
+    # ms, not a >=0 always-true predicate -- a genuinely 0ms-old delivery
+    # (the common case at this granularity in a fast test) doesn't match
+    # `idle=0`. reclaim_idle_ms=900_000 in production makes this a non-issue
+    # (entries are always well past it by the time they're stale); here a
+    # tiny sleep makes "reclaim_idle_ms=0" reliably mean "everything is
+    # eligible", matching this test's intent.
+    time.sleep(0.01)
+
+    consumer = _ReclaimingConsumer(consumer_name="c2")
+    reclaimed = consumer.reclaim_stale(rc, "s")
+
+    assert len(reclaimed) == 1
+    pending = rc.xpending_range("s", "reclaim-consumers", min="-", max="+", count=10)
+    assert pending[0]["consumer"] == "c2"  # ownership transferred
+    assert pending[0]["times_delivered"] == 2
+
+
+def test_reclaim_stale_gives_up_at_max_deliveries():
+    import fakeredis
+
+    rc: Any = fakeredis.FakeValkey(decode_responses=True)
+    rc.xadd("s", {"a": "1"})
+    rc.xgroup_create("s", "reclaim-consumers", id="0")
+    # Deliver max_deliveries times via repeated reclaim (each reclaim bumps
+    # times_delivered by one, mirroring repeated XCLAIMs of the same entry).
+    rc.xreadgroup("reclaim-consumers", "c1", streams={"s": ">"}, count=10)
+
+    consumer = _ReclaimingConsumer(consumer_name="c2")
+    time.sleep(0.01)
+    consumer.reclaim_stale(rc, "s")  # times_delivered: 1 -> 2
+
+    time.sleep(0.01)
+    reclaimed = consumer.reclaim_stale(rc, "s")
+
+    assert reclaimed == []
+    pending = rc.xpending_range("s", "reclaim-consumers", min="-", max="+", count=10)
+    assert pending == []  # given up: DLQ'd + ACKed, no longer pending

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -642,7 +642,7 @@ def _helm_worker_queues(values_path: Path) -> set[str]:
     """Union of queue lists across every enabled worker pool in helm values."""
     values = _load_yaml(values_path)
     consumed: set[str] = set()
-    for pool in ("worker", "workerIngest", "workerHeavy"):
+    for pool in ("worker", "workerIngest", "workerExternalIngest", "workerHeavy"):
         cfg = values.get(pool) or {}
         if cfg.get("enabled") is False:
             continue

--- a/tests/test_external_ingest_payload_store.py
+++ b/tests/test_external_ingest_payload_store.py
@@ -1,0 +1,160 @@
+"""Tests for external_ingest.payload_store (CHAOS-2693 D2/CC22).
+
+Follows the confirmed sqlite-in-memory convention (no live-Postgres pytest
+marker exists in this codebase -- see tests/test_rate_limit_observations.py)
+adapted for async: aiosqlite + AsyncSession, matching
+tests/api/auth/test_invite_flow.py's fixture pattern (AGENTS.md explicitly
+allows aiosqlite for test fixtures).
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.external_ingest import payload_store
+from dev_health_ops.models.external_ingest import ExternalIngestBatchPayload
+from dev_health_ops.models.git import Base
+from tests._helpers import tables_of
+
+_TABLES = tables_of(ExternalIngestBatchPayload)
+
+
+@pytest_asyncio.fixture
+async def session():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as s:
+        yield s
+    await engine.dispose()
+
+
+def _uuid() -> uuid.UUID:
+    return uuid.uuid4()
+
+
+@pytest.mark.asyncio
+async def test_insert_fetch_delete_round_trip(session: AsyncSession):
+    ingestion_id = _uuid()
+    payload = b'{"records": [1, 2, 3]}'
+
+    await payload_store.upsert_payload(
+        session,
+        ingestion_id=ingestion_id,
+        org_id="org-1",
+        schema_version="external-ingest.v1",
+        payload_bytes=payload,
+    )
+    await session.commit()
+
+    fetched = await payload_store.fetch_payload(
+        session, ingestion_id=ingestion_id, org_id="org-1"
+    )
+    assert fetched == payload
+
+    await payload_store.delete_payload(session, ingestion_id=ingestion_id)
+    await session.commit()
+
+    assert (
+        await payload_store.fetch_payload(
+            session, ingestion_id=ingestion_id, org_id="org-1"
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_fetch_with_mismatched_org_returns_none(session: AsyncSession):
+    """Tenant isolation: org_id is in the predicate even though ingestion_id
+    alone is already unique (house rule: org_id in every lookup predicate)."""
+    ingestion_id = _uuid()
+    await payload_store.upsert_payload(
+        session,
+        ingestion_id=ingestion_id,
+        org_id="org-1",
+        schema_version="external-ingest.v1",
+        payload_bytes=b"payload",
+    )
+    await session.commit()
+
+    assert (
+        await payload_store.fetch_payload(
+            session, ingestion_id=ingestion_id, org_id="org-2"
+        )
+        is None
+    )
+
+
+@pytest.mark.asyncio
+async def test_upsert_updates_existing_row_in_place(session: AsyncSession):
+    """CC22: a RETRY accept reuses the same ingestion_id -- upsert_payload
+    must UPDATE the existing row (stream_unavailable case: row exists,
+    worker never ran), not attempt a colliding INSERT."""
+    ingestion_id = _uuid()
+    await payload_store.upsert_payload(
+        session,
+        ingestion_id=ingestion_id,
+        org_id="org-1",
+        schema_version="external-ingest.v1",
+        payload_bytes=b"first-attempt",
+    )
+    await session.commit()
+
+    await payload_store.upsert_payload(
+        session,
+        ingestion_id=ingestion_id,
+        org_id="org-1",
+        schema_version="external-ingest.v1",
+        payload_bytes=b"second-attempt-after-retry",
+    )
+    await session.commit()
+
+    fetched = await payload_store.fetch_payload(
+        session, ingestion_id=ingestion_id, org_id="org-1"
+    )
+    assert fetched == b"second-attempt-after-retry"
+
+
+@pytest.mark.asyncio
+async def test_upsert_recreates_row_after_delete(session: AsyncSession):
+    """CC22: the other RETRY case (worker already deleted the row on
+    ``failed``) -- upsert_payload must INSERT again for the same
+    ingestion_id, not error."""
+    ingestion_id = _uuid()
+    await payload_store.upsert_payload(
+        session,
+        ingestion_id=ingestion_id,
+        org_id="org-1",
+        schema_version="external-ingest.v1",
+        payload_bytes=b"attempt-1",
+    )
+    await session.commit()
+    await payload_store.delete_payload(session, ingestion_id=ingestion_id)
+    await session.commit()
+
+    await payload_store.upsert_payload(
+        session,
+        ingestion_id=ingestion_id,
+        org_id="org-1",
+        schema_version="external-ingest.v1",
+        payload_bytes=b"attempt-2-after-failed-retry",
+    )
+    await session.commit()
+
+    fetched = await payload_store.fetch_payload(
+        session, ingestion_id=ingestion_id, org_id="org-1"
+    )
+    assert fetched == b"attempt-2-after-failed-retry"
+
+
+@pytest.mark.asyncio
+async def test_delete_missing_row_is_a_noop(session: AsyncSession):
+    await payload_store.delete_payload(session, ingestion_id=_uuid())
+    await session.commit()  # must not raise


### PR DESCRIPTION
Pointer-only per-org Valkey streams (external-ingest:{org}:batches/:dlq) with the raw payload in Postgres via payload_store; PERMANENT fail-closed invariant: enqueue_batch 503s unless the payload row is durable. Router accept call-site persists payload before enqueue (team-lead-authorized amendment per master-spec wave assignment; CHAOS-2695 completes the CC22 ordering in wave 4). Default-off XPENDING/XCLAIM reclaim extension on the shared StreamConsumer (max_deliveries=5, 15min idle, terminal-status idempotent-skip); consumer refuses to claim entries when CHAOS-2697's processor seam is absent; DLQ-write failure never ACKs the source entry; permanent-failure ACK additionally gated on the failed-status write not raising (unavailable seam = documented interim, CC13 RETRY recovers). worker-external-ingest container + queue wiring incl. tests/test_compose_config.py update and CHAOS-2699's late_ack exclusion line.

Verification: gate GATE PASSED x3 (final: 6570 passed / 0 failed, env-isolated); codex adversarial review 2 rounds — R1: 1 CRITICAL (payload-black-hole between waves — resolved via the authorized router amendment + permanent invariant) + 2 HIGH fixed (refuse-to-claim, DLQ-ACK); R2: 2 HIGH fixed (orphan-payload cleanup on enqueue failure w/ regression test; ACK gate on raised mark_batch_failed w/ pending-entry regression test). Live verification (agent, pre-fix; mechanics unchanged): XRANGE-proven pointer enqueue, reclaim, DLQ-after-max-deliveries, fail-closed 503 via broken REDIS_URL. Implementer agent was terminated by a spend limit post-verification; final codex round-2 fixes, tests, and this PR completed by the orchestrator. Closes CHAOS-2693.