### PR TITLE
fix(security): sanitize report_runs/sso_providers/audit_logs error writes (CHAOS-2784)

### DIFF
--- a/src/dev_health_ops/api/services/audit.py
+++ b/src/dev_health_ops/api/services/audit.py
@@ -16,6 +16,7 @@ from dev_health_ops.models.audit import (
     AuditLog,
     AuditResourceType,
 )
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +110,11 @@ class AuditService:
             changes=changes,
             request_metadata=req_metadata if req_metadata else None,
             status=status,
-            error_message=error_message,
+            # CHAOS-2784: audit_logs.error_message is a free-form Text
+            # column; callers (e.g. SSO SAML/OIDC processing failures) pass
+            # str(exc) straight through, so redact credential-shaped
+            # substrings before persisting (CHAOS-2766).
+            error_message=sanitize_error_text(error_message),
         )
 
         self.session.add(audit_log)

--- a/src/dev_health_ops/api/services/sso.py
+++ b/src/dev_health_ops/api/services/sso.py
@@ -29,6 +29,7 @@ from dev_health_ops.models.sso import (
     SSOProviderStatus,
 )
 from dev_health_ops.models.users import AuthProvider, Membership, User
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
 logger = logging.getLogger(__name__)
 
@@ -388,7 +389,12 @@ class SSOService:
     ) -> None:
         provider = await self.get_provider(org_id, provider_id)
         if provider:
-            setattr(provider, "last_error", error)
+            # CHAOS-2784: sso_providers.last_error is a free-form Text column
+            # fed with str(exc) by every call site (SAML/OIDC processing
+            # errors) -- redact credential-shaped substrings before
+            # persisting, same as the other legacy error-text sinks
+            # (CHAOS-2766).
+            setattr(provider, "last_error", sanitize_error_text(error))
             setattr(provider, "last_error_at", datetime.now(timezone.utc))
             setattr(provider, "status", SSOProviderStatus.ERROR.value)
             await self.session.flush()

--- a/src/dev_health_ops/api/utils/audit.py
+++ b/src/dev_health_ops/api/utils/audit.py
@@ -7,6 +7,7 @@ from fastapi import Request
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.models.audit import AuditAction, AuditLog, AuditResourceType
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
 
 def extract_request_metadata(request: Request) -> dict[str, str]:
@@ -57,6 +58,10 @@ def emit_audit_log(
         request_id=metadata.get("request_id"),
     )
     setattr(entry, "status", status)
-    setattr(entry, "error_message", error_message)
+    # CHAOS-2784: second writer to audit_logs.error_message (distinct from
+    # AuditService.log) -- same redaction requirement, no transaction
+    # semantics changed (db.add/flush only; commit-or-rollback stays with
+    # the caller's get_postgres_session scope).
+    setattr(entry, "error_message", sanitize_error_text(error_message))
     db.add(entry)
     return entry

--- a/src/dev_health_ops/llm/credentials.py
+++ b/src/dev_health_ops/llm/credentials.py
@@ -174,6 +174,19 @@ def _audit_org_byo_base_url_fallback(
             AuditLog,
             AuditResourceType,
         )
+        from dev_health_ops.sync.error_sanitize import sanitize_error_text
+
+        # CHAOS-2784: `reason` comes from validate_llm_base_url and can embed
+        # raw tenant-controlled input (e.g. an invalid-port ValueError
+        # interpolates the literal, attacker-chosen port text), and
+        # `base_url` is the org's raw BYO value -- SSRF validation rejects
+        # userinfo-bearing URLs but still routes the *original* base_url
+        # here for the audit trail. Both are direct AuditLog(...)
+        # constructions (not routed through AuditService.log or
+        # emit_audit_log), so redact credential-shaped substrings before
+        # persisting, same as those two sinks.
+        sanitized_reason = sanitize_error_text(reason) or "invalid_base_url"
+        sanitized_base_url = sanitize_error_text(_safe_log_value(base_url))
 
         with get_postgres_session_sync() as session:
             session.add(
@@ -188,12 +201,12 @@ def _audit_org_byo_base_url_fallback(
                     ),
                     changes={
                         "provider": _safe_log_value(provider_name),
-                        "base_url": _safe_log_value(base_url),
-                        "reason": reason or "invalid_base_url",
+                        "base_url": sanitized_base_url,
+                        "reason": sanitized_reason,
                     },
                     request_metadata={"source": "llm_credentials_resolver"},
                     status="failure",
-                    error_message=reason or "invalid_base_url",
+                    error_message=sanitized_reason,
                 )
             )
             session.flush()

--- a/src/dev_health_ops/workers/report_task.py
+++ b/src/dev_health_ops/workers/report_task.py
@@ -9,6 +9,7 @@ from typing import Any
 
 from sqlalchemy import select
 
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 from dev_health_ops.workers.celery_app import celery_app
 
 logger = logging.getLogger(__name__)
@@ -165,6 +166,13 @@ def execute_saved_report(self, report_id: str, run_id: str) -> dict:
 
     except Exception as exc:
         logger.exception("Report execution failed for run %s", run_id)
+        # CHAOS-2784: report_runs.error / error_traceback are free-form Text
+        # columns populated from str(exc) / traceback.format_exc() -- neither
+        # controls what a downstream client library or provider response body
+        # embeds in an exception message, so redact credential-shaped
+        # substrings before persisting (mirrors sync/dispatch_outbox.py and
+        # workers/sync_units.py, CHAOS-2766).
+        sanitized_error = sanitize_error_text(exc)
         with get_postgres_session_sync() as session:
             run = session.execute(
                 select(ReportRun).where(ReportRun.id == run_uuid)
@@ -180,8 +188,12 @@ def execute_saved_report(self, report_id: str, run_id: str) -> dict:
                         "duration_seconds",
                         (completed_at - started_at).total_seconds(),
                     )
-                setattr(run, "error", str(exc))
-                setattr(run, "error_traceback", traceback.format_exc())
+                setattr(run, "error", sanitized_error)
+                setattr(
+                    run,
+                    "error_traceback",
+                    sanitize_error_text(traceback.format_exc()),
+                )
                 session.commit()
 
             report_obj = session.execute(
@@ -192,4 +204,4 @@ def execute_saved_report(self, report_id: str, run_id: str) -> dict:
                 setattr(report_obj, "last_run_status", ReportRunStatus.FAILED.value)
                 session.commit()
 
-        return {"status": "failed", "run_id": run_id, "error": str(exc)}
+        return {"status": "failed", "run_id": run_id, "error": sanitized_error}

--- a/tests/api/services/test_audit_error_sanitize.py
+++ b/tests/api/services/test_audit_error_sanitize.py
@@ -1,0 +1,100 @@
+"""CHAOS-2784: audit_logs.error_message must not persist raw exception text.
+
+Two independent writers populate ``audit_logs.error_message`` with raw,
+often exception-derived text: ``AuditService.log`` (and its
+``log_create``/``log_update``/``log_delete``/``log_login`` wrappers) and the
+standalone ``emit_audit_log`` helper used by the auth routers (SSO
+SAML/OIDC failures pass ``str(exc)`` straight through -- see
+``api/auth/sso/router.py``). If either exception message embeds a
+credential -- e.g. an IdP/DB/broker URL with userinfo, or a bare provider
+token -- it used to persist verbatim. This proves both sinks now route
+through ``sanitize_error_text`` (CHAOS-2766) before the write, and that
+``emit_audit_log``'s transaction semantics (``db.add`` only, no
+commit/flush -- CHAOS-2498's emit-then-raise rollback trap) are unchanged.
+
+See ``tests/test_error_sanitize.py`` for why every fixture secret is
+assembled via ``_fake_secret(...)`` at runtime with a neutral name instead of
+a literal -- required to defeat CI's Gitleaks scan.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dev_health_ops.api.services.audit import AuditService
+from dev_health_ops.api.utils.audit import emit_audit_log
+from dev_health_ops.models.audit import AuditAction, AuditResourceType
+from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
+
+
+def _fake_secret(*parts: str) -> str:
+    """Assemble a synthetic, redaction-target-shaped fixture at runtime (see
+    tests/test_error_sanitize.py's module docstring for why this isn't a
+    plain string literal -- Gitleaks matches file bytes, not runtime
+    values)."""
+    return "".join(parts)
+
+
+# URL-userinfo shape (a broker/DB connection string surfacing in an
+# exception message).
+_FIXTURE_1 = _fake_secret("brokerXuser", ":", "brokerXvalue456")
+# Provider PAT-prefix shape, self-identifying regardless of surrounding text.
+_FIXTURE_2 = _fake_secret("ghp_", "FAKEcdefghijklmno1234567890")
+
+
+@pytest.mark.asyncio
+async def test_audit_service_log_sanitizes_secret_bearing_error_message():
+    session = MagicMock()
+    session.add = MagicMock()
+    session.flush = AsyncMock()
+
+    service = AuditService(session)
+    raw_error = (
+        "webhook dispatch failed -- connection string "
+        f"amqp://{_FIXTURE_1}@broker.internal:5672/vhost unreachable"
+    )
+
+    audit_log = await service.log(
+        org_id=uuid.uuid4(),
+        action=AuditAction.UPDATE,
+        resource_type=AuditResourceType.SSO_PROVIDER,
+        resource_id="provider-1",
+        status="failure",
+        error_message=raw_error,
+    )
+
+    assert audit_log.error_message is not None
+    assert _FIXTURE_1 not in audit_log.error_message
+    assert REDACTION_MARKER in audit_log.error_message
+    assert "webhook dispatch failed" in audit_log.error_message
+    session.add.assert_called_once_with(audit_log)
+
+
+def test_emit_audit_log_sanitizes_secret_bearing_error_message():
+    db = MagicMock()
+    raw_error = f"identity provider callback failed -- token {_FIXTURE_2} rejected"
+
+    entry = emit_audit_log(
+        db=db,
+        org_id=uuid.uuid4(),
+        action=AuditAction.LOGIN_FAILED,
+        resource_type=AuditResourceType.SESSION,
+        resource_id="user-1",
+        status="failure",
+        error_message=raw_error,
+    )
+
+    assert entry.error_message is not None
+    assert _FIXTURE_2 not in entry.error_message
+    assert REDACTION_MARKER in entry.error_message
+    assert "identity provider callback failed" in entry.error_message
+
+    # CHAOS-2498 rollback trap: emit_audit_log must stay add-only (no
+    # commit/flush of its own) so the caller's get_postgres_session
+    # commit-before-raise contract is untouched by this sanitize fix.
+    db.add.assert_called_once_with(entry)
+    db.flush.assert_not_called()
+    db.commit.assert_not_called()

--- a/tests/api/services/test_sso_error_sanitize.py
+++ b/tests/api/services/test_sso_error_sanitize.py
@@ -1,0 +1,83 @@
+"""CHAOS-2784: sso_providers.last_error must not persist raw exception text.
+
+Every ``SSOService.record_error`` call site (SAML/OIDC processing failures in
+``api/auth/sso/router.py``) passes ``str(exc)`` straight through. If that
+exception message embeds a credential -- e.g. an IdP token endpoint call
+surfacing an ``Authorization`` header, the same shape CHAOS-2758 found in
+``sync_run_units.error`` -- it used to persist verbatim into
+``sso_providers.last_error``. This proves the sink now routes through
+``sanitize_error_text`` (CHAOS-2766) before the write.
+
+See ``tests/test_error_sanitize.py`` for why every fixture secret is
+assembled via ``_fake_secret(...)`` at runtime with a neutral name instead of
+a literal -- required to defeat CI's Gitleaks scan.
+"""
+
+from __future__ import annotations
+
+import uuid
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from dev_health_ops.api.services.sso import SSOService
+from dev_health_ops.models.sso import SSOProvider, SSOProviderStatus
+from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
+
+
+def _fake_secret(*parts: str) -> str:
+    """Assemble a synthetic, redaction-target-shaped fixture at runtime (see
+    tests/test_error_sanitize.py's module docstring for why this isn't a
+    plain string literal -- Gitleaks matches file bytes, not runtime
+    values)."""
+    return "".join(parts)
+
+
+_FIXTURE_1 = _fake_secret("ghp_", "FAKEmnopqrstuv1234567890XY")
+
+
+@pytest.mark.asyncio
+async def test_record_error_sanitizes_secret_bearing_message():
+    org_id = uuid.uuid4()
+    provider_id = uuid.uuid4()
+    provider = SSOProvider(
+        org_id=org_id,
+        name="Example OIDC",
+        protocol="oidc",
+        config={},
+    )
+
+    session = MagicMock()
+    execute_result = MagicMock()
+    execute_result.scalar_one_or_none.return_value = provider
+    session.execute = AsyncMock(return_value=execute_result)
+    session.flush = AsyncMock()
+
+    service = SSOService(session)
+    # Bare "Bearer <token>" shape (no leading "Authorization:" header name) --
+    # the other sink tests in this changeset cover the header-name and
+    # URL-userinfo shapes, this covers sanitize_error_text's second pattern.
+    raw_error = f"token exchange failed -- used Bearer {_FIXTURE_1}"
+
+    await service.record_error(org_id, provider_id, raw_error)
+
+    assert provider.last_error is not None
+    assert _FIXTURE_1 not in provider.last_error
+    assert REDACTION_MARKER in provider.last_error
+    assert "token exchange failed" in provider.last_error
+    assert provider.status == SSOProviderStatus.ERROR.value
+    assert provider.last_error_at is not None
+
+
+@pytest.mark.asyncio
+async def test_record_error_no_provider_is_a_noop():
+    session = MagicMock()
+    execute_result = MagicMock()
+    execute_result.scalar_one_or_none.return_value = None
+    session.execute = AsyncMock(return_value=execute_result)
+    session.flush = AsyncMock()
+
+    service = SSOService(session)
+    await service.record_error(uuid.uuid4(), uuid.uuid4(), "unused")
+
+    session.flush.assert_not_called()

--- a/tests/test_byo_base_url_ssrf.py
+++ b/tests/test_byo_base_url_ssrf.py
@@ -23,8 +23,17 @@ from dev_health_ops.llm.providers._http import (
     make_hardened_async_httpx_client,
     make_hardened_httpx_client,
 )
+from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
 
 os.environ.setdefault("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+
+
+def _fake_secret(*parts: str) -> str:
+    """Assemble a synthetic, redaction-target-shaped fixture at runtime
+    instead of a literal (see tests/test_error_sanitize.py's module
+    docstring) -- CI's Gitleaks scan matches file bytes, not runtime
+    values."""
+    return "".join(parts)
 
 
 def _addrinfo(address: str):
@@ -146,6 +155,85 @@ def test_org_disallowed_base_url_falls_back_and_audits(
     assert entry.status == "failure"
     assert entry.changes["provider"] == "openai"
     assert entry.changes["base_url"] == "http://evil.example/v1"
+
+
+def test_org_invalid_port_reason_is_sanitized_in_audit_row(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """CHAOS-2784: validate_llm_base_url's invalid-port branch interpolates
+    the raw exception text verbatim (``f"LLM base_url is invalid: {exc}"``),
+    and urllib's ``SplitResult.port`` embeds whatever the org put after the
+    last ``:`` in its BYO base_url directly into that ValueError message. If
+    that text happens to be credential-shaped, it must not survive into
+    audit_logs.error_message / changes.reason unredacted -- this sink
+    constructs AuditLog(...) directly (not via AuditService.log or
+    emit_audit_log) so it needs its own sanitize_error_text call.
+    """
+    org_id = str(uuid.uuid4())
+    audit_session = _AuditSession()
+
+    @contextmanager
+    def fake_session():
+        yield audit_session
+
+    monkeypatch.setattr("dev_health_ops.db.get_postgres_session_sync", fake_session)
+    fixture_port_value = _fake_secret("ghp_", "FAKEabcdefgh1234567890XYZ")
+    bad_url = f"https://example.test:{fixture_port_value}/v1"
+    org = {
+        "provider": "openai",
+        "api_key": "sk-org",
+        "base_url": bad_url,
+    }
+    with _patch_org(org):
+        assert creds.resolve_usable_org_llm_provider(org_id=org_id) == ""
+
+    assert audit_session.flushed is True
+    assert audit_session.added
+    entry = audit_session.added[0]
+
+    assert entry.error_message is not None
+    assert fixture_port_value not in entry.error_message
+    assert REDACTION_MARKER in entry.error_message
+    assert "LLM base_url is invalid" in entry.error_message
+
+    assert entry.changes["reason"] is not None
+    assert fixture_port_value not in entry.changes["reason"]
+    assert REDACTION_MARKER in entry.changes["reason"]
+
+
+def test_org_userinfo_base_url_is_sanitized_in_audit_row(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    """CHAOS-2784: the SSRF guard rejects a userinfo-bearing base_url with a
+    fixed reason string, but the *original* (credential-bearing) base_url is
+    still what gets passed to the audit fallback for the diagnostic trail --
+    it must be redacted before landing in changes.base_url."""
+    org_id = str(uuid.uuid4())
+    audit_session = _AuditSession()
+
+    @contextmanager
+    def fake_session():
+        yield audit_session
+
+    monkeypatch.setattr("dev_health_ops.db.get_postgres_session_sync", fake_session)
+    fixture_userinfo_value = _fake_secret("Zqxelm", "1234567890", "abc")
+    bad_url = f"https://tenantuser:{fixture_userinfo_value}@example.test/v1"
+    org = {
+        "provider": "openai",
+        "api_key": "sk-org",
+        "base_url": bad_url,
+    }
+    with _patch_org(org):
+        assert creds.resolve_usable_org_llm_provider(org_id=org_id) == ""
+
+    assert audit_session.flushed is True
+    assert audit_session.added
+    entry = audit_session.added[0]
+
+    assert entry.changes["base_url"] is not None
+    assert fixture_userinfo_value not in entry.changes["base_url"]
+    assert REDACTION_MARKER in entry.changes["base_url"]
+    assert "example.test/v1" in entry.changes["base_url"]
 
 
 def test_org_public_https_base_url_is_usable():

--- a/tests/test_report_task_error_sanitize.py
+++ b/tests/test_report_task_error_sanitize.py
@@ -1,0 +1,132 @@
+"""CHAOS-2784: report_runs.error / error_traceback must not persist raw
+exception text.
+
+``execute_saved_report``'s failure handler used to write ``str(exc)`` and
+``traceback.format_exc()`` straight into ``report_runs.error`` /
+``report_runs.error_traceback`` -- if the report execution path raises an
+exception whose message embeds a credential (e.g. an upstream API client
+surfacing an ``Authorization`` header, the same shape CHAOS-2758 found in
+``sync_run_units.error``), it would persist verbatim. This proves the sink now
+routes through ``sanitize_error_text`` (CHAOS-2766) before either DB write and
+before the task's return value.
+
+See ``tests/test_error_sanitize.py`` for the module docstring explaining why
+every fixture secret is assembled via ``_fake_secret(...)`` at runtime with a
+neutral name instead of a literal -- required to defeat CI's Gitleaks scan.
+"""
+
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.reports import ReportRun, ReportRunStatus, SavedReport
+from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
+from tests._helpers import tables_of
+
+
+def _fake_secret(*parts: str) -> str:
+    """Assemble a synthetic, redaction-target-shaped fixture at runtime (see
+    tests/test_error_sanitize.py's module docstring for why this isn't a
+    plain string literal -- Gitleaks matches file bytes, not runtime
+    values)."""
+    return "".join(parts)
+
+
+_FIXTURE_1 = _fake_secret("ghp_", "FAKEqrstuvwxyz1234567890AB")
+
+
+@pytest.fixture
+def sync_session_maker(tmp_path):
+    db_path = tmp_path / "report-task-sanitize.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine, tables=tables_of(SavedReport, ReportRun))
+    return sessionmaker(bind=engine, expire_on_commit=False)
+
+
+def test_execute_saved_report_sanitizes_secret_bearing_failure(
+    monkeypatch, sync_session_maker
+):
+    with sync_session_maker() as seed:
+        report = SavedReport(
+            org_id="org-1",
+            name="Weekly health",
+            report_plan={},
+            parameters={},
+        )
+        seed.add(report)
+        seed.flush()
+        report_uuid = report.id
+
+        run = ReportRun(
+            report_id=report_uuid,
+            status=ReportRunStatus.PENDING.value,
+            triggered_by="manual",
+        )
+        seed.add(run)
+        seed.flush()
+        run_uuid = run.id
+
+        seed.commit()
+
+    @contextmanager
+    def fake_session_scope():
+        session = sync_session_maker()
+        try:
+            yield session
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    async def _raise_with_secret(plan, chart_specs, clickhouse_dsn):
+        raise RuntimeError(
+            f"upstream call failed -- Authorization: Bearer {_FIXTURE_1}"
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.db.get_postgres_session_sync", fake_session_scope
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.db.require_clickhouse_uri", lambda: "clickhouse://fake/db"
+    )
+    monkeypatch.setattr("dev_health_ops.db.reset_async_engines", lambda: None)
+    monkeypatch.setattr(
+        "dev_health_ops.reports.engine.execute_report", _raise_with_secret
+    )
+    # SQLite (unlike the production Postgres backend) doesn't round-trip
+    # tzinfo on DateTime(timezone=True) columns, so the previously-persisted
+    # `started_at` comes back naive while `completed_at` is computed fresh as
+    # tz-aware -- an unrelated test-harness artifact, not something this
+    # sanitize fix touches. Short-circuit the (irrelevant to this test)
+    # duration_seconds computation rather than fighting sqlite's tz handling.
+    monkeypatch.setattr(
+        "dev_health_ops.workers.report_task._datetime_or_none", lambda value: None
+    )
+
+    from dev_health_ops.workers.report_task import execute_saved_report
+
+    result = execute_saved_report(str(report_uuid), str(run_uuid))
+
+    assert result["status"] == "failed"
+    assert _FIXTURE_1 not in result["error"]
+    assert REDACTION_MARKER in result["error"]
+
+    with sync_session_maker() as verify:
+        persisted = verify.get(ReportRun, run_uuid)
+        assert persisted is not None
+
+        assert persisted.error is not None
+        assert _FIXTURE_1 not in persisted.error
+        assert REDACTION_MARKER in persisted.error
+        assert "upstream call failed" in persisted.error
+
+        assert persisted.error_traceback is not None
+        assert _FIXTURE_1 not in persisted.error_traceback
+        assert REDACTION_MARKER in persisted.error_traceback


### PR DESCRIPTION
## Summary

CHAOS-2766 (ops#1123) introduced `sanitize_error_text` (`src/dev_health_ops/sync/error_sanitize.py`) and applied it to the sync-side legacy error-text sinks (`sync_run_units.error` and siblings). Codex review against `main@6ea948028` found three more free-form `Text` DB columns still writing **raw** exception text — this PR closes those gaps at the write path only. A follow-up adversarial codex pass found a fourth writer of the same `audit_logs.error_message` column that a naive grep for call-site kwargs missed (see "Fix round" below).

- **`report_runs.error` / `report_runs.error_traceback`** (`workers/report_task.py`, `execute_saved_report`'s failure handler) — was `str(exc)` / `traceback.format_exc()` verbatim, plus the same raw text in the Celery task's return dict.
- **`sso_providers.last_error`** (`api/services/sso.py`, `SSOService.record_error`) — every SAML/OIDC processing-failure call site in `api/auth/sso/router.py` passes `str(exc)` through unchanged.
- **`audit_logs.error_message`** — three independent writers found via grep for all assignments to this column/attribute AND all direct `AuditLog(...)` constructions repo-wide, all fixed:
  - `AuditService.log` (`api/services/audit.py`), used by `log_create`/`log_update`/`log_delete`/`log_login`.
  - `emit_audit_log` (`api/utils/audit.py`), used directly by the auth routers — including the SSO SAML/OIDC failure paths above, which pass `str(exc)` as `error_message`.
  - `_audit_org_byo_base_url_fallback` (`llm/credentials.py`) — found in the fix-round adversarial pass. This sink constructs `AuditLog(...)` directly (not via either helper above), so it was invisible to a grep scoped to helper call-site kwargs. It wrote the raw `reason` from `validate_llm_base_url` into both `error_message` and `changes.reason` — `reason` can embed tenant-controlled text verbatim (e.g. an invalid port makes urllib's `SplitResult.port` raise a `ValueError` that interpolates whatever the org put after the last `:` in its BYO `base_url`). The same function also persisted the raw, possibly userinfo-bearing `base_url` into `changes.base_url`; both are now sanitized before the write.

Each site now wraps the persisted value in `sanitize_error_text(...)` at the point of assignment, using the module's default redaction + 4000-char truncation (all affected columns are unbounded `Text`/`JSON`, matching the module's documented default — no tighter `max_length` needed here).

## Not in scope

- **At-rest scrub of already-persisted rows.** This is a write-path fix only; historical rows with raw error text will be handled by CHAOS-2780's scrub command.
- `_SECRET_PATTERNS` / `sanitize_error_text` itself — unmodified.
- Transaction semantics — unmodified. In particular, `emit_audit_log` stays `db.add`-only (no commit/flush of its own), so the CHAOS-2498 emit-then-raise rollback contract (commit-before-raise happens in the caller's `get_postgres_session` scope) is untouched.

## Tests

One test per sink, each seeding a secret-bearing failure and asserting the persisted/returned value contains `[REDACTED]` and **not** the raw secret substring:

- `tests/test_report_task_error_sanitize.py` — Authorization-header shape, via a real sqlite-backed `ReportRun`/`SavedReport` round trip through `execute_saved_report`.
- `tests/api/services/test_sso_error_sanitize.py` — bare `Bearer <token>` shape (no header name), via `SSOService.record_error`.
- `tests/api/services/test_audit_error_sanitize.py` — URL-userinfo shape (`AuditService.log`) and PAT-prefix shape (`emit_audit_log`), covering both original `audit_logs.error_message` writers independently. Also asserts `emit_audit_log` remains add-only (no flush/commit).
- `tests/test_byo_base_url_ssrf.py` (fix round) — two new tests against the `_audit_org_byo_base_url_fallback` sink: an invalid-port ValueError embedding a runtime-constructed token-shaped string (proving `error_message`/`changes.reason` are redacted), and a userinfo-bearing `base_url` (proving `changes.base_url` is redacted). The pre-existing `test_org_disallowed_base_url_falls_back_and_audits` in the same file is unchanged and still passes (its fixture URL contains no secret-shaped substring, so sanitization is a no-op for it).

All fixture secrets are assembled at runtime via a neutral `_fake_secret(...)` helper with generic `_FIXTURE_N`/`fixture_*_value` names (no `token`/`key`/`secret` in any identifier on the same line as a quoted value), mirroring the CHAOS-2766/#1123 convention required to avoid false-positive Gitleaks hits on the PR diff.

## Test plan

- [x] `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=ci_local_validate_2784 bash ci/local_validate.sh` — full gate green after both rounds: ruff format/check, mypy, full unit suite (6367 passed, 44 pre-existing/unrelated skips), live ClickHouse argMax proof.
- [x] New sink tests pass in isolation and as part of the full suite.
- [x] Grepped for other writers to each of the three exact columns, including all direct `AuditLog(...)`/`ReportRun(...)`/`SSOProvider(...)` constructions repo-wide (not just helper call-site kwargs) — no writers left unsanitized beyond the four fixed here.
- [x] Two independent codex review passes: an initial plain `codex review --base main` (clean) and a follow-up adversarial pass that caught the `llm/credentials.py` gap fixed in this round.