### PR TITLE
fix(metrics): schedule daily metrics and complexity per active org (CHAOS-2849, CHAOS-2850)

### DIFF
--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -161,9 +161,11 @@ The system registers Celery tasks under the `workers/` directory. The primary re
 | ~~`sync_team_drift` / `reconcile_team_members`~~ | — | — | **Deleted in CHAOS-2600 CS6 (CHAOS-2607).** Both Celery tasks and `workers/sync_team.py` are removed (they were fail-closed no-ops in CS5). ClickHouse is the team/identity system of record; the Postgres drift engine + member-reconcile no longer exist. |
 | `run_daily_metrics` | `metrics daily` | `metrics` | Computes daily repository and user metrics. Source: `metrics_daily.py`. |
 | `dispatch_daily_metrics_partitioned` | `metrics daily` (partitioned) | `default` | Partitions daily metrics across organizations and fans out. Source: `metrics_partitioned.py`. |
+| `dispatch_daily_metrics_for_all_orgs` | None | `default` | Fans out `dispatch_daily_metrics_partitioned` per active organization (CHAOS-2849) so `repo_metrics_daily` is populated for real (UUID-scoped) tenants, not just the blank-org default. Source: `metrics_partitioned.py`. |
 | `run_daily_metrics_batch` | None | `metrics` | Processes a batch of repositories for daily metrics. Source: `metrics_partitioned.py`. |
 | `run_daily_metrics_finalize_task` | None | `default` | Finalizes daily metrics computation. Source: `metrics_partitioned.py`. |
 | `run_complexity_job` | None | `metrics` | Analyzes code complexity for repositories. Source: `metrics_extra.py:16-319`. |
+| `dispatch_complexity_job` | None | `default` | Fans out `run_complexity_job` per active organization on an independent daily cadence (CHAOS-2850), so complexity refreshes even for orgs with infrequent syncs. Source: `metrics_extra.py`. |
 | `run_dora_metrics` | None | `metrics` | Computes DORA metrics. Source: `metrics_extra.py:16-319`. |
 | `run_release_impact_job` | None | `metrics` | Computes release impact metrics. Source: `metrics_extra.py:16-319`. |
 | `dispatch_release_impact` | None | `default` | Fans out release impact computation. Source: `metrics_extra.py`. |
@@ -193,7 +195,8 @@ The system registers Celery tasks under the `workers/` directory. The primary re
 |----------|------|----------|-------|
 | `dispatch-scheduled-syncs` | `dispatch_scheduled_syncs` | Every 300 seconds (5 minutes) | `default` |
 | `dispatch-scheduled-metrics` | `dispatch_scheduled_metrics` | Every 300 seconds (5 minutes) | `default` |
-| `run-daily-metrics` | `dispatch_daily_metrics_partitioned` | Daily at 01:00 UTC | `default` |
+| `run-complexity-daily` | `dispatch_complexity_job` | Daily at 00:45 UTC | `default` |
+| `run-daily-metrics` | `dispatch_daily_metrics_for_all_orgs` | Daily at 01:00 UTC | `default` |
 | `run-recommendations` | `run_recommendations_job` | Daily at 02:00 UTC | `metrics` |
 | `run-release-impact-daily` | `dispatch_release_impact` | Daily at 01:30 UTC | `default` |
 | `run-capacity-forecast` | `run_capacity_forecast_job` | Mondays at 04:00 UTC | `metrics` |

--- a/src/dev_health_ops/metrics/job_complexity_db.py
+++ b/src/dev_health_ops/metrics/job_complexity_db.py
@@ -209,8 +209,14 @@ def run_complexity_db_job(
     """
     Compute complexity metrics from ClickHouse git_files/git_blame contents.
 
-    Note: For backfill_days > 1, this job reuses the current file snapshot
-    across the requested days because historical file snapshots are not stored.
+    Note: complexity has no historical snapshot storage. Regardless of
+    ``backfill_days``, this job always writes exactly ONE row -- for
+    ``date`` -- computed from the CURRENT git_files/git_blame contents.
+    Reusing that single snapshot across a multi-day backfill window would
+    fabricate duplicate flat ``cyclomatic_per_kloc`` rows and flatline
+    ``complexity_delta``'s trailing 30-day trend (CHAOS-2850). A genuine
+    trend only comes from the daily ``dispatch_complexity_job`` cadence
+    running on distinct real days as the code actually changes.
     """
     resolved_db_url = db_url or os.getenv("DATABASE_URI") or os.getenv("DATABASE_URL")
     if not resolved_db_url:
@@ -239,11 +245,19 @@ def run_complexity_db_job(
             return 0
 
         if backfill_days > 1:
-            logger.info(
-                "Backfill requested; reusing current file snapshot for each day."
+            logger.warning(
+                "complexity backfill_days=%d requested, but historical file "
+                "snapshots are not stored -- complexity can only be computed "
+                "from the CURRENT git_files/git_blame contents. Writing a "
+                "single row for %s only, not %d duplicate flat rows, to avoid "
+                "fabricating a misleading flat complexity_delta trend "
+                "(CHAOS-2850).",
+                backfill_days,
+                date.isoformat(),
+                backfill_days,
             )
 
-        days = _date_range(date, max(1, int(backfill_days)))
+        days = _date_range(date, 1)
         repos_with_data = 0
         for repo_uuid, repo_name in repos:
             repo_label = repo_name or str(repo_uuid)

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -37,6 +37,8 @@ late_ack_excluded_tasks = (
     "dev_health_ops.workers.tasks.dispatch_scheduled_syncs",
     "dev_health_ops.workers.tasks.dispatch_scheduled_metrics",
     "dev_health_ops.workers.tasks.dispatch_daily_metrics_partitioned",
+    "dev_health_ops.workers.tasks.dispatch_daily_metrics_for_all_orgs",
+    "dev_health_ops.workers.tasks.dispatch_complexity_job",
     "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned",
     "dev_health_ops.workers.tasks.dispatch_release_impact",
     "dev_health_ops.workers.tasks.dispatch_membership_backfill",
@@ -129,9 +131,26 @@ beat_schedule = {
         "schedule": 300.0,
         "options": {"queue": "default"},
     },
+    # Fans out per active organization (CHAOS-2849): discover_repos (job_daily.py)
+    # scopes the repos query by org_id, so a single blank-org run would never
+    # match a real (UUID-scoped) tenant's rows and repo_metrics_daily would never
+    # be populated. dispatch_daily_metrics_for_all_orgs enumerates active orgs and
+    # enqueues one dispatch_daily_metrics_partitioned per org_id.
     "run-daily-metrics": {
-        "task": "dev_health_ops.workers.tasks.dispatch_daily_metrics_partitioned",
+        "task": "dev_health_ops.workers.tasks.dispatch_daily_metrics_for_all_orgs",
         "schedule": crontab(hour=1, minute=0),
+        "options": {"queue": "default"},
+    },
+    # Complexity daily floor cadence (CHAOS-2850): run_complexity_job previously
+    # only ran chained after a git sync, so an org with infrequent syncs left
+    # repo_complexity_daily stale, and complexity_delta's trailing 30-day window
+    # (compounding_risk.py) read a flat trend. This dispatcher fans out one
+    # run_complexity_job per active org daily, independent of sync activity.
+    # Scheduled before run-daily-metrics (01:00) so the daily hotspot/risk compute
+    # reads a freshly-refreshed complexity snapshot for the day.
+    "run-complexity-daily": {
+        "task": "dev_health_ops.workers.tasks.dispatch_complexity_job",
+        "schedule": crontab(hour=0, minute=45),
         "options": {"queue": "default"},
     },
     # Daily safety net for recommendations_daily (CHAOS-2373). The primary

--- a/src/dev_health_ops/workers/metrics_extra.py
+++ b/src/dev_health_ops/workers/metrics_extra.py
@@ -90,6 +90,60 @@ def run_complexity_job(
 @celery_app.task(
     bind=True,
     max_retries=3,
+    queue="default",
+    name="dev_health_ops.workers.tasks.dispatch_complexity_job",
+)
+def dispatch_complexity_job(
+    self,
+    db_url: str | None = None,
+    day: str | None = None,
+) -> dict:
+    """Fan out ``run_complexity_job`` per active org on a daily cadence (CHAOS-2850).
+
+    ``run_complexity_job`` previously only ran chained after a git sync
+    (post_sync_dispatch.py), so an org with infrequent syncs left
+    ``repo_complexity_daily`` stale for days at a time. Because
+    ``complexity_delta`` (compounding_risk.py) reads a trailing 30-day
+    window from that table, a stale table reads as a flat trend even
+    though nothing about the compute itself is wrong. This dispatcher
+    gives complexity an independent daily floor cadence -- the same
+    fan-out shape as ``dispatch_release_impact`` /
+    ``dispatch_membership_backfill`` -- so every active org's complexity
+    refreshes at least once per day regardless of sync activity.
+
+    Args:
+        db_url: ClickHouse connection string (defaults to CLICKHOUSE_URI env)
+        day: Target day as ISO string (defaults to today, resolved per task)
+
+    Returns:
+        dict with the list of dispatched org_ids
+    """
+    from dev_health_ops.workers.recommendations_tasks import _discover_active_org_ids
+
+    try:
+        # strict=True: a Postgres enumeration failure must RAISE (not
+        # collapse to ["default"]) so the once-daily run retries instead of
+        # silently reporting a clean empty success while computing zero orgs.
+        org_ids = _discover_active_org_ids(strict=True)
+    except Exception as exc:
+        logger.exception("dispatch_complexity_job failed to enumerate orgs")
+        raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))
+
+    dispatched: list[str] = []
+    for org_id in org_ids:
+        run_complexity_job.apply_async(
+            kwargs={"db_url": db_url, "day": day, "org_id": org_id},
+            queue="metrics",
+        )
+        dispatched.append(org_id)
+
+    logger.info("Complexity dispatch: dispatched=%d organizations", len(dispatched))
+    return {"dispatched": dispatched}
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=3,
     queue="metrics",
     name="dev_health_ops.workers.tasks.run_dora_metrics",
 )

--- a/src/dev_health_ops/workers/metrics_partitioned.py
+++ b/src/dev_health_ops/workers/metrics_partitioned.py
@@ -121,6 +121,76 @@ def dispatch_daily_metrics_partitioned(
 @celery_app.task(
     bind=True,
     max_retries=3,
+    queue="default",
+    name="dev_health_ops.workers.tasks.dispatch_daily_metrics_for_all_orgs",
+)
+def dispatch_daily_metrics_for_all_orgs(
+    self,
+    db_url: str | None = None,
+    day: str | None = None,
+    backfill_days: int = 1,
+    batch_size: int = 5,
+    sink: str = "auto",
+    provider: str = "auto",
+) -> dict:
+    """Fan out ``dispatch_daily_metrics_partitioned`` per active org (CHAOS-2849).
+
+    ``discover_repos`` (job_daily.py) scopes the ``repos`` query by
+    ``org_id``. The beat-scheduled 01:00 UTC ``run-daily-metrics`` entry
+    previously called ``dispatch_daily_metrics_partitioned`` directly with
+    NO ``org_id``, which defaults to the literal string ``"default"`` --
+    never a real (UUID-scoped) tenant's rows. ``repo_metrics_daily`` was
+    therefore never populated for any real organization. This dispatcher
+    enumerates active organizations and enqueues one per-org partitioned
+    dispatch, the same fan-out shape used by ``dispatch_release_impact``
+    and ``dispatch_membership_backfill``.
+
+    Args:
+        db_url: Database connection string (defaults to env)
+        day: Target day as ISO string (defaults to today, resolved per task)
+        backfill_days: Number of days to backfill
+        batch_size: Number of repos per batch task
+        sink: Sink type (auto|clickhouse)
+        provider: Work item provider (auto|all|jira|github|gitlab|none)
+
+    Returns:
+        dict with the list of dispatched org_ids and a skipped count
+    """
+    from dev_health_ops.workers.recommendations_tasks import _discover_active_org_ids
+
+    try:
+        # strict=True: a Postgres enumeration failure must RAISE (not
+        # collapse to ["default"]) so the once-daily run retries instead of
+        # silently reporting a clean empty success while computing zero
+        # orgs (mirrors dispatch_release_impact / dispatch_membership_backfill).
+        org_ids = _discover_active_org_ids(strict=True)
+    except Exception as exc:
+        logger.exception("dispatch_daily_metrics_for_all_orgs failed to enumerate orgs")
+        raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))
+
+    dispatched: list[str] = []
+    for org_id in org_ids:
+        dispatch_daily_metrics_partitioned.apply_async(
+            kwargs={
+                "org_id": org_id,
+                "db_url": db_url,
+                "day": day,
+                "backfill_days": backfill_days,
+                "batch_size": batch_size,
+                "sink": sink,
+                "provider": provider,
+            },
+            queue="default",
+        )
+        dispatched.append(org_id)
+
+    logger.info("Daily metrics dispatch: dispatched=%d organizations", len(dispatched))
+    return {"dispatched": dispatched, "skipped": 0}
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=3,
     queue="metrics",
     name="dev_health_ops.workers.tasks.run_daily_metrics_batch",
 )

--- a/src/dev_health_ops/workers/metrics_tasks.py
+++ b/src/dev_health_ops/workers/metrics_tasks.py
@@ -3,18 +3,22 @@ from dev_health_ops.workers.metrics_daily import (
     run_daily_metrics,
 )
 from dev_health_ops.workers.metrics_extra import (
+    dispatch_complexity_job,
     dispatch_release_impact,
     run_complexity_job,
     run_dora_metrics,
     run_release_impact_job,
 )
 from dev_health_ops.workers.metrics_partitioned import (
+    dispatch_daily_metrics_for_all_orgs,
     dispatch_daily_metrics_partitioned,
     run_daily_metrics_batch,
     run_daily_metrics_finalize_task,
 )
 
 __all__ = [
+    "dispatch_complexity_job",
+    "dispatch_daily_metrics_for_all_orgs",
     "dispatch_daily_metrics_partitioned",
     "dispatch_release_impact",
     "dispatch_scheduled_metrics",

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -1,4 +1,6 @@
 from dev_health_ops.workers.metrics_tasks import (
+    dispatch_complexity_job,
+    dispatch_daily_metrics_for_all_orgs,
     dispatch_daily_metrics_partitioned,
     dispatch_release_impact,
     dispatch_scheduled_metrics,
@@ -58,6 +60,8 @@ __all__ = [
     "_inject_provider_token",
     "_invalidate_metrics_cache",
     "_resolve_env_credentials",
+    "dispatch_complexity_job",
+    "dispatch_daily_metrics_for_all_orgs",
     "dispatch_daily_metrics_partitioned",
     "dispatch_investment_materialize_partitioned",
     "dispatch_release_impact",

--- a/tests/test_complexity_schedule.py
+++ b/tests/test_complexity_schedule.py
@@ -1,0 +1,163 @@
+"""CHAOS-2850: complexity must refresh on a reliable, independent daily cadence.
+
+``run_complexity_job`` previously only ran chained after a git sync
+(post_sync_dispatch.py). An org with infrequent syncs left
+``repo_complexity_daily`` stale for days, and ``complexity_delta``
+(compounding_risk.py) reads a trailing 30-day window from that table, so a
+stale table reads as a flat trend. These tests prove:
+
+* the wiring seam -- a registered Celery task + a daily beat entry that
+  points at the per-org dispatcher, scheduled ahead of run-daily-metrics,
+* the dispatcher fans out one ``run_complexity_job`` per active org with the
+  real org_id (never blank), and
+* an enumeration failure surfaces as a retry/failure rather than a silent
+  empty success.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from celery.schedules import crontab
+
+# Import connectors first to defeat the providers._base <-> connectors circular
+# import that otherwise breaks collection when this module (transitively)
+# imports compute/sink modules in isolation (CHAOS-2370 precedent).
+import dev_health_ops.connectors  # noqa: F401
+
+
+class TestComplexityDispatcherRegistered:
+    def test_task_importable_and_callable(self) -> None:
+        from dev_health_ops.workers.metrics_extra import dispatch_complexity_job
+
+        assert callable(dispatch_complexity_job)
+
+    def test_task_exported_from_tasks_module(self) -> None:
+        from dev_health_ops.workers import tasks
+
+        assert "dispatch_complexity_job" in tasks.__all__
+        assert hasattr(tasks, "dispatch_complexity_job")
+
+    def test_task_is_celery_task(self) -> None:
+        from dev_health_ops.workers.metrics_extra import dispatch_complexity_job
+
+        assert hasattr(dispatch_complexity_job, "apply_async")
+        assert hasattr(dispatch_complexity_job, "delay")
+        assert (
+            dispatch_complexity_job.name
+            == "dev_health_ops.workers.tasks.dispatch_complexity_job"
+        )
+        # Lightweight dispatcher (DB enumeration only) -> default queue,
+        # mirroring dispatch_release_impact / dispatch_daily_metrics_for_all_orgs.
+        assert dispatch_complexity_job.queue == "default"
+
+
+class TestComplexityBeatSchedule:
+    def test_beat_schedule_dispatches_complexity_daily(self) -> None:
+        from dev_health_ops.workers.config import beat_schedule
+
+        assert "run-complexity-daily" in beat_schedule
+        entry = beat_schedule["run-complexity-daily"]
+        assert entry["task"] == "dev_health_ops.workers.tasks.dispatch_complexity_job"
+        assert entry["options"]["queue"] == "default"
+
+    def test_beat_schedule_uses_crontab(self) -> None:
+        from dev_health_ops.workers.config import beat_schedule
+
+        schedule = beat_schedule["run-complexity-daily"]["schedule"]
+        assert isinstance(schedule, crontab)
+
+    def test_complexity_runs_before_daily_metrics(self) -> None:
+        """Complexity must refresh before run-daily-metrics (01:00 UTC) so the
+        daily hotspot/risk compute reads a freshly-refreshed snapshot."""
+        from dev_health_ops.workers.config import beat_schedule
+
+        complexity_schedule = beat_schedule["run-complexity-daily"]["schedule"]
+        daily_metrics_schedule = beat_schedule["run-daily-metrics"]["schedule"]
+
+        def _minute_of_day(schedule: crontab) -> int:
+            hour = next(iter(schedule.hour))
+            minute = next(iter(schedule.minute))
+            return hour * 60 + minute
+
+        assert _minute_of_day(complexity_schedule) < _minute_of_day(
+            daily_metrics_schedule
+        )
+
+    def test_late_ack_excluded(self) -> None:
+        """The dispatcher is DB-enumeration-only and should not hold a late ack."""
+        from dev_health_ops.workers.config import late_ack_excluded_tasks
+
+        assert (
+            "dev_health_ops.workers.tasks.dispatch_complexity_job"
+            in late_ack_excluded_tasks
+        )
+
+
+class TestComplexityDispatcherFansOutPerOrg:
+    def test_dispatcher_enqueues_one_task_per_active_org(self) -> None:
+        """The dispatcher enumerates active orgs and enqueues per real org_id."""
+        from dev_health_ops.workers import metrics_extra
+
+        org_a = str(uuid4())
+        org_b = str(uuid4())
+
+        session = MagicMock()
+        # _discover_active_org_ids uses the legacy session.query(...).filter(...)
+        # style (not session.execute(select(...))), unlike dispatch_release_impact.
+        session.query.return_value.filter.return_value.all.return_value = [
+            (org_a,),
+            (org_b,),
+        ]
+        cm = MagicMock()
+        cm.__enter__.return_value = session
+        cm.__exit__.return_value = False
+
+        with (
+            patch(
+                "dev_health_ops.db.get_postgres_session_sync",
+                return_value=cm,
+            ),
+            patch.object(metrics_extra.run_complexity_job, "apply_async") as mock_apply,
+        ):
+            result = metrics_extra.dispatch_complexity_job.run(day="2026-06-13")
+
+        assert mock_apply.call_count == 2
+        dispatched_orgs = {
+            call.kwargs["kwargs"]["org_id"] for call in mock_apply.call_args_list
+        }
+        assert dispatched_orgs == {org_a, org_b}
+        assert "" not in dispatched_orgs
+        for call in mock_apply.call_args_list:
+            assert call.kwargs["queue"] == "metrics"
+            assert call.kwargs["kwargs"]["day"] == "2026-06-13"
+        assert set(result["dispatched"]) == {org_a, org_b}
+
+    def test_dispatcher_raises_on_enumeration_failure(self) -> None:
+        """A transient Postgres failure must NOT report an empty success."""
+        import celery.exceptions
+
+        from dev_health_ops.workers import metrics_extra
+
+        cm = MagicMock()
+        cm.__enter__.side_effect = RuntimeError("postgres unavailable")
+
+        with (
+            patch(
+                "dev_health_ops.db.get_postgres_session_sync",
+                return_value=cm,
+            ),
+            patch.object(metrics_extra.run_complexity_job, "apply_async") as mock_apply,
+        ):
+            raised: Exception | None = None
+            try:
+                metrics_extra.dispatch_complexity_job.run()
+            except (celery.exceptions.Retry, RuntimeError) as exc:
+                raised = exc
+
+        assert raised is not None, (
+            "dispatcher must raise (retry/failure) on enumeration failure, "
+            "not silently return an empty success"
+        )
+        mock_apply.assert_not_called()

--- a/tests/test_daily_metrics_org_schedule.py
+++ b/tests/test_daily_metrics_org_schedule.py
@@ -1,0 +1,206 @@
+"""CHAOS-2849: repo_metrics_daily must be scheduled per active org.
+
+``discover_repos`` (job_daily.py) scopes the ``repos`` ClickHouse query by
+``org_id``. The beat-scheduled 01:00 UTC ``run-daily-metrics`` entry used to
+call ``dispatch_daily_metrics_partitioned`` directly with NO ``org_id``,
+which defaults to the literal string ``"default"`` -- never a real
+(UUID-scoped) tenant's rows. ``repo_metrics_daily`` was therefore never
+populated for any real organization. These tests prove:
+
+* the wiring seam -- a registered Celery task + a daily beat entry that
+  points at the per-org dispatcher,
+* the dispatcher fans out one ``dispatch_daily_metrics_partitioned`` per
+  active org with the real org_id (never ``"default"`` / blank), and
+* an enumeration failure surfaces as a retry/failure rather than a silent
+  empty success.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+from celery.schedules import crontab
+
+# Import connectors first to defeat the providers._base <-> connectors circular
+# import that otherwise breaks collection when this module (transitively)
+# imports compute/sink modules in isolation (CHAOS-2370 precedent).
+import dev_health_ops.connectors  # noqa: F401
+
+
+class TestDailyMetricsDispatcherRegistered:
+    def test_task_importable_and_callable(self) -> None:
+        from dev_health_ops.workers.metrics_partitioned import (
+            dispatch_daily_metrics_for_all_orgs,
+        )
+
+        assert callable(dispatch_daily_metrics_for_all_orgs)
+
+    def test_task_exported_from_tasks_module(self) -> None:
+        from dev_health_ops.workers import tasks
+
+        assert "dispatch_daily_metrics_for_all_orgs" in tasks.__all__
+        assert hasattr(tasks, "dispatch_daily_metrics_for_all_orgs")
+
+    def test_task_is_celery_task(self) -> None:
+        from dev_health_ops.workers.metrics_partitioned import (
+            dispatch_daily_metrics_for_all_orgs,
+        )
+
+        assert hasattr(dispatch_daily_metrics_for_all_orgs, "apply_async")
+        assert hasattr(dispatch_daily_metrics_for_all_orgs, "delay")
+        assert (
+            dispatch_daily_metrics_for_all_orgs.name
+            == "dev_health_ops.workers.tasks.dispatch_daily_metrics_for_all_orgs"
+        )
+        # Lightweight dispatcher (DB enumeration only) -> default queue,
+        # mirroring dispatch_release_impact / dispatch_membership_backfill.
+        assert dispatch_daily_metrics_for_all_orgs.queue == "default"
+
+
+class TestDailyMetricsBeatSchedule:
+    def test_beat_schedule_points_at_the_per_org_dispatcher(self) -> None:
+        from dev_health_ops.workers.config import beat_schedule
+
+        assert "run-daily-metrics" in beat_schedule
+        entry = beat_schedule["run-daily-metrics"]
+        # MUST point at the per-org dispatcher, not the blank-org-defaulting
+        # partitioned task directly (the CHAOS-2849 defect).
+        assert (
+            entry["task"]
+            == "dev_health_ops.workers.tasks.dispatch_daily_metrics_for_all_orgs"
+        )
+        assert entry["options"]["queue"] == "default"
+
+    def test_beat_schedule_uses_daily_crontab(self) -> None:
+        from dev_health_ops.workers.config import beat_schedule
+
+        schedule = beat_schedule["run-daily-metrics"]["schedule"]
+        assert isinstance(schedule, crontab)
+
+    def test_late_ack_excluded(self) -> None:
+        """The dispatcher is DB-enumeration-only and should not hold a late ack."""
+        from dev_health_ops.workers.config import late_ack_excluded_tasks
+
+        assert (
+            "dev_health_ops.workers.tasks.dispatch_daily_metrics_for_all_orgs"
+            in late_ack_excluded_tasks
+        )
+
+
+class TestDailyMetricsDispatcherFansOutPerOrg:
+    def test_dispatcher_enqueues_one_task_per_active_org(self) -> None:
+        """The dispatcher enumerates active orgs and enqueues per real org_id."""
+        from dev_health_ops.workers import metrics_partitioned
+
+        org_a = str(uuid4())
+        org_b = str(uuid4())
+
+        session = MagicMock()
+        # _discover_active_org_ids uses the legacy session.query(...).filter(...)
+        # style (not session.execute(select(...))), unlike dispatch_release_impact.
+        session.query.return_value.filter.return_value.all.return_value = [
+            (org_a,),
+            (org_b,),
+        ]
+        cm = MagicMock()
+        cm.__enter__.return_value = session
+        cm.__exit__.return_value = False
+
+        with (
+            patch(
+                "dev_health_ops.db.get_postgres_session_sync",
+                return_value=cm,
+            ),
+            patch.object(
+                metrics_partitioned.dispatch_daily_metrics_partitioned, "apply_async"
+            ) as mock_apply,
+        ):
+            result = metrics_partitioned.dispatch_daily_metrics_for_all_orgs.run(
+                day="2026-06-13", backfill_days=1
+            )
+
+        # One enqueue per active org, each carrying the REAL org_id (never
+        # "default" / blank).
+        assert mock_apply.call_count == 2
+        dispatched_orgs = {
+            call.kwargs["kwargs"]["org_id"] for call in mock_apply.call_args_list
+        }
+        assert dispatched_orgs == {org_a, org_b}
+        assert "default" not in dispatched_orgs
+        assert "" not in dispatched_orgs
+        for call in mock_apply.call_args_list:
+            assert call.kwargs["queue"] == "default"
+            assert call.kwargs["kwargs"]["day"] == "2026-06-13"
+            assert call.kwargs["kwargs"]["backfill_days"] == 1
+        assert set(result["dispatched"]) == {org_a, org_b}
+
+    def test_dispatcher_raises_on_enumeration_failure(self) -> None:
+        """A transient Postgres failure must NOT report an empty success.
+
+        Swallowing the enumeration error and returning
+        ``{"dispatched": [], "skipped": 0}`` would make Celery beat treat the
+        run as successful while computing zero orgs -- every tenant would go
+        another day without repo_metrics_daily rows and nothing would page on
+        it. The dispatcher must surface the failure via Celery's retry
+        machinery (which re-raises here) so transient errors are retried.
+        """
+        import celery.exceptions
+
+        from dev_health_ops.workers import metrics_partitioned
+
+        cm = MagicMock()
+        cm.__enter__.side_effect = RuntimeError("postgres unavailable")
+
+        with (
+            patch(
+                "dev_health_ops.db.get_postgres_session_sync",
+                return_value=cm,
+            ),
+            patch.object(
+                metrics_partitioned.dispatch_daily_metrics_partitioned, "apply_async"
+            ) as mock_apply,
+        ):
+            raised: Exception | None = None
+            try:
+                metrics_partitioned.dispatch_daily_metrics_for_all_orgs.run()
+            except (celery.exceptions.Retry, RuntimeError) as exc:
+                raised = exc
+
+        assert raised is not None, (
+            "dispatcher must raise (retry/failure) on enumeration failure, "
+            "not silently return an empty success"
+        )
+        mock_apply.assert_not_called()
+
+    def test_dispatcher_falls_back_to_default_org_when_no_active_orgs(self) -> None:
+        """Single-tenant / community installs: no Organization rows -> default org.
+
+        Mirrors ``_discover_active_org_ids``'s designed fallback (used
+        identically by ``dispatch_membership_backfill``) so a self-hosted
+        install with no Postgres Organization rows still gets its daily
+        metrics computed under the ``"default"`` org_id instead of silently
+        dispatching nothing.
+        """
+        from dev_health_ops.workers import metrics_partitioned
+
+        session = MagicMock()
+        session.execute.return_value.all.return_value = []
+        cm = MagicMock()
+        cm.__enter__.return_value = session
+        cm.__exit__.return_value = False
+
+        with (
+            patch(
+                "dev_health_ops.db.get_postgres_session_sync",
+                return_value=cm,
+            ),
+            patch.object(
+                metrics_partitioned.dispatch_daily_metrics_partitioned, "apply_async"
+            ) as mock_apply,
+        ):
+            result = metrics_partitioned.dispatch_daily_metrics_for_all_orgs.run()
+
+        mock_apply.assert_called_once()
+        assert mock_apply.call_args.kwargs["kwargs"]["org_id"] == "default"
+        assert result["dispatched"] == ["default"]

--- a/tests/test_metrics_complexity_db.py
+++ b/tests/test_metrics_complexity_db.py
@@ -150,3 +150,99 @@ def test_complexity_db_job_falls_back_to_blame(monkeypatch):
         "src/alpha.py",
         "src/beta.py",
     }
+
+
+def test_complexity_db_job_backfill_writes_single_day_not_duplicate_flat_rows(
+    monkeypatch,
+):
+    """CHAOS-2850: backfill_days > 1 must not fabricate duplicate flat rows.
+
+    Historical file snapshots are not stored, so re-using the CURRENT
+    git_files content across N backfill days would write N identical
+    cyclomatic_per_kloc rows -- flatlining complexity_delta's trailing
+    30-day window (load_repo_complexity_delta_30d) for the whole backfill
+    period. Only the target day's row may be written.
+    """
+    repo_id = uuid.uuid4()
+    files = [("src/alpha.py", "def alpha():\n    return 1\n")]
+    client = FakeClickHouseClient(files)
+    sink = FakeClickHouseSink(client)
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink)
+
+    rc = job.run_complexity_db_job(
+        repo_id=repo_id,
+        db_url="clickhouse://localhost:8123/default",
+        date=date(2025, 1, 30),
+        backfill_days=30,
+        language_globs=None,
+        max_files=None,
+        org_id="test-org",
+    )
+
+    assert rc == 0
+    assert len(sink.dailies) == 1, (
+        f"Expected exactly one repo_complexity_daily row (the target day), "
+        f"got {len(sink.dailies)} -- backfill must not fabricate duplicate "
+        f"flat historical rows."
+    )
+    assert sink.dailies[0].day == date(2025, 1, 30)
+
+
+def test_complexity_db_job_produces_distinct_values_across_days_when_code_differs(
+    monkeypatch,
+):
+    """CHAOS-2850: complexity must NOT be static across days when code changes.
+
+    Each real calendar day's run scans whatever is CURRENTLY in git_files at
+    that moment. A simple function on day 1 and a heavily-branching version
+    of the same file on day 2 must yield genuinely different
+    cyclomatic_per_kloc -- proving the daily cadence (not a fabricated
+    backfill) is what produces a real trend.
+    """
+    repo_id = uuid.uuid4()
+
+    day1_files = [("src/alpha.py", "def alpha():\n    return 1\n")]
+    day2_files = [
+        (
+            "src/alpha.py",
+            "def alpha(x):\n"
+            "    if x > 0 and x < 100 or x == 5:\n"
+            "        return 1\n"
+            "    return 0\n",
+        )
+    ]
+
+    sink1 = FakeClickHouseSink(FakeClickHouseClient(day1_files))
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink1)
+    rc1 = job.run_complexity_db_job(
+        repo_id=repo_id,
+        db_url="clickhouse://localhost:8123/default",
+        date=date(2025, 1, 5),
+        backfill_days=1,
+        language_globs=None,
+        max_files=None,
+        org_id="test-org",
+    )
+    assert rc1 == 0
+    day1_daily = sink1.dailies[0]
+
+    sink2 = FakeClickHouseSink(FakeClickHouseClient(day2_files))
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink2)
+    rc2 = job.run_complexity_db_job(
+        repo_id=repo_id,
+        db_url="clickhouse://localhost:8123/default",
+        date=date(2025, 1, 6),
+        backfill_days=1,
+        language_globs=None,
+        max_files=None,
+        org_id="test-org",
+    )
+    assert rc2 == 0
+    day2_daily = sink2.dailies[0]
+
+    assert day1_daily.day == date(2025, 1, 5)
+    assert day2_daily.day == date(2025, 1, 6)
+    assert day1_daily.cyclomatic_per_kloc != day2_daily.cyclomatic_per_kloc, (
+        "Complexity must reflect the actual code scanned on each day, not "
+        "stay static across days."
+    )

--- a/tests/test_p1_bug_fixes.py
+++ b/tests/test_p1_bug_fixes.py
@@ -82,10 +82,12 @@ class TestBeatScheduleMetrics:
 
         assert "run-daily-metrics" in beat_schedule
         entry = beat_schedule["run-daily-metrics"]
-        # gh-422: beat schedule now dispatches partitioned metrics
+        # CHAOS-2849: the beat entry now points at the per-org fan-out
+        # dispatcher, not the blank-org-defaulting partitioned task directly
+        # (gh-422 only wired the partitioned task, not org scoping).
         assert (
             entry["task"]
-            == "dev_health_ops.workers.tasks.dispatch_daily_metrics_partitioned"
+            == "dev_health_ops.workers.tasks.dispatch_daily_metrics_for_all_orgs"
         )
         assert entry["options"]["queue"] == "default"
 


### PR DESCRIPTION
## Summary

Fixes two coupled scheduling bugs in the daily-metrics pipeline.

### CHAOS-2849 (P0): `repo_metrics_daily` never written under real org UUIDs

The beat-scheduled `run-daily-metrics` entry (01:00 UTC) called
`dispatch_daily_metrics_partitioned` directly with **no** `org_id`, which
defaults to the literal string `"default"`. `discover_repos` scopes the
`repos` ClickHouse query by `org_id`, so this never matched a real
(UUID-scoped) tenant's rows — `repo_metrics_daily` was never populated for
any real organization.

**Fix:** add `dispatch_daily_metrics_for_all_orgs`, which enumerates active
organizations (via the existing `_discover_active_org_ids` helper) and fans
out one per-org `dispatch_daily_metrics_partitioned` call — the same shape
already used by `dispatch_release_impact` / `dispatch_membership_backfill`.
The beat entry now points at this dispatcher. A Postgres enumeration
failure raises/retries rather than silently reporting an empty success.

### CHAOS-2850 (P1): complexity is static

Two compounding causes:

1. `run_complexity_db_job`'s `backfill_days > 1` path reused the **current**
   `git_files`/`git_blame` snapshot across every day in the requested
   window, writing duplicate flat `cyclomatic_per_kloc` rows. Since there is
   no historical snapshot storage, this flatlined `complexity_delta`'s
   trailing 30-day trend for the whole backfill period.
2. `run_complexity_job` only ever ran chained after a git sync
   (`post_sync_dispatch`), so an org with infrequent syncs left
   `repo_complexity_daily` stale for days.

**Fix:**
1. The job now always writes exactly one row (for the target day),
   regardless of `backfill_days`, logging a warning instead of fabricating
   misleading duplicate historical rows.
2. Add `dispatch_complexity_job`, a daily per-org fan-out dispatcher
   (same shape as the others), scheduled at **00:45 UTC** — ahead of
   `run-daily-metrics` so the daily hotspot/risk compute reads a
   freshly-refreshed snapshot.

## Tests

- `tests/test_daily_metrics_org_schedule.py` (new): dispatcher wiring,
  beat-schedule pointer, org-scoped fan-out (never `"default"`/blank),
  enumeration-failure retry, single-tenant fallback.
- `tests/test_complexity_schedule.py` (new): same coverage for the
  complexity dispatcher, plus a schedule-ordering check (complexity runs
  before daily metrics).
- `tests/test_metrics_complexity_db.py`: backfill no longer writes
  duplicate flat rows; complexity values differ across two days when the
  underlying code differs.
- `tests/test_p1_bug_fixes.py`: updated to assert the beat entry now points
  at the org-scoped dispatcher (the prior assertion encoded the CHAOS-2849
  defect).

## Verification

- `bash ci/local_validate.sh` — full gate green (ruff format/check, mypy,
  ClickHouse scratch-db migrate, full unit suite: 6802 passed / 44 skipped,
  live argMax proof).
- Pre-commit/pre-push lefthook gates (ruff, mypy) passed on commit and push.

## Scope

Minimal/surgical: no Postgres model changes (no Alembic migration needed),
no changes to `web/`, `system_webhooks.py`, or `providers/*/code_client.py`.

Refs: CHAOS-2849, CHAOS-2850