### PR TITLE
feat(external-ingest): idempotency + one-active-owner accept flow (CHAOS-2695)

### DIFF
--- a/docs/architecture/external-ingest-idempotency-ownership.md
+++ b/docs/architecture/external-ingest-idempotency-ownership.md
@@ -1,0 +1,222 @@
+# External ingest: idempotency + source-ownership policy (CHAOS-2695)
+
+Part of the CHAOS-2690 external customer-push ingestion epic. This document
+is the durable record of the batch idempotency policy and the
+one-active-owner rule enforced by `POST /api/v1/external-ingest/batches`,
+plus the admin validate proxy. Companion docs:
+`external-ingest-rest-contract.md` (envelope/endpoints),
+`external-ingest-status-store.md` (2694 store),
+`external-ingest-stream-design.md` (2693 stream/payload),
+`customer-push-authz.md` (2696/2712 tokens + registration).
+
+## Modules
+
+| Module | Owns |
+|---|---|
+| `api/external_ingest/idempotency.py` | `compute_payload_hash`, 4-way `resolve_batch_idempotency` (NEW/REPLAY/CONFLICT/RETRY) |
+| `external_ingest/ownership.py` | CC5 per-provider instance matching + `resolve_effective_mode` (shared by admin registration and accept path) |
+| `api/external_ingest/status.py` | store: `create_batch`, `find_existing_batch`, `reset_for_retry`, transitions |
+| `api/external_ingest/router.py` | the CC22 accept sequence wiring |
+| `api/admin/routers/customer_push.py` | registration-time 409 policy (reuses ownership.py predicates) + `POST .../sources/{id}/validate` |
+
+`idempotency.py` lives in the API package rather than the brief's
+`dev_health_ops/external_ingest/` because it is accept-time-only and its
+store dependency lives there; importing the store from the sibling package
+would recurse through `api/external_ingest/__init__` (which imports
+`router`, which imports `idempotency`) into a circular ImportError.
+`ownership.py` (models-only imports, worker-shareable) keeps the brief's
+placement.
+
+## Batch identity + canonicalization
+
+Identity key: `(org_id, source_system, source_instance, idempotency_key)`,
+unique **forever** (no TTL — a deliberate deviation from the legacy
+`/api/v1/ingest` 24h Redis cache; durable dedup is what makes reprocessing
+safe). Reusing a key string against a different `source.instance` is a
+different logical batch, never a conflict.
+
+Payload hash: SHA-256 over
+`json.dumps(envelope.model_dump(mode="json"), sort_keys=True,
+separators=(",", ":"), ensure_ascii=True)` — computed on the
+**schema-validated Pydantic model**, never raw bytes. Pydantic's
+`mode="json"` dump normalizes timestamp spellings (`...Z` vs `...+00:00`);
+`sort_keys` (recursive) + `separators` remove field-order and whitespace
+variance. The `records` array is position-significant (NOT sorted): CLI
+exports are deterministically ordered, and a synthetic cross-kind sort key
+isn't worth the complexity — a nondeterministic exporter should be fixed,
+not papered over.
+
+## Outcomes (4-way, not the plan's literal 3-way)
+
+| Outcome | Condition | Response |
+|---|---|---|
+| `NEW` | no existing row | insert row (`accepted`, `attempts=1`) → payload upsert → COMMIT → enqueue → **202** |
+| `REPLAY` | same hash, row not retryable | **200** with the full `GET /batches/{id}` status envelope (a replayed batch may already be `completed`; the 202 shape would misreport it, and 200 lets `dev-hops push --poll` short-circuit) |
+| `CONFLICT` | different hash | **409** `idempotency_conflict`; the original row is never touched |
+| `RETRY` | same hash AND (`status ∈ {stream_unavailable, failed}` OR `accepted` older than `EXTERNAL_INGEST_ACCEPTED_STALE_MINUTES` = 15) | `reset_for_retry` (same ingestion_id, `attempts += 1`, prior outcome fields + rejection rows cleared) → payload re-upsert → COMMIT → re-enqueue → **202** |
+
+`RETRY` exists because the 503-on-stream-unavailable contract leaves a
+durable row the client is told to resubmit against; treating that resubmit
+as `REPLAY` would return the stale status forever. The stale-`accepted`
+extension (post-critique CC13) closes the crash-before-XADD / stream-trim
+fail-open where `accepted` was otherwise unrecoverable; a *young* accepted
+row replays instead, so an in-flight enqueue is never raced by an
+impatient client. Hash mismatch dominates status: a different payload
+against a `failed` row is still a 409.
+
+**Stale `processing` deliberately REPLAYs** — a narrowing of the
+reconciliation header's literal "accepted/processing" (adversarial-review
+finding). A row stuck in `accepted` is invisible to every worker (the
+pointer never reached the stream), so the client resubmit is the *only*
+recovery — that is CC13's actual target. A `processing` row proves a
+worker holds the pointer; dead-worker recovery is the CHAOS-2693 stream
+reclaim path and the `failed` terminal status (already retryable), while a
+client-driven retry would race a slow-but-alive worker's terminal CAS with
+no attempt fence (double-apply, superseded attempt's counters winning). If
+operational need appears, CHAOS-2697+ can extend with attempt-fenced
+retries (attempt number carried in the stream entry and CAS'd through
+`mark_processing`/`complete_batch`).
+
+`reset_for_retry` is a CAS on the observed status (loser re-reads and
+replays) and deletes the prior attempt's rejection rows — without that, the
+retry's own `complete_batch` would violate the `(ingestion_id,
+record_index)` unique index. `recompute_*` fields are left for the worker
+to overwrite (CHAOS-2699).
+
+True same-key insert race (pre-check miss + unique-constraint collision +
+winner's row not yet visible): **503** `ingest_temporarily_unavailable` —
+the client's idempotent retry resolves it. The insert runs in a SAVEPOINT
+(`create_batch`), so the collision never poisons the caller's session.
+
+**Duplicate stream pointers are expected, not a bug.** A stale-`accepted`
+RETRY during a long consumer outage can re-enqueue a pointer whose first
+XADD actually succeeded — this is indistinguishable from crash-before-XADD
+on the accept side, and it is deliberately NOT "solved" with a durable
+enqueue marker (a crash after XADD but before the marker write just
+inverts the bug; exactly-once across Postgres + Valkey is not achievable
+at this boundary). The pipeline is at-least-once end to end — the
+CHAOS-2693 reclaim machinery itself redelivers entries — and dedup lives
+at processing time: single-replica consumer (CC11), `mark_processing` /
+`complete_batch` compare-and-swap transitions, ReplacingMergeTree sinks,
+and coalesced recompute (CHAOS-2699). A redelivered pointer for a
+terminal batch is skipped; for an in-flight one it processes serially and
+no-ops at the terminal CAS.
+
+## Accept sequence (master-spec CC22)
+
+```
+parse/size/version/kind checks (400/413)
+→ require_matching_source (token↔envelope source binding, 2712)
+→ resolve_effective_mode (403 source_not_registered / source_disabled /
+  source_owned_by_fullchaos_sync)
+→ compute_payload_hash
+→ resolve_batch_idempotency        # FIRST Postgres write
+→ [CONFLICT → 409 | REPLAY → 200]
+→ [RETRY → reset_for_retry (CAS; loser → 200 replay)]
+→ upsert_payload (same txn) → COMMIT
+→ enqueue_batch (pointer only; fail-closed payload-durability check)
+→ [StreamUnavailableError → mark_stream_unavailable → COMMIT → 503]
+→ 202
+```
+
+On the 503 path the payload row is **kept** (supersedes CHAOS-2693's
+interim orphan-delete): it is referenced by the durable
+`stream_unavailable` status row, the same-key retry reuses it via the same
+ingestion_id, and deleting it could black-hole an enqueue whose XADD
+actually landed before the error surfaced. Never-retried leftovers are the
+CHAOS-2769 reconciler's job.
+
+## One-active-owner resolution
+
+`resolve_effective_mode(session, org_id, system, instance)` →
+`fullchaos_sync | customer_push | disabled | unclaimed`. Precedence:
+
+1. **Explicit `external_ingest_sources` row wins** — `disabled` if disabled
+   (or `mode=disabled`), else its mode — EXCEPT a `customer_push` row is
+   overridden by a managed source that **actively owns** the same instance
+   (source `is_enabled` AND parent `Integration.is_active`). This
+   accept-time re-check is deliberate defense-in-depth: nothing on the
+   `api/admin/routers/sync.py` side knows about `external_ingest_sources`,
+   so managed sync can be connected to the same repo *after* registration.
+2. No explicit row: an actively-owning managed source implies
+   `fullchaos_sync` (derived at read time, never mirrored/backfilled —
+   touching every provider-connect path to dual-write would be far riskier
+   than a read-time derivation).
+3. Otherwise `unclaimed`.
+
+Instance matching is per-provider (master-spec CC5) because
+`integration_sources.external_id` is not uniformly the human-readable name:
+
+| system | matches instance against |
+|---|---|
+| github, jira | `external_id`, `full_name` |
+| gitlab | `full_name`, `metadata.path_with_namespace`, `external_id` (numeric project id) |
+| linear | org-wide placeholder (`external_id == "linear"` or `metadata.org_wide_placeholder`) matches **any** instance; else `external_id`/`full_name`/`name` |
+| custom | never conflicts |
+
+Provider comparison is `func.lower()`d on both sides (managed rows may
+carry `"GitHub"`), and instance comparison is case-insensitive on both
+sides (adversarial-review finding): GitHub full names, GitLab paths, and
+Jira/Linear keys are case-insensitive identifiers on their providers — no
+two managed entities can differ only by case — while sync stores them as
+the provider API returned them, so an exact match would let `Acme/API`
+fail to block `acme/api`. The same predicates run at registration time
+(2696's 409 + warnings policy in the admin router) and accept time —
+single source of truth, brief decision 12.
+
+Registration itself also rejects **case-variant duplicate customer-push
+sources** (409, adversarial-review finding): the DB unique constraint is
+on the raw `(org, system, instance)`, so without the app-level
+case-folded pre-check one org could register `Acme/API` and `acme/api`
+as two enabled sources for the same logical repository, splitting the
+owner and idempotency namespaces. The stored instance keeps the user's
+casing (token binding and envelope matching stay exact against it); a
+DB-level canonical unique index is a tracked follow-up (needs a
+migration, which this changeset deliberately ships none of).
+
+On the data plane, `require_matching_source` already binds the token to a
+registered write-eligible row, so `unclaimed`/`disabled` are practically
+unreachable at accept time; the load-bearing outcome is the
+`fullchaos_sync` override.
+
+## Error codes raised by this changeset (CC16 envelope)
+
+| HTTP | code | when |
+|---|---|---|
+| 409 | `idempotency_conflict` | same key, different payload hash |
+| 503 | `ingest_temporarily_unavailable` | sub-ms concurrent same-key race |
+| 503 | `stream_unavailable` | enqueue failed; row marked, retry same key |
+| 403 | `source_not_registered` | resolved mode `unclaimed` |
+| 403 | `source_disabled` | resolved mode `disabled` |
+| 403 | `source_owned_by_fullchaos_sync` | resolved mode `fullchaos_sync` |
+
+All via `ExternalIngestError` (`{"error": {code, message}}`), not
+HTTPException detail-dicts (brief D13 overruled by reconciliation).
+
+## Admin validate proxy (CC25)
+
+`POST /api/v1/admin/customer-push/sources/{source_id}/validate` —
+session-auth twin of the data-plane `POST /validate` for the web console's
+Screen 5 (validate-only; the console-push proxy was cut from v1). Same
+`validate_records` + size/version/count checks; snake_case
+`AdminValidateResponse` matching the web's `CustomerPushValidateResponse`,
+with `external_id` enriched from the record wrapper. Envelope-level
+failures return **200 `valid: false`** with synthetic error rows (the
+console renders them as results; the web mock contract pinned this shape).
+It does NOT check the envelope's `source` against the path's source — that
+binding is a token-auth concept enforced at push time.
+
+## Record-level identity (contract for 2697/2698)
+
+No separate dedup table: per-record identity delegates to each ClickHouse
+sink's existing ReplacingMergeTree `ORDER BY` + sink-stamped version column
+(`synced_at`/`last_synced` at write time — never customer-supplied
+`updatedAt`). Customer-pushed repos MUST derive `Repo.id` via the same
+`get_repo_uuid_from_repo` composition native sync uses, or a mode switch
+silently forks the repo row (flagged epic-wide; owned by CHAOS-2697).
+
+## Environment
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `EXTERNAL_INGEST_ACCEPTED_STALE_MINUTES` | `15` | age beyond which an `accepted`/`processing` row is presumed lost and a same-key resubmit becomes RETRY |

--- a/docs/architecture/external-ingest-stream-design.md
+++ b/docs/architecture/external-ingest-stream-design.md
@@ -25,6 +25,16 @@ enqueue, and the retry/reclaim/DLQ machinery.
 > sat inertly on the stream). The epic owner must sequence CHAOS-2693 and
 > CHAOS-2695 into the same deployment, or hold CHAOS-2691/2693 out of any
 > environment that accepts real traffic until CHAOS-2695 merges.
+>
+> **RESOLVED (CHAOS-2695):** the payload upsert was pulled forward into
+> CHAOS-2693's own PR (authorized router amendment: `upsert_payload` +
+> commit before enqueue), and CHAOS-2695's full CC22 rewrite has since
+> landed the idempotency-row-first sequence around it -- see
+> [external-ingest-idempotency-ownership.md](external-ingest-idempotency-ownership.md).
+> Note: on a stream-unavailable 503 the payload row is now deliberately
+> KEPT (the durable `stream_unavailable` status row references it and the
+> same-key RETRY reuses it), superseding the interim orphan-delete this
+> doc's D2 era assumed.
 
 ## Per-org streams, not one shared stream
 

--- a/src/dev_health_ops/api/admin/routers/customer_push.py
+++ b/src/dev_health_ops/api/admin/routers/customer_push.py
@@ -15,6 +15,7 @@ from datetime import datetime, timezone
 from typing import Any
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import ValidationError
 from sqlalchemy import func, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -25,6 +26,7 @@ from dev_health_ops.api.admin.schemas.customer_push import (
     AdminBatchListResponse,
     AdminBatchResponse,
     AdminRejectedRecordResponse,
+    AdminValidateResponse,
     IngestSourceCreate,
     IngestSourcePatch,
     IngestSourceResponse,
@@ -33,6 +35,8 @@ from dev_health_ops.api.admin.schemas.customer_push import (
     IngestTokenResponse,
 )
 from dev_health_ops.api.external_ingest import status as ingest_status
+from dev_health_ops.api.external_ingest.errors import ExternalIngestError
+from dev_health_ops.api.external_ingest.router import _read_body_enforcing_size_limit
 from dev_health_ops.api.external_ingest.schemas import (
     MAX_BODY_BYTES_DEFAULT,
     MAX_RECORDS_DEFAULT,
@@ -42,6 +46,8 @@ from dev_health_ops.api.external_ingest.schemas import (
 )
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.utils.audit import emit_audit_log
+from dev_health_ops.external_ingest.ownership import find_matching_managed_sources
+from dev_health_ops.external_ingest.validate import validate_records
 from dev_health_ops.models.audit import AuditAction, AuditResourceType
 from dev_health_ops.models.ingest_auth import (
     TOKEN_PREFIX_DISPLAY_LENGTH,
@@ -53,7 +59,7 @@ from dev_health_ops.models.ingest_auth import (
     generate_ingest_token,
     hash_ingest_token,
 )
-from dev_health_ops.models.integrations import Integration, IntegrationSource
+from dev_health_ops.models.integrations import Integration
 
 from .common import get_session
 
@@ -196,31 +202,15 @@ async def _get_org_token(
     return token
 
 
-def _linear_is_org_wide_placeholder(source: IntegrationSource) -> bool:
-    metadata = source.metadata_ or {}
-    if metadata.get("org_wide_placeholder") is True:
-        return True
-    return (source.external_id or "").strip().lower() == "linear"
-
-
-def _matches_instance(system: str, instance: str, source: IntegrationSource) -> bool:
-    """CC5 per-provider matching (see docs/architecture/customer-push-authz.md)."""
-    if system in ("github", "jira"):
-        return instance in (source.external_id, source.full_name)
-    if system == "gitlab":
-        path_with_namespace = (source.metadata_ or {}).get("path_with_namespace")
-        return instance in (source.full_name, path_with_namespace, source.external_id)
-    if system == "linear":
-        if _linear_is_org_wide_placeholder(source):
-            return True
-        return instance in (source.external_id, source.full_name, source.name)
-    return False
-
-
 async def _resolve_ownership(
     session: AsyncSession, org_id: str, system: str, instance: str
 ) -> tuple[uuid.UUID | None, list[str]]:
     """Run CC5 per-provider ownership matching against managed integration_sources.
+
+    The matching predicates live in ``dev_health_ops.external_ingest.ownership``
+    (CHAOS-2695, brief decision 12: the SAME logic runs here at registration
+    time and in the data-plane accept path's ``resolve_effective_mode``) --
+    this wrapper only applies the registration-time POLICY on top.
 
     Returns ``(matched_integration_source_id, warnings)``. Raises 409
     ``source_owned_by_fullchaos_sync`` if a managed source matches this
@@ -241,26 +231,9 @@ async def _resolve_ownership(
     if system == "custom":
         return matched_id, warnings
 
-    # func.lower(...) on both sides: nearby sync-creation paths (e.g.
-    # IntegrationCreate) don't enforce lowercase provider values, so a
-    # mixed-case managed row ("GitHub") must still be found and block a
-    # lowercase "github" customer-push registration -- a bare `==` here
-    # would silently bypass the one-active-owner 409.
-    candidate_rows = (
-        await session.execute(
-            select(IntegrationSource, Integration.is_active)
-            .join(Integration, IntegrationSource.integration_id == Integration.id)
-            .where(
-                IntegrationSource.org_id == org_id,
-                func.lower(IntegrationSource.provider) == system,
-            )
-        )
-    ).all()
-    matches = [
-        (source, integration_is_active)
-        for source, integration_is_active in candidate_rows
-        if _matches_instance(system, instance, source)
-    ]
+    matches = await find_matching_managed_sources(
+        session, org_id=org_id, system=system, instance=instance
+    )
     enabled_match = next(
         (
             source
@@ -374,6 +347,40 @@ async def create_source(
     system = _validate_system(payload.system)
     mode = _validate_mode(payload.mode)
     _reject_fullchaos_hosted_webhook_mode(payload.webhook_mode)
+
+    # Case-insensitive duplicate check BEFORE insert (CHAOS-2695
+    # adversarial-review finding): the unique constraint is on the RAW
+    # (org, system, instance), but provider instance identifiers are
+    # case-insensitive (GitHub full names, GitLab paths, Jira/Linear keys)
+    # -- without this, 'Acme/API' and 'acme/api' register as two enabled
+    # sources for the same logical repository, splitting the one-active-owner
+    # and idempotency namespaces. The stored instance keeps the user's
+    # casing (tokens/envelopes then match it exactly); only the collision
+    # check folds case. App-level only (this changeset ships no migrations);
+    # a DB-level canonical unique index is tracked as a follow-up.
+    case_variant = (
+        (
+            await session.execute(
+                select(IngestSource).where(
+                    IngestSource.org_id == org_id,
+                    IngestSource.system == system,
+                    func.lower(IngestSource.instance)
+                    == payload.instance.strip().lower(),
+                )
+            )
+        )
+        .scalars()
+        .first()
+    )
+    if case_variant is not None:
+        raise HTTPException(
+            status_code=409,
+            detail=(
+                f"A source is already registered for system='{system}' "
+                f"instance='{case_variant.instance}' in this organization "
+                "(instance identifiers are case-insensitive)"
+            ),
+        )
 
     matched_id: uuid.UUID | None = None
     warnings: list[str] = []
@@ -826,6 +833,131 @@ async def get_batch_detail(
         org_id=org_id,
         rejected_records_limit=rejected_records_limit,
         rejected_records_offset=rejected_records_offset,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Validate proxy (CHAOS-2695) -- session-auth twin of the token-authed
+# data-plane POST /api/v1/external-ingest/validate, for the web console's
+# Screen 5. VALIDATE-ONLY: the console-push proxy (POST .../batches,
+# producer="web-console") was CUT from v1 (master-spec CC25); the ingestion
+# write path stays exclusively token-authed.
+# ---------------------------------------------------------------------------
+
+
+def _validate_failure(
+    code: str, message: str, path: str | None
+) -> AdminValidateResponse:
+    """Envelope-level failure as a 200 ``valid: false`` result row.
+
+    Deliberately NOT a 4xx (see ``AdminValidateResponse``'s docstring): the
+    console renders these as validation results; only auth/404 scope errors
+    surface as HTTP errors on this route.
+    """
+    return AdminValidateResponse(
+        valid=False,
+        items_accepted=0,
+        items_rejected=0,
+        errors=[
+            AdminRejectedRecordResponse(
+                index=0,
+                kind="unknown",
+                external_id=None,
+                code=code,
+                message=message,
+                path=path,
+            )
+        ],
+    )
+
+
+@router.post(
+    "/customer-push/sources/{source_id}/validate",
+    response_model=AdminValidateResponse,
+)
+async def validate_source_payload(
+    source_id: str,
+    request: Request,
+    session: AsyncSession = Depends(get_session),
+    current_user: AuthenticatedUser = Depends(get_admin_user),
+) -> AdminValidateResponse:
+    """Validate a batch envelope against the wire schemas, per-record.
+
+    Mirrors the data-plane ``POST /validate`` semantics exactly (same
+    ``validate_records``, same size/version/count checks) so a payload that
+    validates here validates there -- it does NOT check the envelope's
+    ``source`` against this route's source (the data plane enforces that at
+    push time via the token's source binding, which has no analogue in a
+    session-authed console request). The ``source_id`` path segment is a
+    tenant/scope check only.
+    """
+    await _get_org_source(session, current_user.org_id, source_id)
+
+    try:
+        raw = await _read_body_enforcing_size_limit(request)
+    except ExternalIngestError as exc:
+        return _validate_failure(exc.code, exc.message, None)
+
+    try:
+        envelope = BatchEnvelope.model_validate_json(raw)
+    except ValidationError as exc:
+        return AdminValidateResponse(
+            valid=False,
+            items_accepted=0,
+            items_rejected=0,
+            errors=[
+                AdminRejectedRecordResponse(
+                    index=0,
+                    kind="unknown",
+                    external_id=None,
+                    code="invalid_envelope",
+                    message=err["msg"],
+                    path=".".join(str(part) for part in err["loc"]) or None,
+                )
+                # Cap pathological inputs; the first errors are the
+                # actionable ones for a console user.
+                for err in exc.errors()[:50]
+            ],
+        )
+
+    if envelope.schema_version != SCHEMA_VERSION:
+        return _validate_failure(
+            "unsupported_schema_version",
+            f"Unsupported schemaVersion: {envelope.schema_version!r}",
+            "schemaVersion",
+        )
+
+    max_records = _external_ingest_limits()["maxRecordsPerBatch"]
+    if len(envelope.records) > max_records:
+        return _validate_failure(
+            "batch_too_large",
+            f"Batch has {len(envelope.records)} records; max is {max_records}",
+            "records",
+        )
+
+    errors = validate_records(envelope.records)
+    rejected_indices = {item.index for item in errors}
+    return AdminValidateResponse(
+        valid=not errors,
+        items_accepted=len(envelope.records) - len(rejected_indices),
+        items_rejected=len(rejected_indices),
+        errors=[
+            AdminRejectedRecordResponse(
+                index=item.index,
+                kind=item.kind,
+                # ValidationErrorItem has no external_id; enrich from the
+                # record wrapper for console-table correlation.
+                external_id=(
+                    envelope.records[item.index].external_id
+                    if 0 <= item.index < len(envelope.records)
+                    else None
+                ),
+                code=item.code,
+                message=item.message,
+                path=item.path,
+            )
+            for item in errors
+        ],
     )
 
 

--- a/src/dev_health_ops/api/admin/schemas/customer_push.py
+++ b/src/dev_health_ops/api/admin/schemas/customer_push.py
@@ -209,3 +209,23 @@ class AdminBatchListResponse(BaseModel):
     total: int
     limit: int
     offset: int
+
+
+class AdminValidateResponse(BaseModel):
+    """POST .../sources/{id}/validate (CHAOS-2695, master-spec CC25).
+
+    snake_case to match the admin-plane convention and the web client's
+    ``CustomerPushValidateResponse`` (dev-health-web ``lib/admin/types.ts``)
+    -- the data-plane ``ValidationResponse`` is the camelCase twin.
+    Envelope-level failures (malformed JSON/envelope, wrong schemaVersion,
+    oversized batch) are ALSO reported through this 200 shape (``valid:
+    false`` + synthetic error rows), never as 4xx: the console panel renders
+    these rows as results, and the web mock contract
+    (dev-health-web tests/mocks/handlers.ts) pinned that behavior before
+    this endpoint landed.
+    """
+
+    valid: bool
+    items_accepted: int
+    items_rejected: int
+    errors: list[AdminRejectedRecordResponse]

--- a/src/dev_health_ops/api/external_ingest/idempotency.py
+++ b/src/dev_health_ops/api/external_ingest/idempotency.py
@@ -1,0 +1,229 @@
+"""Batch idempotency resolution for external customer-push ingestion (CHAOS-2695).
+
+Implements the NEW / REPLAY / CONFLICT / RETRY policy over CHAOS-2694's
+direct-SQL status store (``status.py``) — this module owns the DECISION,
+the store owns the rows. Lives in the API package (deliberate deviation
+from the brief's ``dev_health_ops/external_ingest/`` placement): the policy
+is accept-time-only and its store dependency lives here — importing the
+store from the sibling package would recurse through this package's
+``__init__`` (which imports ``router``, which imports this module) into a
+circular ImportError. ``external_ingest/ownership.py`` (models-only
+imports, worker-shareable) keeps the brief's placement. Keys are unique
+FOREVER per
+``(org_id, source_system, source_instance, idempotency_key)`` (no TTL —
+deliberate deviation from the legacy ``/api/v1/ingest`` 24h Redis cache;
+"reprocessing must be safe" requires durable dedup, brief §2).
+
+Outcome semantics (brief decision 7 + post-critique CC13):
+
+- ``NEW``       — no row existed; one was inserted (``status='accepted'``,
+  ``attempts=1``). Caller persists the payload row and enqueues.
+- ``REPLAY``    — same key, same payload hash, batch not retryable → return
+  the CURRENT status (200, brief decision 8), do NOT re-enqueue.
+- ``CONFLICT``  — same key, different payload hash → 409
+  ``idempotency_conflict``. Never overwrites the original row.
+- ``RETRY``     — same key, same hash, and the existing row is safe to
+  re-accept: ``status`` in ``RETRYABLE_STATUSES`` ({stream_unavailable,
+  failed}), OR ``accepted`` gone stale (``updated_at`` older than
+  ``EXTERNAL_INGEST_ACCEPTED_STALE_MINUTES``, default 15 — closes the
+  crash-before-XADD / stream-trim fail-open where ``accepted`` was otherwise
+  unrecoverable; stale ``processing`` deliberately REPLAYs, see
+  ``_STALE_ELIGIBLE_STATUSES``). Caller resets the row (attempts+=1,
+  status→accepted), refreshes the payload, and re-enqueues the SAME
+  ingestion_id.
+
+See docs/architecture/external-ingest-idempotency-ownership.md.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from enum import Enum
+
+from pydantic import BaseModel
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.models.external_ingest import BatchStatus
+
+from .status import (
+    BatchRow,
+    DuplicateIdempotencyKeyError,
+    create_batch,
+    find_existing_batch,
+)
+
+RETRYABLE_STATUSES = frozenset(
+    {BatchStatus.STREAM_UNAVAILABLE.value, BatchStatus.FAILED.value}
+)
+
+#: accepted rows younger than this are REPLAY (the enqueue may still be
+#: in flight); older ones are presumed lost and RETRY.
+ACCEPTED_STALE_MINUTES_DEFAULT = 15
+
+#: Only ``accepted`` is stale-retryable — a DELIBERATE narrowing of the
+#: reconciliation header's literal "accepted/processing" (adversarial-review
+#: finding). A row stuck in ``accepted`` means the pointer never became
+#: visible on the stream (crash between COMMIT and XADD, or trimmed before
+#: first delivery): no worker can ever see it, so the client's same-key
+#: resubmit is the ONLY recovery path — that is the fail-open CC13 exists to
+#: close. A row in ``processing`` proves a worker HAS the pointer; its
+#: recovery paths are the stream reclaim machinery (CHAOS-2693) and the
+#: ``failed`` terminal status (already RETRYABLE), and a client-driven retry
+#: there would race a slow-but-alive worker's terminal CAS with no attempt
+#: fence — the retried attempt and the original could both apply, with the
+#: superseded attempt's counters winning. Stale ``processing`` therefore
+#: REPLAYs. If operational need appears, CHAOS-2697+ can extend this with an
+#: attempt-fenced design (attempt number in the stream entry, CAS'd through
+#: mark_processing/complete_batch).
+_STALE_ELIGIBLE_STATUSES = frozenset({BatchStatus.ACCEPTED.value})
+
+__all__ = [
+    "ACCEPTED_STALE_MINUTES_DEFAULT",
+    "RETRYABLE_STATUSES",
+    "IdempotencyOutcome",
+    "IdempotencyOutcomeKind",
+    "IngestTemporarilyUnavailableError",
+    "accepted_stale_minutes",
+    "compute_payload_hash",
+    "resolve_batch_idempotency",
+]
+
+
+class IngestTemporarilyUnavailableError(RuntimeError):
+    """True concurrent same-key race: our INSERT hit the unique constraint
+    but the winning row is not visible yet (uncommitted, or itself rolled
+    back). Maps to ``503 ingest_temporarily_unavailable`` (master-spec CC16)
+    — the client's idempotency-safe retry resolves it on the next attempt."""
+
+
+class IdempotencyOutcomeKind(str, Enum):
+    NEW = "new"
+    REPLAY = "replay"
+    CONFLICT = "conflict"
+    RETRY = "retry"
+
+
+@dataclass(frozen=True)
+class IdempotencyOutcome:
+    kind: IdempotencyOutcomeKind
+    batch: BatchRow
+
+
+def accepted_stale_minutes() -> int:
+    return int(
+        os.environ.get(
+            "EXTERNAL_INGEST_ACCEPTED_STALE_MINUTES",
+            str(ACCEPTED_STALE_MINUTES_DEFAULT),
+        )
+    )
+
+
+def compute_payload_hash(envelope: BaseModel) -> str:
+    """SHA-256 hex digest of the canonicalized, schema-validated envelope.
+
+    MUST be called on the already-validated Pydantic model (post envelope
+    validation in the router), never on raw request bytes — canonicalization
+    relies on ``model_dump(mode="json")`` normalizing timestamp formats
+    (``...Z`` vs ``...+00:00``) and on ``sort_keys``/``separators`` removing
+    field-order and whitespace variance (brief decisions 1-2). The full
+    envelope is hashed, ``records`` in given order — record order is
+    position-significant by design (brief decisions 3-4).
+    """
+    canonical = json.dumps(
+        envelope.model_dump(mode="json"),
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def _classify_existing(
+    existing: BatchRow, payload_hash: str, now: datetime
+) -> IdempotencyOutcome:
+    if existing.payload_hash != payload_hash:
+        return IdempotencyOutcome(IdempotencyOutcomeKind.CONFLICT, existing)
+    if existing.status in RETRYABLE_STATUSES:
+        return IdempotencyOutcome(IdempotencyOutcomeKind.RETRY, existing)
+    if existing.status in _STALE_ELIGIBLE_STATUSES:
+        age = now - existing.updated_at
+        if age > timedelta(minutes=accepted_stale_minutes()):
+            return IdempotencyOutcome(IdempotencyOutcomeKind.RETRY, existing)
+    return IdempotencyOutcome(IdempotencyOutcomeKind.REPLAY, existing)
+
+
+async def resolve_batch_idempotency(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    source_system: str,
+    source_instance: str,
+    idempotency_key: str,
+    payload_hash: str,
+    schema_version: str,
+    producer: str | None,
+    producer_version: str | None,
+    window_started_at: datetime | None,
+    window_ended_at: datetime | None,
+    items_received: int,
+) -> IdempotencyOutcome:
+    """Resolve NEW / REPLAY / CONFLICT / RETRY for a batch identity.
+
+    MUST be the first Postgres write in the accept sequence (master-spec
+    CC22: idempotency row → payload row → COMMIT → enqueue) — the unique
+    index on ``(org_id, source_system, source_instance, idempotency_key)``
+    is the serialization point for concurrent same-key accepts. The insert
+    runs inside ``create_batch``'s SAVEPOINT, so a losing racer only rolls
+    back the savepoint, not the caller's session. Does NOT commit.
+
+    Raises :class:`IngestTemporarilyUnavailableError` when the insert loses
+    the race but the winner's row is not yet visible (map to 503).
+    """
+    now = datetime.now(timezone.utc)
+    existing = await find_existing_batch(
+        session,
+        org_id=org_id,
+        source_system=source_system,
+        source_instance=source_instance,
+        idempotency_key=idempotency_key,
+    )
+    if existing is not None:
+        return _classify_existing(existing, payload_hash, now)
+
+    try:
+        created = await create_batch(
+            session,
+            ingestion_id=uuid.uuid4(),
+            org_id=org_id,
+            idempotency_key=idempotency_key,
+            payload_hash=payload_hash,
+            source_system=source_system,
+            source_instance=source_instance,
+            producer=producer,
+            producer_version=producer_version,
+            schema_version=schema_version,
+            window_started_at=window_started_at,
+            window_ended_at=window_ended_at,
+            items_received=items_received,
+        )
+    except DuplicateIdempotencyKeyError:
+        raced = await find_existing_batch(
+            session,
+            org_id=org_id,
+            source_system=source_system,
+            source_instance=source_instance,
+            idempotency_key=idempotency_key,
+        )
+        if raced is None:
+            raise IngestTemporarilyUnavailableError(
+                "A concurrent request for the same idempotency key is in "
+                "progress. Retry."
+            ) from None
+        return _classify_existing(raced, payload_hash, now)
+
+    return IdempotencyOutcome(IdempotencyOutcomeKind.NEW, created)

--- a/src/dev_health_ops/api/external_ingest/router.py
+++ b/src/dev_health_ops/api/external_ingest/router.py
@@ -1,10 +1,14 @@
-"""External-ingest REST contract: 4 endpoints (CHAOS-2691).
+"""External-ingest REST contract: 4 endpoints (CHAOS-2691 + CHAOS-2695).
 
-``POST /batches`` only checks envelope shape + the record-kind allowlist
-(400 on any unknown kind) — deep per-record validation happens eagerly in
-``POST /validate`` and durably in the CHAOS-2697 worker, so a customer's
-momentary schema drift on a handful of records doesn't drop an entire batch
-(see docs/architecture/external-ingest-rest-contract.md). ``GET /schemas*``
+``POST /batches`` checks envelope shape + the record-kind allowlist (400 on
+any unknown kind), then runs the full CC22 accept sequence — token source
+binding, one-active-owner check, NEW/REPLAY/CONFLICT/RETRY idempotency
+(``idempotency.py``/``external_ingest/ownership.py``, CHAOS-2695) — before
+the durable payload write + pointer enqueue. Deep per-record validation
+happens eagerly in ``POST /validate`` and durably in the CHAOS-2697 worker,
+so a customer's momentary schema drift on a handful of records doesn't drop
+an entire batch (see docs/architecture/external-ingest-rest-contract.md and
+docs/architecture/external-ingest-idempotency-ownership.md). ``GET /schemas*``
 (CHAOS-2692) is generated from the same ``schemas.py`` Pydantic models via
 ``schema_registry.py`` — a versioned bundle with ``$defs``, per-record-kind
 ``$ref``s + examples, and an ETag; this module never redeclares those
@@ -13,12 +17,13 @@ models. See docs/architecture/adr-005-external-ingest-schema-discovery.md.
 
 from __future__ import annotations
 
+import json
 import logging
 import os
 from typing import Annotated
-from uuid import uuid4
 
 from fastapi import APIRouter, Depends, Header, Request, Response
+from fastapi.responses import JSONResponse
 from pydantic import ValidationError
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -31,11 +36,22 @@ from dev_health_ops.api.middleware.rate_limit import (
     get_ingest_token_key,
     limiter,
 )
-from dev_health_ops.external_ingest.payload_store import delete_payload, upsert_payload
+from dev_health_ops.external_ingest.ownership import (
+    EffectiveMode,
+    resolve_effective_mode,
+)
+from dev_health_ops.external_ingest.payload_store import upsert_payload
+from dev_health_ops.external_ingest.recompute_status import get_recompute_jobs
 from dev_health_ops.external_ingest.validate import validate_records
 
 from .auth import IngestAuthContext, require_ingest_scope, require_matching_source
 from .errors import ExternalIngestError
+from .idempotency import (
+    IdempotencyOutcomeKind,
+    IngestTemporarilyUnavailableError,
+    compute_payload_hash,
+    resolve_batch_idempotency,
+)
 from .schema_registry import compute_etag, get_bundle, list_versions
 from .schemas import (
     MAX_BODY_BYTES_DEFAULT,
@@ -45,6 +61,14 @@ from .schemas import (
     BatchAcceptedResponse,
     BatchEnvelope,
     ValidationResponse,
+)
+from .status import (
+    BatchRow,
+    _batch_to_status_response,
+    get_batch,
+    list_rejections,
+    mark_stream_unavailable,
+    reset_for_retry,
 )
 from .streams import StreamUnavailableError, enqueue_batch
 
@@ -245,6 +269,57 @@ async def validate_batch(
     )
 
 
+def _ownership_error(
+    mode: EffectiveMode, system: str, instance: str
+) -> ExternalIngestError:
+    """Map a non-customer_push effective mode to its brief §7 error."""
+    if mode == "unclaimed":
+        return ExternalIngestError(
+            403,
+            "source_not_registered",
+            f"No ingest source is registered for system='{system}' "
+            f"instance='{instance}' in this organization. Register it under "
+            "/org/admin/integrations before pushing.",
+        )
+    if mode == "disabled":
+        return ExternalIngestError(
+            403,
+            "source_disabled",
+            f"Ingest source '{system}:{instance}' is disabled for this organization.",
+        )
+    return ExternalIngestError(
+        403,
+        "source_owned_by_fullchaos_sync",
+        f"Source '{system}:{instance}' is currently managed by "
+        "FullChaos-hosted sync. Disable managed sync for this source before "
+        "pushing customer data, or contact support.",
+    )
+
+
+async def _replay_status_response(
+    session: AsyncSession, org_id: str, batch: BatchRow
+) -> JSONResponse:
+    """REPLAY -> 200 OK with the FULL current-status envelope (brief decision
+    8): the replayed batch may already be completed/partial, and the narrow
+    202-accepted shape would misreport it. Same body as GET /batches/{id}
+    (first error page, default limits) so ``dev-hops push batch --poll`` can
+    short-circuit in one round trip."""
+    errors, errors_total = await list_rejections(
+        session, org_id=org_id, ingestion_id=batch.ingestion_id, limit=50, offset=0
+    )
+    recompute_jobs = await get_recompute_jobs(
+        session,
+        org_id=org_id,
+        source_system=batch.source_system,
+        source_instance=batch.source_instance,
+        dispatched_at=batch.recompute_dispatched_at,
+    )
+    body = _batch_to_status_response(batch, errors, errors_total, 50, 0, recompute_jobs)
+    return JSONResponse(
+        status_code=200, content=json.loads(body.model_dump_json(by_alias=True))
+    )
+
+
 @router.post("/batches", response_model=BatchAcceptedResponse, status_code=202)
 @limiter.limit(INGEST_BATCH_LIMIT, key_func=get_ingest_token_key)
 async def accept_batch(
@@ -252,7 +327,11 @@ async def accept_batch(
     session: Annotated[AsyncSession, Depends(get_postgres_session_dep)],
     ctx: IngestAuthContext = Depends(_require_ingest_write),
     idempotency_key_header: str | None = Header(default=None, alias="Idempotency-Key"),
-) -> BatchAcceptedResponse:
+) -> Response:
+    """Full CC22 accept sequence (CHAOS-2695): envelope checks -> token
+    source binding -> ownership -> idempotency (FIRST Postgres write) ->
+    payload upsert -> COMMIT -> pointer enqueue. See
+    docs/architecture/external-ingest-idempotency-ownership.md."""
     raw = await _read_body_enforcing_size_limit(request)
     envelope = _parse_envelope_or_400(raw)
     _check_idempotency_header_matches_body(envelope, idempotency_key_header)
@@ -266,18 +345,89 @@ async def accept_batch(
     # source_mismatch / source_disabled).
     require_matching_source(ctx, envelope.source.system, envelope.source.instance)
 
-    ingestion_id = str(uuid4())
-    window = envelope.window
+    # One-active-owner re-check at accept time (CC5/CC14 defense in depth):
+    # require_matching_source only proves the token binds to a registered,
+    # write-eligible source row -- it cannot see a managed sync source that
+    # was connected to the SAME instance AFTER registration (nothing on the
+    # api/admin/routers/sync.py side knows about external_ingest_sources).
+    mode = await resolve_effective_mode(
+        session,
+        org_id=ctx.org_id,
+        system=envelope.source.system,
+        instance=envelope.source.instance,
+    )
+    if mode != "customer_push":
+        raise _ownership_error(mode, envelope.source.system, envelope.source.instance)
 
-    # Persist the raw payload BEFORE enqueueing the pointer (D2/CC9): the
-    # stream entry never carries payload bytes, so a worker fetching by
-    # ingestion_id must always find a durable row. Committed here, ahead of
-    # enqueue_batch()'s own fail-closed payload-durability check (streams.py)
-    # -- that check opens an independent read after this commit, so it must
-    # already be visible. This is the interim (pre-CHAOS-2695) accept flow:
-    # no idempotency/ownership resolution or status-row write yet (CHAOS-2695
-    # wave 4 owns that full CC22 rewrite) -- adding only the payload
-    # persistence this issue (CHAOS-2693) owns.
+    window = envelope.window
+    payload_hash = compute_payload_hash(envelope)
+    try:
+        # FIRST Postgres write of the accept sequence (CC22) -- the unique
+        # idempotency index is the serialization point for concurrent
+        # same-key accepts.
+        outcome = await resolve_batch_idempotency(
+            session,
+            org_id=ctx.org_id,
+            source_system=envelope.source.system,
+            source_instance=envelope.source.instance,
+            idempotency_key=envelope.idempotency_key,
+            payload_hash=payload_hash,
+            schema_version=envelope.schema_version,
+            producer=envelope.source.producer,
+            producer_version=envelope.source.producer_version,
+            window_started_at=window.started_at if window else None,
+            window_ended_at=window.ended_at if window else None,
+            items_received=len(envelope.records),
+        )
+    except IngestTemporarilyUnavailableError as exc:
+        raise ExternalIngestError(
+            503,
+            "ingest_temporarily_unavailable",
+            "A concurrent request for the same idempotency key is in progress. Retry.",
+        ) from exc
+
+    if outcome.kind is IdempotencyOutcomeKind.CONFLICT:
+        raise ExternalIngestError(
+            409,
+            "idempotency_conflict",
+            f"Idempotency key '{envelope.idempotency_key}' was already used "
+            f"for source '{envelope.source.system}:{envelope.source.instance}' "
+            "with a different payload. Use a new idempotencyKey, or retry "
+            "with the exact original payload to get the cached status.",
+        )
+    if outcome.kind is IdempotencyOutcomeKind.REPLAY:
+        return await _replay_status_response(session, ctx.org_id, outcome.batch)
+
+    batch = outcome.batch
+    ingestion_id = str(batch.ingestion_id)
+
+    if outcome.kind is IdempotencyOutcomeKind.RETRY:
+        # Re-accept the SAME ingestion_id (attempts += 1, prior attempt's
+        # outcome fields cleared). CAS on the status we classified against:
+        # losing it means a concurrent retry won or a live worker finished a
+        # stale-looking batch first -- either way the fresh row is the truth,
+        # answer as a REPLAY instead of double-accepting.
+        won = await reset_for_retry(
+            session,
+            org_id=ctx.org_id,
+            ingestion_id=batch.ingestion_id,
+            from_status=batch.status,
+        )
+        if not won:
+            fresh = await get_batch(
+                session, org_id=ctx.org_id, ingestion_id=batch.ingestion_id
+            )
+            assert fresh is not None  # the row existed; transitions never delete
+            return await _replay_status_response(session, ctx.org_id, fresh)
+
+    # Persist the raw payload in the SAME transaction as the status row
+    # (D2/CC9/CC22): the stream entry never carries payload bytes, so a
+    # worker fetching by ingestion_id must always find a durable row. The
+    # commit lands BEFORE enqueue_batch()'s own fail-closed
+    # payload-durability check (streams.py), which opens an independent
+    # read. On RETRY this refreshes the (hash-identical) bytes -- the
+    # ``failed`` case may have had its payload already deleted by the
+    # worker's terminal cleanup (D7).
     await upsert_payload(
         session,
         ingestion_id=ingestion_id,
@@ -300,30 +450,33 @@ async def accept_batch(
             window_ended_at=window.ended_at if window else None,
         )
     except StreamUnavailableError as exc:
-        # Adversarial-review round-2: without cleanup, every customer retry of
-        # a 503 leaves another committed multi-MB payload row behind (each
-        # accept mints a fresh ingestion_id in this interim flow, so nothing
-        # ever reuses or prunes them). Best-effort delete keeps "payload row
-        # exists" ~equivalent to "a pointer may exist". Residual orphans from
-        # a crash between commit and enqueue remain possible -- the
-        # CHAOS-2769 reconciler / CHAOS-2695 status rows are the systematic
-        # answer; a failed delete here must never mask the customer-facing
-        # 503.
-        try:
-            await delete_payload(session, ingestion_id=ingestion_id)
-            await session.commit()
-        except Exception:
-            logger.exception(
-                "orphan payload cleanup failed for ingestion_id=%s", ingestion_id
-            )
+        # The batch row is durable, so record the failed enqueue on it and
+        # commit BEFORE raising (mark_stream_unavailable's contract) -- the
+        # client's same-key retry then resolves as RETRY against the same
+        # ingestion_id. The payload row is deliberately KEPT (supersedes
+        # CHAOS-2693's interim orphan-delete: it is now referenced by the
+        # status row, the retry reuses it, and deleting it could black-hole
+        # an enqueue whose XADD actually landed before the error surfaced);
+        # never-retried leftovers are CHAOS-2769's reconciler's job.
+        await mark_stream_unavailable(
+            session, org_id=ctx.org_id, ingestion_id=batch.ingestion_id
+        )
+        await session.commit()
         raise ExternalIngestError(
-            503, "stream_unavailable", "Ingest stream unavailable"
+            503,
+            "stream_unavailable",
+            "The durable ingest stream is temporarily unavailable. The batch "
+            f"was recorded as '{ingestion_id}'; retry with the same "
+            "idempotencyKey once available.",
         ) from exc
 
-    return BatchAcceptedResponse(
-        ingestion_id=ingestion_id,
-        items_received=len(envelope.records),
-        stream=stream,
+    return JSONResponse(
+        status_code=202,
+        content=BatchAcceptedResponse(
+            ingestion_id=ingestion_id,
+            items_received=len(envelope.records),
+            stream=stream,
+        ).model_dump(by_alias=True),
     )
 
 

--- a/src/dev_health_ops/api/external_ingest/status.py
+++ b/src/dev_health_ops/api/external_ingest/status.py
@@ -67,6 +67,7 @@ __all__ = [
     "create_batch",
     "mark_processing",
     "mark_stream_unavailable",
+    "reset_for_retry",
     "complete_batch",
     "get_batch",
     "list_batches",
@@ -292,13 +293,17 @@ async def create_batch(
     window_ended_at: datetime | None,
     items_received: int,
 ) -> BatchRow:
-    """INSERT a new ``status='accepted'`` row. Caller (CHAOS-2691's
-    ``POST /batches`` handler, after CHAOS-2693's stream enqueue has already
-    SUCCEEDED -- never write a status row for a batch that failed to enqueue
-    durably) must have already called ``find_existing_batch()`` for the
-    idempotency pre-check. Raises ``DuplicateIdempotencyKeyError`` on a
-    concurrent-insert race. Does NOT commit -- caller commits once the
-    accept sequence's other writes (e.g. the payload row) also succeed."""
+    """INSERT a new ``status='accepted'`` row. This is the FIRST write in
+    the accept sequence (master-spec CC22: idempotency row -> payload row ->
+    COMMIT -> stream enqueue) -- the row is written BEFORE the enqueue is
+    attempted, so a failed enqueue leaves a durable row the caller must
+    transition via ``mark_stream_unavailable()`` (commit-before-raise), and
+    the client's same-key retry resolves as RETRY instead of vanishing.
+    Callers go through ``external_ingest/idempotency.py``'s
+    ``resolve_batch_idempotency()``, which runs the ``find_existing_batch()``
+    pre-check and maps the ``DuplicateIdempotencyKeyError`` race. Does NOT
+    commit -- caller commits once the accept sequence's other writes (the
+    payload row) also succeed."""
     now = datetime.now(timezone.utc)
     params: dict[str, Any] = {
         "ingestion_id": str(ingestion_id),
@@ -450,6 +455,63 @@ async def mark_stream_unavailable(
         from_status=BatchStatus.ACCEPTED,
         to_status=BatchStatus.STREAM_UNAVAILABLE,
     )
+
+
+async def reset_for_retry(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    ingestion_id: uuid.UUID,
+    from_status: str,
+) -> bool:
+    """Re-accept an existing batch row for a RETRY outcome (CHAOS-2695).
+
+    ``status -> accepted``, ``attempts += 1``, and the previous attempt's
+    outcome fields are cleared -- including its rejection rows, which MUST
+    be deleted here or the retry's own ``complete_batch()`` would violate
+    the ``(ingestion_id, record_index)`` unique index when it re-inserts
+    diagnostics for the same records.
+
+    Atomic CAS on the caller's observed ``from_status`` (same pattern as
+    ``complete_batch``): returns ``False`` without touching anything if the
+    row already moved (a concurrent retry won, or a live worker completed a
+    stale-looking batch first) -- the caller should re-read and treat the
+    fresh row as a REPLAY. ``recompute_*`` fields are deliberately left
+    alone (CHAOS-2699 owns them; the worker overwrites them on the retry's
+    completion). Does NOT commit.
+    """
+    now = datetime.now(timezone.utc)
+    cas_result = await session.execute(
+        text(
+            f"""
+            UPDATE {_BATCHES_TABLE}
+            SET status = :status, attempts = attempts + 1,
+                items_accepted = 0, items_rejected = 0,
+                record_counts = NULL, error_summary = NULL,
+                completed_at = NULL, updated_at = :updated_at
+            WHERE org_id = :org_id AND ingestion_id = :ingestion_id
+                AND status = :expected_status
+            """
+        ),
+        {
+            "status": BatchStatus.ACCEPTED.value,
+            "updated_at": now,
+            "org_id": org_id,
+            "ingestion_id": str(ingestion_id),
+            "expected_status": from_status,
+        },
+    )
+    if int(getattr(cas_result, "rowcount", 0) or 0) != 1:
+        return False
+
+    await session.execute(
+        text(
+            f"DELETE FROM {_REJECTIONS_TABLE} "
+            "WHERE org_id = :org_id AND ingestion_id = :ingestion_id"
+        ),
+        {"org_id": org_id, "ingestion_id": str(ingestion_id)},
+    )
+    return True
 
 
 async def complete_batch(

--- a/src/dev_health_ops/external_ingest/ownership.py
+++ b/src/dev_health_ops/external_ingest/ownership.py
@@ -1,0 +1,195 @@
+"""One-active-owner resolution for external customer-push ingestion (CHAOS-2695).
+
+Single source of truth for CC5's per-provider instance matching (brief
+decision 12 / master-spec CC5): the SAME predicates run at both enforcement
+points — registration time (``api/admin/routers/customer_push.py``, 409) and
+batch-accept time (``api/external_ingest/router.py``, 403). fullchaos_sync
+ownership is DERIVED at read time from ``integrations``/``integration_sources``
+(native sync's existing tables), never mirrored into
+``external_ingest_sources`` (brief decision 11) — so a managed sync connected
+AFTER a customer_push registration is still caught here on the next accept.
+
+``instance`` matching is per-provider because ``integration_sources.external_id``
+is NOT uniformly the human-readable name (master-spec CC5): GitHub stores
+``owner/repo`` there, GitLab stores the NUMERIC project id (the path lives in
+``full_name`` / ``metadata_.path_with_namespace``), and Linear stores a team
+UUID or the literal ``"linear"`` org-wide placeholder that owns ALL teams.
+
+See docs/architecture/external-ingest-idempotency-ownership.md.
+"""
+
+from __future__ import annotations
+
+from typing import Literal
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
+from dev_health_ops.models.integrations import Integration, IntegrationSource
+
+EffectiveMode = Literal["fullchaos_sync", "customer_push", "disabled", "unclaimed"]
+
+__all__ = [
+    "EffectiveMode",
+    "find_active_managed_owner",
+    "find_matching_managed_sources",
+    "linear_is_org_wide_placeholder",
+    "matches_instance",
+    "resolve_effective_mode",
+]
+
+
+def linear_is_org_wide_placeholder(source: IntegrationSource) -> bool:
+    """A Linear integration source that owns the WHOLE workspace (all teams).
+
+    ``api/admin/routers/sync.py`` creates such rows with either an explicit
+    ``org_wide_placeholder`` metadata flag or the literal external_id
+    ``"linear"``; both spellings must match any Linear instance string.
+    """
+    metadata = source.metadata_ or {}
+    if metadata.get("org_wide_placeholder") is True:
+        return True
+    return (source.external_id or "").strip().lower() == "linear"
+
+
+def _candidate_set(*values: object) -> set[str]:
+    return {v.strip().lower() for v in values if isinstance(v, str) and v.strip()}
+
+
+def matches_instance(system: str, instance: str, source: IntegrationSource) -> bool:
+    """CC5 per-provider matching (see docs/architecture/customer-push-authz.md).
+
+    Comparisons are case-insensitive on BOTH sides (adversarial-review
+    finding): GitHub repo full names, GitLab paths, and Jira/Linear keys are
+    case-insensitive identifiers on their providers (no two managed entities
+    can differ only by case), and sync stores them as the provider API
+    happened to return them — an exact match would let a managed
+    ``Acme/API`` row silently fail to block a customer-push ``acme/api``
+    registration/accept, defeating one-active-owner.
+    """
+    inst = instance.strip().lower()
+    if not inst:
+        return False
+    if system in ("github", "jira"):
+        return inst in _candidate_set(source.external_id, source.full_name)
+    if system == "gitlab":
+        path_with_namespace = (source.metadata_ or {}).get("path_with_namespace")
+        return inst in _candidate_set(
+            source.full_name, path_with_namespace, source.external_id
+        )
+    if system == "linear":
+        if linear_is_org_wide_placeholder(source):
+            return True
+        return inst in _candidate_set(source.external_id, source.full_name, source.name)
+    return False
+
+
+async def find_matching_managed_sources(
+    session: AsyncSession, *, org_id: str, system: str, instance: str
+) -> list[tuple[IntegrationSource, bool]]:
+    """All managed ``integration_sources`` rows matching (org, system, instance).
+
+    Returns ``(source, parent_integration_is_active)`` pairs. ``custom``
+    systems have no managed equivalent and always return ``[]``. The
+    candidate query is org+provider-scoped with ``func.lower(...)`` on the
+    provider (nearby sync-creation paths don't enforce lowercase provider
+    values, so a mixed-case managed row must still be found); the
+    per-provider instance predicate then filters in Python because GitLab's
+    metadata-path and Linear's placeholder rules aren't expressible as one
+    indexed SQL predicate.
+    """
+    if system == "custom":
+        return []
+
+    candidate_rows = (
+        await session.execute(
+            select(IntegrationSource, Integration.is_active)
+            .join(Integration, IntegrationSource.integration_id == Integration.id)
+            .where(
+                IntegrationSource.org_id == org_id,
+                func.lower(IntegrationSource.provider) == system,
+            )
+        )
+    ).all()
+    return [
+        (source, bool(integration_is_active))
+        for source, integration_is_active in candidate_rows
+        if matches_instance(system, instance, source)
+    ]
+
+
+async def find_active_managed_owner(
+    session: AsyncSession, *, org_id: str, system: str, instance: str
+) -> IntegrationSource | None:
+    """The managed source that ACTIVELY owns this instance, if any.
+
+    "Active ownership" = the source row is ``is_enabled`` AND its parent
+    ``Integration`` is ``is_active`` (post-critique CC5/CC14) — a source row
+    left enabled under a since-deactivated integration no longer counts.
+    """
+    matches = await find_matching_managed_sources(
+        session, org_id=org_id, system=system, instance=instance
+    )
+    return next(
+        (
+            source
+            for source, integration_is_active in matches
+            if source.is_enabled and integration_is_active
+        ),
+        None,
+    )
+
+
+async def resolve_effective_mode(
+    session: AsyncSession, *, org_id: str, system: str, instance: str
+) -> EffectiveMode:
+    """Resolve the single active ingestion owner for (org, system, instance).
+
+    Precedence (brief §6.5, post-critique CC5/CC14):
+
+    1. An explicit ``external_ingest_sources`` row wins — ``disabled`` if
+       the row is disabled (or mode=disabled), its mode otherwise — EXCEPT
+       that a ``customer_push`` row is still overridden by a managed source
+       that ACTIVELY owns the same instance (defense-in-depth, brief
+       decision 12: nothing stops ``api/admin/routers/sync.py`` from
+       connecting managed sync to the same repo AFTER registration).
+    2. With no explicit row, an actively-owning managed source implies
+       ``fullchaos_sync`` (legacy/native ownership, never registered here).
+    3. Otherwise ``unclaimed``.
+
+    On the data plane this runs after ``require_matching_source`` already
+    bound the token to a registered write-eligible source, so ``unclaimed``/
+    ``disabled`` are unreachable there in practice — the load-bearing outcome
+    at accept time is the step-1 fullchaos_sync override. Callers map
+    outcomes to errors per brief §7 (403 ``source_not_registered`` /
+    ``source_disabled`` / ``source_owned_by_fullchaos_sync``).
+    """
+    explicit = (
+        await session.execute(
+            select(IngestSource).where(
+                IngestSource.org_id == org_id,
+                IngestSource.system == system,
+                IngestSource.instance == instance,
+            )
+        )
+    ).scalar_one_or_none()
+
+    if explicit is not None:
+        if not explicit.enabled or explicit.mode == IngestSourceMode.DISABLED.value:
+            return "disabled"
+        if explicit.mode == IngestSourceMode.FULLCHAOS_SYNC.value:
+            return "fullchaos_sync"
+        owner = await find_active_managed_owner(
+            session, org_id=org_id, system=system, instance=instance
+        )
+        if owner is not None:
+            return "fullchaos_sync"
+        return "customer_push"
+
+    owner = await find_active_managed_owner(
+        session, org_id=org_id, system=system, instance=instance
+    )
+    if owner is not None:
+        return "fullchaos_sync"
+    return "unclaimed"

--- a/tests/api/admin/test_customer_push.py
+++ b/tests/api/admin/test_customer_push.py
@@ -19,6 +19,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.models.audit import AuditLog
 from dev_health_ops.models.git import Base
@@ -808,3 +809,220 @@ async def test_full_lifecycle_produces_expected_audit_rows(session_maker, client
     assert actions.count("ingest_source_registered") == 1
     assert actions.count("ingest_token_created") == 1
     assert actions.count("ingest_token_rotated") == 1
+
+
+@pytest.mark.asyncio
+async def test_create_source_case_variant_duplicate_409(client):
+    """CHAOS-2695 adversarial-review: provider instance identifiers are
+    case-insensitive, so a case-variant re-registration must 409 -- otherwise
+    two enabled sources own the same logical repository under split
+    one-active-owner / idempotency namespaces."""
+    ac, _ = client
+    first = await _create_source(ac, system="github", instance="Acme/API")
+    assert first.status_code == 201
+
+    duplicate = await _create_source(ac, system="github", instance="acme/api")
+
+    assert duplicate.status_code == 409
+    assert "case-insensitive" in duplicate.json()["detail"]
+
+    # A genuinely different instance still registers fine.
+    other = await _create_source(ac, system="github", instance="acme/other")
+    assert other.status_code == 201
+
+
+# ---------------------------------------------------------------------------
+# Validate proxy (CHAOS-2695) -- session-auth twin of the data-plane
+# POST /validate for the web console's Screen 5 (master-spec CC25:
+# validate-only; no console-push proxy exists).
+# ---------------------------------------------------------------------------
+
+_VALID_COMMIT_PAYLOAD = {
+    "repositoryExternalId": "acme/api",
+    "hash": "abc1234567",
+    "authorWhen": "2026-06-25T00:00:00Z",
+}
+
+
+def _validate_envelope(records: list[dict]) -> dict:
+    return {
+        "schemaVersion": SCHEMA_VERSION,
+        "idempotencyKey": "console-validate-1",
+        "source": {
+            "type": "customer_push",
+            "system": "github",
+            "instance": "acme/api",
+        },
+        "records": records,
+    }
+
+
+async def _registered_source_id(ac) -> str:
+    resp = await _create_source(ac, system="github", instance="acme/api")
+    assert resp.status_code == 201
+    return resp.json()["id"]
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_valid_payload(client):
+    ac, _ = client
+    source_id = await _registered_source_id(ac)
+
+    resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/validate",
+        json=_validate_envelope(
+            [
+                {
+                    "kind": "commit.v1",
+                    "externalId": "abc1234567",
+                    "payload": _VALID_COMMIT_PAYLOAD,
+                }
+            ]
+        ),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    # snake_case admin-plane contract (web CustomerPushValidateResponse)
+    assert body == {
+        "valid": True,
+        "items_accepted": 1,
+        "items_rejected": 0,
+        "errors": [],
+    }
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_reports_per_record_errors_with_external_id(client):
+    ac, _ = client
+    source_id = await _registered_source_id(ac)
+
+    bad_commit = {k: v for k, v in _VALID_COMMIT_PAYLOAD.items() if k != "hash"}
+    resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/validate",
+        json=_validate_envelope(
+            [
+                {
+                    "kind": "commit.v1",
+                    "externalId": "good-1",
+                    "payload": _VALID_COMMIT_PAYLOAD,
+                },
+                {"kind": "commit.v1", "externalId": "bad-2", "payload": bad_commit},
+            ]
+        ),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert body["items_accepted"] == 1
+    assert body["items_rejected"] == 1
+    (error,) = body["errors"]
+    assert error["index"] == 1
+    assert error["kind"] == "commit.v1"
+    # Enriched from the record wrapper (ValidationErrorItem itself has no
+    # external_id) for console-table correlation.
+    assert error["external_id"] == "bad-2"
+    assert error["code"] == "missing_required_field"
+    assert error["path"].startswith("records[1].payload")
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_unknown_kind_reported_per_record(client):
+    ac, _ = client
+    source_id = await _registered_source_id(ac)
+
+    resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/validate",
+        json=_validate_envelope(
+            [{"kind": "deployment.v1", "externalId": "d1", "payload": {}}]
+        ),
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert body["errors"][0]["code"] == "unknown_kind"
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_envelope_failure_is_200_result(client):
+    """Envelope-level failures render as validation RESULTS (200,
+    valid:false), never 4xx -- the console panel renders these rows, and the
+    web mock contract pinned this before the endpoint landed."""
+    ac, _ = client
+    source_id = await _registered_source_id(ac)
+
+    resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/validate",
+        json={"schemaVersion": SCHEMA_VERSION, "records": []},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert body["items_accepted"] == 0
+    assert body["items_rejected"] == 0
+    assert body["errors"]
+    assert all(err["code"] == "invalid_envelope" for err in body["errors"])
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_malformed_json_is_200_result(client):
+    ac, _ = client
+    source_id = await _registered_source_id(ac)
+
+    resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/validate",
+        content=b"{not json",
+        headers={"content-type": "application/json"},
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert body["errors"][0]["code"] == "invalid_envelope"
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_wrong_schema_version_is_200_result(client):
+    ac, _ = client
+    source_id = await _registered_source_id(ac)
+
+    envelope = _validate_envelope(
+        [
+            {
+                "kind": "commit.v1",
+                "externalId": "abc1234567",
+                "payload": _VALID_COMMIT_PAYLOAD,
+            }
+        ]
+    )
+    envelope["schemaVersion"] = "external-ingest.v99"
+    resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{source_id}/validate", json=envelope
+    )
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["valid"] is False
+    assert body["errors"][0]["code"] == "unsupported_schema_version"
+    assert body["errors"][0]["path"] == "schemaVersion"
+
+
+@pytest.mark.asyncio
+async def test_validate_proxy_unknown_source_404(client):
+    ac, _ = client
+    resp = await ac.post(
+        f"/api/v1/admin/customer-push/sources/{uuid.uuid4()}/validate",
+        json=_validate_envelope(
+            [
+                {
+                    "kind": "commit.v1",
+                    "externalId": "abc1234567",
+                    "payload": _VALID_COMMIT_PAYLOAD,
+                }
+            ]
+        ),
+    )
+    assert resp.status_code == 404

--- a/tests/api/test_external_ingest_router.py
+++ b/tests/api/test_external_ingest_router.py
@@ -1,23 +1,29 @@
-"""Tests for the external-ingest REST contract (CHAOS-2691).
+"""Tests for the external-ingest REST contract (CHAOS-2691 + CHAOS-2695).
 
 Covers the brief's test plan: envelope/kind/size validation (D2/D4), the D1
 idempotency header/body match, D6's fail-closed stream-unavailable mapping,
-and D8's schema discovery endpoints. Auth (`require_ingest_scope`'s real,
-DB-backed body -- CHAOS-2712) is exercised end-to-end in
+D8's schema discovery endpoints, and (CHAOS-2695) the CC22 accept flow --
+NEW/REPLAY/CONFLICT/RETRY against a REAL aiosqlite-backed session (only
+``enqueue_batch`` is faked; the status/payload/ownership tables are live, so
+these tests exercise the actual store SQL). Auth (`require_ingest_scope`'s
+real, DB-backed body -- CHAOS-2712) is exercised end-to-end in
 tests/api/external_ingest/test_auth.py; this file overrides the bound scope
-dependencies for every test below so router-contract tests don't need a
-database.
+dependencies for every test below.
 """
 
 from __future__ import annotations
 
 import importlib
 import sys
+import uuid as uuid_mod
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
+from dev_health_ops.api.external_ingest import status as status_mod
 from dev_health_ops.api.external_ingest.auth import IngestAuthContext
 from dev_health_ops.api.external_ingest.schemas import (
     RECORD_KIND_MODELS,
@@ -25,7 +31,17 @@ from dev_health_ops.api.external_ingest.schemas import (
 )
 from dev_health_ops.api.external_ingest.streams import StreamUnavailableError
 from dev_health_ops.api.main import app
+from dev_health_ops.external_ingest.payload_store import payload_exists
+from dev_health_ops.models.external_ingest import (
+    ExternalIngestBatch,
+    ExternalIngestBatchPayload,
+    ExternalIngestRecomputeJob,
+    ExternalIngestRejection,
+)
+from dev_health_ops.models.git import Base
 from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
+from dev_health_ops.models.integrations import Integration, IntegrationSource
+from tests._helpers import tables_of
 
 # __init__.py exports the APIRouter as "router", shadowing the module name —
 # force-load the actual module so we can reach its internals (the bound
@@ -54,53 +70,70 @@ TEST_CTX = IngestAuthContext(
     source=_TEST_SOURCE,
 )
 
+_TABLES = tables_of(
+    ExternalIngestBatch,
+    ExternalIngestRejection,
+    ExternalIngestBatchPayload,
+    ExternalIngestRecomputeJob,
+    IngestSource,
+    Integration,
+    IntegrationSource,
+)
+
 
 async def _default_fake_enqueue(**kwargs) -> str:
     return "stream-x"
 
 
-async def _default_fake_upsert_payload(*args, **kwargs) -> None:
-    return None
-
-
-class _FakeSession:
-    """Commit-only stand-in: accept_batch calls ``session.commit()`` directly
-    after the (mocked) ``upsert_payload``, so the fake must expose it."""
-
-    async def commit(self) -> None:
-        return None
-
-
-async def _fake_postgres_session_dep():
-    # Router-contract tests don't need a database (module docstring) --
-    # upsert_payload is mocked by default (see _default_fake_upsert_payload)
-    # so this session object is never used for real I/O; only the
-    # payload-persistence integration tests (test_external_ingest_router_
-    # payload_persistence.py) exercise a real session.
-    yield _FakeSession()
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    """Real aiosqlite DB (CHAOS-2695): the accept flow's ownership resolve +
+    idempotency store + payload upsert all run their actual SQL. Seeds the
+    registered write-eligible source row matching TEST_CTX's bound source --
+    ``resolve_effective_mode`` reads external_ingest_sources for it."""
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'external-ingest-router.db'}"
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    async with maker() as session:
+        session.add(
+            IngestSource(
+                org_id="test-org",
+                system="github",
+                instance="acme/api",
+                mode=IngestSourceMode.CUSTOMER_PUSH.value,
+                enabled=True,
+            )
+        )
+        await session.commit()
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
 
 
 @pytest_asyncio.fixture
-async def client(monkeypatch):
+async def client(session_maker, monkeypatch):
     # Overriding require_ingest_scope (the factory) would not intercept
     # anything: router.py binds each scope's closure once at import time via
     # Depends(_require_schema_read)/Depends(_require_ingest_write), and
     # FastAPI's dependency_overrides matches on that exact callable — not on
     # the factory that produced it. Override the bound objects directly so
-    # unit tests never exercise D7's real (WARN-logging) interim auth body.
+    # unit tests never exercise the real DB-backed auth body.
+    async def _session_override():
+        async with session_maker() as session:
+            yield session
+
     app.dependency_overrides[router_mod._require_schema_read] = lambda: TEST_CTX
     app.dependency_overrides[router_mod._require_ingest_write] = lambda: TEST_CTX
-    app.dependency_overrides[router_mod.get_postgres_session_dep] = (
-        _fake_postgres_session_dep
-    )
-    # Amendment (team-lead-authorized router touch, see PR): accept_batch now
-    # persists the payload before enqueueing. Default both to working
-    # async no-ops so every existing contract-level test (envelope/kind/size
-    # validation, schema discovery, etc.) keeps not needing a database;
-    # individual tests below still override enqueue_batch for their own
-    # success/failure scenarios.
+    app.dependency_overrides[router_mod.get_postgres_session_dep] = _session_override
+    # Only the Valkey stream boundary is faked; individual tests override
+    # enqueue_batch again for their own success/failure scenarios.
     monkeypatch.setattr(router_mod, "enqueue_batch", _default_fake_enqueue)
-    monkeypatch.setattr(router_mod, "upsert_payload", _default_fake_upsert_payload)
     # raise_app_exceptions=False: Starlette's ServerErrorMiddleware sends the
     # sanitized 500 response *then* re-raises so ASGI-server-level logging
     # still sees it; without this, httpx's ASGITransport re-raises instead of
@@ -376,25 +409,18 @@ async def test_stream_unavailable_returns_503(client, monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_enqueue_failure_deletes_orphan_payload(client, monkeypatch):
-    """Adversarial-review round-2: a 503 (stream unavailable) must not leave
-    the just-committed payload row behind -- each accept mints a fresh
-    ingestion_id in the interim flow, so customer retries of a 503 would
-    otherwise accumulate one orphan multi-MB row per attempt."""
-    upserted: list[str] = []
-    deleted: list[str] = []
-
-    async def _fake_upsert(session, *, ingestion_id, **kwargs):
-        upserted.append(str(ingestion_id))
-
-    async def _fake_delete(session, *, ingestion_id):
-        deleted.append(str(ingestion_id))
+async def test_enqueue_failure_keeps_payload_and_marks_stream_unavailable(
+    client, session_maker, monkeypatch
+):
+    """CHAOS-2695 supersedes CHAOS-2693's interim orphan-delete: the payload
+    row is now referenced by the durable status row (status
+    ``stream_unavailable``) and the client's same-key retry reuses BOTH via
+    the same ingestion_id -- deleting it could also black-hole an enqueue
+    whose XADD actually landed before the error surfaced."""
 
     def _raise(**kwargs):
         raise StreamUnavailableError("boom")
 
-    monkeypatch.setattr(router_mod, "upsert_payload", _fake_upsert)
-    monkeypatch.setattr(router_mod, "delete_payload", _fake_delete)
     monkeypatch.setattr(router_mod, "enqueue_batch", _raise)
     envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
 
@@ -402,8 +428,240 @@ async def test_enqueue_failure_deletes_orphan_payload(client, monkeypatch):
 
     assert resp.status_code == 503
     assert resp.json()["error"]["code"] == "stream_unavailable"
-    assert len(upserted) == 1
-    assert deleted == upserted  # the orphan row was cleaned up
+    async with session_maker() as session:
+        batch = await status_mod.find_existing_batch(
+            session,
+            org_id="test-org",
+            source_system="github",
+            source_instance="acme/api",
+            idempotency_key="test-key-1",
+        )
+        assert batch is not None
+        assert batch.status == "stream_unavailable"
+        assert str(batch.ingestion_id) in resp.json()["error"]["message"]
+        assert await payload_exists(
+            session, ingestion_id=batch.ingestion_id, org_id="test-org"
+        )
+
+
+@pytest.mark.asyncio
+async def test_retry_after_stream_unavailable_reuses_ingestion_id(
+    client, session_maker, monkeypatch
+):
+    """RETRY (brief decision 7): a same-key resubmit after a 503 must
+    re-attempt the enqueue on the SAME ingestion_id (attempts += 1), never
+    mint a second row or replay the stale stream_unavailable status."""
+
+    def _raise(**kwargs):
+        raise StreamUnavailableError("boom")
+
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+
+    monkeypatch.setattr(router_mod, "enqueue_batch", _raise)
+    first = await client.post(f"{BASE}/batches", json=envelope)
+    assert first.status_code == 503
+
+    enqueued: list[dict] = []
+
+    async def _ok(**kwargs):
+        enqueued.append(kwargs)
+        return "stream-x"
+
+    monkeypatch.setattr(router_mod, "enqueue_batch", _ok)
+    second = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert second.status_code == 202
+    body = second.json()
+    async with session_maker() as session:
+        batch = await status_mod.find_existing_batch(
+            session,
+            org_id="test-org",
+            source_system="github",
+            source_instance="acme/api",
+            idempotency_key="test-key-1",
+        )
+    assert batch is not None
+    assert body["ingestionId"] == str(batch.ingestion_id)
+    assert batch.status == "accepted"
+    assert batch.attempts == 2
+    assert len(enqueued) == 1
+    assert enqueued[0]["ingestion_id"] == str(batch.ingestion_id)
+
+
+@pytest.mark.asyncio
+async def test_accept_persists_batch_row_with_hash_and_producer(client, session_maker):
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+    envelope["source"]["producer"] = "acme-ci"
+    envelope["source"]["producerVersion"] = "1.2.3"
+
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 202
+    async with session_maker() as session:
+        batch = await status_mod.get_batch(
+            session,
+            org_id="test-org",
+            ingestion_id=uuid_mod.UUID(resp.json()["ingestionId"]),
+        )
+    assert batch is not None
+    assert batch.status == "accepted"
+    assert batch.attempts == 1
+    assert len(batch.payload_hash) == 64  # sha256 hex
+    assert batch.producer == "acme-ci"
+    assert batch.producer_version == "1.2.3"
+    assert batch.items_received == 1
+
+
+@pytest.mark.asyncio
+async def test_replay_same_key_same_payload_returns_200_status_envelope(client):
+    """REPLAY -> 200 (not 202) with the full GET /batches/{id}-shaped body
+    (brief decision 8) and no second enqueue/row."""
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+
+    first = await client.post(f"{BASE}/batches", json=envelope)
+    assert first.status_code == 202
+
+    second = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert second.status_code == 200
+    body = second.json()
+    assert body["ingestionId"] == first.json()["ingestionId"]
+    assert body["status"] == "accepted"
+    assert body["attempts"] == 1  # replay never increments
+    assert body["itemsReceived"] == 1
+    assert "recompute" in body  # full status envelope, not the 202 shape
+    assert "stream" not in body
+
+
+@pytest.mark.asyncio
+async def test_replay_is_field_order_insensitive(client):
+    """Canonicalization (brief decisions 1-2): reordering JSON keys must
+    hash identically -> REPLAY, not CONFLICT."""
+    record = _record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])
+    envelope = _envelope([record])
+    first = await client.post(f"{BASE}/batches", json=envelope)
+    assert first.status_code == 202
+
+    reordered = {
+        "records": [
+            {
+                "payload": dict(reversed(list(record["payload"].items()))),
+                "externalId": record["externalId"],
+                "kind": record["kind"],
+            }
+        ],
+        "source": envelope["source"],
+        "idempotencyKey": envelope["idempotencyKey"],
+        "schemaVersion": envelope["schemaVersion"],
+    }
+    second = await client.post(f"{BASE}/batches", json=reordered)
+
+    assert second.status_code == 200
+    assert second.json()["ingestionId"] == first.json()["ingestionId"]
+
+
+@pytest.mark.asyncio
+async def test_conflict_same_key_different_payload_409(client):
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+    first = await client.post(f"{BASE}/batches", json=envelope)
+    assert first.status_code == 202
+
+    different = _envelope(
+        [
+            _record(
+                "commit.v1",
+                "OTHER",
+                {**VALID_PAYLOADS["commit.v1"], "hash": "fff9999999"},
+            )
+        ]
+    )
+    second = await client.post(f"{BASE}/batches", json=different)
+
+    assert second.status_code == 409
+    assert second.json()["error"]["code"] == "idempotency_conflict"
+
+
+@pytest.mark.asyncio
+async def test_same_key_different_instance_is_independent(
+    client, session_maker, monkeypatch
+):
+    """The idempotency namespace is (org, system, instance, key) -- reusing
+    a key string against a DIFFERENT registered instance is a fresh NEW
+    batch, not a conflict (brief §2)."""
+    async with session_maker() as session:
+        session.add(
+            IngestSource(
+                org_id="test-org",
+                system="github",
+                instance="acme/other",
+                mode=IngestSourceMode.CUSTOMER_PUSH.value,
+                enabled=True,
+            )
+        )
+        await session.commit()
+    other_ctx = IngestAuthContext(
+        org_id="test-org",
+        scopes=frozenset({"ingest:write"}),
+        source=IngestSource(
+            org_id="test-org",
+            system="github",
+            instance="acme/other",
+            mode=IngestSourceMode.CUSTOMER_PUSH.value,
+            enabled=True,
+        ),
+    )
+
+    first = await client.post(
+        f"{BASE}/batches",
+        json=_envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])]),
+    )
+    assert first.status_code == 202
+
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: other_ctx
+    try:
+        other_envelope = _envelope(
+            [_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])]
+        )
+        other_envelope["source"]["instance"] = "acme/other"
+        second = await client.post(f"{BASE}/batches", json=other_envelope)
+    finally:
+        app.dependency_overrides[router_mod._require_ingest_write] = lambda: TEST_CTX
+
+    assert second.status_code == 202
+    assert second.json()["ingestionId"] != first.json()["ingestionId"]
+
+
+@pytest.mark.asyncio
+async def test_accept_rejected_when_fullchaos_actively_owns_instance(
+    client, session_maker
+):
+    """Accept-time one-active-owner re-check (CC5/CC14 defense in depth): a
+    managed sync source connected to the same instance AFTER registration
+    must 403 even though the token still binds to a write-eligible row."""
+    async with session_maker() as session:
+        integration = Integration(
+            org_id="test-org", provider="GitHub", name="managed-github"
+        )
+        session.add(integration)
+        await session.flush()
+        session.add(
+            IntegrationSource(
+                org_id="test-org",
+                integration_id=integration.id,
+                provider="GitHub",  # mixed case on purpose: func.lower matching
+                source_type="repository",
+                external_id="acme/api",
+                name="api",
+                full_name="acme/api",
+            )
+        )
+        await session.commit()
+
+    envelope = _envelope([_record("commit.v1", "c1", VALID_PAYLOADS["commit.v1"])])
+    resp = await client.post(f"{BASE}/batches", json=envelope)
+
+    assert resp.status_code == 403
+    assert resp.json()["error"]["code"] == "source_owned_by_fullchaos_sync"
 
 
 @pytest.mark.asyncio

--- a/tests/external_ingest/test_idempotency.py
+++ b/tests/external_ingest/test_idempotency.py
@@ -1,0 +1,499 @@
+"""Unit tests for the CHAOS-2695 idempotency policy (brief §9).
+
+Canonicalization invariance is pure (no DB); the 4-way outcome matrix runs
+against the REAL direct-SQL store (aiosqlite) so the unique-constraint /
+SAVEPOINT race handling is exercised for real, per house convention
+(tests/test_external_ingest_status_api.py). Live-Postgres divergence is
+covered by the changeset's §11 live verification, not here.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.external_ingest import idempotency as idem
+from dev_health_ops.api.external_ingest import status as status_mod
+from dev_health_ops.api.external_ingest.idempotency import (
+    IdempotencyOutcomeKind,
+    IngestTemporarilyUnavailableError,
+    compute_payload_hash,
+    resolve_batch_idempotency,
+)
+from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION, BatchEnvelope
+from dev_health_ops.models.external_ingest import (
+    ExternalIngestBatch,
+    ExternalIngestRejection,
+)
+from dev_health_ops.models.git import Base
+from tests._helpers import tables_of
+
+_TABLES = tables_of(ExternalIngestBatch, ExternalIngestRejection)
+
+ORG = "org-1"
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'external-ingest-idempotency.db'}"
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# Canonicalization (brief decisions 1-3)
+# ---------------------------------------------------------------------------
+
+
+def _envelope_dict(**overrides) -> dict:
+    base = {
+        "schemaVersion": SCHEMA_VERSION,
+        "idempotencyKey": "key-1",
+        "source": {
+            "type": "customer_push",
+            "system": "github",
+            "instance": "acme/api",
+        },
+        "window": {
+            "startedAt": "2026-06-25T00:00:00Z",
+            "endedAt": "2026-06-26T00:00:00Z",
+        },
+        "records": [
+            {
+                "kind": "commit.v1",
+                "externalId": "abc1234567",
+                "payload": {
+                    "repositoryExternalId": "acme/api",
+                    "hash": "abc1234567",
+                    "authorWhen": "2026-06-25T12:00:00Z",
+                },
+            }
+        ],
+    }
+    base.update(overrides)
+    return base
+
+
+def test_canonicalization_field_order_invariant():
+    ordered = BatchEnvelope.model_validate(_envelope_dict())
+    reordered_raw = dict(reversed(list(_envelope_dict().items())))
+    reordered_raw["records"] = [
+        dict(reversed(list(record.items()))) for record in reordered_raw["records"]
+    ]
+    reordered = BatchEnvelope.model_validate(reordered_raw)
+
+    assert compute_payload_hash(ordered) == compute_payload_hash(reordered)
+
+
+def test_canonicalization_whitespace_invariant():
+    import json as json_mod
+
+    minified = json_mod.dumps(_envelope_dict(), separators=(",", ":"))
+    pretty = json_mod.dumps(_envelope_dict(), indent=4)
+
+    assert compute_payload_hash(
+        BatchEnvelope.model_validate_json(minified)
+    ) == compute_payload_hash(BatchEnvelope.model_validate_json(pretty))
+
+
+def test_canonicalization_timestamp_format_invariant():
+    zulu = BatchEnvelope.model_validate(_envelope_dict())
+    offset_dict = _envelope_dict()
+    offset_dict["window"] = {
+        "startedAt": "2026-06-25T00:00:00+00:00",
+        "endedAt": "2026-06-26T00:00:00+00:00",
+    }
+    offset = BatchEnvelope.model_validate(offset_dict)
+
+    assert compute_payload_hash(zulu) == compute_payload_hash(offset)
+
+
+def test_record_order_is_position_significant():
+    """Brief decision 3: records are NOT sorted before hashing -- swapping
+    two records is a different payload (CONFLICT), by design."""
+    two = _envelope_dict()
+    second = {
+        "kind": "commit.v1",
+        "externalId": "def8901234",
+        "payload": {
+            "repositoryExternalId": "acme/api",
+            "hash": "def8901234",
+            "authorWhen": "2026-06-25T13:00:00Z",
+        },
+    }
+    two["records"] = [two["records"][0], second]
+    swapped = _envelope_dict()
+    swapped["records"] = [second, dict(_envelope_dict()["records"][0])]
+
+    assert compute_payload_hash(
+        BatchEnvelope.model_validate(two)
+    ) != compute_payload_hash(BatchEnvelope.model_validate(swapped))
+
+
+# ---------------------------------------------------------------------------
+# Outcome matrix (brief decision 7 + post-critique CC13 stale-accepted)
+# ---------------------------------------------------------------------------
+
+
+async def _resolve(
+    session,
+    *,
+    idempotency_key: str = "key-1",
+    payload_hash: str = "h" * 64,
+    source_instance: str = "acme/api",
+    items_received: int = 3,
+):
+    return await resolve_batch_idempotency(
+        session,
+        org_id=ORG,
+        source_system="github",
+        source_instance=source_instance,
+        idempotency_key=idempotency_key,
+        payload_hash=payload_hash,
+        schema_version=SCHEMA_VERSION,
+        producer="pytest",
+        producer_version="1.0",
+        window_started_at=None,
+        window_ended_at=None,
+        items_received=items_received,
+    )
+
+
+async def _set_status(
+    session_maker, ingestion_id: uuid.UUID, status: str, *, updated_at=None
+) -> None:
+    async with session_maker() as session:
+        params = {"status": status, "ingestion_id": str(ingestion_id)}
+        set_clause = "status = :status"
+        if updated_at is not None:
+            set_clause += ", updated_at = :updated_at"
+            params["updated_at"] = updated_at
+        await session.execute(
+            text(
+                "UPDATE external_ingest_batches SET "
+                + set_clause
+                + " WHERE ingestion_id = :ingestion_id"
+            ),
+            params,
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_new_batch_returns_new_outcome(session_maker):
+    async with session_maker() as session:
+        outcome = await _resolve(session)
+        await session.commit()
+
+    assert outcome.kind is IdempotencyOutcomeKind.NEW
+    assert outcome.batch.status == "accepted"
+    assert outcome.batch.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_replay_same_key_same_hash_returns_existing_row(session_maker):
+    async with session_maker() as session:
+        first = await _resolve(session)
+        await session.commit()
+    async with session_maker() as session:
+        second = await _resolve(session)
+
+    assert second.kind is IdempotencyOutcomeKind.REPLAY
+    assert second.batch.ingestion_id == first.batch.ingestion_id
+
+
+@pytest.mark.asyncio
+async def test_conflict_same_key_different_hash(session_maker):
+    async with session_maker() as session:
+        await _resolve(session)
+        await session.commit()
+    async with session_maker() as session:
+        outcome = await _resolve(session, payload_hash="x" * 64)
+
+    assert outcome.kind is IdempotencyOutcomeKind.CONFLICT
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("retryable_status", ["stream_unavailable", "failed"])
+async def test_retry_outcome_for_retryable_statuses(session_maker, retryable_status):
+    async with session_maker() as session:
+        first = await _resolve(session)
+        await session.commit()
+    await _set_status(session_maker, first.batch.ingestion_id, retryable_status)
+
+    async with session_maker() as session:
+        outcome = await _resolve(session)
+
+    assert outcome.kind is IdempotencyOutcomeKind.RETRY
+    assert outcome.batch.ingestion_id == first.batch.ingestion_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_status", ["completed", "partial"])
+async def test_replay_not_retry_for_terminal_statuses(session_maker, terminal_status):
+    async with session_maker() as session:
+        first = await _resolve(session)
+        await session.commit()
+    await _set_status(session_maker, first.batch.ingestion_id, terminal_status)
+
+    async with session_maker() as session:
+        outcome = await _resolve(session)
+
+    assert outcome.kind is IdempotencyOutcomeKind.REPLAY
+
+
+@pytest.mark.asyncio
+async def test_stale_accepted_becomes_retry(session_maker):
+    """Post-critique CC13: an accepted row older than the stale window is
+    presumed lost (crash-before-XADD / stream trim -- no worker can ever see
+    it) and RETRY -- otherwise `accepted` would be permanently
+    unrecoverable."""
+    async with session_maker() as session:
+        first = await _resolve(session)
+        await session.commit()
+    stale = datetime.now(timezone.utc) - timedelta(minutes=16)
+    await _set_status(
+        session_maker, first.batch.ingestion_id, "accepted", updated_at=stale
+    )
+
+    async with session_maker() as session:
+        outcome = await _resolve(session)
+
+    assert outcome.kind is IdempotencyOutcomeKind.RETRY
+
+
+@pytest.mark.asyncio
+async def test_stale_processing_stays_replay(session_maker):
+    """Adversarial-review finding: a stale `processing` row must NOT be
+    client-retryable -- a worker provably holds the pointer, and an unfenced
+    retry would race a slow-but-alive worker's terminal CAS (double-apply).
+    Recovery for dead workers is the stream reclaim path / `failed` status,
+    both outside this policy."""
+    async with session_maker() as session:
+        first = await _resolve(session)
+        await session.commit()
+    stale = datetime.now(timezone.utc) - timedelta(minutes=120)
+    await _set_status(
+        session_maker, first.batch.ingestion_id, "processing", updated_at=stale
+    )
+
+    async with session_maker() as session:
+        outcome = await _resolve(session)
+
+    assert outcome.kind is IdempotencyOutcomeKind.REPLAY
+
+
+@pytest.mark.asyncio
+async def test_young_accepted_stays_replay(session_maker):
+    async with session_maker() as session:
+        await _resolve(session)
+        await session.commit()
+
+    async with session_maker() as session:
+        outcome = await _resolve(session)
+
+    assert outcome.kind is IdempotencyOutcomeKind.REPLAY
+
+
+@pytest.mark.asyncio
+async def test_stale_window_env_override(session_maker, monkeypatch):
+    monkeypatch.setenv("EXTERNAL_INGEST_ACCEPTED_STALE_MINUTES", "1")
+    async with session_maker() as session:
+        first = await _resolve(session)
+        await session.commit()
+    barely_old = datetime.now(timezone.utc) - timedelta(minutes=2)
+    await _set_status(
+        session_maker, first.batch.ingestion_id, "accepted", updated_at=barely_old
+    )
+
+    async with session_maker() as session:
+        outcome = await _resolve(session)
+
+    assert outcome.kind is IdempotencyOutcomeKind.RETRY
+
+
+@pytest.mark.asyncio
+async def test_conflict_wins_over_retryable_status(session_maker):
+    """Hash mismatch dominates: a different payload against a failed row is
+    still a 409 CONFLICT, never a silent overwrite via RETRY."""
+    async with session_maker() as session:
+        first = await _resolve(session)
+        await session.commit()
+    await _set_status(session_maker, first.batch.ingestion_id, "failed")
+
+    async with session_maker() as session:
+        outcome = await _resolve(session, payload_hash="x" * 64)
+
+    assert outcome.kind is IdempotencyOutcomeKind.CONFLICT
+
+
+@pytest.mark.asyncio
+async def test_unique_constraint_scoped_to_org_system_instance(session_maker):
+    """Same key string across two source instances = two independent NEW
+    rows (brief §2: no cross-source namespacing)."""
+    async with session_maker() as session:
+        first = await _resolve(session, source_instance="acme/api")
+        await session.commit()
+    async with session_maker() as session:
+        second = await _resolve(session, source_instance="acme/other")
+        await session.commit()
+
+    assert first.kind is IdempotencyOutcomeKind.NEW
+    assert second.kind is IdempotencyOutcomeKind.NEW
+    assert first.batch.ingestion_id != second.batch.ingestion_id
+
+
+@pytest.mark.asyncio
+async def test_lost_insert_race_reclassifies_winner_row(session_maker, monkeypatch):
+    """DuplicateIdempotencyKeyError -> re-read the winner's row and apply the
+    same hash policy (here: same hash, accepted -> REPLAY)."""
+    async with session_maker() as session:
+        winner = await _resolve(session)
+        await session.commit()
+
+    finds = {"n": 0}
+    real_find = idem.find_existing_batch
+
+    async def _find_miss_then_hit(session, **kwargs):
+        finds["n"] += 1
+        if finds["n"] == 1:
+            return None  # pre-check misses; the INSERT then collides
+        return await real_find(session, **kwargs)
+
+    monkeypatch.setattr(idem, "find_existing_batch", _find_miss_then_hit)
+
+    async with session_maker() as session:
+        outcome = await _resolve(session)
+
+    assert outcome.kind is IdempotencyOutcomeKind.REPLAY
+    assert outcome.batch.ingestion_id == winner.batch.ingestion_id
+
+
+@pytest.mark.asyncio
+async def test_true_race_raises_temporarily_unavailable(session_maker, monkeypatch):
+    """The winner's row is not visible on the post-conflict re-read (still
+    uncommitted) -> IngestTemporarilyUnavailableError (503)."""
+
+    async def _find_none(session, **kwargs):
+        return None
+
+    async def _create_collides(session, **kwargs):
+        raise status_mod.DuplicateIdempotencyKeyError(
+            org_id=ORG,
+            source_system="github",
+            source_instance="acme/api",
+            idempotency_key="key-1",
+        )
+
+    monkeypatch.setattr(idem, "find_existing_batch", _find_none)
+    monkeypatch.setattr(idem, "create_batch", _create_collides)
+
+    async with session_maker() as session:
+        with pytest.raises(IngestTemporarilyUnavailableError):
+            await _resolve(session)
+
+
+# ---------------------------------------------------------------------------
+# reset_for_retry (store-level half of the RETRY contract)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_reset_for_retry_clears_failed_attempt_and_rejections(session_maker):
+    async with session_maker() as session:
+        first = await _resolve(session, items_received=2)
+        await session.commit()
+    ingestion_id = first.batch.ingestion_id
+
+    rejections = [
+        status_mod.RejectedRecord(
+            record_index=i,
+            record_kind="commit.v1",
+            external_id=f"c{i}",
+            code="invalid_field",
+            message="bad",
+            path=None,
+        )
+        for i in range(2)
+    ]
+    async with session_maker() as session:
+        await status_mod.mark_processing(session, org_id=ORG, ingestion_id=ingestion_id)
+        failed = await status_mod.complete_batch(
+            session,
+            org_id=ORG,
+            ingestion_id=ingestion_id,
+            items_accepted=0,
+            items_rejected=2,
+            rejections=rejections,
+        )
+        await session.commit()
+    assert failed.status == "failed"
+
+    async with session_maker() as session:
+        won = await status_mod.reset_for_retry(
+            session, org_id=ORG, ingestion_id=ingestion_id, from_status="failed"
+        )
+        await session.commit()
+    assert won is True
+
+    async with session_maker() as session:
+        row = await status_mod.get_batch(session, org_id=ORG, ingestion_id=ingestion_id)
+        assert row is not None
+        assert row.status == "accepted"
+        assert row.attempts == 2
+        assert row.items_accepted == 0
+        assert row.items_rejected == 0
+        assert row.error_summary is None
+        assert row.completed_at is None
+        stored, total = await status_mod.list_rejections(
+            session, org_id=ORG, ingestion_id=ingestion_id
+        )
+        assert stored == []
+        assert total == 0
+
+        # The retry attempt can complete again without tripping the
+        # (ingestion_id, record_index) unique index on rejection rows.
+        await status_mod.mark_processing(session, org_id=ORG, ingestion_id=ingestion_id)
+        done = await status_mod.complete_batch(
+            session,
+            org_id=ORG,
+            ingestion_id=ingestion_id,
+            items_accepted=1,
+            items_rejected=1,
+            rejections=rejections[:1],
+        )
+        await session.commit()
+    assert done.status == "partial"
+    assert done.attempts == 2
+
+
+@pytest.mark.asyncio
+async def test_reset_for_retry_cas_loses_on_status_move(session_maker):
+    async with session_maker() as session:
+        first = await _resolve(session)
+        await session.commit()
+    await _set_status(session_maker, first.batch.ingestion_id, "completed")
+
+    async with session_maker() as session:
+        won = await status_mod.reset_for_retry(
+            session,
+            org_id=ORG,
+            ingestion_id=first.batch.ingestion_id,
+            from_status="stream_unavailable",
+        )
+    assert won is False

--- a/tests/external_ingest/test_ownership.py
+++ b/tests/external_ingest/test_ownership.py
@@ -1,0 +1,374 @@
+"""Unit tests for CHAOS-2695's one-active-owner resolution (brief §9).
+
+Exercises the CC5 per-provider matching matrix (GitHub/Jira exact, GitLab
+metadata path, Linear org-wide placeholder, case-insensitive provider) and
+``resolve_effective_mode``'s precedence rules, against a real aiosqlite DB.
+"""
+
+from __future__ import annotations
+
+import uuid
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.external_ingest.ownership import (
+    find_active_managed_owner,
+    resolve_effective_mode,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
+from dev_health_ops.models.integrations import Integration, IntegrationSource
+from tests._helpers import tables_of
+
+_TABLES = tables_of(IngestSource, Integration, IntegrationSource)
+
+ORG = "org-1"
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'external-ingest-ownership.db'}"
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _seed_managed(
+    session_maker,
+    *,
+    provider: str,
+    external_id: str,
+    full_name: str,
+    name: str | None = None,
+    metadata_: dict | None = None,
+    source_enabled: bool = True,
+    integration_active: bool = True,
+    org_id: str = ORG,
+) -> None:
+    integration_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add(
+            Integration(
+                id=integration_id,
+                org_id=org_id,
+                provider=provider,
+                name=f"{provider}-integration",
+                is_active=integration_active,
+            )
+        )
+        session.add(
+            IntegrationSource(
+                org_id=org_id,
+                integration_id=integration_id,
+                provider=provider,
+                source_type="repository",
+                external_id=external_id,
+                name=name or full_name,
+                full_name=full_name,
+                metadata_=metadata_ or {},
+                is_enabled=source_enabled,
+            )
+        )
+        await session.commit()
+
+
+async def _seed_explicit(
+    session_maker,
+    *,
+    system: str = "github",
+    instance: str = "acme/api",
+    mode: str = IngestSourceMode.CUSTOMER_PUSH.value,
+    enabled: bool = True,
+) -> None:
+    async with session_maker() as session:
+        session.add(
+            IngestSource(
+                org_id=ORG, system=system, instance=instance, mode=mode, enabled=enabled
+            )
+        )
+        await session.commit()
+
+
+async def _mode(session_maker, *, system: str = "github", instance: str = "acme/api"):
+    async with session_maker() as session:
+        return await resolve_effective_mode(
+            session, org_id=ORG, system=system, instance=instance
+        )
+
+
+# ---------------------------------------------------------------------------
+# Explicit-row precedence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unclaimed_when_no_rows_anywhere(session_maker):
+    assert await _mode(session_maker) == "unclaimed"
+
+
+@pytest.mark.asyncio
+async def test_customer_push_when_explicit_row_enabled(session_maker):
+    await _seed_explicit(session_maker)
+    assert await _mode(session_maker) == "customer_push"
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_explicit_row_disabled(session_maker):
+    await _seed_explicit(session_maker, enabled=False)
+    assert await _mode(session_maker) == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_disabled_when_explicit_row_mode_disabled(session_maker):
+    await _seed_explicit(session_maker, mode=IngestSourceMode.DISABLED.value)
+    assert await _mode(session_maker) == "disabled"
+
+
+@pytest.mark.asyncio
+async def test_fullchaos_when_explicit_row_mode_fullchaos(session_maker):
+    await _seed_explicit(session_maker, mode=IngestSourceMode.FULLCHAOS_SYNC.value)
+    assert await _mode(session_maker) == "fullchaos_sync"
+
+
+@pytest.mark.asyncio
+async def test_explicit_customer_push_overridden_by_active_managed_owner(
+    session_maker,
+):
+    """Defense in depth (brief decision 12): managed sync connected AFTER the
+    customer_push registration flips the effective mode back to
+    fullchaos_sync at accept time."""
+    await _seed_explicit(session_maker)
+    await _seed_managed(
+        session_maker, provider="github", external_id="acme/api", full_name="acme/api"
+    )
+    assert await _mode(session_maker) == "fullchaos_sync"
+
+
+@pytest.mark.asyncio
+async def test_explicit_customer_push_survives_inactive_managed_match(session_maker):
+    await _seed_explicit(session_maker)
+    await _seed_managed(
+        session_maker,
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+        integration_active=False,
+    )
+    assert await _mode(session_maker) == "customer_push"
+
+
+# ---------------------------------------------------------------------------
+# Derived fullchaos_sync (CC5 per-provider matching)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_fullchaos_sync_derived_from_github_external_id(session_maker):
+    await _seed_managed(
+        session_maker, provider="github", external_id="acme/api", full_name="acme/api"
+    )
+    assert await _mode(session_maker) == "fullchaos_sync"
+
+
+@pytest.mark.asyncio
+async def test_fullchaos_sync_derived_case_insensitive_provider(session_maker):
+    """Managed rows may carry mixed-case providers ('GitHub'); the lookup is
+    lowercased on both sides or the one-active-owner check silently never
+    fires (2696 adversarial-review finding, kept by the shared predicates)."""
+    await _seed_managed(
+        session_maker, provider="GitHub", external_id="acme/api", full_name="acme/api"
+    )
+    assert await _mode(session_maker) == "fullchaos_sync"
+
+
+@pytest.mark.asyncio
+async def test_instance_matching_is_case_insensitive_both_directions(session_maker):
+    """Adversarial-review finding: provider identifiers are case-insensitive
+    (GitHub full names, GitLab paths, Jira keys) but sync stores them as the
+    provider API returned them -- exact comparison would let `Acme/API`
+    managed rows fail to block an `acme/api` customer push."""
+    await _seed_managed(
+        session_maker, provider="github", external_id="Acme/API", full_name="Acme/API"
+    )
+    assert await _mode(session_maker, instance="acme/api") == "fullchaos_sync"
+    assert await _mode(session_maker, instance="ACME/api") == "fullchaos_sync"
+
+
+@pytest.mark.asyncio
+async def test_gitlab_metadata_path_case_insensitive(session_maker):
+    await _seed_managed(
+        session_maker,
+        provider="gitlab",
+        external_id="12345",
+        full_name="Group/Project",
+        metadata_={"path_with_namespace": "Group/Project"},
+    )
+    assert (
+        await _mode(session_maker, system="gitlab", instance="group/project")
+        == "fullchaos_sync"
+    )
+
+
+@pytest.mark.asyncio
+async def test_jira_key_case_insensitive(session_maker):
+    await _seed_managed(
+        session_maker, provider="jira", external_id="PROJ", full_name="PROJ"
+    )
+    assert await _mode(session_maker, system="jira", instance="proj") == (
+        "fullchaos_sync"
+    )
+
+
+@pytest.mark.asyncio
+async def test_gitlab_matches_metadata_path_not_numeric_external_id(session_maker):
+    """GitLab stores the NUMERIC project id in external_id (CC5) -- the
+    human-readable instance string must match via full_name/metadata path."""
+    await _seed_managed(
+        session_maker,
+        provider="gitlab",
+        external_id="12345",
+        full_name="group/project",
+        metadata_={"path_with_namespace": "group/project"},
+    )
+    assert (
+        await _mode(session_maker, system="gitlab", instance="group/project")
+        == "fullchaos_sync"
+    )
+    assert (
+        await _mode(session_maker, system="gitlab", instance="12345")
+        == "fullchaos_sync"
+    )
+    assert (
+        await _mode(session_maker, system="gitlab", instance="group/other")
+        == "unclaimed"
+    )
+
+
+@pytest.mark.asyncio
+async def test_jira_matches_external_id(session_maker):
+    await _seed_managed(
+        session_maker, provider="jira", external_id="PROJ", full_name="PROJ"
+    )
+    assert await _mode(session_maker, system="jira", instance="PROJ") == (
+        "fullchaos_sync"
+    )
+
+
+@pytest.mark.asyncio
+async def test_linear_org_wide_placeholder_owns_all_teams(session_maker):
+    await _seed_managed(
+        session_maker, provider="linear", external_id="linear", full_name="Linear"
+    )
+    assert (
+        await _mode(session_maker, system="linear", instance="ANY-TEAM")
+        == "fullchaos_sync"
+    )
+
+
+@pytest.mark.asyncio
+async def test_linear_placeholder_via_metadata_flag(session_maker):
+    await _seed_managed(
+        session_maker,
+        provider="linear",
+        external_id=str(uuid.uuid4()),
+        full_name="Workspace",
+        metadata_={"org_wide_placeholder": True},
+    )
+    assert (
+        await _mode(session_maker, system="linear", instance="CHAOS")
+        == "fullchaos_sync"
+    )
+
+
+@pytest.mark.asyncio
+async def test_linear_team_matches_by_name(session_maker):
+    await _seed_managed(
+        session_maker,
+        provider="linear",
+        external_id=str(uuid.uuid4()),
+        full_name="team-chaos",
+        name="CHAOS",
+    )
+    assert (
+        await _mode(session_maker, system="linear", instance="CHAOS")
+        == "fullchaos_sync"
+    )
+    assert await _mode(session_maker, system="linear", instance="OTHER") == "unclaimed"
+
+
+@pytest.mark.asyncio
+async def test_not_derived_when_integration_inactive(session_maker):
+    await _seed_managed(
+        session_maker,
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+        integration_active=False,
+    )
+    assert await _mode(session_maker) == "unclaimed"
+
+
+@pytest.mark.asyncio
+async def test_not_derived_when_source_disabled(session_maker):
+    await _seed_managed(
+        session_maker,
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+        source_enabled=False,
+    )
+    assert await _mode(session_maker) == "unclaimed"
+
+
+@pytest.mark.asyncio
+async def test_other_org_rows_never_match(session_maker):
+    await _seed_managed(
+        session_maker,
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+        org_id="other-org",
+    )
+    assert await _mode(session_maker) == "unclaimed"
+
+
+@pytest.mark.asyncio
+async def test_custom_never_conflicts(session_maker):
+    await _seed_managed(
+        session_maker, provider="custom", external_id="my-tool", full_name="my-tool"
+    )
+    await _seed_explicit(session_maker, system="custom", instance="my-tool")
+    assert (
+        await _mode(session_maker, system="custom", instance="my-tool")
+        == "customer_push"
+    )
+
+
+@pytest.mark.asyncio
+async def test_find_active_managed_owner_returns_matching_row(session_maker):
+    await _seed_managed(
+        session_maker, provider="github", external_id="acme/api", full_name="acme/api"
+    )
+    async with session_maker() as session:
+        owner = await find_active_managed_owner(
+            session, org_id=ORG, system="github", instance="acme/api"
+        )
+        assert owner is not None
+        assert owner.external_id == "acme/api"
+        assert (
+            await find_active_managed_owner(
+                session, org_id=ORG, system="github", instance="acme/other"
+            )
+            is None
+        )


### PR DESCRIPTION
Implements CHAOS-2695 (wave 4): batch idempotency policy + one-active-owner enforcement, rewiring `POST /api/v1/external-ingest/batches` to the full master-spec CC22 accept sequence, plus the admin validate proxy (CC25, validate-only).

Spec: `docs/superpowers/plans/2026-07-01-chaos-2690-implementation/briefs/brief-2695-idempotency.md` (reconciliation header governs). New durable policy record: `docs/architecture/external-ingest-idempotency-ownership.md`.

## What's here

- **`api/external_ingest/idempotency.py`** — `compute_payload_hash` (SHA-256 over the canonicalized, schema-validated envelope; field-order/whitespace/timestamp-format invariant; record order position-significant by design) + 4-way `resolve_batch_idempotency` (NEW / REPLAY / CONFLICT / RETRY) over 2694's direct-SQL store. Keys unique forever per `(org, system, instance, key)`. True insert race → 503 `ingest_temporarily_unavailable`. *Placement deviation from the brief (api package, not `dev_health_ops/external_ingest/`): the store dependency lives here and the sibling-package import recurses through `api/external_ingest/__init__` → `router` → this module into a circular ImportError.*
- **`external_ingest/ownership.py`** — CC5 per-provider instance matching factored out of 2696's admin router (single source of truth, brief D12) + `resolve_effective_mode`. An explicit `customer_push` registration is overridden at accept time by a managed source that actively owns the same instance (defense-in-depth: sync-side code doesn't know about `external_ingest_sources`).
- **`status.py`** — `reset_for_retry` (CAS on observed status; `attempts += 1`; clears the prior attempt's outcome fields AND rejection rows, which would otherwise trip the `(ingestion_id, record_index)` unique index on re-completion). `create_batch` docstring corrected to the CC22 write order.
- **`router.py` accept rewrite** — ownership 403s → idempotency (FIRST Postgres write) → CONFLICT 409 `idempotency_conflict` / REPLAY **200 with the full status envelope** (brief D8) / NEW+RETRY → payload upsert (same txn) → COMMIT → enqueue → on `StreamUnavailableError`: `mark_stream_unavailable` + commit-before-raise 503. **The payload row is now kept on the 503 path** (supersedes 2693's interim orphan-delete: the durable `stream_unavailable` row references it, RETRY reuses it via the same ingestion_id, and deleting could black-hole an XADD that actually landed).
- **Admin validate proxy** `POST /api/v1/admin/customer-push/sources/{id}/validate` — session-auth twin of the data-plane `/validate` for web Screen 5. snake_case response matching the web's `CustomerPushValidateResponse`; envelope-level failures return 200 `valid:false` result rows (pinned by the web mock contract); `external_id` enriched from record wrappers. Web follow-up (flag flip + restored round-trip e2e) is prepared on `chaos-2695-validate-flag` and lands after this merges.

## Adversarial review (codex, 2 rounds)

**Round 1 (2 HIGH, both fixed):**
1. *Case/alias-sensitive instance matching bypasses one-active-owner* → `matches_instance` now folds case on both sides (provider identifiers are case-insensitive; no two managed entities can differ only by case, so over-matching is impossible). Regression tests for GitHub/GitLab-metadata-path/Jira case variants.
2. *Stale-`processing` retry races a slow-but-alive worker's terminal CAS* → stale-RETRY narrowed to `accepted` only — a **documented deviation from the reconciliation header's literal "accepted/processing"**. Rationale: a stuck-`accepted` row is invisible to every worker (pointer never reached the stream — client resubmit is the only recovery, CC13's actual target), while a `processing` row proves a worker holds the pointer; dead-worker recovery is 2693's reclaim + the `failed` status (already retryable). Attempt-fenced retries left as a 2697+ extension if operationally needed.

**Round 2 (2 HIGH: 1 fixed, 1 refuted):**
1. *Case-variant duplicate customer-push registrations split the owner/idempotency namespace* → fixed app-level: `create_source` now 409s on a case-folded collision (stored casing preserved; token/envelope matching stays exact against the single registered spelling). DB-level functional unique index needs a migration (this changeset ships none by ratified scope) → **CHAOS-2783** filed.
2. *Stale-`accepted` retry can duplicate an already-enqueued pointer* → **refuted**: duplicate pointer delivery is the pipeline's designed baseline (2693's reclaim machinery itself redelivers); dedup lives at processing time (CC11 single consumer, `mark_processing`/`complete_batch` CAS, RMT sinks, coalesced recompute). The proposed durable enqueue marker cannot close the window (crash after XADD before marker inverts the bug — two-system exactly-once). Now documented explicitly in the arch doc so future reviews don't re-derive it.

## Verification record

- **Gate** (`env -i … SCRATCH_DB=ci_local_validate_2695 bash ci/local_validate.sh`): green ×3 across rounds; final run **6,712 passed / 0 failed** (+44 tests from this changeset: canonicalization ×4, outcome matrix incl. stale/CAS/race branches, ownership matrix incl. case variants + linear placeholder + gitlab metadata path, router CC22 flow against a real aiosqlite store, admin proxy contract ×8, case-variant registration).
- **Live verification** (scratch PG `ci_2695` via `dev-hops migrate postgres upgrade` w/ explicit DSNs; real dev Valkey; uvicorn from this worktree; real `fcpush_` token): **21/21 checks** — NEW 202 + durable payload row; REPLAY 200 full envelope same id, attempts stable; CONFLICT 409; RETRY 202 same ingestion_id attempts 1→2 (from `stream_unavailable`) and 2→3 (stale-accepted backdate), young-accepted REPLAYs; mixed-case (`GitHub`) managed source → 403 `source_owned_by_fullchaos_sync`, deactivating the integration releases ownership → 202. Stream evidence: XLEN 4 / 2 distinct ingestion_ids (3 XADDs for the retried key — same id each time). Scratch DB dropped, stream key deleted.

Closes CHAOS-2695.
