### PR TITLE
docs(external-ingest): customer-push developer/user documentation (CHAOS-2711)

### DIFF
--- a/docs/architecture/adr/003-external-ingest-test-docs-strategy.md
+++ b/docs/architecture/adr/003-external-ingest-test-docs-strategy.md
@@ -1,0 +1,113 @@
+# ADR-003: External Ingest Test & Docs Strategy
+
+**Status**: DECIDED
+**Created**: 2026-07-02
+**Updated**: 2026-07-02
+**Parent Issue**: CHAOS-2711 (epic: CHAOS-2690 External customer-push ingestion API)
+
+## Context
+
+CHAOS-2690's customer-push ingestion API was implemented across ten sub-issues
+(CHAOS-2691 through CHAOS-2700). Two things needed a decision once the implementation had
+landed: how the developer/user documentation is authored and kept from drifting off the real
+API, and how the single-source-of-truth example payloads are shared between docs, the CLI, and
+the (separately owned) end-to-end test.
+
+This ADR records those decisions per the house rule that decisions get documented in the same
+changeset that makes them.
+
+---
+
+## Decision 1: Docs are written against merged code, not the pre-implementation brief
+
+### Context
+
+CHAOS-2711 was originally scoped against `docs/superpowers/plans/2026-07-01-chaos-2690-
+implementation/briefs/brief-2702-e2e-docs.md`, written before any of CHAOS-2691-2700 existed.
+That brief's §2 "pinned contract" was explicitly a placeholder ("if a sibling issue's
+implementation drifts from this contract, update this brief's Section 2, not the other way
+around" — a note aimed at keeping CHAOS-2702's E2E test buildable before dependencies landed).
+
+By the time CHAOS-2711 was implemented, all ten sibling issues were merged. Several details in
+the brief's pinned contract differ from what actually shipped:
+
+- The brief's error example used `code: "missing_external_id"`; the real vocabulary
+  (`dev_health_ops.external_ingest.validate`) is `missing_required_field` / `invalid_literal` /
+  `invalid_field` / `unknown_kind`.
+- The brief's Postgres sketch (`customer_push_sources`, `ingest_tokens`, snake_case tables)
+  differs from the real schema (`external_ingest_sources`, `external_ingest_tokens`, real
+  migration numbers, `Mapped[...]`/SQLAlchemy models in
+  `dev_health_ops/models/ingest_auth.py`).
+- The brief's status vocabulary omitted `stream_unavailable`, a real, documented interim status
+  between `accepted` and `processing`.
+- ADR numbering: the brief assumed a flat `docs/architecture/adr-006-...` naming scheme
+  (following siblings' `adr-003`/`adr-004`/`adr-005` files). This ADR instead uses the
+  repo's other existing ADR convention — the numbered subdirectory
+  `docs/architecture/adr/NNN-*.md` (see ADR-001) — since that's the format this issue was
+  scoped to follow. Both numbering schemes now coexist in this repo; a future cleanup could
+  unify them, but is out of scope here.
+
+### Decision
+
+**Document the real merged implementation, not the brief.** Every endpoint, field name,
+status code, error code, and scope in the shipped docs
+(`docs/customer-push-ingestion/*.md`) was verified directly against source
+(`src/dev_health_ops/api/external_ingest/*.py`, `src/dev_health_ops/external_ingest/*.py`,
+`src/dev_health_ops/models/ingest_auth.py`, `src/dev_health_ops/push/cli.py`) — never
+transcribed from the brief. Where the two disagree, source wins.
+
+## Decision 2: Canonical examples are shared via `pymdownx.snippets`, not retyped
+
+### Context
+
+CHAOS-2692 already ships 9 canonical, schema-registry-served example payloads at
+`src/dev_health_ops/api/external_ingest/examples/<kind>.v1.json` — these are also what
+`GET /schemas/{version}` embeds per-kind and what `dev-hops push sample --kind <kind>` prints.
+Hand-retyping them into the schema-reference doc would let the doc drift from the actual
+packaged fixtures the first time either changed.
+
+### Decision
+
+`mkdocs.yml`'s `markdown_extensions` gained `pymdownx.snippets`, scoped via `base_path` to
+`src/dev_health_ops/api/external_ingest/examples`. `docs/customer-push-ingestion/
+schemas-and-idempotency.md` includes each example with `--8<-- "<kind>.v1.json"` inside a
+fenced code block, so the doc always renders the exact bytes shipped in the package. CHAOS-2701
+(fixture/example drift tests) owns keeping the *package* examples themselves valid; this ADR
+only records that the docs reference them by inclusion, never by copy.
+
+`mkdocs.yml` is edited exclusively by this issue for the whole CHAOS-2690 epic (nav section +
+this extension) — sibling issues do not touch it.
+
+## Decision 3: Docs scope explicitly excludes the E2E test and CI/CD runnable examples
+
+### Context
+
+CHAOS-2702 (E2E test) and CHAOS-2713 (CI/CD runnable examples) are separate sub-issues in the
+same epic. Both touch adjacent ground: CHAOS-2702 exercises the exact lifecycle this issue
+documents (`validate → batch → stream → worker → sinks → status → bounded recompute`);
+CHAOS-2713 will ship runnable GitHub Actions/GitLab CI examples that go beyond the doc snippets
+here.
+
+### Decision
+
+`docs/customer-push-ingestion/*.md` documents the API surface and lifecycle *prose*, and links
+out rather than duplicating: CI/CD runnable pipeline examples are marked "see CHAOS-2713" rather
+than authored here, and the authorization *design rationale* (why tokens are scoped/bound the
+way they are) is left to CHAOS-2712 — these docs describe the resulting credential UX
+(register a source, mint a scoped token, rotate it) rather than re-litigating that design.
+
+---
+
+## Summary of Decisions
+
+| Decision | Status |
+|---|---|
+| Document merged code, not the pre-implementation brief | **DECIDED** |
+| Share canonical examples via `pymdownx.snippets`, base_path = the examples package | **DECIDED** |
+| Docs link to, not duplicate, CHAOS-2702 (E2E)/CHAOS-2713 (CI/CD examples)/CHAOS-2712 (authz design) | **DECIDED** |
+
+## Changelog
+
+| Date | Change |
+|------|--------|
+| 2026-07-02 | Initial version, recording the docs-vs-brief and snippet-sharing decisions made while implementing CHAOS-2711. |

--- a/docs/customer-push-ingestion/api-reference.md
+++ b/docs/customer-push-ingestion/api-reference.md
@@ -215,8 +215,35 @@ Lists batches for the caller's org.
 - **Auth scope:** `ingest:status`
 - **Query params:** `sourceSystem`, `sourceInstance`, `status`, `createdAfter`, `createdBefore`
   (all optional filters), `limit` (1-200, default 50), `offset` (default 0).
-- **Success — `200`:** `{"items": [...], "total": N, "limit": 50, "offset": 0}` — each item is
-  the same shape as a `GET /batches/{id}` response, minus `errors`/`errorSummary`/`recompute`.
+- **Success — `200`:**
+
+```json
+{
+  "items": [
+    {
+      "ingestionId": "b6c1e6b0-...-uuid",
+      "status": "partial",
+      "itemsReceived": 250,
+      "itemsAccepted": 248,
+      "itemsRejected": 2,
+      "source": {"system": "github", "instance": "acme/api"},
+      "window": {"startedAt": "2026-06-25T00:00:00Z", "endedAt": "2026-06-26T00:00:00Z"},
+      "producer": "dev-hops-cli",
+      "createdAt": "2026-06-26T00:01:00Z",
+      "completedAt": "2026-06-26T00:01:05Z"
+    }
+  ],
+  "total": 1,
+  "limit": 50,
+  "offset": 0
+}
+```
+
+  Each list item is a **narrower** shape than a `GET /batches/{id}` response — it has exactly
+  these 10 fields (`ingestionId`, `status`, `itemsReceived`, `itemsAccepted`, `itemsRejected`,
+  `source`, `window`, `producer`, `createdAt`, `completedAt`) and none of the detail-only
+  fields: no `attempts`, `producerVersion`, `updatedAt`, `errors`, `errorSummary`, or
+  `recompute`. Fetch `GET /batches/{id}` for any of those.
 - **Failure modes:** `401 invalid_token`, `403 insufficient_scope`, `429 rate_limited`.
 
 ---

--- a/docs/customer-push-ingestion/api-reference.md
+++ b/docs/customer-push-ingestion/api-reference.md
@@ -1,0 +1,268 @@
+# Customer Push Ingestion: REST API Reference
+
+All routes are mounted under the prefix `/api/v1/external-ingest`. See
+[Overview](overview.md) for the request lifecycle and
+[Schemas & Idempotency](schemas-and-idempotency.md) for the batch envelope and record-kind
+field reference.
+
+## Authentication
+
+Every route below except the two `GET /schemas*` discovery routes requires:
+
+```
+Authorization: Bearer fcpush_<token>
+```
+
+Tokens are minted by an org admin (see [Setup Guide](setup-guide.md)) and are **not** JWTs —
+they're independent, hashed bearer credentials resolved by a dedicated auth dependency, scoped
+to one of three scopes:
+
+| Scope | Grants |
+|---|---|
+| `schema:read` | `POST /validate`, `GET /schemas`, `GET /schemas/{version}` |
+| `ingest:write` | `POST /batches` (also requires the token to be bound to a specific source) |
+| `ingest:status` | `GET /batches`, `GET /batches/{ingestion_id}` |
+
+A token can be **org-wide** (not bound to a source) only if its scopes are a subset of
+`{schema:read, ingest:status}` — `ingest:write` always requires a source-bound token, and a
+source-bound token can only push data for that exact `(system, instance)` (a mismatch is
+`403 source_mismatch`).
+
+`GET /schemas` and `GET /schemas/{schema_version}` do not validate the bearer value at all
+(they're public schema-discovery routes) — rate-limited by client IP instead of by token.
+
+## Error envelope
+
+Every error response (including an unexpected `500`) uses this shape:
+
+```json
+{
+  "error": {
+    "code": "source_mismatch",
+    "message": "Payload source does not match the token's bound source",
+    "errors": [ ]
+  }
+}
+```
+
+`errors` is present (a list of per-field/per-record problem objects) only for `400
+invalid_envelope` (Pydantic field errors) — see [Troubleshooting](troubleshooting.md) for the
+full error-code vocabulary and remediation per code.
+
+## Rate limits
+
+| Route(s) | Limit | Keyed by |
+|---|---|---|
+| `POST /batches` | 60/minute | validated token |
+| `POST /validate` | 60/minute | validated token |
+| `GET /batches`, `GET /batches/{id}`, `GET /schemas`, `GET /schemas/{version}` | 120/minute | validated token (or forwarded IP for the two public schema routes) |
+| Ingest-auth attempts (any bearer, before validation) | 100/minute per IP | forwarded IP |
+| Ingest-auth *failures* specifically | 30/minute per IP | forwarded IP |
+
+Exceeding any limit returns `429` with `{"error": {"code": "rate_limited", ...}}`.
+
+---
+
+## `POST /api/v1/external-ingest/validate`
+
+Validates a batch envelope (shape + per-record payload) without writing anything or enqueueing
+work. Use this in CI, or via `dev-hops push validate`, before submitting a real batch.
+
+- **Auth scope:** `schema:read`
+- **Request body:** a [batch envelope](schemas-and-idempotency.md#the-batch-envelope)
+- **Success — `200`:**
+
+```json
+{
+  "valid": false,
+  "itemsAccepted": 8,
+  "itemsRejected": 2,
+  "errors": [
+    {
+      "index": 3,
+      "kind": "pull_request.v1",
+      "code": "missing_required_field",
+      "message": "Field required",
+      "path": "records[3].payload.state"
+    }
+  ]
+}
+```
+
+- **Failure modes:**
+  - `400 invalid_envelope` — malformed JSON or envelope shape (bad `schemaVersion` field type,
+    missing `source`, empty `records`, etc.)
+  - `400 unsupported_schema_version` — `schemaVersion` isn't `external-ingest.v1`
+  - `400 batch_too_large` — more than `maxRecordsPerBatch` records (default 1000)
+  - `413 payload_too_large` — request body exceeds `maxBodyBytes` (default 10MB)
+  - `401 invalid_token`, `403 insufficient_scope`, `429 rate_limited`
+
+Per-record problems (unknown kind, missing/invalid fields) are reported as `200` with
+`valid: false` and one `errors[]` item per problem — they do **not** produce a 4xx, since a
+partially-invalid batch is exactly what this endpoint exists to surface.
+
+---
+
+## `POST /api/v1/external-ingest/batches`
+
+Accepts a batch for durable, asynchronous processing.
+
+- **Auth scope:** `ingest:write` (token must be bound to the `source.system`/`source.instance`
+  in the request body)
+- **Headers:** optional `Idempotency-Key` — if present, it must match the body's
+  `idempotencyKey` exactly (`400 idempotency_key_mismatch` otherwise). The body field is
+  canonical; the header is an optional Stripe-style alias for generic HTTP client ergonomics.
+- **Request body:** a [batch envelope](schemas-and-idempotency.md#the-batch-envelope)
+- **Success — `202 Accepted`:**
+
+```json
+{
+  "ingestionId": "b6c1e6b0-...-uuid",
+  "status": "accepted",
+  "itemsReceived": 250,
+  "stream": "external-ingest:<org_id>:batches"
+}
+```
+
+  A replayed request (same idempotency key + identical payload, see
+  [Idempotency](schemas-and-idempotency.md#idempotency)) instead returns **`200`** with the
+  *current* full status envelope (the same shape as `GET /batches/{id}` below) — not the
+  narrow 202 shape, since the batch may already be `completed`/`partial`.
+
+- **Failure modes:**
+  - `400` — `invalid_envelope`, `idempotency_key_mismatch`, `unsupported_schema_version`,
+    `unknown_record_kind` (any record's `kind` isn't one of the 9 known kinds — the whole batch
+    is rejected, no partial acceptance), `batch_too_large`
+  - `401 invalid_token`
+  - `403` — `source_mismatch` (payload source doesn't match the token's bound source),
+    `source_disabled`, `source_not_registered`, `source_owned_by_fullchaos_sync`,
+    `insufficient_scope`
+  - `409 idempotency_conflict` — same idempotency key already used with a **different**
+    payload
+  - `413 payload_too_large`
+  - `429 rate_limited`
+  - `503` — `ingest_temporarily_unavailable` (a concurrent request for the same idempotency key
+    is in flight; retry) or `stream_unavailable` (the batch was durably recorded but could not
+    be enqueued; retry with the same `idempotencyKey`)
+
+See [Troubleshooting](troubleshooting.md) for remediation per code.
+
+---
+
+## `GET /api/v1/external-ingest/batches/{ingestion_id}`
+
+Fetches the current status and diagnostics for one batch.
+
+- **Auth scope:** `ingest:status`
+- **Query params:** `errorLimit` (1-200, default 50), `errorOffset` (default 0) — paginate the
+  `errors[]` list.
+- **Success — `200`:**
+
+```json
+{
+  "ingestionId": "b6c1e6b0-...-uuid",
+  "status": "partial",
+  "attempts": 1,
+  "itemsReceived": 250,
+  "itemsAccepted": 248,
+  "itemsRejected": 2,
+  "source": {"system": "github", "instance": "acme/api"},
+  "window": {"startedAt": "2026-06-25T00:00:00Z", "endedAt": "2026-06-26T00:00:00Z"},
+  "producer": "dev-hops-cli",
+  "producerVersion": "0.12.0",
+  "createdAt": "2026-06-26T00:01:00Z",
+  "updatedAt": "2026-06-26T00:01:05Z",
+  "completedAt": "2026-06-26T00:01:05Z",
+  "errorSummary": {
+    "total_rejected": 2,
+    "stored_rejections": 2,
+    "truncated": false,
+    "top_codes": [{"code": "missing_required_field", "count": 2}]
+  },
+  "errors": [
+    {"index": 3, "kind": "pull_request.v1", "externalId": "acme/api#482",
+     "code": "missing_required_field", "message": "Field required",
+     "path": "records[3].payload.state"}
+  ],
+  "errorsTotal": 2,
+  "errorsLimit": 50,
+  "errorsOffset": 0,
+  "recompute": {
+    "status": "dispatched",
+    "scope": {"repoIds": ["..."], "teamIds": [], "windowStartedAt": "...",
+              "windowEndedAt": "...", "cappedDays": false, "cappedRepos": false},
+    "dispatchedAt": "2026-06-26T00:01:06Z",
+    "completedAt": null,
+    "error": null,
+    "jobs": [{"task": "run_daily_metrics", "taskId": "...", "queue": "metrics", "repoId": "..."}]
+  }
+}
+```
+
+  `status` is one of `accepted | stream_unavailable | processing | completed | partial |
+  failed` — see [Troubleshooting](troubleshooting.md#status-polling) for the full transition
+  diagram. `recompute.status` is one of `not_applicable | pending | dispatched |
+  skipped_no_scope | failed`.
+
+- **Failure modes:** `404 not_found` (unknown id, or belongs to a different org — both map to
+  the identical 404 to avoid leaking cross-org existence), `401 invalid_token`,
+  `403 insufficient_scope`, `429 rate_limited`.
+
+## `GET /api/v1/external-ingest/batches`
+
+Lists batches for the caller's org.
+
+- **Auth scope:** `ingest:status`
+- **Query params:** `sourceSystem`, `sourceInstance`, `status`, `createdAfter`, `createdBefore`
+  (all optional filters), `limit` (1-200, default 50), `offset` (default 0).
+- **Success — `200`:** `{"items": [...], "total": N, "limit": 50, "offset": 0}` — each item is
+  the same shape as a `GET /batches/{id}` response, minus `errors`/`errorSummary`/`recompute`.
+- **Failure modes:** `401 invalid_token`, `403 insufficient_scope`, `429 rate_limited`.
+
+---
+
+## `GET /api/v1/external-ingest/schemas`
+
+Lists supported schema versions and record kinds. **Public** (no bearer validation) —
+rate-limited by client IP.
+
+- **Success — `200`:**
+
+```json
+{
+  "schemaVersions": ["external-ingest.v1"],
+  "recordKinds": ["commit.v1", "identity.v1", "pull_request.v1", "repository.v1",
+                  "review.v1", "team.v1", "work_item.v1", "work_item_dependency.v1",
+                  "work_item_transition.v1"],
+  "limits": {"maxRecordsPerBatch": 1000, "maxBodyBytes": 10000000}
+}
+```
+
+## `GET /api/v1/external-ingest/schemas/{schema_version}`
+
+Returns the full JSON Schema bundle (envelope + per-record-kind `$ref`s + `$defs` + canonical
+examples) for a schema version, generated directly from the server's Pydantic models. **Public**
+(no bearer validation), rate-limited by client IP. Supports conditional `If-None-Match` /
+`ETag` caching (`304` on a matching ETag; the ETag covers the schema *and* the live `limits`
+block, so a limits change is never masked behind a stale 304).
+
+- **Success — `200`** (headers: `ETag`, `Cache-Control: public, max-age=3600,
+  must-revalidate`) — see [Schemas & Idempotency](schemas-and-idempotency.md) for how to read
+  the bundle.
+- **`304 Not Modified`** if `If-None-Match` matches the current ETag.
+- **Failure modes:** `404 unsupported_schema_version` — unknown `schema_version` (note: this
+  is the same error `code` string used for the *400* `POST /batches`/`POST /validate` case,
+  but with a `404` status here since the version is a URL path segment).
+
+---
+
+## Admin validate proxy (session-authed, not token-authed)
+
+`POST /api/v1/admin/customer-push/sources/{source_id}/validate` is a **session-JWT +
+admin-role** authenticated twin of `POST /validate`, used by the web console. It mirrors the
+same envelope/version/size/per-record checks, but reports every failure — including malformed
+envelopes and version mismatches — as a `200` with `valid: false` (never a 4xx), since the
+console renders each response as a validation result row. The `source_id` path segment is a
+tenant-scope check only; it does not verify the payload's `source` field against it (that
+check only applies to the token-authed data-plane write path). See
+[Setup Guide](setup-guide.md) for the source-registration admin routes this proxy sits next to.

--- a/docs/customer-push-ingestion/overview.md
+++ b/docs/customer-push-ingestion/overview.md
@@ -1,0 +1,95 @@
+# Customer Push Ingestion: Overview
+
+Customer-push ingestion lets a customer's own systems (CI pipelines, ETL jobs, custom
+integrations) push repository, work-item, and review data directly into FullChaos over a
+versioned REST API, instead of FullChaos pulling it via a managed GitHub/GitLab/Jira/Linear
+connector.
+
+!!! note "Not the same thing as provider webhooks"
+    This is a different ingestion path from [Webhooks](../webhooks.md). Provider webhooks
+    (`/api/v1/webhooks/*`) are FullChaos-managed sync reacting to GitHub/GitLab/Jira events in
+    real time. Customer-push ingestion (`/api/v1/external-ingest/*`) is the customer's own
+    system actively submitting batches of normalized records, on its own schedule. See
+    [Webhooks](../webhooks.md) for the provider-webhook path.
+
+## When to use customer-push vs. FullChaos-managed sync
+
+| Use FullChaos-managed sync (native connectors) when... | Use customer-push ingestion when... |
+|---|---|
+| Your GitHub/GitLab/Jira/Linear instance is directly reachable and you're comfortable granting FullChaos an integration/OAuth connection. | Your source systems are firewalled, air-gapped, or you don't want to grant a third-party integration. |
+| You want zero-maintenance, fully automatic sync. | You already run an ETL/CI pipeline and want to push data on your own schedule. |
+| Your provider is one of the natively supported connectors. | You have a `custom` internal system with no native FullChaos connector. |
+
+A given `(system, instance)` pair (e.g. `github` / `acme/api`) can only be owned by **one**
+active ingestion path at a time — see [Schemas & Idempotency](schemas-and-idempotency.md) and
+[Setup Guide](setup-guide.md) for the one-active-owner registration rules. If FullChaos-managed
+sync is actively connected to the same instance, customer-push writes for that instance are
+rejected with `403 source_owned_by_fullchaos_sync`.
+
+## REST, not GraphQL
+
+Customer-push ingestion is a **REST** API (`/api/v1/external-ingest/*`), authenticated with a
+dedicated bearer token (`fcpush_...`), completely separate from the GraphQL API used for
+analytics exploration and the web UI. Once customer-pushed data lands and is normalized, it is
+readable through the same GraphQL API / UI / metrics views as data from any other connector —
+ingestion is REST-only, but querying the results stays GraphQL/API/UI as usual. See
+[GraphQL Overview](../api/graphql-overview.md) for the analytics side.
+
+## Lifecycle
+
+A batch of records goes through the following stages:
+
+1. **Validate** (optional, recommended) — `POST /api/v1/external-ingest/validate` checks
+   envelope shape and per-record payload validity against the versioned schema, without
+   writing anything. Use this in CI before submitting a real batch.
+2. **Batch accept** — `POST /api/v1/external-ingest/batches` runs the full accept sequence:
+   auth/scope check, source-ownership check (one-active-owner), idempotency resolution
+   (new/replay/conflict/retry), a durable Postgres write of the raw payload, and a commit —
+   *before* the batch is queued for processing. The endpoint returns `202 Accepted` with an
+   `ingestionId` as soon as the batch is durably recorded; it does not wait for processing.
+3. **Stream** — once the payload is durable, the batch is enqueued as a pointer (not the
+   payload itself) onto a per-org Valkey/Redis stream (`external-ingest:<org_id>:batches`). If
+   the stream is unavailable, the API fails closed with `503 stream_unavailable` rather than
+   silently dropping the batch — the durable Postgres row lets a same-key retry recover.
+4. **Worker** — a dedicated external-ingest worker consumes the stream, re-validates each
+   record (the same validation logic `POST /validate` uses), and normalizes accepted records.
+5. **Sinks** — normalized records are written to the same ClickHouse/Postgres tables used by
+   FullChaos-managed sync (repositories, pull requests, reviews, commits, identities, teams,
+   work items, work-item transitions, work-item dependencies).
+6. **Status** — `GET /api/v1/external-ingest/batches/{ingestion_id}` reports the batch's
+   lifecycle status (`accepted → processing → completed|partial|failed`, with
+   `stream_unavailable` as a recoverable interim state), per-record rejection diagnostics, and
+   an `errorSummary`. See [Troubleshooting](troubleshooting.md).
+7. **Bounded recompute** — once the worker completes a batch, affected metrics are recomputed
+   for the scope the batch actually touched (its repos/teams/window), not a full-org
+   recompute. `GET /batches/{id}` surfaces this as a `recompute` block
+   (`not_applicable|pending|dispatched|skipped_no_scope|failed`) with the dispatched Celery
+   job ids.
+
+```text
+validate ──▶ batches (202 + ingestionId) ──▶ stream ──▶ worker ──▶ sinks
+                                                            │
+                                                            ▼
+                                        GET /batches/{id} ◀── bounded recompute
+```
+
+## Record kinds
+
+A batch's `records[]` array carries a mix of the 9 canonical record kinds
+(`repository.v1`, `identity.v1`, `team.v1`, `work_item.v1`, `work_item_transition.v1`,
+`work_item_dependency.v1`, `pull_request.v1`, `review.v1`, `commit.v1`). See
+[Schemas & Idempotency](schemas-and-idempotency.md) for the full field reference and canonical
+example payloads.
+
+## Where to go next
+
+- [API Reference](api-reference.md) — every REST endpoint, request/response shapes, status
+  codes.
+- [Schemas & Idempotency](schemas-and-idempotency.md) — the record envelope, the 9 record
+  kinds, idempotency semantics, batch limits.
+- [Troubleshooting](troubleshooting.md) — rejected-record diagnostics, status polling, common
+  failure modes and remediation.
+- [Setup Guide](setup-guide.md) — register a source, create/rotate a credential, submit your
+  first batch.
+- CI/CD-runnable pipeline examples (GitHub Actions, GitLab CI) are tracked separately —
+  see CHAOS-2713.

--- a/docs/customer-push-ingestion/schemas-and-idempotency.md
+++ b/docs/customer-push-ingestion/schemas-and-idempotency.md
@@ -40,7 +40,7 @@ never drift from what the server actually accepts. Validate your integration aga
 | `idempotencyKey` | 1-255 chars. Unique **forever** per `(org, source.system, source.instance, idempotencyKey)` — no TTL. See [Idempotency](#idempotency). |
 | `source.type` | Always `customer_push`. |
 | `source.system` | One of `github`, `gitlab`, `jira`, `linear`, `custom`. |
-| `source.instance` | The provider instance identifier — for git systems this must equal each record's `repositoryExternalId`/`externalId` (provider full name, e.g. `owner/repo`, not a URL). Matching against your token's bound source and the source-registration record is **case-insensitive**. |
+| `source.instance` | The provider instance identifier — for git systems this must equal each record's `repositoryExternalId`/`externalId` (provider full name, e.g. `owner/repo`, not a URL). **Must match your `ingest:write` token's bound source with EXACT casing** — the accept-time check (`require_matching_source`) is a plain string comparison, so a token bound to `Acme/API` rejects an envelope with `source.instance: "acme/api"` with `403 source_mismatch`. Registration-time ownership/dedup (whether an instance is already registered, and one-active-owner-vs-managed-sync checks) IS case-insensitive — which is why you can't separately register `Acme/API` and `acme/api` — but that leniency does not extend to this accept-time token/envelope match. Always send the exact instance string used when the source was registered. |
 | `source.producer` / `source.producerVersion` | Optional, free-text — identifies the client (e.g. `dev-hops-cli` / `0.12.0`). |
 | `window` | Optional. `startedAt`/`endedAt` — `endedAt` must be `>= startedAt`. |
 | `records` | 1-1000 entries (see [Batch limits](#batch-limits)). |
@@ -81,6 +81,27 @@ silently dropped data. Field names below are the wire (camelCase) names.
 `backlog | todo | in_progress | in_review | blocked | done | canceled | unknown`.
 `review.v1`'s `state` is one of `APPROVED | CHANGES_REQUESTED | COMMENTED | DISMISSED |
 PENDING`. `pull_request.v1`'s `state` is one of `open | closed | merged`.
+
+## Kind x System Matrix
+
+Not every record kind is valid under every `source.system` — the worker (not `POST /validate`,
+which has no source context to check against) enforces which kinds a given system may push.
+Sending a disallowed kind is rejected with `unsupported_kind_for_system` — see
+[Troubleshooting](troubleshooting.md#rejected-record-diagnostics).
+
+| `source.system` | Allowed record kinds |
+|---|---|
+| `github` | All 9 kinds: `repository.v1`, `pull_request.v1`, `review.v1`, `commit.v1` (git family) + `work_item.v1`, `work_item_transition.v1`, `work_item_dependency.v1` (work-item family) + `team.v1`, `identity.v1` (org-scoped) |
+| `gitlab` | All 9 kinds (same as `github`) |
+| `jira` | `work_item.v1`, `work_item_transition.v1`, `work_item_dependency.v1` (work-item family) + `team.v1`, `identity.v1` (org-scoped) — no git-family kinds |
+| `linear` | Same as `jira` — work-item family + org-scoped only |
+| `custom` | `repository.v1`, `pull_request.v1`, `review.v1`, `commit.v1` (git family) + `team.v1`, `identity.v1` (org-scoped) — no work-item family in v1 |
+
+For `github`/`gitlab`/`custom` sources, every git-family record's repository identifier
+(`repository.v1`'s `externalId`, or `repositoryExternalId` on the other three git-family kinds)
+must also match the batch's `source.instance` (case-insensitive at this per-record check) — a
+mismatch is rejected with `record_outside_source_instance`. A batch covering multiple
+repositories must be split into one batch per `source.instance`.
 
 ### Canonical example payloads
 

--- a/docs/customer-push-ingestion/schemas-and-idempotency.md
+++ b/docs/customer-push-ingestion/schemas-and-idempotency.md
@@ -1,0 +1,176 @@
+# Customer Push Ingestion: Schemas & Idempotency
+
+## Schema versioning
+
+The wire contract is versioned as a whole: `schemaVersion: "external-ingest.v1"`. There is
+currently exactly one supported version. A batch or validate request with any other
+`schemaVersion` value is rejected with `400 unsupported_schema_version` (or `404` from
+`GET /schemas/{version}` if you ask for an unknown version by URL).
+
+`GET /api/v1/external-ingest/schemas/{schema_version}` returns the full JSON Schema for this
+version — generated directly from the server's Pydantic models (never hand-written), so it can
+never drift from what the server actually accepts. Validate your integration against it in CI.
+
+## The batch envelope
+
+```json
+{
+  "schemaVersion": "external-ingest.v1",
+  "idempotencyKey": "acme-github-prs-2026-06-26T00:00:00Z",
+  "source": {
+    "type": "customer_push",
+    "system": "github",
+    "instance": "acme/api",
+    "producer": "dev-hops-cli",
+    "producerVersion": "0.12.0"
+  },
+  "window": {
+    "startedAt": "2026-06-25T00:00:00Z",
+    "endedAt": "2026-06-26T00:00:00Z"
+  },
+  "records": [
+    {"kind": "pull_request.v1", "externalId": "acme/api#482", "payload": { "...": "..." }}
+  ]
+}
+```
+
+| Field | Notes |
+|---|---|
+| `schemaVersion` | Must be `external-ingest.v1`. |
+| `idempotencyKey` | 1-255 chars. Unique **forever** per `(org, source.system, source.instance, idempotencyKey)` — no TTL. See [Idempotency](#idempotency). |
+| `source.type` | Always `customer_push`. |
+| `source.system` | One of `github`, `gitlab`, `jira`, `linear`, `custom`. |
+| `source.instance` | The provider instance identifier — for git systems this must equal each record's `repositoryExternalId`/`externalId` (provider full name, e.g. `owner/repo`, not a URL). Matching against your token's bound source and the source-registration record is **case-insensitive**. |
+| `source.producer` / `source.producerVersion` | Optional, free-text — identifies the client (e.g. `dev-hops-cli` / `0.12.0`). |
+| `window` | Optional. `startedAt`/`endedAt` — `endedAt` must be `>= startedAt`. |
+| `records` | 1-1000 entries (see [Batch limits](#batch-limits)). |
+
+### The record envelope
+
+Every entry in `records[]` is a generic wrapper:
+
+```json
+{"kind": "pull_request.v1", "externalId": "acme/api#482", "payload": { }}
+```
+
+| Field | Notes |
+|---|---|
+| `kind` | A versioned record kind, e.g. `pull_request.v1` — see the 9 kinds below. An unknown `kind` fails the *whole batch* with `400 unknown_record_kind` at `POST /batches` (no partial acceptance); `POST /validate` instead reports it as a per-record `unknown_kind` error and continues checking the rest. |
+| `externalId` | 1-512 chars. A correlation id used purely for error reporting/diagnostics — it is **not** validated against the payload's own natural key. |
+| `payload` | The kind-specific record body — validated per-kind (see below). |
+
+## The 9 record kinds
+
+Each `payload` is validated against a versioned Pydantic model with `extra="forbid"` — this is
+a customer-facing, versioned contract, so an unrecognized field is a loud validation error, not
+silently dropped data. Field names below are the wire (camelCase) names.
+
+| Kind | Required fields | Notable optional fields |
+|---|---|---|
+| `repository.v1` | `externalId`, `sourceSystem` | `defaultRef`, `tags[]`, `settings{}` |
+| `identity.v1` | `canonicalId`, `updatedAt` | `displayName`, `email`, `providerIdentities{}`, `teamIds[]`, `isActive` |
+| `team.v1` | `id`, `name`, `updatedAt` | `description`, `members[]`, `projectKeys[]`, `repoPatterns[]`, `nativeTeamKey`, `parentTeamId` |
+| `work_item.v1` | `externalKey`, `provider`, `title`, `status`, `createdAt` | `type`, `statusRaw`, `repositoryExternalId`, `projectKey`, `assignees[]`, `labels[]`, `storyPoints`, `sprintId`, `parentId`, `epicId`, `url` |
+| `work_item_transition.v1` | `externalKey`, `provider`, `occurredAt`, `fromStatus`, `toStatus` | `workItemType`, `fromStatusRaw`, `toStatusRaw`, `actor` |
+| `work_item_dependency.v1` | `sourceExternalKey`, `targetExternalKey`, `relationshipType` | `sourceWorkItemType`, `targetWorkItemType`, `relationshipTypeRaw` |
+| `pull_request.v1` | `repositoryExternalId`, `number`, `state`, `createdAt` | `title`, `body`, `authorName`, `authorEmail`, `mergedAt`, `closedAt`, `headBranch`, `baseBranch`, `additions`, `deletions`, `changedFiles`, `reviewsCount`, `commentsCount`, `url` |
+| `review.v1` | `repositoryExternalId`, `pullRequestNumber`, `reviewId`, `reviewer`, `state`, `submittedAt` | — |
+| `commit.v1` | `repositoryExternalId`, `hash`, `authorWhen` | `message`, `authorName`, `authorEmail`, `committerName`, `committerEmail`, `committerWhen`, `parents` |
+
+`status` (`work_item.v1`) and `fromStatus`/`toStatus` (`work_item_transition.v1`) are one of:
+`backlog | todo | in_progress | in_review | blocked | done | canceled | unknown`.
+`review.v1`'s `state` is one of `APPROVED | CHANGES_REQUESTED | COMMENTED | DISMISSED |
+PENDING`. `pull_request.v1`'s `state` is one of `open | closed | merged`.
+
+### Canonical example payloads
+
+These are the exact, server-shipped example payloads (`src/dev_health_ops/api/external_ingest/examples/*.json`) — the same files served in each record kind's `examples[]` in `GET /schemas/{version}`, and what `dev-hops push sample --kind <kind>` prints. They are the source of truth for valid payload shape.
+
+**`repository.v1`**
+
+```json
+--8<-- "repository.v1.json"
+```
+
+**`identity.v1`**
+
+```json
+--8<-- "identity.v1.json"
+```
+
+**`team.v1`**
+
+```json
+--8<-- "team.v1.json"
+```
+
+**`work_item.v1`**
+
+```json
+--8<-- "work_item.v1.json"
+```
+
+**`work_item_transition.v1`**
+
+```json
+--8<-- "work_item_transition.v1.json"
+```
+
+**`work_item_dependency.v1`**
+
+```json
+--8<-- "work_item_dependency.v1.json"
+```
+
+**`pull_request.v1`**
+
+```json
+--8<-- "pull_request.v1.json"
+```
+
+**`review.v1`**
+
+```json
+--8<-- "review.v1.json"
+```
+
+**`commit.v1`**
+
+```json
+--8<-- "commit.v1.json"
+```
+
+## Idempotency
+
+Every batch is identified by `(org_id, source.system, source.instance, idempotencyKey)` —
+unique **forever** (no TTL, unlike the legacy `/api/v1/ingest` router's 24h cache). Resubmitting
+the same key is always safe. The payload hash used for comparison is a SHA-256 digest of the
+canonicalized (sorted keys, normalized timestamps), schema-validated envelope — so resending
+byte-identical JSON with different field order or `Z` vs `+00:00` timestamps still hashes the
+same.
+
+| Outcome | When | What happens |
+|---|---|---|
+| **New** | No row exists yet for this key. | A new batch is accepted (`202`) and enqueued normally. |
+| **Replay** | Same key, same payload hash, and the batch isn't in a retryable state. | Returns **`200`** with the batch's *current* full status envelope (same shape as `GET /batches/{id}`) — nothing is re-enqueued. |
+| **Conflict** | Same key, but a **different** payload hash. | `409 idempotency_conflict`. The original batch is never overwritten — use a new `idempotencyKey`, or resend the exact original payload to get the replayed status. |
+| **Retry** | Same key, same hash, and the existing batch is in a recoverable state: `stream_unavailable`, `failed`, or `accepted` for longer than `EXTERNAL_INGEST_ACCEPTED_STALE_MINUTES` (default 15 minutes — covers a crash between the Postgres commit and the stream enqueue). | The **same** `ingestion_id` is re-accepted (`attempts` incremented, prior outcome cleared) and re-enqueued. |
+
+A concurrent request racing for the same idempotency key (two requests landing before either
+commits) gets `503 ingest_temporarily_unavailable` — retry with the same key; it resolves to
+replay/retry on the next attempt.
+
+## Batch limits
+
+| Limit | Default | Override |
+|---|---|---|
+| Max records per batch | 1000 | `EXTERNAL_INGEST_MAX_RECORDS` |
+| Max request body size | 10,000,000 bytes (10MB) | `EXTERNAL_INGEST_MAX_BODY_BYTES` |
+
+Both are also reported live in `GET /schemas` / `GET /schemas/{version}`'s `limits` block, and
+`dev-hops push batch` fetches them before submitting (unless `--skip-limits-check` is passed) so
+the CLI enforces the server's actual current limits rather than hardcoded defaults. Exceeding
+either limit is `400 batch_too_large` (record count) or `413 payload_too_large` (body size).
+
+See [Troubleshooting](troubleshooting.md) for how these show up as HTTP errors and how to
+remediate, and [Setup Guide](setup-guide.md) for a first end-to-end walkthrough.

--- a/docs/customer-push-ingestion/setup-guide.md
+++ b/docs/customer-push-ingestion/setup-guide.md
@@ -1,0 +1,191 @@
+# Customer Push Ingestion: Setup Guide
+
+This walks through registering a source, minting a credential, validating a payload, and
+submitting your first batch. See [Overview](overview.md) for when customer-push is the right
+choice, and [API Reference](api-reference.md) / [Schemas & Idempotency](schemas-and-idempotency.md)
+for the full contract.
+
+## 1. Register a source
+
+Every `(system, instance)` pair your org pushes data for must be registered first — this is
+what enforces the one-active-owner rule (a source can't be simultaneously customer-push and
+FullChaos-managed sync) and what an `ingest:write` token binds to.
+
+Source registration and token management are **admin-role, session-authenticated** endpoints
+(`/api/v1/admin/customer-push/*`) — normally driven through the FullChaos web console. If you
+need to script it (e.g. infra-as-code), authenticate as an org admin and call the API directly:
+
+```bash
+curl -X POST "https://your-fullchaos-instance/api/v1/admin/customer-push/sources" \
+  -H "Authorization: Bearer <admin-session-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "system": "github",
+    "instance": "acme/api",
+    "display_name": "Acme API repo",
+    "mode": "customer_push"
+  }'
+```
+
+If a FullChaos-managed sync source already actively owns `github`/`acme/api` in your org, this
+returns `409` with `code: "source_owned_by_fullchaos_sync"` — disable managed sync for that
+instance first. A registered-but-not-actively-owned managed source instead surfaces as a
+non-blocking `warnings[]` entry in the response.
+
+Registering under a system/instance that only differs by case from an existing registration
+(e.g. `Acme/API` vs `acme/api`) is also rejected with `409` — instance matching is
+case-insensitive.
+
+## 2. Create an ingest token
+
+Tokens are scoped and (for write access) bound to a single source:
+
+```bash
+curl -X POST "https://your-fullchaos-instance/api/v1/admin/customer-push/sources/<source_id>/tokens" \
+  -H "Authorization: Bearer <admin-session-token>" \
+  -H "Content-Type: application/json" \
+  -d '{
+    "name": "ci-pipeline-token",
+    "scopes": ["ingest:write", "ingest:status"]
+  }'
+```
+
+The response's `token` field is the **only time the plaintext token is returned** —
+`fcpush_<random>` — store it in your CI secret store immediately. Later reads
+(`GET /customer-push/tokens`) only show `token_prefix` (first 12 characters) for identification.
+
+An org-wide token (not bound to any source, for read-only use across all your registered
+sources) can only use `schema:read`/`ingest:status` scopes — `ingest:write` always requires a
+source-bound token:
+
+```bash
+curl -X POST "https://your-fullchaos-instance/api/v1/admin/customer-push/tokens" \
+  -H "Authorization: Bearer <admin-session-token>" \
+  -H "Content-Type: application/json" \
+  -d '{"name": "read-only-monitor", "scopes": ["ingest:status"]}'
+```
+
+### Rotating a token
+
+Rotation is a **hard, immediate cutover** — the old token stops working the instant the new one
+is issued (no grace window):
+
+```bash
+curl -X POST "https://your-fullchaos-instance/api/v1/admin/customer-push/tokens/<token_id>/rotate" \
+  -H "Authorization: Bearer <admin-session-token>"
+```
+
+The response is a fresh `IngestTokenCreateResponse` (new plaintext `token`, same name/scopes/
+source binding, same expiry offset if the original had one). Update your CI secret immediately
+after rotating. To revoke without rotating: `POST .../tokens/{token_id}/revoke`.
+
+Export the new token for the CLI examples below:
+
+```bash
+export FULLCHAOS_API_URL="https://your-fullchaos-instance"
+export FULLCHAOS_INGEST_TOKEN="fcpush_..."
+export FULLCHAOS_ORG_ID="<your-org-id>"
+```
+
+## 3. Test before production: validate
+
+Validate locally (no network call — checks shape/fields against the schema):
+
+```bash
+dev-hops push sample --kind pull_request > sample-batch.json
+dev-hops push validate sample-batch.json
+```
+
+```text
+valid: 1 record(s) accepted
+```
+
+Or validate against the live server (also checks scope/auth, still doesn't write anything):
+
+```bash
+curl -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/validate" \
+  -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @sample-batch.json
+```
+
+Wire your own export into the same shape (see
+[Schemas & Idempotency](schemas-and-idempotency.md) for the record kinds and canonical example
+payloads) and validate it the same way before ever calling `push batch`.
+
+## 4. First successful batch
+
+Using the CLI (submits, then polls until the batch reaches a terminal status):
+
+```bash
+dev-hops push batch sample-batch.json --poll
+```
+
+```text
+ingestion_id: b6c1e6b0-...-uuid
+status: completed
+items_received: 1
+items_accepted: 1
+items_rejected: 0
+```
+
+Or with cURL (submit only — poll separately with `GET /batches/{id}`):
+
+```bash
+curl -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/batches" \
+  -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data-binary @sample-batch.json
+```
+
+```json
+{"ingestionId": "b6c1e6b0-...-uuid", "status": "accepted", "itemsReceived": 1,
+ "stream": "external-ingest:<org_id>:batches"}
+```
+
+Resubmitting the exact same file again is always safe — same `idempotencyKey` + identical
+payload resolves as a **replay** (`200`, not a duplicate `202`). See
+[Idempotency](schemas-and-idempotency.md#idempotency).
+
+## 5. Verify data landed
+
+Poll status by `ingestion_id`:
+
+```bash
+dev-hops push status b6c1e6b0-...-uuid --poll
+```
+
+```text
+ingestion_id: b6c1e6b0-...-uuid
+status: completed
+items_received: 1
+items_accepted: 1
+items_rejected: 0
+```
+
+Or with cURL:
+
+```bash
+curl "$FULLCHAOS_API_URL/api/v1/external-ingest/batches/b6c1e6b0-...-uuid" \
+  -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN"
+```
+
+A `partial` status with `itemsRejected > 0` means some records were rejected — see
+`errors[]`/`errorSummary` in the response, and
+[Troubleshooting](troubleshooting.md#rejected-record-diagnostics) for the error-code
+vocabulary and fixes.
+
+Once `status` is `completed` (or `partial`, for the accepted records), the normalized data is
+queryable through the regular FullChaos GraphQL API / web UI / metrics views — same as data
+from any native connector. See [GraphQL Overview](../api/graphql-overview.md).
+
+## Next steps
+
+- [API Reference](api-reference.md) — every endpoint in detail.
+- [Schemas & Idempotency](schemas-and-idempotency.md) — all 9 record kinds, canonical
+  examples, idempotency rules, batch limits.
+- [Troubleshooting](troubleshooting.md) — status polling, rejected-record diagnostics, and
+  remediation for every failure mode.
+- [CLI Reference](../ops/cli-reference.md#push) — the full `dev-hops push` command reference.
+- CI/CD-runnable pipeline examples (GitHub Actions, GitLab CI) are tracked separately — see
+  CHAOS-2713.

--- a/docs/customer-push-ingestion/troubleshooting.md
+++ b/docs/customer-push-ingestion/troubleshooting.md
@@ -1,0 +1,106 @@
+# Customer Push Ingestion: Troubleshooting
+
+## Status polling
+
+`GET /api/v1/external-ingest/batches/{ingestion_id}` (or `dev-hops push status <id> --poll` /
+`dev-hops push batch <file> --poll`) reports `status` as one of:
+
+```
+accepted ──▶ processing ──▶ completed
+   │                    ├──▶ partial
+   │                    └──▶ failed
+   └──▶ stream_unavailable ──▶ (retry same idempotencyKey) ──▶ accepted
+```
+
+| Status | Meaning |
+|---|---|
+| `accepted` | Durably recorded in Postgres; not yet picked up by the worker. |
+| `stream_unavailable` | The batch was durably recorded, but the durable stream enqueue failed (Redis/Valkey outage). Recoverable: resubmit `POST /batches` with the **same** `idempotencyKey` once the stream is available again — this resolves as a **retry**, re-enqueueing the same `ingestion_id`. |
+| `processing` | A worker has picked up the batch and is normalizing/writing records. |
+| `completed` | All records accepted; `itemsRejected == 0`. |
+| `partial` | Some records were accepted, some rejected; `itemsAccepted + itemsRejected == itemsReceived`, both positive. Check `errors[]`/`errorSummary`. |
+| `failed` | The batch failed at a system level before producing per-record results (e.g. worker crash, schema-version mismatch caught late) — `itemsAccepted = 0`, `itemsRejected = itemsReceived`, `errorSummary.system_failure = true`. Retryable (same idempotency key). |
+
+A same-key retry is always safe — it never double-processes a batch: `accepted`/
+`stream_unavailable`/`failed` are the only retryable states, and a stale `accepted` (worker
+never saw the pointer) only becomes retryable after 15 minutes (see
+[Idempotency](schemas-and-idempotency.md#idempotency)).
+
+## Rejected-record diagnostics
+
+`GET /batches/{id}` includes:
+
+```json
+"errorSummary": {
+  "total_rejected": 8,
+  "stored_rejections": 8,
+  "truncated": false,
+  "top_codes": [{"code": "missing_required_field", "count": 6}, {"code": "invalid_field", "count": 2}]
+},
+"errors": [
+  {"index": 12, "kind": "pull_request.v1", "externalId": "acme/api#501",
+   "code": "missing_required_field", "message": "Field required",
+   "path": "records[12].payload.state"}
+]
+```
+
+- `errors[]` is paginated (`errorLimit`/`errorOffset` query params, 1-200, default 50) and
+  capped server-side at a maximum number of stored rejection rows per batch — if
+  `errorSummary.truncated` is `true`, `total_rejected` exceeds what was persisted; the
+  first-N are always the ones stored.
+- Per-record error `code` vocabulary (identical between `POST /validate` and worker-side
+  rejections, since both call the same validation function):
+
+| Code | Meaning |
+|---|---|
+| `unknown_kind` | `records[i].kind` isn't one of the 9 supported kinds. |
+| `missing_required_field` | A required field is absent from `payload`. |
+| `invalid_literal` | A field's value isn't one of its allowed literal/enum values. |
+| `invalid_field` | Any other field-level validation failure (wrong type, failed length/range constraint, etc). |
+
+- `path` points at the offending field: `records[<index>].payload.<field.path>` (or
+  `records[<index>].kind` for `unknown_kind`).
+
+Always run `POST /validate` (or `dev-hops push validate`) before `POST /batches` in CI to catch
+these before they cost a real batch attempt.
+
+## Common failure modes and remediation
+
+| HTTP | `code` | Cause | Remediation |
+|---|---|---|---|
+| 400 | `invalid_envelope` | Malformed JSON, or the envelope itself fails schema validation (bad types, missing `source`, empty `records`). | Fix the envelope; check `errors[]` for the specific Pydantic field errors. |
+| 400 | `idempotency_key_mismatch` | `Idempotency-Key` header doesn't match the body's `idempotencyKey`. | Send the same value in both, or omit the header (body is canonical). |
+| 400 | `unsupported_schema_version` | `schemaVersion` isn't `external-ingest.v1`. | Update the client / check `GET /schemas` for the current supported version. |
+| 400 | `unknown_record_kind` | A record's `kind` isn't one of the 9 known kinds (only on `POST /batches`; `/validate` reports this per-record instead). | Fix the record's `kind`, or run `POST /validate` first to catch this before submitting. |
+| 400 | `batch_too_large` | More than `maxRecordsPerBatch` records (default 1000). | Split into multiple batches. |
+| 401 | `invalid_token` | Missing/malformed `Authorization: Bearer fcpush_...` header, unknown token, or a revoked/expired token. | Check the token is present, correctly prefixed, and not revoked/expired — rotate if needed (see [Setup Guide](setup-guide.md)). |
+| 403 | `insufficient_scope` | Token lacks the scope the route requires. | Mint a token with the needed scope (`schema:read`/`ingest:write`/`ingest:status`). |
+| 403 | `source_mismatch` | Token is bound to a different `(system, instance)` than the envelope's `source`. | Use the token minted for this exact source, or fix `source.system`/`source.instance` in the envelope. |
+| 403 | `source_not_registered` | No source is registered for this `(system, instance)` in this org. | Register the source first (admin API — see [Setup Guide](setup-guide.md)). |
+| 403 | `source_disabled` | The registered source exists but is disabled, or not in `customer_push` mode. | Enable the source / set its mode to `customer_push`. |
+| 403 | `source_owned_by_fullchaos_sync` | FullChaos-managed sync is actively connected to the same `(system, instance)`. | Disable managed sync for that instance before pushing customer data, or contact support. |
+| 409 | `idempotency_conflict` | Same `idempotencyKey` was already used with a **different** payload. | Use a new `idempotencyKey` for genuinely different data, or resend the exact original payload. |
+| 413 | `payload_too_large` | Request body exceeds `maxBodyBytes` (default 10MB). | Split into multiple batches, or trim payload fields. |
+| 429 | `rate_limited` | Exceeded the per-token or per-IP rate limit (see [API Reference](api-reference.md#rate-limits)). | Back off and retry after a short delay; check you're not retrying in a hot loop. |
+| 503 | `ingest_temporarily_unavailable` | A concurrent request for the same idempotency key is already in flight. | Retry shortly with the same key. |
+| 503 | `stream_unavailable` | The batch was durably recorded, but the stream (Valkey/Redis) enqueue failed. | Retry with the **same** `idempotencyKey`; this resolves as a retry against the same `ingestion_id`. |
+| 500 | `internal_error` | Unexpected server error. | Retry with backoff; contact support with the `ingestionId` (if one was returned) if it persists. |
+
+## Operational troubleshooting
+
+- **Batch stuck in `accepted` for a long time:** the stream enqueue may have failed silently
+  from the client's perspective (a 503 the client didn't see/retry). Poll `GET
+  /batches/{id}` — after `EXTERNAL_INGEST_ACCEPTED_STALE_MINUTES` (default 15 min) a same-key
+  retry will pick it back up.
+- **Batch stuck in `processing`:** the worker consumer group may be behind or the worker may
+  have died mid-processing. This does not require client action — the consumer's redelivery
+  and DLQ machinery (per-org streams, `external-ingest:<org_id>:batches` /
+  `external-ingest:<org_id>:dlq`) handles recovery; if a batch never resolves, it eventually
+  reaches a terminal `failed` status which is itself retryable.
+- **Recompute never shows `dispatched`:** check `recompute.status` — `skipped_no_scope` means
+  the batch didn't touch any repos/teams that map to a recompute scope (e.g. it only carried
+  `identity.v1`/`team.v1` records); `not_applicable` is the initial value before the worker has
+  made a recompute decision.
+- **Cross-org 404s:** `GET /batches/{id}` returns an identical `404 not_found` whether the id
+  doesn't exist or belongs to a different org — this is deliberate (avoids leaking cross-org
+  existence), not a bug.

--- a/docs/customer-push-ingestion/troubleshooting.md
+++ b/docs/customer-push-ingestion/troubleshooting.md
@@ -79,9 +79,12 @@ never saw the pointer) only becomes retryable after 15 minutes (see
 **Remediation:**
 
 - `unsupported_kind_for_system` — only send record kinds that are valid for the source's
-  system (e.g. don't send `work_item.v1` under a `github`/`gitlab`/`custom` source, and don't
-  send git-family kinds under a `jira`/`linear` source). See the matrix in
-  [Schemas & Idempotency](schemas-and-idempotency.md#kind-x-system-matrix).
+  system: a `custom` source rejects the work-item family (`work_item.v1`,
+  `work_item_transition.v1`, `work_item_dependency.v1`) — send those under a
+  `github`/`gitlab`/`jira`/`linear` source instead. A `jira`/`linear` source rejects the git
+  family (`repository.v1`, `pull_request.v1`, `review.v1`, `commit.v1`) — send those under a
+  `github`/`gitlab`/`custom` source instead. `github` and `gitlab` sources accept all 9 kinds.
+  See the matrix in [Schemas & Idempotency](schemas-and-idempotency.md#kind-x-system-matrix).
 - `record_outside_source_instance` — keep every git-family record's repository identifier
   (`externalId` for `repository.v1`, `repositoryExternalId` elsewhere) equal to the batch's
   `source.instance`. A batch pushing data for multiple repositories must be split into one

--- a/docs/customer-push-ingestion/troubleshooting.md
+++ b/docs/customer-push-ingestion/troubleshooting.md
@@ -48,21 +48,49 @@ never saw the pointer) only becomes retryable after 15 minutes (see
   capped server-side at a maximum number of stored rejection rows per batch — if
   `errorSummary.truncated` is `true`, `total_rejected` exceeds what was persisted; the
   first-N are always the ones stored.
-- Per-record error `code` vocabulary (identical between `POST /validate` and worker-side
-  rejections, since both call the same validation function):
 
-| Code | Meaning |
-|---|---|
-| `unknown_kind` | `records[i].kind` isn't one of the 9 supported kinds. |
-| `missing_required_field` | A required field is absent from `payload`. |
-| `invalid_literal` | A field's value isn't one of its allowed literal/enum values. |
-| `invalid_field` | Any other field-level validation failure (wrong type, failed length/range constraint, etc). |
+!!! warning "`POST /validate` is shape-only — it does NOT catch everything the worker rejects"
+    `POST /validate` and the worker share the same *shape* validation
+    (`external_ingest.validate.validate_records`), but the worker additionally enforces two
+    source-context rules that `/validate` has no way to check (it never receives a registered
+    source to check against): the CC6 kind×system matrix, and git-family repo-instance
+    scoping. **A record can pass `/validate` cleanly and still be rejected once the batch is
+    processed**, showing up in `GET /batches/{id}`'s `errors[]` with one of the two extra codes
+    below.
+
+- Per-record error `code` vocabulary. `unknown_kind`/`missing_required_field`/
+  `invalid_literal`/`invalid_field` are shape errors, produced identically by `POST /validate`
+  and the worker (both call `validate_records`). `unsupported_kind_for_system` and
+  `record_outside_source_instance` are **worker-only** — they require the batch's registered
+  `source.system`/`source.instance`, which `/validate` never has:
+
+| Code | Meaning | Only from |
+|---|---|---|
+| `unknown_kind` | `records[i].kind` isn't one of the 9 supported kinds. | `/validate` and worker |
+| `missing_required_field` | A required field is absent from `payload`. | `/validate` and worker |
+| `invalid_literal` | A field's value isn't one of its allowed literal/enum values. | `/validate` and worker |
+| `invalid_field` | Any other field-level validation failure (wrong type, failed length/range constraint, etc). | `/validate` and worker |
+| `unsupported_kind_for_system` | The record's `kind` isn't allowed for the batch's `source.system` (e.g. a `commit.v1` record under a `jira` source) — see the kind×system matrix in [Schemas & Idempotency](schemas-and-idempotency.md#kind-x-system-matrix). | worker only |
+| `record_outside_source_instance` | A git-family record (`repository.v1`/`pull_request.v1`/`review.v1`/`commit.v1`) references a repository identifier that doesn't match the batch's `source.instance` (case-insensitive comparison). | worker only |
 
 - `path` points at the offending field: `records[<index>].payload.<field.path>` (or
-  `records[<index>].kind` for `unknown_kind`).
+  `records[<index>].kind` for `unknown_kind`/`unsupported_kind_for_system`).
+
+**Remediation:**
+
+- `unsupported_kind_for_system` — only send record kinds that are valid for the source's
+  system (e.g. don't send `work_item.v1` under a `github`/`gitlab`/`custom` source, and don't
+  send git-family kinds under a `jira`/`linear` source). See the matrix in
+  [Schemas & Idempotency](schemas-and-idempotency.md#kind-x-system-matrix).
+- `record_outside_source_instance` — keep every git-family record's repository identifier
+  (`externalId` for `repository.v1`, `repositoryExternalId` elsewhere) equal to the batch's
+  `source.instance`. A batch pushing data for multiple repositories must be split into one
+  batch per `source.instance`.
 
 Always run `POST /validate` (or `dev-hops push validate`) before `POST /batches` in CI to catch
-these before they cost a real batch attempt.
+shape errors before they cost a real batch attempt — but note it cannot catch the two
+worker-only codes above, since those need the registered source context that only exists at
+accept/processing time.
 
 ## Common failure modes and remediation
 

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -1389,7 +1389,7 @@ Submits a batch to `POST /api/v1/external-ingest/batches`. Reads a JSON file, or
 |------|-------|
 | `--api-url`, `--token`, `--org` | See [Credentials](#credentials-batch-status) above. |
 | `--poll` | Poll `GET /batches/{id}` until the batch reaches a terminal status, instead of returning immediately after the `202`/`200`. |
-| `--poll-interval` | Seconds between polls. Default 2 (an internal floor of 0.5s is enforced). |
+| `--poll-interval` | Seconds between polls. Default 5 (an internal floor of 0.5s is enforced). |
 | `--poll-timeout` | Give up polling after this many seconds. |
 | `--skip-limits-check` | Skip the `GET /schemas` limits pre-flight; enforce hardcoded client defaults (1000 records / 10MB) instead of the server's live limits. |
 | `--json` | Emit machine-readable JSON to stdout. |

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -1330,6 +1330,111 @@ dev-hops sync git --provider github \
 
 ---
 
+## push
+
+`dev-hops push` is the client CLI for [Customer Push Ingestion](../customer-push-ingestion/overview.md)
+— submitting your own data to `/api/v1/external-ingest/*` instead of relying on a FullChaos-managed
+connector. See [Setup Guide](../customer-push-ingestion/setup-guide.md) for a full first-batch
+walkthrough and [Schemas & Idempotency](../customer-push-ingestion/schemas-and-idempotency.md)
+for the record kinds. `push` subcommands are excluded from `dev-hops`'s global `--org` auto-resolution
+and ClickHouse/Postgres preflight entirely — `validate`/`sample` are fully offline; `batch`/`status`
+talk to the FullChaos API over HTTP and resolve their own credentials (below).
+
+### Credentials (`batch` / `status`)
+
+| Flag | Env var | Notes |
+|------|---------|-------|
+| `--api-url` | `FULLCHAOS_API_URL` | FullChaos API base URL. |
+| `--token` | `FULLCHAOS_INGEST_TOKEN` (deprecated alias: `FULLCHAOS_API_TOKEN`) | An `fcpush_...` ingest token — see [Setup Guide](../customer-push-ingestion/setup-guide.md). |
+| `--org` | `FULLCHAOS_ORG_ID` | Organization id. |
+
+A flag always wins over its env var. If any of the three can't be resolved, the command prints
+`error: missing required: ...` to stderr and exits 2 — not an argparse `required=True` error,
+so the env-var fallback still works.
+
+### `dev-hops push validate <payload>`
+
+Validates a batch envelope locally — **no network call**. Reads a JSON file, or `-` for stdin.
+
+| Flag | Notes |
+|------|-------|
+| `--schema` | Schema version to validate against. Default and only supported value: `external-ingest.v1`. |
+| `--json` | Emit machine-readable JSON to stdout instead of a human rejection table. |
+
+```bash
+dev-hops push validate batch.json
+dev-hops push validate - < batch.json --json
+```
+
+### `dev-hops push sample`
+
+Prints a canonical sample batch envelope built from the packaged example payloads (the same
+files `GET /schemas/{version}` embeds) — no network call.
+
+| Flag | Notes |
+|------|-------|
+| `--kind KIND` | One record kind, bare or versioned (e.g. `pull_request` or `pull_request.v1`). Mutually exclusive with `--all`. |
+| `--all` | Combined batch envelope with one record of every kind. Mutually exclusive with `--kind`. |
+
+```bash
+dev-hops push sample --kind pull_request > sample.json
+dev-hops push sample --all | dev-hops push validate -
+```
+
+### `dev-hops push batch <payload>`
+
+Submits a batch to `POST /api/v1/external-ingest/batches`. Reads a JSON file, or `-` for stdin.
+
+| Flag | Notes |
+|------|-------|
+| `--api-url`, `--token`, `--org` | See [Credentials](#credentials-batch-status) above. |
+| `--poll` | Poll `GET /batches/{id}` until the batch reaches a terminal status, instead of returning immediately after the `202`/`200`. |
+| `--poll-interval` | Seconds between polls. Default 2 (an internal floor of 0.5s is enforced). |
+| `--poll-timeout` | Give up polling after this many seconds. |
+| `--skip-limits-check` | Skip the `GET /schemas` limits pre-flight; enforce hardcoded client defaults (1000 records / 10MB) instead of the server's live limits. |
+| `--json` | Emit machine-readable JSON to stdout. |
+
+```bash
+dev-hops push batch sample.json --poll
+dev-hops push batch - --json < sample.json
+```
+
+### `dev-hops push status <ingestion_id>`
+
+Fetches (and optionally polls) a batch's status via `GET /batches/{id}`.
+
+| Flag | Notes |
+|------|-------|
+| `--api-url`, `--token`, `--org` | See [Credentials](#credentials-batch-status) above. |
+| `--poll`, `--poll-interval`, `--poll-timeout` | Same semantics as `push batch`. |
+| `--json` | Emit machine-readable JSON to stdout. |
+
+```bash
+dev-hops push status b6c1e6b0-...-uuid --poll
+```
+
+### `dev-hops push export <provider>`
+
+Reserved extension point for provider-native export helpers (e.g. `github`, `gitlab`). **Not
+implemented in v1** — every provider currently prints an error and exits with a data-failure
+status. Use `dev-hops push sample` plus a hand-written export, or the provider's native
+FullChaos connector, in the meantime.
+
+### `push` exit codes
+
+`push` uses its own exit-code contract, distinct from the rest of `dev-hops` (see
+[Exit Codes](#exit-codes) below):
+
+| Code | Meaning |
+|------|---------|
+| 0 | Success |
+| 1 | Data-level failure — invalid payload, or a batch that completed with rejections / reached a terminal `failed` status |
+| 2 | Usage error — bad/missing CLI args, or unresolved `--api-url`/`--token`/`--org` |
+| 3 | Transport/API error after retries, or `stream_unavailable` |
+| 4 | Poll timeout — the batch was still non-terminal when `--poll-timeout` elapsed |
+
+---
+
 ## Exit Codes
 
 | Code | Meaning |

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -924,7 +924,7 @@ paper over:
   GitLab code-dataset paths remain under the frozen `connectors/` tree
   (`connectors/github.py`'s PyGithub-based `GitHubConnector`, `connectors/
   gitlab.py`'s python-gitlab-based `GitLabConnector`). No new code may be added
-  there (see [`AGENTS.md`](../../AGENTS.md)); rate-limit/actuals
+  there (see the repo-root `AGENTS.md`, outside this docs site); rate-limit/actuals
   instrumentation for those datasets lands as the fetch moves to
   `providers/github/` / `providers/gitlab/` — tracked as its own
   canonical-provider-migration effort in

--- a/docs/webhooks.md
+++ b/docs/webhooks.md
@@ -2,6 +2,14 @@
 
 This document describes how to configure webhooks for real-time data synchronization in Dev Health Ops.
 
+!!! note "Not the same thing as customer-push ingestion"
+    These provider webhooks (`/api/v1/webhooks/*`) are part of **FullChaos-managed sync** —
+    FullChaos reacting to GitHub/GitLab/Jira events on your behalf once you've connected an
+    integration. If instead you want to actively push normalized data from your own systems
+    (CI pipelines, ETL jobs, air-gapped environments) over a versioned REST API, see
+    [Customer Push Ingestion](customer-push-ingestion/overview.md) — a separate ingestion
+    path under `/api/v1/external-ingest/*`.
+
 ## GitHub Configuration
 
 1. Go to your repository or organization **Settings**.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -33,6 +33,12 @@ nav:
   - Email Setup: email-setup.md
   - SSO Setup: sso-setup.md
   - Webhooks: webhooks.md
+  - Customer Push Ingestion:
+      - Overview: customer-push-ingestion/overview.md
+      - API Reference: customer-push-ingestion/api-reference.md
+      - Schemas & Idempotency: customer-push-ingestion/schemas-and-idempotency.md
+      - Troubleshooting: customer-push-ingestion/troubleshooting.md
+      - Setup Guide: customer-push-ingestion/setup-guide.md
   - Alerting: alerting.md
   - Architecture:
       - Overview: architecture.md
@@ -52,6 +58,7 @@ nav:
       - Enterprise Overview: architecture/enterprise-overview.md
       - Licensing: architecture/licensing.md
       - ADR-001 Enterprise Edition: architecture/adr/001-enterprise-edition.md
+      - ADR-003 External Ingest Test/Docs Strategy: architecture/adr/003-external-ingest-test-docs-strategy.md
       - BYO-LLM Architecture: architecture/byo-llm-architecture.md
   - Operations:
       - Observability Tooling: ops/observability-tooling.md
@@ -149,3 +156,7 @@ markdown_extensions:
           format: !!python/name:pymdownx.superfences.fence_code_format
   - pymdownx.tabbed:
       alternate_style: true
+  - pymdownx.snippets:
+      base_path:
+        - src/dev_health_ops/api/external_ingest/examples
+      check_paths: true


### PR DESCRIPTION
## CHAOS-2711 — Developer + user documentation for customer-push ingestion

mkdocs documentation for the CHAOS-2690 external customer-push pipeline, written and grep-verified against the merged code (router/status/schemas/validate/auth/idempotency/ownership/normalize, models/ingest_auth, admin customer_push, cli push subcommands).

### New pages (`docs/customer-push-ingestion/`)
- **overview.md** — lifecycle (validate→batch→stream→worker→sinks→status→bounded recompute), REST-vs-GraphQL (ingestion = REST; analytics stays GraphQL/API/UI), customer-push vs FullChaos-managed sync.
- **api-reference.md** — every `/api/v1/external-ingest` route (validate, batches POST, batches/{id} GET, batches list, schemas, schemas/{version}) + admin validate proxy: method, scope, request/response shape, status codes, error envelope. Exact `BatchListItemResponse` field list.
- **schemas-and-idempotency.md** — `external-ingest.v1`, record envelope `{kind, externalId, payload}`, 9 versioned kinds, kind×system matrix (mirrors `ALLOWED_KINDS_BY_SYSTEM`), idempotency (replay 200 same id / conflict 409), retry, limits (1000/10MB). Canonical example payloads snippet-included (`--8<--`) from the CHAOS-2692 package examples.
- **troubleshooting.md** — rejection diagnostics + code vocabulary (shape codes from `/validate` vs worker-only `unsupported_kind_for_system`/`record_outside_source_instance`), status polling, failure modes + remediation.
- **setup-guide.md** — register source, create/rotate credentials, test-before-production, verify-data-landed, first-batch walkthrough with cURL + `dev-hops push` examples.
- **architecture/adr/003-external-ingest-test-docs-strategy.md** — records the docs/test-layer decisions.

### Modified
`mkdocs.yml` (nav section + ADR-003 line + `pymdownx.snippets` base_path), `docs/webhooks.md` (disambiguation admonition), `docs/ops/cli-reference.md` (`## push` section: validate/sample/batch/status/export + real flags), `docs/providers/rate-limit-policy.md` (fixed a pre-existing out-of-docs-dir link that already broke `mkdocs build --strict`).

### Codex adversarial review — 3 rounds, all accuracy findings resolved
- **r1** (3): validate-vs-worker rejection vocabularies documented as identical (worker adds source-context codes) → corrected + kind×system matrix added; "case-insensitive" instance matching claim → corrected to exact/case-sensitive at accept time (`require_matching_source`), case-insensitive only for registration dedup; `GET /batches` list shape wrong → exact `BatchListItemResponse` fields.
- **r2** (1): remediation example wrongly listed github/gitlab as disallowing `work_item.v1` → narrowed to the actually-disallowed combos (custom rejects work-item family; jira/linear reject git family).
- **r3** (1, low): `--poll-interval` default documented 2s → real 5s.

### Verification
`make docs:check` clean; `mkdocs build --strict` exit 0 / zero warnings; offline gate `env -i … SCRATCH_DB=ci_local_validate_2711 bash ci/local_validate.sh` **GATE PASSED** (6878/0). All claims grep-verified against merged source.

### Flagged for follow-up (code, not docs)
Accept-time `require_matching_source` uses exact-casing `source.instance` comparison while registration/ownership dedup is case-insensitive — a genuine split (documented here so customers send exact casing). Separately: the migration tree has a duplicate `0032` revision (tracked CHAOS-2832).
