### PR TITLE
fix(work-graph): derive Linear attachment issue PR edges

### DIFF
--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -211,6 +211,41 @@ class WorkGraphBuilder:
             return Provenance.NATIVE
         return Provenance.NATIVE
 
+    @staticmethod
+    def _parse_pr_dependency_source(value: object) -> tuple[str, int, str] | None:
+        source = str(value or "")
+        if source.startswith("ghpr:"):
+            body = source.removeprefix("ghpr:")
+            separator = "#"
+            provider = "github"
+        elif source.startswith("gitlab:"):
+            body = source.removeprefix("gitlab:")
+            separator = "!"
+            provider = "gitlab"
+        else:
+            return None
+
+        if separator not in body:
+            return None
+        repo_slug, number = body.rsplit(separator, 1)
+        if not repo_slug or not number.isdigit():
+            return None
+        pr_number = int(number)
+        if pr_number <= 0:
+            return None
+        return repo_slug, pr_number, provider
+
+    def _row_org_id(self, row: dict[str, object]) -> str:
+        return str(row.get("org_id") or self.config.org_id or "")
+
+    def _is_linear_pr_attachment_dependency(self, row: dict[str, object]) -> bool:
+        return (
+            str(row.get("relationship_type_raw") or "") == "linear_attachment"
+            and str(row.get("target_work_item_id") or "").startswith("linear:")
+            and self._parse_pr_dependency_source(row.get("source_work_item_id"))
+            is not None
+        )
+
     def add_release_node(
         self,
         release_ref: str,
@@ -381,8 +416,12 @@ class WorkGraphBuilder:
 
         logger.info("Starting work graph build...")
 
+        self._delete_stale_pr_dependency_issue_edges()
+
         # 1. Build issue->issue edges from work_item_dependencies
         stats["issue_issue_edges"] = self._build_issue_issue_edges()
+
+        self._derive_issue_pr_links_from_dependencies()
 
         # 2. Build issue->PR edges from existing fast-path table (prerequisite)
         issue_pr_existing, stats["issue_pr_edges"] = (
@@ -542,6 +581,190 @@ class WorkGraphBuilder:
         )
         return len(edges)
 
+    def _derive_issue_pr_links_from_dependencies(self) -> int:
+        if not self.config.org_id:
+            return 0
+
+        dependency_query = """
+        SELECT
+            org_id,
+            source_work_item_id,
+            target_work_item_id,
+            relationship_type_raw,
+            last_synced
+        FROM work_item_dependencies FINAL
+        WHERE 1=1
+        """
+        org_id_clause = self._org_id_clause()
+        if org_id_clause:
+            dependency_query += f" {org_id_clause}"
+
+        repo_query = """
+        SELECT org_id, id, repo
+        FROM repos FINAL
+        WHERE 1=1
+        """
+        if org_id_clause:
+            repo_query += f" {org_id_clause}"
+
+        pr_query = """
+        SELECT org_id, repo_id, number, created_at
+        FROM git_pull_requests FINAL
+        WHERE 1=1
+        """
+        if org_id_clause:
+            pr_query += f" {org_id_clause}"
+        if self.config.from_date:
+            pr_query += f" AND created_at >= '{_format_datetime_for_clickhouse(self.config.from_date)}'"
+        if self.config.to_date:
+            pr_query += f" AND created_at <= '{_format_datetime_for_clickhouse(self.config.to_date)}'"
+        if self.config.repo_id:
+            pr_query += f" AND repo_id = '{self.config.repo_id}'"
+
+        work_item_query = """
+        SELECT org_id, work_item_id
+        FROM work_items FINAL
+        WHERE 1=1
+        """
+        if org_id_clause:
+            work_item_query += f" {org_id_clause}"
+
+        dependency_rows = self.sink.query_dicts(dependency_query, {})
+        if not dependency_rows:
+            return 0
+
+        repo_rows = self.sink.query_dicts(repo_query, {})
+        pr_rows = self.sink.query_dicts(pr_query, {})
+        work_item_rows = self.sink.query_dicts(work_item_query, {})
+
+        repo_lookup: dict[tuple[str, str], uuid.UUID] = {}
+        for row in repo_rows:
+            repo_slug = str(row.get("repo") or "")
+            repo_id = row.get("id")
+            if not repo_slug or not repo_id:
+                continue
+            try:
+                repo_uuid = (
+                    repo_id
+                    if isinstance(repo_id, uuid.UUID)
+                    else uuid.UUID(str(repo_id))
+                )
+            except ValueError:
+                continue
+            repo_lookup[(self._row_org_id(row), repo_slug)] = repo_uuid
+
+        pr_lookup: dict[tuple[str, uuid.UUID, int], object] = {}
+        for row in pr_rows:
+            repo_id = row.get("repo_id")
+            pr_number = row.get("number")
+            if repo_id is None or pr_number is None:
+                continue
+            try:
+                repo_uuid = (
+                    repo_id
+                    if isinstance(repo_id, uuid.UUID)
+                    else uuid.UUID(str(repo_id))
+                )
+                pr_number_int = int(pr_number)
+            except (TypeError, ValueError):
+                continue
+            pr_lookup[(self._row_org_id(row), repo_uuid, pr_number_int)] = row.get(
+                "created_at"
+            )
+
+        valid_work_items = {
+            (self._row_org_id(row), str(row.get("work_item_id")))
+            for row in work_item_rows
+            if row.get("work_item_id")
+        }
+
+        links: list[WorkGraphIssuePR] = []
+        seen: set[tuple[str, uuid.UUID, int]] = set()
+        for row in dependency_rows:
+            if not self._is_linear_pr_attachment_dependency(row):
+                continue
+            parsed = self._parse_pr_dependency_source(row.get("source_work_item_id"))
+            if not parsed:
+                continue
+            target_work_item_id = str(row.get("target_work_item_id") or "")
+            if not target_work_item_id:
+                continue
+
+            org_id = self._row_org_id(row)
+            if (org_id, target_work_item_id) not in valid_work_items:
+                continue
+
+            repo_slug, pr_number, provider = parsed
+            repo_id = repo_lookup.get((org_id, repo_slug))
+            if not repo_id:
+                continue
+            if (org_id, repo_id, pr_number) not in pr_lookup:
+                continue
+
+            identity = (target_work_item_id, repo_id, pr_number)
+            if identity in seen:
+                continue
+            seen.add(identity)
+
+            last_synced = row.get("last_synced") or self._now
+            if isinstance(last_synced, str):
+                try:
+                    last_synced = datetime.fromisoformat(
+                        last_synced.replace("Z", "+00:00")
+                    )
+                except ValueError:
+                    last_synced = self._now
+            if not isinstance(last_synced, datetime):
+                last_synced = self._now
+            if last_synced.tzinfo is None:
+                last_synced = last_synced.replace(tzinfo=timezone.utc)
+
+            links.append(
+                WorkGraphIssuePR(
+                    repo_id=repo_id,
+                    work_item_id=target_work_item_id,
+                    pr_number=pr_number,
+                    confidence=1.0,
+                    provenance=Provenance.NATIVE,
+                    evidence=str(
+                        row.get("relationship_type_raw") or f"{provider}_attachment"
+                    ),
+                    last_synced=last_synced,
+                )
+            )
+
+        self._write_issue_pr_links(links)
+        logger.info(
+            "Derived %d issue->PR links from work_item_dependencies", len(links)
+        )
+        return len(links)
+
+    def _delete_stale_pr_dependency_issue_edges(self) -> None:
+        if not self.config.org_id:
+            return
+        command = getattr(getattr(self.sink, "client", None), "command", None)
+        if not callable(command):
+            return
+
+        where_parts = [
+            "source_type = 'issue'",
+            "target_type = 'issue'",
+            "evidence = 'linear_attachment'",
+            "startsWith(target_id, 'linear:')",
+            "(startsWith(source_id, 'ghpr:') OR startsWith(source_id, 'gitlab:'))",
+        ]
+        params: dict[str, str] = {}
+        if self.config.org_id:
+            where_parts.append("org_id = {org_id:String}")
+            params["org_id"] = self.config.org_id
+
+        command(
+            "ALTER TABLE work_graph_edges DELETE WHERE "
+            + " AND ".join(where_parts)
+            + " SETTINGS mutations_sync=2",
+            parameters=params or None,
+        )
+
     def _build_issue_issue_edges(self) -> int:
         """
         Build edges from work_item_dependencies.
@@ -580,6 +803,10 @@ class WorkGraphBuilder:
             last_synced = row.get("last_synced")
 
             if not source_id or not target_id:
+                continue
+            if self._parse_pr_dependency_source(
+                source_id
+            ) or self._parse_pr_dependency_source(target_id):
                 continue
 
             # Map relationship type to EdgeType
@@ -1396,8 +1623,12 @@ class WorkGraphBuilder:
             p.evidence,
             p.last_synced,
             pr.created_at
-        FROM work_graph_issue_pr AS p
-        INNER JOIN git_pull_requests AS pr ON (toString(p.repo_id) = toString(pr.repo_id) AND p.pr_number = pr.number)
+        FROM work_graph_issue_pr AS p FINAL
+        INNER JOIN git_pull_requests AS pr FINAL ON (
+            toString(p.repo_id) = toString(pr.repo_id)
+            AND p.pr_number = pr.number
+            AND toString(p.org_id) = toString(pr.org_id)
+        )
         """
         where_parts: list[str] = []
         if self.config.repo_id:
@@ -1658,8 +1889,8 @@ class WorkGraphBuilder:
             p.evidence,
             p.last_synced,
             c.author_when
-        FROM work_graph_pr_commit AS p
-        INNER JOIN git_commits AS c ON (
+        FROM work_graph_pr_commit AS p FINAL
+        INNER JOIN git_commits AS c FINAL ON (
             toString(p.repo_id) = toString(c.repo_id)
             AND p.commit_hash = c.hash
             AND toString(p.org_id) = toString(c.org_id)

--- a/tests/work_graph/test_builder.py
+++ b/tests/work_graph/test_builder.py
@@ -87,6 +87,221 @@ class TestWorkGraphBuilder:
             fake_sink.close.assert_called_once()
 
 
+class TestDependencyIssuePrLinks:
+    def test_linear_attachment_derives_issue_pr_fast_path_link(self):
+        repo_id = uuid.uuid4()
+        synced_at = datetime(2026, 7, 1, 12, 0, tzinfo=timezone.utc)
+
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.write_work_graph_issue_pr = MagicMock()
+
+        def mock_query(query, params):
+            if "work_item_dependencies" in query:
+                return [
+                    {
+                        "org_id": "org-a",
+                        "source_work_item_id": "ghpr:full-chaos/dev-health-ops#968",
+                        "target_work_item_id": "linear:CHAOS-2400",
+                        "relationship_type_raw": "linear_attachment",
+                        "last_synced": synced_at,
+                    }
+                ]
+            if "FROM repos" in query:
+                return [
+                    {
+                        "org_id": "org-a",
+                        "id": repo_id,
+                        "repo": "full-chaos/dev-health-ops",
+                    }
+                ]
+            if "git_pull_requests" in query:
+                return [
+                    {
+                        "org_id": "org-a",
+                        "repo_id": repo_id,
+                        "number": 968,
+                        "created_at": synced_at,
+                    }
+                ]
+            if "work_items" in query:
+                return [{"org_id": "org-a", "work_item_id": "linear:CHAOS-2400"}]
+            return []
+
+        fake_sink.query_dicts.side_effect = mock_query
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default", org_id="org-a")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_issue_pr_links_from_dependencies()
+            builder.close()
+
+        assert count == 1
+        records = fake_sink.write_work_graph_issue_pr.call_args[0][0]
+        assert len(records) == 1
+        record = records[0]
+        assert record.repo_id == repo_id
+        assert record.work_item_id == "linear:CHAOS-2400"
+        assert record.pr_number == 968
+        assert record.provenance == "native"
+        assert record.confidence == 1.0
+        assert record.evidence == "linear_attachment"
+        assert record.org_id == "org-a"
+
+    def test_pr_attachment_dependency_is_not_written_as_issue_issue_edge(self):
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.write_work_graph_edges = MagicMock()
+        fake_sink.query_dicts.return_value = [
+            {
+                "source_work_item_id": "ghpr:full-chaos/dev-health-ops#968",
+                "target_work_item_id": "linear:CHAOS-2400",
+                "relationship_type": "relates_to",
+                "relationship_type_raw": "linear_attachment",
+                "last_synced": datetime(2026, 7, 1, tzinfo=timezone.utc),
+            }
+        ]
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._build_issue_issue_edges()
+            builder.close()
+
+        assert count == 0
+        fake_sink.write_work_graph_edges.assert_not_called()
+
+    def test_regular_dependency_still_writes_issue_issue_edge(self):
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.write_work_graph_edges = MagicMock()
+        fake_sink.query_dicts.return_value = [
+            {
+                "source_work_item_id": "linear:CHAOS-2400",
+                "target_work_item_id": "linear:CHAOS-2401",
+                "relationship_type": "blocks",
+                "relationship_type_raw": "blocks",
+                "last_synced": datetime(2026, 7, 1, tzinfo=timezone.utc),
+            }
+        ]
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._build_issue_issue_edges()
+            builder.close()
+
+        assert count == 1
+        fake_sink.write_work_graph_edges.assert_called_once()
+        edge = fake_sink.write_work_graph_edges.call_args[0][0][0]
+        assert edge.source_type == "issue"
+        assert edge.source_id == "linear:CHAOS-2400"
+        assert edge.target_type == "issue"
+        assert edge.target_id == "linear:CHAOS-2401"
+        assert edge.edge_type == "blocks"
+
+    def test_stale_pr_dependency_issue_edge_cleanup_is_scoped(self):
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.client = MagicMock()
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default", org_id="org-a")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            builder._delete_stale_pr_dependency_issue_edges()
+            builder.close()
+
+        sql = fake_sink.client.command.call_args.args[0]
+        params = fake_sink.client.command.call_args.kwargs["parameters"]
+        assert "ALTER TABLE work_graph_edges DELETE WHERE" in sql
+        assert "source_type = 'issue'" in sql
+        assert "target_type = 'issue'" in sql
+        assert "evidence = 'linear_attachment'" in sql
+        assert "github_comment_linear_url" not in sql
+        assert "startsWith(source_id, 'ghpr:')" in sql
+        assert "startsWith(source_id, 'gitlab:')" in sql
+        assert "startsWith(target_id, 'linear:')" in sql
+        assert "org_id = {org_id:String}" in sql
+        assert params == {"org_id": "org-a"}
+
+    def test_generic_pr_shaped_dependency_does_not_derive_issue_pr_link(self):
+        repo_id = uuid.uuid4()
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.write_work_graph_issue_pr = MagicMock()
+
+        def mock_query(query, params):
+            if "work_item_dependencies" in query:
+                return [
+                    {
+                        "org_id": "org-a",
+                        "source_work_item_id": "ghpr:full-chaos/dev-health-ops#10",
+                        "target_work_item_id": "gh:full-chaos/dev-health-ops#123",
+                        "relationship_type_raw": "blocks",
+                        "last_synced": datetime(2026, 7, 1, tzinfo=timezone.utc),
+                    }
+                ]
+            if "FROM repos" in query:
+                return [
+                    {
+                        "org_id": "org-a",
+                        "id": repo_id,
+                        "repo": "full-chaos/dev-health-ops",
+                    }
+                ]
+            if "git_pull_requests" in query:
+                return [{"org_id": "org-a", "repo_id": repo_id, "number": 10}]
+            if "work_items" in query:
+                return [
+                    {
+                        "org_id": "org-a",
+                        "work_item_id": "gh:full-chaos/dev-health-ops#123",
+                    }
+                ]
+            return []
+
+        fake_sink.query_dicts.side_effect = mock_query
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default", org_id="org-a")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_issue_pr_links_from_dependencies()
+            builder.close()
+
+        assert count == 0
+        fake_sink.write_work_graph_issue_pr.assert_not_called()
+
+    def test_dependency_derivation_skips_unscoped_builds(self):
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.query_dicts = MagicMock()
+        fake_sink.write_work_graph_issue_pr = MagicMock()
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            count = builder._derive_issue_pr_links_from_dependencies()
+            builder._delete_stale_pr_dependency_issue_edges()
+            builder.close()
+
+        assert count == 0
+        fake_sink.query_dicts.assert_not_called()
+        fake_sink.write_work_graph_issue_pr.assert_not_called()
+        fake_sink.client.command.assert_not_called()
+
+
 class TestHeuristicMatching:
     """Tests for heuristic issue->PR matching with binary search optimization."""
 
@@ -707,7 +922,36 @@ class TestFastPathTenantIsolation:
         normalized = " ".join(sql.split())
         # Both join sides must be org-scoped together.
         assert "toString(p.org_id) = toString(c.org_id)" in normalized
+        assert "work_graph_pr_commit AS p FINAL" in normalized
+        assert "git_commits AS c FINAL" in normalized
         # The selected org is still pinned via the WHERE filter.
+        assert "p.org_id = 'org-a'" in normalized
+
+    def test_issue_pr_fast_path_uses_final_and_scopes_prs_by_org(self):
+        captured: dict[str, str] = {}
+
+        def mock_query(query, params):
+            if "work_graph_issue_pr AS p" in query:
+                captured["query"] = query
+            return []
+
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+        fake_sink.query_dicts.side_effect = mock_query
+
+        config = BuildConfig(dsn="clickhouse://localhost:9000/default", org_id="org-a")
+        with patch(
+            "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+        ):
+            builder = WorkGraphBuilder(config)
+            builder._build_issue_pr_edges_from_fast_path()
+            builder.close()
+
+        sql = captured["query"]
+        normalized = " ".join(sql.split())
+        assert "work_graph_issue_pr AS p FINAL" in normalized
+        assert "git_pull_requests AS pr FINAL" in normalized
+        assert "toString(p.org_id) = toString(pr.org_id)" in normalized
         assert "p.org_id = 'org-a'" in normalized
 
     def test_cross_tenant_commit_collision_is_excluded(self):


### PR DESCRIPTION
## Summary
- derive `work_graph_issue_pr` rows from trusted Linear attachment dependencies (`ghpr:` / `gitlab:` sources linked to `linear:` targets)
- skip PR-shaped Linear attachment dependencies when building issue-to-issue graph edges
- scope derivation and stale-edge cleanup by org, and use `FINAL`/org-equality joins in fast-path graph reads
- add regression coverage for derivation, stale cleanup, generic PR-shaped dependency skips, unscoped skips, and fast-path SQL guards

## Linear
- Fix issue: https://linear.app/fullchaos/issue/CHAOS-2821/fix-linear-attachment-pr-links-in-work-graph
- Follow-up: https://linear.app/fullchaos/issue/CHAOS-2820/unify-sync-entrypoints-and-coverage-cursor-semantics

## Validation
- `python -m ruff check src/dev_health_ops/work_graph/builder.py tests/work_graph/test_builder.py`
- `.venv/bin/python -m pytest tests/work_graph/test_builder.py -q`
- `bash ci/local_validate.sh`
- live CLI smoke: `AUTO_RUN_MIGRATIONS=false SENTRY_DSN= .venv/bin/python -m dev_health_ops.cli work-graph build --org 70d529e0-3c06-4597-8480-794fd02328b6 --db clickhouse://ch:ch@localhost:8123/default --from 2025-10-01 --to=$(date -I)`

SCREENSHOT-WAIVER: backend-only work-graph materialization fix; no rendered UI changed.