### PR TITLE
fix(metrics): harden tenant-scoped repo reads

### DIFF
--- a/src/dev_health_ops/metrics/job_complexity_db.py
+++ b/src/dev_health_ops/metrics/job_complexity_db.py
@@ -68,7 +68,7 @@ def _load_repos(
     return repos
 
 
-def _git_file_counts(client: Any, repo_id: uuid.UUID) -> tuple[int, int]:
+def _git_file_counts(client: Any, repo_id: uuid.UUID, org_id: str) -> tuple[int, int]:
     rows = _query_rows(
         client,
         """
@@ -77,8 +77,9 @@ def _git_file_counts(client: Any, repo_id: uuid.UUID) -> tuple[int, int]:
           countIf(contents IS NOT NULL AND contents != '') AS non_empty
         FROM git_files
         WHERE repo_id = {repo_id:UUID}
+          AND org_id = {org_id:String}
         """,
-        {"repo_id": str(repo_id)},
+        {"repo_id": str(repo_id), "org_id": org_id},
     )
     if not rows:
         return 0, 0
@@ -87,17 +88,18 @@ def _git_file_counts(client: Any, repo_id: uuid.UUID) -> tuple[int, int]:
 
 
 def _load_git_files(
-    client: Any, repo_id: uuid.UUID, limit: int | None
+    client: Any, repo_id: uuid.UUID, org_id: str, limit: int | None
 ) -> list[tuple[str, str]]:
     query = """
         SELECT path, contents
         FROM git_files
         WHERE repo_id = {repo_id:UUID}
+          AND org_id = {org_id:String}
           AND contents IS NOT NULL
           AND contents != ''
         ORDER BY path
     """
-    params: dict = {"repo_id": str(repo_id)}
+    params: dict = {"repo_id": str(repo_id), "org_id": org_id}
     if limit is not None:
         query = f"{query} LIMIT {{limit:UInt64}}"
         params["limit"] = int(limit)
@@ -106,16 +108,17 @@ def _load_git_files(
 
 
 def _load_missing_paths(
-    client: Any, repo_id: uuid.UUID, limit: int | None
+    client: Any, repo_id: uuid.UUID, org_id: str, limit: int | None
 ) -> list[str]:
     query = """
         SELECT path
         FROM git_files
         WHERE repo_id = {repo_id:UUID}
+          AND org_id = {org_id:String}
           AND (contents IS NULL OR contents = '')
         ORDER BY path
     """
-    params: dict = {"repo_id": str(repo_id)}
+    params: dict = {"repo_id": str(repo_id), "org_id": org_id}
     if limit is not None:
         query = f"{query} LIMIT {{limit:UInt64}}"
         params["limit"] = int(limit)
@@ -126,6 +129,7 @@ def _load_missing_paths(
 def _load_blame_contents(
     client: Any,
     repo_id: uuid.UUID,
+    org_id: str,
     paths: Sequence[str] | None,
     limit: int | None,
 ) -> list[tuple[str, str]]:
@@ -141,8 +145,9 @@ def _load_blame_contents(
           ) AS contents
         FROM git_blame
         WHERE repo_id = {repo_id:UUID}
+          AND org_id = {org_id:String}
     """
-    params: dict = {"repo_id": str(repo_id)}
+    params: dict = {"repo_id": str(repo_id), "org_id": org_id}
     if paths:
         query += " AND path IN {paths:Array(String)}"
         params["paths"] = list(paths)
@@ -154,20 +159,27 @@ def _load_blame_contents(
     return [(row[0], row[1]) for row in rows]
 
 
-def _max_last_synced(client: Any, table: str, repo_id: uuid.UUID) -> datetime | None:
+def _max_last_synced(
+    client: Any, table: str, repo_id: uuid.UUID, org_id: str
+) -> datetime | None:
     rows = _query_rows(
         client,
-        f"SELECT maxOrNull(last_synced) FROM {table} WHERE repo_id = {{repo_id:UUID}}",
-        {"repo_id": str(repo_id)},
+        f"""
+        SELECT maxOrNull(last_synced)
+        FROM {table}
+        WHERE repo_id = {{repo_id:UUID}}
+          AND org_id = {{org_id:String}}
+        """,
+        {"repo_id": str(repo_id), "org_id": org_id},
     )
     if not rows:
         return None
     return rows[0][0]
 
 
-def _build_ref(client: Any, repo_id: uuid.UUID) -> str:
-    last_synced = _max_last_synced(client, "git_files", repo_id)
-    blame_synced = _max_last_synced(client, "git_blame", repo_id)
+def _build_ref(client: Any, repo_id: uuid.UUID, org_id: str) -> str:
+    last_synced = _max_last_synced(client, "git_files", repo_id, org_id)
+    blame_synced = _max_last_synced(client, "git_blame", repo_id, org_id)
     candidates = [dt for dt in [last_synced, blame_synced] if dt]
     if not candidates:
         return "db_last_synced:unknown"
@@ -261,13 +273,13 @@ def run_complexity_db_job(
         repos_with_data = 0
         for repo_uuid, repo_name in repos:
             repo_label = repo_name or str(repo_uuid)
-            total_files, non_empty = _git_file_counts(sink.client, repo_uuid)
+            total_files, non_empty = _git_file_counts(sink.client, repo_uuid, org_id)
 
             files: list[tuple[str, str]] = []
             remaining = max_files
 
             if non_empty > 0:
-                git_files = _load_git_files(sink.client, repo_uuid, remaining)
+                git_files = _load_git_files(sink.client, repo_uuid, org_id, remaining)
                 files.extend(git_files)
                 if remaining is not None:
                     remaining = max(remaining - len(git_files), 0)
@@ -281,7 +293,7 @@ def run_complexity_db_job(
                         total_files,
                     )
                     missing_paths = _load_missing_paths(
-                        sink.client, repo_uuid, remaining
+                        sink.client, repo_uuid, org_id, remaining
                     )
                     missing_paths = [
                         path for path in missing_paths if scanner.should_process(path)
@@ -290,6 +302,7 @@ def run_complexity_db_job(
                         blame_files = _load_blame_contents(
                             sink.client,
                             repo_uuid,
+                            org_id,
                             missing_paths,
                             remaining,
                         )
@@ -300,14 +313,16 @@ def run_complexity_db_job(
                         "Repo %s has no git_files contents; falling back to git_blame.",
                         repo_label,
                     )
-                files = _load_blame_contents(sink.client, repo_uuid, None, remaining)
+                files = _load_blame_contents(
+                    sink.client, repo_uuid, org_id, None, remaining
+                )
 
             files = _filter_files(scanner, files, max_files)
             if not files:
                 logger.warning("No scannable contents found for repo %s.", repo_label)
                 continue
 
-            ref_value = _build_ref(sink.client, repo_uuid)
+            ref_value = _build_ref(sink.client, repo_uuid, org_id)
             file_results = scanner.scan_file_contents(files)
             if not file_results:
                 logger.warning("No complexity data found for repo %s.", repo_label)

--- a/src/dev_health_ops/workers/metrics_partitioned.py
+++ b/src/dev_health_ops/workers/metrics_partitioned.py
@@ -48,6 +48,7 @@ def dispatch_daily_metrics_partitioned(
     Returns:
         dict with dispatched count, batch_count, and days
     """
+    from dev_health_ops.metrics.job_daily import discover_repos
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 
     db_url = db_url or _get_db_url()
@@ -63,8 +64,13 @@ def dispatch_daily_metrics_partitioned(
 
     try:
         ch_sink = ClickHouseMetricsSink(db_url)
-        rows = ch_sink.client.query("SELECT id FROM repos").result_rows
-        repo_ids = [str(row[0]) for row in rows]
+        repos = discover_repos(
+            "clickhouse",
+            ch_sink,
+            org_id=org_id,
+            provider=provider,
+        )
+        repo_ids = [str(repo.repo_id) for repo in repos]
     except Exception as exc:
         logger.exception("Failed to discover repos for partitioned dispatch: %s", exc)
         return {"status": "error", "error": str(exc)}

--- a/tests/test_bugsink_regressions.py
+++ b/tests/test_bugsink_regressions.py
@@ -42,7 +42,9 @@ def test_dispatch_daily_metrics_partitioned_defaults_none_org_id(
     )
 
     mock_sink_instance = MagicMock()
-    mock_sink_instance.client.query.return_value.result_rows = [(str(uuid.uuid4()),)]
+    mock_sink_instance.client.query.return_value.result_rows = [
+        (str(uuid.uuid4()), "default/repo", None, "github")
+    ]
     mock_sink_cls.return_value = mock_sink_instance
 
     mock_chord_instance = MagicMock()

--- a/tests/test_metrics_complexity_db.py
+++ b/tests/test_metrics_complexity_db.py
@@ -35,12 +35,14 @@ class FakeClickHouseClient:
 
 def test_load_blame_contents_query_uses_arraysort():
     client = FakeClickHouseClient([])
-    job._load_blame_contents(client, uuid.uuid4(), None, None)
+    job._load_blame_contents(client, uuid.uuid4(), "test-org", None, None)
     assert client.queries
-    query, _params = client.queries[0]
+    query, params = client.queries[0]
     assert "arraySort" in query
     assert "groupArray" in query
     assert "ORDER BY line_no" not in query
+    assert "org_id = {org_id:String}" in query
+    assert params["org_id"] == "test-org"
 
 
 class FakeClickHouseSink:
@@ -245,4 +247,82 @@ def test_complexity_db_job_produces_distinct_values_across_days_when_code_differ
     assert day1_daily.cyclomatic_per_kloc != day2_daily.cyclomatic_per_kloc, (
         "Complexity must reflect the actual code scanned on each day, not "
         "stay static across days."
+    )
+
+
+class FakeTenantCollisionClient:
+    def __init__(self, repo_id, rows_by_org, blame_by_org, last_synced_by_org):
+        self.repo_id = repo_id
+        self.rows_by_org = rows_by_org
+        self.blame_by_org = blame_by_org
+        self.last_synced_by_org = last_synced_by_org
+        self.queries = []
+
+    def query(self, query, parameters=None):
+        params = parameters or {}
+        self.queries.append((query, params))
+        org_id = params.get("org_id")
+        rows = self.rows_by_org.get(org_id, [])
+        if "maxOrNull(last_synced)" in query and "git_files" in query:
+            return FakeQueryResult([[self.last_synced_by_org.get(org_id)]])
+        if "maxOrNull(last_synced)" in query and "git_blame" in query:
+            return FakeQueryResult([[None]])
+        if "FROM git_files" in query and "count()" in query:
+            non_empty = [row for row in rows if row[1]]
+            return FakeQueryResult([[len(rows), len(non_empty)]])
+        if "FROM git_files" in query and "contents" in query and "count()" not in query:
+            return FakeQueryResult(rows)
+        if "FROM git_blame" in query:
+            return FakeQueryResult(self.blame_by_org.get(org_id, []))
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+def test_complexity_db_job_scopes_git_file_reads_by_org_id(monkeypatch):
+    repo_id = uuid.uuid4()
+    client = FakeTenantCollisionClient(
+        repo_id,
+        rows_by_org={
+            "org-a": [("src/a.py", "")],
+            "org-b": [
+                (
+                    "src/b.py",
+                    "",
+                )
+            ],
+        },
+        blame_by_org={
+            "org-a": [("src/a.py", "def a():\n    return 1\n")],
+            "org-b": [
+                (
+                    "src/b.py",
+                    "def b(x):\n    if x:\n        return 1\n    return 0\n",
+                )
+            ],
+        },
+        last_synced_by_org={
+            "org-a": datetime(2025, 1, 2, 3, 4, 5),
+            "org-b": datetime(2025, 1, 9, 3, 4, 5),
+        },
+    )
+    sink = FakeClickHouseSink(client)
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink)
+
+    rc = job.run_complexity_db_job(
+        repo_id=repo_id,
+        db_url="clickhouse://localhost:8123/default",
+        date=date(2025, 1, 5),
+        backfill_days=1,
+        language_globs=None,
+        max_files=None,
+        org_id="org-a",
+    )
+
+    assert rc == 0
+    assert {snap.file_path for snap in sink.snapshots} == {"src/a.py"}
+    assert all(
+        "org_id = {org_id:String}" in query and params.get("org_id") == "org-a"
+        for query, params in client.queries
+        if "FROM git_files" in query
+        or "FROM git_blame" in query
+        or "maxOrNull(last_synced)" in query
     )

--- a/tests/test_parallel_metrics.py
+++ b/tests/test_parallel_metrics.py
@@ -39,7 +39,7 @@ class TestDispatchDailyMetricsPartitioned:
             dispatch_daily_metrics_partitioned,
         )
 
-        fake_rows = [(str(uuid.uuid4()),) for _ in range(7)]
+        fake_rows = [(str(uuid.uuid4()), f"repo-{i}", None, "github") for i in range(7)]
         mock_sink_instance = MagicMock()
         mock_sink_instance.client.query.return_value.result_rows = fake_rows
         mock_sink_cls.return_value = mock_sink_instance
@@ -64,6 +64,100 @@ class TestDispatchDailyMetricsPartitioned:
         assert result["batch_count"] == 3
         mock_chord.assert_called_once()
         mock_chord_instance.assert_called_once()
+
+    @patch("dev_health_ops.workers.metrics_partitioned.chord")
+    @patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+    def test_repo_discovery_is_scoped_to_requested_org(self, mock_sink_cls, mock_chord):
+        from dev_health_ops.workers.metrics_partitioned import (
+            dispatch_daily_metrics_partitioned,
+        )
+
+        org_a_repo = str(uuid.uuid4())
+        org_b_repo = str(uuid.uuid4())
+
+        def query(_sql, parameters=None):
+            org_id = str((parameters or {}).get("org_id") or "")
+            rows = (
+                [(org_a_repo, "org-a/repo", None, "github")]
+                if org_id == "org-a"
+                else [(org_b_repo, "org-b/repo", None, "github")]
+            )
+            return MagicMock(result_rows=rows)
+
+        mock_sink_instance = MagicMock()
+        mock_sink_instance.client.query.side_effect = query
+        mock_sink_cls.return_value = mock_sink_instance
+        mock_chord_instance = MagicMock()
+        mock_chord.return_value = mock_chord_instance
+
+        task = dispatch_daily_metrics_partitioned
+        task.push_request(id="dispatch-tenant-scope")
+        try:
+            result = task(
+                org_id="org-a",
+                db_url="clickhouse://fake",
+                day="2025-01-15",
+                backfill_days=1,
+                batch_size=10,
+            )
+        finally:
+            task.pop_request()
+
+        assert result["repo_count"] == 1
+        query_text, query_kwargs = (
+            mock_sink_instance.client.query.call_args.args[0],
+            mock_sink_instance.client.query.call_args.kwargs,
+        )
+        assert "WHERE org_id = {org_id:String}" in query_text
+        assert query_kwargs["parameters"] == {"org_id": "org-a"}
+        batch_signatures = mock_chord.call_args.args[0]
+        assert batch_signatures[0].kwargs["repo_ids"] == [org_a_repo]
+        assert org_b_repo not in batch_signatures[0].kwargs["repo_ids"]
+
+    @patch("dev_health_ops.workers.metrics_partitioned.chord")
+    @patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
+    def test_org_scoped_dispatch_cannot_batch_another_org_repo(
+        self, mock_sink_cls, mock_chord
+    ):
+        from dev_health_ops.workers.metrics_partitioned import (
+            dispatch_daily_metrics_partitioned,
+        )
+
+        org_a_repo = str(uuid.uuid4())
+        org_b_repo = str(uuid.uuid4())
+
+        def query(_sql, parameters=None):
+            org_id = str((parameters or {}).get("org_id") or "")
+            rows_by_org = {
+                "org-a": [(org_a_repo, "org-a/repo", None, "github")],
+                "org-b": [(org_b_repo, "org-b/repo", None, "github")],
+            }
+            return MagicMock(result_rows=rows_by_org.get(org_id, []))
+
+        mock_sink_instance = MagicMock()
+        mock_sink_instance.client.query.side_effect = query
+        mock_sink_cls.return_value = mock_sink_instance
+        mock_chord_instance = MagicMock()
+        mock_chord.return_value = mock_chord_instance
+
+        task = dispatch_daily_metrics_partitioned
+        task.push_request(id="dispatch-no-cross-tenant-batch")
+        try:
+            result = task(
+                org_id="org-a",
+                db_url="clickhouse://fake",
+                day="2025-01-15",
+                backfill_days=1,
+                batch_size=10,
+            )
+        finally:
+            task.pop_request()
+
+        assert result["repo_count"] == 1
+        batch_signatures = mock_chord.call_args.args[0]
+        assert batch_signatures[0].kwargs["repo_ids"] == [org_a_repo]
+        assert org_b_repo not in batch_signatures[0].kwargs["repo_ids"]
+        assert batch_signatures[0].kwargs["org_id"] == "org-a"
 
     @patch("dev_health_ops.workers.metrics_partitioned.chord")
     @patch("dev_health_ops.metrics.sinks.clickhouse.ClickHouseMetricsSink")
@@ -95,7 +189,7 @@ class TestDispatchDailyMetricsPartitioned:
             run_daily_metrics_finalize_task,
         )
 
-        fake_rows = [(str(uuid.uuid4()),)]
+        fake_rows = [(str(uuid.uuid4()), "repo", None, "github")]
         mock_sink_instance = MagicMock()
         mock_sink_instance.client.query.return_value.result_rows = fake_rows
         mock_sink_cls.return_value = mock_sink_instance


### PR DESCRIPTION
## Summary
- Reuse org-scoped/deduped repo discovery in partitioned daily metrics dispatch.
- Scope complexity DB reads for git_files, git_blame, and last_synced by org_id.
- Add tenant-isolation regressions for daily metric batching and same repo_id complexity collisions.

## CHAOS-2853 verification
Step 1 found both reported gaps were real on current main after #1172:
- partitioned daily metrics still used raw unscoped SELECT id FROM repos;
- complexity DB git_files/git_blame/last_synced reads were repo_id-only despite org-scoped repo discovery.

## Validation
- pytest tests/test_parallel_metrics.py::TestDispatchDailyMetricsPartitioned::test_repo_discovery_is_scoped_to_requested_org tests/test_parallel_metrics.py::TestDispatchDailyMetricsPartitioned::test_org_scoped_dispatch_cannot_batch_another_org_repo tests/test_metrics_complexity_db.py::test_load_blame_contents_query_uses_arraysort tests/test_metrics_complexity_db.py::test_complexity_db_job_scopes_git_file_reads_by_org_id
- pytest tests/test_bugsink_regressions.py::test_dispatch_daily_metrics_partitioned_defaults_none_org_id tests/test_parallel_metrics.py::TestDispatchDailyMetricsPartitioned::test_org_scoped_dispatch_cannot_batch_another_org_repo tests/test_metrics_complexity_db.py::test_complexity_db_job_scopes_git_file_reads_by_org_id
- SKIP_CLICKHOUSE=1 bash ci/local_validate.sh

Note: full ClickHouse local_validate was attempted without SKIP_CLICKHOUSE and failed during existing scratch migration 027 with UNKNOWN_TABLE repo_metrics_daily_new before unit tests. The skipped-ClickHouse gate passed the full non-ClickHouse unit suite.

SCREENSHOT-WAIVER: backend-only ops change; no rendered UI.