### PR TITLE
fix(investment): resolve team attribution from WITA (CHAOS-2833)

### DIFF
--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -199,6 +199,11 @@ One path: `run_team_autoimport` → `team_autoimport_<provider>.populate()` → 
   same-provider donor), Jira (`test_jira_issue_project_wins_over_linked_issue`,
   `test_assignee_membership_wins_over_jira_linked_donor`). (Provider *link-capture* — distinct from
   the resolver — is also tested per provider, e.g. `test_gitlab_captures_external_key_*`.)
+- **Chart team attribution:** Investment Sankey, GraphQL TEAM flow-matrix/chord, team
+  Cycle Time × Throughput quadrant axes, and work-unit investment team evidence read the
+  primary `work_item_team_attributions` snapshot before rolling up team totals. Cycle-time
+  rows can still provide activity windows, durations, and co-occurrence bridges, but not the
+  owning team identity.
 - **Why it matters:** the team/project/member **dimension** is populated by the per-provider
   team/project/member sync. **"Auto Import" is a UX option** (checkboxes to import teams, projects,
   and members from an integration → `run_team_autoimport`, writing ClickHouse directly); manual
@@ -396,10 +401,12 @@ boundary).
 erDiagram
     work_items ||--o{ work_item_dependencies : "source of edges"
     work_items ||--o{ work_item_cycle_times : "completed to cycle row"
+    work_items ||--o{ work_item_team_attributions : "primary attribution candidates"
     work_item_dependencies }o--|| work_items : "target or extkey to donor issue"
-    teams ||--o{ work_item_cycle_times : "team_id"
-    work_item_cycle_times ||--o{ investment_coverage : "team/repo coverage %"
-    work_item_cycle_times ||--o{ team_exchange_chord : "cross-team flows"
+    teams ||--o{ work_item_team_attributions : "team_id"
+    work_item_team_attributions ||--o{ investment_coverage : "team/repo coverage %"
+    work_item_team_attributions ||--o{ team_exchange_chord : "team identity"
+    work_item_cycle_times ||--o{ team_exchange_chord : "activity/day/scope bridge"
 
     work_items {
         string work_item_id PK
@@ -418,9 +425,16 @@ erDiagram
     }
     work_item_cycle_times {
         string work_item_id
-        string team_id "inherited when a PR borrows a donor"
         string work_scope_id
         date   day
+        string org_id
+    }
+    work_item_team_attributions {
+        string work_item_id
+        string team_id "latest primary owner"
+        string source
+        uint8  is_primary
+        datetime computed_at
         string org_id
     }
     teams {
@@ -430,10 +444,9 @@ erDiagram
     }
 ```
 
-The chord and coverage both read `work_item_cycle_times.team_id`. Before
-inheritance, PR rows carried `unassigned`, so they never bridged to the issue
-trackers' teams; after, a PR's row carries the donor issue's team and the two
-providers finally co-occur on a team dimension.
+Coverage and team-identity hydration read latest primary rows from
+`work_item_team_attributions`. Cycle-time rows can still provide activity dates,
+durations, and co-occurrence bridges, but they are not the owning team source.
 
 ---
 
@@ -526,7 +539,16 @@ does not collapse to `unassigned`.
    SELECT count() FROM members WHERE org_id = '<org_id>';
    SELECT count() FROM team_memberships WHERE org_id = '<org_id>' AND provider = 'linear';
    SELECT count() FROM team_project_ownership WHERE org_id = '<org_id>' AND provider = 'linear';
-   SELECT team_id, count() FROM work_item_cycle_times WHERE org_id = '<org_id>' GROUP BY team_id;
+   SELECT team_id, count() FROM work_item_team_attributions FINAL
+   WHERE org_id = '<org_id>'
+     AND is_primary = 1
+     AND (work_item_id, computed_at) IN (
+       SELECT work_item_id, max(computed_at)
+       FROM work_item_team_attributions
+       WHERE org_id = '<org_id>'
+       GROUP BY work_item_id
+     )
+   GROUP BY team_id;
    ```
 
 | Aspect | `job_work_items` (sync) | `job_daily` (recompute) |
@@ -578,12 +600,13 @@ migration**, only a data replay.
 
 ### Why a plain backfill is not enough
 
-The investment **allocation** views derive team at *query time*: the coverage %
-and team-exchange chord read `work_unit_investments` and **LEFT JOIN**
-`work_item_cycle_times` for `argMax(team_id, …)`. So three things must be true,
-and the backfill **runner only re-runs `run_work_items_sync_job` — it does NOT
-fan out** to the work-graph or investment jobs (only the live sync path chains
-those). They must be triggered explicitly.
+The investment **allocation** views derive team at *query time*: the coverage %, 
+team-exchange chord, team Cycle Time × Throughput quadrant, and work-unit
+investment evidence read `work_unit_investments` / cycle-time activity and join
+latest primary `work_item_team_attributions` rows for team identity. So three
+things must be true, and the backfill **runner only re-runs
+`run_work_items_sync_job` — it does NOT fan out** to the work-graph or investment
+jobs (only the live sync path chains those). They must be triggered explicitly.
 
 ```mermaid
 flowchart TD
@@ -592,10 +615,10 @@ flowchart TD
         L["Linear (issues + attachment edges)"]
         G["GitHub / GitLab (PRs/MRs + comment/body edges)"]
     end
-    SYNC --> CT["work_item_dependencies (extkey/attachment edges)<br/>+ work_item_cycle_times.team_id (inherited)"]
+    SYNC --> CT["work_item_dependencies (extkey/attachment edges)<br/>+ work_item_team_attributions (latest primary owner)<br/>+ work_item_cycle_times (activity bridge)"]
     CT --> WG["3. work-graph build"]
     WG --> IM["4. investment materialize (--force)"]
-    IM --> Q["5. allocation coverage % + chord<br/>recover via query-time join to cycle_times"]
+    IM --> Q["5. allocation coverage % + chord<br/>recover via query-time join to primary attribution"]
 ```
 
 ### Ordered steps (per affected org)
@@ -605,14 +628,15 @@ flowchart TD
    nothing: the PR/MR rows and their edges come from the git providers, and the
    donor issues come from Linear. A single `--provider all` run (or per-provider
    with Linear synced so its issues are present) writes the edges and recomputes
-   `work_item_cycle_times.team_id`. The org is derived from the sync config
+   `work_item_team_attributions`. The org is derived from the sync config
    (#923), so `--org` is optional.
 3. **Work-graph build**, then
 4. **Investment materialize (`--force`)** — these rebuild `work_unit_investments`
    + its `structural_evidence_json.issues` (the coverage join keys); the backfill
    does not trigger them.
-5. **Verify & recover** — the coverage % and chord recover automatically via the
-   query-time join. Confirm the links were captured:
+5. **Verify & recover** — the coverage %, chord, team Cycle Time × Throughput
+   quadrant, and work-unit investment evidence recover automatically via the
+   query-time join to primary attribution. Confirm the links were captured:
 
    ```sql
    SELECT relationship_type_raw, count()

--- a/src/dev_health_ops/api/graphql/loaders/team_loader.py
+++ b/src/dev_health_ops/api/graphql/loaders/team_loader.py
@@ -61,20 +61,23 @@ class TeamLoader(CachedDataLoader[str, TeamData | None]):
             List of TeamData objects (or None for missing teams).
         """
         from dev_health_ops.api.queries.client import query_dicts
+        from dev_health_ops.api.queries.investment import (
+            PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE,
+        )
 
         if not keys or self._client is None:
             return [None] * len(keys)
 
-        # Query all teams in a single batch
-        sql = """
-            SELECT DISTINCT
-                team_id,
-                team_name,
-                org_id,
-                count() OVER (PARTITION BY team_id) as member_count
-            FROM work_item_cycle_times
+        sql = f"""
+            SELECT
+                toString(team_id) AS team_id,
+                ifNull(nullIf(any(team_name), ''), toString(team_id)) AS team_name,
+                count() AS member_count
+            FROM {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE}
             WHERE team_id IN %(team_ids)s
-              AND org_id = %(org_id)s
+              AND team_id IS NOT NULL
+              AND team_id != ''
+            GROUP BY team_id
             ORDER BY team_id
         """
         params = {"team_ids": list(keys), "org_id": self._org_id}
@@ -90,7 +93,7 @@ class TeamLoader(CachedDataLoader[str, TeamData | None]):
                     team_map[team_id] = TeamData(
                         team_id=team_id,
                         team_name=str(row.get("team_name", team_id)),
-                        org_id=str(row.get("org_id", self._org_id)),
+                        org_id=self._org_id,
                         member_count=int(row.get("member_count", 0)),
                     )
 
@@ -142,19 +145,30 @@ class TeamByNameLoader(CachedDataLoader[str, TeamData | None]):
             List of TeamData objects (or None for missing teams).
         """
         from dev_health_ops.api.queries.client import query_dicts
+        from dev_health_ops.api.queries.investment import (
+            PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE,
+        )
 
         if not keys or self._client is None:
             return [None] * len(keys)
 
-        sql = """
-            SELECT DISTINCT
-                team_id,
-                team_name,
-                org_id,
-                count() OVER (PARTITION BY team_id) as member_count
-            FROM work_item_cycle_times
-            WHERE lower(team_name) IN %(team_names)s
-              AND org_id = %(org_id)s
+        sql = f"""
+            SELECT
+                toString(team_id) AS team_id,
+                ifNull(nullIf(any(raw_team_name), ''), toString(team_id)) AS team_name,
+                count() AS member_count
+            FROM (
+                SELECT
+                    work_item_id,
+                    team_id,
+                    team_name AS raw_team_name
+                FROM {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE}
+            ) AS t
+            WHERE lower(raw_team_name) IN %(team_names)s
+              AND team_id IS NOT NULL
+              AND team_id != ''
+              AND raw_team_name IS NOT NULL
+            GROUP BY team_id
             ORDER BY team_name
         """
         params = {"team_names": [k.lower() for k in keys], "org_id": self._org_id}
@@ -170,7 +184,7 @@ class TeamByNameLoader(CachedDataLoader[str, TeamData | None]):
                     team_map[team_name.lower()] = TeamData(
                         team_id=str(row.get("team_id", "")),
                         team_name=team_name,
-                        org_id=str(row.get("org_id", self._org_id)),
+                        org_id=self._org_id,
                         member_count=int(row.get("member_count", 0)),
                     )
 

--- a/src/dev_health_ops/api/graphql/resolvers/analytics.py
+++ b/src/dev_health_ops/api/graphql/resolvers/analytics.py
@@ -13,6 +13,7 @@ from dev_health_ops.api.queries.investment import (
     LATEST_WORK_UNIT_AUTHORS_CTE,
     LATEST_WORK_UNIT_INVESTMENTS_CTE,
     LATEST_WORK_UNIT_REPO_EFFORT_CTE,
+    PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE,
     fetch_investment_quality_stats,
 )
 from dev_health_ops.api.queries.investment_membership_scope import (
@@ -680,7 +681,7 @@ async def resolve_analytics(
                         "work_unit_investments.from_ts < %(end_date)s "
                         "AND work_unit_investments.to_ts >= %(start_date)s"
                     )
-                    joins = """
+                    joins = f"""
                         LEFT JOIN (
                             SELECT
                                 work_unit_id,
@@ -697,15 +698,7 @@ async def resolve_analytics(
                                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                                     [work_unit_investments.work_unit_id]
                                 )) AS issue_id
-                                LEFT JOIN (
-                                    SELECT
-                                        work_item_id,
-                                        argMax(team_id, computed_at) AS team_id,
-                                        argMax(team_name, computed_at) AS team_name
-                                    FROM work_item_cycle_times
-                                    WHERE org_id = %(org_id)s
-                                    GROUP BY work_item_id
-                                ) AS t ON t.work_item_id = issue_id
+                                LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t ON t.work_item_id = issue_id
                                 GROUP BY work_unit_id, team_id, team
                             )
                             GROUP BY work_unit_id

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -13,6 +13,7 @@ from dev_health_ops.api.queries.investment import (
     LATEST_WORK_UNIT_AUTHORS_CTE,
     LATEST_WORK_UNIT_INVESTMENTS_CTE,
     LATEST_WORK_UNIT_REPO_EFFORT_CTE,
+    PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE,
 )
 
 from ..authz import enforce_org_scope
@@ -193,7 +194,7 @@ def _get_context_params(
 
         # Add team join if TEAM dimension is used or filters require it
         if Dimension.TEAM in dimensions or needs_team_join:
-            team_join = """
+            team_join = f"""
             LEFT JOIN (
                 SELECT
                     work_unit_id,
@@ -210,15 +211,7 @@ def _get_context_params(
                         JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                         [work_unit_investments.work_unit_id]
                     )) AS issue_id
-                    LEFT JOIN (
-                        SELECT
-                            work_item_id,
-                            argMax(team_id, computed_at) AS team_id,
-                            argMax(team_name, computed_at) AS team_name
-                        FROM work_item_cycle_times
-                        WHERE org_id = %(org_id)s
-                        GROUP BY work_item_id
-                    ) AS t ON t.work_item_id = issue_id
+                    LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t ON t.work_item_id = issue_id
                     GROUP BY work_unit_id, team_id, team_label
                 )
                 GROUP BY work_unit_id

--- a/src/dev_health_ops/api/graphql/sql/templates.py
+++ b/src/dev_health_ops/api/graphql/sql/templates.py
@@ -8,6 +8,10 @@ from __future__ import annotations
 
 from typing import Any
 
+from dev_health_ops.api.queries.investment import (
+    PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE,
+)
+
 from .validate import BucketInterval, Dimension, Measure
 
 
@@ -181,23 +185,33 @@ SETTINGS max_execution_time = %(timeout)s
 
 
 def flow_matrix_team_nodes_template() -> str:
-    """Nodes query for TEAM flow matrix, sourced from work_item_cycle_times.
+    """Nodes query for TEAM flow matrix.
 
-    Counts distinct work items per team in the window. The cycle_times table
-    carries the canonical per-work-item team assignment (one row per work item
-    per completed day) with real team diversity, unlike investment_metrics_daily
-    which aggregates and may collapse to a single team in sparse data.
+    Counts distinct completed work items per authoritative primary team in the
+    window. ``work_item_cycle_times`` supplies the activity/day/scope bridge;
+    ``work_item_team_attributions`` supplies the team identity.
     """
-    return """
+    return f"""
+WITH team_activity AS (
+    SELECT
+        wct.work_item_id,
+        wct.work_scope_id,
+        wct.day,
+        wct.org_id,
+        t.team_id AS team_id
+    FROM work_item_cycle_times AS wct FINAL
+    INNER JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t
+      ON t.work_item_id = wct.work_item_id
+    WHERE wct.day >= %(start_date)s AND wct.day <= %(end_date)s
+      AND wct.org_id = %(org_id)s
+      AND t.team_id IS NOT NULL
+      AND t.team_id != ''
+)
 SELECT
     'TEAM' AS dimension,
     toString(team_id) AS node_id,
     uniqExact(work_item_id) AS value
-FROM work_item_cycle_times
-WHERE day >= %(start_date)s AND day <= %(end_date)s
-  AND work_item_cycle_times.org_id = %(org_id)s
-  AND team_id IS NOT NULL
-  AND team_id != ''
+FROM team_activity
 GROUP BY node_id
 ORDER BY value DESC
 LIMIT %(limit_per_dim)s
@@ -206,7 +220,7 @@ SETTINGS max_execution_time = %(timeout)s
 
 
 def flow_matrix_team_edges_template() -> str:
-    """Asymmetric cross-team edges from work_item_cycle_times.
+    """Asymmetric cross-team edges from cycle-time activity and WITA teams.
 
     Self-joins on (work_scope_id, day, org_id) so every pair of teams that
     completed work in the same scope on the same day becomes an edge. The
@@ -224,23 +238,34 @@ def flow_matrix_team_edges_template() -> str:
     handoff (schema doesn't encode those natively), but a real directional
     signal that populates on any org with cross-team repo sharing.
     """
-    return """
+    return f"""
+WITH team_activity AS (
+    SELECT
+        wct.work_item_id,
+        wct.work_scope_id,
+        wct.day,
+        wct.org_id,
+        t.team_id AS team_id
+    FROM work_item_cycle_times AS wct FINAL
+    INNER JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t
+      ON t.work_item_id = wct.work_item_id
+    WHERE wct.day >= %(start_date)s AND wct.day <= %(end_date)s
+      AND wct.org_id = %(org_id)s
+      AND t.team_id IS NOT NULL
+      AND t.team_id != ''
+)
 SELECT
     'TEAM' AS source_dimension,
     'TEAM' AS target_dimension,
     toString(a.team_id) AS source,
     toString(b.team_id) AS target,
     uniqExact(a.work_item_id) AS value
-FROM work_item_cycle_times AS a
-INNER JOIN work_item_cycle_times AS b
+FROM team_activity AS a
+INNER JOIN team_activity AS b
   ON a.work_scope_id = b.work_scope_id
   AND a.day = b.day
   AND a.org_id = b.org_id
-WHERE a.day >= %(start_date)s AND a.day <= %(end_date)s
-  AND a.org_id = %(org_id)s
-  AND a.team_id IS NOT NULL AND a.team_id != ''
-  AND b.team_id IS NOT NULL AND b.team_id != ''
-  AND a.team_id != b.team_id
+WHERE a.team_id != b.team_id
 GROUP BY source, target
 ORDER BY value DESC
 LIMIT %(max_edges)s

--- a/src/dev_health_ops/api/queries/aggregated_flame.py
+++ b/src/dev_health_ops/api/queries/aggregated_flame.py
@@ -6,6 +6,7 @@ from datetime import date
 from typing import Any
 
 from .client import query_dicts
+from .investment import PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE
 
 
 async def fetch_cycle_breakdown(
@@ -165,30 +166,39 @@ async def fetch_throughput(
     }
     params["org_id"] = org_id
 
-    filters = ["day >= %(start_day)s", "day < %(end_day)s", "org_id = %(org_id)s"]
+    filters = [
+        "wct.day >= %(start_day)s",
+        "wct.day < %(end_day)s",
+        "wct.org_id = %(org_id)s",
+    ]
     if team_id:
-        filters.append("team_id = %(team_id)s")
+        filters.append("t.team_id = %(team_id)s")
         params["team_id"] = team_id
     if provider:
-        filters.append("provider = %(provider)s")
+        filters.append("wct.provider = %(provider)s")
         params["provider"] = provider
     if work_scope_id:
-        filters.append("work_scope_id = %(work_scope_id)s")
+        filters.append("wct.work_scope_id = %(work_scope_id)s")
         params["work_scope_id"] = work_scope_id
 
     where_clause = " AND ".join(filters)
+    team_key_expr = "coalesce(nullIf(t.team_id, ''), 'unassigned')"
 
-    # Query work_item_metrics_daily for aggregate counts by team
-    # Note: No work_type available in this table, so we use 'All' as synthetic type
     query = f"""
         SELECT
             'All' AS work_type,
-            coalesce(nullIf(team_name, ''), 'Unassigned') AS team_name,
-            sum(items_completed) AS items_completed,
-            sum(items_started) AS items_started
-        FROM work_item_metrics_daily FINAL
+            if(
+                {team_key_expr} = 'unassigned',
+                'Unassigned',
+                coalesce(nullIf(any(t.team_name), ''), {team_key_expr})
+            ) AS team_name,
+            uniqExact(wct.work_item_id) AS items_completed,
+            0 AS items_started
+        FROM work_item_cycle_times AS wct FINAL
+        LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t
+          ON t.work_item_id = wct.work_item_id
         WHERE {where_clause}
-        GROUP BY team_name
+        GROUP BY {team_key_expr}
         HAVING items_completed > 0
         ORDER BY items_completed DESC
         LIMIT %(limit)s
@@ -218,25 +228,32 @@ async def fetch_throughput_by_type(
 
     # Filter by completed_at date range, not day column
     filters = [
-        "completed_at >= toDateTime(%(start_day)s)",
-        "completed_at < toDateTime(%(end_day)s)",
-        "completed_at IS NOT NULL",
-        "org_id = %(org_id)s",
+        "wct.completed_at >= toDateTime(%(start_day)s)",
+        "wct.completed_at < toDateTime(%(end_day)s)",
+        "wct.completed_at IS NOT NULL",
+        "wct.org_id = %(org_id)s",
     ]
     if team_id:
-        filters.append("team_id = %(team_id)s")
+        filters.append("t.team_id = %(team_id)s")
         params["team_id"] = team_id
 
     where_clause = " AND ".join(filters)
+    team_key_expr = "coalesce(nullIf(t.team_id, ''), 'unassigned')"
 
     query = f"""
         SELECT
-            coalesce(nullIf(type, ''), 'unclassified') AS work_type,
-            coalesce(nullIf(team_name, ''), 'Unassigned') AS team_name,
-            count(*) AS items_completed
-        FROM work_item_cycle_times
+            coalesce(nullIf(wct.type, ''), 'unclassified') AS work_type,
+            if(
+                {team_key_expr} = 'unassigned',
+                'Unassigned',
+                coalesce(nullIf(any(t.team_name), ''), {team_key_expr})
+            ) AS team_name,
+            uniqExact(wct.work_item_id) AS items_completed
+        FROM work_item_cycle_times AS wct FINAL
+        LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t
+          ON t.work_item_id = wct.work_item_id
         WHERE {where_clause}
-        GROUP BY work_type, team_name
+        GROUP BY work_type, {team_key_expr}
         HAVING items_completed > 0
         ORDER BY items_completed DESC
         LIMIT %(limit)s

--- a/src/dev_health_ops/api/queries/investment.py
+++ b/src/dev_health_ops/api/queries/investment.py
@@ -256,6 +256,35 @@ LATEST_WORK_UNIT_AUTHORS_CTE = """
 """.rstrip()
 
 
+# CHAOS-2833: Investment Sankey/coverage team resolution previously joined
+# work_item_cycle_times for team_id/team_name -- a cycle-time metrics rollup,
+# not the authoritative attribution source. A work item can carry a primary
+# row in work_item_team_attributions (the CHAOS-2600 precedence-resolved
+# winner) with no matching work_item_cycle_times row, which surfaced as a
+# false TEAM:unassigned Sankey node even though attribution already existed.
+# This is the single source every Investment Sankey/coverage team join must
+# read from: work_item_team_attributions FINAL, is_primary = 1, latest by
+# computed_at per work_item_id (docs/architecture/team-attribution.md §0).
+# Filter to the latest snapshot before reading plain nullable team fields so a
+# newer primary row with NULL team fields clears an older assigned team.
+# Centralized so no caller drifts back onto work_item_cycle_times.
+PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE = """(
+    SELECT
+        work_item_id,
+        team_id,
+        team_name
+    FROM work_item_team_attributions FINAL
+    WHERE org_id = %(org_id)s
+      AND is_primary = 1
+      AND (work_item_id, computed_at) IN (
+          SELECT work_item_id, max(computed_at)
+          FROM work_item_team_attributions
+          WHERE org_id = %(org_id)s
+          GROUP BY work_item_id
+      )
+)""".rstrip()
+
+
 async def fetch_investment_breakdown(
     sink: BaseMetricsSink,
     *,
@@ -462,15 +491,7 @@ async def fetch_investment_team_edges(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
                 )) AS issue_id
-                LEFT JOIN (
-                    SELECT
-                        work_item_id,
-                        argMax(team_id, computed_at) AS team_id,
-                        argMax(team_name, computed_at) AS team_name
-                    FROM work_item_cycle_times
-                    WHERE org_id = %(org_id)s
-                    GROUP BY work_item_id
-                ) AS t ON t.work_item_id = issue_id
+                LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s
                   AND work_unit_investments.to_ts >= %(start_ts)s
                   AND work_unit_investments.org_id = %(org_id)s
@@ -536,15 +557,7 @@ async def fetch_investment_repo_team_edges(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
                 )) AS issue_id
-                LEFT JOIN (
-                    SELECT
-                        work_item_id,
-                        argMax(team_id, computed_at) AS team_id,
-                        argMax(team_name, computed_at) AS team_name
-                    FROM work_item_cycle_times
-                    WHERE org_id = %(org_id)s
-                    GROUP BY work_item_id
-                ) AS t ON t.work_item_id = issue_id
+                LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s
                   AND work_unit_investments.to_ts >= %(start_ts)s
                   AND work_unit_investments.org_id = %(org_id)s
@@ -612,15 +625,7 @@ async def fetch_investment_team_category_repo_edges(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
                 )) AS issue_id
-                LEFT JOIN (
-                    SELECT
-                        work_item_id,
-                        argMax(team_id, computed_at) AS team_id,
-                        argMax(team_name, computed_at) AS team_name
-                    FROM work_item_cycle_times
-                    WHERE org_id = %(org_id)s
-                    GROUP BY work_item_id
-                ) AS t ON t.work_item_id = issue_id
+                LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s
                   AND work_unit_investments.to_ts >= %(start_ts)s
                   AND work_unit_investments.org_id = %(org_id)s
@@ -688,15 +693,7 @@ async def fetch_investment_team_subcategory_repo_edges(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
                 )) AS issue_id
-                LEFT JOIN (
-                    SELECT
-                        work_item_id,
-                        argMax(team_id, computed_at) AS team_id,
-                        argMax(team_name, computed_at) AS team_name
-                    FROM work_item_cycle_times
-                    WHERE org_id = %(org_id)s
-                    GROUP BY work_item_id
-                ) AS t ON t.work_item_id = issue_id
+                LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s
                   AND work_unit_investments.to_ts >= %(start_ts)s
                   AND work_unit_investments.org_id = %(org_id)s
@@ -768,15 +765,7 @@ async def fetch_investment_unassigned_counts(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
                 )) AS issue_id
-                LEFT JOIN (
-                    SELECT
-                        work_item_id,
-                        argMax(team_id, computed_at) AS team_id,
-                        argMax(team_name, computed_at) AS team_name
-                    FROM work_item_cycle_times
-                    WHERE org_id = %(org_id)s
-                    GROUP BY work_item_id
-                ) AS t ON t.work_item_id = issue_id
+                LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s
                   AND work_unit_investments.to_ts >= %(start_ts)s
                   AND work_unit_investments.org_id = %(org_id)s
@@ -903,7 +892,7 @@ async def fetch_investment_quality_stats(
     team_filter = ""
     if team_scope_ids:
         params["team_scope_ids"] = team_scope_ids
-        team_join = """
+        team_join = f"""
         LEFT JOIN (
             SELECT
                 work_unit_id,
@@ -920,15 +909,7 @@ async def fetch_investment_quality_stats(
                     JSONExtract(structural_evidence_json, 'issues', 'Array(String)'),
                     [work_unit_investments.work_unit_id]
                 )) AS issue_id
-                LEFT JOIN (
-                    SELECT
-                        work_item_id,
-                        argMax(team_id, computed_at) AS team_id,
-                        argMax(team_name, computed_at) AS team_name
-                    FROM work_item_cycle_times
-                    WHERE org_id = %(org_id)s
-                    GROUP BY work_item_id
-                ) AS t ON t.work_item_id = issue_id
+                LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t ON t.work_item_id = issue_id
                 WHERE work_unit_investments.from_ts < %(end_ts)s
                   AND work_unit_investments.to_ts >= %(start_ts)s
                   AND work_unit_investments.org_id = %(org_id)s

--- a/src/dev_health_ops/api/queries/quadrant.py
+++ b/src/dev_health_ops/api/queries/quadrant.py
@@ -7,6 +7,7 @@ from dev_health_ops.clickhouse_dedup import dedup_from
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
+from .investment import PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE
 
 
 def _bucket_expr(bucket: str) -> str:
@@ -53,5 +54,55 @@ async def fetch_quadrant_metric(
     params: dict[str, Any] = {"start_day": start_day, "end_day": end_day}
     if scope_params:
         params.update(scope_params)
+    params["org_id"] = org_id
+    return await query_dicts(sink, query, params)
+
+
+async def fetch_work_item_team_quadrant_metric(
+    sink: BaseMetricsSink,
+    *,
+    metric: str,
+    start_day: date,
+    end_day: date,
+    bucket: str,
+    org_id: str = "",
+) -> list[dict[str, Any]]:
+    bucket_expr = _bucket_expr(bucket)
+    if metric == "throughput":
+        value_expr = "uniqExact(work_item_id)"
+        metric_filter = ""
+    elif metric == "cycle_time":
+        value_expr = "avg(cycle_time_hours)"
+        metric_filter = "AND cycle_time_hours IS NOT NULL"
+    else:
+        raise ValueError(f"Unsupported attributed team quadrant metric: {metric}")
+
+    query = f"""
+        WITH team_activity AS (
+            SELECT
+                wct.day,
+                wct.work_item_id,
+                wct.cycle_time_hours,
+                t.team_id AS team_id,
+                t.team_name AS team_name
+            FROM work_item_cycle_times AS wct FINAL
+            INNER JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t
+              ON t.work_item_id = wct.work_item_id
+            WHERE wct.day >= %(start_day)s AND wct.day < %(end_day)s
+              AND wct.org_id = %(org_id)s
+              AND t.team_id IS NOT NULL
+              AND t.team_id != ''
+              {metric_filter}
+        )
+        SELECT
+            {bucket_expr} AS bucket,
+            toString(team_id) AS entity_id,
+            ifNull(nullIf(any(team_name), ''), toString(team_id)) AS entity_label,
+            {value_expr} AS value
+        FROM team_activity
+        GROUP BY bucket, entity_id
+        ORDER BY bucket
+    """
+    params: dict[str, Any] = {"start_day": start_day, "end_day": end_day}
     params["org_id"] = org_id
     return await query_dicts(sink, query, params)

--- a/src/dev_health_ops/api/queries/work_unit_investments.py
+++ b/src/dev_health_ops/api/queries/work_unit_investments.py
@@ -120,12 +120,19 @@ async def fetch_work_item_team_assignments(
     query = """
         SELECT
             work_item_id,
-            argMax(team_id, computed_at) AS team_id,
-            argMax(team_name, computed_at) AS team_name
-        FROM work_item_cycle_times
+            team_id,
+            team_name
+        FROM work_item_team_attributions FINAL
         WHERE work_item_id IN {work_item_ids:Array(String)}
           AND org_id = {org_id:String}
-        GROUP BY work_item_id
+          AND is_primary = 1
+          AND (work_item_id, computed_at) IN (
+              SELECT work_item_id, max(computed_at)
+              FROM work_item_team_attributions
+              WHERE work_item_id IN {work_item_ids:Array(String)}
+                AND org_id = {org_id:String}
+              GROUP BY work_item_id
+          )
     """
     rows: list[dict[str, Any]] = []
     for chunk in _chunks(ids):

--- a/src/dev_health_ops/api/services/quadrant.py
+++ b/src/dev_health_ops/api/services/quadrant.py
@@ -22,7 +22,10 @@ from ..models.schemas import (
 )
 from ..queries.client import clickhouse_client, query_dicts
 from ..queries.people import fetch_person_team_id, resolve_person_identity
-from ..queries.quadrant import fetch_quadrant_metric
+from ..queries.quadrant import (
+    fetch_quadrant_metric,
+    fetch_work_item_team_quadrant_metric,
+)
 from ..utils import build_reverse_alias_map, normalize_alias
 from .filtering import time_window
 from .people_identity import (
@@ -45,6 +48,7 @@ class MetricSpec:
     join_clause: str = ""
     where_clause: str = ""
     transform: Callable[[float], float] = lambda value: value
+    use_primary_team_attribution: bool = False
 
 
 @dataclass(frozen=True)
@@ -85,6 +89,7 @@ TEAM_METRICS: dict[str, MetricSpec] = {
         entity_expr="m.team_id",
         label_expr=TEAM_LABEL,
         where_clause="AND m.team_id != ''",
+        use_primary_team_attribution=True,
     ),
     "cycle_time": MetricSpec(
         metric="cycle_time",
@@ -96,6 +101,7 @@ TEAM_METRICS: dict[str, MetricSpec] = {
         label_expr=TEAM_LABEL,
         where_clause="AND m.cycle_time_p50_hours IS NOT NULL AND m.team_id != ''",
         transform=lambda value: value / 24.0,
+        use_primary_team_attribution=True,
     ),
     "wip": MetricSpec(
         metric="wip",
@@ -532,37 +538,39 @@ async def build_quadrant_response(
         x_spec = _metric_spec(definition.x.metric, group_scope)
         y_spec = _metric_spec(definition.y.metric, group_scope)
 
+        async def _fetch_metric_rows(spec: MetricSpec) -> list[dict[str, Any]]:
+            if (
+                definition.type == "cycle_throughput"
+                and group_scope == "team"
+                and spec.use_primary_team_attribution
+            ):
+                return await fetch_work_item_team_quadrant_metric(
+                    sink,
+                    metric=spec.metric,
+                    start_day=start_day,
+                    end_day=end_day,
+                    bucket=bucket,
+                    org_id=org_id,
+                )
+            return await fetch_quadrant_metric(
+                sink,
+                table=spec.table,
+                value_expr=spec.value_expr,
+                start_day=start_day,
+                end_day=end_day,
+                bucket=bucket,
+                entity_expr=spec.entity_expr,
+                label_expr=spec.label_expr,
+                join_clause=spec.join_clause,
+                where_clause=spec.where_clause,
+                scope_filter=scope_filter,
+                scope_params=scope_params,
+                org_id=org_id,
+            )
+
         x_rows, y_rows = await asyncio.gather(
-            fetch_quadrant_metric(
-                sink,
-                table=x_spec.table,
-                value_expr=x_spec.value_expr,
-                start_day=start_day,
-                end_day=end_day,
-                bucket=bucket,
-                entity_expr=x_spec.entity_expr,
-                label_expr=x_spec.label_expr,
-                join_clause=x_spec.join_clause,
-                where_clause=x_spec.where_clause,
-                scope_filter=scope_filter,
-                scope_params=scope_params,
-                org_id=org_id,
-            ),
-            fetch_quadrant_metric(
-                sink,
-                table=y_spec.table,
-                value_expr=y_spec.value_expr,
-                start_day=start_day,
-                end_day=end_day,
-                bucket=bucket,
-                entity_expr=y_spec.entity_expr,
-                label_expr=y_spec.label_expr,
-                join_clause=y_spec.join_clause,
-                where_clause=y_spec.where_clause,
-                scope_filter=scope_filter,
-                scope_params=scope_params,
-                org_id=org_id,
-            ),
+            _fetch_metric_rows(x_spec),
+            _fetch_metric_rows(y_spec),
         )
 
         team_labels = (

--- a/tests/api/graphql/loaders/test_loader_org_scoping.py
+++ b/tests/api/graphql/loaders/test_loader_org_scoping.py
@@ -69,7 +69,10 @@ async def test_team_loader_scopes_query_by_org_id(monkeypatch):
     loader = TeamLoader(client=object(), org_id="org-A")
     await loader.batch_load(["team-1"])
 
-    assert "AND org_id = %(org_id)s" in str(captured["sql"])
+    assert "WHERE org_id = %(org_id)s" in str(captured["sql"])
+    assert "FROM work_item_team_attributions FINAL" in str(captured["sql"])
+    assert "is_primary = 1" in str(captured["sql"])
+    assert "work_item_cycle_times" not in str(captured["sql"])
     assert captured["params"]["org_id"] == "org-A"
 
 
@@ -89,5 +92,8 @@ async def test_team_by_name_loader_scopes_query_by_org_id(monkeypatch):
     loader = TeamByNameLoader(client=object(), org_id="org-A")
     await loader.batch_load(["Core Team"])
 
-    assert "AND org_id = %(org_id)s" in str(captured["sql"])
+    assert "WHERE org_id = %(org_id)s" in str(captured["sql"])
+    assert "FROM work_item_team_attributions FINAL" in str(captured["sql"])
+    assert "is_primary = 1" in str(captured["sql"])
+    assert "work_item_cycle_times" not in str(captured["sql"])
     assert captured["params"]["org_id"] == "org-A"

--- a/tests/api/graphql/test_graphql_investment_team_attribution_sql.py
+++ b/tests/api/graphql/test_graphql_investment_team_attribution_sql.py
@@ -23,6 +23,14 @@ def _assert_team_attribution_sql(sql: str) -> None:
     assert "JSONExtract(structural_evidence_json, 'issues', 'Array(String)')" in sql
     assert "[work_unit_investments.work_unit_id]" in sql
     assert "t.work_item_id = issue_id" in sql
+    # CHAOS-2833: the GraphQL Sankey TEAM join and coverage query must read
+    # the primary ClickHouse attribution rows, never the legacy cycle-times
+    # rollup that produced false unassigned team nodes.
+    assert "FROM work_item_team_attributions FINAL" in sql
+    assert "is_primary = 1" in sql
+    assert "(work_item_id, computed_at) IN" in sql
+    assert "max(computed_at)" in sql
+    assert "work_item_cycle_times" not in sql
 
 
 def test_graphql_sankey_team_join_scopes_org_and_uses_work_unit_fallback() -> None:

--- a/tests/api/queries/test_aggregated_flame_team_attribution_sql.py
+++ b/tests/api/queries/test_aggregated_flame_team_attribution_sql.py
@@ -1,0 +1,71 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.queries import aggregated_flame
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+
+def _capture(monkeypatch: pytest.MonkeyPatch) -> dict[str, Any]:
+    captured: dict[str, Any] = {"query": "", "params": {}}
+
+    async def fake_query_dicts(_sink: Any, query: str, params: dict[str, Any]):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(aggregated_flame, "query_dicts", fake_query_dicts)
+    return captured
+
+
+def _assert_primary_attribution_sql(query: str) -> None:
+    assert "FROM work_item_cycle_times AS wct FINAL" in query
+    assert "FROM work_item_team_attributions FINAL" in query
+    assert "is_primary = 1" in query
+    assert "LEFT JOIN" in query
+    assert "t.work_item_id = wct.work_item_id" in query
+    assert "'Unassigned'" in query
+    assert "t.team_id IS NOT NULL" not in query
+    assert "work_item_metrics_daily" not in query
+
+
+@pytest.mark.asyncio
+async def test_throughput_fallback_uses_primary_attribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture(monkeypatch)
+
+    await aggregated_flame.fetch_throughput(
+        cast(BaseMetricsSink, object()),
+        start_day=date(2026, 1, 1),
+        end_day=date(2026, 2, 1),
+        team_id="team-a",
+        limit=20,
+        org_id="org-a",
+    )
+
+    _assert_primary_attribution_sql(str(captured["query"]))
+    assert "t.team_id = %(team_id)s" in str(captured["query"])
+    assert captured["params"]["org_id"] == "org-a"
+
+
+@pytest.mark.asyncio
+async def test_throughput_by_type_uses_primary_attribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture(monkeypatch)
+
+    await aggregated_flame.fetch_throughput_by_type(
+        cast(BaseMetricsSink, object()),
+        start_day=date(2026, 1, 1),
+        end_day=date(2026, 2, 1),
+        team_id="team-a",
+        limit=20,
+        org_id="org-a",
+    )
+
+    _assert_primary_attribution_sql(str(captured["query"]))
+    assert "coalesce(nullIf(wct.type, ''), 'unclassified')" in str(captured["query"])

--- a/tests/api/queries/test_rerun_rollup_dedup.py
+++ b/tests/api/queries/test_rerun_rollup_dedup.py
@@ -72,6 +72,28 @@ async def test_quadrant_metric_leaves_plain_mergetree_untouched(
 
 
 @pytest.mark.asyncio
+async def test_quadrant_team_work_item_metric_uses_primary_attribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured = _capture(monkeypatch, quadrant)
+    await quadrant.fetch_work_item_team_quadrant_metric(
+        cast(BaseMetricsSink, object()),
+        metric="throughput",
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 2),
+        bucket="week",
+        org_id="org-a",
+    )
+
+    assert "FROM work_item_team_attributions FINAL" in captured["query"]
+    assert "FROM work_item_cycle_times AS wct FINAL" in captured["query"]
+    assert "is_primary = 1" in captured["query"]
+    assert "(work_item_id, computed_at) IN" in captured["query"]
+    assert "max(computed_at)" in captured["query"]
+    assert "work_item_metrics_daily" not in captured["query"]
+
+
+@pytest.mark.asyncio
 async def test_person_metric_value_dedups_rmt_table(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/api/test_investment_repo_effort_live.py
+++ b/tests/api/test_investment_repo_effort_live.py
@@ -45,6 +45,7 @@ from urllib.parse import urlparse
 import pytest
 
 import dev_health_ops.api.queries.investment as investment_queries
+from dev_health_ops.metrics.schemas import WorkItemTeamAttributionRecord
 
 CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
 
@@ -161,6 +162,7 @@ def _cleanup(sink: Any, org_id: str) -> None:
         "work_unit_repo_effort",
         "repos",
         "work_item_cycle_times",
+        "work_item_team_attributions",
     ):
         sink.client.command(
             f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
@@ -443,11 +445,27 @@ async def test_scope_filter_resolves_team_for_multi_repo_unit(sink):
             ],
             column_names=_wure_cols(),
         )
-        # The unit's issue is owned by a team.
-        sink.client.insert(
-            "work_item_cycle_times",
-            [["ISSUE-SCOPE-1", "Team Scope", COMPUTED_AT, org]],
-            column_names=["work_item_id", "team_name", "computed_at", "org_id"],
+        # CHAOS-2833: the unit's issue is owned by a team via the primary
+        # ClickHouse attribution row (work_item_cycle_times is no longer read
+        # for Sankey/repo-team team resolution -- proving this fixture still
+        # resolves 'Team Scope' pins the migration for the repo-scope-filter
+        # interaction, not just the plain team join).
+        sink.write_work_item_team_attributions(
+            [
+                WorkItemTeamAttributionRecord(
+                    work_item_id="ISSUE-SCOPE-1",
+                    provider="linear",
+                    source="native_team",
+                    is_primary=1,
+                    confidence="high",
+                    evidence="native_team_key=team-scope",
+                    computed_at=COMPUTED_AT,
+                    repo_id=repo_in,
+                    team_id="team-scope",
+                    team_name="Team Scope",
+                    org_id=org,
+                )
+            ]
         )
 
         # Scope to the in-scope repo only (mirrors build_scope_filter_multi).

--- a/tests/api/test_investment_team_attribution_live.py
+++ b/tests/api/test_investment_team_attribution_live.py
@@ -1,0 +1,353 @@
+"""Live-ClickHouse behavioral proof for CHAOS-2833.
+
+The Investment Sankey previously resolved `TEAM` labels by joining
+`work_item_cycle_times`, which does not carry every provider's work items (it
+is a cycle-time rollup, not the authoritative attribution table). Work items
+with a primary row in `work_item_team_attributions` but no matching
+`work_item_cycle_times` row collapsed to the false `TEAM:unassigned` node even
+though attribution existed -- the exact false-unassigned gap described in the
+CHAOS-2833 evidence (189 work units, `teamCoverage` ~0.86 instead of ~1.0).
+
+This file seeds ONLY `work_item_team_attributions` (never `work_item_cycle_times`)
+for a work item referenced by a work unit's `structural_evidence_json.issues`,
+and proves against REAL ClickHouse that:
+
+* the REST investment Sankey/coverage fetchers (`api/queries/investment.py`)
+  resolve the attributed team, not 'unassigned', and `missing_team` is zero;
+* the GraphQL Sankey compiler (`api/graphql/sql/compiler.py`) resolves the
+  SAME attributed team label for the TEAM dimension (REST/GraphQL parity);
+* the work item id is Jira-shaped (`PROJ-42`), not Linear-shaped, proving the
+  join is provider-agnostic (org-scoped `work_item_id` only, no provider
+  filter) per the platform's provider x entity coverage contract.
+
+Mock-based SQL-shape tests (`test_investment_team_attribution_sql.py`,
+`graphql/test_graphql_investment_team_attribution_sql.py`) only string-match
+the compiled SQL; only a live engine proves the join actually resolves rows
+end-to-end (mirrors the argMax-proof rationale in `ops/AGENTS.md`).
+
+Opt-in (filtered from unit/CI runs): ``pytest -m clickhouse``. Provision an
+ISOLATED scratch DB first, e.g.::
+
+    docker exec dev-health-clickhouse-1 clickhouse-client --query \\
+        "CREATE DATABASE IF NOT EXISTS ci_live_2833"
+    CLICKHOUSE_URI=clickhouse://ch:ch@localhost:8123/ci_live_2833 \\
+        .venv/bin/python -m pytest tests/api/test_investment_team_attribution_live.py -m clickhouse
+    docker exec dev-health-clickhouse-1 clickhouse-client --query \\
+        "DROP DATABASE ci_live_2833"
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from datetime import date, datetime, timezone
+from typing import Any
+from urllib.parse import urlparse
+
+import pytest
+
+import dev_health_ops.api.queries.investment as investment_queries
+from dev_health_ops.metrics.schemas import WorkItemTeamAttributionRecord
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason=(
+            "Requires CLICKHOUSE_URI pointed at an ISOLATED scratch DB, e.g. "
+            "clickhouse://ch:ch@localhost:8123/ci_live_2833"
+        ),
+    ),
+]
+
+FROM_TS = datetime(2026, 1, 5, tzinfo=timezone.utc)
+TO_TS = datetime(2026, 1, 6, tzinfo=timezone.utc)
+COMPUTED_AT = datetime(2026, 1, 7, tzinfo=timezone.utc)
+# Query window strictly containing [FROM_TS, TO_TS).
+START = datetime(2026, 1, 1, tzinfo=timezone.utc)
+END = datetime(2026, 2, 1, tzinfo=timezone.utc)
+START_DATE = date(2026, 1, 1)
+END_DATE = date(2026, 2, 1)
+
+# Jira-shaped, deliberately NOT Linear -- non-Linear work items carry
+# `native_team_key=None`, so this proves the join resolves via the
+# autoimport-populated `work_item_team_attributions` row regardless of
+# provider (never Linear-only coverage; see AGENTS.md provider x entity
+# contract).
+ATTRIBUTED_ISSUE_ID = "PROJ-42"
+ATTRIBUTED_TEAM_NAME = "Attributed Team"
+STALE_ISSUE_ID = "PROJ-STALE-42"
+
+
+def _scratch_db() -> str:
+    assert CLICKHOUSE_URI is not None
+    return (urlparse(CLICKHOUSE_URI).path or "").lstrip("/")
+
+
+@pytest.fixture(scope="module")
+def sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    # Safety rule (repo policy): ``ensure_schema(force=True)`` rebuilds tables,
+    # so this live test must NEVER touch the real local ``default`` database.
+    db = _scratch_db()
+    if db in ("", "default"):
+        pytest.skip(
+            "refusing to run against the 'default' database; point CLICKHOUSE_URI "
+            "at an isolated scratch DB (e.g. .../ci_live_2833)"
+        )
+    s = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    s.ensure_schema(force=True)
+    yield s
+    s.close()
+
+
+def _wui_cols() -> list[str]:
+    return [
+        "work_unit_id",
+        "from_ts",
+        "to_ts",
+        "repo_id",
+        "effort_metric",
+        "effort_value",
+        "subcategory_distribution_json",
+        "structural_evidence_json",
+        "computed_at",
+        "org_id",
+    ]
+
+
+def _cleanup(sink: Any, org_id: str) -> None:
+    for table in (
+        "work_unit_investments",
+        "work_item_cycle_times",
+        "work_item_team_attributions",
+    ):
+        sink.client.command(
+            f"ALTER TABLE {table} DELETE WHERE org_id = {{o:String}} "
+            "SETTINGS mutations_sync=2",
+            parameters={"o": org_id},
+        )
+
+
+def _seed_attributed_work_unit(sink: Any, org: str, *, repo_id: uuid.UUID) -> None:
+    feature = {"Feature Delivery.product": 1.0}
+    evidence = f'{{"issues": ["{ATTRIBUTED_ISSUE_ID}"]}}'
+
+    sink.client.insert(
+        "work_unit_investments",
+        [
+            [
+                "wu-attr",
+                FROM_TS,
+                TO_TS,
+                None,
+                "fte_days",
+                100.0,
+                feature,
+                evidence,
+                COMPUTED_AT,
+                org,
+            ]
+        ],
+        column_names=_wui_cols(),
+    )
+
+    # CHAOS-2833: seed ONLY the primary attribution row -- deliberately no
+    # `work_item_cycle_times` row for this work item -- so a pass here can
+    # only be explained by the fix reading `work_item_team_attributions`.
+    sink.write_work_item_team_attributions(
+        [
+            WorkItemTeamAttributionRecord(
+                work_item_id=ATTRIBUTED_ISSUE_ID,
+                provider="jira",
+                source="native_team",
+                is_primary=1,
+                confidence="high",
+                evidence="native_team_key=attributed-team",
+                computed_at=COMPUTED_AT,
+                repo_id=repo_id,
+                team_id="team-attributed",
+                team_name=ATTRIBUTED_TEAM_NAME,
+                org_id=org,
+            )
+        ]
+    )
+
+
+def _seed_unassigned_latest_work_unit(
+    sink: Any, org: str, *, repo_id: uuid.UUID
+) -> None:
+    feature = {"Feature Delivery.product": 1.0}
+    evidence = f'{{"issues": ["{STALE_ISSUE_ID}"]}}'
+
+    sink.client.insert(
+        "work_unit_investments",
+        [
+            [
+                "wu-stale-clear",
+                FROM_TS,
+                TO_TS,
+                None,
+                "fte_days",
+                100.0,
+                feature,
+                evidence,
+                COMPUTED_AT,
+                org,
+            ]
+        ],
+        column_names=_wui_cols(),
+    )
+
+    sink.write_work_item_team_attributions(
+        [
+            WorkItemTeamAttributionRecord(
+                work_item_id=STALE_ISSUE_ID,
+                provider="jira",
+                source="native_team",
+                is_primary=1,
+                confidence="high",
+                evidence="native_team_key=old-team",
+                computed_at=COMPUTED_AT,
+                repo_id=repo_id,
+                team_id="old-team",
+                team_name="Old Team",
+                org_id=org,
+            ),
+            WorkItemTeamAttributionRecord(
+                work_item_id=STALE_ISSUE_ID,
+                provider="jira",
+                source="unassigned",
+                is_primary=1,
+                confidence="low",
+                evidence="latest snapshot has no owning team",
+                computed_at=datetime(2026, 1, 8, tzinfo=timezone.utc),
+                repo_id=repo_id,
+                team_id=None,
+                team_name=None,
+                org_id=org,
+            ),
+        ]
+    )
+
+
+@pytest.mark.asyncio
+async def test_rest_investment_sankey_resolves_primary_attribution_not_cycle_times(
+    sink,
+):
+    org = f"test-chaos-2833-rest-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    try:
+        _seed_attributed_work_unit(sink, org, repo_id=repo_id)
+
+        team_edges = await investment_queries.fetch_investment_team_edges(
+            sink,
+            start_ts=START,
+            end_ts=END,
+            scope_filter="",
+            scope_params={},
+            org_id=org,
+        )
+        by_team = {row["target"]: float(row["value"]) for row in team_edges}
+        assert by_team.get(ATTRIBUTED_TEAM_NAME) == pytest.approx(100.0), by_team
+        assert "unassigned" not in by_team, by_team
+
+        repo_team_rows = await investment_queries.fetch_investment_repo_team_edges(
+            sink,
+            start_ts=START,
+            end_ts=END,
+            scope_filter="",
+            scope_params={},
+            org_id=org,
+        )
+        assert repo_team_rows, repo_team_rows
+        assert all(row["team"] == ATTRIBUTED_TEAM_NAME for row in repo_team_rows), (
+            repo_team_rows
+        )
+
+        counts = await investment_queries.fetch_investment_unassigned_counts(
+            sink,
+            start_ts=START,
+            end_ts=END,
+            scope_filter="",
+            scope_params={},
+            org_id=org,
+        )
+        assert counts["missing_team"] == 0, counts
+    finally:
+        _cleanup(sink, org)
+
+
+@pytest.mark.asyncio
+async def test_rest_investment_sankey_uses_latest_primary_tuple_with_null_team(
+    sink,
+):
+    org = f"test-chaos-2833-null-latest-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    try:
+        _seed_unassigned_latest_work_unit(sink, org, repo_id=repo_id)
+
+        team_edges = await investment_queries.fetch_investment_team_edges(
+            sink,
+            start_ts=START,
+            end_ts=END,
+            scope_filter="",
+            scope_params={},
+            org_id=org,
+        )
+        by_team = {row["target"]: float(row["value"]) for row in team_edges}
+        assert by_team.get("unassigned") == pytest.approx(100.0), by_team
+        assert "Old Team" not in by_team, by_team
+    finally:
+        _cleanup(sink, org)
+
+
+@pytest.mark.asyncio
+async def test_graphql_sankey_compiler_resolves_same_primary_attribution(sink):
+    """REST/GraphQL parity: compile_sankey's TEAM join must resolve the SAME
+    attributed team label as the REST fetchers above, from the SAME fixture.
+    """
+    from dev_health_ops.api.graphql.sql.compiler import SankeyRequest, compile_sankey
+    from dev_health_ops.api.queries.client import query_dicts
+
+    org = f"test-chaos-2833-graphql-{uuid.uuid4()}"
+    repo_id = uuid.uuid4()
+    try:
+        _seed_attributed_work_unit(sink, org, repo_id=repo_id)
+
+        nodes_qs, edges_qs = compile_sankey(
+            SankeyRequest(
+                path=["theme", "team"],
+                measure="count",
+                start_date=START_DATE,
+                end_date=END_DATE,
+                use_investment=True,
+            ),
+            org_id=org,
+        )
+
+        node_ids_by_dim: dict[str, set[str]] = {}
+        for sql, params in nodes_qs:
+            for row in await query_dicts(sink, sql, params):
+                node_ids_by_dim.setdefault(str(row["dimension"]), set()).add(
+                    str(row["node_id"])
+                )
+
+        team_nodes = node_ids_by_dim.get("TEAM", set())
+        assert ATTRIBUTED_TEAM_NAME in team_nodes, node_ids_by_dim
+        assert "unassigned" not in team_nodes, node_ids_by_dim
+
+        edge_targets: set[str] = set()
+        for sql, params in edges_qs:
+            for row in await query_dicts(sink, sql, params):
+                if str(row["target_dimension"]) == "TEAM":
+                    edge_targets.add(str(row["target"]))
+
+        assert ATTRIBUTED_TEAM_NAME in edge_targets, edge_targets
+        assert "unassigned" not in edge_targets, edge_targets
+    finally:
+        _cleanup(sink, org)

--- a/tests/api/test_investment_team_attribution_sql.py
+++ b/tests/api/test_investment_team_attribution_sql.py
@@ -15,6 +15,13 @@ def assert_team_attribution_sql(sql: str) -> None:
     assert "JSONExtract(structural_evidence_json, 'issues', 'Array(String)')" in sql
     assert "[work_unit_investments.work_unit_id]" in sql
     assert "t.work_item_id = issue_id" in sql
+    # CHAOS-2833: team resolution MUST read the authoritative primary
+    # ClickHouse attribution rows, never the legacy cycle-times rollup.
+    assert "FROM work_item_team_attributions FINAL" in sql
+    assert "is_primary = 1" in sql
+    assert "(work_item_id, computed_at) IN" in sql
+    assert "max(computed_at)" in sql
+    assert "work_item_cycle_times" not in sql
 
 
 @pytest.mark.asyncio
@@ -50,6 +57,40 @@ async def test_investment_team_attribution_sql_scopes_org_and_uses_work_unit_fal
         scope_filter="",
         scope_params={},
         org_id="org-1",
+    )
+
+    assert_team_attribution_sql(str(captured["sql"]))
+    assert captured["params"]["org_id"] == "org-1"
+
+
+@pytest.mark.asyncio
+async def test_investment_quality_stats_team_scope_sql_uses_primary_attribution(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """CHAOS-2833: fetch_investment_quality_stats' team_scope_ids join is the
+    same unit_team pattern duplicated across investment.py -- it must be
+    migrated to the primary attribution source too, not just the edge
+    fetchers covered above.
+    """
+    captured: dict[str, Any] = {"sql": "", "params": {}}
+
+    async def fake_query_dicts(
+        _sink: BaseMetricsSink, sql: str, params: dict[str, Any]
+    ):
+        captured["sql"] = sql
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(investment_queries, "query_dicts", fake_query_dicts)
+
+    await investment_queries.fetch_investment_quality_stats(
+        cast(BaseMetricsSink, object()),
+        start_ts=datetime(2026, 5, 24, tzinfo=timezone.utc),
+        end_ts=datetime(2026, 6, 8, tzinfo=timezone.utc),
+        scope_filter="",
+        scope_params={},
+        org_id="org-1",
+        team_scope_ids=["team-1"],
     )
 
     assert_team_attribution_sql(str(captured["sql"]))

--- a/tests/api/test_work_unit_investments_query.py
+++ b/tests/api/test_work_unit_investments_query.py
@@ -70,6 +70,11 @@ async def test_work_unit_lookup_queries_use_typed_array_params(monkeypatch):
     )
 
     assert "work_item_id IN {work_item_ids:Array(String)}" in captured[0]["query"]
+    assert "FROM work_item_team_attributions FINAL" in captured[0]["query"]
+    assert "is_primary = 1" in captured[0]["query"]
+    assert "(work_item_id, computed_at) IN" in captured[0]["query"]
+    assert "max(computed_at)" in captured[0]["query"]
+    assert "work_item_cycle_times" not in captured[0]["query"]
     assert "%(work_item_ids)s" not in captured[0]["query"]
     assert captured[0]["params"]["work_item_ids"] == [
         "linear:CHAOS-1",

--- a/tests/graphql/test_flow_matrix.py
+++ b/tests/graphql/test_flow_matrix.py
@@ -58,18 +58,23 @@ class TestCompileFlowMatrix:
         assert len(nodes_queries) == 1
         assert len(edges_queries) == 1
 
-    def test_team_edges_use_asymmetric_cooccurrence(self) -> None:
-        """TEAM edges come from a self-join on work_item_cycle_times counting
-        the SOURCE team's distinct work items per shared scope+day — so edge
-        (A, B).value counts A's items, (B, A).value counts B's, producing an
-        asymmetric matrix whenever team volumes differ.
+    def test_team_edges_use_primary_attribution_and_asymmetric_cooccurrence(
+        self,
+    ) -> None:
+        """TEAM edges bridge cycle-time activity through primary attribution.
+
+        The SOURCE team's distinct work items per shared scope+day still make
+        edge (A, B).value count A's items and (B, A).value count B's, producing
+        an asymmetric matrix whenever team volumes differ.
         """
         _, edges_queries = compile_flow_matrix(_req("team"), org_id="org-1")
         edge_sql, _params = edges_queries[0]
         assert "'TEAM' AS source_dimension" in edge_sql
         assert "'TEAM' AS target_dimension" in edge_sql
-        assert "work_item_cycle_times AS a" in edge_sql
-        assert "INNER JOIN work_item_cycle_times AS b" in edge_sql
+        assert "FROM work_item_cycle_times AS wct FINAL" in edge_sql
+        assert "FROM work_item_team_attributions FINAL" in edge_sql
+        assert "is_primary = 1" in edge_sql
+        assert "INNER JOIN team_activity AS b" in edge_sql
         assert "a.work_scope_id = b.work_scope_id" in edge_sql
         assert "a.day = b.day" in edge_sql
         # asymmetric: count source-side items only, not product of both
@@ -82,7 +87,9 @@ class TestCompileFlowMatrix:
         stay consistent after the adapter's prefix-strip."""
         nodes_queries, _ = compile_flow_matrix(_req("team"), org_id="org-1")
         nodes_sql, _ = nodes_queries[0]
-        assert "work_item_cycle_times" in nodes_sql
+        assert "FROM work_item_cycle_times AS wct FINAL" in nodes_sql
+        assert "FROM work_item_team_attributions FINAL" in nodes_sql
+        assert "is_primary = 1" in nodes_sql
         assert "'TEAM' AS dimension" in nodes_sql
 
     @pytest.mark.parametrize("dim", ["team", "repo", "work_type"])

--- a/tests/test_quadrant.py
+++ b/tests/test_quadrant.py
@@ -81,18 +81,19 @@ async def test_quadrant_resolves_team_uuid_label_from_team_catalog(monkeypatch):
     async def _fake_client(_db_url):
         yield object()
 
-    async def _fake_metric(
+    async def _unexpected_rollup_metric(*_args, **_kwargs):
+        raise AssertionError("cycle_throughput team axes must use primary attribution")
+
+    async def _fake_attributed_metric(
         _sink,
         *,
-        value_expr,
+        metric,
         start_day,
         end_day,
         bucket,
-        entity_expr,
-        label_expr,
         **_,
     ):
-        value = 100.0 if "loc_touched" in value_expr else 8.0
+        value = 100.0 if metric == "cycle_time" else 8.0
         return [
             {
                 "bucket": date(2024, 1, 1),
@@ -110,7 +111,12 @@ async def test_quadrant_resolves_team_uuid_label_from_team_catalog(monkeypatch):
         "dev_health_ops.api.services.quadrant.clickhouse_client", _fake_client
     )
     monkeypatch.setattr(
-        "dev_health_ops.api.services.quadrant.fetch_quadrant_metric", _fake_metric
+        "dev_health_ops.api.services.quadrant.fetch_quadrant_metric",
+        _unexpected_rollup_metric,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.fetch_work_item_team_quadrant_metric",
+        _fake_attributed_metric,
     )
     monkeypatch.setattr(
         "dev_health_ops.api.services.quadrant.query_dicts",
@@ -197,3 +203,59 @@ async def test_churn_quadrant_forces_repo_grain(monkeypatch):
     assert any("prs_merged" in expr for expr in captured_value_exprs)
     # Repo labels pass through untouched (no team-catalog resolution).
     assert response.points[0].entity_label == "checkout-service"
+
+
+@pytest.mark.asyncio
+async def test_wip_quadrant_keeps_rollup_throughput_source(monkeypatch):
+    @asynccontextmanager
+    async def _fake_client(_db_url):
+        yield object()
+
+    captured_metrics: list[str] = []
+
+    async def _fake_metric(_sink, *, value_expr, **_):
+        captured_metrics.append(value_expr)
+        return [
+            {
+                "bucket": date(2024, 1, 1),
+                "entity_id": "team-a",
+                "entity_label": "team-a",
+                "value": 8.0,
+            }
+        ]
+
+    async def _unexpected_attributed_metric(*_args, **_kwargs):
+        raise AssertionError("only cycle_throughput should use attributed raw rows")
+
+    async def _fake_query_dicts(*_args, **_kwargs):
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.clickhouse_client", _fake_client
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.fetch_quadrant_metric", _fake_metric
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.fetch_work_item_team_quadrant_metric",
+        _unexpected_attributed_metric,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.query_dicts",
+        _fake_query_dicts,
+        raising=False,
+    )
+
+    await build_quadrant_response(
+        db_url="clickhouse://test",
+        org_id="test-org",
+        type="wip_throughput",
+        scope_type="team",
+        scope_id="",
+        range_days=30,
+        bucket="week",
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 1, 8),
+    )
+
+    assert any("items_completed" in metric for metric in captured_metrics)


### PR DESCRIPTION
## Summary
- Resolve Investment Sankey/coverage team labels from latest primary ClickHouse work_item_team_attributions instead of stale work_item_cycle_times rollups.
- Apply the same WITA source to GraphQL TEAM flow/chord, team Cycle Time x Throughput quadrant, work-unit investment evidence, TeamLoader, and aggregated throughput flame labels.
- Preserve Unassigned throughput totals for latest-null/no-WITA rows and update team-attribution docs to match latest-primary semantics.

## Verification
- bash ci/local_validate.sh
- pytest tests/api/test_investment_team_attribution_live.py -m clickhouse
- Manual live ClickHouse driver covering assigned, no-WITA, and latest-null unassigned throughput/loader behavior
- Oracle review: PASS after unassigned throughput fix

SCREENSHOT-WAIVER: Backend/API/query/docs-only change; no rendered web UI changed.

Linear: CHAOS-2833