### PR TITLE
fix(metrics): align compounding risk CLI backfill flags

### DIFF
--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -70,7 +70,7 @@ These inputs are supplied through global flags or environment variables (`--anal
 
 ```bash
 $ dev-hops metrics compounding-risk        # no CLICKHOUSE_URI / org configured
-usage: dev-health-ops metrics compounding-risk [-h] [--day DAY] ...
+usage: dev-health-ops metrics compounding-risk [-h] [--since SINCE | --backfill BACKFILL] ...
 dev-health-ops metrics compounding-risk: error: missing required input(s):
   - ClickHouse analytics database — pass --analytics-db or set CLICKHOUSE_URI (...)
   - organization id — pass --org or set ORG_ID (could not auto-resolve ...)
@@ -145,7 +145,7 @@ dev-hops sync git --provider gitlab \
 | `--project-id` | GitLab project ID |
 | `--since` | Start datetime (ISO 8601). Mutually exclusive with `--backfill` |
 | `--before` | End date (exclusive, default: tomorrow) |
-| `--backfill N` | Backfill N days ending at `--before`. Mutually exclusive with `--since` |
+| `--backfill N` | Backfill N days ending before `--before`. Mutually exclusive with `--since` |
 | `--sink` | Analytics backend (`clickhouse` only; default) |
 
 `--date` is a deprecated hidden alias for `--before`.
@@ -339,7 +339,7 @@ dev-hops metrics daily \
 |--------|-------------|
 | `--since` | Start date. Mutually exclusive with `--backfill` |
 | `--before` | End date (exclusive, default: tomorrow) |
-| `--backfill N` | Compute N days ending at `--before` (default: 1) |
+| `--backfill N` | Compute N days ending before `--before` (default: 1) |
 | `--repo-id` | Filter to specific repository |
 | `--sink` | Analytics backend (`clickhouse` only) |
 
@@ -364,7 +364,7 @@ dev-hops metrics rebuild \
 | `--repo-id` | Repo UUID to rebuild; repeatable. Omit to rebuild all repos |
 | `--since` | Start date (inclusive). Mutually exclusive with `--backfill` |
 | `--before` | End date (exclusive, default: tomorrow) |
-| `--backfill N` | Process N days ending at `--before` (default: 1) |
+| `--backfill N` | Process N days ending before `--before` (default: 1) |
 | `--sink` | Analytics backend (`clickhouse` only) |
 | `--provider` | Restrict to a single provider (default: `auto`) |
 
@@ -477,17 +477,22 @@ Compute the Compounding Risk composite from persisted inputs (`repo_metrics_dail
 ```bash
 dev-hops metrics compounding-risk --org "$ORG_ID"
 
-# Backfill additional days ending at --day
-dev-hops metrics compounding-risk --day 2025-02-02 --backfill 7
+# Backfill seven days ending before 2025-02-02, i.e. through 2025-02-01
+dev-hops metrics compounding-risk --before 2025-02-02 --backfill 7
+
+# Explicit inclusive start with exclusive end
+dev-hops metrics compounding-risk --since 2025-01-01 --before 2025-02-02
 ```
 
 **Options:**
 | Option | Description |
 |--------|-------------|
-| `--day` | Target day (UTC, default: today) |
-| `--backfill N` | Additional days to backfill, inclusive (default: 0) |
+| `--since` | Start date (inclusive). Mutually exclusive with `--backfill` |
+| `--before` | End date (exclusive, default: tomorrow) |
+| `--backfill N` | Process N days ending before `--before` (default: 1) |
+| `--sink` | Analytics backend (`clickhouse` only) |
 
-> Note: `metrics compounding-risk` uses `--day` + `--backfill` rather than the `--since`/`--before`/`--backfill` range shared by the other metrics commands.
+> CHAOS-2475 follow-up: `--day` is not supported. Use `--before <day-after-target> --backfill 1` for one historical day.
 
 ---
 
@@ -881,7 +886,7 @@ dev-hops backfill run \
 | `--config-id` | Sync configuration UUID (required) |
 | `--since` | Start date (ISO 8601). Mutually exclusive with `--backfill` |
 | `--before` | End date (exclusive, default: tomorrow) |
-| `--backfill N` | Backfill N days ending at `--before`. Mutually exclusive with `--since` |
+| `--backfill N` | Backfill N days ending before `--before`. Mutually exclusive with `--since` |
 | `--sink` | Analytics backend (`clickhouse` only; default) |
 
 Backfill depth is limited by organization tier:

--- a/docs/ops/runbook-ingestion-failures.md
+++ b/docs/ops/runbook-ingestion-failures.md
@@ -109,8 +109,8 @@ dev-hops metrics complexity \
 
 dev-hops metrics compounding-risk \
   --org <org_id> \
-  --day 2024-01-08 \
-  --backfill 7
+  --since 2024-01-01 \
+  --before 2024-01-08
 ```
 
 ### 3. Historical Backfill

--- a/src/dev_health_ops/metrics/job_compounding_risk.py
+++ b/src/dev_health_ops/metrics/job_compounding_risk.py
@@ -6,7 +6,7 @@ already-persisted ``repo_metrics_daily`` + ``repo_complexity_daily`` rows
 and emits one row per repo (and per team) per day.
 
 Usage:
-    dev-hops metrics compounding-risk --org ORG [--day YYYY-MM-DD] [--backfill N]
+    dev-hops metrics compounding-risk --org ORG [--since YYYY-MM-DD] [--before YYYY-MM-DD] [--backfill N]
 """
 
 from __future__ import annotations
@@ -24,14 +24,21 @@ from dev_health_ops.metrics.compounding_risk import (
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 from dev_health_ops.providers.teams import build_repo_pattern_resolver
 from dev_health_ops.storage import detect_db_type
+from dev_health_ops.utils.cli import (
+    add_date_range_args,
+    add_sink_arg,
+    resolve_date_range,
+    validate_sink,
+)
 
 logger = logging.getLogger(__name__)
 
 
 def _date_range(end_day: date, backfill_days: int) -> list[date]:
-    if backfill_days <= 0:
+    if backfill_days <= 1:
         return [end_day]
-    return [end_day - timedelta(days=i) for i in range(backfill_days, -1, -1)]
+    start_day = end_day - timedelta(days=backfill_days - 1)
+    return [start_day + timedelta(days=i) for i in range(backfill_days)]
 
 
 def _fetch_repo_metrics_for_day(sink: Any, org_id: str, day: date) -> list[Any]:
@@ -159,7 +166,7 @@ async def run_compounding_risk_job(
     logger.info(
         "compounding-risk: done, %d rows written across %d day(s)",
         total_rows,
-        backfill_days + 1,
+        max(1, backfill_days),
     )
     return 0
 
@@ -173,31 +180,21 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
             "given day range and writes compounding_risk_daily."
         ),
     )
-    p.add_argument(
-        "--day",
-        type=lambda s: date.fromisoformat(s),
-        default=None,
-        help="Target day (UTC). Defaults to today.",
-    )
-    p.add_argument(
-        "--backfill",
-        type=int,
-        default=0,
-        dest="backfill_days",
-        help="Additional days to backfill (inclusive). Default 0.",
-    )
+    add_date_range_args(p, include_deprecated_aliases=False)
+    add_sink_arg(p)
     p.set_defaults(func=_cmd_compounding_risk)
 
 
 async def _cmd_compounding_risk(ns: argparse.Namespace) -> int:
     try:
+        validate_sink(ns)
         db_url = resolve_sink_uri(ns)
-        day = ns.day or datetime.now(timezone.utc).date()
+        day, backfill_days = resolve_date_range(ns)
         org_id = getattr(ns, "org", None) or os.getenv("ORG_ID") or ""
         return await run_compounding_risk_job(
             db_url=db_url,
             day=day,
-            backfill_days=int(ns.backfill_days or 0),
+            backfill_days=backfill_days,
             org_id=org_id,
         )
     except Exception as exc:

--- a/src/dev_health_ops/utils/cli.py
+++ b/src/dev_health_ops/utils/cli.py
@@ -16,7 +16,9 @@ from dev_health_ops.utils.datetime import utc_today
 logger = logging.getLogger(__name__)
 
 
-def add_date_range_args(parser: argparse.ArgumentParser) -> None:
+def add_date_range_args(
+    parser: argparse.ArgumentParser, *, include_deprecated_aliases: bool = True
+) -> None:
     """Add unified ``--since``, ``--before``, and ``--backfill`` flags.
 
     These three flags define the time window for sync/metrics operations:
@@ -49,13 +51,14 @@ def add_date_range_args(parser: argparse.ArgumentParser) -> None:
         help="End date (exclusive, ISO YYYY-MM-DD). Defaults to tomorrow (i.e. through today).",
     )
 
-    # Hidden deprecated aliases — emit warnings when used
-    parser.add_argument(
-        "--day", type=date.fromisoformat, default=None, help=argparse.SUPPRESS
-    )
-    parser.add_argument(
-        "--date", type=date.fromisoformat, default=None, help=argparse.SUPPRESS
-    )
+    if include_deprecated_aliases:
+        # Hidden deprecated aliases — emit warnings when used.
+        parser.add_argument(
+            "--day", type=date.fromisoformat, default=None, help=argparse.SUPPRESS
+        )
+        parser.add_argument(
+            "--date", type=date.fromisoformat, default=None, help=argparse.SUPPRESS
+        )
 
 
 def add_sink_arg(parser: argparse.ArgumentParser) -> None:

--- a/tests/test_compounding_risk_cli.py
+++ b/tests/test_compounding_risk_cli.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+import pytest
+
+from dev_health_ops import cli
+from dev_health_ops.metrics import job_compounding_risk
+
+
+@pytest.mark.asyncio
+async def test_compounding_risk_accepts_shared_date_backfill_flags(monkeypatch):
+    captured: dict[str, Any] = {}
+
+    async def fake_run_compounding_risk_job(**kwargs: Any) -> int:
+        captured.update(kwargs)
+        return 0
+
+    monkeypatch.setattr(
+        job_compounding_risk,
+        "run_compounding_risk_job",
+        fake_run_compounding_risk_job,
+    )
+    monkeypatch.setattr(
+        job_compounding_risk,
+        "resolve_sink_uri",
+        lambda ns: ns.analytics_db,
+    )
+
+    parser = cli.build_parser()
+    ns = parser.parse_args(
+        [
+            "metrics",
+            "compounding-risk",
+            "--analytics-db",
+            "clickhouse://user:pass@localhost:8123/default",
+            "--org",
+            "00000000-0000-0000-0000-000000000000",
+            "--before",
+            "2025-02-02",
+            "--backfill",
+            "7",
+        ]
+    )
+    cli._resolve_org(ns)
+
+    assert await ns.func(ns) == 0
+    assert captured == {
+        "db_url": "clickhouse://user:pass@localhost:8123/default",
+        "day": date(2025, 2, 1),
+        "backfill_days": 7,
+        "org_id": "00000000-0000-0000-0000-000000000000",
+    }
+
+
+def test_compounding_risk_backfill_range_is_same_size_as_other_metrics():
+    assert job_compounding_risk._date_range(date(2025, 2, 1), 7) == [
+        date(2025, 1, 26),
+        date(2025, 1, 27),
+        date(2025, 1, 28),
+        date(2025, 1, 29),
+        date(2025, 1, 30),
+        date(2025, 1, 31),
+        date(2025, 2, 1),
+    ]
+
+
+def test_compounding_risk_rejects_removed_day_alias():
+    parser = cli.build_parser()
+
+    with pytest.raises(SystemExit):
+        parser.parse_args(["metrics", "compounding-risk", "--day", "2025-02-01"])


### PR DESCRIPTION
## Summary
- align `metrics compounding-risk` with shared `--since` / `--before` / `--backfill` date handling
- remove `--day` support for compounding-risk and add parser regression tests
- update CLI docs and ingestion-failure runbook examples for the CHAOS-2475 follow-up

## Verification
- `bash ci/local_validate.sh`
- manual CLI QA: `metrics compounding-risk --help`, removed `--day` rejection, and `--before 2025-02-02 --backfill 7` reaching the ClickHouse handler with fake local creds