### PR TITLE
feat(providers): instrument GitLab tests actuals (CHAOS-2813)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -989,10 +989,13 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
 
 | Route family | Dimension(s) | Covers | Confidence |
 | --- | --- | --- | --- |
-| `project` | `rest_core` | Project metadata, commits, files/blame, security, feature-flags | high–low |
+| `project` | `rest_core` | Project metadata, commits, files/blame, feature-flags | high–low |
 | `merge_requests` | `rest_core` | Merge request iterators (pagination-heavy) | medium |
 | `notes` | `rest_core` | MR/issue note + discussion expansion | low |
-| `pipelines` | `rest_core` | CI/CD pipeline + job expansion | low |
+| `pipelines` | `rest_core` | CI/CD pipeline listing + job expansion (`GitLabCodeClient.get_pipelines`) | low |
+| `deployments` | `rest_core` | Deployments, releases, deployment→MR resolution (`GitLabCodeClient`, CHAOS-2773 CS11) | low |
+| `security` | `rest_core` | Vulnerability findings + dependency-scan alerts (`GitLabCodeClient`, CHAOS-2773 CS10) | low |
+| `tests` | `rest_core` | Pipeline test_report, pipeline jobs, job artifact download (`GitLabCodeClient`, CHAOS-2773 CS12) | low |
 | `issues` | `rest_core` | Issue iterator + per-issue events | medium |
 | `milestones` | `rest_core` | Project/group milestone iterators | medium |
 | `epics` | `rest_core` | Group epic expansion (premium APIs) | low |
@@ -1172,8 +1175,17 @@ paper over:
   [LaunchDarkly](#launchdarkly) above. GitLab's feature-flags fetch
   (`get_feature_flags` / `get_project_name`) is likewise closed as of
   [CHAOS-2785](https://linear.app/fullchaos/issue/CHAOS-2785) — see
-  [GitLab](#gitlab) above — while the rest of GitLab's frozen
-  code-dataset methods remain unmigrated pending CHAOS-2773 CS17.
+  [GitLab](#gitlab) above — while GitLab's `security`
+  ([CHAOS-2811](https://linear.app/fullchaos/issue/CHAOS-2811), CS10),
+  `pipelines`+`deployments`
+  ([CHAOS-2812](https://linear.app/fullchaos/issue/CHAOS-2812), CS11), and
+  `tests` (+CI adapter usage draining;
+  [CHAOS-2813](https://linear.app/fullchaos/issue/CHAOS-2813), CS12)
+  code-dataset families are migrated onto the canonical, instrumented
+  `providers/gitlab/code_client.py::GitLabCodeClient` — GitLab's remaining
+  frozen code-dataset methods (`git`/`commit_stats`/`files`/`blame`/
+  `merge_requests` listing + repo-metadata/batch orchestration) stay
+  unmigrated pending their own CHAOS-2773 changesets through CS17.
 
 
 ## References

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -1585,12 +1585,12 @@ def _is_report_name(name: str) -> bool:
 
 def _fetch_gitlab_test_reports_sync(
     connector: Any,
-    gl_project: Any,
     project_id: int,
     since: datetime | None,
     default_branch: str | None,
     max_pipelines: int,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> tuple[
     list[tuple[str, dict[str, Any], datetime | None, datetime | None]],
     list[tuple[str, list[tuple[str, bytes]]]],
@@ -1601,108 +1601,163 @@ def _fetch_gitlab_test_reports_sync(
     ``[(run_id, test_report_json, started_at, finished_at), ...]`` (GitLab's
     parsed JUnit JSON + the pipeline timestamps used to date the suites) and
     ``coverage_members`` is ``[(run_id, [(filename, bytes), ...]), ...]`` from
-    job artifact ZIPs. ``run_id`` is ``str(pipeline.id)`` so rows join to the
-    pipeline. Bounded to the default branch and ``max_pipelines`` pipelines.
+    job artifact ZIPs. ``run_id`` is ``str(pipeline["id"])`` so rows join to
+    the pipeline. Bounded to the default branch and ``max_pipelines``
+    pipelines.
+
+    CHAOS-2773 CS12: fetches via the canonical, instrumented
+    ``providers.gitlab.code_client.GitLabCodeClient`` (built on the shared
+    ``InstrumentedRESTCore``) instead of the frozen python-gitlab
+    ``gl_project.pipelines.list()`` + the un-instrumented
+    ``connectors/utils/rest.py`` (``get_pipeline_test_report`` / ``get_list``
+    / ``download_job_artifacts``). Dispatched via ``loop.run_in_executor``
+    (a plain worker thread with no running event loop), so bridging to the
+    async client with ``asyncio.run()`` here is safe -- mirrors
+    ``_fetch_gitlab_pipelines_sync`` / ``_fetch_gitlab_deployments_sync`` /
+    ``_fetch_gitlab_security_alerts_sync``. ONE client instance covers the
+    whole project scan (pipeline listing + every pipeline's test_report +
+    jobs + artifact downloads), matching the CS2 "one client per unit"
+    drain contract.
+
+    ``usage_sink`` (CHAOS-2803/CS2), when given, receives the client's
+    drained per-request usage observations in a ``finally:`` on BOTH the
+    success and failure path.
     """
     from dev_health_ops.connectors.utils.safe_archive import iter_zip_members
 
-    test_reports: list[
-        tuple[str, dict[str, Any], datetime | None, datetime | None]
-    ] = []
-    coverage_members: list[tuple[str, list[tuple[str, bytes]]]] = []
     since_aware = since
     if since_aware is not None and since_aware.tzinfo is None:
         since_aware = since_aware.replace(tzinfo=timezone.utc)
 
-    # Filter by update time SERVER-SIDE. We must NOT early-`break` on created_at:
-    # the list is ordered by updated_at, and a recently-updated pipeline can be
-    # old by created_at, so breaking would silently skip valid in-window
-    # pipelines (Codex review). The max_pipelines cap bounds the scan instead.
-    list_params: dict[str, Any] = {
-        "per_page": 100,
-        "order_by": "updated_at",
-        "sort": "desc",
-    }
-    if since_aware is not None:
-        list_params["updated_after"] = since_aware.isoformat()
+    drained_observations: list[dict[str, Any]] = []
+
+    async def _run() -> tuple[
+        list[tuple[str, dict[str, Any], datetime | None, datetime | None]],
+        list[tuple[str, list[tuple[str, bytes]]]],
+    ]:
+        test_reports: list[
+            tuple[str, dict[str, Any], datetime | None, datetime | None]
+        ] = []
+        coverage_members: list[tuple[str, list[tuple[str, bytes]]]] = []
+
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                # Filter by update time SERVER-SIDE. We must NOT early-`break`
+                # on created_at: the list is ordered by updated_at, and a
+                # recently-updated pipeline can be old by created_at, so
+                # breaking would silently skip valid in-window pipelines
+                # (Codex review). The max_pipelines cap (applied below, AFTER
+                # the default-branch filter) bounds the scan instead.
+                try:
+                    raw_pipelines = await client.iter_pipelines_since(
+                        project_id, since=since_aware, per_page=100
+                    )
+                except Exception as exc:
+                    logging.warning(
+                        "Could not list pipelines for GitLab project %s: %s",
+                        project_id,
+                        exc,
+                    )
+                    return test_reports, coverage_members
+
+                count = 0
+                for pipeline in raw_pipelines:
+                    if count >= max_pipelines:
+                        break
+                    ref = pipeline.get("ref")
+                    if default_branch and ref and ref != default_branch:
+                        continue
+                    pipeline_id = pipeline.get("id")
+                    if pipeline_id is None:
+                        continue
+                    count += 1
+                    run_id = str(pipeline_id)
+                    created_at = safe_parse_datetime(pipeline.get("created_at"))
+                    started_at = (
+                        safe_parse_datetime(pipeline.get("started_at")) or created_at
+                    )
+                    finished_at = safe_parse_datetime(pipeline.get("finished_at"))
+
+                    if (
+                        until is not None
+                        and isinstance(started_at, datetime)
+                        and started_at.astimezone(timezone.utc) > until
+                    ):
+                        continue
+
+                    # Native parsed test report (pass/fail/duration) — preferred over XML.
+                    try:
+                        report = await client.get_pipeline_test_report(
+                            project_id, pipeline_id
+                        )
+                        if report and report.get("test_suites"):
+                            test_reports.append(
+                                (run_id, report, started_at, finished_at)
+                            )
+                    except Exception as exc:
+                        logging.debug(
+                            "test_report failed for pipeline %s: %s",
+                            pipeline_id,
+                            exc,
+                        )
+
+                    # Coverage from job artifacts (best-effort, bounded).
+                    try:
+                        jobs = await client.iter_pipeline_jobs(
+                            project_id, pipeline_id, per_page=100
+                        )
+                    except Exception:
+                        jobs = []
+                    members: list[tuple[str, bytes]] = []
+                    artifact_jobs = 0
+                    for job in jobs:
+                        if artifact_jobs >= MAX_ARTIFACTS_PER_RUN:
+                            break
+                        if not (job.get("artifacts_file") or job.get("artifacts")):
+                            continue
+                        job_id = job.get("id")
+                        if job_id is None:
+                            continue
+                        artifact_jobs += 1
+                        try:
+                            data = await client.download_job_artifact(
+                                project_id, job_id
+                            )
+                        except Exception as exc:
+                            logging.debug(
+                                "artifact download failed for job %s: %s",
+                                job_id,
+                                exc,
+                            )
+                            continue
+                        if not data:
+                            continue
+                        try:
+                            members.extend(
+                                iter_zip_members(data, name_filter=_is_report_name)
+                            )
+                        except zipfile.BadZipFile:
+                            continue
+                    if members:
+                        coverage_members.append((run_id, members))
+
+                return test_reports, coverage_members
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+
     try:
-        if max_pipelines > 100:
-            raw_pipelines = gl_project.pipelines.list(**list_params, as_list=False)
-        else:
-            raw_pipelines = gl_project.pipelines.list(**list_params, get_all=False)
+        test_reports, coverage_members = asyncio.run(_run())
     except Exception as exc:
         logging.warning(
-            "Could not list pipelines for GitLab project %s: %s", project_id, exc
+            "Failed to fetch GitLab test reports for project %s: %s",
+            project_id,
+            exc,
         )
-        return test_reports, coverage_members
-
-    count = 0
-    for pipeline in raw_pipelines:
-        if count >= max_pipelines:
-            break
-        ref = getattr(pipeline, "ref", None)
-        if default_branch and ref and ref != default_branch:
-            continue
-        pipeline_id = getattr(pipeline, "id", None)
-        if pipeline_id is None:
-            continue
-        count += 1
-        run_id = str(pipeline_id)
-        created_at = safe_parse_datetime(getattr(pipeline, "created_at", None))
-        started_at = (
-            safe_parse_datetime(getattr(pipeline, "started_at", None)) or created_at
+        test_reports, coverage_members = [], []
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_test_reports_sync", drained_observations, usage_sink
         )
-        finished_at = safe_parse_datetime(getattr(pipeline, "finished_at", None))
-
-        if (
-            until is not None
-            and isinstance(started_at, datetime)
-            and started_at.astimezone(timezone.utc) > until
-        ):
-            continue
-
-        # Native parsed test report (pass/fail/duration) — preferred over XML.
-        try:
-            report = connector.rest_client.get_pipeline_test_report(
-                project_id, pipeline_id
-            )
-            if report and report.get("test_suites"):
-                test_reports.append((run_id, report, started_at, finished_at))
-        except Exception as exc:
-            logging.debug("test_report failed for pipeline %s: %s", pipeline_id, exc)
-
-        # Coverage from job artifacts (best-effort, bounded).
-        try:
-            jobs = connector.rest_client.get_list(
-                f"projects/{project_id}/pipelines/{pipeline_id}/jobs",
-                params={"per_page": 100},
-            )
-        except Exception:
-            jobs = []
-        members: list[tuple[str, bytes]] = []
-        artifact_jobs = 0
-        for job in jobs:
-            if artifact_jobs >= MAX_ARTIFACTS_PER_RUN:
-                break
-            if not (job.get("artifacts_file") or job.get("artifacts")):
-                continue
-            job_id = job.get("id")
-            if job_id is None:
-                continue
-            artifact_jobs += 1
-            try:
-                data = connector.rest_client.download_job_artifacts(project_id, job_id)
-            except Exception as exc:
-                logging.debug("artifact download failed for job %s: %s", job_id, exc)
-                continue
-            if not data:
-                continue
-            try:
-                members.extend(iter_zip_members(data, name_filter=_is_report_name))
-            except zipfile.BadZipFile:
-                continue
-        if members:
-            coverage_members.append((run_id, members))
 
     return test_reports, coverage_members
 
@@ -1719,6 +1774,7 @@ async def _sync_gitlab_test_reports(
     loop: asyncio.AbstractEventLoop,
     since: datetime | None,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> None:
     """Ingest TestOps data for one GitLab project (CHAOS-2370).
 
@@ -1732,6 +1788,13 @@ async def _sync_gitlab_test_reports(
     from dev_health_ops.providers.gitlab.testops_pipeline import GitLabCIAdapter
 
     # (1) Extended pipelines + jobs. Explicit token (Codex review item G).
+    # ``adapter`` (CHAOS-2773 CS12) now opts into instrumentation via
+    # ``BasePipelineAdapter``'s ``usage_resolver``/``diagnostic_header_names``
+    # class attributes (shared foundation with CHAOS-2806/CS5's
+    # GitHubActionsAdapter) -- drained unconditionally in the ``finally:``
+    # below on BOTH the success and failure path, mirroring the code-client
+    # helpers above.
+    adapter: GitLabCIAdapter | None = None
     try:
         adapter = GitLabCIAdapter(base_url=connector.rest_client.base_url, token=token)
         processor = TestOpsPipelineProcessor(ingestion_sink)
@@ -1756,18 +1819,25 @@ async def _sync_gitlab_test_reports(
             project_id,
             exc,
         )
+    finally:
+        if adapter is not None:
+            _drain_gitlab_code_usage(
+                "_sync_gitlab_test_reports[adapter]",
+                adapter.drain_usage_observations(),
+                usage_sink,
+            )
 
     default_branch = getattr(gl_project, "default_branch", None)
     test_reports, coverage_members = await loop.run_in_executor(
         None,
         _fetch_gitlab_test_reports_sync,
         connector,
-        gl_project,
         project_id,
         since,
         default_branch,
         MAX_RUNS_PER_SYNC,
         until,
+        usage_sink,
     )
 
     suite_rows: list[Any] = []
@@ -2031,6 +2101,7 @@ async def process_gitlab_project(
                 loop=loop,
                 since=since,
                 until=until,
+                usage_sink=usage_sink,
             )
 
         if sync_deployments:
@@ -2379,6 +2450,7 @@ async def process_gitlab_projects_batch(
                     ingestion_sink=ingestion_sink,
                     loop=loop,
                     since=since,
+                    usage_sink=usage_sink,
                 )
             except Exception as e:
                 logging.warning(

--- a/src/dev_health_ops/providers/_base.py
+++ b/src/dev_health_ops/providers/_base.py
@@ -10,6 +10,7 @@ import httpx
 
 from dev_health_ops.exceptions import APIException, AuthenticationException
 from dev_health_ops.metrics.testops_schemas import JobRunRow, PipelineRunExtendedRow
+from dev_health_ops.providers.usage import OperationResolver, UsageRecorder
 
 
 @dataclass(slots=True)
@@ -22,6 +23,8 @@ class PipelineSyncBatch:
 class BasePipelineAdapter(ABC):
     provider: str
     token_env_var: str = ""
+    usage_resolver: OperationResolver | None = None
+    diagnostic_header_names: tuple[str, ...] = ()
 
     def __init__(
         self,
@@ -44,6 +47,11 @@ class BasePipelineAdapter(ABC):
         self.timeout = timeout
         self._transport = transport
         self._client: httpx.AsyncClient | None = None
+        self._usage = (
+            UsageRecorder(resolver=self.usage_resolver)
+            if self.usage_resolver is not None
+            else None
+        )
 
     def _token_from_env(self) -> str | None:
         if not self.token_env_var:
@@ -83,9 +91,11 @@ class BasePipelineAdapter(ABC):
         url: str,
         *,
         params: dict[str, Any] | None = None,
+        operation: str | None = None,
     ) -> tuple[Any, httpx.Response]:
         client = await self._get_client()
         response = await client.request(method, url, params=params)
+        self._record_response_usage(response, operation=operation or f"{method} {url}")
         if response.status_code == 401:
             raise AuthenticationException(
                 f"{self.provider} authentication failed: {response.text}"
@@ -102,6 +112,7 @@ class BasePipelineAdapter(ABC):
         *,
         params: dict[str, Any] | None = None,
         data_key: str | None = None,
+        operation: str | None = None,
     ) -> list[Any]:
         aggregated: list[Any] = []
         page = 1
@@ -111,7 +122,7 @@ class BasePipelineAdapter(ABC):
         while True:
             current_params["page"] = page
             payload, response = await self._request_json(
-                "GET", url, params=current_params
+                "GET", url, params=current_params, operation=operation
             )
             items = payload.get(data_key, []) if data_key else payload
             if not isinstance(items, list):
@@ -140,6 +151,43 @@ class BasePipelineAdapter(ABC):
         if item_count < self.per_page:
             return None
         return current_page + 1
+
+    def _record_response_usage(
+        self, response: httpx.Response, *, operation: str
+    ) -> None:
+        if self._usage is None:
+            return
+        lowered = {str(k).lower(): str(v) for k, v in response.headers.items()}
+        safe_headers = {
+            name: lowered[name]
+            for name in self.diagnostic_header_names
+            if name in lowered
+        }
+        rate_limit: dict[str, Any] = {}
+        for header_name, field_name in (
+            ("x-ratelimit-remaining", "remaining"),
+            ("ratelimit-remaining", "remaining"),
+            ("x-ratelimit-reset", "reset"),
+            ("ratelimit-reset", "reset"),
+            ("x-ratelimit-limit", "limit"),
+            ("ratelimit-limit", "limit"),
+            ("x-ratelimit-used", "used"),
+            ("retry-after", "retry_after"),
+        ):
+            if header_name in safe_headers:
+                rate_limit[field_name] = safe_headers[header_name]
+        self._usage.record(
+            transport="rest",
+            operation=operation,
+            headers=safe_headers,
+            rate_limit=rate_limit,
+            status=response.status_code,
+        )
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        if self._usage is None:
+            return []
+        return self._usage.drain()
 
     @staticmethod
     def parse_datetime(value: object) -> datetime | None:

--- a/src/dev_health_ops/providers/gitlab/budget.py
+++ b/src/dev_health_ops/providers/gitlab/budget.py
@@ -416,6 +416,23 @@ GITLAB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
         transport="rest",
         operation_markers=("security:",),
     ),
+    # CHAOS-2773 CS12: the "tests" code-dataset client (pipeline test_report
+    # + pipeline jobs + job artifact download) likewise authors its own
+    # "tests:" prefix rather than reusing "pipelines:" -- even though the
+    # ESTIMATOR (``_dataset_estimates`` above) buckets ``TESTS`` under the
+    # SAME "pipelines" dimension as ``CICD``/``DEPLOYMENTS`` (estimate
+    # vocabulary is frozen, CHAOS-2773 non-goals), the ACTUALS resolver is a
+    # separate concern: a dedicated family per code-client method group lets
+    # ``budget_comparison`` distinguish tests-specific traffic from bare
+    # pipeline-listing traffic, mirroring CS10's "security"/CS11's
+    # "deployments" precedent (both also actuals-only splits from their
+    # estimator bucket).
+    UsageRouteFamily(
+        "tests",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("tests:",),
+    ),
 )
 
 GITLAB_USAGE_ROUTE_FAMILY_KEYS = frozenset(

--- a/src/dev_health_ops/providers/gitlab/code_client.py
+++ b/src/dev_health_ops/providers/gitlab/code_client.py
@@ -90,6 +90,7 @@ _RESET_HEADER_NAME = "RateLimit-Reset"
 _SECURITY_FAMILY_PREFIX = "security"
 _PIPELINES_FAMILY_PREFIX = "pipelines"
 _DEPLOYMENTS_FAMILY_PREFIX = "deployments"
+_TESTS_FAMILY_PREFIX = "tests"
 
 
 @dataclass(frozen=True)
@@ -490,6 +491,162 @@ class GitLabCodeClient:
             paginate=False,
             max_items=100,
         )
+
+    async def iter_pipelines_since(
+        self,
+        project_id: int | str,
+        *,
+        since: datetime | None = None,
+        per_page: int = 100,
+        max_pages: int = 30,
+    ) -> list[dict[str, Any]]:
+        """Raw (unmapped) pipeline list dicts, newest-``updated_at`` first,
+        optionally server-side filtered to ``updated_after=since`` -- mirrors
+        the legacy python-gitlab ``gl_project.pipelines.list(order_by=
+        "updated_at", sort="desc", updated_after=...)`` call in
+        ``processors/gitlab.py::_fetch_gitlab_test_reports_sync`` (CHAOS-2773
+        CS12).
+
+        Returns RAW dicts rather than :class:`GitLabPipelineData` because the
+        ``tests`` family's caller needs the ``ref`` field for default-branch
+        filtering (the narrower dataclass built for the ``cicd``/``pipelines``
+        families does not carry it), and needs a scan bounded by PAGES rather
+        than by matching-item count -- the legacy lazy python-gitlab generator
+        stopped once enough REF-MATCHING pipelines were found, but this
+        core's paginators are eager, so ``max_pages`` intentionally leaves
+        headroom above a single-branch scan of ``MAX_RUNS_PER_SYNC`` pipelines
+        so branch filtering downstream doesn't silently shrink the effective
+        search window. See :meth:`get_pipelines` for the mapped,
+        item-capped sibling the ``cicd``/``pipelines`` families use.
+        """
+        params: dict[str, Any] = {"order_by": "updated_at", "sort": "desc"}
+        if since is not None:
+            params["updated_after"] = since.isoformat()
+        return await self._core.paginate_page_param(
+            f"/projects/{project_id}/pipelines",
+            operation=f"{_TESTS_FAMILY_PREFIX}:GET /projects/{{id}}/pipelines",
+            params=params,
+            per_page=per_page,
+            max_pages=max_pages,
+        )
+
+    async def get_pipeline_test_report(
+        self, project_id: int | str, pipeline_id: int | str
+    ) -> dict[str, Any]:
+        """Fetch GitLab's native parsed JUnit test report for a pipeline.
+
+        Mirrors ``GitLabRESTClient.get_pipeline_test_report``
+        (``connectors/utils/rest.py``, FROZEN) field-for-field: ``GET
+        /projects/{id}/pipelines/{pipeline_id}/test_report`` returns
+        already-parsed test suites/cases JSON, so no artifact download or
+        XML parsing is needed for GitLab pass/fail/duration metrics
+        (CHAOS-2370). Errors -- INCLUDING a 404 (no report for this
+        pipeline) -- propagate, matching the connector's own ``get()``
+        contract; callers handle best-effort (pre-existing behavior:
+        ``processors/gitlab.py`` wraps this in a broad ``except Exception``
+        per pipeline).
+        """
+        response = await self._core.request(
+            "GET",
+            f"/projects/{project_id}/pipelines/{pipeline_id}/test_report",
+            operation=(
+                f"{_TESTS_FAMILY_PREFIX}:GET "
+                "/projects/{id}/pipelines/{id}/test_report"
+            ),
+        )
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise APIException(
+                f"Unexpected GitLab test report response: {type(payload)!r}"
+            )
+        return payload
+
+    async def iter_pipeline_jobs(
+        self,
+        project_id: int | str,
+        pipeline_id: int | str,
+        *,
+        per_page: int = 100,
+    ) -> list[dict[str, Any]]:
+        """List jobs for a pipeline -- SINGLE PAGE only. This is a
+        pre-existing connector quirk (``GitLabRESTClient.get_list`` never
+        looped on ``page``/``X-Next-Page``), preserved here for strict
+        parity with the ``tests``-family coverage/artifact-discovery call
+        site in ``processors/gitlab.py::_fetch_gitlab_test_reports_sync``
+        (CHAOS-2773 CS12 -- default is parity, not a behavior change, same
+        philosophy as CS10's security pathfinder). Deliberately does NOT
+        pass ``include_retried`` -- unlike ``GitLabCIAdapter``'s own jobs
+        fetch for the ``job_runs`` rows, the legacy coverage/artifact scan
+        never requested retried jobs either.
+        """
+        return await self._get_gitlab_list(
+            f"/projects/{project_id}/pipelines/{pipeline_id}/jobs",
+            operation=(
+                f"{_TESTS_FAMILY_PREFIX}:GET /projects/{{id}}/pipelines/{{id}}/jobs"
+            ),
+            params={},
+            per_page=per_page,
+            paginate=False,
+            max_items=per_page,
+        )
+
+    async def download_job_artifact(
+        self,
+        project_id: int | str,
+        job_id: int | str,
+        *,
+        max_bytes: int = 100 * 1024 * 1024,
+    ) -> bytes:
+        """Download a job's artifacts ZIP (for coverage / fallback JUnit).
+
+        Mirrors ``GitLabRESTClient.download_job_artifacts``
+        (``connectors/utils/rest.py``, FROZEN): returns ``b""`` when the job
+        has no artifacts or they have expired (404), matching the
+        connector's own best-effort, convenience-empty contract. Unlike the
+        legacy ``requests``-streamed download, the shared
+        ``InstrumentedRESTCore`` buffers the full response before this
+        method can inspect its size (CS1 exposes no streaming primitive) --
+        the byte cap is therefore enforced POST-fetch: an oversized payload
+        is discarded (empty bytes returned, warning logged) rather than
+        aborting the transfer early. The pre-CS12 memory-cap intent
+        (CHAOS-2370) is preserved; only the enforcement point moves.
+        """
+        operation = f"{_TESTS_FAMILY_PREFIX}:GET /projects/{{id}}/jobs/{{id}}/artifacts"
+        try:
+            response = await self._core.request(
+                "GET",
+                f"/projects/{project_id}/jobs/{job_id}/artifacts",
+                operation=operation,
+                raw_redirect=True,
+            )
+        except NotFoundException:
+            return b""
+        if response.status_code in {301, 302, 303, 307, 308}:
+            location = response.headers.get("Location")
+            if not location:
+                raise APIException(
+                    f"GitLab artifact redirect for job {job_id} omitted Location"
+                )
+            response = await self._core.request_unauthenticated(
+                location,
+                operation=f"{operation} follow",
+            )
+            if response.status_code in {404, 410}:
+                return b""
+            if response.status_code >= 400:
+                raise APIException(
+                    "GitLab artifact redirect download failed for job "
+                    f"{job_id}: HTTP {response.status_code}"
+                )
+        content = response.content
+        if len(content) > max_bytes:
+            logger.warning(
+                "GitLab job artifact for job %s exceeds %d byte cap; discarding",
+                job_id,
+                max_bytes,
+            )
+            return b""
+        return content
 
     async def _get_gitlab_list(
         self,

--- a/src/dev_health_ops/providers/gitlab/testops_pipeline.py
+++ b/src/dev_health_ops/providers/gitlab/testops_pipeline.py
@@ -7,11 +7,15 @@ from uuid import UUID
 
 from dev_health_ops.metrics.testops_schemas import JobRunRow, PipelineRunExtendedRow
 from dev_health_ops.providers._base import BasePipelineAdapter, PipelineSyncBatch
+from dev_health_ops.providers._http import GITLAB_DIAGNOSTIC_HEADER_NAMES
+from dev_health_ops.providers.gitlab.budget import GITLAB_USAGE_RESOLVER
 
 
 class GitLabCIAdapter(BasePipelineAdapter):
     provider = "gitlab_ci"
     token_env_var = "GITLAB_TOKEN"
+    usage_resolver = GITLAB_USAGE_RESOLVER
+    diagnostic_header_names = GITLAB_DIAGNOSTIC_HEADER_NAMES
 
     @property
     def default_headers(self) -> dict[str, str]:
@@ -93,6 +97,7 @@ class GitLabCIAdapter(BasePipelineAdapter):
         pipelines = await self._paginate(
             f"/projects/{encoded_project}/pipelines",
             params=params,
+            operation=f"tests:GET /projects/{project_id}/pipelines",
         )
 
         pipeline_rows: list[PipelineRunExtendedRow] = []
@@ -140,6 +145,7 @@ class GitLabCIAdapter(BasePipelineAdapter):
             jobs = await self._paginate(
                 f"/projects/{encoded_project}/pipelines/{pipeline.get('id')}/jobs",
                 params={"include_retried": True},
+                operation=f"tests:GET /projects/{project_id}/pipelines/{{id}}/jobs",
             )
             for job in jobs:
                 job_started_at = self.parse_datetime(job.get("started_at"))

--- a/tests/providers/test_gitlab_code_client.py
+++ b/tests/providers/test_gitlab_code_client.py
@@ -17,12 +17,14 @@ from __future__ import annotations
 import time
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
+from typing import Any, cast
 
 import httpx
 import pytest
 
 from dev_health_ops.exceptions import (
     AuthenticationException,
+    NotFoundException,
     RateLimitException,
 )
 from dev_health_ops.providers.gitlab.code_client import GitLabCodeClient
@@ -702,6 +704,174 @@ class TestDeploymentsParity:
 
         assert len(deployments) == 1
         assert calls[_DEPLOYMENTS_PATH] == 1
+
+
+_TEST_REPORT_PATH = "/api/v4/projects/42/pipelines/11/test_report"
+_PIPELINE_JOBS_PATH = "/api/v4/projects/42/pipelines/11/jobs"
+_ARTIFACT_PATH = "/api/v4/projects/42/jobs/99/artifacts"
+_ARTIFACT_REDIRECT_PATH = "/artifact.zip"
+
+
+class TestTestsFamilyParity:
+    """CHAOS-2773 CS12: GitLab ``tests`` family (pipeline listing scoped to
+    the test-report scan, native JUnit test_report, pipeline jobs, job
+    artifact download) -- parity with the legacy
+    ``connectors/utils/rest.py::GitLabRESTClient.get_pipeline_test_report``
+    / ``get_list`` / ``download_job_artifacts`` (FROZEN) and the
+    python-gitlab ``gl_project.pipelines.list()`` call both used to ride,
+    now on ``GitLabCodeClient`` (built on the shared
+    ``InstrumentedRESTCore``). Every request carries the ``tests:`` family
+    prefix so tests usage is distinct from base CI/CD pipeline usage."""
+
+    @pytest.mark.asyncio
+    async def test_iter_pipelines_since_request_params_and_usage_family(
+        self,
+    ) -> None:
+        pipeline = {
+            "id": 11,
+            "ref": "main",
+            "created_at": "2026-02-01T00:00:00Z",
+        }
+        transport, calls = _router_transport(
+            {_PIPELINES_PATH: _json_response(200, [pipeline])}
+        )
+        client = _client(transport)
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+
+        pipelines = await client.iter_pipelines_since(42, since=since)
+
+        assert pipelines == [pipeline]
+        assert calls[_PIPELINES_PATH] == 1
+        query = dict(transport.captured_urls[_PIPELINES_PATH].params)  # type: ignore[attr-defined]
+        assert query == {
+            "order_by": "updated_at",
+            "sort": "desc",
+            "updated_after": "2026-01-01T00:00:00+00:00",
+            "page": "1",
+            "per_page": "100",
+        }
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "tests"
+
+    @pytest.mark.asyncio
+    async def test_iter_pipelines_since_omits_updated_after_when_since_none(
+        self,
+    ) -> None:
+        transport, calls = _router_transport({_PIPELINES_PATH: _json_response(200, [])})
+        client = _client(transport)
+
+        await client.iter_pipelines_since(42)
+
+        query = dict(transport.captured_urls[_PIPELINES_PATH].params)  # type: ignore[attr-defined]
+        assert "updated_after" not in query
+        assert calls[_PIPELINES_PATH] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_pipeline_test_report_returns_parsed_json(self) -> None:
+        report_body = {"test_suites": [{"name": "unit", "total_count": 3}]}
+        transport, calls = _router_transport(
+            {_TEST_REPORT_PATH: _json_response(200, report_body)}
+        )
+        client = _client(transport)
+
+        report = await client.get_pipeline_test_report(42, 11)
+
+        assert report == report_body
+        assert calls[_TEST_REPORT_PATH] == 1
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "tests"
+
+    @pytest.mark.asyncio
+    async def test_get_pipeline_test_report_404_propagates(self) -> None:
+        transport, _ = _router_transport({_TEST_REPORT_PATH: _empty_response(404)})
+        client = _client(transport)
+
+        with pytest.raises(NotFoundException):
+            await client.get_pipeline_test_report(42, 11)
+
+    @pytest.mark.asyncio
+    async def test_iter_pipeline_jobs_single_page_no_include_retried(
+        self,
+    ) -> None:
+        jobs_page = [{"id": i, "name": f"job-{i}"} for i in range(100)]
+        transport, calls = _router_transport(
+            {
+                _PIPELINE_JOBS_PATH: _json_response(
+                    200, jobs_page, headers={"X-Next-Page": "2"}
+                )
+            }
+        )
+        client = _client(transport)
+
+        jobs = await client.iter_pipeline_jobs(42, 11)
+
+        assert len(jobs) == 100
+        assert calls[_PIPELINE_JOBS_PATH] == 1
+        query = dict(transport.captured_urls[_PIPELINE_JOBS_PATH].params)  # type: ignore[attr-defined]
+        assert "include_retried" not in query
+
+    @pytest.mark.asyncio
+    async def test_download_job_artifact_returns_bytes_on_200(self) -> None:
+        transport, calls = _router_transport(
+            {_ARTIFACT_PATH: httpx.Response(200, content=b"zip-bytes", headers={})}
+        )
+        client = _client(transport)
+
+        data = await client.download_job_artifact(42, 99)
+
+        assert data == b"zip-bytes"
+        assert calls[_ARTIFACT_PATH] == 1
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "tests"
+
+    @pytest.mark.asyncio
+    async def test_download_job_artifact_follows_presigned_redirect(self) -> None:
+        transport, calls = _router_transport(
+            {
+                _ARTIFACT_PATH: httpx.Response(
+                    302,
+                    headers={"Location": "https://storage.example/artifact.zip"},
+                ),
+                _ARTIFACT_REDIRECT_PATH: httpx.Response(
+                    200,
+                    content=b"redirected-zip-bytes",
+                    headers={},
+                ),
+            }
+        )
+        client = _client(transport)
+
+        data = await client.download_job_artifact(42, 99)
+
+        assert data == b"redirected-zip-bytes"
+        assert calls[_ARTIFACT_PATH] == 1
+        assert calls[_ARTIFACT_REDIRECT_PATH] == 1
+        captured_headers = cast(Any, transport).captured_headers
+        assert "PRIVATE-TOKEN" not in captured_headers[_ARTIFACT_REDIRECT_PATH]
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "tests"
+        assert observations[0]["request_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_download_job_artifact_returns_empty_on_404(self) -> None:
+        transport, _ = _router_transport({_ARTIFACT_PATH: _empty_response(404)})
+        client = _client(transport)
+
+        data = await client.download_job_artifact(42, 99)
+
+        assert data == b""
+
+    @pytest.mark.asyncio
+    async def test_download_job_artifact_discards_over_byte_cap(self) -> None:
+        transport, _ = _router_transport(
+            {_ARTIFACT_PATH: httpx.Response(200, content=b"x" * 100, headers={})}
+        )
+        client = _client(transport)
+
+        data = await client.download_job_artifact(42, 99, max_bytes=10)
+
+        assert data == b""
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_code_window_upper_bound.py
+++ b/tests/test_code_window_upper_bound.py
@@ -131,37 +131,44 @@ def test_gitlab_test_reports_fetch_skips_post_window_pipelines() -> None:
     # CHAOS-2573 (Codex review): coverage_members carry no timestamp and are
     # ingested unconditionally, so a post-window pipeline must be dropped at the
     # source -- before its native report OR coverage artifacts are collected.
-    in_window = SimpleNamespace(
-        id=1,
-        ref="main",
-        created_at="2026-01-11T00:00:00Z",
-        started_at="2026-01-11T00:00:00Z",
-        finished_at="2026-01-11T01:00:00Z",
-    )
-    post_window = SimpleNamespace(
-        id=2,
-        ref="main",
-        created_at="2026-01-20T00:00:00Z",
-        started_at="2026-01-20T00:00:00Z",
-        finished_at="2026-01-20T01:00:00Z",
-    )
-    gl_project = MagicMock()
-    gl_project.pipelines.list.return_value = [post_window, in_window]
-    connector = MagicMock()
-    connector.rest_client.get_pipeline_test_report.return_value = {
-        "test_suites": [{"name": "suite"}]
+    # CHAOS-2773 CS12: pipeline listing + test_report/jobs now ride the
+    # canonical, instrumented ``GitLabCodeClient`` instead of python-gitlab's
+    # ``gl_project.pipelines.list()`` + ``connector.rest_client.*``.
+    in_window = {
+        "id": 1,
+        "ref": "main",
+        "created_at": "2026-01-11T00:00:00Z",
+        "started_at": "2026-01-11T00:00:00Z",
+        "finished_at": "2026-01-11T01:00:00Z",
     }
-    connector.rest_client.get_list.return_value = []  # no jobs -> no coverage
-
-    test_reports, coverage_members = _fetch_gitlab_test_reports_sync(
-        connector, gl_project, 123, SINCE, "main", 50, UNTIL
+    post_window = {
+        "id": 2,
+        "ref": "main",
+        "created_at": "2026-01-20T00:00:00Z",
+        "started_at": "2026-01-20T00:00:00Z",
+        "finished_at": "2026-01-20T01:00:00Z",
+    }
+    connector = MagicMock()
+    client = _async_cm(MagicMock())
+    client.iter_pipelines_since = AsyncMock(return_value=[post_window, in_window])
+    client.get_pipeline_test_report = AsyncMock(
+        return_value={"test_suites": [{"name": "suite"}]}
     )
+    client.iter_pipeline_jobs = AsyncMock(return_value=[])  # no jobs -> no coverage
+    client.drain_usage_observations = MagicMock(return_value=[])
+
+    with patch(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        return_value=client,
+    ):
+        test_reports, coverage_members = _fetch_gitlab_test_reports_sync(
+            connector, 123, SINCE, "main", 50, UNTIL
+        )
 
     assert {run_id for run_id, *_ in test_reports} == {"1"}
     # The post-window pipeline is skipped before any report/coverage fetch.
     queried_ids = {
-        call.args[1]
-        for call in connector.rest_client.get_pipeline_test_report.call_args_list
+        call.args[1] for call in client.get_pipeline_test_report.await_args_list
     }
     assert queried_ids == {1}
 
@@ -252,3 +259,96 @@ async def test_gitlab_test_reports_forwards_until_date_to_testops() -> None:
 
     proc.fetch_and_store.assert_awaited_once()
     assert proc.fetch_and_store.await_args.kwargs["until_date"] == UNTIL
+
+
+@pytest.mark.asyncio
+async def test_gitlab_test_reports_drains_ci_adapter_usage_into_sink() -> None:
+    """CHAOS-2773 CS12: GitLabCIAdapter now opts into BasePipelineAdapter's
+    usage instrumentation (shared foundation with CHAOS-2806/CS5) -- its
+    drained observations must flow into the caller-owned usage_sink in the
+    finally: block, on the success path."""
+    loop = asyncio.get_running_loop()
+    proc = MagicMock()
+    proc.fetch_and_store = AsyncMock(
+        return_value=SimpleNamespace(pipeline_runs=0, job_runs=0)
+    )
+    adapter = _async_cm(MagicMock())
+    adapter.drain_usage_observations = MagicMock(
+        return_value=[{"route_family": "tests"}]
+    )
+    usage_sink: list[dict[str, object]] = []
+
+    with (
+        patch(
+            "dev_health_ops.providers.gitlab.testops_pipeline.GitLabCIAdapter",
+            return_value=adapter,
+        ),
+        patch(
+            "dev_health_ops.processors.testops_pipeline.TestOpsPipelineProcessor",
+            return_value=proc,
+        ),
+        patch(
+            "dev_health_ops.processors.gitlab._fetch_gitlab_test_reports_sync",
+            return_value=([], []),
+        ),
+    ):
+        await _sync_gitlab_test_reports(
+            connector=MagicMock(),
+            gl_project=MagicMock(default_branch="main"),
+            project_id=123,
+            token="t",
+            repo_id="repo-1",
+            org_id="org-1",
+            ingestion_sink=MagicMock(),
+            loop=loop,
+            since=SINCE,
+            usage_sink=usage_sink,
+        )
+
+    adapter.drain_usage_observations.assert_called_once()
+    assert usage_sink == [{"route_family": "tests"}]
+
+
+@pytest.mark.asyncio
+async def test_gitlab_test_reports_drains_ci_adapter_usage_on_failure_path() -> None:
+    """CHAOS-2773 CS12: the adapter's usage is drained in the finally: block
+    even when fetch_and_store raises -- the CS2 contract requires BOTH the
+    success and failure path to preserve partial observations."""
+    loop = asyncio.get_running_loop()
+    proc = MagicMock()
+    proc.fetch_and_store = AsyncMock(side_effect=RuntimeError("boom"))
+    adapter = _async_cm(MagicMock())
+    adapter.drain_usage_observations = MagicMock(
+        return_value=[{"route_family": "tests"}]
+    )
+    usage_sink: list[dict[str, object]] = []
+
+    with (
+        patch(
+            "dev_health_ops.providers.gitlab.testops_pipeline.GitLabCIAdapter",
+            return_value=adapter,
+        ),
+        patch(
+            "dev_health_ops.processors.testops_pipeline.TestOpsPipelineProcessor",
+            return_value=proc,
+        ),
+        patch(
+            "dev_health_ops.processors.gitlab._fetch_gitlab_test_reports_sync",
+            return_value=([], []),
+        ),
+    ):
+        await _sync_gitlab_test_reports(
+            connector=MagicMock(),
+            gl_project=MagicMock(default_branch="main"),
+            project_id=123,
+            token="t",
+            repo_id="repo-1",
+            org_id="org-1",
+            ingestion_sink=MagicMock(),
+            loop=loop,
+            since=SINCE,
+            usage_sink=usage_sink,
+        )
+
+    adapter.drain_usage_observations.assert_called_once()
+    assert usage_sink == [{"route_family": "tests"}]

--- a/tests/test_processors_gitlab.py
+++ b/tests/test_processors_gitlab.py
@@ -8,6 +8,7 @@ from dev_health_ops.processors.gitlab import (
     _fetch_gitlab_deployments_sync,
     _fetch_gitlab_incidents_sync,
     _fetch_gitlab_pipelines_sync,
+    _fetch_gitlab_test_reports_sync,
     process_gitlab_project,
 )
 from dev_health_ops.providers.gitlab.code_client import (
@@ -25,12 +26,22 @@ class _FakeGitLabCodeClient:
         releases=None,
         merge_requests=None,
         observations=None,
+        pipelines_raw=None,
+        test_reports=None,
+        jobs=None,
+        artifacts=None,
     ):
         self.pipelines = pipelines or []
         self.deployments = deployments or []
         self.releases = releases or []
         self.merge_requests = merge_requests or []
         self.observations = observations or []
+        self.pipelines_raw = pipelines_raw or []
+        # CHAOS-2773 CS12: per-pipeline-id test_report / jobs / artifact-bytes
+        # fixtures for the ``tests`` family fetch.
+        self.test_reports = test_reports or {}
+        self.jobs = jobs or {}
+        self.artifacts = artifacts or {}
 
     async def __aenter__(self):
         return self
@@ -49,6 +60,18 @@ class _FakeGitLabCodeClient:
 
     async def get_deployment_merge_requests(self, project_id, sha):
         return self.merge_requests
+
+    async def iter_pipelines_since(self, project_id, *, since=None, per_page=100):
+        return self.pipelines_raw
+
+    async def get_pipeline_test_report(self, project_id, pipeline_id):
+        return self.test_reports.get(pipeline_id, {})
+
+    async def iter_pipeline_jobs(self, project_id, pipeline_id, *, per_page=100):
+        return self.jobs.get(pipeline_id, [])
+
+    async def download_job_artifact(self, project_id, job_id, *, max_bytes=None):
+        return self.artifacts.get(job_id, b"")
 
     def drain_usage_observations(self):
         observations = list(self.observations)
@@ -417,6 +440,72 @@ def test_fetch_gitlab_deployments_sync(monkeypatch):
         2023, 1, 2, 0, 0, 0, tzinfo=timezone.utc
     )
     assert usage_sink == [{"route_family": "deployments"}]
+
+
+def test_fetch_gitlab_test_reports_sync(monkeypatch):
+    pipeline_raw = {
+        "id": 1,
+        "ref": "main",
+        "created_at": "2023-01-01T00:00:00Z",
+        "started_at": "2023-01-01T00:01:00Z",
+        "finished_at": "2023-01-01T00:05:00Z",
+    }
+    usage_sink: list[dict[str, str]] = []
+    fake_client = _FakeGitLabCodeClient(
+        pipelines_raw=[pipeline_raw],
+        test_reports={1: {"test_suites": [{"name": "suite"}]}},
+        jobs={1: [{"id": 9, "artifacts_file": {"filename": "a.zip"}}]},
+        artifacts={9: b""},  # no artifact bytes -> no coverage members
+        observations=[{"route_family": "tests"}],
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+
+    test_reports, coverage_members = _fetch_gitlab_test_reports_sync(
+        Mock(),
+        project_id=1,
+        since=None,
+        default_branch="main",
+        max_pipelines=10,
+        usage_sink=usage_sink,
+    )
+
+    assert len(test_reports) == 1
+    run_id, report, started_at, finished_at = test_reports[0]
+    assert run_id == "1"
+    assert report == {"test_suites": [{"name": "suite"}]}
+    assert started_at == datetime(2023, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    assert coverage_members == []
+    assert usage_sink == [{"route_family": "tests"}]
+
+
+def test_fetch_gitlab_test_reports_sync_skips_other_branch_pipelines(monkeypatch):
+    other_branch_pipeline = {
+        "id": 2,
+        "ref": "feature-x",
+        "created_at": "2023-01-01T00:00:00Z",
+    }
+    fake_client = _FakeGitLabCodeClient(
+        pipelines_raw=[other_branch_pipeline],
+        test_reports={2: {"test_suites": [{"name": "suite"}]}},
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+
+    test_reports, coverage_members = _fetch_gitlab_test_reports_sync(
+        Mock(),
+        project_id=1,
+        since=None,
+        default_branch="main",
+        max_pipelines=10,
+    )
+
+    assert test_reports == []
+    assert coverage_members == []
 
 
 def test_fetch_gitlab_incidents_sync():


### PR DESCRIPTION
## Summary
- route GitLab tests-family fetches through GitLabCodeClient
- add tests route-family actuals and GitLab TestOps adapter usage draining
- preserve GitLab artifact redirect handling without forwarding PRIVATE-TOKEN
- document migrated GitLab tests actuals coverage

## Validation
- Oracle review: PASS
- uv run --extra dev python -m pytest tests/providers/test_gitlab_code_client.py tests/test_processors_gitlab.py tests/test_code_window_upper_bound.py -q
- env -i PATH="/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.krew/bin:/Users/chris/.pyenv/shims:/Users/chris/.pyenv/bin:/Users/chris/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/lib/ruby/gems/3.3.0/bin:/opt/homebrew/opt/ruby/bin:/opt/homebrew/opt/sqlite/bin:/opt/homebrew/opt/python/libexec/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:/Users/chris/.cargo/bin:/Users/chris/.lmstudio/bin:/Users/chris/.docker/bin:/Users/chris/.local/share/go/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/iTerm.app/Contents/Resources/utilities:/Users/chris/.orbstack/bin" HOME="/Users/chris" TMPDIR="/var/folders/fc/1xbvf93j4t31_5mslw1x6gq40000gn/T/" SCRATCH_DB="ci_local_validate_2813" bash ci/local_validate.sh

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.