### PR TITLE
fix(sync): ingest security data in normal flows

### DIFF
--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -565,7 +565,25 @@ class GitHubCodeClient:
                 operation=operation,
                 params=params,
             )
-        except (AuthenticationException, NotFoundException):
+        except AuthenticationException as exc:
+            logger.warning(
+                "GitHub security endpoint unavailable provider=github owner=%s "
+                "repo=%s endpoint=%s status=auth error=%s",
+                owner,
+                repo,
+                endpoint,
+                exc,
+            )
+            return []
+        except NotFoundException as exc:
+            logger.warning(
+                "GitHub security endpoint unavailable provider=github owner=%s "
+                "repo=%s endpoint=%s status=404 error=%s",
+                owner,
+                repo,
+                endpoint,
+                exc,
+            )
             return []
         alerts = [build(item) for item in items]
         if max_alerts is not None:

--- a/src/dev_health_ops/providers/gitlab/code_client.py
+++ b/src/dev_health_ops/providers/gitlab/code_client.py
@@ -378,8 +378,9 @@ class GitLabCodeClient:
                 params={"per_page": per_page},
             )
         except (NotFoundException, _GitLabSecurityForbidden) as exc:
-            logger.debug(
-                "GitLab vulnerability findings unavailable for project %s: %s",
+            logger.warning(
+                "GitLab security endpoint unavailable provider=gitlab project_id=%s "
+                "endpoint=vulnerability_findings error=%s",
                 project_id,
                 exc,
             )
@@ -402,8 +403,11 @@ class GitLabCodeClient:
                 params={"per_page": per_page},
             )
         except (NotFoundException, _GitLabSecurityForbidden) as exc:
-            logger.debug(
-                "GitLab dependencies unavailable for project %s: %s", project_id, exc
+            logger.warning(
+                "GitLab security endpoint unavailable provider=gitlab project_id=%s "
+                "endpoint=dependencies error=%s",
+                project_id,
+                exc,
             )
             return []
         payload = response.json()

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -58,6 +58,7 @@ from dev_health_ops.models import (
     SyncRunUnitStatus,
 )
 from dev_health_ops.sync.datasets import (
+    DatasetKey,
     DatasetSpec,
     WatermarkBehavior,
     get_dataset_spec,
@@ -145,7 +146,10 @@ def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
         session, integration
     )
     sources = _load_enabled_sources(session, integration, request.source_ids)
-    datasets = _load_enabled_datasets(session, integration, request.dataset_keys)
+    dataset_keys = _ensure_security_dataset_for_scheduled_code_host_sync(
+        session, integration, request
+    )
+    datasets = _load_enabled_datasets(session, integration, dataset_keys)
     now = datetime.now(timezone.utc)
 
     planned_units = _build_planned_units(
@@ -316,6 +320,56 @@ def _load_enabled_sources(
             return []
         query = query.filter(IntegrationSource.id.in_(source_uuids))
     return list(query.order_by(IntegrationSource.full_name, IntegrationSource.id).all())
+
+
+_CODE_HOST_SECURITY_PROVIDERS = frozenset({"github", "gitlab"})
+_SCHEDULED_SECURITY_TRIGGER = "schedule"
+
+
+def _ensure_security_dataset_for_scheduled_code_host_sync(
+    session: Session,
+    integration: Integration,
+    request: SyncPlanRequest,
+) -> tuple[str, ...] | None:
+    """Ensure normal scheduled code-host syncs also plan security ingestion.
+
+    Historical sync configs only ran the security dataset when users explicitly
+    selected the legacy ``security`` target. Normal scheduled GitHub/GitLab syncs
+    should refresh repository security alerts alongside the rest of the code-host
+    crawl, without overriding an operator-disabled security dataset row.
+    """
+
+    provider = str(integration.provider).lower()
+    requested = request.dataset_keys
+    if provider not in _CODE_HOST_SECURITY_PROVIDERS:
+        return requested
+    if request.triggered_by != _SCHEDULED_SECURITY_TRIGGER:
+        return requested
+
+    if requested is not None and DatasetKey.SECURITY.value not in requested:
+        requested = (*requested, DatasetKey.SECURITY.value)
+
+    security_dataset = (
+        session.query(IntegrationDataset)
+        .filter(
+            IntegrationDataset.org_id == integration.org_id,
+            IntegrationDataset.integration_id == integration.id,
+            IntegrationDataset.dataset_key == DatasetKey.SECURITY.value,
+        )
+        .one_or_none()
+    )
+    if security_dataset is None:
+        session.add(
+            IntegrationDataset(
+                org_id=integration.org_id,
+                integration_id=integration.id,
+                dataset_key=DatasetKey.SECURITY.value,
+                is_enabled=True,
+                options={"auto_enabled_by": "scheduled_code_host_sync"},
+            )
+        )
+        session.flush()
+    return requested
 
 
 def _load_enabled_datasets(

--- a/src/dev_health_ops/workers/system_webhooks.py
+++ b/src/dev_health_ops/workers/system_webhooks.py
@@ -218,7 +218,7 @@ def _process_github_event(
                 sync_cicd=False,
                 sync_deployments=False,
                 sync_incidents=False,
-                sync_security=False,
+                sync_security=True,
                 sync_tests=False,
             )
         elif event_type == "pull_request":
@@ -232,7 +232,7 @@ def _process_github_event(
                 sync_cicd=False,
                 sync_deployments=False,
                 sync_incidents=False,
-                sync_security=False,
+                sync_security=True,
                 sync_tests=False,
             )
         elif event_type in ("issue_created", "issue_updated", "issue_closed"):
@@ -246,7 +246,7 @@ def _process_github_event(
                 sync_cicd=False,
                 sync_deployments=False,
                 sync_incidents=True,
-                sync_security=False,
+                sync_security=True,
                 sync_tests=False,
             )
         elif event_type == "deployment":
@@ -260,7 +260,7 @@ def _process_github_event(
                 sync_cicd=False,
                 sync_deployments=True,
                 sync_incidents=False,
-                sync_security=False,
+                sync_security=True,
                 sync_tests=False,
             )
         elif event_type == "workflow_run":
@@ -274,7 +274,7 @@ def _process_github_event(
                 sync_cicd=True,
                 sync_deployments=False,
                 sync_incidents=False,
-                sync_security=False,
+                sync_security=True,
                 sync_tests=False,
             )
 
@@ -415,7 +415,7 @@ def _process_gitlab_event(
                 sync_cicd=False,
                 sync_deployments=False,
                 sync_incidents=False,
-                sync_security=False,
+                sync_security=True,
                 sync_tests=False,
             )
         elif event_type == "merge_request":
@@ -429,7 +429,7 @@ def _process_gitlab_event(
                 sync_cicd=False,
                 sync_deployments=False,
                 sync_incidents=False,
-                sync_security=False,
+                sync_security=True,
                 sync_tests=False,
             )
         elif event_type in ("issue_created", "issue_updated", "issue_closed"):
@@ -443,7 +443,7 @@ def _process_gitlab_event(
                 sync_cicd=False,
                 sync_deployments=False,
                 sync_incidents=True,
-                sync_security=False,
+                sync_security=True,
                 sync_tests=False,
             )
         elif event_type == "pipeline":
@@ -457,7 +457,7 @@ def _process_gitlab_event(
                 sync_cicd=True,
                 sync_deployments=False,
                 sync_incidents=False,
-                sync_security=False,
+                sync_security=True,
                 sync_tests=False,
             )
 

--- a/tests/providers/test_github_code_client_security.py
+++ b/tests/providers/test_github_code_client_security.py
@@ -216,14 +216,24 @@ class TestDegradeToEmpty:
         await client.close()
 
     @pytest.mark.asyncio
-    async def test_404_degrades_to_empty(self) -> None:
+    async def test_404_degrades_to_empty_with_log(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         client = _client(
             httpx.MockTransport(
                 lambda r: httpx.Response(404, json={"message": "Not Found"})
             )
         )
-        alerts = await client.get_security_advisories("acme", "widgets")
+        with caplog.at_level("WARNING"):
+            alerts = await client.get_security_advisories("acme", "widgets")
         assert alerts == []
+        assert any(
+            "provider=github" in r.message
+            and "repo=widgets" in r.message
+            and "endpoint=security-advisories" in r.message
+            and "status=404" in r.message
+            for r in caplog.records
+        )
         await client.close()
 
     @pytest.mark.asyncio

--- a/tests/providers/test_gitlab_code_client.py
+++ b/tests/providers/test_gitlab_code_client.py
@@ -329,7 +329,9 @@ class TestBestEffortSuppression:
         assert alerts[0].source == "gitlab_vulnerability"
 
     @pytest.mark.asyncio
-    async def test_both_endpoints_forbidden_yields_empty_list_no_raise(self) -> None:
+    async def test_both_endpoints_forbidden_yields_empty_list_no_raise(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
         transport, _ = _router_transport(
             {
                 _PROJECT_PATH: _json_response(200, _PROJECT_RESPONSE),
@@ -339,7 +341,21 @@ class TestBestEffortSuppression:
         )
         client = _client(transport)
 
-        assert await client.get_security_alerts(42) == []
+        with caplog.at_level("WARNING"):
+            assert await client.get_security_alerts(42) == []
+        messages = [record.message for record in caplog.records]
+        assert any(
+            "provider=gitlab" in message
+            and "project_id=42" in message
+            and "endpoint=vulnerability_findings" in message
+            for message in messages
+        )
+        assert any(
+            "provider=gitlab" in message
+            and "project_id=42" in message
+            and "endpoint=dependencies" in message
+            for message in messages
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workers/test_planner_only_routing.py
+++ b/tests/workers/test_planner_only_routing.py
@@ -28,6 +28,7 @@ from dev_health_ops.models import (
     IntegrationDataset,
     IntegrationSource,
     SyncRunMode,
+    SyncRunUnit,
 )
 from dev_health_ops.models.settings import SyncConfiguration
 from dev_health_ops.models.users import Organization
@@ -294,6 +295,11 @@ def test_scheduler_routes_migrated_config_through_planner(db_session, monkeypatc
     )
     assert len(plan_calls) == 1, "plan_sync_run must be called exactly once"
     assert len(dispatch_calls) == 1, "dispatch_sync_run.apply_async must be called once"
+    dataset_keys = {
+        unit.dataset_key
+        for unit in db_session.query(SyncRunUnit).order_by(SyncRunUnit.dataset_key)
+    }
+    assert dataset_keys == {"commits", "security"}
 
 
 # ---------------------------------------------------------------------------

--- a/tests/workers/test_system_webhooks_rate_limit.py
+++ b/tests/workers/test_system_webhooks_rate_limit.py
@@ -9,8 +9,9 @@ behavior (the sync is best-effort garnish for those). Follow-up to CHAOS-2803.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any, cast
-from unittest.mock import MagicMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -76,6 +77,41 @@ def test_github_non_rate_limit_error_degrades(monkeypatch: pytest.MonkeyPatch) -
     assert "error" in result
 
 
+@pytest.mark.parametrize(
+    "event_type",
+    ["push", "pull_request", "issue_created", "deployment", "workflow_run"],
+)
+def test_github_webhook_events_request_security_sync(
+    monkeypatch: pytest.MonkeyPatch, event_type: str
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "x")
+    process_repo = AsyncMock()
+
+    async def run_with_store(db_url, db_type, handler, org_id=None):
+        await handler(MagicMock())
+
+    with (
+        patch(
+            "dev_health_ops.workers.system_webhooks._get_db_url",
+            return_value="clickhouse://x",
+        ),
+        patch("dev_health_ops.storage.resolve_db_type", return_value="clickhouse"),
+        patch("dev_health_ops.storage.run_with_store", side_effect=run_with_store),
+        patch("dev_health_ops.processors.github.process_github_repo", process_repo),
+        patch(
+            "dev_health_ops.workers.system_webhooks.run_async",
+            side_effect=lambda awaitable: asyncio.run(awaitable),
+        ),
+    ):
+        result = system_webhooks._process_github_event(
+            event_type, _GITHUB_PAYLOAD, "org-1", None
+        )
+
+    assert result["processed"] is True
+    assert process_repo.await_args is not None
+    assert process_repo.await_args.kwargs["sync_security"] is True
+
+
 def test_gitlab_rate_limit_reraises(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITLAB_TOKEN", "x")
     p1, p2, p3 = _patch_storage()
@@ -92,6 +128,42 @@ def test_gitlab_rate_limit_reraises(monkeypatch: pytest.MonkeyPatch) -> None:
             system_webhooks._process_gitlab_event(
                 "push", _GITLAB_PAYLOAD, "org-1", None
             )
+
+
+@pytest.mark.parametrize(
+    "event_type", ["push", "merge_request", "issue_created", "pipeline"]
+)
+def test_gitlab_webhook_events_request_security_sync(
+    monkeypatch: pytest.MonkeyPatch, event_type: str
+) -> None:
+    monkeypatch.setenv("GITLAB_TOKEN", "x")
+    process_project = AsyncMock()
+
+    async def run_with_store(db_url, db_type, handler, org_id=None):
+        await handler(MagicMock())
+
+    with (
+        patch(
+            "dev_health_ops.workers.system_webhooks._get_db_url",
+            return_value="clickhouse://x",
+        ),
+        patch("dev_health_ops.storage.resolve_db_type", return_value="clickhouse"),
+        patch("dev_health_ops.storage.run_with_store", side_effect=run_with_store),
+        patch(
+            "dev_health_ops.processors.gitlab.process_gitlab_project", process_project
+        ),
+        patch(
+            "dev_health_ops.workers.system_webhooks.run_async",
+            side_effect=lambda awaitable: asyncio.run(awaitable),
+        ),
+    ):
+        result = system_webhooks._process_gitlab_event(
+            event_type, _GITLAB_PAYLOAD, "org-1", None
+        )
+
+    assert result["processed"] is True
+    assert process_project.await_args is not None
+    assert process_project.await_args.kwargs["sync_security"] is True
 
 
 def test_jira_rate_limit_reraises() -> None:


### PR DESCRIPTION
## Summary
- Enables security ingestion on GitHub/GitLab webhook-triggered normal sync paths.
- Auto-includes the security dataset in scheduled GitHub/GitLab planner runs when legacy configs did not explicitly select it, without re-enabling an explicitly disabled security dataset row.
- Logs optional GitHub/GitLab security endpoint 403/404 degradations with provider/source/endpoint provenance instead of silently returning empty.
- Verified ClickHouse migrations 033_security_alerts_org_id.sql and 042_rmt_org_id_dedup_keys.py are applied by the local validation gate.

References CHAOS-2852.

## Validation
- LSP diagnostics: clean on changed files
- uv run --extra dev pytest tests/workers/test_system_webhooks_rate_limit.py tests/workers/test_planner_only_routing.py tests/providers/test_github_code_client_security.py tests/providers/test_gitlab_code_client.py
- bash ci/local_validate.sh

SCREENSHOT-WAIVER: backend-only ops security-sync change; no UI rendered.