### PR TITLE
fix(metrics): read repos schema columns for compounding risk

### DIFF
--- a/src/dev_health_ops/api/graphql/loaders/repo_loader.py
+++ b/src/dev_health_ops/api/graphql/loaders/repo_loader.py
@@ -68,14 +68,15 @@ class RepoLoader(CachedDataLoader[str, RepoData | None]):
 
         sql = """
             SELECT
-                id as repo_id,
-                name as repo_name,
+                toString(id) as repo_id,
+                argMax(repo, last_synced) as repo_name,
                 org_id,
-                default_branch,
-                language
+                NULL AS default_branch,
+                NULL AS language
             FROM repos
-            WHERE id IN %(repo_ids)s
+            WHERE toString(id) IN %(repo_ids)s
               AND org_id = %(org_id)s
+            GROUP BY org_id, id
         """
         params = {"repo_ids": list(keys), "org_id": self._org_id}
 
@@ -148,14 +149,15 @@ class RepoByNameLoader(CachedDataLoader[str, RepoData | None]):
 
         sql = """
             SELECT
-                id as repo_id,
-                name as repo_name,
+                toString(id) as repo_id,
+                argMax(repo, last_synced) as repo_name,
                 org_id,
-                default_branch,
-                language
+                NULL AS default_branch,
+                NULL AS language
             FROM repos
-            WHERE lower(name) IN %(repo_names)s
-              AND org_id = %(org_id)s
+            WHERE org_id = %(org_id)s
+            GROUP BY org_id, id
+            HAVING lower(repo_name) IN %(repo_names)s
         """
         params = {"repo_names": [k.lower() for k in keys], "org_id": self._org_id}
 

--- a/src/dev_health_ops/metrics/job_compounding_risk.py
+++ b/src/dev_health_ops/metrics/job_compounding_risk.py
@@ -94,9 +94,10 @@ async def _load_repo_to_team(sink: Any, org_id: str) -> dict[str, str]:
 
     repos = sink.query_dicts(
         """
-        SELECT toString(repo_id) AS repo_id, full_name
+        SELECT toString(id) AS repo_id, argMax(repo, last_synced) AS full_name
         FROM repos
         WHERE org_id = {org_id:String}
+        GROUP BY org_id, id
         """,
         {"org_id": org_id},
     )

--- a/tests/api/graphql/loaders/test_loader_org_scoping.py
+++ b/tests/api/graphql/loaders/test_loader_org_scoping.py
@@ -29,6 +29,13 @@ async def test_repo_loader_scopes_query_by_org_id(monkeypatch):
     loader = RepoLoader(client=object(), org_id="org-A")
     await loader.batch_load(["repo-1"])
 
+    sql = str(captured["sql"])
+    assert "toString(id) as repo_id" in sql
+    assert "argMax(repo, last_synced) as repo_name" in sql
+    assert "NULL AS default_branch" in sql
+    assert "NULL AS language" in sql
+    assert "GROUP BY org_id, id" in sql
+    assert "name as repo_name" not in sql
     assert "AND org_id = %(org_id)s" in str(captured["sql"])
     assert captured["params"]["org_id"] == "org-A"
 
@@ -49,7 +56,14 @@ async def test_repo_by_name_loader_scopes_query_by_org_id(monkeypatch):
     loader = RepoByNameLoader(client=object(), org_id="org-A")
     await loader.batch_load(["Repo-One"])
 
-    assert "AND org_id = %(org_id)s" in str(captured["sql"])
+    sql = str(captured["sql"])
+    assert "toString(id) as repo_id" in sql
+    assert "argMax(repo, last_synced) as repo_name" in sql
+    assert "GROUP BY org_id, id" in sql
+    assert "HAVING lower(repo_name) IN %(repo_names)s" in sql
+    assert "lower(name)" not in sql
+    assert "name as repo_name" not in sql
+    assert "WHERE org_id = %(org_id)s" in sql
     assert captured["params"]["org_id"] == "org-A"
 
 

--- a/tests/test_compounding_risk_cli.py
+++ b/tests/test_compounding_risk_cli.py
@@ -71,3 +71,41 @@ def test_compounding_risk_rejects_removed_day_alias():
 
     with pytest.raises(SystemExit):
         parser.parse_args(["metrics", "compounding-risk", "--day", "2025-02-01"])
+
+
+@pytest.mark.asyncio
+async def test_load_repo_to_team_reads_repo_identifier_from_repos_id():
+    class FakeSink:
+        query: str = ""
+
+        async def get_all_teams(self) -> list[dict[str, Any]]:
+            return [
+                {
+                    "id": "team-1",
+                    "name": "Team One",
+                    "repo_patterns": ["full-chaos/dev-health-ops"],
+                }
+            ]
+
+        def query_dicts(
+            self, query: str, parameters: dict[str, Any]
+        ) -> list[dict[str, Any]]:
+            self.query = query
+            assert parameters == {"org_id": "org-1"}
+            return [
+                {
+                    "repo_id": "550e8400-e29b-41d4-a716-446655440000",
+                    "full_name": "full-chaos/dev-health-ops",
+                }
+            ]
+
+    sink = FakeSink()
+
+    result = await job_compounding_risk._load_repo_to_team(sink, "org-1")
+
+    assert "toString(id) AS repo_id" in sink.query
+    assert "argMax(repo, last_synced) AS full_name" in sink.query
+    assert "GROUP BY org_id, id" in sink.query
+    assert "toString(repo_id)" not in sink.query
+    assert "SELECT toString(id) AS repo_id, full_name" not in sink.query
+    assert result == {"550e8400-e29b-41d4-a716-446655440000": "team-1"}


### PR DESCRIPTION
## Summary
- fix compounding-risk repo-to-team lookup to read `repos.id` / `repos.repo` instead of nonexistent `repo_id` / `full_name`
- collapse `repos` ReplacingMergeTree rows with `argMax(repo, last_synced)` before mapping repo names
- update GraphQL repo loaders to use canonical ClickHouse columns and latest-row grouping
- add regressions for the compounding-risk query and repo loader SQL shape

## Validation
- `bash ci/local_validate.sh` passed
- pre-commit hooks passed for both commits
- pre-push hooks passed

SCREENSHOT-WAIVER: backend-only ClickHouse query/schema fix; no rendered UI changed.