### PR TITLE
docs(external-ingest): customer examples quickstart + docs-drift guard (CHAOS-2701)

### DIFF
--- a/docs/customer-push-ingestion/examples.md
+++ b/docs/customer-push-ingestion/examples.md
@@ -1,0 +1,130 @@
+# Examples & quickstart
+
+A copy-paste path from a **sample payload** to a **persisted, verifiable batch**. It uses
+the `dev-hops push` CLI and the equivalent raw REST calls. For the full per-kind payload
+catalog see [Schemas & Idempotency](schemas-and-idempotency.md); for credential setup see
+the [Setup Guide](setup-guide.md).
+
+!!! note "REST, not GraphQL"
+    Ingestion is REST-only — there is no GraphQL ingestion mutation in v1 (see the
+    [Overview](overview.md#rest-not-graphql)). GraphQL/API/UI remain for *querying* the
+    results once they land.
+
+## 1. Generate a sample batch envelope
+
+`dev-hops push sample` prints one of the canonical, server-shipped example payloads (the
+same files served in each kind's `examples[]` from `GET /schemas/{version}`). Pick a single
+kind, or `--all` for a combined envelope with one record of every kind:
+
+```bash
+# one record kind
+dev-hops push sample --kind pull_request > sample-batch.json
+
+# one record of every v1 kind
+dev-hops push sample --all > sample-batch.json
+```
+
+A single-record envelope looks like this (the `pull_request.v1` record body is the exact
+package example, snippet-included here so it can never drift from what the server accepts):
+
+```json
+{
+  "schemaVersion": "external-ingest.v1",
+  "idempotencyKey": "acme-github-prs-2026-06-26",
+  "source": {
+    "type": "customer_push",
+    "system": "github",
+    "instance": "github.com/acme",
+    "producer": "dev-hops-cli",
+    "producerVersion": "0.12.0"
+  },
+  "window": { "startedAt": "2026-06-25T00:00:00Z", "endedAt": "2026-06-26T00:00:00Z" },
+  "records": [
+    {
+      "kind": "pull_request.v1",
+      "externalId": "acme/api#4821",
+      "payload":
+--8<-- "pull_request.v1.json"
+    }
+  ]
+}
+```
+
+## 2. Validate before you push
+
+Validation is local and makes **no network call** — run it in CI to catch shape problems
+(`unknown_kind`, `missing_required_field`, `invalid_literal`, `invalid_field`) before
+spending an ingest call. Read a file, or `-` for stdin:
+
+```bash
+dev-hops push validate sample-batch.json
+# or piped straight from sample:
+dev-hops push sample --kind pull_request | dev-hops push validate -
+```
+
+The REST equivalent (`POST /validate`, scope `schema:read`) returns `200` with
+`{"valid": true|false, "itemsRejected": N, "errors": [...]}` and never enqueues:
+
+```bash
+curl -sS -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/validate" \
+  -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data @sample-batch.json
+```
+
+!!! warning "`/validate` is shape-only"
+    It does **not** enforce the source-system↔kind matrix or `source.instance` scoping —
+    the worker does. A record can pass `/validate` and still be rejected at processing with
+    `unsupported_kind_for_system` or `record_outside_source_instance`. See
+    [Troubleshooting](troubleshooting.md).
+
+## 3. Push the batch
+
+`push batch` submits to `POST /api/v1/external-ingest/batches` (scope `ingest:write`) and,
+with `--poll`, blocks until a terminal status. Credentials come from flags or the
+`FULLCHAOS_API_URL` / `FULLCHAOS_INGEST_TOKEN` / `FULLCHAOS_ORG_ID` env vars:
+
+```bash
+export FULLCHAOS_API_URL="https://app.fullchaos.example"
+export FULLCHAOS_INGEST_TOKEN="fcpush_…"        # ingest:write scope, from your secret store
+export FULLCHAOS_ORG_ID="…"
+
+dev-hops push batch --poll sample-batch.json
+```
+
+Raw REST — `202 Accepted` returns `{"ingestionId": "…", "status": "accepted", …}`:
+
+```bash
+curl -sS -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/batches" \
+  -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN" \
+  -H "Content-Type: application/json" \
+  --data @sample-batch.json
+```
+
+!!! note "Idempotency & source ownership"
+    Re-posting the same `idempotencyKey` + payload returns `200` with the same
+    `ingestionId` (replay); a different payload under the same key returns `409`. A source
+    instance has exactly one active owner — a second registration of the same instance
+    (case-insensitive) is rejected `409`, and at push time `source.instance` must match the
+    registered casing exactly. See the [Setup Guide](setup-guide.md#1-register-a-source).
+
+## 4. Poll status & verify it landed
+
+```bash
+# push batch --poll already does this; to check later:
+dev-hops push status --poll <ingestion_id>
+```
+
+Raw REST (`GET /batches/{ingestion_id}`, scope `ingest:status`) reports
+`itemsAccepted` / `itemsRejected` and, once terminal (`completed` / `partial` / `failed`),
+per-record `errors[]`:
+
+```bash
+curl -sS "$FULLCHAOS_API_URL/api/v1/external-ingest/batches/<ingestion_id>" \
+  -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN"
+```
+
+A `completed` (or `partial`) status with `itemsAccepted >= 1` means the records are
+persisted and will surface in the product once the debounced metric recompute runs. The
+same validate → push → poll sequence is what you wire into a GitHub Actions / GitLab CI /
+generic runner job to push on a schedule.

--- a/docs/customer-push-ingestion/examples.md
+++ b/docs/customer-push-ingestion/examples.md
@@ -117,11 +117,15 @@ curl -sS -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/batches" \
 ```
 
 !!! note "Idempotency & source ownership"
-    Re-posting the same `idempotencyKey` + payload returns `200` with the same
-    `ingestionId` (replay); a different payload under the same key returns `409`. A source
-    instance has exactly one active owner — a second registration of the same instance
-    (case-insensitive) is rejected `409`, and at push time `source.instance` must match the
-    registered casing exactly. See the [Setup Guide](setup-guide.md#1-register-a-source).
+    Re-posting the same `idempotencyKey` + payload returns `200` (replay, same
+    `ingestionId`) **when the prior batch is not retryable**; if it's in a retryable state
+    (`stream_unavailable`, `failed`, or a stale `accepted`), the same `ingestionId` is reset
+    and re-enqueued with a fresh `202` — so a recovery retry after a stream outage is
+    expected to return `202`, not `200`. A different payload under the same key always
+    returns `409`. A source instance has exactly one active owner — a second registration of
+    the same instance (case-insensitive) is rejected `409`, and at push time
+    `source.instance` must match the registered casing exactly. See the
+    [Setup Guide](setup-guide.md#1-register-a-source).
 
 ## 4. Poll status & verify it landed
 

--- a/docs/customer-push-ingestion/examples.md
+++ b/docs/customer-push-ingestion/examples.md
@@ -30,25 +30,33 @@ package example, snippet-included here so it can never drift from what the serve
 ```json
 {
   "schemaVersion": "external-ingest.v1",
-  "idempotencyKey": "acme-github-prs-2026-06-26",
+  "idempotencyKey": "sample-pull_request.v1",
   "source": {
     "type": "customer_push",
     "system": "github",
-    "instance": "github.com/acme",
+    "instance": "acme/api",
     "producer": "dev-hops-cli",
-    "producerVersion": "0.12.0"
+    "producerVersion": "1.0.0"
   },
-  "window": { "startedAt": "2026-06-25T00:00:00Z", "endedAt": "2026-06-26T00:00:00Z" },
+  "window": { "startedAt": "2026-06-20T00:00:00Z", "endedAt": "2026-06-26T00:00:00Z" },
   "records": [
     {
       "kind": "pull_request.v1",
-      "externalId": "acme/api#4821",
+      "externalId": "acme/api#482",
       "payload":
 --8<-- "pull_request.v1.json"
     }
   ]
 }
 ```
+
+!!! warning "`source.instance` scopes git-family records"
+    Note `source.instance` is `acme/api` — the **same** repository identifier as the
+    record's `repositoryExternalId`. The worker rejects a git-family record
+    (`repository`/`pull_request`/`review`/`commit`) whose repo falls outside the batch's
+    `source.instance` with `record_outside_source_instance`, and `source.instance` must
+    also match your registered source's casing exactly (else `403 source_mismatch`). Push
+    each repository's git records under a source registered for that repository.
 
 ## 2. Validate before you push
 
@@ -86,11 +94,18 @@ with `--poll`, blocks until a terminal status. Credentials come from flags or th
 
 ```bash
 export FULLCHAOS_API_URL="https://app.fullchaos.example"
-export FULLCHAOS_INGEST_TOKEN="fcpush_…"        # ingest:write scope, from your secret store
+export FULLCHAOS_INGEST_TOKEN="fcpush_…"        # from your secret store (scopes below)
 export FULLCHAOS_ORG_ID="…"
 
 dev-hops push batch --poll sample-batch.json
 ```
+
+!!! important "Scope the token for the whole flow"
+    This quickstart's single token drives three routes with **three different** scopes:
+    `POST /validate` needs `schema:read`, `POST /batches` needs `ingest:write`, and the
+    `GET /batches/{id}` polling (`--poll`, `push status`) needs `ingest:status`. Mint the
+    token with **all three** (`schema:read`, `ingest:write`, `ingest:status`) or a
+    write-only token will submit the batch and then `403` on the status poll.
 
 Raw REST — `202 Accepted` returns `{"ingestionId": "…", "status": "accepted", …}`:
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ nav:
       - Schemas & Idempotency: customer-push-ingestion/schemas-and-idempotency.md
       - Troubleshooting: customer-push-ingestion/troubleshooting.md
       - Setup Guide: customer-push-ingestion/setup-guide.md
+      - Examples & Quickstart: customer-push-ingestion/examples.md
   - Alerting: alerting.md
   - Architecture:
       - Overview: architecture.md

--- a/tests/test_customer_push_docs_examples.py
+++ b/tests/test_customer_push_docs_examples.py
@@ -1,0 +1,66 @@
+"""Drift guard binding the customer-push docs to the record-kind registry (CHAOS-2701).
+
+Every v1 record kind exposed by ``schema_registry.iter_record_kinds()`` must have its
+canonical example payload snippet-included (``--8<-- "<kind>.json"``) somewhere under
+``docs/customer-push-ingestion/`` -- so adding a new record kind fails CI until the
+customer-facing docs show an example for it, and every snippet path a doc references must
+resolve to a real example file. Offline; runs in the default unit suite.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+import pytest
+
+from dev_health_ops.api.external_ingest import schema_registry as registry
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+_DOCS_DIR = _REPO_ROOT / "docs" / "customer-push-ingestion"
+# pymdownx.snippets base_path for these docs (mkdocs.yml).
+_EXAMPLES_DIR = (
+    _REPO_ROOT / "src" / "dev_health_ops" / "api" / "external_ingest" / "examples"
+)
+
+# ``--8<-- "pull_request.v1.json"`` (double or single quotes, arbitrary leading whitespace).
+_SNIPPET_RE = re.compile(r"""--8<--\s+["']([^"'\n]+)["']""")
+
+
+def _all_snippet_refs() -> list[tuple[Path, str]]:
+    refs: list[tuple[Path, str]] = []
+    for md in sorted(_DOCS_DIR.glob("*.md")):
+        for target in _SNIPPET_RE.findall(md.read_text()):
+            refs.append((md, target))
+    return refs
+
+
+def test_every_record_kind_has_a_docs_example() -> None:
+    """A `<kind>.v1.json` snippet include must appear in the customer-push docs."""
+    included = {target for _md, target in _all_snippet_refs()}
+    missing = [
+        f"{kind}.json"
+        for kind, _model in registry.iter_record_kinds()
+        if f"{kind}.json" not in included
+    ]
+    assert not missing, (
+        "record kinds have no example snippet-included under "
+        f'docs/customer-push-ingestion/: {missing}. Add a `--8<-- "<kind>.json"` '
+        "include (see examples.md / schemas-and-idempotency.md)."
+    )
+
+
+def test_every_docs_snippet_reference_resolves() -> None:
+    """No customer-push doc may reference a snippet file that doesn't exist."""
+    dangling = [
+        f"{md.relative_to(_REPO_ROOT)} -> {target}"
+        for md, target in _all_snippet_refs()
+        if not (_EXAMPLES_DIR / target).is_file()
+    ]
+    assert not dangling, f"docs reference missing snippet files: {dangling}"
+
+
+@pytest.mark.parametrize("kind", [k for k, _ in registry.iter_record_kinds()])
+def test_registry_example_file_exists(kind: str) -> None:
+    """The registry's kinds and the on-disk example files stay in lockstep."""
+    assert (_EXAMPLES_DIR / f"{kind}.json").is_file(), f"no example file for {kind}"


### PR DESCRIPTION
## CHAOS-2701 — Customer examples & docs

Most of this issue's scope was delivered by sibling PRs already merged (CHAOS-2711 docs cover REST-vs-GraphQL, credentials, idempotency, conflict policy, and a `dev-hops push` walkthrough; CHAOS-2692's `test_examples_validate.py` asserts every kind's example validates; CHAOS-2711 snippet-includes all 9 example payloads). This PR adds the genuinely-remaining, non-duplicative pieces.

### Added
- **`docs/customer-push-ingestion/examples.md`** — a focused copy-paste **quickstart**: sample → validate → push → poll → verify, in both `dev-hops push` and raw REST, snippet-including the canonical `pull_request.v1` payload and linking to the full per-kind catalog + setup guide. Satisfies the AC "customer can validate and push a sample payload from docs."
- **`tests/test_customer_push_docs_examples.py`** — a **drift/completeness guard** binding the docs to `schema_registry.iter_record_kinds()`: every v1 kind must be snippet-included in the customer-push docs, and every snippet path must resolve. A future record kind now fails CI until its customer example lands.
- **`mkdocs.yml`** — nav entry for the examples page.

### Codex adversarial review — 2 rounds
- **r1** (2 high): the hand-written envelope had `source.instance: github.com/acme` but the payload's `repositoryExternalId` is `acme/api` → the git-family record would be rejected `record_outside_source_instance` — now mirrors the real `dev-hops push sample` output (`instance: acme/api`, `externalId: acme/api#482`) so the copy-paste batch actually lands, with a warning about `source.instance` git-family scoping. And the single quickstart token was labelled `ingest:write` but drives validate/push/poll → now documents it must carry `schema:read + ingest:write + ingest:status`.
- **r2** (1 medium): the same-key idempotency note oversimplified — now qualifies that `200` replay applies only when the prior batch isn't retryable; retryable states (`stream_unavailable`/`failed`/stale `accepted`) re-enqueue the same `ingestionId` with a fresh `202`.

### Verification
Guard test passes; `make docs:check` clean; `mkdocs build --strict` exit 0 / zero warnings; offline gate `env -i … SCRATCH_DB=ci_local_validate_2701 bash ci/local_validate.sh` **GATE PASSED** (6925/0, includes the new guard test). Every command/flag/scope/path grep-verified against the merged CLI + API.
