### PR TITLE
fix(webhooks): re-raise RateLimitException to the Celery retry path (CHAOS-2829)

### DIFF
--- a/src/dev_health_ops/workers/system_webhooks.py
+++ b/src/dev_health_ops/workers/system_webhooks.py
@@ -4,6 +4,7 @@ import logging
 import os
 from datetime import datetime, timezone
 
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.utils.datetime import utc_today
 from dev_health_ops.workers.async_runner import run_async
 from dev_health_ops.workers.celery_app import celery_app
@@ -99,7 +100,16 @@ def process_webhook_event(
             event_type,
             exc,
         )
-        raise self.retry(exc=exc, countdown=30 * (2**self.request.retries))
+        # Honor a provider-supplied rate-limit delay when the escaping exception
+        # carries one (RateLimitException.retry_after_seconds); otherwise fall
+        # back to the generic exponential backoff.
+        retry_after = getattr(exc, "retry_after_seconds", None)
+        countdown = (
+            int(retry_after)
+            if isinstance(retry_after, (int, float)) and retry_after > 0
+            else 30 * (2**self.request.retries)
+        )
+        raise self.retry(exc=exc, countdown=countdown)
 
 
 def _is_duplicate_delivery(provider: str, delivery_id: str) -> bool:
@@ -251,6 +261,16 @@ def _process_github_event(
     try:
         run_async(run_with_store(db_url, db_type, _sync_handler, org_id=org_id))
         return {"processed": True, "repo": f"{owner}/{repo}", "event": event_type}
+    except RateLimitException:
+        # Rate limits must reach the outer task's Celery retry path, not be
+        # degraded to a successful {processed: False} result — GitHub will not
+        # resend the webhook, so a swallowed rate limit permanently drops the
+        # sync. Let it escape after the finally-drains in the processor have run.
+        logger.warning(
+            "Rate limited processing GitHub webhook %s; deferring for retry",
+            event_type,
+        )
+        raise
     except Exception as e:
         logger.error("Failed to process GitHub webhook %s: %s", event_type, e)
         return {"processed": False, "error": str(e)}
@@ -423,6 +443,14 @@ def _process_gitlab_event(
     try:
         run_async(run_with_store(db_url, db_type, _sync_handler, org_id=org_id))
         return {"processed": True, "project_id": project_id, "event": event_type}
+    except RateLimitException:
+        # Same contract as the GitHub path: rate limits must reach the outer
+        # Celery retry rather than being degraded to a successful result.
+        logger.warning(
+            "Rate limited processing GitLab webhook %s; deferring for retry",
+            event_type,
+        )
+        raise
     except Exception as e:
         logger.error("Failed to process GitLab webhook %s: %s", event_type, e)
         return {"processed": False, "error": str(e)}
@@ -451,6 +479,14 @@ def _process_jira_event(
             org_id=org_id or "",
         )
         return {"processed": True, "event": event_type}
+    except RateLimitException:
+        # Same contract as the GitHub/GitLab paths: rate limits must reach the
+        # outer Celery retry rather than being degraded to a successful result.
+        logger.warning(
+            "Rate limited processing Jira webhook %s; deferring for retry",
+            event_type,
+        )
+        raise
     except Exception as e:
         logger.error("Failed to process Jira webhook %s: %s", event_type, e)
         return {"processed": False, "error": str(e)}

--- a/src/dev_health_ops/workers/system_webhooks.py
+++ b/src/dev_health_ops/workers/system_webhooks.py
@@ -109,21 +109,27 @@ def process_webhook_event(
         )
         # Honor a provider-supplied rate-limit delay when the escaping exception
         # carries one (RateLimitException.retry_after_seconds); otherwise fall
-        # back to the generic exponential backoff. Guard against non-finite or
-        # absurd values (e.g. a proxy echoing ``Retry-After: inf`` -> float(inf)):
-        # int(inf) raises OverflowError, which would escape this handler and drop
-        # the very webhook the retry exists to preserve. Round fractional delays
-        # up so a sub-second value still yields a real (>=1s) countdown.
+        # back to the generic exponential backoff. Any value that would raise
+        # while being turned into a countdown must degrade to the fallback rather
+        # than escape this handler and drop the very webhook the retry exists to
+        # preserve. int and float are handled separately on purpose:
+        #   * a huge int (e.g. Retry-After echoed as a 400-digit number) makes
+        #     math.isfinite() / float() raise OverflowError, so clamp ints with a
+        #     pure-int min() that never coerces to float;
+        #   * a float may be inf/nan, so gate on math.isfinite() and ceil() so a
+        #     sub-second value still yields a real (>=1s) countdown.
         retry_after = getattr(exc, "retry_after_seconds", None)
-        if (
-            isinstance(retry_after, (int, float))
-            and not isinstance(retry_after, bool)
+        countdown = 30 * (2**self.request.retries)
+        if isinstance(retry_after, bool):
+            pass  # bool is an int subclass; never a real delay
+        elif isinstance(retry_after, int) and retry_after > 0:
+            countdown = min(retry_after, _MAX_RETRY_COUNTDOWN_SECONDS)
+        elif (
+            isinstance(retry_after, float)
             and math.isfinite(retry_after)
             and retry_after > 0
         ):
             countdown = min(math.ceil(retry_after), _MAX_RETRY_COUNTDOWN_SECONDS)
-        else:
-            countdown = 30 * (2**self.request.retries)
         raise self.retry(exc=exc, countdown=countdown)
 
 

--- a/src/dev_health_ops/workers/system_webhooks.py
+++ b/src/dev_health_ops/workers/system_webhooks.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import math
 import os
 from datetime import datetime, timezone
 
@@ -11,6 +12,12 @@ from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.task_utils import _get_db_url, _invalidate_sync_cache
 
 logger = logging.getLogger(__name__)
+
+# Upper bound for a provider-supplied rate-limit retry delay. Caps absurd or
+# adversarial ``Retry-After`` values so an oversized (but finite) countdown
+# can't park a webhook retry for an unreasonable span; real rate limits clear
+# well within an hour.
+_MAX_RETRY_COUNTDOWN_SECONDS = 3600
 
 
 @celery_app.task(
@@ -102,13 +109,21 @@ def process_webhook_event(
         )
         # Honor a provider-supplied rate-limit delay when the escaping exception
         # carries one (RateLimitException.retry_after_seconds); otherwise fall
-        # back to the generic exponential backoff.
+        # back to the generic exponential backoff. Guard against non-finite or
+        # absurd values (e.g. a proxy echoing ``Retry-After: inf`` -> float(inf)):
+        # int(inf) raises OverflowError, which would escape this handler and drop
+        # the very webhook the retry exists to preserve. Round fractional delays
+        # up so a sub-second value still yields a real (>=1s) countdown.
         retry_after = getattr(exc, "retry_after_seconds", None)
-        countdown = (
-            int(retry_after)
-            if isinstance(retry_after, (int, float)) and retry_after > 0
-            else 30 * (2**self.request.retries)
-        )
+        if (
+            isinstance(retry_after, (int, float))
+            and not isinstance(retry_after, bool)
+            and math.isfinite(retry_after)
+            and retry_after > 0
+        ):
+            countdown = min(math.ceil(retry_after), _MAX_RETRY_COUNTDOWN_SECONDS)
+        else:
+            countdown = 30 * (2**self.request.retries)
         raise self.retry(exc=exc, countdown=countdown)
 
 

--- a/tests/workers/test_system_webhooks_rate_limit.py
+++ b/tests/workers/test_system_webhooks_rate_limit.py
@@ -206,3 +206,12 @@ def test_outer_task_fractional_retry_after_is_ceiled() -> None:
         RateLimitException("limited", retry_after_seconds=90.5)
     )
     assert countdown == 91
+
+
+def test_outer_task_huge_int_retry_after_is_clamped_without_overflow() -> None:
+    """An integer too large to convert to float (math.isfinite/float would raise
+    OverflowError) is clamped via pure-int comparison, not dropped."""
+    countdown = _capture_outer_countdown(
+        RateLimitException("limited", retry_after_seconds=10**400)
+    )
+    assert countdown == system_webhooks._MAX_RETRY_COUNTDOWN_SECONDS

--- a/tests/workers/test_system_webhooks_rate_limit.py
+++ b/tests/workers/test_system_webhooks_rate_limit.py
@@ -1,0 +1,156 @@
+"""CHAOS-2829: webhook handlers must not swallow rate limits.
+
+A ``RateLimitException`` raised while processing a webhook must reach the outer
+Celery retry path rather than being degraded to a successful ``processed:False``
+result. Providers do not resend webhooks, so a swallowed rate limit permanently
+drops that webhook-driven sync. Non-rate-limit errors keep the degrade-and-log
+behavior (the sync is best-effort garnish for those). Follow-up to CHAOS-2803.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.workers import system_webhooks
+
+_GITHUB_PAYLOAD = {"repository": {"owner": {"login": "acme"}, "name": "widget"}}
+_GITLAB_PAYLOAD = {"project": {"id": 123}}
+_JIRA_PAYLOAD = {"issue": {"key": "ENG-1"}}
+
+
+def _patch_storage() -> Any:
+    """Neutralize the DB/storage plumbing so the sync-execution try block is the
+    only thing under test; ``run_async`` is what each test drives."""
+    return (
+        patch(
+            "dev_health_ops.workers.system_webhooks._get_db_url",
+            return_value="clickhouse://x",
+        ),
+        patch("dev_health_ops.storage.resolve_db_type", return_value="clickhouse"),
+        patch("dev_health_ops.storage.run_with_store", return_value=MagicMock()),
+    )
+
+
+def test_github_pull_request_rate_limit_reraises(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "x")
+    p1, p2, p3 = _patch_storage()
+    with (
+        p1,
+        p2,
+        p3,
+        patch(
+            "dev_health_ops.workers.system_webhooks.run_async",
+            side_effect=RateLimitException(
+                "gh secondary limit", retry_after_seconds=90
+            ),
+        ),
+    ):
+        with pytest.raises(RateLimitException):
+            system_webhooks._process_github_event(
+                "pull_request", _GITHUB_PAYLOAD, "org-1", None
+            )
+
+
+def test_github_non_rate_limit_error_degrades(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "x")
+    p1, p2, p3 = _patch_storage()
+    with (
+        p1,
+        p2,
+        p3,
+        patch(
+            "dev_health_ops.workers.system_webhooks.run_async",
+            side_effect=ValueError("transient parse error"),
+        ),
+    ):
+        result = system_webhooks._process_github_event(
+            "pull_request", _GITHUB_PAYLOAD, "org-1", None
+        )
+    assert result["processed"] is False
+    assert "error" in result
+
+
+def test_gitlab_rate_limit_reraises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITLAB_TOKEN", "x")
+    p1, p2, p3 = _patch_storage()
+    with (
+        p1,
+        p2,
+        p3,
+        patch(
+            "dev_health_ops.workers.system_webhooks.run_async",
+            side_effect=RateLimitException("gl limit", retry_after_seconds=30),
+        ),
+    ):
+        with pytest.raises(RateLimitException):
+            system_webhooks._process_gitlab_event(
+                "push", _GITLAB_PAYLOAD, "org-1", None
+            )
+
+
+def test_jira_rate_limit_reraises() -> None:
+    with patch(
+        "dev_health_ops.metrics.job_work_items.run_work_items_sync_job",
+        side_effect=RateLimitException("jira limit", retry_after_seconds=60),
+    ):
+        with pytest.raises(RateLimitException):
+            system_webhooks._process_jira_event("issue_updated", _JIRA_PAYLOAD, "org-1")
+
+
+def test_outer_task_honors_retry_after_countdown() -> None:
+    """The Celery retry countdown uses the exception's retry_after_seconds."""
+    captured: dict[str, Any] = {}
+
+    class _RetrySentinel(Exception):
+        pass
+
+    def _fake_retry(*, exc: Any, countdown: int) -> None:
+        captured["countdown"] = countdown
+        raise _RetrySentinel
+
+    with (
+        patch(
+            "dev_health_ops.workers.system_webhooks._process_github_event",
+            side_effect=RateLimitException("limited", retry_after_seconds=120),
+        ),
+        patch.object(system_webhooks.process_webhook_event, "retry", _fake_retry),
+    ):
+        task = cast(Any, system_webhooks.process_webhook_event)
+        with pytest.raises(_RetrySentinel):
+            task.run(
+                provider="github", event_type="pull_request", payload=_GITHUB_PAYLOAD
+            )
+    assert captured["countdown"] == 120
+
+
+def test_outer_task_falls_back_to_exponential_countdown() -> None:
+    """A rate limit with no retry_after_seconds falls back to exponential backoff."""
+    captured: dict[str, Any] = {}
+
+    class _RetrySentinel(Exception):
+        pass
+
+    def _fake_retry(*, exc: Any, countdown: int) -> None:
+        captured["countdown"] = countdown
+        raise _RetrySentinel
+
+    with (
+        patch(
+            "dev_health_ops.workers.system_webhooks._process_github_event",
+            side_effect=RateLimitException("limited"),  # retry_after_seconds=None
+        ),
+        patch.object(system_webhooks.process_webhook_event, "retry", _fake_retry),
+    ):
+        task = cast(Any, system_webhooks.process_webhook_event)
+        with pytest.raises(_RetrySentinel):
+            task.run(
+                provider="github", event_type="pull_request", payload=_GITHUB_PAYLOAD
+            )
+    # retries defaults to 0 outside a worker context: 30 * 2**0 == 30
+    assert captured["countdown"] == 30

--- a/tests/workers/test_system_webhooks_rate_limit.py
+++ b/tests/workers/test_system_webhooks_rate_limit.py
@@ -154,3 +154,55 @@ def test_outer_task_falls_back_to_exponential_countdown() -> None:
             )
     # retries defaults to 0 outside a worker context: 30 * 2**0 == 30
     assert captured["countdown"] == 30
+
+
+def _capture_outer_countdown(exc: BaseException) -> int:
+    """Run the outer task with a processor that raises ``exc`` and return the
+    countdown handed to ``self.retry`` (never actually retrying)."""
+    captured: dict[str, Any] = {}
+
+    class _RetrySentinel(Exception):
+        pass
+
+    def _fake_retry(*, exc: Any, countdown: int) -> None:
+        captured["countdown"] = countdown
+        raise _RetrySentinel
+
+    with (
+        patch(
+            "dev_health_ops.workers.system_webhooks._process_github_event",
+            side_effect=exc,
+        ),
+        patch.object(system_webhooks.process_webhook_event, "retry", _fake_retry),
+    ):
+        task = cast(Any, system_webhooks.process_webhook_event)
+        with pytest.raises(_RetrySentinel):
+            task.run(
+                provider="github", event_type="pull_request", payload=_GITHUB_PAYLOAD
+            )
+    return captured["countdown"]
+
+
+def test_outer_task_infinite_retry_after_falls_back_to_exponential() -> None:
+    """A non-finite retry_after_seconds must not reach int() (OverflowError);
+    it falls back to exponential backoff so the webhook still retries."""
+    countdown = _capture_outer_countdown(
+        RateLimitException("limited", retry_after_seconds=float("inf"))
+    )
+    assert countdown == 30  # 30 * 2**0, not an OverflowError
+
+
+def test_outer_task_absurd_finite_retry_after_is_clamped() -> None:
+    """An oversized but finite retry_after_seconds is clamped to the cap."""
+    countdown = _capture_outer_countdown(
+        RateLimitException("limited", retry_after_seconds=10**9)
+    )
+    assert countdown == system_webhooks._MAX_RETRY_COUNTDOWN_SECONDS
+
+
+def test_outer_task_fractional_retry_after_is_ceiled() -> None:
+    """A sub-second/fractional delay rounds up to a real (>=1s) countdown."""
+    countdown = _capture_outer_countdown(
+        RateLimitException("limited", retry_after_seconds=90.5)
+    )
+    assert countdown == 91


### PR DESCRIPTION
## Summary

Follow-up to CHAOS-2803 (#1151). GitHub/GitLab/Jira webhook handlers caught `RateLimitException` in the generic `except Exception` clause and returned `{"processed": False}`. The outer task treats that as a permanent failure and does not retry -- and since the provider will not resend the webhook, a rate-limited sync was silently and permanently dropped.

- Import `RateLimitException` and add a dedicated `except RateLimitException: log + raise` block before the generic handler in all three webhook processors (`_process_github_event`, `_process_gitlab_event`, `_process_jira_event`), so the exception escapes to the outer task's Celery retry path instead of being swallowed.
- The outer `process_webhook_event` retry now honors a provider-supplied `retry_after_seconds` on `RateLimitException` for the retry countdown, falling back to the existing exponential backoff when not present.
- Added `tests/workers/test_system_webhooks_rate_limit.py` (6 tests, all passing) covering re-raise behavior for all three handlers and the countdown logic.

## Test plan

- [x] `pytest tests/workers/test_system_webhooks_rate_limit.py -q` -- 6 passed
- [x] ruff + mypy clean on both changed files (pre-commit/pre-push hooks passed)
- [ ] Online CI (this repo's local gate runs offline/no-network; one unrelated pre-existing failure noted below is expected to be green in CI)

## Note on gate status

The local gate has exactly one unrelated pre-existing failure: `tests/test_admin_credentials.py::test_gitlab_connection_helper_sanitizes_raw_response_body` (`KeyError: 'status'`). This diff touches only `src/dev_health_ops/workers/system_webhooks.py` (plus the new test file) -- it does not touch admin credentials code. Confirmed pre-existing by running the same test against a clean `origin/main` checkout, where it also fails. Root cause: `_test_gitlab_connection`'s SSRF DNS guard (`socket.getaddrinfo`) is not mocked by that test, so it fails offline/no-network before ever reaching the mocked `httpx.AsyncClient` -- this is the known offline-gate/live-DNS pattern. Filed as CHAOS-2830 (follow-up to CHAOS-2780) and being fixed directly in a separate PR.