### PR TITLE
feat(providers): instrument GitHub CI and tests actuals (CHAOS-2806)

### DIFF
--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -346,6 +346,62 @@ def _fetch_github_workflow_runs_sync(gh_repo, repo_id, max_runs, since):
     return runs
 
 
+async def _fetch_github_workflow_runs_async(
+    connector,
+    owner: str,
+    repo_name: str,
+    repo_id,
+    max_runs: int,
+    since: datetime | None,
+    usage_sink: list[dict[str, Any]] | None = None,
+) -> list[CiPipelineRun]:
+    runs: list[CiPipelineRun] = []
+    client = _github_code_client_from_connector(connector)
+    try:
+        try:
+            raw_runs = await client.get_workflow_runs(
+                owner,
+                repo_name,
+                max_runs=max_runs,
+            )
+        except Exception as exc:
+            logging.debug("Failed to fetch workflow runs: %s", exc)
+            return runs
+
+        for run in raw_runs:
+            started_at = run.started_at
+            if started_at is None:
+                continue
+            if since is not None and started_at.astimezone(timezone.utc) < since:
+                continue
+            runs.append(
+                build_ci_pipeline_run(
+                    repo_id=repo_id,
+                    run_id=run.run_id,
+                    status=run.status,
+                    queued_at=run.queued_at,
+                    started_at=started_at,
+                    finished_at=run.finished_at,
+                    retry_count=run.retry_count,
+                )
+            )
+        return runs
+    finally:
+        drained = client.drain_usage_observations()
+        if usage_sink is not None:
+            usage_sink.extend(drained)
+        elif drained:
+            logging.debug(
+                "_fetch_github_workflow_runs_async: drained %d cicd usage "
+                "observation(s) for %s/%s with no adapter-owned sink (legacy "
+                "entry point) -- logging only, not persisted",
+                len(drained),
+                owner,
+                repo_name,
+            )
+        await client.close()
+
+
 async def _fetch_github_deployments_async(
     connector,
     owner: str,
@@ -1507,6 +1563,7 @@ async def _sync_github_test_reports(
     loop: asyncio.AbstractEventLoop,
     since: datetime | None,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> None:
     """Ingest TestOps data for one GitHub repo (CHAOS-2370).
 
@@ -1528,16 +1585,30 @@ async def _sync_github_test_reports(
             base_url=connector._rest_base_url(), token=connector.token
         )
         processor = TestOpsPipelineProcessor(ingestion_sink)
-        async with adapter:
-            result = await processor.fetch_and_store(
-                adapter,
-                since_date=since,
-                until_date=until,
-                owner=owner,
-                repo=repo_name,
-                repo_id=repo_id,
-                org_id=org_id,
-            )
+        try:
+            async with adapter:
+                result = await processor.fetch_and_store(
+                    adapter,
+                    since_date=since,
+                    until_date=until,
+                    owner=owner,
+                    repo=repo_name,
+                    repo_id=repo_id,
+                    org_id=org_id,
+                )
+        finally:
+            drained = adapter.drain_usage_observations()
+            if usage_sink is not None:
+                usage_sink.extend(drained)
+            elif drained:
+                logging.debug(
+                    "_sync_github_test_reports: drained %d tests usage "
+                    "observation(s) for %s/%s with no adapter-owned sink "
+                    "(legacy entry point) -- logging only, not persisted",
+                    len(drained),
+                    owner,
+                    repo_name,
+                )
         logging.info(
             "TestOps GitHub %s/%s: %d pipelines, %d jobs",
             owner,
@@ -1790,13 +1861,14 @@ async def process_github_repo(
 
             if sync_cicd:
                 logging.info("Fetching CI/CD workflow runs from GitHub...")
-                pipeline_runs = await loop.run_in_executor(
-                    None,
-                    _fetch_github_workflow_runs_sync,
-                    gh_repo,
+                pipeline_runs = await _fetch_github_workflow_runs_async(
+                    connector,
+                    owner,
+                    repo_name,
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink=usage_sink,
                 )
                 pipeline_runs = _filter_after(pipeline_runs, until, "started_at")
                 if pipeline_runs:
@@ -1815,6 +1887,7 @@ async def process_github_repo(
                     loop=loop,
                     since=since,
                     until=until,
+                    usage_sink=usage_sink,
                 )
 
             if sync_deployments:
@@ -2121,15 +2194,15 @@ async def process_github_repos_batch(
 
         if sync_cicd:
             try:
-                if gh_repo is None:
-                    gh_repo = connector.github.get_repo(repo_info.full_name)
-                pipeline_runs = await loop.run_in_executor(
-                    None,
-                    _fetch_github_workflow_runs_sync,
-                    gh_repo,
+                batch_owner, _, batch_repo = repo_info.full_name.partition("/")
+                pipeline_runs = await _fetch_github_workflow_runs_async(
+                    connector,
+                    batch_owner,
+                    batch_repo,
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink=usage_sink,
                 )
                 if pipeline_runs:
                     await ingestion_sink.insert_ci_pipeline_runs(pipeline_runs)
@@ -2155,6 +2228,7 @@ async def process_github_repos_batch(
                     ingestion_sink=ingestion_sink,
                     loop=loop,
                     since=since,
+                    usage_sink=usage_sink,
                 )
             except Exception as e:
                 logging.warning(

--- a/src/dev_health_ops/providers/_base.py
+++ b/src/dev_health_ops/providers/_base.py
@@ -10,6 +10,7 @@ import httpx
 
 from dev_health_ops.exceptions import APIException, AuthenticationException
 from dev_health_ops.metrics.testops_schemas import JobRunRow, PipelineRunExtendedRow
+from dev_health_ops.providers.usage import OperationResolver, UsageRecorder
 
 
 @dataclass(slots=True)
@@ -22,6 +23,8 @@ class PipelineSyncBatch:
 class BasePipelineAdapter(ABC):
     provider: str
     token_env_var: str = ""
+    usage_resolver: OperationResolver | None = None
+    diagnostic_header_names: tuple[str, ...] = ()
 
     def __init__(
         self,
@@ -44,6 +47,11 @@ class BasePipelineAdapter(ABC):
         self.timeout = timeout
         self._transport = transport
         self._client: httpx.AsyncClient | None = None
+        self._usage = (
+            UsageRecorder(resolver=self.usage_resolver)
+            if self.usage_resolver is not None
+            else None
+        )
 
     def _token_from_env(self) -> str | None:
         if not self.token_env_var:
@@ -83,9 +91,11 @@ class BasePipelineAdapter(ABC):
         url: str,
         *,
         params: dict[str, Any] | None = None,
+        operation: str | None = None,
     ) -> tuple[Any, httpx.Response]:
         client = await self._get_client()
         response = await client.request(method, url, params=params)
+        self._record_response_usage(response, operation=operation or f"{method} {url}")
         if response.status_code == 401:
             raise AuthenticationException(
                 f"{self.provider} authentication failed: {response.text}"
@@ -102,6 +112,7 @@ class BasePipelineAdapter(ABC):
         *,
         params: dict[str, Any] | None = None,
         data_key: str | None = None,
+        operation: str | None = None,
     ) -> list[Any]:
         aggregated: list[Any] = []
         page = 1
@@ -111,7 +122,7 @@ class BasePipelineAdapter(ABC):
         while True:
             current_params["page"] = page
             payload, response = await self._request_json(
-                "GET", url, params=current_params
+                "GET", url, params=current_params, operation=operation
             )
             items = payload.get(data_key, []) if data_key else payload
             if not isinstance(items, list):
@@ -140,6 +151,43 @@ class BasePipelineAdapter(ABC):
         if item_count < self.per_page:
             return None
         return current_page + 1
+
+    def _record_response_usage(
+        self, response: httpx.Response, *, operation: str
+    ) -> None:
+        if self._usage is None:
+            return
+        lowered = {str(k).lower(): str(v) for k, v in response.headers.items()}
+        safe_headers = {
+            name: lowered[name]
+            for name in self.diagnostic_header_names
+            if name in lowered
+        }
+        rate_limit: dict[str, Any] = {}
+        for header_name, field_name in (
+            ("x-ratelimit-remaining", "remaining"),
+            ("ratelimit-remaining", "remaining"),
+            ("x-ratelimit-reset", "reset"),
+            ("ratelimit-reset", "reset"),
+            ("x-ratelimit-limit", "limit"),
+            ("ratelimit-limit", "limit"),
+            ("x-ratelimit-used", "used"),
+            ("retry-after", "retry_after"),
+        ):
+            if header_name in safe_headers:
+                rate_limit[field_name] = safe_headers[header_name]
+        self._usage.record(
+            transport="rest",
+            operation=operation,
+            headers=safe_headers,
+            rate_limit=rate_limit,
+            status=response.status_code,
+        )
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        if self._usage is None:
+            return []
+        return self._usage.drain()
 
     @staticmethod
     def parse_datetime(value: object) -> datetime | None:

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -58,6 +58,7 @@ logger = logging.getLogger(__name__)
 # GITHUB_USAGE_ROUTE_FAMILIES entry), bypassing the substring marker scan.
 SECURITY_ROUTE_FAMILY = "security"
 DEPLOYMENTS_ROUTE_FAMILY = "deployments"
+CICD_ROUTE_FAMILY = "cicd"
 _GITHUB_DEPLOYMENTS_PER_PAGE = 100
 
 
@@ -77,6 +78,16 @@ class GitHubDeploymentData:
     tag: str | None
     tag_name: str | None
     payload: Mapping[str, Any] | None
+
+
+@dataclass(frozen=True)
+class GitHubWorkflowRunData:
+    run_id: str
+    status: str | None
+    queued_at: datetime | None
+    started_at: datetime | None
+    finished_at: datetime | None
+    retry_count: int
 
 
 def _lowered_github_headers(response: httpx.Response) -> dict[str, str]:
@@ -276,6 +287,24 @@ def _deployment_from_item(item: Mapping[str, Any]) -> GitHubDeploymentData:
     )
 
 
+def _workflow_run_from_item(item: Mapping[str, Any]) -> GitHubWorkflowRunData:
+    queued_at = _parse_alert_datetime(item.get("created_at"))
+    started_at = _parse_alert_datetime(item.get("run_started_at")) or queued_at
+    run_attempt = item.get("run_attempt")
+    try:
+        retry_count = max(0, int(run_attempt or 1) - 1)
+    except (TypeError, ValueError):
+        retry_count = 0
+    return GitHubWorkflowRunData(
+        run_id=str(item.get("id", "")),
+        status=item.get("conclusion") or item.get("status"),
+        queued_at=queued_at,
+        started_at=started_at,
+        finished_at=_parse_alert_datetime(item.get("updated_at")),
+        retry_count=retry_count,
+    )
+
+
 def _pull_request_merged_at(item: Mapping[str, Any]) -> datetime | None:
     return _parse_alert_datetime(item.get("merged_at"))
 
@@ -430,6 +459,29 @@ class GitHubCodeClient:
             items = items[:max_releases]
         return [_release_from_item(item) for item in items if isinstance(item, Mapping)]
 
+    async def get_workflow_runs(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        max_runs: int,
+    ) -> list[GitHubWorkflowRunData]:
+        if max_runs <= 0:
+            return []
+        operation = f"{CICD_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/actions/runs"
+        items = await self._core.paginate_link_header(
+            f"/repos/{owner}/{repo}/actions/runs",
+            operation=operation,
+            params={"per_page": _GITHUB_DEPLOYMENTS_PER_PAGE},
+            data_key="workflow_runs",
+            max_pages=_page_cap_for_limit(max_runs),
+        )
+        return [
+            _workflow_run_from_item(item)
+            for item in items[:max_runs]
+            if isinstance(item, Mapping)
+        ]
+
     async def get_deployments(
         self,
         owner: str,
@@ -534,9 +586,11 @@ class GitHubCodeClient:
 
 
 __all__ = [
+    "CICD_ROUTE_FAMILY",
     "DEPLOYMENTS_ROUTE_FAMILY",
     "GitHubCodeClient",
     "GitHubDeploymentData",
+    "GitHubWorkflowRunData",
     "GitHubReleaseData",
     "SECURITY_ROUTE_FAMILY",
 ]

--- a/src/dev_health_ops/providers/github/testops_pipeline.py
+++ b/src/dev_health_ops/providers/github/testops_pipeline.py
@@ -6,11 +6,15 @@ from uuid import UUID
 
 from dev_health_ops.metrics.testops_schemas import JobRunRow, PipelineRunExtendedRow
 from dev_health_ops.providers._base import BasePipelineAdapter, PipelineSyncBatch
+from dev_health_ops.providers._http import GITHUB_DIAGNOSTIC_HEADER_NAMES
+from dev_health_ops.providers.github.budget import GITHUB_USAGE_RESOLVER
 
 
 class GitHubActionsAdapter(BasePipelineAdapter):
     provider = "github_actions"
     token_env_var = "GITHUB_TOKEN"
+    usage_resolver = GITHUB_USAGE_RESOLVER
+    diagnostic_header_names = GITHUB_DIAGNOSTIC_HEADER_NAMES
 
     @property
     def default_headers(self) -> dict[str, str]:
@@ -76,6 +80,7 @@ class GitHubActionsAdapter(BasePipelineAdapter):
             f"/repos/{owner}/{repo}/actions/runs",
             params=params,
             data_key="workflow_runs",
+            operation=f"tests:GET /repos/{owner}/{repo}/actions/runs",
         )
 
         pipeline_rows: list[PipelineRunExtendedRow] = []
@@ -135,6 +140,7 @@ class GitHubActionsAdapter(BasePipelineAdapter):
             jobs = await self._paginate(
                 f"/repos/{owner}/{repo}/actions/runs/{workflow_run.get('id')}/jobs",
                 data_key="jobs",
+                operation=f"tests:GET /repos/{owner}/{repo}/actions/runs/{{id}}/jobs",
             )
             for job in jobs:
                 job_started_at = self.parse_datetime(job.get("started_at"))

--- a/tests/test_ci_pipeline_retry_count.py
+++ b/tests/test_ci_pipeline_retry_count.py
@@ -24,9 +24,15 @@ import pytest
 # pre-existing providers._base <-> connectors circular import when this file
 # is collected in isolation.
 import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.processors.base_git import build_ci_pipeline_run
-from dev_health_ops.processors.github import _fetch_github_workflow_runs_sync
+from dev_health_ops.processors.github import (
+    _fetch_github_workflow_runs_async,
+    _fetch_github_workflow_runs_sync,
+    _sync_github_test_reports,
+)
 from dev_health_ops.processors.gitlab import _fetch_gitlab_pipelines_sync
+from dev_health_ops.providers.github.code_client import GitHubWorkflowRunData
 from dev_health_ops.providers.gitlab.code_client import GitLabPipelineData
 from dev_health_ops.storage.mixins.cicd import CicdMixin
 
@@ -109,6 +115,114 @@ def test_github_workflow_run_absent_run_attempt_defaults_to_zero():
     )
 
     assert runs[0].retry_count == 0
+
+
+class _GitHubWorkflowRunClient:
+    def __init__(self, runs: list[GitHubWorkflowRunData]) -> None:
+        self.runs = runs
+        self.closed = False
+
+    async def get_workflow_runs(
+        self, owner: str, repo: str, *, max_runs: int
+    ) -> list[GitHubWorkflowRunData]:
+        return self.runs[:max_runs]
+
+    def drain_usage_observations(self) -> list[dict[str, object]]:
+        return [{"route_family": "cicd", "request_count": 1}]
+
+    async def close(self) -> None:
+        self.closed = True
+
+
+@pytest.mark.asyncio
+async def test_github_workflow_run_async_drains_cicd_usage(monkeypatch):
+    run = GitHubWorkflowRunData(
+        run_id="200",
+        status="success",
+        queued_at=datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        started_at=_STARTED,
+        finished_at=datetime(2023, 1, 1, 0, 5, 0, tzinfo=timezone.utc),
+        retry_count=2,
+    )
+    client = _GitHubWorkflowRunClient([run])
+    monkeypatch.setattr(
+        "dev_health_ops.processors.github._github_code_client_from_connector",
+        lambda connector: client,
+    )
+    usage_sink: list[dict[str, object]] = []
+
+    runs = await _fetch_github_workflow_runs_async(
+        object(),
+        "acme",
+        "widgets",
+        repo_id=None,
+        max_runs=10,
+        since=None,
+        usage_sink=usage_sink,
+    )
+
+    assert len(runs) == 1
+    assert runs[0].run_id == "200"
+    assert runs[0].retry_count == 2
+    assert usage_sink == [{"route_family": "cicd", "request_count": 1}]
+    assert client.closed is True
+
+
+@pytest.mark.asyncio
+async def test_sync_github_test_reports_drains_adapter_usage(monkeypatch):
+    class _Adapter:
+        def __init__(self, *, base_url: str, token: str) -> None:
+            self.base_url = base_url
+            self.token = token
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        def drain_usage_observations(self) -> list[dict[str, object]]:
+            return [{"route_family": "tests", "request_count": 2}]
+
+    class _Processor:
+        def __init__(self, ingestion_sink: object) -> None:
+            self.ingestion_sink = ingestion_sink
+
+        async def fetch_and_store(self, adapter: _Adapter, **kwargs: object):
+            return SimpleNamespace(pipeline_runs=1, job_runs=1)
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.github.testops_pipeline.GitHubActionsAdapter",
+        _Adapter,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.testops_pipeline.TestOpsPipelineProcessor",
+        _Processor,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.github._fetch_github_test_artifacts_sync",
+        lambda *args: [],
+    )
+    usage_sink: list[dict[str, object]] = []
+    connector = SimpleNamespace(
+        token="token",
+        _rest_base_url=lambda: "https://api.github.test",
+    )
+
+    await _sync_github_test_reports(
+        connector=connector,
+        gh_repo=SimpleNamespace(default_branch="main"),
+        owner="acme",
+        repo_name="widgets",
+        repo_id=None,
+        org_id="org-1",
+        ingestion_sink=cast(IngestionSink, object()),
+        loop=__import__("asyncio").get_running_loop(),
+        since=None,
+        usage_sink=usage_sink,
+    )
+
+    assert usage_sink == [{"route_family": "tests", "request_count": 2}]
 
 
 class _GitLabPipelineClient:

--- a/tests/testops/test_pipeline_ingestion.py
+++ b/tests/testops/test_pipeline_ingestion.py
@@ -110,6 +110,7 @@ async def test_github_actions_adapter_maps_runs_and_jobs() -> None:
         org_id="org-1",
         since_date=_dt("2026-04-01T00:00:00Z"),
     )
+    observations = adapter.drain_usage_observations()
     await adapter.close()
 
     assert len(batch.pipeline_runs) == 1
@@ -127,6 +128,9 @@ async def test_github_actions_adapter_maps_runs_and_jobs() -> None:
     assert job["duration_seconds"] == 150.0
     assert job["runner_type"] == "hosted"
     assert batch.last_synced_cursor == _dt("2026-04-01T10:07:00Z")
+    assert len(observations) == 1
+    assert observations[0]["route_family"] == "tests"
+    assert observations[0]["request_count"] == 2
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- route GitHub Actions workflow-run CI sync through the canonical GitHubCodeClient
- add BasePipelineAdapter usage recording for GitHub TestOps adapter calls
- drain CI and TestOps usage observations into the processor-owned usage sink

## Validation
- Oracle review: PASS
- uv run --extra dev python -m pytest tests/test_ci_pipeline_retry_count.py tests/testops/test_pipeline_ingestion.py -q
- env -i PATH="/opt/homebrew/share/google-cloud-sdk/bin:/Users/chris/.krew/bin:/Users/chris/.pyenv/shims:/Users/chris/.pyenv/bin:/Users/chris/.local/bin:/opt/homebrew/bin:/opt/homebrew/sbin:/opt/homebrew/lib/ruby/gems/3.3.0/bin:/opt/homebrew/opt/ruby/bin:/opt/homebrew/opt/sqlite/bin:/opt/homebrew/opt/python/libexec/bin:/opt/homebrew/opt/coreutils/libexec/gnubin:/Users/chris/.cargo/bin:/Users/chris/.lmstudio/bin:/Users/chris/.docker/bin:/Users/chris/.local/share/go/bin:/usr/local/bin:/System/Cryptexes/App/usr/bin:/usr/bin:/bin:/usr/sbin:/sbin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/local/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/bin:/var/run/com.apple.security.cryptexd/codex.system/bootstrap/usr/appleinternal/bin:/pkg/env/global/bin:/Library/Apple/usr/bin:/usr/local/MacGPG2/bin:/Applications/iTerm.app/Contents/Resources/utilities:/Users/chris/.orbstack/bin" HOME="/Users/chris" TMPDIR="/var/folders/fc/1xbvf93j4t31_5mslw1x6gq40000gn/T/" SCRATCH_DB="ci_local_validate_2806" bash ci/local_validate.sh

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.