### PR TITLE
feat(providers): code-dataset usage drain plumbing + prs/pr_social attribution (CHAOS-2803)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -918,7 +918,7 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
   so this stays an abstract reservation for both families. `pr_social`'s
   primary (`graphql_cost`) traffic IS now measured as of
   [CHAOS-2803](https://linear.app/fullchaos/issue/CHAOS-2803) (CS2, see
-  [Usage drain wiring](#usage-drain-wiring--first-re-bucketing-chaos-2773-cs2)
+  [Usage drain wiring](#usage-drain-wiring-first-re-bucketing-chaos-2773-cs2)
   above) for the PR review-batch enrichment; the REST `prs` listing itself
   remains on the frozen connector, unmeasured, pending CHAOS-2773 CS8. See
   [Known gaps](#known-gaps).
@@ -1149,7 +1149,7 @@ paper over:
   (`graphql_cost`) traffic from the PR review-batch enrichment IS now
   instrumented as of [CHAOS-2803](https://linear.app/fullchaos/issue/CHAOS-2803)
   (CS2) — see
-  [Usage drain wiring](#usage-drain-wiring--first-re-bucketing-chaos-2773-cs2)
+  [Usage drain wiring](#usage-drain-wiring-first-re-bucketing-chaos-2773-cs2)
   above; the REST `prs` listing and every other GitHub/GitLab code-dataset
   family remain uninstrumented pending their own CHAOS-2773 changeset (see
   "Frozen `connectors/` path" below). There is also no cross-run

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -822,6 +822,69 @@ built on this core (CS3+) are expected to author both the label and its
 family prefix themselves, so resolution for their traffic is deterministic
 by construction rather than by marker tuning.
 
+### Usage drain wiring + first re-bucketing (CHAOS-2773 CS2)
+
+CS1 landed the shared transport/resolver plumbing but migrated no traffic.
+[CHAOS-2803](https://linear.app/fullchaos/issue/CHAOS-2803) (CS2) is the
+proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
+
+- **`usage_sink` contract.** `processors/dataset_adapters.py::_run_github_dataset`
+  / `_run_gitlab_dataset` own a `usage_sink: list[dict]` list, pass it into
+  `process_github_repo` / `process_gitlab_project`, and the processor drains
+  every instrumented client it constructs into it in a `finally:` block — on
+  BOTH the success and failure path. On success the returned payload gains
+  `observations: {provider_usage: <sink>}`, the exact shape
+  `workers/sync_units.py::_attach_budget_comparison` joins as-is. On a
+  mid-sync raise, whatever was drained before the exception is attached to it
+  via `providers/usage.py::attach_partial_observations` — a provider-neutral
+  alias for the mechanism `metrics/job_work_items.py` already used for the
+  work-items sync path (`attach_work_item_partial_observations`, which now
+  delegates to it); both write the SAME exception attribute, so
+  `workers/sync_units.py::_merge_partial_observations_into_result` reads
+  either origin unchanged. Within the review batch itself, failure semantics
+  are split: a `RateLimitException` PROPAGATES (after the finally-drain) so
+  the unit defers to RETRYING with the partial actuals preserved — swallowing
+  it would stamp SUCCESS with reviews silently missing and bypass the
+  deferral branch entirely (codex HIGH on the CS2 review); any other
+  review-fetch error keeps the pre-existing degrade-and-log behavior, since
+  reviews are optional enrichment on top of the PR rows. Legacy entry points
+  that call a processor without an adapter-owned sink (the CLI
+  `processors/sync.py` batch path, webhooks) get `usage_sink=None`; the
+  processor still drains any client it builds (so its recorder never leaks
+  across calls) but only logs the observations at debug level — never
+  persisted.
+- **First intentional re-bucketing: `prs` / `pr_social`.** GitHub's PR
+  review-batch enrichment (`processors/github.py::_enrich_prs_with_reviews_batch`)
+  constructs a local `GitHubWorkClient` to batch-fetch reviews over GraphQL,
+  but never drained it and emitted an unprefixed operation label — so its
+  traffic silently fell through the resolver's transport default onto
+  `work_item_prs` (documented as a gap below) and was discarded outright (no
+  drain at all). CS2 fixes both: the client is now drained via the
+  `usage_sink` contract above, and its GraphQL calls are labeled with the
+  `pr_social:` prefix (the CS1 short-circuit convention), so they resolve
+  DIRECTLY to the `pr_social` route family the estimator already reserves for
+  the `prs`/`pr-reviews`/`pr-comments` dataset family. The unprefixed call
+  shape (`operation_family=None`) is preserved exactly for the work-items
+  PR-as-work-item path (`providers/github/provider.py`), which keeps
+  resolving to `work_item_prs` unshifted — pinned by
+  `tests/providers/test_usage_resolver_prefix.py`'s new
+  `pr_social:`-prefixed cases alongside its existing unshifted-attribution
+  proof, and by call-count tests in
+  `tests/providers/test_github_pr_social_batch.py` (N physical GraphQL
+  requests → one aggregated `pr_social`/`graphql_cost` observation with
+  `request_count == N`; a mid-pagination failure leaves the prior successful
+  request(s) drained). The REST `prs` listing itself (raw PyGithub
+  `get_pulls`) stays on the frozen connector, unlabeled, until CHAOS-2773 CS8
+  — `providers/github/budget.py`'s `prs` marker is therefore left empty
+  (never flip a marker before its traffic exists, per the migration
+  strategy above), while `pr_social`'s GRAPHQL_COST marker is flipped to
+  document it as now-instrumented.
+- **GitLab.** `process_gitlab_project` accepts the same `usage_sink`
+  parameter for a uniform cross-provider adapter contract, but no GitLab code
+  client drains into it yet — GitLab code-dataset fetch stays entirely on the
+  frozen connector until CHAOS-2773 Wave B. The sink is inert (always empty)
+  for GitLab today; this is expected, not a bug.
+
 ## Per-provider policy
 
 ### GitHub
@@ -849,8 +912,15 @@ by construction rather than by marker tuning.
   - **(c) permission / SSO / other 403** — no rate-limit markers → non-retryable
     `AuthenticationException`. This short-circuits the otherwise-wasteful retry
     spin on an unfixable permission/SAML-SSO error.
-- **Known gaps.** `pr_social` / `work_item_prs` secondary-limit pressure is
-  *estimated*, not measured from real header actuals; see
+- **Known gaps.** `pr_social` / `work_item_prs` **secondary-limit** pressure
+  (the `secondary_abuse_risk` dimension) is still *estimated*, not measured —
+  no client observes a distinct secondary-limit signal on a success response,
+  so this stays an abstract reservation for both families. `pr_social`'s
+  primary (`graphql_cost`) traffic IS now measured as of
+  [CHAOS-2803](https://linear.app/fullchaos/issue/CHAOS-2803) (CS2, see
+  [Usage drain wiring](#usage-drain-wiring--first-re-bucketing-chaos-2773-cs2)
+  above) for the PR review-batch enrichment; the REST `prs` listing itself
+  remains on the frozen connector, unmeasured, pending CHAOS-2773 CS8. See
   [Known gaps](#known-gaps).
 
 #### Route families
@@ -1072,11 +1142,19 @@ paper over:
   [Actual-vs-estimated calibration](#actual-vs-estimated-calibration-chaos-2759)
   above) wherever CHAOS-2754's recorder actually drained actuals for a
   route_family, but the recorder only records where a client calls it.
-  GitHub `pr_social`/`work_item_prs` secondary pressure, Linear
-  request/complexity actuals, and LaunchDarkly route-remaining are still
-  **uninstrumented**, so those families never produce a comparison row.
-  There is also no cross-run aggregation/dashboard yet — calibration today is
-  visible per-unit (result + structured log), not rolled up over time.
+  GitHub/GitLab `pr_social`/`work_item_prs` **secondary** (`secondary_abuse_risk`)
+  pressure, Linear request/complexity actuals, and LaunchDarkly
+  route-remaining are still **uninstrumented**, so those families never
+  produce a comparison row for that dimension. GitHub `pr_social`'s primary
+  (`graphql_cost`) traffic from the PR review-batch enrichment IS now
+  instrumented as of [CHAOS-2803](https://linear.app/fullchaos/issue/CHAOS-2803)
+  (CS2) — see
+  [Usage drain wiring](#usage-drain-wiring--first-re-bucketing-chaos-2773-cs2)
+  above; the REST `prs` listing and every other GitHub/GitLab code-dataset
+  family remain uninstrumented pending their own CHAOS-2773 changeset (see
+  "Frozen `connectors/` path" below). There is also no cross-run
+  aggregation/dashboard yet — calibration today is visible per-unit (result +
+  structured log), not rolled up over time.
 - **Frozen `connectors/` path.** GitHub's `git`/`commit_stats`/`files`/`blame`/
   `cicd`/`tests`/`deployments`/`security` route families and the equivalent
   GitLab code-dataset paths remain under the frozen `connectors/` tree

--- a/src/dev_health_ops/metrics/job_work_items.py
+++ b/src/dev_health_ops/metrics/job_work_items.py
@@ -56,7 +56,11 @@ from dev_health_ops.providers.teams import (
     load_team_resolver,
     normalize_team_id,
 )
-from dev_health_ops.providers.usage import drain_provider_usage
+from dev_health_ops.providers.usage import (
+    attach_partial_observations,
+    drain_provider_usage,
+    read_partial_observations,
+)
 from dev_health_ops.storage import detect_db_type
 from dev_health_ops.utils.cli import (
     add_date_range_args,
@@ -316,12 +320,6 @@ def _build_linear_work_client(
     )
 
 
-# Exception attribute carrying best-effort usage observations gathered before a
-# mid-sync raise, so the worker deferral/failure stamp can persist actuals even
-# when the unit never returns normally (CHAOS-2754).
-_PARTIAL_OBSERVATIONS_ATTR = "dev_health_partial_observations"
-
-
 def _build_work_item_observations(
     *,
     github_usage: list[dict[str, Any]],
@@ -351,19 +349,29 @@ def attach_work_item_partial_observations(
     exc: BaseException, observations: dict[str, Any]
 ) -> None:
     """Stash partial usage observations on an in-flight exception (no-op when
-    empty) so a rate-limit deferral / failure can still record actuals."""
+    empty) so a rate-limit deferral / failure can still record actuals.
 
-    if observations:
-        setattr(exc, _PARTIAL_OBSERVATIONS_ATTR, observations)
+    Delegates to the provider-neutral ``providers.usage.attach_partial_observations``
+    (CHAOS-2803/CS2), which now owns the exception-attribute mechanism; kept
+    here (same name/behavior) since this is the work-items sync job's public
+    call site and is pinned by existing tests.
+    """
+
+    attach_partial_observations(exc, observations)
 
 
 def read_work_item_partial_observations(
     exc: BaseException,
 ) -> dict[str, Any] | None:
-    """Read observations attached by :func:`attach_work_item_partial_observations`."""
+    """Read observations attached by :func:`attach_work_item_partial_observations`.
 
-    observations = getattr(exc, _PARTIAL_OBSERVATIONS_ATTR, None)
-    return observations if isinstance(observations, dict) else None
+    Delegates to ``providers.usage.read_partial_observations`` (CHAOS-2803/CS2)
+    -- same underlying exception attribute, so this also reads observations
+    attached via the provider-neutral ``attach_partial_observations`` alias
+    (e.g. from the code-dataset adapters).
+    """
+
+    return read_partial_observations(exc)
 
 
 def run_work_items_sync_job(

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -9,6 +9,10 @@ from dev_health_ops.credentials.resolver import (
     gitlab_credentials_from_mapping,
     resolve_gitlab_url,
 )
+from dev_health_ops.providers.usage import (
+    PROVIDER_USAGE_OBSERVATION_KEY,
+    attach_partial_observations,
+)
 from dev_health_ops.storage import resolve_db_type, run_with_store
 from dev_health_ops.sync.datasets import DatasetKey
 from dev_health_ops.workers.async_runner import run_async
@@ -203,6 +207,13 @@ def _run_github_dataset(
     owner, repo_name = _github_repo_parts(context.source_external_id)
     flags = _explicit_flags(context)
     token = _github_credentials(context)
+    # CHAOS-2803/CS2: adapter-owned sink. process_github_repo drains every
+    # instrumented client it constructs (currently: the PR review-batch's
+    # local GitHubWorkClient) into this list in a `finally:` block, on both
+    # the success AND failure path -- the list is mutated in place, so
+    # whatever was drained before a mid-sync raise is still visible here even
+    # though the raise unwinds through run_async below.
+    usage_sink: list[dict[str, Any]] = []
 
     async def _handler(store: Any) -> None:
         await process_github_repo(
@@ -227,10 +238,16 @@ def _run_github_dataset(
             sync_commit_stats=flags["sync_commit_stats"],
             sync_files=flags["sync_files"],
             sync_blame=flags["sync_blame"],
+            usage_sink=usage_sink,
         )
 
-    run_async(_run_with_reused_or_new_store(context, runtime, _handler))
-    return {
+    try:
+        run_async(_run_with_reused_or_new_store(context, runtime, _handler))
+    except Exception as exc:
+        _attach_usage_sink_to_exception(exc, usage_sink)
+        raise
+
+    result: dict[str, Any] = {
         "provider": context.provider,
         "dataset": context.dataset_key,
         "source": context.source_external_id,
@@ -244,6 +261,9 @@ def _run_github_dataset(
         if context.window_end is not None
         else None,
     }
+    if usage_sink:
+        result["observations"] = {PROVIDER_USAGE_OBSERVATION_KEY: list(usage_sink)}
+    return result
 
 
 def _run_gitlab_dataset(
@@ -254,6 +274,12 @@ def _run_gitlab_dataset(
     project_id = _gitlab_project_id(context.source_external_id)
     token, gitlab_url = _gitlab_credentials(context)
     flags = _explicit_flags(context)
+    # CHAOS-2803/CS2: adapter-owned sink (see _run_github_dataset). No
+    # instrumented client is constructed by process_gitlab_project yet (GitLab
+    # code-dataset fetch stays on the frozen connector until CHAOS-2773 Wave
+    # B), so this sink is inert today -- the plumbing is wired now so a
+    # future GitLab code client only has to start draining into it.
+    usage_sink: list[dict[str, Any]] = []
 
     async def _handler(store: Any) -> None:
         await process_gitlab_project(
@@ -278,10 +304,16 @@ def _run_gitlab_dataset(
             sync_commit_stats=flags["sync_commit_stats"],
             sync_files=flags["sync_files"],
             sync_blame=flags["sync_blame"],
+            usage_sink=usage_sink,
         )
 
-    run_async(_run_with_reused_or_new_store(context, runtime, _handler))
-    return {
+    try:
+        run_async(_run_with_reused_or_new_store(context, runtime, _handler))
+    except Exception as exc:
+        _attach_usage_sink_to_exception(exc, usage_sink)
+        raise
+
+    result: dict[str, Any] = {
         "provider": context.provider,
         "dataset": context.dataset_key,
         "source": context.source_external_id,
@@ -295,6 +327,24 @@ def _run_gitlab_dataset(
         if context.window_end is not None
         else None,
     }
+    if usage_sink:
+        result["observations"] = {PROVIDER_USAGE_OBSERVATION_KEY: list(usage_sink)}
+    return result
+
+
+def _attach_usage_sink_to_exception(
+    exc: BaseException, usage_sink: list[dict[str, Any]]
+) -> None:
+    """Preserve actuals drained before a mid-sync raise (CHAOS-2754) so the
+    worker's rate-limit deferral / failure stamp can still persist them --
+    the code-dataset twin of ``job_work_items.attach_work_item_partial_observations``,
+    via the provider-neutral alias (CHAOS-2803/CS2). No-ops when the sink is
+    empty. Never suppresses the error."""
+
+    if usage_sink:
+        attach_partial_observations(
+            exc, {PROVIDER_USAGE_OBSERVATION_KEY: list(usage_sink)}
+        )
 
 
 def _run_work_item_dataset(context: SyncTaskContext) -> dict[str, Any]:

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -53,6 +53,7 @@ from dev_health_ops.processors.testops_ingest import (
 )
 from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
 from dev_health_ops.providers.pr_state import normalize_pr_state
+from dev_health_ops.providers.usage import drain_provider_usage
 from dev_health_ops.utils import (
     AGGREGATE_STATS_MARKER,
     BATCH_SIZE,
@@ -629,6 +630,13 @@ def _collect_github_pr_objects(
     return pr_objects, raw_gh_prs
 
 
+# Route family this batch's GraphQL reviews traffic re-buckets to (CHAOS-2803
+# CS2 -- was previously mis-bucketed to work_item_prs via the transport
+# default, since the client emitted this operation with no family prefix; see
+# the CS1 short-circuit convention in providers/usage.py::OperationResolver).
+_PR_SOCIAL_ROUTE_FAMILY = "pr_social"
+
+
 def _enrich_prs_with_reviews_batch(
     connector,
     owner: str,
@@ -639,16 +647,39 @@ def _enrich_prs_with_reviews_batch(
     ingestion_sink: IngestionSink,
     loop: asyncio.AbstractEventLoop,
     gate: "RateLimitGate",
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> list[GitPullRequestReview]:
     """Batch-fetch reviews for all PRs and enrich pr_objects in place.
 
     Collects all review objects and returns them for a single bulk insert,
     replacing the N+1 pattern (one review API call per PR).
+
+    Constructs a local, per-call ``GitHubWorkClient`` (CHAOS-2803/CS2: this
+    was previously never drained, silently discarding its usage actuals).
+    ``usage_sink``, when given, is drained into in a ``finally:`` block on
+    BOTH the success and failure path. Failure semantics are split:
+    ``RateLimitException`` PROPAGATES (after the finally-drain) so the
+    adapter can attach the partial ``pr_social`` usage to the exception and
+    the worker can defer the unit to RETRYING; any other fetch error keeps
+    the pre-existing degrade-and-log behavior (reviews are optional
+    enrichment on top of the PR rows). ``usage_sink=None`` (a legacy entry
+    point with no adapter-owned sink -- CLI batch sync, webhooks) still
+    drains the client (so its recorder never leaks across calls) but only
+    logs the observations at debug level -- never persisted (CHAOS-2773 plan
+    §2, last bullet).
+
+    The reviews GraphQL call is labeled with the ``pr_social:`` family prefix
+    (CS1's explicit-prefix resolver short-circuit) so its traffic resolves to
+    the ``pr_social`` route family the estimator already budgets for, instead
+    of the unprefixed transport default (``work_item_prs``) that the
+    work-items PR-as-work-item path (``providers/github/provider.py``)
+    continues to emit unshifted.
     """
     all_review_objects: list[GitPullRequestReview] = []
     pr_objects_by_number = {int(pr.number): pr for pr in pr_objects}
     reviews_by_pr = {}
 
+    review_client: GitHubWorkClient | None = None
     try:
         review_client = _github_work_client_from_connector(connector, gate=gate)
         for pr_number, reviews in review_client.iter_pr_reviews_batch(
@@ -656,12 +687,43 @@ def _enrich_prs_with_reviews_batch(
             repo=repo_name,
             prs=raw_gh_prs,
             limit=None,
+            operation_family=_PR_SOCIAL_ROUTE_FAMILY,
         ):
             reviews_by_pr[int(pr_number)] = reviews
+    except RateLimitException:
+        # A rate limit must PROPAGATE (codex HIGH on CHAOS-2803): swallowing
+        # it here would stamp the unit SUCCESS with reviews silently missing
+        # and bypass both the adapter's partial-observation attach and the
+        # worker's RETRYING/not_before deferral branch (sync_units.py). The
+        # `finally:` below still runs during the unwind, so the partial
+        # pr_social usage recorded before the 429 is drained into the sink
+        # FIRST and travels with the exception (CHAOS-2754 failure-path
+        # preservation).
+        raise
     except Exception as e:
+        # Intentional degrade-and-log (pre-existing semantic): review data is
+        # optional enrichment garnish on top of the PR rows -- a non-rate-limit
+        # fetch failure (schema drift, permission edge, transient GraphQL
+        # error) must not fail the whole PR sync. Only rate limits are
+        # re-raised above, because they carry deferral semantics.
         logging.debug(
             "Failed to batch-fetch reviews for %s/%s: %s", owner, repo_name, e
         )
+    finally:
+        if review_client is not None:
+            drained = drain_provider_usage(review_client)
+            if usage_sink is not None:
+                usage_sink.extend(drained)
+            elif drained:
+                logging.debug(
+                    "_enrich_prs_with_reviews_batch: drained %d %s usage "
+                    "observation(s) for %s/%s with no adapter-owned sink "
+                    "(legacy entry point) -- logging only, not persisted",
+                    len(drained),
+                    _PR_SOCIAL_ROUTE_FAMILY,
+                    owner,
+                    repo_name,
+                )
 
     for gh_pr in raw_gh_prs:
         pr_number = int(getattr(gh_pr, "number", 0) or 0)
@@ -745,12 +807,14 @@ def _sync_github_prs_to_store(
     gate: RateLimitGate | None = None,
     since: datetime | None = None,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> int:
     """Fetch all PRs for a repo and insert them in batches.
 
     Runs in a worker thread; uses run_coroutine_threadsafe to write batches.
     Reviews are fetched in a single batch pass after all PRs are collected,
-    avoiding N+1 API calls.
+    avoiding N+1 API calls. ``usage_sink`` is threaded through to
+    ``_enrich_prs_with_reviews_batch`` (CHAOS-2803/CS2) -- see its docstring.
     """
     logging.info(
         "Fetching PRs for %s/%s...",
@@ -788,6 +852,7 @@ def _sync_github_prs_to_store(
         ingestion_sink=ingestion_sink,
         loop=loop,
         gate=gate,
+        usage_sink=usage_sink,
     )
 
     # Phase 3: persist reviews in one bulk insert
@@ -1526,9 +1591,18 @@ async def process_github_repo(
     sync_commit_stats: bool | None = None,
     sync_files: bool | None = None,
     sync_blame: bool | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> None:
     """
     Process a GitHub repository using the GitHub connector.
+
+    ``usage_sink`` (CHAOS-2803/CS2), when given, is the caller-owned list
+    every instrumented client this call constructs drains into (currently:
+    the PR review-batch's local ``GitHubWorkClient`` -- see
+    ``_enrich_prs_with_reviews_batch``). ``None`` (the default, used by the
+    legacy CLI batch/webhook entry points that do not own a sink) still
+    drains any such client but only logs the observations, never persisting
+    them.
     """
     if not CONNECTORS_AVAILABLE:
         raise RuntimeError("Connectors unavailable. Install required dependencies.")
@@ -1653,6 +1727,7 @@ async def process_github_repo(
                     None,
                     since,
                     until,
+                    usage_sink,
                 )
                 logging.info(f"Stored {pr_total} pull requests from GitHub")
 

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -1778,9 +1778,17 @@ async def process_gitlab_project(
     sync_commit_stats: bool | None = None,
     sync_files: bool | None = None,
     sync_blame: bool | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> None:
     """
     Process a GitLab project using the GitLab connector.
+
+    ``usage_sink`` (CHAOS-2803/CS2) mirrors ``process_github_repo``'s
+    adapter-owned drain sink for symmetry with ``dataset_adapters.py``. No
+    instrumented client is constructed by this function yet -- GitLab
+    code-dataset fetch stays on the frozen connector until CHAOS-2773 Wave B
+    migrates it -- so it is currently unused and accepted only so the
+    caller-side contract is uniform across providers.
     """
     if not CONNECTORS_AVAILABLE:
         raise RuntimeError(

--- a/src/dev_health_ops/providers/github/budget.py
+++ b/src/dev_health_ops/providers/github/budget.py
@@ -334,6 +334,22 @@ def _fallback_credential_scope(
 # instrumented: every REST read in a work-item unit consumes the work_items
 # budget and every GraphQL POST consumes the work_item_prs budget, so resolution
 # is transport-based via the resolver defaults below.
+#
+# `pr_social` (GRAPHQL_COST) is the first code-dataset family whose fetch path
+# IS instrumented (CHAOS-2803/CS2): the PR review-batch enrichment
+# (`processors/github.py::_enrich_prs_with_reviews_batch`) constructs its own
+# local `GitHubWorkClient` and labels its GraphQL calls with the explicit
+# `"pr_social:"` prefix (CS1's resolver short-circuit, `providers/usage.py`),
+# so this marker documents that the family is now live rather than driving
+# resolution itself -- the short-circuit matches on `route_family` alone,
+# irrespective of `operation_markers`. The REST `prs` listing (raw PyGithub
+# `get_pulls`, `_collect_github_pr_objects`) and the `pr_social`
+# SECONDARY_ABUSE_RISK dimension remain uninstrumented/estimate-only: no
+# client observes a distinct secondary-limit signal on success responses (an
+# abstract reservation, like `work_item_prs`' SECONDARY_ABUSE_RISK sibling),
+# and the REST prs traffic itself stays on the frozen connector pending
+# CHAOS-2773 CS8 -- so their markers stay empty per the plan's "never flip a
+# marker before its traffic" rule (§3).
 GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("repo", BudgetDimension.REST_CORE),
     UsageRouteFamily("git", BudgetDimension.REST_CORE),
@@ -344,7 +360,9 @@ GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("blame", BudgetDimension.REST_CORE),
     UsageRouteFamily("blame", BudgetDimension.CONTENTS_BLOB),
     UsageRouteFamily("prs", BudgetDimension.REST_CORE),
-    UsageRouteFamily("pr_social", BudgetDimension.GRAPHQL_COST),
+    UsageRouteFamily(
+        "pr_social", BudgetDimension.GRAPHQL_COST, operation_markers=("pr_social:",)
+    ),
     UsageRouteFamily("pr_social", BudgetDimension.SECONDARY_ABUSE_RISK),
     UsageRouteFamily("cicd", BudgetDimension.REST_CORE),
     UsageRouteFamily("cicd", BudgetDimension.CONTENTS_BLOB),

--- a/src/dev_health_ops/providers/github/client.py
+++ b/src/dev_health_ops/providers/github/client.py
@@ -168,6 +168,16 @@ def _diagnostic_headers(headers: object) -> dict[str, str]:
     return {name: lowered[name] for name in _DIAGNOSTIC_HEADER_NAMES if name in lowered}
 
 
+def _prefixed_operation(operation_family: str | None, label: str) -> str:
+    """Apply the CS1 explicit-prefix resolver convention (``providers/usage.py::
+    OperationResolver``) to a GraphQL operation label: ``"<family>:<label>"``
+    when ``operation_family`` is given, else ``label`` unchanged (CHAOS-2803).
+    """
+    if not operation_family:
+        return label
+    return f"{operation_family}:{label}"
+
+
 def _github_error_message(data: object) -> str:
     if isinstance(data, dict):
         message = data.get("message")
@@ -839,6 +849,7 @@ class GitHubWorkClient:
         reviews_limit: int | None = None,
         events_limit: int | None = 0,
         batch_size: int = 50,
+        operation_family: str | None = None,
     ) -> Iterable[BatchedPRPayload]:
         """Fetch PR issue comments, reviews, and review comments in GraphQL batches.
 
@@ -849,6 +860,14 @@ class GitHubWorkClient:
         query per up-to-50 PRs. Nested connections are page-limited to control
         GraphQL cost and are paginated per PR only when the first page indicates
         more data.
+
+        ``operation_family`` (CHAOS-2803/CS1 short-circuit convention), when
+        given, prefixes every GraphQL operation label this call emits with
+        ``"<family>:"`` so ``OperationResolver`` resolves the recorded usage
+        DIRECTLY to that route family, bypassing the substring marker scan.
+        ``None`` (the default) preserves the existing unprefixed label exactly
+        -- unshifted attribution for callers that predate this convention
+        (``providers/github/provider.py``'s work-items PR-as-work-item path).
         """
         numbers: list[int] = []
         for pr in prs:
@@ -870,6 +889,7 @@ class GitHubWorkClient:
                 review_comments_first=self._connection_first(review_comments_limit),
                 reviews_first=self._connection_first(reviews_limit),
                 events_first=self._connection_first(events_limit),
+                operation_family=operation_family,
             )
             yield from self._complete_pr_social_payloads(
                 owner=owner,
@@ -879,6 +899,7 @@ class GitHubWorkClient:
                 review_comments_limit=review_comments_limit,
                 reviews_limit=reviews_limit,
                 events_limit=events_limit,
+                operation_family=operation_family,
             )
 
     def iter_pr_comments_batch(
@@ -926,8 +947,12 @@ class GitHubWorkClient:
         repo: str,
         prs: Sequence[_GitHubPullRequestLike],
         limit: int | None = None,
+        operation_family: str | None = None,
     ) -> Iterable[tuple[int, tuple[GitHubGraphQLReview, ...]]]:
-        """Return reviews keyed by PR number."""
+        """Return reviews keyed by PR number.
+
+        See :meth:`iter_pr_social_data_batch` for ``operation_family``.
+        """
         for payload in self.iter_pr_social_data_batch(
             owner=owner,
             repo=repo,
@@ -935,6 +960,7 @@ class GitHubWorkClient:
             comments_limit=0,
             review_comments_limit=0,
             reviews_limit=limit,
+            operation_family=operation_family,
         ):
             yield payload.number, payload.reviews
 
@@ -1021,6 +1047,7 @@ class GitHubWorkClient:
         reviews_after: str | None = None,
         events_first: int = 0,
         events_after: str | None = None,
+        operation_family: str | None = None,
     ) -> dict[int, dict[str, Any]]:
         aliases: list[str] = []
         for idx, number in enumerate(numbers):
@@ -1073,7 +1100,7 @@ class GitHubWorkClient:
         """
         with gate_call(self.gate):
             data = self._query_graphql(
-                "POST /graphql PR social data",
+                _prefixed_operation(operation_family, "POST /graphql PR social data"),
                 query,
                 variables={"owner": owner, "repo": repo},
             )
@@ -1091,6 +1118,7 @@ class GitHubWorkClient:
         review_id: str,
         first: int,
         after: str | None,
+        operation_family: str | None = None,
     ) -> dict[str, Any] | None:
         query = """
         query($reviewId: ID!, $first: Int!, $after: String) {
@@ -1106,7 +1134,9 @@ class GitHubWorkClient:
         """
         with gate_call(self.gate):
             data = self._query_graphql(
-                "POST /graphql PR review comments",
+                _prefixed_operation(
+                    operation_family, "POST /graphql PR review comments"
+                ),
                 query,
                 variables={"reviewId": review_id, "first": first, "after": after},
             )
@@ -1124,6 +1154,7 @@ class GitHubWorkClient:
         review_comments_limit: int | None,
         reviews_limit: int | None,
         events_limit: int | None = 0,
+        operation_family: str | None = None,
     ) -> Iterable[BatchedPRPayload]:
         for number, pr_node in initial.items():
             comments_connection = pr_node.get("comments")
@@ -1145,6 +1176,7 @@ class GitHubWorkClient:
                     review_comments_first=0,
                     reviews_first=0,
                     comments_after=comments_cursor,
+                    operation_family=operation_family,
                 ).get(number, {})
                 more_connection = (
                     more.get("comments") if isinstance(more, dict) else None
@@ -1173,6 +1205,7 @@ class GitHubWorkClient:
                     review_comments_first=self._connection_first(review_comments_limit),
                     reviews_first=self._connection_first(remaining_reviews),
                     reviews_after=reviews_cursor,
+                    operation_family=operation_family,
                 ).get(number, {})
                 more_reviews = more.get("reviews") if isinstance(more, dict) else None
                 reviews_nodes.extend(self._connection_nodes(more_reviews))
@@ -1205,6 +1238,7 @@ class GitHubWorkClient:
                         review_id=review_node_id,
                         first=self._connection_first(remaining_comments),
                         after=review_comment_cursor,
+                        operation_family=operation_family,
                     )
                     review_comments.extend(
                         self._comment_from_graphql(node)
@@ -1238,6 +1272,7 @@ class GitHubWorkClient:
                     reviews_first=0,
                     events_first=self._connection_first(remaining_events),
                     events_after=events_cursor,
+                    operation_family=operation_family,
                 ).get(number, {})
                 more_events = (
                     more.get("timelineItems") if isinstance(more, dict) else None

--- a/src/dev_health_ops/providers/usage.py
+++ b/src/dev_health_ops/providers/usage.py
@@ -248,3 +248,38 @@ def provider_usage_observations(client: object) -> dict[str, Any]:
 
     observations = drain_provider_usage(client)
     return {PROVIDER_USAGE_OBSERVATION_KEY: observations} if observations else {}
+
+
+# ---------------------------------------------------------------------------
+# Partial-observations-on-exception mechanism (CHAOS-2754 / CHAOS-2803 CS2)
+# ---------------------------------------------------------------------------
+# Exception attribute carrying best-effort usage observations gathered before a
+# mid-sync raise, so a worker deferral/failure stamp can persist actuals even
+# when the unit never returns normally. Originally implemented inline in
+# ``metrics/job_work_items.py`` for the work-items sync path only; hoisted here
+# so non-work-item callers (the CHAOS-2773 code-dataset adapters in
+# ``processors/dataset_adapters.py``) do not need to import a metrics module
+# just to preserve partial actuals across a raise. ``metrics/job_work_items.py``
+# now delegates its ``attach_work_item_partial_observations`` /
+# ``read_work_item_partial_observations`` to the functions below (same
+# attribute name, so anything already reading it -- e.g.
+# ``workers/sync_units.py::_merge_partial_observations_into_result`` --
+# continues to work unchanged for both callers).
+_PARTIAL_OBSERVATIONS_ATTR = "dev_health_partial_observations"
+
+
+def attach_partial_observations(
+    exc: BaseException, observations: dict[str, Any]
+) -> None:
+    """Stash partial usage observations on an in-flight exception (no-op when
+    empty) so a rate-limit deferral / failure can still record actuals."""
+
+    if observations:
+        setattr(exc, _PARTIAL_OBSERVATIONS_ATTR, observations)
+
+
+def read_partial_observations(exc: BaseException) -> dict[str, Any] | None:
+    """Read observations attached by :func:`attach_partial_observations`."""
+
+    observations = getattr(exc, _PARTIAL_OBSERVATIONS_ATTR, None)
+    return observations if isinstance(observations, dict) else None

--- a/tests/providers/test_github_pr_social_batch.py
+++ b/tests/providers/test_github_pr_social_batch.py
@@ -608,6 +608,148 @@ def test_batched_pr_reviews_preserve_rest_consumed_fields() -> None:
     assert reviews[0].url == "https://github.test/review/10"
 
 
+# ---------------------------------------------------------------------------
+# CHAOS-2803/CS2: pr_social usage-drain call-count + attribution proofs.
+# ---------------------------------------------------------------------------
+
+
+def test_iter_pr_reviews_batch_with_operation_family_records_pr_social_usage() -> None:
+    """N GraphQL requests issued by the review batch (here: one initial page
+    plus one pagination follow-up, forced via hasNextPage) aggregate into
+    exactly ONE drained observation with request_count == N, keyed to the
+    pr_social route family -- proving both the re-bucketing (Task B) and that
+    every physical request is counted (not just the first)."""
+    client, graphql, _gate = _client()
+    graphql.last_response_status = 200
+    graphql.query.side_effect = [
+        {
+            "repository": {
+                "pr0": {
+                    "number": 1,
+                    "reviews": {
+                        "nodes": [_review_node(10)],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "r1"},
+                    },
+                }
+            }
+        },
+        {
+            "repository": {
+                "pr0": {
+                    "number": 1,
+                    "reviews": {
+                        "nodes": [_review_node(11)],
+                        "pageInfo": {"hasNextPage": False, "endCursor": None},
+                    },
+                }
+            }
+        },
+    ]
+
+    reviews = dict(
+        client.iter_pr_reviews_batch(
+            owner="owner",
+            repo="repo",
+            prs=[_pr(1)],
+            limit=10,
+            operation_family="pr_social",
+        )
+    )[1]
+
+    assert [review.id for review in reviews] == [10, 11]
+    assert graphql.query.call_count == 2
+
+    observations = client.drain_usage_observations()
+    assert observations == [
+        {
+            "transport": "graphql",
+            "route_family": "pr_social",
+            "dimension": "graphql_cost",
+            "request_count": 2,
+            "example_operation": "pr_social:POST /graphql PR social data",
+            "latest_status": 200,
+        }
+    ]
+
+
+def test_iter_pr_reviews_batch_without_operation_family_stays_work_item_prs() -> None:
+    """No operation_family (the pre-CS2 call shape, still used by the
+    work-items PR-as-work-item path in providers/github/provider.py) keeps
+    the unprefixed label and resolves via the transport default -- proving
+    the CS2 fix is additive, not a change to the default resolution."""
+    client, graphql, _gate = _client()
+    graphql.last_response_status = 200
+    graphql.query.return_value = {
+        "repository": {
+            "pr0": {
+                "number": 1,
+                "reviews": {
+                    "nodes": [_review_node(10)],
+                    "pageInfo": {"hasNextPage": False, "endCursor": None},
+                },
+            }
+        }
+    }
+
+    dict(
+        client.iter_pr_reviews_batch(owner="owner", repo="repo", prs=[_pr(1)], limit=10)
+    )
+
+    observations = client.drain_usage_observations()
+    assert len(observations) == 1
+    assert observations[0]["route_family"] == "work_item_prs"
+    assert observations[0]["example_operation"] == "POST /graphql PR social data"
+
+
+def test_iter_pr_reviews_batch_failure_mid_pagination_leaves_partial_usage_drained() -> (
+    None
+):
+    """A raise on the SECOND (pagination) request must not discard the
+    observation recorded for the FIRST, successful request -- the recorder
+    aggregates per physical round trip as it goes, so whatever succeeded
+    before a mid-batch failure is still present when the caller drains."""
+    client, graphql, gate = _client()
+    graphql.last_response_status = 200
+    graphql.query.side_effect = [
+        {
+            "repository": {
+                "pr0": {
+                    "number": 1,
+                    "reviews": {
+                        "nodes": [_review_node(10)],
+                        "pageInfo": {"hasNextPage": True, "endCursor": "r1"},
+                    },
+                }
+            }
+        },
+        RateLimitException("limited", retry_after_seconds=5.0),
+    ]
+
+    with pytest.raises(RateLimitException):
+        list(
+            client.iter_pr_reviews_batch(
+                owner="owner",
+                repo="repo",
+                prs=[_pr(1)],
+                limit=10,
+                operation_family="pr_social",
+            )
+        )
+
+    gate.penalize.assert_called_once_with(5.0)
+    observations = client.drain_usage_observations()
+    assert observations == [
+        {
+            "transport": "graphql",
+            "route_family": "pr_social",
+            "dimension": "graphql_cost",
+            "request_count": 1,
+            "example_operation": "pr_social:POST /graphql PR social data",
+            "latest_status": 200,
+        }
+    ]
+
+
 def _timeline_node(typename: str, created_at: str, login: str) -> dict[str, object]:
     return {
         "__typename": typename,

--- a/tests/providers/test_usage_resolver_prefix.py
+++ b/tests/providers/test_usage_resolver_prefix.py
@@ -123,6 +123,50 @@ def test_gitlab_existing_labels_resolve_unshifted(
 
 
 # ---------------------------------------------------------------------------
+# 1b. CHAOS-2803/CS2: the FIRST intentional re-bucketing. The PR review-batch
+# enrichment (processors/github.py::_enrich_prs_with_reviews_batch) now labels
+# its local GitHubWorkClient's GraphQL calls with the "pr_social:" prefix, so
+# they resolve to `pr_social` instead of the unprefixed transport default
+# (`work_item_prs`) -- while the SAME literal label, unprefixed (still emitted
+# by providers/github/provider.py's work-items PR-as-work-item path, which
+# never passes operation_family), keeps resolving to `work_item_prs` exactly
+# as it always has (see GITHUB_EXISTING_LABELS above, unchanged).
+# ---------------------------------------------------------------------------
+
+GITHUB_CS2_PREFIXED_LABELS: tuple[tuple[str, str, tuple[str, BudgetDimension]], ...] = (
+    (
+        "graphql",
+        "pr_social:POST /graphql PR social data",
+        ("pr_social", BudgetDimension.GRAPHQL_COST),
+    ),
+    (
+        "graphql",
+        "pr_social:POST /graphql PR review comments",
+        ("pr_social", BudgetDimension.GRAPHQL_COST),
+    ),
+)
+
+
+@pytest.mark.parametrize("transport,operation,expected", GITHUB_CS2_PREFIXED_LABELS)
+def test_github_review_batch_prefixed_labels_resolve_to_pr_social(
+    transport: str, operation: str, expected: tuple[str, BudgetDimension]
+) -> None:
+    assert (
+        GITHUB_USAGE_RESOLVER.resolve(transport=transport, operation=operation)
+        == expected
+    )
+
+
+def test_github_review_batch_unprefixed_label_still_resolves_to_work_item_prs() -> None:
+    """Sanity check mirroring the GitLab pipelines/project one below: the SAME
+    literal operation, without the family prefix, is untouched -- proving the
+    CS2 fix is additive (a new label, not a resolver default change)."""
+    assert GITHUB_USAGE_RESOLVER.resolve(
+        transport="graphql", operation="POST /graphql PR social data"
+    ) == ("work_item_prs", BudgetDimension.GRAPHQL_COST)
+
+
+# ---------------------------------------------------------------------------
 # 2. Representative prefixed labels per registered family short-circuit.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -645,3 +645,272 @@ def test_work_item_derivative_preserves_non_null_window_start_not_midnight(
         f"Expected window_start={mid_day_start.isoformat()!r} but got {result['window_start']!r}; "
         "adapter fell back to midnight instead of preserving context.window_start"
     )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-2803/CS2: code-dataset usage_sink contract (_run_github_dataset /
+# _run_gitlab_dataset). Without this, code-dataset processors could drain
+# every instrumented client into a sink and it would still never reach the
+# unit result -- the adapter is the seam that turns "drained somewhere deep
+# in a processor" into "observations.provider_usage on the returned payload".
+# ---------------------------------------------------------------------------
+
+_FAKE_PR_SOCIAL_RECORD = {
+    "transport": "graphql",
+    "route_family": "pr_social",
+    "dimension": "graphql_cost",
+    "request_count": 3,
+    "example_operation": "pr_social:POST /graphql PR social data",
+}
+
+
+def test_github_dataset_result_includes_provider_usage_when_processor_drains_sink() -> (
+    None
+):
+    """The adapter passes its OWN usage_sink list into process_github_repo;
+    when the (mocked) processor drains something into it, the returned
+    payload gains observations.provider_usage with that exact content."""
+    ctx = _context(dataset_key="pr-reviews", processor_flags=_flags(sync_prs=True))
+
+    async def _fake_process_github_repo(**kwargs: object) -> None:
+        sink = kwargs["usage_sink"]
+        assert isinstance(sink, list) and sink == []
+        sink.append(dict(_FAKE_PR_SOCIAL_RECORD))
+
+    with patch(
+        "dev_health_ops.processors.github.process_github_repo",
+        _fake_process_github_repo,
+    ):
+        result = run_dataset_unit(ctx, _runtime())
+
+    assert result["observations"] == {"provider_usage": [_FAKE_PR_SOCIAL_RECORD]}
+
+
+def test_github_dataset_no_drain_omits_observations_key() -> None:
+    """A processor that drains nothing (the common case for every family
+    besides prs/pr_social until later CS waves) must not fabricate an empty
+    observations.provider_usage -- mirrors _build_work_item_observations'
+    "only emit if truthy" convention."""
+    ctx = _context(dataset_key="commits", processor_flags=_flags(sync_git=True))
+    processor = AsyncMock()
+
+    with patch("dev_health_ops.processors.github.process_github_repo", processor):
+        result = run_dataset_unit(ctx, _runtime())
+
+    processor.assert_awaited_once()
+    await_args = processor.await_args
+    assert await_args is not None
+    assert await_args.kwargs["usage_sink"] == []
+    assert "observations" not in result
+
+
+def test_github_dataset_failure_attaches_partial_observations_to_exception() -> None:
+    """CHAOS-2754 clobber rule: a processor that drains SOME usage into the
+    sink and then raises must still surface those actuals -- attached to the
+    exception via the provider-neutral alias -- so the worker's deferral/
+    failure stamp can persist them, even though run_dataset_unit itself
+    re-raises (never swallows the error)."""
+    from dev_health_ops.providers.usage import read_partial_observations
+
+    ctx = _context(dataset_key="pr-reviews", processor_flags=_flags(sync_prs=True))
+
+    async def _failing_process_github_repo(**kwargs: object) -> None:
+        sink = kwargs["usage_sink"]
+        assert isinstance(sink, list)
+        sink.append(dict(_FAKE_PR_SOCIAL_RECORD))
+        raise RuntimeError("boom mid-sync")
+
+    with patch(
+        "dev_health_ops.processors.github.process_github_repo",
+        _failing_process_github_repo,
+    ):
+        with pytest.raises(RuntimeError, match="boom mid-sync") as exc_info:
+            run_dataset_unit(ctx, _runtime())
+
+    partial = read_partial_observations(exc_info.value)
+    assert partial == {"provider_usage": [_FAKE_PR_SOCIAL_RECORD]}
+
+
+def test_github_dataset_rate_limit_propagates_with_partials_and_type_intact() -> None:
+    """Codex HIGH (PR #1151): the deferral interleaving that matters most.
+    A RateLimitException escaping the processor (the review batch now
+    re-raises it instead of degrade-and-log) must leave run_dataset_unit as
+    the SAME canonical exception type -- sync_units' deferral branch matches
+    on isinstance(RateLimitException) -- with retry_after_seconds intact AND
+    the partial pr_social usage attached, and there is no success result at
+    all (so a partial fetch can never be stamped SUCCESS with reviews
+    silently missing)."""
+    from dev_health_ops.exceptions import RateLimitException
+    from dev_health_ops.providers.usage import read_partial_observations
+
+    ctx = _context(dataset_key="pr-reviews", processor_flags=_flags(sync_prs=True))
+
+    async def _rate_limited_process_github_repo(**kwargs: object) -> None:
+        sink = kwargs["usage_sink"]
+        assert isinstance(sink, list)
+        # Mirrors the processor contract: the finally-drain has already moved
+        # the partial usage into the sink before the exception unwinds.
+        sink.append(dict(_FAKE_PR_SOCIAL_RECORD))
+        raise RateLimitException("429 Too Many Requests", retry_after_seconds=120)
+
+    with patch(
+        "dev_health_ops.processors.github.process_github_repo",
+        _rate_limited_process_github_repo,
+    ):
+        with pytest.raises(RateLimitException) as exc_info:
+            run_dataset_unit(ctx, _runtime())
+
+    assert exc_info.value.retry_after_seconds == 120
+    partial = read_partial_observations(exc_info.value)
+    assert partial == {"provider_usage": [_FAKE_PR_SOCIAL_RECORD]}
+
+
+def test_github_dataset_failure_without_any_drain_attaches_nothing() -> None:
+    """A processor that raises before draining anything must not attach an
+    empty/fabricated partial-observations payload to the exception."""
+    from dev_health_ops.providers.usage import read_partial_observations
+
+    ctx = _context(dataset_key="commits", processor_flags=_flags(sync_git=True))
+
+    async def _failing_process_github_repo(**kwargs: object) -> None:
+        raise RuntimeError("boom before any drain")
+
+    with patch(
+        "dev_health_ops.processors.github.process_github_repo",
+        _failing_process_github_repo,
+    ):
+        with pytest.raises(RuntimeError) as exc_info:
+            run_dataset_unit(ctx, _runtime())
+
+    assert read_partial_observations(exc_info.value) is None
+
+
+def test_gitlab_dataset_result_includes_provider_usage_when_processor_drains_sink() -> (
+    None
+):
+    """GitLab twin of the GitHub success-drain test: the plumbing is uniform
+    across providers even though no GitLab code client drains into it yet
+    (CHAOS-2773 Wave B) -- this proves the CONTRACT works generically."""
+    ctx = _context(
+        provider="gitlab",
+        dataset_key="pr-reviews",
+        source_external_id="123",
+        processor_flags=_flags(sync_prs=True),
+        credentials={"token": "gitlab-token", "gitlab_url": "https://gitlab.example"},
+    )
+    fake_record = {
+        "transport": "rest",
+        "route_family": "merge_requests",
+        "dimension": "rest_core",
+        "request_count": 2,
+    }
+
+    async def _fake_process_gitlab_project(**kwargs: object) -> None:
+        sink = kwargs["usage_sink"]
+        assert isinstance(sink, list) and sink == []
+        sink.append(dict(fake_record))
+
+    with patch(
+        "dev_health_ops.processors.gitlab.process_gitlab_project",
+        _fake_process_gitlab_project,
+    ):
+        result = run_dataset_unit(ctx, _runtime())
+
+    assert result["observations"] == {"provider_usage": [fake_record]}
+
+
+def test_gitlab_dataset_failure_attaches_partial_observations_to_exception() -> None:
+    """GitLab twin of the GitHub failure-drain test."""
+    from dev_health_ops.providers.usage import read_partial_observations
+
+    ctx = _context(
+        provider="gitlab",
+        dataset_key="pr-reviews",
+        source_external_id="123",
+        processor_flags=_flags(sync_prs=True),
+        credentials={"token": "gitlab-token", "gitlab_url": "https://gitlab.example"},
+    )
+    fake_record = {
+        "transport": "rest",
+        "route_family": "merge_requests",
+        "dimension": "rest_core",
+        "request_count": 1,
+    }
+
+    async def _failing_process_gitlab_project(**kwargs: object) -> None:
+        sink = kwargs["usage_sink"]
+        assert isinstance(sink, list)
+        sink.append(dict(fake_record))
+        raise RuntimeError("boom mid-sync gitlab")
+
+    with patch(
+        "dev_health_ops.processors.gitlab.process_gitlab_project",
+        _failing_process_gitlab_project,
+    ):
+        with pytest.raises(RuntimeError, match="boom mid-sync gitlab") as exc_info:
+            run_dataset_unit(ctx, _runtime())
+
+    partial = read_partial_observations(exc_info.value)
+    assert partial == {"provider_usage": [fake_record]}
+
+
+def test_github_dataset_observations_join_through_real_attach_budget_comparison() -> (
+    None
+):
+    """CHAOS-2803/CS2: the adapter's returned payload's observations shape
+    must be exactly what workers.sync_units._attach_budget_comparison expects
+    -- proven with a REAL (unmocked) call to that function AND the real
+    GitHub budget estimator, without needing a live GitHub API. This is the
+    proof that markers + draining are not enough on their own: the payload
+    shape has to join too."""
+    from dev_health_ops.sync.budget import estimate_provider_budget
+    from dev_health_ops.workers.sync_units import _attach_budget_comparison
+
+    ctx = _context(dataset_key="pr-reviews", processor_flags=_flags(sync_prs=True))
+
+    async def _fake_process_github_repo(**kwargs: object) -> None:
+        # A single aggregated observation with request_count=3 -- matching the
+        # REAL shape UsageRecorder.drain() returns (one dict per unique
+        # (transport, route_family, dimension) key, already summed), and the
+        # pr_social/graphql_cost bucket the estimator reserves for the
+        # prs/pr-reviews/pr-comments dataset family (providers/github/budget.py
+        # _dataset_estimates).
+        sink = kwargs["usage_sink"]
+        assert isinstance(sink, list)
+        sink.append(dict(_FAKE_PR_SOCIAL_RECORD))
+
+    with patch(
+        "dev_health_ops.processors.github.process_github_repo",
+        _fake_process_github_repo,
+    ):
+        result = run_dataset_unit(ctx, _runtime())
+
+    provider_usage = result["observations"]["provider_usage"]
+    assert len(provider_usage) == 1
+    assert provider_usage[0]["route_family"] == "pr_social"
+
+    budget_audit = [estimate.to_dict() for estimate in estimate_provider_budget(ctx)]
+    pr_social_estimate = next(
+        entry
+        for entry in budget_audit
+        if entry["route_family"] == "pr_social"
+        and entry["bucket"]["dimension"] == "graphql_cost"
+    )
+    assert pr_social_estimate["estimated_units"] > 0
+
+    joined = _attach_budget_comparison(
+        result,
+        budget_audit,
+        log_ctx={},
+        computed_at=datetime.now(timezone.utc),
+    )
+
+    comparisons = joined["observations"]["budget_comparison"]
+    pr_social_comparison = next(
+        row for row in comparisons if row["route_family"] == "pr_social"
+    )
+    assert pr_social_comparison["dimension"] == "graphql_cost"
+    assert pr_social_comparison["actual_requests"] == 3
+    assert (
+        pr_social_comparison["estimated_units"] == pr_social_estimate["estimated_units"]
+    )

--- a/tests/test_github_pr_changes_requested_sync.py
+++ b/tests/test_github_pr_changes_requested_sync.py
@@ -151,13 +151,17 @@ async def test_github_pr_sync_writes_changes_requested_count_from_reviews():
             raise AssertionError("per-PR review fetch should not be used")
 
     class _BatchReviewClient:
-        calls: list[tuple[str, str, list[int], int | None]] = []
+        calls: list[tuple[str, str, list[int], int | None, str | None]] = []
 
         def __init__(self, **_kwargs):
             self.graphql = None
 
-        def iter_pr_reviews_batch(self, *, owner, repo, prs, limit):
-            self.calls.append((owner, repo, [pr.number for pr in prs], limit))
+        def iter_pr_reviews_batch(
+            self, *, owner, repo, prs, limit, operation_family=None
+        ):
+            self.calls.append(
+                (owner, repo, [pr.number for pr in prs], limit, operation_family)
+            )
             for pr in prs:
                 yield pr.number, tuple(reviews_by_pr.get(pr.number, []))
 
@@ -180,7 +184,9 @@ async def test_github_pr_sync_writes_changes_requested_count_from_reviews():
         )
 
     assert total == 2
-    assert _BatchReviewClient.calls == [("o", "r", [1, 2], None)]
+    # CHAOS-2803/CS2: the review batch labels its GraphQL calls with the
+    # "pr_social" family so they re-bucket off the work_item_prs default.
+    assert _BatchReviewClient.calls == [("o", "r", [1, 2], None, "pr_social")]
 
     prs = {pr.number: pr for batch in store.pr_batches for pr in batch}
     assert prs[1].changes_requested_count == 2

--- a/tests/test_github_pr_usage_drain.py
+++ b/tests/test_github_pr_usage_drain.py
@@ -1,0 +1,404 @@
+"""CHAOS-2803/CS2: usage-drain plumbing for the PR review-batch enrichment.
+
+``_enrich_prs_with_reviews_batch`` (processors/github.py) constructs a local
+``GitHubWorkClient`` to batch-fetch PR reviews via GraphQL. Before CS2 this
+client was never drained -- its recorded usage was silently discarded, so the
+review-batch's real GraphQL traffic never surfaced as a ``budget_comparison``
+actual. This file pins the drain contract through ``_sync_github_prs_to_store``
+(the real call chain ``process_github_repo`` uses): an adapter-owned
+``usage_sink`` list is threaded down and populated in a ``finally:`` block,
+and the "no sink" (legacy CLI batch / webhook) path still drains the client
+but only logs the observations -- never persists, never raises.
+"""
+
+import asyncio
+import uuid
+from datetime import datetime, timezone
+from typing import Any, cast
+from unittest.mock import patch
+
+import pytest
+
+# Initialize the connectors package before processors to avoid the
+# pre-existing providers._base <-> connectors circular import when this file
+# is collected in isolation (mirrors test_processors_pr_mr_rate_limit.py).
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.processors.github import _sync_github_prs_to_store
+
+
+class _NoSleepGate:
+    def wait_sync(self) -> None:
+        return
+
+    def penalize(self, delay_seconds=None) -> float:
+        return float(delay_seconds or 0)
+
+    def reset(self) -> None:
+        return
+
+
+class _FakeStore:
+    def __init__(self):
+        self.pr_batches: list[list[Any]] = []
+        self.review_batches: list[list[Any]] = []
+
+    async def insert_git_pull_requests(self, batch):
+        self.pr_batches.append(list(batch))
+
+    async def insert_git_pull_request_reviews(self, batch):
+        self.review_batches.append(list(batch))
+
+
+class _FakeGithub:
+    def __init__(self, repo):
+        self._repo = repo
+
+    def get_repo(self, _full_name: str):
+        return self._repo
+
+
+class _PRIter:
+    def __init__(self, items):
+        self._items = list(items)
+        self._idx = 0
+
+    def __iter__(self):
+        return self
+
+    def __next__(self):
+        if self._idx >= len(self._items):
+            raise StopIteration
+        item = self._items[self._idx]
+        self._idx += 1
+        return item
+
+
+class _FakePRUser:
+    def __init__(self, login="octo"):
+        self.login = login
+        self.email = None
+
+
+class _FakePRRef:
+    def __init__(self, ref):
+        self.ref = ref
+
+
+class _FakePR:
+    def __init__(self, number: int):
+        self.number = number
+        self.title = f"PR {number}"
+        self.body = None
+        self.state = "closed"
+        self.user = _FakePRUser()
+        self.created_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        self.merged_at = None
+        self.closed_at = None
+        self.head = _FakePRRef("feature")
+        self.base = _FakePRRef("main")
+        self.additions = 0
+        self.deletions = 0
+        self.changed_files = 0
+        self.comments = 0
+
+
+class _FakeRepo:
+    def __init__(self, pull_items):
+        self._pull_items = pull_items
+
+    def get_pulls(self, state="all", sort=None, direction=None):
+        return _PRIter(self._pull_items)
+
+
+class _Connector:
+    def __init__(self, fake_repo):
+        self.github = _FakeGithub(fake_repo)
+        self.token = "token"
+        self.per_page = 100
+        self.graphql = object()
+
+    def _rest_base_url(self):
+        return "https://api.github.com"
+
+
+class _DrainingBatchReviewClient:
+    """Fake work client whose ``drain_usage_observations`` returns canned
+    records, so tests can assert the DRAIN side of the contract without
+    depending on the real GitHubWorkClient/UsageRecorder plumbing (already
+    covered separately in tests/providers/test_github_pr_social_batch.py)."""
+
+    instances: list["_DrainingBatchReviewClient"] = []
+
+    def __init__(self, **_kwargs):
+        self.graphql = None
+        self.drained = False
+        type(self).instances.append(self)
+
+    def iter_pr_reviews_batch(self, *, owner, repo, prs, limit, operation_family=None):
+        self.operation_family = operation_family
+        for pr in prs:
+            yield pr.number, ()
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        self.drained = True
+        return [
+            {
+                "transport": "graphql",
+                "route_family": "pr_social",
+                "dimension": "graphql_cost",
+                "request_count": 1,
+                "example_operation": "pr_social:POST /graphql PR social data",
+            }
+        ]
+
+
+@pytest.fixture(autouse=True)
+def _reset_instances():
+    _DrainingBatchReviewClient.instances = []
+    yield
+    _DrainingBatchReviewClient.instances = []
+
+
+@pytest.mark.asyncio
+async def test_sync_prs_drains_review_client_into_adapter_owned_sink():
+    """The adapter-owned usage_sink list is populated with the review-batch
+    client's drained observations under the pr_social family."""
+    loop = asyncio.get_running_loop()
+    repo_id = uuid.uuid4()
+    store = _FakeStore()
+    fake_repo = _FakeRepo([_FakePR(1), _FakePR(2)])
+    usage_sink: list[dict[str, Any]] = []
+
+    with patch(
+        "dev_health_ops.processors.github.GitHubWorkClient",
+        _DrainingBatchReviewClient,
+    ):
+        total = await loop.run_in_executor(
+            None,
+            cast(Any, _sync_github_prs_to_store),
+            _Connector(fake_repo),
+            "o",
+            "r",
+            repo_id,
+            store,
+            loop,
+            50,  # batch_size
+            "all",
+            _NoSleepGate(),
+            None,  # since
+            None,  # until
+            usage_sink,
+        )
+
+    assert total == 2
+    assert len(_DrainingBatchReviewClient.instances) == 1
+    assert _DrainingBatchReviewClient.instances[0].drained is True
+    assert usage_sink == [
+        {
+            "transport": "graphql",
+            "route_family": "pr_social",
+            "dimension": "graphql_cost",
+            "request_count": 1,
+            "example_operation": "pr_social:POST /graphql PR social data",
+        }
+    ]
+
+
+@pytest.mark.asyncio
+async def test_sync_prs_without_sink_drains_client_but_logs_only(caplog):
+    """CHAOS-2773 plan §2 last bullet: legacy entry points (no adapter-owned
+    sink -- the default when usage_sink is omitted, e.g. the CLI batch path
+    and webhooks) still drain the review client -- so its recorder does not
+    accumulate/leak across calls -- but the drained observations are only
+    logged at debug level, never persisted, and no exception is raised."""
+    loop = asyncio.get_running_loop()
+    repo_id = uuid.uuid4()
+    store = _FakeStore()
+    fake_repo = _FakeRepo([_FakePR(1)])
+
+    with (
+        patch(
+            "dev_health_ops.processors.github.GitHubWorkClient",
+            _DrainingBatchReviewClient,
+        ),
+        caplog.at_level("DEBUG", logger="root"),
+    ):
+        # usage_sink omitted entirely -- exercises the default (None) path.
+        total = await loop.run_in_executor(
+            None,
+            cast(Any, _sync_github_prs_to_store),
+            _Connector(fake_repo),
+            "o",
+            "r",
+            repo_id,
+            store,
+            loop,
+            50,
+            "all",
+            _NoSleepGate(),
+        )
+
+    assert total == 1
+    assert len(_DrainingBatchReviewClient.instances) == 1
+    assert _DrainingBatchReviewClient.instances[0].drained is True
+    assert any(
+        "drained" in record.message and "no adapter-owned sink" in record.message
+        for record in caplog.records
+    )
+
+
+# ---------------------------------------------------------------------------
+# Codex HIGH (PR #1151): the review-batch catch-all must NOT swallow a
+# RateLimitException -- it must propagate (after the finally-drain) so the
+# adapter attaches the partial pr_social usage and sync_units defers the unit
+# to RETRYING instead of stamping SUCCESS with reviews silently missing.
+# Non-rate-limit enrichment errors keep the pre-existing degrade-and-log
+# semantic (reviews are optional garnish on top of the PR rows).
+# ---------------------------------------------------------------------------
+
+_PARTIAL_PR_SOCIAL_RECORD = {
+    "transport": "graphql",
+    "route_family": "pr_social",
+    "dimension": "graphql_cost",
+    "request_count": 1,
+    "example_operation": "pr_social:POST /graphql PR social data",
+}
+
+
+class _RateLimitedAfterOneRequestClient:
+    """Fake work client: yields one PR's reviews then raises the canonical
+    RateLimitException mid-batch; drain returns the one recorded request."""
+
+    instances: list["_RateLimitedAfterOneRequestClient"] = []
+
+    def __init__(self, **_kwargs):
+        self.graphql = None
+        self.drained = False
+        type(self).instances.append(self)
+
+    def iter_pr_reviews_batch(self, *, owner, repo, prs, limit, operation_family=None):
+        yield prs[0].number, ()
+        raise RateLimitException("429 Too Many Requests", retry_after_seconds=120)
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        self.drained = True
+        return [dict(_PARTIAL_PR_SOCIAL_RECORD)]
+
+
+class _FailingBatchReviewClient:
+    """Fake work client whose batch fetch fails with a NON-rate-limit error."""
+
+    instances: list["_FailingBatchReviewClient"] = []
+
+    def __init__(self, **_kwargs):
+        self.graphql = None
+        self.drained = False
+        type(self).instances.append(self)
+
+    def iter_pr_reviews_batch(self, *, owner, repo, prs, limit, operation_family=None):
+        raise RuntimeError("GraphQL schema drift")
+        yield  # pragma: no cover - make this a generator
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        self.drained = True
+        return [dict(_PARTIAL_PR_SOCIAL_RECORD)]
+
+
+@pytest.fixture(autouse=True)
+def _reset_failure_client_instances():
+    _RateLimitedAfterOneRequestClient.instances = []
+    _FailingBatchReviewClient.instances = []
+    yield
+    _RateLimitedAfterOneRequestClient.instances = []
+    _FailingBatchReviewClient.instances = []
+
+
+@pytest.mark.asyncio
+async def test_sync_prs_rate_limit_propagates_after_partial_drain():
+    """A RateLimitException raised mid-review-batch PROPAGATES out of
+    _sync_github_prs_to_store: no success return, no PR rows persisted this
+    attempt (the worker defers and retries the whole unit) -- while the
+    finally-drain has already moved the partial pr_social usage into the
+    adapter-owned sink, so the deferral stamp still records the actuals
+    (the sink is exactly what _run_github_dataset attaches to the exception,
+    pinned by test_dataset_adapters' failure-path tests)."""
+    loop = asyncio.get_running_loop()
+    repo_id = uuid.uuid4()
+    store = _FakeStore()
+    fake_repo = _FakeRepo([_FakePR(1), _FakePR(2)])
+    usage_sink: list[dict[str, Any]] = []
+
+    with patch(
+        "dev_health_ops.processors.github.GitHubWorkClient",
+        _RateLimitedAfterOneRequestClient,
+    ):
+        with pytest.raises(RateLimitException) as exc_info:
+            await loop.run_in_executor(
+                None,
+                cast(Any, _sync_github_prs_to_store),
+                _Connector(fake_repo),
+                "o",
+                "r",
+                repo_id,
+                store,
+                loop,
+                50,
+                "all",
+                _NoSleepGate(),
+                None,  # since
+                None,  # until
+                usage_sink,
+            )
+
+    assert exc_info.value.retry_after_seconds == 120
+    # The drain ran BEFORE the exception unwound past the processor.
+    assert len(_RateLimitedAfterOneRequestClient.instances) == 1
+    assert _RateLimitedAfterOneRequestClient.instances[0].drained is True
+    assert usage_sink == [_PARTIAL_PR_SOCIAL_RECORD]
+    # No success-path persistence happened: the unit defers, nothing stamped.
+    assert store.pr_batches == []
+    assert store.review_batches == []
+
+
+@pytest.mark.asyncio
+async def test_sync_prs_non_rate_limit_error_still_degrades_gracefully():
+    """The pre-existing degrade-and-log semantic is preserved for
+    NON-rate-limit review-batch errors: PRs are still persisted (reviews are
+    optional enrichment), no exception propagates, and the client is still
+    drained into the sink."""
+    loop = asyncio.get_running_loop()
+    repo_id = uuid.uuid4()
+    store = _FakeStore()
+    fake_repo = _FakeRepo([_FakePR(1), _FakePR(2)])
+    usage_sink: list[dict[str, Any]] = []
+
+    with patch(
+        "dev_health_ops.processors.github.GitHubWorkClient",
+        _FailingBatchReviewClient,
+    ):
+        total = await loop.run_in_executor(
+            None,
+            cast(Any, _sync_github_prs_to_store),
+            _Connector(fake_repo),
+            "o",
+            "r",
+            repo_id,
+            store,
+            loop,
+            50,
+            "all",
+            _NoSleepGate(),
+            None,  # since
+            None,  # until
+            usage_sink,
+        )
+
+    assert total == 2
+    assert len(_FailingBatchReviewClient.instances) == 1
+    assert _FailingBatchReviewClient.instances[0].drained is True
+    assert usage_sink == [_PARTIAL_PR_SOCIAL_RECORD]
+    # PRs persisted despite the failed (optional) review enrichment.
+    persisted_prs = [pr for batch in store.pr_batches for pr in batch]
+    assert len(persisted_prs) == 2
+    assert store.review_batches == []

--- a/tests/test_provider_usage.py
+++ b/tests/test_provider_usage.py
@@ -376,3 +376,74 @@ def test_github_usage_key_backward_compat() -> None:
         "linear_page_count",
         "linear_batch_count",
     )
+
+
+# ---------------------------------------------------------------------------
+# Provider-neutral partial-observations alias (CHAOS-2803/CS2)
+# ---------------------------------------------------------------------------
+
+
+def test_attach_and_read_partial_observations_round_trip() -> None:
+    from dev_health_ops.providers.usage import (
+        attach_partial_observations,
+        read_partial_observations,
+    )
+
+    exc = RuntimeError("boom")
+    observations = {"provider_usage": [{"route_family": "pr_social"}]}
+
+    attach_partial_observations(exc, observations)
+
+    assert read_partial_observations(exc) == observations
+
+
+def test_attach_partial_observations_is_noop_for_empty_payload() -> None:
+    from dev_health_ops.providers.usage import (
+        attach_partial_observations,
+        read_partial_observations,
+    )
+
+    exc = RuntimeError("boom")
+    attach_partial_observations(exc, {})
+
+    assert read_partial_observations(exc) is None
+
+
+def test_read_partial_observations_returns_none_when_never_attached() -> None:
+    from dev_health_ops.providers.usage import read_partial_observations
+
+    assert read_partial_observations(RuntimeError("boom")) is None
+
+
+def test_job_work_items_partial_observations_helpers_delegate_to_providers_usage() -> (
+    None
+):
+    """metrics/job_work_items.py's attach_work_item_partial_observations /
+    read_work_item_partial_observations now delegate to the provider-neutral
+    alias in providers/usage.py (CHAOS-2803/CS2) -- pinning that BOTH ends
+    read/write the SAME exception attribute, so cross-module reads (e.g.
+    workers/sync_units.py reading what dataset_adapters.py attached) work."""
+    from dev_health_ops.metrics.job_work_items import (
+        attach_work_item_partial_observations,
+        read_work_item_partial_observations,
+    )
+    from dev_health_ops.providers.usage import (
+        attach_partial_observations,
+        read_partial_observations,
+    )
+
+    exc = RuntimeError("boom")
+    observations = {"provider_usage": [{"route_family": "work_items"}]}
+
+    # Written via the work-items helper, read via the provider-neutral one.
+    attach_work_item_partial_observations(exc, observations)
+    assert read_partial_observations(exc) == observations
+
+    other_exc = RuntimeError("boom2")
+    other_observations = {"provider_usage": [{"route_family": "pr_social"}]}
+
+    # Written via the provider-neutral helper (the code-dataset adapter's call
+    # site), read via the work-items helper (workers/sync_units.py's call
+    # site) -- proves the SAME underlying attribute either way.
+    attach_partial_observations(other_exc, other_observations)
+    assert read_work_item_partial_observations(other_exc) == other_observations


### PR DESCRIPTION
## CHAOS-2773 CS2 — proof-of-pipe: first code-dataset `budget_comparison` rows

CS1 (#1149) landed the instrumented transport core + resolver explicit-prefix short-circuit but migrated no traffic. Without CS2, markers alone still yield **zero** `observations.budget_comparison` rows for code datasets: `_run_github_dataset`/`_run_gitlab_dataset` returned no `observations` key, and the one incidentally-instrumented client — the PR review-batch `GitHubWorkClient` in `processors/github.py::_enrich_prs_with_reviews_batch` — was **never drained** and mis-bucketed its GraphQL traffic onto `work_item_prs` via the unprefixed transport default.

### A. `usage_sink` contract (adapter → processor → result/exception)
- `processors/dataset_adapters.py::_run_github_dataset` / `_run_gitlab_dataset` own a `usage_sink: list[dict]`, pass it into `process_github_repo` / `process_gitlab_project`; processors drain every instrumented client they construct into it in a `finally:` block — success **and** failure paths.
- **Success**: returned payload gains `observations: {provider_usage: <sink>}` — the exact shape `workers/sync_units.py::_attach_budget_comparison` joins as-is (proven by a test running the REAL join + the REAL GitHub estimator: `test_github_dataset_observations_join_through_real_attach_budget_comparison`).
- **Failure**: partial actuals attach to the in-flight exception via the new provider-neutral `providers/usage.py::attach_partial_observations` / `read_partial_observations` — an ADDITIVE alias; `metrics/job_work_items.py::attach_work_item_partial_observations` now delegates to it (same exception attribute), so the deferral/failure merge at `sync_units.py:1265/:1686` reads either origin unchanged. `error_category` / `next_retry_at` untouched (CHAOS-2754 clobber rule, pinned by existing `test_usage_survives_rate_limit_deferral`).

### B. `prs`/`pr_social` attribution fix (first intentional re-bucketing)
- `_enrich_prs_with_reviews_batch` drains its local work client into the sink and labels its GraphQL calls `pr_social:POST /graphql PR social data` (CS1 short-circuit convention) via a new optional `operation_family` param threaded through `iter_pr_reviews_batch` → `iter_pr_social_data_batch` → the page fetchers. Unprefixed callers (`providers/github/provider.py` work-items PR path) keep resolving to `work_item_prs` UNSHIFTED — the CS1 exhaustive resolver test is **extended** (new `pr_social:` cases + an unprefixed-same-literal sanity check), not weakened.
- `providers/github/budget.py`: `pr_social` GRAPHQL_COST marker flipped to `("pr_social:",)` in the same changeset as the traffic (plan rule). `prs` REST + `pr_social` SECONDARY_ABUSE_RISK markers stay empty: the REST listing remains on the frozen connector until CS8, and secondary is an abstract reservation with no per-request signal. **Estimator untouched.**

### C. Legacy entry points
CLI batch path (`processors/sync.py`) and webhooks call processors with `usage_sink=None` (the default): the review client is still drained — its recorder never leaks across calls — but observations are only logged at debug level, never persisted; no crashes on the None path.

### Tests (+15 new, 3 updated files)
- Call-count proofs: N physical GraphQL requests → ONE aggregated `pr_social`/`graphql_cost` observation with `request_count == N`; mid-pagination `RateLimitException` leaves the prior successful request drained (`tests/providers/test_github_pr_social_batch.py`).
- Adapter contract: success drain → `observations.provider_usage`; failure drain → partial observations readable off the exception; no-drain → no fabricated `observations`; GitLab twins; REAL `_attach_budget_comparison` + REAL estimator join proof (`tests/test_dataset_adapters.py`).
- Alias round-trip + cross-module delegation pins (`tests/test_provider_usage.py`).
- Legacy no-sink path: drained + logged, not persisted, no exception (`tests/test_github_pr_usage_drain.py`).
- Resolver: `pr_social:` labels short-circuit; every pre-existing label still resolves unchanged (`tests/providers/test_usage_resolver_prefix.py`).

### Docs (same changeset — doc-drift guard green)
`docs/providers/rate-limit-policy.md`: new "Usage drain wiring + first re-bucketing (CHAOS-2773 CS2)" section; GitHub per-provider Known-gaps and global Known-gaps updated to reflect `pr_social` graphql_cost now measured / prs REST still frozen.

### Codex HIGH fix (lead review pass, squashed in)

The review-batch catch-all previously swallowed `RateLimitException`: a mid-pagination 429 would drain partial `pr_social` usage but stamp the unit **SUCCESS** with reviews silently missing — bypassing both the adapter's attach-and-reraise and `sync_units`' deferral branch. Fixed: `_enrich_prs_with_reviews_batch` now catches the canonical `RateLimitException` SEPARATELY and re-raises it after the `finally:` drain completes, so the adapter attaches the partial actuals and the worker defers the unit to RETRYING. Degrade-and-log is retained ONLY for non-rate-limit enrichment errors (intentional pre-existing semantic — reviews are optional garnish on the PR rows; commented at the catch site). +3 tests: processor-level propagate-after-partial-drain (no PR rows persisted, sink populated), processor-level non-rate-limit degrade regression (PRs still persisted), adapter-level `RateLimitException` type + `retry_after_seconds` + partials preservation through `run_dataset_unit`. Policy-doc CS2 section updated with the split failure semantics.

### Live-verify note
Worker-context GitHub credentials are DB-encrypted; decrypting them host-side was flagged out of scope for this sandbox, so the first `budget_comparison` rows are demonstrated on the fixture path via the real-join test above (real `_attach_budget_comparison`, real `GitHubBudgetEstimator`, real resolver — only the HTTP fetch is mocked). A worker-context live sync after merge will produce the first live rows for `pr_social`.

### Gate
`env -i PATH HOME TMPDIR SCRATCH_DB=ci_local_validate_2803 bash ci/local_validate.sh` fully green: ruff format/check, mypy (1310 files), FULL unit suite **6653 passed / 44 skipped** (rerun after the HIGH fix), scratch-CH migrate + argMax live-exec proof. Log: `/tmp/claude/chaos-2803-gate.log`.

### Constraints held
`connectors/` untouched; estimator constants/reservations/`SYNC_BUDGET_*` untouched; observation keys additive (`github_usage` + all existing keys keep emitting); no fetch-path rewiring (CS3+).

**Rollback unit: this PR alone until CS3 merges.**

Linear: CHAOS-2803 (epic CHAOS-2773)
