### PR TITLE
feat(providers): GitHub App installation-token minting via providers auth (CHAOS-2786)

### DIFF
--- a/src/dev_health_ops/discovery/repos.py
+++ b/src/dev_health_ops/discovery/repos.py
@@ -44,7 +44,8 @@ def _github_token_from_credentials(credentials: dict[str, Any]) -> str:
     """Resolve a usable GitHub token from a credentials mapping.
 
     Supports both PAT (``token``) and GitHub App auth; for App auth an
-    installation token is minted via the GitHub connector.
+    installation token is minted via ``providers.github.app_auth`` (no
+    dependency on the ``connectors`` package).
     """
     from dev_health_ops.credentials.resolver import github_credentials_from_mapping
 
@@ -56,9 +57,14 @@ def _github_token_from_resolved_credentials(gh_credentials: Any | None) -> str:
     if gh_credentials is None:
         return ""
     if gh_credentials.is_app_auth:
-        from dev_health_ops.connectors.github import GitHubConnector
+        from dev_health_ops.providers.github.app_auth import mint_installation_token
 
-        return GitHubConnector(credentials=gh_credentials).token
+        return mint_installation_token(
+            app_id=gh_credentials.app_id,
+            private_key=gh_credentials.private_key,
+            installation_id=gh_credentials.installation_id,
+            base_url=gh_credentials.base_url,
+        )
     return gh_credentials.token or ""
 
 
@@ -143,7 +149,7 @@ def _discover_github_app_installation_repos(
 ) -> list[tuple[str, ...]]:
     import requests
 
-    from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
+    from dev_health_ops.providers.github.app_auth import mint_installation_token
 
     app_id = getattr(github_credentials, "app_id", None)
     private_key = getattr(github_credentials, "private_key", None)
@@ -156,12 +162,12 @@ def _discover_github_app_installation_repos(
     base_url = str(
         getattr(github_credentials, "base_url", None) or "https://api.github.com"
     ).rstrip("/")
-    token = GitHubAppTokenProvider(
+    token = mint_installation_token(
         app_id=str(app_id),
         private_key=str(private_key),
         installation_id=str(installation_id),
-        api_base_url=base_url,
-    ).get_token()
+        base_url=base_url,
+    )
 
     result: list[tuple[str, ...]] = []
     page = 1

--- a/src/dev_health_ops/providers/github/app_auth.py
+++ b/src/dev_health_ops/providers/github/app_auth.py
@@ -1,0 +1,163 @@
+"""GitHub App installation-token minting, standalone on httpx.
+
+Discovery (``dev_health_ops.discovery.repos``) needs a bare installation
+access token for GitHub App auth but must not depend on the frozen
+``connectors.github.GitHubConnector`` (CHAOS-2786). This module mirrors the
+JWT construction and installation-token exchange semantics of
+``connectors.utils.github_app.GitHubAppTokenProvider`` --  RS256 JWT with
+``iss``/``iat``/``exp`` claims, ``POST /app/installations/{id}/access_tokens``,
+GHE base-url join, transient-5xx retry with no retry on 4xx -- using httpx
+instead of requests, and with no import of ``connectors``.
+
+This intentionally does not replicate the connector's token *caching* layer:
+every discovery call site constructs a fresh credentials object and wants a
+single fresh mint, so caching across calls has no observable effect there
+(see repos.py's ``_github_token_from_resolved_credentials``). Callers that
+need a long-lived, auto-refreshing token should not reach for this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+import httpx
+import jwt
+
+logger = logging.getLogger(__name__)
+
+GITHUB_API_BASE_URL = "https://api.github.com"
+JWT_TTL_SECONDS = 600
+DEFAULT_TIMEOUT_SECONDS = 30.0
+TOKEN_EXCHANGE_MAX_RETRIES = 3  # total attempts (initial + retries)
+TOKEN_EXCHANGE_INITIAL_DELAY_SECONDS = 1.0
+TOKEN_EXCHANGE_MAX_DELAY_SECONDS = 10.0
+TOKEN_EXCHANGE_BACKOFF_FACTOR = 2.0
+
+
+class GitHubAppAuthError(RuntimeError):
+    """Raised when GitHub App authentication cannot produce an installation token."""
+
+
+class GitHubAppTransientError(GitHubAppAuthError):
+    """Transient GitHub App auth failure (5xx / network) that is safe to retry."""
+
+
+def create_github_app_jwt(
+    *,
+    app_id: str,
+    private_key: str,
+    now: int | None = None,
+) -> str:
+    """Sign a GitHub App JWT with RS256.
+
+    GitHub requires ``iss`` to be the App ID and ``exp`` no more than ten
+    minutes in the future. ``iat`` is backdated slightly to tolerate clock skew.
+    """
+    issued_at = int(now if now is not None else time.time()) - 60
+    payload = {
+        "iat": issued_at,
+        "exp": issued_at + JWT_TTL_SECONDS,
+        "iss": str(app_id),
+    }
+    return str(jwt.encode(payload, private_key, algorithm="RS256"))
+
+
+def _installation_access_tokens_url(base_url: str | None, installation_id: str) -> str:
+    resolved = str(base_url or GITHUB_API_BASE_URL).rstrip("/")
+    return f"{resolved}/app/installations/{installation_id}/access_tokens"
+
+
+def mint_installation_token(
+    *,
+    app_id: str,
+    private_key: str,
+    installation_id: str,
+    base_url: str | None = None,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+    max_retries: int = TOKEN_EXCHANGE_MAX_RETRIES,
+    transport: httpx.BaseTransport | None = None,
+) -> str:
+    """Mint a fresh GitHub App installation access token via httpx.
+
+    :param app_id: GitHub App ID (JWT ``iss`` claim).
+    :param private_key: PEM-encoded RS256 private key for the App.
+    :param installation_id: Installation ID to mint a token for.
+    :param base_url: REST API base URL. Defaults to ``api.github.com``; for
+        GitHub Enterprise pass the GHE REST base (e.g.
+        ``https://ghe.example.com/api/v3``) -- joined as-is, no path rewriting.
+    :param timeout: Per-request timeout in seconds.
+    :param max_retries: Total attempts (initial + retries) on transient (5xx /
+        network) failures. 4xx failures are never retried.
+    :param transport: Optional httpx transport override (tests use
+        ``httpx.MockTransport``).
+    :returns: The bare installation access token string.
+    :raises ValueError: Missing app_id/private_key/installation_id.
+    :raises GitHubAppAuthError: Non-retryable failure (4xx, malformed response).
+    :raises GitHubAppTransientError: Retries on 5xx/network exhausted.
+    """
+    if not app_id:
+        raise ValueError("GitHub App auth requires app_id")
+    if not private_key:
+        raise ValueError("GitHub App auth requires private_key")
+    if not installation_id:
+        raise ValueError("GitHub App auth requires installation_id")
+
+    url = _installation_access_tokens_url(base_url, installation_id)
+
+    delay = TOKEN_EXCHANGE_INITIAL_DELAY_SECONDS
+    last_exception: GitHubAppTransientError | None = None
+
+    with httpx.Client(timeout=timeout, transport=transport) as client:
+        for attempt in range(max_retries):
+            app_jwt = create_github_app_jwt(app_id=app_id, private_key=private_key)
+            try:
+                response = client.post(
+                    url,
+                    headers={
+                        "Accept": "application/vnd.github+json",
+                        "Authorization": f"Bearer {app_jwt}",
+                        "X-GitHub-Api-Version": "2022-11-28",
+                    },
+                )
+            except httpx.HTTPError as exc:
+                last_exception = GitHubAppTransientError(
+                    f"GitHub App installation token exchange request failed: {exc}"
+                )
+            else:
+                if response.status_code >= 400:
+                    if 500 <= response.status_code < 600:
+                        last_exception = GitHubAppTransientError(
+                            "GitHub App installation token exchange failed: "
+                            f"HTTP {response.status_code}"
+                        )
+                    else:
+                        raise GitHubAppAuthError(
+                            "GitHub App installation token exchange failed: "
+                            f"HTTP {response.status_code}"
+                        )
+                else:
+                    data: dict[str, Any] = response.json()
+                    token = data.get("token")
+                    expires_at = data.get("expires_at")
+                    if not token or not expires_at:
+                        raise GitHubAppAuthError(
+                            "GitHub App installation token response missing "
+                            "token or expires_at"
+                        )
+                    return str(token)
+
+            if attempt < max_retries - 1:
+                logger.warning(
+                    "GitHub App installation token exchange attempt %s/%s "
+                    "failed: %s. Retrying...",
+                    attempt + 1,
+                    max_retries,
+                    last_exception,
+                )
+                time.sleep(min(delay, TOKEN_EXCHANGE_MAX_DELAY_SECONDS))
+                delay *= TOKEN_EXCHANGE_BACKOFF_FACTOR
+
+    assert last_exception is not None
+    raise last_exception

--- a/tests/providers/test_github_app_auth.py
+++ b/tests/providers/test_github_app_auth.py
@@ -1,0 +1,288 @@
+"""Tests for the standalone providers-side GitHub App token minting utility.
+
+CHAOS-2786: discovery must mint GitHub App installation tokens without
+depending on the frozen ``connectors.github.GitHubConnector``. This module
+covers ``dev_health_ops.providers.github.app_auth`` in isolation: RS256 JWT
+construction, the installation-token exchange over httpx (via
+``httpx.MockTransport`` -- no real network), GHE base-url joining, and error
+semantics parity with ``connectors.utils.github_app.GitHubAppTokenProvider``
+(transient 5xx/network retries, no retry on 4xx).
+
+The RSA keypair used to sign JWTs is generated at runtime via the
+``cryptography`` library -- never a committed PEM literal -- to keep secret
+scanners (gitleaks) quiet and avoid shipping a real-looking key fixture.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from typing import Any
+from unittest.mock import patch
+
+import httpx
+import jwt
+import pytest
+from cryptography.hazmat.primitives import serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+
+from dev_health_ops.providers.github.app_auth import (
+    TOKEN_EXCHANGE_MAX_RETRIES,
+    GitHubAppAuthError,
+    GitHubAppTransientError,
+    create_github_app_jwt,
+    mint_installation_token,
+)
+
+
+@pytest.fixture(scope="module")
+def rsa_keypair() -> tuple[str, rsa.RSAPrivateKey]:
+    """Generate a synthetic RSA keypair for signing/verifying test JWTs."""
+    private_key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    pem = private_key.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    ).decode("utf-8")
+    return pem, private_key
+
+
+def _ok_response(token: str = "installation-token") -> httpx.Response:
+    expires_at = (datetime.now(timezone.utc) + timedelta(minutes=20)).isoformat()
+    return httpx.Response(201, json={"token": token, "expires_at": expires_at})
+
+
+# ---------------------------------------------------------------------------
+# JWT construction
+# ---------------------------------------------------------------------------
+
+
+def test_create_github_app_jwt_signs_rs256_with_claims(rsa_keypair) -> None:
+    pem, private_key = rsa_keypair
+    now = 1_700_000_000
+
+    token = create_github_app_jwt(app_id="99999", private_key=pem, now=now)
+
+    decoded = jwt.decode(
+        token,
+        private_key.public_key(),
+        algorithms=["RS256"],
+        options={"verify_exp": False},
+    )
+    assert decoded["iss"] == "99999"
+    assert decoded["iat"] == now - 60
+    assert decoded["exp"] - decoded["iat"] == 600
+
+
+# ---------------------------------------------------------------------------
+# mint_installation_token -- success paths
+# ---------------------------------------------------------------------------
+
+
+def test_mint_installation_token_success_hits_correct_endpoint_and_headers(
+    rsa_keypair,
+) -> None:
+    pem, _ = rsa_keypair
+    captured: dict[str, Any] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        captured["url"] = str(request.url)
+        captured["accept"] = request.headers["accept"]
+        captured["api_version"] = request.headers["x-github-api-version"]
+        auth_header = request.headers["authorization"]
+        assert auth_header.startswith("Bearer ")
+        decoded = jwt.decode(
+            auth_header.removeprefix("Bearer "),
+            options={"verify_signature": False},
+        )
+        captured["jwt_claims"] = decoded
+        return _ok_response("installation-token")
+
+    token = mint_installation_token(
+        app_id="12345",
+        private_key=pem,
+        installation_id="67890",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert token == "installation-token"
+    assert (
+        captured["url"]
+        == "https://api.github.com/app/installations/67890/access_tokens"
+    )
+    assert captured["accept"] == "application/vnd.github+json"
+    assert captured["api_version"] == "2022-11-28"
+    assert captured["jwt_claims"]["iss"] == "12345"
+
+
+def test_mint_installation_token_joins_ghe_base_url(rsa_keypair) -> None:
+    pem, _ = rsa_keypair
+    seen_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_urls.append(str(request.url))
+        return _ok_response("ghe-token")
+
+    token = mint_installation_token(
+        app_id="12345",
+        private_key=pem,
+        installation_id="67890",
+        base_url="https://ghe.example.com/api/v3/",
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert token == "ghe-token"
+    assert seen_urls == [
+        "https://ghe.example.com/api/v3/app/installations/67890/access_tokens"
+    ]
+
+
+def test_mint_installation_token_defaults_base_url_when_none(rsa_keypair) -> None:
+    pem, _ = rsa_keypair
+    seen_urls: list[str] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen_urls.append(str(request.url))
+        return _ok_response()
+
+    mint_installation_token(
+        app_id="12345",
+        private_key=pem,
+        installation_id="67890",
+        base_url=None,
+        transport=httpx.MockTransport(handler),
+    )
+
+    assert seen_urls == ["https://api.github.com/app/installations/67890/access_tokens"]
+
+
+# ---------------------------------------------------------------------------
+# mint_installation_token -- error / retry semantics
+# ---------------------------------------------------------------------------
+
+
+def test_mint_installation_token_does_not_retry_4xx(rsa_keypair) -> None:
+    pem, _ = rsa_keypair
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(401, json={"message": "Bad credentials"})
+
+    with patch("dev_health_ops.providers.github.app_auth.time.sleep") as sleep:
+        with pytest.raises(GitHubAppAuthError) as excinfo:
+            mint_installation_token(
+                app_id="12345",
+                private_key=pem,
+                installation_id="67890",
+                transport=httpx.MockTransport(handler),
+            )
+
+    assert not isinstance(excinfo.value, GitHubAppTransientError)
+    assert calls["count"] == 1
+    sleep.assert_not_called()
+
+
+def test_mint_installation_token_retries_transient_5xx_then_succeeds(
+    rsa_keypair,
+) -> None:
+    pem, _ = rsa_keypair
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            return httpx.Response(503)
+        return _ok_response("recovered-token")
+
+    with patch("dev_health_ops.providers.github.app_auth.time.sleep") as sleep:
+        token = mint_installation_token(
+            app_id="12345",
+            private_key=pem,
+            installation_id="67890",
+            transport=httpx.MockTransport(handler),
+        )
+
+    assert token == "recovered-token"
+    assert calls["count"] == 2
+    sleep.assert_called_once()
+
+
+def test_mint_installation_token_retries_network_error_then_succeeds(
+    rsa_keypair,
+) -> None:
+    pem, _ = rsa_keypair
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        if calls["count"] == 1:
+            raise httpx.ConnectError("boom", request=request)
+        return _ok_response("net-recovered-token")
+
+    with patch("dev_health_ops.providers.github.app_auth.time.sleep"):
+        token = mint_installation_token(
+            app_id="12345",
+            private_key=pem,
+            installation_id="67890",
+            transport=httpx.MockTransport(handler),
+        )
+
+    assert token == "net-recovered-token"
+    assert calls["count"] == 2
+
+
+def test_mint_installation_token_exhausts_retries_on_persistent_5xx(
+    rsa_keypair,
+) -> None:
+    pem, _ = rsa_keypair
+    calls = {"count": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        calls["count"] += 1
+        return httpx.Response(503)
+
+    with patch("dev_health_ops.providers.github.app_auth.time.sleep"):
+        with pytest.raises(GitHubAppTransientError) as excinfo:
+            mint_installation_token(
+                app_id="12345",
+                private_key=pem,
+                installation_id="67890",
+                transport=httpx.MockTransport(handler),
+            )
+
+    # Exhausted transient still surfaces as GitHubAppAuthError for callers
+    # that only catch the parent type.
+    assert isinstance(excinfo.value, GitHubAppAuthError)
+    assert calls["count"] == TOKEN_EXCHANGE_MAX_RETRIES
+
+
+def test_mint_installation_token_rejects_response_missing_expiry(rsa_keypair) -> None:
+    pem, _ = rsa_keypair
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(201, json={"token": "no-expiry"})
+
+    with pytest.raises(GitHubAppAuthError):
+        mint_installation_token(
+            app_id="12345",
+            private_key=pem,
+            installation_id="67890",
+            transport=httpx.MockTransport(handler),
+        )
+
+
+@pytest.mark.parametrize(
+    ("app_id", "private_key", "installation_id"),
+    [
+        ("", "key", "install"),
+        ("app", "", "install"),
+        ("app", "key", ""),
+    ],
+)
+def test_mint_installation_token_requires_all_credential_fields(
+    app_id: str, private_key: str, installation_id: str
+) -> None:
+    with pytest.raises(ValueError):
+        mint_installation_token(
+            app_id=app_id, private_key=private_key, installation_id=installation_id
+        )

--- a/tests/test_sync_partitioning.py
+++ b/tests/test_sync_partitioning.py
@@ -64,15 +64,13 @@ class TestDiscoverReposForConfig:
         mock_gh.assert_called_once()
 
     @patch("requests.get")
-    @patch("dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider")
+    @patch("dev_health_ops.providers.github.app_auth.mint_installation_token")
     def test_github_app_all_repos_lists_installation_repositories(
-        self, mock_token_provider_cls, mock_get
+        self, mock_mint_token, mock_get
     ):
         from dev_health_ops.discovery.repos import discover_repos_for_config
 
-        mock_token_provider_cls.return_value.get_token.return_value = (
-            "installation-token"
-        )
+        mock_mint_token.return_value = "installation-token"
         mock_response = MagicMock(status_code=200)
         mock_response.json.return_value = {
             "repositories": [
@@ -99,11 +97,13 @@ class TestDiscoverReposForConfig:
         )
 
         assert result == [("orgA", "api"), ("orgA", "api-worker")]
-        mock_token_provider_cls.assert_called_once_with(
+        # Installation token is minted via the standalone providers.github
+        # utility (CHAOS-2786), not the connectors-side GitHubAppTokenProvider.
+        mock_mint_token.assert_called_once_with(
             app_id="123",
             private_key="private-key",
             installation_id="456",
-            api_base_url="https://api.github.test",
+            base_url="https://api.github.test",
         )
         mock_get.assert_called_once()
         assert mock_get.call_args.args[0] == (
@@ -114,15 +114,13 @@ class TestDiscoverReposForConfig:
         )
 
     @patch("requests.get")
-    @patch("dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider")
+    @patch("dev_health_ops.providers.github.app_auth.mint_installation_token")
     def test_github_app_all_repos_installation_api_failure_raises(
-        self, mock_token_provider_cls, mock_get
+        self, mock_mint_token, mock_get
     ):
         from dev_health_ops.discovery.repos import discover_repos_for_config
 
-        mock_token_provider_cls.return_value.get_token.return_value = (
-            "installation-token"
-        )
+        mock_mint_token.return_value = "installation-token"
         mock_get.return_value = MagicMock(status_code=401, text="bad credentials")
         config = _make_config(
             provider="github",
@@ -138,6 +136,46 @@ class TestDiscoverReposForConfig:
                     "installation_id": "456",
                 },
             )
+
+    @patch("requests.get")
+    @patch("dev_health_ops.providers.github.app_auth.mint_installation_token")
+    def test_github_app_all_repos_defaults_base_url_and_propagates_mint_error(
+        self, mock_mint_token, mock_get
+    ):
+        """The ``all_repos`` App-auth path (Codex-flagged CHAOS-2786 gap) --
+
+        (a) defaults ``base_url`` to ``api.github.com`` through the new
+        minter exactly like the non-``all_repos`` path, and (b) propagates
+        whatever the minter raises (``providers.github.app_auth`` errors,
+        not a connectors-side exception type) without ever calling the
+        installation-listing endpoint.
+        """
+        from dev_health_ops.discovery.repos import discover_repos_for_config
+        from dev_health_ops.providers.github.app_auth import GitHubAppAuthError
+
+        mock_mint_token.side_effect = GitHubAppAuthError("boom")
+        config = _make_config(
+            provider="github",
+            sync_options={"all_repos": True, "search": "orgA/*"},
+        )
+
+        with pytest.raises(GitHubAppAuthError, match="boom"):
+            discover_repos_for_config(
+                config,
+                {
+                    "app_id": "123",
+                    "private_key": "private-key",
+                    "installation_id": "456",
+                },
+            )
+
+        mock_mint_token.assert_called_once_with(
+            app_id="123",
+            private_key="private-key",
+            installation_id="456",
+            base_url="https://api.github.com",
+        )
+        mock_get.assert_not_called()
 
     @patch("dev_health_ops.discovery.repos.discover_gitlab_repos")
     def test_gitlab_delegates_to_gitlab_discovery(self, mock_gl):

--- a/tests/test_worker_github_app_auth.py
+++ b/tests/test_worker_github_app_auth.py
@@ -6,15 +6,28 @@ failed in the Celery worker (CHAOS-2234). These tests lock the fix: the worker
 and repo-discovery paths build a typed :class:`GitHubCredentials` (PAT or App)
 via ``github_credentials_from_mapping`` and mint an installation token for App
 auth.
+
+CHAOS-2786 moved BOTH discovery-side installation-token mints -- the frozen
+``connectors.github.GitHubConnector`` (single-repo/owner App auth) and
+``connectors.utils.github_app.GitHubAppTokenProvider`` (the ``all_repos``
+App-installation-listing path, flagged by Codex review as a second
+divergent implementation the first pass missed) -- onto
+``dev_health_ops.providers.github.app_auth.mint_installation_token`` (a
+standalone httpx utility). discovery/repos.py no longer imports anything
+from ``dev_health_ops.connectors`` at all. The tests below cover both the
+new wiring and that boundary.
 """
 
 from __future__ import annotations
 
+import ast
+import inspect
 from types import SimpleNamespace
 from unittest.mock import patch
 
 from dev_health_ops.credentials import CredentialSource
 from dev_health_ops.credentials.resolver import github_credentials_from_mapping
+from dev_health_ops.discovery import repos as repos_mod
 
 # ---------------------------------------------------------------------------
 # github_credentials_from_mapping
@@ -108,9 +121,7 @@ def _make_config(provider: str, sync_options: dict | None = None):
     return SimpleNamespace(provider=provider, sync_options=sync_options or {})
 
 
-def test_discover_github_app_auth_mints_token_via_connector() -> None:
-    from dev_health_ops.discovery import repos as repos_mod
-
+def test_discover_github_app_auth_mints_token_via_providers_app_auth() -> None:
     app_credentials = {
         "app_id": "12345",
         "private_key": "synthetic-private-key",
@@ -120,19 +131,149 @@ def test_discover_github_app_auth_mints_token_via_connector() -> None:
 
     with (
         patch.object(repos_mod, "discover_github_repos") as discover,
-        patch("dev_health_ops.connectors.github.GitHubConnector") as connector_cls,
+        patch(
+            "dev_health_ops.providers.github.app_auth.mint_installation_token"
+        ) as mint_token,
     ):
-        connector_cls.return_value = SimpleNamespace(token="installation-token")
+        mint_token.return_value = "installation-token"
         discover.return_value = [("my-org", "api")]
 
         result = repos_mod.discover_repos_for_config(config, app_credentials)
 
     assert result == [("my-org", "api")]
-    # App credentials were converted to a typed credential and the connector
-    # minted an installation token from them.
-    assert connector_cls.call_args.kwargs["credentials"].is_app_auth is True
+    # App credentials were converted to a typed credential and the providers
+    # auth utility minted an installation token from them (no GitHubConnector).
+    assert mint_token.call_args.kwargs["app_id"] == "12345"
+    assert mint_token.call_args.kwargs["private_key"] == "synthetic-private-key"
+    assert mint_token.call_args.kwargs["installation_id"] == "67890"
     # discover_github_repos receives the minted token string, not raw app fields.
     assert discover.call_args.args[1] == "installation-token"
+
+
+def _is_connectors_target(name: str | None) -> bool:
+    return name is not None and (
+        name == "dev_health_ops.connectors"
+        or name.startswith("dev_health_ops.connectors.")
+    )
+
+
+def _find_connectors_imports(source: str) -> list[str]:
+    """Return every ``dev_health_ops.connectors``-reaching import in ``source``.
+
+    Walks the AST (covering import statements nested inside function bodies,
+    i.e. the lazy-import style this codebase uses throughout) rather than
+    substring-matching, so formatting/comments can't fool it. Handles every
+    import *form* that can name a connectors symbol:
+
+    - ``import dev_health_ops.connectors[.x][ as y]``
+    - ``from dev_health_ops.connectors[.x] import y``
+    - ``from dev_health_ops import connectors`` -- the form a first version of
+      this guard missed (flagged by Codex adversarial review round 2 on
+      CHAOS-2786's PR): ``ImportFrom.module`` is just ``"dev_health_ops"``
+      here, so a module-prefix-only check passes it clean. Fixed by resolving
+      each imported *alias* to its fully-qualified dotted name
+      (``f"{module}.{alias.name}"``) and checking that instead of the bare
+      module string.
+    - ``importlib.import_module("dev_health_ops.connectors...")`` with a
+      string-literal argument (best-effort; a dynamically-built string isn't
+      statically resolvable and isn't this codebase's style anyway).
+    """
+    tree = ast.parse(source)
+    found: list[str] = []
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            found.extend(
+                alias.name for alias in node.names if _is_connectors_target(alias.name)
+            )
+        elif isinstance(node, ast.ImportFrom) and node.level == 0:
+            module = node.module or ""
+            for alias in node.names:
+                full = f"{module}.{alias.name}" if module else alias.name
+                if _is_connectors_target(full):
+                    found.append(full)
+        elif (
+            isinstance(node, ast.Call)
+            and isinstance(node.func, ast.Attribute)
+            and node.func.attr == "import_module"
+            and isinstance(node.func.value, ast.Name)
+            and node.func.value.id == "importlib"
+            and node.args
+            and isinstance(node.args[0], ast.Constant)
+            and isinstance(node.args[0].value, str)
+            and _is_connectors_target(node.args[0].value)
+        ):
+            found.append(node.args[0].value)
+
+    return found
+
+
+def test_connectors_import_guard_catches_named_submodule_import_form() -> None:
+    """Prove the guard itself trips on the exact form it previously missed.
+
+    Codex adversarial review round 2 verified that
+    ``from dev_health_ops import connectors`` -- placed inside a function
+    body, matching this codebase's lazy-import convention -- parses as
+    ``ImportFrom(module='dev_health_ops', names=[alias(name='connectors')])``
+    and slipped past a guard that only checked ``ImportFrom.module`` for a
+    connectors prefix. This is a synthetic-source regression test for the
+    *guard*, not for ``discovery/repos.py`` (see
+    ``test_discovery_repos_module_has_no_connectors_package_import`` below
+    for that): it proves ``_find_connectors_imports`` now flags this form,
+    an unrelated sibling import in the same statement is not mistakenly
+    flagged, and an unrelated module ("connectors" as a local/attribute name
+    that isn't ``dev_health_ops.connectors``) is left alone.
+    """
+    regressed_source = """
+def _mint_token_the_wrong_way():
+    from dev_health_ops import connectors, credentials
+
+    return connectors.github.GitHubConnector(credentials=credentials).token
+"""
+    found = _find_connectors_imports(regressed_source)
+    assert found == ["dev_health_ops.connectors"]
+
+    clean_source = """
+def _mint_token_the_right_way():
+    from dev_health_ops.providers.github.app_auth import mint_installation_token
+
+    return mint_installation_token(app_id="1", private_key="k", installation_id="2")
+"""
+    assert _find_connectors_imports(clean_source) == []
+
+    unrelated_source = """
+def _uses_an_unrelated_local_named_connectors():
+    connectors = {"github": object()}
+    return connectors["github"]
+"""
+    assert _find_connectors_imports(unrelated_source) == []
+
+
+def test_discovery_repos_module_has_no_connectors_package_import() -> None:
+    """discovery/repos.py must not import ANYTHING from ``dev_health_ops.connectors``.
+
+    A first-pass version of this test only rejected the literal strings
+    ``GitHubConnector``/``connectors.github``, which passed even though
+    ``_discover_github_app_installation_repos`` (the ``all_repos=True``
+    App-auth path) still minted tokens via
+    ``dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider`` --
+    a second, divergent JWT/retry implementation living in the same module
+    (caught by Codex adversarial review round 1 on CHAOS-2786's PR). Both
+    App-auth call sites now go through ``providers.github.app_auth`` instead,
+    so the boundary is: no ``dev_health_ops.connectors`` import anywhere in
+    this module, full stop -- no allowlist. See
+    ``test_connectors_import_guard_catches_named_submodule_import_form``
+    above for proof the detector itself (round 2 hardening) can't be fooled
+    by the ``from dev_health_ops import connectors`` form.
+    """
+    source = inspect.getsource(repos_mod)
+    connectors_imports = _find_connectors_imports(source)
+
+    assert connectors_imports == [], (
+        "discovery/repos.py must not import from dev_health_ops.connectors "
+        f"(found: {connectors_imports})"
+    )
+    assert "dev_health_ops.providers.github.app_auth" in source
 
 
 def test_discover_github_pat_passes_token_through() -> None:


### PR DESCRIPTION
## Summary

`discovery/repos.py` had TWO divergent GitHub App installation-token-minting implementations, both depending on the frozen `connectors` package (CHAOS-2773's shared REST core, CS1, doesn't exist yet, so this is built standalone following `providers/` conventions):

1. `_github_token_from_resolved_credentials` (the non-`all_repos` path) constructed `GitHubConnector(credentials=...)` solely to read `.token` off it.
2. `_discover_github_app_installation_repos` (the `all_repos=True` App-installation-listing path) separately minted via `connectors.utils.github_app.GitHubAppTokenProvider(...).get_token()` directly — a second, independent JWT/retry implementation in the same file. (Caught by Codex adversarial review after the first pass only migrated #1.)

Both are now migrated onto one new utility:

- Adds `providers/github/app_auth.py`: a standalone httpx-based `mint_installation_token()` — RS256 JWT (`iss`/`iat`/`exp` claims, 60s clock-skew backdate, 10min TTL), `POST /app/installations/{id}/access_tokens` with `X-GitHub-Api-Version: 2022-11-28`, GHE base-url join (as-is, no path rewriting), transient-5xx/network retry (3 attempts, exponential backoff) with no retry on 4xx.
- Rewires **both** discovery call sites onto it. `discovery/repos.py` no longer imports anything from `dev_health_ops.connectors`, full stop — enforced by an AST-based test (walks the module, including lazily-imported function bodies) rather than a substring check on one class name, so a future regression on either path gets caught.

### Parity notes
- Mirrors `connectors.utils.github_app.GitHubAppTokenProvider`'s JWT construction and installation-token exchange semantics exactly (verified against its source + its existing test suite's expectations), using `httpx` instead of `requests`.
- Intentionally does **not** replicate the connector's token-caching layer: every discovery call site mints fresh per call today (no caching is ever observed from either call site), so a plain one-shot mint is exact behavioral parity, not a simplification that changes behavior.
- Error types (`GitHubAppAuthError`, `GitHubAppTransientError`) are new local classes in `providers/github/app_auth.py`, not reused from `connectors` — no caller outside the connectors test suite `isinstance`-checks the connectors-side classes, so this doesn't change observable behavior for either discovery call site (verified via grep).
- `_discover_github_app_installation_repos`'s own `/installation/repositories` pagination call still uses `requests` directly — untouched, since that's a plain third-party HTTP call with no `connectors` dependency, out of scope for this ticket.

### Out of scope (left untouched)
- `connectors/` package — not modified, per the migration's rule that the old path stays in tree.

## Test plan
- [x] `tests/providers/test_github_app_auth.py` (12 tests): JWT RS256 signing/claims (runtime-generated RSA keypair — no committed PEM), successful mint (endpoint, headers, JWT claims via `httpx.MockTransport`), GHE base-url join, default base-url, no-retry-on-4xx, retry-then-succeed on transient 5xx, retry-then-succeed on network error, retry-exhaustion, malformed-response rejection, missing-credential-field validation.
- [x] `tests/test_worker_github_app_auth.py`: `test_discover_github_app_auth_mints_token_via_providers_app_auth` patches the new utility for the non-`all_repos` path; `test_discovery_repos_module_has_no_connectors_package_import` — AST-walk asserting **zero** `dev_health_ops.connectors` imports anywhere in `discovery/repos.py` (module-level or nested in lazily-imported function bodies), no allowlist.
- [x] `tests/test_sync_partitioning.py`: `test_github_app_all_repos_lists_installation_repositories` and `test_github_app_all_repos_installation_api_failure_raises` updated to patch the new utility for the `all_repos=True` path; new `test_github_app_all_repos_defaults_base_url_and_propagates_mint_error` covers base-url defaulting and error propagation through the minter for that path specifically.
- [x] `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=ci_local_validate_2786 bash ci/local_validate.sh` — GATE PASSED (ruff format/check, mypy across 1285 files, full unit suite: 6375 passed / 44 skipped, live ClickHouse argMax proof).
- [x] Gitleaks-safe: RSA test keypair generated at runtime via `cryptography.hazmat`, never committed as a PEM literal.

## Review history
- Codex adversarial review (round 1): 1 medium finding — second connectors-dependent token minter (`_discover_github_app_installation_repos`, the `all_repos=True` path) missed by the first migration pass. Fixed.
- Codex adversarial review (round 2, focused re-pass): confirmed no runtime regression in the round-1 fix, but 1 medium finding on the regression guard itself — the AST boundary test's `ImportFrom` check only inspected `node.module` for a `connectors` prefix, so `from dev_health_ops import connectors` (module=`"dev_health_ops"`, alias=`"connectors"`) parsed clean and slipped past it. Fixed by resolving each imported alias to its fully-qualified dotted name before checking, plus a synthetic-source test (`test_connectors_import_guard_catches_named_submodule_import_form`) that proves the detector itself catches that exact form (and doesn't false-positive on an unrelated local variable named `connectors`). All rounds squashed into one commit.
