### PR TITLE
feat(providers): instrument GitLab commit actuals (CHAOS-2814)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -195,9 +195,9 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
   `actual_requests`; the two are reported side by side, not blended into one
   number.
 - **A route_family/dimension with an estimate but no drained actuals this
-  run produces no row** (GitHub/GitLab code datasets still on the frozen
-  connector path, a `contents_blob`/`secondary_abuse_risk` dimension sharing
-  its single REST call with an already-recorded `rest_core` dimension, …) —
+  run produces no row** (code datasets that have not yet migrated off the
+  frozen connector path, a `contents_blob`/`secondary_abuse_risk` dimension
+  sharing its single REST call with an already-recorded `rest_core` dimension, …) —
   never a fabricated 100% over-estimation.
 - **`unbudgeted_actual`** is the reverse case: actual traffic on a
   route_family/dimension with **no matching estimate at all**, including the
@@ -880,10 +880,12 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
   strategy above), while `pr_social`'s GRAPHQL_COST marker is flipped to
   document it as now-instrumented.
 - **GitLab.** `process_gitlab_project` accepts the same `usage_sink`
-  parameter for a uniform cross-provider adapter contract, but no GitLab code
-  client drains into it yet — GitLab code-dataset fetch stays entirely on the
-  frozen connector until CHAOS-2773 Wave B. The sink is inert (always empty)
-  for GitLab today; this is expected, not a bug.
+  parameter for a uniform cross-provider adapter contract. Migrated
+  GitLabCodeClient-backed families drain into it on both success and failure:
+  `security` (CS10), `pipelines`/`deployments` (CS11), `tests` (CS12), and
+  commits + aggregate commit stats under the existing `project` family (CS13).
+  Frozen connector-only paths still leave the sink untouched until their own
+  migration changeset lands.
 
 ## Per-provider policy
 
@@ -1159,8 +1161,8 @@ paper over:
   aggregation/dashboard yet — calibration today is visible per-unit (result +
   structured log), not rolled up over time.
 - **Frozen `connectors/` path.** GitHub's `git`/`commit_stats`/`files`/`blame`/
-  `cicd`/`tests`/`deployments`/`security` route families and the equivalent
-  GitLab code-dataset paths remain under the frozen `connectors/` tree
+  `cicd`/`tests`/`deployments`/`security` route families and GitLab code-dataset
+  paths that have not been explicitly called out as migrated remain under the frozen `connectors/` tree
   (`connectors/github.py`'s PyGithub-based `GitHubConnector`, `connectors/
   gitlab.py`'s python-gitlab-based `GitLabConnector`). No new code may be added
   there (see [`AGENTS.md`](../../AGENTS.md)); rate-limit/actuals
@@ -1180,10 +1182,12 @@ paper over:
   `pipelines`+`deployments`
   ([CHAOS-2812](https://linear.app/fullchaos/issue/CHAOS-2812), CS11), and
   `tests` (+CI adapter usage draining;
-  [CHAOS-2813](https://linear.app/fullchaos/issue/CHAOS-2813), CS12)
+  [CHAOS-2813](https://linear.app/fullchaos/issue/CHAOS-2813), CS12), and
+  commits + aggregate commit stats under the `project` family
+  ([CHAOS-2814](https://linear.app/fullchaos/issue/CHAOS-2814), CS13)
   code-dataset families are migrated onto the canonical, instrumented
   `providers/gitlab/code_client.py::GitLabCodeClient` — GitLab's remaining
-  frozen code-dataset methods (`git`/`commit_stats`/`files`/`blame`/
+  frozen code-dataset methods (`files`/`blame`/
   `merge_requests` listing + repo-metadata/batch orchestration) stay
   unmigrated pending their own CHAOS-2773 changesets through CS17.
 

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -10,7 +10,6 @@ from dev_health_ops.analytics.complexity import (
     ComplexityScanner,
 )
 from dev_health_ops.connectors.models import SecurityAlertData
-from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models import git as git_models
 from dev_health_ops.models.git import (
@@ -78,6 +77,12 @@ else:
     ConnectorException = Exception
     RateLimitConfig = None
     RateLimitGate = None
+
+
+def _is_rate_limit_exception(exc: Exception) -> bool:
+    from dev_health_ops.exceptions import RateLimitException
+
+    return isinstance(exc, RateLimitException)
 
 
 # --- GitLab Sync Helpers ---
@@ -187,9 +192,9 @@ def _fetch_gitlab_commit_stats_sync(
                                 new_file_mode="unknown",
                             )
                         )
-                    except RateLimitException:
-                        raise
                     except Exception as e:
+                        if _is_rate_limit_exception(e):
+                            raise
                         logging.warning(
                             "Failed to get stats for commit %s: %s",
                             commit_hash,
@@ -2359,14 +2364,12 @@ async def process_gitlab_projects_batch(
                 )
                 if stats_objects:
                     await ingestion_sink.insert_git_commit_stats(stats_objects)
-            except RateLimitException:
-                # CHAOS-2814/CS13: mirror the GitHub batch's
-                # ``except (RateLimitException, RateLimitExceededException): raise``
-                # -- an exhausted rate limit must propagate so the batch/job is
-                # marked failed and retried, not be swallowed by the broad
-                # ``except Exception`` below as a per-project warning.
-                raise
             except Exception as e:
+                if _is_rate_limit_exception(e):
+                    # CHAOS-2814/CS13: an exhausted rate limit must propagate so
+                    # the batch/job is marked failed and retried, not swallowed
+                    # as a per-project warning.
+                    raise
                 logging.warning(
                     "Failed to fetch commits for GitLab project %s: %s",
                     project_info.full_name,
@@ -2651,6 +2654,7 @@ async def process_gitlab_projects_batch(
                 try:
                     await join_task
                 except asyncio.CancelledError:
+                    # Expected: join_task was cancelled after consumer_task ended first.
                     pass
                 await consumer_task  # re-raises the consumer's exception
             await results_queue.put(_queue_sentinel)

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -10,6 +10,7 @@ from dev_health_ops.analytics.complexity import (
     ComplexityScanner,
 )
 from dev_health_ops.connectors.models import SecurityAlertData
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models import git as git_models
 from dev_health_ops.models.git import (
@@ -91,135 +92,119 @@ def _fetch_gitlab_project_info_sync(connector, project_id):
 
 
 def _fetch_gitlab_commits_sync(
-    gl_project,
+    connector,
+    project_id,
     max_commits: int | None,
     repo_id,
     since: datetime | None = None,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ):
-    """Sync helper to fetch GitLab commits."""
-    list_params: dict[str, object] = {"per_page": 100, "get_all": False}
-    if since is not None:
-        since_iso = since.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-        list_params["since"] = since_iso
-    if until is not None:
-        until_iso = until.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
-        list_params["until"] = until_iso
+    """Sync helper to fetch GitLab commits via the canonical code client."""
+    drained_observations: list[dict[str, Any]] = []
 
-    commit_objects = []
-    count = 0
-    commit_hashes = []
-    page = 1
-    per_page = min(max_commits, 100) if max_commits else 100
-    stop_due_to_since = False
+    async def _run():
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await client.get_commits(
+                    project_id,
+                    max_commits=max_commits,
+                    since=since,
+                    until=until,
+                )
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
 
-    while True:
-        if max_commits is not None and count >= max_commits:
-            break
-
-        page_params = dict(list_params)
-        page_params["page"] = page
-        page_params["per_page"] = per_page
-        commits_page = gl_project.commits.list(**page_params)
-        if not commits_page:
-            break
-        logging.debug(
-            "GitLab commits page %d returned %d items",
-            page,
-            len(commits_page),
+    try:
+        raw_commits = asyncio.run(_run())
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_commits_sync", drained_observations, usage_sink
         )
 
-        for commit in commits_page:
-            if max_commits is not None and count >= max_commits:
+    commit_objects = []
+    commit_hashes = []
+    for commit in raw_commits:
+        committed_when = commit.committed_date
+        if until is not None and isinstance(committed_when, datetime):
+            if committed_when.astimezone(timezone.utc) > until:
+                continue
+        if since is not None and isinstance(committed_when, datetime):
+            if committed_when.astimezone(timezone.utc) < since:
                 break
 
-            committed_when = None
-            if hasattr(commit, "committed_date") and commit.committed_date:
-                try:
-                    committed_when = safe_parse_datetime(commit.committed_date)
-                except Exception:
-                    committed_when = None
-
-            if until is not None and isinstance(committed_when, datetime):
-                if committed_when.astimezone(timezone.utc) > until:
-                    continue
-
-            if since is not None and isinstance(committed_when, datetime):
-                if committed_when.astimezone(timezone.utc) < since:
-                    stop_due_to_since = True
-                    break
-
-            git_commit = GitCommit(
+        commit_objects.append(
+            GitCommit(
                 repo_id=repo_id,
-                hash=commit.id,
+                hash=commit.commit_id,
                 message=commit.message,
-                author_name=(
-                    commit.author_name if hasattr(commit, "author_name") else "Unknown"
-                ),
+                author_name=commit.author_name or "Unknown",
                 author_email=None,
-                author_when=(
-                    safe_parse_datetime(commit.authored_date)
-                    if hasattr(commit, "authored_date")
-                    else datetime.now(timezone.utc)
-                ),
-                committer_name=(
-                    commit.committer_name
-                    if hasattr(commit, "committer_name")
-                    else "Unknown"
-                ),
+                author_when=commit.authored_date or datetime.now(timezone.utc),
+                committer_name=commit.committer_name or "Unknown",
                 committer_email=None,
-                committer_when=(
-                    safe_parse_datetime(commit.committed_date)
-                    if hasattr(commit, "committed_date")
-                    else datetime.now(timezone.utc)
-                ),
-                parents=len(commit.parent_ids) if hasattr(commit, "parent_ids") else 0,
+                committer_when=commit.committed_date or datetime.now(timezone.utc),
+                parents=len(commit.parent_ids),
             )
-            commit_objects.append(git_commit)
-            commit_hashes.append(commit.id)
-            count += 1
-
-        if stop_due_to_since or len(commits_page) < per_page:
-            break
-        page += 1
+        )
+        commit_hashes.append(commit.commit_id)
 
     return commit_hashes, commit_objects
 
 
 def _fetch_gitlab_commit_stats_sync(
-    gl_project, commit_hashes, repo_id, max_stats, gate=None
+    connector,
+    project_id,
+    commit_hashes,
+    repo_id,
+    max_stats,
+    gate=None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ):
-    """Sync helper to fetch detailed commit stats from GitLab.
-
-    Each commit detail is one REST call, so each iteration waits on the
-    rate-limit gate.
-    """
+    """Sync helper to fetch detailed commit stats from GitLab."""
     gate = BaseGitProcessor.ensure_gate(gate)
-    stats_objects = []
+    drained_observations: list[dict[str, Any]] = []
 
-    for commit_hash in commit_hashes[:max_stats]:
-        try:
-            if gate is not None:
-                gate.wait_sync()
-            detailed_commit = gl_project.commits.get(commit_hash)
-            if hasattr(detailed_commit, "stats"):
-                stat = GitCommitStat(
-                    repo_id=repo_id,
-                    commit_hash=commit_hash,
-                    file_path=AGGREGATE_STATS_MARKER,
-                    additions=detailed_commit.stats.get("additions", 0),
-                    deletions=detailed_commit.stats.get("deletions", 0),
-                    old_file_mode="unknown",
-                    new_file_mode="unknown",
-                )
-                stats_objects.append(stat)
-        except Exception as e:
-            logging.warning(
-                "Failed to get stats for commit %s: %s",
-                commit_hash,
-                e,
-            )
-    return stats_objects
+    async def _run():
+        stats_objects = []
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                for commit_hash in commit_hashes[:max_stats]:
+                    try:
+                        if gate is not None:
+                            gate.wait_sync()
+                        detailed_stats = await client.get_commit_stats(
+                            project_id, commit_hash
+                        )
+                        stats_objects.append(
+                            GitCommitStat(
+                                repo_id=repo_id,
+                                commit_hash=commit_hash,
+                                file_path=AGGREGATE_STATS_MARKER,
+                                additions=detailed_stats.additions,
+                                deletions=detailed_stats.deletions,
+                                old_file_mode="unknown",
+                                new_file_mode="unknown",
+                            )
+                        )
+                    except RateLimitException:
+                        raise
+                    except Exception as e:
+                        logging.warning(
+                            "Failed to get stats for commit %s: %s",
+                            commit_hash,
+                            e,
+                        )
+                return stats_objects
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+
+    try:
+        return asyncio.run(_run())
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_commit_stats_sync", drained_observations, usage_sink
+        )
 
 
 def _fetch_gitlab_mrs_sync(connector, project_id, repo_id, max_mrs):
@@ -1332,6 +1317,7 @@ async def _backfill_gitlab_missing_data(
     include_files: bool = True,
     include_blame: bool = True,
     include_commit_stats: bool = True,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> None:
     # check_backfill_needs's blame_only flag doubles as "skip commit stats".
     needs = await check_backfill_needs(
@@ -1409,47 +1395,41 @@ async def _backfill_gitlab_missing_data(
             )
 
     if needs_commit_stats:
-        try:
-            commits = project.commits.list(
-                ref_name=default_branch, per_page=100, get_all=True
-            )
-        except TypeError:
-            commits = project.commits.list(
-                ref_name=default_branch, per_page=100, all=True
-            )
-
-        async with AsyncBatchCollector(
-            ingestion_sink.insert_git_commit_stats
-        ) as stats_collector:
-            commit_count = 0
-            for commit in commits or []:
-                if max_commits and commit_count >= max_commits:
-                    break
-                commit_count += 1
-                sha = getattr(commit, "id", None) or getattr(commit, "sha", None)
-                if not sha:
-                    continue
-                try:
-                    stats = connector.get_commit_stats_by_project(
-                        sha=sha,
-                        project_name=project_full_name,
-                    )
-                    stats_collector.add(
-                        GitCommitStat(
-                            repo_id=db_repo.id,
-                            commit_hash=sha,
-                            file_path=AGGREGATE_STATS_MARKER,
-                            additions=getattr(stats, "additions", 0),
-                            deletions=getattr(stats, "deletions", 0),
-                            old_file_mode="unknown",
-                            new_file_mode="unknown",
-                        )
-                    )
-                    await stats_collector.maybe_flush()
-                except Exception as e:
-                    logging.debug(
-                        f"Failed commit stat fetch for {project_full_name}@{sha}: {e}"
-                    )
+        # CHAOS-2814/CS13: fetch commits + detailed stats via the canonical,
+        # instrumented GitLabCodeClient helpers (``_fetch_gitlab_commits_sync``
+        # / ``_fetch_gitlab_commit_stats_sync``) instead of the frozen
+        # python-gitlab ``project.commits.list()`` + the un-instrumented
+        # ``connector.get_commit_stats_by_project()``. Dispatched via
+        # ``loop.run_in_executor`` (mirrors every other GitLab sync helper,
+        # e.g. ``_sync_gitlab_commit_stats``) since the sync helpers bridge
+        # to the async client with their own ``asyncio.run()`` and cannot be
+        # awaited directly from this already-running event loop.
+        loop = asyncio.get_running_loop()
+        commit_hashes, _ = await loop.run_in_executor(
+            None,
+            _fetch_gitlab_commits_sync,
+            connector,
+            project_full_name,
+            max_commits,
+            db_repo.id,
+            None,
+            None,
+            usage_sink,
+        )
+        stats_limit = resolve_commit_stats_limit(len(commit_hashes), max_commits, None)
+        stats_objects = await loop.run_in_executor(
+            None,
+            _fetch_gitlab_commit_stats_sync,
+            connector,
+            project_full_name,
+            commit_hashes,
+            db_repo.id,
+            stats_limit,
+            None,
+            usage_sink,
+        )
+        if stats_objects:
+            await ingestion_sink.insert_git_commit_stats(stats_objects)
 
     if needs_blame and file_paths:
         # Bound the blame crawl: one REST call per file, so cap the number of
@@ -1513,13 +1493,15 @@ async def _backfill_gitlab_missing_data(
 
 async def _sync_gitlab_commits(
     *,
-    gl_project: Any,
+    connector: Any,
+    project_id: int,
     db_repo: Repo,
     ingestion_sink: IngestionSink,
     loop: asyncio.AbstractEventLoop,
     max_commits: int | None,
     since: datetime | None,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> tuple[list[str], int]:
     if max_commits is None:
         logging.info("Fetching all commits from GitLab...")
@@ -1528,11 +1510,13 @@ async def _sync_gitlab_commits(
     commit_hashes, commit_objects = await loop.run_in_executor(
         None,
         _fetch_gitlab_commits_sync,
-        gl_project,
+        connector,
+        project_id,
         max_commits,
         db_repo.id,
         since,
         until,
+        usage_sink,
     )
     if commit_objects:
         await ingestion_sink.insert_git_commit_data(commit_objects)
@@ -1542,7 +1526,8 @@ async def _sync_gitlab_commits(
 
 async def _sync_gitlab_commit_stats(
     *,
-    gl_project: Any,
+    connector: Any,
+    project_id: int,
     db_repo: Repo,
     ingestion_sink: IngestionSink,
     loop: asyncio.AbstractEventLoop,
@@ -1550,26 +1535,32 @@ async def _sync_gitlab_commit_stats(
     since: datetime | None,
     until: datetime | None = None,
     commit_hashes: list[str] | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> int:
     if commit_hashes is None:
         commit_hashes, _ = await loop.run_in_executor(
             None,
             _fetch_gitlab_commits_sync,
-            gl_project,
+            connector,
+            project_id,
             max_commits,
             db_repo.id,
             since,
             until,
+            usage_sink,
         )
     logging.info("Fetching commit stats from GitLab...")
     stats_limit = resolve_commit_stats_limit(len(commit_hashes), max_commits, since)
     stats_objects = await loop.run_in_executor(
         None,
         _fetch_gitlab_commit_stats_sync,
-        gl_project,
+        connector,
+        project_id,
         commit_hashes,
         db_repo.id,
         stats_limit,
+        None,
+        usage_sink,
     )
     if stats_objects:
         await ingestion_sink.insert_git_commit_stats(stats_objects)
@@ -1937,11 +1928,9 @@ async def process_gitlab_project(
     Process a GitLab project using the GitLab connector.
 
     ``usage_sink`` (CHAOS-2803/CS2) mirrors ``process_github_repo``'s
-    adapter-owned drain sink for symmetry with ``dataset_adapters.py``. No
-    instrumented client is constructed by this function yet -- GitLab
-    code-dataset fetch stays on the frozen connector until CHAOS-2773 Wave B
-    migrates it -- so it is currently unused and accepted only so the
-    caller-side contract is uniform across providers.
+    adapter-owned drain sink for symmetry with ``dataset_adapters.py``. GitLab
+    code-client helpers drain their per-request observations into this sink on
+    both success and failure; legacy connector-only paths leave it untouched.
     """
     if not CONNECTORS_AVAILABLE:
         raise RuntimeError(
@@ -2032,18 +2021,21 @@ async def process_gitlab_project(
         commit_hashes: list[str] | None = None
         if run_commits:
             commit_hashes, _ = await _sync_gitlab_commits(
-                gl_project=gl_project,
+                connector=connector,
+                project_id=project_id,
                 db_repo=db_repo,
                 ingestion_sink=ingestion_sink,
                 loop=loop,
                 max_commits=max_commits,
                 since=since,
                 until=until,
+                usage_sink=usage_sink,
             )
 
         if run_commit_stats:
             await _sync_gitlab_commit_stats(
-                gl_project=gl_project,
+                connector=connector,
+                project_id=project_id,
                 db_repo=db_repo,
                 ingestion_sink=ingestion_sink,
                 loop=loop,
@@ -2051,6 +2043,7 @@ async def process_gitlab_project(
                 since=since,
                 until=until,
                 commit_hashes=commit_hashes,
+                usage_sink=usage_sink,
             )
 
         if sync_prs:
@@ -2339,17 +2332,16 @@ async def process_gitlab_projects_batch(
             else:
                 commit_limit = max_commits_per_project or 100
             try:
-                if gl_project is None:
-                    gl_project = await loop.run_in_executor(
-                        None, connector.gitlab.projects.get, project_info.id
-                    )
                 commit_hashes, commit_objects = await loop.run_in_executor(
                     None,
                     _fetch_gitlab_commits_sync,
-                    gl_project,
+                    connector,
+                    project_info.id,
                     commit_limit,
                     db_repo.id,
                     since,
+                    None,
+                    usage_sink,
                 )
                 if commit_objects:
                     await ingestion_sink.insert_git_commit_data(commit_objects)
@@ -2357,13 +2349,23 @@ async def process_gitlab_projects_batch(
                 stats_objects = await loop.run_in_executor(
                     None,
                     _fetch_gitlab_commit_stats_sync,
-                    gl_project,
+                    connector,
+                    project_info.id,
                     commit_hashes,
                     db_repo.id,
                     50 if commit_limit is None else min(commit_limit, 50),
+                    None,
+                    usage_sink,
                 )
                 if stats_objects:
                     await ingestion_sink.insert_git_commit_stats(stats_objects)
+            except RateLimitException:
+                # CHAOS-2814/CS13: mirror the GitHub batch's
+                # ``except (RateLimitException, RateLimitExceededException): raise``
+                # -- an exhausted rate limit must propagate so the batch/job is
+                # marked failed and retried, not be swallowed by the broad
+                # ``except Exception`` below as a per-project warning.
+                raise
             except Exception as e:
                 logging.warning(
                     "Failed to fetch commits for GitLab project %s: %s",
@@ -2635,7 +2637,22 @@ async def process_gitlab_projects_batch(
                     ),
                 )
 
-            await results_queue.join()
+            # Wait for the queue to drain, but bail out if the consumer dies
+            # first: store_result may propagate a RateLimitException (CHAOS-2814/
+            # CS13), leaving un-task_done()'d items so results_queue.join()
+            # would hang forever. FIRST_COMPLETED lets us detect that and
+            # re-raise instead -- mirrors process_github_repos_batch.
+            join_task = asyncio.create_task(results_queue.join())
+            done, _pending = await asyncio.wait(
+                {join_task, consumer_task}, return_when=asyncio.FIRST_COMPLETED
+            )
+            if consumer_task in done:
+                join_task.cancel()
+                try:
+                    await join_task
+                except asyncio.CancelledError:
+                    pass
+                await consumer_task  # re-raises the consumer's exception
             await results_queue.put(_queue_sentinel)
             await consumer_task
         else:

--- a/src/dev_health_ops/providers/gitlab/code_client.py
+++ b/src/dev_health_ops/providers/gitlab/code_client.py
@@ -12,8 +12,8 @@ python-gitlab and then rode the un-instrumented
 actuals instrumentation (CHAOS-2754) requires a client that owns a
 ``UsageRecorder`` -- so this module ports the fetch/error-handling/field-
 mapping logic and adds the recorder the frozen connector could never carry.
-Later GitLab-wave changesets (CS11 pipelines+deployments, CS12 tests, ...)
-copy this shape.
+Later GitLab-wave changesets (CS11 pipelines+deployments, CS12 tests, CS13
+commits+stats, ...) copy this shape.
 
 Behavior parity with ``GitLabConnector.get_security_alerts``
 (``connectors/gitlab.py`` ~1268-1379, riding ``connectors/utils/rest.py``'s
@@ -45,11 +45,12 @@ Behavior parity with ``GitLabConnector.get_security_alerts``
   scan API carries no per-vulnerability timestamp; that is the connector's
   own pre-existing choice, not something this migration invents.
 
-Every operation this client issues carries the explicit ``"security:"``
-family prefix (CHAOS-2773 CS1's ``OperationResolver`` prefix short-circuit,
+Every operation this client issues carries an explicit family prefix
+(CHAOS-2773 CS1's ``OperationResolver`` prefix short-circuit,
 ``providers/usage.py``) so usage resolution is deterministic by
 construction rather than by marker-substring tuning -- see
-``providers/gitlab/budget.py``'s ``security`` route family.
+``providers/gitlab/budget.py``'s ``security``, ``pipelines``,
+``deployments``, ``tests``, and ``project`` route families.
 """
 
 from __future__ import annotations
@@ -88,6 +89,7 @@ _RESET_HEADER_NAME = "RateLimit-Reset"
 # Explicit family prefix every operation this client issues is labeled with
 # (see the module docstring's "Every operation" paragraph).
 _SECURITY_FAMILY_PREFIX = "security"
+_PROJECT_FAMILY_PREFIX = "project"
 _PIPELINES_FAMILY_PREFIX = "pipelines"
 _DEPLOYMENTS_FAMILY_PREFIX = "deployments"
 _TESTS_FAMILY_PREFIX = "tests"
@@ -112,6 +114,24 @@ class GitLabDeploymentData:
     finished_at: datetime | None
     sha: str | None
     raw_payload: dict[str, Any]
+
+
+@dataclass(frozen=True)
+class GitLabCommitData:
+    commit_id: str
+    message: str | None
+    author_name: str | None
+    authored_date: datetime | None
+    committer_name: str | None
+    committed_date: datetime | None
+    parent_ids: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class GitLabCommitStatsData:
+    commit_id: str
+    additions: int
+    deletions: int
 
 
 class _GitLabSecurityForbidden(APIException):
@@ -277,11 +297,65 @@ def _map_deployment(item: dict[str, Any]) -> GitLabDeploymentData:
     )
 
 
+def _map_commit(item: dict[str, Any]) -> GitLabCommitData:
+    parent_ids = item.get("parent_ids")
+    return GitLabCommitData(
+        commit_id=str(item.get("id") or item.get("short_id") or ""),
+        message=item.get("message"),
+        author_name=item.get("author_name"),
+        authored_date=_parse_gitlab_datetime(item.get("authored_date")),
+        committer_name=item.get("committer_name"),
+        committed_date=_parse_gitlab_datetime(item.get("committed_date")),
+        parent_ids=tuple(str(parent) for parent in parent_ids or []),
+    )
+
+
+def _coerce_int(value: object) -> int:
+    if not isinstance(value, str | int | float):
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _map_commit_stats(commit_id: str, item: dict[str, Any]) -> GitLabCommitStatsData:
+    stats = item.get("stats")
+    if not isinstance(stats, dict):
+        stats = {}
+    return GitLabCommitStatsData(
+        commit_id=commit_id,
+        additions=_coerce_int(stats.get("additions")),
+        deletions=_coerce_int(stats.get("deletions")),
+    )
+
+
+def _format_gitlab_window_datetime(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _encode_project_id(project_id: int | str) -> str:
+    """Percent-encode a project id/path for use as ONE URL path segment.
+
+    Mirrors ``_resolve_project_id``'s own encoding below (and
+    ``feature_flags.py``'s ``encoded_project``): digits are unreserved per
+    RFC 3986 so a plain numeric id round-trips unchanged, while a
+    namespaced path (``group/project``) is escaped exactly as GitLab's own
+    docs require for the ``/projects/{id_or_path}`` family (GitLab decodes
+    the WHOLE path segment server-side). ``safe=""`` also forces '/' itself
+    to be escaped -- the caller-supplied ``project_id`` is not trusted to be
+    a bare numeric id, so a value smuggling extra path segments (``../``) or
+    query metacharacters (``?``) collapses to inert data in a single
+    segment instead of being interpreted as additional URL structure.
+    """
+    return urllib.parse.quote(str(project_id), safe="")
+
+
 class GitLabCodeClient:
     """Canonical GitLab code-dataset client (CHAOS-2773 CS10 pathfinder).
 
-    Currently covers the "security" dataset (vulnerability findings +
-    dependency-scan alerts). Built on the shared ``InstrumentedRESTCore`` so
+    Covers migrated GitLab code datasets (security, pipelines/deployments,
+    tests, commits + aggregate commit stats). Built on the shared ``InstrumentedRESTCore`` so
     every physical HTTP hop is recorded through ONE owned ``UsageRecorder``,
     mirroring ``GitLabWorkClient`` / ``GitLabFeatureFlagsClient``'s
     rate-limit conventions.
@@ -475,6 +549,65 @@ class GitLabCodeClient:
             max_items=max_deployments,
         )
         return [_map_deployment(item) for item in raw_items[:max_deployments]]
+
+    async def get_commits(
+        self,
+        project_id: int | str,
+        *,
+        max_commits: int | None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+        per_page: int = 100,
+    ) -> list[GitLabCommitData]:
+        if max_commits is not None and max_commits <= 0:
+            return []
+        params: dict[str, Any] = {}
+        if since is not None:
+            params["since"] = _format_gitlab_window_datetime(since)
+        if until is not None:
+            params["until"] = _format_gitlab_window_datetime(until)
+
+        effective_per_page = min(max_commits, per_page) if max_commits else per_page
+        encoded_project_id = _encode_project_id(project_id)
+        path = f"/projects/{encoded_project_id}/repository/commits"
+        operation = f"{_PROJECT_FAMILY_PREFIX}:GET /projects/{{id}}/repository/commits"
+        if max_commits is None:
+            raw_items = await self._core.paginate_page_param(
+                path,
+                operation=operation,
+                params=params,
+                per_page=effective_per_page,
+                max_pages=10_000,
+            )
+            return [_map_commit(item) for item in raw_items if isinstance(item, dict)]
+
+        raw_items = await self._get_gitlab_list(
+            path,
+            operation=operation,
+            params=params,
+            per_page=effective_per_page,
+            paginate=max_commits > effective_per_page,
+            max_items=max_commits,
+        )
+        return [_map_commit(item) for item in raw_items[:max_commits]]
+
+    async def get_commit_stats(
+        self, project_id: int | str, commit_sha: str
+    ) -> GitLabCommitStatsData:
+        encoded_project_id = _encode_project_id(project_id)
+        encoded_sha = urllib.parse.quote(str(commit_sha), safe="")
+        response = await self._core.request(
+            "GET",
+            f"/projects/{encoded_project_id}/repository/commits/{encoded_sha}",
+            operation=(
+                f"{_PROJECT_FAMILY_PREFIX}:GET "
+                "/projects/{id}/repository/commits/{sha}"
+            ),
+        )
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise APIException(f"Unexpected GitLab commit response: {type(payload)!r}")
+        return _map_commit_stats(commit_sha, payload)
 
     async def get_deployment_merge_requests(
         self, project_id: int | str, sha: str
@@ -696,4 +829,10 @@ class GitLabCodeClient:
         await self.close()
 
 
-__all__ = ["GitLabCodeClient", "GitLabDeploymentData", "GitLabPipelineData"]
+__all__ = [
+    "GitLabCodeClient",
+    "GitLabCommitData",
+    "GitLabCommitStatsData",
+    "GitLabDeploymentData",
+    "GitLabPipelineData",
+]

--- a/tests/providers/test_gitlab_budget.py
+++ b/tests/providers/test_gitlab_budget.py
@@ -4,6 +4,7 @@ from collections.abc import Mapping
 from datetime import datetime, timezone
 
 from dev_health_ops.providers.gitlab.budget import (
+    GITLAB_USAGE_RESOLVER,
     GITLAB_USAGE_ROUTE_FAMILIES,
     GitLabBudgetEstimator,
 )
@@ -95,6 +96,11 @@ def test_gitlab_budget_has_code_client_family_prefix_markers() -> None:
 
     assert families["pipelines"].operation_markers == ("pipelines:",)
     assert families["deployments"].operation_markers == ("deployments:",)
+    assert families["security"].operation_markers == ("security:",)
+    assert families["tests"].operation_markers == ("tests:",)
+    assert GITLAB_USAGE_RESOLVER.resolve(
+        transport="rest", operation="project:GET /projects/{id}/repository/commits"
+    ) == ("project", BudgetDimension.REST_CORE)
 
 
 def test_gitlab_budget_route_family_limits_override_dimension_defaults() -> None:

--- a/tests/providers/test_gitlab_code_client.py
+++ b/tests/providers/test_gitlab_code_client.py
@@ -18,6 +18,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from email.utils import format_datetime
 from typing import Any, cast
+from urllib.parse import quote
 
 import httpx
 import pytest
@@ -57,12 +58,19 @@ def _router_transport(
     calls: dict[str, int] = {}
     captured_headers: dict[str, httpx.Headers] = {}
     captured_urls: dict[str, httpx.URL] = {}
+    # Keyed by the same DECODED ``request.url.path`` the router matches on --
+    # ``.path`` itself decodes a percent-encoded '/' (%2F) back to a literal
+    # '/', so it cannot prove wire-level path-segment encoding happened;
+    # ``.raw_path`` retains the percent-encoding actually sent on the wire
+    # (see ``TestProjectIdPathEncoding``).
+    captured_raw_paths: dict[str, bytes] = {}
 
     def handler(request: httpx.Request) -> httpx.Response:
         path = request.url.path
         calls[path] = calls.get(path, 0) + 1
         captured_headers[path] = request.headers
         captured_urls[path] = request.url
+        captured_raw_paths[path] = request.url.raw_path
         entry = routes[path]
         if isinstance(entry, list):
             idx = min(calls[path] - 1, len(entry) - 1)
@@ -73,6 +81,7 @@ def _router_transport(
     transport.calls = calls  # type: ignore[attr-defined]
     transport.captured_headers = captured_headers  # type: ignore[attr-defined]
     transport.captured_urls = captured_urls  # type: ignore[attr-defined]
+    transport.captured_raw_paths = captured_raw_paths  # type: ignore[attr-defined]
     return transport, calls
 
 
@@ -559,6 +568,8 @@ _PIPELINES_PATH = "/api/v4/projects/42/pipelines"
 _RELEASES_PATH = "/api/v4/projects/42/releases"
 _DEPLOYMENTS_PATH = "/api/v4/projects/42/deployments"
 _DEPLOYMENT_MRS_PATH = "/api/v4/projects/42/repository/commits/abc123/merge_requests"
+_COMMITS_PATH = "/api/v4/projects/42/repository/commits"
+_COMMIT_DETAIL_PATH = "/api/v4/projects/42/repository/commits/abc123"
 
 
 class TestPipelinesParity:
@@ -704,6 +715,262 @@ class TestDeploymentsParity:
 
         assert len(deployments) == 1
         assert calls[_DEPLOYMENTS_PATH] == 1
+
+
+class TestCommitsParity:
+    @pytest.mark.asyncio
+    async def test_commit_list_params_mapping_and_usage_family(self) -> None:
+        commit = {
+            "id": "abc123",
+            "message": "ship it",
+            "author_name": "Ada",
+            "authored_date": "2026-01-10T00:00:00Z",
+            "committer_name": "Grace",
+            "committed_date": "2026-01-10T00:01:00Z",
+            "parent_ids": ["parent1"],
+        }
+        transport, calls = _router_transport(
+            {_COMMITS_PATH: _json_response(200, [commit])}
+        )
+        client = _client(transport)
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        until = datetime(2026, 1, 31, tzinfo=timezone.utc)
+
+        commits = await client.get_commits(42, max_commits=10, since=since, until=until)
+
+        assert calls[_COMMITS_PATH] == 1
+        assert commits[0].commit_id == "abc123"
+        assert commits[0].message == "ship it"
+        assert commits[0].author_name == "Ada"
+        assert commits[0].committer_name == "Grace"
+        assert commits[0].parent_ids == ("parent1",)
+        query = dict(transport.captured_urls[_COMMITS_PATH].params)  # type: ignore[attr-defined]
+        assert query == {
+            "since": "2026-01-01T00:00:00Z",
+            "until": "2026-01-31T00:00:00Z",
+            "page": "1",
+            "per_page": "10",
+        }
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "project"
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_commit_list_paginates_until_cap(self) -> None:
+        page_one = [
+            {"id": f"sha-{i}", "committed_date": "2026-01-10T00:00:00Z"}
+            for i in range(100)
+        ]
+        page_two = [{"id": "sha-100", "committed_date": "2026-01-10T00:00:00Z"}]
+        transport, calls = _router_transport(
+            {
+                _COMMITS_PATH: [
+                    _json_response(200, page_one, headers={"X-Next-Page": "2"}),
+                    _json_response(200, page_two),
+                ]
+            }
+        )
+        client = _client(transport)
+
+        commits = await client.get_commits(42, max_commits=101)
+
+        assert len(commits) == 101
+        assert calls[_COMMITS_PATH] == 2
+
+    @pytest.mark.asyncio
+    async def test_commit_stats_maps_aggregate_stats_and_usage_family(self) -> None:
+        detail = {"id": "abc123", "stats": {"additions": 12, "deletions": 3}}
+        transport, calls = _router_transport(
+            {_COMMIT_DETAIL_PATH: _json_response(200, detail)}
+        )
+        client = _client(transport)
+
+        stats = await client.get_commit_stats(42, "abc123")
+
+        assert calls[_COMMIT_DETAIL_PATH] == 1
+        assert stats.commit_id == "abc123"
+        assert stats.additions == 12
+        assert stats.deletions == 3
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "project"
+        assert observations[0]["request_count"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Project-id path-segment encoding (CHAOS-2814 security review): get_commits
+# / get_commit_stats must percent-encode a caller-supplied project_id/path
+# into ONE opaque URL path segment -- never literal additional path
+# structure or query metacharacters. httpx's ``request.url.path`` decodes a
+# percent-encoded '/' (%2F) back to a literal '/' for display, so these
+# tests assert on ``request.url.raw_path`` (the actual wire bytes) via
+# ``transport.captured_raw_paths`` -- ``.path`` alone cannot prove encoding
+# occurred.
+# ---------------------------------------------------------------------------
+
+
+class TestProjectIdPathEncoding:
+    @pytest.mark.asyncio
+    async def test_commits_encodes_project_id_containing_slash(self) -> None:
+        commit = {"id": "abc123", "committed_date": "2026-01-10T00:00:00Z"}
+        raw_project_id = "group/project"
+        decoded_path = "/api/v4/projects/group/project/repository/commits"
+        transport, calls = _router_transport(
+            {decoded_path: _json_response(200, [commit])}
+        )
+        client = _client(transport)
+
+        commits = await client.get_commits(raw_project_id, max_commits=10)
+
+        assert calls[decoded_path] == 1
+        assert commits[0].commit_id == "abc123"
+        raw_path = transport.captured_raw_paths[decoded_path]  # type: ignore[attr-defined]
+        assert (
+            raw_path.split(b"?")[0]
+            == (
+                f"/api/v4/projects/{quote(raw_project_id, safe='')}/repository/commits"
+            ).encode()
+        )
+
+    @pytest.mark.asyncio
+    async def test_commits_encodes_project_id_containing_query_metacharacter(
+        self,
+    ) -> None:
+        commit = {"id": "abc123", "committed_date": "2026-01-10T00:00:00Z"}
+        raw_project_id = "42?evil=1"
+        decoded_path = "/api/v4/projects/42?evil=1/repository/commits"
+        transport, calls = _router_transport(
+            {decoded_path: _json_response(200, [commit])}
+        )
+        client = _client(transport)
+
+        commits = await client.get_commits(raw_project_id, max_commits=10)
+
+        assert calls[decoded_path] == 1
+        assert commits[0].commit_id == "abc123"
+        raw_path = transport.captured_raw_paths[decoded_path]  # type: ignore[attr-defined]
+        assert (
+            raw_path.split(b"?", 1)[0]
+            == (
+                f"/api/v4/projects/{quote(raw_project_id, safe='')}/repository/commits"
+            ).encode()
+        )
+        # The '?' must have been escaped INTO the project-id segment, not
+        # parsed as the start of the query string -- only the real per_page/
+        # page params the client adds should appear as query parameters.
+        assert dict(transport.captured_urls[decoded_path].params) == {  # type: ignore[attr-defined]
+            "page": "1",
+            "per_page": "10",
+        }
+
+    @pytest.mark.asyncio
+    async def test_commits_encodes_project_id_containing_path_traversal(self) -> None:
+        commit = {"id": "abc123", "committed_date": "2026-01-10T00:00:00Z"}
+        raw_project_id = "../../etc/passwd"
+        decoded_path = "/api/v4/projects/../../etc/passwd/repository/commits"
+        transport, calls = _router_transport(
+            {decoded_path: _json_response(200, [commit])}
+        )
+        client = _client(transport)
+
+        commits = await client.get_commits(raw_project_id, max_commits=10)
+
+        assert calls[decoded_path] == 1
+        assert commits[0].commit_id == "abc123"
+        raw_path = transport.captured_raw_paths[decoded_path]  # type: ignore[attr-defined]
+        expected_segment = quote(raw_project_id, safe="")
+        assert (
+            raw_path.split(b"?")[0]
+            == (f"/api/v4/projects/{expected_segment}/repository/commits").encode()
+        )
+        # Every literal '/' inside the traversal payload must be escaped --
+        # the wire path carries exactly the client's own two structural
+        # slashes ("/api/v4/projects/" .. "/repository/commits"), never the
+        # attacker-controlled ones.
+        assert b"..%2F" in raw_path
+        assert b"/../" not in raw_path
+
+    @pytest.mark.asyncio
+    async def test_commits_numeric_project_id_path_is_unencoded(self) -> None:
+        """Regression: a plain numeric project_id must still reach the wire
+        byte-for-byte unencoded (digits are unreserved per RFC 3986)."""
+        commit = {"id": "abc123", "committed_date": "2026-01-10T00:00:00Z"}
+        transport, calls = _router_transport(
+            {_COMMITS_PATH: _json_response(200, [commit])}
+        )
+        client = _client(transport)
+
+        await client.get_commits(42, max_commits=10)
+
+        assert calls[_COMMITS_PATH] == 1
+        raw_path = transport.captured_raw_paths[_COMMITS_PATH]  # type: ignore[attr-defined]
+        assert raw_path.split(b"?")[0] == _COMMITS_PATH.encode()
+
+    @pytest.mark.asyncio
+    async def test_commit_stats_encodes_project_id_containing_slash(self) -> None:
+        detail = {"id": "abc123", "stats": {"additions": 1, "deletions": 2}}
+        raw_project_id = "group/project"
+        decoded_path = "/api/v4/projects/group/project/repository/commits/abc123"
+        transport, calls = _router_transport(
+            {decoded_path: _json_response(200, detail)}
+        )
+        client = _client(transport)
+
+        stats = await client.get_commit_stats(raw_project_id, "abc123")
+
+        assert calls[decoded_path] == 1
+        assert stats.additions == 1
+        assert stats.deletions == 2
+        raw_path = transport.captured_raw_paths[decoded_path]  # type: ignore[attr-defined]
+        assert (
+            raw_path
+            == (
+                f"/api/v4/projects/{quote(raw_project_id, safe='')}"
+                "/repository/commits/abc123"
+            ).encode()
+        )
+
+    @pytest.mark.asyncio
+    async def test_commit_stats_encodes_project_id_containing_path_traversal(
+        self,
+    ) -> None:
+        detail = {"id": "abc123", "stats": {"additions": 1, "deletions": 2}}
+        raw_project_id = "../../etc/passwd"
+        decoded_path = "/api/v4/projects/../../etc/passwd/repository/commits/abc123"
+        transport, calls = _router_transport(
+            {decoded_path: _json_response(200, detail)}
+        )
+        client = _client(transport)
+
+        stats = await client.get_commit_stats(raw_project_id, "abc123")
+
+        assert calls[decoded_path] == 1
+        assert stats.additions == 1
+        raw_path = transport.captured_raw_paths[decoded_path]  # type: ignore[attr-defined]
+        expected_segment = quote(raw_project_id, safe="")
+        assert (
+            raw_path
+            == (
+                f"/api/v4/projects/{expected_segment}/repository/commits/abc123"
+            ).encode()
+        )
+        assert b"/../" not in raw_path
+
+    @pytest.mark.asyncio
+    async def test_commit_stats_numeric_project_id_path_is_unencoded(self) -> None:
+        """Regression: a plain numeric project_id must still reach the wire
+        byte-for-byte unencoded (digits are unreserved per RFC 3986)."""
+        detail = {"id": "abc123", "stats": {"additions": 12, "deletions": 3}}
+        transport, calls = _router_transport(
+            {_COMMIT_DETAIL_PATH: _json_response(200, detail)}
+        )
+        client = _client(transport)
+
+        stats = await client.get_commit_stats(42, "abc123")
+
+        assert calls[_COMMIT_DETAIL_PATH] == 1
+        assert stats.additions == 12
+        raw_path = transport.captured_raw_paths[_COMMIT_DETAIL_PATH]  # type: ignore[attr-defined]
+        assert raw_path == _COMMIT_DETAIL_PATH.encode()
 
 
 _TEST_REPORT_PATH = "/api/v4/projects/42/pipelines/11/test_report"

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -7,6 +7,7 @@ import threading
 import time
 from datetime import datetime, timezone
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import Mock, patch
 
 import pytest
@@ -1365,7 +1366,15 @@ async def test_process_gitlab_projects_batch_stores_commits_and_stats(monkeypatc
 
     result = BatchResult(repository=project, stats=None, success=True)
 
-    def fake_fetch_commits(gl_project, max_commits, repo_id, since=None):
+    def fake_fetch_commits(
+        connector,
+        project_id,
+        max_commits,
+        repo_id,
+        since=None,
+        until=None,
+        usage_sink=None,
+    ):
         commit = GitCommit(
             repo_id=repo_id,
             hash="gitlab123",
@@ -1380,7 +1389,15 @@ async def test_process_gitlab_projects_batch_stores_commits_and_stats(monkeypatc
         )
         return ["raw"], [commit]
 
-    def fake_fetch_commit_stats(gl_project, commit_hashes, repo_id, max_stats):
+    def fake_fetch_commit_stats(
+        connector,
+        project_id,
+        commit_hashes,
+        repo_id,
+        max_stats,
+        gate=None,
+        usage_sink=None,
+    ):
         return [
             GitCommitStat(
                 repo_id=repo_id,
@@ -1450,6 +1467,173 @@ async def test_process_gitlab_projects_batch_stores_commits_and_stats(monkeypatc
     expected_repo_id = get_repo_uuid_from_repo(project.full_name)
     assert all(c.repo_id == expected_repo_id for c in recorded_commits)
     assert "gitlab123" in {s.commit_hash for s in recorded_stats}
+
+
+@pytest.mark.asyncio
+async def test_process_gitlab_projects_batch_commit_rate_limit_propagates(
+    monkeypatch,
+):
+    """CHAOS-2814/CS13: an exhausted RateLimitException raised while fetching
+    commits/commit-stats for one project in the batch must propagate out of
+    ``process_gitlab_projects_batch`` (mirrors
+    ``process_github_repos_batch``'s ``except (RateLimitException,
+    RateLimitExceededException): raise`` before the broad
+    ``except Exception`` in ``store_result``), not be swallowed as a
+    per-project warning."""
+    _enable_connector_stubs(monkeypatch)
+
+    recorded_stats: list[Any] = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    project = Mock()
+    project.id = 501
+    project.full_name = "group/rate-limited"
+    project.url = "https://example.com/group/rate-limited"
+    project.default_branch = "main"
+
+    result = BatchResult(repository=project, stats=None, success=True)
+
+    def fake_fetch_commits(*args, **kwargs):
+        raise RateLimitException("limited", retry_after_seconds=42.0)
+
+    class DummyConnector:
+        def __init__(self, url: str, private_token: str):
+            self.url = url
+            self.private_token = private_token
+
+        async def get_projects_with_stats_async(self, **kwargs):
+            on_project_complete = kwargs.get("on_project_complete")
+            if on_project_complete:
+                on_project_complete(result)
+            return [result]
+
+        def close(self):
+            return
+
+    monkeypatch.setattr(processors.gitlab, "GitLabConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.gitlab, "_fetch_gitlab_commits_sync", fake_fetch_commits
+    )
+
+    with pytest.raises(RateLimitException) as exc_info:
+        await processors.gitlab.process_gitlab_projects_batch(
+            store=DummyStore(),
+            token="test_token",
+            gitlab_url="https://gitlab.com",
+            group_name="group",
+            pattern="group/*",
+            batch_size=1,
+            max_concurrent=1,
+            rate_limit_delay=0,
+            use_async=True,
+            sync_prs=False,
+            sync_cicd=False,
+            sync_deployments=False,
+            sync_incidents=False,
+            sync_security=False,
+            sync_tests=False,
+            backfill_missing=False,
+        )
+
+    assert exc_info.value.retry_after_seconds == 42.0
+    assert recorded_stats == []
+
+
+@pytest.mark.asyncio
+async def test_process_gitlab_projects_batch_multi_project_rate_limit_does_not_hang(
+    monkeypatch,
+):
+    """The consumer-death FIRST_COMPLETED guard (mirrors
+    ``process_github_repos_batch``) must stop ``results_queue.join()`` from
+    hanging forever when the consumer task dies mid-batch with un-task_done()'d
+    items still queued behind the failing project."""
+    _enable_connector_stubs(monkeypatch)
+
+    recorded_stats: list[Any] = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    def make_result(index: int):
+        project = Mock()
+        project.id = index
+        project.full_name = f"group/rate-limited-{index}"
+        project.url = f"https://example.com/group/rate-limited-{index}"
+        project.default_branch = "main"
+        return BatchResult(repository=project, stats=None, success=True)
+
+    results = [make_result(index) for index in range(3)]
+
+    def fake_fetch_commits(*args, **kwargs):
+        raise RateLimitException("limited", retry_after_seconds=42.0)
+
+    class DummyConnector:
+        def __init__(self, url: str, private_token: str):
+            self.url = url
+            self.private_token = private_token
+
+        async def get_projects_with_stats_async(self, **kwargs):
+            on_project_complete = kwargs.get("on_project_complete")
+            if on_project_complete:
+                for result in results:
+                    on_project_complete(result)
+            return results
+
+        def close(self):
+            return
+
+    monkeypatch.setattr(processors.gitlab, "GitLabConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.gitlab, "_fetch_gitlab_commits_sync", fake_fetch_commits
+    )
+
+    with pytest.raises(RateLimitException) as exc_info:
+        await asyncio.wait_for(
+            processors.gitlab.process_gitlab_projects_batch(
+                store=DummyStore(),
+                token="test_token",
+                gitlab_url="https://gitlab.com",
+                group_name="group",
+                pattern="group/*",
+                batch_size=1,
+                max_concurrent=1,
+                rate_limit_delay=0,
+                use_async=True,
+                sync_prs=False,
+                sync_cicd=False,
+                sync_deployments=False,
+                sync_incidents=False,
+                sync_security=False,
+                sync_tests=False,
+                backfill_missing=False,
+            ),
+            timeout=2,
+        )
+
+    assert exc_info.value.retry_after_seconds == 42.0
+    assert recorded_stats == []
 
 
 @pytest.mark.asyncio

--- a/tests/test_code_window_upper_bound.py
+++ b/tests/test_code_window_upper_bound.py
@@ -53,26 +53,40 @@ def test_github_commits_fetch_omits_until_when_none() -> None:
     gh_repo.get_commits.assert_called_once_with(since=SINCE)
 
 
-def test_gitlab_commits_fetch_passes_until_to_commits_list() -> None:
-    gl_project = MagicMock()
-    gl_project.commits.list.return_value = []
+def test_gitlab_commits_fetch_passes_window_to_code_client() -> None:
+    connector = MagicMock()
+    client = _async_cm(MagicMock())
+    client.get_commits = AsyncMock(return_value=[])
+    client.drain_usage_observations = MagicMock(return_value=[])
 
-    _fetch_gitlab_commits_sync(gl_project, None, "repo-1", since=SINCE, until=UNTIL)
+    with patch(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        return_value=client,
+    ):
+        _fetch_gitlab_commits_sync(
+            connector, 123, None, "repo-1", since=SINCE, until=UNTIL
+        )
 
-    assert gl_project.commits.list.call_count == 1
-    params = gl_project.commits.list.call_args.kwargs
-    assert params["until"] == UNTIL.isoformat().replace("+00:00", "Z")
-    assert params["since"] == SINCE.isoformat().replace("+00:00", "Z")
+    client.get_commits.assert_awaited_once_with(
+        123, max_commits=None, since=SINCE, until=UNTIL
+    )
 
 
 def test_gitlab_commits_fetch_omits_until_when_none() -> None:
-    gl_project = MagicMock()
-    gl_project.commits.list.return_value = []
+    connector = MagicMock()
+    client = _async_cm(MagicMock())
+    client.get_commits = AsyncMock(return_value=[])
+    client.drain_usage_observations = MagicMock(return_value=[])
 
-    _fetch_gitlab_commits_sync(gl_project, None, "repo-1", since=SINCE)
+    with patch(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        return_value=client,
+    ):
+        _fetch_gitlab_commits_sync(connector, 123, None, "repo-1", since=SINCE)
 
-    params = gl_project.commits.list.call_args.kwargs
-    assert "until" not in params
+    client.get_commits.assert_awaited_once_with(
+        123, max_commits=None, since=SINCE, until=None
+    )
 
 
 def _record(ts: datetime | None, field: str = "started_at") -> SimpleNamespace:

--- a/tests/test_gitlab_content_backfill.py
+++ b/tests/test_gitlab_content_backfill.py
@@ -9,6 +9,8 @@ upgrade through ``_backfill_gitlab_missing_data``.
 from __future__ import annotations
 
 import uuid
+from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -21,6 +23,10 @@ from dev_health_ops.connectors import GitLabConnector
 from dev_health_ops.processors.gitlab import (
     _backfill_gitlab_missing_data,
     _fetch_scannable_contents,
+)
+from dev_health_ops.providers.gitlab.code_client import (
+    GitLabCommitData,
+    GitLabCommitStatsData,
 )
 
 
@@ -299,3 +305,161 @@ class TestGitLabBackfillContents:
 
         connector.gitlab.projects.get.assert_not_called()
         sink.insert_git_file_data.assert_not_called()
+
+
+class _FakeGitLabCodeClientForStats:
+    """Minimal instrumented GitLabCodeClient stand-in for the commit-stats
+    backfill branch (CHAOS-2814/CS13)."""
+
+    def __init__(self, *, commits=None, commit_stats=None, observations=None):
+        self.commits = commits or []
+        self.commit_stats = commit_stats or {}
+        self.observations = observations or []
+        self.get_commits_calls: list[Any] = []
+        self.get_commit_stats_calls: list[Any] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get_commits(
+        self, project_id, *, max_commits, since=None, until=None, per_page=100
+    ):
+        self.get_commits_calls.append(project_id)
+        return self.commits[:max_commits] if max_commits is not None else self.commits
+
+    async def get_commit_stats(self, project_id, commit_sha):
+        self.get_commit_stats_calls.append((project_id, commit_sha))
+        return self.commit_stats[commit_sha]
+
+    def drain_usage_observations(self):
+        observations = list(self.observations)
+        self.observations.clear()
+        return observations
+
+
+class TestGitLabBackfillCommitStats:
+    """CHAOS-2814/CS13: the commit-stats backfill branch must fetch through
+    the canonical, instrumented GitLabCodeClient (``_fetch_gitlab_commits_sync``
+    / ``_fetch_gitlab_commit_stats_sync``) -- never the frozen python-gitlab
+    ``project.commits.list()`` or the un-instrumented
+    ``connector.get_commit_stats_by_project()``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_backfill_commit_stats_uses_gitlab_code_client(self, monkeypatch):
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=False)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        recorded_stats: list[Any] = []
+        sink = Mock()
+        sink.insert_git_commit_stats = AsyncMock(side_effect=recorded_stats.extend)
+
+        commit = GitLabCommitData(
+            commit_id="abc123",
+            message="ship it",
+            author_name="Ada",
+            authored_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            committer_name="Ada",
+            committed_date=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            parent_ids=(),
+        )
+        fake_client = _FakeGitLabCodeClientForStats(
+            commits=[commit],
+            commit_stats={"abc123": GitLabCommitStatsData("abc123", 5, 2)},
+            observations=[{"route_family": "project"}],
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = Mock()
+        # The legacy, frozen connector API must never be invoked by the fixed
+        # backfill path.
+        connector.get_commit_stats_by_project = Mock(
+            side_effect=AssertionError(
+                "legacy connector.get_commit_stats_by_project must not be called"
+            )
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        usage_sink: list[dict[str, Any]] = []
+
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_files=False,
+            include_blame=False,
+            include_commit_stats=True,
+            usage_sink=usage_sink,
+        )
+
+        # Fetched via the canonical GitLabCodeClient, keyed by project_full_name
+        # (the caller-supplied project id/path), not the frozen connector API.
+        assert fake_client.get_commits_calls == ["group/proj"]
+        assert fake_client.get_commit_stats_calls == [("group/proj", "abc123")]
+        connector.get_commit_stats_by_project.assert_not_called()
+        connector.gitlab.projects.get.return_value.commits.list.assert_not_called()
+
+        assert len(recorded_stats) == 1
+        assert recorded_stats[0].commit_hash == "abc123"
+        assert recorded_stats[0].additions == 5
+        assert recorded_stats[0].deletions == 2
+        assert recorded_stats[0].repo_id == db_repo.id
+
+        # usage_sink plumbing (CHAOS-2803/CS2): the client's drained per-request
+        # observations must reach the caller-supplied sink.
+        assert usage_sink == [{"route_family": "project"}]
+
+    @pytest.mark.asyncio
+    async def test_backfill_skips_commit_stats_when_already_present(self, monkeypatch):
+        """Regression guard: when the store already has commit stats, the
+        GitLabCodeClient must not be invoked at all."""
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=True)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        sink = Mock()
+        sink.insert_git_commit_stats = AsyncMock()
+
+        connector = Mock()
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        client_factory = Mock()
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            client_factory,
+        )
+
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_files=False,
+            include_blame=False,
+            include_commit_stats=True,
+        )
+
+        client_factory.assert_not_called()
+        sink.insert_git_commit_stats.assert_not_called()

--- a/tests/test_processors_gitlab.py
+++ b/tests/test_processors_gitlab.py
@@ -1,10 +1,14 @@
 from datetime import datetime, timezone
+from typing import Any
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.models.git import CiPipelineRun, Deployment, Incident
 from dev_health_ops.processors.gitlab import (
+    _fetch_gitlab_commit_stats_sync,
+    _fetch_gitlab_commits_sync,
     _fetch_gitlab_deployments_sync,
     _fetch_gitlab_incidents_sync,
     _fetch_gitlab_pipelines_sync,
@@ -12,6 +16,8 @@ from dev_health_ops.processors.gitlab import (
     process_gitlab_project,
 )
 from dev_health_ops.providers.gitlab.code_client import (
+    GitLabCommitData,
+    GitLabCommitStatsData,
     GitLabDeploymentData,
     GitLabPipelineData,
 )
@@ -23,6 +29,9 @@ class _FakeGitLabCodeClient:
         *,
         pipelines=None,
         deployments=None,
+        commits=None,
+        commit_stats=None,
+        commit_stats_errors=None,
         releases=None,
         merge_requests=None,
         observations=None,
@@ -33,6 +42,9 @@ class _FakeGitLabCodeClient:
     ):
         self.pipelines = pipelines or []
         self.deployments = deployments or []
+        self.commits = commits or []
+        self.commit_stats = commit_stats or {}
+        self.commit_stats_errors = commit_stats_errors or {}
         self.releases = releases or []
         self.merge_requests = merge_requests or []
         self.observations = observations or []
@@ -60,6 +72,16 @@ class _FakeGitLabCodeClient:
 
     async def get_deployment_merge_requests(self, project_id, sha):
         return self.merge_requests
+
+    async def get_commits(
+        self, project_id, *, max_commits, since=None, until=None, per_page=100
+    ):
+        return self.commits[:max_commits]
+
+    async def get_commit_stats(self, project_id, commit_sha):
+        if commit_sha in self.commit_stats_errors:
+            raise self.commit_stats_errors[commit_sha]
+        return self.commit_stats[commit_sha]
 
     async def iter_pipelines_since(self, project_id, *, since=None, per_page=100):
         return self.pipelines_raw
@@ -394,6 +416,99 @@ def test_fetch_gitlab_pipelines_sync(monkeypatch):
     assert pipelines[0].queued_at == datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc)
     assert pipelines[0].started_at == datetime(2023, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
     assert usage_sink == [{"route_family": "pipelines"}]
+
+
+def test_fetch_gitlab_commits_sync(monkeypatch):
+    committed_at = datetime(2023, 1, 1, 0, 1, 0, tzinfo=timezone.utc)
+    commit = GitLabCommitData(
+        commit_id="abc123",
+        message="ship it",
+        author_name="Ada",
+        authored_date=datetime(2023, 1, 1, 0, 0, 0, tzinfo=timezone.utc),
+        committer_name="Grace",
+        committed_date=committed_at,
+        parent_ids=("parent",),
+    )
+    usage_sink: list[dict[str, Any]] = []
+    fake_client = _FakeGitLabCodeClient(
+        commits=[commit], observations=[{"route_family": "project"}]
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+
+    commit_hashes, commit_objects = _fetch_gitlab_commits_sync(
+        Mock(), project_id=1, max_commits=10, repo_id=None, usage_sink=usage_sink
+    )
+
+    assert commit_hashes == ["abc123"]
+    assert len(commit_objects) == 1
+    assert commit_objects[0].hash == "abc123"
+    assert commit_objects[0].message == "ship it"
+    assert commit_objects[0].parents == 1
+    assert commit_objects[0].committer_when == committed_at
+    assert usage_sink == [{"route_family": "project"}]
+
+
+def test_fetch_gitlab_commit_stats_sync_drains_on_success(monkeypatch):
+    usage_sink: list[dict[str, Any]] = []
+    fake_client = _FakeGitLabCodeClient(
+        commit_stats={"abc123": GitLabCommitStatsData("abc123", 12, 3)},
+        observations=[{"route_family": "project"}],
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+
+    stats = _fetch_gitlab_commit_stats_sync(
+        Mock(), 1, ["abc123"], None, 10, usage_sink=usage_sink
+    )
+
+    assert len(stats) == 1
+    assert stats[0].commit_hash == "abc123"
+    assert stats[0].additions == 12
+    assert stats[0].deletions == 3
+    assert usage_sink == [{"route_family": "project"}]
+
+
+def test_fetch_gitlab_commit_stats_sync_drains_on_failure(monkeypatch):
+    usage_sink: list[dict[str, Any]] = []
+    fake_client = _FakeGitLabCodeClient(
+        commit_stats_errors={"abc123": RuntimeError("boom")},
+        observations=[{"route_family": "project"}],
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+
+    stats = _fetch_gitlab_commit_stats_sync(
+        Mock(), 1, ["abc123"], None, 10, usage_sink=usage_sink
+    )
+
+    assert stats == []
+    assert usage_sink == [{"route_family": "project"}]
+
+
+def test_fetch_gitlab_commit_stats_sync_reraises_rate_limit(monkeypatch):
+    usage_sink: list[dict[str, Any]] = []
+    fake_client = _FakeGitLabCodeClient(
+        commit_stats_errors={"abc123": RateLimitException("limited")},
+        observations=[{"route_family": "project"}],
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+
+    with pytest.raises(RateLimitException):
+        _fetch_gitlab_commit_stats_sync(
+            Mock(), 1, ["abc123"], None, 10, usage_sink=usage_sink
+        )
+
+    assert usage_sink == [{"route_family": "project"}]
 
 
 def test_fetch_gitlab_deployments_sync(monkeypatch):


### PR DESCRIPTION
## Summary
- migrate GitLab commit listing and commit stats onto GitLabCodeClient
- drain project-family usage observations through sync, backfill, and batch paths
- propagate GitLab commit rate limits correctly and update provider docs

## Validation
- OTEL_SDK_DISABLED=true bash ci/local_validate.sh
- pre-push: ruff format --check, ruff check, mypy
- LSP diagnostics clean on changed provider/processor files

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.