### PR TITLE
feat(external-ingest): worker processor + normalization (CHAOS-2697)

### DIFF
--- a/docs/architecture/external-ingest-worker.md
+++ b/docs/architecture/external-ingest-worker.md
@@ -112,14 +112,31 @@ does the same on the give-up path. A subsequent same-key resubmission
 (RETRY) re-upserts the payload under the same `ingestion_id`. Never-retried
 orphans are the CHAOS-2769 reconciler's job.
 
-**`mark_batch_failed` raises on failure.** The consumer's ACK gate depends
-on it: if the terminal-`failed` write cannot land, the entry must stay
-un-ACKed so a later redelivery retries the status write — ACKing past a
-lost write strands the batch non-terminal with the pointer gone
-(2693 adversarial-review round-2). It uses `status.mark_failed`, which
-transitions from ANY non-terminal status (permanent failures raised before
-`mark_processing` leave `accepted`) and is a no-op for terminal/unknown
-batches, so DLQ re-drives and duplicate pointers stay idempotent.
+**`mark_batch_failed` raises on failure; the consumer marks FIRST, DLQs
+second.** The consumer's ACK gate depends on the raise: if the
+terminal-`failed` write cannot land, the entry must stay un-ACKed so a later
+redelivery retries the status write — ACKing past a lost write strands the
+batch non-terminal with the pointer gone (2693 adversarial-review round-2).
+Both give-up paths (sync `move_to_dlq` from `reclaim_stale`, async
+permanent-failure) write the DLQ row only AFTER the mark is durable
+(2697 round-2): the old DLQ-then-mark order XADDed a duplicate DLQ row on
+every retry during a Postgres outage, eventually evicting distinct failures
+from the capped approximate DLQ stream. `status.mark_failed` transitions
+from ANY non-terminal status (permanent failures raised before
+`mark_processing` leave `accepted`), forces the counter invariant
+(`items_accepted=0`, `items_rejected=items_received`, `record_counts=NULL`
+— failed means nothing accepted, and GET/list consumers key off these), and
+is a no-op for terminal/unknown batches, so DLQ re-drives and duplicate
+pointers stay idempotent.
+
+**Give-up with unrecoverable entry fields.** `reclaim_stale` hands
+`move_to_dlq` only a message ID; the fields are re-read via XRANGE. A
+transient re-read failure is NOT safe to ACK (return `False`, retry later —
+2697 round-2 HIGH: collapsing it with "absent" let a Redis blip ACK away an
+unmarked batch). An authoritatively-absent entry (MAXLEN-trimmed while
+pending) has nothing addressable to mark: a tombstone DLQ row is written
+and the entry ACKed; the possibly-stranded batch row is the CHAOS-2769
+orphan-batch reconciler's territory.
 
 **Source provenance resolution.** `source_id` (CC8) is looked up from
 `external_ingest_sources` case-insensitively (2695 blocks case-variant

--- a/docs/architecture/external-ingest-worker.md
+++ b/docs/architecture/external-ingest-worker.md
@@ -1,0 +1,140 @@
+# External ingest: worker processor (CHAOS-2697)
+
+Part of the CHAOS-2690 external customer-push ingestion epic. This document
+records the worker-side processing contract and the decisions behind
+`external_ingest/normalize.py` + `external_ingest/processor.py`. Companion
+docs: `external-ingest-rest-contract.md` (envelope/endpoints),
+`external-ingest-stream-design.md` (2693 stream/consumer/DLQ),
+`external-ingest-status-store.md` (2694 store),
+`external-ingest-idempotency-ownership.md` (2695 accept-path policy),
+`external-ingest-sink-writes.md` (2698 sink writes),
+`external-ingest-bounded-recompute.md` (2699 bounded recompute).
+
+## Modules
+
+| Module | Owns |
+|---|---|
+| `external_ingest/normalize.py` | pure record validation/partitioning: CC17 shape delegation + CC6 matrix + instance scope → `NormalizedBatch` + collapsed rejections |
+| `external_ingest/processor.py` | the impure orchestrator: `process_batch` (CC23) + `mark_batch_failed` (give-up path) |
+
+Merging `processor.py` is what **arms the consumer**: 2693's
+`_processor_available()` deployment-order guard keys on this module's
+importability and refuses to claim entries until it exists. No consumer
+config change was needed.
+
+## `process_batch` sequence (master-spec CC23)
+
+```
+schema_version / source_system / ingestion_id sanity     (Permanent on fail)
+→ require_clickhouse_uri()                               (RuntimeError = transient)
+→ get_batch: terminal? → return 0 (idempotent skip, CC11 post-critique)
+→ mark_processing (CAS accepted|stream_unavailable → processing) → COMMIT
+→ re-read: not processing? → yield (return 0; another actor owns the row)
+→ fetch_payload (missing → Permanent)
+→ resolve source_id from external_ingest_sources        (missing → Permanent)
+→ parse envelope; pointer↔payload source + count checks (mismatch → Permanent)
+→ normalize_batch (per-record rejections, never raises)
+→ [any accepted] write_batch + retry ladder             (exhausted → transient)
+→ complete_batch (CAS processing → completed|partial|failed, + record_counts)
+→ delete_payload (same txn) → COMMIT
+→ schedule_or_coalesce(...) ONCE                         (best-effort, never fails ingest)
+→ return items_accepted
+```
+
+## Decisions
+
+**Permanent vs transient classification.** `PermanentProcessingError`
+(immediate DLQ + `mark_batch_failed`) is reserved for states no retry can
+fix: wrong schema version, non-UUID pointer, missing status row, missing
+payload row, unregistered source, pointer/payload disagreement, corrupt
+envelope. Everything else — including `TransientSinkWriteError` after the
+ladder and a missing `CLICKHOUSE_URI` — leaves the entry un-ACKed for
+2693's reclaim ladder (15 min idle, max 5 deliveries). Erring transient is
+deliberate: a wrongly-permanent classification destroys a batch, a
+wrongly-transient one costs at most ~75 minutes of reclaim cycles before
+the give-up path produces the same DLQ outcome.
+
+**Sink retry ladder keys off `SinkWriteResult.errors`, not exceptions.**
+`sinks.write_batch()` never raises — per-kind failures come back as error
+entries (batch-call granularity). The ladder (initial attempt + retries at
+2s/4s/8s, CC11) re-runs the WHOLE batch each attempt; that is safe because
+every sink is a ReplacingMergeTree upsert on natural keys, and only the
+final attempt's outcome counts. Sink errors never become per-record
+rejections: a kind-level ClickHouse failure is a system problem, not a data
+problem, so the batch must not complete `partial` with valid-but-unwritten
+records counted as rejected.
+
+**`stream_unavailable` pointers are processed, not wedged.** A 503'd accept
+whose XADD actually landed leaves a live pointer for a `stream_unavailable`
+row (the expected-duplicate-pointer case in the 2695 doc). `mark_processing`
+therefore CASes from `accepted` OR `stream_unavailable`. Processing it is
+strictly better than skipping: the payload row is durable by the accept
+sequence's ordering, and the client's same-key retry then REPLAYs the
+terminal outcome instead of re-accepting. A concurrent stale-`accepted`
+RETRY serializes against the same row CAS; the processor re-reads after
+`mark_processing` and yields (`return 0`) if it did not win.
+
+**Rejections collapse to one per record index.** The status store's
+`(ingestion_id, record_index)` unique constraint permits exactly one
+persisted diagnostic per record; multi-field shape failures keep the first
+`validate_records` error (field order). `items_rejected` counts rejected
+RECORDS, so counts always reconcile with `items_received`
+(`complete_batch` enforces the sum).
+
+**CC6 enforcement lives in `normalize.py`; instance scope is
+case-insensitive.** `validate.py` (CC17, imported unchanged) owns shape
+only; `sinks.py` asserts-but-never-rejects. The kind×system matrix and the
+git-family `repositoryExternalId == source.instance` rule reject here. The
+instance comparison casefolds both sides — same rationale as 2695's
+ownership matching: provider identifiers are case-insensitive and
+`derive_repo_uuid` lower-cases its seed, so a case-variant identifier is
+the same repo and cannot fork identity. (The sink's exact-match
+`record_outside_source_instance` *warning* may still fire for accepted
+case-variants; diagnostic noise, accepted.)
+
+**Recompute vocabulary: FULL kind names.** `schedule_or_coalesce` /
+`plan_recompute` intersect `record_kinds` against `.v1`-suffixed sets
+(`pull_request.v1`), while `SinkWriteResult.affected_scope.record_kinds`
+carries bare names (`pull_request`). The processor passes the
+normalization-level kind names (`NormalizationResult.record_counts` keys) —
+passing the sink scope through would silently plan zero recompute. The
+dispatch is wrapped best-effort (log-and-continue): the batch is already
+terminal and durable; a Valkey/Celery hiccup must not fail ingestion or
+un-ACK the entry.
+
+**`record_counts` is written by the worker only.** `complete_batch` gained
+an optional `record_counts` parameter (per-kind accepted counts, full kind
+names) — the column existed since 2694 with no writer.
+
+**Payload cleanup on terminal status (CC9).** `process_batch` deletes the
+payload row in the same transaction as `complete_batch`; `mark_batch_failed`
+does the same on the give-up path. A subsequent same-key resubmission
+(RETRY) re-upserts the payload under the same `ingestion_id`. Never-retried
+orphans are the CHAOS-2769 reconciler's job.
+
+**`mark_batch_failed` raises on failure.** The consumer's ACK gate depends
+on it: if the terminal-`failed` write cannot land, the entry must stay
+un-ACKed so a later redelivery retries the status write — ACKing past a
+lost write strands the batch non-terminal with the pointer gone
+(2693 adversarial-review round-2). It uses `status.mark_failed`, which
+transitions from ANY non-terminal status (permanent failures raised before
+`mark_processing` leave `accepted`) and is a no-op for terminal/unknown
+batches, so DLQ re-drives and duplicate pointers stay idempotent.
+
+**Source provenance resolution.** `source_id` (CC8) is looked up from
+`external_ingest_sources` case-insensitively (2695 blocks case-variant
+duplicates, so at most one logical source matches). A source disabled
+*after* accept still resolves — the batch was accepted while write-eligible;
+a *deleted* source is a `PermanentProcessingError` (rows would be
+unattributable).
+
+## Environment
+
+| Variable | Default | Meaning |
+|---|---|---|
+| `CLICKHOUSE_URI` | — (required) | sink DSN passed to `sinks.write_batch` |
+
+Retry ladder timing is code-constant (`SINK_RETRY_BACKOFF_SECONDS =
+(2, 4, 8)`), pinned by CC11 alongside 2693's `reclaim_idle_ms=900_000` —
+changing one without the other reopens the duplicate-concurrent-processing
+window the 15-minute reclaim idle was sized against.

--- a/docs/architecture/external-ingest-worker.md
+++ b/docs/architecture/external-ingest-worker.md
@@ -112,22 +112,28 @@ does the same on the give-up path. A subsequent same-key resubmission
 (RETRY) re-upserts the payload under the same `ingestion_id`. Never-retried
 orphans are the CHAOS-2769 reconciler's job.
 
-**`mark_batch_failed` raises on failure; the consumer marks FIRST, DLQs
-second.** The consumer's ACK gate depends on the raise: if the
-terminal-`failed` write cannot land, the entry must stay un-ACKed so a later
-redelivery retries the status write — ACKing past a lost write strands the
-batch non-terminal with the pointer gone (2693 adversarial-review round-2).
-Both give-up paths (sync `move_to_dlq` from `reclaim_stale`, async
-permanent-failure) write the DLQ row only AFTER the mark is durable
-(2697 round-2): the old DLQ-then-mark order XADDed a duplicate DLQ row on
-every retry during a Postgres outage, eventually evicting distinct failures
-from the capped approximate DLQ stream. `status.mark_failed` transitions
-from ANY non-terminal status (permanent failures raised before
-`mark_processing` leave `accepted`), forces the counter invariant
-(`items_accepted=0`, `items_rejected=items_received`, `record_counts=NULL`
-— failed means nothing accepted, and GET/list consumers key off these), and
-is a no-op for terminal/unknown batches, so DLQ re-drives and duplicate
-pointers stay idempotent.
+**Give-up ordering: idempotent DLQ write FIRST, then `mark_batch_failed`
+(which raises on failure); ACK only after both.** Three adversarial rounds
+converged here. Round 1: the ACK must gate on the mark result — ACKing past
+a raised `mark_batch_failed` strands the batch non-terminal with the
+pointer gone (a `processing` row REPLAYs, never RETRYs). Round 2: naive
+DLQ-first XADDed a duplicate DLQ row on every mark-failure retry during a
+Postgres outage, eventually evicting distinct failures from the capped
+approximate DLQ stream. Round 3: the mark-first "fix" for that LOSES the
+DLQ row entirely when the mark lands but the XADD fails — the now-terminal
+batch makes every redelivery take the consumer's idempotent-skip guard,
+which ACKs without ever retrying the DLQ write. Resolution: DLQ-first with
+a per-entry `…:dlq:written:<entry_id>` marker (set best-effort right after
+a successful XADD; check-then-write is safe under the CC11 single-consumer
+invariant) — a failed XADD leaves the batch untouched and the entry pending
+(self-healing), a failed mark retries with the marker suppressing duplicate
+rows, and only full success ACKs. `status.mark_failed` transitions from ANY
+non-terminal status (permanent failures raised before `mark_processing`
+leave `accepted`), forces the counter invariant (`items_accepted=0`,
+`items_rejected=items_received`, `record_counts=NULL` — failed means
+nothing accepted, and GET/list consumers key off these), and is a no-op for
+terminal/unknown batches, so DLQ re-drives and duplicate pointers stay
+idempotent.
 
 **Give-up with unrecoverable entry fields.** `reclaim_stale` hands
 `move_to_dlq` only a message ID; the fields are re-read via XRANGE. A

--- a/docs/architecture/external-ingest-worker.md
+++ b/docs/architecture/external-ingest-worker.md
@@ -122,12 +122,19 @@ Postgres outage, eventually evicting distinct failures from the capped
 approximate DLQ stream. Round 3: the mark-first "fix" for that LOSES the
 DLQ row entirely when the mark lands but the XADD fails — the now-terminal
 batch makes every redelivery take the consumer's idempotent-skip guard,
-which ACKs without ever retrying the DLQ write. Resolution: DLQ-first with
-a per-entry `…:dlq:written:<entry_id>` marker (set best-effort right after
-a successful XADD; check-then-write is safe under the CC11 single-consumer
-invariant) — a failed XADD leaves the batch untouched and the entry pending
-(self-healing), a failed mark retries with the marker suppressing duplicate
-rows, and only full success ACKs. `status.mark_failed` transitions from ANY
+which ACKs without ever retrying the DLQ write. Round 4: the marker cannot be treated
+as proof the DLQ row still exists — the DLQ is `maxlen`-capped, so under
+sustained pressure a high-volume org can trim the original row while the
+mark outage keeps the entry pending, and a marker-only short-circuit would
+then mark-and-ACK with no surviving DLQ record. Resolution: DLQ-first with
+a per-entry `…:dlq:written:<entry_id>` marker that stores the DLQ
+**stream-id** of the row it wrote (set best-effort right after a successful
+XADD; check-then-write is safe under the CC11 single-consumer invariant). On
+a marker hit the code re-reads that exact stream-id and only short-circuits
+if it is still present; a trimmed row falls through to a fresh XADD. Net: a
+failed XADD leaves the batch untouched and the entry pending (self-healing),
+a failed mark retries with the marker suppressing duplicate rows *while the
+row survives*, a trimmed row is rewritten, and only full success ACKs. `status.mark_failed` transitions from ANY
 non-terminal status (permanent failures raised before `mark_processing`
 leave `accepted`), forces the counter invariant (`items_accepted=0`,
 `items_rejected=items_received`, `record_counts=NULL` — failed means

--- a/src/dev_health_ops/api/external_ingest/consumer.py
+++ b/src/dev_health_ops/api/external_ingest/consumer.py
@@ -276,27 +276,37 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         (adversarial-review finding: a swallowed DLQ-write failure must not
         silently drop the entry with no DLQ record).
 
-        Idempotency (CHAOS-2697 adversarial rounds 2+3): a per-entry marker
-        key is set right after a successful XADD, so a source entry retried
-        across mark-failure cycles produces exactly one DLQ row instead of
-        flooding the capped/approximate stream. The check-then-write is safe
-        without WATCH/MULTI because of the CC11 deployment invariant
-        (exactly ONE consumer identity ever runs this code for a given
-        entry). The marker set itself is best-effort: if it fails after the
-        XADD landed, a later retry can write at most one extra DLQ row per
-        such blip -- bounded noise, unlike the unbounded per-cycle
-        duplication the marker exists to stop.
+        Idempotency (CHAOS-2697 adversarial rounds 2-4): a per-entry marker
+        key stores the DLQ stream-id of the row a prior attempt wrote, so a
+        source entry retried across mark-failure cycles produces exactly one
+        DLQ row instead of flooding the capped/approximate stream. The
+        check-then-write is safe without WATCH/MULTI because of the CC11
+        deployment invariant (exactly ONE consumer identity ever runs this
+        code for a given entry).
+
+        Round-4 correctness: the marker is NOT proof-of-existence on its own.
+        The DLQ is capped (``maxlen=STREAM_MAXLEN``), so under sustained
+        pressure a high-volume org can TRIM the original row while a
+        ``mark_batch_failed``/Postgres outage keeps the source entry pending.
+        On a marker hit we therefore re-read the stored stream-id and only
+        short-circuit if that exact row is STILL present; if it was trimmed
+        we fall through and write a fresh row (refreshing the marker), so a
+        failed batch can never end up ACKed with no surviving DLQ record.
+        The marker set itself is best-effort: if it fails after the XADD
+        landed, a later retry writes at most one extra DLQ row -- bounded
+        noise, unlike the unbounded per-cycle duplication the marker stops.
         """
         org_id = data.get("org_id") or self._org_id_from_stream_key(stream_key)
         dlq = dlq_name(org_id)
         marker = f"{dlq}:written:{entry_id}"
         try:
-            if rc.exists(marker):
-                # A prior attempt already landed the DLQ row (its mark or
-                # ACK failed afterwards) -- report success without a
+            prior_id = rc.get(marker)
+            if prior_id and self._dlq_entry_present(rc, dlq, prior_id):
+                # A prior attempt's DLQ row is still on the stream (its mark
+                # or ACK failed afterwards) -- report success without a
                 # duplicate XADD.
                 return org_id, True
-            rc.xadd(
+            new_id = rc.xadd(
                 dlq,
                 {
                     "original_stream": stream_key,
@@ -313,7 +323,7 @@ class ExternalIngestStreamConsumer(StreamConsumer):
             logger.exception("Failed to move entry %s to DLQ", entry_id)
             return org_id, False
         try:
-            rc.set(marker, "1", ex=DLQ_MARKER_TTL_SECONDS)
+            rc.set(marker, new_id, ex=DLQ_MARKER_TTL_SECONDS)
         except Exception:
             logger.exception(
                 "DLQ row for entry %s written but its dedup marker was not -- "
@@ -321,6 +331,21 @@ class ExternalIngestStreamConsumer(StreamConsumer):
                 entry_id,
             )
         return org_id, True
+
+    @staticmethod
+    def _dlq_entry_present(rc: Any, dlq: str, entry_id: str) -> bool:
+        """Whether a specific DLQ stream-id is still present (not trimmed out
+        of the capped stream). A re-read failure is treated as "present" --
+        the safe direction here is to NOT rewrite (avoid a duplicate on a
+        transient blip); the round-4 hole was the opposite assumption
+        (marker existence alone implying the row survived)."""
+        try:
+            return bool(rc.xrange(dlq, min=entry_id, max=entry_id))
+        except Exception:
+            logger.exception(
+                "Failed to verify DLQ row %s on %s; assuming present", entry_id, dlq
+            )
+            return True
 
     @staticmethod
     def _resolve_mark_batch_failed():

--- a/src/dev_health_ops/api/external_ingest/consumer.py
+++ b/src/dev_health_ops/api/external_ingest/consumer.py
@@ -156,11 +156,16 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         is a SYNC call site, outside of any running event loop -- safe to
         use :func:`run_async` for the ``mark_batch_failed`` side effect.
 
-        Returns whether the DLQ write itself succeeded (base class contract,
-        adversarial-review finding): the caller (``reclaim_stale``) must NOT
-        ack the source entry when this is ``False``, or a DLQ write failure
-        (e.g. a transient Redis blip) would silently lose the entry with no
-        DLQ record at all.
+        Returns whether it is safe to ACK the source entry (base class
+        contract): requires BOTH the DLQ write to succeed (adversarial-review
+        finding: a swallowed DLQ-write failure must not silently drop the
+        entry with no DLQ record) AND, when an ingestion_id is present, the
+        failed-status write to be safe (CHAOS-2697 adversarial review: this
+        sync path previously ignored the mark result while its async twin
+        ``_dlq_entry_async`` gated on it -- ACKing past a raised
+        ``mark_batch_failed`` strands the batch in a non-terminal status with
+        the entry gone, and a ``processing`` row REPLAYs rather than RETRYs,
+        leaving the customer no recovery handle at all).
         """
         data = self._fetch_entry_fields(rc, stream_key, entry_id)
         org_id, dlq_written = self._xadd_dlq_entry(
@@ -168,9 +173,10 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         )
         ingestion_id = data.get("ingestion_id")
         if dlq_written and ingestion_id:
-            self._mark_batch_failed_best_effort(
+            marked_ok = self._mark_batch_failed_best_effort(
                 org_id=org_id, ingestion_id=ingestion_id, reason=reason
             )
+            return dlq_written and marked_ok
         return dlq_written
 
     async def _dlq_entry_async(
@@ -258,10 +264,20 @@ class ExternalIngestStreamConsumer(StreamConsumer):
 
     def _mark_batch_failed_best_effort(
         self, *, org_id: str, ingestion_id: str, reason: str
-    ) -> None:
+    ) -> bool:
         """Sync path: used by :meth:`move_to_dlq`, itself only ever called
         outside a running event loop (the shared base's synchronous
-        ``reclaim_stale()``)."""
+        ``reclaim_stale()``).
+
+        Returns whether it is safe to ACK the source entry with respect to
+        status marking -- the same contract as
+        :meth:`_mark_batch_failed_best_effort_async` (see its docstring for
+        the full rationale): ``True`` when the batch was marked failed OR the
+        seam is unresolvable; ``False`` ONLY when a resolvable
+        ``mark_batch_failed`` raised, so the caller leaves the entry un-ACKed
+        for a status-write retry on a later reclaim cycle (CHAOS-2697
+        adversarial review -- this path previously swallowed the failure and
+        let ``reclaim_stale()`` ACK the batch's only retry handle away)."""
         mark_batch_failed = self._resolve_mark_batch_failed()
         if mark_batch_failed is None:
             logger.warning(
@@ -270,24 +286,27 @@ class ExternalIngestStreamConsumer(StreamConsumer):
                 ingestion_id,
                 org_id,
             )
-            return
+            return True
         try:
             result = mark_batch_failed(
                 ingestion_id=ingestion_id, org_id=org_id, reason=reason
             )
             if inspect.isawaitable(result):
-                # mark_batch_failed's concrete return type is unknown until
-                # CHAOS-2697 defines it; inspect.isawaitable narrows to the
-                # broader Awaitable protocol, but run_async expects a
-                # Coroutine specifically -- an async def's return value
-                # always is one at runtime.
+                # inspect.isawaitable narrows to the broader Awaitable
+                # protocol, but run_async expects a Coroutine specifically --
+                # an async def's return value always is one at runtime. The
+                # isawaitable guard also tolerates test fakes that return
+                # plain values.
                 run_async(cast(Coroutine[Any, Any, Any], result))
         except Exception:
             logger.exception(
-                "mark_batch_failed failed for ingestion_id=%s org=%s",
+                "mark_batch_failed failed for ingestion_id=%s org=%s -- "
+                "leaving source entry un-ACKed for a status-write retry",
                 ingestion_id,
                 org_id,
             )
+            return False
+        return True
 
     async def _mark_batch_failed_best_effort_async(
         self, *, org_id: str, ingestion_id: str, reason: str

--- a/src/dev_health_ops/api/external_ingest/consumer.py
+++ b/src/dev_health_ops/api/external_ingest/consumer.py
@@ -58,6 +58,10 @@ BATCH_SIZE = 50
 BLOCK_MS = 5000
 RECLAIM_IDLE_MS = 900_000  # 15 min, master-spec CC11 post-critique
 MAX_DELIVERIES = 5
+# TTL for the per-entry "DLQ row written" idempotency marker -- matches the
+# payload-store prune horizon (EXTERNAL_INGEST_PAYLOAD_MAX_AGE_HOURS=168);
+# any retry cycle still alive after that has long since been re-driven.
+DLQ_MARKER_TTL_SECONDS = 7 * 24 * 3600
 
 _TERMINAL_STATUS_VALUES = {s.value for s in TERMINAL_STATUSES}
 
@@ -164,14 +168,20 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         use :func:`run_async` for the ``mark_batch_failed`` side effect.
 
         Returns whether it is safe to ACK the source entry (base class
-        contract). MARK-FIRST ordering (CHAOS-2697 adversarial review rounds
-        1+2): the terminal-``failed`` status write must be durable BEFORE the
-        DLQ row is written -- ACKing past a raised ``mark_batch_failed``
-        strands the batch in a non-terminal status with the entry gone (a
-        ``processing`` row REPLAYs rather than RETRYs, no customer recovery),
-        and writing the DLQ row first meant every mark-failure retry XADDed a
-        duplicate, flooding the capped/approximate DLQ during a Postgres
-        outage until distinct failures evicted.
+        contract): requires BOTH the (idempotent) DLQ write to succeed AND,
+        when an ingestion_id is present, the failed-status write to be safe.
+
+        Ordering (adversarial rounds 1-3): DLQ-FIRST, with the write made
+        idempotent via ``_xadd_dlq_entry``'s marker. Round 1 gated the ACK
+        on the mark result; round 2 flipped to mark-first to stop
+        mark-failure retries from flooding the capped DLQ with duplicates;
+        round 3 showed mark-first LOSES the DLQ row entirely when the mark
+        lands but the XADD fails (the now-terminal batch makes every
+        redelivery take the idempotent-skip guard, which ACKs without ever
+        retrying the DLQ write). DLQ-first + marker dedup satisfies all
+        three: a failed XADD leaves the batch untouched and the entry
+        pending (self-healing retry), a failed mark retries with the marker
+        suppressing duplicate rows, and only full success ACKs.
 
         Unrecoverable-fields path: a transient XRANGE failure returns
         ``False`` (retry later); an authoritatively-absent entry
@@ -185,17 +195,7 @@ class ExternalIngestStreamConsumer(StreamConsumer):
             # Transient re-read failure: retrying later is productive.
             return False
         ingestion_id = data.get("ingestion_id")
-        if ingestion_id:
-            org_id = data.get("org_id") or self._org_id_from_stream_key(stream_key)
-            marked_ok = self._mark_batch_failed_best_effort(
-                org_id=org_id, ingestion_id=ingestion_id, reason=reason
-            )
-            if not marked_ok:
-                # No DLQ write on this attempt: the retry (entry stays
-                # pending) re-runs the mark, and only a durable mark
-                # proceeds to XADD -- at most one DLQ row per entry.
-                return False
-        else:
+        if not ingestion_id:
             logger.error(
                 "Entry %s on %s has no recoverable fields (trimmed while "
                 "pending?) -- writing tombstone DLQ row and ACKing; any "
@@ -203,9 +203,18 @@ class ExternalIngestStreamConsumer(StreamConsumer):
                 entry_id,
                 stream_key,
             )
-        _org_id, dlq_written = self._xadd_dlq_entry(
+        org_id, dlq_written = self._xadd_dlq_entry(
             rc, stream_key, entry_id, reason, data
         )
+        if not dlq_written:
+            # Batch deliberately not yet marked: the retry re-runs this
+            # whole method with nothing terminal to short-circuit it.
+            return False
+        if ingestion_id:
+            marked_ok = self._mark_batch_failed_best_effort(
+                org_id=org_id, ingestion_id=ingestion_id, reason=reason
+            )
+            return marked_ok
         return dlq_written
 
     async def _dlq_entry_async(
@@ -222,22 +231,16 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         than call :meth:`_mark_batch_failed_best_effort` (which itself calls
         :func:`run_async`), or ``run_async``'s own re-entrancy guard raises.
 
-        Same MARK-FIRST ordering and ACK contract as :meth:`move_to_dlq`
-        (see its docstring): the failed-status write must be durable before
-        the DLQ row is written, so a Postgres outage leaves the entry
-        pending with NO duplicate DLQ rows accumulating across retries.
-        Entries on this path always carry their field dict, so the
-        tombstone branch here only covers a malformed producer entry.
+        Same DLQ-FIRST-with-idempotent-write ordering and ACK contract as
+        :meth:`move_to_dlq` (see its docstring for the round 1-3 history):
+        a failed XADD returns ``False`` with the batch untouched (retry
+        reproduces the permanent error and re-attempts); a failed mark
+        returns ``False`` with the marker suppressing duplicate DLQ rows on
+        the retry. Entries on this path always carry their field dict, so
+        the tombstone branch here only covers a malformed producer entry.
         """
         ingestion_id = data.get("ingestion_id")
-        if ingestion_id:
-            org_id = data.get("org_id") or self._org_id_from_stream_key(stream_key)
-            marked_ok = await self._mark_batch_failed_best_effort_async(
-                org_id=org_id, ingestion_id=ingestion_id, reason=reason
-            )
-            if not marked_ok:
-                return False
-        else:
+        if not ingestion_id:
             logger.error(
                 "Entry %s on %s carries no ingestion_id -- writing tombstone "
                 "DLQ row and ACKing; any stranded batch row is the "
@@ -245,9 +248,16 @@ class ExternalIngestStreamConsumer(StreamConsumer):
                 entry_id,
                 stream_key,
             )
-        _org_id, dlq_written = self._xadd_dlq_entry(
+        org_id, dlq_written = self._xadd_dlq_entry(
             rc, stream_key, entry_id, reason, data
         )
+        if not dlq_written:
+            return False
+        if ingestion_id:
+            marked_ok = await self._mark_batch_failed_best_effort_async(
+                org_id=org_id, ingestion_id=ingestion_id, reason=reason
+            )
+            return marked_ok
         return dlq_written
 
     def _xadd_dlq_entry(
@@ -258,17 +268,34 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         reason: str,
         data: dict[str, str],
     ) -> tuple[str, bool]:
-        """XADD to the per-org DLQ (sync -- the redis client itself is never
-        async). Per-org (D1): a single bad-actor/misconfigured org flooding
-        poison batches must not crowd out DLQ visibility for other orgs.
-        Returns ``(org_id, succeeded)`` -- callers use ``succeeded`` to
-        decide whether it is safe to ack the source entry (adversarial-review
-        finding: a swallowed DLQ-write failure must not silently drop the
-        entry with no DLQ record).
+        """Idempotently XADD to the per-org DLQ (sync -- the redis client
+        itself is never async). Per-org (D1): a single bad-actor/misconfigured
+        org flooding poison batches must not crowd out DLQ visibility for
+        other orgs. Returns ``(org_id, succeeded)`` -- callers use
+        ``succeeded`` to decide whether it is safe to ack the source entry
+        (adversarial-review finding: a swallowed DLQ-write failure must not
+        silently drop the entry with no DLQ record).
+
+        Idempotency (CHAOS-2697 adversarial rounds 2+3): a per-entry marker
+        key is set right after a successful XADD, so a source entry retried
+        across mark-failure cycles produces exactly one DLQ row instead of
+        flooding the capped/approximate stream. The check-then-write is safe
+        without WATCH/MULTI because of the CC11 deployment invariant
+        (exactly ONE consumer identity ever runs this code for a given
+        entry). The marker set itself is best-effort: if it fails after the
+        XADD landed, a later retry can write at most one extra DLQ row per
+        such blip -- bounded noise, unlike the unbounded per-cycle
+        duplication the marker exists to stop.
         """
         org_id = data.get("org_id") or self._org_id_from_stream_key(stream_key)
         dlq = dlq_name(org_id)
+        marker = f"{dlq}:written:{entry_id}"
         try:
+            if rc.exists(marker):
+                # A prior attempt already landed the DLQ row (its mark or
+                # ACK failed afterwards) -- report success without a
+                # duplicate XADD.
+                return org_id, True
             rc.xadd(
                 dlq,
                 {
@@ -285,6 +312,14 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         except Exception:
             logger.exception("Failed to move entry %s to DLQ", entry_id)
             return org_id, False
+        try:
+            rc.set(marker, "1", ex=DLQ_MARKER_TTL_SECONDS)
+        except Exception:
+            logger.exception(
+                "DLQ row for entry %s written but its dedup marker was not -- "
+                "a later retry may write one duplicate row",
+                entry_id,
+            )
         return org_id, True
 
     @staticmethod

--- a/src/dev_health_ops/api/external_ingest/consumer.py
+++ b/src/dev_health_ops/api/external_ingest/consumer.py
@@ -131,7 +131,7 @@ class ExternalIngestStreamConsumer(StreamConsumer):
 
     def _fetch_entry_fields(
         self, rc: Any, stream_key: str, entry_id: str
-    ) -> dict[str, str]:
+    ) -> dict[str, str] | None:
         """Re-read a single entry's fields by ID.
 
         Used only by :meth:`move_to_dlq`'s give-up path (invoked by the
@@ -139,12 +139,19 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         the message ID from ``XPENDING``). Freshly-read/reclaimed entries
         handled via :meth:`handle_entries` already carry their field dict
         and never call this.
+
+        Tri-state (adversarial-review round 2): ``None`` = the XRANGE itself
+        failed (transient -- retrying later is productive, the caller must
+        NOT ACK); ``{}`` = the read succeeded but the entry is gone
+        (MAXLEN-trimmed while pending -- authoritatively unrecoverable).
+        Collapsing the two let a transient Redis blip ACK away an entry
+        whose batch was never marked failed.
         """
         try:
             rows = rc.xrange(stream_key, min=entry_id, max=entry_id)
         except Exception:
             logger.exception("Failed to re-read entry %s for DLQ routing", entry_id)
-            return {}
+            return None
         if not rows:
             return {}
         _id, data = rows[0]
@@ -157,26 +164,48 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         use :func:`run_async` for the ``mark_batch_failed`` side effect.
 
         Returns whether it is safe to ACK the source entry (base class
-        contract): requires BOTH the DLQ write to succeed (adversarial-review
-        finding: a swallowed DLQ-write failure must not silently drop the
-        entry with no DLQ record) AND, when an ingestion_id is present, the
-        failed-status write to be safe (CHAOS-2697 adversarial review: this
-        sync path previously ignored the mark result while its async twin
-        ``_dlq_entry_async`` gated on it -- ACKing past a raised
-        ``mark_batch_failed`` strands the batch in a non-terminal status with
-        the entry gone, and a ``processing`` row REPLAYs rather than RETRYs,
-        leaving the customer no recovery handle at all).
+        contract). MARK-FIRST ordering (CHAOS-2697 adversarial review rounds
+        1+2): the terminal-``failed`` status write must be durable BEFORE the
+        DLQ row is written -- ACKing past a raised ``mark_batch_failed``
+        strands the batch in a non-terminal status with the entry gone (a
+        ``processing`` row REPLAYs rather than RETRYs, no customer recovery),
+        and writing the DLQ row first meant every mark-failure retry XADDed a
+        duplicate, flooding the capped/approximate DLQ during a Postgres
+        outage until distinct failures evicted.
+
+        Unrecoverable-fields path: a transient XRANGE failure returns
+        ``False`` (retry later); an authoritatively-absent entry
+        (MAXLEN-trimmed while pending) has nothing addressable to mark, so a
+        tombstone DLQ row is written and the entry ACKed -- the possibly
+        still-non-terminal batch row is exactly what the CHAOS-2769
+        orphan-batch reconciler exists to heal.
         """
         data = self._fetch_entry_fields(rc, stream_key, entry_id)
-        org_id, dlq_written = self._xadd_dlq_entry(
-            rc, stream_key, entry_id, reason, data
-        )
+        if data is None:
+            # Transient re-read failure: retrying later is productive.
+            return False
         ingestion_id = data.get("ingestion_id")
-        if dlq_written and ingestion_id:
+        if ingestion_id:
+            org_id = data.get("org_id") or self._org_id_from_stream_key(stream_key)
             marked_ok = self._mark_batch_failed_best_effort(
                 org_id=org_id, ingestion_id=ingestion_id, reason=reason
             )
-            return dlq_written and marked_ok
+            if not marked_ok:
+                # No DLQ write on this attempt: the retry (entry stays
+                # pending) re-runs the mark, and only a durable mark
+                # proceeds to XADD -- at most one DLQ row per entry.
+                return False
+        else:
+            logger.error(
+                "Entry %s on %s has no recoverable fields (trimmed while "
+                "pending?) -- writing tombstone DLQ row and ACKing; any "
+                "stranded batch row is the CHAOS-2769 reconciler's target",
+                entry_id,
+                stream_key,
+            )
+        _org_id, dlq_written = self._xadd_dlq_entry(
+            rc, stream_key, entry_id, reason, data
+        )
         return dlq_written
 
     async def _dlq_entry_async(
@@ -193,22 +222,32 @@ class ExternalIngestStreamConsumer(StreamConsumer):
         than call :meth:`_mark_batch_failed_best_effort` (which itself calls
         :func:`run_async`), or ``run_async``'s own re-entrancy guard raises.
 
-        Returns whether the source entry may be ACKed: requires BOTH the DLQ
-        write to succeed (same rationale as :meth:`move_to_dlq`) AND, when an
-        ingestion_id is present, the failed-status write to be safe (see
-        :meth:`_mark_batch_failed_best_effort_async` -- adversarial-review
-        round-2: ACKing past a raised ``mark_batch_failed`` strands the batch
-        in a non-terminal status with the entry gone).
+        Same MARK-FIRST ordering and ACK contract as :meth:`move_to_dlq`
+        (see its docstring): the failed-status write must be durable before
+        the DLQ row is written, so a Postgres outage leaves the entry
+        pending with NO duplicate DLQ rows accumulating across retries.
+        Entries on this path always carry their field dict, so the
+        tombstone branch here only covers a malformed producer entry.
         """
-        org_id, dlq_written = self._xadd_dlq_entry(
-            rc, stream_key, entry_id, reason, data
-        )
         ingestion_id = data.get("ingestion_id")
-        if dlq_written and ingestion_id:
+        if ingestion_id:
+            org_id = data.get("org_id") or self._org_id_from_stream_key(stream_key)
             marked_ok = await self._mark_batch_failed_best_effort_async(
                 org_id=org_id, ingestion_id=ingestion_id, reason=reason
             )
-            return dlq_written and marked_ok
+            if not marked_ok:
+                return False
+        else:
+            logger.error(
+                "Entry %s on %s carries no ingestion_id -- writing tombstone "
+                "DLQ row and ACKing; any stranded batch row is the "
+                "CHAOS-2769 reconciler's target",
+                entry_id,
+                stream_key,
+            )
+        _org_id, dlq_written = self._xadd_dlq_entry(
+            rc, stream_key, entry_id, reason, data
+        )
         return dlq_written
 
     def _xadd_dlq_entry(

--- a/src/dev_health_ops/api/external_ingest/consumer.py
+++ b/src/dev_health_ops/api/external_ingest/consumer.py
@@ -64,16 +64,17 @@ _TERMINAL_STATUS_VALUES = {s.value for s in TERMINAL_STATUSES}
 
 def _processor_available() -> bool:
     """Whether CHAOS-2697's ``external_ingest.processor`` module (owning
-    ``process_batch``/``mark_batch_failed``) is importable yet.
+    ``process_batch``/``mark_batch_failed``) is importable.
 
     Deployment-order guard (adversarial-review finding): this issue's beat
-    schedule/queue wiring ships ahead of CHAOS-2697's worker implementation
-    by design (master-spec wave plan), so the consumer must check this
-    before claiming any entries rather than draining the stream into a
-    guaranteed-ImportError retry ladder.
+    schedule/queue wiring shipped ahead of CHAOS-2697's worker implementation
+    by design (master-spec wave plan), so the consumer checks this before
+    claiming any entries rather than draining the stream into a
+    guaranteed-ImportError retry ladder. CHAOS-2697 has since landed — the
+    guard now passes and is kept as rollback protection.
     """
     try:
-        import dev_health_ops.external_ingest.processor  # type: ignore  # noqa: F401
+        import dev_health_ops.external_ingest.processor  # noqa: F401
     except ImportError:
         return False
     return True
@@ -244,15 +245,12 @@ class ExternalIngestStreamConsumer(StreamConsumer):
     @staticmethod
     def _resolve_mark_batch_failed():
         """Give-up path calls ``external_ingest.processor.mark_batch_failed``
-        (CHAOS-2697's pinned worker contract, CC23). Import-tolerant:
-        CHAOS-2697 lands after this issue, so until it does, this returns
-        ``None`` rather than raising ImportError into the consumer loop.
+        (CHAOS-2697's pinned worker contract, CC23). Import-tolerant: kept
+        even now that CHAOS-2697 has landed, so a rollback that removes the
+        processor module degrades to the logged-warning path rather than
+        raising ImportError into the consumer loop.
         """
         try:
-            # CHAOS-2697's module; doesn't exist yet at this issue's
-            # implementation time (see module docstring) -- the
-            # missing-stubs diagnostic for this module path is already
-            # silenced once per file by _processor_available()'s import.
             from dev_health_ops.external_ingest.processor import mark_batch_failed
         except ImportError:
             return None
@@ -360,16 +358,14 @@ class ExternalIngestStreamConsumer(StreamConsumer):
     ) -> int:
         from dev_health_ops.external_ingest.processor import process_batch
 
-        result = process_batch(
+        # CHAOS-2697's pinned contract (CC23): async, returns items_accepted.
+        return await process_batch(
             ingestion_id=data["ingestion_id"],
             org_id=data["org_id"],
             source_system=data["source_system"],
             source_instance=data["source_instance"],
             schema_version=data["schema_version"],
         )
-        if inspect.isawaitable(result):
-            result = await result
-        return int(result)
 
     def process_entry(
         self, stream_key: str, entry_id: str, data: dict[str, str]

--- a/src/dev_health_ops/api/external_ingest/status.py
+++ b/src/dev_health_ops/api/external_ingest/status.py
@@ -699,7 +699,12 @@ async def mark_failed(
     ``processing`` or count reconciliation: the whole point is that the worker
     never got far enough to produce counts (schema-version mismatch and
     missing-payload failures raise before ``mark_processing``, leaving
-    ``accepted``). Idempotent: returns ``False`` (untouched row) when already
+    ``accepted``). The published counter invariant still holds (adversarial
+    round 2): ``failed`` means zero accepted, so ``items_rejected`` is forced
+    to ``items_received`` (a system failure rejects the whole batch as far as
+    GET/list consumers are concerned; no per-record rejection rows exist --
+    ``error_summary.system_failure`` carries the cause) and ``record_counts``
+    is cleared. Idempotent: returns ``False`` (untouched row) when already
     terminal or missing. Does NOT commit."""
     now = datetime.now(timezone.utc)
     result = await session.execute(
@@ -708,6 +713,8 @@ async def mark_failed(
             f"""
             UPDATE {_BATCHES_TABLE}
             SET status = :status, error_summary = :error_summary,
+                items_accepted = 0, items_rejected = items_received,
+                record_counts = NULL,
                 completed_at = :completed_at, updated_at = :updated_at
             WHERE org_id = :org_id AND ingestion_id = :ingestion_id
                 AND status NOT IN (:completed, :partial, :failed)

--- a/src/dev_health_ops/api/external_ingest/status.py
+++ b/src/dev_health_ops/api/external_ingest/status.py
@@ -71,6 +71,7 @@ __all__ = [
     "mark_stream_unavailable",
     "reset_for_retry",
     "complete_batch",
+    "mark_failed",
     "get_batch",
     "list_batches",
     "list_rejections",
@@ -431,16 +432,34 @@ async def _transition_status(
 async def mark_processing(
     session: AsyncSession, *, org_id: str, ingestion_id: uuid.UUID
 ) -> None:
-    """``accepted -> processing``. Idempotent: a no-op UPDATE (``WHERE
-    status = 'accepted'``) if already processing/terminal, so redelivered
-    stream entries (at-least-once) never regress a terminal status back to
-    processing."""
-    await _transition_status(
-        session,
-        org_id=org_id,
-        ingestion_id=ingestion_id,
-        from_status=BatchStatus.ACCEPTED,
-        to_status=BatchStatus.PROCESSING,
+    """``accepted|stream_unavailable -> processing``. Idempotent: a no-op
+    UPDATE if already processing/terminal, so redelivered stream entries
+    (at-least-once) never regress a terminal status back to processing.
+
+    ``stream_unavailable`` is included (CHAOS-2697): a 503'd accept whose
+    XADD actually landed before the error surfaced leaves a live pointer for
+    a ``stream_unavailable`` row (the expected-duplicate-pointer case,
+    docs/architecture/external-ingest-idempotency-ownership.md). Processing
+    it is strictly better than wedging: the payload row is durable, and the
+    client's same-key retry then REPLAYs the terminal outcome instead of
+    re-accepting. A concurrent ``reset_for_retry`` serializes against this
+    CAS on the row lock — whichever loses re-reads and yields."""
+    now = datetime.now(timezone.utc)
+    await session.execute(
+        # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        text(
+            f"UPDATE {_BATCHES_TABLE} SET status = :new_status, updated_at = :updated_at "
+            "WHERE org_id = :org_id AND ingestion_id = :ingestion_id "
+            "AND status IN (:accepted, :stream_unavailable)"
+        ),
+        {
+            "new_status": BatchStatus.PROCESSING.value,
+            "updated_at": now,
+            "org_id": org_id,
+            "ingestion_id": str(ingestion_id),
+            "accepted": BatchStatus.ACCEPTED.value,
+            "stream_unavailable": BatchStatus.STREAM_UNAVAILABLE.value,
+        },
     )
 
 
@@ -529,6 +548,7 @@ async def complete_batch(
     items_accepted: int,
     items_rejected: int,
     rejections: list[RejectedRecord],
+    record_counts: dict[str, int] | None = None,
 ) -> BatchRow:
     """``processing -> {completed, partial, failed}`` (derived from counts,
     see ``terminal_status_for``). Idempotent: if called twice for the same
@@ -557,7 +577,11 @@ async def complete_batch(
     that commits afterward never exposes a terminal status without its
     rejection rows already durable, and the ``(ingestion_id, record_index)``
     unique index is a second, DB-enforced backstop against ever
-    double-inserting a rejection row."""
+    double-inserting a rejection row.
+
+    ``record_counts`` (CHAOS-2697): per-kind accepted counts keyed by FULL
+    kind name (``{"pull_request.v1": 12}``) — the worker is this column's
+    only writer (see the model comment in ``models/external_ingest.py``)."""
     current = await get_batch(session, org_id=org_id, ingestion_id=ingestion_id)
     if current is None:
         raise ValueError(f"external ingest batch not found: {ingestion_id}")
@@ -594,6 +618,7 @@ async def complete_batch(
             UPDATE {_BATCHES_TABLE}
             SET status = :status, items_accepted = :items_accepted,
                 items_rejected = :items_rejected, error_summary = :error_summary,
+                record_counts = :record_counts,
                 completed_at = :completed_at, updated_at = :updated_at
             WHERE org_id = :org_id AND ingestion_id = :ingestion_id
                 AND status = :expected_status
@@ -605,6 +630,9 @@ async def complete_batch(
             "items_rejected": items_rejected,
             "error_summary": (
                 json.dumps(error_summary) if error_summary is not None else None
+            ),
+            "record_counts": (
+                json.dumps(record_counts) if record_counts is not None else None
             ),
             "completed_at": now,
             "updated_at": now,
@@ -655,6 +683,51 @@ async def complete_batch(
     updated = await get_batch(session, org_id=org_id, ingestion_id=ingestion_id)
     assert updated is not None
     return updated
+
+
+async def mark_failed(
+    session: AsyncSession,
+    *,
+    org_id: str,
+    ingestion_id: uuid.UUID,
+    reason: str,
+) -> bool:
+    """Force a batch to terminal ``failed`` from ANY non-terminal status —
+    the consumer's give-up path (CHAOS-2697 ``mark_batch_failed``, master-spec
+    CC11: max_deliveries exhausted or a ``PermanentProcessingError`` DLQ'd the
+    entry). Unlike ``complete_batch`` this deliberately does not require
+    ``processing`` or count reconciliation: the whole point is that the worker
+    never got far enough to produce counts (schema-version mismatch and
+    missing-payload failures raise before ``mark_processing``, leaving
+    ``accepted``). Idempotent: returns ``False`` (untouched row) when already
+    terminal or missing. Does NOT commit."""
+    now = datetime.now(timezone.utc)
+    result = await session.execute(
+        # nosemgrep: python.sqlalchemy.security.audit.avoid-sqlalchemy-text.avoid-sqlalchemy-text
+        text(
+            f"""
+            UPDATE {_BATCHES_TABLE}
+            SET status = :status, error_summary = :error_summary,
+                completed_at = :completed_at, updated_at = :updated_at
+            WHERE org_id = :org_id AND ingestion_id = :ingestion_id
+                AND status NOT IN (:completed, :partial, :failed)
+            """
+        ),
+        {
+            "status": BatchStatus.FAILED.value,
+            "error_summary": json.dumps(
+                {"system_failure": True, "reason": reason[:500]}
+            ),
+            "completed_at": now,
+            "updated_at": now,
+            "org_id": org_id,
+            "ingestion_id": str(ingestion_id),
+            "completed": BatchStatus.COMPLETED.value,
+            "partial": BatchStatus.PARTIAL.value,
+            "failed": BatchStatus.FAILED.value,
+        },
+    )
+    return int(getattr(result, "rowcount", 0) or 0) == 1
 
 
 async def get_batch(

--- a/src/dev_health_ops/external_ingest/normalize.py
+++ b/src/dev_health_ops/external_ingest/normalize.py
@@ -1,0 +1,262 @@
+"""Pure worker-side normalization for external-ingest batches (CHAOS-2697).
+
+Turns a parsed batch envelope's ``records`` into the :class:`NormalizedBatch`
+shape ``sinks.write_batch()`` consumes, plus per-record rejections. Pure — no
+I/O, no ClickHouse/Postgres calls — so it is unit-testable without services
+and safe to re-run on redelivered stream entries.
+
+Validation layering (master-spec CC6/CC17):
+
+- Shape validation delegates to ``external_ingest.validate.validate_records``
+  UNCHANGED (CC17: single owner, created complete by CHAOS-2691) so the
+  ``POST /validate`` endpoint and this worker can never diverge on what a
+  structurally valid record is.
+- The kind x system matrix and the git-family instance-scope rule (CC6) are
+  enforced HERE, as per-record rejections — ``validate.py`` deliberately
+  excludes them (they need source context), and ``sinks.py`` only
+  asserts-but-never-rejects (its ``record_outside_source_instance`` is a
+  write-time warning). This module is the reject decision point.
+
+The instance-scope comparison is case-INSENSITIVE (``casefold`` both sides),
+deliberately looser than ``sinks._check_instance_scope``'s exact-match
+warning: GitHub/GitLab full names and Jira/Linear keys are case-insensitive
+identifiers on their providers (the same finding that made CHAOS-2695's
+ownership matching case-insensitive), and ``derive_repo_uuid`` lower-cases
+its seed — a case-variant identifier derives the SAME repo UUID, so
+rejecting it would refuse data that cannot fork repo identity. The sink's
+exact-match warning may still fire for such records; that is diagnostic
+noise, not a contract violation.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from dataclasses import dataclass, field
+
+from pydantic import BaseModel, ValidationError
+
+from dev_health_ops.api.external_ingest.schemas import (
+    RECORD_KIND_MODELS,
+    RecordEnvelope,
+)
+from dev_health_ops.external_ingest.types import NormalizedBatch
+from dev_health_ops.external_ingest.validate import validate_records
+
+logger = logging.getLogger(__name__)
+
+_GIT_FAMILY_KINDS = frozenset(
+    {"repository.v1", "pull_request.v1", "review.v1", "commit.v1"}
+)
+_WORK_ITEM_FAMILY_KINDS = frozenset(
+    {"work_item.v1", "work_item_transition.v1", "work_item_dependency.v1"}
+)
+_ORG_SCOPED_KINDS = frozenset({"team.v1", "identity.v1"})
+
+#: Master-spec CC6 kind x system matrix. ``custom`` excludes the work_item
+#: family in v1 (would widen the ``WorkItem.provider`` Literal vocabulary).
+ALLOWED_KINDS_BY_SYSTEM: dict[str, frozenset[str]] = {
+    "github": _GIT_FAMILY_KINDS | _WORK_ITEM_FAMILY_KINDS | _ORG_SCOPED_KINDS,
+    "gitlab": _GIT_FAMILY_KINDS | _WORK_ITEM_FAMILY_KINDS | _ORG_SCOPED_KINDS,
+    "jira": _WORK_ITEM_FAMILY_KINDS | _ORG_SCOPED_KINDS,
+    "linear": _WORK_ITEM_FAMILY_KINDS | _ORG_SCOPED_KINDS,
+    "custom": _GIT_FAMILY_KINDS | _ORG_SCOPED_KINDS,
+}
+
+#: CC6: systems whose git-family records must reference the batch's own
+#: source.instance (jira/linear have no git-family kinds to scope).
+_INSTANCE_SCOPED_SYSTEMS = frozenset({"github", "gitlab", "custom"})
+
+#: kind -> (NormalizedBatch list attribute, record_index_by_kind key,
+#: emit dicts?). Dict kinds are ``model_dump()``ed to the snake_case field
+#: names ``sinks.py``'s row builders read; work-item-family kinds pass the
+#: validated pydantic instances through (sinks duck-types attribute access).
+_KIND_DISPATCH: dict[str, tuple[str, str, bool]] = {
+    "repository.v1": ("repositories", "repository", True),
+    "identity.v1": ("identities", "identity", True),
+    "team.v1": ("teams", "team", True),
+    "pull_request.v1": ("pull_requests", "pull_request", True),
+    "review.v1": ("reviews", "review", True),
+    "commit.v1": ("commits", "commit", True),
+    "work_item.v1": ("work_items", "work_item", False),
+    "work_item_transition.v1": ("work_item_transitions", "work_item_transition", False),
+    "work_item_dependency.v1": (
+        "work_item_dependencies",
+        "work_item_dependency",
+        False,
+    ),
+}
+
+
+@dataclass(frozen=True)
+class RecordRejection:
+    """One rejected record. Exactly one per rejected index — the status
+    store's ``(ingestion_id, record_index)`` unique constraint allows a
+    single persisted diagnostic per record, so multi-field shape failures
+    collapse to the first error (``validate_records`` emits them in field
+    order)."""
+
+    index: int
+    kind: str
+    external_id: str | None
+    code: str
+    message: str
+    path: str | None
+
+
+@dataclass
+class NormalizationResult:
+    batch: NormalizedBatch
+    rejections: list[RecordRejection] = field(default_factory=list)
+    #: Accepted records per FULL kind name (e.g. ``{"pull_request.v1": 12}``)
+    #: — the vocabulary both the batch row's ``record_counts`` column and
+    #: CHAOS-2699's recompute planner expect (``plan_recompute`` intersects
+    #: against ``.v1``-suffixed kind sets; the sink scope's bare-kind names
+    #: would silently never trigger recompute).
+    record_counts: dict[str, int] = field(default_factory=dict)
+    items_received: int = 0
+
+    @property
+    def items_rejected(self) -> int:
+        return len(self.rejections)
+
+    @property
+    def items_accepted(self) -> int:
+        return self.items_received - len(self.rejections)
+
+
+def _git_family_repo_identifier(kind: str, payload_model: BaseModel) -> str:
+    """The repo identifier CC6 scopes to source.instance: ``repository.v1``
+    carries it as its own ``external_id``; the other git-family kinds
+    reference it as ``repository_external_id``."""
+    if kind == "repository.v1":
+        return str(getattr(payload_model, "external_id", "") or "")
+    return str(getattr(payload_model, "repository_external_id", "") or "")
+
+
+def normalize_batch(
+    *,
+    org_id: str,
+    source_id: uuid.UUID,
+    source_system: str,
+    source_instance: str,
+    ingestion_id: uuid.UUID,
+    records: list[RecordEnvelope],
+) -> NormalizationResult:
+    """Validate + normalize one batch's records. Never raises for record
+    content — every per-record problem becomes a :class:`RecordRejection`;
+    callers decide batch-level outcomes from the counts."""
+    batch = NormalizedBatch(
+        org_id=org_id,
+        source_id=source_id,
+        source_system=source_system,
+        source_instance=source_instance,
+        ingestion_id=ingestion_id,
+    )
+    result = NormalizationResult(batch=batch, items_received=len(records))
+
+    # CC17: shape validation is validate.py's verdict, imported unchanged.
+    # First error per index wins the (single) persisted rejection slot.
+    shape_error_by_index: dict[int, tuple[str, str, str | None]] = {}
+    for item in validate_records(records):
+        shape_error_by_index.setdefault(
+            item.index, (item.code, item.message, item.path)
+        )
+
+    allowed_kinds = ALLOWED_KINDS_BY_SYSTEM.get(source_system, frozenset())
+    instance_folded = source_instance.casefold()
+
+    for index, record in enumerate(records):
+        shape_error = shape_error_by_index.get(index)
+        if shape_error is not None:
+            code, message, path = shape_error
+            result.rejections.append(
+                RecordRejection(
+                    index=index,
+                    kind=record.kind,
+                    external_id=record.external_id,
+                    code=code,
+                    message=message,
+                    path=path,
+                )
+            )
+            continue
+
+        if record.kind not in allowed_kinds:
+            result.rejections.append(
+                RecordRejection(
+                    index=index,
+                    kind=record.kind,
+                    external_id=record.external_id,
+                    code="unsupported_kind_for_system",
+                    message=(
+                        f"record kind {record.kind!r} is not accepted for "
+                        f"source system {source_system!r} (master-spec CC6)"
+                    ),
+                    path=f"records[{index}].kind",
+                )
+            )
+            continue
+
+        model_cls = RECORD_KIND_MODELS[record.kind]
+        try:
+            payload_model = model_cls.model_validate(record.payload)
+        except ValidationError:  # pragma: no cover - validate_records already
+            # passed this exact payload against this exact model; reaching
+            # here would mean the two diverged (a CC17 violation), so fail
+            # the record loudly rather than crash the batch.
+            logger.exception(
+                "normalize_batch: model_validate diverged from validate_records "
+                "for kind=%s index=%d",
+                record.kind,
+                index,
+            )
+            result.rejections.append(
+                RecordRejection(
+                    index=index,
+                    kind=record.kind,
+                    external_id=record.external_id,
+                    code="invalid_field",
+                    message="payload failed validation during normalization",
+                    path=f"records[{index}].payload",
+                )
+            )
+            continue
+
+        if (
+            record.kind in _GIT_FAMILY_KINDS
+            and source_system in _INSTANCE_SCOPED_SYSTEMS
+        ):
+            identifier = _git_family_repo_identifier(record.kind, payload_model)
+            if identifier.casefold() != instance_folded:
+                result.rejections.append(
+                    RecordRejection(
+                        index=index,
+                        kind=record.kind,
+                        external_id=record.external_id,
+                        code="record_outside_source_instance",
+                        message=(
+                            f"repository identifier {identifier!r} does not "
+                            f"match this batch's source.instance "
+                            f"{source_instance!r} (master-spec CC6)"
+                        ),
+                        path=f"records[{index}].payload",
+                    )
+                )
+                continue
+
+        attr, index_key, as_dict = _KIND_DISPATCH[record.kind]
+        target: list = getattr(batch, attr)
+        target.append(payload_model.model_dump() if as_dict else payload_model)
+        batch.record_index_by_kind.setdefault(index_key, []).append(index)
+        result.record_counts[record.kind] = result.record_counts.get(record.kind, 0) + 1
+
+    return result
+
+
+__all__ = [
+    "ALLOWED_KINDS_BY_SYSTEM",
+    "NormalizationResult",
+    "RecordRejection",
+    "normalize_batch",
+]

--- a/src/dev_health_ops/external_ingest/processor.py
+++ b/src/dev_health_ops/external_ingest/processor.py
@@ -1,0 +1,454 @@
+"""Worker-side batch processor for external ingest (CHAOS-2697).
+
+The pinned worker contract (master-spec CC23, consumed by CHAOS-2693's
+``api/external_ingest/consumer.py`` — its ``_processor_available()``
+deployment-order guard keys on this module's importability, so merging this
+file is what arms the beat-scheduled consumer):
+
+- ``process_batch(*, ingestion_id, org_id, source_system, source_instance,
+  schema_version) -> int`` — fetch payload → re-validate per record
+  (``validate.py`` unchanged + the CC6 matrix, via ``normalize.py``) →
+  ``sinks.write_batch()`` with the CC11 in-process retry ladder → terminal
+  status + rejection diagnostics via ``api/external_ingest/status.py`` →
+  delete the payload row → ``schedule_or_coalesce(...)`` once (best-effort).
+- ``mark_batch_failed(*, ingestion_id, org_id, reason)`` — the consumer's
+  give-up path (max_deliveries exhausted / permanent DLQ). MUST raise on
+  failure: the consumer's ACK gate leaves the entry un-ACKed when this
+  raises, so a transient Postgres outage retries the status write instead of
+  stranding the batch in a non-terminal status with the entry gone.
+
+Failure classification (consumer contract):
+
+- ``PermanentProcessingError`` — unsupported schema version, corrupt/missing
+  payload, unregistered source, pointer/payload disagreement. The consumer
+  DLQs immediately and marks the batch failed.
+- Any other exception — treated as transient; the entry stays in the PEL for
+  the reclaim ladder. ``TransientSinkWriteError`` (sink writes still failing
+  after the retry ladder) is deliberately in this class.
+
+Replay safety: every path here tolerates a second invocation for the same
+``ingestion_id`` (CC11 post-critique). The terminal-status check short-
+circuits redelivered pointers; ``mark_processing``/``complete_batch`` are
+CAS transitions; sink writes are ReplacingMergeTree upserts on natural keys;
+recompute is debounce-coalesced. See
+docs/architecture/external-ingest-worker.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import uuid
+
+from pydantic import ValidationError
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION, BatchEnvelope
+from dev_health_ops.api.external_ingest.status import (
+    RejectedRecord,
+    complete_batch,
+    get_batch,
+    mark_failed,
+    mark_processing,
+)
+from dev_health_ops.db import get_postgres_session, require_clickhouse_uri
+from dev_health_ops.external_ingest.errors import PermanentProcessingError
+from dev_health_ops.external_ingest.normalize import (
+    ALLOWED_KINDS_BY_SYSTEM,
+    NormalizationResult,
+    normalize_batch,
+)
+from dev_health_ops.external_ingest.payload_store import delete_payload, fetch_payload
+from dev_health_ops.external_ingest.recompute import schedule_or_coalesce
+from dev_health_ops.external_ingest.sinks import write_batch
+from dev_health_ops.external_ingest.types import NormalizedBatch, SinkWriteResult
+from dev_health_ops.models.external_ingest import TERMINAL_STATUSES, BatchStatus
+from dev_health_ops.models.ingest_auth import IngestSource
+
+logger = logging.getLogger(__name__)
+
+#: CC11 in-process retry ladder for sink-write transients: initial attempt
+#: plus one retry per backoff value (2s/4s/8s — 14s worst-case sleep, which
+#: is why 2693 raised ``reclaim_idle_ms`` to 15 minutes).
+SINK_RETRY_BACKOFF_SECONDS: tuple[float, ...] = (2.0, 4.0, 8.0)
+
+_TERMINAL_STATUS_VALUES = {s.value for s in TERMINAL_STATUSES}
+
+
+class TransientSinkWriteError(RuntimeError):
+    """Sink writes still failing after the in-process retry ladder.
+
+    Deliberately NOT a ``PermanentProcessingError``: the consumer treats it
+    as transient, leaving the entry in the PEL for the reclaim ladder
+    (up to ``max_deliveries``) before the give-up path DLQs it — ClickHouse
+    outages should get minutes of runway, not an instant DLQ."""
+
+
+def _parse_ingestion_uuid(value: str) -> uuid.UUID:
+    try:
+        return uuid.UUID(value)
+    except (ValueError, AttributeError, TypeError) as exc:
+        raise PermanentProcessingError(
+            f"stream entry carries a non-UUID ingestion_id: {value!r}"
+        ) from exc
+
+
+async def _resolve_source_id(
+    session: AsyncSession, *, org_id: str, source_system: str, source_instance: str
+) -> uuid.UUID:
+    """The registered source's UUID, stamped as row provenance (CC8
+    ``source_id`` column). Case-insensitive match on both system and
+    instance, consistent with CHAOS-2695's ownership predicates (case-variant
+    duplicates are blocked at registration, so at most one logical source
+    matches). A source disabled AFTER accept still resolves — the batch was
+    accepted while write-eligible and its data is already durable; prefer the
+    write-eligible row only as a tiebreak against pre-2695 legacy duplicates.
+    """
+    rows = (
+        (
+            await session.execute(
+                select(IngestSource)
+                .where(
+                    IngestSource.org_id == org_id,
+                    func.lower(IngestSource.system) == source_system.strip().lower(),
+                    func.lower(IngestSource.instance)
+                    == source_instance.strip().lower(),
+                )
+                .order_by(IngestSource.created_at)
+            )
+        )
+        .scalars()
+        .all()
+    )
+    if not rows:
+        raise PermanentProcessingError(
+            f"no registered ingest source for org={org_id!r} "
+            f"source={source_system}/{source_instance} — cannot attribute "
+            "provenance (source_id) for this batch"
+        )
+    for row in rows:
+        if row.is_write_eligible():
+            return row.id
+    return rows[0].id
+
+
+def _parse_envelope(payload_bytes: bytes, *, ingestion_id: str) -> BatchEnvelope:
+    try:
+        data = json.loads(payload_bytes)
+    except (ValueError, UnicodeDecodeError) as exc:
+        raise PermanentProcessingError(
+            f"payload for batch {ingestion_id} is not valid JSON: {exc}"
+        ) from exc
+    try:
+        return BatchEnvelope.model_validate(data)
+    except ValidationError as exc:
+        raise PermanentProcessingError(
+            f"payload for batch {ingestion_id} is not a valid "
+            f"{SCHEMA_VERSION} envelope: {exc.error_count()} validation error(s)"
+        ) from exc
+
+
+async def _write_with_retries(
+    batch: NormalizedBatch, *, clickhouse_dsn: str
+) -> SinkWriteResult:
+    """``write_batch`` never raises — per-kind failures come back in
+    ``result.errors`` (batch-call granularity). Retrying the WHOLE batch is
+    safe (RMT upserts on natural keys), so the ladder re-runs everything and
+    only the final attempt's outcome counts."""
+    result = await write_batch(batch, clickhouse_dsn=clickhouse_dsn)
+    for delay in SINK_RETRY_BACKOFF_SECONDS:
+        if not result.errors:
+            break
+        logger.warning(
+            "external_ingest.processor.sink_retry ingestion_id=%s errors=%d "
+            "retry_in=%.0fs",
+            batch.ingestion_id,
+            len(result.errors),
+            delay,
+        )
+        await asyncio.sleep(delay)
+        result = await write_batch(batch, clickhouse_dsn=clickhouse_dsn)
+    if result.errors:
+        first = result.errors[0]
+        raise TransientSinkWriteError(
+            f"{len(result.errors)} sink write failure(s) persisted through "
+            f"{1 + len(SINK_RETRY_BACKOFF_SECONDS)} attempts for batch "
+            f"{batch.ingestion_id} (first: {first.kind}: {first.message})"
+        )
+    for warning in result.warnings:
+        logger.warning(
+            "external_ingest.processor.sink_warning ingestion_id=%s kind=%s "
+            "index=%d code=%s: %s",
+            batch.ingestion_id,
+            warning.kind,
+            warning.record_index,
+            warning.code,
+            warning.message,
+        )
+    return result
+
+
+def _rejections_for_store(norm: NormalizationResult) -> list[RejectedRecord]:
+    return [
+        RejectedRecord(
+            record_index=r.index,
+            record_kind=r.kind,
+            external_id=r.external_id,
+            code=r.code,
+            message=r.message,
+            path=r.path,
+        )
+        for r in norm.rejections
+    ]
+
+
+async def _dispatch_recompute_best_effort(
+    *,
+    org_id: str,
+    source_system: str,
+    source_instance: str,
+    ingestion_id: str,
+    norm: NormalizationResult,
+    sink_result: SinkWriteResult,
+    window_started_at,
+    window_ended_at,
+) -> None:
+    """CC23: ``schedule_or_coalesce`` ONCE at the end; a dispatch failure
+    never fails ingestion (the batch is already terminal + durable).
+
+    ``record_kinds`` uses the FULL kind names from normalization
+    (``pull_request.v1``) — the planner's ``_GIT_KINDS``/``_WORK_ITEM_KINDS``
+    vocabularies are ``.v1``-suffixed, so the sink scope's bare-kind names
+    would silently plan zero recompute. ``schedule_or_coalesce`` is sync
+    (Valkey pipeline + ``apply_async`` + a possible synchronous fallback into
+    ``get_postgres_session_sync``) — run in a thread, matching the sink
+    layer's ``asyncio.to_thread`` convention for sync clients."""
+    scope = sink_result.affected_scope
+    try:
+        await asyncio.to_thread(
+            schedule_or_coalesce,
+            org_id=org_id,
+            source_system=source_system,
+            source_instance=source_instance,
+            ingestion_id=ingestion_id,
+            repo_ids={str(repo_id) for repo_id in scope.repo_ids},
+            team_ids=set(scope.team_ids),
+            window_start=scope.min_timestamp or window_started_at,
+            window_end=scope.max_timestamp or window_ended_at,
+            record_kinds=set(norm.record_counts),
+        )
+    except Exception:
+        logger.exception(
+            "external_ingest.processor.recompute_dispatch_failed "
+            "ingestion_id=%s org_id=%s (best-effort; batch is already terminal)",
+            ingestion_id,
+            org_id,
+        )
+
+
+async def process_batch(
+    *,
+    ingestion_id: str,
+    org_id: str,
+    source_system: str,
+    source_instance: str,
+    schema_version: str,
+) -> int:
+    """Process one accepted batch end to end. Returns ``items_accepted``
+    (0 for an idempotent skip). See the module docstring for the failure
+    classification the consumer relies on."""
+    if schema_version != SCHEMA_VERSION:
+        raise PermanentProcessingError(
+            f"unsupported schema version {schema_version!r} on stream entry "
+            f"for batch {ingestion_id} (worker speaks {SCHEMA_VERSION!r} only)"
+        )
+    if source_system not in ALLOWED_KINDS_BY_SYSTEM:
+        raise PermanentProcessingError(
+            f"unknown source system {source_system!r} on stream entry for "
+            f"batch {ingestion_id}"
+        )
+    batch_uuid = _parse_ingestion_uuid(ingestion_id)
+    # Resolve config before touching batch status: a missing CLICKHOUSE_URI
+    # raises RuntimeError (transient — operator-fixable) without moving the
+    # row out of its retryable status.
+    clickhouse_dsn = require_clickhouse_uri()
+
+    async with get_postgres_session() as session:
+        row = await get_batch(session, org_id=org_id, ingestion_id=batch_uuid)
+        if row is None:
+            # The accept path commits the batch row before the pointer ever
+            # reaches the stream, and rows are never deleted — a missing row
+            # is cross-environment pollution or corruption, not a race.
+            raise PermanentProcessingError(
+                f"no status row for batch {ingestion_id} (org={org_id!r})"
+            )
+        if row.status in _TERMINAL_STATUS_VALUES:
+            logger.info(
+                "external_ingest.processor.skip_terminal ingestion_id=%s status=%s",
+                ingestion_id,
+                row.status,
+            )
+            return 0
+
+        await mark_processing(session, org_id=org_id, ingestion_id=batch_uuid)
+        # Commit the processing transition BEFORE any sink write (CHAOS-2498
+        # commit-before-risky pattern): a crash mid-write must leave a row
+        # that says a worker attempted it, and GET /batches must not report
+        # 'accepted' for a batch whose rows are landing in ClickHouse.
+        await session.commit()
+
+        row = await get_batch(session, org_id=org_id, ingestion_id=batch_uuid)
+        if row is None or row.status != BatchStatus.PROCESSING.value:
+            # Lost the CAS: a concurrent stale-RETRY re-accepted the row (its
+            # fresh pointer owns it now) or another actor completed it. With
+            # the single-replica deployment invariant this is razor-thin, but
+            # yielding is always safe — ACK this pointer and move on.
+            logger.info(
+                "external_ingest.processor.yield_lost_cas ingestion_id=%s status=%s",
+                ingestion_id,
+                "<missing>" if row is None else row.status,
+            )
+            return 0
+
+        payload = await fetch_payload(session, ingestion_id=batch_uuid, org_id=org_id)
+        if payload is None:
+            # enqueue_batch's fail-closed invariant guarantees the payload was
+            # durable before the pointer became visible; a missing row means
+            # the prune sweep (CC9, 168h) or a prior terminal cleanup beat us.
+            raise PermanentProcessingError(
+                f"payload row for batch {ingestion_id} is missing (pruned or "
+                "already cleaned up) — batch cannot be processed"
+            )
+        source_id = await _resolve_source_id(
+            session,
+            org_id=org_id,
+            source_system=source_system,
+            source_instance=source_instance,
+        )
+
+        envelope = _parse_envelope(payload, ingestion_id=ingestion_id)
+        if (
+            envelope.source.system != source_system
+            or envelope.source.instance != source_instance
+        ):
+            raise PermanentProcessingError(
+                f"stream pointer for batch {ingestion_id} says "
+                f"{source_system}/{source_instance} but the stored payload "
+                f"says {envelope.source.system}/{envelope.source.instance}"
+            )
+        if len(envelope.records) != row.items_received:
+            raise PermanentProcessingError(
+                f"stored payload for batch {ingestion_id} has "
+                f"{len(envelope.records)} records but the batch row recorded "
+                f"items_received={row.items_received}"
+            )
+
+        norm = normalize_batch(
+            org_id=org_id,
+            source_id=source_id,
+            source_system=source_system,
+            source_instance=source_instance,
+            ingestion_id=batch_uuid,
+            records=envelope.records,
+        )
+
+        sink_result: SinkWriteResult | None = None
+        if norm.items_accepted > 0:
+            # Raises TransientSinkWriteError past the ladder -> the session
+            # context rolls back nothing (processing is committed), the entry
+            # stays in the PEL, and the reclaim ladder retries us whole.
+            sink_result = await _write_with_retries(
+                norm.batch, clickhouse_dsn=clickhouse_dsn
+            )
+
+        await complete_batch(
+            session,
+            org_id=org_id,
+            ingestion_id=batch_uuid,
+            items_accepted=norm.items_accepted,
+            items_rejected=norm.items_rejected,
+            rejections=_rejections_for_store(norm),
+            record_counts=norm.record_counts or None,
+        )
+        # CC9: the worker deletes the payload row on terminal status, in the
+        # same transaction — a failed-batch resubmission (RETRY) re-upserts it.
+        await delete_payload(session, ingestion_id=batch_uuid)
+        await session.commit()
+
+    if sink_result is not None:
+        await _dispatch_recompute_best_effort(
+            org_id=org_id,
+            source_system=source_system,
+            source_instance=source_instance,
+            ingestion_id=ingestion_id,
+            norm=norm,
+            sink_result=sink_result,
+            window_started_at=row.window_started_at,
+            window_ended_at=row.window_ended_at,
+        )
+
+    logger.info(
+        "external_ingest.processor.completed ingestion_id=%s org_id=%s "
+        "accepted=%d rejected=%d",
+        ingestion_id,
+        org_id,
+        norm.items_accepted,
+        norm.items_rejected,
+    )
+    return norm.items_accepted
+
+
+async def mark_batch_failed(*, ingestion_id: str, org_id: str, reason: str) -> None:
+    """Consumer give-up path (CC11/CC23). Forces the batch terminal-``failed``
+    from any non-terminal status and cleans up its payload row.
+
+    RAISES on failure (never swallow — the consumer's ACK gate): if the
+    status write cannot land, the entry must stay un-ACKed so a later
+    redelivery retries it; ACKing past a lost write would strand the batch
+    non-terminal with the pointer gone. Idempotent for already-terminal or
+    unknown batches (a DLQ re-drive or duplicate pointer is a no-op).
+    """
+    try:
+        batch_uuid = uuid.UUID(ingestion_id)
+    except (ValueError, AttributeError, TypeError):
+        # Nothing addressable to mark; the DLQ entry itself is the record.
+        logger.warning(
+            "external_ingest.processor.mark_failed_unaddressable "
+            "ingestion_id=%r org_id=%s",
+            ingestion_id,
+            org_id,
+        )
+        return
+
+    async with get_postgres_session() as session:
+        transitioned = await mark_failed(
+            session, org_id=org_id, ingestion_id=batch_uuid, reason=reason
+        )
+        if transitioned:
+            await delete_payload(session, ingestion_id=batch_uuid)
+            logger.warning(
+                "external_ingest.processor.marked_failed ingestion_id=%s "
+                "org_id=%s reason=%s",
+                ingestion_id,
+                org_id,
+                reason,
+            )
+        else:
+            logger.info(
+                "external_ingest.processor.mark_failed_noop ingestion_id=%s "
+                "org_id=%s (already terminal or unknown)",
+                ingestion_id,
+                org_id,
+            )
+        # get_postgres_session commits on clean exit; an exception anywhere
+        # above propagates (rollback + re-raise) per the RAISES contract.
+
+
+__all__ = [
+    "SINK_RETRY_BACKOFF_SECONDS",
+    "TransientSinkWriteError",
+    "mark_batch_failed",
+    "process_batch",
+]

--- a/tests/api/test_external_ingest_consumer.py
+++ b/tests/api/test_external_ingest_consumer.py
@@ -45,6 +45,12 @@ _REAL_IS_BATCH_TERMINAL_ASYNC = (
 )
 # Same rationale, for the module-wide `_processor_available` autouse stub.
 _REAL_PROCESSOR_AVAILABLE = consumer_mod._processor_available
+# Same rationale, for the module-wide `_resolve_mark_batch_failed` autouse
+# stub (CHAOS-2697: the processor module exists now, so the real resolver
+# would hand any give-up path the REAL Postgres-backed mark_batch_failed).
+_REAL_RESOLVE_MARK_BATCH_FAILED = (
+    consumer_mod.ExternalIngestStreamConsumer._resolve_mark_batch_failed
+)
 
 
 @pytest.fixture
@@ -109,6 +115,22 @@ def _processor_available(monkeypatch):
     monkeypatch.setattr(consumer_mod, "_processor_available", lambda: True)
 
 
+@pytest.fixture(autouse=True)
+def _mark_batch_failed_unresolvable(monkeypatch):
+    """CHAOS-2697's processor module exists now, so the real
+    ``_resolve_mark_batch_failed()`` would resolve the REAL Postgres-backed
+    ``mark_batch_failed`` inside any test whose give-up path runs -- reaching
+    for a live database from a unit test. Default every test to the
+    unresolvable branch (the pre-2697 behavior these mechanics tests were
+    written against); the tests exercising the resolution contract itself
+    restore ``_REAL_RESOLVE_MARK_BATCH_FAILED`` and install a fake module."""
+    monkeypatch.setattr(
+        consumer_mod.ExternalIngestStreamConsumer,
+        "_resolve_mark_batch_failed",
+        staticmethod(lambda: None),
+    )
+
+
 class TestHappyPath:
     def test_success_acks_and_not_pending(self, fake_redis):
         stream, entry_id = _xadd_batch(fake_redis)
@@ -159,10 +181,15 @@ class TestPermanentFailure:
         assert dlq_data["entry_id"] == entry_id
 
     def test_calls_mark_batch_failed(self, fake_redis, monkeypatch):
-        # dev_health_ops.external_ingest.processor is CHAOS-2697's module and
-        # does not exist yet in this issue's scope -- inject a stand-in so we
-        # can assert the give-up path calls it exactly as CC23 pins, without
-        # depending on 2697 having landed.
+        # Restore the real resolver (the autouse stub defaults it to
+        # unresolvable) and inject a stand-in module so we can assert the
+        # give-up path resolves and calls mark_batch_failed exactly as CC23
+        # pins -- without the real Postgres-backed implementation running.
+        monkeypatch.setattr(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_resolve_mark_batch_failed",
+            staticmethod(_REAL_RESOLVE_MARK_BATCH_FAILED),
+        )
         fake_processor = types.ModuleType("dev_health_ops.external_ingest.processor")
         mark_failed = AsyncMock()
         setattr(
@@ -194,6 +221,11 @@ class TestPermanentFailure:
         a non-terminal status while the entry is gone. Leaving it pending
         lets a later redelivery retry the status write (a duplicate DLQ entry
         on that retry is accepted operational noise)."""
+        monkeypatch.setattr(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_resolve_mark_batch_failed",
+            staticmethod(_REAL_RESOLVE_MARK_BATCH_FAILED),
+        )
         fake_processor = types.ModuleType("dev_health_ops.external_ingest.processor")
         mark_failed = AsyncMock(side_effect=RuntimeError("pg down"))
         setattr(fake_processor, "mark_batch_failed", mark_failed)
@@ -222,9 +254,21 @@ class TestPermanentFailure:
         )
         assert len(pending) == 1
 
-    def test_missing_processor_module_does_not_crash_consumer(self, fake_redis):
-        """Before CHAOS-2697 lands, processor.py doesn't exist -- the
-        give-up path must log and continue, not crash the consumer loop."""
+    def test_missing_processor_module_does_not_crash_consumer(
+        self, fake_redis, monkeypatch
+    ):
+        """Rollback scenario: if a deploy removes CHAOS-2697's processor.py
+        again, the give-up path must log and continue, not crash the consumer
+        loop. Simulated by poisoning the sys.modules entry (a ``None`` value
+        makes ``import`` raise ImportError) under the REAL resolver."""
+        monkeypatch.setattr(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_resolve_mark_batch_failed",
+            staticmethod(_REAL_RESOLVE_MARK_BATCH_FAILED),
+        )
+        monkeypatch.setitem(
+            sys.modules, "dev_health_ops.external_ingest.processor", None
+        )
         stream, _entry_id = _xadd_batch(fake_redis, org_id="org-no-processor")
         c = _consumer()
         with patch.object(
@@ -319,6 +363,11 @@ class TestReclaim:
         # above) exercises the awaited counterpart; this test is the sync
         # counterpart's regression coverage for the same class of bug (a
         # nested/re-entrant run_async() call would raise here).
+        monkeypatch.setattr(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_resolve_mark_batch_failed",
+            staticmethod(_REAL_RESOLVE_MARK_BATCH_FAILED),
+        )
         fake_processor = types.ModuleType("dev_health_ops.external_ingest.processor")
         mark_failed = AsyncMock()
         setattr(
@@ -518,11 +567,12 @@ class TestProcessorAvailabilityGuard:
 
     def test_processor_available_reflects_real_import(self):
         """Sanity check on the real (unmocked) helper: CHAOS-2697's module
-        genuinely does not exist yet at this issue's implementation time.
-        Uses the reference captured at collection time (module docstring
-        note above) since the autouse fixture in this file replaces
+        exists now, so the deployment-order guard genuinely passes — this is
+        the assertion that "merging processor.py arms the consumer". Uses the
+        reference captured at collection time (module docstring note above)
+        since the autouse fixture in this file replaces
         ``consumer_mod._processor_available`` for every other test."""
-        assert _REAL_PROCESSOR_AVAILABLE() is False
+        assert _REAL_PROCESSOR_AVAILABLE() is True
 
 
 class TestIdempotentSkipGuard:

--- a/tests/api/test_external_ingest_consumer.py
+++ b/tests/api/test_external_ingest_consumer.py
@@ -334,8 +334,13 @@ class TestReclaim:
         assert len(pending_before) == 1
         assert pending_before[0]["times_delivered"] == 1
 
-        # Second pass: reclaim_stale() picks it up (idle=0 means everything
-        # is eligible), process_entry now succeeds.
+        # Second pass: reclaim_stale() picks it up, process_entry now
+        # succeeds. The sleep is load-bearing: fakeredis's XPENDING IDLE
+        # filter requires actual elapsed wall-clock ms (idle=0 does NOT mean
+        # "always eligible" -- see the identical note in the give-up test
+        # below); back-to-back consume() calls can land in the same 0ms tick
+        # under -n-distributed parallel load, making reclaim find nothing.
+        time.sleep(0.01)
         with patch.object(
             consumer_mod.ExternalIngestStreamConsumer,
             "_process_entry_async",
@@ -414,6 +419,53 @@ class TestReclaim:
         mark_failed.assert_awaited_once()
         _args, kwargs = mark_failed.call_args
         assert kwargs["reason"] == "max_deliveries_exceeded"
+
+    def test_give_up_with_failing_mark_batch_failed_leaves_entry_unacked(
+        self, fake_redis, monkeypatch
+    ):
+        """CHAOS-2697 adversarial-review HIGH: the sync give-up path
+        (``reclaim_stale() -> move_to_dlq``) must NOT ACK when the DLQ write
+        succeeded but ``mark_batch_failed`` raised -- ACKing would strand the
+        batch in a non-terminal status with its only retry handle gone (a
+        ``processing`` row REPLAYs, never RETRYs). Sync twin of
+        ``test_mark_batch_failed_raising_leaves_entry_unacked`` above."""
+        monkeypatch.setattr(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_resolve_mark_batch_failed",
+            staticmethod(_REAL_RESOLVE_MARK_BATCH_FAILED),
+        )
+        fake_processor = types.ModuleType("dev_health_ops.external_ingest.processor")
+        mark_failed = AsyncMock(side_effect=RuntimeError("pg down"))
+        setattr(fake_processor, "mark_batch_failed", mark_failed)
+        monkeypatch.setitem(
+            sys.modules, "dev_health_ops.external_ingest.processor", fake_processor
+        )
+
+        stream, entry_id = _xadd_batch(fake_redis, org_id="org-giveup-markfail")
+        c = _consumer(reclaim_idle_ms=0, max_deliveries=1)
+
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_process_entry_async",
+            AsyncMock(side_effect=RuntimeError("still broken")),
+        ):
+            # iter 1: fresh read, delivery #1, fails transiently, pending.
+            c.consume(max_iterations=1)
+            # iter 2: reclaim_stale sees delivery #1 >= max_deliveries(1) ->
+            # give-up -> DLQ write SUCCEEDS but mark_batch_failed raises ->
+            # move_to_dlq must return False -> entry must stay pending.
+            time.sleep(0.01)
+            c.consume(max_iterations=1)
+
+        mark_failed.assert_awaited_once()
+        dlq_entries = fake_redis.xrange("external-ingest:org-giveup-markfail:dlq")
+        assert len(dlq_entries) == 1  # the DLQ record itself was written...
+        pending = fake_redis.xpending_range(
+            stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
+        )
+        # ...but the source entry keeps its retry handle for the status write.
+        assert len(pending) == 1
+        assert pending[0]["message_id"] == entry_id
 
 
 class TestPerOrgDlqIsolation:

--- a/tests/api/test_external_ingest_consumer.py
+++ b/tests/api/test_external_ingest_consumer.py
@@ -15,6 +15,7 @@ import time
 import types
 import uuid
 from contextlib import asynccontextmanager
+from typing import Any
 from unittest.mock import AsyncMock, patch
 
 import pytest
@@ -216,11 +217,13 @@ class TestPermanentFailure:
     def test_mark_batch_failed_raising_leaves_entry_unacked(
         self, fake_redis, monkeypatch
     ):
-        """Adversarial-review rounds 2 (2693) + 2 (2697): when the
-        failed-status write raises, the entry must NOT be ACKed (the batch
-        would strand non-terminal with the entry gone) AND -- mark-first
-        ordering -- no DLQ row may be written yet, or every retry would XADD
-        a duplicate into the capped DLQ during a Postgres outage."""
+        """Adversarial-review rounds 1-3 (CHAOS-2697): when the failed-status
+        write raises, the entry must NOT be ACKed (the batch would strand
+        non-terminal with the entry gone), the DLQ row IS written (DLQ-first
+        ordering -- round 3: mark-first lost the row entirely when the XADD
+        failed after a successful mark), and retry cycles must NOT
+        accumulate duplicate DLQ rows (round 2: the per-entry marker
+        dedups)."""
         monkeypatch.setattr(
             consumer_mod.ExternalIngestStreamConsumer,
             "_resolve_mark_batch_failed",
@@ -236,19 +239,26 @@ class TestPermanentFailure:
         stream, _entry_id = _xadd_batch(
             fake_redis, org_id="org-mark-raises", ingestion_id="ingest-mark-raises"
         )
-        c = _consumer()
+        c = _consumer(reclaim_idle_ms=0)
         with patch.object(
             consumer_mod.ExternalIngestStreamConsumer,
             "_process_entry_async",
             AsyncMock(side_effect=PermanentProcessingError("nope")),
         ):
             c.consume(max_iterations=1)
+            # Retry cycle (reclaim redelivers the still-pending entry; the
+            # sleep is the fakeredis XPENDING-idle requirement documented in
+            # TestReclaim): the mark fails again, and the marker must
+            # suppress a duplicate DLQ row.
+            time.sleep(0.01)
+            c.consume(max_iterations=1)
 
-        mark_failed.assert_awaited_once()
-        # Mark-first ordering: no DLQ row until the status write is durable
-        # (retries must not accumulate duplicates in the capped DLQ)...
+        assert mark_failed.await_count == 2
+        # DLQ-first ordering: the row IS written (round 3: mark-first lost it
+        # when the XADD failed after the mark landed) -- exactly once across
+        # both attempts (round 2: marker dedup)...
         dlq_entries = fake_redis.xrange("external-ingest:org-mark-raises:dlq")
-        assert dlq_entries == []
+        assert len(dlq_entries) == 1
         # ...and the source entry remains pending (NOT acked) for a retry.
         pending = fake_redis.xpending_range(
             stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
@@ -428,9 +438,10 @@ class TestReclaim:
         (``reclaim_stale() -> move_to_dlq``) must NOT ACK when
         ``mark_batch_failed`` raised -- ACKing would strand the batch in a
         non-terminal status with its only retry handle gone (a ``processing``
-        row REPLAYs, never RETRYs). Round-2 refinement: mark-first ordering
-        means no DLQ row is written either, so outage retries cannot flood
-        the capped DLQ. Sync twin of
+        row REPLAYs, never RETRYs). Rounds 2-3 refinement: the DLQ row IS
+        written (DLQ-first; mark-first lost it on XADD failure) but exactly
+        once across retry cycles (marker dedup -- outage retries previously
+        flooded the capped DLQ). Sync twin of
         ``test_mark_batch_failed_raising_leaves_entry_unacked`` above."""
         monkeypatch.setattr(
             consumer_mod.ExternalIngestStreamConsumer,
@@ -459,11 +470,15 @@ class TestReclaim:
             # move_to_dlq must return False -> entry must stay pending.
             time.sleep(0.01)
             c.consume(max_iterations=1)
+            # iter 3: give-up retried -- the marker must dedup the DLQ row
+            # while the mark keeps failing.
+            time.sleep(0.01)
+            c.consume(max_iterations=1)
 
-        mark_failed.assert_awaited_once()
-        # Mark-first: no DLQ row while the status write keeps failing...
+        assert mark_failed.await_count == 2
+        # DLQ-first: exactly one DLQ row across both give-up attempts...
         dlq_entries = fake_redis.xrange("external-ingest:org-giveup-markfail:dlq")
-        assert dlq_entries == []
+        assert len(dlq_entries) == 1
         pending = fake_redis.xpending_range(
             stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
         )
@@ -611,6 +626,55 @@ class TestMoveToDlqFailureIsSwallowed:
         assert len(pending) == 1
         assert pending[0]["message_id"] == entry_id
         assert broken.xrange("external-ingest:org-dlq-broken-reclaim:dlq") == []
+
+    def test_broken_dlq_xadd_never_marks_batch_failed(self, monkeypatch):
+        """CHAOS-2697 adversarial round 3: with DLQ-first ordering, a failed
+        DLQ XADD must leave the batch UNMARKED. Marking first would let the
+        idempotent-skip guard ACK the redelivered entry (the batch is now
+        terminal) before the DLQ write is ever retried -- silent DLQ loss.
+        Once the DLQ write recovers, the mark proceeds and the entry may be
+        ACKed."""
+
+        class FlakyDlq(FakeValkey):
+            fail_next = True
+
+            def xadd(self, name, *args, **kwargs):
+                if name.endswith(":dlq") and FlakyDlq.fail_next:
+                    FlakyDlq.fail_next = False
+                    raise ConnectionError("dlq blip")
+                return super().xadd(name, *args, **kwargs)
+
+        FlakyDlq.fail_next = True
+        # Any: valkey's sync xrange is typed Awaitable-or-value; the untyped
+        # fake fixtures elsewhere in this file get the same treatment.
+        rc: Any = FlakyDlq(decode_responses=True)
+        stream, entry_id = _xadd_batch(rc, org_id="org-dlq-flaky")
+
+        monkeypatch.setattr(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_resolve_mark_batch_failed",
+            staticmethod(_REAL_RESOLVE_MARK_BATCH_FAILED),
+        )
+        fake_processor = types.ModuleType("dev_health_ops.external_ingest.processor")
+        mark_failed = AsyncMock()
+        setattr(fake_processor, "mark_batch_failed", mark_failed)
+        monkeypatch.setitem(
+            sys.modules, "dev_health_ops.external_ingest.processor", fake_processor
+        )
+        c = _consumer()
+
+        # Attempt 1: XADD fails -> not safe to ACK, and crucially the batch
+        # was never marked (nothing for the terminal-skip guard to see).
+        assert c.move_to_dlq(rc, stream, entry_id, "gave up") is False
+        mark_failed.assert_not_awaited()
+        assert rc.xrange("external-ingest:org-dlq-flaky:dlq") == []
+
+        # Attempt 2 (retry): DLQ recovers -> row written -> mark runs ->
+        # safe to ACK.
+        assert c.move_to_dlq(rc, stream, entry_id, "gave up") is True
+        mark_failed.assert_awaited_once()
+        dlq_entries = rc.xrange("external-ingest:org-dlq-flaky:dlq")
+        assert len(dlq_entries) == 1
 
 
 class TestProcessorAvailabilityGuard:

--- a/tests/api/test_external_ingest_consumer.py
+++ b/tests/api/test_external_ingest_consumer.py
@@ -676,6 +676,51 @@ class TestMoveToDlqFailureIsSwallowed:
         dlq_entries = rc.xrange("external-ingest:org-dlq-flaky:dlq")
         assert len(dlq_entries) == 1
 
+    def test_marker_hit_rewrites_when_original_dlq_row_trimmed(self, fake_redis):
+        """CHAOS-2697 adversarial round 4 HIGH: the dedup marker must not
+        suppress a fresh DLQ write once the original row has been trimmed
+        from the capped stream. Otherwise a mark/ACK after trimming leaves a
+        failed batch with no surviving DLQ record -- silent DLQ loss under
+        sustained pressure. On a marker hit the code verifies the stored
+        stream-id is still present and, if trimmed, writes a fresh row."""
+        stream, entry_id = _xadd_batch(fake_redis, org_id="org-dlq-trim")
+        c = _consumer()
+        dlq = "external-ingest:org-dlq-trim:dlq"
+
+        assert c.move_to_dlq(fake_redis, stream, entry_id, "gave up") is True
+        first = fake_redis.xrange(dlq)
+        assert len(first) == 1
+        marker = f"{dlq}:written:{entry_id}"
+        # The marker stores the DLQ stream-id, not a bare flag.
+        assert fake_redis.get(marker) == first[0][0]
+
+        # Simulate the capped stream trimming the original row out.
+        fake_redis.xdel(dlq, first[0][0])
+        assert fake_redis.xrange(dlq) == []
+
+        # Retry: marker still points at the now-gone id -> must write fresh.
+        # The empty-then-non-empty transition proves a fresh XADD happened
+        # (a marker-only short-circuit would leave the stream empty -- the
+        # round-4 silent-loss bug). Not asserting id-inequality: fakeredis
+        # resets a drained stream's auto-id to <ms>-0 and can collide within
+        # one millisecond, unlike real Redis's monotonic last_id.
+        assert c.move_to_dlq(fake_redis, stream, entry_id, "gave up") is True
+        second = fake_redis.xrange(dlq)
+        assert len(second) == 1
+        assert fake_redis.get(marker) == second[0][0]
+
+    def test_marker_hit_with_surviving_row_does_not_duplicate(self, fake_redis):
+        """The dedup still holds when the original row survives (round-2
+        property preserved by the round-4 change): a marker hit whose stored
+        id is still present short-circuits without a second XADD."""
+        stream, entry_id = _xadd_batch(fake_redis, org_id="org-dlq-keep")
+        c = _consumer()
+        dlq = "external-ingest:org-dlq-keep:dlq"
+
+        assert c.move_to_dlq(fake_redis, stream, entry_id, "gave up") is True
+        assert c.move_to_dlq(fake_redis, stream, entry_id, "gave up") is True
+        assert len(fake_redis.xrange(dlq)) == 1
+
 
 class TestProcessorAvailabilityGuard:
     """Deployment-order guard (adversarial-review finding): before

--- a/tests/api/test_external_ingest_consumer.py
+++ b/tests/api/test_external_ingest_consumer.py
@@ -216,11 +216,11 @@ class TestPermanentFailure:
     def test_mark_batch_failed_raising_leaves_entry_unacked(
         self, fake_redis, monkeypatch
     ):
-        """Adversarial-review round-2: a DLQ-written entry must NOT be ACKed
-        when the failed-status write raised -- otherwise the batch strands in
-        a non-terminal status while the entry is gone. Leaving it pending
-        lets a later redelivery retry the status write (a duplicate DLQ entry
-        on that retry is accepted operational noise)."""
+        """Adversarial-review rounds 2 (2693) + 2 (2697): when the
+        failed-status write raises, the entry must NOT be ACKed (the batch
+        would strand non-terminal with the entry gone) AND -- mark-first
+        ordering -- no DLQ row may be written yet, or every retry would XADD
+        a duplicate into the capped DLQ during a Postgres outage."""
         monkeypatch.setattr(
             consumer_mod.ExternalIngestStreamConsumer,
             "_resolve_mark_batch_failed",
@@ -245,10 +245,11 @@ class TestPermanentFailure:
             c.consume(max_iterations=1)
 
         mark_failed.assert_awaited_once()
-        # DLQ entry was written...
+        # Mark-first ordering: no DLQ row until the status write is durable
+        # (retries must not accumulate duplicates in the capped DLQ)...
         dlq_entries = fake_redis.xrange("external-ingest:org-mark-raises:dlq")
-        assert len(dlq_entries) == 1
-        # ...but the source entry remains pending (NOT acked) for a retry.
+        assert dlq_entries == []
+        # ...and the source entry remains pending (NOT acked) for a retry.
         pending = fake_redis.xpending_range(
             stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
         )
@@ -424,10 +425,12 @@ class TestReclaim:
         self, fake_redis, monkeypatch
     ):
         """CHAOS-2697 adversarial-review HIGH: the sync give-up path
-        (``reclaim_stale() -> move_to_dlq``) must NOT ACK when the DLQ write
-        succeeded but ``mark_batch_failed`` raised -- ACKing would strand the
-        batch in a non-terminal status with its only retry handle gone (a
-        ``processing`` row REPLAYs, never RETRYs). Sync twin of
+        (``reclaim_stale() -> move_to_dlq``) must NOT ACK when
+        ``mark_batch_failed`` raised -- ACKing would strand the batch in a
+        non-terminal status with its only retry handle gone (a ``processing``
+        row REPLAYs, never RETRYs). Round-2 refinement: mark-first ordering
+        means no DLQ row is written either, so outage retries cannot flood
+        the capped DLQ. Sync twin of
         ``test_mark_batch_failed_raising_leaves_entry_unacked`` above."""
         monkeypatch.setattr(
             consumer_mod.ExternalIngestStreamConsumer,
@@ -458,14 +461,45 @@ class TestReclaim:
             c.consume(max_iterations=1)
 
         mark_failed.assert_awaited_once()
+        # Mark-first: no DLQ row while the status write keeps failing...
         dlq_entries = fake_redis.xrange("external-ingest:org-giveup-markfail:dlq")
-        assert len(dlq_entries) == 1  # the DLQ record itself was written...
+        assert dlq_entries == []
         pending = fake_redis.xpending_range(
             stream, consumer_mod.CONSUMER_GROUP, min="-", max="+", count=10
         )
-        # ...but the source entry keeps its retry handle for the status write.
+        # ...and the source entry keeps its retry handle for the status write.
         assert len(pending) == 1
         assert pending[0]["message_id"] == entry_id
+
+    def test_give_up_transient_field_reread_failure_does_not_ack(self, fake_redis):
+        """CHAOS-2697 adversarial-review round-2 HIGH: a transient XRANGE
+        failure while re-reading the entry's fields must not be treated as
+        safe-to-ACK -- the batch would never be marked failed and its retry
+        handle would vanish. move_to_dlq must return False (retry later)."""
+        stream, entry_id = _xadd_batch(fake_redis, org_id="org-xrange-fail")
+        c = _consumer()
+        with patch.object(
+            consumer_mod.ExternalIngestStreamConsumer,
+            "_fetch_entry_fields",
+            lambda self, rc, sk, eid: None,
+        ):
+            assert c.move_to_dlq(fake_redis, stream, entry_id, "gave up") is False
+        assert fake_redis.xrange("external-ingest:org-xrange-fail:dlq") == []
+
+    def test_give_up_trimmed_entry_writes_tombstone_and_acks(self, fake_redis):
+        """An entry MAXLEN-trimmed while pending has no recoverable fields:
+        nothing addressable to mark, so the give-up path writes a tombstone
+        DLQ row and reports safe-to-ACK -- the possibly-stranded batch row is
+        the CHAOS-2769 orphan reconciler's target, not a reason to retry a
+        re-read that is authoritatively empty forever."""
+        c = _consumer()
+        stream = "external-ingest:org-trimmed:batches"
+        # Entry ID that was never XADDed: XRANGE succeeds and returns [].
+        assert c.move_to_dlq(fake_redis, stream, "0-1", "gave up") is True
+        dlq_entries = fake_redis.xrange("external-ingest:org-trimmed:dlq")
+        assert len(dlq_entries) == 1
+        assert dlq_entries[0][1]["ingestion_id"] == ""
+        assert dlq_entries[0][1]["org_id"] == "org-trimmed"
 
 
 class TestPerOrgDlqIsolation:

--- a/tests/external_ingest/test_normalize.py
+++ b/tests/external_ingest/test_normalize.py
@@ -1,0 +1,261 @@
+"""Unit tests for external_ingest.normalize (CHAOS-2697).
+
+Pure — no services, no mocks of our own modules: ``normalize_batch`` runs the
+real ``validate_records`` (CC17) and the real pydantic kind models, so these
+tests pin the actual reject/accept decisions the worker will make.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from dev_health_ops.api.external_ingest.schemas import (
+    RECORD_KIND_MODELS,
+    RecordEnvelope,
+)
+from dev_health_ops.external_ingest.normalize import (
+    ALLOWED_KINDS_BY_SYSTEM,
+    normalize_batch,
+)
+
+ORG = "org-1"
+SOURCE_ID = uuid.uuid4()
+INGESTION_ID = uuid.uuid4()
+INSTANCE = "acme/api"
+
+#: One minimal VALID payload per kind (github vocabulary, scoped to INSTANCE).
+VALID_PAYLOADS: dict[str, dict] = {
+    "repository.v1": {"externalId": INSTANCE, "sourceSystem": "github"},
+    "identity.v1": {"canonicalId": "u1", "updatedAt": "2026-07-01T00:00:00Z"},
+    "team.v1": {"id": "t1", "name": "Team One", "updatedAt": "2026-07-01T00:00:00Z"},
+    "work_item.v1": {
+        "externalKey": "42",
+        "provider": "github",
+        "title": "Fix it",
+        "status": "todo",
+        "createdAt": "2026-07-01T00:00:00Z",
+    },
+    "work_item_transition.v1": {
+        "externalKey": "42",
+        "provider": "github",
+        "occurredAt": "2026-07-01T01:00:00Z",
+        "fromStatus": "todo",
+        "toStatus": "in_progress",
+    },
+    "work_item_dependency.v1": {
+        "sourceExternalKey": "42",
+        "targetExternalKey": "43",
+        "relationshipType": "blocks",
+    },
+    "pull_request.v1": {
+        "repositoryExternalId": INSTANCE,
+        "number": 7,
+        "state": "merged",
+        "createdAt": "2026-07-01T00:00:00Z",
+    },
+    "review.v1": {
+        "repositoryExternalId": INSTANCE,
+        "pullRequestNumber": 7,
+        "reviewId": "r1",
+        "reviewer": "alice",
+        "state": "APPROVED",
+        "submittedAt": "2026-07-01T02:00:00Z",
+    },
+    "commit.v1": {
+        "repositoryExternalId": INSTANCE,
+        "hash": "abc1234",
+        "authorWhen": "2026-07-01T00:00:00Z",
+    },
+}
+
+#: kind -> (NormalizedBatch list attribute, record_index_by_kind key)
+_EXPECTED_PLACEMENT = {
+    "repository.v1": ("repositories", "repository"),
+    "identity.v1": ("identities", "identity"),
+    "team.v1": ("teams", "team"),
+    "work_item.v1": ("work_items", "work_item"),
+    "work_item_transition.v1": ("work_item_transitions", "work_item_transition"),
+    "work_item_dependency.v1": ("work_item_dependencies", "work_item_dependency"),
+    "pull_request.v1": ("pull_requests", "pull_request"),
+    "review.v1": ("reviews", "review"),
+    "commit.v1": ("commits", "commit"),
+}
+
+
+def _rec(
+    kind: str, payload: dict | None = None, external_id: str = "x-1"
+) -> RecordEnvelope:
+    return RecordEnvelope(
+        kind=kind,
+        external_id=external_id,
+        payload=VALID_PAYLOADS[kind] if payload is None else payload,
+    )
+
+
+def _normalize(records, *, source_system="github", source_instance=INSTANCE):
+    return normalize_batch(
+        org_id=ORG,
+        source_id=SOURCE_ID,
+        source_system=source_system,
+        source_instance=source_instance,
+        ingestion_id=INGESTION_ID,
+        records=records,
+    )
+
+
+class TestHappyPath:
+    def test_all_nine_kinds_accepted_and_placed(self) -> None:
+        records = [_rec(kind) for kind in VALID_PAYLOADS]
+        result = _normalize(records)
+
+        assert result.items_received == 9
+        assert result.items_rejected == 0
+        assert result.items_accepted == 9
+        assert result.record_counts == {kind: 1 for kind in VALID_PAYLOADS}
+        for index, kind in enumerate(VALID_PAYLOADS):
+            attr, index_key = _EXPECTED_PLACEMENT[kind]
+            assert len(getattr(result.batch, attr)) == 1, kind
+            assert result.batch.record_index_by_kind[index_key] == [index], kind
+
+    def test_dict_kinds_dump_snake_case_keys(self) -> None:
+        result = _normalize([_rec("pull_request.v1")])
+        (row,) = result.batch.pull_requests
+        assert isinstance(row, dict)
+        # snake_case field names, matching what sinks.py's row builders read.
+        assert row["repository_external_id"] == INSTANCE
+        assert row["number"] == 7
+        assert "repositoryExternalId" not in row
+
+    def test_work_item_family_passes_model_instances(self) -> None:
+        result = _normalize([_rec("work_item.v1")])
+        (item,) = result.batch.work_items
+        assert item.external_key == "42"  # attribute access (sinks duck-types)
+
+    def test_batch_identity_fields_stamped(self) -> None:
+        result = _normalize([_rec("repository.v1")])
+        assert result.batch.org_id == ORG
+        assert result.batch.source_id == SOURCE_ID
+        assert result.batch.ingestion_id == INGESTION_ID
+        assert result.batch.source_system == "github"
+        assert result.batch.source_instance == INSTANCE
+
+
+class TestShapeRejections:
+    def test_invalid_payload_rejected_with_validate_py_code(self) -> None:
+        records = [
+            _rec("repository.v1"),
+            _rec("work_item.v1", payload={"externalKey": "42"}),  # missing required
+        ]
+        result = _normalize(records)
+        assert result.items_accepted == 1
+        assert result.items_rejected == 1
+        (rejection,) = result.rejections
+        assert rejection.index == 1
+        assert rejection.kind == "work_item.v1"
+        assert rejection.code == "missing_required_field"
+        assert rejection.external_id == "x-1"
+        assert rejection.path is not None and "records[1].payload" in rejection.path
+
+    def test_multiple_field_errors_collapse_to_one_rejection(self) -> None:
+        # Three missing required fields -> validate_records emits three
+        # items, but the (ingestion_id, record_index) unique constraint
+        # allows exactly one persisted rejection per record.
+        result = _normalize([_rec("work_item.v1", payload={})])
+        assert result.items_rejected == 1
+        assert result.rejections[0].code == "missing_required_field"
+
+    def test_unknown_kind_rejected(self) -> None:
+        record = RecordEnvelope(kind="nonsense.v9", external_id="x", payload={})
+        result = _normalize([record])
+        (rejection,) = result.rejections
+        assert rejection.code == "unknown_kind"
+
+    def test_rejections_preserve_original_indices(self) -> None:
+        records = [
+            _rec("work_item.v1", payload={}),  # 0: shape reject
+            _rec("commit.v1"),  # 1: accepted
+            _rec("work_item.v1", payload={}),  # 2: shape reject
+        ]
+        result = _normalize(records)
+        assert [r.index for r in result.rejections] == [0, 2]
+        assert result.batch.record_index_by_kind["commit"] == [1]
+
+
+class TestKindSystemMatrix:
+    @pytest.mark.parametrize(
+        "kind", ["repository.v1", "pull_request.v1", "review.v1", "commit.v1"]
+    )
+    def test_git_family_rejected_for_jira_and_linear(self, kind: str) -> None:
+        for system in ("jira", "linear"):
+            result = _normalize([_rec(kind)], source_system=system)
+            (rejection,) = result.rejections
+            assert rejection.code == "unsupported_kind_for_system", (system, kind)
+
+    @pytest.mark.parametrize(
+        "kind",
+        ["work_item.v1", "work_item_transition.v1", "work_item_dependency.v1"],
+    )
+    def test_work_item_family_rejected_for_custom(self, kind: str) -> None:
+        result = _normalize([_rec(kind)], source_system="custom")
+        (rejection,) = result.rejections
+        assert rejection.code == "unsupported_kind_for_system"
+        assert rejection.path == "records[0].kind"
+
+    def test_org_scoped_kinds_accepted_everywhere(self) -> None:
+        for system in ALLOWED_KINDS_BY_SYSTEM:
+            result = _normalize(
+                [_rec("team.v1"), _rec("identity.v1")], source_system=system
+            )
+            assert result.items_rejected == 0, system
+
+    def test_matrix_matches_master_spec_cc6(self) -> None:
+        git = {"repository.v1", "pull_request.v1", "review.v1", "commit.v1"}
+        wi = {"work_item.v1", "work_item_transition.v1", "work_item_dependency.v1"}
+        org = {"team.v1", "identity.v1"}
+        assert ALLOWED_KINDS_BY_SYSTEM["github"] == git | wi | org
+        assert ALLOWED_KINDS_BY_SYSTEM["gitlab"] == git | wi | org
+        assert ALLOWED_KINDS_BY_SYSTEM["jira"] == wi | org
+        assert ALLOWED_KINDS_BY_SYSTEM["linear"] == wi | org
+        assert ALLOWED_KINDS_BY_SYSTEM["custom"] == git | org
+        # Every kind the wire schema knows is reachable through some system.
+        reachable = frozenset().union(*ALLOWED_KINDS_BY_SYSTEM.values())
+        assert reachable == set(RECORD_KIND_MODELS)
+
+
+class TestInstanceScope:
+    def test_out_of_instance_git_record_rejected(self) -> None:
+        payload = dict(VALID_PAYLOADS["commit.v1"], repositoryExternalId="other/repo")
+        result = _normalize([_rec("commit.v1", payload=payload)])
+        (rejection,) = result.rejections
+        assert rejection.code == "record_outside_source_instance"
+
+    def test_out_of_instance_repository_rejected_via_own_external_id(self) -> None:
+        payload = {"externalId": "other/repo", "sourceSystem": "github"}
+        result = _normalize([_rec("repository.v1", payload=payload)])
+        (rejection,) = result.rejections
+        assert rejection.code == "record_outside_source_instance"
+
+    def test_case_variant_instance_accepted(self) -> None:
+        # GitHub identifiers are case-insensitive and derive_repo_uuid
+        # lower-cases its seed: a case variant is the SAME repo, not an
+        # out-of-scope one (module docstring rationale).
+        payload = dict(VALID_PAYLOADS["commit.v1"], repositoryExternalId="Acme/API")
+        result = _normalize([_rec("commit.v1", payload=payload)])
+        assert result.items_rejected == 0
+
+    def test_work_item_family_not_instance_scoped(self) -> None:
+        # CC6 scopes only the git family; a work item referencing another
+        # repo is allowed (repo linkage is optional metadata there).
+        payload = dict(
+            VALID_PAYLOADS["work_item.v1"], repositoryExternalId="other/repo"
+        )
+        result = _normalize([_rec("work_item.v1", payload=payload)])
+        assert result.items_rejected == 0
+
+    def test_jira_batches_never_instance_scoped(self) -> None:
+        result = _normalize(
+            [_rec("work_item.v1")], source_system="jira", source_instance="ABC"
+        )
+        assert result.items_rejected == 0

--- a/tests/external_ingest/test_processor.py
+++ b/tests/external_ingest/test_processor.py
@@ -588,6 +588,11 @@ class TestMarkBatchFailed:
             "system_failure": True,
             "reason": "max_deliveries_exceeded",
         }
+        # Counter invariant (adversarial round 2): failed = zero accepted;
+        # the whole batch counts as rejected for GET/list consumers.
+        assert row.items_accepted == 0
+        assert row.items_rejected == row.items_received == 1
+        assert row.record_counts is None
         assert row.completed_at is not None
         async with session_maker() as session:
             assert not await payload_exists(

--- a/tests/external_ingest/test_processor.py
+++ b/tests/external_ingest/test_processor.py
@@ -1,0 +1,634 @@
+"""Unit tests for external_ingest.processor (CHAOS-2697).
+
+Real aiosqlite-backed status/payload/source tables (the store SQL actually
+runs — same approach as tests/api/test_external_ingest_router.py); only the
+two out-of-process boundaries are faked: ``sinks.write_batch`` (ClickHouse)
+and ``recompute.schedule_or_coalesce`` (Valkey/Celery).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+import uuid
+from contextlib import asynccontextmanager
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION
+from dev_health_ops.api.external_ingest.status import (
+    create_batch,
+    get_batch,
+    list_rejections,
+)
+from dev_health_ops.external_ingest import processor as processor_mod
+from dev_health_ops.external_ingest import recompute as recompute_mod
+from dev_health_ops.external_ingest.errors import PermanentProcessingError
+from dev_health_ops.external_ingest.payload_store import payload_exists, upsert_payload
+from dev_health_ops.external_ingest.processor import (
+    TransientSinkWriteError,
+    mark_batch_failed,
+    process_batch,
+)
+from dev_health_ops.external_ingest.types import (
+    AffectedScope,
+    SinkWriteError,
+    SinkWriteResult,
+)
+from dev_health_ops.models.external_ingest import (
+    ExternalIngestBatch,
+    ExternalIngestBatchPayload,
+    ExternalIngestRejection,
+)
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
+from tests._helpers import tables_of
+
+ORG = "org-2697"
+SYSTEM = "github"
+INSTANCE = "acme/api"
+REPO_UUID = uuid.uuid4()
+
+_TABLES = tables_of(
+    ExternalIngestBatch,
+    ExternalIngestRejection,
+    ExternalIngestBatchPayload,
+    IngestSource,
+)
+
+VALID_REPO = {
+    "kind": "repository.v1",
+    "externalId": INSTANCE,
+    "payload": {"externalId": INSTANCE, "sourceSystem": "github"},
+}
+VALID_COMMIT = {
+    "kind": "commit.v1",
+    "externalId": f"{INSTANCE}@abc1234",
+    "payload": {
+        "repositoryExternalId": INSTANCE,
+        "hash": "abc1234",
+        "authorWhen": "2026-07-01T00:00:00Z",
+    },
+}
+INVALID_WORK_ITEM = {"kind": "work_item.v1", "externalId": "wi-bad", "payload": {}}
+OUT_OF_INSTANCE_COMMIT = {
+    "kind": "commit.v1",
+    "externalId": "other/repo@def5678",
+    "payload": {
+        "repositoryExternalId": "other/repo",
+        "hash": "def5678",
+        "authorWhen": "2026-07-01T00:00:00Z",
+    },
+}
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'external-ingest-processor.db'}"
+    )
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def source_id(session_maker) -> uuid.UUID:
+    source = IngestSource(
+        org_id=ORG,
+        system=SYSTEM,
+        instance=INSTANCE,
+        mode=IngestSourceMode.CUSTOMER_PUSH.value,
+        enabled=True,
+    )
+    async with session_maker() as session:
+        session.add(source)
+        await session.commit()
+        return source.id
+
+
+@pytest.fixture
+def fake_sink(monkeypatch):
+    """write_batch stand-in: succeeds, reporting one repo in scope."""
+
+    async def _write(batch, *, clickhouse_dsn):
+        return SinkWriteResult(
+            ingestion_id=batch.ingestion_id,
+            org_id=batch.org_id,
+            counts_written={"repository": len(batch.repositories)},
+            errors=[],
+            warnings=[],
+            affected_scope=AffectedScope(
+                org_id=batch.org_id,
+                source_systems={batch.source_system},
+                source_instances={batch.source_instance},
+                repo_ids={REPO_UUID},
+            ),
+        )
+
+    mock = AsyncMock(side_effect=_write)
+    monkeypatch.setattr(processor_mod, "write_batch", mock)
+    return mock
+
+
+@pytest.fixture
+def fake_recompute(monkeypatch):
+    mock = MagicMock()
+    monkeypatch.setattr(processor_mod, "schedule_or_coalesce", mock)
+    return mock
+
+
+@pytest.fixture(autouse=True)
+def _clickhouse_uri(monkeypatch):
+    monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://ch:ch@fake:8123/ci_test")
+
+
+@pytest.fixture(autouse=True)
+def _patched_session(monkeypatch, session_maker):
+    """Mirror the real get_postgres_session semantics (commit on clean exit,
+    rollback + re-raise on exception) against the aiosqlite engine."""
+
+    @asynccontextmanager
+    async def _fake_session():
+        async with session_maker() as session:
+            try:
+                yield session
+                await session.commit()
+            except Exception:
+                await session.rollback()
+                raise
+
+    monkeypatch.setattr(processor_mod, "get_postgres_session", _fake_session)
+
+
+async def _seed_batch(
+    session_maker,
+    *,
+    records: list[dict],
+    status: str | None = None,
+    items_received: int | None = None,
+    envelope_instance: str = INSTANCE,
+    source_instance: str = INSTANCE,
+    with_payload: bool = True,
+) -> str:
+    envelope = {
+        "schemaVersion": SCHEMA_VERSION,
+        "idempotencyKey": "key-2697",
+        "source": {
+            "type": "customer_push",
+            "system": SYSTEM,
+            "instance": envelope_instance,
+        },
+        "records": records,
+    }
+    ingestion_id = uuid.uuid4()
+    async with session_maker() as session:
+        await create_batch(
+            session,
+            ingestion_id=ingestion_id,
+            org_id=ORG,
+            idempotency_key="key-2697",
+            payload_hash="hash-2697",
+            source_system=SYSTEM,
+            source_instance=source_instance,
+            producer=None,
+            producer_version=None,
+            schema_version=SCHEMA_VERSION,
+            window_started_at=None,
+            window_ended_at=None,
+            items_received=(
+                items_received if items_received is not None else len(records)
+            ),
+        )
+        if with_payload:
+            await upsert_payload(
+                session,
+                ingestion_id=str(ingestion_id),
+                org_id=ORG,
+                schema_version=SCHEMA_VERSION,
+                payload_bytes=json.dumps(envelope).encode(),
+            )
+        if status is not None:
+            await session.execute(
+                text(
+                    "UPDATE external_ingest_batches SET status = :status "
+                    "WHERE ingestion_id = :ingestion_id"
+                ),
+                {"status": status, "ingestion_id": str(ingestion_id)},
+            )
+        await session.commit()
+    return str(ingestion_id)
+
+
+async def _get_row(session_maker, ingestion_id: str):
+    async with session_maker() as session:
+        return await get_batch(
+            session, org_id=ORG, ingestion_id=uuid.UUID(ingestion_id)
+        )
+
+
+def _process(ingestion_id: str, **overrides):
+    kwargs = dict(
+        ingestion_id=ingestion_id,
+        org_id=ORG,
+        source_system=SYSTEM,
+        source_instance=INSTANCE,
+        schema_version=SCHEMA_VERSION,
+    )
+    kwargs.update(overrides)
+    return process_batch(**kwargs)
+
+
+@pytest.mark.asyncio
+class TestHappyPath:
+    async def test_completes_batch_end_to_end(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(
+            session_maker, records=[VALID_REPO, VALID_COMMIT]
+        )
+
+        accepted = await _process(ingestion_id)
+
+        assert accepted == 2
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None
+        assert row.status == "completed"
+        assert row.items_accepted == 2
+        assert row.items_rejected == 0
+        assert row.record_counts == {"repository.v1": 1, "commit.v1": 1}
+        assert row.completed_at is not None
+        fake_sink.assert_awaited_once()
+        # CC9: payload row deleted on terminal status.
+        async with session_maker() as session:
+            assert not await payload_exists(
+                session, ingestion_id=ingestion_id, org_id=ORG
+            )
+
+    async def test_source_id_stamped_from_registry_case_insensitively(
+        self, session_maker, fake_sink, fake_recompute
+    ):
+        # Registered casing differs from the pointer's — CHAOS-2695 blocks
+        # case-variant duplicates, so a lower() match is the same source.
+        source = IngestSource(
+            org_id=ORG,
+            system=SYSTEM,
+            instance="Acme/API",
+            mode=IngestSourceMode.CUSTOMER_PUSH.value,
+            enabled=True,
+        )
+        async with session_maker() as session:
+            session.add(source)
+            await session.commit()
+            expected_source_id = source.id
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+
+        await _process(ingestion_id)
+
+        (batch_arg,), _kwargs = fake_sink.await_args
+        assert batch_arg.source_id == expected_source_id
+        assert batch_arg.org_id == ORG
+
+    async def test_recompute_dispatched_once_with_planner_vocabulary(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(
+            session_maker, records=[VALID_REPO, VALID_COMMIT]
+        )
+
+        await _process(ingestion_id)
+
+        fake_recompute.assert_called_once()
+        kwargs = fake_recompute.call_args.kwargs
+        # Kwargs must bind the REAL schedule_or_coalesce signature — the
+        # celery-signature-contract rule: drift fails here, not silently.
+        inspect.signature(recompute_mod.schedule_or_coalesce).bind(**kwargs)
+        assert kwargs["org_id"] == ORG
+        assert kwargs["ingestion_id"] == ingestion_id
+        assert kwargs["repo_ids"] == {str(REPO_UUID)}
+        # FULL kind names (planner's .v1 vocabulary), not sink bare names.
+        assert kwargs["record_kinds"] == {"repository.v1", "commit.v1"}
+
+    async def test_second_invocation_is_an_idempotent_skip(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+        assert await _process(ingestion_id) == 1
+
+        assert await _process(ingestion_id) == 0
+
+        fake_sink.assert_awaited_once()  # not re-written on replay
+        fake_recompute.assert_called_once()
+
+    async def test_stream_unavailable_batch_is_processed(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        # A 503'd accept whose XADD actually landed: expected duplicate
+        # pointer for a stream_unavailable row — process it, don't wedge.
+        ingestion_id = await _seed_batch(
+            session_maker, records=[VALID_REPO], status="stream_unavailable"
+        )
+
+        accepted = await _process(ingestion_id)
+
+        assert accepted == 1
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None and row.status == "completed"
+
+
+@pytest.mark.asyncio
+class TestRejections:
+    async def test_partial_batch_persists_collapsed_rejections(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(
+            session_maker,
+            records=[VALID_COMMIT, INVALID_WORK_ITEM, OUT_OF_INSTANCE_COMMIT],
+        )
+
+        accepted = await _process(ingestion_id)
+
+        assert accepted == 1
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None
+        assert row.status == "partial"
+        assert row.items_accepted == 1
+        assert row.items_rejected == 2
+        assert row.record_counts == {"commit.v1": 1}
+        async with session_maker() as session:
+            rejections, total_stored = await list_rejections(
+                session, org_id=ORG, ingestion_id=uuid.UUID(ingestion_id)
+            )
+        assert total_stored == 2
+        by_index = {r.record_index: r for r in rejections}
+        assert set(by_index) == {1, 2}
+        assert by_index[1].code == "missing_required_field"
+        assert by_index[2].code == "record_outside_source_instance"
+
+    async def test_all_rejected_becomes_failed_and_skips_sinks(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(session_maker, records=[INVALID_WORK_ITEM])
+
+        accepted = await _process(ingestion_id)
+
+        assert accepted == 0
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None and row.status == "failed"
+        fake_sink.assert_not_awaited()
+        fake_recompute.assert_not_called()
+        async with session_maker() as session:
+            assert not await payload_exists(
+                session, ingestion_id=ingestion_id, org_id=ORG
+            )
+
+
+@pytest.mark.asyncio
+class TestSinkRetryLadder:
+    async def test_persistent_sink_errors_raise_transient_after_ladder(
+        self, session_maker, source_id, fake_recompute, monkeypatch
+    ):
+        error = SinkWriteError(
+            record_index=-1,
+            kind="repository",
+            external_id=None,
+            code="clickhouse_insert_failed",
+            message="connection refused",
+        )
+
+        async def _failing_write(batch, *, clickhouse_dsn):
+            return SinkWriteResult(
+                ingestion_id=batch.ingestion_id,
+                org_id=batch.org_id,
+                errors=[error],
+                affected_scope=AffectedScope(org_id=batch.org_id),
+            )
+
+        write_mock = AsyncMock(side_effect=_failing_write)
+        monkeypatch.setattr(processor_mod, "write_batch", write_mock)
+        sleeps: list[float] = []
+
+        async def _fake_sleep(delay):
+            sleeps.append(delay)
+
+        monkeypatch.setattr(asyncio, "sleep", _fake_sleep)
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+
+        with pytest.raises(TransientSinkWriteError):
+            await _process(ingestion_id)
+
+        assert write_mock.await_count == 4  # initial + one per backoff step
+        assert sleeps == [2.0, 4.0, 8.0]
+        row = await _get_row(session_maker, ingestion_id)
+        # Transient: batch stays in-flight for the reclaim ladder; payload
+        # survives so the retry can re-run the whole thing.
+        assert row is not None and row.status == "processing"
+        async with session_maker() as session:
+            assert await payload_exists(session, ingestion_id=ingestion_id, org_id=ORG)
+        fake_recompute.assert_not_called()
+
+    async def test_recovery_mid_ladder_completes(
+        self, session_maker, source_id, fake_recompute, monkeypatch
+    ):
+        error = SinkWriteError(
+            record_index=-1,
+            kind="repository",
+            external_id=None,
+            code="clickhouse_insert_failed",
+            message="blip",
+        )
+        outcomes = iter([[error], [error], []])
+
+        async def _flaky_write(batch, *, clickhouse_dsn):
+            return SinkWriteResult(
+                ingestion_id=batch.ingestion_id,
+                org_id=batch.org_id,
+                errors=next(outcomes),
+                affected_scope=AffectedScope(org_id=batch.org_id),
+            )
+
+        write_mock = AsyncMock(side_effect=_flaky_write)
+        monkeypatch.setattr(processor_mod, "write_batch", write_mock)
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+
+        accepted = await _process(ingestion_id)
+
+        assert accepted == 1
+        assert write_mock.await_count == 3
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None and row.status == "completed"
+
+
+@pytest.mark.asyncio
+class TestPermanentFailures:
+    async def test_schema_version_mismatch(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+
+        with pytest.raises(PermanentProcessingError, match="schema version"):
+            await _process(ingestion_id, schema_version="external-ingest.v2")
+
+        row = await _get_row(session_maker, ingestion_id)
+        # Raised before mark_processing: still retryable-accepted.
+        assert row is not None and row.status == "accepted"
+
+    async def test_unknown_source_system(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+        with pytest.raises(PermanentProcessingError, match="source system"):
+            await _process(ingestion_id, source_system="subversion")
+
+    async def test_non_uuid_ingestion_id(self, source_id, fake_sink, fake_recompute):
+        with pytest.raises(PermanentProcessingError, match="non-UUID"):
+            await _process("not-a-uuid")
+
+    async def test_missing_status_row(self, source_id, fake_sink, fake_recompute):
+        with pytest.raises(PermanentProcessingError, match="no status row"):
+            await _process(str(uuid.uuid4()))
+
+    async def test_missing_payload(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(
+            session_maker, records=[VALID_REPO], with_payload=False
+        )
+        with pytest.raises(PermanentProcessingError, match="payload row"):
+            await _process(ingestion_id)
+
+    async def test_unregistered_source(self, session_maker, fake_sink, fake_recompute):
+        # No IngestSource row seeded at all (deleted after accept).
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+        with pytest.raises(
+            PermanentProcessingError, match="no registered ingest source"
+        ):
+            await _process(ingestion_id)
+
+    async def test_pointer_payload_source_disagreement(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(
+            session_maker, records=[VALID_REPO], envelope_instance="acme/other"
+        )
+        with pytest.raises(PermanentProcessingError, match="stored payload says"):
+            await _process(ingestion_id)
+
+    async def test_record_count_disagreement(
+        self, session_maker, source_id, fake_sink, fake_recompute
+    ):
+        ingestion_id = await _seed_batch(
+            session_maker, records=[VALID_REPO], items_received=3
+        )
+        with pytest.raises(PermanentProcessingError, match="items_received"):
+            await _process(ingestion_id)
+
+
+@pytest.mark.asyncio
+class TestRecomputeBestEffort:
+    async def test_dispatch_failure_never_fails_ingestion(
+        self, session_maker, source_id, fake_sink, monkeypatch
+    ):
+        boom = MagicMock(side_effect=RuntimeError("valkey exploded"))
+        monkeypatch.setattr(processor_mod, "schedule_or_coalesce", boom)
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+
+        accepted = await _process(ingestion_id)
+
+        assert accepted == 1
+        boom.assert_called_once()
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None and row.status == "completed"
+
+
+@pytest.mark.asyncio
+class TestLostCas:
+    async def test_yields_zero_when_processing_transition_not_won(
+        self, session_maker, source_id, fake_sink, fake_recompute, monkeypatch
+    ):
+        monkeypatch.setattr(processor_mod, "mark_processing", AsyncMock())
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+
+        accepted = await _process(ingestion_id)
+
+        assert accepted == 0
+        fake_sink.assert_not_awaited()
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None and row.status == "accepted"
+
+
+@pytest.mark.asyncio
+class TestMarkBatchFailed:
+    async def test_forces_failed_and_deletes_payload(self, session_maker, source_id):
+        ingestion_id = await _seed_batch(
+            session_maker, records=[VALID_REPO], status="processing"
+        )
+
+        await mark_batch_failed(
+            ingestion_id=ingestion_id, org_id=ORG, reason="max_deliveries_exceeded"
+        )
+
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None
+        assert row.status == "failed"
+        assert row.error_summary == {
+            "system_failure": True,
+            "reason": "max_deliveries_exceeded",
+        }
+        assert row.completed_at is not None
+        async with session_maker() as session:
+            assert not await payload_exists(
+                session, ingestion_id=ingestion_id, org_id=ORG
+            )
+
+    async def test_accepted_batch_can_be_failed(self, session_maker, source_id):
+        # Permanent failures raised before mark_processing leave 'accepted'.
+        ingestion_id = await _seed_batch(session_maker, records=[VALID_REPO])
+        await mark_batch_failed(
+            ingestion_id=ingestion_id, org_id=ORG, reason="bad envelope"
+        )
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None and row.status == "failed"
+
+    async def test_terminal_batch_is_left_alone(self, session_maker, source_id):
+        ingestion_id = await _seed_batch(
+            session_maker, records=[VALID_REPO], status="completed"
+        )
+
+        await mark_batch_failed(ingestion_id=ingestion_id, org_id=ORG, reason="late")
+
+        row = await _get_row(session_maker, ingestion_id)
+        assert row is not None and row.status == "completed"
+        async with session_maker() as session:
+            # Payload untouched on the no-op path.
+            assert await payload_exists(session, ingestion_id=ingestion_id, org_id=ORG)
+
+    async def test_non_uuid_ingestion_id_is_a_noop(self, source_id):
+        await mark_batch_failed(ingestion_id="junk", org_id=ORG, reason="r")
+
+    async def test_raises_on_store_failure(self, source_id, monkeypatch):
+        # The RAISES contract (consumer ACK gate): a failed status write must
+        # propagate so the entry stays un-ACKed for a later retry.
+        @asynccontextmanager
+        async def _broken_session():
+            raise RuntimeError("pg down")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr(processor_mod, "get_postgres_session", _broken_session)
+        with pytest.raises(RuntimeError, match="pg down"):
+            await mark_batch_failed(
+                ingestion_id=str(uuid.uuid4()), org_id=ORG, reason="r"
+            )


### PR DESCRIPTION
## CHAOS-2697 — External-ingest worker / processor

The last runtime piece of the CHAOS-2690 external customer-push epic. Fills 2693's consumer seam: with `external_ingest/processor.py` present, `_processor_available()` flips true and the consumer begins claiming batches.

### What ships
- **`external_ingest/normalize.py`** (new, pure) — CC6 kind×system matrix (`ALLOWED_KINDS_BY_SYSTEM`), case-insensitive git-family instance-scope, one `RecordRejection` per index. Shape validation delegates UNCHANGED to `validate.py` (CC17 single-owner).
- **`external_ingest/processor.py`** (new) — `process_batch(*, ingestion_id, org_id, source_system, source_instance, schema_version) -> int` (CC23): schema/system/uuid sanity → `require_clickhouse_uri` → terminal-skip → `mark_processing` CAS+commit → re-read/yield-if-lost → payload fetch → source_id resolve → envelope + pointer↔payload source/count checks → `normalize_batch` → `_write_with_retries` (CC11 backoff `(2,4,8)s`, exhausted → `TransientSinkWriteError`) → `complete_batch(+record_counts)` + `delete_payload` same txn → best-effort `schedule_or_coalesce` ONCE. `mark_batch_failed` RAISES on failure (consumer ACK-gate).
- **`api/external_ingest/status.py`** — `mark_processing` CASes from `accepted|stream_unavailable`; `complete_batch` gains `record_counts`; new `mark_failed` forces `failed` from any non-terminal status with counter invariant (`items_accepted=0`, `items_rejected=items_received`, `record_counts=NULL`).
- **`api/external_ingest/consumer.py`** — give-up / DLQ path, hardened through 5 codex rounds (below).
- **`docs/architecture/external-ingest-worker.md`** (new) — CC23 sequence, failure classification, full give-up-ordering history.

### Failure classification
`PermanentProcessingError` → immediate DLQ. Everything else (incl. `TransientSinkWriteError`) → transient/reclaim (CC11 reclaim ladder).

### Codex adversarial review — 5 rounds, each a distinct real bug
1. ACK past a raised `mark_batch_failed` → gate sync give-up ACK on the mark result.
2. DLQ-then-mark duplicate flood → mark-first ordering + counter invariant.
3. mark-first lost the DLQ row when XADD failed after the mark landed (terminal batch → idempotent-skip ACK) → **DLQ-first** + per-entry dedup marker.
4. marker-as-flag suppressed rewrite after a capped-stream TRIM → marker stores the DLQ **stream-id**, re-reads via `_dlq_entry_present`, rewrites if trimmed.
5. **verify-only → approve, no material findings.**

Final ordering: DLQ-FIRST (idempotent via `…:dlq:written:<entry_id>` marker holding the stream-id) → `mark_batch_failed` (raises on fail) → ACK only after both.

### Verification
- Gate ×5 green — final **6878 passed / 0 failed** (`env -i … bash ci/local_validate.sh`).
- Live-verified **20/20 twice** on scratch PG+CH `ci_2697` + Valkey db15 (6 phases: normalize matrix, CAS transitions, payload split, DLQ idempotency incl. trim-rewrite, recompute dispatch, counter invariants). Scratch state torn down.
