### PR TITLE
fix(sync): instance-scope GitLab work-item unit matching (CHAOS-2801)

### DIFF
--- a/docs/architecture/sync-unit-model.md
+++ b/docs/architecture/sync-unit-model.md
@@ -63,7 +63,7 @@ Legend: **once/run** = fetched once per sync run (correct); **per-unit** = re-fe
 | Provider | teams / orgs | members | projects / boards | cycles / sprints | issues / PRs |
 | -------- | ------------ | ------- | ----------------- | ---------------- | ------------ |
 | **GitHub** | discovery (once/run) | discovery | discovery | n/a | per source/window (work-item) |
-| **GitLab** | discovery (once/run) | discovery | discovery | n/a | per source/window (work-item, scoped via `settings.project_id` — CHAOS-2763) |
+| **GitLab** | discovery (once/run) | discovery | discovery | n/a | per source/window (work-item, scoped via `settings.project_id`, instance-scoped via `settings.gitlab_instance_url` — CHAOS-2763 / CHAOS-2801) |
 | **Jira** | once/run (resolver) | n/a here | per-unit JQL scope ✅ | **per-unit** ⚠️ (`get_sprint` in issue loop) | per source/window (work-item) |
 | **Linear** | **per-unit** ⚠️ (`iter_teams()` all teams) | discovery | discovery | **per-unit** ⚠️ (`iter_cycles()` per team) | per source/window (work-item) |
 
@@ -76,6 +76,75 @@ The ⚠️ cells are the work this epic removes. GitHub/GitLab already solved th
 3. **Source fan-out.** Work-item units that ignore their own source — Linear `IngestionContext(repo=None)` → all teams; GitHub `discover_repos` without a repo filter → all org repos; GitLab likewise (its `repo_name` is a numeric project id, not the `path_with_namespace` on `repos.repo`, so a naive filter can't reuse the GitHub match). **Fix (P1, shipped on the source-scoping branch):** thread the unit's `source_external_id` so a unit syncs only its one source; preserve the no-source CLI/org-wide path. GitHub shipped first (CHAOS-2720); GitLab shipped via a separate match branch keyed on the discovered repo's `settings.project_id` (CHAOS-2763), since the id spaces don't overlap.
 
 **Target acceptance:** total provider API requests for a backfill scale `O(issues + teams + cycles/projects)`, not `O(windows × datasets × sources)`, across all four providers.
+
+### GitLab numeric-id scoping is instance-scoped (CHAOS-2801)
+
+GitLab `project_id` is only unique **within one GitLab instance** — it is not a
+global identifier. An org with two GitLab integrations (two self-hosted
+instances, or one self-hosted instance + gitlab.com) can have both discover a
+project with the same numeric id. The CHAOS-2763 id-match alone (`repo_name ==
+str(settings.project_id)`) cannot tell those two rows apart; a unit
+authenticated to instance A could match instance B's same-id row, fetch
+project `123` from instance A, and write the result under instance B's
+`repo_id` (codex HIGH finding on PR #1143, round 3).
+
+**Fix:** both GitLab repo write sites (`process_gitlab_project` and
+`process_gitlab_projects_batch` in `processors/gitlab.py`) now persist the
+connector's configured base URL as `settings.gitlab_instance_url` alongside
+`settings.project_id`. The work-item scoping loop
+(`metrics/job_work_items.py`) resolves this unit's own authenticated GitLab
+host up front (reusing the same credential resolution the fetch call already
+performs — no new credential path) and compares it against each numeric-id
+match's `settings.gitlab_instance_url`.
+
+Both the persist path and the comparison use the **single shared normalizer**
+`normalize_gitlab_instance` (`providers/gitlab/instance.py`): lowercased
+`scheme://host[:port]`, userinfo/path ignored, and the scheme's **default
+port stripped** (http:80, https:443) while non-default ports are preserved.
+Never fork a second copy — equivalent spellings of the same endpoint
+(`https://host` vs `https://host:443` vs `HTTPS://Host/api/v4/`) must never
+false-mismatch, or a harmless credential formatting change would flip every
+row of a healthy integration to mismatch-reject and trip the CHAOS-2737
+fail-closed path org-wide.
+
+The write sites persist the **normalizer result directly**: when it returns
+`None` (blank/malformed input) the key is **omitted** — never the raw URL,
+which could retain path/query/userinfo from a malformed value at rest (the
+CHAOS-2766/2780 credential-retention leak class) and would violate the
+"unknown" semantic the scoping site relies on. An absent key reads exactly
+like a pre-CHAOS-2801 row.
+
+**Semantic — the three-case instance rule** (when the unit's instance is
+known, per `project_id`; a row with a known *differing* discriminator is
+always rejected):
+
+| Same-`project_id` discriminated rows | Legacy (no-discriminator) rows | Outcome |
+| --- | --- | --- |
+| (a) at least one **matches** the unit's instance | dropped (shadowed) | scope to the discriminated match(es) only |
+| (b) **none exist** | **accepted** | absent-accept — pure-legacy orgs unchanged (zero blast radius) |
+| (c) only **mismatching** ones exist | dropped | **fail closed** — nothing matches; `require_source` raises with its audit log |
+
+Case (c) rationale (codex HIGH, PR #1148 round-2): a known mismatching
+discriminator *proves* cross-instance ambiguity exists for that numeric id —
+the legacy row is plausibly the other instance's pre-discriminator row, so
+accepting it risks the exact wrong-`repo_id` write this fix closes. Cases
+(a)+(c) collapse to one predicate: a legacy row is accepted **only when no
+same-`project_id` row carries any known discriminator**. Remediation for a
+case-(c) failure is re-running discovery, which now stamps
+`gitlab_instance_url` on every row.
+
+Compatibility: an existing pure-legacy single-GitLab-instance org sees
+**zero** behavior change (case b). An org that later adds a second instance
+gains the full safety once its repos are re-discovered/re-synced and pick up
+the discriminator. When the unit's own instance is **unknown** (e.g. a bare
+CLI/env-only run with no resolvable base URL) the check never engages;
+behavior matches pre-CHAOS-2801.
+
+A rejected row is simply not "discovered" for that unit — the existing
+CHAOS-2737 `require_source` fail-closed path (raise when a unit's source
+never matched any repo) applies unchanged if no other row matches. This
+supersedes the "Known limitation (deferred: CHAOS-2801)" note carried by
+PR #1143. GitHub-path behavior is unaffected.
 
 ## Invariants this model must preserve
 

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -48,6 +48,7 @@ from dev_health_ops.models.work_items import (
     WorkItem,
     WorkItemType,
 )
+from dev_health_ops.providers.gitlab.instance import normalize_gitlab_instance
 from dev_health_ops.providers.identity import load_identity_resolver
 from dev_health_ops.providers.status_mapping import load_status_mapping
 from dev_health_ops.providers.teams import (
@@ -588,22 +589,140 @@ def run_work_items_sync_job(
         # repos are NOT added here, so they keep fetching by ``full_name`` —
         # unchanged, existing behavior; only an id-matched unit's identifier
         # resolution changes.
+        #
+        # CHAOS-2801 [codex HIGH, PR #1143 round-3]: numeric ``project_id``
+        # is only unique WITHIN one GitLab instance — two GitLab integrations
+        # in the same org (different self-hosted instances, or one self-hosted
+        # + gitlab.com) can both expose ``project_id=123``. Without an
+        # instance check, a unit authenticated to instance A could match
+        # instance B's row purely on the numeric id, then fetch project 123
+        # from A and persist/write the result under B's ``repo_id``.
+        #
+        # Resolve this unit's authenticated GitLab client (token + base URL)
+        # up front — *before* the id-matching loop, not after it as before —
+        # so ``gitlab_unit_instance`` is available at match time. This is a
+        # reordering only: ``_build_gitlab_work_client`` was already called
+        # unconditionally whenever "gitlab" is in ``provider_set`` (previously
+        # just after this block, at the ``fetch_gitlab_work_items`` call
+        # site); moving it earlier does not change whether/when it can raise.
+        #
+        # Design semantic — the three-case instance rule (documented in
+        # docs/architecture/sync-unit-model.md and the CHAOS-2801 PR body).
+        # ``normalize_gitlab_instance`` (providers/gitlab/instance.py) is the
+        # SINGLE normalizer, shared with the write sites that persist
+        # ``settings.gitlab_instance_url`` — never fork a second copy
+        # (default-port/case/path spelling differences would otherwise
+        # false-mismatch, codex MED PR #1148 round-1).
+        #
+        # When the unit's instance is KNOWN, per project_id:
+        #   (a) a same-project_id row with a MATCHING discriminator exists
+        #       -> scope to the discriminated match(es) ONLY; mismatching
+        #       and undiscriminated (legacy) rows are dropped. Without the
+        #       legacy drop, absent-accept would act as a CO-MATCH (codex
+        #       HIGH, PR #1148 round-1): both repo_ids would enter
+        #       ``gitlab_id_scoped_project_ids`` and the single fetch
+        #       against this unit's client would also be written under the
+        #       legacy (possibly other-instance) row's ``repo_id``.
+        #   (b) NO discriminated row exists at all for this project_id ->
+        #       ACCEPT legacy rows. This is the compatibility pin: a
+        #       pure-legacy org (every row written before this change) sees
+        #       zero behavior change.
+        #   (c) only MISMATCHING discriminated row(s) exist -> FAIL CLOSED
+        #       for this project_id: the mismatch rows are rejected AND the
+        #       legacy rows are dropped too (codex HIGH, PR #1148 round-2).
+        #       A known mismatching discriminator PROVES cross-instance
+        #       ambiguity exists for this numeric id — the legacy row is
+        #       plausibly that other instance's pre-discriminator row, so
+        #       accepting it risks the exact wrong-repo_id write this fix
+        #       closes. Nothing matches, so the existing CHAOS-2737
+        #       ``require_source`` path below raises with its audit log;
+        #       remediation is re-discovery, which now stamps
+        #       discriminators on every row.
+        # Cases (a)+(c) collapse to one predicate: a legacy row is accepted
+        # ONLY when no same-project_id row carries ANY known discriminator.
+        # When the unit's instance is UNKNOWN (e.g. a bare CLI run with no
+        # resolvable base URL), the check never engages; behavior matches
+        # pre-CHAOS-2801.
+        #
+        # This never changes GitHub-path behavior and never weakens the
+        # existing CHAOS-2737 fail-closed ``require_source`` path below — a
+        # rejected row simply does not count as "discovered", so a unit with
+        # no other matching row still raises exactly as before.
+        gl_token: str = ""
+        gl_url: str | None = None
+        gitlab_unit_instance: str | None = None
+        if "gitlab" in provider_set:
+            gl_token, gl_url = _build_gitlab_work_client(
+                org_id=org_id, credentials=credentials
+            )
+            gitlab_unit_instance = normalize_gitlab_instance(gl_url)
+
         gitlab_id_scoped_project_ids: dict[uuid.UUID, str] = {}
         if repo_name and "gitlab" in provider_set:
             wanted_gl = repo_name.strip()
             is_numeric_id = re.fullmatch(r"[0-9]+", wanted_gl) is not None
+
+            def _gl_id_match(settings: dict[str, Any]) -> bool:
+                project_id = settings.get("project_id")
+                return project_id is not None and str(project_id).strip() == wanted_gl
+
+            # Pre-pass (codex HIGH, PR #1148 rounds 1+2): does ANY
+            # same-project_id row carry a KNOWN discriminator, and does any
+            # of those MATCH this unit's instance? A legacy
+            # (no-discriminator) row is accepted below ONLY when no known
+            # discriminator exists at all for this project_id — a matching
+            # one shadows it (case a), and a mismatching-only one proves
+            # cross-instance ambiguity and fails closed (case c).
+            has_discriminated_row = False
+            has_discriminated_match = False
+            if is_numeric_id and gitlab_unit_instance is not None:
+                for repo in discovered_repos:
+                    if repo.source != "gitlab":
+                        continue
+                    settings = _repo_settings_dict(repo)
+                    if not _gl_id_match(settings):
+                        continue
+                    row_instance = normalize_gitlab_instance(
+                        settings.get("gitlab_instance_url")
+                    )
+                    if row_instance is not None:
+                        has_discriminated_row = True
+                        if row_instance == gitlab_unit_instance:
+                            has_discriminated_match = True
+                            break
+
             scoped_gl: list[Any] = []
             dropped_gl = 0
+            dropped_gl_instance_mismatch = 0
+            dropped_gl_shadowed_legacy = 0
+            dropped_gl_ambiguous_legacy = 0
             for repo in discovered_repos:
                 if repo.source != "gitlab":
                     scoped_gl.append(repo)
                     continue
+                settings = _repo_settings_dict(repo)
                 if is_numeric_id:
-                    settings = _repo_settings_dict(repo)
-                    project_id = settings.get("project_id")
-                    matched = (
-                        project_id is not None and str(project_id).strip() == wanted_gl
-                    )
+                    matched = _gl_id_match(settings)
+                    if matched and gitlab_unit_instance is not None:
+                        row_instance = normalize_gitlab_instance(
+                            settings.get("gitlab_instance_url")
+                        )
+                        if row_instance is not None and row_instance != (
+                            gitlab_unit_instance
+                        ):
+                            matched = False
+                            dropped_gl_instance_mismatch += 1
+                        elif row_instance is None and has_discriminated_row:
+                            # Some same-project_id row has a KNOWN
+                            # discriminator, so this legacy row must not
+                            # match: shadowed by a matching row (case a) or
+                            # fail-closed on cross-instance ambiguity when
+                            # only mismatching rows exist (case c).
+                            matched = False
+                            if has_discriminated_match:
+                                dropped_gl_shadowed_legacy += 1
+                            else:
+                                dropped_gl_ambiguous_legacy += 1
                 else:
                     matched = (
                         repo.full_name or ""
@@ -612,7 +731,7 @@ def run_work_items_sync_job(
                     dropped_gl += 1
                     continue
                 if is_numeric_id:
-                    gitlab_id_scoped_project_ids[repo.repo_id] = str(project_id).strip()
+                    gitlab_id_scoped_project_ids[repo.repo_id] = wanted_gl
                 scoped_gl.append(repo)
             if dropped_gl:
                 logger.info(
@@ -620,6 +739,38 @@ def run_work_items_sync_job(
                     "dropped %d off-source repo(s)",
                     repo_name,
                     dropped_gl,
+                )
+            if dropped_gl_instance_mismatch:
+                logger.warning(
+                    "CHAOS-2801: dropped %d GitLab repo(s) matching project_id "
+                    "'%s' but a different instance than this unit's "
+                    "authenticated GitLab host — cross-instance numeric-id "
+                    "collision, not this unit's project",
+                    dropped_gl_instance_mismatch,
+                    repo_name,
+                )
+            if dropped_gl_shadowed_legacy:
+                logger.warning(
+                    "CHAOS-2801: dropped %d legacy GitLab repo row(s) with no "
+                    "instance discriminator for project_id '%s' — a row "
+                    "discriminated to this unit's instance already matched, "
+                    "so the undiscriminated row(s) must not co-match (they "
+                    "may belong to a different instance); re-discovery will "
+                    "stamp them",
+                    dropped_gl_shadowed_legacy,
+                    repo_name,
+                )
+            if dropped_gl_ambiguous_legacy:
+                logger.warning(
+                    "CHAOS-2801: dropped %d legacy GitLab repo row(s) with no "
+                    "instance discriminator for project_id '%s' — another "
+                    "row carries a KNOWN, MISMATCHING instance discriminator "
+                    "for the same project_id, proving cross-instance "
+                    "ambiguity; failing closed rather than risking a "
+                    "wrong-instance write. Remediation: re-run discovery "
+                    "(it now stamps gitlab_instance_url on every row)",
+                    dropped_gl_ambiguous_legacy,
+                    repo_name,
                 )
             discovered_repos = scoped_gl
 
@@ -768,9 +919,10 @@ def run_work_items_sync_job(
                 transitions.extend(list(proj_tr or []))
 
         if "gitlab" in provider_set:
-            gl_token, gl_url = _build_gitlab_work_client(
-                org_id=org_id, credentials=credentials
-            )
+            # gl_token/gl_url were already resolved above (before the
+            # CHAOS-2801 instance-scoping block) so the unit's authenticated
+            # instance is known at match time; reused here rather than
+            # re-resolved.
             items, tr, gl_ai_attributions = fetch_gitlab_work_items(
                 repos=discovered_repos,
                 since=since_dt,

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -47,6 +47,7 @@ from dev_health_ops.processors.testops_ingest import (
     ingest_report_members,
 )
 from dev_health_ops.processors.testops_tests import process_gitlab_test_report
+from dev_health_ops.providers.gitlab.instance import normalize_gitlab_instance
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.utils import (
     AGGREGATE_STATS_MARKER,
@@ -1812,20 +1813,41 @@ async def process_gitlab_project(
             else gl_project.name
         )
 
+        repo_settings: dict[str, Any] = {
+            "source": "gitlab",
+            "project_id": gl_project.id,
+            "url": gl_project.web_url if hasattr(gl_project, "web_url") else None,
+            "default_branch": (
+                gl_project.default_branch
+                if hasattr(gl_project, "default_branch")
+                else "main"
+            ),
+        }
+        # CHAOS-2801: the *instance* this project id was resolved against —
+        # the connector's configured base URL, not the project's own
+        # (optional) web_url above. Numeric ``project_id`` values are only
+        # unique within one GitLab instance, so a work-item unit scoping by
+        # id (job_work_items.py) uses this to reject a same-id row from a
+        # DIFFERENT instance. Persisted through the SAME shared normalizer
+        # the comparison site uses (single function, no second copy) so
+        # equivalent URL spellings — case, trailing slash, /api/v4 suffix,
+        # explicit default :443/:80, userinfo — can never false-mismatch.
+        # The normalizer result is persisted DIRECTLY: when it is None
+        # (blank/malformed input) the key is OMITTED — never the raw URL,
+        # which could retain path/query/userinfo from a malformed value
+        # (credential-in-URL retention, the CHAOS-2766/2780 leak class) and
+        # would violate the documented "unknown" semantic the scoping site
+        # relies on. An absent key reads as "unknown", exactly like rows
+        # written before this field existed.
+        gitlab_instance_url = normalize_gitlab_instance(gitlab_url)
+        if gitlab_instance_url is not None:
+            repo_settings["gitlab_instance_url"] = gitlab_instance_url
+
         db_repo = Repo(
             repo_path=None,  # Not a local repo
             repo=full_name,
             provider="gitlab",
-            settings={
-                "source": "gitlab",
-                "project_id": gl_project.id,
-                "url": gl_project.web_url if hasattr(gl_project, "web_url") else None,
-                "default_branch": (
-                    gl_project.default_branch
-                    if hasattr(gl_project, "default_branch")
-                    else "main"
-                ),
-            },
+            settings=repo_settings,
             tags=["gitlab"],
         )
 
@@ -2093,17 +2115,28 @@ async def process_gitlab_projects_batch(
             return
 
         project_info = result.repository
+        batch_repo_settings: dict[str, Any] = {
+            "source": "gitlab",
+            "project_id": project_info.id,
+            "url": project_info.url,
+            "default_branch": project_info.default_branch,
+            "batch_processed": True,
+        }
+        # CHAOS-2801: instance discriminator — see the twin write site's
+        # comment in process_gitlab_project above (same shared normalizer,
+        # same normalized-or-omitted rule: never persist the raw URL when
+        # the normalizer returns None). ``gitlab_url`` here is the
+        # connector's configured base URL for the whole batch (this
+        # function's own parameter), not per-project.
+        batch_instance_url = normalize_gitlab_instance(gitlab_url)
+        if batch_instance_url is not None:
+            batch_repo_settings["gitlab_instance_url"] = batch_instance_url
+
         db_repo = Repo(
             repo_path=None,  # Not a local repo
             repo=project_info.full_name,
             provider="gitlab",
-            settings={
-                "source": "gitlab",
-                "project_id": project_info.id,
-                "url": project_info.url,
-                "default_branch": project_info.default_branch,
-                "batch_processed": True,
-            },
+            settings=batch_repo_settings,
             tags=["gitlab"],
         )
 

--- a/src/dev_health_ops/providers/gitlab/instance.py
+++ b/src/dev_health_ops/providers/gitlab/instance.py
@@ -1,0 +1,67 @@
+"""GitLab instance-identity normalization (CHAOS-2801).
+
+A GitLab ``project_id`` is only unique within one GitLab *instance*, so
+work-item unit scoping discriminates same-id rows by the instance they were
+discovered from. This module is the SINGLE normalizer for that discriminator
+— used at BOTH the persist path (``processors/gitlab.py`` repo write sites,
+which stamp ``settings.gitlab_instance_url``) and the comparison site
+(``metrics/job_work_items.py`` numeric-id scoping). Never introduce a second
+copy: a divergence between what is persisted and what is compared silently
+re-opens the cross-instance collision (codex HIGH on PR #1143) or, worse,
+false-mismatches every row of a healthy integration and trips the
+CHAOS-2737 fail-closed path org-wide (codex MED on PR #1148).
+
+Stdlib-only on purpose so it is importable from processors, metrics, and
+tests without any dependency cycle.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import urlsplit
+
+# Default ports are stripped so equivalent spellings of the same endpoint
+# ("https://host" vs "https://host:443") never false-mismatch — a harmless
+# credential formatting change must not flip an integration's every row to
+# mismatch-reject (codex MED, PR #1148). Non-default ports are preserved:
+# two GitLab instances CAN legitimately run on different ports of one host.
+_DEFAULT_PORTS = {"http": 80, "https": 443}
+
+
+def normalize_gitlab_instance(url: object) -> str | None:
+    """Normalize a GitLab base/instance URL to a comparable discriminator.
+
+    Returns ``scheme://host[:port]`` with:
+
+    * scheme + host lowercased,
+    * userinfo and path/query/fragment ignored (``https://HOST/api/v4/`` and
+      ``https://host`` compare equal),
+    * scheme defaulting to ``https`` when absent (``gitlab.example.com``),
+    * the port stripped when it is the scheme's default (http:80,
+      https:443) and preserved otherwise.
+
+    Returns ``None`` when ``url`` is not a non-blank string, has no
+    parseable host, or carries a malformed port — callers treat ``None`` as
+    "discriminator unknown/absent", never as a distinct instance.
+    """
+    if not isinstance(url, str) or not url.strip():
+        return None
+    candidate = url.strip()
+    if "://" not in candidate:
+        candidate = f"//{candidate}"
+    try:
+        parsed = urlsplit(candidate)
+    except ValueError:
+        return None
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        return None
+    scheme = (parsed.scheme or "https").strip().lower()
+    try:
+        port = parsed.port
+    except ValueError:
+        # Malformed port (e.g. "https://host:notaport") — unknown, not a
+        # distinct instance.
+        return None
+    if port is not None and port != _DEFAULT_PORTS.get(scheme):
+        return f"{scheme}://{host}:{port}"
+    return f"{scheme}://{host}"

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -18,7 +18,12 @@ from dev_health_ops.connectors import (
     match_repo_pattern,
 )
 from dev_health_ops.exceptions import RateLimitException
-from dev_health_ops.models.git import GitCommit, GitCommitStat, get_repo_uuid_from_repo
+from dev_health_ops.models.git import (
+    GitCommit,
+    GitCommitStat,
+    Repo,
+    get_repo_uuid_from_repo,
+)
 from dev_health_ops.processors import github as _github_processor
 from dev_health_ops.processors import gitlab as _gitlab_processor
 
@@ -223,6 +228,107 @@ async def test_process_gitlab_projects_batch_upserts_during_sync_processing(
         rate_limit_delay=0,
         use_async=False,
     )
+
+
+@pytest.mark.asyncio
+async def test_process_gitlab_projects_batch_persists_instance_discriminator(
+    monkeypatch,
+):
+    """[CHAOS-2801] process_gitlab_projects_batch must persist the batch's
+    configured base URL (this call's own ``gitlab_url`` argument) as
+    ``settings.gitlab_instance_url`` on every written ``Repo`` row — same
+    discriminator, same shared ``normalize_gitlab_instance``, as the
+    single-project write site (process_gitlab_project), so
+    job_work_items.py's numeric-id scoping can reject a same-``project_id``
+    row discovered from a DIFFERENT GitLab instance. The input below carries
+    an explicit default :443 port and a trailing slash that must be
+    normalized away at persist time (codex MED PR #1148)."""
+    _enable_connector_stubs(monkeypatch)
+
+    monkeypatch.setattr(
+        processors.gitlab, "_fetch_gitlab_commits_sync", lambda *a, **k: ([], [])
+    )
+    monkeypatch.setattr(
+        processors.gitlab, "_fetch_gitlab_commit_stats_sync", lambda *a, **k: []
+    )
+
+    inserted_repos: list[Repo] = []
+    inserted = threading.Event()
+
+    class DummyStore:
+        async def insert_repo(self, repo: Repo) -> None:
+            inserted_repos.append(repo)
+            inserted.set()
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            return
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    store = DummyStore()
+
+    project = Mock()
+    project.id = 456
+    project.full_name = "group/proj"
+    project.url = "https://example.com/group/proj"
+    project.default_branch = "main"
+
+    result = BatchResult(repository=project, stats=None, success=True)
+
+    class DummyConnector:
+        def __init__(self, url: str, private_token: str):
+            self.url = url
+            self.private_token = private_token
+            self.rest_client = Mock(get_merge_requests=lambda **kwargs: [])
+            self.gitlab = Mock()
+            self.gitlab.projects = Mock(get=lambda project_id: None)
+
+        def get_projects_with_stats(self, **kwargs):
+            on_project_complete = kwargs.get("on_project_complete")
+            if on_project_complete:
+                on_project_complete(result)
+
+            # Runs in the executor's worker thread (this whole method does,
+            # since ``use_async=False``): give the main loop's thread time to
+            # process the call_soon_threadsafe-scheduled enqueue and run
+            # store_result before this method returns and unblocks
+            # ``results_queue.join()`` — mirrors the sibling upsert-during-
+            # sync-processing test above, same race.
+            deadline = time.time() + 2
+            while time.time() < deadline and not inserted.is_set():
+                time.sleep(0.01)
+            assert inserted.is_set(), "Expected upsert during sync processing"
+            return [result]
+
+        def close(self):
+            return
+
+    monkeypatch.setattr(processors.gitlab, "GitLabConnector", DummyConnector)
+
+    await processors.gitlab.process_gitlab_projects_batch(
+        store=store,
+        token="test_token",
+        gitlab_url="https://gitlab-self-hosted.example.com:443/",
+        group_name="group",
+        pattern="group/*",
+        batch_size=1,
+        max_concurrent=1,
+        rate_limit_delay=0,
+        use_async=False,
+    )
+
+    assert len(inserted_repos) == 1
+    assert (
+        inserted_repos[0].settings["gitlab_instance_url"]
+        == "https://gitlab-self-hosted.example.com"
+    )
+    # The per-project url (BatchResult.repository.url) stays untouched.
+    assert inserted_repos[0].settings["url"] == "https://example.com/group/proj"
+    assert inserted_repos[0].settings["project_id"] == 456
 
 
 @pytest.mark.asyncio

--- a/tests/test_processors_gitlab.py
+++ b/tests/test_processors_gitlab.py
@@ -174,6 +174,127 @@ async def test_process_gitlab_project_no_sync_flags(monkeypatch):
         mock_store.insert_incidents.assert_not_called()
 
 
+async def _run_process_gitlab_project_capture_repo(monkeypatch, *, gitlab_url):
+    """Run ``process_gitlab_project`` against a fully-stubbed connector and
+    return the ``Repo`` handed to ``store.insert_repo`` (CHAOS-2801 write-site
+    harness)."""
+    monkeypatch.setattr("dev_health_ops.processors.gitlab.CONNECTORS_AVAILABLE", True)
+
+    mock_store = AsyncMock()
+    mock_gl_project = Mock()
+    mock_gl_project.id = 123
+    mock_gl_project.name = "test-project"
+    mock_gl_project.path_with_namespace = "group/test-project"
+    mock_gl_project.web_url = "https://gitlab.com/group/test-project"
+    mock_gl_project.default_branch = "main"
+
+    with (
+        patch("dev_health_ops.processors.gitlab.GitLabConnector") as _MockConnector,  # noqa: F841
+        patch(
+            "dev_health_ops.processors.gitlab._fetch_gitlab_project_info_sync",
+            return_value=mock_gl_project,
+        ),
+        patch(
+            "dev_health_ops.processors.gitlab._fetch_gitlab_commits_sync",
+            return_value=([], []),
+        ),
+        patch(
+            "dev_health_ops.processors.gitlab._fetch_gitlab_commit_stats_sync",
+            return_value=[],
+        ),
+        patch(
+            "dev_health_ops.processors.gitlab._sync_gitlab_mrs_to_store", return_value=0
+        ),
+        patch("dev_health_ops.processors.gitlab._fetch_gitlab_pipelines_sync"),
+        patch("dev_health_ops.processors.gitlab._fetch_gitlab_deployments_sync"),
+        patch("dev_health_ops.processors.gitlab._fetch_gitlab_incidents_sync"),
+        patch(
+            "dev_health_ops.processors.gitlab._backfill_gitlab_missing_data",
+            new_callable=AsyncMock,
+        ),
+    ):
+        await process_gitlab_project(
+            store=mock_store,
+            project_id=123,
+            token="test-token",
+            gitlab_url=gitlab_url,
+            sync_cicd=False,
+            sync_deployments=False,
+            sync_incidents=False,
+        )
+
+    mock_store.insert_repo.assert_called_once()
+    return mock_store.insert_repo.call_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_process_gitlab_project_persists_instance_discriminator(monkeypatch):
+    """[CHAOS-2801] process_gitlab_project must persist the connector's
+    configured base URL as ``settings.gitlab_instance_url`` on the written
+    ``Repo`` row -- the discriminator job_work_items.py's numeric-id scoping
+    uses to reject a same-``project_id`` row from a DIFFERENT GitLab
+    instance. Persisted in NORMALIZED form via the shared
+    ``normalize_gitlab_instance`` (the input below deliberately carries
+    mixed case, an explicit default :443 port, and a path suffix -- all of
+    which must be normalized away at persist time, codex MED PR #1148).
+    Independent of the project's own (optional) ``web_url`` (kept unchanged
+    in ``settings.url``)."""
+    written_repo = await _run_process_gitlab_project_capture_repo(
+        monkeypatch, gitlab_url="https://GitLab-A.example.com:443/api/v4/"
+    )
+    assert (
+        written_repo.settings["gitlab_instance_url"] == "https://gitlab-a.example.com"
+    )
+    # The project's own web_url stays untouched under its existing key.
+    assert written_repo.settings["url"] == "https://gitlab.com/group/test-project"
+    assert written_repo.settings["project_id"] == 123
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "bad_gitlab_url",
+    [
+        "",
+        "   ",
+        "https://gitlab.example.com:notaport",
+    ],
+)
+async def test_process_gitlab_project_unknown_instance_url_omits_discriminator(
+    monkeypatch, bad_gitlab_url
+):
+    """[CHAOS-2801 codex MED, PR #1148 round-2] When the normalizer cannot
+    parse the connector URL (blank/malformed), the discriminator key must be
+    OMITTED -- never the raw value. Persisting the raw string would defeat
+    the documented "unknown" semantic AND retain path/query/userinfo from a
+    malformed URL at rest (the CHAOS-2766/2780 credential-retention leak
+    class). An absent key reads back as "unknown", identical to a
+    pre-CHAOS-2801 row."""
+    written_repo = await _run_process_gitlab_project_capture_repo(
+        monkeypatch, gitlab_url=bad_gitlab_url
+    )
+    assert "gitlab_instance_url" not in written_repo.settings
+    # The raw value must not appear under any other settings key either.
+    if bad_gitlab_url.strip():
+        assert bad_gitlab_url not in list(written_repo.settings.values())
+
+
+@pytest.mark.asyncio
+async def test_process_gitlab_project_userinfo_stripped_from_discriminator(monkeypatch):
+    """[CHAOS-2801 codex MED, PR #1148 round-2] A parseable URL carrying
+    userinfo persists the canonical host-only discriminator; the userinfo
+    component (credential-in-URL shape) never reaches the settings JSON at
+    rest."""
+    account_label = "svc-" + "sync-account"  # neutral, runtime-joined
+    written_repo = await _run_process_gitlab_project_capture_repo(
+        monkeypatch,
+        gitlab_url=f"https://{account_label}@GitLab-A.example.com/",
+    )
+    assert (
+        written_repo.settings["gitlab_instance_url"] == "https://gitlab-a.example.com"
+    )
+    assert account_label not in written_repo.settings["gitlab_instance_url"]
+
+
 def test_fetch_gitlab_pipelines_sync():
     mock_pipeline = Mock()
     mock_pipeline.id = 1

--- a/tests/test_work_item_source_scope.py
+++ b/tests/test_work_item_source_scope.py
@@ -284,15 +284,25 @@ def _run_gitlab(
     require_source: bool,
     repos: list[DiscoveredRepo],
     provider: str = "gitlab",
+    gitlab_url: str | None = None,
 ) -> list[list[DiscoveredRepo]]:
     """Run the gitlab work-item sync job with a faked fetcher; returns the list
     of ``repos`` kwargs the fetcher was invoked with (one entry per call, so
     ``len(...)`` is the invocation count and an empty list means never called).
+
+    ``gitlab_url`` stands in for this unit's resolved/authenticated GitLab
+    instance (what ``_build_gitlab_work_client`` would normally return
+    alongside the token). Defaults to ``None`` — "instance unknown" — which
+    keeps every pre-CHAOS-2801 test in this module exercising the
+    instance-check as a no-op (see ``normalize_gitlab_instance``,
+    providers/gitlab/instance.py).
     """
     _patch_common(monkeypatch)
     monkeypatch.setattr(job, "_discover_repos", lambda **_kwargs: list(repos))
     monkeypatch.setattr(
-        job, "_build_gitlab_work_client", lambda **_kwargs: ("gl-token", None)
+        job,
+        "_build_gitlab_work_client",
+        lambda **_kwargs: ("gl-token", gitlab_url),
     )
 
     calls: list[list[DiscoveredRepo]] = []
@@ -663,3 +673,480 @@ def test_gitlab_cli_org_wide_path_still_fetches_by_full_name(
     assert not any(
         ref in {"123", "456", "789"} for ref in _RecordingGitLabAPIClient.calls
     )
+
+
+# --- CHAOS-2801: instance-scoped GitLab unit matching ------------------------
+#
+# [codex HIGH, PR #1143 round-3] Numeric ``project_id`` is only unique WITHIN
+# one GitLab instance. Two GitLab integrations in the same org (two
+# self-hosted instances, or one self-hosted + gitlab.com) can each discover a
+# project with the SAME numeric id. Before this fix, a unit authenticated to
+# instance A could match instance B's same-id row, fetch project 123 from A,
+# and write/normalize the result under B's ``repo_id`` — silently mixing two
+# tenants' GitLab data under the wrong row.
+#
+# Design semantic — the three-case instance rule (see job_work_items.py's
+# scoping-block comment and docs/architecture/sync-unit-model.md). When the
+# unit's instance is known, per project_id:
+#   (a) a same-project_id row with a MATCHING discriminator exists -> scope
+#       to the discriminated match ONLY; mismatching AND undiscriminated
+#       (legacy) rows are dropped. Without the legacy drop, absent-accept
+#       would act as a CO-MATCH (codex HIGH, PR #1148 round-1): both
+#       repo_ids would enter gitlab_id_scoped_project_ids and one fetch
+#       against instance A's client would also be written under the legacy
+#       (possibly instance-B) row's repo_id.
+#   (b) NO discriminated row exists at all -> ACCEPT legacy rows (zero
+#       blast radius for today's pure-legacy single-instance orgs).
+#   (c) only MISMATCHING discriminated row(s) exist -> FAIL CLOSED: the
+#       mismatch rows are rejected and the legacy rows are dropped too
+#       (codex HIGH, PR #1148 round-2) — a known mismatching discriminator
+#       PROVES cross-instance ambiguity for that numeric id, and the legacy
+#       row is plausibly the other instance's pre-discriminator row.
+#       Nothing matches, so the CHAOS-2737 require_source path raises;
+#       remediation is re-discovery (which now stamps discriminators).
+# When the unit's instance is unknown, the check never engages
+# (pre-CHAOS-2801 behavior, pinned separately below).
+#
+# ``normalize_gitlab_instance`` (providers/gitlab/instance.py) is the single
+# shared normalizer for both the persisted discriminator and the comparison,
+# so equivalent URL spellings (case, trailing slash, /api/v4 suffix,
+# explicit default :443/:80 port) never false-mismatch (codex MED, PR #1148).
+
+_INSTANCE_A = "https://gitlab-a.example.com"
+_INSTANCE_B = "https://gitlab-b.example.com"
+
+
+def _gitlab_repos_with_instance(
+    *, entries: list[tuple[str, int, str | None]]
+) -> list[DiscoveredRepo]:
+    """Build GitLab ``DiscoveredRepo`` rows with an explicit
+    ``gitlab_instance_url`` discriminator. ``entries`` is
+    ``(full_name, project_id, instance_url_or_None)`` — ``None`` means "no
+    discriminator" (a pre-CHAOS-2801 row)."""
+    repos: list[DiscoveredRepo] = []
+    for full_name, project_id, instance_url in entries:
+        settings: dict[str, object] = {"project_id": project_id}
+        if instance_url is not None:
+            settings["gitlab_instance_url"] = instance_url
+        repos.append(
+            DiscoveredRepo(
+                repo_id=uuid.uuid4(),
+                full_name=full_name,
+                source="gitlab",
+                settings=settings,
+            )
+        )
+    return repos
+
+
+def test_gitlab_unit_instance_scope_rejects_cross_instance_project_id_collision(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[CHAOS-2801 regression] A unit authenticated to instance A must match
+    only instance A's row when two GitLab integrations both discover a
+    project with the same numeric id."""
+    repos = _gitlab_repos_with_instance(
+        entries=[
+            ("grp/proj-a", 123, _INSTANCE_A),
+            ("other-grp/proj-x", 123, _INSTANCE_B),
+        ]
+    )
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="123",
+        require_source=True,
+        repos=repos,
+        gitlab_url=_INSTANCE_A,
+    )
+    # Invocation-count assertion: the fetcher runs exactly once, for
+    # instance A's row only — instance B's same-id row never reaches it.
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"grp/proj-a"}
+
+
+def test_gitlab_unit_instance_scope_real_fetch_invoked_once_for_matched_instance(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[CHAOS-2801 regression] Exercises the REAL ``fetch_gitlab_work_items``
+    (recording GitLab API client, not the mocked fetcher used above). Each
+    matched project makes exactly 2 API calls (issues + MRs, ``org_id`` is
+    set so MR-attribution scanning runs). If the cross-instance row or the
+    legacy no-discriminator row were not filtered, they would ALSO reach the
+    fetcher and the count would rise to 4 or 6 — the count is the signal,
+    since every row carries the identical project id string and the calls
+    can't be told apart by identifier alone. The legacy row here pins the
+    codex-HIGH (PR #1148) shadow rule at the API level: one fetch, one
+    write-target repo, even in a mixed legacy/discriminated org."""
+    _patch_common(monkeypatch)
+    _patch_gitlab_client_factory(monkeypatch)
+    _RecordingGitLabAPIClient.calls = []
+    repos = _gitlab_repos_with_instance(
+        entries=[
+            ("grp/proj-a", 123, _INSTANCE_A),
+            ("other-grp/proj-x", 123, _INSTANCE_B),
+            ("legacy-grp/proj-y", 123, None),
+        ]
+    )
+    monkeypatch.setattr(job, "_discover_repos", lambda **_kwargs: list(repos))
+    monkeypatch.setattr(
+        job,
+        "_build_gitlab_work_client",
+        lambda **_kwargs: ("gl-token", _INSTANCE_A),
+    )
+
+    run_job: Any = job.run_work_items_sync_job
+    run_job(
+        db_url="clickhouse://test",
+        day=date(2026, 5, 2),
+        backfill_days=1,
+        provider="gitlab",
+        org_id=str(uuid.uuid4()),
+        repo_name="123",
+        require_source=True,
+    )
+
+    assert len(_RecordingGitLabAPIClient.calls) == 2, _RecordingGitLabAPIClient.calls
+    assert set(_RecordingGitLabAPIClient.calls) == {"123"}
+
+
+def test_gitlab_unit_instance_scope_accepts_row_with_no_discriminator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[CHAOS-2801 compat pin] A row with no ``gitlab_instance_url`` (every
+    row written before this change) still matches when the unit's own
+    instance IS known and NO discriminated same-id match exists — zero blast
+    radius for today's pure-legacy single-GitLab-instance orgs."""
+    repos = _gitlab_repos_with_instance(entries=[("grp/proj-a", 123, None)])
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="123",
+        require_source=True,
+        repos=repos,
+        gitlab_url=_INSTANCE_A,
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"grp/proj-a"}
+
+
+def test_gitlab_unit_instance_scope_discriminated_match_shadows_legacy_row(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[CHAOS-2801 codex HIGH, PR #1148 regression] Absent-accept must NOT
+    act as a co-match. With instance A's discriminated row matched AND a
+    legacy no-discriminator row sharing the same project_id, only the
+    discriminated row may be scoped: if both entered
+    ``gitlab_id_scoped_project_ids``, the single fetch against A's client
+    would also be written under the legacy row's repo_id — the exact
+    cross-instance corruption this PR closes (the legacy row may well be
+    instance B's project 123, just discovered before discriminators
+    existed). Asserts the fetch is invoked once and the write targets ONLY
+    the discriminated row's repo_id."""
+    repos = _gitlab_repos_with_instance(
+        entries=[
+            ("grp/proj-a", 123, _INSTANCE_A),
+            ("legacy-grp/proj-y", 123, None),
+        ]
+    )
+    discriminated_repo_id = repos[0].repo_id
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="123",
+        require_source=True,
+        repos=repos,
+        gitlab_url=_INSTANCE_A,
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"grp/proj-a"}
+    # Write-target pin: the repos handed to the fetcher determine which
+    # repo_id the fetched data is written/normalized under.
+    assert {r.repo_id for r in calls[0]} == {discriminated_repo_id}
+
+
+def test_gitlab_unit_instance_scope_mismatch_plus_legacy_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[CHAOS-2801 codex HIGH, PR #1148 round-2, case (c)] A known
+    MISMATCHING discriminator for the same project_id PROVES cross-instance
+    ambiguity exists for that numeric id — the legacy no-discriminator row
+    is plausibly that other instance's pre-discriminator row. Accepting it
+    (as the round-1 shadow rule did — the previous version of this very
+    test pinned that wrong call) risks fetching from instance A and writing
+    under B's repo_id. New rule: legacy rows are accepted ONLY when NO
+    same-project_id row carries ANY known discriminator; here one does
+    (mismatching), so BOTH rows drop and the CHAOS-2737 ``require_source``
+    fail-closed path raises. Remediation is re-discovery, which now stamps
+    discriminators on every row."""
+    repos = _gitlab_repos_with_instance(
+        entries=[
+            ("other-grp/proj-x", 123, _INSTANCE_B),
+            ("legacy-grp/proj-y", 123, None),
+        ]
+    )
+    calls: list[list[DiscoveredRepo]] = []
+    with pytest.raises(ValueError, match="source was not discovered"):
+        calls = _run_gitlab(
+            monkeypatch,
+            repo_name="123",
+            require_source=True,
+            repos=repos,
+            gitlab_url=_INSTANCE_A,
+        )
+    assert calls == []
+
+
+def test_gitlab_unit_instance_scope_three_row_mismatch_ambiguity_fails_closed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[CHAOS-2801 codex HIGH, PR #1148 round-2 — explicit three-row case]
+    Unit on instance A; project_id=123 rows: known-B (mismatch), known-C
+    (mismatch), and a legacy no-discriminator row. Every row is dropped —
+    both mismatches rejected outright, the legacy row dropped for
+    cross-instance ambiguity (two other instances demonstrably share this
+    numeric id) — and the unit fails closed with ZERO fetch invocations."""
+    repos = _gitlab_repos_with_instance(
+        entries=[
+            ("other-grp/proj-x", 123, _INSTANCE_B),
+            ("third-grp/proj-z", 123, "https://gitlab-c.example.com"),
+            ("legacy-grp/proj-y", 123, None),
+        ]
+    )
+    calls: list[list[DiscoveredRepo]] = []
+    with pytest.raises(ValueError, match="source was not discovered"):
+        calls = _run_gitlab(
+            monkeypatch,
+            repo_name="123",
+            require_source=True,
+            repos=repos,
+            gitlab_url=_INSTANCE_A,
+        )
+    assert calls == []
+
+
+def test_gitlab_unit_instance_scope_noop_when_unit_instance_unknown(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[CHAOS-2801] When THIS unit's own instance can't be resolved, the
+    instance check never engages — a row that DOES carry a (different)
+    discriminator is still matched, exactly as pre-CHAOS-2801."""
+    repos = _gitlab_repos_with_instance(entries=[("grp/proj-a", 123, _INSTANCE_B)])
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="123",
+        require_source=True,
+        repos=repos,
+        gitlab_url=None,
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"grp/proj-a"}
+
+
+def test_gitlab_unit_instance_scope_mismatch_fails_closed_when_no_other_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[CHAOS-2801] When the only project_id match is on a DIFFERENT known
+    instance, the row is dropped and — since nothing else matches — the
+    existing CHAOS-2737 ``require_source`` fail-closed path raises, exactly
+    as if the project had never been discovered at all. The fetcher is never
+    invoked."""
+    repos = _gitlab_repos_with_instance(
+        entries=[("other-grp/proj-x", 123, _INSTANCE_B)]
+    )
+    calls: list[list[DiscoveredRepo]] = []
+    with pytest.raises(ValueError, match="source was not discovered"):
+        calls = _run_gitlab(
+            monkeypatch,
+            repo_name="123",
+            require_source=True,
+            repos=repos,
+            gitlab_url=_INSTANCE_A,
+        )
+    assert calls == []
+
+
+def test_gitlab_unit_instance_scope_equivalent_url_spellings_match(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """[CHAOS-2801 codex MED, PR #1148] Equivalent spellings of the SAME
+    endpoint must never false-mismatch: the persisted discriminator carries
+    an explicit default :443 port + trailing slash while the unit's
+    credential URL is uppercase with no port. A false mismatch here would
+    reject every row of a healthy integration and trip the CHAOS-2737
+    fail-closed path org-wide on a harmless credential formatting change."""
+    repos = _gitlab_repos_with_instance(
+        entries=[("grp/proj-a", 123, "https://gitlab-a.example.com:443/")]
+    )
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="123",
+        require_source=True,
+        repos=repos,
+        gitlab_url="https://GITLAB-A.example.com",
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"grp/proj-a"}
+
+
+# --- normalize_gitlab_instance unit pins (codex MED, PR #1148) ---------------
+#
+# The single shared normalizer (providers/gitlab/instance.py) used at BOTH
+# the write sites' persist path and the scoping comparison.
+
+
+@pytest.mark.parametrize(
+    ("left", "right"),
+    [
+        # Explicit default port is stripped (https:443, http:80).
+        ("https://gitlab.example.com", "https://gitlab.example.com:443"),
+        ("http://gitlab.example.com", "http://gitlab.example.com:80"),
+        # Host + scheme casing.
+        ("https://gitlab.example.com", "HTTPS://GITLAB.EXAMPLE.COM"),
+        # Trailing slash and API path suffix.
+        ("https://gitlab.example.com", "https://gitlab.example.com/"),
+        ("https://gitlab.example.com", "https://gitlab.example.com/api/v4"),
+        # Userinfo is discarded.
+        ("https://gitlab.example.com", "https://user@gitlab.example.com"),
+        # Scheme-less input defaults to https.
+        ("https://gitlab.example.com", "gitlab.example.com"),
+        # All of it at once.
+        (
+            "https://gitlab.example.com",
+            "HTTPS://GitLab.Example.com:443/api/v4/",
+        ),
+    ],
+)
+def test_normalize_gitlab_instance_equivalent_spellings(left: str, right: str) -> None:
+    from dev_health_ops.providers.gitlab.instance import normalize_gitlab_instance
+
+    assert normalize_gitlab_instance(left) == normalize_gitlab_instance(right)
+    # ``left`` is already in canonical form in every pair — normalization
+    # must be a fixed point on it (scheme-specific: http rows stay http).
+    assert normalize_gitlab_instance(left) == left
+
+
+def test_normalize_gitlab_instance_non_default_port_still_distinct() -> None:
+    """Two GitLab instances CAN legitimately run on different ports of one
+    host — a non-default port must remain part of the discriminator."""
+    from dev_health_ops.providers.gitlab.instance import normalize_gitlab_instance
+
+    assert (
+        normalize_gitlab_instance("https://gitlab.example.com:8443")
+        == "https://gitlab.example.com:8443"
+    )
+    assert normalize_gitlab_instance(
+        "https://gitlab.example.com:8443"
+    ) != normalize_gitlab_instance("https://gitlab.example.com")
+    # http on 443 is NOT http's default — preserved, and distinct from https.
+    assert (
+        normalize_gitlab_instance("http://gitlab.example.com:443")
+        == "http://gitlab.example.com:443"
+    )
+
+
+def test_normalize_gitlab_instance_unknown_inputs() -> None:
+    """Missing/blank/unparseable inputs are ``None`` — "unknown", never a
+    distinct instance."""
+    from dev_health_ops.providers.gitlab.instance import normalize_gitlab_instance
+
+    assert normalize_gitlab_instance(None) is None
+    assert normalize_gitlab_instance("") is None
+    assert normalize_gitlab_instance("   ") is None
+    assert normalize_gitlab_instance(123) is None
+    assert normalize_gitlab_instance("https://gitlab.example.com:notaport") is None
+
+
+# --- insert_repo -> discover_repos JSON round-trip (codex MED, PR #1148) -----
+#
+# ``ClickHouseStore.insert_repo`` encodes ``repos.settings`` via
+# ``_json_or_none`` (json.dumps) and ``discover_repos`` (job_daily.py)
+# decodes it via ``_parse_repo_settings`` (json.loads). These round-trip
+# tests exercise the REAL encode + decode pair — not a hand-rolled stand-in
+# — and then run the real scoping loop on the round-tripped settings, for
+# both the canonical (discriminator present) and unknown (key omitted at
+# the write site) shapes.
+
+
+def _roundtrip_settings(settings: dict[str, object]) -> dict[str, object]:
+    from dev_health_ops.metrics.job_daily import _parse_repo_settings
+    from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+    encoded = ClickHouseStore._json_or_none(settings)
+    assert isinstance(encoded, str)
+    return _parse_repo_settings(encoded)
+
+
+def test_gitlab_instance_discriminator_survives_settings_json_roundtrip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Canonical case: a write-site settings dict carrying the normalized
+    discriminator survives the real insert_repo/discover_repos JSON
+    round-trip, and the scoping loop then (a) matches it for a same-instance
+    unit and (b) rejects it fail-closed for a different-instance unit."""
+    roundtripped = _roundtrip_settings(
+        {
+            "source": "gitlab",
+            "project_id": 123,
+            "gitlab_instance_url": _INSTANCE_A,
+            "default_branch": "main",
+        }
+    )
+    assert roundtripped["gitlab_instance_url"] == _INSTANCE_A
+    repo = DiscoveredRepo(
+        repo_id=uuid.uuid4(),
+        full_name="grp/proj-a",
+        source="gitlab",
+        settings=roundtripped,
+    )
+
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="123",
+        require_source=True,
+        repos=[repo],
+        gitlab_url=_INSTANCE_A,
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"grp/proj-a"}
+
+    with pytest.raises(ValueError, match="source was not discovered"):
+        _run_gitlab(
+            monkeypatch,
+            repo_name="123",
+            require_source=True,
+            repos=[repo],
+            gitlab_url=_INSTANCE_B,
+        )
+
+
+def test_gitlab_unknown_discriminator_survives_settings_json_roundtrip(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Unknown case: the write site OMITS ``gitlab_instance_url`` when the
+    normalizer returns None; the omitted key survives the real JSON
+    round-trip as an absent key (never a raw/None placeholder that could be
+    mistaken for a distinct instance) and the scoping loop treats the row
+    as legacy-unknown — accepted when no discriminated row exists (case b).
+    """
+    roundtripped = _roundtrip_settings(
+        {
+            "source": "gitlab",
+            "project_id": 123,
+            "default_branch": "main",
+        }
+    )
+    assert "gitlab_instance_url" not in roundtripped
+    repo = DiscoveredRepo(
+        repo_id=uuid.uuid4(),
+        full_name="legacy-grp/proj-y",
+        source="gitlab",
+        settings=roundtripped,
+    )
+
+    calls = _run_gitlab(
+        monkeypatch,
+        repo_name="123",
+        require_source=True,
+        repos=[repo],
+        gitlab_url=_INSTANCE_A,
+    )
+    assert len(calls) == 1
+    assert {r.full_name for r in calls[0]} == {"legacy-grp/proj-y"}


### PR DESCRIPTION
## Summary

CHAOS-2801 — supersedes PR #1143's `Known limitation (deferred: CHAOS-2801)` note. GitLab `project_id` is only unique **within one GitLab instance**. The CHAOS-2763 id-scoping loop in `run_work_items_sync_job` (job_work_items.py:597-615 on main) matched any GitLab repo row whose `settings.project_id` equaled the unit's numeric `repo_name`, with no check that the row came from the *same* GitLab instance the unit is authenticated to. An org with two GitLab integrations (two self-hosted instances, or one self-hosted + gitlab.com) could have both discover a project with the same numeric id; a unit authenticated to instance A could match instance B's row, fetch project 123 from instance A, and write/normalize the result under instance B's `repo_id` (codex HIGH, PR #1143 round-3).

- **`src/dev_health_ops/providers/gitlab/instance.py`** (new): `normalize_gitlab_instance` — the SINGLE shared normalizer for the instance discriminator, stdlib-only. Lowercased `scheme://host[:port]`; userinfo/path ignored; the scheme's **default port stripped** (http:80, https:443) with non-default ports preserved; unparseable input → `None` ("unknown", never a distinct instance).
- **`src/dev_health_ops/processors/gitlab.py`**: both GitLab repo write sites (`process_gitlab_project`, `process_gitlab_projects_batch`) persist the connector's configured base URL — run through the shared normalizer — as `settings.gitlab_instance_url`. The normalizer result is persisted **directly**: when it is `None` (blank/malformed input) the key is **omitted**, never the raw URL — a raw fallback would defeat the documented "unknown" semantic AND retain path/query/userinfo from malformed URLs at rest (the CHAOS-2766/2780 credential-retention leak class; codex MED, round-2). `settings.url` (the project's own web URL) is untouched.
- **`src/dev_health_ops/metrics/job_work_items.py`**: the GitLab work-item unit's authenticated instance (token + base URL) is resolved *before* the numeric-id scoping loop (a reordering of the existing credential resolution, not a new path) and compared — via the same shared normalizer — against each id-matched row's `settings.gitlab_instance_url` under the three-case rule below.

## Design semantic — the three-case instance rule

When the unit's instance is known, per `project_id` (a row with a known *differing* discriminator is always rejected):

| Same-`project_id` discriminated rows | Legacy (no-discriminator) rows | Outcome |
| --- | --- | --- |
| (a) at least one **matches** the unit's instance | dropped (shadowed) | scope to the discriminated match(es) only |
| (b) **none exist** | **accepted** | absent-accept — pure-legacy orgs unchanged (zero blast radius) |
| (c) only **mismatching** ones exist | dropped | **fail closed** — nothing matches; `require_source` raises with its audit log |

- Case (a) closes the round-1 codex HIGH: absent-accept must not act as a **co-match** — otherwise instance A's discriminated row and a legacy row would both enter `gitlab_id_scoped_project_ids`, and the single fetch against A's client would also be written under the legacy (possibly instance-B) row's `repo_id`.
- Case (c) closes the round-2 codex HIGH: a known **mismatching** discriminator *proves* cross-instance ambiguity exists for that numeric id — the legacy row is plausibly the other instance's pre-discriminator row, so accepting it risks the exact wrong-`repo_id` write this PR closes. Cases (a)+(c) collapse to one predicate: **a legacy row is accepted only when no same-`project_id` row carries any known discriminator.** Remediation for a case-(c) failure is re-running discovery, which now stamps `gitlab_instance_url` on every row.
- Case (b) is the compatibility pin: today's pure-legacy single-GitLab-instance orgs see zero behavior change.
- Unit instance **unknown** (bare CLI/env-only run with no resolvable base URL) → the check never engages; pre-CHAOS-2801 behavior.

Equivalent URL spellings never false-mismatch (codex MED, round-1): `https://host`, `https://host:443`, `HTTPS://Host/api/v4/` normalize identically at BOTH the persist and comparison sites — a harmless credential formatting change cannot flip an integration's rows to mismatch-reject.

A rejected row is simply not "discovered" for that unit — the existing CHAOS-2737 `require_source` fail-closed path applies unchanged when nothing else matches. GitHub-path behavior is untouched.

Documented in `docs/architecture/sync-unit-model.md` ("GitLab numeric-id scoping is instance-scoped (CHAOS-2801)", incl. the three-case table) and in code comments at the scoping site, both write sites, and the shared normalizer module.

## Test plan

Scoping rule:
- [x] `test_gitlab_unit_instance_scope_rejects_cross_instance_project_id_collision` — A vs B discriminated rows; unit A matches only A's row (invocation-count assertion).
- [x] `test_gitlab_unit_instance_scope_discriminated_match_shadows_legacy_row` — case (a): known+unknown same-`project_id` rows → only the discriminated row scoped, fetch invoked once, write targets ONLY its `repo_id`.
- [x] `test_gitlab_unit_instance_scope_mismatch_plus_legacy_fails_closed` — case (c): B-mismatch + legacy → BOTH dropped, `require_source` raises, zero fetch invocations (rewrites the round-1 test that pinned the wrong legacy-accept call).
- [x] `test_gitlab_unit_instance_scope_three_row_mismatch_ambiguity_fails_closed` — explicit three-row case: B-mismatch + C-mismatch + legacy → fail closed, zero fetch invocations.
- [x] `test_gitlab_unit_instance_scope_accepts_row_with_no_discriminator` — case (b): pure-legacy accepted.
- [x] `test_gitlab_unit_instance_scope_real_fetch_invoked_once_for_matched_instance` — A+B+legacy through the REAL `fetch_gitlab_work_items` (recording client): exactly 2 API calls, not 4/6.
- [x] `test_gitlab_unit_instance_scope_noop_when_unit_instance_unknown`, `test_gitlab_unit_instance_scope_mismatch_fails_closed_when_no_other_match` — disengage + single-mismatch fail-closed pins.

Normalizer + spellings:
- [x] `test_gitlab_unit_instance_scope_equivalent_url_spellings_match` — end-to-end `:443/` vs uppercase-no-port.
- [x] `test_normalize_gitlab_instance_equivalent_spellings` (8 pairs), `..._non_default_port_still_distinct` (:8443, http:443), `..._unknown_inputs` (None/blank/non-str/malformed-port).

Write sites + round-trip (codex MED round-2):
- [x] `test_process_gitlab_project_persists_instance_discriminator` — mixed-case + `:443` + `/api/v4/` input → normalized persist.
- [x] `test_process_gitlab_project_unknown_instance_url_omits_discriminator` (3 params: blank/whitespace/malformed-port) — key OMITTED; raw value nowhere in settings.
- [x] `test_process_gitlab_project_userinfo_stripped_from_discriminator` — userinfo never reaches settings at rest.
- [x] `test_process_gitlab_projects_batch_persists_instance_discriminator` — batch write site, `:443/` input normalized.
- [x] `test_gitlab_instance_discriminator_survives_settings_json_roundtrip` / `test_gitlab_unknown_discriminator_survives_settings_json_roundtrip` — REAL `ClickHouseStore._json_or_none` encode → REAL `_parse_repo_settings` (discover_repos) decode → real scoping loop, canonical + unknown shapes.

- [x] Full pre-existing `tests/test_work_item_source_scope.py` suite (CHAOS-2720/2763 contracts) green — 101 tests total across the three touched test files.
- [x] `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=ci_local_validate_2801 bash ci/local_validate.sh` — fully green.
