### PR TITLE
fix(metrics): dedupe discover_repos to latest repos row (CHAOS-2787)

### DIFF
--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -116,13 +116,57 @@ def discover_repos(
             )
         ]
 
-    # Query repos from ClickHouse, scoped by org_id
+    # Query repos from ClickHouse, scoped by org_id.
+    #
+    # ``repos`` is a ReplacingMergeTree(last_synced) ordered by (org_id, id)
+    # (migration 027). ``insert_repo`` always writes a fresh row per sync
+    # rather than short-circuiting on an existing row (CHAOS-1775), so
+    # multiple logical versions of the same (org_id, id) routinely coexist
+    # until a background merge collapses them -- a plain ``SELECT *`` here
+    # returns those pre-merge duplicates as separate DiscoveredRepo entries,
+    # causing duplicate per-project fetches downstream (CHAOS-2787). Dedup
+    # server-side to the latest row per (org_id, id) via argMax(*, last_synced)
+    # rather than relying on background merges or FINAL.
+    #
+    # All three projected columns (repo, settings, provider) MUST come from
+    # the SAME winning physical row. Three independent
+    # argMax(col, last_synced) aggregates each pick a tied-row winner
+    # *independently* when two versions share the exact same last_synced --
+    # realistic here, since ``last_synced`` is only DateTime64(3) and
+    # ``insert_repo`` stamps it from ``datetime.now()``, so rapid re-syncs of
+    # the same (org_id, id) can land in the same millisecond. That would let
+    # discover_repos synthesize a Frankenstein row (e.g. a new repo name with
+    # a stale provider). Instead, collapse to a SINGLE
+    # ``argMax(tuple(repo, settings, provider), last_synced)`` -- exactly one
+    # row is chosen as "latest", and the three values are unwrapped from that
+    # one row via ``tupleElement``, guaranteeing internal consistency. Ties
+    # resolve to an arbitrary but internally-consistent version (matching
+    # ReplacingMergeTree's own tie semantics); a deterministic tie-breaker
+    # beyond that is not required here.
+    #
+    # ``settings`` is Nullable(String): a bare argMax(settings, last_synced)
+    # SKIPS NULL values entirely, so an older *non-NULL* settings value would
+    # incorrectly mask a genuinely NULL settings value on the latest row.
+    # Wrapping the whole projection in tuple(...) sidesteps this too -- the
+    # outer tuple is never NULL itself even when its ``settings`` element is,
+    # so argMax compares/carries it correctly, and tupleElement(...) then
+    # unwraps each value, NULL and all.
     try:
-        query = "SELECT id, repo, settings, provider FROM repos"
+        query = (
+            "SELECT id, "
+            "tupleElement(latest, 1) AS repo, "
+            "tupleElement(latest, 2) AS settings, "
+            "tupleElement(latest, 3) AS provider "
+            "FROM ("
+            "SELECT id, "
+            "argMax(tuple(repo, settings, provider), last_synced) AS latest "
+            "FROM repos"
+        )
         params: dict[str, str] = {}
         if org_id:
             query += " WHERE org_id = {org_id:String}"
             params["org_id"] = org_id
+        query += " GROUP BY org_id, id)"
         rows = primary_sink.client.query(query, parameters=params).result_rows
         return [
             DiscoveredRepo(

--- a/tests/test_backfill_integration.py
+++ b/tests/test_backfill_integration.py
@@ -180,3 +180,62 @@ class TestSourceFilteringInWorkItemFetchers:
         gitlab_repos = [r for r in repos if r.source == "gitlab"]
         assert len(gitlab_repos) == 1
         assert gitlab_repos[0].repo_id == gl_id
+
+
+def test_discover_repos_query_dedupes_via_argmax_group_by():
+    """discover_repos' ClickHouse query must dedupe to the latest row per
+    (org_id, id) via a SINGLE argMax/GROUP BY rather than a plain ``SELECT *``
+    (CHAOS-2787).
+
+    ``repos`` is a ReplacingMergeTree(last_synced) ordered by (org_id, id)
+    (migration 027); ``insert_repo`` always writes a fresh row per sync
+    (CHAOS-1775), so pre-merge duplicates routinely exist. This pins the SQL
+    shape server-side dedup depends on: a single
+    ``argMax(tuple(repo, settings, provider), last_synced)`` (NOT three
+    independent argMax calls -- those could each resolve a last_synced TIE
+    to a *different* physical row, synthesizing a Frankenstein result) with
+    the three columns then unwrapped via ``tupleElement(latest, N)``. The
+    outer tuple() wrap also means the ``settings`` (Nullable(String)) column
+    is carried through even when NULL, since a bare
+    ``argMax(settings, last_synced)`` would skip NULLs entirely and let an
+    older non-NULL settings value mask a genuinely NULL latest value. Live
+    behavioral proof of the dedup, tie-consistency, and NULL-handling lives
+    in ``tests/test_discover_repos_dedup_live.py`` (opt-in, needs
+    ClickHouse)."""
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    mock_sink = SimpleNamespace(client=MagicMock())
+    mock_sink.client.query.return_value = SimpleNamespace(result_rows=[])
+
+    discover_repos(backend="clickhouse", primary_sink=mock_sink, org_id="org-x")
+
+    query_arg = mock_sink.client.query.call_args.args[0]
+    assert "argMax(tuple(repo, settings, provider), last_synced) AS latest" in query_arg
+    assert "tupleElement(latest, 1) AS repo" in query_arg
+    assert "tupleElement(latest, 2) AS settings" in query_arg
+    assert "tupleElement(latest, 3) AS provider" in query_arg
+    assert "GROUP BY org_id, id" in query_arg
+    assert "WHERE org_id = {org_id:String}" in query_arg
+    # Guard against regressing to three independent argMax calls.
+    assert "argMax(repo, last_synced)" not in query_arg
+    assert "argMax(provider, last_synced)" not in query_arg
+
+    params = mock_sink.client.query.call_args.kwargs["parameters"]
+    assert params == {"org_id": "org-x"}
+
+
+def test_discover_repos_query_omits_where_without_org_id():
+    """No org_id => no WHERE clause, but the GROUP BY dedup still applies."""
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    mock_sink = SimpleNamespace(client=MagicMock())
+    mock_sink.client.query.return_value = SimpleNamespace(result_rows=[])
+
+    discover_repos(backend="clickhouse", primary_sink=mock_sink)
+
+    query_arg = mock_sink.client.query.call_args.args[0]
+    assert "WHERE" not in query_arg
+    assert "GROUP BY org_id, id" in query_arg
+
+    params = mock_sink.client.query.call_args.kwargs["parameters"]
+    assert params == {}

--- a/tests/test_discover_repos_dedup_live.py
+++ b/tests/test_discover_repos_dedup_live.py
@@ -1,0 +1,315 @@
+"""Live-ClickHouse regression tests for CHAOS-2787.
+
+``discover_repos`` (``dev_health_ops.metrics.job_daily``) SELECTs from the
+ClickHouse ``repos`` table, a ``ReplacingMergeTree(last_synced)`` ordered by
+``(org_id, id)`` (migration 027). ``ClickHouseStorage.insert_repo`` always
+writes a fresh row per sync rather than short-circuiting on an existing row
+(CHAOS-1775: needed so a re-run under a different ``--org`` refreshes
+``org_id`` rather than stranding it), so multiple logical versions of the same
+``(org_id, id)`` routinely coexist as separate physical rows until a
+background merge collapses them. A plain ``SELECT * FROM repos`` therefore
+returned those pre-merge duplicates as separate ``DiscoveredRepo`` entries,
+causing duplicate per-project fetches downstream in every provider's
+work-item sync.
+
+These tests insert raw, un-merged duplicate rows directly (no ``OPTIMIZE
+TABLE ... FINAL``) and assert ``discover_repos`` already collapses them
+server-side via ``argMax(..., last_synced)`` -- proving the fix does not
+depend on background merges ever running.
+
+One test (``..._tied_last_synced_returns_internally_consistent_row``) inserts
+two versions sharing the exact SAME ``last_synced`` -- realistic since
+``last_synced`` is only ``DateTime64(3)`` and ``insert_repo`` stamps it from
+``datetime.now()``, so rapid re-syncs can land in the same millisecond. It
+guards against a Frankenstein result: three independent
+``argMax(col, last_synced)`` aggregates could each resolve the tie to a
+*different* physical row (e.g. a new repo name paired with a stale
+provider). The fix aggregates all three columns as a single
+``argMax(tuple(repo, settings, provider), last_synced)`` so exactly one row
+wins and all three values come from it together. Either version winning is
+acceptable -- ties resolve arbitrarily, matching ReplacingMergeTree's own
+tie semantics -- but the result must never mix values across versions.
+
+Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI (e.g. clickhouse://ch:ch@localhost:8123/default)",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+def _insert_repo_version(
+    sink,
+    *,
+    repo_id: uuid.UUID,
+    org_id: str,
+    repo: str,
+    provider: str,
+    settings: str | None,
+    last_synced: datetime,
+) -> None:
+    """Insert one raw physical version of a ``repos`` row.
+
+    Bypasses ``insert_repo`` (which always stamps ``last_synced=now()``) so
+    tests can control ordering explicitly and simulate two pre-merge versions
+    of the same ``(org_id, id)`` coexisting as separate parts.
+    """
+    sink.client.insert(
+        "repos",
+        [
+            [
+                repo_id,
+                repo,
+                None,  # ref
+                last_synced,  # created_at (reused; irrelevant to this test)
+                settings,
+                None,  # tags
+                last_synced,
+                provider,
+                org_id,
+            ]
+        ],
+        column_names=[
+            "id",
+            "repo",
+            "ref",
+            "created_at",
+            "settings",
+            "tags",
+            "last_synced",
+            "provider",
+            "org_id",
+        ],
+    )
+
+
+def _cleanup(sink, org_id: str) -> None:
+    sink.client.command(
+        "ALTER TABLE repos DELETE WHERE org_id = {org_id:String} "
+        "SETTINGS mutations_sync=2",
+        parameters={"org_id": org_id},
+    )
+
+
+def test_discover_repos_returns_latest_version_when_duplicates_exist(sink) -> None:
+    """Two un-merged versions of the same (org_id, id) must collapse to ONE
+    DiscoveredRepo carrying the LATEST version's repo name/provider/settings."""
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    org_id = f"test-chaos-2787-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(days=1)
+
+    try:
+        # Older version. Physical insert order is irrelevant -- only
+        # last_synced determines "latest" -- so this is written first but
+        # carries the EARLIER timestamp.
+        _insert_repo_version(
+            sink,
+            repo_id=repo_id,
+            org_id=org_id,
+            repo="org/old-name",
+            provider="unknown",
+            settings='{"legacy": true}',
+            last_synced=t0,
+        )
+        # Newer version. No merge/OPTIMIZE performed -- both rows remain
+        # physically present as separate parts, exactly as they would
+        # in production between merges.
+        _insert_repo_version(
+            sink,
+            repo_id=repo_id,
+            org_id=org_id,
+            repo="org/new-name",
+            provider="github",
+            settings='{"legacy": false, "new": 1}',
+            last_synced=t1,
+        )
+
+        results = discover_repos(backend="clickhouse", primary_sink=sink, org_id=org_id)
+
+        assert len(results) == 1, (
+            f"expected exactly one deduped DiscoveredRepo for repo_id={repo_id}, "
+            f"got {len(results)}: {results}"
+        )
+        (repo,) = results
+        assert repo.repo_id == repo_id
+        assert repo.full_name == "org/new-name"
+        assert repo.source == "github"
+        assert repo.settings == '{"legacy": false, "new": 1}'
+    finally:
+        _cleanup(sink, org_id)
+
+
+def test_discover_repos_latest_null_settings_not_masked_by_older_non_null(
+    sink,
+) -> None:
+    """Latest version has NULL settings; older version has non-NULL settings.
+
+    A bare ``argMax(settings, last_synced)`` SKIPS NULL values entirely, so it
+    would incorrectly resurrect the OLDER non-NULL settings blob instead of
+    the genuinely-NULL latest value. This pins the outer
+    ``tuple(repo, settings, provider)`` wrap (never NULL itself, even when
+    its ``settings`` element is) that fixes that (CHAOS-2787)."""
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    org_id = f"test-chaos-2787-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    t0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    t1 = t0 + timedelta(days=1)
+
+    try:
+        _insert_repo_version(
+            sink,
+            repo_id=repo_id,
+            org_id=org_id,
+            repo="org/repo",
+            provider="github",
+            settings='{"had": "settings"}',
+            last_synced=t0,
+        )
+        _insert_repo_version(
+            sink,
+            repo_id=repo_id,
+            org_id=org_id,
+            repo="org/repo",
+            provider="github",
+            settings=None,
+            last_synced=t1,
+        )
+
+        results = discover_repos(backend="clickhouse", primary_sink=sink, org_id=org_id)
+
+        assert len(results) == 1
+        (repo,) = results
+        assert repo.settings == {}, (
+            f"expected the latest (NULL) settings to survive as {{}}, got "
+            f"{repo.settings!r} -- a bare argMax(settings, last_synced) would "
+            "incorrectly resurrect the older non-NULL value here"
+        )
+    finally:
+        _cleanup(sink, org_id)
+
+
+def test_discover_repos_distinct_repo_ids_each_returned_once(sink) -> None:
+    """Two distinct repo ids under the same org must each surface exactly
+    once, with no cross-id contamination from the GROUP BY (org_id, id)."""
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    org_id = f"test-chaos-2787-{uuid.uuid4()}"
+    repo_id_a = uuid.uuid4()
+    repo_id_b = uuid.uuid4()
+    now = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    try:
+        _insert_repo_version(
+            sink,
+            repo_id=repo_id_a,
+            org_id=org_id,
+            repo="org/repo-a",
+            provider="github",
+            settings=None,
+            last_synced=now,
+        )
+        _insert_repo_version(
+            sink,
+            repo_id=repo_id_b,
+            org_id=org_id,
+            repo="org/repo-b",
+            provider="gitlab",
+            settings=None,
+            last_synced=now,
+        )
+
+        results = discover_repos(backend="clickhouse", primary_sink=sink, org_id=org_id)
+
+        by_id = {r.repo_id: r for r in results}
+        assert set(by_id) == {repo_id_a, repo_id_b}, (
+            f"expected both distinct repo ids to survive independently, got {by_id}"
+        )
+        assert by_id[repo_id_a].full_name == "org/repo-a"
+        assert by_id[repo_id_a].source == "github"
+        assert by_id[repo_id_b].full_name == "org/repo-b"
+        assert by_id[repo_id_b].source == "gitlab"
+    finally:
+        _cleanup(sink, org_id)
+
+
+def test_discover_repos_tied_last_synced_returns_internally_consistent_row(
+    sink,
+) -> None:
+    """Two versions sharing the exact SAME last_synced (a realistic tie --
+    DateTime64(3) resolution, insert_repo stamps from datetime.now()) must
+    not be split-brained across independent argMax aggregates.
+
+    Before the fix, three independent argMax(col, last_synced) calls could
+    each resolve the tie to a different physical row, e.g. returning
+    version A's repo name with version B's provider/settings -- a
+    Frankenstein row that never existed. The single
+    argMax(tuple(repo, settings, provider), last_synced) aggregate
+    guarantees whichever version wins, ALL three projected values come from
+    that one row together. Either version winning is acceptable; only
+    cross-version mixing is a bug."""
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    org_id = f"test-chaos-2787-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    tie = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+    version_a = ("org/tie-a", "github", '{"which": "a"}')
+    version_b = ("org/tie-b", "gitlab", '{"which": "b"}')
+
+    try:
+        for repo, provider, settings in (version_a, version_b):
+            _insert_repo_version(
+                sink,
+                repo_id=repo_id,
+                org_id=org_id,
+                repo=repo,
+                provider=provider,
+                settings=settings,
+                last_synced=tie,
+            )
+
+        results = discover_repos(backend="clickhouse", primary_sink=sink, org_id=org_id)
+
+        assert len(results) == 1, (
+            f"expected exactly one deduped DiscoveredRepo under a last_synced "
+            f"tie, got {len(results)}: {results}"
+        )
+        (repo,) = results
+        got = (repo.full_name, repo.source, repo.settings)
+        assert got in (version_a, version_b), (
+            f"result {got!r} does not match EITHER tied version whole -- "
+            f"expected {version_a!r} or {version_b!r}, got a mix of both "
+            "(three independent argMax aggregates resolved the tie "
+            "differently per column)"
+        )
+    finally:
+        _cleanup(sink, org_id)


### PR DESCRIPTION
## Summary

Fixes [CHAOS-2787](https://linear.app/full-chaos/issue/CHAOS-2787): `discover_repos` (`src/dev_health_ops/metrics/job_daily.py`, `discover_repos()`) SELECTed from the ClickHouse `repos` table with **no latest-row dedup**.

`repos` is `ReplacingMergeTree(last_synced)` ordered by `(org_id, id)` (migration `027_add_org_id_to_sorting_keys.py`). `insert_repo` (`src/dev_health_ops/storage/clickhouse.py:246`) intentionally **always writes a fresh row per sync** rather than short-circuiting on an existing one (CHAOS-1775 — needed so a re-run under a different `--org` refreshes `org_id` instead of stranding it). That means multiple logical versions of the same `(org_id, id)` routinely coexist as separate physical rows until a background merge collapses them. A plain `SELECT * FROM repos` returned those pre-merge duplicates as separate `DiscoveredRepo` entries, causing duplicate per-project fetches downstream in every provider's work-item sync (pre-existing for every provider, not GitHub/GitLab-specific).

## Fix

`discover_repos` now dedupes server-side via `GROUP BY (org_id, id)` + a **single**
`argMax(tuple(repo, settings, provider), last_synced)`, unwrapped via `tupleElement`:

```sql
SELECT
    id,
    tupleElement(latest, 1) AS repo,
    tupleElement(latest, 2) AS settings,
    tupleElement(latest, 3) AS provider
FROM (
    SELECT id, argMax(tuple(repo, settings, provider), last_synced) AS latest
    FROM repos
    [WHERE org_id = {org_id:String}]
    GROUP BY org_id, id
)
```

**Why one aggregate instead of three independent `argMax(col, last_synced)` calls** (an earlier revision of this PR used three, and adversarial review caught the gap): `repos.last_synced` is only `DateTime64(3)`, and `insert_repo` stamps it from `datetime.now()`, so rapid re-syncs of the same `(org_id, id)` can realistically land in the same millisecond. Three independent `argMax` aggregates are each free to resolve that tie to a *different* physical row, which could synthesize a Frankenstein result (e.g. a new repo name paired with a stale provider). Wrapping all three projected columns in one `argMax(tuple(...), last_synced)` guarantees exactly one row is chosen as "latest," and every projected value comes from that same row — no cross-version mixing is possible by construction.

`settings` is `Nullable(String)`. The same tuple-wrap also fixes the earlier known issue: a bare `argMax(settings, last_synced)` **skips NULL values entirely**, so an older non-NULL `settings` blob would incorrectly mask a genuinely NULL `settings` value on the latest row. `tuple(repo, settings, provider)` is never NULL itself (even when its `settings` element is), so `argMax` compares/carries it correctly, and `tupleElement(latest, N)` unwraps each value, NULL and all.

**Tie-breaking semantics**: when two versions genuinely tie on `last_synced`, this dedup resolves to an arbitrary but internally-consistent version — matching `ReplacingMergeTree`'s own tie semantics (it doesn't guarantee a deterministic winner either). A stricter deterministic tie-breaker (e.g. an explicit version/sequence column) was considered and is **not** required here per review discussion; row-internal-consistency is the actual correctness bar.

The function's return shape (4 columns: `id, repo, settings, provider`) and all existing filters (org scoping) are unchanged.

## Known overlap — CHAOS-2763

`DiscoveredRepo.settings` is still returned as a **raw JSON string** (no `json.loads`) even though the field is annotated `dict`. That parse fix is [CHAOS-2763](https://linear.app/full-chaos/issue/CHAOS-2763)'s — a separate planned PR touching this same function. This diff intentionally only touches the SQL/dedup, not settings parsing, so whichever PR merges second should rebase trivially against the other.

## Tests

- `tests/test_discover_repos_dedup_live.py` (new, live ClickHouse, opt-in via `pytest -m clickhouse`, mirrors `tests/test_rmt_org_id_dedup_live.py`):
  - `test_discover_repos_returns_latest_version_when_duplicates_exist` — two un-merged versions of the same `(org_id, id)` (different `last_synced`) collapse to exactly one `DiscoveredRepo` carrying the **latest** version's `repo`/`provider`/`settings`.
  - `test_discover_repos_latest_null_settings_not_masked_by_older_non_null` — latest version has NULL `settings`, older has non-NULL; result reflects the latest (NULL → `{}`), pinning the tuple-wrap.
  - `test_discover_repos_distinct_repo_ids_each_returned_once` — distinct repo ids under the same org are each returned once, no cross-id contamination from the `GROUP BY`.
  - `test_discover_repos_tied_last_synced_returns_internally_consistent_row` (**new**, from adversarial review) — two versions sharing the exact same `last_synced`; the returned row must match one tied version *whole* (never a mix of both), pinning the single-tuple-aggregate fix.
  - Verified manually: reverting `job_daily.py` to the pre-fix plain-`SELECT *` query makes the first two tests fail with `assert 2 == 1` (duplicate rows returned); restoring the fix makes all four pass. The tie scenario did **not** empirically reproduce cross-column divergence against the earlier three-independent-`argMax` revision on this ClickHouse build across 5 repeated runs (a single query's aggregator appears to process all three columns' states together per row, per build) — but the single-tuple aggregate removes that risk by construction regardless of ClickHouse version/settings/execution plan, which is the point of the fix.
- `tests/test_backfill_integration.py` (existing mocked-client style, extended): `test_discover_repos_query_dedupes_via_argmax_group_by` and `test_discover_repos_query_omits_where_without_org_id` pin the emitted SQL shape (single tuple-argMax/GROUP BY/tupleElement unwrap) as a fast unit-suite regression guard, including a negative assertion that the three-independent-argMax shape does not regress back in.

## Gate

`env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=ci_local_validate_2787 bash ci/local_validate.sh` — **GATE PASSED**: ruff format/check ✔, mypy ✔, full unit suite (6362 passed, 44 skipped) ✔, live argMax proof (real engine) ✔. Log: `/tmp/claude/chaos-2787-gate.log`.

Note: the new `test_discover_repos_dedup_live.py` is `@pytest.mark.clickhouse`-marked (opt-in, matching repo convention — `ci/run_tests.sh unit_tests()`/`ci_tests()` filter `not clickhouse`), so it does not run in the automated gate; it was manually verified against a scratch ClickHouse DB before/after the fix as described above.

## Test plan

- [x] Full local gate green (lint, mypy, 6362 unit tests, live argMax proof)
- [x] Live-ClickHouse regression tests pass against the fix and fail against the pre-fix query (manually verified)
- [x] Tied-`last_synced` regression test passes against the single-tuple-aggregate fix
- [x] Return shape and existing org-scoping filter unchanged