### PR TITLE
feat(providers): instrument GitHub deployments (CHAOS-2805)

### DIFF
--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -346,86 +346,81 @@ def _fetch_github_workflow_runs_sync(gh_repo, repo_id, max_runs, since):
     return runs
 
 
-def _resolve_github_deployment_pr(gh_repo, sha, gate):
-    """Resolve the merged PR for a deployed commit via /commits/{sha}/pulls.
-
-    Costs up to two gated API calls per deployment. Failure-soft: any
-    lookup error leaves the deployment without PR attribution rather than
-    failing the sync.
-    """
-    if not sha:
-        return None, None
-    try:
-        if gate is not None:
-            gate.wait_sync()
-        commit = gh_repo.get_commit(sha)
-        if gate is not None:
-            gate.wait_sync()
-        pulls = list(commit.get_pulls()[:10])
-    except Exception as exc:
-        logging.debug("Failed PR lookup for deployed commit %s: %s", sha, exc)
-        return None, None
-    merged = [pr for pr in pulls if getattr(pr, "merged_at", None) is not None]
-    # Prefer the PR that directly merged this commit: get_pulls() also
-    # returns PRs that merely contain the SHA (e.g. stacked merges).
-    direct = [pr for pr in merged if getattr(pr, "merge_commit_sha", None) == sha]
-    chosen = (
-        direct[0]
-        if direct
-        else (merged[0] if merged else (pulls[0] if pulls else None))
-    )
-    if chosen is None:
-        return None, None
-    return getattr(chosen, "number", None), getattr(chosen, "merged_at", None)
-
-
-def _fetch_github_deployments_sync(gh_repo, repo_id, max_deployments, since, gate=None):
-    gate = BaseGitProcessor.ensure_gate(gate)
+async def _fetch_github_deployments_async(
+    connector,
+    owner: str,
+    repo_name: str,
+    repo_id,
+    max_deployments: int | None,
+    since: datetime | None,
+    usage_sink: list[dict[str, Any]] | None = None,
+) -> list[Deployment]:
     deployments: list[Deployment] = []
-    if not hasattr(gh_repo, "get_deployments"):
-        return deployments
+    client = _github_code_client_from_connector(connector)
     release_objects = []
-    if hasattr(gh_repo, "get_releases"):
+    try:
         try:
-            release_objects = list(gh_repo.get_releases()[:max_deployments])
+            release_objects = await client.get_deployment_releases(
+                owner,
+                repo_name,
+                max_releases=max_deployments,
+            )
         except Exception as exc:
             logging.debug("Failed to fetch GitHub releases for release_ref: %s", exc)
-    try:
-        raw_deployments = list(gh_repo.get_deployments()[:max_deployments])
-    except Exception as exc:
-        logging.debug("Failed to fetch deployments: %s", exc)
-        return deployments
-
-    for dep in raw_deployments:
-        created_at = getattr(dep, "created_at", None)
-        if not isinstance(created_at, datetime):
-            continue
-        if since is not None and created_at.astimezone(timezone.utc) < since:
-            continue
-        enrichment = get_release_ref_enrichment(
-            dep,
-            "github",
-            releases=release_objects,
-        )
-        pr_number, pr_merged_at = _resolve_github_deployment_pr(
-            gh_repo, getattr(dep, "sha", None), gate
-        )
-        deployments.append(
-            build_deployment(
-                repo_id=repo_id,
-                deployment_id=str(getattr(dep, "id", "")),
-                status=getattr(dep, "state", None),
-                environment=getattr(dep, "environment", None),
-                started_at=created_at,
-                finished_at=None,
-                deployed_at=created_at,
-                merged_at=pr_merged_at,
-                pull_request_number=pr_number,
-                release_ref=enrichment.release_ref,
-                release_ref_confidence=enrichment.confidence,
+        try:
+            raw_deployments = await client.get_deployments(
+                owner,
+                repo_name,
+                max_deployments=max_deployments,
             )
-        )
-    return deployments
+        except Exception as exc:
+            logging.debug("Failed to fetch deployments: %s", exc)
+            return deployments
+
+        for dep in raw_deployments:
+            created_at = dep.created_at
+            if not isinstance(created_at, datetime):
+                continue
+            if since is not None and created_at.astimezone(timezone.utc) < since:
+                continue
+            enrichment = get_release_ref_enrichment(
+                dep,
+                "github",
+                releases=release_objects,
+            )
+            pr_number, pr_merged_at = await client.get_deployment_pull_request(
+                owner, repo_name, dep.sha
+            )
+            deployments.append(
+                build_deployment(
+                    repo_id=repo_id,
+                    deployment_id=dep.deployment_id,
+                    status=dep.state,
+                    environment=dep.environment,
+                    started_at=created_at,
+                    finished_at=None,
+                    deployed_at=created_at,
+                    merged_at=pr_merged_at,
+                    pull_request_number=pr_number,
+                    release_ref=enrichment.release_ref,
+                    release_ref_confidence=enrichment.confidence,
+                )
+            )
+        return deployments
+    finally:
+        drained = client.drain_usage_observations()
+        if usage_sink is not None:
+            usage_sink.extend(drained)
+        elif drained:
+            logging.debug(
+                "_fetch_github_deployments_async: drained %d deployments usage "
+                "observation(s) for %s/%s with no adapter-owned sink (legacy "
+                "entry point) -- logging only, not persisted",
+                len(drained),
+                owner,
+                repo_name,
+            )
+        await client.close()
 
 
 def _fetch_github_incidents_sync(gh_repo, repo_id, max_issues, since):
@@ -1824,13 +1819,14 @@ async def process_github_repo(
 
             if sync_deployments:
                 logging.info("Fetching deployments from GitHub...")
-                deployments = await loop.run_in_executor(
-                    None,
-                    _fetch_github_deployments_sync,
-                    gh_repo,
+                deployments = await _fetch_github_deployments_async(
+                    connector,
+                    owner,
+                    repo_name,
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink=usage_sink,
                 )
                 deployments = _filter_after(
                     deployments, until, "deployed_at", "started_at"
@@ -1949,6 +1945,7 @@ async def process_github_repos_batch(
     blame_only: bool = False,
     backfill_missing: bool = True,
     since: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> None:
     """
     Process multiple GitHub repositories using batch processing with
@@ -2168,15 +2165,15 @@ async def process_github_repos_batch(
 
         if sync_deployments:
             try:
-                if gh_repo is None:
-                    gh_repo = connector.github.get_repo(repo_info.full_name)
-                deployments = await loop.run_in_executor(
-                    None,
-                    _fetch_github_deployments_sync,
-                    gh_repo,
+                batch_owner, _, batch_repo = repo_info.full_name.partition("/")
+                deployments = await _fetch_github_deployments_async(
+                    connector,
+                    batch_owner,
+                    batch_repo,
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink=usage_sink,
                 )
                 if deployments:
                     await ingestion_sink.insert_deployments(deployments)

--- a/src/dev_health_ops/providers/github/budget.py
+++ b/src/dev_health_ops/providers/github/budget.py
@@ -351,15 +351,12 @@ def _fallback_credential_scope(
 # CHAOS-2773 CS8 -- so their markers stay empty per the plan's "never flip a
 # marker before its traffic" rule (§3).
 #
-# `security` (REST_CORE) is the first GitHub code-dataset family fully off the
-# frozen connector (CHAOS-2773 CS3): `providers/github/code_client.py::
-# GitHubCodeClient` fetches Dependabot alerts, code-scanning alerts, and
-# security advisories via `InstrumentedRESTCore` and labels every operation
-# with the explicit `"security:"` prefix, so this marker documents live
-# traffic (the CS1 explicit-prefix short-circuit resolves those labels
-# directly, irrespective of `operation_markers`) -- populated now that the
-# family's fetch path is actually instrumented, per the plan's "never flip a
-# marker before its traffic" rule (§3).
+# `security` (REST_CORE) and deployments REST_CORE now fetch through
+# `providers/github/code_client.py::GitHubCodeClient`, labeling operations
+# with explicit family prefixes so CS1's resolver short-circuit resolves them
+# directly. deployments CONTENTS_BLOB remains empty/deferred until artifact or
+# blob traffic is migrated; markers are populated only for live instrumented
+# traffic.
 GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("repo", BudgetDimension.REST_CORE),
     UsageRouteFamily("git", BudgetDimension.REST_CORE),
@@ -378,7 +375,9 @@ GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("cicd", BudgetDimension.CONTENTS_BLOB),
     UsageRouteFamily("tests", BudgetDimension.REST_CORE),
     UsageRouteFamily("tests", BudgetDimension.CONTENTS_BLOB),
-    UsageRouteFamily("deployments", BudgetDimension.REST_CORE),
+    UsageRouteFamily(
+        "deployments", BudgetDimension.REST_CORE, operation_markers=("deployments:",)
+    ),
     UsageRouteFamily("deployments", BudgetDimension.CONTENTS_BLOB),
     UsageRouteFamily(
         "security", BudgetDimension.REST_CORE, operation_markers=("security:",)

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -23,7 +23,10 @@ Behavior parity with the connector is pinned by
 from __future__ import annotations
 
 import logging
+from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime
+from math import ceil
 from typing import Any
 
 import httpx
@@ -51,9 +54,29 @@ logger = logging.getLogger(__name__)
 
 # CS1 resolver explicit-prefix short-circuit (providers/usage.py::
 # OperationResolver): every operation this client labels resolves DIRECTLY to
-# the "security" route family (providers/github/budget.py's
+# the matching route family (providers/github/budget.py's
 # GITHUB_USAGE_ROUTE_FAMILIES entry), bypassing the substring marker scan.
 SECURITY_ROUTE_FAMILY = "security"
+DEPLOYMENTS_ROUTE_FAMILY = "deployments"
+_GITHUB_DEPLOYMENTS_PER_PAGE = 100
+
+
+@dataclass(frozen=True)
+class GitHubReleaseData:
+    tag_name: str | None
+
+
+@dataclass(frozen=True)
+class GitHubDeploymentData:
+    deployment_id: str
+    state: str | None
+    environment: str | None
+    created_at: datetime | None
+    sha: str | None
+    ref: str | None
+    tag: str | None
+    tag_name: str | None
+    payload: Mapping[str, Any] | None
 
 
 def _lowered_github_headers(response: httpx.Response) -> dict[str, str]:
@@ -226,6 +249,68 @@ def _security_advisory_from_item(item: dict[str, Any]) -> SecurityAlertData:
     )
 
 
+def _release_from_item(item: Mapping[str, Any]) -> GitHubReleaseData:
+    tag_name = item.get("tag_name")
+    return GitHubReleaseData(tag_name=str(tag_name) if tag_name is not None else None)
+
+
+def _deployment_from_item(item: Mapping[str, Any]) -> GitHubDeploymentData:
+    payload = item.get("payload")
+    deployment_id = item.get("id")
+    sha = item.get("sha")
+    ref = item.get("ref")
+    tag = item.get("tag")
+    tag_name = item.get("tag_name")
+    state = item.get("state") or item.get("status")
+    environment = item.get("environment")
+    return GitHubDeploymentData(
+        deployment_id=str(deployment_id or ""),
+        state=str(state) if state is not None else None,
+        environment=str(environment) if environment is not None else None,
+        created_at=_parse_alert_datetime(item.get("created_at")),
+        sha=str(sha) if sha is not None else None,
+        ref=str(ref) if ref is not None else None,
+        tag=str(tag) if tag is not None else None,
+        tag_name=str(tag_name) if tag_name is not None else None,
+        payload=payload if isinstance(payload, Mapping) else None,
+    )
+
+
+def _pull_request_merged_at(item: Mapping[str, Any]) -> datetime | None:
+    return _parse_alert_datetime(item.get("merged_at"))
+
+
+def _pull_request_number(item: Mapping[str, Any]) -> int | None:
+    raw_number = item.get("number")
+    try:
+        return int(raw_number) if raw_number is not None else None
+    except (TypeError, ValueError):
+        return None
+
+
+def _choose_deployment_pull_request(
+    pulls: list[Mapping[str, Any]], sha: str
+) -> tuple[int | None, datetime | None]:
+    merged = [pull for pull in pulls if _pull_request_merged_at(pull) is not None]
+    direct = [pull for pull in merged if pull.get("merge_commit_sha") == sha]
+    chosen = (
+        direct[0]
+        if direct
+        else (merged[0] if merged else (pulls[0] if pulls else None))
+    )
+    if chosen is None:
+        return None, None
+    return _pull_request_number(chosen), _pull_request_merged_at(chosen)
+
+
+def _page_cap_for_limit(
+    limit: int | None, per_page: int = _GITHUB_DEPLOYMENTS_PER_PAGE
+) -> int:
+    if limit is None:
+        return 100
+    return max(1, ceil(limit / per_page))
+
+
 class GitHubCodeClient:
     """Instrumented httpx client for GitHub code-dataset families
     (CHAOS-2773 CS3+). CS3 exposes the ``security`` family only.
@@ -327,6 +412,73 @@ class GitHubCodeClient:
             build=_security_advisory_from_item,
         )
 
+    async def get_deployment_releases(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        max_releases: int | None = None,
+    ) -> list[GitHubReleaseData]:
+        operation = f"{DEPLOYMENTS_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/releases"
+        items = await self._core.paginate_link_header(
+            f"/repos/{owner}/{repo}/releases",
+            operation=operation,
+            params={"per_page": _GITHUB_DEPLOYMENTS_PER_PAGE},
+            max_pages=_page_cap_for_limit(max_releases),
+        )
+        if max_releases is not None:
+            items = items[:max_releases]
+        return [_release_from_item(item) for item in items if isinstance(item, Mapping)]
+
+    async def get_deployments(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        max_deployments: int | None = None,
+    ) -> list[GitHubDeploymentData]:
+        operation = f"{DEPLOYMENTS_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/deployments"
+        items = await self._core.paginate_link_header(
+            f"/repos/{owner}/{repo}/deployments",
+            operation=operation,
+            params={"per_page": _GITHUB_DEPLOYMENTS_PER_PAGE},
+            max_pages=_page_cap_for_limit(max_deployments),
+        )
+        if max_deployments is not None:
+            items = items[:max_deployments]
+        return [
+            _deployment_from_item(item) for item in items if isinstance(item, Mapping)
+        ]
+
+    async def get_deployment_pull_request(
+        self,
+        owner: str,
+        repo: str,
+        sha: str | None,
+    ) -> tuple[int | None, datetime | None]:
+        if not sha:
+            return None, None
+        operation = (
+            f"{DEPLOYMENTS_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/commits/{sha}/pulls"
+        )
+        try:
+            response = await self._core.request(
+                "GET",
+                f"/repos/{owner}/{repo}/commits/{sha}/pulls",
+                operation=operation,
+                params={"per_page": 10},
+                headers={"Accept": "application/vnd.github.groot-preview+json"},
+            )
+            pulls = response.json()
+        except Exception as exc:
+            logger.debug("Failed PR lookup for deployed commit %s: %s", sha, exc)
+            return None, None
+        if not isinstance(pulls, list):
+            logger.debug("Unexpected PR lookup payload for deployed commit %s", sha)
+            return None, None
+        pull_items = [pull for pull in pulls if isinstance(pull, Mapping)]
+        return _choose_deployment_pull_request(pull_items, sha)
+
     async def _get_security_alerts(
         self,
         owner: str,
@@ -382,6 +534,9 @@ class GitHubCodeClient:
 
 
 __all__ = [
+    "DEPLOYMENTS_ROUTE_FAMILY",
     "GitHubCodeClient",
+    "GitHubDeploymentData",
+    "GitHubReleaseData",
     "SECURITY_ROUTE_FAMILY",
 ]

--- a/tests/providers/test_github_code_client_deployments.py
+++ b/tests/providers/test_github_code_client_deployments.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import AsyncMock
+
+import httpx
+import pytest
+
+from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.code_client import GitHubCodeClient
+
+
+def _client(transport: httpx.AsyncBaseTransport) -> GitHubCodeClient:
+    return GitHubCodeClient(auth=GitHubAuth(token="unit-test-pat"), transport=transport)
+
+
+def _sequence(
+    responses: list[httpx.Response],
+) -> tuple[httpx.MockTransport, dict[str, int]]:
+    calls = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        response = responses[min(calls["n"], len(responses) - 1)]
+        calls["n"] += 1
+        return response
+
+    return httpx.MockTransport(handler), calls
+
+
+def test_deployments_send_token_and_accept_headers() -> None:
+    asyncio.run(_test_deployments_send_token_and_accept_headers())
+
+
+async def _test_deployments_send_token_and_accept_headers() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=[])
+
+    client = _client(httpx.MockTransport(handler))
+    await client.get_deployments("acme", "widgets")
+    await client.close()
+
+    assert seen[0].headers["Authorization"] == "token unit-test-pat"
+    assert seen[0].headers["Accept"] == "application/vnd.github+json"
+
+
+def test_deployments_follow_link_header_pages() -> None:
+    asyncio.run(_test_deployments_follow_link_header_pages())
+
+
+async def _test_deployments_follow_link_header_pages() -> None:
+    page1 = httpx.Response(
+        200,
+        json=[{"id": 1, "created_at": "2026-01-01T00:00:00Z"}],
+        headers={
+            "Link": (
+                "<https://api.github.com/repos/acme/widgets/deployments?page=2>; "
+                'rel="next"'
+            )
+        },
+    )
+    page2 = httpx.Response(200, json=[{"id": 2, "created_at": "2026-01-02T00:00:00Z"}])
+    transport, calls = _sequence([page1, page2])
+    client = _client(transport)
+
+    deployments = await client.get_deployments("acme", "widgets")
+    await client.close()
+
+    assert [deployment.deployment_id for deployment in deployments] == ["1", "2"]
+    assert calls["n"] == 2
+
+
+def test_deployment_first_request_params_followups_use_link_url() -> None:
+    asyncio.run(_test_deployment_first_request_params_followups_use_link_url())
+
+
+async def _test_deployment_first_request_params_followups_use_link_url() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if len(seen) == 1:
+            return httpx.Response(
+                200,
+                json=[{"id": 1, "created_at": "2026-01-01T00:00:00Z"}],
+                headers={
+                    "Link": (
+                        "<https://api.github.com/repos/acme/widgets/deployments?page=2>; "
+                        'rel="next"'
+                    )
+                },
+            )
+        return httpx.Response(
+            200, json=[{"id": 2, "created_at": "2026-01-02T00:00:00Z"}]
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    await client.get_deployments("acme", "widgets")
+    await client.close()
+
+    assert seen[0].url.params["per_page"] == "100"
+    assert "per_page" not in seen[1].url.params
+
+
+def test_deployments_max_limit_bounds_pagination() -> None:
+    asyncio.run(_test_deployments_max_limit_bounds_pagination())
+
+
+async def _test_deployments_max_limit_bounds_pagination() -> None:
+    page1 = httpx.Response(
+        200,
+        json=[{"id": 1, "created_at": "2026-01-01T00:00:00Z"}],
+        headers={
+            "Link": (
+                "<https://api.github.com/repos/acme/widgets/deployments?page=2>; "
+                'rel="next"'
+            )
+        },
+    )
+    page2 = httpx.Response(200, json=[{"id": 2, "created_at": "2026-01-02T00:00:00Z"}])
+    transport, calls = _sequence([page1, page2])
+    client = _client(transport)
+
+    deployments = await client.get_deployments("acme", "widgets", max_deployments=1)
+    await client.close()
+
+    assert [deployment.deployment_id for deployment in deployments] == ["1"]
+    assert calls["n"] == 1
+
+
+def test_deployment_releases_max_limit_bounds_pagination() -> None:
+    asyncio.run(_test_deployment_releases_max_limit_bounds_pagination())
+
+
+async def _test_deployment_releases_max_limit_bounds_pagination() -> None:
+    page1 = httpx.Response(
+        200,
+        json=[{"tag_name": "v1"}],
+        headers={
+            "Link": (
+                "<https://api.github.com/repos/acme/widgets/releases?page=2>; "
+                'rel="next"'
+            )
+        },
+    )
+    page2 = httpx.Response(200, json=[{"tag_name": "v2"}])
+    transport, calls = _sequence([page1, page2])
+    client = _client(transport)
+
+    releases = await client.get_deployment_releases("acme", "widgets", max_releases=1)
+    await client.close()
+
+    assert [release.tag_name for release in releases] == ["v1"]
+    assert calls["n"] == 1
+
+
+def test_deployment_field_mapping() -> None:
+    asyncio.run(_test_deployment_field_mapping())
+
+
+async def _test_deployment_field_mapping() -> None:
+    payload = [
+        {
+            "id": 99,
+            "state": "success",
+            "environment": "prod",
+            "created_at": "2026-01-01T00:00:00Z",
+            "sha": "abc123",
+            "ref": "v1.2.3",
+            "payload": {"release_tag": "v1.2.3"},
+        }
+    ]
+    client = _client(httpx.MockTransport(lambda r: httpx.Response(200, json=payload)))
+
+    deployments = await client.get_deployments("acme", "widgets")
+    await client.close()
+
+    deployment = deployments[0]
+    assert deployment.deployment_id == "99"
+    assert deployment.state == "success"
+    assert deployment.environment == "prod"
+    assert deployment.created_at == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert deployment.sha == "abc123"
+    assert deployment.ref == "v1.2.3"
+    assert deployment.payload == {"release_tag": "v1.2.3"}
+
+
+def test_deployment_pr_lookup_prefers_direct_merge() -> None:
+    asyncio.run(_test_deployment_pr_lookup_prefers_direct_merge())
+
+
+async def _test_deployment_pr_lookup_prefers_direct_merge() -> None:
+    pulls: list[dict[str, Any]] = [
+        {
+            "number": 100,
+            "merged_at": "2026-01-02T00:00:00Z",
+            "merge_commit_sha": "other",
+        },
+        {
+            "number": 42,
+            "merged_at": "2026-01-03T00:00:00Z",
+            "merge_commit_sha": "abc123",
+        },
+    ]
+    client = _client(httpx.MockTransport(lambda r: httpx.Response(200, json=pulls)))
+
+    number, merged_at = await client.get_deployment_pull_request(
+        "acme", "widgets", "abc123"
+    )
+    await client.close()
+
+    assert number == 42
+    assert merged_at == datetime(2026, 1, 3, tzinfo=timezone.utc)
+
+
+def test_deployment_pr_lookup_failure_is_soft() -> None:
+    asyncio.run(_test_deployment_pr_lookup_failure_is_soft())
+
+
+async def _test_deployment_pr_lookup_failure_is_soft() -> None:
+    client = _client(
+        httpx.MockTransport(lambda r: httpx.Response(404, json={"message": "missing"}))
+    )
+
+    assert await client.get_deployment_pull_request("acme", "widgets", "abc") == (
+        None,
+        None,
+    )
+    await client.close()
+
+
+def test_deployments_rate_limited_403_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    asyncio.run(_test_deployments_rate_limited_403_retries(monkeypatch))
+
+
+async def _test_deployments_rate_limited_403_retries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr(
+        "dev_health_ops.providers._http.asyncio.sleep", AsyncMock(return_value=None)
+    )
+    limited = httpx.Response(
+        403,
+        headers={"Retry-After": "0"},
+        json={"message": "You have exceeded a secondary rate limit."},
+    )
+    ok = httpx.Response(200, json=[{"id": 5, "created_at": "2026-01-01T00:00:00Z"}])
+    transport, calls = _sequence([limited, ok])
+    client = _client(transport)
+
+    deployments = await client.get_deployments("acme", "widgets")
+    await client.close()
+
+    assert [deployment.deployment_id for deployment in deployments] == ["5"]
+    assert calls["n"] == 2
+
+
+def test_deployments_usage_resolves_to_deployments_family() -> None:
+    asyncio.run(_test_deployments_usage_resolves_to_deployments_family())
+
+
+async def _test_deployments_usage_resolves_to_deployments_family() -> None:
+    client = _client(httpx.MockTransport(lambda r: httpx.Response(200, json=[])))
+
+    await client.get_deployments("acme", "widgets")
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert len(observations) == 1
+    assert observations[0]["route_family"] == "deployments"
+    assert observations[0]["request_count"] == 1

--- a/tests/test_deployment_pr_inference.py
+++ b/tests/test_deployment_pr_inference.py
@@ -8,9 +8,12 @@ the exact label ``incident`` with no diagnosability.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import datetime, timezone
 from unittest.mock import Mock
+
+import pytest
 
 # Initialize the connectors package before processors to avoid the
 # pre-existing providers._base <-> connectors circular import when this file
@@ -19,9 +22,8 @@ import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.connectors.utils.rest import GitLabRESTClient
 from dev_health_ops.processors.base_git import resolve_incident_labels
 from dev_health_ops.processors.github import (
-    _fetch_github_deployments_sync,
+    _fetch_github_deployments_async,
     _fetch_github_incidents_sync,
-    _resolve_github_deployment_pr,
 )
 from dev_health_ops.processors.gitlab import (
     _fetch_gitlab_incidents_sync,
@@ -41,82 +43,63 @@ class _NoWaitGate:
 
 
 class TestGitHubDeploymentPRInference:
-    def test_resolves_merged_pr(self) -> None:
-        merged_pr = Mock(number=42, merged_at=NOW, merge_commit_sha="abc123")
-        open_pr = Mock(number=43, merged_at=None)
-        commit = Mock()
-        commit.get_pulls.return_value = [open_pr, merged_pr]
-        gh_repo = Mock()
-        gh_repo.get_commit.return_value = commit
-        gate = _NoWaitGate()
+    def test_deployments_carry_pr_attribution(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        asyncio.run(self._test_deployments_carry_pr_attribution(monkeypatch))
 
-        number, merged_at = _resolve_github_deployment_pr(gh_repo, "abc123", gate)
+    async def _test_deployments_carry_pr_attribution(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from dev_health_ops.providers.github.code_client import GitHubDeploymentData
 
-        assert (number, merged_at) == (42, NOW)
-        gh_repo.get_commit.assert_called_once_with("abc123")
-        assert gate.waits == 2
+        class FakeDeploymentClient:
+            def __init__(self) -> None:
+                self.closed = False
 
-    def test_prefers_pr_that_directly_merged_the_sha(self) -> None:
-        """get_pulls() also returns PRs that merely contain the SHA
-        (stacked merges); the direct merger must win regardless of order."""
-        containing_pr = Mock(number=100, merged_at=NOW, merge_commit_sha="other")
-        direct_pr = Mock(number=42, merged_at=NOW, merge_commit_sha="abc123")
-        commit = Mock()
-        commit.get_pulls.return_value = [containing_pr, direct_pr]
-        gh_repo = Mock()
-        gh_repo.get_commit.return_value = commit
+            async def get_deployment_releases(self, owner, repo_name, *, max_releases):
+                return []
 
-        number, _ = _resolve_github_deployment_pr(gh_repo, "abc123", _NoWaitGate())
+            async def get_deployments(self, owner, repo_name, *, max_deployments):
+                return [
+                    GitHubDeploymentData(
+                        deployment_id="99",
+                        state="success",
+                        environment="prod",
+                        created_at=NOW,
+                        sha="abc123",
+                        ref=None,
+                        tag=None,
+                        tag_name=None,
+                        payload=None,
+                    )
+                ]
 
-        assert number == 42
+            async def get_deployment_pull_request(self, owner, repo_name, sha):
+                return 42, NOW
 
-    def test_falls_back_to_first_pr_when_none_merged(self) -> None:
-        open_pr = Mock(number=7, merged_at=None)
-        commit = Mock()
-        commit.get_pulls.return_value = [open_pr]
-        gh_repo = Mock()
-        gh_repo.get_commit.return_value = commit
+            def drain_usage_observations(self):
+                return [{"route_family": "deployments", "request_count": 3}]
 
-        number, merged_at = _resolve_github_deployment_pr(
-            gh_repo, "abc123", _NoWaitGate()
+            async def close(self) -> None:
+                self.closed = True
+
+        fake_client = FakeDeploymentClient()
+        monkeypatch.setattr(
+            "dev_health_ops.processors.github._github_code_client_from_connector",
+            lambda connector: fake_client,
         )
+        usage_sink: list[dict[str, object]] = []
 
-        assert (number, merged_at) == (7, None)
-
-    def test_no_sha_skips_lookup(self) -> None:
-        gh_repo = Mock()
-        assert _resolve_github_deployment_pr(gh_repo, None, _NoWaitGate()) == (
-            None,
-            None,
-        )
-        gh_repo.get_commit.assert_not_called()
-
-    def test_lookup_failure_is_soft(self) -> None:
-        gh_repo = Mock()
-        gh_repo.get_commit.side_effect = RuntimeError("boom")
-        assert _resolve_github_deployment_pr(gh_repo, "abc", _NoWaitGate()) == (
-            None,
-            None,
-        )
-
-    def test_deployments_carry_pr_attribution(self) -> None:
-        dep = Mock(id=99, state="success", environment="prod", created_at=NOW)
-        dep.sha = "abc123"
-        merged_pr = Mock(number=42, merged_at=NOW)
-        commit = Mock()
-        commit.get_pulls.return_value = [merged_pr]
-        gh_repo = Mock()
-        gh_repo.get_deployments.return_value = [dep]
-        gh_repo.get_releases.return_value = []
-        gh_repo.get_commit.return_value = commit
-
-        deployments = _fetch_github_deployments_sync(
-            gh_repo, REPO_ID, 10, None, _NoWaitGate()
+        deployments = await _fetch_github_deployments_async(
+            Mock(), "acme", "widgets", REPO_ID, 10, None, usage_sink=usage_sink
         )
 
         assert len(deployments) == 1
         assert deployments[0].pull_request_number == 42
         assert deployments[0].merged_at == NOW
+        assert usage_sink == [{"route_family": "deployments", "request_count": 3}]
+        assert fake_client.closed is True
 
 
 class TestGitLabDeploymentMRInference:

--- a/tests/test_github_batch_deployments_usage_sink.py
+++ b/tests/test_github_batch_deployments_usage_sink.py
@@ -1,0 +1,92 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from dev_health_ops.processors import github as github_processor
+
+
+def test_batch_deployments_threads_usage_sink(monkeypatch: pytest.MonkeyPatch) -> None:
+    asyncio.run(_test_batch_deployments_threads_usage_sink(monkeypatch))
+
+
+async def _test_batch_deployments_threads_usage_sink(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    repo = SimpleNamespace(
+        id=1001,
+        name="widgets",
+        full_name="acme/widgets",
+        url="https://example.com/acme/widgets",
+        default_branch="main",
+        language="Python",
+    )
+    usage_sink: list[dict[str, Any]] = []
+    seen_sink: list[list[dict[str, Any]] | None] = []
+
+    class DummyStore:
+        org_id = "org-1"
+
+        async def insert_repo(self, repo_obj: object) -> None:
+            return None
+
+        async def insert_deployments(self, deployments: object) -> None:
+            return None
+
+    class DummyConnector:
+        def __init__(self, token: str) -> None:
+            self.token = token
+
+        def list_repositories(self, **kwargs: object) -> list[object]:
+            return [repo]
+
+        def close(self) -> None:
+            return None
+
+        def __enter__(self) -> DummyConnector:
+            return self
+
+        def __exit__(self, exc_type: object, exc: object, tb: object) -> None:
+            self.close()
+
+    async def fake_fetch_deployments(
+        connector: object,
+        owner: str,
+        repo_name: str,
+        repo_id: object,
+        max_deployments: int | None,
+        since: object,
+        usage_sink: list[dict[str, Any]] | None = None,
+    ) -> list[object]:
+        seen_sink.append(usage_sink)
+        if usage_sink is not None:
+            usage_sink.append({"route_family": "deployments", "request_count": 1})
+        return []
+
+    monkeypatch.setattr(github_processor, "CONNECTORS_AVAILABLE", True)
+    monkeypatch.setattr(github_processor, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        github_processor, "_fetch_github_deployments_async", fake_fetch_deployments
+    )
+
+    await github_processor.process_github_repos_batch(
+        store=DummyStore(),
+        token="unit-test-pat",
+        org_name="acme",
+        pattern="acme/*",
+        sync_git=False,
+        sync_prs=False,
+        sync_cicd=False,
+        sync_deployments=True,
+        sync_incidents=False,
+        sync_security=False,
+        sync_tests=False,
+        backfill_missing=False,
+        usage_sink=usage_sink,
+    )
+
+    assert seen_sink == [usage_sink]
+    assert usage_sink == [{"route_family": "deployments", "request_count": 1}]


### PR DESCRIPTION
## Summary
- migrate GitHub deployment and release fetches onto the instrumented GitHubCodeClient
- preserve deployment PR attribution and release_ref enrichment
- thread deployment usage observations through batch sync persistence

## Validation
- Oracle follow-up: PASS, no blocking findings
- pytest tests/providers/test_github_code_client_deployments.py tests/test_github_batch_deployments_usage_sink.py tests/test_deployment_pr_inference.py
- ruff format --check .
- ruff check .
- mypy --install-types --non-interactive .
- env -i PATH="/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.krew/bin:/Users/chris/.pyenv/shims:/Users/chris/.pyenv/bin:/Users/chris/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/lib/ruby/gems/3.3.0/bin:/opt/homebrew/opt/ruby/bin:/opt/homebrew/opt/sqlite/bin:/opt/homebrew/opt/python/libexec/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:/Users/chris/.cargo/bin:/Users/chris/.lmstudio/bin:/Users/chris/.docker/bin:/Users/chris/.local/share/go/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/iTerm.app/Contents/Resources/utilities:/Users/chris/.orbstack/bin" HOME="/Users/chris" TMPDIR="/var/folders/fc/1xbvf93j4t31_5mslw1x6gq40000gn/T/" bash ci/local_validate.sh

SCREENSHOT-WAIVER: backend/provider instrumentation only; no rendered UI changes.