### PR TITLE
feat(providers): instrument GitHub security family on GitHubCodeClient (CHAOS-2804)

### DIFF
--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -52,6 +52,7 @@ from dev_health_ops.processors.testops_ingest import (
     ingest_report_members,
 )
 from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
+from dev_health_ops.providers.github.code_client import GitHubCodeClient
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.providers.usage import drain_provider_usage
 from dev_health_ops.utils import (
@@ -478,19 +479,68 @@ def _fetch_github_incidents_sync(gh_repo, repo_id, max_issues, since):
     return incidents
 
 
-def _fetch_github_security_alerts_sync(
-    connector, owner, repo_name, repo_id, max_alerts, since
-):
-    """Sync helper to fetch GitHub security alerts (Dependabot, code scanning, advisories)."""
+def _github_code_client_from_connector(connector) -> GitHubCodeClient:
+    """Build a ``GitHubCodeClient`` from an already-authenticated connector.
+
+    Mirrors ``_github_work_client_from_connector`` (below): the connector has
+    already resolved a plain PAT or a GitHub App installation token onto
+    ``self.token`` (and, for GHE, its REST base URL onto
+    ``_rest_base_url()``), so this helper reuses that resolution rather than
+    duplicating GitHub App auth in the httpx client (CHAOS-2773 CS3 scope).
+    """
+    rest_base_url = getattr(connector, "_rest_base_url", None)
+    raw_base_url = rest_base_url() if callable(rest_base_url) else None
+    base_url = raw_base_url if isinstance(raw_base_url, str) else None
+    token = getattr(connector, "token", None)
+    return GitHubCodeClient(auth=GitHubAuth(token=token, base_url=base_url))
+
+
+async def _fetch_github_security_alerts_async(
+    connector,
+    owner: str,
+    repo_name: str,
+    repo_id,
+    max_alerts: int | None,
+    since: datetime | None,
+    usage_sink: list[dict[str, Any]] | None = None,
+) -> list[Any]:
+    """Fetch GitHub security alerts (Dependabot, code scanning, advisories) via
+    the instrumented httpx ``GitHubCodeClient`` (CHAOS-2773 CS3), replacing
+    the frozen connector's ``get_dependabot_alerts`` / ``get_code_scanning_alerts``
+    / ``get_security_advisories``.
+
+    Preserves the pre-existing per-endpoint degrade-and-log semantics
+    byte-for-byte: a fetch failure on any ONE of the three endpoints
+    (including an exhausted ``RateLimitException``) is logged at debug level
+    and does NOT fail the other two endpoints or the overall repo sync --
+    security alerts are optional enrichment, never a blocking dataset. This
+    was already true of the pre-migration sync helper (each ``fetch_fn`` call
+    was wrapped in its own ``try/except Exception``); the client swap changes
+    WHERE the alerts come from, not this contract.
+
+    ``usage_sink`` (CHAOS-2803/CS2), when given, is drained into in a
+    ``finally:`` block on BOTH the success and failure path, so a mid-sync
+    raise elsewhere in the caller still carries these actuals via the
+    adapter's ``attach_partial_observations`` at the outer boundary
+    (``processors/dataset_adapters.py``). ``usage_sink=None`` (the legacy
+    ``process_github_repos_batch`` entry point, which owns no sink) still
+    drains the client so its recorder never leaks across calls, but only
+    logs the observations at debug level -- never persisted.
+    """
     security_alert_cls = getattr(git_models, "SecurityAlert")
-    alerts = []
-    for fetch_fn in [
-        connector.get_dependabot_alerts,
-        connector.get_code_scanning_alerts,
-        connector.get_security_advisories,
-    ]:
-        try:
-            raw_alerts = fetch_fn(owner, repo_name, max_alerts=max_alerts)
+    alerts: list[Any] = []
+    client = _github_code_client_from_connector(connector)
+    try:
+        for fetch in (
+            client.get_dependabot_alerts,
+            client.get_code_scanning_alerts,
+            client.get_security_advisories,
+        ):
+            try:
+                raw_alerts = await fetch(owner, repo_name, max_alerts=max_alerts)
+            except Exception as exc:
+                logging.debug("Failed to fetch %s: %s", fetch.__name__, exc)
+                continue
             for item in raw_alerts:
                 created_at = item.created_at
                 if not created_at:
@@ -514,9 +564,21 @@ def _fetch_github_security_alerts_sync(
                         dismissed_at=item.dismissed_at,
                     )
                 )
-        except Exception as exc:
-            logging.debug("Failed to fetch %s: %s", fetch_fn.__name__, exc)
-    return alerts
+        return alerts
+    finally:
+        drained = client.drain_usage_observations()
+        if usage_sink is not None:
+            usage_sink.extend(drained)
+        elif drained:
+            logging.debug(
+                "_fetch_github_security_alerts_async: drained %d security usage "
+                "observation(s) for %s/%s with no adapter-owned sink (legacy "
+                "entry point) -- logging only, not persisted",
+                len(drained),
+                owner,
+                repo_name,
+            )
+        await client.close()
 
 
 def _collect_github_pr_objects(
@@ -1794,15 +1856,14 @@ async def process_github_repo(
 
             if sync_security:
                 logging.info("Fetching security alerts from GitHub...")
-                security_alerts = await loop.run_in_executor(
-                    None,
-                    _fetch_github_security_alerts_sync,
+                security_alerts = await _fetch_github_security_alerts_async(
                     connector,
                     owner,
                     repo_name,
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink=usage_sink,
                 )
                 security_alerts = _filter_after(security_alerts, until, "created_at")
                 if security_alerts:
@@ -2150,9 +2211,7 @@ async def process_github_repos_batch(
         if sync_security:
             try:
                 owner, repo_name = _split_full_name(repo_info.full_name)
-                security_alerts = await loop.run_in_executor(
-                    None,
-                    _fetch_github_security_alerts_sync,
+                security_alerts = await _fetch_github_security_alerts_async(
                     connector,
                     owner,
                     repo_name,

--- a/src/dev_health_ops/providers/github/budget.py
+++ b/src/dev_health_ops/providers/github/budget.py
@@ -327,8 +327,8 @@ def _fallback_credential_scope(
 # ---------------------------------------------------------------------------
 # Declares the full budget vocabulary the GitHub estimator emits so recorded
 # actuals key by the same (route_family, dimension) an estimate is keyed by.
-# Code-dataset families (git/commit_stats/files/blame/cicd/tests/deployments/
-# security) are budgeted but fetched through the frozen dataset path with no
+# Code-dataset families (git/commit_stats/files/blame/cicd/tests/deployments)
+# are budgeted but fetched through the frozen dataset path with no
 # instrumented client, so they carry no operation markers here (documented gap;
 # see docs/architecture/rate-limit-policy.md). Only the work-item families are
 # instrumented: every REST read in a work-item unit consumes the work_items
@@ -350,6 +350,16 @@ def _fallback_credential_scope(
 # and the REST prs traffic itself stays on the frozen connector pending
 # CHAOS-2773 CS8 -- so their markers stay empty per the plan's "never flip a
 # marker before its traffic" rule (§3).
+#
+# `security` (REST_CORE) is the first GitHub code-dataset family fully off the
+# frozen connector (CHAOS-2773 CS3): `providers/github/code_client.py::
+# GitHubCodeClient` fetches Dependabot alerts, code-scanning alerts, and
+# security advisories via `InstrumentedRESTCore` and labels every operation
+# with the explicit `"security:"` prefix, so this marker documents live
+# traffic (the CS1 explicit-prefix short-circuit resolves those labels
+# directly, irrespective of `operation_markers`) -- populated now that the
+# family's fetch path is actually instrumented, per the plan's "never flip a
+# marker before its traffic" rule (§3).
 GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("repo", BudgetDimension.REST_CORE),
     UsageRouteFamily("git", BudgetDimension.REST_CORE),
@@ -370,7 +380,9 @@ GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("tests", BudgetDimension.CONTENTS_BLOB),
     UsageRouteFamily("deployments", BudgetDimension.REST_CORE),
     UsageRouteFamily("deployments", BudgetDimension.CONTENTS_BLOB),
-    UsageRouteFamily("security", BudgetDimension.REST_CORE),
+    UsageRouteFamily(
+        "security", BudgetDimension.REST_CORE, operation_markers=("security:",)
+    ),
     UsageRouteFamily("work_items", BudgetDimension.REST_CORE),
     UsageRouteFamily("work_item_prs", BudgetDimension.GRAPHQL_COST),
     UsageRouteFamily("work_item_prs", BudgetDimension.SECONDARY_ABUSE_RISK),

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -1,0 +1,387 @@
+"""GitHub instrumented httpx code client (CHAOS-2773 CS3 pathfinder).
+
+Ports the "security" code-dataset family -- Dependabot alerts, code-scanning
+alerts, security advisories -- off the frozen ``connectors/github.py`` REST
+methods (``get_dependabot_alerts`` / ``get_code_scanning_alerts`` /
+``get_security_advisories`` and their shared ``_get_security_alert_page``
+pager) onto ``providers/_http.py::InstrumentedRESTCore``.
+
+This is the epic's PATHFINDER client: the shape here (one owned
+``InstrumentedRESTCore`` configured with GitHub's diagnostic headers and 403
+triage, ``"<family>:"``-prefixed operation labels for the CS1 resolver
+short-circuit, degrade-to-empty on a permission/SSO 403 or 404 for these
+OPTIONAL endpoints, ``RateLimitException`` on a rate-limited 403 or an
+exhausted 429) is the template later changesets (CS4 deployments, CS5
+cicd/tests, ...) copy for their own GitHub code-dataset families -- each
+adding sibling methods to this same client labeled with their own family
+prefix, never a second ``InstrumentedRESTCore`` construction pattern.
+
+Behavior parity with the connector is pinned by
+``tests/providers/test_github_code_client_security.py``.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+from dev_health_ops.connectors.models import SecurityAlertData
+from dev_health_ops.exceptions import (
+    AuthenticationException,
+    NotFoundException,
+    RateLimitException,
+)
+from dev_health_ops.providers._http import (
+    GITHUB_DIAGNOSTIC_HEADER_NAMES,
+    InstrumentedRESTCore,
+    _default_is_retryable_status,
+    github_rest_base_url,
+)
+from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.ratelimit import (
+    classify_github_403,
+    github_retry_after_seconds,
+)
+from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
+
+logger = logging.getLogger(__name__)
+
+# CS1 resolver explicit-prefix short-circuit (providers/usage.py::
+# OperationResolver): every operation this client labels resolves DIRECTLY to
+# the "security" route family (providers/github/budget.py's
+# GITHUB_USAGE_ROUTE_FAMILIES entry), bypassing the substring marker scan.
+SECURITY_ROUTE_FAMILY = "security"
+
+
+def _lowered_github_headers(response: httpx.Response) -> dict[str, str]:
+    """Lower-cased diagnostic headers -- the shape both ``classify_github_403``
+    and ``github_retry_after_seconds`` expect (never the Authorization/token
+    header, which is not in ``GITHUB_DIAGNOSTIC_HEADER_NAMES``)."""
+    lowered = {str(k).lower(): str(v) for k, v in response.headers.items()}
+    return {
+        name: lowered[name]
+        for name in GITHUB_DIAGNOSTIC_HEADER_NAMES
+        if name in lowered
+    }
+
+
+def _response_host(response: httpx.Response) -> str | None:
+    host = getattr(getattr(response, "url", None), "host", None)
+    return host if isinstance(host, str) and host else None
+
+
+def _classify_github_code_client_error(
+    response: httpx.Response, operation: str
+) -> None:
+    """``InstrumentedRESTCore.classify_error`` hook: triage a 403 through the
+    shared ``classify_github_403`` (the SAME classifier
+    ``GitHubWorkClient._raise_github_exception`` uses -- no second copy of the
+    primary/secondary/permission decision).
+
+    A rate-limited 403 (primary or secondary/abuse) raises the canonical
+    ``RateLimitException`` here, short-circuiting the core's generic
+    classification. A permission/SSO/other 403 -- or any other status --
+    returns normally, falling through to the core's default (401/403/404/429/
+    5xx) classification, which raises ``AuthenticationException`` for that
+    403 case -- exactly matching ``connectors/github.py``'s "return None ->
+    caller decides" contract.
+    """
+    status = response.status_code
+    if status == 401:
+        logger.warning(
+            "GitHub security endpoint 401 on %s headers=%s -- degrading to "
+            "empty (check token validity)",
+            operation,
+            _lowered_github_headers(response),
+        )
+        return
+    if status != 403:
+        return
+    headers = _lowered_github_headers(response)
+    classification = classify_github_403(headers=headers, message=response.text)
+    if not classification.is_rate_limit:
+        logger.warning(
+            "GitHub security endpoint non-rate-limit 403 on %s headers=%s -- "
+            "degrading to empty (check token scope / SSO authorization)",
+            operation,
+            headers,
+        )
+        return
+    logger.warning(
+        "GitHub rate limit (403) on %s headers=%s reason=%s",
+        operation,
+        headers,
+        classification.reason,
+    )
+    raise RateLimitException(
+        f"GitHub rate limit (403) on {operation} (headers={headers})",
+        retry_after_seconds=classification.retry_after_seconds,
+        signal=RateLimitSignal(
+            provider="github",
+            host=_response_host(response),
+            dimension=classification.dimension,
+            retry_after_seconds=classification.retry_after_seconds,
+            reset_at=RateLimitSignal.reset_at_from_epoch_seconds(
+                headers.get("x-ratelimit-reset")
+            ),
+            reason=classification.reason,
+            request_id=headers.get("x-github-request-id"),
+        ),
+    )
+
+
+def _resolve_github_retry_after(response: httpx.Response) -> float | None:
+    """``InstrumentedRESTCore.resolve_retry_after`` hook: wraps
+    ``github_retry_after_seconds`` (which takes a lower-cased header mapping)
+    to match the core's ``Callable[[httpx.Response], float | None]`` shape."""
+    return github_retry_after_seconds(_lowered_github_headers(response))
+
+
+def _github_is_retryable_status(response: httpx.Response) -> bool:
+    """``InstrumentedRESTCore.is_retryable_status`` hook: extend the default
+    (429 / 5xx) to ALSO retry a RATE-LIMITED 403 -- GitHub secondary/abuse
+    limits arrive as a 403 (often with ``Retry-After``), which the default
+    predicate would treat as terminal. Restores the frozen connector's
+    ``retry_with_backoff(exceptions=(RateLimitException, APIException))``
+    parity: a rate-limited 403 gets backed-off retries before the terminal
+    ``RateLimitException``. A plain permission/SSO 403 is NOT a rate limit and
+    stays non-retryable (it degrades to empty for these optional endpoints)."""
+    if response.status_code == 403:
+        return classify_github_403(
+            headers=_lowered_github_headers(response), message=response.text
+        ).is_rate_limit
+    return _default_is_retryable_status(response)
+
+
+def _parse_alert_datetime(value: object) -> datetime | None:
+    """Byte-for-byte port of ``connectors/github.py::
+    GitHubConnector._parse_github_datetime`` -- a naive/aware ISO-8601 string
+    (GitHub always sends a ``Z``-suffixed UTC timestamp) -> ``datetime``."""
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        logger.debug("Failed to parse GitHub datetime: %s", value)
+        return None
+
+
+def _dependabot_alert_from_item(item: dict[str, Any]) -> SecurityAlertData:
+    advisory = item.get("security_advisory") or {}
+    dependency = item.get("dependency") or {}
+    package = dependency.get("package") or {}
+    return SecurityAlertData(
+        alert_id=f"dependabot:{item['number']}",
+        source="dependabot",
+        severity=advisory.get("severity"),
+        state=item["state"],
+        package_name=package.get("name"),
+        cve_id=advisory.get("cve_id"),
+        url=item.get("html_url"),
+        title=advisory.get("summary"),
+        description=advisory.get("description"),
+        created_at=_parse_alert_datetime(item.get("created_at")),
+        fixed_at=_parse_alert_datetime(item.get("fixed_at")),
+        dismissed_at=_parse_alert_datetime(item.get("dismissed_at")),
+    )
+
+
+def _code_scanning_alert_from_item(item: dict[str, Any]) -> SecurityAlertData:
+    rule = item.get("rule") or {}
+    most_recent_instance = item.get("most_recent_instance") or {}
+    message = most_recent_instance.get("message") or {}
+    return SecurityAlertData(
+        alert_id=f"code_scanning:{item['number']}",
+        source="code_scanning",
+        severity=rule.get("severity"),
+        state=item["state"],
+        package_name=None,
+        cve_id=None,
+        url=item.get("html_url"),
+        title=rule.get("description"),
+        description=message.get("text"),
+        created_at=_parse_alert_datetime(item.get("created_at")),
+        fixed_at=None,
+        dismissed_at=_parse_alert_datetime(item.get("dismissed_at")),
+    )
+
+
+def _security_advisory_from_item(item: dict[str, Any]) -> SecurityAlertData:
+    return SecurityAlertData(
+        alert_id=f"advisory:{item['ghsa_id']}",
+        source="advisory",
+        severity=item.get("severity"),
+        state=item.get("state"),
+        package_name=None,
+        cve_id=item.get("cve_id"),
+        url=item.get("html_url"),
+        title=item.get("summary"),
+        description=item.get("description"),
+        created_at=_parse_alert_datetime(item.get("created_at")),
+        fixed_at=None,
+        dismissed_at=None,
+    )
+
+
+class GitHubCodeClient:
+    """Instrumented httpx client for GitHub code-dataset families
+    (CHAOS-2773 CS3+). CS3 exposes the ``security`` family only.
+
+    :param auth: Token + optional GHE base URL. Mirrors
+        ``providers/github/client.py::GitHubAuth`` -- callers that already
+        resolved a GitHub App installation token onto a connector (this
+        client's only construction path today, via
+        ``processors/github.py::_github_code_client_from_connector``) pass
+        that resolved plain token here; this client does not itself refresh
+        short-lived App tokens (CS3 scope; the connector already did that).
+    :param transport: Optional ``httpx.AsyncBaseTransport`` override, passed
+        straight through to the owned ``InstrumentedRESTCore`` -- the seam
+        parity tests use to mock GitHub's REST API (``httpx.MockTransport``),
+        never live network (offline gate).
+    """
+
+    def __init__(
+        self, *, auth: GitHubAuth, transport: httpx.AsyncBaseTransport | None = None
+    ) -> None:
+        if not auth.token:
+            raise ValueError("GitHubCodeClient requires a resolved token")
+        self.auth = auth
+
+        # Deferred import mirrors providers/github/client.py: budget.py is the
+        # source of truth for the route-family vocabulary, imported lazily to
+        # avoid a module-load-order cycle.
+        from dev_health_ops.providers.github.budget import GITHUB_USAGE_RESOLVER
+
+        self._core = InstrumentedRESTCore(
+            base_url=github_rest_base_url(auth.base_url),
+            provider="github",
+            resolver=GITHUB_USAGE_RESOLVER,
+            headers={
+                "Authorization": f"token {auth.token}",
+                "Accept": "application/vnd.github+json",
+            },
+            diagnostic_header_names=GITHUB_DIAGNOSTIC_HEADER_NAMES,
+            classify_error=_classify_github_code_client_error,
+            resolve_retry_after=_resolve_github_retry_after,
+            is_retryable_status=_github_is_retryable_status,
+            transport=transport,
+        )
+
+    async def get_dependabot_alerts(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        state: str = "open",
+        max_alerts: int | None = None,
+    ) -> list[SecurityAlertData]:
+        """GET /repos/{owner}/{repo}/dependabot/alerts (paginated)."""
+        return await self._get_security_alerts(
+            owner,
+            repo,
+            endpoint="dependabot/alerts",
+            params={"state": state, "per_page": 100},
+            max_alerts=max_alerts,
+            build=_dependabot_alert_from_item,
+        )
+
+    async def get_code_scanning_alerts(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        state: str = "open",
+        max_alerts: int | None = None,
+    ) -> list[SecurityAlertData]:
+        """GET /repos/{owner}/{repo}/code-scanning/alerts (paginated)."""
+        return await self._get_security_alerts(
+            owner,
+            repo,
+            endpoint="code-scanning/alerts",
+            params={"state": state, "per_page": 100},
+            max_alerts=max_alerts,
+            build=_code_scanning_alert_from_item,
+        )
+
+    async def get_security_advisories(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        state: str | None = None,
+        max_alerts: int | None = None,
+    ) -> list[SecurityAlertData]:
+        """GET /repos/{owner}/{repo}/security-advisories (paginated)."""
+        params: dict[str, Any] = {"per_page": 100}
+        if state is not None:
+            params["state"] = state
+        return await self._get_security_alerts(
+            owner,
+            repo,
+            endpoint="security-advisories",
+            params=params,
+            max_alerts=max_alerts,
+            build=_security_advisory_from_item,
+        )
+
+    async def _get_security_alerts(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        endpoint: str,
+        params: dict[str, Any],
+        max_alerts: int | None,
+        build: Any,
+    ) -> list[SecurityAlertData]:
+        """Shared pager for the three security endpoints -- ports
+        ``connectors/github.py::_get_security_alert_page`` onto
+        ``InstrumentedRESTCore.paginate_link_header`` (Link-header
+        ``rel="next"`` pagination; the first request applies ``params``,
+        follow-up requests use the absolute next URL as-is, matching the
+        connector byte-for-byte).
+
+        A permission/SSO 403 (``AuthenticationException``, not a rate limit
+        per ``classify_github_403``) or a 404 (``NotFoundException``) on
+        these OPTIONAL endpoints degrades to an EMPTY list -- discarding any
+        items already gathered from earlier pages in this call, exactly like
+        the connector's ``return []`` (the feature is likely disabled, or the
+        token lacks the scope). A rate-limited 403 or an exhausted 429 raises
+        ``RateLimitException`` and is NOT caught here -- it propagates to the
+        caller (``processors/github.py``'s per-endpoint degrade-and-log loop
+        decides from there, unchanged from today).
+        """
+        operation = f"{SECURITY_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/{endpoint}"
+        try:
+            items = await self._core.paginate_link_header(
+                f"/repos/{owner}/{repo}/{endpoint}",
+                operation=operation,
+                params=params,
+            )
+        except (AuthenticationException, NotFoundException):
+            return []
+        alerts = [build(item) for item in items]
+        if max_alerts is not None:
+            alerts = alerts[:max_alerts]
+        return alerts
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        return self._core.drain_usage_observations()
+
+    async def close(self) -> None:
+        await self._core.close()
+
+    async def __aenter__(self) -> GitHubCodeClient:
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        await self.close()
+
+
+__all__ = [
+    "GitHubCodeClient",
+    "SECURITY_ROUTE_FAMILY",
+]

--- a/tests/providers/test_github_code_client_security.py
+++ b/tests/providers/test_github_code_client_security.py
@@ -1,0 +1,469 @@
+"""Parity tests for providers/github/code_client.py::GitHubCodeClient
+(CHAOS-2773 CS3).
+
+Proves the httpx-based ``GitHubCodeClient`` reproduces
+``connectors/github.py``'s frozen security-alert fetch (``get_dependabot_alerts``
+/ ``get_code_scanning_alerts`` / ``get_security_advisories`` and their shared
+``_get_security_alert_page`` pager) byte-for-byte: Link-header pagination,
+403/404 degrade-to-empty on these optional endpoints, 429 -> RateLimitException,
+and identical ``SecurityAlertData`` field mapping. All HTTP is mocked at the
+transport layer (``httpx.MockTransport``) -- no live network (offline gate).
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+
+from dev_health_ops.exceptions import RateLimitException
+from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.code_client import GitHubCodeClient
+
+
+def _client(
+    transport: httpx.AsyncBaseTransport, *, token: str = "ghp_test_token"
+) -> GitHubCodeClient:
+    return GitHubCodeClient(auth=GitHubAuth(token=token), transport=transport)
+
+
+def _handler_sequence(responses: list[httpx.Response]) -> httpx.MockTransport:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        response = responses[min(calls["n"], len(responses) - 1)]
+        calls["n"] += 1
+        return response
+
+    transport = httpx.MockTransport(handler)
+    transport.calls = calls  # type: ignore[attr-defined]
+    return transport
+
+
+def _mock_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No-op ``asyncio.sleep`` so retry backoff (429 / rate-limited 403) does
+    not actually block the test."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers._http.asyncio.sleep",
+        AsyncMock(return_value=None),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Auth / headers
+# ---------------------------------------------------------------------------
+
+
+class TestAuthHeaders:
+    @pytest.mark.asyncio
+    async def test_sends_token_and_accept_headers(self) -> None:
+        seen: list[httpx.Request] = []
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return httpx.Response(200, json=[])
+
+        client = _client(httpx.MockTransport(handler), token="unit-test-pat")
+        await client.get_dependabot_alerts("acme", "widgets")
+
+        assert seen[0].headers["Authorization"] == "token unit-test-pat"
+        assert seen[0].headers["Accept"] == "application/vnd.github+json"
+        await client.close()
+
+    def test_missing_token_raises(self) -> None:
+        with pytest.raises(ValueError, match="resolved token"):
+            GitHubCodeClient(auth=GitHubAuth(token=None))
+
+
+# ---------------------------------------------------------------------------
+# Pagination via Link header (rel="next")
+# ---------------------------------------------------------------------------
+
+
+class TestPagination:
+    @pytest.mark.asyncio
+    async def test_follows_link_header_across_pages(self) -> None:
+        page1 = httpx.Response(
+            200,
+            json=[{"number": 1, "state": "open", "html_url": "u1"}],
+            headers={
+                "Link": (
+                    "<https://api.github.com/repos/acme/widgets/dependabot/alerts"
+                    '?page=2>; rel="next"'
+                )
+            },
+        )
+        page2 = httpx.Response(
+            200, json=[{"number": 2, "state": "open", "html_url": "u2"}]
+        )
+        transport = _handler_sequence([page1, page2])
+        client = _client(transport)
+
+        alerts = await client.get_dependabot_alerts("acme", "widgets")
+
+        assert [a.alert_id for a in alerts] == ["dependabot:1", "dependabot:2"]
+        assert transport.calls["n"] == 2  # type: ignore[attr-defined]
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_first_request_applies_params_followups_use_absolute_url(
+        self,
+    ) -> None:
+        seen: list[httpx.Request] = []
+        page1 = httpx.Response(
+            200,
+            json=[{"number": 1, "state": "open"}],
+            headers={
+                "Link": (
+                    "<https://api.github.com/repos/acme/widgets/dependabot/alerts"
+                    '?page=2>; rel="next"'
+                )
+            },
+        )
+        page2 = httpx.Response(200, json=[{"number": 2, "state": "open"}])
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen.append(request)
+            return page1 if len(seen) == 1 else page2
+
+        client = _client(httpx.MockTransport(handler))
+        await client.get_dependabot_alerts("acme", "widgets", state="open")
+
+        assert seen[0].url.params["state"] == "open"
+        assert seen[0].url.params["per_page"] == "100"
+        # The second (absolute next-url) request carries no re-applied params
+        # beyond what the Link header itself encoded.
+        assert "state" not in seen[1].url.params
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_no_link_header_single_page(self) -> None:
+        client = _client(
+            httpx.MockTransport(
+                lambda r: httpx.Response(200, json=[{"number": 1, "state": "open"}])
+            )
+        )
+        alerts = await client.get_code_scanning_alerts("acme", "widgets")
+        assert len(alerts) == 1
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_max_alerts_truncates_after_full_pagination(self) -> None:
+        page1 = httpx.Response(
+            200,
+            json=[{"number": 1, "state": "open"}, {"number": 2, "state": "open"}],
+            headers={
+                "Link": (
+                    "<https://api.github.com/repos/acme/widgets/dependabot/alerts"
+                    '?page=2>; rel="next"'
+                )
+            },
+        )
+        page2 = httpx.Response(200, json=[{"number": 3, "state": "open"}])
+        transport = _handler_sequence([page1, page2])
+        client = _client(transport)
+
+        alerts = await client.get_dependabot_alerts("acme", "widgets", max_alerts=2)
+
+        assert [a.alert_id for a in alerts] == ["dependabot:1", "dependabot:2"]
+        # Pagination still ran to completion (matches the connector, which
+        # fetches all pages before the alert-building loop truncates).
+        assert transport.calls["n"] == 2  # type: ignore[attr-defined]
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# 403 / 404 degrade-to-empty (optional endpoints)
+# ---------------------------------------------------------------------------
+
+
+class TestDegradeToEmpty:
+    @pytest.mark.asyncio
+    async def test_permission_403_degrades_to_empty(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = _client(
+            httpx.MockTransport(
+                lambda r: httpx.Response(
+                    403, json={"message": "Resource not accessible"}
+                )
+            )
+        )
+        with caplog.at_level("WARNING"):
+            alerts = await client.get_dependabot_alerts("acme", "widgets")
+        assert alerts == []
+        # Diagnosability parity: a permission/SSO 403 must be logged (safe
+        # headers only) before degrading -- never silently drop all alerts.
+        assert any("non-rate-limit 403" in r.message for r in caplog.records)
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_401_degrades_to_empty_with_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        client = _client(
+            httpx.MockTransport(
+                lambda r: httpx.Response(401, json={"message": "Bad credentials"})
+            )
+        )
+        with caplog.at_level("WARNING"):
+            alerts = await client.get_dependabot_alerts("acme", "widgets")
+        assert alerts == []
+        assert any("401" in r.message for r in caplog.records)
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_404_degrades_to_empty(self) -> None:
+        client = _client(
+            httpx.MockTransport(
+                lambda r: httpx.Response(404, json={"message": "Not Found"})
+            )
+        )
+        alerts = await client.get_security_advisories("acme", "widgets")
+        assert alerts == []
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_mid_pagination_403_discards_partial_results(self) -> None:
+        # Matches connectors/github.py::_get_security_alert_page exactly: a
+        # non-rate-limited 403 on page 2 returns [] -- NOT the items already
+        # gathered from page 1.
+        page1 = httpx.Response(
+            200,
+            json=[{"number": 1, "state": "open"}],
+            headers={
+                "Link": (
+                    "<https://api.github.com/repos/acme/widgets/code-scanning/alerts"
+                    '?page=2>; rel="next"'
+                )
+            },
+        )
+        page2 = httpx.Response(403, json={"message": "Resource not accessible"})
+        transport = _handler_sequence([page1, page2])
+        client = _client(transport)
+
+        alerts = await client.get_code_scanning_alerts("acme", "widgets")
+
+        assert alerts == []
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# 429 -> RateLimitException / rate-limited 403 -> RateLimitException
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimit:
+    @pytest.mark.asyncio
+    async def test_429_exhaustion_raises_rate_limit_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from unittest.mock import AsyncMock
+
+        monkeypatch.setattr(
+            "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+        )
+        client = _client(
+            httpx.MockTransport(
+                lambda r: httpx.Response(429, headers={"Retry-After": "5"})
+            )
+        )
+        with pytest.raises(RateLimitException) as excinfo:
+            await client.get_dependabot_alerts("acme", "widgets")
+        assert excinfo.value.retry_after_seconds == pytest.approx(5.0)
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_primary_rate_limit_403_raises_rate_limit_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _mock_sleep(monkeypatch)
+        reset_epoch = int(time.time()) + 120
+        client = _client(
+            httpx.MockTransport(
+                lambda r: httpx.Response(
+                    403,
+                    headers={
+                        "X-RateLimit-Remaining": "0",
+                        "X-RateLimit-Reset": str(reset_epoch),
+                    },
+                    json={"message": "API rate limit exceeded"},
+                )
+            )
+        )
+        with pytest.raises(RateLimitException) as excinfo:
+            await client.get_dependabot_alerts("acme", "widgets")
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.provider == "github"
+        assert signal.reason == "primary"
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_secondary_abuse_403_raises_rate_limit_exception(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _mock_sleep(monkeypatch)
+        client = _client(
+            httpx.MockTransport(
+                lambda r: httpx.Response(
+                    403,
+                    headers={"Retry-After": "30"},
+                    json={"message": "You have exceeded a secondary rate limit."},
+                )
+            )
+        )
+        with pytest.raises(RateLimitException) as excinfo:
+            await client.get_code_scanning_alerts("acme", "widgets")
+        assert excinfo.value.retry_after_seconds == pytest.approx(30.0)
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "secondary"
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_rate_limited_403_then_200_retries_and_succeeds(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Finding-1 parity fix: a transient secondary/abuse 403 is RETRIED
+        # (mirrors the connector's retry_with_backoff), not abandoned on the
+        # first response -- a 403-then-200 sequence yields the 200 payload.
+        _mock_sleep(monkeypatch)
+        limited = httpx.Response(
+            403,
+            headers={"Retry-After": "0"},
+            json={"message": "You have exceeded a secondary rate limit."},
+        )
+        ok = httpx.Response(200, json=[{"number": 5, "state": "open"}])
+        transport = _handler_sequence([limited, ok])
+        client = _client(transport)
+
+        alerts = await client.get_code_scanning_alerts("acme", "widgets")
+
+        assert [a.alert_id for a in alerts] == ["code_scanning:5"]
+        assert transport.calls["n"] == 2  # type: ignore[attr-defined]
+        await client.close()
+
+    @pytest.mark.asyncio
+    async def test_usage_observations_key_under_security_route_family(self) -> None:
+        client = _client(httpx.MockTransport(lambda r: httpx.Response(200, json=[])))
+        await client.get_dependabot_alerts("acme", "widgets")
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "security"
+        assert observations[0]["request_count"] == 1
+        await client.close()
+
+
+# ---------------------------------------------------------------------------
+# Field mapping parity (connectors/github.py::get_*_alerts byte-for-byte)
+# ---------------------------------------------------------------------------
+
+
+class TestFieldMapping:
+    @pytest.mark.asyncio
+    async def test_dependabot_alert_field_mapping(self) -> None:
+        payload = [
+            {
+                "number": 42,
+                "state": "open",
+                "html_url": "https://github.com/acme/widgets/security/dependabot/42",
+                "created_at": "2024-01-01T00:00:00Z",
+                "fixed_at": None,
+                "dismissed_at": None,
+                "security_advisory": {
+                    "severity": "high",
+                    "cve_id": "CVE-2024-1234",
+                    "summary": "Vulnerable dependency",
+                    "description": "Full description",
+                },
+                "dependency": {"package": {"name": "left-pad"}},
+            }
+        ]
+        client = _client(
+            httpx.MockTransport(lambda r: httpx.Response(200, json=payload))
+        )
+        alerts = await client.get_dependabot_alerts("acme", "widgets")
+        await client.close()
+
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.alert_id == "dependabot:42"
+        assert alert.source == "dependabot"
+        assert alert.severity == "high"
+        assert alert.state == "open"
+        assert alert.package_name == "left-pad"
+        assert alert.cve_id == "CVE-2024-1234"
+        assert alert.url == "https://github.com/acme/widgets/security/dependabot/42"
+        assert alert.title == "Vulnerable dependency"
+        assert alert.description == "Full description"
+        assert alert.created_at is not None
+        assert alert.fixed_at is None
+        assert alert.dismissed_at is None
+
+    @pytest.mark.asyncio
+    async def test_code_scanning_alert_field_mapping(self) -> None:
+        payload = [
+            {
+                "number": 7,
+                "state": "open",
+                "html_url": "https://github.com/acme/widgets/security/code-scanning/7",
+                "created_at": "2024-02-02T00:00:00Z",
+                "dismissed_at": "2024-02-03T00:00:00Z",
+                "rule": {"severity": "error", "description": "SQL injection"},
+                "most_recent_instance": {"message": {"text": "Tainted input"}},
+            }
+        ]
+        client = _client(
+            httpx.MockTransport(lambda r: httpx.Response(200, json=payload))
+        )
+        alerts = await client.get_code_scanning_alerts("acme", "widgets")
+        await client.close()
+
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.alert_id == "code_scanning:7"
+        assert alert.source == "code_scanning"
+        assert alert.severity == "error"
+        assert alert.state == "open"
+        assert alert.package_name is None
+        assert alert.cve_id is None
+        assert alert.title == "SQL injection"
+        assert alert.description == "Tainted input"
+        assert alert.fixed_at is None
+        assert alert.dismissed_at is not None
+
+    @pytest.mark.asyncio
+    async def test_security_advisory_field_mapping(self) -> None:
+        payload = [
+            {
+                "ghsa_id": "GHSA-xxxx-yyyy-zzzz",
+                "state": "published",
+                "severity": "critical",
+                "cve_id": "CVE-2024-9999",
+                "html_url": "https://github.com/acme/widgets/security/advisories/GHSA-xxxx",
+                "summary": "Critical advisory",
+                "description": "Advisory description",
+                "created_at": "2024-03-03T00:00:00Z",
+            }
+        ]
+        client = _client(
+            httpx.MockTransport(lambda r: httpx.Response(200, json=payload))
+        )
+        alerts = await client.get_security_advisories("acme", "widgets")
+        await client.close()
+
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.alert_id == "advisory:GHSA-xxxx-yyyy-zzzz"
+        assert alert.source == "advisory"
+        assert alert.severity == "critical"
+        assert alert.state == "published"
+        assert alert.package_name is None
+        assert alert.cve_id == "CVE-2024-9999"
+        assert alert.title == "Critical advisory"
+        assert alert.description == "Advisory description"
+        assert alert.fixed_at is None
+        assert alert.dismissed_at is None

--- a/tests/test_security_alerts.py
+++ b/tests/test_security_alerts.py
@@ -1,6 +1,9 @@
 import uuid
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import MagicMock
+
+import pytest
 
 from dev_health_ops.connectors.models import SecurityAlertData
 
@@ -72,26 +75,77 @@ class TestSecurityAlertModel:
         assert alert.source == "dependabot"
 
 
-class TestFetchGithubSecurityAlertsSync:
-    def _make_connector(self, dependabot=None, code_scanning=None, advisories=None):
-        connector = MagicMock()
-        connector.get_dependabot_alerts = MagicMock(return_value=dependabot or [])
-        connector.get_code_scanning_alerts = MagicMock(return_value=code_scanning or [])
-        connector.get_security_advisories = MagicMock(return_value=advisories or [])
-        return connector
+class _StubGitHubCodeClient:
+    """Stand-in for ``providers/github/code_client.py::GitHubCodeClient``
+    (CHAOS-2773 CS3) that returns canned alerts without any HTTP transport --
+    the transport-level behavior (pagination, 403/404/429, field mapping) is
+    pinned separately by
+    ``tests/providers/test_github_code_client_security.py``. This stub only
+    exercises ``_fetch_github_security_alerts_async``'s orchestration:
+    combining the three endpoints, the ``since`` filter, and the
+    per-endpoint degrade-and-log behavior on a fetch failure."""
 
-    def test_combines_all_sources(self):
-        from dev_health_ops.processors.github import (
-            _fetch_github_security_alerts_sync,
+    def __init__(
+        self,
+        dependabot=None,
+        code_scanning=None,
+        advisories=None,
+        code_scanning_error=None,
+    ):
+        self._dependabot = dependabot or []
+        self._code_scanning = code_scanning or []
+        self._advisories = advisories or []
+        self._code_scanning_error = code_scanning_error
+
+    async def get_dependabot_alerts(self, owner, repo, *, max_alerts=None):
+        return self._dependabot
+
+    async def get_code_scanning_alerts(self, owner, repo, *, max_alerts=None):
+        if self._code_scanning_error is not None:
+            raise self._code_scanning_error
+        return self._code_scanning
+
+    async def get_security_advisories(self, owner, repo, *, max_alerts=None):
+        return self._advisories
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        return []
+
+    async def close(self) -> None:
+        return None
+
+
+class TestFetchGithubSecurityAlertsSync:
+    def _make_client(
+        self,
+        dependabot=None,
+        code_scanning=None,
+        advisories=None,
+        code_scanning_error=None,
+    ):
+        return _StubGitHubCodeClient(
+            dependabot=dependabot,
+            code_scanning=code_scanning,
+            advisories=advisories,
+            code_scanning_error=code_scanning_error,
         )
 
-        connector = self._make_connector(
+    @pytest.mark.asyncio
+    async def test_combines_all_sources(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dev_health_ops.processors import github as github_processor
+
+        client = self._make_client(
             dependabot=[_make_alert("dependabot", "dependabot:1")],
             code_scanning=[_make_alert("code_scanning", "code_scanning:1")],
             advisories=[_make_alert("advisory", "advisory:1")],
         )
-        result = _fetch_github_security_alerts_sync(
-            connector, "owner", "repo", FAKE_REPO_ID, 100, None
+        monkeypatch.setattr(
+            github_processor,
+            "_github_code_client_from_connector",
+            lambda connector: client,
+        )
+        result = await github_processor._fetch_github_security_alerts_async(
+            MagicMock(), "owner", "repo", FAKE_REPO_ID, 100, None
         )
         sources = [a.source for a in result]
         assert "dependabot" in sources
@@ -99,37 +153,66 @@ class TestFetchGithubSecurityAlertsSync:
         assert "advisory" in sources
         assert len(result) == 3
 
-    def test_filters_by_since(self):
-        from dev_health_ops.processors.github import (
-            _fetch_github_security_alerts_sync,
-        )
+    @pytest.mark.asyncio
+    async def test_filters_by_since(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from dev_health_ops.processors import github as github_processor
 
-        connector = self._make_connector(
-            dependabot=[_make_alert("dependabot")],
+        client = self._make_client(dependabot=[_make_alert("dependabot")])
+        monkeypatch.setattr(
+            github_processor,
+            "_github_code_client_from_connector",
+            lambda connector: client,
         )
-        result = _fetch_github_security_alerts_sync(
-            connector, "owner", "repo", FAKE_REPO_ID, 100, FEB_1
+        result = await github_processor._fetch_github_security_alerts_async(
+            MagicMock(), "owner", "repo", FAKE_REPO_ID, 100, FEB_1
         )
         assert len(result) == 0
 
-    def test_handles_partial_failure(self):
-        from dev_health_ops.processors.github import (
-            _fetch_github_security_alerts_sync,
-        )
+    @pytest.mark.asyncio
+    async def test_handles_partial_failure(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev_health_ops.processors import github as github_processor
 
-        connector = self._make_connector(
+        client = self._make_client(
             dependabot=[_make_alert("dependabot", "dependabot:1")],
             advisories=[_make_alert("advisory", "advisory:1")],
+            code_scanning_error=Exception("API error"),
         )
-        connector.get_code_scanning_alerts.side_effect = Exception("API error")
-        connector.get_code_scanning_alerts.__name__ = "get_code_scanning_alerts"
-        result = _fetch_github_security_alerts_sync(
-            connector, "owner", "repo", FAKE_REPO_ID, 100, None
+        monkeypatch.setattr(
+            github_processor,
+            "_github_code_client_from_connector",
+            lambda connector: client,
+        )
+        result = await github_processor._fetch_github_security_alerts_async(
+            MagicMock(), "owner", "repo", FAKE_REPO_ID, 100, None
         )
         assert len(result) == 2
         sources = {a.source for a in result}
         assert "dependabot" in sources
         assert "advisory" in sources
+
+    @pytest.mark.asyncio
+    async def test_drains_usage_sink(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """CHAOS-2803/CS2 contract: the client is drained into the
+        caller-owned ``usage_sink`` list, mutated in place, regardless of
+        fetch outcome."""
+        from dev_health_ops.processors import github as github_processor
+
+        client = self._make_client()
+        client.drain_usage_observations = lambda: [
+            {"route_family": "security", "request_count": 3}
+        ]
+        monkeypatch.setattr(
+            github_processor,
+            "_github_code_client_from_connector",
+            lambda connector: client,
+        )
+        usage_sink: list[dict[str, Any]] = []
+        await github_processor._fetch_github_security_alerts_async(
+            MagicMock(), "owner", "repo", FAKE_REPO_ID, 100, None, usage_sink=usage_sink
+        )
+        assert usage_sink == [{"route_family": "security", "request_count": 3}]
 
 
 class TestFetchGitlabSecurityAlertsSync:


### PR DESCRIPTION
## CHAOS-2804 — CS3: GitHub security family on GitHubCodeClient (CHAOS-2773 pathfinder)

Migrates the GitHub **security** code-dataset family (Dependabot alerts, code-scanning alerts, security advisories) off the frozen PyGithub `connectors/github.py` path onto a new instrumented httpx `GitHubCodeClient` built on `InstrumentedRESTCore`. This is the GitHub-wave **pathfinder** that CS4–CS9 copy.

### What changed
- **New** `providers/github/code_client.py` — `GitHubCodeClient`: one owned `InstrumentedRESTCore`, `"security:"`-prefixed operation labels (CS1 resolver short-circuit), GitHub 403 triage via `classify_github_403`, real per-request usage recording.
- `processors/github.py` — `_fetch_github_security_alerts_async` now calls the new client (via `_github_code_client_from_connector`) instead of the connector; usage drains through the CS2 `usage_sink` contract.
- `providers/github/budget.py` — `security` route-family now carries `operation_markers=("security:",)` (was empty) so budget calibration lights up.
- **New** `tests/providers/test_github_code_client_security.py` + updated `tests/test_security_alerts.py`.

### Parity preserved
Link-header pagination; `Authorization: token` + `Accept: application/vnd.github+json`; 403/404 on optional endpoints degrade to empty; 429 + rate-limited 403 → retried (backoff) then `RateLimitException`; identical `SecurityAlertData` field mapping. `connectors/` untouched (frozen).

### Adversarial review (2 rounds)
Round-1 findings **fixed**: (1) rate-limited secondary/abuse 403s are now retryable via a GitHub-specific `is_retryable_status` (restores the connector's `retry_with_backoff` parity; mirrors the GitLab sibling client); (2) permission/SSO 403 + 401 now emit a safe-headers diagnostic log before degrading to empty (no more silent all-alerts drop). Regression tests added for both.

### Deferred (follow-ups filed)
- **CHAOS-2847** — the shared core deliberately doesn't follow 3xx; renamed/transferred-repo 301s now degrade to empty (narrow, self-healing window). Proper fix = same-host-only redirect following in the shared pager/core (benefits all migrated families).
- **CHAOS-2846** — processor-level `except Exception` still swallows `RateLimitException` (pre-existing parity; same blast-radius profile as CHAOS-2831).

### Validation
`ci/local_validate.sh` **GATE PASSED** — ruff + mypy + full unit suite (6714 passed / 44 skipped) + live-ClickHouse argMax proof.

SCREENSHOT-WAIVER: backend-only change, no UI/render surface.

Epic: CHAOS-2773 · Closes CHAOS-2804
