### PR TITLE
docs(external-ingest): CI/CD push examples for GitHub Actions, GitLab, generic runners (CHAOS-2713)

### DIFF
--- a/docs/customer-push-ingestion/ci-cd.md
+++ b/docs/customer-push-ingestion/ci-cd.md
@@ -12,6 +12,13 @@ and raw `curl` + `jq` (no dev-hops dependency). The full runnable files live in
 
 ## Security requirements
 
+!!! note "Required environment for the `dev-hops` CLI examples"
+    `dev-hops push batch` / `push status` require **`FULLCHAOS_API_URL`**,
+    **`FULLCHAOS_INGEST_TOKEN`**, and **`FULLCHAOS_ORG_ID`** (flag or env) — the command
+    exits `2` with a usage error if any is unset. Store the token as a secret and the org id
+    as a non-secret variable. The raw-`curl` examples don't need `FULLCHAOS_ORG_ID` (the
+    token already binds the org server-side).
+
 These apply to **every** example below — they are not optional:
 
 - **Store the ingest token in the platform's secret store**, never in the repo:

--- a/docs/customer-push-ingestion/ci-cd.md
+++ b/docs/customer-push-ingestion/ci-cd.md
@@ -42,6 +42,10 @@ These apply to **every** example below — they are not optional:
 - **Rotate tokens regularly.** Mint a new token via the sources/tokens API,
   update the secret, then revoke the old one — overlap the two during cutover so
   in-flight jobs don't fail. See the [Setup Guide](setup-guide.md).
+- **Pin the `dev-hops` install.** The push job holds the ingest token, so never
+  `pip install` an unpinned package — a compromised release could exfiltrate the
+  token. Install a fixed `dev-health-ops==<version>` you validated, or run from a
+  trusted prebuilt image; the CLI examples below pin by default.
 
 ## GitHub Actions
 

--- a/docs/customer-push-ingestion/ci-cd.md
+++ b/docs/customer-push-ingestion/ci-cd.md
@@ -1,0 +1,101 @@
+# CI/CD examples
+
+Runnable, copy-paste examples for pushing batches from common automation
+environments. Every example follows the same **validate → push → poll** shape
+covered in [Examples & Quickstart](examples.md), so a malformed batch fails the
+job before it reaches the ingest API, and the job only succeeds once the batch
+reaches a terminal `completed` / `partial` status.
+
+Each example is available in two flavours: the `dev-hops push` CLI (less code)
+and raw `curl` + `jq` (no dev-hops dependency). The full runnable files live in
+[`examples/customer-push/`](https://github.com/full-chaos/dev-health-ops/tree/main/examples/customer-push).
+
+## Security requirements
+
+These apply to **every** example below — they are not optional:
+
+- **Store the ingest token in the platform's secret store**, never in the repo:
+  GitHub Actions → repository/organization **Secrets**; GitLab CI → **masked +
+  protected** CI/CD variables; systemd/cron → an `EnvironmentFile` at mode `0600`
+  owned by the service user.
+- **Use a least-privilege token.** A pushing job needs only the `ingest:write`
+  scope (plus `schema:read` for the pre-flight limits check and `ingest:status`
+  for polling). Do not reuse a broad admin token.
+- **Never send provider credentials to FullChaos.** Customer push means *your*
+  automation reads *your* systems and pushes derived records. Your GitHub/GitLab
+  PATs, Jira tokens, etc. stay in your environment — the only credential that
+  ever reaches FullChaos is the `fcpush_…` ingest token.
+- **Rotate tokens regularly.** Mint a new token via the sources/tokens API,
+  update the secret, then revoke the old one — overlap the two during cutover so
+  in-flight jobs don't fail. See the [Setup Guide](setup-guide.md).
+
+## GitHub Actions
+
+Copy into your repository as `.github/workflows/fullchaos-push.yml`. Set
+`FULLCHAOS_INGEST_TOKEN` as a repository secret.
+
+=== "dev-hops CLI"
+
+    ```yaml
+    --8<-- "github-actions.yml"
+    ```
+
+=== "curl"
+
+    ```yaml
+    --8<-- "github-actions-curl.yml"
+    ```
+
+## GitLab CI
+
+Copy into your project as `.gitlab-ci.yml`. Set `FULLCHAOS_INGEST_TOKEN` as a
+**masked + protected** CI/CD variable.
+
+=== "dev-hops CLI"
+
+    ```yaml
+    --8<-- "gitlab-ci.yml"
+    ```
+
+=== "curl"
+
+    ```yaml
+    --8<-- "gitlab-ci-curl.yml"
+    ```
+
+## Generic runner
+
+No GitHub/GitLab assumptions — a portable POSIX `sh` script that runs in any
+Docker container, Jenkins shell step, or on a laptop. Requires only `curl` and
+`jq`. Pass the batch envelope as the first argument:
+
+```bash
+FULLCHAOS_API_URL=https://app.fullchaos.example \
+FULLCHAOS_INGEST_TOKEN=fcpush_… \
+./generic-runner.sh batch.json
+```
+
+```sh
+--8<-- "generic-runner.sh"
+```
+
+## cron / systemd (self-hosted)
+
+For self-hosted customers pushing on a schedule without a CI platform. The
+service runs the generic runner; the timer drives it hourly. Keep the token in
+`/etc/fullchaos/push.env` at mode `0600`.
+
+=== "systemd service"
+
+    ```ini
+    --8<-- "fullchaos-push.service"
+    ```
+
+=== "systemd timer"
+
+    ```ini
+    --8<-- "fullchaos-push.timer"
+    ```
+
+The timer file also documents the equivalent plain-`crontab` line for hosts
+without systemd.

--- a/docs/customer-push-ingestion/ci-cd.md
+++ b/docs/customer-push-ingestion/ci-cd.md
@@ -2,9 +2,16 @@
 
 Runnable, copy-paste examples for pushing batches from common automation
 environments. Every example follows the same **validate → push → poll** shape
-covered in [Examples & Quickstart](examples.md), so a malformed batch fails the
-job before it reaches the ingest API, and the job only succeeds once the batch
-reaches a terminal `completed` / `partial` status.
+covered in [Examples & Quickstart](examples.md), so a malformed batch is caught
+at the validate step before it is submitted to `POST /batches`. (The `dev-hops`
+validate runs entirely locally with no network call; the raw-`curl` validate
+calls `POST /validate` — an authenticated shape check that never enqueues.)
+
+The job succeeds only when the batch reaches `completed` with **zero rejected
+records**. `partial` is terminal but means some records were rejected, so the
+examples treat it as a **failure** by default (set `ALLOW_PARTIAL=1` to accept
+it); `failed` always fails. This mirrors `dev-hops push --poll`, which is
+non-zero unless the batch completed without rejections.
 
 Each example is available in two flavours: the `dev-hops push` CLI (less code)
 and raw `curl` + `jq` (no dev-hops dependency). The full runnable files live in

--- a/examples/customer-push/fullchaos-push.service
+++ b/examples/customer-push/fullchaos-push.service
@@ -1,0 +1,20 @@
+# FullChaos customer-push -- systemd service (paired with the .timer below).
+#
+# Install (as root) to /etc/systemd/system/fullchaos-push.service, put the
+# token in /etc/fullchaos/push.env (chmod 600, owned by the service user), then:
+#   systemctl enable --now fullchaos-push.timer
+#
+# /etc/fullchaos/push.env contains (0600, never world-readable):
+#   FULLCHAOS_API_URL=https://app.fullchaos.example
+#   FULLCHAOS_INGEST_TOKEN=fcpush_...          # ingest:write + schema:read only
+[Unit]
+Description=Push a customer batch to FullChaos
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=oneshot
+User=fullchaos
+EnvironmentFile=/etc/fullchaos/push.env
+# Your extractor writes /var/lib/fullchaos/batch.json before this runs.
+ExecStart=/opt/fullchaos/generic-runner.sh /var/lib/fullchaos/batch.json

--- a/examples/customer-push/fullchaos-push.service
+++ b/examples/customer-push/fullchaos-push.service
@@ -6,7 +6,7 @@
 #
 # /etc/fullchaos/push.env contains (0600, never world-readable):
 #   FULLCHAOS_API_URL=https://app.fullchaos.example
-#   FULLCHAOS_INGEST_TOKEN=fcpush_...          # ingest:write + schema:read only
+#   FULLCHAOS_INGEST_TOKEN=fcpush_...    # schema:read + ingest:write + ingest:status
 [Unit]
 Description=Push a customer batch to FullChaos
 After=network-online.target

--- a/examples/customer-push/fullchaos-push.timer
+++ b/examples/customer-push/fullchaos-push.timer
@@ -1,0 +1,18 @@
+# FullChaos customer-push -- systemd timer (drives fullchaos-push.service hourly).
+# Install to /etc/systemd/system/fullchaos-push.timer, then:
+#   systemctl enable --now fullchaos-push.timer
+#
+# For a plain crontab instead of systemd, the equivalent hourly line is:
+#   0 * * * * FULLCHAOS_API_URL=https://app.fullchaos.example \
+#     FULLCHAOS_INGEST_TOKEN="$(cat /etc/fullchaos/token)" \
+#     /opt/fullchaos/generic-runner.sh /var/lib/fullchaos/batch.json
+# (keep /etc/fullchaos/token at mode 0600; never inline the token in crontab).
+[Unit]
+Description=Run the FullChaos customer-push hourly
+
+[Timer]
+OnCalendar=hourly
+Persistent=true
+
+[Install]
+WantedBy=timers.target

--- a/examples/customer-push/generic-runner.sh
+++ b/examples/customer-push/generic-runner.sh
@@ -6,7 +6,7 @@
 #
 # Provide the batch envelope as $1 (a JSON file) and set:
 #   FULLCHAOS_API_URL       e.g. https://app.fullchaos.example
-#   FULLCHAOS_INGEST_TOKEN  fcpush_... token with ingest:write + schema:read
+#   FULLCHAOS_INGEST_TOKEN  fcpush_... token: schema:read + ingest:write + ingest:status
 # The token belongs in the runner's secret store / an env file with mode 0600 --
 # never commit it, and never pass a provider credential to FullChaos.
 #
@@ -38,8 +38,16 @@ while [ "${i}" -lt 60 ]; do
   status=$(echo "${body}" | jq -r '.status')
   echo "status: ${status}"
   case "${status}" in
-    completed|partial) echo "${body}" | jq .; exit 0 ;;
-    failed)            echo "${body}" | jq .; exit 1 ;;
+    completed) echo "${body}" | jq .; exit 0 ;;
+    partial)
+      # Batch processed but some records were REJECTED. Fail by default so CI
+      # surfaces the dropped data (mirrors `dev-hops push`, which is non-zero
+      # unless completed with zero rejections); set ALLOW_PARTIAL=1 to accept.
+      echo "${body}" | jq .
+      [ "${ALLOW_PARTIAL:-0}" = "1" ] && exit 0
+      echo "batch 'partial': records were rejected (see errors above)" >&2
+      exit 1 ;;
+    failed) echo "${body}" | jq .; exit 1 ;;
   esac
   i=$((i + 1))
   sleep 5

--- a/examples/customer-push/generic-runner.sh
+++ b/examples/customer-push/generic-runner.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env sh
+# FullChaos customer-push from ANY runner (portable POSIX sh, raw REST).
+#
+# No GitHub/GitLab assumptions -- works in a bare Docker container, a Jenkins
+# shell step, a Buildkite job, or a laptop. Only `curl` and `jq` are required.
+#
+# Provide the batch envelope as $1 (a JSON file) and set:
+#   FULLCHAOS_API_URL       e.g. https://app.fullchaos.example
+#   FULLCHAOS_INGEST_TOKEN  fcpush_... token with ingest:write + schema:read
+# The token belongs in the runner's secret store / an env file with mode 0600 --
+# never commit it, and never pass a provider credential to FullChaos.
+#
+# Usage: FULLCHAOS_API_URL=... FULLCHAOS_INGEST_TOKEN=... ./generic-runner.sh batch.json
+set -eu
+
+batch="${1:?usage: generic-runner.sh <batch-envelope.json>}"
+: "${FULLCHAOS_API_URL:?set FULLCHAOS_API_URL}"
+: "${FULLCHAOS_INGEST_TOKEN:?set FULLCHAOS_INGEST_TOKEN}"
+auth="Authorization: Bearer ${FULLCHAOS_INGEST_TOKEN}"
+base="${FULLCHAOS_API_URL}/api/v1/external-ingest"
+
+# 1. Validate (scope schema:read) -- no enqueue; abort on valid:false.
+resp=$(curl -sS -X POST "${base}/validate" -H "${auth}" \
+  -H "Content-Type: application/json" --data @"${batch}")
+echo "validate: ${resp}"
+echo "${resp}" | jq -e '.valid == true' >/dev/null
+
+# 2. Submit (scope ingest:write) -- 202 Accepted returns ingestionId.
+resp=$(curl -sS -X POST "${base}/batches" -H "${auth}" \
+  -H "Content-Type: application/json" --data @"${batch}")
+echo "submit: ${resp}"
+id=$(echo "${resp}" | jq -r '.ingestionId')
+
+# 3. Poll status (scope ingest:status) until terminal.
+i=0
+while [ "${i}" -lt 60 ]; do
+  body=$(curl -sS "${base}/batches/${id}" -H "${auth}")
+  status=$(echo "${body}" | jq -r '.status')
+  echo "status: ${status}"
+  case "${status}" in
+    completed|partial) echo "${body}" | jq .; exit 0 ;;
+    failed)            echo "${body}" | jq .; exit 1 ;;
+  esac
+  i=$((i + 1))
+  sleep 5
+done
+echo "timed out waiting for terminal status" >&2
+exit 1

--- a/examples/customer-push/github-actions-curl.yml
+++ b/examples/customer-push/github-actions-curl.yml
@@ -1,0 +1,61 @@
+# FullChaos customer-push via GitHub Actions (raw REST, no dev-hops dependency).
+#
+# Copy into YOUR repository as `.github/workflows/fullchaos-push.yml`.
+# FULLCHAOS_INGEST_TOKEN is a repository secret (ingest:write + schema:read scopes).
+name: fullchaos-push-curl
+on:
+  schedule:
+    - cron: "0 * * * *"
+  workflow_dispatch: {}
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    env:
+      FULLCHAOS_API_URL: https://app.fullchaos.example
+      FULLCHAOS_INGEST_TOKEN: ${{ secrets.FULLCHAOS_INGEST_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Replace with your own extractor that writes a batch envelope to batch.json.
+      - name: Build batch
+        run: cp examples/batch.json batch.json
+
+      # Validate (scope schema:read); fail the job if the API reports valid:false.
+      - name: Validate
+        run: |
+          set -euo pipefail
+          resp=$(curl -sS -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/validate" \
+            -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN" \
+            -H "Content-Type: application/json" --data @batch.json)
+          echo "$resp"
+          echo "$resp" | jq -e '.valid == true' >/dev/null
+
+      # Submit (scope ingest:write); capture ingestionId from the 202 response.
+      - name: Push
+        id: push
+        run: |
+          set -euo pipefail
+          resp=$(curl -sS -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/batches" \
+            -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN" \
+            -H "Content-Type: application/json" --data @batch.json)
+          echo "$resp"
+          echo "id=$(echo "$resp" | jq -r '.ingestionId')" >> "$GITHUB_OUTPUT"
+
+      # Poll status (scope ingest:status) until terminal; fail on `failed`.
+      - name: Poll status
+        run: |
+          set -euo pipefail
+          id="${{ steps.push.outputs.id }}"
+          for _ in $(seq 1 60); do
+            body=$(curl -sS "$FULLCHAOS_API_URL/api/v1/external-ingest/batches/$id" \
+              -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN")
+            status=$(echo "$body" | jq -r '.status')
+            echo "status=$status"
+            case "$status" in
+              completed|partial) echo "$body" | jq .; exit 0 ;;
+              failed)            echo "$body" | jq .; exit 1 ;;
+            esac
+            sleep 5
+          done
+          echo "timed out waiting for terminal status"; exit 1

--- a/examples/customer-push/github-actions-curl.yml
+++ b/examples/customer-push/github-actions-curl.yml
@@ -60,7 +60,8 @@ jobs:
           echo "$resp"
           echo "id=$(echo "$resp" | jq -r '.ingestionId')" >> "$GITHUB_OUTPUT"
 
-      # Poll status (scope ingest:status) until terminal; fail on `failed`.
+      # Poll status (scope ingest:status) until terminal; success only on
+      # `completed`, fail on `partial` (records rejected) and `failed`.
       - name: Poll status
         run: |
           set -euo pipefail

--- a/examples/customer-push/github-actions-curl.yml
+++ b/examples/customer-push/github-actions-curl.yml
@@ -1,7 +1,7 @@
 # FullChaos customer-push via GitHub Actions (raw REST, no dev-hops dependency).
 #
 # Copy into YOUR repository as `.github/workflows/fullchaos-push.yml`.
-# FULLCHAOS_INGEST_TOKEN is a repository secret (ingest:write + schema:read scopes).
+# FULLCHAOS_INGEST_TOKEN is a repository secret (schema:read + ingest:write + ingest:status).
 name: fullchaos-push-curl
 on:
   schedule:
@@ -17,9 +17,27 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      # Replace with your own extractor that writes a batch envelope to batch.json.
+      # YOUR extractor must write a batch envelope to batch.json here. This
+      # dependency-free placeholder writes a minimal valid single-record batch;
+      # replace it with your real extractor. `source.instance` must equal the
+      # repository the git-family records belong to.
       - name: Build batch
-        run: cp examples/batch.json batch.json
+        run: |
+          cat > batch.json <<'JSON'
+          {
+            "schemaVersion": "external-ingest.v1",
+            "idempotencyKey": "ci-sample-2026-06-26",
+            "source": {"type": "customer_push", "system": "github", "instance": "acme/api"},
+            "window": {"startedAt": "2026-06-20T00:00:00Z", "endedAt": "2026-06-26T00:00:00Z"},
+            "records": [
+              {"kind": "pull_request.v1", "externalId": "acme/api#482",
+               "payload": {"repositoryExternalId": "acme/api", "number": 482,
+                 "title": "Fix login redirect loop", "state": "merged",
+                 "authorName": "Alice Doe", "authorEmail": "alice@acme.example",
+                 "createdAt": "2026-06-21T10:00:00Z", "mergedAt": "2026-06-22T15:30:00Z"}}
+            ]
+          }
+          JSON
 
       # Validate (scope schema:read); fail the job if the API reports valid:false.
       - name: Validate
@@ -53,8 +71,14 @@ jobs:
             status=$(echo "$body" | jq -r '.status')
             echo "status=$status"
             case "$status" in
-              completed|partial) echo "$body" | jq .; exit 0 ;;
-              failed)            echo "$body" | jq .; exit 1 ;;
+              completed) echo "$body" | jq .; exit 0 ;;
+              partial)
+                # Some records were REJECTED -- fail so CI surfaces dropped data
+                # (set ALLOW_PARTIAL=1 in env to accept partial batches).
+                echo "$body" | jq .
+                [ "${ALLOW_PARTIAL:-0}" = "1" ] && exit 0
+                echo "batch 'partial': records rejected (see errors above)"; exit 1 ;;
+              failed) echo "$body" | jq .; exit 1 ;;
             esac
             sleep 5
           done

--- a/examples/customer-push/github-actions.yml
+++ b/examples/customer-push/github-actions.yml
@@ -3,7 +3,8 @@
 # Copy into YOUR repository as `.github/workflows/fullchaos-push.yml`.
 # Store the ingest token as a repository/organization secret named
 # FULLCHAOS_INGEST_TOKEN (Settings -> Secrets and variables -> Actions).
-# The token needs only the `ingest:write` + `schema:read` scopes -- never a
+# The token needs the `schema:read` + `ingest:write` + `ingest:status` scopes
+# (validate / push / poll) -- never a
 # provider PAT, and never your FullChaos login.
 name: fullchaos-push
 on:

--- a/examples/customer-push/github-actions.yml
+++ b/examples/customer-push/github-actions.yml
@@ -23,7 +23,10 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Install dev-hops
-        run: pipx install dev-health-ops   # or your pinned distribution
+        # PIN to the version you validated -- this job holds the ingest token,
+        # so never install an unpinned package (a bad release could exfiltrate
+        # it). Prefer a trusted prebuilt image or hash-verified install in CI.
+        run: pipx install "dev-health-ops==1.0.0"
 
       # Build your batch envelope however you like -- here we just emit a
       # canonical sample. Replace this step with your own extractor that

--- a/examples/customer-push/github-actions.yml
+++ b/examples/customer-push/github-actions.yml
@@ -1,0 +1,40 @@
+# FullChaos customer-push via GitHub Actions (dev-hops CLI).
+#
+# Copy into YOUR repository as `.github/workflows/fullchaos-push.yml`.
+# Store the ingest token as a repository/organization secret named
+# FULLCHAOS_INGEST_TOKEN (Settings -> Secrets and variables -> Actions).
+# The token needs only the `ingest:write` + `schema:read` scopes -- never a
+# provider PAT, and never your FullChaos login.
+name: fullchaos-push
+on:
+  schedule:
+    - cron: "0 * * * *"   # hourly; adjust to your push cadence
+  workflow_dispatch: {}
+
+jobs:
+  push:
+    runs-on: ubuntu-latest
+    env:
+      FULLCHAOS_API_URL: https://app.fullchaos.example
+      FULLCHAOS_INGEST_TOKEN: ${{ secrets.FULLCHAOS_INGEST_TOKEN }}
+      FULLCHAOS_ORG_ID: ${{ vars.FULLCHAOS_ORG_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install dev-hops
+        run: pipx install dev-health-ops   # or your pinned distribution
+
+      # Build your batch envelope however you like -- here we just emit a
+      # canonical sample. Replace this step with your own extractor that
+      # writes a batch envelope JSON to batch.json.
+      - name: Build batch
+        run: dev-hops push sample --all > batch.json
+
+      # Validate first (no network call) so a malformed batch fails the job
+      # before it ever reaches the ingest API.
+      - name: Validate
+        run: dev-hops push validate batch.json
+
+      # Submit and block until a terminal status; a non-zero exit fails the job.
+      - name: Push and poll
+        run: dev-hops push batch --poll batch.json

--- a/examples/customer-push/gitlab-ci-curl.yml
+++ b/examples/customer-push/gitlab-ci-curl.yml
@@ -47,7 +47,8 @@ fullchaos-push-curl:
         -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN" \
         -H "Content-Type: application/json" --data @batch.json)
       echo "$resp"; id=$(echo "$resp" | jq -r '.ingestionId')
-    # Poll (ingest:status) until terminal; fail on `failed`.
+    # Poll (ingest:status) until terminal; success only on `completed`,
+    # fail on `partial` (records rejected) and `failed`.
     - |
       for _ in $(seq 1 60); do
         body=$(curl -sS "$FULLCHAOS_API_URL/api/v1/external-ingest/batches/$id" \

--- a/examples/customer-push/gitlab-ci-curl.yml
+++ b/examples/customer-push/gitlab-ci-curl.yml
@@ -1,7 +1,7 @@
 # FullChaos customer-push via GitLab CI (raw REST, no dev-hops dependency).
 #
 # Copy into YOUR project as `.gitlab-ci.yml`. FULLCHAOS_INGEST_TOKEN is a
-# masked + protected CI/CD variable (ingest:write + schema:read scopes).
+# masked + protected CI/CD variable (schema:read + ingest:write + ingest:status).
 stages: [push]
 
 fullchaos-push-curl:
@@ -16,8 +16,25 @@ fullchaos-push-curl:
     - apk add --no-cache curl jq
   script:
     - set -euo pipefail
-    # Replace with your own extractor writing a batch envelope to batch.json.
-    - cp examples/batch.json batch.json
+    # YOUR extractor must write a batch envelope to batch.json. This
+    # dependency-free placeholder writes a minimal valid single-record batch;
+    # replace it. `source.instance` must equal the records' repository.
+    - |
+      cat > batch.json <<'JSON'
+      {
+        "schemaVersion": "external-ingest.v1",
+        "idempotencyKey": "ci-sample-2026-06-26",
+        "source": {"type": "customer_push", "system": "github", "instance": "acme/api"},
+        "window": {"startedAt": "2026-06-20T00:00:00Z", "endedAt": "2026-06-26T00:00:00Z"},
+        "records": [
+          {"kind": "pull_request.v1", "externalId": "acme/api#482",
+           "payload": {"repositoryExternalId": "acme/api", "number": 482,
+             "title": "Fix login redirect loop", "state": "merged",
+             "authorName": "Alice Doe", "authorEmail": "alice@acme.example",
+             "createdAt": "2026-06-21T10:00:00Z", "mergedAt": "2026-06-22T15:30:00Z"}}
+        ]
+      }
+      JSON
     # Validate (schema:read); abort if valid:false.
     - |
       resp=$(curl -sS -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/validate" \
@@ -37,8 +54,14 @@ fullchaos-push-curl:
           -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN")
         status=$(echo "$body" | jq -r '.status'); echo "status=$status"
         case "$status" in
-          completed|partial) echo "$body" | jq .; exit 0 ;;
-          failed)            echo "$body" | jq .; exit 1 ;;
+          completed) echo "$body" | jq .; exit 0 ;;
+          partial)
+            # Some records were REJECTED -- fail so CI surfaces dropped data
+            # (set ALLOW_PARTIAL=1 to accept partial batches).
+            echo "$body" | jq .
+            [ "${ALLOW_PARTIAL:-0}" = "1" ] && exit 0
+            echo "batch 'partial': records rejected (see errors above)"; exit 1 ;;
+          failed) echo "$body" | jq .; exit 1 ;;
         esac
         sleep 5
       done

--- a/examples/customer-push/gitlab-ci-curl.yml
+++ b/examples/customer-push/gitlab-ci-curl.yml
@@ -1,0 +1,45 @@
+# FullChaos customer-push via GitLab CI (raw REST, no dev-hops dependency).
+#
+# Copy into YOUR project as `.gitlab-ci.yml`. FULLCHAOS_INGEST_TOKEN is a
+# masked + protected CI/CD variable (ingest:write + schema:read scopes).
+stages: [push]
+
+fullchaos-push-curl:
+  stage: push
+  image: alpine:3.20
+  variables:
+    FULLCHAOS_API_URL: "https://app.fullchaos.example"
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+  before_script:
+    - apk add --no-cache curl jq
+  script:
+    - set -euo pipefail
+    # Replace with your own extractor writing a batch envelope to batch.json.
+    - cp examples/batch.json batch.json
+    # Validate (schema:read); abort if valid:false.
+    - |
+      resp=$(curl -sS -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/validate" \
+        -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN" \
+        -H "Content-Type: application/json" --data @batch.json)
+      echo "$resp"; echo "$resp" | jq -e '.valid == true' >/dev/null
+    # Submit (ingest:write); capture ingestionId.
+    - |
+      resp=$(curl -sS -X POST "$FULLCHAOS_API_URL/api/v1/external-ingest/batches" \
+        -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN" \
+        -H "Content-Type: application/json" --data @batch.json)
+      echo "$resp"; id=$(echo "$resp" | jq -r '.ingestionId')
+    # Poll (ingest:status) until terminal; fail on `failed`.
+    - |
+      for _ in $(seq 1 60); do
+        body=$(curl -sS "$FULLCHAOS_API_URL/api/v1/external-ingest/batches/$id" \
+          -H "Authorization: Bearer $FULLCHAOS_INGEST_TOKEN")
+        status=$(echo "$body" | jq -r '.status'); echo "status=$status"
+        case "$status" in
+          completed|partial) echo "$body" | jq .; exit 0 ;;
+          failed)            echo "$body" | jq .; exit 1 ;;
+        esac
+        sleep 5
+      done
+      echo "timed out"; exit 1

--- a/examples/customer-push/gitlab-ci.yml
+++ b/examples/customer-push/gitlab-ci.yml
@@ -1,0 +1,23 @@
+# FullChaos customer-push via GitLab CI (dev-hops CLI).
+#
+# Copy into YOUR project as `.gitlab-ci.yml` (or include it). Store the ingest
+# token as a MASKED + PROTECTED CI/CD variable named FULLCHAOS_INGEST_TOKEN
+# (Settings -> CI/CD -> Variables). It needs only ingest:write + schema:read --
+# never a provider token or your FullChaos login.
+stages: [push]
+
+fullchaos-push:
+  stage: push
+  image: python:3.12-slim
+  variables:
+    FULLCHAOS_API_URL: "https://app.fullchaos.example"
+    # FULLCHAOS_INGEST_TOKEN / FULLCHAOS_ORG_ID come from masked CI/CD variables.
+  rules:
+    - if: '$CI_PIPELINE_SOURCE == "schedule"'
+    - if: '$CI_PIPELINE_SOURCE == "web"'
+  script:
+    - pip install --quiet dev-health-ops
+    # Replace with your own extractor writing a batch envelope to batch.json.
+    - dev-hops push sample --all > batch.json
+    - dev-hops push validate batch.json          # local, no network call
+    - dev-hops push batch --poll batch.json        # non-zero exit fails the job

--- a/examples/customer-push/gitlab-ci.yml
+++ b/examples/customer-push/gitlab-ci.yml
@@ -17,7 +17,10 @@ fullchaos-push:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
     - if: '$CI_PIPELINE_SOURCE == "web"'
   script:
-    - pip install --quiet dev-health-ops
+    # PIN to the version you validated -- this job holds the ingest token, so
+    # never install an unpinned package. Prefer a trusted prebuilt image or a
+    # hash/lockfile-verified install in CI.
+    - pip install --quiet "dev-health-ops==1.0.0"
     # Replace with your own extractor writing a batch envelope to batch.json.
     - dev-hops push sample --all > batch.json
     - dev-hops push validate batch.json          # local, no network call

--- a/examples/customer-push/gitlab-ci.yml
+++ b/examples/customer-push/gitlab-ci.yml
@@ -2,7 +2,8 @@
 #
 # Copy into YOUR project as `.gitlab-ci.yml` (or include it). Store the ingest
 # token as a MASKED + PROTECTED CI/CD variable named FULLCHAOS_INGEST_TOKEN
-# (Settings -> CI/CD -> Variables). It needs only ingest:write + schema:read --
+# (Settings -> CI/CD -> Variables). It needs schema:read + ingest:write + ingest:status
+# (validate / push / poll) --
 # never a provider token or your FullChaos login.
 stages: [push]
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Troubleshooting: customer-push-ingestion/troubleshooting.md
       - Setup Guide: customer-push-ingestion/setup-guide.md
       - Examples & Quickstart: customer-push-ingestion/examples.md
+      - CI/CD Examples: customer-push-ingestion/ci-cd.md
   - Alerting: alerting.md
   - Architecture:
       - Overview: architecture.md
@@ -160,4 +161,5 @@ markdown_extensions:
   - pymdownx.snippets:
       base_path:
         - src/dev_health_ops/api/external_ingest/examples
+        - examples/customer-push
       check_paths: true

--- a/tests/test_customer_push_docs_examples.py
+++ b/tests/test_customer_push_docs_examples.py
@@ -18,9 +18,15 @@ from dev_health_ops.api.external_ingest import schema_registry as registry
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]
 _DOCS_DIR = _REPO_ROOT / "docs" / "customer-push-ingestion"
-# pymdownx.snippets base_path for these docs (mkdocs.yml).
+# The canonical record-kind example payloads live here (also a snippets base_path).
 _EXAMPLES_DIR = (
     _REPO_ROOT / "src" / "dev_health_ops" / "api" / "external_ingest" / "examples"
+)
+# All pymdownx.snippets base_path dirs (mkdocs.yml) a customer-push doc may
+# ``--8<--`` from. Keep in sync with mkdocs.yml's snippets base_path list.
+_SNIPPET_BASE_DIRS = (
+    _EXAMPLES_DIR,
+    _REPO_ROOT / "examples" / "customer-push",
 )
 
 # ``--8<-- "pull_request.v1.json"`` (double or single quotes, arbitrary leading whitespace).
@@ -51,11 +57,15 @@ def test_every_record_kind_has_a_docs_example() -> None:
 
 
 def test_every_docs_snippet_reference_resolves() -> None:
-    """No customer-push doc may reference a snippet file that doesn't exist."""
+    """No customer-push doc may reference a snippet file that doesn't exist.
+
+    A snippet resolves if it exists under ANY configured base_path dir (the
+    package examples dir or ``examples/customer-push``).
+    """
     dangling = [
         f"{md.relative_to(_REPO_ROOT)} -> {target}"
         for md, target in _all_snippet_refs()
-        if not (_EXAMPLES_DIR / target).is_file()
+        if not any((base / target).is_file() for base in _SNIPPET_BASE_DIRS)
     ]
     assert not dangling, f"docs reference missing snippet files: {dangling}"
 


### PR DESCRIPTION
## CHAOS-2713 — CI/CD examples for GitHub Actions, GitLab runners, and generic runners

Runnable, copy-paste customer automation examples for the external customer-push pipeline, plus a tabbed docs page. Every example follows the same **validate → push → poll** shape and is accurate against the merged CLI + REST API.

### Runnable examples (`examples/customer-push/`)
GitHub Actions (dev-hops + curl), GitLab CI (dev-hops + curl), a portable POSIX `generic-runner.sh` (any Docker/Jenkins/laptop, curl+jq only), and a systemd `service`/`timer` (+ crontab note) for self-hosted. **None placed under `.github/workflows/`** — they are documentation artifacts, not executed by this repo.

### Docs
- **`docs/customer-push-ingestion/ci-cd.md`** — tabbed (`pymdownx.tabbed`) page snippet-including the runnable files, with a **Security** section: platform secret storage, least-privilege token (`schema:read`/`ingest:write`/`ingest:status`), never relay provider credentials, token rotation, and pinned installs.
- `mkdocs.yml` — nav entry + `examples/customer-push` added to the snippets base_path.
- Extends CHAOS-2701's docs-drift guard test to resolve snippets against both base_path dirs.

### Codex adversarial review — 3 rounds, all resolved
- **r1** (2 high + 2 med): example token comments omitted `ingest:status` (polling `GET /batches/{id}` needs it) → added to all; curl loops treated `partial` (= accepted **+ rejected**) as success → now **fail by default** with `ALLOW_PARTIAL=1` opt-in, mirroring `dev-hops push`'s non-zero-unless-completed; curl workflows `cp`'d a nonexistent `examples/batch.json` → now write a minimal valid batch inline via heredoc (validated against the `pull_request.v1` model); `FULLCHAOS_ORG_ID` (required by `push batch`) was undocumented → documented.
- **r2** (1 med): the ci-cd overview still called `partial` a success and implied validation stays client-side → rewritten (success = `completed` with zero rejections; `dev-hops` validate is local, curl `/validate` is an auth shape check).
- **r3** (1 med): unpinned `pip install dev-health-ops` in a token-scoped job (supply-chain risk) → pinned `dev-health-ops==<version>` in both CLI examples + a Security note.

### Verification
Offline gate `env -i … SCRATCH_DB=ci_local_validate_2713 bash ci/local_validate.sh` **GATE PASSED** (6925/0, incl. the extended drift guard); `make docs:check` clean; `mkdocs build --strict` exit 0 / zero warnings; `sh -n` clean on the shell script. Rebased onto the merged CHAOS-2701 tip. Every command/flag/scope/endpoint grep-verified against the merged code.
