### PR TITLE
Fix investment categorization LLM validation failures (CHAOS-2828)

### DIFF
--- a/docs/architecture/investment-categorization-pipeline.md
+++ b/docs/architecture/investment-categorization-pipeline.md
@@ -102,10 +102,11 @@ deterministic.
 `validate_llm_payload` (in `llm_schema.py`) enforces:
 
 - top-level keys are exactly `subcategories`, `evidence_quotes`, `uncertainty`;
+- the prompt and schema require all 15 canonical subcategory keys, with `0` for irrelevant categories; runtime validation defensively fills any missing canonical keys after sum validation and before normalization;
 - every subcategory key is in the canonical set; each probability in `[0, 1]`;
-- the distribution sums within `[0.9, 1.1]` — a clean `[0.98, 1.02]` sum is accepted as-is, a near-miss is renormalized and flagged `probability_sum_renormalized` in the audit, and `≤ 0` or outside `[0.9, 1.1]` is rejected;
+- the distribution sums within `[0.9, 1.1]`, a clean `[0.98, 1.02]` sum is accepted as-is, a near-miss is renormalized and flagged `probability_sum_renormalized` in the audit, and `≤ 0` or outside `[0.9, 1.1]` is rejected;
 - each evidence quote is a **literal substring** of the provided source text
-  (anti-hallucination), 1–10 quotes, `source ∈ {issue, pr, commit}`;
+  (anti-hallucination), 1-10 quotes, `source ∈ {issue, pr, commit}`, and each quote is `≤ 280` chars;
 - `uncertainty` is non-empty and ≤ 280 chars.
 
 On failure, exactly **one repair re-prompt** is attempted (the validation errors are

--- a/docs/llm/categorization-contract.md
+++ b/docs/llm/categorization-contract.md
@@ -35,7 +35,7 @@ There are exactly three top-level keys — `subcategories`, `evidence_quotes`,
 
 | Requirement | Details |
 |-------------|---------|
-| `subcategories` | Probabilities over the canonical subcategory keys (see [Investment Taxonomy](../product/investment-taxonomy.md)); each value `0–1`. A sum in the clean band `[0.98, 1.02]` is accepted as-is; a sum in `[0.9, 1.1]` but outside the clean band is renormalized and flagged with `probability_sum_renormalized:{total}` in `categorization_errors_json`; a sum `≤ 0` or outside `[0.9, 1.1]` is rejected |
+| `subcategories` | Probabilities over all 15 canonical subcategory keys (see [Investment Taxonomy](../product/investment-taxonomy.md)); the prompt and schema require every key, with `0` for irrelevant categories. Each value is `0-1`. A sum in the clean band `[0.98, 1.02]` is accepted as-is; a sum in `[0.9, 1.1]` but outside the clean band is renormalized and flagged with `probability_sum_renormalized:{total}` in `categorization_errors_json`; a sum `≤ 0` or outside `[0.9, 1.1]` is rejected |
 | `evidence_quotes` | A **list** of 1–10 objects, each exactly `{ "quote", "source", "id" }` |
 | `quote` | An **extractive substring** of the provided source text (≤ 280 chars). Matching is whitespace-tolerant, but the **exact source span** is what gets persisted |
 | `source` | One of `issue`, `pr`, `commit` |
@@ -48,9 +48,20 @@ There are exactly three top-level keys — `subcategories`, `evidence_quotes`,
 {
   "subcategories": {
     "feature_delivery.customer": 0.45,
+    "feature_delivery.roadmap": 0.0,
+    "feature_delivery.enablement": 0.0,
     "operational.incident_response": 0.25,
+    "operational.on_call": 0.0,
+    "operational.support": 0.0,
+    "maintenance.refactor": 0.10,
+    "maintenance.upgrade": 0.0,
+    "maintenance.debt": 0.0,
+    "quality.testing": 0.0,
     "quality.bugfix": 0.20,
-    "maintenance.refactor": 0.10
+    "quality.reliability": 0.0,
+    "risk.security": 0.0,
+    "risk.compliance": 0.0,
+    "risk.vulnerability": 0.0
   },
   "evidence_quotes": [
     { "quote": "requested by customer", "source": "issue", "id": "E1" },
@@ -60,14 +71,14 @@ There are exactly three top-level keys — `subcategories`, `evidence_quotes`,
 }
 ```
 
-> The prompt requests a value for **all 15** subcategories. Validation requires every
-> provided key to be canonical and the values to sum within `[0.9, 1.1]` — a clean sum in
-> `[0.98, 1.02]` is accepted as-is, while a near-miss is renormalized and flagged with
-> `probability_sum_renormalized:{total}`. The validation step then fills any missing keys
-> with `0` and renormalizes via
-> `ensure_full_subcategory_vector`. Keys must match `investment_taxonomy.py` exactly —
-> obsolete keys like `operational.external` or `feature_delivery.platform` are rejected
-> as `unknown_subcategory`.
+> The prompt and schema require all 15 canonical subcategories, with `0` for irrelevant
+> categories. Validation requires every provided key to be canonical and the values to
+> sum within `[0.9, 1.1]`, a clean sum in `[0.98, 1.02]` is accepted as-is, while a
+> near-miss is renormalized and flagged with `probability_sum_renormalized:{total}`.
+> After that sum check, the validation step defensively fills any missing canonical keys
+> with `0` and renormalizes via `ensure_full_subcategory_vector`. Keys must match
+> `investment_taxonomy.py` exactly, obsolete keys like `operational.external` or
+> `feature_delivery.platform` are rejected as `unknown_subcategory`.
 
 ### Two-stage process
 

--- a/src/dev_health_ops/llm/providers/openai.py
+++ b/src/dev_health_ops/llm/providers/openai.py
@@ -267,9 +267,9 @@ def categorization_json_schema() -> dict[str, Any]:
                     "required": ["quote", "source", "id"],
                     "additionalProperties": False,
                     "properties": {
-                        "quote": {"type": "string"},
+                        "quote": {"type": "string", "minLength": 1, "maxLength": 280},
                         "source": {"type": "string", "enum": ["issue", "pr", "commit"]},
-                        "id": {"type": "string"},
+                        "id": {"type": "string", "minLength": 1},
                     },
                 },
             },

--- a/src/dev_health_ops/work_graph/investment/categorize.py
+++ b/src/dev_health_ops/work_graph/investment/categorize.py
@@ -28,11 +28,18 @@ CANONICAL_PROMPT = """You are categorizing work unit evidence into canonical inv
 
 Rules:
 - Output JSON only. No markdown, no explanations.
-- Use ONLY these subcategories as keys: {subcategories}
-- Provide a probability distribution across all subcategories (values 0-1, sum to 1).
-- Provide evidence_quotes as 1-10 items with exact substrings from the source text.
+- Use ALL 15 canonical subcategories as keys, exactly once each, and use ONLY these keys: {subcategories}
+- Provide a probability distribution across all 15 subcategories.
+- Every subcategory value must be a number from 0 to 1.
+- At least one subcategory value MUST be non-zero.
+- Irrelevant subcategories MUST be 0.
+- The 15 probability values MUST sum to exactly 1.
+- Provide evidence_quotes as 1-10 items with exact substrings copied from the source text.
 - evidence_quotes items must have: quote, source (issue|pr|commit), id.
 - evidence_quotes id MUST be the bracketed handle shown before an evidence block (for example "E1"), copied exactly.
+- evidence_quotes quote MUST be non-empty and <= 280 characters.
+- evidence_quotes quote MUST be an exact source substring, not a paraphrase, not a summary, and not normalized text.
+- Do NOT use ellipses unless the literal ellipsis characters appear in the source substring.
 - Provide uncertainty as a short string (1-280 chars).
 - No extra keys.
 
@@ -67,7 +74,19 @@ REPAIR_PROMPT = """Your previous response failed validation.
 Errors:
 {errors}
 
-Return JSON only matching the schema and rules.
+Repair requirements:
+- Return JSON only matching the schema and rules.
+- Keep all 15 canonical subcategory keys.
+- Ensure at least one subcategory value is non-zero.
+- Ensure the full probability distribution sums to exactly 1.
+- Set irrelevant subcategories to 0.
+- Every evidence quote must be a non-empty exact source substring with length <= 280.
+- Copy evidence id handles exactly from the source blocks.
+- Do not paraphrase, summarize, or invent evidence.
+
+Targeted fixes:
+{guidance}
+
 """
 
 FALLBACK_PRIOR = {
@@ -173,9 +192,30 @@ def build_categorization_prompt(bundle: TextBundle) -> str:
     return _build_prompt(bundle.source_block)
 
 
+def _repair_guidance(errors: list[str]) -> str:
+    guidance: list[str] = []
+    if any(err.startswith("evidence_quote_too_long") for err in errors):
+        guidance.append(
+            "- For evidence_quote_too_long: replace the quote with a shorter exact substring from the same source text, 1-280 characters only."
+        )
+    if any(err.startswith("probability_sum_out_of_range:0.0000") for err in errors):
+        guidance.append(
+            "- For probability_sum_out_of_range:0.0000: all probabilities were zero. Assign non-zero probability to the relevant canonical subcategories so the total becomes exactly 1."
+        )
+    elif any(err.startswith("probability_sum_out_of_range") for err in errors):
+        guidance.append(
+            "- For probability_sum_out_of_range: adjust the subcategory values so their total is exactly 1 while keeping all 15 canonical keys present."
+        )
+    if not guidance:
+        guidance.append(
+            "- Fix every listed validation error and return one fully valid JSON object."
+        )
+    return "\n".join(guidance)
+
+
 def _build_repair_prompt(errors: list[str], source_block: str) -> str:
     errors_text = "\n".join(f"- {err}" for err in errors)
-    repair = REPAIR_PROMPT.format(errors=errors_text)
+    repair = REPAIR_PROMPT.format(errors=errors_text, guidance=_repair_guidance(errors))
     return f"{repair}\n\n{_build_prompt(source_block)}"
 
 

--- a/tests/llm/test_openai_categorization_schema.py
+++ b/tests/llm/test_openai_categorization_schema.py
@@ -1,0 +1,31 @@
+from __future__ import annotations
+
+from dev_health_ops.llm.providers.openai import categorization_json_schema
+from dev_health_ops.work_graph.investment.taxonomy import SUBCATEGORIES
+
+
+def test_categorization_schema_enforces_quote_length_bounds():
+    schema = categorization_json_schema()
+    quote_schema = schema["properties"]["evidence_quotes"]["items"]["properties"][
+        "quote"
+    ]
+
+    assert quote_schema["type"] == "string"
+    assert quote_schema["minLength"] == 1
+    assert quote_schema["maxLength"] == 280
+
+
+def test_categorization_schema_enforces_non_empty_id():
+    schema = categorization_json_schema()
+    id_schema = schema["properties"]["evidence_quotes"]["items"]["properties"]["id"]
+
+    assert id_schema["type"] == "string"
+    assert id_schema["minLength"] == 1
+
+
+def test_categorization_schema_matches_canonical_subcategories():
+    schema = categorization_json_schema()
+    subcategory_schema = schema["properties"]["subcategories"]
+
+    assert set(subcategory_schema["required"]) == set(SUBCATEGORIES)
+    assert set(subcategory_schema["properties"]) == set(SUBCATEGORIES)

--- a/tests/work_graph/test_investment_categorize.py
+++ b/tests/work_graph/test_investment_categorize.py
@@ -43,6 +43,32 @@ def _bundle() -> TextBundle:
     )
 
 
+def _valid_repaired_response() -> str:
+    return """{
+      "subcategories": {
+        "feature_delivery.customer": 0.0,
+        "feature_delivery.roadmap": 0.6,
+        "feature_delivery.enablement": 0.0,
+        "operational.incident_response": 0.0,
+        "operational.on_call": 0.0,
+        "operational.support": 0.0,
+        "maintenance.refactor": 0.0,
+        "maintenance.upgrade": 0.0,
+        "maintenance.debt": 0.0,
+        "quality.testing": 0.0,
+        "quality.bugfix": 0.4,
+        "quality.reliability": 0.0,
+        "risk.security": 0.0,
+        "risk.compliance": 0.0,
+        "risk.vulnerability": 0.0
+      },
+      "evidence_quotes": [
+        { "quote": "Fix login outage", "source": "issue", "id": "E1" }
+      ],
+      "uncertainty": "Some uncertainty remains."
+    }"""
+
+
 def test_retry_limit_and_fallback(monkeypatch):
     provider = StubProvider(["not json", "still not json"])
     monkeypatch.setattr(
@@ -63,16 +89,7 @@ def test_repaired_status(monkeypatch):
     provider = StubProvider(
         [
             "not json",
-            """{
-              "subcategories": {
-                "feature_delivery.roadmap": 0.55,
-                "quality.bugfix": 0.40
-              },
-              "evidence_quotes": [
-                { "quote": "Fix login outage", "source": "issue", "id": "E1" }
-              ],
-              "uncertainty": "Some uncertainty remains."
-            }""",
+            _valid_repaired_response(),
         ]
     )
     monkeypatch.setattr(
@@ -83,7 +100,94 @@ def test_repaired_status(monkeypatch):
     assert provider.calls == 2
     assert "Output schema" in provider.prompts[1]
     assert outcome.status == "repaired"
-    assert outcome.warnings == ["probability_sum_renormalized:0.9500"]
+    assert outcome.warnings == []
     assert outcome.llm_calls == 2
     assert outcome.input_tokens == 30
     assert outcome.output_tokens == 15
+
+
+def test_repair_prompt_includes_targeted_guidance_for_zero_mass_and_long_quote(
+    monkeypatch,
+):
+    long_quote = "Fix login outage for auth service " * 10
+    provider = StubProvider(
+        [
+            f"""{{
+              "subcategories": {{
+                "feature_delivery.customer": 0.0,
+                "feature_delivery.roadmap": 0.0,
+                "feature_delivery.enablement": 0.0,
+                "operational.incident_response": 0.0,
+                "operational.on_call": 0.0,
+                "operational.support": 0.0,
+                "maintenance.refactor": 0.0,
+                "maintenance.upgrade": 0.0,
+                "maintenance.debt": 0.0,
+                "quality.testing": 0.0,
+                "quality.bugfix": 0.0,
+                "quality.reliability": 0.0,
+                "risk.security": 0.0,
+                "risk.compliance": 0.0,
+                "risk.vulnerability": 0.0
+              }},
+              "evidence_quotes": [
+                {{ "quote": "{long_quote}", "source": "issue", "id": "E1" }}
+              ],
+              "uncertainty": "Some uncertainty remains."
+            }}""",
+            _valid_repaired_response(),
+        ]
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.categorize.get_provider",
+        lambda name, model=None: provider,
+    )
+
+    outcome = asyncio.run(categorize_text_bundle(_bundle(), llm_provider="mock"))
+
+    assert outcome.status == "repaired"
+    assert provider.calls == 2
+    assert "evidence_quote_too_long:0" in provider.prompts[1]
+    assert "probability_sum_out_of_range:0.0000" in provider.prompts[1]
+    assert "replace the quote with a shorter exact substring" in provider.prompts[1]
+    assert "all probabilities were zero" in provider.prompts[1]
+
+
+def test_repair_fallback_reports_repaired_response_errors(monkeypatch):
+    long_quote = "Fix login outage for auth service " * 10
+    invalid_payload = f"""{{
+      "subcategories": {{
+        "feature_delivery.customer": 0.0,
+        "feature_delivery.roadmap": 0.0,
+        "feature_delivery.enablement": 0.0,
+        "operational.incident_response": 0.0,
+        "operational.on_call": 0.0,
+        "operational.support": 0.0,
+        "maintenance.refactor": 0.0,
+        "maintenance.upgrade": 0.0,
+        "maintenance.debt": 0.0,
+        "quality.testing": 0.0,
+        "quality.bugfix": 0.0,
+        "quality.reliability": 0.0,
+        "risk.security": 0.0,
+        "risk.compliance": 0.0,
+        "risk.vulnerability": 0.0
+      }},
+      "evidence_quotes": [
+        {{ "quote": "{long_quote}", "source": "issue", "id": "E1" }}
+      ],
+      "uncertainty": "Some uncertainty remains."
+    }}"""
+    provider = StubProvider([invalid_payload, invalid_payload])
+    monkeypatch.setattr(
+        "dev_health_ops.work_graph.investment.categorize.get_provider",
+        lambda name, model=None: provider,
+    )
+
+    outcome = asyncio.run(categorize_text_bundle(_bundle(), llm_provider="mock"))
+
+    assert outcome.status == "invalid_llm_output"
+    assert outcome.errors == [
+        "probability_sum_out_of_range:0.0000",
+        "evidence_quote_too_long:0",
+    ]

--- a/tests/work_graph/test_llm_schema.py
+++ b/tests/work_graph/test_llm_schema.py
@@ -129,6 +129,38 @@ def test_degenerate_probability_sum_still_rejected():
     assert any("probability_sum_out_of_range:0.5000" in err for err in result.errors)
 
 
+def test_all_zero_probability_sum_is_rejected():
+    payload: dict[str, object] = {
+        "subcategories": {key: 0.0 for key in SUBCATEGORIES},
+        "evidence_quotes": [
+            {"quote": "Fix login outage", "source": "issue", "id": "E1"}
+        ],
+        "uncertainty": "Reasonable confidence based on evidence.",
+    }
+    result = validate_llm_payload(payload, _source_texts(), _handle_map())
+    assert not result.ok
+    assert any("probability_sum_out_of_range:0.0000" in err for err in result.errors)
+
+
+def test_exact_quote_over_280_chars_is_rejected():
+    long_quote = "Fix login outage for auth service " * 10
+    source_texts = {
+        "issue": {"jira:ABC-1": long_quote},
+        "pr": _source_texts()["pr"],
+        "commit": _source_texts()["commit"],
+    }
+    payload: dict[str, object] = {
+        "subcategories": {"quality.bugfix": 1.0},
+        "evidence_quotes": [{"quote": long_quote, "source": "issue", "id": "E1"}],
+        "uncertainty": "Reasonable confidence based on evidence.",
+    }
+
+    assert len(long_quote) > 280
+    result = validate_llm_payload(payload, source_texts, _handle_map())
+    assert not result.ok
+    assert any("evidence_quote_too_long:0" in err for err in result.errors)
+
+
 def test_evidence_quote_substring_check_normalizes_whitespace():
     source_text = _source_texts()["commit"]["repo@abc"]
     payload: dict[str, object] = {


### PR DESCRIPTION
## Summary
- Tighten investment categorization prompt/repair guidance for all-zero probability mass and overlong evidence quotes.
- Add OpenAI schema constraints for non-empty evidence quotes, max 280-char quote length, and non-empty evidence IDs.
- Add regression coverage for `probability_sum_out_of_range:0.0000`, `evidence_quote_too_long`, repair success/fallback, and schema taxonomy drift.
- Align categorization docs and examples with the all-15-key prompt/schema contract.

## Linear
- CHAOS-2828

## Verification
- `python -m pytest tests/work_graph/test_llm_schema.py tests/work_graph/test_investment_categorize.py tests/llm/test_openai_categorization_schema.py`
- `python -m ruff check src/dev_health_ops/work_graph/investment/categorize.py src/dev_health_ops/llm/providers/openai.py tests/work_graph/test_llm_schema.py tests/work_graph/test_investment_categorize.py tests/llm/test_openai_categorization_schema.py`
- `python -m ruff format --check src/dev_health_ops/work_graph/investment/categorize.py src/dev_health_ops/llm/providers/openai.py tests/work_graph/test_llm_schema.py tests/work_graph/test_investment_categorize.py tests/llm/test_openai_categorization_schema.py`
- `PYTHONPATH=src python <manual categorizer repair driver>` observed `manual-driver-ok repaired 1 1.0`
- Git hooks: pre-commit and pre-push ruff/mypy passed.

SCREENSHOT-WAIVER: backend/docs/test-only change; no rendered web UI changed.