### PR TITLE
feat(providers): instrumented REST core + resolver prefix short-circuit + shared rate-limit classifiers (CHAOS-2802)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -695,6 +695,133 @@ candidate — an expired cooldown does not cause every sibling to dispatch at
 once beyond what DispatchGuard's concurrency cap already allows
 (`test_cooldown_expiry_drains_bounded_by_concurrency_cap`).
 
+## Instrumented transport core (CHAOS-2773 CS1)
+
+[CHAOS-2773](https://linear.app/fullchaos/issue/CHAOS-2773) migrates the
+frozen GitHub/GitLab code-dataset fetch paths (`git`, `commit_stats`,
+`files`, `blame`, `cicd`, `tests`, `deployments`, `security` and their
+GitLab equivalents — see the "Frozen `connectors/` path" entry under
+[Known gaps](#known-gaps)) off `connectors/` onto canonical, instrumented
+`providers/github/` / `providers/gitlab/` clients. **CS1 lands the shared
+foundation every per-family changeset (CS3+) builds on; it does NOT itself
+migrate any dataset** — the frozen connector path is unchanged and remains
+the live fetch path for every code-dataset family until its own changeset
+cuts over.
+
+**`providers/_http.py::InstrumentedRESTCore`** is the one httpx transport
+primitive every canonical code client composes (never inherits) — mirroring
+`providers/launchdarkly/client.py` (the sanctioned template) and the
+"will be folded into the shared core once it lands" precedent already noted
+on `providers/gitlab/feature_flags.py`:
+
+- `request(method, path, *, operation, params, headers)` records ONE
+  `UsageRecorder.record` per PHYSICAL HTTP round trip, including retried
+  429/5xx attempts — never one record per logical call. The recorded
+  diagnostic-header set is **provider-configurable**
+  (`diagnostic_header_names` constructor param): code clients pass
+  `GITHUB_DIAGNOSTIC_HEADER_NAMES` / `GITLAB_DIAGNOSTIC_HEADER_NAMES`, which
+  are pinned by parity tests
+  (`tests/providers/test_http_core.py::TestDiagnosticHeaderParity`) to match
+  the existing work-client recorders' header sets EXACTLY (request IDs,
+  `x-ratelimit-used`/`-resource`, `x-accepted-github-permissions`,
+  `x-request-id`/`x-runtime` — never the token), so observations from the
+  core are shape-compatible with today's `latest_headers` diagnostics.
+- Retry/backoff and terminal-429 delay resolution go through the EXISTING
+  shared `providers/_ratelimit.py` helpers — `Retry-After` first
+  (delta-seconds or HTTP-date), **falling back to the provider's
+  epoch-seconds reset header** (`reset_header_name`:
+  `X-RateLimit-Reset`/`RateLimit-Reset`) via
+  `resolve_retry_after_seconds(...)`, the provider-parameterized
+  generalization of #1142's `gitlab_resolve_retry_after_seconds` (which now
+  delegates to it — still exactly one implementation). This matters at the
+  worker boundary: `workers/sync_units.py` plans a deferral's `not_before`
+  from `exc.retry_after_seconds`, not `signal.reset_at`, so a reset-only
+  429 must carry the derived delay rather than `None` (which would wake the
+  unit on the 60s default instead of the provider's real reset window). On
+  retry exhaustion of a 429 the core raises the canonical
+  `dev_health_ops.exceptions.RateLimitException` carrying a CHAOS-2753
+  `RateLimitSignal` built via `RateLimitSignal.reset_at_from_epoch_seconds`
+  (GitHub/GitLab both report epoch SECONDS, unlike LaunchDarkly's epoch
+  milliseconds) — `integration_id`/`route_family` are left `None`
+  (worker-boundary enrichment, unchanged).
+- **Explicit redirect policy + unauthenticated follow-up hop.** The
+  underlying httpx client never follows redirects, so the core refuses to
+  let a 3xx masquerade as success: by default any 3xx is a terminal
+  `APIException` naming the redirect target (the physical attempt is still
+  recorded — no unaccounted hops). The two-hop pattern for GitHub's
+  artifact-zip download (`connectors/github.py::download_artifact_zip`;
+  ports in CS5): (1) a per-call `raw_redirect=True` opt-in returns the 3xx
+  response itself (recorded, never retried); (2)
+  `request_unauthenticated(location, operation=...)` follows the absolute
+  `Location` through a SECOND, headerless client owned by the core — httpx
+  sends a client's default headers even on absolute-URL requests and
+  rejects `Authorization: None`, so a separate no-default-headers client is
+  the only clean way to keep the provider token off the pre-signed
+  blob/CDN URL. The hop is still recorded through the same `UsageRecorder`,
+  and the response comes back unclassified (the pre-signed host is a
+  different error domain — the artifact contract's 404/410 →
+  convenience-empty decision belongs to the CS5 code client, not the
+  transport). Pinned end-to-end by
+  `tests/providers/test_http_core.py::TestUnauthenticatedFollow` (second
+  hop carries no `Authorization`, both hops recorded one apiece).
+- `paginate_link_header` (GitHub's RFC 5988 `Link` header) and
+  `paginate_page_param` (GitLab's `page`/`per_page` + `X-Next-Page`) both
+  carry hard page caps as a defensive backstop against a misbehaving/looping
+  cursor.
+- Base-URL joining reuses the existing `GitHubAuth.base_url` /
+  `GitLabAuth.base_url` string fields (`github_rest_base_url` /
+  `gitlab_rest_base_url`) — GHE (`https://ghe.example.com/api/v3`, joined
+  as-is) and self-hosted GitLab (`GITLAB_URL` + `/api/v4`) both preserved.
+- Credential resolution stays entirely ABOVE this module — it never touches
+  auth, only the headers a caller already resolved.
+- **Composition, not inheritance.** The core's own status-code
+  classification is intentionally generic (429/5xx retry; 401/403/404/other
+  4xx map to the obvious exception). GitHub's 403 triage and GitLab's
+  header-qualified-403 semantics are NOT baked in here — a future code
+  client wires them in via the `is_retryable_status` / `classify_error`
+  extension points, reusing the shared classifiers below.
+
+**Shared 403/429 classifiers** (extracted so a REST work client and its
+future httpx code-client twin never carry a second copy of the same
+triage):
+
+- `providers/github/ratelimit.py::classify_github_403` — primary
+  (`x-ratelimit-remaining: 0`) vs. secondary/abuse (`Retry-After` header or
+  documented body wording) vs. permission/SSO (not a rate limit).
+  `providers/github/client.py::GitHubWorkClient._raise_github_exception` now
+  delegates to it for the 403 branch; behavior is pinned by porting the
+  relevant cases from `tests/test_github_403_observability.py` into
+  `tests/providers/test_github_ratelimit_classifier.py`.
+- `providers/gitlab/ratelimit.py::classify_gitlab_status` — 429-primary /
+  header-qualified-403-secondary, built directly on the
+  `providers/_ratelimit.py` primitives (`gitlab_403_is_rate_limited` /
+  `gitlab_resolve_retry_after_seconds`, #1142).
+  `providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit` now delegates
+  to it, so exactly one predicate/delay implementation exists for GitLab
+  (the #1142 feature-flags client already called the `_ratelimit.py`
+  primitives directly; this closes the remaining gap in the work client).
+
+**Resolver explicit-prefix short-circuit**
+(`providers/usage.py::OperationResolver.resolve`). The substring marker scan
+alone cannot carry a family-prefixed operation-label scheme: families are
+scanned in order and the FIRST marker hit wins, and GitLab's `project`
+family already registers broad markers (`"/projects/:id"`, `"/projects/"`)
+that would swallow, e.g., a `pipelines:GET /projects/:id/pipelines` label
+before `pipelines` is ever consulted. Fixed structurally: before the marker
+scan runs, an operation label of the form `"<registered-family>:..."`
+resolves DIRECTLY to that family. Unprefixed labels — every existing
+work-client label today — take the marker-scan path completely UNCHANGED,
+pinned by an exhaustive label→family resolver test
+(`tests/providers/test_usage_resolver_prefix.py`) that (a) asserts every
+current GitHub/GitLab work-client operation label resolves EXACTLY as it did
+before this change, (b) asserts representative prefixed labels per
+registered family resolve directly to that family, and (c) asserts no
+existing work-client label accidentally starts with a registered
+`"<family>:"` prefix (the false-trigger regression guard). Code clients
+built on this core (CS3+) are expected to author both the label and its
+family prefix themselves, so resolution for their traffic is deterministic
+by construction rather than by marker tuning.
+
 ## Per-provider policy
 
 ### GitHub

--- a/src/dev_health_ops/providers/_http.py
+++ b/src/dev_health_ops/providers/_http.py
@@ -1,0 +1,721 @@
+"""Shared instrumented REST transport core (CHAOS-2773 CS1).
+
+``InstrumentedRESTCore`` is the epic's foundation: the one httpx transport
+primitive every canonical code client (``GitHubCodeClient``,
+``GitLabCodeClient``, and any provider added later) composes rather than
+inherits from. It mirrors the shape already proven by
+``providers/launchdarkly/client.py`` (the sanctioned template, #1126) and
+``providers/gitlab/feature_flags.py`` (the #1142 "will be folded into the
+shared core once it lands" precedent) -- one owned ``UsageRecorder``, one
+``UsageRecorder.record`` per PHYSICAL HTTP round trip including retried
+attempts, ``Retry-After``-aware backoff, and the canonical
+``dev_health_ops.exceptions.RateLimitException`` + CHAOS-2753
+``RateLimitSignal`` on exhaustion.
+
+**Composition, not inheritance.** This module owns transport mechanics only:
+requests, retries, pagination, usage recording, and a *default* status-code
+classification good enough to exercise in isolation. It deliberately does
+NOT know GitHub's 403 triage or GitLab's header-qualified-403 semantics --
+those stay in ``providers/github/ratelimit.py`` / ``providers/gitlab/
+ratelimit.py`` and are wired in by a future code client via the
+``is_retryable_status`` / ``classify_error`` extension points below (CS3+).
+Credential resolution also stays entirely above this module: callers build
+their own ``httpx`` headers (bearer token, ``PRIVATE-TOKEN``, ...) and pass
+them in; this core never touches auth.
+
+**Base-URL joining** reuses the existing ``GitHubAuth.base_url`` /
+``GitLabAuth.base_url`` string fields (``providers/github/client.py`` /
+``providers/gitlab/client.py``) -- callers pass the raw string those
+dataclasses already carry into :func:`github_rest_base_url` /
+:func:`gitlab_rest_base_url` below, so this module never imports those
+provider client modules (that would invert the dependency direction: they
+will import ``_http`` in CS3+, not the reverse).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+import httpx
+
+from dev_health_ops.exceptions import (
+    APIException,
+    AuthenticationException,
+    NotFoundException,
+    RateLimitException,
+)
+from dev_health_ops.providers._ratelimit import resolve_retry_after_seconds
+from dev_health_ops.providers.usage import OperationResolver, UsageRecorder
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Base-URL joining (GHE / self-hosted GitLab)
+# ---------------------------------------------------------------------------
+
+GITHUB_DEFAULT_BASE_URL = "https://api.github.com"
+GITLAB_DEFAULT_BASE_URL = "https://gitlab.com"
+_GITLAB_API_V4_PREFIX = "/api/v4"
+
+
+def github_rest_base_url(base_url: str | None) -> str:
+    """Resolve the GitHub REST API base URL from ``GitHubAuth.base_url``.
+
+    ``None`` (or empty) resolves to ``api.github.com``. A GitHub Enterprise
+    value is the FULL REST base including the ``/api/v3`` suffix (e.g.
+    ``https://ghe.example.com/api/v3``) -- joined AS-IS with no path
+    rewriting, mirroring ``providers/github/app_auth.py::
+    _installation_access_tokens_url`` and ``connectors/github.py``'s
+    ``Github(base_url=...)`` construction (both existing GHE precedents).
+    """
+    return str(base_url or GITHUB_DEFAULT_BASE_URL).rstrip("/")
+
+
+def gitlab_rest_base_url(base_url: str | None) -> str:
+    """Resolve the GitLab REST API base URL from ``GitLabAuth.base_url``.
+
+    ``GitLabAuth.base_url`` is the instance HOST only (``https://gitlab.com``
+    or a self-hosted URL, e.g. ``https://gitlab.example.com``) -- python-gitlab
+    and ``providers/gitlab/feature_flags.py`` both append ``/api/v4``
+    themselves; this mirrors that join exactly (``connectors/gitlab.py``'s
+    ``api_url = f"{url}/api/v4"``).
+    """
+    return (
+        f"{str(base_url or GITLAB_DEFAULT_BASE_URL).rstrip('/')}{_GITLAB_API_V4_PREFIX}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic header extraction (provider-configurable)
+# ---------------------------------------------------------------------------
+
+# Per-provider diagnostic header allowlists. These MUST stay in exact parity
+# with the sets the existing work-client recorders preserve
+# (providers/github/client.py::_DIAGNOSTIC_HEADER_NAMES and
+# providers/gitlab/client.py::_DIAGNOSTIC_HEADER_NAMES) so a code client
+# built on this core emits the SAME ``latest_headers`` shape as the existing
+# recorders -- request IDs and permission diagnostics included. Parity is
+# pinned by tests/providers/test_http_core.py::TestDiagnosticHeaderParity
+# (codex review MED-1 on PR #1149). Code clients (CS3+) pass the matching
+# tuple as ``diagnostic_header_names``.
+GITHUB_DIAGNOSTIC_HEADER_NAMES = (
+    "x-ratelimit-limit",
+    "x-ratelimit-remaining",
+    "x-ratelimit-reset",
+    "x-ratelimit-used",
+    "x-ratelimit-resource",
+    "retry-after",
+    "x-github-request-id",
+    "x-accepted-github-permissions",
+)
+
+GITLAB_DIAGNOSTIC_HEADER_NAMES = (
+    "ratelimit-limit",
+    "ratelimit-remaining",
+    "ratelimit-reset",
+    "retry-after",
+    "x-request-id",
+    "x-runtime",
+)
+
+# Generic default: the union of both providers' rate-limit/diagnostic sets --
+# safe when a caller has not passed a provider-specific tuple yet.
+_DEFAULT_DIAGNOSTIC_HEADER_NAMES = tuple(
+    dict.fromkeys(GITHUB_DIAGNOSTIC_HEADER_NAMES + GITLAB_DIAGNOSTIC_HEADER_NAMES)
+)
+
+
+def _diagnostic_headers(
+    headers: httpx.Headers, names: tuple[str, ...]
+) -> dict[str, str]:
+    lowered = {str(k).lower(): str(v) for k, v in headers.items()}
+    return {name: lowered[name] for name in names if name in lowered}
+
+
+def _default_rate_limit_fields(safe_headers: dict[str, str]) -> dict[str, Any]:
+    rate_limit: dict[str, Any] = {}
+    remaining = safe_headers.get("x-ratelimit-remaining") or safe_headers.get(
+        "ratelimit-remaining"
+    )
+    reset = safe_headers.get("x-ratelimit-reset") or safe_headers.get("ratelimit-reset")
+    limit = safe_headers.get("x-ratelimit-limit") or safe_headers.get("ratelimit-limit")
+    used = safe_headers.get("x-ratelimit-used")
+    resource = safe_headers.get("x-ratelimit-resource")
+    retry_after = safe_headers.get("retry-after")
+    if remaining is not None:
+        rate_limit["remaining"] = remaining
+    if reset is not None:
+        rate_limit["reset"] = reset
+    if limit is not None:
+        rate_limit["limit"] = limit
+    if used is not None:
+        rate_limit["used"] = used
+    if resource is not None:
+        rate_limit["resource"] = resource
+    if retry_after is not None:
+        rate_limit["retry_after"] = retry_after
+    return rate_limit
+
+
+def _response_host(response: httpx.Response) -> str | None:
+    host = getattr(getattr(response, "url", None), "host", None)
+    return host if isinstance(host, str) and host else None
+
+
+# ---------------------------------------------------------------------------
+# Default retry / classification policy
+# ---------------------------------------------------------------------------
+
+_DEFAULT_RETRYABLE_STATUSES = frozenset({429, 500, 502, 503, 504})
+_DEFAULT_MAX_RETRIES = 5
+_DEFAULT_INITIAL_BACKOFF_SECONDS = 1.0
+_DEFAULT_MAX_BACKOFF_SECONDS = 60.0
+_DEFAULT_TIMEOUT_SECONDS = 30.0
+_DEFAULT_RESET_HEADER_NAME = "X-RateLimit-Reset"
+
+IsRetryableStatus = Callable[[httpx.Response], bool]
+ResolveRetryAfter = Callable[[httpx.Response], float | None]
+ClassifyError = Callable[[httpx.Response, str], None]
+
+
+def _default_is_retryable_status(response: httpx.Response) -> bool:
+    return response.status_code in _DEFAULT_RETRYABLE_STATUSES
+
+
+@dataclass
+class InstrumentedRESTCore:
+    """Provider-agnostic, instrumented httpx REST transport (CHAOS-2773 CS1).
+
+    One instance is owned by one code client, built per sync unit -- same
+    lifecycle contract as ``UsageRecorder`` (no cross-unit/cross-org state).
+
+    :param base_url: Already-joined REST API base (see
+        :func:`github_rest_base_url` / :func:`gitlab_rest_base_url`).
+    :param provider: Provider slug (``"github"`` / ``"gitlab"``) stamped onto
+        every ``RateLimitSignal`` this core raises.
+    :param resolver: The provider's ``OperationResolver``
+        (``GITHUB_USAGE_RESOLVER`` / ``GITLAB_USAGE_RESOLVER``) -- this core
+        builds and owns its own :class:`UsageRecorder` from it, mirroring
+        every existing canonical client's ``__init__``.
+    :param headers: Default headers sent with every request (auth token,
+        ``Accept``, ...). Credential resolution happens ABOVE this module;
+        this is just the resulting header dict.
+    :param reset_header_name: Header carrying the epoch-seconds rate-limit
+        reset used by the DEFAULT 429 classification AND the default
+        retry-delay derivation
+        (``X-RateLimit-Reset`` for GitHub, ``RateLimit-Reset`` for GitLab).
+    :param diagnostic_header_names: Response-header allowlist recorded onto
+        usage observations (never the token/Authorization header). Code
+        clients pass their provider's tuple
+        (:data:`GITHUB_DIAGNOSTIC_HEADER_NAMES` /
+        :data:`GITLAB_DIAGNOSTIC_HEADER_NAMES`) so the recorded
+        ``latest_headers`` shape matches the existing work-client recorders
+        exactly; the default is the safe union of both.
+    :param is_retryable_status: Predicate deciding whether a response status
+        should be retried in-place. Defaults to ``{429, 500, 502, 503, 504}``;
+        a GitLab code client overrides this to also retry a
+        header-qualified 403 (mirrors ``providers/gitlab/feature_flags.py``).
+    :param resolve_retry_after: Resolves the backoff delay for a retryable
+        response. Default (``None``) uses the shared
+        :func:`providers._ratelimit.resolve_retry_after_seconds` -- the
+        #1142 delay resolution generalized over ``reset_header_name``:
+        ``Retry-After`` when present (delta-seconds or HTTP-date), else
+        derived from the provider's epoch-seconds reset header, so a
+        reset-only 429 still carries the server's real window instead of
+        falling back to the worker's short default (codex HIGH on PR #1149).
+    :param classify_error: Optional hook invoked with ``(response, operation)``
+        for any TERMINAL non-2xx response (retries exhausted, or a
+        non-retryable status) BEFORE the built-in default classification. May
+        raise a domain-specific exception (e.g. GitHub's 403 triage); if it
+        returns without raising, the default classification below still runs.
+    """
+
+    base_url: str
+    provider: str
+    resolver: OperationResolver
+    headers: dict[str, str] = field(default_factory=dict)
+    timeout: float = _DEFAULT_TIMEOUT_SECONDS
+    max_retries: int = _DEFAULT_MAX_RETRIES
+    initial_backoff_seconds: float = _DEFAULT_INITIAL_BACKOFF_SECONDS
+    max_backoff_seconds: float = _DEFAULT_MAX_BACKOFF_SECONDS
+    reset_header_name: str = _DEFAULT_RESET_HEADER_NAME
+    diagnostic_header_names: tuple[str, ...] = _DEFAULT_DIAGNOSTIC_HEADER_NAMES
+    is_retryable_status: IsRetryableStatus = field(default=_default_is_retryable_status)
+    resolve_retry_after: ResolveRetryAfter | None = None
+    classify_error: ClassifyError | None = None
+    transport: httpx.AsyncBaseTransport | None = None
+
+    def __post_init__(self) -> None:
+        self._usage = UsageRecorder(resolver=self.resolver)
+        self._client: httpx.AsyncClient | None = None
+        self._bare_client: httpx.AsyncClient | None = None
+
+    async def _get_client(self) -> httpx.AsyncClient:
+        if self._client is None or self._client.is_closed:
+            self._client = httpx.AsyncClient(
+                base_url=self.base_url,
+                headers=self.headers,
+                timeout=self.timeout,
+                transport=self.transport,
+            )
+        return self._client
+
+    async def _get_bare_client(self) -> httpx.AsyncClient:
+        """Second client with NO caller default headers (no ``Authorization``,
+        no API-version pins) for :meth:`request_unauthenticated`. httpx sends
+        a client's default headers even on absolute-URL requests and rejects
+        ``headers={'Authorization': None}``, so a separate headerless client
+        is the only clean way to issue a deliberately unauthenticated hop
+        (codex re-pass MED on PR #1149). Shares the transport/timeout so
+        tests and mocks see both hops through one seam."""
+        if self._bare_client is None or self._bare_client.is_closed:
+            self._bare_client = httpx.AsyncClient(
+                timeout=self.timeout,
+                transport=self.transport,
+            )
+        return self._bare_client
+
+    # ------------------------------------------------------------------
+    # Core request loop
+    # ------------------------------------------------------------------
+
+    async def request(
+        self,
+        method: str,
+        path: str,
+        *,
+        operation: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        json: Any | None = None,
+        raw_redirect: bool = False,
+    ) -> httpx.Response:
+        """Issue one LOGICAL request, retrying transparently in place.
+
+        Every PHYSICAL HTTP round trip -- including retried 429/5xx attempts
+        -- records exactly one usage observation via ``_record_usage``
+        (CHAOS-2754 contract: actuals are real request counts, never
+        abstract units). ``operation`` is the caller-authored label (often a
+        path TEMPLATE, e.g. ``"cicd:GET /repos/{o}/{r}/actions/runs"``,
+        distinct from the literal ``path`` sent over the wire) used both for
+        usage-recorder resolution and for diagnostic messages.
+
+        **Redirect policy (codex MED-2 on PR #1149).** The underlying client
+        never follows redirects (httpx default), so an un-handled 3xx would
+        otherwise masquerade as a success with no hop accounting and blow up
+        later at ``.json()``. Default: any 3xx is a terminal
+        ``APIException`` naming the redirect target. ``raw_redirect=True``
+        opts a single call into receiving the 3xx response itself (still
+        recorded as one physical round trip, never retried) -- the first
+        half of the two-hop artifact pattern below.
+
+        **Two-hop unauthenticated-follow pattern (CS5's artifact-zip
+        contract, connectors/github.py::download_artifact_zip).** GitHub's
+        artifact download 302s to a pre-signed blob/CDN URL that MUST be
+        fetched without forwarding ``Authorization``. httpx sends the
+        client's default headers even on absolute-URL requests, so the
+        follow-up cannot go through :meth:`request` -- use
+        :meth:`request_unauthenticated` for the second hop, which issues it
+        with NO client default headers while still recording the physical
+        attempt::
+
+            first = await core.request(
+                "GET", f"/repos/{o}/{r}/actions/artifacts/{i}/zip",
+                operation="tests:GET artifact zip", raw_redirect=True,
+            )
+            if first.status_code in (301, 302, 303, 307, 308):
+                blob = await core.request_unauthenticated(
+                    first.headers["Location"],
+                    operation="tests:GET artifact zip follow",
+                )
+        """
+        client = await self._get_client()
+        delay = self.initial_backoff_seconds
+        last_network_exc: Exception | None = None
+
+        for attempt in range(self.max_retries):
+            try:
+                response = await client.request(
+                    method, path, params=params, headers=headers, json=json
+                )
+            except (httpx.TimeoutException, httpx.ConnectError) as exc:
+                last_network_exc = exc
+                if attempt < self.max_retries - 1:
+                    logger.warning(
+                        "%s request to %s failed (attempt %d/%d): %s",
+                        self.provider,
+                        operation,
+                        attempt + 1,
+                        self.max_retries,
+                        exc,
+                    )
+                    await asyncio.sleep(delay)
+                    delay = min(delay * 2, self.max_backoff_seconds)
+                    continue
+                raise APIException(
+                    f"{self.provider} request failed on {operation}: {exc}"
+                ) from exc
+
+            self._record_response_usage(response, operation=operation)
+
+            if response.status_code < 300:
+                return response
+
+            if response.status_code < 400:
+                if raw_redirect:
+                    return response
+                raise APIException(
+                    f"{self.provider} unexpected redirect on {operation}: HTTP "
+                    f"{response.status_code} -> "
+                    f"{response.headers.get('Location', '<no Location header>')}; "
+                    "the instrumented core does not follow redirects (pass "
+                    "raw_redirect=True to receive the redirect response and "
+                    "handle Location manually)"
+                )
+
+            if self.is_retryable_status(response) and attempt < self.max_retries - 1:
+                retry_after = self._resolve_retry_after(response) or delay
+                logger.warning(
+                    "%s %d on %s (attempt %d/%d), retrying in %.1fs",
+                    self.provider,
+                    response.status_code,
+                    operation,
+                    attempt + 1,
+                    self.max_retries,
+                    retry_after,
+                )
+                await asyncio.sleep(retry_after)
+                delay = min(delay * 2, self.max_backoff_seconds)
+                continue
+
+            self._raise_for_status(response, operation=operation)
+
+        if last_network_exc is not None:
+            raise APIException(
+                f"{self.provider} request failed after {self.max_retries} attempts "
+                f"on {operation}"
+            ) from last_network_exc
+        raise APIException(
+            f"{self.provider} request failed on {operation}: unknown error"
+        )
+
+    async def request_unauthenticated(
+        self,
+        url: str,
+        *,
+        operation: str,
+        method: str = "GET",
+        headers: dict[str, str] | None = None,
+    ) -> httpx.Response:
+        """Issue one deliberately UNAUTHENTICATED request, still recorded.
+
+        The second hop of the two-hop redirect pattern (see :meth:`request`'s
+        redirect-policy docs): after ``raw_redirect=True`` hands back a 3xx,
+        this follows the absolute ``Location`` with NO client default headers
+        -- no ``Authorization``, no API-version pins, nothing beyond what the
+        caller passes explicitly in ``headers`` -- so a pre-signed blob/CDN
+        URL never sees the provider token (codex re-pass MED on PR #1149;
+        contract per connectors/github.py::download_artifact_zip).
+
+        The physical attempt is recorded through the SAME ``UsageRecorder``
+        as :meth:`request` (the hop is real provider-triggered traffic), and
+        the response is returned AS-IS: no retry loop and no status
+        classification, because the pre-signed host is a different error
+        domain from the provider API -- e.g. the artifact contract treats
+        404/410 as convenience-empty, which the code client (CS5) decides,
+        not this transport. Network-level failures raise ``APIException``
+        like the main path.
+
+        :param url: ABSOLUTE URL (a redirect ``Location``); relative paths
+            are rejected -- they would silently resolve against nothing and
+            a relative Location should be followed via :meth:`request`,
+            which keeps auth, instead.
+        """
+        if not url.lower().startswith(("http://", "https://")):
+            raise ValueError(
+                "request_unauthenticated requires an absolute http(s) URL "
+                f"(got {url!r}); relative redirect targets stay on the "
+                "authenticated client via request()"
+            )
+        client = await self._get_bare_client()
+        try:
+            response = await client.request(method, url, headers=headers)
+        except (httpx.TimeoutException, httpx.ConnectError) as exc:
+            raise APIException(
+                f"{self.provider} unauthenticated request failed on {operation}: {exc}"
+            ) from exc
+        self._record_response_usage(response, operation=operation)
+        return response
+
+    def _resolve_retry_after(self, response: httpx.Response) -> float | None:
+        """Resolve the server-advertised retry delay for a response.
+
+        Uses the caller-supplied ``resolve_retry_after`` override when set;
+        otherwise the shared ``providers/_ratelimit.py`` resolution:
+        ``Retry-After`` first, falling back to deriving the delay from the
+        provider's epoch-seconds reset header (``reset_header_name``). The
+        fallback matters for terminal 429s: the worker deferral path plans
+        ``not_before`` from ``exc.retry_after_seconds``, NOT from
+        ``signal.reset_at`` -- a reset-only 429 that left
+        ``retry_after_seconds=None`` would wake the unit on the 60s default
+        instead of the provider's real reset window (codex HIGH, PR #1149).
+        """
+        if self.resolve_retry_after is not None:
+            return self.resolve_retry_after(response)
+        return resolve_retry_after_seconds(
+            response.headers, reset_header_name=self.reset_header_name
+        )
+
+    def _raise_for_status(self, response: httpx.Response, *, operation: str) -> None:
+        """Terminal classification for a non-2xx response (retries exhausted,
+        or a status :attr:`is_retryable_status` never considered retryable).
+
+        ``classify_error`` (if set) runs FIRST and may raise a
+        provider-specific exception (GitHub 403 triage, GitLab
+        header-qualified 403, ...); returning normally falls through to the
+        generic default below.
+        """
+        if self.classify_error is not None:
+            self.classify_error(response, operation)
+
+        status = response.status_code
+        if status == 401:
+            raise AuthenticationException(
+                f"{self.provider} authentication failed on {operation}"
+            )
+        if status == 403:
+            raise AuthenticationException(
+                f"{self.provider} forbidden on {operation}: {response.text}"
+            )
+        if status == 404:
+            raise NotFoundException(
+                f"{self.provider} resource not found on {operation}: {response.url}"
+            )
+        if status == 429:
+            retry_after = self._resolve_retry_after(response)
+            raise RateLimitException(
+                f"{self.provider} rate limit exceeded on {operation}",
+                retry_after_seconds=retry_after,
+                signal=RateLimitSignal(
+                    provider=self.provider,
+                    host=_response_host(response),
+                    # integration_id / route_family are enriched at the
+                    # worker boundary (CHAOS-2753) -- clients never set them.
+                    dimension=BudgetDimension.REST_CORE,
+                    retry_after_seconds=retry_after,
+                    reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                        response.headers.get(self.reset_header_name)
+                    ),
+                    reason="primary",
+                ),
+            )
+        if status >= 500:
+            raise APIException(
+                f"{self.provider} server error on {operation}: {status} - {response.text}"
+            )
+        raise APIException(
+            f"{self.provider} API error on {operation}: {status} - {response.text}"
+        )
+
+    # ------------------------------------------------------------------
+    # Paginators (hard page caps -- defensive against a misbehaving/looping
+    # cursor; mirrors providers/gitlab/feature_flags.py's _MAX_PAGES bound)
+    # ------------------------------------------------------------------
+
+    async def paginate_link_header(
+        self,
+        path: str,
+        *,
+        operation: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        data_key: str | None = None,
+        max_pages: int = 100,
+    ) -> list[Any]:
+        """Paginate a GitHub-style endpoint via the RFC 5988 ``Link`` header.
+
+        Follows ``rel="next"`` until absent or ``max_pages`` is hit. GitHub's
+        ``next`` link is an ABSOLUTE url (including a GHE host), which httpx
+        honors directly regardless of the client's configured ``base_url``.
+
+        :param data_key: When the endpoint wraps its list in an envelope
+            (e.g. GitHub Actions' ``{"workflow_runs": [...]}"``), the key to
+            extract; ``None`` when the JSON payload IS the list.
+        """
+        items: list[Any] = []
+        next_url: str | None = path
+        next_params: dict[str, Any] | None = dict(params or {}) if params else None
+        pages = 0
+        while next_url is not None:
+            if pages >= max_pages:
+                logger.warning(
+                    "%s pagination hit the %d-page cap for %s",
+                    self.provider,
+                    max_pages,
+                    operation,
+                )
+                break
+            response = await self.request(
+                "GET",
+                next_url,
+                operation=operation,
+                params=next_params,
+                headers=headers,
+            )
+            pages += 1
+            payload = response.json()
+            page_items = payload.get(data_key, []) if data_key else payload
+            if not isinstance(page_items, list):
+                raise APIException(
+                    f"Unexpected paginated response for {operation}: {type(page_items)!r}"
+                )
+            items.extend(page_items)
+            next_url = _parse_link_header_next(response.headers.get("Link"))
+            # The next URL already carries its own query string; only the
+            # FIRST request applies caller-supplied params.
+            next_params = None
+        return items
+
+    async def paginate_page_param(
+        self,
+        path: str,
+        *,
+        operation: str,
+        params: dict[str, Any] | None = None,
+        headers: dict[str, str] | None = None,
+        per_page: int = 100,
+        max_pages: int = 100,
+    ) -> list[Any]:
+        """Paginate a GitLab-style endpoint via ``page``/``per_page`` query
+        params, following ``X-Next-Page`` when present (falling back to an
+        item-count heuristic when it is absent, e.g. an older/mocked
+        instance) -- mirrors ``providers/_base.py::BasePipelineAdapter.
+        _paginate`` and ``providers/gitlab/feature_flags.py::_next_page``.
+        """
+        items: list[Any] = []
+        page: int | None = 1
+        pages = 0
+        while page is not None:
+            if pages >= max_pages:
+                logger.warning(
+                    "%s pagination hit the %d-page cap for %s",
+                    self.provider,
+                    max_pages,
+                    operation,
+                )
+                break
+            current_params = dict(params or {})
+            current_params["page"] = page
+            current_params.setdefault("per_page", per_page)
+            response = await self.request(
+                "GET",
+                path,
+                operation=operation,
+                params=current_params,
+                headers=headers,
+            )
+            pages += 1
+            payload = response.json()
+            if not isinstance(payload, list):
+                raise APIException(
+                    f"Unexpected paginated response for {operation}: {type(payload)!r}"
+                )
+            if not payload:
+                break
+            items.extend(payload)
+            page = self._next_page_param(response, page, len(payload), per_page)
+        return items
+
+    @staticmethod
+    def _next_page_param(
+        response: httpx.Response, current_page: int, item_count: int, per_page: int
+    ) -> int | None:
+        next_page_header = response.headers.get("X-Next-Page")
+        if next_page_header:
+            try:
+                return int(next_page_header)
+            except ValueError:
+                return None
+        if item_count < per_page:
+            return None
+        return current_page + 1
+
+    # ------------------------------------------------------------------
+    # Usage recording (CHAOS-2754)
+    # ------------------------------------------------------------------
+
+    def _record_response_usage(
+        self, response: httpx.Response, *, operation: str
+    ) -> None:
+        safe_headers = _diagnostic_headers(
+            response.headers, self.diagnostic_header_names
+        )
+        self._usage.record(
+            transport="rest",
+            operation=operation,
+            headers=safe_headers,
+            rate_limit=_default_rate_limit_fields(safe_headers),
+            status=response.status_code,
+        )
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        return self._usage.drain()
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    async def close(self) -> None:
+        if self._client is not None and not self._client.is_closed:
+            await self._client.aclose()
+            self._client = None
+        if self._bare_client is not None and not self._bare_client.is_closed:
+            await self._bare_client.aclose()
+            self._bare_client = None
+
+    async def __aenter__(self) -> InstrumentedRESTCore:
+        await self._get_client()
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        await self.close()
+
+
+def _parse_link_header_next(link_header: str | None) -> str | None:
+    """Extract the ``rel="next"`` URL from an RFC 5988 ``Link`` header.
+
+    Returns ``None`` when the header is absent or carries no ``next`` rel
+    (the last page) -- GitHub omits the header entirely on a single-page
+    result and drops the ``next`` segment on the final page of a multi-page
+    result.
+    """
+    if not link_header:
+        return None
+    for segment in link_header.split(","):
+        parts = segment.split(";")
+        if len(parts) < 2:
+            continue
+        url_part = parts[0].strip()
+        if not (url_part.startswith("<") and url_part.endswith(">")):
+            continue
+        rel_is_next = any(param.strip().lower() == 'rel="next"' for param in parts[1:])
+        if rel_is_next:
+            return url_part[1:-1]
+    return None
+
+
+__all__ = [
+    "GITHUB_DEFAULT_BASE_URL",
+    "GITHUB_DIAGNOSTIC_HEADER_NAMES",
+    "GITLAB_DEFAULT_BASE_URL",
+    "GITLAB_DIAGNOSTIC_HEADER_NAMES",
+    "InstrumentedRESTCore",
+    "github_rest_base_url",
+    "gitlab_rest_base_url",
+]

--- a/src/dev_health_ops/providers/_ratelimit.py
+++ b/src/dev_health_ops/providers/_ratelimit.py
@@ -151,26 +151,29 @@ def gitlab_403_is_rate_limited(headers: Any) -> bool:
     )
 
 
-def gitlab_resolve_retry_after_seconds(headers: Any) -> float | None:
-    """Resolve the effective retry delay for a rate-limited GitLab response.
+def resolve_retry_after_seconds(
+    headers: Any, *, reset_header_name: str
+) -> float | None:
+    """Resolve the effective retry delay from rate-limit response headers.
 
     Prefers ``Retry-After`` via :func:`parse_retry_after_header` (handles
     both delta-seconds and HTTP-date forms). When that header is absent or
-    unparseable, derives the delay from ``RateLimit-Reset`` (an absolute
-    epoch-seconds timestamp) instead of leaving the caller with ``None`` --
-    a caller that treats "no Retry-After" as "no signal at all" and falls
-    back to its own short default backoff ends up re-hammering a
-    still-throttled self-hosted instance sooner than the server intends.
-
-    Mirrors ``providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit``'s
-    ``Retry-After`` / ``RateLimit-Reset`` fallback byte-for-byte; extracted
-    here so GitLab provider clients other than ``GitLabWorkClient`` derive
-    the SAME delay from the SAME headers instead of reimplementing (or
-    worse, silently omitting) the ``RateLimit-Reset`` fallback.
+    unparseable, derives the delay from ``reset_header_name`` (an absolute
+    epoch-seconds timestamp -- ``X-RateLimit-Reset`` for GitHub,
+    ``RateLimit-Reset`` for GitLab) instead of leaving the caller with
+    ``None`` -- a caller that treats "no Retry-After" as "no signal at all"
+    and falls back to its own short default backoff ends up re-hammering a
+    still-throttled instance sooner than the server intends. Provider-
+    parameterized generalization of the GitLab-specific delay resolution
+    shipped in #1142 (see :func:`gitlab_resolve_retry_after_seconds`, which
+    now delegates here) so the CHAOS-2773 CS1 shared REST core reuses ONE
+    implementation instead of growing a second copy.
 
     :param headers: any object exposing a ``.get(name)`` mapping interface --
         an ``httpx.Headers``, a plain ``dict``, or python-gitlab's
         ``response_headers``.
+    :param reset_header_name: header carrying the provider's epoch-seconds
+        rate-limit reset timestamp.
     """
     retry_after = parse_retry_after_header(headers)
     if retry_after is not None:
@@ -178,7 +181,7 @@ def gitlab_resolve_retry_after_seconds(headers: Any) -> float | None:
     if headers is None:
         return None
     try:
-        reset_raw = headers.get("RateLimit-Reset")
+        reset_raw = headers.get(reset_header_name)
     except AttributeError:
         return None
     if reset_raw is None:
@@ -187,3 +190,25 @@ def gitlab_resolve_retry_after_seconds(headers: Any) -> float | None:
         return max(0.0, float(reset_raw) - time.time())
     except (TypeError, ValueError):
         return None
+
+
+def gitlab_resolve_retry_after_seconds(headers: Any) -> float | None:
+    """Resolve the effective retry delay for a rate-limited GitLab response.
+
+    Prefers ``Retry-After`` via :func:`parse_retry_after_header` (handles
+    both delta-seconds and HTTP-date forms). When that header is absent or
+    unparseable, derives the delay from ``RateLimit-Reset`` (an absolute
+    epoch-seconds timestamp) instead of leaving the caller with ``None``.
+
+    Mirrors ``providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit``'s
+    ``Retry-After`` / ``RateLimit-Reset`` fallback byte-for-byte; extracted
+    here so GitLab provider clients other than ``GitLabWorkClient`` derive
+    the SAME delay from the SAME headers instead of reimplementing (or
+    worse, silently omitting) the ``RateLimit-Reset`` fallback. Thin
+    GitLab-pinned wrapper over :func:`resolve_retry_after_seconds`.
+
+    :param headers: any object exposing a ``.get(name)`` mapping interface --
+        an ``httpx.Headers``, a plain ``dict``, or python-gitlab's
+        ``response_headers``.
+    """
+    return resolve_retry_after_seconds(headers, reset_header_name="RateLimit-Reset")

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -31,6 +31,7 @@ from dev_health_ops.credentials.resolver import (
 )
 from dev_health_ops.credentials.types import GitHubCredentials
 from dev_health_ops.providers._ratelimit import gate_call
+from dev_health_ops.providers.github.ratelimit import classify_github_403
 from dev_health_ops.providers.usage import UsageRecorder
 from dev_health_ops.sync.budget_types import BudgetDimension
 from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
@@ -175,23 +176,6 @@ def _github_error_message(data: object) -> str:
     if data is None:
         return ""
     return str(data)
-
-
-def _retry_after_seconds(headers: dict[str, str]) -> float | None:
-    retry_after = headers.get("retry-after")
-    if retry_after is not None:
-        try:
-            return float(retry_after)
-        except ValueError:
-            return None
-
-    reset = headers.get("x-ratelimit-reset")
-    if reset is not None:
-        try:
-            return max(0.0, float(reset) - time.time())
-        except ValueError:
-            return None
-    return None
 
 
 class _GitHubLabelLike(Protocol):
@@ -595,17 +579,12 @@ class GitHubWorkClient:
                 f"GitHub resource not found on {operation}: {message} (headers={headers})"
             ) from exc
         if status == 403:
-            lowered = message.lower()
-            is_rate_limit = (
-                headers.get("x-ratelimit-remaining") == "0"
-                or "retry-after" in headers
-                or "rate limit" in lowered
-                or "abuse" in lowered
-                or "secondary" in lowered
-            )
-            if is_rate_limit:
-                retry_after = _retry_after_seconds(headers)
-                is_primary = headers.get("x-ratelimit-remaining") == "0"
+            # 403 triage (primary rate limit / secondary-abuse / permission-SSO)
+            # is extracted to providers/github/ratelimit.py::classify_github_403
+            # (CHAOS-2773 CS1) so this REST work client and any future httpx
+            # GitHubCodeClient share ONE classifier -- no second copy.
+            classification = classify_github_403(headers=headers, message=message)
+            if classification.is_rate_limit:
                 logger.warning(
                     "GitHub rate limit (403) on %s headers=%s message=%s",
                     operation,
@@ -614,19 +593,15 @@ class GitHubWorkClient:
                 )
                 raise RateLimitException(
                     f"GitHub rate limit (403) on {operation}: {message} (headers={headers})",
-                    retry_after_seconds=retry_after,
+                    retry_after_seconds=classification.retry_after_seconds,
                     signal=RateLimitSignal(
                         provider="github",
-                        dimension=(
-                            BudgetDimension.REST_CORE
-                            if is_primary
-                            else BudgetDimension.SECONDARY_ABUSE_RISK
-                        ),
-                        retry_after_seconds=retry_after,
+                        dimension=classification.dimension,
+                        retry_after_seconds=classification.retry_after_seconds,
                         reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
                             headers.get("x-ratelimit-reset")
                         ),
-                        reason="primary" if is_primary else "secondary",
+                        reason=classification.reason,
                         request_id=headers.get("x-github-request-id"),
                     ),
                 ) from exc

--- a/src/dev_health_ops/providers/github/ratelimit.py
+++ b/src/dev_health_ops/providers/github/ratelimit.py
@@ -1,0 +1,117 @@
+"""Shared GitHub 403 triage (CHAOS-2773 CS1).
+
+Extracted from ``providers/github/client.py::GitHubWorkClient.
+_raise_github_exception`` so the REST work client and any future httpx-based
+``GitHubCodeClient`` (CS3+) classify a 403 through the SAME function -- no
+second copy of the primary/secondary/permission decision. Behavior is
+pinned by porting the relevant classification cases from
+``tests/test_github_403_observability.py`` (which exercises the frozen
+``connectors/github.py`` twin of this same triage) into
+``tests/providers/test_github_ratelimit_classifier.py``.
+
+A GitHub 403 is one of three things, distinguished only by response headers
+and, when headers are absent, the body's documented wording
+(docs/providers/rate-limit-policy.md#github):
+
+- **(a) primary rate limit** -- ``x-ratelimit-remaining: 0``.
+- **(b) secondary/abuse limit** -- ``Retry-After`` present, or the body
+  carries GitHub's documented ``rate limit`` / ``abuse`` / ``secondary``
+  wording.
+- **(c) permission / SSO / other 403** -- none of the above; NOT a rate
+  limit, so the caller must raise a non-retryable error (this module never
+  raises -- it only classifies; the caller decides how to signal "not a rate
+  limit" for its own exception hierarchy).
+"""
+
+from __future__ import annotations
+
+import time
+from collections.abc import Mapping
+from dataclasses import dataclass
+
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+
+@dataclass(frozen=True)
+class GitHubRateLimitClassification:
+    """Result of classifying a GitHub 403 (or any status carrying the same
+    rate-limit header vocabulary) via :func:`classify_github_403`."""
+
+    is_rate_limit: bool
+    is_primary: bool = False
+    dimension: BudgetDimension | None = None
+    reason: str | None = None
+    retry_after_seconds: float | None = None
+
+
+_NOT_RATE_LIMITED = GitHubRateLimitClassification(is_rate_limit=False)
+
+
+def classify_github_403(
+    *, headers: Mapping[str, str], message: str
+) -> GitHubRateLimitClassification:
+    """Classify a GitHub 403 using its diagnostic headers + error message.
+
+    :param headers: lower-cased diagnostic headers (as produced by both
+        ``providers/github/client.py::_diagnostic_headers`` and
+        ``connectors/utils/graphql.py::safe_github_headers`` -- callers pass
+        their own already-filtered dict; this function does not care about
+        the token/Authorization header since it never receives it).
+    :param message: the error body / message text (checked for the
+        documented secondary/abuse wording when no header settles it).
+    """
+    lowered_message = message.lower()
+    is_rate_limit = (
+        headers.get("x-ratelimit-remaining") == "0"
+        or "retry-after" in headers
+        or "rate limit" in lowered_message
+        or "abuse" in lowered_message
+        or "secondary" in lowered_message
+    )
+    if not is_rate_limit:
+        return _NOT_RATE_LIMITED
+
+    is_primary = headers.get("x-ratelimit-remaining") == "0"
+    return GitHubRateLimitClassification(
+        is_rate_limit=True,
+        is_primary=is_primary,
+        dimension=(
+            BudgetDimension.REST_CORE
+            if is_primary
+            else BudgetDimension.SECONDARY_ABUSE_RISK
+        ),
+        reason="primary" if is_primary else "secondary",
+        retry_after_seconds=github_retry_after_seconds(headers),
+    )
+
+
+def github_retry_after_seconds(headers: Mapping[str, str]) -> float | None:
+    """Resolve the effective retry delay for a rate-limited GitHub response.
+
+    Prefers the explicit ``retry-after`` header (secondary/abuse limits);
+    falls back to deriving from ``x-ratelimit-reset`` (an absolute
+    epoch-seconds timestamp, primary limits) -- mirrors
+    ``providers/github/client.py``'s pre-extraction ``_retry_after_seconds``
+    byte-for-byte.
+    """
+    retry_after = headers.get("retry-after")
+    if retry_after is not None:
+        try:
+            return float(retry_after)
+        except ValueError:
+            return None
+
+    reset = headers.get("x-ratelimit-reset")
+    if reset is not None:
+        try:
+            return max(0.0, float(reset) - time.time())
+        except ValueError:
+            return None
+    return None
+
+
+__all__ = [
+    "GitHubRateLimitClassification",
+    "classify_github_403",
+    "github_retry_after_seconds",
+]

--- a/src/dev_health_ops/providers/gitlab/client.py
+++ b/src/dev_health_ops/providers/gitlab/client.py
@@ -13,11 +13,10 @@ from dev_health_ops.connectors.utils.rate_limit_queue import (
     create_rate_limit_gate,
 )
 from dev_health_ops.exceptions import RateLimitException
-from dev_health_ops.providers._ratelimit import gate_call, parse_retry_after_header
+from dev_health_ops.providers._ratelimit import gate_call
+from dev_health_ops.providers.gitlab.ratelimit import maybe_raise_gitlab_rate_limit
 from dev_health_ops.providers.usage import UsageRecorder
 from dev_health_ops.providers.utils import EnvSpec, read_env_spec
-from dev_health_ops.sync.budget_types import BudgetDimension
-from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
 logger = logging.getLogger(__name__)
 
@@ -42,7 +41,15 @@ def _diagnostic_headers(headers: object) -> dict[str, str]:
 def _maybe_raise_gitlab_rate_limit(exc: BaseException) -> None:
     """Raise RateLimitException if exc is a GitLab rate-limit error (HTTP 429,
     or 403 carrying rate-limit headers); otherwise return None so callers
-    continue their existing handling."""
+    continue their existing handling.
+
+    Delegates the actual 429/header-qualified-403 predicate + delay
+    computation to ``providers/gitlab/ratelimit.py`` (CHAOS-2773 CS1), itself
+    built on the shared ``providers/_ratelimit.py`` helpers
+    (``gitlab_403_is_rate_limited`` / ``gitlab_resolve_retry_after_seconds``,
+    #1142) -- so exactly one predicate/delay implementation exists for
+    GitLab, not a second copy inline here.
+    """
     import gitlab  # python-gitlab; keep lazy to match existing import semantics
 
     if isinstance(exc, RateLimitException):
@@ -51,7 +58,6 @@ def _maybe_raise_gitlab_rate_limit(exc: BaseException) -> None:
         return None
     status = getattr(exc, "response_code", None)
     headers = getattr(exc, "response_headers", None) or {}
-    retry_after = parse_retry_after_header(headers)
 
     def _hdr(name: str) -> str | None:
         try:
@@ -59,39 +65,13 @@ def _maybe_raise_gitlab_rate_limit(exc: BaseException) -> None:
         except AttributeError:
             return None
 
-    is_rate_limited = status == 429 or (
-        status == 403
-        and (
-            retry_after is not None
-            or str(_hdr("RateLimit-Remaining")) == "0"
-            or _hdr("Retry-After") is not None
+    try:
+        maybe_raise_gitlab_rate_limit(
+            status=status, headers=headers, request_id=_hdr("X-Request-Id")
         )
-    )
-    if not is_rate_limited:
-        return None
-    # Prefer Retry-After; else derive from RateLimit-Reset (epoch seconds) if present.
-    reset_raw = _hdr("RateLimit-Reset")
-    if retry_after is None and reset_raw is not None:
-        try:
-            import time as _t
-
-            retry_after = max(0.0, float(reset_raw) - _t.time())
-        except (TypeError, ValueError):
-            retry_after = None
-    raise RateLimitException(
-        f"GitLab rate limited (HTTP {status})",
-        retry_after_seconds=retry_after,
-        signal=RateLimitSignal(
-            provider="gitlab",
-            dimension=BudgetDimension.REST_CORE,
-            retry_after_seconds=retry_after,
-            reset_at=RateLimitSignal.reset_at_from_epoch_seconds(reset_raw),
-            # 429 is the documented quota limit; a header-qualified 403 is the
-            # softer/abuse-style signal -- mirror GitHub's primary/secondary split.
-            reason="primary" if status == 429 else "secondary",
-            request_id=_hdr("X-Request-Id"),
-        ),
-    ) from exc
+    except RateLimitException as rate_limit_exc:
+        raise rate_limit_exc from exc
+    return None
 
 
 class _ListManager(Protocol):

--- a/src/dev_health_ops/providers/gitlab/ratelimit.py
+++ b/src/dev_health_ops/providers/gitlab/ratelimit.py
@@ -1,0 +1,133 @@
+"""Shared GitLab rate-limit classifier (CHAOS-2773 CS1).
+
+Consolidates GitLab's 429-primary / header-qualified-403-secondary
+classification into ONE call site, built directly on the shared predicate +
+delay primitives already merged in ``providers/_ratelimit.py``
+(``gitlab_403_is_rate_limited`` / ``gitlab_resolve_retry_after_seconds``,
+#1142 -- the #1142 feature-flags client already uses them directly). This
+module is what ``providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit``
+now DELEGATES to, so exactly one predicate/delay implementation exists for
+GitLab (the work client no longer re-derives the same boolean/delay logic a
+second time), and it doubles as the classifier any future httpx-based
+``GitLabCodeClient`` (CS3+) reuses via
+:class:`~dev_health_ops.providers._http.InstrumentedRESTCore`'s
+``classify_error`` extension point.
+
+**429 vs. 403 convention** (docs/providers/rate-limit-policy.md#gitlab): 429
+is GitLab's documented quota limit and is ALWAYS a rate limit; a 403 is
+permission/feature-disabled UNLESS it carries rate-limit headers (some
+self-managed instances front a throttled request with 403 instead of 429),
+in which case it is treated as the softer "secondary" signal -- mirroring
+GitHub's primary/secondary split.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.providers._ratelimit import (
+    gitlab_403_is_rate_limited,
+    gitlab_resolve_retry_after_seconds,
+)
+from dev_health_ops.sync.budget_types import BudgetDimension
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
+
+
+@dataclass(frozen=True)
+class GitLabRateLimitClassification:
+    """Result of classifying a GitLab response status + headers."""
+
+    is_rate_limit: bool
+    reason: str | None = None  # "primary" (429) | "secondary" (header-qualified 403)
+    retry_after_seconds: float | None = None
+
+
+_NOT_RATE_LIMITED = GitLabRateLimitClassification(is_rate_limit=False)
+
+
+def _header_get(headers: Any, name: str) -> str | None:
+    if headers is None:
+        return None
+    try:
+        return headers.get(name)
+    except AttributeError:
+        return None
+
+
+def classify_gitlab_status(
+    *, status: int | None, headers: Any
+) -> GitLabRateLimitClassification:
+    """Classify a GitLab response status + headers for rate-limit signal.
+
+    :param status: HTTP status code (``response_code`` on a python-gitlab
+        ``GitlabError``, or ``response.status_code`` on an httpx response).
+    :param headers: any ``.get(name)``-mapping object -- ``httpx.Headers``, a
+        plain ``dict``, or python-gitlab's ``response_headers``.
+    """
+    if status == 429:
+        return GitLabRateLimitClassification(
+            is_rate_limit=True,
+            reason="primary",
+            retry_after_seconds=gitlab_resolve_retry_after_seconds(headers),
+        )
+    if status == 403 and gitlab_403_is_rate_limited(headers):
+        return GitLabRateLimitClassification(
+            is_rate_limit=True,
+            reason="secondary",
+            retry_after_seconds=gitlab_resolve_retry_after_seconds(headers),
+        )
+    return _NOT_RATE_LIMITED
+
+
+def build_gitlab_rate_limit_exception(
+    *,
+    status: int | None,
+    headers: Any,
+    classification: GitLabRateLimitClassification,
+    request_id: str | None = None,
+) -> RateLimitException:
+    """Build the canonical ``RateLimitException`` + ``RateLimitSignal`` for a
+    response already classified as rate-limited (call
+    :func:`classify_gitlab_status` first; ``classification.is_rate_limit``
+    must be ``True``)."""
+    return RateLimitException(
+        f"GitLab rate limited (HTTP {status})",
+        retry_after_seconds=classification.retry_after_seconds,
+        signal=RateLimitSignal(
+            provider="gitlab",
+            dimension=BudgetDimension.REST_CORE,
+            retry_after_seconds=classification.retry_after_seconds,
+            # GitLab reports its reset window as epoch SECONDS (unlike
+            # LaunchDarkly's epoch milliseconds).
+            reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                _header_get(headers, "RateLimit-Reset")
+            ),
+            reason=classification.reason,
+            request_id=request_id,
+        ),
+    )
+
+
+def maybe_raise_gitlab_rate_limit(
+    *, status: int | None, headers: Any, request_id: str | None = None
+) -> None:
+    """Raise the canonical GitLab ``RateLimitException`` if rate-limited,
+    else return ``None`` (the caller's non-rate-limit handling continues)."""
+    classification = classify_gitlab_status(status=status, headers=headers)
+    if classification.is_rate_limit:
+        raise build_gitlab_rate_limit_exception(
+            status=status,
+            headers=headers,
+            classification=classification,
+            request_id=request_id,
+        )
+
+
+__all__ = [
+    "GitLabRateLimitClassification",
+    "build_gitlab_rate_limit_exception",
+    "classify_gitlab_status",
+    "maybe_raise_gitlab_rate_limit",
+]

--- a/src/dev_health_ops/providers/usage.py
+++ b/src/dev_health_ops/providers/usage.py
@@ -76,6 +76,23 @@ class OperationResolver:
     When no family matches, the transport's entry in ``defaults`` is used; if
     the transport itself is unknown the observation collapses onto
     :data:`UNCLASSIFIED_ROUTE_FAMILY` (still bounded, never per-operation).
+
+    **Explicit-prefix short-circuit (CHAOS-2773 CS1).** Before the substring
+    marker scan runs, an operation label of the form ``"<route_family>:..."``
+    resolves DIRECTLY to that family (still transport-filtered), bypassing
+    the marker scan entirely. This exists because broad legacy substring
+    markers are ambiguous by construction -- e.g. GitLab's ``project`` family
+    registers ``"/projects/:id"`` / ``"/projects/"`` as markers, so a
+    self-authored label like ``"pipelines:GET /projects/:id/pipelines"``
+    would otherwise be swallowed by ``project`` (listed first) before
+    ``pipelines`` is ever consulted. Canonical code clients author both the
+    label and the family prefix themselves, so resolution for THOSE labels is
+    deterministic and unambiguous by construction rather than by marker
+    tuning. Unprefixed labels (every existing work-client operation label
+    today) never hit this branch and take the marker-scan path UNCHANGED --
+    pinned by ``tests/providers/test_usage_resolver_prefix.py``, which also
+    asserts no existing work-client label accidentally starts with a
+    registered ``"<family>:"`` prefix (the false-trigger regression guard).
     """
 
     families: tuple[UsageRouteFamily, ...] = ()
@@ -86,6 +103,11 @@ class OperationResolver:
 
     def resolve(self, *, transport: str, operation: str) -> tuple[str, BudgetDimension]:
         lowered = operation.lower()
+        prefix_match = self._resolve_explicit_prefix(
+            transport=transport, lowered=lowered
+        )
+        if prefix_match is not None:
+            return prefix_match
         for family in self.families:
             if family.transport is not None and family.transport != transport:
                 continue
@@ -97,6 +119,20 @@ class OperationResolver:
             if default_transport == transport:
                 return (route_family, dimension)
         return (UNCLASSIFIED_ROUTE_FAMILY, _default_dimension_for_transport(transport))
+
+    def _resolve_explicit_prefix(
+        self, *, transport: str, lowered: str
+    ) -> tuple[str, BudgetDimension] | None:
+        """Return the first registered family whose ``"<family>:"`` prefix
+        matches ``lowered``, respecting the same per-family transport filter
+        the marker scan uses, or ``None`` when no registered family prefixes
+        the label (the common case for every unprefixed/legacy label)."""
+        for family in self.families:
+            if family.transport is not None and family.transport != transport:
+                continue
+            if lowered.startswith(f"{family.route_family}:"):
+                return (family.route_family, family.dimension)
+        return None
 
 
 def _default_dimension_for_transport(transport: str) -> BudgetDimension:

--- a/tests/providers/test_github_ratelimit_classifier.py
+++ b/tests/providers/test_github_ratelimit_classifier.py
@@ -1,0 +1,196 @@
+"""Tests for providers/github/ratelimit.py (CHAOS-2773 CS1).
+
+Ports the relevant classification cases from
+``tests/test_github_403_observability.py`` (which pins the frozen
+``connectors/github.py`` twin of this same triage) onto the extracted
+``classify_github_403`` -- the shared classifier
+``providers/github/client.py::GitHubWorkClient._raise_github_exception`` now
+delegates to, and any future httpx ``GitHubCodeClient`` (CS3+) will too.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dev_health_ops.exceptions import AuthenticationException, RateLimitException
+from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
+from dev_health_ops.providers.github.ratelimit import (
+    classify_github_403,
+    github_retry_after_seconds,
+)
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+
+class TestClassifyGitHub403:
+    def test_primary_rate_limit_remaining_zero(self) -> None:
+        result = classify_github_403(
+            headers={"x-ratelimit-remaining": "0", "x-ratelimit-reset": "12345"},
+            message="API rate limit exceeded",
+        )
+        assert result.is_rate_limit is True
+        assert result.is_primary is True
+        assert result.reason == "primary"
+        assert result.dimension is BudgetDimension.REST_CORE
+
+    def test_secondary_abuse_via_retry_after_header(self) -> None:
+        result = classify_github_403(
+            headers={"retry-after": "42"},
+            message="You have exceeded a secondary rate limit.",
+        )
+        assert result.is_rate_limit is True
+        assert result.is_primary is False
+        assert result.reason == "secondary"
+        assert result.dimension is BudgetDimension.SECONDARY_ABUSE_RISK
+        assert result.retry_after_seconds == pytest.approx(42.0)
+
+    def test_secondary_abuse_via_body_wording_without_retry_after(self) -> None:
+        # GitHub-documented case: the body carries the wording but with NO
+        # Retry-After header and NO x-ratelimit-remaining:0 -- must still
+        # classify RETRYABLE (secondary), not "not a rate limit".
+        result = classify_github_403(
+            headers={},
+            message="You have exceeded a secondary rate limit. Please wait a few minutes.",
+        )
+        assert result.is_rate_limit is True
+        assert result.reason == "secondary"
+        # No Retry-After and no x-ratelimit-reset -- retry_after_seconds is
+        # None; the CALLER (GitHubWorkClient) applies its own default wait,
+        # mirroring the pre-extraction behavior exactly.
+        assert result.retry_after_seconds is None
+
+    def test_abuse_wording_variant(self) -> None:
+        result = classify_github_403(headers={}, message="abuse detection triggered")
+        assert result.is_rate_limit is True
+        assert result.reason == "secondary"
+
+    def test_permission_sso_403_is_not_a_rate_limit(self) -> None:
+        result = classify_github_403(
+            headers={"x-github-request-id": "REQ:1"},
+            message="Resource protected by organization SAML enforcement.",
+        )
+        assert result.is_rate_limit is False
+        assert result.is_primary is False
+        assert result.dimension is None
+        assert result.reason is None
+
+    def test_bare_permission_403_no_headers_no_wording(self) -> None:
+        result = classify_github_403(
+            headers={}, message="Resource not accessible by integration"
+        )
+        assert result.is_rate_limit is False
+
+    def test_primary_wins_over_body_wording_when_both_present(self) -> None:
+        # x-ratelimit-remaining: 0 always signals primary regardless of body
+        # wording.
+        result = classify_github_403(
+            headers={"x-ratelimit-remaining": "0"},
+            message="unrelated message",
+        )
+        assert result.is_rate_limit is True
+        assert result.is_primary is True
+        assert result.reason == "primary"
+
+
+class TestGithubRetryAfterSeconds:
+    def test_prefers_retry_after_header(self) -> None:
+        assert github_retry_after_seconds({"retry-after": "30"}) == pytest.approx(30.0)
+
+    def test_falls_back_to_reset_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(
+            "dev_health_ops.providers.github.ratelimit.time.time", lambda: 100.0
+        )
+        assert github_retry_after_seconds(
+            {"x-ratelimit-reset": "150"}
+        ) == pytest.approx(50.0)
+
+    def test_no_headers_returns_none(self) -> None:
+        assert github_retry_after_seconds({}) is None
+
+    def test_garbage_retry_after_returns_none(self) -> None:
+        assert github_retry_after_seconds({"retry-after": "soon"}) is None
+
+
+# ---------------------------------------------------------------------------
+# GitHubWorkClient._raise_github_exception delegates to the classifier
+# (behavior-parity ported from tests/test_github_403_observability.py).
+# ---------------------------------------------------------------------------
+
+
+class _StubGithubException(Exception):
+    def __init__(self, status: int, data: dict, headers: dict) -> None:
+        super().__init__(str(data))
+        self.status = status
+        self.data = data
+        self.headers = headers
+
+
+def _client_for_raise() -> GitHubWorkClient:
+    # Constructing via __new__ avoids the network-touching __init__.
+    # _record_rest_usage defensively getattr()s self._usage (tolerated when
+    # absent) but does `self.github.rate_limiting` unconditionally, so
+    # `github` itself must at least exist as an attribute (None is fine --
+    # getattr(None, "rate_limiting", None) degrades gracefully).
+    client = GitHubWorkClient.__new__(GitHubWorkClient)
+    client.github = None  # type: ignore[assignment]
+    return client
+
+
+class TestRaiseGithubExceptionDelegation:
+    def test_permission_403_raises_non_retryable_auth_error(self) -> None:
+        from github import GithubException
+
+        client = _client_for_raise()
+        exc = GithubException(
+            403,
+            {"message": "Resource protected by organization SAML enforcement."},
+            {"x-github-request-id": "REQ:42"},
+        )
+        with pytest.raises(AuthenticationException) as excinfo:
+            client._raise_github_exception(exc, operation="GET /repos/o/r")
+        assert "REQ:42" in str(excinfo.value)
+
+    def test_primary_rate_limit_403_raises_rate_limit_with_signal(self) -> None:
+        from github import GithubException
+
+        client = _client_for_raise()
+        exc = GithubException(
+            403,
+            {"message": "API rate limit exceeded"},
+            {
+                "x-ratelimit-remaining": "0",
+                "x-ratelimit-reset": str(int(time.time()) + 60),
+            },
+        )
+        with pytest.raises(RateLimitException) as excinfo:
+            client._raise_github_exception(exc, operation="GET /repos/o/r")
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.reason == "primary"
+        assert signal.dimension is BudgetDimension.REST_CORE
+
+    def test_secondary_rate_limit_403_raises_rate_limit_with_signal(self) -> None:
+        from github import GithubException
+
+        client = _client_for_raise()
+        exc = GithubException(
+            403,
+            {"message": "You have exceeded a secondary rate limit"},
+            {"retry-after": "13"},
+        )
+        with pytest.raises(RateLimitException) as excinfo:
+            client._raise_github_exception(exc, operation="GET /repos/o/r")
+        assert excinfo.value.retry_after_seconds == pytest.approx(13.0)
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.reason == "secondary"
+        assert signal.dimension is BudgetDimension.SECONDARY_ABUSE_RISK
+
+
+def test_github_auth_from_credentials_roundtrip() -> None:
+    # Smoke check that GitHubAuth (reused by the future GHE base-url join)
+    # is still importable/constructible from this module untouched.
+    auth = GitHubAuth(token="t", base_url="https://ghe.example.com/api/v3")
+    assert auth.base_url == "https://ghe.example.com/api/v3"
+    assert auth.is_app_auth is False

--- a/tests/providers/test_gitlab_ratelimit_classifier.py
+++ b/tests/providers/test_gitlab_ratelimit_classifier.py
@@ -1,0 +1,146 @@
+"""Tests for providers/gitlab/ratelimit.py (CHAOS-2773 CS1).
+
+``providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit`` now delegates
+to ``classify_gitlab_status`` / ``maybe_raise_gitlab_rate_limit`` here, which
+are themselves built directly on the shared ``providers/_ratelimit.py``
+primitives (``gitlab_403_is_rate_limited`` / ``gitlab_resolve_retry_after_seconds``,
+#1142) -- so exactly one predicate/delay implementation exists for GitLab.
+These tests pin behavior parity with the pre-extraction inline logic (already
+covered end-to-end by ``tests/providers/test_gitlab_client_ratelimit.py``,
+which stays green untouched) and additionally exercise the classifier
+directly, independent of a python-gitlab exception object.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.providers.gitlab.ratelimit import (
+    classify_gitlab_status,
+    maybe_raise_gitlab_rate_limit,
+)
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+
+class TestClassifyGitlabStatus:
+    def test_429_is_always_rate_limited_primary(self) -> None:
+        result = classify_gitlab_status(status=429, headers={})
+        assert result.is_rate_limit is True
+        assert result.reason == "primary"
+
+    def test_plain_403_no_headers_is_not_rate_limited(self) -> None:
+        result = classify_gitlab_status(status=403, headers={})
+        assert result.is_rate_limit is False
+        assert result.reason is None
+
+    def test_403_with_retry_after_is_rate_limited_secondary(self) -> None:
+        result = classify_gitlab_status(status=403, headers={"Retry-After": "9"})
+        assert result.is_rate_limit is True
+        assert result.reason == "secondary"
+        assert result.retry_after_seconds == pytest.approx(9.0)
+
+    def test_403_with_rate_limit_remaining_zero_is_rate_limited_secondary(self) -> None:
+        result = classify_gitlab_status(
+            status=403, headers={"RateLimit-Remaining": "0"}
+        )
+        assert result.is_rate_limit is True
+        assert result.reason == "secondary"
+
+    def test_403_with_nonzero_remaining_and_no_retry_after_is_not_rate_limited(
+        self,
+    ) -> None:
+        result = classify_gitlab_status(
+            status=403, headers={"RateLimit-Remaining": "42"}
+        )
+        assert result.is_rate_limit is False
+
+    def test_403_retry_after_falls_back_to_rate_limit_reset(self) -> None:
+        reset_epoch = int(time.time()) + 300
+        result = classify_gitlab_status(
+            status=403,
+            headers={"RateLimit-Remaining": "0", "RateLimit-Reset": str(reset_epoch)},
+        )
+        assert result.retry_after_seconds is not None
+        assert 290 <= result.retry_after_seconds <= 300
+
+    def test_401_is_not_rate_limited(self) -> None:
+        assert classify_gitlab_status(status=401, headers={}).is_rate_limit is False
+
+    def test_none_status_is_not_rate_limited(self) -> None:
+        assert classify_gitlab_status(status=None, headers={}).is_rate_limit is False
+
+    def test_none_headers_does_not_raise(self) -> None:
+        assert classify_gitlab_status(status=403, headers=None).is_rate_limit is False
+        result = classify_gitlab_status(status=429, headers=None)
+        assert result.is_rate_limit is True
+        assert result.retry_after_seconds is None
+
+
+class TestMaybeRaiseGitlabRateLimit:
+    def test_raises_with_signal_on_429(self) -> None:
+        with pytest.raises(RateLimitException) as excinfo:
+            maybe_raise_gitlab_rate_limit(
+                status=429, headers={"Retry-After": "5"}, request_id="req-1"
+            )
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.provider == "gitlab"
+        assert signal.dimension is BudgetDimension.REST_CORE
+        assert signal.reason == "primary"
+        assert signal.request_id == "req-1"
+        assert excinfo.value.retry_after_seconds == pytest.approx(5.0)
+
+    def test_no_op_when_not_rate_limited(self) -> None:
+        # Must return without raising -- callers rely on this to fall through
+        # to their own non-rate-limit handling.
+        maybe_raise_gitlab_rate_limit(status=403, headers={})
+        maybe_raise_gitlab_rate_limit(status=200, headers={})
+
+
+# ---------------------------------------------------------------------------
+# providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit delegation
+# ---------------------------------------------------------------------------
+
+
+class TestClientDelegation:
+    def test_gitlab_error_429_raises_with_cause_chained(self) -> None:
+        import gitlab
+
+        from dev_health_ops.providers.gitlab.client import (
+            _maybe_raise_gitlab_rate_limit,
+        )
+
+        original = gitlab.exceptions.GitlabError("rate limited", response_code=429)
+        with pytest.raises(RateLimitException) as excinfo:
+            _maybe_raise_gitlab_rate_limit(original)
+        assert excinfo.value.__cause__ is original
+
+    def test_gitlab_error_plain_403_returns_none(self) -> None:
+        import gitlab
+
+        from dev_health_ops.providers.gitlab.client import (
+            _maybe_raise_gitlab_rate_limit,
+        )
+
+        original = gitlab.exceptions.GitlabError("forbidden", response_code=403)
+        _maybe_raise_gitlab_rate_limit(original)  # must not raise
+
+    def test_non_gitlab_error_returns_none(self) -> None:
+        from dev_health_ops.providers.gitlab.client import (
+            _maybe_raise_gitlab_rate_limit,
+        )
+
+        _maybe_raise_gitlab_rate_limit(RuntimeError("boom"))  # must not raise
+
+    def test_already_canonical_rate_limit_exception_reraised_as_is(self) -> None:
+        from dev_health_ops.providers.gitlab.client import (
+            _maybe_raise_gitlab_rate_limit,
+        )
+
+        original = RateLimitException("already classified")
+        with pytest.raises(RateLimitException) as excinfo:
+            _maybe_raise_gitlab_rate_limit(original)
+        assert excinfo.value is original

--- a/tests/providers/test_http_core.py
+++ b/tests/providers/test_http_core.py
@@ -1,0 +1,1015 @@
+"""Tests for providers/_http.py::InstrumentedRESTCore (CHAOS-2773 CS1).
+
+Covers the shared transport primitive every canonical code client (CS3+)
+will compose: recorder-per-physical-attempt (including retries),
+Retry-After-honoring backoff, exhaustion -> canonical RateLimitException +
+RateLimitSignal, the ``classify_error``/``is_retryable_status`` extension
+points, both paginators (including the documented edge cases: missing Link
+header, empty GitLab X-Next-Page, empty first page, hard page caps), and
+GHE / self-hosted-GitLab base-URL joining.
+"""
+
+from __future__ import annotations
+
+import time
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from dev_health_ops.exceptions import (
+    APIException,
+    AuthenticationException,
+    NotFoundException,
+    RateLimitException,
+)
+from dev_health_ops.providers._http import (
+    GITHUB_DEFAULT_BASE_URL,
+    GITHUB_DIAGNOSTIC_HEADER_NAMES,
+    GITLAB_DEFAULT_BASE_URL,
+    GITLAB_DIAGNOSTIC_HEADER_NAMES,
+    InstrumentedRESTCore,
+    github_rest_base_url,
+    gitlab_rest_base_url,
+)
+from dev_health_ops.providers.usage import OperationResolver, UsageRouteFamily
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+_GITHUB_RESOLVER = OperationResolver(
+    families=(UsageRouteFamily("git", BudgetDimension.REST_CORE),),
+    defaults=(("rest", "unclassified_default", BudgetDimension.REST_CORE),),
+)
+
+
+def _core(**overrides: object) -> InstrumentedRESTCore:
+    kwargs: dict[str, object] = {
+        "base_url": "https://api.github.com",
+        "provider": "github",
+        "resolver": _GITHUB_RESOLVER,
+        "max_retries": 3,
+    }
+    kwargs.update(overrides)
+    return InstrumentedRESTCore(**kwargs)  # type: ignore[arg-type]
+
+
+def _handler_sequence(responses: list[httpx.Response]) -> httpx.MockTransport:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        response = responses[min(calls["n"], len(responses) - 1)]
+        calls["n"] += 1
+        return response
+
+    transport = httpx.MockTransport(handler)
+    transport.calls = calls  # type: ignore[attr-defined]
+    return transport
+
+
+# ---------------------------------------------------------------------------
+# Base-URL joining (GHE / self-hosted GitLab)
+# ---------------------------------------------------------------------------
+
+
+class TestBaseUrlJoining:
+    def test_github_default_base_url(self) -> None:
+        assert github_rest_base_url(None) == GITHUB_DEFAULT_BASE_URL
+
+    def test_github_empty_string_falls_back_to_default(self) -> None:
+        assert github_rest_base_url("") == GITHUB_DEFAULT_BASE_URL
+
+    def test_github_ghe_base_url_joined_as_is(self) -> None:
+        # GHE's REST base already carries /api/v3 -- no path rewriting.
+        assert (
+            github_rest_base_url("https://ghe.example.com/api/v3")
+            == "https://ghe.example.com/api/v3"
+        )
+
+    def test_github_ghe_base_url_trailing_slash_stripped(self) -> None:
+        assert (
+            github_rest_base_url("https://ghe.example.com/api/v3/")
+            == "https://ghe.example.com/api/v3"
+        )
+
+    def test_gitlab_default_base_url_gets_api_v4_suffix(self) -> None:
+        assert gitlab_rest_base_url(None) == f"{GITLAB_DEFAULT_BASE_URL}/api/v4"
+
+    def test_gitlab_self_hosted_base_url_gets_api_v4_suffix(self) -> None:
+        assert (
+            gitlab_rest_base_url("https://gitlab.example.com")
+            == "https://gitlab.example.com/api/v4"
+        )
+
+    def test_gitlab_trailing_slash_stripped_before_suffix(self) -> None:
+        assert (
+            gitlab_rest_base_url("https://gitlab.example.com/")
+            == "https://gitlab.example.com/api/v4"
+        )
+
+    @pytest.mark.asyncio
+    async def test_ghe_base_url_actually_used_end_to_end(self) -> None:
+        """Proves the join isn't just a string helper -- a real request
+        constructed against a GHE-joined base actually hits that host/path."""
+        seen: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["url"] = str(request.url)
+            return httpx.Response(200, json={"ok": True})
+
+        core = _core(
+            base_url=github_rest_base_url("https://ghe.example.com/api/v3"),
+            transport=httpx.MockTransport(handler),
+        )
+        await core.request(
+            "GET", "/repos/acme/widgets", operation="git:GET /repos/acme/widgets"
+        )
+
+        assert seen["url"] == "https://ghe.example.com/api/v3/repos/acme/widgets"
+
+    @pytest.mark.asyncio
+    async def test_gitlab_self_hosted_base_url_actually_used_end_to_end(self) -> None:
+        seen: dict[str, str] = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["url"] = str(request.url)
+            return httpx.Response(200, json={"id": 1})
+
+        core = _core(
+            base_url=gitlab_rest_base_url("https://gitlab.example.com"),
+            provider="gitlab",
+            transport=httpx.MockTransport(handler),
+        )
+        await core.request("GET", "/projects/1", operation="project:GET /projects/:id")
+
+        assert seen["url"] == "https://gitlab.example.com/api/v4/projects/1"
+
+
+# ---------------------------------------------------------------------------
+# request() -- retries, usage recording, exhaustion
+# ---------------------------------------------------------------------------
+
+
+class TestRequestRetriesAndUsage:
+    @pytest.mark.asyncio
+    async def test_success_records_one_observation(self) -> None:
+        core = _core(
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json=[]))
+        )
+        response = await core.request(
+            "GET", "/repos/a/b", operation="git:GET /repos/a/b"
+        )
+
+        assert response.status_code == 200
+        observations = core.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "git"
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_retried_attempts_each_record_one_observation(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+        transport = _handler_sequence(
+            [
+                httpx.Response(429, headers={"Retry-After": "1"}),
+                httpx.Response(429, headers={"Retry-After": "1"}),
+                httpx.Response(200, json=[1, 2]),
+            ]
+        )
+        core = _core(transport=transport, max_retries=5)
+        response = await core.request(
+            "GET", "/repos/a/b", operation="git:GET /repos/a/b"
+        )
+
+        assert response.status_code == 200
+        observations = core.drain_usage_observations()
+        assert len(observations) == 1
+        # Every PHYSICAL round trip -- both failed 429 attempts AND the
+        # final success -- is recorded (CHAOS-2754: real request counts).
+        assert observations[0]["request_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_after_header_honored(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        monkeypatch.setattr("dev_health_ops.providers._http.asyncio.sleep", _fake_sleep)
+        transport = _handler_sequence(
+            [
+                httpx.Response(429, headers={"Retry-After": "17"}),
+                httpx.Response(200, json=[]),
+            ]
+        )
+        core = _core(transport=transport, max_retries=3)
+        await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+
+        assert sleep_calls == [17.0]
+
+    @pytest.mark.asyncio
+    async def test_429_exhaustion_raises_rate_limit_with_signal(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+        reset_epoch = int(time.time()) + 120
+        transport = httpx.MockTransport(
+            lambda r: httpx.Response(
+                429,
+                headers={"Retry-After": "5", "X-RateLimit-Reset": str(reset_epoch)},
+            )
+        )
+        core = _core(transport=transport, max_retries=3)
+
+        with pytest.raises(RateLimitException) as excinfo:
+            await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+
+        assert excinfo.value.retry_after_seconds == pytest.approx(5.0)
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.provider == "github"
+        assert signal.reason == "primary"
+        assert signal.dimension is BudgetDimension.REST_CORE
+        # integration_id/route_family are worker-boundary enrichment -- the
+        # client never populates them.
+        assert signal.integration_id is None
+        assert signal.route_family is None
+        assert signal.reset_at is not None
+        assert abs(signal.reset_at.timestamp() - reset_epoch) < 2
+
+        # Every attempt -- including the ones that ultimately raised --
+        # still recorded a usage observation.
+        observations = core.drain_usage_observations()
+        assert observations[0]["request_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_reset_header_name_override_for_gitlab_style_headers(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # A future GitLab code client overrides reset_header_name to
+        # "RateLimit-Reset" (GitLab's header, unlike GitHub's
+        # "X-RateLimit-Reset") -- the default must not silently ignore it.
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+        reset_epoch = int(time.time()) + 90
+        transport = httpx.MockTransport(
+            lambda r: httpx.Response(429, headers={"RateLimit-Reset": str(reset_epoch)})
+        )
+        core = _core(
+            transport=transport,
+            provider="gitlab",
+            reset_header_name="RateLimit-Reset",
+            max_retries=1,
+        )
+
+        with pytest.raises(RateLimitException) as excinfo:
+            await core.request(
+                "GET", "/projects/1", operation="project:GET /projects/1"
+            )
+
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.provider == "gitlab"
+        assert signal.reset_at is not None
+        assert abs(signal.reset_at.timestamp() - reset_epoch) < 2
+        # The worker-visible delay must ALSO come from the reset header
+        # (codex HIGH): the deferral path plans not_before from
+        # retry_after_seconds, not signal.reset_at.
+        assert excinfo.value.retry_after_seconds is not None
+        assert 85 <= excinfo.value.retry_after_seconds <= 90
+
+    @pytest.mark.asyncio
+    async def test_reset_only_429_derives_retry_after_from_reset_header(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Codex HIGH (PR #1149): a terminal 429 carrying ONLY the provider's
+        reset header (no Retry-After) must surface retry_after_seconds
+        derived from the reset delta -- workers/sync_units.py plans the
+        deferral's not_before from exc.retry_after_seconds, so leaving it
+        None wakes the unit on the 60s default instead of the provider's
+        real reset window."""
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+        reset_epoch = int(time.time()) + 1800  # 30-minute primary-limit window
+        transport = httpx.MockTransport(
+            lambda r: httpx.Response(
+                429, headers={"X-RateLimit-Reset": str(reset_epoch)}
+            )
+        )
+        core = _core(transport=transport, max_retries=2)
+
+        with pytest.raises(RateLimitException) as excinfo:
+            await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+
+        retry_after = excinfo.value.retry_after_seconds
+        assert retry_after is not None
+        assert 1790 <= retry_after <= 1800
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.retry_after_seconds == retry_after
+        assert signal.reset_at is not None
+        assert abs(signal.reset_at.timestamp() - reset_epoch) < 2
+
+    @pytest.mark.asyncio
+    async def test_reset_only_429_retry_sleep_uses_reset_delta(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # The in-place retry sleep derives from the reset header too (same
+        # shared resolution), not the generic exponential default.
+        sleep_calls: list[float] = []
+
+        async def _fake_sleep(seconds: float) -> None:
+            sleep_calls.append(seconds)
+
+        monkeypatch.setattr("dev_health_ops.providers._http.asyncio.sleep", _fake_sleep)
+        reset_epoch = int(time.time()) + 40
+        transport = _handler_sequence(
+            [
+                httpx.Response(429, headers={"X-RateLimit-Reset": str(reset_epoch)}),
+                httpx.Response(200, json=[]),
+            ]
+        )
+        core = _core(transport=transport, max_retries=3)
+        await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+
+        assert len(sleep_calls) == 1
+        assert 35 <= sleep_calls[0] <= 40
+
+    @pytest.mark.asyncio
+    async def test_5xx_exhaustion_raises_api_exception_not_rate_limit(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+        transport = httpx.MockTransport(
+            lambda r: httpx.Response(503, text="unavailable")
+        )
+        core = _core(transport=transport, max_retries=3)
+
+        with pytest.raises(APIException) as excinfo:
+            await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+
+        assert not isinstance(excinfo.value, RateLimitException)
+
+    @pytest.mark.asyncio
+    async def test_5xx_then_success_returns_response(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+        transport = _handler_sequence(
+            [httpx.Response(502), httpx.Response(200, json=[1])]
+        )
+        core = _core(transport=transport, max_retries=3)
+        response = await core.request(
+            "GET", "/repos/a/b", operation="git:GET /repos/a/b"
+        )
+        assert response.status_code == 200
+
+    @pytest.mark.asyncio
+    async def test_network_error_retries_then_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            if calls["n"] == 1:
+                raise httpx.ConnectError("boom", request=request)
+            return httpx.Response(200, json=[])
+
+        core = _core(transport=httpx.MockTransport(handler), max_retries=3)
+        response = await core.request(
+            "GET", "/repos/a/b", operation="git:GET /repos/a/b"
+        )
+
+        assert response.status_code == 200
+        assert calls["n"] == 2
+        # A network-level failure never produced a response -- no usage
+        # observation for that attempt (nothing to record).
+        observations = core.drain_usage_observations()
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_network_error_exhaustion_raises_api_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom", request=request)
+
+        core = _core(transport=httpx.MockTransport(handler), max_retries=2)
+        with pytest.raises(APIException):
+            await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+
+    @pytest.mark.asyncio
+    async def test_404_raises_not_found_without_retry(self) -> None:
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(404)
+
+        core = _core(transport=httpx.MockTransport(handler), max_retries=3)
+        with pytest.raises(NotFoundException):
+            await core.request(
+                "GET", "/repos/missing", operation="git:GET /repos/missing"
+            )
+        assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_401_raises_authentication_exception(self) -> None:
+        core = _core(transport=httpx.MockTransport(lambda r: httpx.Response(401)))
+        with pytest.raises(AuthenticationException):
+            await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+
+
+# ---------------------------------------------------------------------------
+# classify_error extension point
+# ---------------------------------------------------------------------------
+
+
+class TestClassifyErrorHook:
+    @pytest.mark.asyncio
+    async def test_classify_error_hook_raises_takes_precedence(self) -> None:
+        def classify(response: httpx.Response, operation: str) -> None:
+            if response.status_code == 403:
+                raise RateLimitException(
+                    "classified as secondary rate limit", retry_after_seconds=9.0
+                )
+
+        core = _core(
+            transport=httpx.MockTransport(lambda r: httpx.Response(403)),
+            classify_error=classify,
+        )
+        with pytest.raises(RateLimitException) as excinfo:
+            await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+        assert excinfo.value.retry_after_seconds == 9.0
+
+    @pytest.mark.asyncio
+    async def test_classify_error_hook_returning_none_falls_through_to_default(
+        self,
+    ) -> None:
+        calls = {"n": 0}
+
+        def classify(response: httpx.Response, operation: str) -> None:
+            calls["n"] += 1
+            return None
+
+        core = _core(
+            transport=httpx.MockTransport(lambda r: httpx.Response(403)),
+            classify_error=classify,
+        )
+        with pytest.raises(AuthenticationException):
+            await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+        assert calls["n"] == 1
+
+    @pytest.mark.asyncio
+    async def test_custom_is_retryable_status_allows_403_retry(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Mirrors what a future GitLab code client needs: a header-qualified
+        # 403 must be retryable, not just 429/5xx.
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+        transport = _handler_sequence(
+            [
+                httpx.Response(403, headers={"Retry-After": "2"}),
+                httpx.Response(200, json=[]),
+            ]
+        )
+        core = _core(
+            transport=transport,
+            max_retries=3,
+            is_retryable_status=lambda r: (
+                r.status_code in {403, 429, 500, 502, 503, 504}
+            ),
+        )
+        response = await core.request(
+            "GET", "/repos/a/b", operation="git:GET /repos/a/b"
+        )
+        assert response.status_code == 200
+
+
+# ---------------------------------------------------------------------------
+# paginate_link_header (GitHub)
+# ---------------------------------------------------------------------------
+
+
+class TestPaginateLinkHeader:
+    @pytest.mark.asyncio
+    async def test_single_page_no_link_header(self) -> None:
+        core = _core(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(200, json=[{"id": 1}, {"id": 2}])
+            )
+        )
+        items = await core.paginate_link_header(
+            "/repos/a/b/commits", operation="git:GET commits"
+        )
+        assert items == [{"id": 1}, {"id": 2}]
+
+    @pytest.mark.asyncio
+    async def test_follows_link_header_across_pages(self) -> None:
+        page1 = httpx.Response(
+            200,
+            json=[{"id": 1}],
+            headers={
+                "Link": '<https://api.github.com/repos/a/b/commits?page=2>; rel="next"'
+            },
+        )
+        page2 = httpx.Response(200, json=[{"id": 2}])
+        transport = _handler_sequence([page1, page2])
+        core = _core(transport=transport)
+        items = await core.paginate_link_header(
+            "/repos/a/b/commits", operation="git:GET commits"
+        )
+        assert items == [{"id": 1}, {"id": 2}]
+        assert transport.calls["n"] == 2  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_link_header_with_multiple_rels_extracts_next_only(self) -> None:
+        page1 = httpx.Response(
+            200,
+            json=[{"id": 1}],
+            headers={
+                "Link": (
+                    '<https://api.github.com/repos/a/b/commits?page=1>; rel="prev", '
+                    '<https://api.github.com/repos/a/b/commits?page=2>; rel="next", '
+                    '<https://api.github.com/repos/a/b/commits?page=9>; rel="last"'
+                )
+            },
+        )
+        page2 = httpx.Response(200, json=[{"id": 2}])
+        transport = _handler_sequence([page1, page2])
+        core = _core(transport=transport)
+        items = await core.paginate_link_header(
+            "/repos/a/b/commits", operation="git:GET commits"
+        )
+        assert [item["id"] for item in items] == [1, 2]
+
+    @pytest.mark.asyncio
+    async def test_data_key_envelope_extraction(self) -> None:
+        core = _core(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(200, json={"workflow_runs": [{"id": 1}]})
+            )
+        )
+        items = await core.paginate_link_header(
+            "/repos/a/b/actions/runs",
+            operation="cicd:GET runs",
+            data_key="workflow_runs",
+        )
+        assert items == [{"id": 1}]
+
+    @pytest.mark.asyncio
+    async def test_hard_page_cap_stops_a_looping_link_header(self) -> None:
+        # A misbehaving/looping Link header (always points to "next") must
+        # not spin forever.
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(
+                200,
+                json=[{"id": 1}],
+                headers={"Link": f'<{request.url}>; rel="next"'},
+            )
+
+        core = _core(transport=httpx.MockTransport(handler))
+        items = await core.paginate_link_header(
+            "/repos/a/b/commits", operation="git:GET commits", max_pages=3
+        )
+        assert len(items) == 3
+
+
+# ---------------------------------------------------------------------------
+# paginate_page_param (GitLab)
+# ---------------------------------------------------------------------------
+
+
+class TestPaginatePageParam:
+    @pytest.mark.asyncio
+    async def test_empty_first_page_stops_immediately(self) -> None:
+        transport = _handler_sequence([httpx.Response(200, json=[])])
+        core = _core(
+            transport=transport, base_url="https://gitlab.com/api/v4", provider="gitlab"
+        )
+        items = await core.paginate_page_param(
+            "/projects/1/repository/commits", operation="project:GET commits"
+        )
+        assert items == []
+        assert transport.calls["n"] == 1  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_follows_x_next_page_header(self) -> None:
+        page1 = httpx.Response(
+            200, json=[{"id": 1}, {"id": 2}], headers={"X-Next-Page": "2"}
+        )
+        page2 = httpx.Response(200, json=[{"id": 3}])
+        transport = _handler_sequence([page1, page2])
+        core = _core(
+            transport=transport, base_url="https://gitlab.com/api/v4", provider="gitlab"
+        )
+        items = await core.paginate_page_param(
+            "/projects/1/repository/commits",
+            operation="project:GET commits",
+            per_page=2,
+        )
+        assert [item["id"] for item in items] == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_empty_x_next_page_header_stops_via_item_count_heuristic(
+        self,
+    ) -> None:
+        # GitLab sends X-Next-Page as a PRESENT but EMPTY header on the last
+        # page -- must not attempt int("") and must fall back to the
+        # item-count heuristic (a short page == last page).
+        page1 = httpx.Response(200, json=[{"id": 1}], headers={"X-Next-Page": ""})
+        transport = _handler_sequence([page1])
+        core = _core(
+            transport=transport, base_url="https://gitlab.com/api/v4", provider="gitlab"
+        )
+        items = await core.paginate_page_param(
+            "/projects/1/repository/commits",
+            operation="project:GET commits",
+            per_page=100,
+        )
+        assert [item["id"] for item in items] == [1]
+        assert transport.calls["n"] == 1  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_missing_x_next_page_falls_back_to_item_count_heuristic(self) -> None:
+        full_page = httpx.Response(200, json=[{"id": 1}, {"id": 2}])
+        short_page = httpx.Response(200, json=[{"id": 3}])
+        transport = _handler_sequence([full_page, short_page])
+        core = _core(
+            transport=transport, base_url="https://gitlab.com/api/v4", provider="gitlab"
+        )
+        items = await core.paginate_page_param(
+            "/projects/1/repository/commits",
+            operation="project:GET commits",
+            per_page=2,
+        )
+        assert [item["id"] for item in items] == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_hard_page_cap_stops_a_looping_cursor(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(200, json=[{"id": 1}], headers={"X-Next-Page": "2"})
+
+        core = _core(
+            transport=httpx.MockTransport(handler),
+            base_url="https://gitlab.com/api/v4",
+            provider="gitlab",
+        )
+        items = await core.paginate_page_param(
+            "/projects/1/repository/commits",
+            operation="project:GET commits",
+            per_page=1,
+            max_pages=4,
+        )
+        assert len(items) == 4
+
+
+# ---------------------------------------------------------------------------
+# Diagnostic-header parity with the existing work-client recorders
+# (codex MED-1 on PR #1149)
+# ---------------------------------------------------------------------------
+
+
+class TestDiagnosticHeaderParity:
+    def test_github_tuple_matches_work_client_recorder_exactly(self) -> None:
+        from dev_health_ops.providers.github.client import (
+            _DIAGNOSTIC_HEADER_NAMES as GITHUB_CLIENT_NAMES,
+        )
+
+        assert set(GITHUB_DIAGNOSTIC_HEADER_NAMES) == set(GITHUB_CLIENT_NAMES)
+
+    def test_gitlab_tuple_matches_work_client_recorder_exactly(self) -> None:
+        from dev_health_ops.providers.gitlab.client import (
+            _DIAGNOSTIC_HEADER_NAMES as GITLAB_CLIENT_NAMES,
+        )
+
+        assert set(GITLAB_DIAGNOSTIC_HEADER_NAMES) == set(GITLAB_CLIENT_NAMES)
+
+    @pytest.mark.asyncio
+    async def test_github_recorded_headers_match_work_client_shape(self) -> None:
+        """A core configured with the GitHub tuple must record EXACTLY the
+        headers the existing GitHubWorkClient recorder preserves -- request
+        id and accepted-permissions included, token/Authorization and junk
+        excluded."""
+        response_headers = {
+            "Authorization": "Bearer ghs_secret",
+            "X-RateLimit-Limit": "5000",
+            "X-RateLimit-Remaining": "4990",
+            "X-RateLimit-Reset": "12345",
+            "X-RateLimit-Used": "10",
+            "X-RateLimit-Resource": "core",
+            "Retry-After": "3",
+            "X-GitHub-Request-Id": "ABCD:1234",
+            "X-Accepted-GitHub-Permissions": "contents=read",
+            "X-Totally-Unrelated": "junk",
+        }
+        core = _core(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(200, json=[], headers=response_headers)
+            ),
+            diagnostic_header_names=GITHUB_DIAGNOSTIC_HEADER_NAMES,
+        )
+        await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+
+        observation = core.drain_usage_observations()[0]
+        assert observation["latest_headers"] == {
+            "x-ratelimit-limit": "5000",
+            "x-ratelimit-remaining": "4990",
+            "x-ratelimit-reset": "12345",
+            "x-ratelimit-used": "10",
+            "x-ratelimit-resource": "core",
+            "retry-after": "3",
+            "x-github-request-id": "ABCD:1234",
+            "x-accepted-github-permissions": "contents=read",
+        }
+        # rate_limit fields carry the GitHub vocabulary incl. used/resource.
+        assert observation["rate_limit"]["used"] == "10"
+        assert observation["rate_limit"]["resource"] == "core"
+
+    @pytest.mark.asyncio
+    async def test_gitlab_recorded_headers_match_work_client_shape(self) -> None:
+        response_headers = {
+            "PRIVATE-TOKEN": "glpat-secret",
+            "RateLimit-Limit": "600",
+            "RateLimit-Remaining": "599",
+            "RateLimit-Reset": "1712345",
+            "Retry-After": "7",
+            "X-Request-Id": "req-42",
+            "X-Runtime": "0.123",
+            "X-Totally-Unrelated": "junk",
+        }
+        core = _core(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(200, json=[], headers=response_headers)
+            ),
+            provider="gitlab",
+            base_url="https://gitlab.com/api/v4",
+            diagnostic_header_names=GITLAB_DIAGNOSTIC_HEADER_NAMES,
+        )
+        await core.request("GET", "/projects/1", operation="project:GET /projects/1")
+
+        observation = core.drain_usage_observations()[0]
+        assert observation["latest_headers"] == {
+            "ratelimit-limit": "600",
+            "ratelimit-remaining": "599",
+            "ratelimit-reset": "1712345",
+            "retry-after": "7",
+            "x-request-id": "req-42",
+            "x-runtime": "0.123",
+        }
+
+    @pytest.mark.asyncio
+    async def test_default_set_never_records_auth_headers(self) -> None:
+        core = _core(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(
+                    200,
+                    json=[],
+                    headers={
+                        "Authorization": "Bearer secret",
+                        "X-RateLimit-Remaining": "1",
+                    },
+                )
+            )
+        )
+        await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+        observation = core.drain_usage_observations()[0]
+        assert "authorization" not in {k.lower() for k in observation["latest_headers"]}
+
+
+# ---------------------------------------------------------------------------
+# Redirect policy (codex MED-2 on PR #1149)
+# ---------------------------------------------------------------------------
+
+
+class TestRedirectPolicy:
+    @pytest.mark.asyncio
+    async def test_301_default_raises_terminal_api_error(self) -> None:
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(
+                301, headers={"Location": "https://api.github.com/repos/new/name"}
+            )
+
+        core = _core(transport=httpx.MockTransport(handler), max_retries=3)
+        with pytest.raises(APIException) as excinfo:
+            await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+
+        message = str(excinfo.value)
+        assert "redirect" in message
+        assert "301" in message
+        assert "https://api.github.com/repos/new/name" in message
+        assert "raw_redirect" in message
+        # Never retried, and not misclassified as a rate limit.
+        assert calls["n"] == 1
+        assert not isinstance(excinfo.value, RateLimitException)
+        # The single physical attempt was still recorded.
+        assert core.drain_usage_observations()[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_302_default_raises_terminal_api_error(self) -> None:
+        core = _core(
+            transport=httpx.MockTransport(
+                lambda r: httpx.Response(
+                    302, headers={"Location": "https://cdn.example/x"}
+                )
+            )
+        )
+        with pytest.raises(APIException) as excinfo:
+            await core.request(
+                "GET",
+                "/repos/a/b/actions/artifacts/1/zip",
+                operation="tests:GET artifact",
+            )
+        assert "302" in str(excinfo.value)
+
+    @pytest.mark.asyncio
+    async def test_raw_redirect_opt_in_returns_the_302_response(self) -> None:
+        """The CS5 artifact-zip contract: the caller reads Location off the
+        302 itself and follows it WITHOUT forwarding Authorization (see
+        connectors/github.py::download_artifact_zip) -- so the opt-in must
+        hand back the raw redirect response, recorded as one physical
+        attempt, never retried and never classified as an error."""
+        presigned = "https://productionresults.blob.core.windows.net/artifact?sig=x"
+        calls = {"n": 0}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            calls["n"] += 1
+            return httpx.Response(302, headers={"Location": presigned})
+
+        core = _core(transport=httpx.MockTransport(handler), max_retries=3)
+        response = await core.request(
+            "GET",
+            "/repos/a/b/actions/artifacts/1/zip",
+            operation="tests:GET artifact zip",
+            raw_redirect=True,
+        )
+
+        assert response.status_code == 302
+        assert response.headers["Location"] == presigned
+        assert calls["n"] == 1
+        assert core.drain_usage_observations()[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_raw_redirect_does_not_leak_into_success_path(self) -> None:
+        # raw_redirect=True must not change 2xx handling.
+        core = _core(
+            transport=httpx.MockTransport(lambda r: httpx.Response(200, json=[1]))
+        )
+        response = await core.request(
+            "GET", "/repos/a/b", operation="git:GET /repos/a/b", raw_redirect=True
+        )
+        assert response.status_code == 200
+        assert response.json() == [1]
+
+
+# ---------------------------------------------------------------------------
+# Unauthenticated follow-up hop (codex re-pass MED on PR #1149): the second
+# half of the two-hop artifact pattern -- follow the 302 Location WITHOUT
+# the client's default Authorization header, still recorded.
+# ---------------------------------------------------------------------------
+
+
+class TestUnauthenticatedFollow:
+    @pytest.mark.asyncio
+    async def test_two_hop_artifact_pattern_strips_auth_and_records_both(self) -> None:
+        """The codex-required end-to-end: obtain a 302 via raw_redirect=True,
+        follow the returned absolute Location via request_unauthenticated,
+        assert the second request carries NO Authorization header (while the
+        first hop DID -- proving default headers exist and are stripped only
+        on the bare path) AND both physical attempts are recorded, one
+        each."""
+        presigned = "https://productionresults.blob.core.windows.net/artifact?sig=x"
+        seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            if request.url.host == "api.github.com":
+                return httpx.Response(302, headers={"Location": presigned})
+            return httpx.Response(200, content=b"zip-bytes")
+
+        core = _core(
+            transport=httpx.MockTransport(handler),
+            headers={
+                "Authorization": "Bearer ghs_token",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+        )
+
+        first = await core.request(
+            "GET",
+            "/repos/a/b/actions/artifacts/1/zip",
+            operation="git:GET artifact zip",
+            raw_redirect=True,
+        )
+        assert first.status_code == 302
+        follow = await core.request_unauthenticated(
+            first.headers["Location"], operation="GET artifact zip follow"
+        )
+        assert follow.status_code == 200
+        assert follow.content == b"zip-bytes"
+
+        assert len(seen) == 2
+        # Hop 1 (authenticated API call) carried the client defaults...
+        assert seen[0].headers.get("Authorization") == "Bearer ghs_token"
+        # ...hop 2 (pre-signed URL) carried NONE of them.
+        assert "authorization" not in seen[1].headers
+        assert "x-github-api-version" not in seen[1].headers
+        assert seen[1].url == httpx.URL(presigned)
+
+        # Both physical attempts recorded, one each: hop 1 resolves via the
+        # "git:" prefix, hop 2 (unprefixed) via the transport default -- two
+        # distinct observations with request_count == 1 apiece.
+        observations = {
+            obs["route_family"]: obs for obs in core.drain_usage_observations()
+        }
+        assert observations["git"]["request_count"] == 1
+        assert observations["unclassified_default"]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_explicit_per_request_headers_are_the_only_extras_sent(self) -> None:
+        seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return httpx.Response(200, content=b"")
+
+        core = _core(
+            transport=httpx.MockTransport(handler),
+            headers={"Authorization": "Bearer secret"},
+        )
+        await core.request_unauthenticated(
+            "https://cdn.example/blob",
+            operation="GET follow",
+            headers={"Accept": "application/octet-stream"},
+        )
+        assert "authorization" not in seen[0].headers
+        assert seen[0].headers["Accept"] == "application/octet-stream"
+
+    @pytest.mark.asyncio
+    async def test_relative_url_is_rejected(self) -> None:
+        core = _core(transport=httpx.MockTransport(lambda r: httpx.Response(200)))
+        with pytest.raises(ValueError, match="absolute"):
+            await core.request_unauthenticated(
+                "/repos/a/b/zipball", operation="GET follow"
+            )
+
+    @pytest.mark.asyncio
+    async def test_response_returned_as_is_without_status_classification(self) -> None:
+        # The pre-signed host is a different error domain: a 404/410 there is
+        # the code client's convenience-empty decision (CS5), never this
+        # transport's -- so non-2xx must come back unraised (but recorded).
+        core = _core(transport=httpx.MockTransport(lambda r: httpx.Response(410)))
+        response = await core.request_unauthenticated(
+            "https://cdn.example/expired", operation="GET follow"
+        )
+        assert response.status_code == 410
+        assert core.drain_usage_observations()[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_network_error_raises_api_exception(self) -> None:
+        def handler(request: httpx.Request) -> httpx.Response:
+            raise httpx.ConnectError("boom", request=request)
+
+        core = _core(transport=httpx.MockTransport(handler))
+        with pytest.raises(APIException):
+            await core.request_unauthenticated(
+                "https://cdn.example/blob", operation="GET follow"
+            )
+
+    @pytest.mark.asyncio
+    async def test_close_closes_both_clients(self) -> None:
+        core = _core(transport=httpx.MockTransport(lambda r: httpx.Response(200)))
+        await core.request("GET", "/repos/a/b", operation="git:GET /repos/a/b")
+        await core.request_unauthenticated(
+            "https://cdn.example/blob", operation="GET follow"
+        )
+        assert core._client is not None
+        assert core._bare_client is not None
+        await core.close()
+        assert core._client is None
+        assert core._bare_client is None

--- a/tests/providers/test_usage_resolver_prefix.py
+++ b/tests/providers/test_usage_resolver_prefix.py
@@ -1,0 +1,260 @@
+"""Exhaustive label->family resolver tests (CHAOS-2773 CS1 [codex HIGH-1]).
+
+``OperationResolver.resolve`` gained an explicit-prefix short-circuit: an
+operation label of the form ``"<registered-family>:..."`` resolves DIRECTLY
+to that family, bypassing the substring marker scan (``providers/usage.py``).
+This file is the "exhaustive" test the plan requires:
+
+1. Every operation label the EXISTING GitHub/GitLab work clients emit today
+   (enumerated by grepping ``providers/github/client.py`` /
+   ``providers/gitlab/client.py`` for their ``operation`` strings) resolves
+   EXACTLY as it did before this change -- attribution is provably
+   unshifted for unprefixed labels.
+2. A representative prefixed label per REGISTERED family (both providers)
+   short-circuits directly to that family, including the exact collision
+   the plan calls out: GitLab's broad ``"/projects/:id"`` / ``"/projects/"``
+   markers (registered under ``project``) must NOT swallow a
+   ``pipelines:...`` label.
+3. None of today's existing (unprefixed) work-client labels accidentally
+   start with any registered ``"<family>:"`` prefix -- the false-trigger
+   regression guard.
+
+A small synthetic-registry suite additionally pins the short-circuit
+mechanism in isolation, independent of the real GitHub/GitLab registries.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.providers.github.budget import (
+    GITHUB_USAGE_RESOLVER,
+    GITHUB_USAGE_ROUTE_FAMILY_KEYS,
+)
+from dev_health_ops.providers.gitlab.budget import (
+    GITLAB_USAGE_RESOLVER,
+    GITLAB_USAGE_ROUTE_FAMILY_KEYS,
+)
+from dev_health_ops.providers.usage import OperationResolver, UsageRouteFamily
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+# ---------------------------------------------------------------------------
+# Every operation label GitHubWorkClient / GitLabWorkClient emit today
+# (grepped from providers/github/client.py and providers/gitlab/client.py --
+# both the f-string templates, interpolated with representative values, and
+# the GraphQL literal labels).
+# ---------------------------------------------------------------------------
+
+GITHUB_EXISTING_LABELS: tuple[tuple[str, str, tuple[str, BudgetDimension]], ...] = (
+    ("rest", "GET /repos/acme/widgets", ("work_items", BudgetDimension.REST_CORE)),
+    (
+        "rest",
+        "GET /repos/acme/widgets/issues",
+        ("work_items", BudgetDimension.REST_CORE),
+    ),
+    ("rest", "GET issue events for #42", ("work_items", BudgetDimension.REST_CORE)),
+    (
+        "rest",
+        "GET /repos/acme/widgets/pulls",
+        ("work_items", BudgetDimension.REST_CORE),
+    ),
+    ("rest", "GET issue comments for #42", ("work_items", BudgetDimension.REST_CORE)),
+    (
+        "rest",
+        "GET pull request review comments for #42",
+        ("work_items", BudgetDimension.REST_CORE),
+    ),
+    (
+        "rest",
+        "GET /repos/acme/widgets/milestones",
+        ("work_items", BudgetDimension.REST_CORE),
+    ),
+    (
+        "graphql",
+        "POST /graphql PR social data",
+        ("work_item_prs", BudgetDimension.GRAPHQL_COST),
+    ),
+    (
+        "graphql",
+        "POST /graphql PR review comments",
+        ("work_item_prs", BudgetDimension.GRAPHQL_COST),
+    ),
+    (
+        "graphql",
+        "POST /graphql project v2 items",
+        ("work_item_prs", BudgetDimension.GRAPHQL_COST),
+    ),
+    (
+        "graphql",
+        "POST /graphql project v2 item changes",
+        ("work_item_prs", BudgetDimension.GRAPHQL_COST),
+    ),
+)
+
+GITLAB_EXISTING_LABELS: tuple[tuple[str, str, tuple[str, BudgetDimension]], ...] = (
+    ("rest", "GET /projects/:id", ("project", BudgetDimension.REST_CORE)),
+    ("rest", "GET iterator page", ("issues", BudgetDimension.REST_CORE)),
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. Existing labels resolve exactly as before this change (unshifted).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("transport,operation,expected", GITHUB_EXISTING_LABELS)
+def test_github_existing_labels_resolve_unshifted(
+    transport: str, operation: str, expected: tuple[str, BudgetDimension]
+) -> None:
+    assert (
+        GITHUB_USAGE_RESOLVER.resolve(transport=transport, operation=operation)
+        == expected
+    )
+
+
+@pytest.mark.parametrize("transport,operation,expected", GITLAB_EXISTING_LABELS)
+def test_gitlab_existing_labels_resolve_unshifted(
+    transport: str, operation: str, expected: tuple[str, BudgetDimension]
+) -> None:
+    assert (
+        GITLAB_USAGE_RESOLVER.resolve(transport=transport, operation=operation)
+        == expected
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Representative prefixed labels per registered family short-circuit.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("family", sorted(GITHUB_USAGE_ROUTE_FAMILY_KEYS))
+def test_github_prefixed_label_resolves_directly_to_its_family(family: str) -> None:
+    operation = f"{family}:GET /repos/acme/widgets/{family}"
+    route_family, _dimension = GITHUB_USAGE_RESOLVER.resolve(
+        transport="rest", operation=operation
+    )
+    assert route_family == family
+
+
+@pytest.mark.parametrize("family", sorted(GITLAB_USAGE_ROUTE_FAMILY_KEYS))
+def test_gitlab_prefixed_label_resolves_directly_to_its_family(family: str) -> None:
+    operation = f"{family}:GET /projects/1/{family}"
+    route_family, _dimension = GITLAB_USAGE_RESOLVER.resolve(
+        transport="rest", operation=operation
+    )
+    assert route_family == family
+
+
+def test_gitlab_pipelines_prefix_not_swallowed_by_broad_project_marker() -> None:
+    """The motivating collision from the plan: GitLab's ``project`` family
+    registers broad substring markers ("/projects/:id", "/projects/") that,
+    absent the short-circuit, would swallow ANY label containing that
+    substring -- including a self-authored ``pipelines:`` label for the
+    (also project-scoped) pipelines endpoint. The explicit prefix must win.
+    """
+    route_family, dimension = GITLAB_USAGE_RESOLVER.resolve(
+        transport="rest", operation="pipelines:GET /projects/:id/pipelines"
+    )
+    assert route_family == "pipelines"
+    assert dimension is BudgetDimension.REST_CORE
+
+    # Sanity check: the SAME literal marker, unprefixed, still resolves to
+    # `project` via the untouched marker scan (proves the fix is additive,
+    # not a marker-scan regression).
+    unprefixed_family, _ = GITLAB_USAGE_RESOLVER.resolve(
+        transport="rest", operation="GET /projects/:id/pipelines"
+    )
+    assert unprefixed_family == "project"
+
+
+# ---------------------------------------------------------------------------
+# 3. False-trigger regression guard: no existing label accidentally
+#    prefix-matches a registered family.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("transport,operation,_expected", GITHUB_EXISTING_LABELS)
+def test_github_existing_labels_never_accidentally_prefix_match(
+    transport: str, operation: str, _expected: tuple[str, BudgetDimension]
+) -> None:
+    lowered = operation.lower()
+    for family in GITHUB_USAGE_ROUTE_FAMILY_KEYS:
+        assert not lowered.startswith(f"{family}:"), (
+            f"{operation!r} accidentally starts with the {family!r} prefix"
+        )
+
+
+@pytest.mark.parametrize("transport,operation,_expected", GITLAB_EXISTING_LABELS)
+def test_gitlab_existing_labels_never_accidentally_prefix_match(
+    transport: str, operation: str, _expected: tuple[str, BudgetDimension]
+) -> None:
+    lowered = operation.lower()
+    for family in GITLAB_USAGE_ROUTE_FAMILY_KEYS:
+        assert not lowered.startswith(f"{family}:"), (
+            f"{operation!r} accidentally starts with the {family!r} prefix"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Synthetic-registry unit tests: pin the short-circuit mechanism in
+# isolation, independent of the real GitHub/GitLab registries above.
+# ---------------------------------------------------------------------------
+
+
+_SYNTHETIC_RESOLVER = OperationResolver(
+    families=(
+        # "alpha" carries a broad marker that would otherwise swallow a
+        # "beta:" labeled operation via ordinary substring scanning.
+        UsageRouteFamily(
+            "alpha", BudgetDimension.REST_CORE, operation_markers=("/beta/",)
+        ),
+        UsageRouteFamily("beta", BudgetDimension.CONTENTS_BLOB),
+        UsageRouteFamily("gamma", BudgetDimension.GRAPHQL_COST, transport="graphql"),
+    ),
+    defaults=(("rest", "fallback", BudgetDimension.REST_CORE),),
+)
+
+
+class TestSyntheticShortCircuit:
+    def test_prefixed_label_bypasses_marker_scan_collision(self) -> None:
+        # Without the short-circuit this would resolve to "alpha" (the
+        # "/beta/" marker matches and alpha is scanned first).
+        route_family, dimension = _SYNTHETIC_RESOLVER.resolve(
+            transport="rest", operation="beta:GET /beta/thing"
+        )
+        assert route_family == "beta"
+        assert dimension is BudgetDimension.CONTENTS_BLOB
+
+    def test_unprefixed_label_still_takes_marker_scan_path(self) -> None:
+        route_family, _ = _SYNTHETIC_RESOLVER.resolve(
+            transport="rest", operation="GET /beta/thing"
+        )
+        assert route_family == "alpha"
+
+    def test_prefix_respects_family_transport_filter(self) -> None:
+        # "gamma:" is registered transport="graphql" only -- a "rest"-labeled
+        # operation prefixed with "gamma:" must NOT short-circuit to it.
+        route_family, _ = _SYNTHETIC_RESOLVER.resolve(
+            transport="rest", operation="gamma:GET /whatever"
+        )
+        assert route_family == "fallback"
+
+        route_family, dimension = _SYNTHETIC_RESOLVER.resolve(
+            transport="graphql", operation="gamma:POST /whatever"
+        )
+        assert route_family == "gamma"
+        assert dimension is BudgetDimension.GRAPHQL_COST
+
+    def test_prefix_is_case_insensitive(self) -> None:
+        route_family, _ = _SYNTHETIC_RESOLVER.resolve(
+            transport="rest", operation="BETA:GET /Beta/Thing"
+        )
+        assert route_family == "beta"
+
+    def test_unregistered_prefix_falls_through_to_marker_scan_then_default(
+        self,
+    ) -> None:
+        route_family, _ = _SYNTHETIC_RESOLVER.resolve(
+            transport="rest", operation="not_a_family:GET /nothing"
+        )
+        assert route_family == "fallback"


### PR DESCRIPTION
## Summary

CHAOS-2773 CS1 — the foundation changeset for the GitHub/GitLab code-dataset provider migration (epic CHAOS-2773). This lands the shared primitives every per-family changeset (CS3+) builds on; it does **not** migrate any dataset itself — the frozen `connectors/` path is untouched and remains the live fetch path until its own cutover.

- **`providers/_http.py` — `InstrumentedRESTCore`** (composition, not inheritance): shared httpx transport core mirroring `providers/launchdarkly/client.py`. `request(method, path, *, operation, params, headers)` records ONE `UsageRecorder.record` per physical HTTP round trip including retried attempts; retry/backoff honors `Retry-After` **falling back to the provider's epoch-seconds reset header** via the shared `providers/_ratelimit.py::resolve_retry_after_seconds` (the provider-parameterized generalization of #1142's `gitlab_resolve_retry_after_seconds`, which now delegates to it — still exactly one implementation), so a reset-only 429 carries the server's real window to the worker deferral path instead of the 60s default; on 429 exhaustion raises the canonical `RateLimitException` + `RateLimitSignal` via `reset_at_from_epoch_seconds` (`integration_id`/`route_family` left `None` for worker-boundary enrichment); **provider-configurable diagnostic-header recording** (`diagnostic_header_names` param + exported `GITHUB_DIAGNOSTIC_HEADER_NAMES`/`GITLAB_DIAGNOSTIC_HEADER_NAMES`, parity-pinned against the existing work-client recorder sets); **explicit redirect policy + auth-leak-free two-hop follow** (any 3xx = terminal `APIException` by default; `raw_redirect=True` returns the raw 302, and `request_unauthenticated(location, operation=...)` follows the absolute `Location` through a SECOND, headerless client owned by the core — httpx sends client default headers on absolute-URL requests too, so this is the only clean way to keep the provider token off the pre-signed blob/CDN URL while still recording the hop; shaped for CS5's artifact-zip contract, `connectors/github.py::download_artifact_zip`); `paginate_link_header` (GitHub) and `paginate_page_param` (GitLab) with hard page caps; `github_rest_base_url`/`gitlab_rest_base_url` preserve GHE (`/api/v3`, joined as-is) and self-hosted GitLab (`+ /api/v4`) base-URL joining, reusing the existing `GitHubAuth.base_url`/`GitLabAuth.base_url` string fields. Extension points (`is_retryable_status`, `classify_error`) let a future code client (CS3+) layer in provider-specific classification without the core knowing about it.

- **`providers/usage.py` — resolver explicit-prefix short-circuit**: `OperationResolver.resolve` now checks whether an operation label starts with `"<registered-family>:"` and, if so, resolves directly to that family, bypassing the substring marker scan. This fixes the collision the plan calls out — GitLab's `project` family registers broad markers (`"/projects/:id"`, `"/projects/"`) that would otherwise swallow a self-authored `pipelines:...` label. Unprefixed labels (every existing work-client label today) take the marker-scan path completely unchanged. Pinned by an exhaustive test enumerating every label the GitHub/GitLab work clients currently emit (asserting unshifted resolution) plus representative prefixed labels per registered family and a false-trigger regression guard.

- **`providers/github/ratelimit.py` + `providers/gitlab/ratelimit.py`** — shared rate-limit classifiers extracted so REST work clients and future httpx code clients never carry a second copy of the same triage:
  - GitHub: `classify_github_403` (primary / secondary-abuse / permission-SSO), extracted from `GitHubWorkClient._raise_github_exception`, which now delegates to it. Behavior pinned by porting the relevant cases from `tests/test_github_403_observability.py`.
  - GitLab: `classify_gitlab_status` / `maybe_raise_gitlab_rate_limit`, built directly on the shared `providers/_ratelimit.py` primitives (`gitlab_403_is_rate_limited` / `gitlab_resolve_retry_after_seconds`, #1142). `providers/gitlab/client.py::_maybe_raise_gitlab_rate_limit` now delegates to it instead of re-deriving the same boolean/delay logic inline.

- **Docs**: `docs/providers/rate-limit-policy.md` gains an "Instrumented transport core" section covering all of the above, including the two-hop artifact pattern.

## Codex adversarial review — all findings addressed in-changeset (3 rounds)

- **HIGH** — reset-only 429 deferred on the 60s default instead of the provider reset window → default delay resolution now derives from `reset_header_name` when `Retry-After` is absent (shared `resolve_retry_after_seconds`; regression tests assert the worker-visible `retry_after_seconds` matches the reset delta on both the terminal and in-place-retry paths).
- **MED** — core observations dropped diagnostics the existing recorders preserve → provider-configurable `diagnostic_header_names` + exact-parity tests (`TestDiagnosticHeaderParity`) against `providers/github/client.py` / `providers/gitlab/client.py` `_DIAGNOSTIC_HEADER_NAMES` and the recorded `latest_headers` shape.
- **MED** — 3xx returned as success with redirects disabled → explicit redirect policy: terminal `APIException` by default (attempt still recorded, never retried), `raw_redirect=True` opt-in (`TestRedirectPolicy`).
- **MED (re-pass)** — raw-redirect Location could not be followed through the core without forwarding `Authorization` → `request_unauthenticated()`: a recorded hop through a second, no-default-headers client. End-to-end test (`TestUnauthenticatedFollow`): 302 via `raw_redirect=True` → follow the absolute `Location` → second request carries NO `Authorization`/API-version header (first hop did) → both physical attempts recorded, one observation each.

## Scope guardrails honored

- `connectors/` untouched (hard ban).
- Frozen budget machinery untouched (no estimator/reservation/`SYNC_BUDGET_*` changes; no `budget.py` marker flips — those land with their per-family cutover changesets).
- No processor rewiring (starts CS2/CS3).
- No existing operation label or marker changed; `providers/launchdarkly` untouched; work-client method surfaces unchanged except the classifier delegation (zero behavior change).

## Test plan

- [x] 4 new test files, 132 new tests: `tests/providers/test_http_core.py` (50 — retries/usage-recording/exhaustion/reset-only-429 delay derivation/pagination edges/GHE+v4 URL joins/classify_error hook/diagnostic-header parity/redirect policy/unauthenticated two-hop follow), `tests/providers/test_usage_resolver_prefix.py` (52 — exhaustive label→family pinning + collision fix + false-trigger guard), `tests/providers/test_github_ratelimit_classifier.py` (15), `tests/providers/test_gitlab_ratelimit_classifier.py` (15).
- [x] Existing suites stay green untouched: `test_github_403_observability.py`, `test_gitlab_client_ratelimit.py`, `test_gitlab_feature_flags_client.py`, `test_rate_limit_signal.py`, `test_rate_limit_policy_doc.py`, GitHub/GitLab budget + iterator tests.
- [x] `env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" SCRATCH_DB=ci_local_validate_2802 bash ci/local_validate.sh` — GATE PASSED after every codex round (final: ruff format/check, mypy clean, full unit suite 6597 passed / 44 skipped, live argMax proof).

🤖 Generated with [Claude Code](https://claude.com/claude-code)