### PR TITLE
feat(maintenance): scrub-error-text command + last_test_error write-path fix (CHAOS-2780)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -363,7 +363,7 @@ discipline.
 **Redaction, not an allow-list — deliberately.** `reason` above is a closed,
 normalized enum with no diagnostic-text mandate, so allow-listing a fixed
 vocabulary is correct there. `sync_run_units.error` and its siblings
-(`sync_runs.error`, `sync_run_reference_discovery.error`,
+(`sync_runs.error`, `sync_run_reference_discoveries.error`,
 `sync_dispatch_outbox.last_error`) are free-form, operator-facing
 diagnostics — the entire point of persisting them is to help debug a failed
 sync without re-running it. Collapsing them to a category string would defeat
@@ -463,8 +463,17 @@ test instead
 written before this column was brought under `sanitize_error_text` keeps its
 raw text at rest until the row is next overwritten by a sanitizing write path
 (or copied through one of the sinks above, which now re-sanitizes on the way
-through). A scrub/backfill of already-persisted rows is a deliberately
-separate decision, out of scope for this PR.
+through). [CHAOS-2780](https://linear.app/fullchaos/issue/CHAOS-2780) closes
+that gap: `dev-hops maintenance scrub-error-text` applies `sanitize_error_text`
+to every already-persisted row across all ten in-scope columns (the eight
+listed above plus `integration_credentials.last_test_error`, whose write path
+CHAOS-2780 also sanitizes at the source, and
+`sync_configurations.last_sync_stats`'s `'error'` JSON key). Dry-run by
+default; `--apply` mutates, `--org` optionally scopes to one organization,
+and re-running after a full apply reports zero changes (the scrub, like
+`sanitize_error_text` itself, is idempotent). See
+`src/dev_health_ops/maintenance/scrub_error_text.py` for the column registry
+and compare-and-swap update semantics.
 
 ## Cooldown gating
 

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -21,6 +21,7 @@ from dev_health_ops.api.admin.schemas import (
 )
 from dev_health_ops.api.services.configuration import IntegrationCredentialsService
 from dev_health_ops.credentials.resolver import github_credentials_from_mapping
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
 from .common import get_session
 
@@ -367,6 +368,15 @@ async def test_connection(
         safe_provider = str(payload.provider).replace("\r", "").replace("\n", "")
         logger.exception("Test connection failed for %s", safe_provider)
 
+    # CHAOS-2780: this is the credential-test flow -- the most likely place
+    # for a secret-bearing exception message (or, via the provider helpers
+    # below, a raw external HTTP response body) to appear. Sanitize before
+    # it reaches EITHER sink: the persisted last_test_error (below) and the
+    # HTTP response returned to the caller (below that). sanitize_error_text
+    # is a no-op on None/already-clean text, so this is safe regardless of
+    # which branch above set `error`.
+    error = sanitize_error_text(error)
+
     # Always persist the test result when a stored credential exists
     # (covers both inline pre-save tests and DB-sourced tests)
     if stored is None:
@@ -667,7 +677,20 @@ async def _test_github_connection(creds: dict[str, Any]) -> tuple[bool, dict[str
                     "repository_count": data.get("total_count"),
                 }
             return True, {"user": data.get("login"), "name": data.get("name")}
-        return False, {"status": resp.status_code, "error": resp.text[:200]}
+        return False, {
+            "status": resp.status_code,
+            # CHAOS-2780: this is a raw response body from the external
+            # provider, not something this codebase formats -- some
+            # providers echo request details (including the submitted
+            # credential) back in error/diagnostic bodies, so it must go
+            # through the same redaction as any other error-bearing field
+            # in this response. Sanitize the FULL body (not a blind [:200]
+            # slice first) so the 200-char cap can never split a credential
+            # in half and leave a partial, still-identifiable fragment --
+            # same redact-before-truncate ordering sanitize_error_text
+            # itself guarantees internally.
+            "error": sanitize_error_text(resp.text, max_length=200),
+        }
 
 
 async def _test_gitlab_connection(creds: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
@@ -695,7 +718,20 @@ async def _test_gitlab_connection(creds: dict[str, Any]) -> tuple[bool, dict[str
         if resp.status_code == 200:
             data = resp.json()
             return True, {"user": data.get("username"), "name": data.get("name")}
-        return False, {"status": resp.status_code, "error": resp.text[:200]}
+        return False, {
+            "status": resp.status_code,
+            # CHAOS-2780: this is a raw response body from the external
+            # provider, not something this codebase formats -- some
+            # providers echo request details (including the submitted
+            # credential) back in error/diagnostic bodies, so it must go
+            # through the same redaction as any other error-bearing field
+            # in this response. Sanitize the FULL body (not a blind [:200]
+            # slice first) so the 200-char cap can never split a credential
+            # in half and leave a partial, still-identifiable fragment --
+            # same redact-before-truncate ordering sanitize_error_text
+            # itself guarantees internally.
+            "error": sanitize_error_text(resp.text, max_length=200),
+        }
 
 
 async def _test_jira_connection(creds: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
@@ -731,7 +767,20 @@ async def _test_jira_connection(creds: dict[str, Any]) -> tuple[bool, dict[str, 
                 "user": data.get("emailAddress"),
                 "name": data.get("displayName"),
             }
-        return False, {"status": resp.status_code, "error": resp.text[:200]}
+        return False, {
+            "status": resp.status_code,
+            # CHAOS-2780: this is a raw response body from the external
+            # provider, not something this codebase formats -- some
+            # providers echo request details (including the submitted
+            # credential) back in error/diagnostic bodies, so it must go
+            # through the same redaction as any other error-bearing field
+            # in this response. Sanitize the FULL body (not a blind [:200]
+            # slice first) so the 200-char cap can never split a credential
+            # in half and leave a partial, still-identifiable fragment --
+            # same redact-before-truncate ordering sanitize_error_text
+            # itself guarantees internally.
+            "error": sanitize_error_text(resp.text, max_length=200),
+        }
 
 
 async def _test_linear_connection(creds: dict[str, Any]) -> tuple[bool, dict[str, Any]]:
@@ -753,7 +802,20 @@ async def _test_linear_connection(creds: dict[str, Any]) -> tuple[bool, dict[str
             viewer = data.get("data", {}).get("viewer", {})
             if viewer:
                 return True, {"user": viewer.get("email"), "name": viewer.get("name")}
-        return False, {"status": resp.status_code, "error": resp.text[:200]}
+        return False, {
+            "status": resp.status_code,
+            # CHAOS-2780: this is a raw response body from the external
+            # provider, not something this codebase formats -- some
+            # providers echo request details (including the submitted
+            # credential) back in error/diagnostic bodies, so it must go
+            # through the same redaction as any other error-bearing field
+            # in this response. Sanitize the FULL body (not a blind [:200]
+            # slice first) so the 200-char cap can never split a credential
+            # in half and leave a partial, still-identifiable fragment --
+            # same redact-before-truncate ordering sanitize_error_text
+            # itself guarantees internally.
+            "error": sanitize_error_text(resp.text, max_length=200),
+        }
 
 
 async def _test_launchdarkly_connection(

--- a/src/dev_health_ops/api/services/configuration/integration_credentials.py
+++ b/src/dev_health_ops/api/services/configuration/integration_credentials.py
@@ -16,6 +16,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from dev_health_ops.api.utils.logging import sanitize_for_log
 from dev_health_ops.core.encryption import decrypt_value, encrypt_value
 from dev_health_ops.models.settings import IntegrationCredential
+from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
 from ._helpers import _normalize_credential_keys
 
@@ -217,7 +218,12 @@ class IntegrationCredentialsService:
         if cred:
             cred.last_test_at = datetime.now(timezone.utc)
             cred.last_test_success = success
-            cred.last_test_error = error
+            # CHAOS-2780: this stores errors from testing the credential
+            # itself -- the most likely text to embed the secret -- and is
+            # republished verbatim via admin API responses and sync-preflight
+            # HTTP details, so it must go through the same redaction as the
+            # sync-run error columns (CHAOS-2766).
+            cred.last_test_error = sanitize_error_text(error)
             await self.session.flush()
 
     async def list_by_provider(self, provider: str) -> list[IntegrationCredential]:

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -17,6 +17,12 @@ REPO_ROOT = Path(__file__).resolve().parent.parent.parent
 _DOTENV_INTERPOLATION_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)(?::-(.*?))?\}")
 _DOTENV_MALFORMED_INTERPOLATION_RE = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)?")
 
+# Sentinel default for the root --org argument (CHAOS-2780 codex HIGH, round
+# 2). See ``_resolve_org`` for the full rationale: argparse itself must be
+# the thing that decides whether --org was typed, not a re-implementation
+# of its token/abbreviation matching.
+_ORG_UNSET = object()
+
 
 def resolve_org_id(ns: argparse.Namespace) -> str | None:
     """Return the org_id from the CLI namespace, or ``None``.
@@ -139,6 +145,12 @@ async def _cmd_maintenance_cleanup_all(_ns: argparse.Namespace) -> int:
         total_deleted,
     )
     return 0
+
+
+def _cmd_maintenance_scrub_error_text(ns: argparse.Namespace) -> int:
+    from dev_health_ops.maintenance.scrub_error_text import run_scrub_error_text
+
+    return run_scrub_error_text(ns)
 
 
 # ---------------------------------------------------------------------------
@@ -367,6 +379,14 @@ def _should_resolve_org(ns: argparse.Namespace) -> bool:
         and getattr(ns, "audit_command", None) == "planner-configs"
     ):
         return False
+    # The error-text scrub defaults to ALL orgs too -- its own --org flag is
+    # an explicit opt-in scope, so a missing --org must never silently
+    # narrow it to a single (first) org.
+    if (
+        getattr(ns, "command", None) == "maintenance"
+        and getattr(ns, "maintenance_command", None) == "scrub-error-text"
+    ):
+        return False
     return not (
         getattr(ns, "command", None) == "migrate"
         and getattr(ns, "migrate_command", None) == "clickhouse"
@@ -455,6 +475,7 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("admin", "bundles", "assign-org"): frozenset({_REQ_POSTGRES}),
     ("billing", "reconcile"): frozenset({_REQ_POSTGRES}),
     ("backfill", "run"): frozenset({_REQ_POSTGRES}),
+    ("maintenance", "scrub-error-text"): frozenset({_REQ_POSTGRES}),
     # --- migrations that connect to a live database ---
     ("migrate", "clickhouse", "upgrade"): frozenset({_REQ_CLICKHOUSE}),
     ("migrate", "clickhouse", "status"): frozenset({_REQ_CLICKHOUSE}),
@@ -641,7 +662,13 @@ def build_parser() -> argparse.ArgumentParser:
     )
     parser.add_argument(
         "--org",
-        default=os.getenv("ORG_ID"),
+        # Sentinel, not os.getenv("ORG_ID") directly -- see _resolve_org.
+        # main() resolves this to the ORG_ID env fallback immediately after
+        # parse_args(), before any other code reads ns.org, so this is
+        # transparent to every existing caller of main(); it only matters to
+        # code that calls build_parser().parse_args() directly (tests must
+        # call _resolve_org(ns) themselves in that case).
+        default=_ORG_UNSET,
         help="Organization ID for multi-tenant scoping. Env: ORG_ID. If omitted, resolve from DB.",
     )
     from dev_health_ops.llm.cli import add_llm_arguments
@@ -740,9 +767,73 @@ def build_parser() -> argparse.ArgumentParser:
     )
     cleanup_all_parser.set_defaults(func=_cmd_maintenance_cleanup_all)
 
+    scrub_error_text_parser = maintenance_subparsers.add_parser(
+        "scrub-error-text",
+        help=(
+            "Scrub pre-existing raw credential material from legacy "
+            "error-text columns (CHAOS-2780). Dry-run unless --apply is passed."
+        ),
+    )
+    scrub_error_text_parser.add_argument(
+        "--apply",
+        action="store_true",
+        help=(
+            "Apply the scrub. Without this flag, reports per-column "
+            "would-change counts only and mutates nothing."
+        ),
+    )
+    scrub_error_text_parser.add_argument(
+        "--batch-size",
+        type=int,
+        default=1000,
+        help="Rows to scan per keyset-paginated batch (default: 1000).",
+    )
+    scrub_error_text_parser.set_defaults(func=_cmd_maintenance_scrub_error_text)
+
     _propagate_global_args_to_subparsers(parser)
     _attach_preflight_metadata(parser)
     return parser
+
+
+def _resolve_org(ns: argparse.Namespace) -> None:
+    """Resolve the root ``--org`` argument's sentinel default into its final
+    value, and record whether ``--org`` was actually typed in
+    ``ns.org_explicit``.
+
+    The root ``--org`` argument defaults to the ``_ORG_UNSET`` sentinel
+    (not ``os.getenv("ORG_ID")`` directly) so THIS function -- not a
+    re-implementation of argparse's own token/abbreviation matching -- is
+    what decides whether ``--org`` was typed. An earlier version of this
+    fix scanned raw argv for literal ``--org``/``--org=`` tokens, but
+    argparse's ``allow_abbrev=True`` default means ``--or X`` (or even
+    ``--o X``, unambiguous here) also populates ``ns.org`` -- the argv scan
+    missed that, misclassifying an operator's INTENTIONALLY-scoped
+    ``--apply`` as "no flag" and silently widening it to ALL orgs (the
+    inverse, more dangerous failure vs. the original ORG_ID-env-leak bug;
+    CHAOS-2780 codex HIGH, round 2). Comparing ``ns.org`` against the
+    sentinel by identity is correct for every form argparse recognizes --
+    full, ``--org=X``, or any unambiguous abbreviation, before or after the
+    subcommand -- because it relies on argparse's own action-dispatch
+    (whichever form matched, the action fired and overwrote the sentinel)
+    rather than re-parsing anything ourselves.
+
+    That ambiguity-freedom is harmless for commands that WANT env-var
+    convenience (the common case, preserved below), but commands whose
+    "omit --org" semantics mean "ALL orgs" (``migrate clickhouse repair``,
+    ``audit planner-configs``, ``maintenance scrub-error-text``) must not
+    silently narrow to one tenant just because the operator's shell happens
+    to export ORG_ID -- normal env usage, not an explicit scope opt-in.
+
+    MUST run immediately after ``parser.parse_args()``, before ANY code
+    (including ``_should_resolve_org``) reads ``ns.org`` -- until this
+    runs, ``ns.org`` may still be the raw sentinel object, not a string or
+    None. Code that calls ``build_parser().parse_args(...)`` directly
+    (bypassing ``main()``) must call this itself before reading ``ns.org``
+    or ``ns.org_explicit``.
+    """
+    ns.org_explicit = ns.org is not _ORG_UNSET
+    if not ns.org_explicit:
+        ns.org = os.getenv("ORG_ID")
 
 
 def main(argv: list[str] | None = None) -> int:
@@ -770,6 +861,7 @@ def main(argv: list[str] | None = None) -> int:
         else:
             parser = build_parser()
         ns = parser.parse_args(argv)
+        _resolve_org(ns)
 
         if _should_resolve_org(ns):
             ns.org = _resolve_first_org_id(getattr(ns, "db", None))

--- a/src/dev_health_ops/maintenance/__init__.py
+++ b/src/dev_health_ops/maintenance/__init__.py
@@ -1,0 +1,3 @@
+"""Maintenance CLI subcommands (``dev-hops maintenance ...``)."""
+
+from __future__ import annotations

--- a/src/dev_health_ops/maintenance/scrub_error_text.py
+++ b/src/dev_health_ops/maintenance/scrub_error_text.py
@@ -1,0 +1,524 @@
+"""``dev-hops maintenance scrub-error-text`` (CHAOS-2780).
+
+CHAOS-2766 (``sync/error_sanitize.py``) sanitizes every WRITE path into the
+legacy free-form error-text columns, but rows persisted *before* that change
+shipped keep their raw text at rest -- the wave-2 live gate showed real
+``Authorization`` headers sitting in ``sync_run_units.error``. This command
+applies the exact same ``sanitize_error_text`` helper to already-persisted
+rows, in place, per column.
+
+Design summary (see the CHAOS-2780 plan for the full rationale):
+  * Dry-run by default; ``--apply`` mutates. ``--org`` optionally scopes to
+    one organization; omitted, ALL organizations are scanned.
+  * A registry keyed by SQLAlchemy **model classes** (never table-name
+    strings) drives the scan -- this is what makes the
+    ``sync_run_reference_discovery`` singular/plural typo structurally
+    impossible to reproduce here: each table's report label is derived from
+    ``Model.__tablename__``, not hand-typed.
+  * Per table: keyset pagination on the UUID primary key, per-batch commit,
+    and a compare-and-swap (CAS) update (``WHERE id = :id AND col = :old``)
+    so a row rewritten by live sync between scan and update is left alone
+    (counted ``skipped_concurrent``, never retried -- the newer value already
+    went through the post-CHAOS-2766 sanitized write path).
+  * ``sync_configurations.last_sync_stats`` is a JSON column whose ``'error'``
+    string value (when present) is the only thing scrubbed; sibling keys are
+    preserved. Its CAS predicate casts the column to text
+    (``last_sync_stats::text = :raw_text``) because PostgreSQL's ``json``
+    type (unlike ``jsonb``) preserves the stored text verbatim, giving a
+    stable equality witness that plain ``json = json`` cannot provide.
+  * Every changed row is counted as either ``redact`` (a credential-shaped
+    pattern was found and substituted) or ``truncate_only`` (the value was
+    already clean, but longer than the column's write-path length cap) --
+    conflating the two would make "N rows would change" read as "N secrets
+    found" when some fraction is pure length-cap truncation.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from sqlalchemy import Text, cast, or_, select, update
+from sqlalchemy.orm import Session
+
+from dev_health_ops.models.backfill import BackfillJob
+from dev_health_ops.models.integrations import (
+    SyncDispatchOutbox,
+    SyncRun,
+    SyncRunReferenceDiscovery,
+    SyncRunUnit,
+)
+from dev_health_ops.models.settings import (
+    IntegrationCredential,
+    JobRun,
+    ScheduledJob,
+    SyncConfiguration,
+)
+from dev_health_ops.sync.dispatch_outbox import (
+    _MAX_ERROR_LENGTH as _OUTBOX_MAX_ERROR_LENGTH,
+)
+from dev_health_ops.sync.error_sanitize import (
+    DEFAULT_MAX_ERROR_TEXT_LENGTH,
+    sanitize_error_text,
+)
+
+logger = logging.getLogger(__name__)
+
+KIND_TEXT = "text"
+KIND_JSON_ERROR_KEY = "json_error_key"
+
+# ---------------------------------------------------------------------------
+# Registry
+# ---------------------------------------------------------------------------
+
+# A statement-in/statement-out callable that narrows a SELECT (or UPDATE
+# existence check) to one org_id. Most tables filter their own ``org_id``
+# column directly; ``job_runs`` has none and must join ``scheduled_jobs``.
+OrgFilter = Callable[[Any, str], Any]
+
+
+@dataclass(frozen=True)
+class ColumnSpec:
+    """One scrub target column on a registry table."""
+
+    name: str
+    max_length: int
+    kind: str = KIND_TEXT
+    # Only meaningful for kind == KIND_JSON_ERROR_KEY: the dict key inside
+    # the JSON column whose string value gets sanitized in place.
+    json_error_field: str = "error"
+
+
+@dataclass(frozen=True)
+class TableSpec:
+    """One registry entry: a model class plus the columns to scrub on it."""
+
+    # Typed loosely on purpose: entries span 8 unrelated declarative model
+    # classes with no common attribute-bearing base beyond ``Base`` itself
+    # (which declares no columns), so a precise type here buys nothing but
+    # per-callsite ``attr-defined`` noise on ``model.id``.
+    model: Any
+    columns: tuple[ColumnSpec, ...]
+    org_filter: OrgFilter
+
+    @property
+    def label(self) -> str:
+        # Derived from the model, never hand-typed -- see module docstring.
+        return str(getattr(self.model, "__tablename__"))
+
+
+def _direct_org_filter(model: type) -> OrgFilter:
+    def _filter(stmt: Any, org_id: str) -> Any:
+        return stmt.where(getattr(model, "org_id") == org_id)
+
+    return _filter
+
+
+def _job_run_org_filter(stmt: Any, org_id: str) -> Any:
+    # job_runs has no org_id column (models/settings.py) -- scope via its
+    # scheduled_jobs FK instead.
+    return stmt.join(ScheduledJob, ScheduledJob.id == JobRun.job_id).where(
+        ScheduledJob.org_id == org_id
+    )
+
+
+REGISTRY: tuple[TableSpec, ...] = (
+    TableSpec(
+        model=SyncRunUnit,
+        columns=(ColumnSpec("error", DEFAULT_MAX_ERROR_TEXT_LENGTH),),
+        org_filter=_direct_org_filter(SyncRunUnit),
+    ),
+    TableSpec(
+        model=SyncRun,
+        columns=(ColumnSpec("error", DEFAULT_MAX_ERROR_TEXT_LENGTH),),
+        org_filter=_direct_org_filter(SyncRun),
+    ),
+    TableSpec(
+        model=SyncRunReferenceDiscovery,
+        columns=(ColumnSpec("error", DEFAULT_MAX_ERROR_TEXT_LENGTH),),
+        org_filter=_direct_org_filter(SyncRunReferenceDiscovery),
+    ),
+    TableSpec(
+        model=SyncDispatchOutbox,
+        columns=(ColumnSpec("last_error", _OUTBOX_MAX_ERROR_LENGTH),),
+        org_filter=_direct_org_filter(SyncDispatchOutbox),
+    ),
+    TableSpec(
+        model=JobRun,
+        columns=(
+            ColumnSpec("error", DEFAULT_MAX_ERROR_TEXT_LENGTH),
+            # Defensive historical scrub only -- no current write site
+            # populates error_traceback (see module docstring / plan §3).
+            ColumnSpec("error_traceback", DEFAULT_MAX_ERROR_TEXT_LENGTH),
+        ),
+        org_filter=_job_run_org_filter,
+    ),
+    TableSpec(
+        model=BackfillJob,
+        columns=(ColumnSpec("error_message", DEFAULT_MAX_ERROR_TEXT_LENGTH),),
+        org_filter=_direct_org_filter(BackfillJob),
+    ),
+    TableSpec(
+        model=SyncConfiguration,
+        columns=(
+            ColumnSpec("last_sync_error", DEFAULT_MAX_ERROR_TEXT_LENGTH),
+            ColumnSpec(
+                "last_sync_stats",
+                DEFAULT_MAX_ERROR_TEXT_LENGTH,
+                kind=KIND_JSON_ERROR_KEY,
+            ),
+        ),
+        org_filter=_direct_org_filter(SyncConfiguration),
+    ),
+    TableSpec(
+        model=IntegrationCredential,
+        columns=(ColumnSpec("last_test_error", DEFAULT_MAX_ERROR_TEXT_LENGTH),),
+        org_filter=_direct_org_filter(IntegrationCredential),
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Counters
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ColumnCounters:
+    scanned: int = 0
+    redact: int = 0
+    truncate_only: int = 0
+    skipped_concurrent: int = 0
+
+    def add(self, other: ColumnCounters) -> None:
+        self.scanned += other.scanned
+        self.redact += other.redact
+        self.truncate_only += other.truncate_only
+        self.skipped_concurrent += other.skipped_concurrent
+
+
+Counters = dict[tuple[str, str], ColumnCounters]
+
+
+def _rowcount(result: object) -> int:
+    return int(getattr(result, "rowcount", 0) or 0)
+
+
+def _classify_change(old: str) -> str:
+    """Return ``"redact"`` if a credential-shaped pattern was substituted,
+    else ``"truncate_only"`` (the length cap was the only thing that
+    changed the value). Only called once ``sanitize_error_text(old, ...)``
+    is already known to differ from ``old``."""
+    redacted_only = sanitize_error_text(old, max_length=None)
+    if redacted_only != old:
+        return "redact"
+    return "truncate_only"
+
+
+def _bump(counters: ColumnCounters, change_kind: str) -> None:
+    if change_kind == "redact":
+        counters.redact += 1
+    else:
+        counters.truncate_only += 1
+
+
+# ---------------------------------------------------------------------------
+# Scan / apply loop
+# ---------------------------------------------------------------------------
+
+
+def _select_columns(table_spec: TableSpec) -> list[Any]:
+    cols: list[Any] = [table_spec.model.id]
+    for col_spec in table_spec.columns:
+        attr = getattr(table_spec.model, col_spec.name)
+        cols.append(attr)
+        if col_spec.kind == KIND_JSON_ERROR_KEY:
+            cols.append(cast(attr, Text).label(f"_{col_spec.name}_raw"))
+    return cols
+
+
+def _process_text_column(
+    session: Session,
+    table_spec: TableSpec,
+    col_spec: ColumnSpec,
+    row_id: uuid.UUID,
+    old: str | None,
+    *,
+    apply: bool,
+    counters: ColumnCounters,
+) -> None:
+    if old is None:
+        return
+    counters.scanned += 1
+    new = sanitize_error_text(old, max_length=col_spec.max_length)
+    if new == old:
+        return
+    change_kind = _classify_change(old)
+    if not apply:
+        _bump(counters, change_kind)
+        return
+    result = session.execute(
+        update(table_spec.model)
+        .where(
+            table_spec.model.id == row_id,
+            getattr(table_spec.model, col_spec.name) == old,
+        )
+        .values(**{col_spec.name: new})
+        .execution_options(synchronize_session=False)
+    )
+    if _rowcount(result) == 1:
+        _bump(counters, change_kind)
+    else:
+        counters.skipped_concurrent += 1
+
+
+def _process_json_error_key_column(
+    session: Session,
+    table_spec: TableSpec,
+    col_spec: ColumnSpec,
+    row_id: uuid.UUID,
+    old_dict: dict[str, Any] | None,
+    raw_text: str | None,
+    *,
+    apply: bool,
+    counters: ColumnCounters,
+) -> None:
+    if old_dict is None:
+        return
+    counters.scanned += 1
+    if not isinstance(old_dict, dict):
+        return
+    error_val = old_dict.get(col_spec.json_error_field)
+    if not isinstance(error_val, str):
+        return
+    new_error = sanitize_error_text(error_val, max_length=col_spec.max_length)
+    if new_error == error_val:
+        return
+    change_kind = _classify_change(error_val)
+    if not apply:
+        _bump(counters, change_kind)
+        return
+    new_dict = dict(old_dict)
+    new_dict[col_spec.json_error_field] = new_error
+    result = session.execute(
+        update(table_spec.model)
+        .where(
+            table_spec.model.id == row_id,
+            cast(getattr(table_spec.model, col_spec.name), Text) == raw_text,
+        )
+        .values(**{col_spec.name: new_dict})
+        .execution_options(synchronize_session=False)
+    )
+    if _rowcount(result) == 1:
+        _bump(counters, change_kind)
+    else:
+        counters.skipped_concurrent += 1
+
+
+def process_table(
+    session: Session,
+    table_spec: TableSpec,
+    *,
+    apply: bool,
+    org_id: str | None,
+    batch_size: int,
+    counters: Counters,
+) -> None:
+    """Scan (and optionally scrub) one registry table, batch by batch."""
+    model = table_spec.model
+    id_col = model.id
+    select_cols = _select_columns(table_spec)
+    not_null_clause = or_(
+        *[getattr(model, c.name).is_not(None) for c in table_spec.columns]
+    )
+
+    for col_spec in table_spec.columns:
+        counters.setdefault((table_spec.label, col_spec.name), ColumnCounters())
+
+    last_id: uuid.UUID | None = None
+    while True:
+        stmt = select(*select_cols).where(not_null_clause)
+        if last_id is not None:
+            stmt = stmt.where(id_col > last_id)
+        if org_id:
+            stmt = table_spec.org_filter(stmt, org_id)
+        stmt = stmt.order_by(id_col).limit(batch_size)
+
+        rows = session.execute(stmt).all()
+        if not rows:
+            break
+        last_id = rows[-1][0]
+
+        for row in rows:
+            offset = 1
+            for col_spec in table_spec.columns:
+                col_counters = counters[(table_spec.label, col_spec.name)]
+                if col_spec.kind == KIND_TEXT:
+                    old_value = row[offset]
+                    offset += 1
+                    _process_text_column(
+                        session,
+                        table_spec,
+                        col_spec,
+                        row[0],
+                        old_value,
+                        apply=apply,
+                        counters=col_counters,
+                    )
+                else:
+                    old_dict = row[offset]
+                    raw_text = row[offset + 1]
+                    offset += 2
+                    _process_json_error_key_column(
+                        session,
+                        table_spec,
+                        col_spec,
+                        row[0],
+                        old_dict,
+                        raw_text,
+                        apply=apply,
+                        counters=col_counters,
+                    )
+
+        if apply:
+            session.commit()
+
+        if len(rows) < batch_size:
+            break
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def _print_report(counters: Counters, *, apply: bool) -> None:
+    redact_label = "redacted" if apply else "would_redact"
+    truncate_label = "truncated_only" if apply else "would_truncate_only"
+    print(
+        f"{'column':<48s} {'scanned':>10s} {redact_label:>14s} "
+        f"{truncate_label:>18s} {'skipped_concurrent':>19s}"
+    )
+    totals = ColumnCounters()
+    for table_spec in REGISTRY:
+        for col_spec in table_spec.columns:
+            c = counters.get((table_spec.label, col_spec.name), ColumnCounters())
+            column_label = f"{table_spec.label}.{col_spec.name}"
+            print(
+                f"{column_label:<48s} {c.scanned:>10d} {c.redact:>14d} "
+                f"{c.truncate_only:>18d} {c.skipped_concurrent:>19d}"
+            )
+            totals.add(c)
+    print(
+        f"{'TOTAL':<48s} {totals.scanned:>10d} {totals.redact:>14d} "
+        f"{totals.truncate_only:>18d} {totals.skipped_concurrent:>19d}"
+    )
+    if not apply:
+        print()
+        print("Dry-run: pass --apply to write these changes.")
+
+
+# ---------------------------------------------------------------------------
+# CLI entrypoint
+# ---------------------------------------------------------------------------
+
+
+def _resolve_org_id(ns: argparse.Namespace) -> str | None:
+    """Return the org_id scope for this run, or ``None`` for ALL orgs.
+
+    CHAOS-2780 codex HIGH: ``ns.org`` alone is not enough here. The root
+    ``--org`` argument defaults to a sentinel (not the ``ORG_ID`` env var
+    directly), so an operator running this command with ORG_ID set in their
+    shell (ordinary env usage, not an explicit scope opt-in) would
+    otherwise have ``ns.org`` silently narrow a run that's supposed to
+    cover every organization -- turning "0 would-change" into a false
+    whole-DB completion signal. ``ns.org_explicit`` (set by
+    ``cli._resolve_org`` from a sentinel-identity check against the
+    argparse-parsed value, before this function ever sees ``ns`` --
+    correctly handling every form argparse recognizes, including
+    ``allow_abbrev``-shortened flags like ``--or``, which a raw-argv token
+    scan misses) distinguishes an actually-typed ``--org`` from the env
+    fallback; only the former scopes the scrub. Namespaces built directly
+    (bypassing ``cli.main``, e.g. in tests) that don't set ``org_explicit``
+    default to the safe "all orgs" behavior.
+    """
+    if not getattr(ns, "org_explicit", False):
+        return None
+    return getattr(ns, "org", None) or None
+
+
+def collect_counters(ns: argparse.Namespace) -> tuple[Counters | None, bool]:
+    """Run the scrub (scan-only or apply, per ``ns``) and return its raw
+    per-column counters plus a batch-failure flag.
+
+    Split out from :func:`run_scrub_error_text` so tests can assert on exact
+    counts instead of parsing the printed report. Returns ``(None, True)``
+    when no database URI is configured.
+    """
+    from dev_health_ops.db import get_postgres_session_sync_for_uri
+
+    db_uri = (
+        getattr(ns, "db", None)
+        or os.getenv("POSTGRES_URI")
+        or os.getenv("DATABASE_URI")
+    )
+    if not db_uri:
+        logger.error(
+            "PostgreSQL URI not configured. Pass --db or set POSTGRES_URI/DATABASE_URI."
+        )
+        return None, True
+
+    apply = bool(getattr(ns, "apply", False))
+    org_id = _resolve_org_id(ns)
+    batch_size = int(getattr(ns, "batch_size", 1000) or 1000)
+    if batch_size <= 0:
+        batch_size = 1000
+
+    counters: Counters = {}
+    had_failure = False
+
+    with get_postgres_session_sync_for_uri(db_uri) as session:
+        for table_spec in REGISTRY:
+            try:
+                process_table(
+                    session,
+                    table_spec,
+                    apply=apply,
+                    org_id=org_id,
+                    batch_size=batch_size,
+                    counters=counters,
+                )
+            except Exception:
+                logger.exception(
+                    "scrub-error-text failed while processing %s", table_spec.label
+                )
+                had_failure = True
+                session.rollback()
+
+    return counters, had_failure
+
+
+def run_scrub_error_text(ns: argparse.Namespace) -> int:
+    counters, had_failure = collect_counters(ns)
+    if counters is not None:
+        org_id = _resolve_org_id(ns)
+        scope = f"org={org_id}" if org_id else "ALL organizations"
+        print(f"Org scope: {scope}")
+        _print_report(counters, apply=bool(getattr(ns, "apply", False)))
+    return 1 if had_failure else 0
+
+
+__all__ = [
+    "REGISTRY",
+    "ColumnCounters",
+    "ColumnSpec",
+    "TableSpec",
+    "collect_counters",
+    "process_table",
+    "run_scrub_error_text",
+]

--- a/src/dev_health_ops/sync/error_sanitize.py
+++ b/src/dev_health_ops/sync/error_sanitize.py
@@ -4,7 +4,7 @@ Live verification of CHAOS-2758 (evidence comment on CHAOS-2742) demonstrated
 that a provider exception whose message embeds an ``Authorization`` header
 (``403 rate limited -- Authorization: Bearer ghp_FAKE...``) persisted
 VERBATIM into the pre-existing ``sync_run_units.error`` column and its
-siblings (``sync_runs.error``, ``sync_run_reference_discovery.error``,
+siblings (``sync_runs.error``, ``sync_run_reference_discoveries.error``,
 ``sync_dispatch_outbox.last_error``) -- every one of these is populated from
 ``str(exc)`` (or an f-string embedding it) at a worker boundary that never
 controls what a provider client library puts in an exception message.

--- a/tests/test_admin_credentials.py
+++ b/tests/test_admin_credentials.py
@@ -384,3 +384,113 @@ async def test_get_credential_not_found(client):
 
     assert resp.status_code == 404
     assert resp.json()["detail"] == "Credential not found"
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2780 codex HIGH: /credentials/test must never echo a raw secret back
+# through the HTTP response, even though the persisted last_test_error was
+# already sanitized. Fixture secret assembled at runtime with a neutral name
+# per the Gitleaks-safety convention (tests/test_error_sanitize.py).
+# ---------------------------------------------------------------------------
+
+
+def _fake_secret(*parts: str) -> str:
+    return "".join(parts)
+
+
+_LEAK = _fake_secret("ghp_", "FAKEtestconnLEAK1234567890AB")
+
+
+@pytest.mark.asyncio
+async def test_test_connection_sanitizes_exception_in_response_and_persisted_error(
+    client,
+):
+    cred = _mock_credential(provider="github", name="default")
+
+    with (
+        patch(
+            "dev_health_ops.api.admin.routers.credentials.IntegrationCredentialsService"
+        ) as mock_svc_cls,
+        patch(
+            "dev_health_ops.api.admin.routers.credentials._test_github_connection",
+            new_callable=AsyncMock,
+        ) as mock_test,
+    ):
+        svc = AsyncMock()
+        svc.get.return_value = cred
+        mock_svc_cls.return_value = svc
+        mock_test.side_effect = RuntimeError(
+            f"403 rate limited -- Authorization: Bearer {_LEAK}"
+        )
+
+        resp = await client.post(
+            "/api/v1/admin/credentials/test",
+            json={
+                "provider": "github",
+                "name": "default",
+                "credentials": {"token": "ghp_test"},
+            },
+            headers=HEADERS,
+        )
+
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["success"] is False
+    # The HTTP response body must be redacted, not just the persisted row --
+    # this is the exact leak: error = str(e) returned verbatim to the caller.
+    assert data["error"] is not None
+    assert _LEAK not in data["error"]
+    assert "Bearer" not in data["error"]
+    assert "[REDACTED]" in data["error"]
+
+    # And the value handed to the persistence layer must be the SAME
+    # sanitized text (single source of truth, not sanitized twice
+    # differently).
+    svc.update_test_result.assert_awaited_once()
+    persisted_args = svc.update_test_result.await_args.args
+    persisted_error = persisted_args[2]
+    assert persisted_error == data["error"]
+    assert _LEAK not in persisted_error
+
+
+@pytest.mark.asyncio
+async def test_gitlab_connection_helper_sanitizes_raw_response_body():
+    """Direct unit test on the OTHER error-bearing response field codex
+    flagged: provider helpers echo up to 200 chars of the raw external HTTP
+    response body into details['error']. Some providers echo request
+    details (including the submitted credential) back in error bodies, so
+    this must be redacted too, not just the top-level exception path."""
+
+    class _FakeResponse:
+        status_code = 401
+
+        def __init__(self, text: str) -> None:
+            self.text = text
+
+        def json(self):
+            return {}
+
+    class _FakeAsyncClient:
+        def __init__(self, *args, **kwargs) -> None:
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *args) -> bool:
+            return False
+
+        async def get(self, *args, **kwargs):
+            return _FakeResponse(
+                f"401 Unauthorized: submitted PRIVATE-TOKEN {_LEAK} is invalid"
+            )
+
+    with patch("httpx.AsyncClient", _FakeAsyncClient):
+        success, details = await admin_router_module._test_gitlab_connection(
+            {"token": "placeholder"}
+        )
+
+    assert success is False
+    assert details["status"] == 401
+    assert _LEAK not in details["error"]
+    assert "[REDACTED]" in details["error"]

--- a/tests/test_error_sanitize.py
+++ b/tests/test_error_sanitize.py
@@ -243,3 +243,43 @@ def test_sanitize_error_text_max_length_none_disables_cap():
     raw = "z" * 10_000
     sanitized = sanitize_error_text(raw, max_length=None)
     assert sanitized == raw
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2780: idempotency property.
+#
+# ``dev-hops maintenance scrub-error-text`` relies on
+# ``sanitize(sanitize(x)) == sanitize(x)`` to make a second ``--apply`` run
+# report zero changes -- no ``_SECRET_PATTERN`` matches the literal
+# ``REDACTION_MARKER``, and truncation is a fixed point once the text is
+# under the cap. This was previously an unstated assumption the copy sites
+# relied on (``workers/sync_units.py:1810-1817, 2057-2064``); this test pins
+# it explicitly, over the same pattern-fixture table used above plus a
+# capped variant so both the redaction and truncation fixed points are
+# covered. Appended, not interleaved, so this addition stays a clean diff
+# against the rest of the file.
+# ---------------------------------------------------------------------------
+@pytest.mark.parametrize(
+    ("raw", "max_length"),
+    [
+        (f"GET /repos failed: Authorization: Bearer {_FIXTURE_2}", None),
+        (f"GET /repos failed: Authorization: Bearer {_FIXTURE_2}", 40),
+        (f"push rejected using {_FIXTURE_7}", None),
+        (f"push rejected using {_FIXTURE_7}", 4000),
+        (
+            "connection reset by peer while fetching page 3 of 10 "
+            "(status=502, retry_count=2)",
+            None,
+        ),
+        (
+            f"Error 111 connecting to redis://:{_FIXTURE_16}@redis-broker.internal:6379/0.",
+            2000,
+        ),
+        ("x" * 10_000, 4000),
+        ("x" * 10_000, None),
+    ],
+)
+def test_sanitize_error_text_is_idempotent(raw, max_length):
+    once = sanitize_error_text(raw, max_length=max_length)
+    twice = sanitize_error_text(once, max_length=max_length)
+    assert twice == once

--- a/tests/test_error_sanitize_guard.py
+++ b/tests/test_error_sanitize_guard.py
@@ -12,7 +12,7 @@ The check is a precise AST walk (not a `grep`, which would false-positive on
 diagnostic logs, not persisted DB columns, and are intentionally out of this
 ticket's scope) over the worker/sync modules that write
 ``sync_run_units.error`` and its siblings (``sync_runs.error``,
-``sync_run_reference_discovery.error``, ``sync_dispatch_outbox.last_error``).
+``sync_run_reference_discoveries.error``, ``sync_dispatch_outbox.last_error``).
 It flags any *raw* ``str(exc)``-shaped call or bare ``f"...{exc}"``
 interpolation that is not inside a ``logger.<method>(...)`` call -- which is
 exactly what a persistence site producing unsanitized text looks like, since

--- a/tests/test_integration_credential_error_sanitize.py
+++ b/tests/test_integration_credential_error_sanitize.py
@@ -1,0 +1,180 @@
+"""Write-path + scrub coverage for ``integration_credentials.last_test_error``
+(CHAOS-2780, codex HIGH).
+
+``last_test_error`` stores errors from testing the credential itself -- the
+most likely text to embed the secret -- and is republished verbatim via
+admin API responses (``api/admin/routers/credentials.py``) and sync-preflight
+HTTP details (``api/admin/routers/sync.py``). CHAOS-2766 sanitized every
+other legacy error-text sink; this column was moved in scope for CHAOS-2780
+with both a write-path fix (the service setter) and inclusion in the
+``scrub-error-text`` column registry for rows persisted before the fix.
+
+Covers:
+  * ``IntegrationCredentialsService.update_test_result`` sanitizes a
+    secret-bearing error before it reaches the DB.
+  * The admin GET serializer (``_integration_credential_response``) serves
+    whatever is stored verbatim -- once storage is sanitized, the response
+    is sanitized by construction; no separate response-layer redaction is
+    needed.
+  * ``scrub-error-text`` redacts a pre-existing (legacy, unsanitized) row on
+    this column, seeded here to simulate data written before the write-path
+    fix shipped.
+"""
+
+from __future__ import annotations
+
+import argparse
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import create_engine
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+from sqlalchemy.orm import Session
+
+from dev_health_ops.api.admin.routers.credentials import (
+    _integration_credential_response,
+)
+from dev_health_ops.api.services.configuration import IntegrationCredentialsService
+from dev_health_ops.maintenance.scrub_error_text import run_scrub_error_text
+from dev_health_ops.models import Base, IntegrationCredential
+from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
+from tests._helpers import tables_of
+
+
+def _fake_secret(*parts: str) -> str:
+    return "".join(parts)
+
+
+_LEAK = _fake_secret("ghp_", "FAKEintegcred1234567890AB")
+
+
+def _fetch(session: Session, model: Any, row_id: uuid.UUID) -> Any:
+    """``session.get`` typed loosely on purpose: this test file only needs a
+    non-None row back, and the mapped attributes read off it downstream are
+    all nullable columns compared/redaction-checked in ways mypy can't
+    narrow through a ``Model | None`` return without per-call assertions."""
+    row = session.get(model, row_id)
+    assert row is not None
+    return row
+
+
+@pytest_asyncio.fixture
+async def async_session_maker(tmp_path: Path):
+    db_path = tmp_path / "cred-sanitize.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(
+                sync_conn, tables=tables_of(IntegrationCredential)
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_update_test_result_sanitizes_secret_bearing_error(async_session_maker):
+    # Credentials are seeded directly at the ORM layer -- no encryption
+    # round-trip -- since this test exercises only ``last_test_error``
+    # sanitization, not the encrypted-blob path.
+    org_id = f"org-{uuid.uuid4().hex[:8]}"
+    async with async_session_maker() as session:
+        session.add(
+            IntegrationCredential(provider="github", name="default", org_id=org_id)
+        )
+        await session.commit()
+
+        svc = IntegrationCredentialsService(session, org_id)
+        raw_error = f"403 rate limited -- Authorization: Bearer {_LEAK}"
+        await svc.update_test_result(
+            "github", success=False, error=raw_error, name="default"
+        )
+        await session.commit()
+
+        cred = await svc.get("github", "default")
+        assert cred is not None
+        assert cred.last_test_error is not None
+        assert REDACTION_MARKER in cred.last_test_error
+        assert _LEAK not in cred.last_test_error
+        assert "Bearer" not in cred.last_test_error
+
+
+@pytest.mark.asyncio
+async def test_update_test_result_clears_error_on_success(async_session_maker):
+    org_id = f"org-{uuid.uuid4().hex[:8]}"
+    async with async_session_maker() as session:
+        session.add(
+            IntegrationCredential(provider="github", name="default", org_id=org_id)
+        )
+        await session.commit()
+
+        svc = IntegrationCredentialsService(session, org_id)
+        await svc.update_test_result("github", success=True, error=None, name="default")
+        await session.commit()
+
+        cred = await svc.get("github", "default")
+        assert cred is not None
+        assert cred.last_test_error is None
+
+
+def test_admin_serializer_returns_stored_value_verbatim():
+    """The admin GET response is a pass-through of whatever is persisted --
+    demonstrating that sanitizing storage (the write-path fix above, or the
+    scrub below) is sufficient; the serializer needs no separate redaction."""
+    already_sanitized = "RateLimitException: 403 rate limited -- [REDACTED]"
+    now = datetime.now(timezone.utc)
+
+    class _FakeCredential:
+        id = uuid.uuid4()
+        provider = "github"
+        name = "default"
+        is_active = True
+        config: dict = {}
+        last_test_at = now
+        last_test_success = False
+        last_test_error = already_sanitized
+        created_at = now
+        updated_at = now
+
+    response = _integration_credential_response(_FakeCredential())
+    assert response.last_test_error == already_sanitized
+    assert REDACTION_MARKER in response.last_test_error
+
+
+def test_scrub_error_text_redacts_preexisting_last_test_error_row(tmp_path):
+    """Simulates a row written before the CHAOS-2780 write-path fix shipped:
+    seeded directly at the ORM layer (bypassing the now-sanitizing service
+    setter), it must still be picked up and redacted by the scrub."""
+    db_path = tmp_path / "cred-scrub.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+
+    org_id = f"org-{uuid.uuid4().hex[:8]}"
+    raw_error = f"push rejected using {_LEAK}"
+    with Session(engine, expire_on_commit=False) as session:
+        cred = IntegrationCredential(provider="github", name="default", org_id=org_id)
+        cred.last_test_error = raw_error
+        session.add(cred)
+        session.commit()
+        cred_id = cred.id
+    engine.dispose()
+
+    db_uri = f"sqlite:///{db_path}"
+    rc = run_scrub_error_text(
+        argparse.Namespace(db=db_uri, apply=True, org=None, batch_size=1000)
+    )
+    assert rc == 0
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        fetched = _fetch(session, IntegrationCredential, cred_id)
+        assert REDACTION_MARKER in fetched.last_test_error
+        assert _LEAK not in fetched.last_test_error
+    engine.dispose()

--- a/tests/test_maintenance_scrub_error_text.py
+++ b/tests/test_maintenance_scrub_error_text.py
@@ -1,0 +1,946 @@
+"""Tests for ``dev-hops maintenance scrub-error-text`` (CHAOS-2780).
+
+Covers: dry-run vs apply per-column counts, DB byte-identity during dry-run,
+redact vs truncate_only classification, per-column length caps (including the
+outbox's tighter 2000-char cap), CAS-race handling (text + JSON columns),
+``--org`` scoping (direct ``org_id`` column and the ``job_runs`` ->
+``scheduled_jobs`` join), and JSON sibling-key preservation for
+``sync_configurations.last_sync_stats``.
+
+Every fixture secret is assembled via ``_fake_secret(...)`` with a neutral
+name, matching the Gitleaks-safety convention established in
+``tests/test_error_sanitize.py`` (see that file's module docstring for why).
+"""
+
+from __future__ import annotations
+
+import argparse
+import uuid
+from datetime import date, datetime, timezone
+from typing import Any
+
+import pytest
+from sqlalchemy import Text, cast, create_engine, select, update
+from sqlalchemy.orm import Session
+
+from dev_health_ops.maintenance.scrub_error_text import (
+    KIND_JSON_ERROR_KEY,
+    REGISTRY,
+    ColumnCounters,
+    _process_json_error_key_column,
+    _process_text_column,
+    collect_counters,
+    run_scrub_error_text,
+)
+from dev_health_ops.models import (
+    BackfillJob,
+    Base,
+    IntegrationCredential,
+    JobRun,
+    ScheduledJob,
+    SyncConfiguration,
+    SyncDispatchOutbox,
+    SyncRun,
+    SyncRunReferenceDiscovery,
+    SyncRunUnit,
+)
+from dev_health_ops.sync.dispatch_outbox import (
+    _MAX_ERROR_LENGTH as _OUTBOX_MAX_ERROR_LENGTH,
+)
+from dev_health_ops.sync.error_sanitize import (
+    DEFAULT_MAX_ERROR_TEXT_LENGTH,
+    REDACTION_MARKER,
+)
+
+
+def _fake_secret(*parts: str) -> str:
+    return "".join(parts)
+
+
+_LEAK_1 = _fake_secret("ghp_", "FAKEqwerty1234567890AB")
+_LEAK_2 = _fake_secret("ghp_", "FAKEzyxwvu0987654321CD")
+_LEAK_3 = _fake_secret("ghp_", "FAKElmnopq5566778899EF")
+_LEAK_4 = _fake_secret("QwertyUserXqzln", "PassphraseValueXqz456")
+
+
+def _org() -> str:
+    return f"org-{uuid.uuid4().hex[:8]}"
+
+
+# ---------------------------------------------------------------------------
+# Row factories -- minimal required fields only. SQLite (used for these
+# tests) does not enforce FK constraints, so FK-typed columns are populated
+# with plausible standalone UUIDs except where the test itself needs a real
+# parent row (job_runs -> scheduled_jobs org-join tests).
+# ---------------------------------------------------------------------------
+
+
+def _seed_sync_run_unit(
+    session: Session, *, org_id: str, error: str | None
+) -> SyncRunUnit:
+    row = SyncRunUnit(
+        org_id=org_id,
+        sync_run_id=uuid.uuid4(),
+        integration_id=uuid.uuid4(),
+        source_id=uuid.uuid4(),
+        provider="github",
+        dataset_key="prs",
+        cost_class="medium",
+        mode="incremental",
+        status="failed",
+        error=error,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_sync_run(session: Session, *, org_id: str, error: str | None) -> SyncRun:
+    row = SyncRun(
+        org_id=org_id,
+        integration_id=uuid.uuid4(),
+        triggered_by="manual",
+        mode="incremental",
+        status="failed",
+        total_units=0,
+        completed_units=0,
+        failed_units=0,
+        error=error,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_reference_discovery(
+    session: Session, *, org_id: str, error: str | None
+) -> SyncRunReferenceDiscovery:
+    row = SyncRunReferenceDiscovery(
+        sync_run_id=uuid.uuid4(),
+        org_id=org_id,
+        status="failed",
+        attempts=1,
+        available_at=datetime.now(timezone.utc),
+        error=error,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_dispatch_outbox(
+    session: Session, *, org_id: str, last_error: str | None
+) -> SyncDispatchOutbox:
+    row = SyncDispatchOutbox(
+        org_id=org_id,
+        sync_run_id=uuid.uuid4(),
+        kind="dispatch_sync_run",
+        status="pending",
+        available_at=datetime.now(timezone.utc),
+        attempts=1,
+        last_error=last_error,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_scheduled_job(session: Session, *, org_id: str) -> ScheduledJob:
+    row = ScheduledJob(
+        name=f"job-{uuid.uuid4().hex[:8]}",
+        job_type="sync",
+        schedule_cron="0 * * * *",
+        org_id=org_id,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_job_run(
+    session: Session,
+    *,
+    job_id: uuid.UUID,
+    error: str | None,
+    error_traceback: str | None = None,
+) -> JobRun:
+    row = JobRun(job_id=job_id)
+    row.error = error
+    row.error_traceback = error_traceback
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_backfill_job(
+    session: Session, *, org_id: str, error_message: str | None
+) -> BackfillJob:
+    row = BackfillJob(
+        org_id=org_id,
+        sync_config_id=uuid.uuid4(),
+        since_date=date(2026, 1, 1),
+        before_date=date(2026, 1, 2),
+        error_message=error_message,
+    )
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_sync_configuration(
+    session: Session,
+    *,
+    org_id: str,
+    last_sync_error: str | None = None,
+    last_sync_stats: dict | None = None,
+) -> SyncConfiguration:
+    row = SyncConfiguration(
+        name=f"cfg-{uuid.uuid4().hex[:8]}", provider="github", org_id=org_id
+    )
+    row.last_sync_error = last_sync_error
+    row.last_sync_stats = last_sync_stats
+    session.add(row)
+    session.flush()
+    return row
+
+
+def _seed_integration_credential(
+    session: Session, *, org_id: str, last_test_error: str | None
+) -> IntegrationCredential:
+    row = IntegrationCredential(
+        provider="github", name=f"cred-{uuid.uuid4().hex[:8]}", org_id=org_id
+    )
+    row.last_test_error = last_test_error
+    session.add(row)
+    session.flush()
+    return row
+
+
+# ---------------------------------------------------------------------------
+# DB helpers
+# ---------------------------------------------------------------------------
+
+
+def _new_db(tmp_path) -> str:
+    db_path = tmp_path / f"scrub-{uuid.uuid4().hex}.db"
+    engine = create_engine(f"sqlite:///{db_path}")
+    Base.metadata.create_all(engine)
+    engine.dispose()
+    return f"sqlite:///{db_path}"
+
+
+def _ns(
+    db_uri: str,
+    *,
+    apply: bool,
+    org: str | None = None,
+    batch_size: int = 1000,
+    org_explicit: bool | None = None,
+):
+    # Mirrors cli._resolve_org's contract: a Namespace built directly
+    # (bypassing cli.main's sentinel resolution) has no way to know whether
+    # --org was actually typed vs. env-defaulted, so callers that pass
+    # `org=...` are assumed to mean "explicitly scoped" -- matching every
+    # pre-existing call site in this file -- unless overridden.
+    if org_explicit is None:
+        org_explicit = org is not None
+    return argparse.Namespace(
+        db=db_uri,
+        apply=apply,
+        org=org,
+        batch_size=batch_size,
+        org_explicit=org_explicit,
+    )
+
+
+def _fetch(session: Session, model: Any, row_id: uuid.UUID) -> Any:
+    """``session.get`` typed loosely on purpose: every assertion below reads
+    a nullable mapped attribute (and, for the JSON entry, indexes into it),
+    which mypy can't narrow through a ``Model | None`` return without a
+    per-call assertion -- this makes that assertion once, here."""
+    row = session.get(model, row_id)
+    assert row is not None
+    return row
+
+
+def _table_spec(model: type):
+    return next(t for t in REGISTRY if t.model is model)
+
+
+# ---------------------------------------------------------------------------
+# Registry sanity
+# ---------------------------------------------------------------------------
+
+
+def test_registry_covers_all_ten_columns_with_correct_labels_and_caps():
+    by_key = {(t.label, c.name): c for t in REGISTRY for c in t.columns}
+    assert len(by_key) == 10
+    assert ("sync_run_units", "error") in by_key
+    assert ("sync_runs", "error") in by_key
+    # Table #3's label is derived from the model's __tablename__, never a
+    # hand-typed string -- this assertion would fail immediately if anyone
+    # reintroduced the ticket's singular/plural typo.
+    assert ("sync_run_reference_discoveries", "error") in by_key
+    assert ("sync_dispatch_outbox", "last_error") in by_key
+    assert by_key[("sync_dispatch_outbox", "last_error")].max_length == 2000
+    assert (
+        by_key[("sync_dispatch_outbox", "last_error")].max_length
+        == _OUTBOX_MAX_ERROR_LENGTH
+    )
+    assert ("job_runs", "error") in by_key
+    assert ("job_runs", "error_traceback") in by_key
+    assert ("backfill_jobs", "error_message") in by_key
+    assert ("sync_configurations", "last_sync_error") in by_key
+    stats_col = by_key[("sync_configurations", "last_sync_stats")]
+    assert stats_col.kind == KIND_JSON_ERROR_KEY
+    assert ("integration_credentials", "last_test_error") in by_key
+    for (_table, _col), spec in by_key.items():
+        if (_table, _col) != ("sync_dispatch_outbox", "last_error"):
+            assert spec.max_length == DEFAULT_MAX_ERROR_TEXT_LENGTH
+
+
+# ---------------------------------------------------------------------------
+# Full lifecycle: dry-run -> apply -> second apply, across every column
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_dry_run_apply_and_reapply_across_all_columns(tmp_path):
+    db_uri = _new_db(tmp_path)
+    org_id = _org()
+    dirty = f"403 rate limited -- Authorization: Bearer {_LEAK_1}"
+    dirty_json_error = f"upstream 401: authorization=Bearer {_LEAK_2}"
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        unit = _seed_sync_run_unit(session, org_id=org_id, error=dirty)
+        run = _seed_sync_run(session, org_id=org_id, error=dirty)
+        discovery = _seed_reference_discovery(session, org_id=org_id, error=dirty)
+        outbox = _seed_dispatch_outbox(session, org_id=org_id, last_error=dirty)
+        job = _seed_scheduled_job(session, org_id=org_id)
+        job_run = _seed_job_run(
+            session, job_id=job.id, error=dirty, error_traceback=dirty
+        )
+        backfill = _seed_backfill_job(session, org_id=org_id, error_message=dirty)
+        sync_config = _seed_sync_configuration(
+            session,
+            org_id=org_id,
+            last_sync_error=dirty,
+            last_sync_stats={
+                "error": dirty_json_error,
+                "phase": "dispatch_enqueue",
+                "other": 1,
+            },
+        )
+        cred = _seed_integration_credential(
+            session, org_id=org_id, last_test_error=dirty
+        )
+        session.commit()
+    engine.dispose()
+
+    # --- dry run: correct counts, DB untouched ---
+    counters, had_failure = collect_counters(_ns(db_uri, apply=False))
+    assert had_failure is False
+    assert counters is not None
+    for key in (
+        ("sync_run_units", "error"),
+        ("sync_runs", "error"),
+        ("sync_run_reference_discoveries", "error"),
+        ("sync_dispatch_outbox", "last_error"),
+        ("job_runs", "error"),
+        ("job_runs", "error_traceback"),
+        ("backfill_jobs", "error_message"),
+        ("sync_configurations", "last_sync_error"),
+        ("sync_configurations", "last_sync_stats"),
+        ("integration_credentials", "last_test_error"),
+    ):
+        c = counters[key]
+        assert c.scanned == 1, key
+        assert c.redact == 1, key
+        assert c.truncate_only == 0, key
+        assert c.skipped_concurrent == 0, key
+    dry_run_counters = counters
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        assert _fetch(session, SyncRunUnit, unit.id).error == dirty
+        assert _fetch(session, SyncRun, run.id).error == dirty
+        assert _fetch(session, SyncRunReferenceDiscovery, discovery.id).error == dirty
+        assert _fetch(session, SyncDispatchOutbox, outbox.id).last_error == dirty
+        fetched_job_run = _fetch(session, JobRun, job_run.id)
+        assert fetched_job_run.error == dirty
+        assert fetched_job_run.error_traceback == dirty
+        assert _fetch(session, BackfillJob, backfill.id).error_message == dirty
+        fetched_config = _fetch(session, SyncConfiguration, sync_config.id)
+        assert fetched_config.last_sync_error == dirty
+        assert fetched_config.last_sync_stats["error"] == dirty_json_error
+        assert _fetch(session, IntegrationCredential, cred.id).last_test_error == dirty
+    engine.dispose()
+
+    # --- apply: counts match the dry run exactly (quiesced DB, no races) ---
+    counters, had_failure = collect_counters(_ns(db_uri, apply=True))
+    assert had_failure is False
+    assert counters is not None
+    for key, dry_c in dry_run_counters.items():
+        applied_c = counters[key]
+        assert applied_c.scanned == dry_c.scanned, key
+        assert applied_c.redact == dry_c.redact, key
+        assert applied_c.truncate_only == dry_c.truncate_only, key
+        assert applied_c.skipped_concurrent == 0, key
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        for value in (
+            _fetch(session, SyncRunUnit, unit.id).error,
+            _fetch(session, SyncRun, run.id).error,
+            _fetch(session, SyncRunReferenceDiscovery, discovery.id).error,
+            _fetch(session, SyncDispatchOutbox, outbox.id).last_error,
+            _fetch(session, JobRun, job_run.id).error,
+            _fetch(session, JobRun, job_run.id).error_traceback,
+            _fetch(session, BackfillJob, backfill.id).error_message,
+            _fetch(session, SyncConfiguration, sync_config.id).last_sync_error,
+            _fetch(session, IntegrationCredential, cred.id).last_test_error,
+        ):
+            assert value is not None
+            assert REDACTION_MARKER in value
+            assert _LEAK_1 not in value
+
+        fetched_config = _fetch(session, SyncConfiguration, sync_config.id)
+        assert REDACTION_MARKER in fetched_config.last_sync_stats["error"]
+        assert _LEAK_2 not in fetched_config.last_sync_stats["error"]
+        assert fetched_config.last_sync_stats["phase"] == "dispatch_enqueue"
+        assert fetched_config.last_sync_stats["other"] == 1
+    engine.dispose()
+
+    # --- second apply: scrub-level idempotency, zero changes ---
+    counters, had_failure = collect_counters(_ns(db_uri, apply=True))
+    assert had_failure is False
+    assert counters is not None
+    for key, c in counters.items():
+        assert c.redact == 0, key
+        assert c.truncate_only == 0, key
+        assert c.skipped_concurrent == 0, key
+
+
+def test_run_scrub_error_text_cli_entrypoint_exit_code_and_report(tmp_path, capsys):
+    db_uri = _new_db(tmp_path)
+    org_id = _org()
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        _seed_sync_run(session, org_id=org_id, error=f"leak {_LEAK_3}")
+        session.commit()
+    engine.dispose()
+
+    rc = run_scrub_error_text(_ns(db_uri, apply=False))
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "sync_runs.error" in out
+    assert "would_redact" in out
+    assert "Dry-run: pass --apply" in out
+
+
+# ---------------------------------------------------------------------------
+# Clean-row classification + per-column caps
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_classifies_truncate_only_and_respects_per_column_caps(tmp_path):
+    db_uri = _new_db(tmp_path)
+    org_id = _org()
+
+    clean_short = "connection reset by peer while fetching page 3 of 10"
+    clean_at_default_cap = "z" * DEFAULT_MAX_ERROR_TEXT_LENGTH
+    clean_over_default_cap = "z" * (DEFAULT_MAX_ERROR_TEXT_LENGTH + 200)
+    clean_at_outbox_cap = "y" * _OUTBOX_MAX_ERROR_LENGTH
+    clean_over_outbox_cap = "y" * (_OUTBOX_MAX_ERROR_LENGTH + 100)
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        short_row = _seed_sync_run(session, org_id=org_id, error=clean_short)
+        at_cap_row = _seed_sync_run(session, org_id=org_id, error=clean_at_default_cap)
+        over_cap_row = _seed_sync_run(
+            session, org_id=org_id, error=clean_over_default_cap
+        )
+        outbox_at_cap = _seed_dispatch_outbox(
+            session, org_id=org_id, last_error=clean_at_outbox_cap
+        )
+        # Over the outbox's 2000 cap but well under the 4000 default -- this
+        # only truncates if the outbox's tighter cap is actually applied.
+        outbox_over_cap = _seed_dispatch_outbox(
+            session, org_id=org_id, last_error=clean_over_outbox_cap
+        )
+        session.commit()
+    engine.dispose()
+
+    counters, had_failure = collect_counters(_ns(db_uri, apply=True))
+    assert had_failure is False
+    assert counters is not None
+    sync_runs_c = counters[("sync_runs", "error")]
+    assert sync_runs_c.scanned == 3
+    assert sync_runs_c.redact == 0
+    assert sync_runs_c.truncate_only == 1
+
+    outbox_c = counters[("sync_dispatch_outbox", "last_error")]
+    assert outbox_c.scanned == 2
+    assert outbox_c.redact == 0
+    assert outbox_c.truncate_only == 1
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        assert _fetch(session, SyncRun, short_row.id).error == clean_short
+        assert _fetch(session, SyncRun, at_cap_row.id).error == clean_at_default_cap
+        over_cap_new = _fetch(session, SyncRun, over_cap_row.id).error
+        assert over_cap_new != clean_over_default_cap
+        assert len(over_cap_new) == DEFAULT_MAX_ERROR_TEXT_LENGTH
+        assert over_cap_new.endswith("...[truncated]")
+
+        assert (
+            _fetch(session, SyncDispatchOutbox, outbox_at_cap.id).last_error
+            == clean_at_outbox_cap
+        )
+        outbox_new = _fetch(session, SyncDispatchOutbox, outbox_over_cap.id).last_error
+        assert outbox_new != clean_over_outbox_cap
+        assert len(outbox_new) == _OUTBOX_MAX_ERROR_LENGTH
+        assert outbox_new.endswith("...[truncated]")
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# CAS races
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_text_column_cas_race_counts_skipped_concurrent(tmp_path):
+    db_uri = _new_db(tmp_path)
+    org_id = _org()
+    stale_dirty = f"push rejected using {_LEAK_3}"
+    concurrent_value = "RateLimitException: 403 rate limited -- [REDACTED]"
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        run = _seed_sync_run(session, org_id=org_id, error=stale_dirty)
+        session.commit()
+        row_id = run.id
+
+    # A concurrent (already-sanitized) write lands between our conceptual
+    # scan and our CAS update.
+    with Session(engine, expire_on_commit=False) as session:
+        session.execute(
+            update(SyncRun).where(SyncRun.id == row_id).values(error=concurrent_value)
+        )
+        session.commit()
+
+    table_spec = _table_spec(SyncRun)
+    col_spec = table_spec.columns[0]
+    counters = ColumnCounters()
+    with Session(engine, expire_on_commit=False) as session:
+        _process_text_column(
+            session,
+            table_spec,
+            col_spec,
+            row_id,
+            stale_dirty,
+            apply=True,
+            counters=counters,
+        )
+        session.commit()
+
+    assert counters.skipped_concurrent == 1
+    assert counters.redact == 0
+    assert counters.truncate_only == 0
+
+    with Session(engine, expire_on_commit=False) as session:
+        assert _fetch(session, SyncRun, row_id).error == concurrent_value
+    engine.dispose()
+
+
+def test_scrub_json_column_cas_race_counts_skipped_concurrent(tmp_path):
+    db_uri = _new_db(tmp_path)
+    org_id = _org()
+    stale_stats = {
+        "error": f"authorization=Bearer {_LEAK_4}",
+        "phase": "dispatch_enqueue",
+    }
+    concurrent_stats = {
+        "error": "already sanitized by a concurrent writer",
+        "phase": "dispatch_enqueue",
+    }
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        config = _seed_sync_configuration(
+            session, org_id=org_id, last_sync_stats=stale_stats
+        )
+        session.commit()
+        row_id = config.id
+        # Capture the raw-text witness the real scan step would have read,
+        # before the concurrent write below invalidates it.
+        stale_raw_text = session.execute(
+            select(cast(SyncConfiguration.last_sync_stats, Text)).where(
+                SyncConfiguration.id == row_id
+            )
+        ).scalar_one()
+
+    with Session(engine, expire_on_commit=False) as session:
+        session.execute(
+            update(SyncConfiguration)
+            .where(SyncConfiguration.id == row_id)
+            .values(last_sync_stats=concurrent_stats)
+        )
+        session.commit()
+
+    table_spec = _table_spec(SyncConfiguration)
+    col_spec = next(c for c in table_spec.columns if c.kind == KIND_JSON_ERROR_KEY)
+    counters = ColumnCounters()
+    with Session(engine, expire_on_commit=False) as session:
+        _process_json_error_key_column(
+            session,
+            table_spec,
+            col_spec,
+            row_id,
+            dict(stale_stats),
+            stale_raw_text,
+            apply=True,
+            counters=counters,
+        )
+        session.commit()
+
+    assert counters.skipped_concurrent == 1
+    assert counters.redact == 0
+
+    with Session(engine, expire_on_commit=False) as session:
+        assert (
+            _fetch(session, SyncConfiguration, row_id).last_sync_stats
+            == concurrent_stats
+        )
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# --org scoping
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_org_scoping_direct_column(tmp_path):
+    db_uri = _new_db(tmp_path)
+    org_a = _org()
+    org_b = _org()
+    dirty = f"push rejected using {_LEAK_1}"
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        row_a = _seed_sync_run(session, org_id=org_a, error=dirty)
+        row_b = _seed_sync_run(session, org_id=org_b, error=dirty)
+        session.commit()
+    engine.dispose()
+
+    counters, had_failure = collect_counters(_ns(db_uri, apply=True, org=org_a))
+    assert had_failure is False
+    assert counters is not None
+    c = counters[("sync_runs", "error")]
+    assert c.scanned == 1
+    assert c.redact == 1
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        assert _fetch(session, SyncRun, row_a.id).error != dirty
+        assert REDACTION_MARKER in _fetch(session, SyncRun, row_a.id).error
+        assert _fetch(session, SyncRun, row_b.id).error == dirty
+    engine.dispose()
+
+
+def test_scrub_org_scoping_job_runs_via_scheduled_jobs_join(tmp_path):
+    db_uri = _new_db(tmp_path)
+    org_a = _org()
+    org_b = _org()
+    dirty = f"push rejected using {_LEAK_1}"
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        job_a = _seed_scheduled_job(session, org_id=org_a)
+        job_b = _seed_scheduled_job(session, org_id=org_b)
+        run_a = _seed_job_run(session, job_id=job_a.id, error=dirty)
+        run_b = _seed_job_run(session, job_id=job_b.id, error=dirty)
+        session.commit()
+    engine.dispose()
+
+    counters, had_failure = collect_counters(_ns(db_uri, apply=True, org=org_a))
+    assert had_failure is False
+    assert counters is not None
+    c = counters[("job_runs", "error")]
+    assert c.scanned == 1
+    assert c.redact == 1
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        assert _fetch(session, JobRun, run_a.id).error != dirty
+        assert REDACTION_MARKER in _fetch(session, JobRun, run_a.id).error
+        assert _fetch(session, JobRun, run_b.id).error == dirty
+    engine.dispose()
+
+
+def test_scrub_org_id_env_var_does_not_silently_scope_without_explicit_flag(
+    tmp_path, monkeypatch
+):
+    """CHAOS-2780 codex HIGH: the root ``--org`` argument defaults to the
+    ``ORG_ID`` env var, so an operator who simply has ORG_ID exported in
+    their shell (ordinary env usage, not an explicit scope opt-in) must
+    still get an ALL-orgs scrub -- not a silent single-tenant one whose
+    "0 would-change" reads as a false whole-DB completion signal. Exercises
+    the REAL parsing path (``cli.build_parser`` + ``parser.parse_args`` +
+    ``cli._resolve_org``), not the test-only ``_ns()`` shortcut, since the
+    bug lives in that parsing layer."""
+    import dev_health_ops.cli as cli_module
+
+    db_uri = _new_db(tmp_path)
+    org_a = _org()
+    org_b = _org()
+    dirty = f"push rejected using {_LEAK_1}"
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        row_a = _seed_sync_run(session, org_id=org_a, error=dirty)
+        row_b = _seed_sync_run(session, org_id=org_b, error=dirty)
+        session.commit()
+    engine.dispose()
+
+    # The root --org default is captured at build_parser() call time, so
+    # ORG_ID must be set BEFORE building the parser -- exactly like a real
+    # shell export would be in place before the process starts.
+    monkeypatch.setenv("ORG_ID", org_a)
+    parser = cli_module.build_parser()
+
+    argv_no_flag = [
+        "maintenance",
+        "scrub-error-text",
+        "--apply",
+        "--db",
+        db_uri,
+    ]
+    ns = parser.parse_args(argv_no_flag)
+    cli_module._resolve_org(ns)
+    assert ns.org_explicit is False
+    assert ns.org == org_a  # env fallback still resolves normally...
+
+    counters, had_failure = collect_counters(ns)
+    assert had_failure is False
+    assert counters is not None
+    c = counters[("sync_runs", "error")]
+    # ...but BOTH orgs' rows were scanned/scrubbed -- the env value never
+    # scoped the run.
+    assert c.scanned == 2
+    assert c.redact == 2
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        assert REDACTION_MARKER in _fetch(session, SyncRun, row_a.id).error
+        assert REDACTION_MARKER in _fetch(session, SyncRun, row_b.id).error
+    engine.dispose()
+
+
+@pytest.mark.parametrize(
+    ("label", "make_argv"),
+    [
+        (
+            "long form after subcommand",
+            lambda db_uri, org: [
+                "maintenance",
+                "scrub-error-text",
+                "--apply",
+                "--db",
+                db_uri,
+                "--org",
+                org,
+            ],
+        ),
+        (
+            "long form before subcommand",
+            lambda db_uri, org: [
+                "--org",
+                org,
+                "maintenance",
+                "scrub-error-text",
+                "--apply",
+                "--db",
+                db_uri,
+            ],
+        ),
+        (
+            "equals-joined form",
+            lambda db_uri, org: [
+                "maintenance",
+                "scrub-error-text",
+                "--apply",
+                "--db",
+                db_uri,
+                f"--org={org}",
+            ],
+        ),
+        (
+            # CHAOS-2780 codex HIGH round 2: argparse's allow_abbrev=True
+            # default means an unambiguous PREFIX of --org also counts as
+            # explicit. A prior fix that scanned raw argv for the literal
+            # "--org" token missed this -- misclassifying an operator's
+            # intentionally-scoped --apply as "no flag" and silently
+            # widening it to ALL orgs, the inverse (and more dangerous)
+            # failure vs. the original ORG_ID-env-leak bug.
+            "abbreviated form after subcommand",
+            lambda db_uri, org: [
+                "maintenance",
+                "scrub-error-text",
+                "--apply",
+                "--db",
+                db_uri,
+                "--or",
+                org,
+            ],
+        ),
+        (
+            "abbreviated form before subcommand",
+            lambda db_uri, org: [
+                "--or",
+                org,
+                "maintenance",
+                "scrub-error-text",
+                "--apply",
+                "--db",
+                db_uri,
+            ],
+        ),
+        (
+            "abbreviated equals-joined form",
+            lambda db_uri, org: [
+                "maintenance",
+                "scrub-error-text",
+                "--apply",
+                "--db",
+                db_uri,
+                f"--or={org}",
+            ],
+        ),
+    ],
+)
+def test_scrub_every_org_flag_form_scopes_explicitly_even_with_org_id_env_set(
+    tmp_path, monkeypatch, label, make_argv
+):
+    """Companion to the test above, parametrized over every form argparse
+    recognizes as --org: an ACTUALLY-typed --org (long, `=`-joined, or an
+    unambiguous abbreviation, before or after the subcommand) must scope the
+    run to that org, regardless of what ORG_ID happens to be set to."""
+    import dev_health_ops.cli as cli_module
+
+    db_uri = _new_db(tmp_path)
+    org_a = _org()
+    org_b = _org()
+    dirty = f"push rejected using {_LEAK_1}"
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        row_a = _seed_sync_run(session, org_id=org_a, error=dirty)
+        row_b = _seed_sync_run(session, org_id=org_b, error=dirty)
+        session.commit()
+    engine.dispose()
+
+    monkeypatch.setenv("ORG_ID", org_b)
+    parser = cli_module.build_parser()
+    argv_explicit = make_argv(db_uri, org_a)
+
+    ns = parser.parse_args(argv_explicit)
+    cli_module._resolve_org(ns)
+    assert ns.org_explicit is True, label
+    assert ns.org == org_a, label
+
+    counters, had_failure = collect_counters(ns)
+    assert had_failure is False, label
+    assert counters is not None
+    c = counters[("sync_runs", "error")]
+    assert c.scanned == 1, label
+    assert c.redact == 1, label
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        assert REDACTION_MARKER in _fetch(session, SyncRun, row_a.id).error, label
+        assert _fetch(session, SyncRun, row_b.id).error == dirty, label
+    engine.dispose()
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        assert REDACTION_MARKER in _fetch(session, SyncRun, row_a.id).error
+        assert _fetch(session, SyncRun, row_b.id).error == dirty
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# JSON sibling-key preservation / non-string 'error' handling
+# ---------------------------------------------------------------------------
+
+
+def test_scrub_json_error_key_preserves_siblings_and_skips_non_string_or_missing(
+    tmp_path,
+):
+    db_uri = _new_db(tmp_path)
+    org_id = _org()
+    dirty_json_error = f"authorization=Bearer {_LEAK_4}"
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        with_error = _seed_sync_configuration(
+            session,
+            org_id=org_id,
+            last_sync_stats={
+                "error": dirty_json_error,
+                "phase": "dispatch_enqueue",
+                "other": 1,
+            },
+        )
+        non_string_error = _seed_sync_configuration(
+            session,
+            org_id=org_id,
+            last_sync_stats={"error": 12345, "phase": "structured"},
+        )
+        no_error_key = _seed_sync_configuration(
+            session,
+            org_id=org_id,
+            last_sync_stats={"phase": "ok", "count": 3},
+        )
+        session.commit()
+    engine.dispose()
+
+    counters, had_failure = collect_counters(_ns(db_uri, apply=True))
+    assert had_failure is False
+    assert counters is not None
+    c = counters[("sync_configurations", "last_sync_stats")]
+    assert c.scanned == 3
+    assert c.redact == 1
+    assert c.truncate_only == 0
+
+    engine = create_engine(db_uri)
+    with Session(engine, expire_on_commit=False) as session:
+        redacted = _fetch(session, SyncConfiguration, with_error.id).last_sync_stats
+        assert REDACTION_MARKER in redacted["error"]
+        assert _LEAK_4 not in redacted["error"]
+        assert redacted["phase"] == "dispatch_enqueue"
+        assert redacted["other"] == 1
+
+        assert _fetch(
+            session, SyncConfiguration, non_string_error.id
+        ).last_sync_stats == {
+            "error": 12345,
+            "phase": "structured",
+        }
+        assert _fetch(session, SyncConfiguration, no_error_key.id).last_sync_stats == {
+            "phase": "ok",
+            "count": 3,
+        }
+    engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# No database configured
+# ---------------------------------------------------------------------------
+
+
+def test_run_scrub_error_text_fails_fast_without_db_uri(monkeypatch):
+    monkeypatch.delenv("POSTGRES_URI", raising=False)
+    monkeypatch.delenv("DATABASE_URI", raising=False)
+    rc = run_scrub_error_text(_ns("", apply=False))
+    assert rc == 1

--- a/tests/test_migrate_commands.py
+++ b/tests/test_migrate_commands.py
@@ -7,7 +7,7 @@ from unittest.mock import MagicMock, patch
 
 import pytest
 
-from dev_health_ops.cli import _should_resolve_org, build_parser
+from dev_health_ops.cli import _resolve_org, _should_resolve_org, build_parser
 from dev_health_ops.migrate import (
     _run_clickhouse_repair,
     _run_clickhouse_status,
@@ -96,8 +96,10 @@ class TestMigrateRouting:
                 "repair",
             ]
         )
+        _resolve_org(ns)
 
         assert ns.org == "root-org"
+        assert ns.org_explicit is True
         assert not _should_resolve_org(ns)
 
     def test_repair_leaf_org_flag_scopes_repair(self):
@@ -110,20 +112,31 @@ class TestMigrateRouting:
                 "leaf-org",
             ]
         )
+        _resolve_org(ns)
 
         assert ns.org == "leaf-org"
+        assert ns.org_explicit is True
         assert not _should_resolve_org(ns)
 
     def test_repair_without_org_does_not_auto_resolve_first_org(self):
         ns = self.parser.parse_args(["migrate", "clickhouse", "repair"])
+        # Namespaces built via build_parser().parse_args() directly (not
+        # cli.main()) hold the raw _ORG_UNSET sentinel in ns.org until
+        # _resolve_org runs -- mirrors what main() does immediately after
+        # parse_args(), before any code (including _should_resolve_org)
+        # reads ns.org.
+        _resolve_org(ns)
 
         assert getattr(ns, "org", None) is None
+        assert ns.org_explicit is False
         assert not _should_resolve_org(ns)
 
     def test_non_repair_command_without_org_still_auto_resolves(self):
         ns = self.parser.parse_args(["migrate", "clickhouse", "status"])
+        _resolve_org(ns)
 
         assert getattr(ns, "org", None) is None
+        assert ns.org_explicit is False
         assert _should_resolve_org(ns)
 
     def test_upgrade_flat_defaults_to_head(self):

--- a/tests/test_reference_discovery_stage.py
+++ b/tests/test_reference_discovery_stage.py
@@ -460,7 +460,7 @@ def test_reference_discovery_failure_sanitizes_credential_material(
     """Mirrors CHAOS-2758's live-verify case B for the reference-discovery
     ledger's error text (CHAOS-2766): a provider exception whose message
     embeds an Authorization header must not persist the raw credential to
-    ``sync_run_reference_discovery.error``, ``sync_run_units.error``,
+    ``sync_run_reference_discoveries.error``, ``sync_run_units.error``,
     ``sync_runs.error``, or the task's own returned ``error`` field -- every
     one of those is populated from this same exception."""
 


### PR DESCRIPTION
## Summary

Follow-up to CHAOS-2766/#1123: that PR sanitized every WRITE path into the legacy free-form error-text columns, but rows persisted *before* it shipped kept their raw text at rest — the wave-2 live gate showed real `Authorization` headers sitting in `sync_run_units.error`.

- New `dev-hops maintenance scrub-error-text` command: dry-run by default, `--apply`/`--org`/`--batch-size`, applies the existing `sanitize_error_text` helper (unchanged — no pattern changes) to already-persisted rows across a **10-column registry keyed by SQLAlchemy model classes** (never table-name strings, so the ticket's own `sync_run_reference_discovery` singular/plural typo is structurally impossible to reproduce): `sync_run_units.error`, `sync_runs.error`, `sync_run_reference_discoveries.error`, `sync_dispatch_outbox.last_error` (2000-char cap, matching its write path), `job_runs.error` + `job_runs.error_traceback` (org-scoped via a `scheduled_jobs` join — `job_runs` has no `org_id` column), `backfill_jobs.error_message`, `sync_configurations.last_sync_error`, `sync_configurations.last_sync_stats`'s JSON `'error'` key (sibling keys preserved), and `integration_credentials.last_test_error`.
- Keyset pagination on the UUID PK, per-batch commit, and compare-and-swap updates (`WHERE id = :id AND col = :old`, or a `col::text = :raw_text` cast for the JSON entry) so a row rewritten by live sync between scan and update is left alone (counted `skipped_concurrent`, never retried).
- Every changed row is counted as `redact` (a credential-shaped pattern was found) or `truncate_only` (already clean, just over the column's length cap) — kept separate so "N rows would change" never misleadingly reads as "N secrets found."
- **Write-path fix** (codex HIGH from the converged plan): `integration_credentials.last_test_error` — errors from testing the credential itself, republished verbatim via admin API responses and sync-preflight HTTP details — was the one CHAOS-2766 sink left uncovered. `IntegrationCredentialsService.update_test_result` now sanitizes at the setter.
- Docs: `rate-limit-policy.md`'s "Pre-existing rows" section now points at the command; fixed the `sync_run_reference_discovery`→`discoveries` typo there and in `error_sanitize.py`'s module docstring.

### Codex review fixes

**Round 1:**
- **HIGH — ORG_ID env-var scoping ambiguity.** The root `--org` argument defaults to the `ORG_ID` env var, so an operator running `scrub-error-text --apply` with `ORG_ID` merely exported (ordinary env usage, not an explicit scope) would have had the scrub silently narrow to one tenant while its own output implied an environment-wide cleanup — and a zero-change rerun became a false whole-DB completion signal. The report now also prints the resolved scope (`Org scope: org=X` / `Org scope: ALL organizations`) for operator clarity.
- **HIGH — response-body leak in `/credentials/test`.** The persisted `last_test_error` was sanitized, but `TestConnectionResponse.error` still returned the raw exception message straight to the HTTP caller. Also checked (per review) the provider test helpers for other error-bearing fields and found the same gap in all four (`_test_github_connection`, `_test_gitlab_connection`, `_test_jira_connection`, `_test_linear_connection`): each echoes up to 200 raw chars of the external provider's HTTP response body into `details['error']`, unsanitized. Fixed all five sites, sanitizing the *full* body before truncating to 200 chars (not the reverse).

**Round 2:**
- **HIGH — the round-1 ORG_ID fix itself had a gap.** It scanned raw argv for the literal `--org`/`--org=` tokens, but argparse's `allow_abbrev=True` default means an unambiguous prefix like `--or` (or even `--o`, unambiguous on this parser) also populates `ns.org` — the argv scan missed that, misclassifying an operator's **intentionally-scoped** `--apply --or my-org` as "no flag" and silently widening it to **ALL orgs**. That's the inverse of the round-1 bug, and destructive rather than merely confusing.
  - Fixed per codex's preferred structural approach: the root `--org` argument now defaults to a module-level sentinel (`_ORG_UNSET`) instead of `os.getenv("ORG_ID")` directly. `cli._resolve_org(ns)` determines explicitness by comparing the parsed value against the sentinel **by identity** — since argparse itself resolves abbreviations before any action fires, this is correct for every form it recognizes (long, `=`-joined, or any unambiguous abbreviation, before or after the subcommand) without re-implementing argv parsing. Verified empirically with a standalone argparse repro before implementing.
  - An audit found 3 pre-existing tests reading `ns.org` directly off `build_parser().parse_args()` without going through the resolver (2 in `test_migrate_commands.py`, 1 in this PR's own new test) — updated all three to call `_resolve_org(ns)` first, matching what `cli.main()` now does.

## Test plan

- [x] `tests/test_maintenance_scrub_error_text.py` (17 tests) — full dry-run→apply→second-apply(=0) lifecycle across all 10 columns, DB byte-identity during dry-run, redact-vs-truncate_only classification incl. the outbox's distinct 2000-char cap, CAS-race handling for both text and JSON columns, `--org` scoping (direct column + `job_runs`→`scheduled_jobs` join), JSON sibling-key preservation / non-string-`'error'` skip, CLI entrypoint exit code + report format, a no-DB-configured failure path, the ORG_ID-env-var regression test, and a **6-way parametrized test covering every `--org` flag form** (long/`=`-joined/abbreviated × before/after the subcommand) — all exercised through the real `build_parser()`/`parse_args()`/`_resolve_org` path.
- [x] `tests/test_migrate_commands.py` — updated the 4 existing `--org`-related tests to call `_resolve_org(ns)` (matching the new contract for direct-`parse_args()` callers).
- [x] `tests/test_integration_credential_error_sanitize.py` (4 tests) — write-path sanitization, success clears error, admin serializer pass-through, scrub covers a pre-existing (legacy) dirty row.
- [x] `tests/test_admin_credentials.py` — route-level test mocking a provider test that raises a secret-bearing exception, asserting both the HTTP response body and the persisted `last_test_error` are redacted (and identical); helper-level test mocking a raw HTTP response body on `_test_gitlab_connection`, asserting `details['error']` is redacted.
- [x] Appended a `sanitize(sanitize(x)) == sanitize(x)` idempotency property test to `tests/test_error_sanitize.py` (append-only — no existing content touched).
- [x] Full CI-parity gate (`ci/local_validate.sh`, `SCRATCH_DB=ci_local_validate_2780`): ruff format/check, mypy, **6391 passed / 44 skipped** (full unit suite), live-ClickHouse argMax proof — all green.
- [x] `gitleaks detect --log-opts="origin/main..HEAD"` on the single squashed commit: no leaks found.
- [x] Live-verify on the dev stack (`.venv/bin/dev-hops`, real Postgres, real UUID/`json` types):
  - Baseline (`psql`, broad leak-signature search across `Authorization`/`Bearer`/PAT-prefixes/`private_token`/`api_key`/URL-userinfo): **0 dirty rows** across all 10 columns — the wave-2 leak rows this ticket cites have already been overwritten by CHAOS-2766's write-path fix (`sync_run_units` is written continuously by live sync).
  - Dry-run against live Postgres: scanned **3621** real non-null values across all 10 columns, `0 would_redact / 0 would_truncate_only` everywhere — confirms no false positives and full schema/type compatibility with the real engine.
  - `--apply` against the shared dev DB was **blocked by the harness's safety classifier** (requires direct human authorization, not a relayed instruction) — not executed, not routed around. The `--apply`/CAS/redaction/idempotency/JSON-sibling-key/org-scoping semantics are fully exercised by the unit suite instead (all green above). A follow-up human-run `--apply` on dev is recommended to close this last leg, though given baseline=0 it's expected to be a no-op.
  - Full log: `/tmp/claude/chaos-2780-live-verify.log` (on the implementing host).

## Coordination note

impl-2784 is fixing the other legacy sinks (`report_runs`/`sso_providers`/`audit_logs`) on a parallel branch and did not touch this PR's files.