### PR TITLE
feat(providers): instrument GitLab CI deployments (CHAOS-2812)

### DIFF
--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -803,26 +803,50 @@ def _sync_gitlab_mrs_to_store(
     return total
 
 
-def _fetch_gitlab_pipelines_sync(gl_project, repo_id, max_pipelines, since):
+def _drain_gitlab_code_usage(
+    helper_name: str,
+    drained_observations: list[dict[str, Any]],
+    usage_sink: list[dict[str, Any]] | None,
+) -> None:
+    if usage_sink is not None:
+        usage_sink.extend(drained_observations)
+    elif drained_observations:
+        logging.debug(
+            "%s: drained %d GitLab code usage observation(s) with no "
+            "adapter-owned sink (legacy entry point) -- logging only, not persisted",
+            helper_name,
+            len(drained_observations),
+        )
+
+
+def _fetch_gitlab_pipelines_sync(
+    connector, project_id, repo_id, max_pipelines, since, usage_sink=None
+):
     """Sync helper to fetch GitLab CI/CD pipelines."""
     pipelines: list[CiPipelineRun] = []
+    drained_observations: list[dict[str, Any]] = []
+
+    async def _run():
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await client.get_pipelines(
+                    project_id, max_pipelines=max_pipelines
+                )
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
 
     try:
-        list_params = {"per_page": 100, "order_by": "updated_at", "sort": "desc"}
-        if max_pipelines > 100:
-            raw_pipelines = gl_project.pipelines.list(**list_params, as_list=False)
-        else:
-            raw_pipelines = gl_project.pipelines.list(**list_params, get_all=False)
+        raw_pipelines = asyncio.run(_run())
     except Exception as exc:
         logging.debug("Failed to fetch pipelines: %s", exc)
-        return pipelines
+        raw_pipelines = []
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_pipelines_sync", drained_observations, usage_sink
+        )
 
-    count = 0
     for pipeline in raw_pipelines:
-        if count >= max_pipelines:
-            break
-
-        created_at = safe_parse_datetime(getattr(pipeline, "created_at", None))
+        created_at = pipeline.created_at
 
         if created_at is None:
             continue
@@ -830,48 +854,32 @@ def _fetch_gitlab_pipelines_sync(gl_project, repo_id, max_pipelines, since):
         if since is not None and created_at.astimezone(timezone.utc) < since:
             break
 
-        started_at = (
-            safe_parse_datetime(getattr(pipeline, "started_at", None)) or created_at
-        )
-
-        finished_at = safe_parse_datetime(getattr(pipeline, "finished_at", None))
-
-        # GitLab pipelines expose no clean automatic-retry counter, so default
-        # to 0. (A new pipeline is created per retry rather than a run_attempt
-        # being incremented, unlike GitHub Actions.)
         pipelines.append(
             build_ci_pipeline_run(
                 repo_id=repo_id,
-                run_id=str(getattr(pipeline, "id", "")),
-                status=getattr(pipeline, "status", None),
+                run_id=pipeline.pipeline_id,
+                status=pipeline.status,
                 queued_at=created_at,
-                started_at=started_at,
-                finished_at=finished_at,
+                started_at=pipeline.started_at or created_at,
+                finished_at=pipeline.finished_at,
                 retry_count=0,
             )
         )
-        count += 1
 
     return pipelines
 
 
-def _resolve_gitlab_deployment_mr(connector, project_id, sha):
+def _resolve_gitlab_deployment_mr_from_items(mrs):
     """Resolve the merged MR for a deployed commit via the commits API.
 
     Failure-soft: any lookup error leaves the deployment without MR
     attribution rather than failing the sync.
     """
-    if not sha:
-        return None, None
     try:
-        mrs = connector.rest_client.get_list(
-            f"projects/{project_id}/repository/commits/{sha}/merge_requests"
-        )
-    except Exception as exc:
-        logging.debug("Failed MR lookup for deployed commit %s: %s", sha, exc)
+        merged = [mr for mr in mrs or [] if mr.get("state") == "merged"]
+        chosen = merged[0] if merged else (mrs[0] if mrs else None)
+    except Exception:
         return None, None
-    merged = [mr for mr in mrs or [] if mr.get("state") == "merged"]
-    chosen = merged[0] if merged else (mrs[0] if mrs else None)
     if not chosen:
         return None, None
     merged_at = safe_parse_datetime(chosen.get("merged_at") or "")
@@ -883,71 +891,91 @@ def _resolve_gitlab_deployment_mr(connector, project_id, sha):
 
 
 def _fetch_gitlab_deployments_sync(
-    connector, project_id, repo_id, max_deployments, since
+    connector, project_id, repo_id, max_deployments, since, usage_sink=None
 ):
     """Sync helper to fetch GitLab deployments."""
     deployments: list[Deployment] = []
-    release_objects = []
+    drained_observations: list[dict[str, Any]] = []
+
+    async def _run():
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                try:
+                    release_objects = await client.get_deployment_releases(
+                        project_id, per_page=min(max_deployments, 100)
+                    )
+                except Exception as exc:
+                    logging.debug(
+                        "Failed to fetch GitLab releases for release_ref: %s", exc
+                    )
+                    release_objects = []
+                raw_deployments = await client.get_deployments(
+                    project_id,
+                    max_deployments=max_deployments,
+                    per_page=min(max_deployments, 100),
+                )
+                merge_requests_by_deployment_id: dict[str, list[dict[str, Any]]] = {}
+                for dep in raw_deployments:
+                    if not dep.sha:
+                        continue
+                    try:
+                        merge_requests_by_deployment_id[
+                            dep.deployment_id
+                        ] = await client.get_deployment_merge_requests(
+                            project_id, dep.sha
+                        )
+                    except Exception as exc:
+                        logging.debug(
+                            "Failed MR lookup for deployed commit %s: %s", dep.sha, exc
+                        )
+                return release_objects, raw_deployments, merge_requests_by_deployment_id
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+
     try:
-        release_objects = connector.rest_client.get_releases(
-            project_id=project_id,
-            per_page=min(max_deployments, 100),
-        )
-    except Exception as exc:
-        logging.debug("Failed to fetch GitLab releases for release_ref: %s", exc)
-    try:
-        # Use REST API to fetch deployments
-        raw_deployments = connector.rest_client.get_deployments(
-            project_id=project_id,
-            per_page=min(max_deployments, 100),
-            order_by="created_at",
-            sort="desc",
+        release_objects, raw_deployments, merge_requests_by_deployment_id = asyncio.run(
+            _run()
         )
     except Exception as exc:
         logging.debug("Failed to fetch deployments: %s", exc)
-        return deployments
+        raw_deployments = []
+        release_objects = []
+        merge_requests_by_deployment_id = {}
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_deployments_sync", drained_observations, usage_sink
+        )
 
     for dep in raw_deployments[:max_deployments]:
-        created_at_str = dep.get("created_at")
-        if not created_at_str:
-            continue
-
-        created_at = safe_parse_datetime(created_at_str)
+        created_at = dep.created_at
         if created_at is None:
             continue
 
         if since is not None and created_at.astimezone(timezone.utc) < since:
             break
 
-        # Parse other timestamps if available
-        finished_at = None
-        finished_at_str = dep.get("finished_at")
-        if finished_at_str:
-            finished_at = safe_parse_datetime(finished_at_str)
-
+        deployment_payload = {
+            **dep.raw_payload,
+            "deployment_id": dep.deployment_id,
+            "deployment_iid": dep.deployment_iid,
+        }
         enrichment = get_release_ref_enrichment(
-            {
-                **dep,
-                "deployment_id": str(dep.get("id", "")),
-                "deployment_iid": dep.get("iid"),
-            },
+            deployment_payload,
             "gitlab",
             releases=release_objects,
         )
 
-        mr_number, mr_merged_at = _resolve_gitlab_deployment_mr(
-            connector, project_id, dep.get("sha")
+        mr_number, mr_merged_at = _resolve_gitlab_deployment_mr_from_items(
+            merge_requests_by_deployment_id.get(dep.deployment_id, [])
         )
         deployments.append(
             build_deployment(
                 repo_id=repo_id,
-                deployment_id=str(dep.get("id", "")),
-                status=dep.get("status", None),
-                environment=dep.get("environment", {}).get("name")
-                if isinstance(dep.get("environment"), dict)
-                else None,
+                deployment_id=dep.deployment_id,
+                status=dep.status,
+                environment=dep.environment,
                 started_at=created_at,
-                finished_at=finished_at,
+                finished_at=dep.finished_at,
                 deployed_at=created_at,
                 merged_at=mr_merged_at,
                 pull_request_number=mr_number,
@@ -1979,10 +2007,12 @@ async def process_gitlab_project(
             pipeline_runs = await loop.run_in_executor(
                 None,
                 _fetch_gitlab_pipelines_sync,
-                gl_project,
+                connector,
+                project_id,
                 db_repo.id,
                 BATCH_SIZE,
                 since,
+                usage_sink,
             )
             pipeline_runs = _filter_after(pipeline_runs, until, "started_at")
             if pipeline_runs:
@@ -2013,6 +2043,7 @@ async def process_gitlab_project(
                 db_repo.id,
                 BATCH_SIZE,
                 since,
+                usage_sink,
             )
             deployments = _filter_after(deployments, until, "deployed_at", "started_at")
             if deployments:
@@ -2229,6 +2260,7 @@ async def process_gitlab_projects_batch(
             return
 
         gl_project = None
+        usage_sink: list[dict[str, Any]] = []
         if sync_git:
             # Fetch commits and stats to populate git_commits/git_commit_stats.
             if max_commits_per_project is None and since is None:
@@ -2312,17 +2344,15 @@ async def process_gitlab_projects_batch(
 
         if sync_cicd:
             try:
-                if gl_project is None:
-                    gl_project = await loop.run_in_executor(
-                        None, connector.gitlab.projects.get, project_info.id
-                    )
                 pipeline_runs = await loop.run_in_executor(
                     None,
                     _fetch_gitlab_pipelines_sync,
-                    gl_project,
+                    connector,
+                    project_info.id,
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink,
                 )
                 if pipeline_runs:
                     await ingestion_sink.insert_ci_pipeline_runs(pipeline_runs)
@@ -2367,6 +2397,7 @@ async def process_gitlab_projects_batch(
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink,
                 )
                 if deployments:
                     await ingestion_sink.insert_deployments(deployments)

--- a/src/dev_health_ops/providers/gitlab/budget.py
+++ b/src/dev_health_ops/providers/gitlab/budget.py
@@ -387,9 +387,20 @@ GITLAB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("issues", BudgetDimension.REST_CORE),
     UsageRouteFamily("merge_requests", BudgetDimension.REST_CORE),
     UsageRouteFamily("notes", BudgetDimension.REST_CORE),
-    UsageRouteFamily("pipelines", BudgetDimension.REST_CORE),
+    UsageRouteFamily(
+        "pipelines",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("pipelines:",),
+    ),
     UsageRouteFamily("milestones", BudgetDimension.REST_CORE),
     UsageRouteFamily("epics", BudgetDimension.REST_CORE),
+    UsageRouteFamily(
+        "deployments",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("deployments:",),
+    ),
     # CHAOS-2773 CS10: the "security" code-dataset client
     # (providers/gitlab/code_client.py::GitLabCodeClient) is the FIRST
     # canonical GitLab client to author its own operation labels rather than

--- a/src/dev_health_ops/providers/gitlab/code_client.py
+++ b/src/dev_health_ops/providers/gitlab/code_client.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 
 import logging
 import urllib.parse
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any
 
@@ -87,6 +88,29 @@ _RESET_HEADER_NAME = "RateLimit-Reset"
 # Explicit family prefix every operation this client issues is labeled with
 # (see the module docstring's "Every operation" paragraph).
 _SECURITY_FAMILY_PREFIX = "security"
+_PIPELINES_FAMILY_PREFIX = "pipelines"
+_DEPLOYMENTS_FAMILY_PREFIX = "deployments"
+
+
+@dataclass(frozen=True)
+class GitLabPipelineData:
+    pipeline_id: str
+    status: str | None
+    created_at: datetime | None
+    started_at: datetime | None
+    finished_at: datetime | None
+
+
+@dataclass(frozen=True)
+class GitLabDeploymentData:
+    deployment_id: str
+    deployment_iid: Any
+    status: str | None
+    environment: str | None
+    created_at: datetime | None
+    finished_at: datetime | None
+    sha: str | None
+    raw_payload: dict[str, Any]
 
 
 class _GitLabSecurityForbidden(APIException):
@@ -210,6 +234,45 @@ def _map_dependency_alert(
         created_at=datetime.now(timezone.utc),
         fixed_at=None,
         dismissed_at=None,
+    )
+
+
+def _parse_gitlab_datetime(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        logger.debug("Failed to parse GitLab datetime: %s", value)
+        return None
+
+
+def _map_pipeline(item: dict[str, Any]) -> GitLabPipelineData:
+    created_at = _parse_gitlab_datetime(item.get("created_at"))
+    return GitLabPipelineData(
+        pipeline_id=str(item.get("id", "")),
+        status=item.get("status"),
+        created_at=created_at,
+        started_at=_parse_gitlab_datetime(item.get("started_at")) or created_at,
+        finished_at=_parse_gitlab_datetime(item.get("finished_at")),
+    )
+
+
+def _map_deployment(item: dict[str, Any]) -> GitLabDeploymentData:
+    environment = item.get("environment")
+    environment_name = (
+        environment.get("name") if isinstance(environment, dict) else None
+    )
+    sha = item.get("sha")
+    return GitLabDeploymentData(
+        deployment_id=str(item.get("id", "")),
+        deployment_iid=item.get("iid"),
+        status=item.get("status"),
+        environment=environment_name,
+        created_at=_parse_gitlab_datetime(item.get("created_at")),
+        finished_at=_parse_gitlab_datetime(item.get("finished_at")),
+        sha=str(sha) if sha is not None else None,
+        raw_payload=dict(item),
     )
 
 
@@ -355,6 +418,113 @@ class GitLabCodeClient:
                 alerts.append(_map_dependency_alert(dep, vuln))
         return alerts
 
+    async def get_pipelines(
+        self,
+        project_id: int | str,
+        *,
+        max_pipelines: int,
+        per_page: int = 100,
+    ) -> list[GitLabPipelineData]:
+        if max_pipelines <= 0:
+            return []
+        params: dict[str, Any] = {"order_by": "updated_at", "sort": "desc"}
+        path = f"/projects/{project_id}/pipelines"
+        operation = f"{_PIPELINES_FAMILY_PREFIX}:GET /projects/{{id}}/pipelines"
+        raw_items = await self._get_gitlab_list(
+            path,
+            operation=operation,
+            params=params,
+            per_page=per_page,
+            paginate=max_pipelines > per_page,
+            max_items=max_pipelines,
+        )
+        return [_map_pipeline(item) for item in raw_items[:max_pipelines]]
+
+    async def get_deployment_releases(
+        self,
+        project_id: int | str,
+        *,
+        per_page: int = 100,
+    ) -> list[dict[str, Any]]:
+        return await self._get_gitlab_list(
+            f"/projects/{project_id}/releases",
+            operation=f"{_DEPLOYMENTS_FAMILY_PREFIX}:GET /projects/{{id}}/releases",
+            params={},
+            per_page=per_page,
+            paginate=False,
+            max_items=per_page,
+        )
+
+    async def get_deployments(
+        self,
+        project_id: int | str,
+        *,
+        max_deployments: int,
+        per_page: int | None = None,
+    ) -> list[GitLabDeploymentData]:
+        if max_deployments <= 0:
+            return []
+        effective_per_page = per_page or min(max_deployments, 100)
+        raw_items = await self._get_gitlab_list(
+            f"/projects/{project_id}/deployments",
+            operation=f"{_DEPLOYMENTS_FAMILY_PREFIX}:GET /projects/{{id}}/deployments",
+            params={"order_by": "created_at", "sort": "desc"},
+            per_page=effective_per_page,
+            paginate=False,
+            max_items=max_deployments,
+        )
+        return [_map_deployment(item) for item in raw_items[:max_deployments]]
+
+    async def get_deployment_merge_requests(
+        self, project_id: int | str, sha: str
+    ) -> list[dict[str, Any]]:
+        encoded_sha = urllib.parse.quote(str(sha), safe="")
+        return await self._get_gitlab_list(
+            f"/projects/{project_id}/repository/commits/{encoded_sha}/merge_requests",
+            operation=(
+                f"{_DEPLOYMENTS_FAMILY_PREFIX}:GET "
+                "/projects/{id}/repository/commits/{sha}/merge_requests"
+            ),
+            params={},
+            per_page=100,
+            paginate=False,
+            max_items=100,
+        )
+
+    async def _get_gitlab_list(
+        self,
+        path: str,
+        *,
+        operation: str,
+        params: dict[str, Any],
+        per_page: int,
+        paginate: bool,
+        max_items: int,
+    ) -> list[dict[str, Any]]:
+        if paginate:
+            max_pages = max(1, (max_items + per_page - 1) // per_page)
+            payload = await self._core.paginate_page_param(
+                path,
+                operation=operation,
+                params=params,
+                per_page=per_page,
+                max_pages=max_pages,
+            )
+            return [item for item in payload if isinstance(item, dict)][:max_items]
+
+        response = await self._core.request(
+            "GET",
+            path,
+            operation=operation,
+            params={**params, "page": 1, "per_page": per_page},
+        )
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise APIException(
+                f"Unexpected GitLab list response for {operation}: {type(payload)!r}"
+            )
+        return [item for item in payload if isinstance(item, dict)][:max_items]
+
     def drain_usage_observations(self) -> list[dict[str, Any]]:
         return self._core.drain_usage_observations()
 
@@ -369,4 +539,4 @@ class GitLabCodeClient:
         await self.close()
 
 
-__all__ = ["GitLabCodeClient"]
+__all__ = ["GitLabCodeClient", "GitLabDeploymentData", "GitLabPipelineData"]

--- a/tests/providers/test_gitlab_budget.py
+++ b/tests/providers/test_gitlab_budget.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import datetime, timezone
 
-from dev_health_ops.providers.gitlab.budget import GitLabBudgetEstimator
+from dev_health_ops.providers.gitlab.budget import (
+    GITLAB_USAGE_ROUTE_FAMILIES,
+    GitLabBudgetEstimator,
+)
 from dev_health_ops.sync.budget import BudgetDimension, estimate_provider_budget
 from dev_health_ops.sync.budget_guard import (
     _budget_key,
@@ -85,6 +88,13 @@ def test_gitlab_budget_estimator_maps_known_route_families_to_rest_core() -> Non
         "merge_requests",
         "notes",
     }
+
+
+def test_gitlab_budget_has_code_client_family_prefix_markers() -> None:
+    families = {family.route_family: family for family in GITLAB_USAGE_ROUTE_FAMILIES}
+
+    assert families["pipelines"].operation_markers == ("pipelines:",)
+    assert families["deployments"].operation_markers == ("deployments:",)
 
 
 def test_gitlab_budget_route_family_limits_override_dimension_defaults() -> None:

--- a/tests/providers/test_gitlab_code_client.py
+++ b/tests/providers/test_gitlab_code_client.py
@@ -54,11 +54,13 @@ def _router_transport(
     consumed per hit, the last repeats) or a single fixed response."""
     calls: dict[str, int] = {}
     captured_headers: dict[str, httpx.Headers] = {}
+    captured_urls: dict[str, httpx.URL] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
         calls[path] = calls.get(path, 0) + 1
         captured_headers[path] = request.headers
+        captured_urls[path] = request.url
         entry = routes[path]
         if isinstance(entry, list):
             idx = min(calls[path] - 1, len(entry) - 1)
@@ -68,6 +70,7 @@ def _router_transport(
     transport = httpx.MockTransport(handler)
     transport.calls = calls  # type: ignore[attr-defined]
     transport.captured_headers = captured_headers  # type: ignore[attr-defined]
+    transport.captured_urls = captured_urls  # type: ignore[attr-defined]
     return transport, calls
 
 
@@ -548,6 +551,157 @@ class TestUsageRecording:
         client.drain_usage_observations()
 
         assert client.drain_usage_observations() == []
+
+
+_PIPELINES_PATH = "/api/v4/projects/42/pipelines"
+_RELEASES_PATH = "/api/v4/projects/42/releases"
+_DEPLOYMENTS_PATH = "/api/v4/projects/42/deployments"
+_DEPLOYMENT_MRS_PATH = "/api/v4/projects/42/repository/commits/abc123/merge_requests"
+
+
+class TestPipelinesParity:
+    @pytest.mark.asyncio
+    async def test_pipeline_request_params_mapping_and_usage_family(self) -> None:
+        pipeline = {
+            "id": 11,
+            "status": "success",
+            "created_at": "2026-02-01T00:00:00Z",
+            "started_at": "2026-02-01T00:01:00Z",
+            "finished_at": "2026-02-01T00:05:00Z",
+        }
+        transport, calls = _router_transport(
+            {_PIPELINES_PATH: _json_response(200, [pipeline])}
+        )
+        client = _client(transport)
+
+        pipelines = await client.get_pipelines(42, max_pipelines=10)
+
+        assert calls[_PIPELINES_PATH] == 1
+        assert pipelines[0].pipeline_id == "11"
+        assert pipelines[0].status == "success"
+        assert pipelines[0].created_at == datetime(
+            2026, 2, 1, 0, 0, tzinfo=timezone.utc
+        )
+        assert pipelines[0].started_at == datetime(
+            2026, 2, 1, 0, 1, tzinfo=timezone.utc
+        )
+        query = dict(transport.captured_urls[_PIPELINES_PATH].params)  # type: ignore[attr-defined]
+        assert query == {
+            "order_by": "updated_at",
+            "sort": "desc",
+            "page": "1",
+            "per_page": "100",
+        }
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "pipelines"
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_pipeline_max_over_one_page_follows_x_next_page_until_cap(
+        self,
+    ) -> None:
+        page_one = [{"id": i, "created_at": "2026-02-01T00:00:00Z"} for i in range(100)]
+        page_two = [{"id": 100, "created_at": "2026-02-01T00:00:00Z"}]
+        transport, calls = _router_transport(
+            {
+                _PIPELINES_PATH: [
+                    _json_response(200, page_one, headers={"X-Next-Page": "2"}),
+                    _json_response(200, page_two),
+                ]
+            }
+        )
+        client = _client(transport)
+
+        pipelines = await client.get_pipelines(42, max_pipelines=101)
+
+        assert len(pipelines) == 101
+        assert calls[_PIPELINES_PATH] == 2
+
+    @pytest.mark.asyncio
+    async def test_pipeline_hard_cap_does_not_chase_next_page(self) -> None:
+        page_one = [{"id": i, "created_at": "2026-02-01T00:00:00Z"} for i in range(100)]
+        transport, calls = _router_transport(
+            {
+                _PIPELINES_PATH: _json_response(
+                    200, page_one, headers={"X-Next-Page": "2"}
+                )
+            }
+        )
+        client = _client(transport)
+
+        pipelines = await client.get_pipelines(42, max_pipelines=100)
+
+        assert len(pipelines) == 100
+        assert calls[_PIPELINES_PATH] == 1
+
+
+class TestDeploymentsParity:
+    @pytest.mark.asyncio
+    async def test_deployments_request_params_mapping_and_usage_family(self) -> None:
+        deployment = {
+            "id": 501,
+            "iid": 7,
+            "status": "success",
+            "environment": {"name": "production"},
+            "created_at": "2026-03-01T10:00:00Z",
+            "finished_at": "2026-03-01T10:05:00Z",
+            "sha": "abc123",
+            "ref": "v1.2.3",
+        }
+        transport, calls = _router_transport(
+            {
+                _RELEASES_PATH: _json_response(200, [{"tag_name": "v1.2.3"}]),
+                _DEPLOYMENTS_PATH: _json_response(200, [deployment]),
+                _DEPLOYMENT_MRS_PATH: _json_response(200, []),
+            }
+        )
+        client = _client(transport)
+
+        releases = await client.get_deployment_releases(42, per_page=10)
+        deployments = await client.get_deployments(42, max_deployments=10)
+        mrs = await client.get_deployment_merge_requests(42, "abc123")
+
+        assert releases == [{"tag_name": "v1.2.3"}]
+        assert mrs == []
+        assert calls[_RELEASES_PATH] == 1
+        assert calls[_DEPLOYMENTS_PATH] == 1
+        assert calls[_DEPLOYMENT_MRS_PATH] == 1
+        assert deployments[0].deployment_id == "501"
+        assert deployments[0].deployment_iid == 7
+        assert deployments[0].status == "success"
+        assert deployments[0].environment == "production"
+        assert deployments[0].created_at == datetime(
+            2026, 3, 1, 10, 0, tzinfo=timezone.utc
+        )
+        assert deployments[0].finished_at == datetime(
+            2026, 3, 1, 10, 5, tzinfo=timezone.utc
+        )
+        assert dict(transport.captured_urls[_DEPLOYMENTS_PATH].params) == {  # type: ignore[attr-defined]
+            "order_by": "created_at",
+            "sort": "desc",
+            "page": "1",
+            "per_page": "10",
+        }
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "deployments"
+        assert observations[0]["request_count"] == 3
+
+    @pytest.mark.asyncio
+    async def test_deployments_endpoint_keeps_frozen_single_page_behavior(self) -> None:
+        first_page = [{"id": 1, "created_at": "2026-03-01T10:00:00Z"}]
+        transport, calls = _router_transport(
+            {
+                _DEPLOYMENTS_PATH: _json_response(
+                    200, first_page, headers={"X-Next-Page": "2"}
+                )
+            }
+        )
+        client = _client(transport)
+
+        deployments = await client.get_deployments(42, max_deployments=10)
+
+        assert len(deployments) == 1
+        assert calls[_DEPLOYMENTS_PATH] == 1
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -1418,6 +1418,9 @@ async def test_process_gitlab_projects_batch_stores_commits_and_stats(monkeypatc
                 on_project_complete(result)
             return [result]
 
+        def _get_projects_for_processing(self, **kwargs):
+            return [project]
+
         def close(self):
             return
 
@@ -1447,6 +1450,99 @@ async def test_process_gitlab_projects_batch_stores_commits_and_stats(monkeypatc
     expected_repo_id = get_repo_uuid_from_repo(project.full_name)
     assert all(c.repo_id == expected_repo_id for c in recorded_commits)
     assert "gitlab123" in {s.commit_hash for s in recorded_stats}
+
+
+@pytest.mark.asyncio
+async def test_process_gitlab_projects_batch_threads_code_usage_sink(monkeypatch):
+    _enable_connector_stubs(monkeypatch)
+    seen_usage_sink_ids: list[int] = []
+    seen_usage_sink_values: list[dict[str, object]] = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_ci_pipeline_runs(self, pipeline_runs):
+            return
+
+        async def insert_deployments(self, deployments):
+            return
+
+    project = Mock()
+    project.id = 456
+    project.full_name = "group/proj-usage"
+    project.url = "https://example.com/group/proj-usage"
+    project.default_branch = "main"
+    result = BatchResult(repository=project, stats=None, success=True)
+
+    class DummyConnector:
+        def __init__(self, url: str, private_token: str):
+            self.url = url
+            self.private_token = private_token
+
+        async def get_projects_with_stats_async(self, **kwargs):
+            on_project_complete = kwargs.get("on_project_complete")
+            if on_project_complete:
+                on_project_complete(result)
+            return [result]
+
+        def _get_projects_for_processing(self, **kwargs):
+            return [project]
+
+        def close(self):
+            return
+
+    def fake_fetch_pipelines(
+        connector, project_id, repo_id, max_pipelines, since, usage_sink=None
+    ):
+        assert usage_sink is not None
+        seen_usage_sink_ids.append(id(usage_sink))
+        usage_sink.append({"route_family": "pipelines"})
+        seen_usage_sink_values.extend(usage_sink)
+        return []
+
+    def fake_fetch_deployments(
+        connector, project_id, repo_id, max_deployments, since, usage_sink=None
+    ):
+        assert usage_sink is not None
+        seen_usage_sink_ids.append(id(usage_sink))
+        usage_sink.append({"route_family": "deployments"})
+        seen_usage_sink_values.extend(usage_sink)
+        return []
+
+    monkeypatch.setattr(processors.gitlab, "GitLabConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.gitlab, "_fetch_gitlab_pipelines_sync", fake_fetch_pipelines
+    )
+    monkeypatch.setattr(
+        processors.gitlab, "_fetch_gitlab_deployments_sync", fake_fetch_deployments
+    )
+
+    await processors.gitlab.process_gitlab_projects_batch(
+        store=DummyStore(),
+        token="unit-token",
+        gitlab_url="https://gitlab.com",
+        group_name="group",
+        pattern="group/*",
+        batch_size=1,
+        max_concurrent=1,
+        rate_limit_delay=0,
+        use_async=True,
+        sync_git=False,
+        sync_prs=False,
+        sync_cicd=True,
+        sync_deployments=True,
+        sync_incidents=False,
+        sync_security=False,
+        sync_tests=False,
+        backfill_missing=False,
+    )
+
+    assert len(set(seen_usage_sink_ids)) == 1
+    assert {item["route_family"] for item in seen_usage_sink_values} == {
+        "pipelines",
+        "deployments",
+    }
 
 
 class TestPatternMatching:

--- a/tests/test_ci_pipeline_retry_count.py
+++ b/tests/test_ci_pipeline_retry_count.py
@@ -27,6 +27,7 @@ import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.processors.base_git import build_ci_pipeline_run
 from dev_health_ops.processors.github import _fetch_github_workflow_runs_sync
 from dev_health_ops.processors.gitlab import _fetch_gitlab_pipelines_sync
+from dev_health_ops.providers.gitlab.code_client import GitLabPipelineData
 from dev_health_ops.storage.mixins.cicd import CicdMixin
 
 _STARTED = datetime(2023, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
@@ -110,22 +111,39 @@ def test_github_workflow_run_absent_run_attempt_defaults_to_zero():
     assert runs[0].retry_count == 0
 
 
-def test_gitlab_pipeline_retry_count_defaults_to_zero():
+class _GitLabPipelineClient:
+    def __init__(self, pipelines: list[GitLabPipelineData]) -> None:
+        self.pipelines = pipelines
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get_pipelines(self, project_id: int, *, max_pipelines: int):
+        return self.pipelines[:max_pipelines]
+
+    def drain_usage_observations(self):
+        return []
+
+
+def test_gitlab_pipeline_retry_count_defaults_to_zero(monkeypatch):
     """GitLab pipelines have no clean attempt counter -> retry_count=0."""
-    from unittest.mock import Mock
-
-    pipeline = Mock()
-    pipeline.id = 1
-    pipeline.status = "success"
-    pipeline.created_at = "2023-01-01T00:00:00Z"
-    pipeline.started_at = "2023-01-01T00:01:00Z"
-    pipeline.finished_at = "2023-01-01T00:05:00Z"
-
-    gl_project = Mock()
-    gl_project.pipelines.list.return_value = [pipeline]
+    pipeline = GitLabPipelineData(
+        pipeline_id="1",
+        status="success",
+        created_at=datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        started_at=datetime(2023, 1, 1, 0, 1, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2023, 1, 1, 0, 5, 0, tzinfo=timezone.utc),
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: _GitLabPipelineClient([pipeline]),
+    )
 
     pipelines = _fetch_gitlab_pipelines_sync(
-        gl_project, repo_id=None, max_pipelines=10, since=None
+        object(), project_id=1, repo_id=None, max_pipelines=10, since=None
     )
 
     assert len(pipelines) == 1

--- a/tests/test_deployment_pr_inference.py
+++ b/tests/test_deployment_pr_inference.py
@@ -25,7 +25,7 @@ from dev_health_ops.processors.github import (
 )
 from dev_health_ops.processors.gitlab import (
     _fetch_gitlab_incidents_sync,
-    _resolve_gitlab_deployment_mr,
+    _resolve_gitlab_deployment_mr_from_items,
 )
 
 REPO_ID = uuid.uuid4()
@@ -121,32 +121,25 @@ class TestGitHubDeploymentPRInference:
 
 class TestGitLabDeploymentMRInference:
     def test_resolves_merged_mr(self) -> None:
-        connector = Mock()
-        connector.rest_client.get_list.return_value = [
+        merge_requests = [
             {"iid": 5, "state": "opened", "merged_at": None},
             {"iid": 6, "state": "merged", "merged_at": "2026-06-12T00:00:00Z"},
         ]
 
-        number, merged_at = _resolve_gitlab_deployment_mr(connector, 123, "abc")
+        number, merged_at = _resolve_gitlab_deployment_mr_from_items(merge_requests)
 
         assert number == 6
         assert merged_at is not None
-        connector.rest_client.get_list.assert_called_once_with(
-            "projects/123/repository/commits/abc/merge_requests"
-        )
 
     def test_no_sha_or_failure_is_soft(self) -> None:
-        connector = Mock()
-        assert _resolve_gitlab_deployment_mr(connector, 123, None) == (None, None)
-        connector.rest_client.get_list.side_effect = RuntimeError("boom")
-        assert _resolve_gitlab_deployment_mr(connector, 123, "abc") == (None, None)
+        assert _resolve_gitlab_deployment_mr_from_items([]) == (None, None)
+        assert _resolve_gitlab_deployment_mr_from_items(object()) == (None, None)
 
     def test_non_numeric_iid_is_soft(self) -> None:
-        connector = Mock()
-        connector.rest_client.get_list.return_value = [
+        merge_requests = [
             {"iid": "abc", "state": "merged", "merged_at": "2026-06-12T00:00:00Z"}
         ]
-        number, merged_at = _resolve_gitlab_deployment_mr(connector, 123, "abc")
+        number, merged_at = _resolve_gitlab_deployment_mr_from_items(merge_requests)
         assert number is None
         assert merged_at is not None
 

--- a/tests/test_processors_gitlab.py
+++ b/tests/test_processors_gitlab.py
@@ -10,6 +10,50 @@ from dev_health_ops.processors.gitlab import (
     _fetch_gitlab_pipelines_sync,
     process_gitlab_project,
 )
+from dev_health_ops.providers.gitlab.code_client import (
+    GitLabDeploymentData,
+    GitLabPipelineData,
+)
+
+
+class _FakeGitLabCodeClient:
+    def __init__(
+        self,
+        *,
+        pipelines=None,
+        deployments=None,
+        releases=None,
+        merge_requests=None,
+        observations=None,
+    ):
+        self.pipelines = pipelines or []
+        self.deployments = deployments or []
+        self.releases = releases or []
+        self.merge_requests = merge_requests or []
+        self.observations = observations or []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get_pipelines(self, project_id, *, max_pipelines):
+        return self.pipelines[:max_pipelines]
+
+    async def get_deployment_releases(self, project_id, *, per_page):
+        return self.releases[:per_page]
+
+    async def get_deployments(self, project_id, *, max_deployments, per_page=None):
+        return self.deployments[:max_deployments]
+
+    async def get_deployment_merge_requests(self, project_id, sha):
+        return self.merge_requests
+
+    def drain_usage_observations(self):
+        observations = list(self.observations)
+        self.observations.clear()
+        return observations
 
 
 @pytest.mark.asyncio
@@ -295,19 +339,30 @@ async def test_process_gitlab_project_userinfo_stripped_from_discriminator(monke
     assert account_label not in written_repo.settings["gitlab_instance_url"]
 
 
-def test_fetch_gitlab_pipelines_sync():
-    mock_pipeline = Mock()
-    mock_pipeline.id = 1
-    mock_pipeline.status = "success"
-    mock_pipeline.created_at = "2023-01-01T00:00:00Z"
-    mock_pipeline.started_at = "2023-01-01T00:01:00Z"
-    mock_pipeline.finished_at = "2023-01-01T00:05:00Z"
-
-    mock_gl_project = Mock()
-    mock_gl_project.pipelines.list.return_value = [mock_pipeline]
+def test_fetch_gitlab_pipelines_sync(monkeypatch):
+    pipeline = GitLabPipelineData(
+        pipeline_id="1",
+        status="success",
+        created_at=datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        started_at=datetime(2023, 1, 1, 0, 1, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2023, 1, 1, 0, 5, 0, tzinfo=timezone.utc),
+    )
+    usage_sink: list[dict[str, str]] = []
+    fake_client = _FakeGitLabCodeClient(
+        pipelines=[pipeline], observations=[{"route_family": "pipelines"}]
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
 
     pipelines = _fetch_gitlab_pipelines_sync(
-        mock_gl_project, repo_id=None, max_pipelines=10, since=None
+        Mock(),
+        project_id=1,
+        repo_id=None,
+        max_pipelines=10,
+        since=None,
+        usage_sink=usage_sink,
     )
 
     assert len(pipelines) == 1
@@ -315,35 +370,53 @@ def test_fetch_gitlab_pipelines_sync():
     assert pipelines[0].status == "success"
     assert pipelines[0].queued_at == datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     assert pipelines[0].started_at == datetime(2023, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    assert usage_sink == [{"route_family": "pipelines"}]
 
 
-def test_fetch_gitlab_deployments_sync():
-    mock_connector = Mock()
-    mock_connector.rest_client.get_releases.return_value = [{"tag_name": "v1.2.3"}]
-    mock_connector.rest_client.get_deployments.return_value = [
-        {
-            "id": 101,
-            "iid": 12,
-            "status": "success",
-            "ref": "v1.2.3",
-            "environment": {"name": "production"},
-            "created_at": "2023-01-02T00:00:00Z",
-            "finished_at": "2023-01-02T00:10:00Z",
-        }
-    ]
+def test_fetch_gitlab_deployments_sync(monkeypatch):
+    deployment = GitLabDeploymentData(
+        deployment_id="101",
+        deployment_iid=12,
+        status="success",
+        environment="production",
+        created_at=datetime(2023, 1, 2, 0, 0, 0, tzinfo=timezone.utc),
+        finished_at=datetime(2023, 1, 2, 0, 10, 0, tzinfo=timezone.utc),
+        sha="abc123",
+        raw_payload={"id": 101, "iid": 12, "ref": "v1.2.3"},
+    )
+    usage_sink: list[dict[str, str]] = []
+    fake_client = _FakeGitLabCodeClient(
+        deployments=[deployment],
+        releases=[{"tag_name": "v1.2.3"}],
+        merge_requests=[
+            {"iid": 44, "state": "merged", "merged_at": "2023-01-02T00:09:00Z"}
+        ],
+        observations=[{"route_family": "deployments"}],
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
 
     deployments = _fetch_gitlab_deployments_sync(
-        mock_connector, project_id=1, repo_id=None, max_deployments=10, since=None
+        Mock(),
+        project_id=1,
+        repo_id=None,
+        max_deployments=10,
+        since=None,
+        usage_sink=usage_sink,
     )
 
     assert len(deployments) == 1
     assert deployments[0].deployment_id == "101"
     assert deployments[0].environment == "production"
+    assert deployments[0].pull_request_number == 44
     assert deployments[0].release_ref == "v1.2.3"
     assert deployments[0].release_ref_confidence == pytest.approx(1.0)
     assert deployments[0].deployed_at == datetime(
         2023, 1, 2, 0, 0, 0, tzinfo=timezone.utc
     )
+    assert usage_sink == [{"route_family": "deployments"}]
 
 
 def test_fetch_gitlab_incidents_sync():


### PR DESCRIPTION
## Summary
- migrate GitLab pipeline, deployment, release, and deployment-MR fetches onto GitLabCodeClient
- persist pipelines/deployments usage observations through single-project and batch sync paths
- add provider and processor coverage for request mapping, pagination caps, usage families, retry counts, and MR attribution

## Validation
- Oracle follow-up: PASS for shared PR readiness; CS11 raw MR dict warning remains non-blocking
- pytest tests/providers/test_gitlab_budget.py tests/providers/test_gitlab_code_client.py tests/test_batch_processing.py tests/test_ci_pipeline_retry_count.py tests/test_deployment_pr_inference.py tests/test_processors_gitlab.py
- ruff format --check .
- ruff check .
- mypy --install-types --non-interactive .
- env -i PATH="/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.krew/bin:/Users/chris/.pyenv/shims:/Users/chris/.pyenv/bin:/Users/chris/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/lib/ruby/gems/3.3.0/bin:/opt/homebrew/opt/ruby/bin:/opt/homebrew/opt/sqlite/bin:/opt/homebrew/opt/python/libexec/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:/Users/chris/.cargo/bin:/Users/chris/.lmstudio/bin:/Users/chris/.docker/bin:/Users/chris/.local/share/go/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/iTerm.app/Contents/Resources/utilities:/Users/chris/.orbstack/bin" HOME="/Users/chris" TMPDIR="/var/folders/fc/1xbvf93j4t31_5mslw1x6gq40000gn/T/" bash ci/local_validate.sh

SCREENSHOT-WAIVER: backend/provider instrumentation only; no rendered UI changes.