### PR TITLE
feat(providers): migrate GitLab feature flags to instrumented httpx client (CHAOS-2785)

### DIFF
--- a/docs/architecture/launchdarkly-sync-budgeting.md
+++ b/docs/architecture/launchdarkly-sync-budgeting.md
@@ -72,7 +72,7 @@ CHAOS-2687 satisfies the budgeting gate for the existing `feature-flags` unit. B
 ## Follow-ups
 
 - Replace fixed request estimates with dynamic estimates driven by project, environment, flag, audit-log, and code-reference fanout.
-- Add GitLab feature-flag budgeting when GitLab feature-flag sync units are enabled.
+- ~~Add GitLab feature-flag budgeting when GitLab feature-flag sync units are enabled.~~ Done: `GitLabBudgetEstimator` already reserves budget for `DatasetKey.FEATURE_FLAGS` (route family `project`, `providers/gitlab/budget.py`), and as of CHAOS-2785 the fetch itself is instrumented too — see [Provider Rate-Limit Policy — GitLab](../providers/rate-limit-policy.md#gitlab) and [Sync usage actuals capture](sync-usage-actuals.md). Dedicated (non-shared) GitLab feature-flag budget families remain a follow-up.
 - Reserve budget for the `projects`, `segments`, and `members` route families once a client fetches them (currently modeled but not emitted or instrumented).
 - Feed the `X-RateLimit-Route-Remaining` low-budget warning into the deferral/cooldown machinery instead of only logging it (see [Provider Rate-Limit Policy — Known gaps](../providers/rate-limit-policy.md#known-gaps)).
 

--- a/docs/architecture/sync-usage-actuals.md
+++ b/docs/architecture/sync-usage-actuals.md
@@ -47,6 +47,7 @@ Drains emit two keys on `ProviderBatch.observations` / the unit-result
 | --- | --- | --- |
 | GitHub | REST + GraphQL | `GitHubProvider.ingest` (both keys) |
 | GitLab | REST | `GitLabProvider.ingest` **and** `metrics.work_items.fetch_gitlab_work_items` (the live worker path) |
+| GitLab feature-flags | REST | `_sync_gitlab_feature_flags` (CHAOS-2785): `GitLabFeatureFlagsClient`, drained into `provider_usage` |
 | Jira | REST | `JiraProvider.ingest` (legacy + atlassian paths) and the `job_work_items` client drain |
 | Linear | GraphQL | `LinearClient` per-POST counting (`X-RateLimit-Requests-*` capture) drained via `job_work_items` |
 | LaunchDarkly | REST | `_sync_launchdarkly_feature_flags` (CHAOS-2761): `LaunchDarklyClient` (flags, audit_log) + `LaunchDarklyCodeReferencesClient` (code_refs), both drained into `provider_usage` |
@@ -84,7 +85,8 @@ attribution would require richer operation labels at the client call sites.
    needs a canonical-provider migration off PyGithub/python-gitlab (much
    larger than a follow-up-ticket-sized change — see [Provider Rate-Limit
    Policy — Known gaps](../providers/rate-limit-policy.md#known-gaps)) and is
-   deferred to its own tracked effort.
+   deferred to its own tracked effort (CHAOS-2773 CS17 for the remaining
+   GitLab code-dataset methods specifically).
 
 > **Resolved (CHAOS-2761):** LaunchDarkly flag/audit-log actuals — previously
 > gap #1 here, blocked on the frozen `connectors/launchdarkly.py` path — are
@@ -92,3 +94,13 @@ attribution would require richer operation labels at the client call sites.
 > `providers/launchdarkly/client.py::LaunchDarklyClient`, and the pre-existing
 > canonical `code_refs.py` client was wired to the same shared recorder. See
 > [LaunchDarkly sync budgeting](launchdarkly-sync-budgeting.md).
+
+> **Resolved (CHAOS-2785):** GitLab feature-flag actuals — `get_feature_flags`
+> / `get_project_name`, previously on the frozen `connectors/gitlab.py`
+> `GitLabConnector` riding the un-instrumented `connectors/utils/rest.py`, are
+> now instrumented via the canonical `providers/gitlab/feature_flags.py::
+> GitLabFeatureFlagsClient`, wired to the shared CHAOS-2754 recorder
+> (resolving under the existing `project` route family). The remaining GitLab
+> code-dataset methods on the connector (`commits`, `files`, `blame`, `cicd`,
+> `tests`, `deployments`, `security`) are unaffected and remain frozen
+> pending CHAOS-2773 CS17.

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -100,6 +100,7 @@ cooperating layers:
    | GitHub REST connector | 3 (`retry_with_backoff(max_retries=3)`) | `connectors/github.py` |
    | GitHub GraphQL client | 5 (`max_retries=5`) | `connectors/utils/graphql.py` |
    | GitLab REST connector | 3 (`retry_with_backoff(max_retries=3)`) | `connectors/gitlab.py` |
+   | GitLab feature-flags (canonical) | 5 (`max_retries=5`) | `providers/gitlab/feature_flags.py` |
    | Jira client (JQL + enrichment) | 4 (`max_retries_429=3` → `+1` initial) | `providers/jira/client.py` |
    | Jira Atlassian REST compat | 5 (`RESTClient(max_retries=5)`) | `connectors/utils/rest.py` |
    | Linear | 5 (`DEFAULT_MAX_ATTEMPTS`) | `providers/linear/client.py` |
@@ -753,8 +754,29 @@ once beyond what DispatchGuard's concurrency cap already allows
   re-raised as a non-retryable `AuthenticationException` so the retry decorator
   does not spin on an unfixable error (`connectors/gitlab.py`, mirroring
   GitHub's permission-403 handling).
+- **Feature-flag fetch migrated off the frozen connector (CHAOS-2785).**
+  `GitLabConnector.get_feature_flags` / `get_project_name`
+  (`connectors/gitlab.py`) previously carried this same 403/429 convention but
+  through the un-instrumented `connectors/utils/rest.py::GitLabRESTClient`, so
+  the fetch never produced actuals. The feature-flags sync unit now fetches
+  through the canonical `providers/gitlab/feature_flags.py::
+  GitLabFeatureFlagsClient` -- byte-for-byte behavior parity (403 stays
+  non-retryable, 429 stays a retryable `RateLimitException` with signal;
+  pinned by `tests/test_gitlab_feature_flags_client.py`), now wired to the
+  shared CHAOS-2754 recorder. `connectors/gitlab.py` is left in place, unused
+  by the feature-flags sync path; its other (code-dataset) methods are
+  untouched and remain frozen pending the larger CHAOS-2773 CS17 migration
+  below.
+- **Actuals instrumentation (CHAOS-2785).** The feature-flags fetch
+  (`get_feature_flags`, `get_project_name`) records real per-request counts
+  through the shared CHAOS-2754 recorder, resolving under the existing
+  `project` route family the `GitLabBudgetEstimator` already reserves for
+  `DatasetKey.FEATURE_FLAGS` -- no new route family or estimator change was
+  needed, since `GITLAB_USAGE_ROUTE_FAMILIES`' `project` marker (`/projects/`)
+  already matches these operations.
 - **Known gaps.** GitLab feature-flag budgeting shares the `project` REST-core
-  family; dedicated GitLab feature-flag budget families are a follow-up.
+  family; dedicated GitLab feature-flag budget families (distinguishing them
+  from generic project-metadata reads in calibration) remain a follow-up.
 
 #### Route families
 <!-- route-families:gitlab -->
@@ -933,7 +955,11 @@ paper over:
   entirely) than a follow-up-ticket-sized change. LaunchDarkly's equivalent
   gap (flag/audit-log fetches on the frozen connector) was closed in
   [CHAOS-2761](https://linear.app/fullchaos/issue/CHAOS-2761); see
-  [LaunchDarkly](#launchdarkly) above.
+  [LaunchDarkly](#launchdarkly) above. GitLab's feature-flags fetch
+  (`get_feature_flags` / `get_project_name`) is likewise closed as of
+  [CHAOS-2785](https://linear.app/fullchaos/issue/CHAOS-2785) — see
+  [GitLab](#gitlab) above — while the rest of GitLab's frozen
+  code-dataset methods remain unmigrated pending CHAOS-2773 CS17.
 
 
 ## References

--- a/src/dev_health_ops/providers/_ratelimit.py
+++ b/src/dev_health_ops/providers/_ratelimit.py
@@ -22,6 +22,7 @@ header), use the helper form::
 
 from __future__ import annotations
 
+import time
 from collections.abc import Iterator
 from contextlib import contextmanager
 from datetime import datetime, timezone
@@ -112,3 +113,77 @@ def penalize_from_response(
     if retry_after is None:
         retry_after = default
     return gate.penalize(retry_after)
+
+
+def gitlab_403_is_rate_limited(headers: Any) -> bool:
+    """Return ``True`` when a GitLab 403 actually carries rate-limit signal.
+
+    GitLab returns 403 both for permission/feature-disabled errors
+    (non-retryable) and, less commonly, for a throttled request that a
+    self-managed instance's proxy tier fronts with 403 instead of 429 --
+    distinguishable only by the presence of rate-limit headers (``Retry-
+    After``, or ``RateLimit-Remaining: 0``); see
+    ``docs/providers/rate-limit-policy.md#gitlab``.
+
+    Mirrors ``providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit``'s
+    403 qualification (the canonical ``GitLabWorkClient``'s classifier). That
+    copy operates on a python-gitlab ``GitlabError`` exception's
+    ``response_code``/``response_headers`` attributes, so it can't be called
+    directly from an httpx-based client; this header-only extraction is the
+    shared predicate every GitLab provider client should use instead of
+    re-deriving the same boolean check a third time.
+
+    :param headers: any object exposing a ``.get(name)`` mapping interface --
+        an ``httpx.Headers``, a plain ``dict``, or python-gitlab's
+        ``response_headers``.
+    """
+    if headers is None:
+        return False
+    try:
+        remaining = headers.get("RateLimit-Remaining")
+        retry_after_raw = headers.get("Retry-After")
+    except AttributeError:
+        return False
+    return (
+        parse_retry_after_header(headers) is not None
+        or str(remaining) == "0"
+        or retry_after_raw is not None
+    )
+
+
+def gitlab_resolve_retry_after_seconds(headers: Any) -> float | None:
+    """Resolve the effective retry delay for a rate-limited GitLab response.
+
+    Prefers ``Retry-After`` via :func:`parse_retry_after_header` (handles
+    both delta-seconds and HTTP-date forms). When that header is absent or
+    unparseable, derives the delay from ``RateLimit-Reset`` (an absolute
+    epoch-seconds timestamp) instead of leaving the caller with ``None`` --
+    a caller that treats "no Retry-After" as "no signal at all" and falls
+    back to its own short default backoff ends up re-hammering a
+    still-throttled self-hosted instance sooner than the server intends.
+
+    Mirrors ``providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit``'s
+    ``Retry-After`` / ``RateLimit-Reset`` fallback byte-for-byte; extracted
+    here so GitLab provider clients other than ``GitLabWorkClient`` derive
+    the SAME delay from the SAME headers instead of reimplementing (or
+    worse, silently omitting) the ``RateLimit-Reset`` fallback.
+
+    :param headers: any object exposing a ``.get(name)`` mapping interface --
+        an ``httpx.Headers``, a plain ``dict``, or python-gitlab's
+        ``response_headers``.
+    """
+    retry_after = parse_retry_after_header(headers)
+    if retry_after is not None:
+        return retry_after
+    if headers is None:
+        return None
+    try:
+        reset_raw = headers.get("RateLimit-Reset")
+    except AttributeError:
+        return None
+    if reset_raw is None:
+        return None
+    try:
+        return max(0.0, float(reset_raw) - time.time())
+    except (TypeError, ValueError):
+        return None

--- a/src/dev_health_ops/providers/gitlab/budget.py
+++ b/src/dev_health_ops/providers/gitlab/budget.py
@@ -283,9 +283,27 @@ def _scaled_units(fixed_floor: int, span_days: int) -> int:
 
 
 def _host_from_credentials(credentials: object) -> str:
+    """Resolve the GitLab instance host a budget bucket should key against.
+
+    CHAOS-2785 review finding: this previously checked only ``base_url`` /
+    ``baseUrl``, so a self-hosted credential row stored under ``gitlab_url``
+    (the key ``credentials/resolver.py::gitlab_credentials_from_mapping`` and
+    ``workers/feature_flag_sync.py``'s ``GitLabFeatureFlagsClient``
+    construction resolve first) fell through to the ``gitlab.com`` default --
+    budget reservation/attribution disagreed with where the physical request
+    actually went. Extended to the same precedence
+    (``gitlab_url > url > base_url``), preserving the existing ``baseUrl``
+    fallback. Host resolution INPUT only -- no change to estimator units,
+    confidence, dimensions, or reservation logic below.
+    """
     base_url = _DEFAULT_BASE_URL
     if isinstance(credentials, Mapping):
-        raw_base_url = credentials.get("base_url") or credentials.get("baseUrl")
+        raw_base_url = (
+            credentials.get("gitlab_url")
+            or credentials.get("url")
+            or credentials.get("base_url")
+            or credentials.get("baseUrl")
+        )
         if raw_base_url:
             base_url = str(raw_base_url)
     host = urlparse(base_url).hostname

--- a/src/dev_health_ops/providers/gitlab/feature_flags.py
+++ b/src/dev_health_ops/providers/gitlab/feature_flags.py
@@ -1,0 +1,447 @@
+"""Canonical GitLab feature-flags client (CHAOS-2785).
+
+This is the ``providers/gitlab/`` migration target for the project
+feature-flags + project-name fetch logic that historically lived on the
+frozen ``connectors/gitlab.py`` (``GitLabConnector.get_feature_flags`` /
+``GitLabConnector.get_project_name``), riding the un-instrumented
+``connectors/utils/rest.py::GitLabRESTClient``. AGENTS.md bans new code under
+``connectors/``, and actuals instrumentation requires a client that owns a
+``UsageRecorder`` (CHAOS-2754) -- so this module ports the fetch/retry/
+pagination logic (behavior parity: 403 stays a non-retryable permission
+error, 429 stays a retryable rate limit, pinned by
+``tests/test_gitlab_connector.py::TestGitLabFeatureFlags403``) and adds the
+recorder the frozen connector could never carry.
+
+Mirrors ``providers/launchdarkly/client.py`` (CHAOS-2761) in shape: a single
+httpx.AsyncClient owned per instance, one retry loop per physical HTTP round
+trip (every attempt -- including retried 429/5xx attempts -- is recorded as
+one real request), and the canonical ``dev_health_ops.exceptions.
+RateLimitException`` + ``RateLimitSignal`` construction. The epic-wide shared
+REST core for GitLab/GitHub/Jira/Linear (CHAOS-2773 CS1) does not exist yet;
+this is built standalone in the LaunchDarkly style and will be folded into
+that shared core once it lands.
+
+``connectors/gitlab.py`` is left in place, unused by the feature-flags sync
+path, but still backs the frozen GitLab code-dataset fetches (commits, files,
+blame, CI/CD, tests, deployments, security) -- migrating those is a much
+larger canonical-provider effort tracked separately under CHAOS-2773 CS17.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import urllib.parse
+from typing import Any
+
+import httpx
+
+from dev_health_ops.api.utils.logging import sanitize_for_log
+from dev_health_ops.connectors.exceptions import (
+    APIException,
+    AuthenticationException,
+    RateLimitException,
+)
+from dev_health_ops.providers._ratelimit import (
+    gitlab_403_is_rate_limited,
+    gitlab_resolve_retry_after_seconds,
+)
+from dev_health_ops.providers.usage import UsageRecorder
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://gitlab.com"
+_API_V4_PREFIX = "/api/v4"
+_DEFAULT_PER_PAGE = 100
+
+# Defensive backstop against a misbehaving/looping pagination cursor -- no
+# GitLab project should plausibly have this many pages of feature flags.
+# Mirrors the audit-log page bound in providers/launchdarkly/client.py.
+_MAX_PAGES = 1000
+
+# GitLab's REST rate-limit headers (RateLimit-*, not X-RateLimit-* like
+# GitHub/LaunchDarkly) -- see providers/gitlab/client.py
+# _maybe_raise_gitlab_rate_limit and docs/providers/rate-limit-policy.md#gitlab.
+_DIAGNOSTIC_HEADER_NAMES = (
+    "ratelimit-limit",
+    "ratelimit-remaining",
+    "ratelimit-reset",
+    "retry-after",
+)
+
+
+def _response_host(response: httpx.Response) -> str | None:
+    """Best-effort host for the responding GitLab instance (self-managed or
+    gitlab.com)."""
+    host = getattr(getattr(response, "url", None), "host", None)
+    return host if isinstance(host, str) and host else None
+
+
+def _diagnostic_headers(headers: object) -> dict[str, str]:
+    get_items = getattr(headers, "items", None)
+    if get_items is None:
+        return {}
+    lowered = {str(k).lower(): str(v) for k, v in get_items()}
+    return {name: lowered[name] for name in _DIAGNOSTIC_HEADER_NAMES if name in lowered}
+
+
+def _raise_for_status(response: httpx.Response) -> None:
+    """Translate HTTP error codes into connector exceptions.
+
+    Parity pin: a plain 403 (Feature Flags disabled for the project, or the
+    token lacks Developer+ access) is **non-retryable** -- GitLab's
+    documented rate limit is 429 (ops#919) -- so it raises
+    ``AuthenticationException`` immediately instead of spending the retry
+    budget on an unfixable permission error. Mirrors
+    ``connectors/gitlab.py::GitLabConnector.get_feature_flags``'s handling,
+    pinned by ``tests/test_gitlab_connector.py::TestGitLabFeatureFlags403``.
+
+    A **header-qualified** 403 (carrying ``Retry-After`` or
+    ``RateLimit-Remaining: 0``) is the documented exception: some
+    self-managed instances front a throttled request with 403 instead of
+    429. That case classifies as a retryable ``RateLimitException`` instead,
+    mirroring ``providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit``
+    (``GitLabWorkClient``'s classifier) via the shared
+    ``providers._ratelimit.gitlab_403_is_rate_limited`` predicate -- checked
+    *before* the non-retryable branch below.
+
+    Both the 429 and header-qualified-403 branches resolve the retry delay
+    via ``providers._ratelimit.gitlab_resolve_retry_after_seconds`` -- the
+    SAME ``Retry-After`` (HTTP-date-aware) + ``RateLimit-Reset`` fallback
+    ``GitLabWorkClient``'s classifier uses -- so a self-hosted instance's
+    advertised cooldown is honored instead of falling through to a shorter
+    caller-local default (``workers/sync_units.py`` plans the worker
+    deferral's re-enqueue delay directly from ``retry_after_seconds``).
+    """
+    status = response.status_code
+    if status == 401:
+        raise AuthenticationException("GitLab authentication failed")
+    if status == 403:
+        if gitlab_403_is_rate_limited(response.headers):
+            retry_after = gitlab_resolve_retry_after_seconds(response.headers)
+            raise RateLimitException(
+                "GitLab rate limit exceeded (403 carrying rate-limit headers)",
+                retry_after_seconds=retry_after,
+                signal=RateLimitSignal(
+                    provider="gitlab",
+                    host=_response_host(response),
+                    dimension=BudgetDimension.REST_CORE,
+                    retry_after_seconds=retry_after,
+                    reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                        response.headers.get("RateLimit-Reset")
+                    ),
+                    # 429 is the documented quota limit; a header-qualified
+                    # 403 is the softer/secondary signal -- mirrors
+                    # providers/gitlab/client.py's primary/secondary split.
+                    reason="secondary",
+                ),
+            )
+        raise AuthenticationException(
+            "GitLab feature flags forbidden (403): the Feature Flags feature "
+            "is disabled for this project or the token lacks the required "
+            f"scope/Developer role. {response.text}"
+        )
+    if status == 429:
+        retry_after = gitlab_resolve_retry_after_seconds(response.headers)
+        raise RateLimitException(
+            "GitLab rate limit exceeded",
+            retry_after_seconds=retry_after,
+            signal=RateLimitSignal(
+                provider="gitlab",
+                host=_response_host(response),
+                dimension=BudgetDimension.REST_CORE,
+                retry_after_seconds=retry_after,
+                # GitLab reports its reset window as epoch SECONDS (unlike
+                # LaunchDarkly's epoch milliseconds).
+                reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                    response.headers.get("RateLimit-Reset")
+                ),
+                reason="primary",
+            ),
+        )
+    if status == 404:
+        raise APIException(f"GitLab resource not found: {response.url}")
+    if status >= 500:
+        raise APIException(f"GitLab server error: {status} - {response.text}")
+    if status >= 400:
+        raise APIException(f"GitLab API error: {status} - {response.text}")
+
+
+class GitLabFeatureFlagsClient:
+    """Async canonical client for GitLab project feature flags (CHAOS-2785).
+
+    :param private_token: GitLab personal/project access token.
+    :param base_url: GitLab instance URL (self-hosted support: pass the
+        org's configured GitLab URL; defaults to gitlab.com).
+    :param timeout: Request timeout in seconds.
+    :param max_retries: Maximum retry attempts on 429 / 5xx errors.
+    :param per_page: Default page size for list endpoints.
+    """
+
+    def __init__(
+        self,
+        *,
+        private_token: str,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout: int = 15,
+        max_retries: int = 5,
+        per_page: int = _DEFAULT_PER_PAGE,
+    ) -> None:
+        self.private_token = private_token
+        self.base_url = base_url.rstrip("/")
+        self.timeout = timeout
+        self.max_retries = max_retries
+        self.per_page = per_page
+        self._client: httpx.AsyncClient | None = None
+
+        # Deferred import mirrors providers/launchdarkly/client.py: budget.py
+        # is the source of truth for the route-family vocabulary, imported
+        # lazily to avoid a module-load-order cycle. GITLAB_USAGE_RESOLVER
+        # already declares a "project" family matching "/projects/" (used by
+        # GitLabWorkClient), which is also the route_family the existing
+        # GitLabBudgetEstimator reserves for the FEATURE_FLAGS dataset -- no
+        # registry changes needed here.
+        from dev_health_ops.providers.gitlab.budget import GITLAB_USAGE_RESOLVER
+
+        self._usage = UsageRecorder(resolver=GITLAB_USAGE_RESOLVER)
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=f"{self.base_url}{_API_V4_PREFIX}",
+                headers={"PRIVATE-TOKEN": self.private_token},
+                timeout=self.timeout,
+            )
+        return self._client
+
+    async def _request(
+        self,
+        method: str,
+        path: str,
+        *,
+        params: dict[str, Any] | None = None,
+    ) -> httpx.Response:
+        """Execute an HTTP request with retry on 429 / 5xx / header-qualified 403.
+
+        Every completed HTTP round trip -- including retried attempts -- is
+        recorded as one real request via ``_record_rest_usage`` (CHAOS-2754
+        contract: actuals are real request counts, never abstract units).
+
+        A 403 carrying rate-limit headers (``Retry-After`` or
+        ``RateLimit-Remaining: 0``) is treated the same as a 429 here --
+        retried in place with backoff, honoring ``Retry-After`` -- rather
+        than escalating to ``RateLimitException`` on the first attempt. A
+        *plain* 403 (no rate-limit headers) is never eligible for retry; it
+        falls straight through to ``_raise_for_status``'s non-retryable
+        ``AuthenticationException`` branch.
+        """
+        client = await self._get_client()
+        delay = 1.0
+        last_exc: Exception | None = None
+
+        for attempt in range(self.max_retries):
+            try:
+                response = await client.request(method, path, params=params)
+                self._record_rest_usage(
+                    f"{method} {path}",
+                    headers=response.headers,
+                    status=response.status_code,
+                )
+
+                is_retryable_status = (
+                    response.status_code == 429
+                    or response.status_code >= 500
+                    or (
+                        response.status_code == 403
+                        and gitlab_403_is_rate_limited(response.headers)
+                    )
+                )
+                if is_retryable_status:
+                    if attempt < self.max_retries - 1:
+                        wait_seconds = (
+                            gitlab_resolve_retry_after_seconds(response.headers)
+                            or delay
+                        )
+                        logger.warning(
+                            "GitLab %d on %s (attempt %d/%d), retrying in %.1fs",
+                            response.status_code,
+                            sanitize_for_log(path),
+                            attempt + 1,
+                            self.max_retries,
+                            wait_seconds,
+                        )
+                        await asyncio.sleep(wait_seconds)
+                        delay = min(delay * 2, 60.0)
+                        continue
+
+                _raise_for_status(response)
+                return response
+
+            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                last_exc = exc
+                if attempt < self.max_retries - 1:
+                    logger.warning(
+                        "GitLab request to %s failed (attempt %d/%d): %s",
+                        sanitize_for_log(path),
+                        attempt + 1,
+                        self.max_retries,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, 60.0)
+                    continue
+                raise APIException(f"GitLab request failed: {exc}") from exc
+
+        if last_exc:
+            raise APIException(
+                f"GitLab request failed after {self.max_retries} attempts"
+            ) from last_exc
+        raise APIException("GitLab request failed: unknown error")
+
+    # ------------------------------------------------------------------
+    # Usage recording (CHAOS-2754 / CHAOS-2785)
+    # ------------------------------------------------------------------
+
+    def _record_usage_observation(
+        self,
+        *,
+        transport: str,
+        operation: str,
+        headers: dict[str, str],
+        rate_limit: dict[str, Any],
+        status: int | None = None,
+    ) -> None:
+        # Aggregation/keying by route_family lives in the shared recorder
+        # (CHAOS-2754); this client only owns the header extraction below.
+        self._usage.record(
+            transport=transport,
+            operation=operation,
+            headers=headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
+
+    def _record_rest_usage(
+        self,
+        operation: str,
+        *,
+        headers: object | None = None,
+        status: int | None = None,
+    ) -> None:
+        safe_headers = _diagnostic_headers(headers or {})
+        rate_limit: dict[str, Any] = {}
+        for source, target in {
+            "ratelimit-remaining": "remaining",
+            "ratelimit-reset": "reset",
+            "ratelimit-limit": "limit",
+            "retry-after": "retry_after",
+        }.items():
+            value = safe_headers.get(source)
+            if value is not None:
+                rate_limit[target] = value
+        self._record_usage_observation(
+            transport="rest",
+            operation=operation,
+            headers=safe_headers,
+            rate_limit=rate_limit,
+            status=status,
+        )
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        return self._usage.drain()
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _next_page(
+        response: httpx.Response, current_page: int, item_count: int, per_page: int
+    ) -> int | None:
+        """Resolve the next page number from GitLab's ``X-Next-Page`` header,
+        falling back to an item-count heuristic when the header is absent
+        (e.g. against a mocked/older GitLab instance)."""
+        next_page_header = response.headers.get("X-Next-Page")
+        if next_page_header:
+            try:
+                return int(next_page_header)
+            except ValueError:
+                return None
+        if item_count < per_page:
+            return None
+        return current_page + 1
+
+    async def get_feature_flags(
+        self,
+        project_id_or_path: int | str,
+        *,
+        per_page: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """Fetch feature flags for a GitLab project via the management API.
+
+        Paginates until GitLab returns an empty page (or no next page), with
+        a defensive ``_MAX_PAGES`` cap against a misbehaving cursor.
+        """
+        encoded_project = urllib.parse.quote(str(project_id_or_path), safe="")
+        endpoint = f"/projects/{encoded_project}/feature_flags"
+        effective_per_page = per_page or self.per_page
+
+        flags: list[dict[str, Any]] = []
+        page: int | None = 1
+        pages_fetched = 0
+        while page is not None:
+            if pages_fetched >= _MAX_PAGES:
+                logger.warning(
+                    "GitLab feature flags pagination hit the %d-page cap for "
+                    "project %s; results may be truncated",
+                    _MAX_PAGES,
+                    sanitize_for_log(str(project_id_or_path)),
+                )
+                break
+            response = await self._request(
+                "GET",
+                endpoint,
+                params={"page": page, "per_page": effective_per_page},
+            )
+            pages_fetched += 1
+            batch = response.json()
+            if not isinstance(batch, list):
+                raise APIException(
+                    f"Unexpected GitLab feature flags response: {type(batch)!r}"
+                )
+            if not batch:
+                break
+            flags.extend(batch)
+            page = self._next_page(response, page, len(batch), effective_per_page)
+
+        logger.info(
+            "Fetched %d GitLab feature flags for project %s",
+            len(flags),
+            sanitize_for_log(str(project_id_or_path)),
+        )
+        return flags
+
+    async def get_project_name(self, project_id_or_path: int | str) -> str:
+        """Return the canonical path for a GitLab project."""
+        encoded_project = urllib.parse.quote(str(project_id_or_path), safe="")
+        response = await self._request("GET", f"/projects/{encoded_project}")
+        data = response.json()
+        if not isinstance(data, dict):
+            return str(project_id_or_path)
+        return str(
+            data.get("path_with_namespace") or data.get("path") or project_id_or_path
+        )
+
+    async def close(self) -> None:
+        """Close the underlying HTTP client."""
+        if self._client and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+
+    async def __aenter__(self) -> GitLabFeatureFlagsClient:
+        return self
+
+    async def __aexit__(self, exc_type, exc_val, exc_tb) -> None:
+        await self.close()

--- a/src/dev_health_ops/workers/feature_flag_sync.py
+++ b/src/dev_health_ops/workers/feature_flag_sync.py
@@ -324,19 +324,31 @@ def _sync_gitlab_feature_flags(
     credentials: dict[str, Any],
     sync_options: dict[str, Any],
 ) -> dict[str, Any]:
-    from dev_health_ops.connectors.gitlab import GitLabConnector
+    from dev_health_ops.metrics.job_work_items import (
+        attach_work_item_partial_observations,
+    )
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
     from dev_health_ops.processors.gitlab_feature_flags import (
         normalize_gitlab_feature_flags,
         snapshot_gitlab_feature_flag_events,
     )
+    from dev_health_ops.providers.gitlab.feature_flags import GitLabFeatureFlagsClient
+    from dev_health_ops.providers.usage import drain_provider_usage
     from dev_health_ops.work_graph.builder import BuildConfig, WorkGraphBuilder
     from dev_health_ops.work_graph.ids import generate_feature_flag_id
     from dev_health_ops.work_graph.models import EdgeType, NodeType, Provenance
 
     token = str(credentials.get("token") or "")
+    # Precedence matches the canonical resolver
+    # (credentials/resolver.py::gitlab_credentials_from_mapping): gitlab_url >
+    # url > base_url on the stored credentials mapping, before falling back to
+    # sync_options / the gitlab.com default. Self-hosted orgs whose credential
+    # row stores the base URL under "gitlab_url" (the key every other GitLab
+    # dataset path resolves through) previously fell through to gitlab.com
+    # here instead (CHAOS-2785 review finding).
     gitlab_url = str(
-        credentials.get("url")
+        credentials.get("gitlab_url")
+        or credentials.get("url")
         or credentials.get("base_url")
         or sync_options.get("gitlab_url")
         or "https://gitlab.com"
@@ -355,76 +367,112 @@ def _sync_gitlab_feature_flags(
             "Feature-flag sync requires CLICKHOUSE_URI / ClickHouse analytics sink"
         )
 
-    connector = GitLabConnector(url=gitlab_url, private_token=token)
-    raw_flags = connector.get_feature_flags(project_id_or_path)
-    project_key = connector.get_project_name(project_id_or_path)
-    repo_id = None
+    async def _run() -> dict[str, Any]:
+        # Real per-request actuals drained through the shared CHAOS-2754
+        # recorder (CHAOS-2785) -- the whole body below is one big try/except
+        # (not just the fetch step) so a failure ANYWHERE downstream of the
+        # fetch (normalization, ClickHouse/WorkGraph writes) still preserves
+        # whatever actuals were already recorded instead of silently dropping
+        # real request counts, mirroring
+        # _sync_launchdarkly_feature_flags (CHAOS-2761).
+        provider_usage_observations: list[dict[str, Any]] = []
+        client: GitLabFeatureFlagsClient | None = None
 
-    flags = normalize_gitlab_feature_flags(
-        raw_flags,
-        project_key=project_key,
-        org_id=org_id,
-        repo_id=repo_id,
-    )
-    events = snapshot_gitlab_feature_flag_events(
-        raw_flags,
-        project_key=project_key,
-        org_id=org_id,
-        repo_id=repo_id,
-    )
+        try:
+            async with GitLabFeatureFlagsClient(
+                private_token=token, base_url=gitlab_url
+            ) as client:
+                raw_flags = await client.get_feature_flags(project_id_or_path)
+                project_key = await client.get_project_name(project_id_or_path)
+            provider_usage_observations.extend(drain_provider_usage(client))
 
-    sink = ClickHouseMetricsSink(db_url)
-    setattr(sink, "org_id", org_id)
-    builder = WorkGraphBuilder(BuildConfig(dsn=db_url, org_id=org_id))
-    try:
-        sink.write_feature_flags(flags)
-        sink.write_feature_flag_events(events)
-
-        latest_events: dict[str, Any] = {}
-        for event in events:
-            existing = latest_events.get(event.flag_key)
-            if existing is None or event.event_ts > existing.event_ts:
-                latest_events[event.flag_key] = event
-
-        for flag in flags:
-            builder.add_feature_flag_node(
-                flag_key=flag.flag_key,
-                provider=flag.provider,
-                project_key=flag.project_key or project_key,
-                repo_id=flag.repo_id,
-                event_ts=flag.created_at,
+            repo_id = None
+            flags = normalize_gitlab_feature_flags(
+                raw_flags,
+                project_key=project_key,
+                org_id=org_id,
+                repo_id=repo_id,
             )
-            latest_event = latest_events.get(flag.flag_key)
-            if latest_event is None:
-                continue
-            flag_id = generate_feature_flag_id(
-                org_id,
-                flag.provider,
-                flag.project_key or project_key,
-                flag.flag_key,
+            events = snapshot_gitlab_feature_flag_events(
+                raw_flags,
+                project_key=project_key,
+                org_id=org_id,
+                repo_id=repo_id,
             )
-            builder.add_feature_flag_edge(
-                flag_id=flag_id,
-                target_type=NodeType.FEATURE_FLAG,
-                target_id=flag_id,
-                edge_type=EdgeType.CONFIG_CHANGED_BY,
-                confidence=1.0,
-                evidence=(
-                    f"{latest_event.event_ts.isoformat()}"
-                    f"|{latest_event.event_type}"
-                    f"|{latest_event.next_state or ''}"
-                ),
-                provenance=Provenance.NATIVE,
-                provider=flag.provider,
-                event_ts=latest_event.event_ts,
-            )
-    finally:
-        builder.close()
-        sink.close()
 
-    return {
-        "flags_synced": len(flags),
-        "events_synced": len(events),
-        "project_key": project_key,
-        "gitlab_url": gitlab_url,
-    }
+            sink = ClickHouseMetricsSink(db_url)
+            setattr(sink, "org_id", org_id)
+            builder = WorkGraphBuilder(BuildConfig(dsn=db_url, org_id=org_id))
+            try:
+                sink.write_feature_flags(flags)
+                sink.write_feature_flag_events(events)
+
+                latest_events: dict[str, Any] = {}
+                for event in events:
+                    existing = latest_events.get(event.flag_key)
+                    if existing is None or event.event_ts > existing.event_ts:
+                        latest_events[event.flag_key] = event
+
+                for flag in flags:
+                    builder.add_feature_flag_node(
+                        flag_key=flag.flag_key,
+                        provider=flag.provider,
+                        project_key=flag.project_key or project_key,
+                        repo_id=flag.repo_id,
+                        event_ts=flag.created_at,
+                    )
+                    latest_event = latest_events.get(flag.flag_key)
+                    if latest_event is None:
+                        continue
+                    flag_id = generate_feature_flag_id(
+                        org_id,
+                        flag.provider,
+                        flag.project_key or project_key,
+                        flag.flag_key,
+                    )
+                    builder.add_feature_flag_edge(
+                        flag_id=flag_id,
+                        target_type=NodeType.FEATURE_FLAG,
+                        target_id=flag_id,
+                        edge_type=EdgeType.CONFIG_CHANGED_BY,
+                        confidence=1.0,
+                        evidence=(
+                            f"{latest_event.event_ts.isoformat()}"
+                            f"|{latest_event.event_type}"
+                            f"|{latest_event.next_state or ''}"
+                        ),
+                        provenance=Provenance.NATIVE,
+                        provider=flag.provider,
+                        event_ts=latest_event.event_ts,
+                    )
+            finally:
+                builder.close()
+                sink.close()
+
+            result: dict[str, Any] = {
+                "flags_synced": len(flags),
+                "events_synced": len(events),
+                "project_key": project_key,
+                "gitlab_url": gitlab_url,
+            }
+            if provider_usage_observations:
+                result["observations"] = {"provider_usage": provider_usage_observations}
+            return result
+        except Exception as exc:
+            # Preserve actuals gathered before the raise so the worker's
+            # deferral/failure stamp can still persist them (CHAOS-2754
+            # contract, reused here verbatim -- see
+            # _sync_launchdarkly_feature_flags for the full rationale).
+            # Draining an already-drained UsageRecorder is safe: drain()
+            # clears its internal state, so re-draining `client` here after
+            # an earlier successful drain returns [] and nothing is
+            # double-counted.
+            if client is not None:
+                provider_usage_observations.extend(drain_provider_usage(client))
+            if provider_usage_observations:
+                attach_work_item_partial_observations(
+                    exc, {"provider_usage": provider_usage_observations}
+                )
+            raise
+
+    return run_async(_run())

--- a/tests/providers/test_gitlab_budget.py
+++ b/tests/providers/test_gitlab_budget.py
@@ -210,6 +210,53 @@ def test_gitlab_budget_estimator_normalizes_camel_case_base_url_for_fingerprint(
     assert snake.bucket.credential_fingerprint == camel.bucket.credential_fingerprint
 
 
+def test_gitlab_budget_estimator_resolves_host_from_gitlab_url_credential_key() -> None:
+    """CHAOS-2785 review finding: a self-hosted credential row stored under
+    ``gitlab_url`` (the key ``credentials/resolver.py::
+    gitlab_credentials_from_mapping`` and ``GitLabFeatureFlagsClient``
+    construction resolve first -- see workers/feature_flag_sync.py) must
+    scope the budget bucket to that host, not fall through to gitlab.com."""
+    gitlab_url_only = GitLabBudgetEstimator().estimate(
+        _context(
+            dataset_key="feature-flags",
+            credentials={
+                "token": "secret-token",
+                "gitlab_url": "https://gitlab.example.com",
+            },
+        )
+    )[0]
+
+    assert gitlab_url_only.bucket.host == "gitlab.example.com"
+
+    # Precedence matches gitlab_credentials_from_mapping: gitlab_url wins
+    # over a stale/incorrect url or base_url on the same mapping.
+    gitlab_url_wins = GitLabBudgetEstimator().estimate(
+        _context(
+            dataset_key="feature-flags",
+            credentials={
+                "token": "secret-token",
+                "gitlab_url": "https://gitlab.example.com",
+                "url": "https://gitlab.com",
+                "base_url": "https://gitlab.com",
+            },
+        )
+    )[0]
+
+    assert gitlab_url_wins.bucket.host == "gitlab.example.com"
+
+    url_key_only = GitLabBudgetEstimator().estimate(
+        _context(
+            dataset_key="feature-flags",
+            credentials={
+                "token": "secret-token",
+                "url": "https://gitlab.other-example.com",
+            },
+        )
+    )[0]
+
+    assert url_key_only.bucket.host == "gitlab.other-example.com"
+
+
 def test_gitlab_budget_estimator_scopes_empty_credentials_to_integration() -> None:
     first = GitLabBudgetEstimator().estimate(
         _context(dataset_key="commits", credentials={}, credential_id=None)

--- a/tests/test_feature_flag_sync.py
+++ b/tests/test_feature_flag_sync.py
@@ -1,14 +1,22 @@
-"""Tests for workers/feature_flag_sync.py's LaunchDarkly cutover (CHAOS-2761).
+"""Tests for workers/feature_flag_sync.py's LaunchDarkly (CHAOS-2761) and
+GitLab (CHAOS-2785) cutovers.
 
-``_sync_launchdarkly_feature_flags`` now fetches flags/audit-log through the
+``_sync_launchdarkly_feature_flags`` fetches flags/audit-log through the
 canonical ``providers/launchdarkly/client.py::LaunchDarklyClient`` (not the
 frozen ``connectors/launchdarkly.py::LaunchDarklyConnector``), and drains real
 per-request actuals from both ``LaunchDarklyClient`` and
 ``LaunchDarklyCodeReferencesClient`` into
-``result["observations"]["provider_usage"]``. This module tests that wiring
-at the seam (fake clients standing in for the real HTTP-backed ones -- the
-clients' own internal per-request counting is covered by
-tests/test_launchdarkly.py) with no network calls.
+``result["observations"]["provider_usage"]``.
+
+``_sync_gitlab_feature_flags`` fetches flags/project-name through the
+canonical ``providers/gitlab/feature_flags.py::GitLabFeatureFlagsClient`` (not
+the frozen ``connectors/gitlab.py::GitLabConnector``), draining the same
+shape of actuals into ``result["observations"]["provider_usage"]``.
+
+This module tests that wiring at the seam (fake clients standing in for the
+real HTTP-backed ones -- the clients' own internal per-request counting is
+covered by tests/test_launchdarkly.py and
+tests/test_gitlab_feature_flags_client.py) with no network calls.
 """
 
 from __future__ import annotations
@@ -20,13 +28,19 @@ import pytest
 
 from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.metrics.job_work_items import read_work_item_partial_observations
-from dev_health_ops.workers.feature_flag_sync import _sync_launchdarkly_feature_flags
+from dev_health_ops.workers.feature_flag_sync import (
+    _sync_gitlab_feature_flags,
+    _sync_launchdarkly_feature_flags,
+)
 
 _SINK_PATCH = "dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink"
 _BUILDER_PATCH = "dev_health_ops.work_graph.builder.WorkGraphBuilder"
 _CLIENT_PATCH = "dev_health_ops.providers.launchdarkly.client.LaunchDarklyClient"
 _CODE_REFS_PATCH = (
     "dev_health_ops.providers.launchdarkly.code_refs.LaunchDarklyCodeReferencesClient"
+)
+_GITLAB_CLIENT_PATCH = (
+    "dev_health_ops.providers.gitlab.feature_flags.GitLabFeatureFlagsClient"
 )
 
 
@@ -319,3 +333,243 @@ def test_sink_write_failure_preserves_all_actuals_gathered_so_far(monkeypatch) -
     # The finally block must still have closed the sink/builder even though
     # the write raised.
     sink.close.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# GitLab (CHAOS-2785)
+# ---------------------------------------------------------------------------
+
+
+def _gitlab_credentials() -> dict[str, Any]:
+    return {"token": "gl-token", "url": "https://gitlab.example.com"}
+
+
+def _make_fake_gitlab_client(
+    usage_observations: list[dict[str, Any]],
+    *,
+    flags: list[dict] | None = None,
+    project_name: str = "group/project",
+    raise_on: str | None = None,
+):
+    """Build a fake stand-in for GitLabFeatureFlagsClient."""
+
+    class _FakeGitLabClient:
+        def __init__(self, *, private_token: str, base_url: str) -> None:
+            self.private_token = private_token
+            self.base_url = base_url
+            self._drained = False
+
+        async def __aenter__(self) -> _FakeGitLabClient:
+            return self
+
+        async def __aexit__(self, *exc_info: object) -> None:
+            return None
+
+        async def get_feature_flags(self, project_id_or_path: object) -> list[dict]:
+            if raise_on == "get_feature_flags":
+                raise RateLimitException(
+                    "GitLab rate limit exceeded", retry_after_seconds=30
+                )
+            return flags or []
+
+        async def get_project_name(self, project_id_or_path: object) -> str:
+            if raise_on == "get_project_name":
+                raise RateLimitException(
+                    "GitLab rate limit exceeded", retry_after_seconds=30
+                )
+            return project_name
+
+        def drain_usage_observations(self) -> list[dict[str, Any]]:
+            # Mirrors UsageRecorder.drain() clearing its state: a second call
+            # after an earlier successful drain returns [] rather than
+            # re-emitting the same observations (double-counting).
+            if self._drained:
+                return []
+            self._drained = True
+            return usage_observations
+
+    return _FakeGitLabClient
+
+
+def test_gitlab_sync_uses_canonical_client_and_threads_provider_usage(
+    monkeypatch,
+) -> None:
+    """Feature-flag + project-name fetches drain into
+    result['observations']['provider_usage']."""
+    usage = [
+        {
+            "transport": "rest",
+            "route_family": "project",
+            "dimension": "rest_core",
+            "request_count": 2,
+        }
+    ]
+    monkeypatch.setattr(
+        _GITLAB_CLIENT_PATCH,
+        _make_fake_gitlab_client(
+            usage, flags=[{"name": "awesome_feature", "active": True}]
+        ),
+    )
+
+    sink_patch, builder_patch = _stub_sink_and_builder()
+    with sink_patch, builder_patch:
+        result = _sync_gitlab_feature_flags(
+            db_url="clickhouse://localhost/default",
+            org_id="org-1",
+            credentials=_gitlab_credentials(),
+            sync_options={"project_id": "group/project"},
+        )
+
+    assert result["flags_synced"] == 1
+    assert result["project_key"] == "group/project"
+    assert result["observations"]["provider_usage"] == usage
+
+
+def test_gitlab_sync_honors_stored_gitlab_url_credential_key(monkeypatch) -> None:
+    """CHAOS-2785 review finding: the canonical credential resolver
+    (credentials/resolver.py::gitlab_credentials_from_mapping) resolves a
+    self-hosted base URL from the stored credentials mapping's ``gitlab_url``
+    key (before ``url``/``base_url``), and every other GitLab dataset path
+    goes through that resolver. The feature-flags sync builds its own
+    ``GitLabFeatureFlagsClient`` directly instead, so it must honor the same
+    key/precedence or a self-hosted org's token is sent to gitlab.com."""
+    constructed: list[tuple[str, str]] = []
+
+    class _RecordingFakeClient:
+        def __init__(self, *, private_token: str, base_url: str) -> None:
+            constructed.append((private_token, base_url))
+
+        async def __aenter__(self) -> _RecordingFakeClient:
+            return self
+
+        async def __aexit__(self, *exc_info: object) -> None:
+            return None
+
+        async def get_feature_flags(self, project_id_or_path: object) -> list[dict]:
+            return []
+
+        async def get_project_name(self, project_id_or_path: object) -> str:
+            return "group/project"
+
+        def drain_usage_observations(self) -> list[dict[str, Any]]:
+            return []
+
+    monkeypatch.setattr(_GITLAB_CLIENT_PATCH, _RecordingFakeClient)
+
+    sink_patch, builder_patch = _stub_sink_and_builder()
+    with sink_patch, builder_patch:
+        _sync_gitlab_feature_flags(
+            db_url="clickhouse://localhost/default",
+            org_id="org-1",
+            credentials={
+                "token": "self-hosted-token",
+                "gitlab_url": "https://gitlab.example.com",
+                # A stale/incorrect "url" must NOT win over "gitlab_url" --
+                # matches the canonical resolver's precedence.
+                "url": "https://gitlab.com",
+            },
+            sync_options={"project_id": "group/project"},
+        )
+
+    assert constructed == [("self-hosted-token", "https://gitlab.example.com")]
+
+
+def test_gitlab_sync_omits_observations_key_when_nothing_drained(monkeypatch) -> None:
+    """No fabricated empty observations dict when the client drains nothing."""
+    monkeypatch.setattr(_GITLAB_CLIENT_PATCH, _make_fake_gitlab_client([]))
+
+    sink_patch, builder_patch = _stub_sink_and_builder()
+    with sink_patch, builder_patch:
+        result = _sync_gitlab_feature_flags(
+            db_url="clickhouse://localhost/default",
+            org_id="org-1",
+            credentials=_gitlab_credentials(),
+            sync_options={"project_id": "group/project"},
+        )
+
+    assert "observations" not in result
+
+
+def test_gitlab_rate_limit_during_fetch_preserves_partial_observations(
+    monkeypatch,
+) -> None:
+    """CHAOS-2754 contract, reused verbatim for GitLab: a mid-sync
+    RateLimitException still carries whatever actuals were recorded before
+    the raise, so the worker deferral path can persist them without ever
+    calling the provider again."""
+    usage = [
+        {
+            "transport": "rest",
+            "route_family": "project",
+            "dimension": "rest_core",
+            "request_count": 1,
+        }
+    ]
+    monkeypatch.setattr(
+        _GITLAB_CLIENT_PATCH,
+        _make_fake_gitlab_client(usage, raise_on="get_project_name"),
+    )
+
+    with pytest.raises(RateLimitException) as excinfo:
+        _sync_gitlab_feature_flags(
+            db_url="clickhouse://localhost/default",
+            org_id="org-1",
+            credentials=_gitlab_credentials(),
+            sync_options={"project_id": "group/project"},
+        )
+
+    observations = read_work_item_partial_observations(excinfo.value)
+    assert observations is not None
+    assert observations["provider_usage"] == usage
+
+
+def test_gitlab_sink_write_failure_preserves_actuals_gathered_so_far(
+    monkeypatch,
+) -> None:
+    """Mirrors test_sink_write_failure_preserves_all_actuals_gathered_so_far
+    for LaunchDarkly: a downstream ClickHouse write failure (not a raise
+    during the fetch itself) must not silently drop already-drained actuals."""
+    usage = [
+        {
+            "transport": "rest",
+            "route_family": "project",
+            "dimension": "rest_core",
+            "request_count": 2,
+        }
+    ]
+    monkeypatch.setattr(
+        _GITLAB_CLIENT_PATCH,
+        _make_fake_gitlab_client(
+            usage, flags=[{"name": "awesome_feature", "active": True}]
+        ),
+    )
+
+    sink = MagicMock()
+    sink.query_dicts.return_value = []
+    sink.write_feature_flags.side_effect = RuntimeError("clickhouse write failed")
+    sink_cls = MagicMock(return_value=sink)
+    builder_cls = MagicMock(return_value=MagicMock())
+
+    with patch(_SINK_PATCH, sink_cls), patch(_BUILDER_PATCH, builder_cls):
+        with pytest.raises(RuntimeError) as excinfo:
+            _sync_gitlab_feature_flags(
+                db_url="clickhouse://localhost/default",
+                org_id="org-1",
+                credentials=_gitlab_credentials(),
+                sync_options={"project_id": "group/project"},
+            )
+
+    observations = read_work_item_partial_observations(excinfo.value)
+    assert observations is not None
+    assert observations["provider_usage"] == usage
+    sink.close.assert_called_once()
+
+
+def test_gitlab_sync_requires_token_and_project() -> None:
+    with pytest.raises(ValueError, match="token and project_id"):
+        _sync_gitlab_feature_flags(
+            db_url="clickhouse://localhost/default",
+            org_id="org-1",
+            credentials={},
+            sync_options={},
+        )

--- a/tests/test_gitlab_feature_flags_client.py
+++ b/tests/test_gitlab_feature_flags_client.py
@@ -1,0 +1,513 @@
+"""Tests for providers/gitlab/feature_flags.py (CHAOS-2785).
+
+``GitLabFeatureFlagsClient`` is the canonical migration target for
+``connectors/gitlab.py``'s ``GitLabConnector.get_feature_flags`` /
+``get_project_name`` (frozen, un-instrumented). These tests pin the same
+403-is-non-retryable / 429-is-retryable behavior as
+``tests/test_gitlab_connector.py::TestGitLabFeatureFlags403`` and additionally
+cover pagination edges and real per-request usage recording through the
+shared CHAOS-2754 recorder -- mirroring
+``tests/test_launchdarkly.py::TestLaunchDarklyClientUsageRecording``.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import httpx
+import pytest
+
+from dev_health_ops.connectors.exceptions import (
+    APIException,
+    AuthenticationException,
+)
+from dev_health_ops.exceptions import RateLimitException as RootRateLimitException
+from dev_health_ops.providers.gitlab.feature_flags import (
+    GitLabFeatureFlagsClient,
+    _raise_for_status,
+)
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+
+def _response(
+    status_code: int,
+    *,
+    headers: dict[str, str] | None = None,
+    text: str = "",
+    json_body: object = None,
+    url: str = "https://gitlab.com/api/v4/projects/1/feature_flags",
+) -> MagicMock:
+    response = MagicMock()
+    response.status_code = status_code
+    response.headers = headers or {}
+    response.text = text
+    response.url = url
+    if json_body is not None:
+        response.json.return_value = json_body
+    return response
+
+
+# ---------------------------------------------------------------------------
+# _raise_for_status
+# ---------------------------------------------------------------------------
+
+
+class TestRaiseForStatus:
+    def test_401_raises_auth(self) -> None:
+        with pytest.raises(AuthenticationException):
+            _raise_for_status(_response(401))
+
+    def test_403_raises_auth_non_retryable(self) -> None:
+        """Parity pin: a PLAIN GitLab 403 (no rate-limit headers) =
+        permission/feature-disabled, never the rate limit (429 is), so it
+        must classify as AuthenticationException -- mirrors
+        tests/test_gitlab_connector.py::TestGitLabFeatureFlags403.
+        """
+        with pytest.raises(AuthenticationException, match="forbidden"):
+            _raise_for_status(_response(403, text="Feature Flags disabled"))
+
+    def test_403_with_retry_after_header_raises_rate_limit(self) -> None:
+        """A header-qualified 403 (some self-managed instances front a
+        throttle with 403 instead of 429) must classify as RateLimitException
+        -- not the non-retryable AuthenticationException -- so the worker
+        deferral path engages. Mirrors
+        providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit's 403
+        qualification via the shared
+        providers._ratelimit.gitlab_403_is_rate_limited predicate."""
+        with pytest.raises(RootRateLimitException) as excinfo:
+            _raise_for_status(_response(403, headers={"Retry-After": "9"}))
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.provider == "gitlab"
+        assert signal.reason == "secondary"
+        assert signal.dimension is BudgetDimension.REST_CORE
+        assert excinfo.value.retry_after_seconds == 9.0
+
+    def test_403_with_rate_limit_remaining_zero_raises_rate_limit(self) -> None:
+        """Same qualification, driven by RateLimit-Remaining: 0 instead of
+        Retry-After -- matches providers/gitlab/client.py's OR condition."""
+        with pytest.raises(RootRateLimitException) as excinfo:
+            _raise_for_status(_response(403, headers={"RateLimit-Remaining": "0"}))
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "secondary"
+
+    def test_403_with_nonzero_remaining_and_no_retry_after_is_not_rate_limited(
+        self,
+    ) -> None:
+        """A 403 with a present-but-nonzero RateLimit-Remaining and no
+        Retry-After is NOT rate-limit-qualified -- stays a plain permission
+        403 (AuthenticationException)."""
+        with pytest.raises(AuthenticationException):
+            _raise_for_status(_response(403, headers={"RateLimit-Remaining": "42"}))
+
+    def test_403_with_http_date_retry_after_derives_seconds_via_shared_parser(
+        self,
+    ) -> None:
+        """The delay must come from providers._ratelimit.
+        gitlab_resolve_retry_after_seconds (HTTP-date-aware), not a local
+        numeric-only parser that would silently drop an HTTP-date
+        Retry-After and leave retry_after_seconds as None."""
+        future = datetime.now(timezone.utc) + timedelta(seconds=120)
+        http_date = format_datetime(future, usegmt=True)
+
+        with pytest.raises(RootRateLimitException) as excinfo:
+            _raise_for_status(_response(403, headers={"Retry-After": http_date}))
+
+        retry_after = excinfo.value.retry_after_seconds
+        assert retry_after is not None
+        assert 100 <= retry_after <= 120
+
+    def test_403_with_no_retry_after_derives_seconds_from_rate_limit_reset(
+        self,
+    ) -> None:
+        """No Retry-After header at all -- retry_after_seconds must be
+        derived from RateLimit-Reset (epoch seconds), matching
+        providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit's
+        fallback, instead of surfacing None (which
+        workers/sync_units.py would otherwise treat as "no signal" and plan
+        the deferral's re-enqueue from a much shorter default)."""
+        reset_epoch = int(time.time()) + 300
+
+        with pytest.raises(RootRateLimitException) as excinfo:
+            _raise_for_status(
+                _response(
+                    403,
+                    headers={
+                        "RateLimit-Remaining": "0",
+                        "RateLimit-Reset": str(reset_epoch),
+                    },
+                )
+            )
+
+        retry_after = excinfo.value.retry_after_seconds
+        assert retry_after is not None
+        assert 290 <= retry_after <= 300
+
+    def test_429_raises_rate_limit_with_signal(self) -> None:
+        with pytest.raises(RootRateLimitException) as excinfo:
+            _raise_for_status(
+                _response(429, headers={"Retry-After": "12", "RateLimit-Reset": "0"})
+            )
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.provider == "gitlab"
+        assert signal.reason == "primary"
+        assert signal.dimension is BudgetDimension.REST_CORE
+        assert excinfo.value.retry_after_seconds == 12.0
+
+    def test_404_raises_api_exception(self) -> None:
+        with pytest.raises(APIException, match="not found"):
+            _raise_for_status(_response(404))
+
+    def test_500_raises_api_exception(self) -> None:
+        with pytest.raises(APIException, match="server error"):
+            _raise_for_status(_response(500, text="boom"))
+
+    def test_200_passes(self) -> None:
+        _raise_for_status(_response(200))
+
+
+# ---------------------------------------------------------------------------
+# get_feature_flags
+# ---------------------------------------------------------------------------
+
+
+class TestGetFeatureFlags:
+    @pytest.fixture
+    def client(self) -> GitLabFeatureFlagsClient:
+        return GitLabFeatureFlagsClient(private_token="test-token")
+
+    @pytest.mark.asyncio
+    async def test_single_page(self, client: GitLabFeatureFlagsClient) -> None:
+        page = _response(
+            200,
+            headers={},
+            json_body=[{"name": "flag-a"}, {"name": "flag-b"}],
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=page)
+        client._client = mock_client
+
+        flags = await client.get_feature_flags("group/project")
+
+        assert [f["name"] for f in flags] == ["flag-a", "flag-b"]
+        mock_client.request.assert_called_once_with(
+            "GET",
+            "/projects/group%2Fproject/feature_flags",
+            params={"page": 1, "per_page": 100},
+        )
+
+    @pytest.mark.asyncio
+    async def test_empty_page_stops_immediately(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        page = _response(200, json_body=[])
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=page)
+        client._client = mock_client
+
+        flags = await client.get_feature_flags(42)
+
+        assert flags == []
+        mock_client.request.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_paginates_via_x_next_page_header(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        page1 = _response(
+            200,
+            headers={"X-Next-Page": "2"},
+            json_body=[{"name": f"flag-{i}"} for i in range(2)],
+        )
+        page2 = _response(200, headers={}, json_body=[{"name": "flag-last"}])
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=[page1, page2])
+        client._client = mock_client
+
+        flags = await client.get_feature_flags("group/project", per_page=2)
+
+        assert len(flags) == 3
+        assert mock_client.request.await_count == 2
+        second_call = mock_client.request.call_args_list[1]
+        assert second_call.kwargs["params"]["page"] == 2
+
+    @pytest.mark.asyncio
+    async def test_pagination_falls_back_to_item_count_when_next_page_absent(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        """When X-Next-Page is absent (older/mocked GitLab), a full page
+        implies another page exists; a short page means the last page."""
+        full_page = _response(
+            200, headers={}, json_body=[{"name": f"flag-{i}"} for i in range(2)]
+        )
+        short_page = _response(200, headers={}, json_body=[{"name": "flag-last"}])
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=[full_page, short_page])
+        client._client = mock_client
+
+        flags = await client.get_feature_flags("group/project", per_page=2)
+
+        assert len(flags) == 3
+        assert mock_client.request.await_count == 2
+
+    @pytest.mark.asyncio
+    async def test_hard_page_cap_stops_a_looping_cursor(
+        self, client: GitLabFeatureFlagsClient, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import dev_health_ops.providers.gitlab.feature_flags as feature_flags_module
+
+        monkeypatch.setattr(feature_flags_module, "_MAX_PAGES", 3)
+
+        # Always a full page with X-Next-Page pointing at itself -- a
+        # misbehaving cursor that never terminates on its own.
+        looping_page = _response(
+            200,
+            headers={"X-Next-Page": "1"},
+            json_body=[{"name": "flag-a"}, {"name": "flag-b"}],
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=looping_page)
+        client._client = mock_client
+
+        flags = await client.get_feature_flags("group/project", per_page=2)
+
+        assert mock_client.request.await_count == 3
+        assert len(flags) == 6
+
+    @pytest.mark.asyncio
+    async def test_403_is_non_retryable(self, client: GitLabFeatureFlagsClient) -> None:
+        """Parity pin (tests/test_gitlab_connector.py::
+        TestGitLabFeatureFlags403::test_forbidden_raises_non_retryable_
+        authentication_exception): a 403 must not consume the retry budget --
+        exactly one request is made before the non-retryable exception is
+        raised."""
+        forbidden = _response(403, text="Feature Flags disabled")
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=forbidden)
+        client._client = mock_client
+
+        with pytest.raises(AuthenticationException):
+            await client.get_feature_flags("group/project")
+
+        assert mock_client.request.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_retried_429_then_success_counts_every_attempt(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        throttled = _response(429, headers={"Retry-After": "0"})
+        ok = _response(200, json_body=[{"name": "flag-a"}])
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=[throttled, ok])
+        client._client = mock_client
+
+        flags = await client.get_feature_flags("group/project")
+
+        assert len(flags) == 1
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "project"
+        assert observations[0]["dimension"] == "rest_core"
+        assert observations[0]["request_count"] == 2, (
+            "the retried 429 attempt AND the eventual success are both real "
+            "requests against the provider"
+        )
+        assert observations[0]["latest_status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_header_qualified_403_is_retried_then_recovers(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        """A 403 carrying Retry-After is retried in place (like a 429), not
+        escalated to AuthenticationException on the first attempt."""
+        throttled_403 = _response(403, headers={"Retry-After": "0"})
+        ok = _response(200, json_body=[{"name": "flag-a"}])
+
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(side_effect=[throttled_403, ok])
+        client._client = mock_client
+
+        flags = await client.get_feature_flags("group/project")
+
+        assert len(flags) == 1
+        assert mock_client.request.await_count == 2
+        observations = client.drain_usage_observations()
+        assert observations[0]["request_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_exhausted_header_qualified_403_retries_raise_rate_limit(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        client.max_retries = 2
+        throttled_403 = _response(403, headers={"RateLimit-Remaining": "0"})
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=throttled_403)
+        client._client = mock_client
+
+        with pytest.raises(RootRateLimitException) as excinfo:
+            await client.get_feature_flags("group/project")
+
+        assert mock_client.request.await_count == 2
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "secondary"
+
+    @pytest.mark.asyncio
+    async def test_exhausted_header_qualified_403_derives_seconds_from_reset(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        """No Retry-After anywhere, only RateLimit-Remaining: 0 +
+        RateLimit-Reset -- the exhausted-retries RateLimitException must
+        still carry a derived retry_after_seconds (not None), matching
+        providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit. Uses
+        max_retries=1 (single attempt = immediately exhausted) so the test
+        doesn't actually sleep the ~300s the derived delay implies -- that
+        derivation is exactly what's under test, not something to wait out."""
+        client.max_retries = 1
+        reset_epoch = int(time.time()) + 300
+        throttled_403 = _response(
+            403,
+            headers={
+                "RateLimit-Remaining": "0",
+                "RateLimit-Reset": str(reset_epoch),
+            },
+        )
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=throttled_403)
+        client._client = mock_client
+
+        with pytest.raises(RootRateLimitException) as excinfo:
+            await client.get_feature_flags("group/project")
+
+        assert mock_client.request.await_count == 1
+        retry_after = excinfo.value.retry_after_seconds
+        assert retry_after is not None
+        assert 290 <= retry_after <= 300
+
+    @pytest.mark.asyncio
+    async def test_exhausted_429_retries_raise_rate_limit_exception(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        client.max_retries = 2
+        throttled = _response(429, headers={"Retry-After": "0"})
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=throttled)
+        client._client = mock_client
+
+        with pytest.raises(RootRateLimitException):
+            await client.get_feature_flags("group/project")
+
+        assert mock_client.request.await_count == 2
+        observations = client.drain_usage_observations()
+        assert observations[0]["request_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_5xx_exhausted_retries_raise_api_exception(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        client.max_retries = 2
+        server_error = _response(500, text="boom")
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=server_error)
+        client._client = mock_client
+
+        with pytest.raises(APIException, match="server error"):
+            await client.get_feature_flags("group/project")
+
+        assert mock_client.request.await_count == 2
+
+
+# ---------------------------------------------------------------------------
+# get_project_name
+# ---------------------------------------------------------------------------
+
+
+class TestGetProjectName:
+    @pytest.fixture
+    def client(self) -> GitLabFeatureFlagsClient:
+        return GitLabFeatureFlagsClient(private_token="test-token")
+
+    @pytest.mark.asyncio
+    async def test_returns_path_with_namespace(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        response = _response(200, json_body={"path_with_namespace": "group/project"})
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=response)
+        client._client = mock_client
+
+        name = await client.get_project_name("group/project")
+
+        assert name == "group/project"
+        mock_client.request.assert_called_once_with(
+            "GET", "/projects/group%2Fproject", params=None
+        )
+
+    @pytest.mark.asyncio
+    async def test_falls_back_to_path(self, client: GitLabFeatureFlagsClient) -> None:
+        response = _response(200, json_body={"path": "project"})
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=response)
+        client._client = mock_client
+
+        assert await client.get_project_name(42) == "project"
+
+    @pytest.mark.asyncio
+    async def test_usage_recorded_under_project_family(
+        self, client: GitLabFeatureFlagsClient
+    ) -> None:
+        response = _response(200, json_body={"path_with_namespace": "group/project"})
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        mock_client.request = AsyncMock(return_value=response)
+        client._client = mock_client
+
+        await client.get_project_name("group/project")
+
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "project"
+        assert observations[0]["dimension"] == "rest_core"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_close_closes_client(self) -> None:
+        client = GitLabFeatureFlagsClient(private_token="test-token")
+        mock_client = AsyncMock(spec=httpx.AsyncClient)
+        mock_client.is_closed = False
+        client._client = mock_client
+
+        await client.close()
+
+        mock_client.aclose.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_context_manager(self) -> None:
+        async with GitLabFeatureFlagsClient(private_token="tok") as client:
+            assert client.private_token == "tok"


### PR DESCRIPTION
## Summary

CHAOS-2754 unified GitHub/GitLab/Jira/Linear actuals capture behind a shared usage recorder with route-family keying; CHAOS-2761 closed this gap for LaunchDarkly. GitLab's feature-flag fetch had the same problem: `GitLabConnector.get_feature_flags` / `get_project_name` (`connectors/gitlab.py`) rode the un-instrumented `connectors/utils/rest.py::GitLabRESTClient`, so GitLab feature-flag sync units produced budget *estimates* but never real *actuals*.

This PR closes that gap for GitLab feature flags, following the LaunchDarkly migration template (PR #1126):

- **New `providers/gitlab/feature_flags.py::GitLabFeatureFlagsClient`** — an httpx-based, behavior-parity migration of the connector's feature-flags fetch/pagination logic, wired to the shared CHAOS-2754 `UsageRecorder`. Preserves the pinned 403/429 semantics (`tests/test_gitlab_connector.py::TestGitLabFeatureFlags403`): a plain 403 (Feature Flags disabled / token lacks Developer+ access) is non-retryable `AuthenticationException`; a 429, or a **header-qualified 403** (`Retry-After` present or `RateLimit-Remaining: 0` — some self-managed instances front a throttle with 403 instead of 429), is a retryable `RateLimitException` carrying a canonical `RateLimitSignal`. Pagination follows GitLab's `X-Next-Page` header, falling back to an item-count heuristic when absent, with a defensive 1000-page cap against a misbehaving cursor.
- **New `providers/_ratelimit.py::gitlab_403_is_rate_limited`** — a shared, header-only extraction of `providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit`'s (the canonical `GitLabWorkClient`'s) 403-qualification predicate.
- **New `providers/_ratelimit.py::gitlab_resolve_retry_after_seconds`** — a shared extraction of that same classifier's delay resolution: prefers `Retry-After` via `parse_retry_after_header` (HTTP-date-aware, not just delta-seconds), falls back to deriving the delay from `RateLimit-Reset` (epoch seconds) when `Retry-After` is absent. Used for **both** 429 and header-qualified-403 in `_raise_for_status` and in the retry loop's backoff computation — no local numeric-only parser remains anywhere in the new client.
- **`workers/feature_flag_sync.py::_sync_gitlab_feature_flags`** — rewired onto the new client (now async, via `run_async`), drains usage into `result.observations.provider_usage`, and preserves partial actuals on a mid-sync `RateLimitException`. Resolves the self-hosted base URL via `credentials["gitlab_url"] > credentials["url"] > credentials["base_url"] > sync_options["gitlab_url"] > gitlab.com` — matching `credentials/resolver.py::gitlab_credentials_from_mapping`'s canonical precedence.
- **`providers/gitlab/budget.py::_host_from_credentials`** — extended to the same `gitlab_url > url > base_url > baseUrl` precedence (host-resolution **input** only — no change to estimator units, confidence, dimensions, or reservation logic), so a self-hosted org's budget bucket is scoped to the host requests actually go to, not `gitlab.com`. True single-point normalization (one shared credential-mapping mutation reaching both budget estimation and client construction) is structurally impractical here: `estimate_provider_budget` is independently invoked from multiple frozen dispatch/reservation call sites (`sync/budget_guard.py`'s `observe_run`/`enforce_run`/`_active_budget_consumption`, `sync_units.py`'s per-unit audit), each building its own separately-decrypted context — no single mutation point reaches all of them without touching that frozen machinery, so per this PR's explicit review constraint the fix stays scoped to the host-resolution helper's input.
- **No other `providers/gitlab/budget.py` changes.** The pre-existing `GITLAB_USAGE_ROUTE_FAMILIES` already declares a `project` family matching the `/projects/` marker (used by `GitLabWorkClient`), and `GitLabBudgetEstimator` already reserves the `project` route family for `DatasetKey.FEATURE_FLAGS` — the new client's operation labels (`GET /projects/{id}/feature_flags`, `GET /projects/{id}`) resolve onto that same family for free, so actuals and estimates already share the same calibration key.
- **`connectors/gitlab.py` is deliberately left in place, unused by this path** (zero diff vs `origin/main`, reverified at every push). Its other (code-dataset: commits/files/blame/CI/CD/tests/deployments/security) methods are untouched and remain frozen — migrating them is a much larger canonical-provider-migration effort tracked under CHAOS-2773 CS17 (deletion of the now-dead `get_feature_flags`/`get_project_name` methods also rides that cleanup). `connectors/utils/rest.py` is also untouched (not deleted — other GitLab code datasets still ride it).
- **Docs updated in the same changeset**: `docs/providers/rate-limit-policy.md`, `docs/architecture/sync-usage-actuals.md`, `docs/architecture/launchdarkly-sync-budgeting.md` (fixed a stale, unrelated "GitLab feature-flag budgeting" follow-up note — budgeting was already implemented, only actuals were missing).

Linear: CHAOS-2785

## Review history

Three rounds of adversarial Codex review, all folded into this single commit:

1. First pass (0 HIGH / 1 MEDIUM / 1 LOW): self-hosted `gitlab_url` credential key ignored by the worker — fixed.
2. Second pass (0 HIGH / 2 MEDIUM): (a) every 403 misclassified as non-retryable even when header-qualified as a rate limit — fixed via a shared classifier predicate; (b) self-hosted budget host attribution defaulting to gitlab.com — fixed (host-resolution-input-only, estimator logic untouched).
3. Third pass (0 HIGH / 1 MEDIUM): the 403 *classification* fix from round 2 was correct, but the *delay* it carried still used a local numeric-only Retry-After parser that silently dropped HTTP-date values and never derived a delay from `RateLimit-Reset` — meaning `retry_after_seconds` could surface as `None` and the worker deferral (`sync_units.py`) would plan a much shorter default re-enqueue, re-hammering an already-throttled self-hosted instance. Fixed by extracting the canonical classifier's full delay-resolution logic into a shared `gitlab_resolve_retry_after_seconds` helper and using it everywhere in the client (both raise sites and the retry loop) — no local parsing surface remains.

## Test plan

- [x] `tests/test_gitlab_feature_flags_client.py` — `_raise_for_status` parity (401/403 plain/403 header-qualified via `Retry-After` numeric and HTTP-date and via `RateLimit-Remaining: 0`+`RateLimit-Reset` fallback/429/404/5xx/200), pagination (single page, empty page, `X-Next-Page`-driven, item-count fallback, hard page-cap), 403 non-retryable (exactly 1 request), header-qualified-403 retried-then-recovers and retry-exhaustion (mirrors 429) including derived-seconds-from-`RateLimit-Reset` on exhaustion, 429 retry-then-success and retry-exhaustion, 5xx retry-exhaustion, `get_project_name`, usage-recording assertions.
- [x] `tests/test_feature_flag_sync.py` — GitLab cutover wiring: observations threading, partial-actuals preservation (mid-sync and downstream-failure), missing-token/project validation, self-hosted `gitlab_url` credential-key precedence.
- [x] `tests/providers/test_gitlab_budget.py` — self-hosted budget host resolution (`gitlab_url`-only, precedence over stale `url`/`base_url`, existing camelCase/snake_case `base_url`/`baseUrl` fingerprint-parity test still passes).
- [x] Existing `tests/test_gitlab_connector.py::TestGitLabFeatureFlags403` and `tests/test_provider_usage.py` (estimator-coverage contract) still pass unmodified — confirms no registry drift.
- [x] Gate: `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=<scratch> bash ci/local_validate.sh` → **GATE PASSED** (re-run after every review round; final run 6395 passed / 44 skipped, lint/mypy/full unit suite/live-ClickHouse argMax proof all green).
- [x] No `uv.lock` changes, no live network calls in tests. `connectors/` confirmed zero-diff vs `origin/main` at every push.