### PR TITLE
test(external-ingest): live e2e customer-push test + fixtures + CI wiring (CHAOS-2702)

### DIFF
--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -77,6 +77,13 @@ jobs:
         options: >-
           --health-cmd "clickhouse-client --user ch --password ch --query 'SELECT 1'" --health-interval 10s --health-timeout 5s --health-retries 5
 
+      valkey:
+        image: valkey/valkey:8-alpine
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "valkey-cli ping" --health-interval 10s --health-timeout 5s --health-retries 5
+
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
@@ -97,6 +104,7 @@ jobs:
           DATABASE_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
           CLICKHOUSE_URI: clickhouse://ch:ch@localhost:8123/default
           POSTGRES_URI: postgresql+asyncpg://postgres:postgres@localhost:5432/test_db
+          REDIS_URL: redis://localhost:6379/0
           LIVE_E2E_FIXTURE_SEED: "20260219"
           LIVE_E2E_API_LOG_FILE: ./live-e2e-api.log
           ENVIRONMENT: test

--- a/.github/workflows/live-e2e.yml
+++ b/.github/workflows/live-e2e.yml
@@ -42,6 +42,7 @@ jobs:
               - 'alembic.ini'
               - 'Makefile'
               - 'scripts/**'
+              - '.github/workflows/live-e2e.yml'
 
   live-e2e:
     needs: [changes]

--- a/ci/run_live_backend_e2e.sh
+++ b/ci/run_live_backend_e2e.sh
@@ -54,10 +54,16 @@ require_cmd curl
 
 CLICKHOUSE_URI_DEFAULT="clickhouse://ch:ch@127.0.0.1:8123/default"
 POSTGRES_URI_DEFAULT="postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/test_db"
+REDIS_URL_DEFAULT="redis://127.0.0.1:6379/0"
 
 CLICKHOUSE_URI="${CLICKHOUSE_URI:-${CLICKHOUSE_URI_DEFAULT}}"
 POSTGRES_URI="${POSTGRES_URI:-${POSTGRES_URI_DEFAULT}}"
 DATABASE_URI="${POSTGRES_URI}"
+# CHAOS-2702: the customer-push external-ingest live e2e module needs a real
+# Valkey/Redis instance (durable stream + bounded-recompute debounce), in
+# addition to the Postgres/ClickHouse this harness already provisions.
+REDIS_URL="${REDIS_URL:-${REDIS_URL_DEFAULT}}"
+export REDIS_URL
 
 API_HOST="${LIVE_E2E_API_HOST:-127.0.0.1}"
 API_PORT="${LIVE_E2E_API_PORT:-18080}"
@@ -90,6 +96,36 @@ cleanup() {
 }
 
 trap cleanup EXIT INT TERM
+
+wait_for_redis() {
+  # CHAOS-2702: fail fast (before burning time on fixture generation / API
+  # boot) if the Valkey service container isn't reachable yet. Uses the
+  # `valkey` python client (already a project dependency, see
+  # tests/test_external_ingest_customer_push_live.py) instead of requiring a
+  # `valkey-cli`/`redis-cli` binary on the runner.
+  local i
+  for ((i = 1; i <= READINESS_ATTEMPTS; i++)); do
+    if REDIS_URL="${REDIS_URL}" run_python - <<'PY'
+import os
+import sys
+
+import valkey
+
+client = valkey.from_url(os.environ["REDIS_URL"])
+try:
+    client.ping()
+except Exception:
+    sys.exit(1)
+PY
+    then
+      echo "Valkey ready after ${i} attempt(s)."
+      return 0
+    fi
+    sleep "${READINESS_SLEEP_SECS}"
+  done
+  echo "ERROR: Timed out waiting for Valkey readiness at ${REDIS_URL}."
+  return 1
+}
 
 generate_auth_token() {
   run_python - <<'PY'
@@ -217,6 +253,9 @@ PY
   return 1
 }
 
+echo "==> waiting for Valkey readiness"
+wait_for_redis
+
 echo "==> generating deterministic ClickHouse fixtures (metrics + work graph)"
 (
   export DISABLE_DOTENV=1
@@ -330,5 +369,16 @@ constraint = payload.get("constraint", {})
 assert constraint.get("title"), constraint
 assert constraint.get("evidence"), constraint
 PY
+
+echo "==> running customer-push external-ingest live e2e test (CHAOS-2702)"
+(
+  export DISABLE_DOTENV=1
+  export CLICKHOUSE_URI="${CLICKHOUSE_URI}"
+  export POSTGRES_URI="${POSTGRES_URI}"
+  export DATABASE_URI="${DATABASE_URI}"
+  export REDIS_URL="${REDIS_URL}"
+  export JWT_SECRET_KEY="${JWT_SECRET_KEY}"
+  run_python -m pytest tests/test_external_ingest_customer_push_live.py -m clickhouse -q
+)
 
 echo "Live backend e2e checks passed."

--- a/ci/run_live_backend_e2e.sh
+++ b/ci/run_live_backend_e2e.sh
@@ -378,6 +378,11 @@ echo "==> running customer-push external-ingest live e2e test (CHAOS-2702)"
   export DATABASE_URI="${DATABASE_URI}"
   export REDIS_URL="${REDIS_URL}"
   export JWT_SECRET_KEY="${JWT_SECRET_KEY}"
+  # Point the test's black-box `client` fixture at the real, already-booted
+  # `dev-hops api` server process (BASE_URL, computed above) instead of an
+  # in-process ASGITransport -- proves the real route-mounting/startup/
+  # uvicorn-config path, not just the FastAPI app object.
+  export LIVE_E2E_BASE_URL="${BASE_URL}"
   run_python -m pytest tests/test_external_ingest_customer_push_live.py -m clickhouse -q
 )
 

--- a/tests/_helpers_external_ingest.py
+++ b/tests/_helpers_external_ingest.py
@@ -1,0 +1,133 @@
+"""Shared fixture loader + batch-envelope builder for external-ingest tests
+(CHAOS-2702).
+
+Single source of truth for the 9 v1 record-kind fixtures under
+``tests/fixtures/external_ingest/v1/*.json`` — consumed by the live e2e
+module (``tests/test_external_ingest_customer_push_live.py``) and the cheap
+offline shape guard (``tests/test_external_ingest_fixtures_shape.py``).
+
+Naming note: the brief called for ``tests/_helpers/external_ingest_fixtures.py``,
+but this repo already has ``tests/_helpers.py`` as a plain module (not a
+package) — a same-named ``tests/_helpers/`` directory would shadow/collide
+with it (ambiguous namespace-package vs. module resolution). This module is
+named ``tests/_helpers_external_ingest.py`` instead to avoid that collision;
+see the CHAOS-2702 PR description for the reconciliation note.
+
+Each fixture file has the shape::
+
+    {
+      "kind": "<kind>.v1",
+      "valid": {"kind": "<kind>.v1", "externalId": "...", "payload": {...}},
+      "invalid": {
+        "kind": "<kind>.v1", "externalId": "...", "payload": {...},
+        "expectedError": {"code": "missing_required_field", "field": "..."}
+      }
+    }
+
+Per the CHAOS-2690 synthesizer reconciliation (brief-2702-e2e-docs.md §
+SYNTHESIZER RECONCILIATION #3), each fixture's ``valid.payload`` is byte/
+structurally IDENTICAL to the canonical package example shipped at
+``src/dev_health_ops/api/external_ingest/examples/<kind>.v1.json`` (CHAOS-2692)
+-- there is no fourth, hand-copied duplicate. ``load_package_example`` reads
+that same file directly so callers (and the shape-guard test) can assert
+equality instead of trusting it by convention.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import dev_health_ops.api.external_ingest.examples as _examples_pkg
+
+FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "external_ingest" / "v1"
+EXAMPLES_DIR = Path(_examples_pkg.__file__).resolve().parent
+
+#: Bare (unversioned) kind names -- fixture filenames and the batch envelope
+#: builder's ``kinds=`` argument use these; wire ``kind`` values are always
+#: the ``.v1``-suffixed form (e.g. ``"pull_request.v1"``).
+ALL_KINDS: list[str] = [
+    "repository",
+    "identity",
+    "team",
+    "work_item",
+    "work_item_transition",
+    "work_item_dependency",
+    "pull_request",
+    "review",
+    "commit",
+]
+
+DEFAULT_SCHEMA_VERSION = "external-ingest.v1"
+
+
+def load_fixture(kind: str) -> dict[str, Any]:
+    """Load ``tests/fixtures/external_ingest/v1/<kind>.json`` (bare kind name,
+    e.g. ``"pull_request"``, not ``"pull_request.v1"``)."""
+    return json.loads((FIXTURE_DIR / f"{kind}.json").read_text())
+
+
+def load_package_example(kind: str) -> dict[str, Any]:
+    """Load the canonical CHAOS-2692 package example payload for ``kind``."""
+    return json.loads((EXAMPLES_DIR / f"{kind}.v1.json").read_text())
+
+
+def _record_envelope(fixture_record: dict[str, Any]) -> dict[str, Any]:
+    """Strip fixture-only bookkeeping keys (``expectedError``) down to the
+    real wire shape (``RecordEnvelope``: ``kind``/``externalId``/``payload``,
+    ``extra="forbid"``) before this record is placed on the wire."""
+    return {
+        "kind": fixture_record["kind"],
+        "externalId": fixture_record["externalId"],
+        "payload": fixture_record["payload"],
+    }
+
+
+def build_batch_envelope(
+    *,
+    idempotency_key: str,
+    source_system: str = "github",
+    source_instance: str = "acme/api",
+    kinds: list[str] | None = None,
+    invalid_kind: str | None = None,
+    window_started_at: str = "2026-06-25T00:00:00Z",
+    window_ended_at: str = "2026-06-26T00:00:00Z",
+    producer: str = "pytest-e2e",
+    producer_version: str = "0.0.0",
+) -> dict[str, Any]:
+    """Build a ``POST /validate`` / ``POST /batches`` request body.
+
+    ``kinds`` (bare names, default ``ALL_KINDS``) contribute their ``valid``
+    record; ``invalid_kind``, if given, additionally appends that kind's
+    ``invalid`` record (deliberately malformed, to exercise rejection
+    diagnostics).
+    """
+    selected_kinds = kinds if kinds is not None else ALL_KINDS
+    records = [_record_envelope(load_fixture(kind)["valid"]) for kind in selected_kinds]
+    if invalid_kind is not None:
+        records.append(_record_envelope(load_fixture(invalid_kind)["invalid"]))
+    return {
+        "schemaVersion": DEFAULT_SCHEMA_VERSION,
+        "idempotencyKey": idempotency_key,
+        "source": {
+            "type": "customer_push",
+            "system": source_system,
+            "instance": source_instance,
+            "producer": producer,
+            "producerVersion": producer_version,
+        },
+        "window": {"startedAt": window_started_at, "endedAt": window_ended_at},
+        "records": records,
+    }
+
+
+__all__ = [
+    "ALL_KINDS",
+    "DEFAULT_SCHEMA_VERSION",
+    "FIXTURE_DIR",
+    "EXAMPLES_DIR",
+    "load_fixture",
+    "load_package_example",
+    "build_batch_envelope",
+]

--- a/tests/fixtures/external_ingest/v1/commit.json
+++ b/tests/fixtures/external_ingest/v1/commit.json
@@ -1,0 +1,28 @@
+{
+  "kind": "commit.v1",
+  "valid": {
+    "kind": "commit.v1",
+    "externalId": "9fceb02d0ae598e95dc970b74767f19372d61af8",
+    "payload": {
+      "repositoryExternalId": "acme/api",
+      "hash": "9fceb02d0ae598e95dc970b74767f19372d61af8",
+      "message": "fix: resolve login redirect loop",
+      "authorName": "Alice Doe",
+      "authorEmail": "alice@acme.example",
+      "authorWhen": "2026-06-21T09:55:00Z",
+      "committerName": "Alice Doe",
+      "committerEmail": "alice@acme.example",
+      "committerWhen": "2026-06-21T09:55:00Z",
+      "parents": 1
+    }
+  },
+  "invalid": {
+    "kind": "commit.v1",
+    "externalId": "9fceb02d0ae598e95dc970b74767f19372d61af8-invalid",
+    "payload": {
+      "repositoryExternalId": "acme/api",
+      "hash": "9fceb02d0ae598e95dc970b74767f19372d61af8"
+    },
+    "expectedError": {"code": "missing_required_field", "field": "authorWhen"}
+  }
+}

--- a/tests/fixtures/external_ingest/v1/identity.json
+++ b/tests/fixtures/external_ingest/v1/identity.json
@@ -1,0 +1,24 @@
+{
+  "kind": "identity.v1",
+  "valid": {
+    "kind": "identity.v1",
+    "externalId": "acme-user-42",
+    "payload": {
+      "canonicalId": "acme-user-42",
+      "displayName": "Alice Doe",
+      "email": "alice@acme.example",
+      "providerIdentities": {"github": ["alicedoe"], "jira": ["alice.doe"]},
+      "teamIds": ["team-platform"],
+      "isActive": true,
+      "updatedAt": "2026-06-25T00:00:00Z"
+    }
+  },
+  "invalid": {
+    "kind": "identity.v1",
+    "externalId": "acme-user-42-invalid",
+    "payload": {
+      "canonicalId": "acme-user-42"
+    },
+    "expectedError": {"code": "missing_required_field", "field": "updatedAt"}
+  }
+}

--- a/tests/fixtures/external_ingest/v1/pull_request.json
+++ b/tests/fixtures/external_ingest/v1/pull_request.json
@@ -1,0 +1,36 @@
+{
+  "kind": "pull_request.v1",
+  "valid": {
+    "kind": "pull_request.v1",
+    "externalId": "acme/api#482",
+    "payload": {
+      "repositoryExternalId": "acme/api",
+      "number": 482,
+      "title": "Fix login redirect loop",
+      "state": "merged",
+      "authorName": "Alice Doe",
+      "authorEmail": "alice@acme.example",
+      "createdAt": "2026-06-21T10:00:00Z",
+      "mergedAt": "2026-06-22T15:30:00Z",
+      "headBranch": "fix/login-redirect",
+      "baseBranch": "main",
+      "additions": 42,
+      "deletions": 10,
+      "changedFiles": 3,
+      "reviewsCount": 2,
+      "commentsCount": 4,
+      "url": "https://github.com/acme/api/pull/482"
+    }
+  },
+  "invalid": {
+    "kind": "pull_request.v1",
+    "externalId": "acme/api#482-invalid",
+    "payload": {
+      "repositoryExternalId": "acme/api",
+      "number": 482,
+      "title": "Missing state",
+      "createdAt": "2026-06-21T10:00:00Z"
+    },
+    "expectedError": {"code": "missing_required_field", "field": "state"}
+  }
+}

--- a/tests/fixtures/external_ingest/v1/repository.json
+++ b/tests/fixtures/external_ingest/v1/repository.json
@@ -1,0 +1,22 @@
+{
+  "kind": "repository.v1",
+  "valid": {
+    "kind": "repository.v1",
+    "externalId": "acme/api",
+    "payload": {
+      "externalId": "acme/api",
+      "sourceSystem": "github",
+      "defaultRef": "main",
+      "tags": ["backend", "core"],
+      "settings": {"visibility": "private"}
+    }
+  },
+  "invalid": {
+    "kind": "repository.v1",
+    "externalId": "acme/api-invalid",
+    "payload": {
+      "externalId": "acme/api"
+    },
+    "expectedError": {"code": "missing_required_field", "field": "sourceSystem"}
+  }
+}

--- a/tests/fixtures/external_ingest/v1/review.json
+++ b/tests/fixtures/external_ingest/v1/review.json
@@ -1,0 +1,26 @@
+{
+  "kind": "review.v1",
+  "valid": {
+    "kind": "review.v1",
+    "externalId": "rev-9001",
+    "payload": {
+      "repositoryExternalId": "acme/api",
+      "pullRequestNumber": 482,
+      "reviewId": "rev-9001",
+      "reviewer": "bob@acme.example",
+      "state": "APPROVED",
+      "submittedAt": "2026-06-22T14:00:00Z"
+    }
+  },
+  "invalid": {
+    "kind": "review.v1",
+    "externalId": "rev-9001-invalid",
+    "payload": {
+      "repositoryExternalId": "acme/api",
+      "pullRequestNumber": 482,
+      "reviewId": "rev-9001",
+      "reviewer": "bob@acme.example"
+    },
+    "expectedError": {"code": "missing_required_field", "field": "state"}
+  }
+}

--- a/tests/fixtures/external_ingest/v1/team.json
+++ b/tests/fixtures/external_ingest/v1/team.json
@@ -1,0 +1,27 @@
+{
+  "kind": "team.v1",
+  "valid": {
+    "kind": "team.v1",
+    "externalId": "team-platform",
+    "payload": {
+      "id": "team-platform",
+      "name": "Platform",
+      "description": "Core platform engineering team",
+      "members": ["acme-user-42"],
+      "projectKeys": ["ABC"],
+      "repoPatterns": ["acme/*"],
+      "isActive": true,
+      "updatedAt": "2026-06-25T00:00:00Z",
+      "nativeTeamKey": "PLAT"
+    }
+  },
+  "invalid": {
+    "kind": "team.v1",
+    "externalId": "team-platform-invalid",
+    "payload": {
+      "id": "team-platform",
+      "name": "Platform"
+    },
+    "expectedError": {"code": "missing_required_field", "field": "updatedAt"}
+  }
+}

--- a/tests/fixtures/external_ingest/v1/work_item.json
+++ b/tests/fixtures/external_ingest/v1/work_item.json
@@ -1,0 +1,38 @@
+{
+  "kind": "work_item.v1",
+  "valid": {
+    "kind": "work_item.v1",
+    "externalId": "ABC-123",
+    "payload": {
+      "externalKey": "ABC-123",
+      "provider": "jira",
+      "title": "Fix login redirect loop",
+      "type": "bug",
+      "status": "in_progress",
+      "statusRaw": "In Progress",
+      "description": "Users are redirected in a loop after SSO login.",
+      "projectKey": "ABC",
+      "projectName": "Acme Platform",
+      "assignees": ["alice@acme.example"],
+      "reporter": "bob@acme.example",
+      "createdAt": "2026-06-20T14:00:00Z",
+      "updatedAt": "2026-06-25T09:30:00Z",
+      "startedAt": "2026-06-21T09:00:00Z",
+      "labels": ["bug", "auth"],
+      "storyPoints": 3,
+      "priorityRaw": "High",
+      "url": "https://acme.atlassian.net/browse/ABC-123"
+    }
+  },
+  "invalid": {
+    "kind": "work_item.v1",
+    "externalId": "ABC-123-invalid",
+    "payload": {
+      "externalKey": "ABC-123",
+      "provider": "jira",
+      "title": "Fix login redirect loop",
+      "createdAt": "2026-06-20T14:00:00Z"
+    },
+    "expectedError": {"code": "missing_required_field", "field": "status"}
+  }
+}

--- a/tests/fixtures/external_ingest/v1/work_item_dependency.json
+++ b/tests/fixtures/external_ingest/v1/work_item_dependency.json
@@ -1,0 +1,22 @@
+{
+  "kind": "work_item_dependency.v1",
+  "valid": {
+    "kind": "work_item_dependency.v1",
+    "externalId": "ABC-123-blocks-ABC-124",
+    "payload": {
+      "sourceExternalKey": "ABC-123",
+      "targetExternalKey": "ABC-124",
+      "relationshipType": "blocks",
+      "relationshipTypeRaw": "blocks"
+    }
+  },
+  "invalid": {
+    "kind": "work_item_dependency.v1",
+    "externalId": "ABC-123-blocks-ABC-124-invalid",
+    "payload": {
+      "sourceExternalKey": "ABC-123",
+      "targetExternalKey": "ABC-124"
+    },
+    "expectedError": {"code": "missing_required_field", "field": "relationshipType"}
+  }
+}

--- a/tests/fixtures/external_ingest/v1/work_item_transition.json
+++ b/tests/fixtures/external_ingest/v1/work_item_transition.json
@@ -1,0 +1,28 @@
+{
+  "kind": "work_item_transition.v1",
+  "valid": {
+    "kind": "work_item_transition.v1",
+    "externalId": "ABC-123-transition-1",
+    "payload": {
+      "externalKey": "ABC-123",
+      "provider": "jira",
+      "occurredAt": "2026-06-21T09:00:00Z",
+      "fromStatus": "todo",
+      "toStatus": "in_progress",
+      "fromStatusRaw": "To Do",
+      "toStatusRaw": "In Progress",
+      "actor": "alice@acme.example"
+    }
+  },
+  "invalid": {
+    "kind": "work_item_transition.v1",
+    "externalId": "ABC-123-transition-1-invalid",
+    "payload": {
+      "externalKey": "ABC-123",
+      "provider": "jira",
+      "occurredAt": "2026-06-21T09:00:00Z",
+      "fromStatus": "todo"
+    },
+    "expectedError": {"code": "missing_required_field", "field": "toStatus"}
+  }
+}

--- a/tests/test_external_ingest_customer_push_live.py
+++ b/tests/test_external_ingest_customer_push_live.py
@@ -61,6 +61,16 @@ simultaneously -- the only module in this repo that needs all three live
 services at once. Run via ``ci/run_live_backend_e2e.sh`` (extended for this
 issue), not ``ci/local_validate.sh`` (ClickHouse-only, per that script's own
 docstring).
+
+SCOPE BOUNDARY -- this module does NOT assert Alembic migration
+deployability. It bootstraps the scratch Postgres schema via
+``Base.metadata.create_all`` (the same convention the harness itself already
+uses, ``ci/run_live_backend_e2e.sh``), because the migration tree currently
+has a duplicate ``0032`` revision (two files at rev 0032 -> two heads ->
+``alembic upgrade head`` fails on a clean DB). Switching the harness to run
+the real migration path, and fixing that duplicate revision, is tracked in
+CHAOS-2832; a broken migration would therefore NOT be caught here until that
+lands.
 """
 
 from __future__ import annotations
@@ -163,9 +173,11 @@ async def _run_consumer_pass() -> int:
 @pytest.fixture(scope="module", autouse=True)
 def _ensure_postgres_schema():
     """Bootstrap the scratch Postgres schema via ``Base.metadata.create_all``
-    (checkfirst) rather than Alembic -- this worktree's migration history has
-    a pre-existing 0032/0034 multi-head overlap (per orchestrator note), and
-    this is the same bootstrap ``ci/run_live_backend_e2e.sh``'s own
+    (checkfirst) rather than Alembic -- the migration history has a
+    pre-existing duplicate ``0032`` revision (two files at rev 0032 -> two
+    heads; ``alembic upgrade head`` fails on a clean DB), tracked in
+    CHAOS-2832, and this is the same bootstrap
+    ``ci/run_live_backend_e2e.sh``'s own
     ``generate_auth_token()`` already relies on for the curl-based checks
     that run before this module's pytest step.
 

--- a/tests/test_external_ingest_customer_push_live.py
+++ b/tests/test_external_ingest_customer_push_live.py
@@ -11,25 +11,49 @@ Postgres + Valkey (never mocks/FakeValkey for the boundary under test):
   durably ``XADD``s a pointer to ``external-ingest:<org_id>:batches``.
 - Idempotency replay (200, same ingestionId, no new stream entry) and
   conflict (409) -- CHAOS-2695.
-- The worker (``dev_health_ops.external_ingest.processor.process_batch``,
-  CHAOS-2697/2693 -- driven directly here, in-test, against the real
-  Valkey-enqueued batch; NOT a Celery task named
-  ``consume_external_ingest_batches`` as an earlier planning draft assumed)
-  normalizes and writes through the real ClickHouse sinks -- rows verified
-  via ``FINAL`` + ``org_id`` predicate for all 9 v1 record-kind families.
+- The worker is driven via the REAL production entry point,
+  ``dev_health_ops.api.external_ingest.consumer.consume_external_ingest_streams
+  (max_iterations=1)`` -- the actual ``ExternalIngestStreamConsumer``, doing a
+  real ``XREADGROUP``/entry-parse/``process_batch``/``XACK`` pass over
+  whatever this org's real Valkey-enqueued pointer(s) look like, NOT a direct
+  hardcoded call to ``process_batch(...)`` (which would bypass the stream
+  metadata contract entirely). Run off the event loop via
+  ``asyncio.to_thread`` since it's a synchronous, blocking-read function
+  (mirrors how Celery actually invokes it -- a separate thread with no
+  ambient event loop, which is what lets ``run_async`` inside it create its
+  own fresh loop safely). It normalizes and writes through the real
+  ClickHouse sinks -- rows verified via ``FINAL`` + ``org_id`` predicate for
+  all 9 v1 record-kind families.
 - ``GET /batches/{id}`` reports accepted/rejected counts and per-record
   rejection diagnostics for a deliberately-invalid record.
-- Bounded metric recompute is proven QUEUED, not executed inline
-  (CHAOS-2699's actual seam: ``schedule_or_coalesce`` debounces via a Valkey
-  guard key and schedules
+- Bounded metric recompute is proven QUEUED, not executed inline. The real
+  dispatch seam (CHAOS-2699) is
   ``workers.external_ingest_recompute.flush_external_ingest_recompute
   .apply_async(countdown=...)`` -- the real ``celery_app.send_task`` calls
   for ``run_daily_metrics``/etc. only happen inside THAT task, which this
-  test never runs; patching the flush task's ``apply_async`` is therefore
-  the load-bearing seam, mirroring
-  ``tests/test_external_ingest_recompute_debounce.py``'s own pattern).
+  test never runs. Only ``apply_async`` is patched (``patch.object`` on the
+  real, registered task object) so the real task/registration/debounce path
+  (including the real Valkey SETNX guard key) still runs; the test also
+  asserts the task's production dotted name to catch a rename.
 - Disabled-source (403) and stream-unavailable (503, never accept-and-warn)
   regressions.
+
+Because ``consume_external_ingest_streams`` discovers ALL orgs' streams via
+a wildcard pattern (``external-ingest:*:batches``), a single call can sweep
+up pending entries left behind by earlier tests in this module (each uses
+its own org_id, so this is inert cross-contamination, not a correctness
+bug) -- assertions below are written to tolerate that rather than assume
+exactly-one-batch-per-call.
+
+Client selection (black-box vs white-box): most scenarios drive the app via
+``client``, which targets a REAL, harness-booted ``dev-hops api`` server
+process when ``LIVE_E2E_BASE_URL`` is set (``ci/run_live_backend_e2e.sh``
+exports it), falling back to an in-process ``ASGITransport`` for standalone
+local runs. The stream-unavailable regression is a deliberate, permanent
+EXCEPTION: it monkeypatches an in-process module attribute
+(``streams.get_redis_client``), which cannot reach into a separately-booted
+server process, so it always uses the always-in-process ``asgi_client``
+fixture regardless of ``LIVE_E2E_BASE_URL``.
 
 Opt-in (filtered from unit/CI-unit runs): ``pytest -m clickhouse``. Requires
 ``CLICKHOUSE_URI``, ``POSTGRES_URI`` (or ``DATABASE_URI``), and ``REDIS_URL``
@@ -41,13 +65,16 @@ docstring).
 
 from __future__ import annotations
 
+import asyncio
 import os
 import uuid
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient
+
+LIVE_E2E_BASE_URL = os.environ.get("LIVE_E2E_BASE_URL")
 
 CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
 POSTGRES_URI = os.environ.get("POSTGRES_URI") or os.environ.get("DATABASE_URI")
@@ -97,6 +124,35 @@ def _redis_client():
     import valkey
 
     return valkey.from_url(REDIS_URL, decode_responses=True)
+
+
+async def _run_consumer_pass() -> int:
+    """Run one bounded ``consume_external_ingest_streams(max_iterations=1)``
+    pass off the event loop (mirrors how Celery actually invokes it -- a
+    separate thread with no ambient event loop).
+
+    ``run_async`` (inside the consumer's ``handle_entries``) calls
+    ``dev_health_ops.db.reset_async_engines()`` before its own
+    ``asyncio.run(...)`` so ITS fresh Postgres engine is bound to the worker
+    thread's temporary loop, not this test's loop -- correct for that call,
+    but it leaves the module-global engine cache pointing at an engine bound
+    to a loop that's about to be destroyed when the thread exits. Any
+    subsequent Postgres access from THIS test's own (module-scoped) loop --
+    e.g. the app's ``GET /batches/{id}`` right after this call -- would then
+    crash with "Future attached to a different loop". Reset again here,
+    back on this test's own loop, so the next ``get_postgres_engine()`` call
+    lazily recreates a fresh engine correctly bound to it.
+    """
+    from dev_health_ops.api.external_ingest.consumer import (
+        consume_external_ingest_streams,
+    )
+    from dev_health_ops.db import reset_async_engines
+
+    accepted = await asyncio.to_thread(
+        consume_external_ingest_streams, max_iterations=1
+    )
+    reset_async_engines()
+    return accepted
 
 
 # ---------------------------------------------------------------------------
@@ -166,6 +222,31 @@ def _reset_ingest_rate_limiter():
 
 @pytest_asyncio.fixture(loop_scope="module")
 async def client():
+    """Black-box client: a real ``httpx.AsyncClient`` against the harness-
+    booted ``dev-hops api`` server process when ``LIVE_E2E_BASE_URL`` is set
+    (so a route-mounting/startup/uvicorn-config regression in the real
+    server process is not false-greened by only ever exercising the FastAPI
+    app object in-process); falls back to in-process ``ASGITransport`` for
+    standalone local runs where no separate server was booted."""
+    if LIVE_E2E_BASE_URL:
+        async with AsyncClient(base_url=LIVE_E2E_BASE_URL) as c:
+            yield c
+        return
+
+    from dev_health_ops.api.main import app
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def asgi_client():
+    """ALWAYS in-process, regardless of ``LIVE_E2E_BASE_URL`` -- the
+    stream-unavailable regression (scenario 9) monkeypatches
+    ``streams_mod.get_redis_client`` on the module object imported into THIS
+    test process; that has no effect on a separately-booted server process,
+    so that one white-box test must use this fixture, never ``client``."""
     from dev_health_ops.api.main import app
 
     transport = ASGITransport(app=app, raise_app_exceptions=False)
@@ -403,9 +484,18 @@ async def test_idempotency_conflict_returns_409(client, source_and_token):
 async def test_worker_processes_all_nine_kinds_and_recompute_is_queued_not_inline(
     client, source_and_token, org_id, ch_sink
 ):
-    from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION
-    from dev_health_ops.external_ingest.processor import process_batch
+    from dev_health_ops.workers.external_ingest_recompute import (
+        flush_external_ingest_recompute,
+    )
     from tests._helpers_external_ingest import ALL_KINDS, build_batch_envelope
+
+    # Registered production task name -- catches a rename/re-registration
+    # regression that would otherwise silently defeat the patch.object below
+    # (patching an attribute on the wrong/stale task object).
+    assert (
+        flush_external_ingest_recompute.name
+        == "dev_health_ops.workers.tasks.flush_external_ingest_recompute"
+    )
 
     envelope = build_batch_envelope(
         idempotency_key=f"e2e-worker-full-{uuid.uuid4()}", kinds=ALL_KINDS
@@ -416,35 +506,39 @@ async def test_worker_processes_all_nine_kinds_and_recompute_is_queued_not_inlin
     assert resp.status_code == 202, resp.text
     ingestion_id = resp.json()["ingestionId"]
 
-    mock_flush_task = MagicMock()
-    with patch(
-        "dev_health_ops.workers.external_ingest_recompute.flush_external_ingest_recompute",
-        mock_flush_task,
-    ):
-        accepted = await process_batch(
-            ingestion_id=ingestion_id,
-            org_id=org_id,
-            source_system="github",
-            source_instance="acme/api",
-            schema_version=SCHEMA_VERSION,
-        )
-    assert accepted == len(ALL_KINDS)
+    # Patch ONLY the enqueue call, not the whole task object: the real
+    # schedule_or_coalesce() dispatch path (including its real Valkey SETNX
+    # debounce guard) still runs; only the actual Celery publish is
+    # intercepted.
+    with patch.object(
+        flush_external_ingest_recompute, "apply_async"
+    ) as mock_apply_async:
+        # Real production entry point: XREADGROUP -> parse -> process_batch
+        # -> XACK, not a hardcoded process_batch(...) call. This discovers
+        # ALL orgs' streams via a wildcard pattern, so it may also sweep up
+        # pending entries left by earlier tests in this module (each has
+        # its own org_id -- harmless cross-contamination) in the same pass;
+        # the return value is therefore a cross-org sum, not scoped to this
+        # test's own ingestion_id, hence the weak sanity check below rather
+        # than an exact-count assertion.
+        accepted = await _run_consumer_pass()
+    assert accepted > 0
 
-    # (a) recompute was QUEUED: schedule_or_coalesce's real dispatch seam is
-    # `flush_external_ingest_recompute.apply_async(countdown=...)`, NOT a
-    # direct `celery_app.send_task(...)` for run_daily_metrics/etc. -- those
-    # only fire from *inside* the flush task once its debounce window
-    # elapses (dev_health_ops/external_ingest/recompute.py). Patching the
-    # flush task itself (mirrors tests/test_external_ingest_recompute_debounce
-    # .py) is therefore the naming-agnostic, real seam.
-    mock_flush_task.apply_async.assert_called_once()
-    call_kwargs = mock_flush_task.apply_async.call_args.kwargs
-    assert call_kwargs["kwargs"] == {
-        "org_id": org_id,
-        "source_system": "github",
-        "source_instance": "acme/api",
-    }
-    assert call_kwargs["countdown"] > 0
+    # (a) recompute was QUEUED for THIS org specifically -- filter by kwargs
+    # rather than assert_called_once(), since other orgs swept up in the
+    # same consumer pass each trigger their own independent apply_async call.
+    matching_calls = [
+        call
+        for call in mock_apply_async.call_args_list
+        if call.kwargs.get("kwargs")
+        == {
+            "org_id": org_id,
+            "source_system": "github",
+            "source_instance": "acme/api",
+        }
+    ]
+    assert len(matching_calls) == 1, mock_apply_async.call_args_list
+    assert matching_calls[0].kwargs["countdown"] > 0
 
     status_resp = await client.get(
         f"{BASE}/batches/{ingestion_id}", headers=_headers(source_and_token)
@@ -483,8 +577,9 @@ async def test_worker_processes_all_nine_kinds_and_recompute_is_queued_not_inlin
 async def test_status_reports_partial_with_rejection_diagnostics(
     client, source_and_token, org_id
 ):
-    from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION
-    from dev_health_ops.external_ingest.processor import process_batch
+    from dev_health_ops.workers.external_ingest_recompute import (
+        flush_external_ingest_recompute,
+    )
     from tests._helpers_external_ingest import build_batch_envelope
 
     envelope = build_batch_envelope(
@@ -498,18 +593,13 @@ async def test_status_reports_partial_with_rejection_diagnostics(
     assert resp.status_code == 202, resp.text
     ingestion_id = resp.json()["ingestionId"]
 
-    with patch(
-        "dev_health_ops.workers.external_ingest_recompute.flush_external_ingest_recompute",
-        MagicMock(),
-    ):
-        accepted = await process_batch(
-            ingestion_id=ingestion_id,
-            org_id=org_id,
-            source_system="github",
-            source_instance="acme/api",
-            schema_version=SCHEMA_VERSION,
-        )
-    assert accepted == 1
+    # Same real production entry point as the previous scenario (finding 2);
+    # only the enqueue call is patched (not asserted here -- covered by the
+    # dedicated recompute scenario above) so a real, unpatched apply_async
+    # never attempts a live Celery broker publish in this test.
+    with patch.object(flush_external_ingest_recompute, "apply_async"):
+        accepted = await _run_consumer_pass()
+    assert accepted > 0
 
     status_resp = await client.get(
         f"{BASE}/batches/{ingestion_id}", headers=_headers(source_and_token)
@@ -559,8 +649,14 @@ async def test_disabled_source_returns_403(client, disabled_source_and_token):
 
 
 async def test_stream_unavailable_returns_503_not_202(
-    client, source_and_token, monkeypatch
+    asgi_client, source_and_token, monkeypatch
 ):
+    # ALWAYS in-process (asgi_client, never the black-box `client` fixture):
+    # this monkeypatches an attribute on the `streams` module as imported
+    # into THIS test process. Against a separately-booted server process
+    # (LIVE_E2E_BASE_URL set) that patch would be invisible -- the server
+    # would enqueue successfully and this test would wrongly expect 503. See
+    # the module docstring's "Client selection" note.
     from dev_health_ops.api.external_ingest import streams as streams_mod
     from tests._helpers_external_ingest import build_batch_envelope
 
@@ -574,7 +670,7 @@ async def test_stream_unavailable_returns_503_not_202(
         idempotency_key=f"e2e-stream-unavailable-{uuid.uuid4()}",
         kinds=["repository"],
     )
-    resp = await client.post(
+    resp = await asgi_client.post(
         f"{BASE}/batches", json=envelope, headers=_headers(source_and_token)
     )
     assert resp.status_code == 503, resp.text

--- a/tests/test_external_ingest_customer_push_live.py
+++ b/tests/test_external_ingest_customer_push_live.py
@@ -1,0 +1,581 @@
+"""Live E2E: validate -> batch -> stream -> worker -> sinks -> status ->
+bounded recompute for the CHAOS-2690 customer-push external-ingest pipeline
+(CHAOS-2702, capstone test of the epic).
+
+Drives the REAL merged implementation end to end against REAL ClickHouse +
+Postgres + Valkey (never mocks/FakeValkey for the boundary under test):
+
+- ``POST /api/v1/external-ingest/validate`` catches an invalid record
+  without ever enqueueing to the real Valkey stream.
+- ``POST /api/v1/external-ingest/batches`` returns 202 + ``ingestionId`` and
+  durably ``XADD``s a pointer to ``external-ingest:<org_id>:batches``.
+- Idempotency replay (200, same ingestionId, no new stream entry) and
+  conflict (409) -- CHAOS-2695.
+- The worker (``dev_health_ops.external_ingest.processor.process_batch``,
+  CHAOS-2697/2693 -- driven directly here, in-test, against the real
+  Valkey-enqueued batch; NOT a Celery task named
+  ``consume_external_ingest_batches`` as an earlier planning draft assumed)
+  normalizes and writes through the real ClickHouse sinks -- rows verified
+  via ``FINAL`` + ``org_id`` predicate for all 9 v1 record-kind families.
+- ``GET /batches/{id}`` reports accepted/rejected counts and per-record
+  rejection diagnostics for a deliberately-invalid record.
+- Bounded metric recompute is proven QUEUED, not executed inline
+  (CHAOS-2699's actual seam: ``schedule_or_coalesce`` debounces via a Valkey
+  guard key and schedules
+  ``workers.external_ingest_recompute.flush_external_ingest_recompute
+  .apply_async(countdown=...)`` -- the real ``celery_app.send_task`` calls
+  for ``run_daily_metrics``/etc. only happen inside THAT task, which this
+  test never runs; patching the flush task's ``apply_async`` is therefore
+  the load-bearing seam, mirroring
+  ``tests/test_external_ingest_recompute_debounce.py``'s own pattern).
+- Disabled-source (403) and stream-unavailable (503, never accept-and-warn)
+  regressions.
+
+Opt-in (filtered from unit/CI-unit runs): ``pytest -m clickhouse``. Requires
+``CLICKHOUSE_URI``, ``POSTGRES_URI`` (or ``DATABASE_URI``), and ``REDIS_URL``
+simultaneously -- the only module in this repo that needs all three live
+services at once. Run via ``ci/run_live_backend_e2e.sh`` (extended for this
+issue), not ``ci/local_validate.sh`` (ClickHouse-only, per that script's own
+docstring).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from unittest.mock import MagicMock, patch
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+POSTGRES_URI = os.environ.get("POSTGRES_URI") or os.environ.get("DATABASE_URI")
+REDIS_URL = os.environ.get("REDIS_URL")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not (CLICKHOUSE_URI and POSTGRES_URI and REDIS_URL),
+        reason="Requires CLICKHOUSE_URI, POSTGRES_URI/DATABASE_URI, and REDIS_URL "
+        "(live customer-push E2E: run via ci/run_live_backend_e2e.sh, not "
+        "ci/local_validate.sh).",
+    ),
+    # Module-scoped event loop (not pytest-asyncio's per-function default):
+    # dev_health_ops.db caches its async Postgres engine as a module global
+    # keyed to whichever event loop first created it -- a fresh per-function
+    # loop would make every test after the first crash with "Future attached
+    # to a different loop" the moment it touched the same cached engine the
+    # ASGI app and this module's own fixtures both share.
+    pytest.mark.asyncio(loop_scope="module"),
+]
+
+BASE = "/api/v1/external-ingest"
+
+# All 9 v1 ClickHouse sink tables this batch must land at least one row in
+# (git-family + org-scoped kinds via the async ClickHouseStore, work-item
+# family via the sync ClickHouseMetricsSink -- brief §2.6). ReplacingMergeTree
+# throughout: every read uses FINAL + an org_id predicate (house rule).
+_ALL_SINK_TABLES = (
+    "repos",
+    "git_commits",
+    "git_pull_requests",
+    "git_pull_request_reviews",
+    "identities",
+    "teams",
+    "work_items",
+    "work_item_transitions",
+    "work_item_dependencies",
+)
+
+
+def _headers(creds: dict) -> dict:
+    return {"Authorization": f"Bearer {creds['token']}"}
+
+
+def _redis_client():
+    import valkey
+
+    return valkey.from_url(REDIS_URL, decode_responses=True)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module", autouse=True)
+def _ensure_postgres_schema():
+    """Bootstrap the scratch Postgres schema via ``Base.metadata.create_all``
+    (checkfirst) rather than Alembic -- this worktree's migration history has
+    a pre-existing 0032/0034 multi-head overlap (per orchestrator note), and
+    this is the same bootstrap ``ci/run_live_backend_e2e.sh``'s own
+    ``generate_auth_token()`` already relies on for the curl-based checks
+    that run before this module's pytest step.
+
+    Importing ``dev_health_ops.api.main`` first registers every ORM model
+    reachable from the app's routers (including ``models.ingest_auth``,
+    ``models.external_ingest``, ``models.integrations``) onto the shared
+    ``Base.metadata`` used below.
+    """
+    if not POSTGRES_URI:
+        yield
+        return
+    from sqlalchemy import create_engine
+
+    import dev_health_ops.api.main  # noqa: F401 -- registers all ORM models
+    from dev_health_ops.models.git import Base
+
+    sync_uri = POSTGRES_URI.replace("+asyncpg", "", 1)
+    engine = create_engine(sync_uri)
+    try:
+        Base.metadata.create_all(engine, checkfirst=True)
+    finally:
+        engine.dispose()
+    yield
+
+
+@pytest.fixture(scope="module")
+def ch_sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None  # skipif guard guarantees it
+    sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    sink.ensure_schema(force=True)
+    yield sink
+    sink.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_ingest_rate_limiter():
+    """The shared slowapi ``limiter`` singleton is process-global in-memory
+    state -- reset between tests so this module's ~10 POSTs never risk
+    tripping INGEST_BATCH_LIMIT/INGEST_VALIDATE_LIMIT (60/minute) from prior
+    test runs sharing the same process (mirrors
+    tests/api/external_ingest/test_auth.py's fixture)."""
+    from dev_health_ops.api.middleware import rate_limit as rate_limit_module
+
+    reset = getattr(rate_limit_module.limiter, "reset", None)
+    if reset is not None:
+        try:
+            reset()
+        except Exception:
+            pass
+    yield
+
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def client():
+    from dev_health_ops.api.main import app
+
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as c:
+        yield c
+
+
+@pytest.fixture
+def org_id() -> str:
+    # Fresh org_id per test: avoids idempotency-key/source-instance
+    # collisions between tests and lets each test register its own
+    # IngestSource/IngestToken without colliding on the
+    # (org_id, system, instance) unique constraint.
+    return f"chaos2702-e2e-{uuid.uuid4()}"
+
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def source_and_token(org_id) -> dict:
+    """Registers a customer_push source (github/acme/api) + mints a real
+    ``fcpush_`` bearer token scoped to it, via direct ORM insert against the
+    same Postgres engine ``require_ingest_scope`` reads from (CHAOS-2696's
+    real models) -- NOT the harness's JWT ``generate_auth_token()``, which
+    mints a user token for a completely different auth path."""
+    from dev_health_ops.db import get_postgres_session
+    from dev_health_ops.models.ingest_auth import (
+        IngestSource,
+        IngestSourceMode,
+        IngestToken,
+        generate_ingest_token,
+        hash_ingest_token,
+    )
+
+    plaintext = generate_ingest_token()
+    async with get_postgres_session() as session:
+        source = IngestSource(
+            org_id=org_id,
+            system="github",
+            instance="acme/api",
+            mode=IngestSourceMode.CUSTOMER_PUSH.value,
+            enabled=True,
+        )
+        session.add(source)
+        await session.flush()
+        source_id = source.id
+        session.add(
+            IngestToken(
+                org_id=org_id,
+                source_id=source_id,
+                name="chaos-2702-e2e-token",
+                token_hash=hash_ingest_token(plaintext),
+                token_prefix=plaintext[:12],
+                scopes=["schema:read", "ingest:write", "ingest:status"],
+            )
+        )
+    return {"token": plaintext, "source_id": source_id, "org_id": org_id}
+
+
+@pytest_asyncio.fixture(loop_scope="module")
+async def disabled_source_and_token(org_id) -> dict:
+    """A registered-but-disabled source + a token bound to it (scenario 8:
+    ``require_matching_source``'s ``is_write_eligible()`` check must 403)."""
+    from dev_health_ops.db import get_postgres_session
+    from dev_health_ops.models.ingest_auth import (
+        IngestSource,
+        IngestSourceMode,
+        IngestToken,
+        generate_ingest_token,
+        hash_ingest_token,
+    )
+
+    plaintext = generate_ingest_token()
+    instance = "acme/disabled-repo"
+    async with get_postgres_session() as session:
+        source = IngestSource(
+            org_id=org_id,
+            system="github",
+            instance=instance,
+            mode=IngestSourceMode.CUSTOMER_PUSH.value,
+            enabled=False,
+        )
+        session.add(source)
+        await session.flush()
+        session.add(
+            IngestToken(
+                org_id=org_id,
+                source_id=source.id,
+                name="chaos-2702-e2e-disabled-token",
+                token_hash=hash_ingest_token(plaintext),
+                token_prefix=plaintext[:12],
+                scopes=["ingest:write"],
+            )
+        )
+    return {"token": plaintext, "instance": instance, "org_id": org_id}
+
+
+# ---------------------------------------------------------------------------
+# 1. POST /validate never enqueues
+# ---------------------------------------------------------------------------
+
+
+async def test_validate_rejects_invalid_record_without_enqueueing(
+    client, source_and_token, org_id
+):
+    from dev_health_ops.api.external_ingest.streams import stream_name
+    from tests._helpers_external_ingest import build_batch_envelope
+
+    envelope = build_batch_envelope(
+        idempotency_key=f"e2e-validate-{uuid.uuid4()}",
+        kinds=["repository"],
+        invalid_kind="pull_request",
+    )
+    resp = await client.post(
+        f"{BASE}/validate", json=envelope, headers=_headers(source_and_token)
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["valid"] is False
+    assert body["itemsRejected"] >= 1
+    assert any(
+        e["code"] == "missing_required_field"
+        and e["path"] == "records[1].payload.state"
+        for e in body["errors"]
+    ), body["errors"]
+
+    rc = _redis_client()
+    try:
+        assert rc.xlen(stream_name(org_id)) == 0
+    finally:
+        rc.close()
+
+
+# ---------------------------------------------------------------------------
+# 2. POST /batches happy path -> real stream gains exactly one entry
+# ---------------------------------------------------------------------------
+
+
+async def test_accept_batch_enqueues_to_real_valkey_stream(
+    client, source_and_token, org_id
+):
+    from dev_health_ops.api.external_ingest.streams import stream_name
+    from tests._helpers_external_ingest import build_batch_envelope
+
+    envelope = build_batch_envelope(
+        idempotency_key=f"e2e-batch-happy-{uuid.uuid4()}",
+        kinds=["repository", "commit"],
+    )
+    rc = _redis_client()
+    try:
+        before = rc.xlen(stream_name(org_id))
+        resp = await client.post(
+            f"{BASE}/batches", json=envelope, headers=_headers(source_and_token)
+        )
+        assert resp.status_code == 202, resp.text
+        body = resp.json()
+        assert body["status"] == "accepted"
+        assert body["itemsReceived"] == 2
+        assert body["stream"] == stream_name(org_id)
+        ingestion_id = body["ingestionId"]
+
+        after = rc.xlen(stream_name(org_id))
+        assert after == before + 1
+        entries = rc.xrange(stream_name(org_id))
+        assert entries[-1][1]["ingestion_id"] == ingestion_id
+    finally:
+        rc.close()
+
+
+# ---------------------------------------------------------------------------
+# 3. Idempotency replay: same envelope+key -> 200, same ingestionId, no
+#    second stream entry (CHAOS-2695 contract)
+# ---------------------------------------------------------------------------
+
+
+async def test_idempotent_replay_returns_200_with_no_new_stream_entry(
+    client, source_and_token, org_id
+):
+    from dev_health_ops.api.external_ingest.streams import stream_name
+    from tests._helpers_external_ingest import build_batch_envelope
+
+    envelope = build_batch_envelope(
+        idempotency_key=f"e2e-replay-{uuid.uuid4()}", kinds=["repository"]
+    )
+    resp1 = await client.post(
+        f"{BASE}/batches", json=envelope, headers=_headers(source_and_token)
+    )
+    assert resp1.status_code == 202, resp1.text
+    ingestion_id = resp1.json()["ingestionId"]
+
+    rc = _redis_client()
+    try:
+        count_after_first = rc.xlen(stream_name(org_id))
+
+        resp2 = await client.post(
+            f"{BASE}/batches", json=envelope, headers=_headers(source_and_token)
+        )
+        assert resp2.status_code == 200, resp2.text
+        body2 = resp2.json()
+        assert body2["ingestionId"] == ingestion_id
+
+        assert rc.xlen(stream_name(org_id)) == count_after_first
+    finally:
+        rc.close()
+
+
+# ---------------------------------------------------------------------------
+# 4. Idempotency conflict: same key, different payload hash -> 409
+# ---------------------------------------------------------------------------
+
+
+async def test_idempotency_conflict_returns_409(client, source_and_token):
+    from tests._helpers_external_ingest import build_batch_envelope
+
+    key = f"e2e-conflict-{uuid.uuid4()}"
+    envelope1 = build_batch_envelope(idempotency_key=key, kinds=["repository"])
+    envelope2 = build_batch_envelope(idempotency_key=key, kinds=["commit"])
+
+    resp1 = await client.post(
+        f"{BASE}/batches", json=envelope1, headers=_headers(source_and_token)
+    )
+    assert resp1.status_code == 202, resp1.text
+
+    resp2 = await client.post(
+        f"{BASE}/batches", json=envelope2, headers=_headers(source_and_token)
+    )
+    assert resp2.status_code == 409, resp2.text
+    assert resp2.json()["error"]["code"] == "idempotency_conflict"
+
+
+# ---------------------------------------------------------------------------
+# 5./7. Worker pass -> all 9 kinds land in ClickHouse; bounded recompute is
+#    QUEUED (real flush-task apply_async), never executed inline
+# ---------------------------------------------------------------------------
+
+
+async def test_worker_processes_all_nine_kinds_and_recompute_is_queued_not_inline(
+    client, source_and_token, org_id, ch_sink
+):
+    from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION
+    from dev_health_ops.external_ingest.processor import process_batch
+    from tests._helpers_external_ingest import ALL_KINDS, build_batch_envelope
+
+    envelope = build_batch_envelope(
+        idempotency_key=f"e2e-worker-full-{uuid.uuid4()}", kinds=ALL_KINDS
+    )
+    resp = await client.post(
+        f"{BASE}/batches", json=envelope, headers=_headers(source_and_token)
+    )
+    assert resp.status_code == 202, resp.text
+    ingestion_id = resp.json()["ingestionId"]
+
+    mock_flush_task = MagicMock()
+    with patch(
+        "dev_health_ops.workers.external_ingest_recompute.flush_external_ingest_recompute",
+        mock_flush_task,
+    ):
+        accepted = await process_batch(
+            ingestion_id=ingestion_id,
+            org_id=org_id,
+            source_system="github",
+            source_instance="acme/api",
+            schema_version=SCHEMA_VERSION,
+        )
+    assert accepted == len(ALL_KINDS)
+
+    # (a) recompute was QUEUED: schedule_or_coalesce's real dispatch seam is
+    # `flush_external_ingest_recompute.apply_async(countdown=...)`, NOT a
+    # direct `celery_app.send_task(...)` for run_daily_metrics/etc. -- those
+    # only fire from *inside* the flush task once its debounce window
+    # elapses (dev_health_ops/external_ingest/recompute.py). Patching the
+    # flush task itself (mirrors tests/test_external_ingest_recompute_debounce
+    # .py) is therefore the naming-agnostic, real seam.
+    mock_flush_task.apply_async.assert_called_once()
+    call_kwargs = mock_flush_task.apply_async.call_args.kwargs
+    assert call_kwargs["kwargs"] == {
+        "org_id": org_id,
+        "source_system": "github",
+        "source_instance": "acme/api",
+    }
+    assert call_kwargs["countdown"] > 0
+
+    status_resp = await client.get(
+        f"{BASE}/batches/{ingestion_id}", headers=_headers(source_and_token)
+    )
+    assert status_resp.status_code == 200, status_resp.text
+    status_body = status_resp.json()
+    assert status_body["status"] == "completed"
+    assert status_body["itemsAccepted"] == len(ALL_KINDS)
+    assert status_body["itemsRejected"] == 0
+
+    # (b) recompute was NOT executed inline: dispatch_and_persist_scope (the
+    # only writer of the batch's recompute_status/jobs, and of any
+    # run_daily_metrics/work_graph/investment-materialize Celery dispatch)
+    # runs exclusively from inside the flush task we just proved was merely
+    # SCHEDULED, not invoked -- so immediately after the worker's status
+    # flip, the batch's recompute block must still show its pre-dispatch
+    # default and zero jobs.
+    assert status_body["recompute"]["status"] == "not_applicable"
+    assert status_body["recompute"]["jobs"] == []
+
+    # ClickHouse rows for all 9 v1 sink tables -- FINAL + org_id predicate
+    # (house rule), one row per family is sufficient.
+    for table in _ALL_SINK_TABLES:
+        result = ch_sink.client.query(
+            f"SELECT count() FROM {table} FINAL WHERE org_id = {{org_id:String}}",
+            parameters={"org_id": org_id},
+        )
+        assert result.result_rows[0][0] >= 1, f"no {table} row for org_id={org_id}"
+
+
+# ---------------------------------------------------------------------------
+# 6. GET /batches/{id} rejection diagnostics (partial status)
+# ---------------------------------------------------------------------------
+
+
+async def test_status_reports_partial_with_rejection_diagnostics(
+    client, source_and_token, org_id
+):
+    from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION
+    from dev_health_ops.external_ingest.processor import process_batch
+    from tests._helpers_external_ingest import build_batch_envelope
+
+    envelope = build_batch_envelope(
+        idempotency_key=f"e2e-partial-{uuid.uuid4()}",
+        kinds=["repository"],
+        invalid_kind="pull_request",
+    )
+    resp = await client.post(
+        f"{BASE}/batches", json=envelope, headers=_headers(source_and_token)
+    )
+    assert resp.status_code == 202, resp.text
+    ingestion_id = resp.json()["ingestionId"]
+
+    with patch(
+        "dev_health_ops.workers.external_ingest_recompute.flush_external_ingest_recompute",
+        MagicMock(),
+    ):
+        accepted = await process_batch(
+            ingestion_id=ingestion_id,
+            org_id=org_id,
+            source_system="github",
+            source_instance="acme/api",
+            schema_version=SCHEMA_VERSION,
+        )
+    assert accepted == 1
+
+    status_resp = await client.get(
+        f"{BASE}/batches/{ingestion_id}", headers=_headers(source_and_token)
+    )
+    assert status_resp.status_code == 200, status_resp.text
+    body = status_resp.json()
+    assert body["status"] == "partial"
+    assert body["itemsAccepted"] == 1
+    assert body["itemsRejected"] == 1
+    assert len(body["errors"]) == 1
+    err = body["errors"][0]
+    assert err["index"] == 1
+    assert err["kind"] == "pull_request.v1"
+    assert err["code"] == "missing_required_field"
+    assert err["message"]
+    assert err["path"] == "records[1].payload.state"
+
+
+# ---------------------------------------------------------------------------
+# 8. Disabled source -> 403
+# ---------------------------------------------------------------------------
+
+
+async def test_disabled_source_returns_403(client, disabled_source_and_token):
+    from tests._helpers_external_ingest import build_batch_envelope
+
+    envelope = build_batch_envelope(
+        idempotency_key=f"e2e-disabled-{uuid.uuid4()}",
+        kinds=["repository"],
+        source_instance=disabled_source_and_token["instance"],
+    )
+    resp = await client.post(
+        f"{BASE}/batches",
+        json=envelope,
+        headers={"Authorization": f"Bearer {disabled_source_and_token['token']}"},
+    )
+    assert resp.status_code == 403, resp.text
+    assert resp.json()["error"]["code"] == "source_disabled"
+
+
+# ---------------------------------------------------------------------------
+# 9. Stream-unavailable -> 503, NEVER accept-and-warn (highest-value
+#    regression per the brief: a reviewer pattern-matching against the
+#    legacy /api/v1/ingest router's accept-and-warn behavior could otherwise
+#    "fix" this back to 202 without realizing it's a deliberate divergence)
+# ---------------------------------------------------------------------------
+
+
+async def test_stream_unavailable_returns_503_not_202(
+    client, source_and_token, monkeypatch
+):
+    from dev_health_ops.api.external_ingest import streams as streams_mod
+    from tests._helpers_external_ingest import build_batch_envelope
+
+    # get_redis_client() already swallows connection errors into None (see
+    # its own docstring/try-except) -- returning None from the client
+    # factory is the real, minimal way to simulate "Valkey unavailable"
+    # without needing an actual outage.
+    monkeypatch.setattr(streams_mod, "get_redis_client", lambda: None)
+
+    envelope = build_batch_envelope(
+        idempotency_key=f"e2e-stream-unavailable-{uuid.uuid4()}",
+        kinds=["repository"],
+    )
+    resp = await client.post(
+        f"{BASE}/batches", json=envelope, headers=_headers(source_and_token)
+    )
+    assert resp.status_code == 503, resp.text
+    assert resp.json()["error"]["code"] == "stream_unavailable"

--- a/tests/test_external_ingest_fixtures_shape.py
+++ b/tests/test_external_ingest_fixtures_shape.py
@@ -1,0 +1,98 @@
+"""Cheap offline guard for the CHAOS-2702 external-ingest fixture set.
+
+Unmarked (no ``clickhouse``/live-service dependency) -- runs in the full
+unit suite and ``ci/local_validate.sh``'s offline gate. Proves:
+
+- every one of the 9 v1 record-kind fixtures parses and has ``valid``/
+  ``invalid`` keys;
+- each fixture's ``valid.payload`` is byte/structurally identical to the
+  canonical CHAOS-2692 package example (reconciliation #3 -- no fourth,
+  hand-copied duplicate);
+- each fixture's ``valid`` record actually validates against the real
+  Pydantic per-kind model, and its ``invalid`` record fails validation with
+  the fixture's own declared ``expectedError`` code/field.
+
+This is pure/offline: it imports ``dev_health_ops.api.external_ingest.schemas``
+(Pydantic models only, no DB/network), matching the CHAOS-2697 worker's own
+validation path (``validate_records``) so the fixtures this test guards are
+the same ones the live e2e module drives.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from dev_health_ops.api.external_ingest.schemas import RECORD_KIND_MODELS
+from dev_health_ops.external_ingest.validate import validate_records
+from tests._helpers_external_ingest import (
+    ALL_KINDS,
+    load_fixture,
+    load_package_example,
+)
+
+
+@pytest.mark.parametrize("kind", ALL_KINDS)
+def test_fixture_parses_with_valid_and_invalid_keys(kind: str) -> None:
+    fixture = load_fixture(kind)
+    assert fixture["kind"] == f"{kind}.v1"
+    assert "valid" in fixture
+    assert "invalid" in fixture
+    for case in ("valid", "invalid"):
+        record = fixture[case]
+        assert record["kind"] == f"{kind}.v1"
+        assert isinstance(record.get("externalId"), str) and record["externalId"]
+        assert isinstance(record.get("payload"), dict)
+
+
+@pytest.mark.parametrize("kind", ALL_KINDS)
+def test_valid_payload_matches_package_example_byte_for_byte(kind: str) -> None:
+    fixture = load_fixture(kind)
+    package_example = load_package_example(kind)
+    assert fixture["valid"]["payload"] == package_example, (
+        f"tests/fixtures/external_ingest/v1/{kind}.json's valid.payload has "
+        f"drifted from the canonical src/dev_health_ops/api/external_ingest/"
+        f"examples/{kind}.v1.json package example (single-source-of-truth "
+        "rule, CHAOS-2690 reconciliation #3)"
+    )
+
+
+@pytest.mark.parametrize("kind", ALL_KINDS)
+def test_valid_record_validates_against_real_pydantic_model(kind: str) -> None:
+    fixture = load_fixture(kind)
+    model = RECORD_KIND_MODELS[f"{kind}.v1"]
+    model.model_validate(fixture["valid"]["payload"])  # must not raise
+
+
+@pytest.mark.parametrize("kind", ALL_KINDS)
+def test_invalid_record_fails_validation_with_declared_expected_error(
+    kind: str,
+) -> None:
+    fixture = load_fixture(kind)
+    invalid = fixture["invalid"]
+    expected = invalid["expectedError"]
+    model = RECORD_KIND_MODELS[f"{kind}.v1"]
+
+    with pytest.raises(ValidationError) as exc_info:
+        model.model_validate(invalid["payload"])
+    fields_in_error = {err["loc"][0] for err in exc_info.value.errors() if err["loc"]}
+    assert expected["field"] in fields_in_error
+
+    # Cross-check against the real POST /validate error-item shape
+    # (validate_records) -- the same function the live e2e module exercises
+    # over HTTP, so this fixture's declared code matches production reality.
+    from dev_health_ops.api.external_ingest.schemas import RecordEnvelope
+
+    record = RecordEnvelope.model_validate(
+        {
+            "kind": invalid["kind"],
+            "externalId": invalid["externalId"],
+            "payload": invalid["payload"],
+        }
+    )
+    errors = validate_records([record])
+    assert any(
+        e.code == expected["code"]
+        and e.path == f"records[0].payload.{expected['field']}"
+        for e in errors
+    ), [e.__dict__ for e in errors]


### PR DESCRIPTION
## CHAOS-2702 — E2E customer-push ingestion test

Capstone live end-to-end test of the CHAOS-2690 external customer-push pipeline, wired into the `live-e2e` CI tier. Drives the REAL merged implementation (no mocks for the boundary under test) against real ClickHouse + Postgres + Valkey.

### Coverage (8 scenarios, `@pytest.mark.clickhouse`)
- `POST /validate` rejects an invalid record with zero enqueue (proves validate never XADDs).
- `POST /batches` → 202 + `ingestionId`; durable `XADD` to `external-ingest:<org_id>:batches` (XLEN/XRANGE).
- Idempotency replay (200, same id, no new entry) + conflict (409) — CHAOS-2695.
- Worker driven via the **real** production entry point `consume_external_ingest_streams(max_iterations=1)` (real `ExternalIngestStreamConsumer` XREADGROUP→parse→`process_batch`→XACK), then ClickHouse rows verified via `FINAL` + `org_id` for all 9 v1 record-kind families.
- `GET /batches/{id}` accepted/rejected counts + per-record rejection diagnostics.
- Bounded recompute proven **queued not inline** (`patch.object(flush_external_ingest_recompute, "apply_async")` — real task/registration/debounce/SETNX-guard participate; only the Celery publish is intercepted; production task name asserted).
- Disabled-source → 403; stream-unavailable → 503 (never accept-and-warn — highest-value regression).

### Files
New: 9 fixture files (`tests/fixtures/external_ingest/v1/*.json` — valid case byte-matches the CHAOS-2692 package examples, invalid case hand-authored), `tests/_helpers_external_ingest.py`, `tests/test_external_ingest_customer_push_live.py`, `tests/test_external_ingest_fixtures_shape.py` (offline unit guard, 36 cases). Modified: `ci/run_live_backend_e2e.sh` (Valkey readiness + `REDIS_URL`/`LIVE_E2E_BASE_URL` export + final pytest step), `.github/workflows/live-e2e.yml` (valkey service + `REDIS_URL` env + workflow-file added to changes filter).

### Client fidelity
Black-box scenarios hit the harness-booted `dev-hops api` server via `LIVE_E2E_BASE_URL` (in-process ASGITransport fallback for standalone runs), so a route-mounting/startup regression can't false-green. The stream-unavailable white-box test stays in-process by necessity (its monkeypatch can't reach a separate process).

### Codex adversarial review — 2 rounds
- **r1** (needs-attention, 2 high + 2 medium): worker bypassed the real consumer → now drives `consume_external_ingest_streams`; in-process client couldn't catch server regressions → hybrid live-server client; recompute mock too coarse → patch only `apply_async`; workflow-only PRs skipped live-e2e → workflow added to changes filter. All fixed.
- **r2** (medium): the e2e bootstraps Postgres via `Base.metadata.create_all`, not Alembic, so a broken migration would false-green the deploy path. Root cause is a genuine **pre-existing** defect — a duplicate `0032` revision (`0032_add_customer_push_ingest_auth` + `0032_drop_sync_config_credential_id`) → two heads → `alembic upgrade head` fails. The `create_all` convention pre-dates this PR (harness already used it) and the proper fix is blocked by that defect, so it's **deferred to CHAOS-2832** (renumber the duplicate + switch the harness to real migrations); this module now honestly documents that it does not assert migration deployability.

### Verification
- Standalone (ASGI fallback), fresh scratch `ci_2702` PG+CH + Valkey db15: **8/8 passed**, independently re-verified by orchestrator after fixes.
- Real HTTP boundary confirmed via hand-booted `dev-hops api` + `LIVE_E2E_BASE_URL` → 8/8.
- Offline gate `env -i … SCRATCH_DB=ci_local_validate_2702 bash ci/local_validate.sh`: **GATE PASSED**, 6914 passed / 44 skipped (36 shape-test cases included; live module correctly clickhouse-filtered out). mypy clean.
- Note: the full harness's pre-existing `/api/v1/home` 401 (local JWT-secret artifact) reproduces on the pristine base script — unrelated to this PR; will confirm clean in GH Actions' isolated service containers.
