### PR TITLE
fix(attribution): migrate WCT team identity reads to WITA (CHAOS-2848)

### DIFF
--- a/docs/architecture/team-attribution.md
+++ b/docs/architecture/team-attribution.md
@@ -199,11 +199,16 @@ One path: `run_team_autoimport` → `team_autoimport_<provider>.populate()` → 
   same-provider donor), Jira (`test_jira_issue_project_wins_over_linked_issue`,
   `test_assignee_membership_wins_over_jira_linked_donor`). (Provider *link-capture* — distinct from
   the resolver — is also tested per provider, e.g. `test_gitlab_captures_external_key_*`.)
-- **Chart team attribution:** Investment Sankey, GraphQL TEAM flow-matrix/chord, team
-  Cycle Time × Throughput quadrant axes, and work-unit investment team evidence read the
-  primary `work_item_team_attributions` snapshot before rolling up team totals. Cycle-time
-  rows can still provide activity windows, durations, and co-occurrence bridges, but not the
-  owning team identity.
+- **Chart and drilldown team attribution:** Investment Sankey, GraphQL TEAM
+  flow-matrix/chord, GraphQL REPO flow-matrix's cross-repo team bridge, team
+  Cycle Time × Throughput quadrant axes, work-unit investment team evidence,
+  issue drilldowns, and flame issue details read the primary
+  `work_item_team_attributions` snapshot before rolling up or displaying team
+  identity. Cycle-time rows can still provide activity windows, durations,
+  work-scope/repo/type bridges, and unassigned/no-WITA detail rows, but not the
+  owning team identity. Person cohort selection reads ClickHouse `identities`
+  membership (`team_ids`) instead of metric rollup team snapshots so a person's
+  current team comparison does not lag behind admin/team-autoimport membership.
 - **Why it matters:** the team/project/member **dimension** is populated by the per-provider
   team/project/member sync. **"Auto Import" is a UX option** (checkboxes to import teams, projects,
   and members from an integration → `run_team_autoimport`, writing ClickHouse directly); manual

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -478,13 +478,13 @@ def compile_flow_matrix(
     team's distinct work_item count. That yields an asymmetric signal that
     unlocks the chord's directional modes.
 
-    For REPO (CHAOS-1292), edges come from the same table joined to
-    work_items (for repo_id) and bridged through (team_id, day) — i.e., when
-    the same team touches multiple repos on one day those repos become
-    cross-edges. For WORK_TYPE, the bridge is (repo_id, day) — multiple
-    work_types on the same repo+day become cross-edges. In all three cases
-    nodes are sourced from the same underlying data so node ids and edge
-    endpoints stay consistent.
+    For REPO (CHAOS-1292/CHAOS-2848), edges come from cycle-time activity
+    joined to work_items (for repo_id) and latest-primary WITA (for team_id),
+    then bridge through (team_id, day) — i.e., when the same authoritative team
+    touches multiple repos on one day those repos become cross-edges. For
+    WORK_TYPE, the bridge is (repo_id, day) — multiple work_types on the same
+    repo+day become cross-edges. In all three cases nodes are sourced from the
+    same underlying data so node ids and edge endpoints stay consistent.
     """
     dimension = validate_dimension(request.dimension)
     measure = validate_measure(request.measure)

--- a/src/dev_health_ops/api/graphql/sql/templates.py
+++ b/src/dev_health_ops/api/graphql/sql/templates.py
@@ -273,7 +273,27 @@ SETTINGS max_execution_time = %(timeout)s
 """
 
 
-_FLOW_MATRIX_ENRICHED_CTE = """WITH enriched AS (
+_FLOW_MATRIX_REPO_ENRICHED_CTE = f"""WITH enriched AS (
+    SELECT
+        wct.work_item_id,
+        t.team_id,
+        wct.day,
+        wct.org_id,
+        wi.repo_id,
+        wi.type AS work_item_type
+    FROM work_item_cycle_times AS wct FINAL
+    INNER JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t
+      ON t.work_item_id = wct.work_item_id
+    INNER JOIN work_items AS wi FINAL ON wct.work_item_id = wi.work_item_id
+    WHERE wct.org_id = %(org_id)s
+      AND wct.day >= %(start_date)s AND wct.day <= %(end_date)s
+      AND wi.org_id = %(org_id)s
+      AND t.team_id IS NOT NULL
+      AND t.team_id != ''
+)"""
+
+
+_FLOW_MATRIX_WORK_TYPE_ENRICHED_CTE = """WITH enriched AS (
     SELECT
         wct.work_item_id,
         wct.team_id,
@@ -318,11 +338,12 @@ SETTINGS max_execution_time = %(timeout)s
 def flow_matrix_repo_edges_template() -> str:
     """Asymmetric cross-repo edges bridged through (team_id, day).
 
-    work_item_cycle_times carries team_id + day per work item but NOT repo_id;
-    work_items carries repo_id. An INNER JOIN on work_item_id produces an
-    enriched per-item row. Self-joining that enriched set on (team_id, day,
-    org_id) gives every pair of repos that the same team touched on the same
-    day — the REPO analog of TEAM's (work_scope_id, day) bridge.
+    work_item_cycle_times carries day per work item but its denormalized
+    team_id is not authoritative for identity. The enriched CTE joins
+    work_item_team_attributions for latest-primary team identity and
+    work_items for repo_id. Self-joining that enriched set on (team_id, day,
+    org_id) gives every pair of repos that the same authoritative team touched
+    on the same day — the REPO analog of TEAM's (work_scope_id, day) bridge.
 
     The edge value is `uniqExact(a.work_item_id)` — the count of SOURCE
     repo's distinct work items in the shared team+day cell, not the cartesian
@@ -337,7 +358,7 @@ def flow_matrix_repo_edges_template() -> str:
     signal that populates on any org with teams spanning multiple repos.
     """
     return f"""
-{_FLOW_MATRIX_ENRICHED_CTE}
+{_FLOW_MATRIX_REPO_ENRICHED_CTE}
 SELECT
     'REPO' AS source_dimension,
     'REPO' AS target_dimension,
@@ -389,7 +410,7 @@ SETTINGS max_execution_time = %(timeout)s
 def flow_matrix_work_type_edges_template() -> str:
     """Asymmetric cross-work_type edges bridged through (repo_id, day).
 
-    Uses the same enrichment CTE as the REPO edges template. Self-joins on
+    Uses cycle-time activity enriched with work item metadata. Self-joins on
     (repo_id, day, org_id) so every pair of work_types completed in the same
     repo on the same day becomes an edge. Excludes self-loops.
 
@@ -401,7 +422,7 @@ def flow_matrix_work_type_edges_template() -> str:
     work_type B" — cross-type cooperation within a repo on a single day.
     """
     return f"""
-{_FLOW_MATRIX_ENRICHED_CTE}
+{_FLOW_MATRIX_WORK_TYPE_ENRICHED_CTE}
 SELECT
     'WORK_TYPE' AS source_dimension,
     'WORK_TYPE' AS target_dimension,

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -892,6 +892,7 @@ async def drilldown_issues_post(
                 metric_scope="team",
                 filters=payload.filters,
                 org_id=current_user.org_id,
+                team_column="t.team_id",
             )
             items = await fetch_issues(
                 sink,
@@ -930,6 +931,7 @@ async def drilldown_issues(
                 metric_scope="team",
                 filters=filters,
                 org_id=current_user.org_id,
+                team_column="t.team_id",
             )
             items = await fetch_issues(
                 sink,

--- a/src/dev_health_ops/api/queries/drilldown.py
+++ b/src/dev_health_ops/api/queries/drilldown.py
@@ -6,6 +6,7 @@ from typing import Any
 from dev_health_ops.api.services.auth import get_current_org_id
 
 from .client import query_dicts
+from .investment import PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE
 
 
 def _assert_org_id(org_id: str) -> None:
@@ -69,19 +70,21 @@ async def fetch_issues(
     _assert_org_id(org_id)
     query = f"""
         SELECT
-            work_item_id,
-            provider,
-            status,
-            team_id,
-            cycle_time_hours,
-            lead_time_hours,
-            started_at,
-            completed_at
-        FROM work_item_cycle_times
-        WHERE day >= %(start_day)s AND day < %(end_day)s
-          AND org_id = %(org_id)s
+            wct.work_item_id,
+            wct.provider,
+            wct.status,
+            nullIf(t.team_id, '') AS team_id,
+            wct.cycle_time_hours,
+            wct.lead_time_hours,
+            wct.started_at,
+            wct.completed_at
+        FROM work_item_cycle_times AS wct FINAL
+        LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t
+          ON t.work_item_id = wct.work_item_id
+        WHERE wct.day >= %(start_day)s AND wct.day < %(end_day)s
+          AND wct.org_id = %(org_id)s
         {scope_filter}
-        ORDER BY completed_at DESC
+        ORDER BY wct.completed_at DESC
         LIMIT %(limit)s
     """
     params = {"start_day": start_day, "end_day": end_day, "limit": limit}

--- a/src/dev_health_ops/api/queries/flame.py
+++ b/src/dev_health_ops/api/queries/flame.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from typing import Any
 
 from .client import query_dicts
+from .investment import PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE
 
 
 async def fetch_pull_request(
@@ -76,20 +77,23 @@ async def fetch_issue(
     work_item_id: str,
     org_id: str = "",
 ) -> dict[str, Any] | None:
-    query = """
+    query = f"""
         SELECT
-            work_item_id,
-            provider,
-            type,
-            status,
-            created_at,
-            started_at,
-            completed_at,
-            team_id,
-            work_scope_id
-        FROM work_item_cycle_times
-        WHERE work_item_id = %(work_item_id)s
-          AND org_id = %(org_id)s
+            wct.work_item_id,
+            wct.provider,
+            wct.type,
+            wct.status,
+            wct.created_at,
+            wct.started_at,
+            wct.completed_at,
+            nullIf(t.team_id, '') AS team_id,
+            wct.work_scope_id
+        FROM work_item_cycle_times AS wct FINAL
+        LEFT JOIN {PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE} AS t
+          ON t.work_item_id = wct.work_item_id
+        WHERE wct.work_item_id = %(work_item_id)s
+          AND wct.org_id = %(org_id)s
+        ORDER BY wct.day DESC
         LIMIT 1
     """
     params = {"work_item_id": work_item_id}

--- a/src/dev_health_ops/api/queries/people.py
+++ b/src/dev_health_ops/api/queries/people.py
@@ -8,11 +8,16 @@ from dev_health_ops.clickhouse_dedup import dedup_from
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from .client import query_dicts
+from .investment import PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE
 from .sql_loader import load_sql
 
 
 def _sql_params(value: Iterable[str]) -> list[str]:
     return [str(item) for item in value if item]
+
+
+def _primary_team_source_sql() -> str:
+    return PRIMARY_WORK_ITEM_TEAM_ATTRIBUTION_SOURCE
 
 
 async def search_people(
@@ -267,8 +272,11 @@ async def fetch_person_issues(
     template = load_sql("people/person_drilldown_issues.sql")
     cursor_filter = ""
     if cursor is not None:
-        cursor_filter = "AND completed_at < %(cursor)s"
-    sql = template.format(cursor_filter=cursor_filter)
+        cursor_filter = "AND wct.completed_at < %(cursor)s"
+    sql = template.format(
+        cursor_filter=cursor_filter,
+        primary_team_attribution_source=_primary_team_source_sql(),
+    )
     params = {
         "start_day": start_day,
         "end_day": end_day,

--- a/src/dev_health_ops/api/services/quadrant.py
+++ b/src/dev_health_ops/api/services/quadrant.py
@@ -331,11 +331,12 @@ async def _resolve_identity_variants(
     sink: BaseMetricsSink,
     *,
     person_id: str,
+    org_id: str,
 ) -> list[str]:
     aliases = load_identity_aliases()
     reverse = build_reverse_alias_map(aliases)
 
-    identity = await resolve_person_identity(sink, person_id=person_id)
+    identity = await resolve_person_identity(sink, person_id=person_id, org_id=org_id)
     if identity:
         normalized = normalize_alias(identity)
         canonical = reverse.get(normalized, identity)
@@ -529,10 +530,14 @@ async def build_quadrant_response(
         scope_params: dict[str, Any] = {}
 
         if group_scope == "person":
-            identities = await _resolve_identity_variants(sink, person_id=scope_id)
+            identities = await _resolve_identity_variants(
+                sink, person_id=scope_id, org_id=org_id
+            )
             if not identities:
                 raise HTTPException(status_code=404, detail="Individual not found")
-            team_filter = await fetch_person_team_id(sink, identities=identities)
+            team_filter = await fetch_person_team_id(
+                sink, identities=identities, org_id=org_id
+            )
             scope_filter, scope_params = _cohort_scope_filter(team_filter)
 
         x_spec = _metric_spec(definition.x.metric, group_scope)

--- a/src/dev_health_ops/api/sql/people/person_drilldown_issues.sql
+++ b/src/dev_health_ops/api/sql/people/person_drilldown_issues.sql
@@ -1,16 +1,18 @@
 SELECT
-    work_item_id,
-    provider,
-    status,
-    team_id,
-    cycle_time_hours,
-    lead_time_hours,
-    started_at,
-    completed_at
-FROM work_item_cycle_times
-WHERE day >= %(start_day)s AND day < %(end_day)s
-  AND assignee IN %(identities)s
-  AND org_id = %(org_id)s
+    wct.work_item_id,
+    wct.provider,
+    wct.status,
+    nullIf(t.team_id, '') AS team_id,
+    wct.cycle_time_hours,
+    wct.lead_time_hours,
+    wct.started_at,
+    wct.completed_at
+FROM work_item_cycle_times AS wct FINAL
+LEFT JOIN {primary_team_attribution_source} AS t
+  ON t.work_item_id = wct.work_item_id
+WHERE wct.day >= %(start_day)s AND wct.day < %(end_day)s
+  AND wct.assignee IN %(identities)s
+  AND wct.org_id = %(org_id)s
   {cursor_filter}
-ORDER BY completed_at DESC
+ORDER BY wct.completed_at DESC
 LIMIT %(limit)s

--- a/src/dev_health_ops/api/sql/people/person_team.sql
+++ b/src/dev_health_ops/api/sql/people/person_team.sql
@@ -1,21 +1,57 @@
 SELECT
     team_id
 FROM (
-    SELECT team_id, day
-    FROM user_metrics_daily
-    WHERE identity_id IN %(identities)s
+    SELECT
+        arrayJoin(team_ids) AS team_id,
+        updated_at
+    FROM identities FINAL
+    WHERE (
+        canonical_id IN %(identities)s
+        OR email IN %(identities)s
+        OR arrayExists(
+            identity -> (
+                (
+                    startsWith(identity, 'github:')
+                    AND has(
+                        JSONExtract(provider_identities, 'github', 'Array(String)'),
+                        replaceRegexpOne(identity, '^github:', '')
+                    )
+                )
+                OR (
+                    startsWith(identity, 'gitlab:')
+                    AND has(
+                        JSONExtract(provider_identities, 'gitlab', 'Array(String)'),
+                        replaceRegexpOne(identity, '^gitlab:', '')
+                    )
+                )
+                OR (
+                    startsWith(identity, 'linear:')
+                    AND has(
+                        JSONExtract(provider_identities, 'linear', 'Array(String)'),
+                        replaceRegexpOne(identity, '^linear:', '')
+                    )
+                )
+                OR (
+                    startsWith(identity, 'jira:accountid:')
+                    AND has(
+                        JSONExtract(provider_identities, 'jira', 'Array(String)'),
+                        replaceRegexpOne(identity, '^jira:accountid:', '')
+                    )
+                )
+                OR (
+                    startsWith(identity, 'accountid:')
+                    AND has(
+                        JSONExtract(provider_identities, 'jira', 'Array(String)'),
+                        replaceRegexpOne(identity, '^accountid:', '')
+                    )
+                )
+            ),
+            %(identities)s
+        )
+    )
       AND org_id = %(org_id)s
-      AND team_id IS NOT NULL
-      AND team_id != ''
-
-    UNION ALL
-
-    SELECT team_id, day
-    FROM work_item_user_metrics_daily FINAL
-    WHERE user_identity IN %(identities)s
-      AND org_id = %(org_id)s
-      AND team_id IS NOT NULL
-      AND team_id != ''
+      AND is_active = 1
 )
-ORDER BY day DESC
+WHERE team_id != ''
+ORDER BY updated_at DESC, team_id
 LIMIT 1

--- a/tests/api/queries/test_drilldown_org_check.py
+++ b/tests/api/queries/test_drilldown_org_check.py
@@ -13,11 +13,13 @@ from dev_health_ops.api.services.auth import _current_org_id, set_current_org_id
 
 class _Sink:
     def __init__(self) -> None:
+        self.last_query: str | None = None
         self.last_params: dict[str, Any] | None = None
 
     def query_dicts(
         self, query: str, params: dict[str, Any] | None
     ) -> list[dict[str, Any]]:
+        self.last_query = query
         self.last_params = params
         return []
 
@@ -88,5 +90,31 @@ async def test_fetch_issues_allows_matching_org_id():
         )
         assert sink.last_params is not None
         assert sink.last_params["org_id"] == "org-X"
+    finally:
+        _current_org_id.set(None)
+
+
+@pytest.mark.asyncio
+async def test_fetch_issues_reads_team_identity_from_wita():
+    try:
+        set_current_org_id("org-X")
+        sink = _Sink()
+        await fetch_issues(
+            sink,
+            start_day=date(2024, 1, 1),
+            end_day=date(2024, 1, 2),
+            scope_filter="AND t.team_id IN %(team_ids)s",
+            scope_params={"team_ids": ["team-new"]},
+            org_id="org-X",
+        )
+
+        assert sink.last_query is not None
+        assert "FROM work_item_cycle_times AS wct FINAL" in sink.last_query
+        assert "FROM work_item_team_attributions FINAL" in sink.last_query
+        assert "LEFT JOIN" in sink.last_query
+        assert "nullIf(t.team_id, '') AS team_id" in sink.last_query
+        assert "wct.team_id" not in sink.last_query
+        assert sink.last_params is not None
+        assert sink.last_params["team_ids"] == ["team-new"]
     finally:
         _current_org_id.set(None)

--- a/tests/api/queries/test_flame_deployment_org_scope.py
+++ b/tests/api/queries/test_flame_deployment_org_scope.py
@@ -17,6 +17,28 @@ from dev_health_ops.api.queries import flame
 
 
 @pytest.mark.asyncio
+async def test_fetch_issue_reads_team_identity_from_wita(monkeypatch):
+    captured: dict[str, object] = {}
+
+    async def _fake_query_dicts(client, query, params):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(flame, "query_dicts", _fake_query_dicts)
+
+    await flame.fetch_issue(object(), work_item_id="issue-1", org_id="org-A")
+
+    query = str(captured["query"])
+    assert "FROM work_item_cycle_times AS wct FINAL" in query
+    assert "FROM work_item_team_attributions FINAL" in query
+    assert "LEFT JOIN" in query
+    assert "nullIf(t.team_id, '') AS team_id" in query
+    assert "wct.team_id" not in query
+    assert captured["params"] == {"work_item_id": "issue-1", "org_id": "org-A"}
+
+
+@pytest.mark.asyncio
 async def test_fetch_deployment_scopes_on_deployments_org_id(monkeypatch):
     captured: dict[str, object] = {}
 

--- a/tests/api/queries/test_people_team_attribution_sql.py
+++ b/tests/api/queries/test_people_team_attribution_sql.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dev_health_ops.api.queries.sql_loader import load_sql
+
+
+def test_person_team_uses_identity_membership_not_metric_rollups() -> None:
+    sql = load_sql("people/person_team.sql")
+
+    assert "FROM identities FINAL" in sql
+    assert "arrayJoin(team_ids) AS team_id" in sql
+    assert "provider_identities" in sql
+    assert "arrayExists" in sql
+    assert "JSONExtract(provider_identities, 'github', 'Array(String)')" in sql
+    assert "JSONExtract(provider_identities, 'gitlab', 'Array(String)')" in sql
+    assert "JSONExtract(provider_identities, 'linear', 'Array(String)')" in sql
+    assert "JSONExtract(provider_identities, 'jira', 'Array(String)')" in sql
+    assert "replaceRegexpOne(identity, '^jira:accountid:', '')" in sql
+    assert "replaceRegexpOne(identity, '^accountid:', '')" in sql
+    assert "position(provider_identities" not in sql
+    assert "user_metrics_daily" not in sql
+    assert "work_item_user_metrics_daily" not in sql

--- a/tests/api/queries/test_person_drilldown_team_attribution_sql.py
+++ b/tests/api/queries/test_person_drilldown_team_attribution_sql.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import Any, cast
+
+import pytest
+
+from dev_health_ops.api.queries import people
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+
+@pytest.mark.asyncio
+async def test_person_issues_read_team_identity_from_wita(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_query_dicts(_sink: Any, query: str, params: dict[str, Any]):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(people, "query_dicts", fake_query_dicts)
+
+    await people.fetch_person_issues(
+        cast(BaseMetricsSink, object()),
+        identities=["dev@example.com"],
+        start_day=date(2026, 1, 1),
+        end_day=date(2026, 1, 31),
+        limit=25,
+        org_id="org-1",
+    )
+
+    query = captured["query"]
+    assert "FROM work_item_cycle_times AS wct FINAL" in query
+    assert "FROM work_item_team_attributions FINAL" in query
+    assert "LEFT JOIN" in query
+    assert "nullIf(t.team_id, '') AS team_id" in query
+    assert "wct.team_id" not in query
+    assert captured["params"]["identities"] == ["dev@example.com"]
+
+
+@pytest.mark.asyncio
+async def test_person_issues_cursor_filters_qualified_completed_at(monkeypatch) -> None:
+    captured: dict[str, Any] = {}
+
+    async def fake_query_dicts(_sink: Any, query: str, params: dict[str, Any]):
+        captured["query"] = query
+        captured["params"] = params
+        return []
+
+    monkeypatch.setattr(people, "query_dicts", fake_query_dicts)
+
+    await people.fetch_person_issues(
+        cast(BaseMetricsSink, object()),
+        identities=["dev@example.com"],
+        start_day=date(2026, 1, 1),
+        end_day=date(2026, 1, 31),
+        limit=25,
+        cursor=datetime(2026, 1, 15),
+        org_id="org-1",
+    )
+
+    assert "AND wct.completed_at < %(cursor)s" in captured["query"]
+    assert captured["params"]["cursor"] == datetime(2026, 1, 15)

--- a/tests/graphql/test_flow_matrix.py
+++ b/tests/graphql/test_flow_matrix.py
@@ -193,13 +193,22 @@ class TestCompileFlowMatrix:
 
 class TestRepoEdgesTemplate:
     """CHAOS-1292: REPO edges use the same asymmetric-cooccurrence shape as
-    TEAM, bridged via (team_id, day) instead of (work_scope_id, day)."""
+    TEAM, bridged via latest-primary WITA team identity and day instead of
+    (work_scope_id, day)."""
 
     def test_self_joins_on_team_day_bridge(self) -> None:
         sql = flow_matrix_repo_edges_template()
         assert "a.team_id = b.team_id" in sql
         assert "a.day = b.day" in sql
         assert "a.org_id = b.org_id" in sql
+
+    def test_bridge_team_identity_comes_from_primary_attribution(self) -> None:
+        sql = flow_matrix_repo_edges_template()
+        assert "FROM work_item_cycle_times AS wct FINAL" in sql
+        assert "FROM work_item_team_attributions FINAL" in sql
+        assert "is_primary = 1" in sql
+        assert "t.team_id" in sql
+        assert "wct.team_id" not in sql
 
     def test_excludes_self_loops(self) -> None:
         """a.repo_id != b.repo_id drops self-loops at the SQL layer so the
@@ -227,13 +236,11 @@ class TestRepoEdgesTemplate:
         assert "'REPO' AS source_dimension" in sql
         assert "'REPO' AS target_dimension" in sql
 
-    def test_guards_both_sides_of_bridge_against_null_and_empty_team(self) -> None:
-        """Without b-side guards, empty-string team_ids would match each other
-        via the JOIN on a.team_id = b.team_id and emit spurious edges. Both
-        sides of the join must filter NULL + empty."""
+    def test_guards_bridge_against_null_and_empty_team(self) -> None:
+        """Empty latest-primary WITA team_ids must not emit repo edges."""
         sql = flow_matrix_repo_edges_template()
-        assert "a.team_id IS NOT NULL AND a.team_id != ''" in sql
-        assert "b.team_id IS NOT NULL AND b.team_id != ''" in sql
+        assert "t.team_id IS NOT NULL" in sql
+        assert "t.team_id != ''" in sql
 
 
 class TestWorkTypeEdgesTemplate:

--- a/tests/test_quadrant.py
+++ b/tests/test_quadrant.py
@@ -74,6 +74,71 @@ def test_quadrant_axis_label_snapshot():
 
 
 @pytest.mark.asyncio
+async def test_person_quadrant_passes_org_to_team_cohort_lookup(monkeypatch):
+    @asynccontextmanager
+    async def _fake_client(_db_url):
+        yield object()
+
+    async def _fake_identity_variants(_sink, *, person_id, org_id):
+        assert person_id == "person-1"
+        assert org_id == "org-X"
+        return ["dev@example.com"]
+
+    async def _fake_person_team(_sink, *, identities, org_id):
+        assert identities == ["dev@example.com"]
+        assert org_id == "org-X"
+        return "team-X"
+
+    async def _fake_metric(
+        _sink,
+        *,
+        scope_filter,
+        scope_params,
+        **_,
+    ):
+        assert scope_filter == "AND m.team_id = %(team_id)s"
+        assert scope_params == {"team_id": "team-X"}
+        return [
+            {
+                "bucket": date(2024, 1, 1),
+                "entity_id": "dev@example.com",
+                "entity_label": "dev@example.com",
+                "value": 2.0,
+            }
+        ]
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.clickhouse_client", _fake_client
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant._resolve_identity_variants",
+        _fake_identity_variants,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.fetch_person_team_id",
+        _fake_person_team,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.api.services.quadrant.fetch_quadrant_metric",
+        _fake_metric,
+    )
+
+    response = await build_quadrant_response(
+        db_url="clickhouse://test",
+        org_id="org-X",
+        type="review_load_latency",
+        scope_type="person",
+        scope_id="person-1",
+        range_days=30,
+        bucket="week",
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 1, 8),
+    )
+
+    assert response.points[0].entity_id
+
+
+@pytest.mark.asyncio
 async def test_quadrant_resolves_team_uuid_label_from_team_catalog(monkeypatch):
     team_uuid = "4e00fff2-df66-5028-8ebd-e4535332300b"
 


### PR DESCRIPTION
## Summary
- move person cohort team lookup to ClickHouse identities/team_ids with provider-key-scoped matching
- return/scope issue drilldown, person drilldown, flame detail, and REPO flow-matrix team identity from latest-primary WITA
- document WITA-backed chart/detail team attribution semantics

## Validation
- Oracle blocker-only review: PASS
- Targeted pytest: 61 passed, 35 warnings
- Manual query-surface driver: passed
- bash ci/local_validate.sh: GATE PASSED (6765 passed, 44 skipped, 54 warnings)

SCREENSHOT-WAIVER: backend/API/query-only attribution change; no rendered UI surface changed.

Linear: CHAOS-2848