### PR TITLE
feat(providers): instrument GitLab security family on GitLabCodeClient (CHAOS-2811)

### DIFF
--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -9,6 +9,7 @@ from dev_health_ops.analytics.complexity import (
     DEFAULT_COMPLEXITY_CONFIG_PATH,
     ComplexityScanner,
 )
+from dev_health_ops.connectors.models import SecurityAlertData
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models import git as git_models
 from dev_health_ops.models.git import (
@@ -1019,16 +1020,60 @@ def _fetch_gitlab_incidents_sync(connector, project_id, repo_id, max_issues, sin
     return incidents
 
 
+def _gitlab_code_client_from_connector(connector):
+    """Build an instrumented ``GitLabCodeClient`` from a legacy connector's
+    resolved credentials (CHAOS-2773 CS10). Mirrors
+    ``processors/github.py::_github_code_client_from_connector`` so both
+    provider pathfinders expose the same factory seam -- also the monkeypatch
+    point for the security-family unit tests."""
+    from dev_health_ops.providers.gitlab.code_client import GitLabCodeClient
+
+    return GitLabCodeClient(
+        private_token=str(connector.private_token or ""),
+        base_url=connector.url,
+    )
+
+
 def _fetch_gitlab_security_alerts_sync(
-    connector, project_id, repo_id, max_alerts, since
+    connector, project_id, repo_id, max_alerts, since, usage_sink=None
 ):
-    """Sync helper to fetch GitLab security alerts (vulnerability findings, dependency scanning)."""
+    """Sync helper to fetch GitLab security alerts (vulnerability findings, dependency scanning).
+
+    CHAOS-2773 CS10: fetches via the canonical, instrumented
+    ``providers.gitlab.code_client.GitLabCodeClient`` (built on the shared
+    ``InstrumentedRESTCore``) instead of the frozen
+    ``GitLabConnector.get_security_alerts`` (python-gitlab + the
+    un-instrumented ``connectors/utils/rest.py``). Both callers dispatch this
+    helper via ``loop.run_in_executor`` (a plain worker thread with no
+    running event loop), so bridging to the async client with
+    ``asyncio.run()`` here is safe.
+
+    ``usage_sink`` (CHAOS-2803/CS2), when given, receives the client's
+    drained per-request usage observations in a ``finally:`` on BOTH the
+    success and failure path, mirroring
+    ``processors/github.py::_enrich_prs_with_reviews_batch``. Any fetch
+    failure is still swallowed here (pre-existing behavior: security alerts
+    are best-effort optional enrichment that must never fail the whole
+    project sync), so there is never an in-flight exception to attach
+    partial observations to -- the unconditional drain below already covers
+    both the success AND failure path.
+    """
+
     security_alert_cls = getattr(git_models, "SecurityAlert")
     alerts = []
+    drained_observations: list[dict[str, Any]] = []
+
+    async def _run() -> list[SecurityAlertData]:
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await client.get_security_alerts(
+                    project_id, max_alerts=max_alerts
+                )
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+
     try:
-        raw_alerts = connector.get_security_alerts(
-            project_id=project_id, max_alerts=max_alerts
-        )
+        raw_alerts = asyncio.run(_run())
         for item in raw_alerts:
             created_at = item.created_at
             if not created_at:
@@ -1054,6 +1099,16 @@ def _fetch_gitlab_security_alerts_sync(
             )
     except Exception as exc:
         logging.debug("Failed to fetch GitLab security alerts: %s", exc)
+    finally:
+        if usage_sink is not None:
+            usage_sink.extend(drained_observations)
+        elif drained_observations:
+            logging.debug(
+                "_fetch_gitlab_security_alerts_sync: drained %d security usage "
+                "observation(s) with no adapter-owned sink (legacy entry "
+                "point) -- logging only, not persisted",
+                len(drained_observations),
+            )
     return alerts
 
 
@@ -1990,6 +2045,7 @@ async def process_gitlab_project(
                 db_repo.id,
                 BATCH_SIZE,
                 since,
+                usage_sink,
             )
             security_alerts = _filter_after(security_alerts, until, "created_at")
             if security_alerts:

--- a/src/dev_health_ops/providers/gitlab/budget.py
+++ b/src/dev_health_ops/providers/gitlab/budget.py
@@ -390,6 +390,21 @@ GITLAB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("pipelines", BudgetDimension.REST_CORE),
     UsageRouteFamily("milestones", BudgetDimension.REST_CORE),
     UsageRouteFamily("epics", BudgetDimension.REST_CORE),
+    # CHAOS-2773 CS10: the "security" code-dataset client
+    # (providers/gitlab/code_client.py::GitLabCodeClient) is the FIRST
+    # canonical GitLab client to author its own operation labels rather than
+    # reuse the work client's undifferentiated "GET iterator page"/project
+    # labels above -- every request it issues carries the explicit
+    # "security:" prefix (OperationResolver's prefix short-circuit,
+    # providers/usage.py), so this entry's operation_markers are declared for
+    # completeness/estimator-coverage but the prefix match alone is already
+    # deterministic.
+    UsageRouteFamily(
+        "security",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("security:",),
+    ),
 )
 
 GITLAB_USAGE_ROUTE_FAMILY_KEYS = frozenset(

--- a/src/dev_health_ops/providers/gitlab/code_client.py
+++ b/src/dev_health_ops/providers/gitlab/code_client.py
@@ -1,0 +1,372 @@
+"""Canonical GitLab "security" code-dataset client (CHAOS-2773 CS10).
+
+This is the GitLab-wave PATHFINDER: the first canonical code client built
+directly on the shared ``providers/_http.py::InstrumentedRESTCore`` (CHAOS-2773
+CS1). It is the ``providers/gitlab/`` migration target for the "security"
+code dataset (vulnerability findings + dependency-scan alerts) that
+historically lived on the FROZEN ``connectors/gitlab.py``
+(``GitLabConnector.get_security_alerts``), which resolved the project via
+python-gitlab and then rode the un-instrumented
+``connectors/utils/rest.py::GitLabRESTClient`` (``get_vulnerability_findings``
+/ ``get_dependencies``). AGENTS.md bans new code under ``connectors/``, and
+actuals instrumentation (CHAOS-2754) requires a client that owns a
+``UsageRecorder`` -- so this module ports the fetch/error-handling/field-
+mapping logic and adds the recorder the frozen connector could never carry.
+Later GitLab-wave changesets (CS11 pipelines+deployments, CS12 tests, ...)
+copy this shape.
+
+Behavior parity with ``GitLabConnector.get_security_alerts``
+(``connectors/gitlab.py`` ~1268-1379, riding ``connectors/utils/rest.py``'s
+``get_vulnerability_findings`` / ``get_dependencies`` ~594-648):
+
+* Resolves the project the same way the connector does -- one ``GET
+  /projects/{id_or_path}`` first, using the RETURNED numeric ``id`` for the
+  two endpoint calls below (the connector does this via
+  ``self.gitlab.projects.get(project_identifier).id``). A failure here
+  (401/403/404/429/5xx) always propagates -- never suppressed, matching the
+  connector's own project-resolution failure semantics.
+* ``GET /projects/{id}/vulnerability_findings`` and ``GET /projects/{id}/
+  dependencies`` -- SINGLE PAGE each. This is a pre-existing connector quirk
+  (neither ``rest.py`` method loops on ``page``/``X-Next-Page``), preserved
+  here for strict parity (CS10 is scoped alongside the parallel CS3 GitHub
+  pathfinder; default is parity, not a behavior change).
+* A PLAIN 403 or a 404 on either optional endpoint degrades to an empty
+  result for that endpoint (best-effort, matching the connector's
+  ``"Forbidden:"`` / ``"Not found:"`` string-matched suppression) -- but a
+  HEADER-QUALIFIED 403 (some self-managed instances front a throttle with
+  403 instead of 429) or a 429 raises the canonical ``RateLimitException``
+  instead of being swallowed, via the shared
+  ``providers/gitlab/ratelimit.py`` classifier (the SAME one
+  ``GitLabWorkClient`` / ``GitLabFeatureFlagsClient`` use -- no second
+  403-qualification implementation for GitLab).
+* Field mapping into ``SecurityAlertData`` (``connectors/models.py``,
+  UNCHANGED) is reproduced field-for-field, including the dependency alert's
+  ``created_at=datetime.now(timezone.utc)`` placeholder -- the dependency
+  scan API carries no per-vulnerability timestamp; that is the connector's
+  own pre-existing choice, not something this migration invents.
+
+Every operation this client issues carries the explicit ``"security:"``
+family prefix (CHAOS-2773 CS1's ``OperationResolver`` prefix short-circuit,
+``providers/usage.py``) so usage resolution is deterministic by
+construction rather than by marker-substring tuning -- see
+``providers/gitlab/budget.py``'s ``security`` route family.
+"""
+
+from __future__ import annotations
+
+import logging
+import urllib.parse
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+
+from dev_health_ops.connectors.models import SecurityAlertData
+from dev_health_ops.exceptions import APIException, NotFoundException
+from dev_health_ops.providers._http import (
+    GITLAB_DIAGNOSTIC_HEADER_NAMES,
+    InstrumentedRESTCore,
+    gitlab_rest_base_url,
+)
+from dev_health_ops.providers.gitlab.ratelimit import (
+    build_gitlab_rate_limit_exception,
+    classify_gitlab_status,
+)
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_BASE_URL = "https://gitlab.com"
+_DEFAULT_TIMEOUT_SECONDS = 15.0
+_DEFAULT_MAX_RETRIES = 5
+
+# GitLab's REST rate-limit reset header (RateLimit-Reset, not the
+# X-RateLimit-Reset default InstrumentedRESTCore assumes) -- mirrors
+# providers/gitlab/feature_flags.py / providers/gitlab/client.py.
+_RESET_HEADER_NAME = "RateLimit-Reset"
+
+# Explicit family prefix every operation this client issues is labeled with
+# (see the module docstring's "Every operation" paragraph).
+_SECURITY_FAMILY_PREFIX = "security"
+
+
+class _GitLabSecurityForbidden(APIException):
+    """Marker for a PLAIN (non-rate-limited) GitLab 403 on an optional
+    security endpoint.
+
+    The shared core's DEFAULT 403 classification raises the same
+    ``AuthenticationException`` a genuine 401 raises, which would make a
+    plain-403 and a real auth failure indistinguishable to a caller trying
+    to suppress-and-degrade on ONLY the former (matching the connector's
+    best-effort behavior). This subclass of the canonical ``APIException``
+    exists purely so :meth:`GitLabCodeClient._get_vulnerability_findings` /
+    :meth:`GitLabCodeClient._get_dependency_alerts` can catch it specifically
+    -- it is never raised for 401, and never escapes project resolution
+    without also being catchable the same way callers already catch
+    ``APIException``.
+    """
+
+
+def _is_retryable_status(response: httpx.Response) -> bool:
+    """429/5xx retry unconditionally; a 403 retries ONLY when header-
+    qualified (mirrors ``providers/gitlab/feature_flags.py``'s retry
+    predicate -- some self-managed instances front a throttle with 403
+    instead of 429)."""
+    if response.status_code in {429, 500, 502, 503, 504}:
+        return True
+    if response.status_code == 403:
+        return classify_gitlab_status(
+            status=403, headers=response.headers
+        ).is_rate_limit
+    return False
+
+
+def _resolve_retry_after(response: httpx.Response) -> float | None:
+    """Adapts the shared core's response-based ``resolve_retry_after`` hook
+    to the header-based GitLab classifier every other GitLab client call
+    site uses directly."""
+    from dev_health_ops.providers._ratelimit import gitlab_resolve_retry_after_seconds
+
+    return gitlab_resolve_retry_after_seconds(response.headers)
+
+
+def _classify_error(response: httpx.Response, operation: str) -> None:
+    """GitLab 403 triage for the shared core's ``classify_error`` hook.
+
+    A header-qualified 403 raises the canonical ``RateLimitException`` via
+    ``providers/gitlab/ratelimit.py`` (the SAME classifier
+    ``GitLabWorkClient`` / ``GitLabFeatureFlagsClient`` use). A PLAIN 403
+    raises :class:`_GitLabSecurityForbidden` instead of the core's default
+    ``AuthenticationException`` -- 401 and a plain 403 must stay
+    distinguishable so the optional-endpoint fetchers below can suppress
+    ONLY the latter, never a genuine auth failure. Every other status
+    (401/404/429/5xx) falls through unchanged to the core's default
+    classification.
+    """
+    if response.status_code != 403:
+        return
+    classification = classify_gitlab_status(status=403, headers=response.headers)
+    if classification.is_rate_limit:
+        raise build_gitlab_rate_limit_exception(
+            status=403,
+            headers=response.headers,
+            classification=classification,
+        )
+    raise _GitLabSecurityForbidden(f"gitlab forbidden on {operation}: {response.text}")
+
+
+def _map_vulnerability_finding(item: dict[str, Any]) -> SecurityAlertData:
+    """Mirrors ``GitLabConnector.get_security_alerts``'s vulnerability-finding
+    mapping (``connectors/gitlab.py`` ~1287-1322) field-for-field."""
+    created_at: datetime | None = None
+    created_at_value = item.get("created_at")
+    if created_at_value:
+        try:
+            created_at = datetime.fromisoformat(created_at_value.replace("Z", "+00:00"))
+        except Exception:
+            logger.debug(
+                "Failed to parse vulnerability finding created_at: %s",
+                created_at_value,
+            )
+
+    cve_id: str | None = None
+    for identifier in item.get("identifiers", []) or []:
+        if identifier.get("type") == "cve":
+            cve_id = identifier.get("name")
+            break
+
+    return SecurityAlertData(
+        alert_id=f"gitlab_vuln:{item['id']}",
+        source="gitlab_vulnerability",
+        severity=item.get("severity"),
+        state=item.get("state"),
+        package_name=None,
+        cve_id=cve_id,
+        url=(item.get("links", {}) or {}).get("url"),
+        title=item.get("name"),
+        description=None,
+        created_at=created_at,
+        fixed_at=None,
+        dismissed_at=None,
+    )
+
+
+def _map_dependency_alert(
+    dep: dict[str, Any], vuln: dict[str, Any]
+) -> SecurityAlertData:
+    """Mirrors ``GitLabConnector.get_security_alerts``'s dependency-alert
+    mapping (``connectors/gitlab.py`` ~1342-1358) field-for-field, including
+    the ``created_at=datetime.now(timezone.utc)`` placeholder (the
+    dependency scan API carries no per-vulnerability timestamp)."""
+    return SecurityAlertData(
+        alert_id=f"gitlab_dep:{vuln['id']}",
+        source="gitlab_dependency",
+        severity=vuln.get("severity"),
+        state=None,
+        package_name=dep.get("name"),
+        cve_id=None,
+        url=vuln.get("url"),
+        title=vuln.get("name"),
+        description=None,
+        created_at=datetime.now(timezone.utc),
+        fixed_at=None,
+        dismissed_at=None,
+    )
+
+
+class GitLabCodeClient:
+    """Canonical GitLab code-dataset client (CHAOS-2773 CS10 pathfinder).
+
+    Currently covers the "security" dataset (vulnerability findings +
+    dependency-scan alerts). Built on the shared ``InstrumentedRESTCore`` so
+    every physical HTTP hop is recorded through ONE owned ``UsageRecorder``,
+    mirroring ``GitLabWorkClient`` / ``GitLabFeatureFlagsClient``'s
+    rate-limit conventions.
+
+    :param private_token: GitLab personal/project access token.
+    :param base_url: GitLab instance URL (self-hosted support).
+    :param timeout: Request timeout in seconds.
+    :param max_retries: Maximum retry attempts on 429 / header-qualified 403
+        / 5xx errors.
+    :param transport: Optional httpx transport override (tests only).
+    """
+
+    def __init__(
+        self,
+        *,
+        private_token: str,
+        base_url: str = _DEFAULT_BASE_URL,
+        timeout: float = _DEFAULT_TIMEOUT_SECONDS,
+        max_retries: int = _DEFAULT_MAX_RETRIES,
+        transport: httpx.AsyncBaseTransport | None = None,
+    ) -> None:
+        # Deferred import mirrors providers/gitlab/feature_flags.py: budget.py
+        # is the source of truth for the route-family vocabulary, imported
+        # lazily to avoid a module-load-order cycle.
+        from dev_health_ops.providers.gitlab.budget import GITLAB_USAGE_RESOLVER
+
+        self._core = InstrumentedRESTCore(
+            base_url=gitlab_rest_base_url(base_url),
+            provider="gitlab",
+            resolver=GITLAB_USAGE_RESOLVER,
+            headers={"PRIVATE-TOKEN": private_token},
+            timeout=timeout,
+            max_retries=max_retries,
+            reset_header_name=_RESET_HEADER_NAME,
+            diagnostic_header_names=GITLAB_DIAGNOSTIC_HEADER_NAMES,
+            is_retryable_status=_is_retryable_status,
+            resolve_retry_after=_resolve_retry_after,
+            classify_error=_classify_error,
+            transport=transport,
+        )
+
+    async def _resolve_project_id(self, project_id_or_path: int | str) -> int:
+        """Resolve a project id/path to its numeric id, mirroring the
+        connector's ``self.gitlab.projects.get(project_identifier).id``. Any
+        error here (401/403/404/429/5xx) propagates -- never suppressed."""
+        encoded = urllib.parse.quote(str(project_id_or_path), safe="")
+        response = await self._core.request(
+            "GET",
+            f"/projects/{encoded}",
+            operation=f"{_SECURITY_FAMILY_PREFIX}:GET /projects/{{id}}",
+        )
+        payload = response.json()
+        return int(payload["id"])
+
+    async def get_security_alerts(
+        self,
+        project_id: int | str,
+        *,
+        max_alerts: int | None = None,
+        per_page: int = 100,
+    ) -> list[SecurityAlertData]:
+        """Fetch vulnerability findings + dependency-scan alerts for a
+        project.
+
+        Mirrors ``GitLabConnector.get_security_alerts`` field-for-field. Both
+        underlying endpoints are best-effort: a plain 403/404 degrades to no
+        rows for that endpoint (logged at debug) instead of failing the
+        whole fetch; a rate limit (429, or a header-qualified 403)
+        PROPAGATES as the canonical ``RateLimitException`` (never
+        swallowed).
+        """
+        actual_project_id = await self._resolve_project_id(project_id)
+        alerts: list[SecurityAlertData] = list(
+            await self._get_vulnerability_findings(actual_project_id, per_page=per_page)
+        )
+        alerts.extend(
+            await self._get_dependency_alerts(actual_project_id, per_page=per_page)
+        )
+        if max_alerts is not None:
+            return alerts[:max_alerts]
+        return alerts
+
+    async def _get_vulnerability_findings(
+        self, project_id: int, *, per_page: int
+    ) -> list[SecurityAlertData]:
+        try:
+            response = await self._core.request(
+                "GET",
+                f"/projects/{project_id}/vulnerability_findings",
+                operation=(
+                    f"{_SECURITY_FAMILY_PREFIX}:GET "
+                    "/projects/{id}/vulnerability_findings"
+                ),
+                params={"per_page": per_page},
+            )
+        except (NotFoundException, _GitLabSecurityForbidden) as exc:
+            logger.debug(
+                "GitLab vulnerability findings unavailable for project %s: %s",
+                project_id,
+                exc,
+            )
+            return []
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise APIException(
+                f"Unexpected GitLab vulnerability findings response: {type(payload)!r}"
+            )
+        return [_map_vulnerability_finding(item) for item in payload]
+
+    async def _get_dependency_alerts(
+        self, project_id: int, *, per_page: int
+    ) -> list[SecurityAlertData]:
+        try:
+            response = await self._core.request(
+                "GET",
+                f"/projects/{project_id}/dependencies",
+                operation=f"{_SECURITY_FAMILY_PREFIX}:GET /projects/{{id}}/dependencies",
+                params={"per_page": per_page},
+            )
+        except (NotFoundException, _GitLabSecurityForbidden) as exc:
+            logger.debug(
+                "GitLab dependencies unavailable for project %s: %s", project_id, exc
+            )
+            return []
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise APIException(
+                f"Unexpected GitLab dependencies response: {type(payload)!r}"
+            )
+        alerts: list[SecurityAlertData] = []
+        for dep in payload:
+            if not isinstance(dep, dict):
+                continue
+            for vuln in dep.get("vulnerabilities") or []:
+                alerts.append(_map_dependency_alert(dep, vuln))
+        return alerts
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        return self._core.drain_usage_observations()
+
+    async def close(self) -> None:
+        await self._core.close()
+
+    async def __aenter__(self) -> GitLabCodeClient:
+        await self._core.__aenter__()
+        return self
+
+    async def __aexit__(self, exc_type: object, exc: object, tb: object) -> None:
+        await self.close()
+
+
+__all__ = ["GitLabCodeClient"]

--- a/tests/providers/test_gitlab_code_client.py
+++ b/tests/providers/test_gitlab_code_client.py
@@ -1,0 +1,569 @@
+"""Tests for providers/gitlab/code_client.py (CHAOS-2773 CS10).
+
+``GitLabCodeClient`` is the GitLab-wave pathfinder: the first canonical code
+client built on the shared ``providers/_http.py::InstrumentedRESTCore``
+(CHAOS-2773 CS1). These are PARITY tests proving it reproduces
+``GitLabConnector.get_security_alerts``'s (``connectors/gitlab.py``, FROZEN)
+behavior for vulnerability findings + dependency-scan alerts: auth header,
+401/403/404/429 handling, identical ``SecurityAlertData`` field mapping, and
+the pre-existing single-page-per-endpoint quirk. httpx is mocked at the
+transport layer via ``httpx.MockTransport`` (the pattern already established
+by ``tests/providers/test_http_core.py``) -- no live network, matching the
+offline local gate.
+"""
+
+from __future__ import annotations
+
+import time
+from datetime import datetime, timedelta, timezone
+from email.utils import format_datetime
+
+import httpx
+import pytest
+
+from dev_health_ops.exceptions import (
+    AuthenticationException,
+    RateLimitException,
+)
+from dev_health_ops.providers.gitlab.code_client import GitLabCodeClient
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+_PROJECT_PATH = "/api/v4/projects/42"
+_FINDINGS_PATH = "/api/v4/projects/42/vulnerability_findings"
+_DEPENDENCIES_PATH = "/api/v4/projects/42/dependencies"
+
+_PROJECT_RESPONSE = {"id": 42, "path_with_namespace": "group/project"}
+
+
+def _json_response(
+    status_code: int, body: object, headers: dict[str, str] | None = None
+) -> httpx.Response:
+    return httpx.Response(status_code, json=body, headers=headers or {})
+
+
+def _empty_response(
+    status_code: int, headers: dict[str, str] | None = None
+) -> httpx.Response:
+    return httpx.Response(status_code, headers=headers or {})
+
+
+def _router_transport(
+    routes: dict[str, list[httpx.Response] | httpx.Response],
+) -> tuple[httpx.MockTransport, dict[str, int]]:
+    """Route requests by URL path, queuing a list of responses per path (one
+    consumed per hit, the last repeats) or a single fixed response."""
+    calls: dict[str, int] = {}
+    captured_headers: dict[str, httpx.Headers] = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        path = request.url.path
+        calls[path] = calls.get(path, 0) + 1
+        captured_headers[path] = request.headers
+        entry = routes[path]
+        if isinstance(entry, list):
+            idx = min(calls[path] - 1, len(entry) - 1)
+            return entry[idx]
+        return entry
+
+    transport = httpx.MockTransport(handler)
+    transport.calls = calls  # type: ignore[attr-defined]
+    transport.captured_headers = captured_headers  # type: ignore[attr-defined]
+    return transport, calls
+
+
+def _client(transport: httpx.MockTransport, **overrides: object) -> GitLabCodeClient:
+    kwargs: dict[str, object] = {
+        "private_token": "test-token",
+        "transport": transport,
+    }
+    kwargs.update(overrides)
+    return GitLabCodeClient(**kwargs)  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# Auth header + project resolution
+# ---------------------------------------------------------------------------
+
+
+class TestAuthAndProjectResolution:
+    @pytest.mark.asyncio
+    async def test_private_token_header_sent_on_every_request(self) -> None:
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, []),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport, private_token="secret-tok")
+
+        await client.get_security_alerts(42)
+
+        for path in (_PROJECT_PATH, _FINDINGS_PATH, _DEPENDENCIES_PATH):
+            assert transport.captured_headers[path]["PRIVATE-TOKEN"] == "secret-tok"  # type: ignore[attr-defined]
+
+    @pytest.mark.asyncio
+    async def test_resolves_numeric_project_id_before_fetching(self) -> None:
+        """Mirrors the connector's ``self.gitlab.projects.get(project_identifier)
+        .id`` resolution -- the id/path passed in is resolved via ONE GET
+        /projects/{id_or_path} first, and the RETURNED numeric id is what the
+        two endpoint calls use."""
+        transport, calls = _router_transport(
+            {
+                "/api/v4/projects/group/project": _json_response(200, {"id": 42}),
+                _FINDINGS_PATH: _json_response(200, []),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport)
+
+        await client.get_security_alerts("group/project")
+
+        assert calls["/api/v4/projects/group/project"] == 1
+        assert calls[_FINDINGS_PATH] == 1
+        assert calls[_DEPENDENCIES_PATH] == 1
+
+    @pytest.mark.asyncio
+    async def test_401_on_project_resolution_propagates(self) -> None:
+        transport, _ = _router_transport({_PROJECT_PATH: _empty_response(401)})
+        client = _client(transport)
+
+        with pytest.raises(AuthenticationException):
+            await client.get_security_alerts(42)
+
+
+# ---------------------------------------------------------------------------
+# Field mapping parity (connectors/gitlab.py::GitLabConnector.get_security_alerts)
+# ---------------------------------------------------------------------------
+
+
+class TestFieldMappingParity:
+    @pytest.mark.asyncio
+    async def test_vulnerability_finding_field_mapping(self) -> None:
+        finding = {
+            "id": 101,
+            "severity": "high",
+            "state": "detected",
+            "name": "SQL Injection",
+            "created_at": "2026-01-15T10:30:00.000Z",
+            "identifiers": [
+                {"type": "other", "name": "ignored"},
+                {"type": "cve", "name": "CVE-2026-1234"},
+            ],
+            "links": {"url": "https://gitlab.example.com/vuln/101"},
+        }
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, [finding]),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42)
+
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.alert_id == "gitlab_vuln:101"
+        assert alert.source == "gitlab_vulnerability"
+        assert alert.severity == "high"
+        assert alert.state == "detected"
+        assert alert.package_name is None
+        assert alert.cve_id == "CVE-2026-1234"
+        assert alert.url == "https://gitlab.example.com/vuln/101"
+        assert alert.title == "SQL Injection"
+        assert alert.description is None
+        assert alert.created_at == datetime(2026, 1, 15, 10, 30, tzinfo=timezone.utc)
+        assert alert.fixed_at is None
+        assert alert.dismissed_at is None
+
+    @pytest.mark.asyncio
+    async def test_vulnerability_finding_missing_created_at_and_cve(self) -> None:
+        finding = {"id": 202, "severity": "low", "state": "resolved", "name": "XSS"}
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, [finding]),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42)
+
+        assert len(alerts) == 1
+        assert alerts[0].created_at is None
+        assert alerts[0].cve_id is None
+        assert alerts[0].url is None
+
+    @pytest.mark.asyncio
+    async def test_dependency_alert_field_mapping(self) -> None:
+        dependency = {
+            "name": "lodash",
+            "vulnerabilities": [
+                {
+                    "id": 303,
+                    "severity": "critical",
+                    "url": "https://gitlab.example.com/vuln/303",
+                    "name": "Prototype Pollution",
+                }
+            ],
+        }
+        before = datetime.now(timezone.utc)
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, []),
+                _DEPENDENCIES_PATH: _json_response(200, [dependency]),
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42)
+        after = datetime.now(timezone.utc)
+
+        assert len(alerts) == 1
+        alert = alerts[0]
+        assert alert.alert_id == "gitlab_dep:303"
+        assert alert.source == "gitlab_dependency"
+        assert alert.severity == "critical"
+        assert alert.state is None
+        assert alert.package_name == "lodash"
+        assert alert.cve_id is None
+        assert alert.url == "https://gitlab.example.com/vuln/303"
+        assert alert.title == "Prototype Pollution"
+        assert alert.description is None
+        # Dependency alerts carry no per-vulnerability timestamp upstream --
+        # the connector's own placeholder (datetime.now(timezone.utc)),
+        # reproduced here byte-for-byte, not something this migration invents.
+        assert alert.created_at is not None
+        assert before <= alert.created_at <= after
+        assert alert.fixed_at is None
+        assert alert.dismissed_at is None
+
+    @pytest.mark.asyncio
+    async def test_dependency_with_no_vulnerabilities_yields_no_alerts(self) -> None:
+        dependency = {"name": "safe-package", "vulnerabilities": []}
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, []),
+                _DEPENDENCIES_PATH: _json_response(200, [dependency]),
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42)
+
+        assert alerts == []
+
+    @pytest.mark.asyncio
+    async def test_max_alerts_truncates_combined_results(self) -> None:
+        findings = [{"id": i, "severity": "low", "state": "detected"} for i in range(3)]
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, findings),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42, max_alerts=2)
+
+        assert len(alerts) == 2
+
+
+# ---------------------------------------------------------------------------
+# Best-effort suppression: plain 403 / 404 degrade to empty per-endpoint
+# ---------------------------------------------------------------------------
+
+
+class TestBestEffortSuppression:
+    @pytest.mark.asyncio
+    async def test_plain_403_on_findings_degrades_to_empty_but_dependencies_still_fetched(
+        self,
+    ) -> None:
+        dependency = {
+            "name": "pkg",
+            "vulnerabilities": [{"id": 1, "severity": "high", "name": "CVE"}],
+        }
+        transport, calls = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _empty_response(403, {}),
+                _DEPENDENCIES_PATH: _json_response(200, [dependency]),
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42)
+
+        assert len(alerts) == 1
+        assert alerts[0].source == "gitlab_dependency"
+        # A plain 403 must not consume the retry budget -- exactly one
+        # request against the forbidden endpoint.
+        assert calls[_FINDINGS_PATH] == 1
+
+    @pytest.mark.asyncio
+    async def test_404_on_dependencies_degrades_to_empty(self) -> None:
+        finding = {"id": 1, "severity": "high", "state": "detected"}
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, [finding]),
+                _DEPENDENCIES_PATH: _empty_response(404),
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42)
+
+        assert len(alerts) == 1
+        assert alerts[0].source == "gitlab_vulnerability"
+
+    @pytest.mark.asyncio
+    async def test_both_endpoints_forbidden_yields_empty_list_no_raise(self) -> None:
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _empty_response(403),
+                _DEPENDENCIES_PATH: _empty_response(404),
+            }
+        )
+        client = _client(transport)
+
+        assert await client.get_security_alerts(42) == []
+
+
+# ---------------------------------------------------------------------------
+# Rate limiting: 429 always, header-qualified 403 -- never a plain 403
+# ---------------------------------------------------------------------------
+
+
+class TestRateLimiting:
+    @pytest.mark.asyncio
+    async def test_429_on_findings_raises_rate_limit_after_exhausting_retries(
+        self,
+    ) -> None:
+        transport, calls = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _empty_response(429, {"Retry-After": "0"}),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport, max_retries=2)
+
+        with pytest.raises(RateLimitException) as excinfo:
+            await client.get_security_alerts(42)
+
+        assert calls[_FINDINGS_PATH] == 2
+        signal = excinfo.value.signal
+        assert signal is not None
+        assert signal.provider == "gitlab"
+        assert signal.reason == "primary"
+        assert signal.dimension is BudgetDimension.REST_CORE
+        assert excinfo.value.retry_after_seconds == 0.0
+
+    @pytest.mark.asyncio
+    async def test_header_qualified_403_on_dependencies_raises_rate_limit(self) -> None:
+        """A 403 carrying rate-limit headers is retried in place like a 429,
+        then classified as RateLimitException on exhaustion -- NOT the
+        non-retryable/suppressible plain-403 path."""
+        transport, calls = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, []),
+                _DEPENDENCIES_PATH: _empty_response(403, {"RateLimit-Remaining": "0"}),
+            }
+        )
+        client = _client(transport, max_retries=2)
+
+        with pytest.raises(RateLimitException) as excinfo:
+            await client.get_security_alerts(42)
+
+        assert calls[_DEPENDENCIES_PATH] == 2
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.reason == "secondary"
+
+    @pytest.mark.asyncio
+    async def test_header_qualified_403_then_recovers_is_not_suppressed_as_forbidden(
+        self,
+    ) -> None:
+        finding = {"id": 1, "severity": "high", "state": "detected"}
+        throttled = _empty_response(403, {"Retry-After": "0"})
+        ok = _json_response(200, [finding])
+        transport, calls = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: [throttled, ok],
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42)
+
+        assert len(alerts) == 1
+        assert calls[_FINDINGS_PATH] == 2
+
+    @pytest.mark.asyncio
+    async def test_429_retry_after_http_date_derives_seconds(self) -> None:
+        future = datetime.now(timezone.utc) + timedelta(seconds=120)
+        http_date = format_datetime(future, usegmt=True)
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _empty_response(429, {"Retry-After": http_date}),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport, max_retries=1)
+
+        with pytest.raises(RateLimitException) as excinfo:
+            await client.get_security_alerts(42)
+
+        retry_after = excinfo.value.retry_after_seconds
+        assert retry_after is not None
+        assert 100 <= retry_after <= 120
+
+    @pytest.mark.asyncio
+    async def test_429_falls_back_to_rate_limit_reset_header(self) -> None:
+        reset_epoch = int(time.time()) + 300
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _empty_response(
+                    429, {"RateLimit-Reset": str(reset_epoch)}
+                ),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport, max_retries=1)
+
+        with pytest.raises(RateLimitException) as excinfo:
+            await client.get_security_alerts(42)
+
+        retry_after = excinfo.value.retry_after_seconds
+        assert retry_after is not None
+        assert 290 <= retry_after <= 300
+
+
+# ---------------------------------------------------------------------------
+# Single-page parity quirk (connectors/utils/rest.py::get_vulnerability_findings
+# / get_dependencies never loop on page/X-Next-Page)
+# ---------------------------------------------------------------------------
+
+
+class TestSinglePageParity:
+    @pytest.mark.asyncio
+    async def test_findings_endpoint_never_paginates_even_with_next_page_header(
+        self,
+    ) -> None:
+        finding = {"id": 1, "severity": "high", "state": "detected"}
+        page = _json_response(200, [finding], headers={"X-Next-Page": "2"})
+        transport, calls = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: page,
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42)
+
+        assert len(alerts) == 1
+        assert calls[_FINDINGS_PATH] == 1
+
+    @pytest.mark.asyncio
+    async def test_dependencies_endpoint_never_paginates_even_with_next_page_header(
+        self,
+    ) -> None:
+        dependency = {
+            "name": "pkg",
+            "vulnerabilities": [{"id": 1, "severity": "high", "name": "CVE"}],
+        }
+        page = _json_response(200, [dependency], headers={"X-Next-Page": "2"})
+        transport, calls = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, []),
+                _DEPENDENCIES_PATH: page,
+            }
+        )
+        client = _client(transport)
+
+        alerts = await client.get_security_alerts(42)
+
+        assert len(alerts) == 1
+        assert calls[_DEPENDENCIES_PATH] == 1
+
+
+# ---------------------------------------------------------------------------
+# Usage recording (CHAOS-2754) + the "security:" prefix short-circuit
+# ---------------------------------------------------------------------------
+
+
+class TestUsageRecording:
+    @pytest.mark.asyncio
+    async def test_all_three_requests_resolve_to_security_route_family(self) -> None:
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, []),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport)
+
+        await client.get_security_alerts(42)
+        observations = client.drain_usage_observations()
+
+        assert len(observations) == 1
+        observation = observations[0]
+        assert observation["route_family"] == "security"
+        assert observation["dimension"] == "rest_core"
+        assert observation["transport"] == "rest"
+        # Project resolve + vulnerability_findings + dependencies == 3 real
+        # physical requests, all bucketed under the SAME family because every
+        # operation label this client emits carries the "security:" prefix.
+        assert observation["request_count"] == 3
+        assert observation["latest_status"] == 200
+
+    @pytest.mark.asyncio
+    async def test_drain_clears_observations(self) -> None:
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, []),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport)
+
+        await client.get_security_alerts(42)
+        client.drain_usage_observations()
+
+        assert client.drain_usage_observations() == []
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    @pytest.mark.asyncio
+    async def test_context_manager_closes_underlying_client(self) -> None:
+        transport, _ = _router_transport(
+            {
+                _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
+                _FINDINGS_PATH: _json_response(200, []),
+                _DEPENDENCIES_PATH: _json_response(200, []),
+            }
+        )
+        async with _client(transport) as client:
+            await client.get_security_alerts(42)

--- a/tests/test_security_alerts.py
+++ b/tests/test_security_alerts.py
@@ -133,29 +133,54 @@ class TestFetchGithubSecurityAlertsSync:
 
 
 class TestFetchGitlabSecurityAlertsSync:
-    def test_fetches_alerts(self):
-        from dev_health_ops.processors.gitlab import (
-            _fetch_gitlab_security_alerts_sync,
-        )
+    class _StubClient:
+        def __init__(self, alerts=None, error=None):
+            self._alerts = alerts or []
+            self._error = error
 
-        connector = MagicMock()
-        connector.get_security_alerts.return_value = [
-            _make_alert("gitlab_vulnerability", "gitlab_vuln:1"),
-            _make_alert("gitlab_dependency", "gitlab_dep:1"),
-        ]
-        result = _fetch_gitlab_security_alerts_sync(
-            connector, 123, FAKE_REPO_ID, 100, None
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *exc):
+            return False
+
+        async def get_security_alerts(self, project_id, max_alerts=None):
+            if self._error is not None:
+                raise self._error
+            return self._alerts
+
+        def drain_usage_observations(self):
+            return []
+
+    def test_fetches_alerts(self, monkeypatch):
+        from dev_health_ops.processors import gitlab as gitlab_processor
+
+        stub = self._StubClient(
+            alerts=[
+                _make_alert("gitlab_vulnerability", "gitlab_vuln:1"),
+                _make_alert("gitlab_dependency", "gitlab_dep:1"),
+            ]
+        )
+        monkeypatch.setattr(
+            gitlab_processor,
+            "_gitlab_code_client_from_connector",
+            lambda connector: stub,
+        )
+        result = gitlab_processor._fetch_gitlab_security_alerts_sync(
+            MagicMock(), 123, FAKE_REPO_ID, 100, None
         )
         assert len(result) == 2
 
-    def test_handles_failure_gracefully(self):
-        from dev_health_ops.processors.gitlab import (
-            _fetch_gitlab_security_alerts_sync,
-        )
+    def test_handles_failure_gracefully(self, monkeypatch):
+        from dev_health_ops.processors import gitlab as gitlab_processor
 
-        connector = MagicMock()
-        connector.get_security_alerts.side_effect = Exception("403 Forbidden")
-        result = _fetch_gitlab_security_alerts_sync(
-            connector, 123, FAKE_REPO_ID, 100, None
+        stub = self._StubClient(error=Exception("403 Forbidden"))
+        monkeypatch.setattr(
+            gitlab_processor,
+            "_gitlab_code_client_from_connector",
+            lambda connector: stub,
+        )
+        result = gitlab_processor._fetch_gitlab_security_alerts_sync(
+            MagicMock(), 123, FAKE_REPO_ID, 100, None
         )
         assert result == []


### PR DESCRIPTION
## CHAOS-2811 — CS10: GitLab security family on GitLabCodeClient (CHAOS-2773 pathfinder)

Migrates the GitLab **security** code-dataset family (vulnerability findings + dependency-scan alerts) off the frozen python-gitlab `connectors/gitlab.py` path onto a new instrumented httpx `GitLabCodeClient` built on `InstrumentedRESTCore`. This is the GitLab-wave **pathfinder** that CS11–CS15 copy.

### What changed
- **New** `providers/gitlab/code_client.py` — `GitLabCodeClient`: one owned `InstrumentedRESTCore`, `"security:"`-prefixed operation labels, GitLab 429 / header-qualified-403 rate-limit classification, real per-request usage recording.
- `processors/gitlab.py` — `_fetch_gitlab_security_alerts_sync` now calls the new client (via `_gitlab_code_client_from_connector`, bridged with `asyncio.run` inside the executor thread) instead of `connector.get_security_alerts`; usage drains through the CS2 `usage_sink` contract.
- `providers/gitlab/budget.py` — **adds** a `security` route-family (`REST_CORE`, `operation_markers=("security:",)`).
- **New** `tests/providers/test_gitlab_code_client.py` + updated `tests/test_security_alerts.py`.

### Parity preserved
`PRIVATE-TOKEN` auth; one `GET /projects/{id}` resolve then vulnerability-findings + dependencies; plain 403/404 on optional endpoints degrade to empty; header-qualified 403 / 429 → `RateLimitException`; single-page fetch quirk preserved (tested); identical `SecurityAlertData` field mapping. `connectors/` and the Jira-shared `connectors/utils/rest.py` untouched (frozen/retained).

### Adversarial review
Codex flagged 2 items, both **pre-existing (non-regression) and deferred** per anti-descent (not introduced by this migration):
- **CHAOS-2846** — processor-level `except Exception` still swallows `RateLimitException` (old connector path swallowed too; needs per-caller worker-deferral semantics + integration tests — same profile as CHAOS-2831).
- **CS15b (CHAOS-2817)** — the batch entry point doesn't thread a `usage_sink`, so batch-path security usage is logged-and-discarded (matches the existing `_enrich_prs_with_reviews_batch` legacy convention; noted on CHAOS-2817).

### Validation
`ci/local_validate.sh` **GATE PASSED** — ruff + mypy + full unit suite (6717 passed / 44 skipped) + live-ClickHouse argMax proof.

SCREENSHOT-WAIVER: backend-only change, no UI/render surface.

Epic: CHAOS-2773 · Closes CHAOS-2811
