### PR TITLE
fix(sync): scope GitLab work-item units to their source project (CHAOS-2763)

### DIFF
--- a/docs/architecture/sync-unit-model.md
+++ b/docs/architecture/sync-unit-model.md
@@ -63,7 +63,7 @@ Legend: **once/run** = fetched once per sync run (correct); **per-unit** = re-fe
 | Provider | teams / orgs | members | projects / boards | cycles / sprints | issues / PRs |
 | -------- | ------------ | ------- | ----------------- | ---------------- | ------------ |
 | **GitHub** | discovery (once/run) | discovery | discovery | n/a | per source/window (work-item) |
-| **GitLab** | discovery (once/run) | discovery | discovery | n/a | per source/window (work-item) |
+| **GitLab** | discovery (once/run) | discovery | discovery | n/a | per source/window (work-item, scoped via `settings.project_id` — CHAOS-2763) |
 | **Jira** | once/run (resolver) | n/a here | per-unit JQL scope ✅ | **per-unit** ⚠️ (`get_sprint` in issue loop) | per source/window (work-item) |
 | **Linear** | **per-unit** ⚠️ (`iter_teams()` all teams) | discovery | discovery | **per-unit** ⚠️ (`iter_cycles()` per team) | per source/window (work-item) |
 
@@ -73,7 +73,7 @@ The ⚠️ cells are the work this epic removes. GitHub/GitLab already solved th
 
 1. **Per-unit reference re-fetch** (Linear teams+cycles; Jira sprints). The dominant fixed overhead. **Fix (P2):** read teams/cycles/sprints from the persisted store via a once-per-run resolver; add a `get_all_sprints` loader and a cycle/sprint producer; bounded source-scoped API fallback on a store miss.
 2. **Work-item-family redundancy.** The 5 family datasets (`work-items`, `work-item-labels`, `work-item-projects`, `work-item-history`, `work-item-comments`) each re-run the *full* ingest, so enabling the family multiplies cost ×5 per source/window. **Fix (P3, target-state):** plan-time collapse to **one** composite ingest per `(source, window)`, writing per-dataset watermarks for each enabled family key.
-3. **Source fan-out.** Work-item units that ignore their own source — Linear `IngestionContext(repo=None)` → all teams; GitHub `discover_repos` without a repo filter → all org repos. **Fix (P1, shipped on the source-scoping branch):** thread the unit's `source_external_id` so a unit syncs only its one source; preserve the no-source CLI/org-wide path.
+3. **Source fan-out.** Work-item units that ignore their own source — Linear `IngestionContext(repo=None)` → all teams; GitHub `discover_repos` without a repo filter → all org repos; GitLab likewise (its `repo_name` is a numeric project id, not the `path_with_namespace` on `repos.repo`, so a naive filter can't reuse the GitHub match). **Fix (P1, shipped on the source-scoping branch):** thread the unit's `source_external_id` so a unit syncs only its one source; preserve the no-source CLI/org-wide path. GitHub shipped first (CHAOS-2720); GitLab shipped via a separate match branch keyed on the discovered repo's `settings.project_id` (CHAOS-2763), since the id spaces don't overlap.
 
 **Target acceptance:** total provider API requests for a backfill scale `O(issues + teams + cycles/projects)`, not `O(windows × datasets × sources)`, across all four providers.
 

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import os
 import uuid
@@ -173,13 +174,35 @@ def discover_repos(
                 repo_id=uuid.UUID(str(r[0])),
                 full_name=r[1],
                 source=r[3] if len(r) > 3 and r[3] != "unknown" else provider,
-                settings=r[2] or {},
+                settings=_parse_repo_settings(r[2]),
             )
             for r in rows
         ]
     except Exception as exc:
         logger.warning("Repo discovery failed: %s", exc)
         return []
+
+
+def _parse_repo_settings(raw: object) -> dict[str, Any]:
+    """Parse the ClickHouse ``repos.settings`` column into a dict.
+
+    ``settings`` is stored as a JSON string (Nullable(String)); the
+    ``DiscoveredRepo.settings: dict[str, object]`` annotation was previously
+    lying — this returned the raw string unparsed, so any per-provider match
+    on a settings key (e.g. CHAOS-2763's gitlab ``project_id`` scoping) would
+    always miss on production data. ``None``/malformed JSON/a non-dict JSON
+    value all yield ``{}`` so downstream numeric-id matching fails closed
+    instead of raising.
+    """
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str) and raw:
+        try:
+            parsed = json.loads(raw)
+        except (TypeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
 
 
 # Backward-compat alias used by job_dora and job_work_items

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -2,7 +2,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import json
 import logging
+import re
 import uuid
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
@@ -111,6 +113,28 @@ def _date_range(end_day: date, backfill_days: int) -> list[date]:
 
 def _has_text(value: object) -> bool:
     return isinstance(value, str) and bool(value.strip())
+
+
+def _repo_settings_dict(repo: Any) -> dict[str, Any]:
+    """Return ``repo.settings`` as a dict regardless of on-disk representation.
+
+    ``discover_repos`` (job_daily.py) parses the ClickHouse ``settings`` JSON
+    string into a dict, but this stays defensive: other callers (backfill,
+    directly-constructed ``DiscoveredRepo`` instances, tests) may still hand
+    back a raw JSON string, ``None``, or an already-parsed dict. Malformed
+    JSON or an unexpected type yields ``{}`` — the CHAOS-2763 gitlab numeric-id
+    match then fails closed rather than raising.
+    """
+    settings = getattr(repo, "settings", None)
+    if isinstance(settings, dict):
+        return settings
+    if isinstance(settings, str):
+        try:
+            parsed = json.loads(settings)
+        except (TypeError, ValueError):
+            return {}
+        return parsed if isinstance(parsed, dict) else {}
+    return {}
 
 
 def _require_work_item_unit_source(
@@ -493,22 +517,32 @@ def run_work_items_sync_job(
             before,
         )
 
-        # CHAOS-2720: A config-aware work-item unit carries exactly one source
-        # repo in ``repo_name``. ``_discover_repos`` only short-circuits on
-        # ``repo_id`` and otherwise returns every repo for the org, so without
-        # scoping the GitHub ingest loop below runs a full ``iter_ingest`` per
-        # org repo — one unit fanning out into N-repo API amplification. Scope
-        # the discovered GitHub repos to the unit's source so a GitHub unit
-        # ingests only its own repo. Matching is case-insensitive on
-        # ``full_name`` because both the source ``external_id`` and
-        # ``repos.repo`` are the GitHub ``owner/repo`` slug (admin sync planner,
-        # api/admin/routers/sync.py). GitLab is intentionally left org-wide
-        # here: its ``repo_name`` is a numeric project id that does not match
-        # ``repos.repo`` (``path_with_namespace``), so a ``full_name`` filter
-        # would empty GitLab discovery and trip the require_source guard below
-        # (CHAOS-2737). Only GitHub-source repos are touched; every other
-        # source passes through unchanged. When ``repo_name`` is absent
-        # (CLI/org-wide), discovery stays org-wide as before.
+        # CHAOS-2720 / CHAOS-2763: A config-aware work-item unit carries exactly
+        # one source repo/project in ``repo_name``. ``_discover_repos`` only
+        # short-circuits on ``repo_id`` and otherwise returns every repo for the
+        # org, so without scoping the GitHub/GitLab ingest loops below run a
+        # full ingest per org repo — one unit fanning out into N-repo API
+        # amplification. Scope the discovered repos to the unit's source so a
+        # unit ingests only its own repo/project.
+        #
+        # GitHub: matching is case-insensitive on ``full_name`` because both
+        # the source ``external_id`` and ``repos.repo`` are the GitHub
+        # ``owner/repo`` slug (admin sync planner, api/admin/routers/sync.py).
+        #
+        # GitLab (below, after this block): the unit's ``repo_name`` is the
+        # numeric GitLab project id (``IntegrationSource.external_id``), which
+        # never matches ``repos.repo`` (``path_with_namespace``) — so
+        # ASCII-decimal inputs match instead against the immutable
+        # ``settings.project_id`` captured at code-dataset sync time. Only
+        # path-shaped (non-numeric) inputs — e.g. CLI ``--repo-name
+        # grp/proj`` — fall back to the case-insensitive ``full_name`` match; a
+        # numeric id never falls back to ``full_name`` (a stale row's mutable
+        # path could otherwise coincidentally equal the id string).
+        #
+        # Only GitHub/GitLab-source repos are touched by their respective
+        # blocks; every other source passes through unchanged. When
+        # ``repo_name`` is absent (CLI/org-wide), discovery stays org-wide as
+        # before.
         if repo_name and "github" in provider_set:
             wanted = repo_name.strip().lower()
             scoped: list[Any] = []
@@ -529,6 +563,65 @@ def run_work_items_sync_job(
                     dropped,
                 )
             discovered_repos = scoped
+
+        # CHAOS-2763: gitlab twin of the GitHub scoping block above. See the
+        # comment there for the full rationale; summary: ASCII-decimal
+        # ``repo_name`` (the unit's canonical source-id shape) matches ONLY
+        # ``settings.project_id`` (never falls back to ``full_name`` —
+        # str.isdigit()-style non-ASCII digits are deliberately excluded via
+        # re.fullmatch so they fall into the path-shaped branch instead).
+        # Path-shaped ``repo_name`` (e.g. CLI ``--repo-name grp/proj``) matches
+        # ``full_name`` case-insensitively, same as GitHub.
+        #
+        # gitlab_id_scoped_project_ids [codex HIGH]: matching a row by its
+        # immutable project_id does NOT make ``repo.full_name`` safe to fetch
+        # by. If project 123 is renamed/moved after discovery and its old
+        # path is later reused by a *different* project, a unit for id "123"
+        # still matches this row by project_id, but fetching by the stale
+        # ``full_name`` would silently pull the wrong project's issues/MRs
+        # and write them under this row's repo_id — defeating the isolation
+        # the id match exists to provide. So every numeric-id-matched repo's
+        # immutable project id is recorded here and threaded into
+        # ``fetch_gitlab_work_items`` to use for the actual GitLab API calls;
+        # ``full_name`` is kept on the (unmodified) ``DiscoveredRepo`` for
+        # display/normalization only. Path-matched and org-wide (no-source)
+        # repos are NOT added here, so they keep fetching by ``full_name`` —
+        # unchanged, existing behavior; only an id-matched unit's identifier
+        # resolution changes.
+        gitlab_id_scoped_project_ids: dict[uuid.UUID, str] = {}
+        if repo_name and "gitlab" in provider_set:
+            wanted_gl = repo_name.strip()
+            is_numeric_id = re.fullmatch(r"[0-9]+", wanted_gl) is not None
+            scoped_gl: list[Any] = []
+            dropped_gl = 0
+            for repo in discovered_repos:
+                if repo.source != "gitlab":
+                    scoped_gl.append(repo)
+                    continue
+                if is_numeric_id:
+                    settings = _repo_settings_dict(repo)
+                    project_id = settings.get("project_id")
+                    matched = (
+                        project_id is not None and str(project_id).strip() == wanted_gl
+                    )
+                else:
+                    matched = (
+                        repo.full_name or ""
+                    ).strip().lower() == wanted_gl.lower()
+                if not matched:
+                    dropped_gl += 1
+                    continue
+                if is_numeric_id:
+                    gitlab_id_scoped_project_ids[repo.repo_id] = str(project_id).strip()
+                scoped_gl.append(repo)
+            if dropped_gl:
+                logger.info(
+                    "Scoped GitLab work-item unit to source project '%s': "
+                    "dropped %d off-source repo(s)",
+                    repo_name,
+                    dropped_gl,
+                )
+            discovered_repos = scoped_gl
 
         if require_source:
             if repo_name and {"github", "gitlab"}.intersection(provider_set):
@@ -688,6 +781,7 @@ def run_work_items_sync_job(
                 include_label_events=True,
                 org_id=org_id,
                 usage_observations=provider_usage_observations,
+                id_scoped_project_ids=gitlab_id_scoped_project_ids,
             )
             work_items.extend(items)
             transitions.extend(tr)

--- a/src/dev_health_ops/metrics/work_items.py
+++ b/src/dev_health_ops/metrics/work_items.py
@@ -457,6 +457,7 @@ def fetch_gitlab_work_items(
     max_label_events: int = 300,
     org_id: str = "",
     usage_observations: list[dict[str, Any]] | None = None,
+    id_scoped_project_ids: dict[uuid.UUID, str] | None = None,
 ) -> tuple[
     list[WorkItem],
     list[WorkItemStatusTransition],
@@ -479,6 +480,21 @@ def fetch_gitlab_work_items(
 
     Credentials (``token`` and optional ``gitlab_url``) are threaded explicitly
     by the caller; this function never reads from ``os.environ``.
+
+    ``id_scoped_project_ids`` [CHAOS-2763 codex HIGH]: maps ``repo_id`` ->
+    immutable GitLab project id, for repos whose work-item unit was matched
+    by numeric ``settings.project_id`` rather than by path (job_work_items.py
+    scoping). Those repos are fetched from the GitLab API using the numeric
+    id, NOT ``repo.full_name``. Matching a row by its immutable project_id
+    does not make its ``full_name`` safe to fetch by: if the project was
+    renamed/moved after discovery and the stale path was reused by a
+    *different* project, fetching by path would silently pull the wrong
+    project's issues/MRs and attribute them to this row's ``repo_id``. Repos
+    absent from the mapping (path-matched units, org-wide/no-source runs)
+    are unaffected and keep fetching by ``full_name`` as before.
+    ``repo.full_name`` itself is always passed to normalization
+    (``project_full_path=``) unchanged — only the API call identifier
+    changes for id-scoped repos.
     """
     from uuid import UUID
 
@@ -486,6 +502,7 @@ def fetch_gitlab_work_items(
     from dev_health_ops.providers.utils import env_flag
 
     deps = get_metrics_dependencies()
+    id_scoped_project_ids = id_scoped_project_ids or {}
 
     client = deps.gitlab_client_factory(token=token, gitlab_url=gitlab_url)
     work_items: dict[str, WorkItem] = {}
@@ -505,9 +522,13 @@ def fetch_gitlab_work_items(
     for repo in repos:
         if repo.source != "gitlab":
             continue
-        logger.debug("GitLab: project=%s", repo.full_name)
+        # Fetch by the immutable project id when this repo's unit was
+        # id-scoped; otherwise (path-matched or org-wide) fetch by the
+        # discovered path, unchanged from before this fix.
+        api_project_ref = id_scoped_project_ids.get(repo.repo_id, repo.full_name)
+        logger.debug("GitLab: project=%s (api_ref=%s)", repo.full_name, api_project_ref)
         for issue in client.iter_project_issues(
-            project_id_or_path=repo.full_name,
+            project_id_or_path=api_project_ref,
             state="all",
             updated_after=since_utc,
         ):
@@ -536,7 +557,7 @@ def fetch_gitlab_work_items(
             assert org_uuid is not None  # for type checker; guarded by scan_mrs
             try:
                 for mr in client.iter_project_merge_requests(
-                    project_id_or_path=repo.full_name,
+                    project_id_or_path=api_project_ref,
                     state="all",
                     updated_after=since_utc,
                 ):

--- a/tests/test_backfill_integration.py
+++ b/tests/test_backfill_integration.py
@@ -66,6 +66,65 @@ def test_discover_repos_sets_source_from_provider():
     assert result_db[1].source == "github"
 
 
+def test_discover_repos_parses_json_string_settings():
+    """CHAOS-2763: ``repos.settings`` comes back from ClickHouse as a raw JSON
+    *string*, not a pre-parsed dict — the ``DiscoveredRepo.settings: dict[str,
+    object]`` annotation was previously lying (the query result was passed
+    through with ``r[2] or {}``, no ``json.loads``). Any per-provider match on
+    a settings key (e.g. gitlab ``project_id`` scoping) always missed on real
+    data before this fix."""
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    repo_id = uuid.uuid4()
+    mock_sink = SimpleNamespace(client=MagicMock())
+    mock_sink.client.query.return_value = SimpleNamespace(
+        result_rows=[
+            (str(repo_id), "grp/proj-a", '{"project_id": 123}', "gitlab"),
+        ]
+    )
+
+    result = discover_repos(backend="clickhouse", primary_sink=mock_sink)
+
+    assert result[0].settings == {"project_id": 123}
+
+
+def test_discover_repos_malformed_json_settings_yields_empty_dict():
+    """A malformed/legacy ``settings`` string must not raise — it degrades to
+    ``{}`` so numeric-id gitlab matching fails closed instead of crashing
+    discovery for the whole org."""
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    repo_id = uuid.uuid4()
+    mock_sink = SimpleNamespace(client=MagicMock())
+    mock_sink.client.query.return_value = SimpleNamespace(
+        result_rows=[
+            (str(repo_id), "grp/proj-a", "{not json", "gitlab"),
+        ]
+    )
+
+    result = discover_repos(backend="clickhouse", primary_sink=mock_sink)
+
+    assert result[0].settings == {}
+
+
+def test_discover_repos_null_settings_yields_empty_dict():
+    """A NULL ``settings`` column (Nullable(String)) must also degrade to
+    ``{}`` rather than raising."""
+    from dev_health_ops.metrics.job_daily import discover_repos
+
+    repo_id = uuid.uuid4()
+    mock_sink = SimpleNamespace(client=MagicMock())
+    mock_sink.client.query.return_value = SimpleNamespace(
+        result_rows=[
+            (str(repo_id), "grp/proj-a", None, "gitlab"),
+        ]
+    )
+
+    result = discover_repos(backend="clickhouse", primary_sink=mock_sink)
+
+    assert result[0].settings == {}
+
+
 class TestSourceFilteringInWorkItemFetchers:
     """Verify that work-item fetcher functions correctly filter repos by source.
 

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -263,6 +263,32 @@ def test_github_work_item_unit_threads_source_scope_contract() -> None:
     assert kwargs["require_source"] is True
 
 
+def test_gitlab_work_item_unit_threads_source_scope_contract() -> None:
+    """CHAOS-2763: gitlab twin of the GitHub contract above. The adapter must
+    hand ``run_work_items_sync_job`` the unit's numeric GitLab project id (the
+    dataset-adapter layer already threads ``context.source_external_id``
+    through for provider in {github, gitlab, linear} — this pins that gitlab
+    is not silently excluded) AND ``require_source=True``, so
+    ``run_work_items_sync_job`` can scope the unit to its own project (call-
+    count proof in tests/test_work_item_source_scope.py).
+    """
+    ctx = _context(
+        provider="gitlab",
+        dataset_key="work-items",
+        source_external_id="123",
+    )
+
+    with patch(
+        "dev_health_ops.metrics.job_work_items.run_work_items_sync_job"
+    ) as work_items:
+        run_dataset_unit(ctx, _runtime())
+
+    work_items.assert_called_once()
+    kwargs = work_items.call_args.kwargs
+    assert kwargs["repo_name"] == "123"
+    assert kwargs["require_source"] is True
+
+
 def test_linear_org_wide_provider_name_placeholder_routes_to_no_source() -> None:
     ctx = _context(
         provider="linear",

--- a/tests/test_work_item_source_scope.py
+++ b/tests/test_work_item_source_scope.py
@@ -1,24 +1,37 @@
-"""CHAOS-2720: a GitHub work-item unit must ingest only its own source repo.
+"""CHAOS-2720 / CHAOS-2763: a GitHub or GitLab work-item unit must ingest only
+its own source repo/project.
 
 ``run_work_items_sync_job`` resolves repos via ``_discover_repos``, which only
 short-circuits on ``repo_id`` and otherwise returns *every* repo for the org.
-Before CHAOS-2720 the GitHub ingest loop iterated the full org list, so a single
-config-aware work-item unit (scoped to one source repo) ran a full
-``iter_ingest`` per org repo — N units × all repos of API amplification.
+Before CHAOS-2720/CHAOS-2763 the GitHub/GitLab ingest loops iterated the full
+org list, so a single config-aware work-item unit (scoped to one source
+repo/project) ran a full ingest per org repo — N units × all repos of API
+amplification.
 
 These tests pin the scope contract at the ``run_work_items_sync_job`` seam:
 
 * a GitHub unit with a ``repo_name`` ingests exactly its source repo,
+* a GitLab unit with a numeric ``repo_name`` (the project id) ingests exactly
+  its source project, matched against the immutable ``settings.project_id``
+  captured at code-dataset sync time — including when ``settings`` arrives as
+  the raw JSON string ``discover_repos`` actually returns in production,
 * the CLI/org-wide path (``repo_name is None``) still fans out to every repo,
-* matching is case-insensitive on the ``owner/repo`` slug,
-* a source repo absent from discovery fails closed (CHAOS-2737), and
-* GitLab units are intentionally left org-wide (numeric project-id source id
-  can't be matched against ``repos.repo`` path-with-namespace here).
+* GitHub matching is case-insensitive on the ``owner/repo`` slug; GitLab
+  path-shaped inputs (CLI ``--repo-name grp/proj``) match ``full_name`` the
+  same way,
+* a source repo/project absent from discovery fails closed (CHAOS-2737),
+  including a gitlab row that exists but lacks ``settings.project_id`` (stale
+  discovery data) — a numeric unit id never falls back to matching
+  ``full_name``, even when a stale row's mutable path happens to equal the id
+  string, and
+* ``provider="all"`` + ``repo_name`` now scopes GitLab discovery the same way
+  it already scoped GitHub (mixed-provider CLI/backfill semantics change).
 """
 
 from __future__ import annotations
 
 import uuid
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import date
 from typing import Any
@@ -26,6 +39,7 @@ from typing import Any
 import pytest
 
 import dev_health_ops.metrics.job_work_items as job
+from dev_health_ops.metrics.dependencies import get_metrics_dependencies
 from dev_health_ops.metrics.work_items import DiscoveredRepo
 
 
@@ -197,31 +211,94 @@ def test_github_unit_missing_source_repo_fails_closed(
     assert _FakeGitHubProvider.calls == []
 
 
-def test_gitlab_unit_stays_org_wide(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Non-regression: GitLab units keep org-wide discovery (CHAOS-2720 scopes
-    GitHub only). A GitLab source id is a numeric project id that does not match
-    ``repos.repo`` (path_with_namespace), so it must not be used as a GitHub-style
-    ``full_name`` filter — doing so would empty discovery and trip require_source.
-    """
-    _patch_common(monkeypatch)
-    gitlab_repos = [
+class _NoOpProvider:
+    """Generic no-op provider double for blocks this module doesn't assert on
+    (Linear in the ``provider="all"`` test) — constructs freely, yields no
+    batches."""
+
+    def __init__(self, *_args: object, **_kwargs: object) -> None:
+        pass
+
+    def iter_ingest(self, _ctx: Any) -> Any:
+        return iter(())
+
+
+class _RecordingGitLabAPIClient:
+    """[CHAOS-2763 codex HIGH] Records the ``project_id_or_path`` every
+    GitLab API call is actually made with — the identifier fetch_gitlab_work_items
+    hands to python-gitlab, not just which ``DiscoveredRepo`` reached the
+    fetcher. Yields no issues/MRs; zero network I/O."""
+
+    calls: list[str] = []
+
+    def iter_project_issues(self, *, project_id_or_path: str, **_kwargs: object) -> Any:
+        type(self).calls.append(project_id_or_path)
+        return iter(())
+
+    def iter_project_merge_requests(
+        self, *, project_id_or_path: str, **_kwargs: object
+    ) -> Any:
+        type(self).calls.append(project_id_or_path)
+        return iter(())
+
+
+def _patch_gitlab_client_factory(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace ``get_metrics_dependencies().gitlab_client_factory`` so the
+    REAL ``fetch_gitlab_work_items`` runs against ``_RecordingGitLabAPIClient``
+    instead of a mocked-away fetcher — the only way to assert on the actual
+    API call identifier (codex HIGH: prior tests mocked ``fetch_gitlab_work_items``
+    entirely and never exercised this code path)."""
+    deps = get_metrics_dependencies()
+    patched = deps.__class__(
+        **{
+            **deps.__dict__,
+            "gitlab_client_factory": lambda **_kwargs: _RecordingGitLabAPIClient(),
+        }
+    )
+    monkeypatch.setattr("dev_health_ops.metrics.dependencies._registry", patched)
+
+
+def _gitlab_repos(
+    *, settings_factory: Callable[[int], object] = lambda pid: {"project_id": pid}
+) -> list[DiscoveredRepo]:
+    return [
         DiscoveredRepo(
             repo_id=uuid.uuid4(),
             full_name=f"grp/proj-{name}",
             source="gitlab",
-            settings={"project_id": pid},
+            # DiscoveredRepo.settings is typed dict[str, object], but the real
+            # ClickHouse row (discover_repos, job_daily.py) hands back a raw
+            # JSON string -- exactly the annotation-lying shape this fix
+            # accounts for via _repo_settings_dict. settings_factory
+            # deliberately exercises both shapes.
+            settings=settings_factory(pid),  # type: ignore[arg-type]
         )
         for name, pid in (("a", 123), ("b", 456), ("c", 789))
     ]
-    monkeypatch.setattr(job, "_discover_repos", lambda **_kwargs: list(gitlab_repos))
+
+
+def _run_gitlab(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    repo_name: str | None,
+    require_source: bool,
+    repos: list[DiscoveredRepo],
+    provider: str = "gitlab",
+) -> list[list[DiscoveredRepo]]:
+    """Run the gitlab work-item sync job with a faked fetcher; returns the list
+    of ``repos`` kwargs the fetcher was invoked with (one entry per call, so
+    ``len(...)`` is the invocation count and an empty list means never called).
+    """
+    _patch_common(monkeypatch)
+    monkeypatch.setattr(job, "_discover_repos", lambda **_kwargs: list(repos))
     monkeypatch.setattr(
         job, "_build_gitlab_work_client", lambda **_kwargs: ("gl-token", None)
     )
 
-    captured: dict[str, Any] = {}
+    calls: list[list[DiscoveredRepo]] = []
 
     def _fake_fetch(*, repos: list[DiscoveredRepo], **_kwargs: object) -> Any:
-        captured["repos"] = list(repos)
+        calls.append(list(repos))
         return ([], [], [])
 
     monkeypatch.setattr(job, "fetch_gitlab_work_items", _fake_fetch)
@@ -231,15 +308,358 @@ def test_gitlab_unit_stays_org_wide(monkeypatch: pytest.MonkeyPatch) -> None:
         db_url="clickhouse://test",
         day=date(2026, 5, 2),
         backfill_days=1,
-        provider="gitlab",
+        provider=provider,
         org_id=str(uuid.uuid4()),
-        repo_name="123",  # numeric project id — the GitLab source external id
-        require_source=True,
+        repo_name=repo_name,
+        require_source=require_source,
     )
+    return calls
 
-    # All three GitLab projects reach the fetcher — unchanged by CHAOS-2720.
-    assert {r.full_name for r in captured["repos"]} == {
+
+def test_gitlab_unit_scopes_fetch_to_source_project(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-2763: a GitLab unit's numeric ``repo_name`` (the project id) scopes
+    discovery to that project's row via ``settings.project_id`` — the twin of
+    the GitHub source-scoping contract above. Before this fix, GitLab units
+    fanned out to every org gitlab project regardless of ``repo_name``.
+    """
+    repos = _gitlab_repos()  # grp/proj-a (123), grp/proj-b (456), grp/proj-c (789)
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="123",
+        require_source=True,
+        repos=repos,
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"grp/proj-a"}
+
+
+def test_gitlab_unit_scopes_with_json_string_settings(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The real ``discover_repos`` production shape: ``settings`` arrives as a
+    raw JSON string, not a pre-parsed dict (the literal ``settings={"project_id":
+    ...}`` used elsewhere in this module is a test convenience, not what
+    ClickHouse actually returns). ``_repo_settings_dict`` must parse it."""
+    repos = _gitlab_repos(
+        settings_factory=lambda pid: f'{{"project_id": {pid}}}',
+    )
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="123",
+        require_source=True,
+        repos=repos,
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"grp/proj-a"}
+
+
+def test_gitlab_cli_org_wide_path_still_fans_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repos = _gitlab_repos()
+    # No source (CLI/org-wide) → discovery stays org-wide, every project reaches
+    # the fetcher — unchanged by CHAOS-2763.
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name=None,
+        require_source=False,
+        repos=repos,
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {
         "grp/proj-a",
         "grp/proj-b",
         "grp/proj-c",
     }
+
+
+def test_gitlab_unit_missing_source_project_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repos = _gitlab_repos()  # project ids 123, 456, 789 — none is 999
+    with pytest.raises(ValueError, match="source was not discovered"):
+        _run_gitlab(
+            monkeypatch,
+            repo_name="999",
+            require_source=True,
+            repos=repos,
+        )
+
+
+def test_gitlab_unit_missing_source_project_fetcher_never_invoked(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Same fail-closed case as above, isolated to assert the fetcher was
+    never called (not just that repos ended up empty) — mirrors the GitHub
+    ``fetcher.calls == []`` assertion."""
+    repos = _gitlab_repos()
+    calls: list[list[DiscoveredRepo]] = []
+    with pytest.raises(ValueError):
+        calls = _run_gitlab(
+            monkeypatch,
+            repo_name="999",
+            require_source=True,
+            repos=repos,
+        )
+    assert calls == []
+
+
+def test_gitlab_unit_path_form_repo_name_matches_full_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Path-shaped (non-numeric) ``repo_name`` — the CLI ``--repo-name
+    grp/proj-a`` form — exercises the ``full_name`` fallback branch, never the
+    numeric ``settings.project_id`` branch."""
+    repos = _gitlab_repos()
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="grp/proj-a",
+        require_source=True,
+        repos=repos,
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"grp/proj-a"}
+
+
+def test_gitlab_stale_row_without_project_id_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[codex MED-1] Rows written before ``settings.project_id`` existed (or a
+    project whose code dataset never ran) have no ``project_id`` to match — a
+    numeric unit id must fail closed rather than silently falling back to
+    org-wide fan-out. This is the documented regression risk gated by G1."""
+    stale_repos = [
+        DiscoveredRepo(
+            repo_id=uuid.uuid4(),
+            full_name=f"grp/proj-{name}",
+            source="gitlab",
+            settings={},
+        )
+        for name in ("a", "b", "c")
+    ]
+    with pytest.raises(ValueError, match="source was not discovered"):
+        _run_gitlab(
+            monkeypatch,
+            repo_name="123",
+            require_source=True,
+            repos=stale_repos,
+        )
+
+
+def test_gitlab_numeric_repo_name_never_matches_full_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[codex MED-2 negative pin] A stale row whose ``full_name`` happens to
+    equal the numeric unit id string must NOT match — numeric inputs match
+    ONLY ``settings.project_id``, by design (a mutable display path could
+    otherwise collide with an immutable id). Asserts the fetcher was never
+    invoked, not just that the matched repo list came back empty."""
+    stale_repo = DiscoveredRepo(
+        repo_id=uuid.uuid4(),
+        full_name="123",
+        source="gitlab",
+        settings={},
+    )
+    calls: list[list[DiscoveredRepo]] = []
+    with pytest.raises(ValueError, match="source was not discovered"):
+        calls = _run_gitlab(
+            monkeypatch,
+            repo_name="123",
+            require_source=True,
+            repos=[stale_repo],
+        )
+    assert calls == []
+
+
+def test_gitlab_malformed_json_settings_falls_back_to_empty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[codex LOW-1] Malformed ``settings`` JSON (legacy/corrupt row) parses to
+    ``{}`` via ``_repo_settings_dict`` rather than raising — deterministic
+    fail-closed for a numeric id, same as the empty-dict stale-row case."""
+    repos = [
+        DiscoveredRepo(
+            repo_id=uuid.uuid4(),
+            full_name="grp/proj-a",
+            source="gitlab",
+            # Deliberately a malformed JSON *string*, not a dict -- see the
+            # _gitlab_repos type-ignore note above.
+            settings="{not json",  # type: ignore[arg-type]
+        )
+    ]
+    with pytest.raises(ValueError, match="source was not discovered"):
+        _run_gitlab(
+            monkeypatch,
+            repo_name="123",
+            require_source=True,
+            repos=repos,
+        )
+
+
+def test_provider_all_with_repo_name_scopes_both_providers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[codex LOW-1] ``provider="all"`` + ``repo_name`` (the mixed-provider
+    CLI/backfill invocation) now scopes GitLab discovery the same way GitHub
+    already was scoped by CHAOS-2720 — a behavior change from the pre-2763
+    org-wide GitLab fan-out (plan risk 4). ``require_source=False`` here, so no
+    raise even though nothing on the gitlab side matches a github-shaped
+    ``repo_name``."""
+    _patch_common(monkeypatch)
+    repos = [
+        DiscoveredRepo(
+            repo_id=uuid.uuid4(),
+            full_name="acme/repo-a",
+            source="github",
+            settings={},
+        ),
+        DiscoveredRepo(
+            repo_id=uuid.uuid4(),
+            full_name="grp/proj-a",
+            source="gitlab",
+            settings={"project_id": 123},
+        ),
+    ]
+    monkeypatch.setattr(job, "_discover_repos", lambda **_kwargs: list(repos))
+    monkeypatch.setattr(job, "_build_github_work_client", lambda **_kwargs: object())
+    monkeypatch.setattr(
+        job, "_build_gitlab_work_client", lambda **_kwargs: ("gl-token", None)
+    )
+    monkeypatch.setattr(job, "_build_jira_work_client", lambda **_kwargs: object())
+    monkeypatch.setattr(job, "_build_linear_work_client", lambda **_kwargs: object())
+    monkeypatch.setattr(
+        job,
+        "fetch_jira_work_items_with_extras",
+        lambda **_kwargs: ([], [], [], [], [], []),
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.metrics.work_items.fetch_synthetic_work_items",
+        lambda **_kwargs: ([], []),
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.providers.github.provider.GitHubProvider",
+        _FakeGitHubProvider,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.providers.linear.provider.LinearProvider",
+        _NoOpProvider,
+    )
+    _FakeGitHubProvider.calls = []
+
+    gitlab_calls: list[list[DiscoveredRepo]] = []
+
+    def _fake_fetch_gitlab(*, repos: list[DiscoveredRepo], **_kwargs: object) -> Any:
+        gitlab_calls.append(list(repos))
+        return ([], [], [])
+
+    monkeypatch.setattr(job, "fetch_gitlab_work_items", _fake_fetch_gitlab)
+
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="all",
+        org_id=str(uuid.uuid4()),
+        repo_name="acme/repo-a",
+        require_source=False,
+    )
+
+    # GitHub: scoped to the source repo per the existing CHAOS-2720 block.
+    assert _FakeGitHubProvider.calls == ["acme/repo-a"]
+    # GitLab: repo_name is path-shaped (non-numeric) here, so it's matched
+    # against full_name -- "acme/repo-a" never matches "grp/proj-a", scoping
+    # the gitlab-source repo out entirely. Fetcher still called once (no raise
+    # since require_source=False) but with zero gitlab-source repos.
+    assert len(gitlab_calls) == 1
+    assert [r for r in gitlab_calls[0] if r.source == "gitlab"] == []
+
+
+def test_gitlab_unit_fetches_by_numeric_project_id_not_stale_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[codex HIGH re-pass] Matching a repo row by its immutable
+    ``settings.project_id`` does NOT make the row's ``full_name`` safe to
+    fetch by. If the project was renamed/moved after discovery and the stale
+    path was later reused by a DIFFERENT project, fetching by path would
+    silently pull the wrong project's issues/MRs and attribute them to this
+    row's ``repo_id`` — defeating the isolation the id match exists to
+    provide. This exercises the REAL ``fetch_gitlab_work_items`` (unlike the
+    scoping tests above, which mock it away entirely) via a recording GitLab
+    API client, and asserts on the actual ``project_id_or_path`` the client
+    was called with — not just on which ``DiscoveredRepo`` reached the
+    fetcher."""
+    _patch_common(monkeypatch)
+    _patch_gitlab_client_factory(monkeypatch)
+    _RecordingGitLabAPIClient.calls = []
+    stale_repo = DiscoveredRepo(
+        repo_id=uuid.uuid4(),
+        # Deliberately stale/mismatched: if the client is ever invoked with
+        # this path instead of the numeric id, the bug has regressed.
+        full_name="grp/now-a-totally-different-project",
+        source="gitlab",
+        settings={"project_id": 123},
+    )
+    monkeypatch.setattr(job, "_discover_repos", lambda **_kwargs: [stale_repo])
+    monkeypatch.setattr(
+        job, "_build_gitlab_work_client", lambda **_kwargs: ("gl-token", None)
+    )
+
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="gitlab",
+        org_id=str(uuid.uuid4()),
+        repo_name="123",  # numeric project id -- triggers id-scoped fetch
+        require_source=True,
+    )
+
+    assert _RecordingGitLabAPIClient.calls, "gitlab API client was never invoked"
+    assert all(ref == "123" for ref in _RecordingGitLabAPIClient.calls), (
+        _RecordingGitLabAPIClient.calls
+    )
+    assert "grp/now-a-totally-different-project" not in _RecordingGitLabAPIClient.calls
+
+
+def test_gitlab_cli_org_wide_path_still_fetches_by_full_name(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Org-wide (no-source) runs are unaffected by the id-scoped-fetch fix —
+    ``gitlab_id_scoped_project_ids`` is only populated for numeric-id-matched
+    units, so an org-wide run keeps fetching every project by its
+    ``full_name``/path exactly as before this fix."""
+    _patch_common(monkeypatch)
+    _patch_gitlab_client_factory(monkeypatch)
+    _RecordingGitLabAPIClient.calls = []
+    repos = _gitlab_repos()  # grp/proj-a (123), grp/proj-b (456), grp/proj-c (789)
+    monkeypatch.setattr(job, "_discover_repos", lambda **_kwargs: list(repos))
+    monkeypatch.setattr(
+        job, "_build_gitlab_work_client", lambda **_kwargs: ("gl-token", None)
+    )
+
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="gitlab",
+        org_id=str(uuid.uuid4()),
+        repo_name=None,
+        require_source=False,
+    )
+
+    assert _RecordingGitLabAPIClient.calls
+    assert set(_RecordingGitLabAPIClient.calls) <= {
+        "grp/proj-a",
+        "grp/proj-b",
+        "grp/proj-c",
+    }
+    # The numeric project ids were never used as the API identifier here —
+    # only path/full_name, unchanged from pre-fix behavior.
+    assert not any(
+        ref in {"123", "456", "789"} for ref in _RecordingGitLabAPIClient.calls
+    )


### PR DESCRIPTION
## Summary

GitLab work-item units fanned out org-wide: a unit scoped to one GitLab
project (`repo_name` = the numeric project id) still discovered and paid
API budget for *every* GitLab repo in the org, because the CHAOS-2720
GitHub scoping filter explicitly excluded GitLab (its `repo_name` is a
numeric project id, which never matches `repos.repo`/`path_with_namespace`).

This mirrors CHAOS-2720 (#1107) for GitLab:

- **New GitLab scoping branch** in `run_work_items_sync_job`
  (`job_work_items.py`), sibling to the existing GitHub block: ASCII-decimal
  `repo_name` (the canonical unit-source-id shape, matched via
  `re.fullmatch(r"[0-9]+")` — deliberately narrower than `str.isdigit()`,
  which would also accept non-ASCII digit characters) matches **only**
  `settings.project_id` on the discovered repo row; path-shaped `repo_name`
  (e.g. CLI `--repo-name grp/proj`) falls back to the existing case-insensitive
  `full_name` match, same as GitHub. A numeric id never falls back to
  `full_name` — a stale row's mutable path could otherwise coincidentally
  equal the id string and silently match the wrong axis.
- **`_repo_settings_dict` helper** — defensively normalizes `repo.settings`
  to a dict regardless of whether it arrives as a dict, a raw JSON string, or
  `None`/malformed JSON (→ `{}`, fails closed for numeric ids).
- **`discover_repos` (`job_daily.py`) parse fix** — the ClickHouse
  `repos.settings` column is a JSON *string*; `discover_repos` was returning
  it unparsed (`r[2] or {}`), so the `DiscoveredRepo.settings: dict[str,
  object]` annotation was lying and any settings-key match (like this one)
  would always miss on real data. Now parsed via `json.loads`
  (isinstance-guarded, `{}` on failure/None).
- No-match now fails closed via the existing CHAOS-2737
  `require_source`/`_require_work_item_unit_source` guard — same audit log
  and `ValueError` GitHub already gets. CLI/backfill/webhook org-wide paths
  (`repo_name=None`) are untouched.
- `provider="all"` + `--repo-name` now scopes GitLab discovery the same way
  it already scoped GitHub — an intentional mixed-provider semantics change
  (pinned by a new test), consistent with the GitHub block's existing
  behavior.
- Docs: `docs/architecture/sync-unit-model.md` corrected (previously read as
  "GitLab is already solved"; now notes CHAOS-2763 and the `project_id`
  match).

Full converged plan (3 rounds of codex adversarial review, also on the Linear
issue): see CHAOS-2763.

## Test matrix (10 tests, plan §4)

All in `tests/test_work_item_source_scope.py` unless noted; every scope test
asserts **fetcher invocation counts**, not just resulting repo lists
(mirrors the GitHub no-fetch-on-missing-source assertion):

1. `test_gitlab_unit_scopes_fetch_to_source_project` — numeric id scopes to
   exactly the matching project (rewrite of the old
   `test_gitlab_unit_stays_org_wide` bug-pin).
2. `test_gitlab_unit_scopes_with_json_string_settings` — same, with
   `settings` as the real production JSON-*string* shape.
3. `test_gitlab_cli_org_wide_path_still_fans_out` — `repo_name=None` stays
   org-wide.
4. `test_gitlab_unit_missing_source_project_fails_closed` +
   `test_gitlab_unit_missing_source_project_fetcher_never_invoked` — no
   match → `ValueError`, fetcher never called.
5. `test_gitlab_unit_path_form_repo_name_matches_full_name` — path-shaped
   CLI input exercises the `full_name` fallback branch.
6. `test_gitlab_stale_row_without_project_id_fails_closed` — rows with
   `settings={}` fail closed (the documented, gated regression risk — see G1
   below).
7. `test_gitlab_work_item_unit_threads_source_scope_contract`
   (`tests/test_dataset_adapters.py`) — adapter threads the numeric project
   id + `require_source=True` into `run_work_items_sync_job`.
8. `test_discover_repos_parses_json_string_settings` +
   `test_discover_repos_malformed_json_settings_yields_empty_dict` +
   `test_discover_repos_null_settings_yields_empty_dict`
   (`tests/test_backfill_integration.py`).
9. `test_gitlab_numeric_repo_name_never_matches_full_name` — negative pin: a
   stale row whose `full_name` happens to equal the numeric id string must
   NOT match; fetcher invocation count asserted as 0.
10. `test_provider_all_with_repo_name_scopes_both_providers` — mixed
    `provider="all"` + `repo_name` pin.

`tests/test_sync_partitioning.py` (CHAOS-2737 guard) — green, unchanged, no
edits needed.

## Gate G1 (blocking merge gate — plan §6)

Per-org stale-row audit against local dev ClickHouse (`dev-health-clickhouse-1`,
argMax tuple-wrap + `JSONHas`, corrected query from the plan's codex re-pass):

```sql
SELECT org_id, countIf(NOT has_pid) AS missing
FROM (
    SELECT org_id, id,
           JSONHas(ifNull(tupleElement(argMax(tuple(settings), last_synced), 1), '{}'), 'project_id') AS has_pid
    FROM repos WHERE provider = 'gitlab' GROUP BY org_id, id
) GROUP BY org_id
```

**Result: 0 rows returned — 0 gitlab-provider rows exist in `repos` at all**
in this environment (`SELECT provider, count() FROM repos` → github-only, 7
rows total). **Gate passes vacuously**: there are zero orgs with gitlab
work-item units to audit, so "missing per org with gitlab units" is 0 for
the (empty) set. No remediation needed, nothing to sign off on.

## Live-verify (plan §6)

No real org in this environment has gitlab work-item units (see G1 above),
so per the plan's explicit fallback ("demonstrate on the fixture path and
say so explicitly"): a recording-stub driver
(`/tmp/claude/chaos2763_live_verify_driver.py`) monkeypatches
`get_metrics_dependencies().gitlab_client_factory` with a call-recording stub
(zero network I/O), fakes `ClickHouseMetricsSink` (zero DB writes/opens), and
feeds a 3-project gitlab fixture (`settings` as raw JSON string — the real
`discover_repos` shape) into the *real*
`run_work_items_sync_job(provider="gitlab", repo_name="123",
require_source=True)`.

- **Pre-fix (`git stash` to `origin/main` HEAD, then re-stash-pop):**
  `GitLab: fetching work items from 3 projects` — all 3 projects reached
  `iter_project_issues`.
- **Post-fix (this branch):**
  `Scoped GitLab work-item unit to source project '123': dropped 2
  off-source repo(s)` → `GitLab: fetching work items from 1 projects` — only
  the source project reached `iter_project_issues`.

**3x → 1x confirmed.** Full driver + logs: `/tmp/claude/chaos-2763-live-verify.log`.

## Codex round-2 fix: fetch by immutable id, not by the (possibly stale) path

Adversarial review of this PR found a **HIGH**: the scoping filter above
correctly *selects* the repo row by immutable `settings.project_id`, but the
fetcher still called the GitLab API with `repo.full_name` as
`project_id_or_path`. Matching a row by id does not make its path safe to
fetch by — if project 123 is renamed/moved after discovery and the stale
path is later reused by a **different** project, an id-matched unit would
match the right row but fetch the **wrong** project's issues/MRs, writing
them under the original `repo_id`.

Fix: `job_work_items.py`'s gitlab scoping block now records
`repo_id -> numeric_project_id` for every numeric-id-matched repo
(`gitlab_id_scoped_project_ids`) and threads it into
`fetch_gitlab_work_items` via a new `id_scoped_project_ids` param
(`work_items.py`), which uses it as `project_id_or_path` for the actual
`client.iter_project_issues`/`iter_project_merge_requests` calls when
present, falling back to `full_name` otherwise (unchanged for path-matched
and org-wide runs). `repo.full_name` is still passed to
`gitlab_issue_to_work_item`/`gitlab_mr_ai_attributions` as
`project_full_path` — unchanged, display/normalization only.

**New regression tests** (`tests/test_work_item_source_scope.py`), both
exercising the **real** `fetch_gitlab_work_items` (unlike the scope tests
above, which mock it away) via a recording GitLab API client stub:

- `test_gitlab_unit_fetches_by_numeric_project_id_not_stale_path` — a repo
  row with `settings.project_id=123` and a deliberately stale/mismatched
  `full_name`; asserts the client was invoked with `"123"`, never the path.
  **Verified to actually catch the regression**: temporarily reverted the
  fix locally, confirmed this test fails with the stale path in the
  recorded calls, then restored the fix and re-confirmed green.
- `test_gitlab_cli_org_wide_path_still_fetches_by_full_name` — org-wide
  (no-source) runs are unaffected; the numeric project ids never appear as
  the API identifier, only `full_name`/path, exactly as before this fix.

**Updated live-verify evidence** (`/tmp/claude/chaos-2763-live-verify.log`):
re-ran the same driver post-fix — the `iter_project_issues` call now shows
`invoked for 1 project(s): ['123']` (the numeric id), where before this fix
round it showed `['grp/proj-a']` (the path). Scoping was already correct (1
project, not 3); now the actual API identifier is correct too.

## Known limitation (deferred: CHAOS-2801)

Codex round-3 review confirmed the direct GitLab fetch calls now correctly
use the numeric id (round-2 fix above) and that the rebase left the
tuple-argMax/settings-parse behavior intact, but flagged that GitLab project
ids are only unique **within a single GitLab instance**: id-scoping as
implemented here is not integration/instance-scoped, so two GitLab
integrations in the same org whose instances happen to assign the same
`project_id` could have a unit for one instance match/fetch a repo row that
actually belongs to the other. This is the residual explicitly pre-accepted
as risk 5 in the original plan ("Self-hosted id spaces … Accepted residual
… disambiguating via `settings.url` is a follow-up if ever real") and
requires threading `integration_id`/resolved `gitlab_url` through discovery
and scoping to fix properly — a kwargs-contract expansion the plan
explicitly rejected as out of scope for this PR. No org today has more than
one GitLab integration with colliding project ids, so this is tracked as a
follow-up rather than blocking this fix: **CHAOS-2801**, with the codex
evidence (`/tmp/claude/codex-review-pr1143-repass.md`) attached to the
issue.

## Coordination note (CHAOS-2787 overlap) — rebased onto #1139

**Update:** PR #1139 (`chaos-2787-discover-repos-dedup`, `discover_repos`
SQL dedup) merged to main first (squash `1d2e4a356`), along with #1140 and
#1141. This branch has been **rebased onto the new `origin/main`** (fetch +
`git rebase origin/main`) — the rebase resolved cleanly with no textual
conflicts (my diff only touched the `settings=r[2] or {}` line and appended
a helper function; #1139's merged version restructured the query into a
single `argMax(tuple(repo, settings, provider), last_synced)` + 3
`tupleElement(...)` unwraps for internal row consistency, which doesn't
overlap the line I changed). **Both behaviors survive**: the deduped
`settings` value from #1139's tuple-argMax now flows straight into my
`_parse_repo_settings()` — verified by rerunning
`tests/test_backfill_integration.py` (14 passed, includes both #1139's and
this PR's `discover_repos` tests) and the full local_validate gate on the
rebased branch (see Gate section below). No manual conflict resolution was
needed for either the source file or the test file (both PRs' new tests in
`tests/test_backfill_integration.py` landed at different points in the file
and merged without collision).

## Gate

`env -i PATH HOME TMPDIR SCRATCH_DB=ci_local_validate_2763 bash
ci/local_validate.sh` — **GATE PASSED** (initial round). ruff format ✓, ruff
check ✓, mypy ✓ (1289 source files), full unit suite ✓ (**6373 passed, 44
skipped** pre-existing/unrelated, 0 failures), live ClickHouse argMax proof ✓
against an isolated scratch DB (created, migrated, proved, dropped — dev
`default` never touched). Log: `/tmp/claude/chaos-2763-gate.log`.

Re-ran after **both** the codex round-2 fix (fetch-identifier threading + 2
new regression tests) **and** the rebase onto post-#1139/#1140/#1141 main —
**GATE PASSED**: ruff format ✓, ruff check ✓, mypy ✓ (1289 source files),
full unit suite ✓ (**6399 passed, 44 skipped** pre-existing/unrelated, 0
failures — count went up from 6373 due to #1139/#1140/#1141's own new
tests now being in the suite), live ClickHouse argMax proof ✓ against
isolated scratch DB `ci_local_validate_2763c` (created, migrated, proved,
dropped). Log: `/tmp/claude/chaos-2763-gate-rebased.log`.

Commit squashed to one (`fix(sync): scope GitLab work-item units to their
source project (CHAOS-2763)`, includes the initial fix + the codex
round-2 fetch-identifier fix, rebased onto the latest main), branch
force-pushed with `--force-with-lease` (`213c99b13` → `3f5e0d08e`).
