### PR TITLE
feat(providers): instrument GitHub git actuals (CHAOS-2807)

### DIFF
--- a/docs/architecture/sync-usage-actuals.md
+++ b/docs/architecture/sync-usage-actuals.md
@@ -46,6 +46,7 @@ Drains emit two keys on `ProviderBatch.observations` / the unit-result
 | Provider | Transport | Drain site |
 | --- | --- | --- |
 | GitHub | REST + GraphQL | `GitHubProvider.ingest` (both keys) |
+| GitHub code datasets | REST | `process_github_repo` / `_backfill_github_missing_data` / `_sync_github_commits` / `_sync_github_commit_stats` (`git` + `commit_stats`, CHAOS-2807) |
 | GitLab | REST | `GitLabProvider.ingest` **and** `metrics.work_items.fetch_gitlab_work_items` (the live worker path) |
 | GitLab feature-flags | REST | `_sync_gitlab_feature_flags` (CHAOS-2785): `GitLabFeatureFlagsClient`, drained into `provider_usage` |
 | Jira | REST | `JiraProvider.ingest` (legacy + atlassian paths) and the `job_work_items` client drain |
@@ -73,20 +74,15 @@ attribution would require richer operation labels at the client call sites.
 
 ## Out-of-scope actuals gaps (documented, not fixed here)
 
-1. **Code-dataset actuals.** The GitHub/GitLab code datasets (`commits`,
-   `files`, `blame`, `cicd`, `tests`, `deployments`, `security`) run through
+1. **Remaining code-dataset actuals.** The GitHub/GitLab code datasets (`files`,
+   `blame`, plus any family not listed as instrumented above) run through
    `processors/dataset_adapters._run_github_dataset` / `_run_gitlab_dataset`,
    which use a shared/reused store rather than an instrumented per-unit work
-   client — they still fetch through the frozen `connectors/github.py`
-   (PyGithub-based) / `connectors/gitlab.py` (python-gitlab-based) connectors.
-   Their budget families (`git`, `commit_stats`, `files`, `blame`, `cicd`,
-   `tests`, `deployments`, `security`) are declared in the GitHub/GitLab usage
-   registries for coverage but carry no operation markers. Instrumenting them
-   needs a canonical-provider migration off PyGithub/python-gitlab (much
-   larger than a follow-up-ticket-sized change — see [Provider Rate-Limit
-   Policy — Known gaps](../providers/rate-limit-policy.md#known-gaps)) and is
-   deferred to its own tracked effort (CHAOS-2773 CS17 for the remaining
-   GitLab code-dataset methods specifically).
+   client. GitHub `git` / `commit_stats` are instrumented through
+   `providers/github/code_client.py::GitHubCodeClient` as of CHAOS-2807; GitHub
+   `files` / `blame` and the remaining GitLab connector-backed code-dataset
+   methods stay on frozen PyGithub/python-gitlab connector paths until their own
+   canonical-provider changesets.
 
 > **Resolved (CHAOS-2761):** LaunchDarkly flag/audit-log actuals — previously
 > gap #1 here, blocked on the frozen `connectors/launchdarkly.py` path — are

--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -195,7 +195,7 @@ CHAOS-2754's normalized `provider_usage` actuals, one row per
   `actual_requests`; the two are reported side by side, not blended into one
   number.
 - **A route_family/dimension with an estimate but no drained actuals this
-  run produces no row** (GitHub/GitLab code datasets still on the frozen
+  run produces no row** (remaining GitHub/GitLab code datasets still on the frozen
   connector path, a `contents_blob`/`secondary_abuse_risk` dimension sharing
   its single REST call with an already-recorded `rest_core` dimension, …) —
   never a fabricated 100% over-estimation.
@@ -922,6 +922,13 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
   above) for the PR review-batch enrichment; the REST `prs` listing itself
   remains on the frozen connector, unmeasured, pending CHAOS-2773 CS8. See
   [Known gaps](#known-gaps).
+- **Actuals instrumentation (CHAOS-2807).** Commit listing (`git`) and
+  per-commit file stats (`commit_stats`) now fetch through
+  `providers/github/code_client.py::GitHubCodeClient` from processor/backfill paths,
+  drain into the shared `usage_sink`, and resolve through explicit `git:` /
+  `commit_stats:` operation prefixes. The `commit_stats` `contents_blob`
+  reservation remains estimate-only because the migrated REST commit-detail call
+  reports as `rest_core`.
 
 #### Route families
 <!-- route-families:github -->
@@ -929,8 +936,8 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
 | Route family | Dimension(s) | Covers | Confidence |
 | --- | --- | --- | --- |
 | `repo` | `rest_core` | Repository metadata | high |
-| `git` | `rest_core` | Commit listing | medium |
-| `commit_stats` | `rest_core`, `contents_blob` | Per-commit file/stat expansion | low |
+| `git` | `rest_core` | Commit listing (`GitHubCodeClient`, CHAOS-2773 CS6) | medium |
+| `commit_stats` | `rest_core`, `contents_blob` | Per-commit file/stat expansion (`GitHubCodeClient` REST core, CHAOS-2773 CS6; contents/blob still estimate-only) | low |
 | `files` | `rest_core`, `contents_blob` | Repository tree/blob reads | low |
 | `blame` | `rest_core`, `contents_blob` | Blame expansion (file-count dependent) | low |
 | `prs` | `rest_core` | Pull requests / reviews / comments core | medium |
@@ -1153,14 +1160,15 @@ paper over:
   instrumented as of [CHAOS-2803](https://linear.app/fullchaos/issue/CHAOS-2803)
   (CS2) — see
   [Usage drain wiring](#usage-drain-wiring-first-re-bucketing-chaos-2773-cs2)
-  above; the REST `prs` listing and every other GitHub/GitLab code-dataset
-  family remain uninstrumented pending their own CHAOS-2773 changeset (see
+  above. GitHub `git` and `commit_stats` REST-core traffic is instrumented as of
+  CHAOS-2807; the REST `prs` listing and remaining GitHub/GitLab code-dataset
+  families stay uninstrumented pending their own CHAOS-2773 changesets (see
   "Frozen `connectors/` path" below). There is also no cross-run
   aggregation/dashboard yet — calibration today is visible per-unit (result +
   structured log), not rolled up over time.
-- **Frozen `connectors/` path.** GitHub's `git`/`commit_stats`/`files`/`blame`/
-  `cicd`/`tests`/`deployments`/`security` route families and the equivalent
-  GitLab code-dataset paths remain under the frozen `connectors/` tree
+- **Frozen `connectors/` path.** GitHub's `files`/`blame`/`prs` and repo
+  metadata/batch orchestration, plus the remaining equivalent GitLab
+  code-dataset paths, remain under the frozen `connectors/` tree
   (`connectors/github.py`'s PyGithub-based `GitHubConnector`, `connectors/
   gitlab.py`'s python-gitlab-based `GitLabConnector`). No new code may be added
   there (see [`AGENTS.md`](../../AGENTS.md)); rate-limit/actuals
@@ -1175,14 +1183,16 @@ paper over:
   [LaunchDarkly](#launchdarkly) above. GitLab's feature-flags fetch
   (`get_feature_flags` / `get_project_name`) is likewise closed as of
   [CHAOS-2785](https://linear.app/fullchaos/issue/CHAOS-2785) — see
-  [GitLab](#gitlab) above — while GitLab's `security`
+  [GitLab](#gitlab) above. GitHub's `git`/`commit_stats`
+  ([CHAOS-2807](https://linear.app/fullchaos/issue/CHAOS-2807), CS6) moved to
+  `providers/github/code_client.py::GitHubCodeClient`; GitLab's `security`
   ([CHAOS-2811](https://linear.app/fullchaos/issue/CHAOS-2811), CS10),
   `pipelines`+`deployments`
   ([CHAOS-2812](https://linear.app/fullchaos/issue/CHAOS-2812), CS11), and
   `tests` (+CI adapter usage draining;
   [CHAOS-2813](https://linear.app/fullchaos/issue/CHAOS-2813), CS12)
   code-dataset families are migrated onto the canonical, instrumented
-  `providers/gitlab/code_client.py::GitLabCodeClient` — GitLab's remaining
+  `providers/gitlab/code_client.py::GitLabCodeClient`. GitLab's remaining
   frozen code-dataset methods (`git`/`commit_stats`/`files`/`blame`/
   `merge_requests` listing + repo-metadata/batch orchestration) stay
   unmigrated pending their own CHAOS-2773 changesets through CS17.

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -108,177 +108,119 @@ def _fetch_github_repo_info_sync(connector, owner, repo_name):
     return gh_repo
 
 
-def _fetch_github_commits_sync(
-    gh_repo,
+def _github_commit_to_model(commit: Any, repo_id: Any) -> GitCommit:
+    return GitCommit(
+        repo_id=repo_id,
+        hash=commit.sha,
+        message=commit.message,
+        author_name=commit.author_name,
+        author_email=commit.author_email,
+        author_when=commit.author_when or datetime.now(timezone.utc),
+        committer_name=commit.committer_name,
+        committer_email=commit.committer_email,
+        committer_when=commit.committer_when or datetime.now(timezone.utc),
+        parents=commit.parent_count,
+    )
+
+
+def _github_commit_stat_to_model(stat: Any, repo_id: Any) -> GitCommitStat:
+    return GitCommitStat(
+        repo_id=repo_id,
+        commit_hash=stat.commit_hash,
+        file_path=stat.file_path,
+        additions=stat.additions,
+        deletions=stat.deletions,
+        old_file_mode=stat.old_file_mode,
+        new_file_mode=stat.new_file_mode,
+    )
+
+
+async def _fetch_github_commits_async(
+    connector: Any,
+    owner: str,
+    repo_name: str,
+    repo_id: Any,
     max_commits: int | None,
-    repo_id,
     since: datetime | None = None,
     until: datetime | None = None,
-):
-    """Sync helper to fetch and parse GitHub commits.
-
-    Returns ``(raw_commits, commit_objects, window_truncated)``. ``window_truncated``
-    is True only when ``max_commits`` was hit AND at least one more commit existed
-    beyond it (peeked but not kept) — i.e. the window genuinely held more commits
-    than we fetched. A complete window of exactly ``max_commits`` returns False, so
-    callers can cover it instead of skipping stats as a false-truncation.
-    """
-    raw_commits: list[Any] = []
-    commits_kwargs: dict[str, Any] = {}
-    if since is not None:
-        commits_kwargs["since"] = since
-    if until is not None:
-        commits_kwargs["until"] = until
-    commits_iter = gh_repo.get_commits(**commits_kwargs)
-
-    window_truncated = False
-    for commit in commits_iter:
-        if max_commits is not None and len(raw_commits) >= max_commits:
-            # We already have ``max_commits`` and the iterator yielded one more:
-            # proof the window was truncated. Don't keep this extra commit.
-            window_truncated = True
-            break
-        raw_commits.append(commit)
-
-    commit_objects = []
-    for commit in raw_commits:
-        if since is not None:
-            commit_when = None
-            if getattr(commit, "commit", None) and getattr(
-                commit.commit, "committer", None
-            ):
-                commit_when = getattr(commit.commit.committer, "date", None)
-            if (
-                commit_when is None
-                and getattr(commit, "commit", None)
-                and getattr(commit.commit, "author", None)
-            ):
-                commit_when = getattr(commit.commit.author, "date", None)
-
-            if (
-                isinstance(commit_when, datetime)
-                and commit_when.astimezone(timezone.utc) < since
-            ):
-                continue
-
-        # Prefer GitHub user `login` when available; do not store emails.
-        author_login = getattr(commit, "author", None)
-        committer_login = getattr(commit, "committer", None)
-
-        author_name = getattr(author_login, "login", None) or (
-            commit.commit.author.name if commit.commit.author else "Unknown"
+    usage_sink: list[dict[str, Any]] | None = None,
+) -> tuple[list[Any], list[GitCommit], bool]:
+    client = _github_code_client_from_connector(connector)
+    try:
+        raw_commits, window_truncated = await client.get_commits(
+            owner,
+            repo_name,
+            max_commits=max_commits,
+            since=since,
+            until=until,
         )
-        committer_name = getattr(committer_login, "login", None) or (
-            commit.commit.committer.name if commit.commit.committer else "Unknown"
-        )
-
-        # Safely obtain emails: prefer commit metadata (no extra API calls),
-        # fallback to user.email but guard against API-triggered exceptions (e.g., 404).
-        def _safe_user_email(user):
-            try:
-                return getattr(user, "email", None)
-            except Exception:
-                return None
-
-        author_email = None
-        if getattr(commit, "commit", None) and getattr(commit.commit, "author", None):
-            author_email = getattr(commit.commit.author, "email", None)
-        if not author_email:
-            author_email = _safe_user_email(author_login)
-
-        committer_email = None
-        if getattr(commit, "commit", None) and getattr(
-            commit.commit, "committer", None
-        ):
-            committer_email = getattr(commit.commit.committer, "email", None)
-        if not committer_email:
-            committer_email = _safe_user_email(committer_login)
-
-        git_commit = GitCommit(
-            repo_id=repo_id,
-            hash=commit.sha,
-            message=commit.commit.message,
-            author_name=author_name,
-            author_email=author_email,
-            author_when=(
-                commit.commit.author.date
-                if commit.commit.author
-                else datetime.now(timezone.utc)
-            ),
-            committer_name=committer_name,
-            committer_email=committer_email,
-            committer_when=(
-                commit.commit.committer.date
-                if commit.commit.committer
-                else datetime.now(timezone.utc)
-            ),
-            parents=len(commit.parents),
-        )
-        commit_objects.append(git_commit)
-    return raw_commits, commit_objects, window_truncated
-
-
-def _fetch_github_commit_stats_sync(
-    raw_commits,
-    repo_id,
-    max_stats,
-    since: datetime | None = None,
-    gate=None,
-):
-    """Sync helper to fetch detailed commit stats (files).
-
-    Accessing ``commit.files`` lazy-loads commit detail — one REST call per
-    commit — so each iteration waits on the rate-limit gate.
-    """
-    gate = BaseGitProcessor.ensure_gate(gate)
-    stats_objects = []
-    for commit in raw_commits[:max_stats]:
-        if since is not None:
-            commit_when = None
-            if getattr(commit, "commit", None) and getattr(
-                commit.commit, "committer", None
-            ):
-                commit_when = getattr(commit.commit.committer, "date", None)
-            if (
-                commit_when is None
-                and getattr(commit, "commit", None)
-                and getattr(commit.commit, "author", None)
-            ):
-                commit_when = getattr(commit.commit.author, "date", None)
-
-            if (
-                isinstance(commit_when, datetime)
-                and commit_when.astimezone(timezone.utc) < since
-            ):
-                continue
-
-        try:
-            if gate is not None:
-                gate.wait_sync()
-            files = commit.files
-            if files is None:
-                continue
-
-            for file in files:
-                stat = GitCommitStat(
-                    repo_id=repo_id,
-                    commit_hash=commit.sha,
-                    file_path=file.filename,
-                    additions=file.additions,
-                    deletions=file.deletions,
-                    old_file_mode="unknown",
-                    new_file_mode="unknown",
-                )
-                stats_objects.append(stat)
-        except (RateLimitException, RateLimitExceededException):
-            raise
-        except Exception as e:
-            logging.warning(
-                "Failed to get stats for commit %s: %s",
-                commit.sha,
-                e,
+        commit_objects = [
+            _github_commit_to_model(commit, repo_id) for commit in raw_commits
+        ]
+        return raw_commits, commit_objects, window_truncated
+    finally:
+        observations = client.drain_usage_observations()
+        await client.close()
+        if usage_sink is not None:
+            usage_sink.extend(observations)
+        elif observations:
+            logging.debug(
+                "_fetch_github_commits_async: drained %d git usage observations",
+                len(observations),
             )
-    return stats_objects
+
+
+async def _fetch_github_commit_stats_async(
+    connector: Any,
+    owner: str,
+    repo_name: str,
+    raw_commits: list[Any],
+    repo_id: Any,
+    max_stats: int,
+    since: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
+) -> list[GitCommitStat]:
+    client = _github_code_client_from_connector(connector)
+    try:
+        stats_objects: list[GitCommitStat] = []
+        for commit in raw_commits[:max_stats]:
+            commit_when = getattr(commit, "committer_when", None) or getattr(
+                commit, "author_when", None
+            )
+            if (
+                since is not None
+                and isinstance(commit_when, datetime)
+                and commit_when.astimezone(timezone.utc) < since
+            ):
+                continue
+            try:
+                file_stats = await client.get_commit_file_stats(
+                    owner, repo_name, commit.sha
+                )
+            except (RateLimitException, RateLimitExceededException):
+                raise
+            except Exception as exc:
+                logging.debug(
+                    "Failed commit stat fetch for %s/%s@%s: %s",
+                    owner,
+                    repo_name,
+                    commit.sha,
+                    exc,
+                )
+                continue
+            for stat in file_stats:
+                stats_objects.append(_github_commit_stat_to_model(stat, repo_id))
+        return stats_objects
+    finally:
+        observations = client.drain_usage_observations()
+        await client.close()
+        if usage_sink is not None:
+            usage_sink.extend(observations)
+        elif observations:
+            logging.debug(
+                "_fetch_github_commit_stats_async: drained %d commit_stats usage observations",
+                len(observations),
+            )
 
 
 def _fetch_github_prs_sync(connector, owner, repo_name, repo_id, max_prs):
@@ -1113,6 +1055,7 @@ async def _backfill_github_missing_data(
     include_commit_stats: bool = True,
     since: datetime | None = None,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> None:
     # Logic matches the CLI sync orchestration.
     logging.info(
@@ -1194,81 +1137,39 @@ async def _backfill_github_missing_data(
             )
 
     if needs_commit_stats:
-        commit_count = 0
         try:
             logging.info(
                 "Backfilling commit stats for %s...",
                 repo_full_name,
             )
-            commits_kwargs: dict[str, Any] = {}
-            if since is not None:
-                commits_kwargs["since"] = since
-            if until is not None:
-                commits_kwargs["until"] = until
-            commits_iter = gh_repo.get_commits(**commits_kwargs)
-            commit_count_for_limit = (
-                max_commits if max_commits is not None else 1_000_000_000
-            )
-            stats_limit = resolve_commit_stats_limit(
-                commit_count_for_limit,
+            raw_commits, _, window_truncated = await _fetch_github_commits_async(
+                connector,
+                owner,
+                repo_name,
+                db_repo.id,
                 max_commits,
                 since,
+                until,
+                usage_sink,
             )
-            candidate_commits: list[Any] = []
-            truncated = False
-            for commit in commits_iter:
-                if len(candidate_commits) >= stats_limit:
-                    truncated = True
-                    break
-                candidate_commits.append(commit)
-            stats_rows: list[GitCommitStat] = []
-            if not (truncated and since is not None):
-                for commit in candidate_commits:
-                    commit_count += 1
-                    try:
-                        detailed = gh_repo.get_commit(commit.sha)
-                        for file in getattr(detailed, "files", []) or []:
-                            stats_rows.append(
-                                GitCommitStat(
-                                    repo_id=db_repo.id,
-                                    commit_hash=commit.sha,
-                                    file_path=getattr(
-                                        file, "filename", AGGREGATE_STATS_MARKER
-                                    ),
-                                    additions=getattr(file, "additions", 0),
-                                    deletions=getattr(file, "deletions", 0),
-                                    old_file_mode="unknown",
-                                    new_file_mode="unknown",
-                                )
-                            )
-                    except (RateLimitException, RateLimitExceededException):
-                        raise
-                    except Exception as e:
-                        logging.debug(
-                            "Failed commit stat fetch for %s@%s: %s",
-                            repo_full_name,
-                            commit.sha,
-                            e,
-                        )
-            if truncated and since is not None:
-                logging.warning(
-                    "Skipped GitHub commit-stat backfill for %s after hitting cap %d; "
-                    "narrow the sync window or raise the commit-stat cap",
-                    repo_full_name,
-                    stats_limit,
-                )
-            else:
-                async with AsyncBatchCollector(
-                    ingestion_sink.insert_git_commit_stats
-                ) as stats_collector:
-                    for stat in stats_rows:
-                        stats_collector.add(stat)
-                        await stats_collector.maybe_flush()
-                logging.info(
-                    "Backfilled commit stats for %d commits in %s",
-                    commit_count,
-                    repo_full_name,
-                )
+            stats_count = await _sync_github_commit_stats(
+                connector=connector,
+                owner=owner,
+                repo_name=repo_name,
+                db_repo=db_repo,
+                ingestion_sink=ingestion_sink,
+                max_commits=max_commits,
+                since=since,
+                until=until,
+                raw_commits=raw_commits,
+                window_truncated=window_truncated,
+                usage_sink=usage_sink,
+            )
+            logging.info(
+                "Backfilled %d commit-stat rows in %s",
+                stats_count,
+                repo_full_name,
+            )
         except (RateLimitException, RateLimitExceededException):
             raise
         except Exception as e:
@@ -1347,28 +1248,30 @@ async def _backfill_github_missing_data(
 
 async def _sync_github_commits(
     *,
-    gh_repo: Any,
+    connector: Any,
+    owner: str,
+    repo_name: str,
     db_repo: Repo,
     ingestion_sink: IngestionSink,
-    loop: asyncio.AbstractEventLoop,
     max_commits: int | None,
     since: datetime | None,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> tuple[list[Any], int, bool]:
     if max_commits is None:
         logging.info("Fetching all commits from GitHub...")
     else:
         logging.info("Fetching up to %d commits from GitHub...", max_commits)
-    raw_commits, commit_objects, *rest = await loop.run_in_executor(
-        None,
-        _fetch_github_commits_sync,
-        gh_repo,
-        max_commits,
+    raw_commits, commit_objects, window_truncated = await _fetch_github_commits_async(
+        connector,
+        owner,
+        repo_name,
         db_repo.id,
+        max_commits,
         since,
         until,
+        usage_sink,
     )
-    window_truncated = bool(rest[0]) if rest else False
     if commit_objects:
         await ingestion_sink.insert_git_commit_data(commit_objects)
         logging.info("Stored %d commits from GitHub", len(commit_objects))
@@ -1390,7 +1293,7 @@ def _windowed_commit_stats_truncated(
     syncs (``since is None``) intentionally use a capped sample and are never
     treated as truncated.
 
-    ``window_truncated`` comes from the fetch (``_fetch_github_commits_sync`` peeks
+    ``window_truncated`` comes from the fetch (``GitHubCodeClient.get_commits`` peeks
     one commit past ``max_commits``); it is the ONLY reliable signal for the
     ``max_commits`` cap, because a complete window of exactly ``max_commits``
     commits is otherwise indistinguishable from a truncated one — counting alone
@@ -1406,27 +1309,29 @@ def _windowed_commit_stats_truncated(
 
 async def _sync_github_commit_stats(
     *,
-    gh_repo: Any,
+    connector: Any,
+    owner: str,
+    repo_name: str,
     db_repo: Repo,
     ingestion_sink: IngestionSink,
-    loop: asyncio.AbstractEventLoop,
     max_commits: int | None,
     since: datetime | None,
     until: datetime | None = None,
     raw_commits: list[Any] | None = None,
     window_truncated: bool = False,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> int:
     if raw_commits is None:
-        raw_commits, _, *rest = await loop.run_in_executor(
-            None,
-            _fetch_github_commits_sync,
-            gh_repo,
-            max_commits,
+        raw_commits, _, window_truncated = await _fetch_github_commits_async(
+            connector,
+            owner,
+            repo_name,
             db_repo.id,
+            max_commits,
             since,
             until,
+            usage_sink,
         )
-        window_truncated = bool(rest[0]) if rest else False
     logging.info("Fetching commit stats from GitHub...")
     stats_limit = resolve_commit_stats_limit(len(raw_commits), max_commits, since)
     if _windowed_commit_stats_truncated(
@@ -1439,14 +1344,15 @@ async def _sync_github_commit_stats(
             stats_limit,
         )
         return 0
-    stats_objects = await loop.run_in_executor(
-        None,
-        _fetch_github_commit_stats_sync,
+    stats_objects = await _fetch_github_commit_stats_async(
+        connector,
+        owner,
+        repo_name,
         raw_commits,
         db_repo.id,
         stats_limit,
         since,
-        BaseGitProcessor.make_default_gate(),
+        usage_sink,
     )
     if stats_objects:
         await ingestion_sink.insert_git_commit_stats(stats_objects)
@@ -1804,6 +1710,7 @@ async def process_github_repo(
                     blame_only=True,
                     since=since,
                     until=until,
+                    usage_sink=usage_sink,
                 )
                 logging.info(
                     "Completed blame-only sync for GitHub repository: %s/%s",
@@ -1816,26 +1723,30 @@ async def process_github_repo(
             window_truncated = False
             if run_commits:
                 raw_commits, _, window_truncated = await _sync_github_commits(
-                    gh_repo=gh_repo,
+                    connector=connector,
+                    owner=owner,
+                    repo_name=repo_name,
                     db_repo=db_repo,
                     ingestion_sink=ingestion_sink,
-                    loop=loop,
                     max_commits=max_commits,
                     since=since,
                     until=until,
+                    usage_sink=usage_sink,
                 )
 
             if run_commit_stats:
                 await _sync_github_commit_stats(
-                    gh_repo=gh_repo,
+                    connector=connector,
+                    owner=owner,
+                    repo_name=repo_name,
                     db_repo=db_repo,
                     ingestion_sink=ingestion_sink,
-                    loop=loop,
                     max_commits=max_commits,
                     since=since,
                     until=until,
                     raw_commits=raw_commits,
                     window_truncated=window_truncated,
+                    usage_sink=usage_sink,
                 )
 
             if sync_prs:
@@ -1974,6 +1885,7 @@ async def process_github_repo(
                         include_commit_stats=False,
                         since=since,
                         until=until,
+                        usage_sink=usage_sink,
                     )
                 except Exception as e:
                     logging.warning(
@@ -2093,6 +2005,7 @@ async def process_github_repos_batch(
                     max_commits=max_commits_per_repo,
                     blame_only=True,
                     since=since,
+                    usage_sink=usage_sink,
                 )
             except Exception as e:
                 logging.debug(
@@ -2113,20 +2026,17 @@ async def process_github_repos_batch(
             else:
                 commit_limit = max_commits_per_repo
             try:
-                if gh_repo is None:
-                    gh_repo = connector.github.get_repo(repo_info.full_name)
-                raw_commits, commit_objects, *rest = await loop.run_in_executor(
-                    None,
-                    _fetch_github_commits_sync,
-                    gh_repo,
-                    commit_limit,
-                    db_repo.id,
-                    since,
+                batch_owner, _, batch_repo = repo_info.full_name.partition("/")
+                raw_commits, _, window_truncated = await _sync_github_commits(
+                    connector=connector,
+                    owner=batch_owner,
+                    repo_name=batch_repo,
+                    db_repo=db_repo,
+                    ingestion_sink=ingestion_sink,
+                    max_commits=commit_limit,
+                    since=since,
+                    usage_sink=usage_sink,
                 )
-                window_truncated = bool(rest[0]) if rest else False
-                if commit_objects:
-                    await ingestion_sink.insert_git_commit_data(commit_objects)
-
                 stats_limit = resolve_commit_stats_limit(
                     len(raw_commits), max_commits_per_repo, since
                 )
@@ -2142,14 +2052,16 @@ async def process_github_repos_batch(
                     )
                 else:
                     await _sync_github_commit_stats(
-                        gh_repo=gh_repo,
+                        connector=connector,
+                        owner=batch_owner,
+                        repo_name=batch_repo,
                         db_repo=db_repo,
                         ingestion_sink=ingestion_sink,
-                        loop=loop,
                         max_commits=max_commits_per_repo,
                         since=since,
                         raw_commits=raw_commits,
                         window_truncated=window_truncated,
+                        usage_sink=usage_sink,
                     )
             except (RateLimitException, RateLimitExceededException):
                 raise
@@ -2289,6 +2201,7 @@ async def process_github_repos_batch(
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink=usage_sink,
                 )
                 if security_alerts:
                     insert_security_alerts = getattr(
@@ -2337,6 +2250,7 @@ async def process_github_repos_batch(
                     include_blame=True,
                     include_commit_stats=False,
                     since=since,
+                    usage_sink=usage_sink,
                 )
             except Exception as e:
                 logging.debug(

--- a/src/dev_health_ops/providers/_http.py
+++ b/src/dev_health_ops/providers/_http.py
@@ -536,7 +536,7 @@ class InstrumentedRESTCore:
         params: dict[str, Any] | None = None,
         headers: dict[str, str] | None = None,
         data_key: str | None = None,
-        max_pages: int = 100,
+        max_pages: int | None = 100,
     ) -> list[Any]:
         """Paginate a GitHub-style endpoint via the RFC 5988 ``Link`` header.
 
@@ -553,7 +553,7 @@ class InstrumentedRESTCore:
         next_params: dict[str, Any] | None = dict(params or {}) if params else None
         pages = 0
         while next_url is not None:
-            if pages >= max_pages:
+            if max_pages is not None and pages >= max_pages:
                 logger.warning(
                     "%s pagination hit the %d-page cap for %s",
                     self.provider,

--- a/src/dev_health_ops/providers/github/budget.py
+++ b/src/dev_health_ops/providers/github/budget.py
@@ -327,13 +327,11 @@ def _fallback_credential_scope(
 # ---------------------------------------------------------------------------
 # Declares the full budget vocabulary the GitHub estimator emits so recorded
 # actuals key by the same (route_family, dimension) an estimate is keyed by.
-# Code-dataset families (git/commit_stats/files/blame/cicd/tests/deployments)
-# are budgeted but fetched through the frozen dataset path with no
-# instrumented client, so they carry no operation markers here (documented gap;
-# see docs/architecture/rate-limit-policy.md). Only the work-item families are
-# instrumented: every REST read in a work-item unit consumes the work_items
-# budget and every GraphQL POST consumes the work_item_prs budget, so resolution
-# is transport-based via the resolver defaults below.
+# Some code-dataset families are budgeted but still fetched through frozen
+# connector paths with no instrumented client, so they carry no operation
+# markers here (documented gap; see docs/providers/rate-limit-policy.md). Every
+# canonical code-client migration adds an explicit family prefix marker only when
+# the live fetch path has moved.
 #
 # `pr_social` (GRAPHQL_COST) is the first code-dataset family whose fetch path
 # IS instrumented (CHAOS-2803/CS2): the PR review-batch enrichment
@@ -351,16 +349,19 @@ def _fallback_credential_scope(
 # CHAOS-2773 CS8 -- so their markers stay empty per the plan's "never flip a
 # marker before its traffic" rule (§3).
 #
-# `security` (REST_CORE) and deployments REST_CORE now fetch through
+# `git` (REST_CORE), `commit_stats` (REST_CORE), `security` (REST_CORE), and
+# deployments REST_CORE now fetch through
 # `providers/github/code_client.py::GitHubCodeClient`, labeling operations
 # with explicit family prefixes so CS1's resolver short-circuit resolves them
-# directly. deployments CONTENTS_BLOB remains empty/deferred until artifact or
-# blob traffic is migrated; markers are populated only for live instrumented
-# traffic.
+# directly. `commit_stats` CONTENTS_BLOB and deployments CONTENTS_BLOB remain
+# empty/deferred until a distinct blob/content path is migrated; markers are
+# populated only for live instrumented traffic.
 GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("repo", BudgetDimension.REST_CORE),
-    UsageRouteFamily("git", BudgetDimension.REST_CORE),
-    UsageRouteFamily("commit_stats", BudgetDimension.REST_CORE),
+    UsageRouteFamily("git", BudgetDimension.REST_CORE, operation_markers=("git:",)),
+    UsageRouteFamily(
+        "commit_stats", BudgetDimension.REST_CORE, operation_markers=("commit_stats:",)
+    ),
     UsageRouteFamily("commit_stats", BudgetDimension.CONTENTS_BLOB),
     UsageRouteFamily("files", BudgetDimension.REST_CORE),
     UsageRouteFamily("files", BudgetDimension.CONTENTS_BLOB),

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -1,10 +1,7 @@
 """GitHub instrumented httpx code client (CHAOS-2773 CS3 pathfinder).
 
-Ports the "security" code-dataset family -- Dependabot alerts, code-scanning
-alerts, security advisories -- off the frozen ``connectors/github.py`` REST
-methods (``get_dependabot_alerts`` / ``get_code_scanning_alerts`` /
-``get_security_advisories`` and their shared ``_get_security_alert_page``
-pager) onto ``providers/_http.py::InstrumentedRESTCore``.
+Ports GitHub code-dataset families off the frozen ``connectors/github.py`` REST
+methods onto ``providers/_http.py::InstrumentedRESTCore``.
 
 This is the epic's PATHFINDER client: the shape here (one owned
 ``InstrumentedRESTCore`` configured with GitHub's diagnostic headers and 403
@@ -23,6 +20,7 @@ Behavior parity with the connector is pinned by
 from __future__ import annotations
 
 import logging
+import urllib.parse
 from collections.abc import Mapping
 from dataclasses import dataclass
 from datetime import datetime
@@ -59,6 +57,8 @@ logger = logging.getLogger(__name__)
 SECURITY_ROUTE_FAMILY = "security"
 DEPLOYMENTS_ROUTE_FAMILY = "deployments"
 CICD_ROUTE_FAMILY = "cicd"
+GIT_ROUTE_FAMILY = "git"
+COMMIT_STATS_ROUTE_FAMILY = "commit_stats"
 _GITHUB_DEPLOYMENTS_PER_PAGE = 100
 
 
@@ -88,6 +88,29 @@ class GitHubWorkflowRunData:
     started_at: datetime | None
     finished_at: datetime | None
     retry_count: int
+
+
+@dataclass(frozen=True)
+class GitHubCommitData:
+    sha: str
+    message: str
+    author_name: str
+    author_email: str | None
+    author_when: datetime | None
+    committer_name: str
+    committer_email: str | None
+    committer_when: datetime | None
+    parent_count: int
+
+
+@dataclass(frozen=True)
+class GitHubCommitFileStatData:
+    commit_hash: str
+    file_path: str
+    additions: int
+    deletions: int
+    old_file_mode: str = "unknown"
+    new_file_mode: str = "unknown"
 
 
 def _lowered_github_headers(response: httpx.Response) -> dict[str, str]:
@@ -305,6 +328,56 @@ def _workflow_run_from_item(item: Mapping[str, Any]) -> GitHubWorkflowRunData:
     )
 
 
+def _commit_author_name(user: object, commit_person: Mapping[str, Any] | None) -> str:
+    login = user.get("login") if isinstance(user, Mapping) else None
+    name = commit_person.get("name") if isinstance(commit_person, Mapping) else None
+    return str(login or name or "Unknown")
+
+
+def _commit_author_email(
+    user: object, commit_person: Mapping[str, Any] | None
+) -> str | None:
+    email = commit_person.get("email") if isinstance(commit_person, Mapping) else None
+    if email:
+        return str(email)
+    user_email = user.get("email") if isinstance(user, Mapping) else None
+    return str(user_email) if user_email else None
+
+
+def _commit_from_item(item: Mapping[str, Any]) -> GitHubCommitData:
+    raw_commit = item.get("commit")
+    commit: Mapping[str, Any] = raw_commit if isinstance(raw_commit, Mapping) else {}
+    raw_author = commit.get("author")
+    author = raw_author if isinstance(raw_author, Mapping) else None
+    raw_committer = commit.get("committer")
+    committer = raw_committer if isinstance(raw_committer, Mapping) else None
+    parents = item.get("parents")
+    return GitHubCommitData(
+        sha=str(item.get("sha") or ""),
+        message=str(commit.get("message") or ""),
+        author_name=_commit_author_name(item.get("author"), author),
+        author_email=_commit_author_email(item.get("author"), author),
+        author_when=_parse_alert_datetime(author.get("date") if author else None),
+        committer_name=_commit_author_name(item.get("committer"), committer),
+        committer_email=_commit_author_email(item.get("committer"), committer),
+        committer_when=_parse_alert_datetime(
+            committer.get("date") if committer else None
+        ),
+        parent_count=len(parents) if isinstance(parents, list) else 0,
+    )
+
+
+def _commit_stat_from_file(
+    commit_sha: str, file_item: Mapping[str, Any]
+) -> GitHubCommitFileStatData:
+    return GitHubCommitFileStatData(
+        commit_hash=commit_sha,
+        file_path=str(file_item.get("filename") or ""),
+        additions=int(file_item.get("additions") or 0),
+        deletions=int(file_item.get("deletions") or 0),
+    )
+
+
 def _pull_request_merged_at(item: Mapping[str, Any]) -> datetime | None:
     return _parse_alert_datetime(item.get("merged_at"))
 
@@ -342,7 +415,7 @@ def _page_cap_for_limit(
 
 class GitHubCodeClient:
     """Instrumented httpx client for GitHub code-dataset families
-    (CHAOS-2773 CS3+). CS3 exposes the ``security`` family only.
+    (CHAOS-2773 CS3+).
 
     :param auth: Token + optional GHE base URL. Mirrors
         ``providers/github/client.py::GitHubAuth`` -- callers that already
@@ -482,6 +555,69 @@ class GitHubCodeClient:
             if isinstance(item, Mapping)
         ]
 
+    async def get_commits(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        max_commits: int | None,
+        since: datetime | None = None,
+        until: datetime | None = None,
+    ) -> tuple[list[GitHubCommitData], bool]:
+        params: dict[str, Any] = {"per_page": _GITHUB_DEPLOYMENTS_PER_PAGE}
+        if since is not None:
+            params["since"] = since.isoformat()
+        if until is not None:
+            params["until"] = until.isoformat()
+        fetch_limit = max_commits + 1 if max_commits is not None else None
+        max_pages = None if fetch_limit is None else _page_cap_for_limit(fetch_limit)
+        operation = f"{GIT_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/commits"
+        encoded_owner = urllib.parse.quote(str(owner), safe="")
+        encoded_repo = urllib.parse.quote(str(repo), safe="")
+        items = await self._core.paginate_link_header(
+            f"/repos/{encoded_owner}/{encoded_repo}/commits",
+            operation=operation,
+            params=params,
+            max_pages=max_pages,
+        )
+        window_truncated = False
+        if fetch_limit is not None and len(items) >= fetch_limit:
+            window_truncated = True
+            items = items[:max_commits]
+        commits = [
+            _commit_from_item(item)
+            for item in items
+            if isinstance(item, Mapping) and item.get("sha")
+        ]
+        return commits, window_truncated
+
+    async def get_commit_file_stats(
+        self,
+        owner: str,
+        repo: str,
+        sha: str,
+    ) -> list[GitHubCommitFileStatData]:
+        operation = (
+            f"{COMMIT_STATS_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/commits/{{sha}}"
+        )
+        encoded_owner = urllib.parse.quote(str(owner), safe="")
+        encoded_repo = urllib.parse.quote(str(repo), safe="")
+        encoded_sha = urllib.parse.quote(str(sha), safe="")
+        response = await self._core.request(
+            "GET",
+            f"/repos/{encoded_owner}/{encoded_repo}/commits/{encoded_sha}",
+            operation=operation,
+        )
+        payload = response.json()
+        files = payload.get("files") if isinstance(payload, Mapping) else None
+        if not isinstance(files, list):
+            return []
+        return [
+            _commit_stat_from_file(sha, file_item)
+            for file_item in files
+            if isinstance(file_item, Mapping) and file_item.get("filename")
+        ]
+
     async def get_deployments(
         self,
         owner: str,
@@ -586,9 +722,13 @@ class GitHubCodeClient:
 
 
 __all__ = [
+    "COMMIT_STATS_ROUTE_FAMILY",
     "CICD_ROUTE_FAMILY",
     "DEPLOYMENTS_ROUTE_FAMILY",
+    "GIT_ROUTE_FAMILY",
     "GitHubCodeClient",
+    "GitHubCommitData",
+    "GitHubCommitFileStatData",
     "GitHubDeploymentData",
     "GitHubWorkflowRunData",
     "GitHubReleaseData",

--- a/tests/providers/test_github_budget.py
+++ b/tests/providers/test_github_budget.py
@@ -3,7 +3,10 @@ from __future__ import annotations
 from collections.abc import Mapping
 from datetime import datetime, timezone
 
-from dev_health_ops.providers.github.budget import GitHubBudgetEstimator
+from dev_health_ops.providers.github.budget import (
+    GITHUB_USAGE_ROUTE_FAMILIES,
+    GitHubBudgetEstimator,
+)
 from dev_health_ops.sync.budget import BudgetDimension, estimate_provider_budget
 from dev_health_ops.sync.budget_guard import (
     _budget_key,
@@ -67,6 +70,17 @@ def test_github_budget_light_metadata_stays_on_core_route_family() -> None:
     assert [
         (estimate.bucket.dimension, estimate.route_family) for estimate in estimates
     ] == [(BudgetDimension.REST_CORE, "repo")]
+
+
+def test_github_git_and_commit_stats_actuals_markers_are_live() -> None:
+    markers = {
+        (family.route_family, family.dimension): family.operation_markers
+        for family in GITHUB_USAGE_ROUTE_FAMILIES
+    }
+
+    assert markers[("git", BudgetDimension.REST_CORE)] == ("git:",)
+    assert markers[("commit_stats", BudgetDimension.REST_CORE)] == ("commit_stats:",)
+    assert markers[("commit_stats", BudgetDimension.CONTENTS_BLOB)] == ()
 
 
 def test_github_budget_estimator_splits_pr_social_pressure() -> None:

--- a/tests/providers/test_github_code_client_commits.py
+++ b/tests/providers/test_github_code_client_commits.py
@@ -1,0 +1,249 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import httpx
+
+from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.code_client import GitHubCodeClient
+
+
+def _client(transport: httpx.AsyncBaseTransport) -> GitHubCodeClient:
+    return GitHubCodeClient(auth=GitHubAuth(token="unit-test-pat"), transport=transport)
+
+
+def test_commits_send_window_params_and_report_truncation() -> None:
+    asyncio.run(_test_commits_send_window_params_and_report_truncation())
+
+
+async def _test_commits_send_window_params_and_report_truncation() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "sha": "a",
+                    "commit": {"message": "one", "author": {}, "committer": {}},
+                    "parents": [],
+                },
+                {
+                    "sha": "b",
+                    "commit": {"message": "two", "author": {}, "committer": {}},
+                    "parents": [],
+                },
+            ],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    until = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+    commits, truncated = await client.get_commits(
+        "acme", "widgets", max_commits=1, since=since, until=until
+    )
+    await client.close()
+
+    assert [commit.sha for commit in commits] == ["a"]
+    assert truncated is True
+    assert seen[0].url.params["since"] == since.isoformat()
+    assert seen[0].url.params["until"] == until.isoformat()
+
+
+def test_commits_exact_size_window_is_not_truncated() -> None:
+    asyncio.run(_test_commits_exact_size_window_is_not_truncated())
+
+
+async def _test_commits_exact_size_window_is_not_truncated() -> None:
+    # A window of exactly ``max_commits`` items (the iterator/pager ended
+    # right at the cap, with no extra commit peeked) is a COMPLETE window,
+    # not a truncated one -- indistinguishable from truncation by count alone,
+    # so this locks the ``fetch_limit`` look-ahead boundary.
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "sha": sha,
+                    "commit": {"message": "m", "author": {}, "committer": {}},
+                    "parents": [],
+                }
+                for sha in ("a", "b", "c")
+            ],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    commits, truncated = await client.get_commits("acme", "widgets", max_commits=3)
+    await client.close()
+
+    assert [commit.sha for commit in commits] == ["a", "b", "c"]
+    assert truncated is False
+
+
+def test_commits_under_cap_window_is_not_truncated() -> None:
+    asyncio.run(_test_commits_under_cap_window_is_not_truncated())
+
+
+async def _test_commits_under_cap_window_is_not_truncated() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "sha": sha,
+                    "commit": {"message": "m", "author": {}, "committer": {}},
+                    "parents": [],
+                }
+                for sha in ("a", "b")
+            ],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    commits, truncated = await client.get_commits("acme", "widgets", max_commits=3)
+    await client.close()
+
+    assert [commit.sha for commit in commits] == ["a", "b"]
+    assert truncated is False
+
+
+def test_commits_usage_resolves_to_git_family() -> None:
+    asyncio.run(_test_commits_usage_resolves_to_git_family())
+
+
+async def _test_commits_usage_resolves_to_git_family() -> None:
+    client = _client(httpx.MockTransport(lambda r: httpx.Response(200, json=[])))
+
+    await client.get_commits("acme", "widgets", max_commits=None)
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert len(observations) == 1
+    assert observations[0]["route_family"] == "git"
+    assert observations[0]["request_count"] == 1
+
+
+def test_uncapped_commits_follow_all_link_pages() -> None:
+    asyncio.run(_test_uncapped_commits_follow_all_link_pages())
+
+
+async def _test_uncapped_commits_follow_all_link_pages() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        page = int(request.url.params.get("page", "1"))
+        headers = {}
+        if page < 101:
+            headers["Link"] = (
+                "<https://api.github.com/repos/acme/widgets/commits?page="
+                f'{page + 1}>; rel="next"'
+            )
+        return httpx.Response(
+            200,
+            headers=headers,
+            json=[
+                {
+                    "sha": f"sha-{page}",
+                    "commit": {"message": "msg", "author": {}, "committer": {}},
+                    "parents": [],
+                }
+            ],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+
+    commits, truncated = await client.get_commits("acme", "widgets", max_commits=None)
+    await client.close()
+
+    assert len(seen) == 101
+    assert commits[-1].sha == "sha-101"
+    assert truncated is False
+
+
+def test_commit_file_stats_usage_resolves_to_commit_stats_family() -> None:
+    asyncio.run(_test_commit_file_stats_usage_resolves_to_commit_stats_family())
+
+
+async def _test_commit_file_stats_usage_resolves_to_commit_stats_family() -> None:
+    client = _client(
+        httpx.MockTransport(
+            lambda r: httpx.Response(
+                200,
+                json={
+                    "files": [
+                        {"filename": "src/app.py", "additions": 3, "deletions": 1}
+                    ]
+                },
+            )
+        )
+    )
+
+    stats = await client.get_commit_file_stats("acme", "widgets", "abc123")
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert [(stat.file_path, stat.additions, stat.deletions) for stat in stats] == [
+        ("src/app.py", 3, 1)
+    ]
+    assert len(observations) == 1
+    assert observations[0]["route_family"] == "commit_stats"
+    assert observations[0]["request_count"] == 1
+
+
+def test_get_commits_percent_encodes_owner_and_repo_path_segments() -> None:
+    asyncio.run(_test_get_commits_percent_encodes_owner_and_repo_path_segments())
+
+
+async def _test_get_commits_percent_encodes_owner_and_repo_path_segments() -> None:
+    # Security review (CHAOS-2807 CS6): owner/repo are untrusted path segments
+    # -- a slash, a query-string character, or a dot-segment must be
+    # percent-encoded so they cannot escape the ``/repos/{owner}/{repo}/commits``
+    # template (path traversal / route confusion / query injection).
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=[])
+
+    client = _client(httpx.MockTransport(handler))
+
+    await client.get_commits("acme/evil", "widgets?x=1", max_commits=None)
+    await client.close()
+
+    assert len(seen) == 1
+    raw_path = seen[0].url.raw_path.decode()
+    assert raw_path.startswith("/repos/acme%2Fevil/widgets%3Fx%3D1/commits?")
+    # The injected ``?x=1`` must NOT surface as a real query parameter --
+    # only the client's own params (per_page) are present.
+    assert seen[0].url.params.get("x") is None
+    assert seen[0].url.params["per_page"] == "100"
+
+
+def test_get_commit_file_stats_percent_encodes_path_segments() -> None:
+    asyncio.run(_test_get_commit_file_stats_percent_encodes_path_segments())
+
+
+async def _test_get_commit_file_stats_percent_encodes_path_segments() -> None:
+    # Security review (CHAOS-2807 CS6): sha (and owner/repo) are untrusted
+    # path segments -- a dot-segment/slash combination must be percent-encoded
+    # so it cannot traverse out of ``/repos/{owner}/{repo}/commits/{sha}``.
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json={"files": []})
+
+    client = _client(httpx.MockTransport(handler))
+
+    await client.get_commit_file_stats("acme", "widgets", "abc/../secret")
+    await client.close()
+
+    assert len(seen) == 1
+    raw_path = seen[0].url.raw_path.decode()
+    assert raw_path == "/repos/acme/widgets/commits/abc%2F..%2Fsecret"
+    # Decoding the wire path collapses back to the literal, untraversed value --
+    # proof the encoded form never let ``..`` act as a real path segment.
+    assert seen[0].url.path == "/repos/acme/widgets/commits/abc/../secret"

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -42,6 +42,42 @@ def _enable_connector_stubs(monkeypatch) -> None:
     monkeypatch.setattr(processors.gitlab, "RateLimitGate", RateLimitGate)
 
 
+def _github_commits_async_from_sync(fake_fetch):
+    async def _wrapped(
+        connector,
+        owner,
+        repo_name,
+        repo_id,
+        max_commits,
+        since=None,
+        until=None,
+        usage_sink=None,
+    ):
+        result = fake_fetch(None, max_commits, repo_id, since)
+        if len(result) == 2:
+            raw_commits, commit_objects = result
+            return raw_commits, commit_objects, False
+        return result
+
+    return _wrapped
+
+
+def _github_commit_stats_async_from_sync(fake_fetch):
+    async def _wrapped(
+        connector,
+        owner,
+        repo_name,
+        raw_commits,
+        repo_id,
+        max_stats,
+        since=None,
+        usage_sink=None,
+    ):
+        return fake_fetch(raw_commits, repo_id, max_stats, since)
+
+    return _wrapped
+
+
 @pytest.mark.asyncio
 async def test_github_async_batch_callback_fires_as_completed(monkeypatch):
     """Fast repos should invoke callback before slow repos in same batch."""
@@ -338,11 +374,13 @@ async def test_process_github_repos_batch_upserts_during_async_processing(monkey
 
     monkeypatch.setattr(
         processors.github,
-        "_fetch_github_commits_sync",
-        lambda *args, **kwargs: ([], []),
+        "_fetch_github_commits_async",
+        _github_commits_async_from_sync(lambda *args, **kwargs: ([], [])),
     )
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commit_stats_sync", lambda *args, **kwargs: []
+        processors.github,
+        "_fetch_github_commit_stats_async",
+        _github_commit_stats_async_from_sync(lambda *args, **kwargs: []),
     )
 
     # A store stub that records when insert_repo is called.
@@ -527,10 +565,14 @@ async def test_process_github_repos_batch_stores_commits_and_stats(monkeypatch):
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+        processors.github,
+        "_fetch_github_commits_async",
+        _github_commits_async_from_sync(fake_fetch_commits),
     )
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commit_stats_sync", fake_fetch_commit_stats
+        processors.github,
+        "_fetch_github_commit_stats_async",
+        _github_commit_stats_async_from_sync(fake_fetch_commit_stats),
     )
 
     store = DummyStore()
@@ -635,10 +677,14 @@ async def test_process_github_repos_batch_over_cap_window_skips_stats(monkeypatc
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+        processors.github,
+        "_fetch_github_commits_async",
+        _github_commits_async_from_sync(fake_fetch_commits),
     )
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commit_stats_sync", fake_fetch_commit_stats
+        processors.github,
+        "_fetch_github_commit_stats_async",
+        _github_commit_stats_async_from_sync(fake_fetch_commit_stats),
     )
 
     store = DummyStore()
@@ -748,10 +794,14 @@ async def test_process_github_repos_batch_truncated_window_skips_stats(monkeypat
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+        processors.github,
+        "_fetch_github_commits_async",
+        _github_commits_async_from_sync(fake_fetch_commits),
     )
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commit_stats_sync", fake_fetch_commit_stats
+        processors.github,
+        "_fetch_github_commit_stats_async",
+        _github_commit_stats_async_from_sync(fake_fetch_commit_stats),
     )
 
     await processors.github.process_github_repos_batch(
@@ -871,10 +921,14 @@ async def test_process_github_repos_batch_undersized_window_writes_stats(monkeyp
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+        processors.github,
+        "_fetch_github_commits_async",
+        _github_commits_async_from_sync(fake_fetch_commits),
     )
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commit_stats_sync", fake_fetch_commit_stats
+        processors.github,
+        "_fetch_github_commit_stats_async",
+        _github_commit_stats_async_from_sync(fake_fetch_commit_stats),
     )
 
     await processors.github.process_github_repos_batch(
@@ -1000,10 +1054,14 @@ async def test_process_github_repos_batch_exact_complete_window_writes_stats(
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+        processors.github,
+        "_fetch_github_commits_async",
+        _github_commits_async_from_sync(fake_fetch_commits),
     )
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commit_stats_sync", fake_fetch_commit_stats
+        processors.github,
+        "_fetch_github_commit_stats_async",
+        _github_commit_stats_async_from_sync(fake_fetch_commit_stats),
     )
 
     await processors.github.process_github_repos_batch(
@@ -1101,7 +1159,9 @@ async def test_process_github_repos_batch_commit_stats_rate_limit_propagates(
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+        processors.github,
+        "_fetch_github_commits_async",
+        _github_commits_async_from_sync(fake_fetch_commits),
     )
 
     with pytest.raises(RateLimitException) as exc_info:
@@ -1201,7 +1261,9 @@ async def test_process_github_repos_batch_multi_repo_rate_limit_does_not_hang(
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+        processors.github,
+        "_fetch_github_commits_async",
+        _github_commits_async_from_sync(fake_fetch_commits),
     )
 
     with pytest.raises(RateLimitException) as exc_info:
@@ -1309,7 +1371,18 @@ async def test_process_github_repos_batch_commit_detail_rate_limit_propagates(
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
-        processors.github, "_fetch_github_commits_sync", fake_fetch_commits
+        processors.github,
+        "_fetch_github_commits_async",
+        _github_commits_async_from_sync(fake_fetch_commits),
+    )
+
+    async def fake_fetch_commit_stats(*args, **kwargs):
+        raise RateLimitException("limited", retry_after_seconds=43.0)
+
+    monkeypatch.setattr(
+        processors.github,
+        "_fetch_github_commit_stats_async",
+        fake_fetch_commit_stats,
     )
 
     with pytest.raises(RateLimitException) as exc_info:

--- a/tests/test_code_window_upper_bound.py
+++ b/tests/test_code_window_upper_bound.py
@@ -18,7 +18,6 @@ from unittest.mock import AsyncMock, MagicMock, patch
 import pytest
 
 from dev_health_ops.processors.github import (
-    _fetch_github_commits_sync,
     _filter_after,
     _sync_github_test_reports,
 )
@@ -33,24 +32,6 @@ from dev_health_ops.processors.gitlab import (
 
 SINCE = datetime(2026, 1, 10, tzinfo=timezone.utc)
 UNTIL = datetime(2026, 1, 12, tzinfo=timezone.utc)
-
-
-def test_github_commits_fetch_passes_until_to_get_commits() -> None:
-    gh_repo = MagicMock()
-    gh_repo.get_commits.return_value = []
-
-    _fetch_github_commits_sync(gh_repo, None, "repo-1", since=SINCE, until=UNTIL)
-
-    gh_repo.get_commits.assert_called_once_with(since=SINCE, until=UNTIL)
-
-
-def test_github_commits_fetch_omits_until_when_none() -> None:
-    gh_repo = MagicMock()
-    gh_repo.get_commits.return_value = []
-
-    _fetch_github_commits_sync(gh_repo, None, "repo-1", since=SINCE)
-
-    gh_repo.get_commits.assert_called_once_with(since=SINCE)
 
 
 def test_gitlab_commits_fetch_passes_until_to_commits_list() -> None:

--- a/tests/test_commit_stats_limit.py
+++ b/tests/test_commit_stats_limit.py
@@ -16,6 +16,7 @@ from typing import Any, cast
 # pre-existing providers._base <-> connectors circular import when this file
 # is collected in isolation.
 import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models.git import Repo
 from dev_health_ops.processors import github
@@ -64,50 +65,6 @@ def test_windowed_truncation_predicate():
     assert trunc(50, False, 100, None) is False  # full-history is never truncated
 
 
-def test_fetch_commits_reports_window_truncation():
-    # The look-ahead: _fetch_github_commits_sync peeks ONE commit past max_commits
-    # so callers can distinguish a complete exact-size window (truncated=False)
-    # from a genuinely truncated one (truncated=True). Counting alone cannot.
-    def _fake_commit(sha: str):
-        person = SimpleNamespace(
-            name="Dev", email=None, date=datetime(2026, 5, 20, tzinfo=timezone.utc)
-        )
-        inner = SimpleNamespace(author=person, committer=person, message="msg")
-        return SimpleNamespace(
-            sha=sha, author=None, committer=None, commit=inner, parents=[]
-        )
-
-    class _FakeRepo:
-        def __init__(self, n: int) -> None:
-            self._commits = [_fake_commit(f"sha-{i}") for i in range(n)]
-
-        def get_commits(self, **kwargs):
-            return iter(self._commits)
-
-    fetch = github._fetch_github_commits_sync
-
-    # window 5, cap 3 -> truncated (a 4th commit existed past the cap, not kept)
-    raw, objs, truncated = fetch(_FakeRepo(5), 3, "repo-1")
-    assert [c.sha for c in raw] == ["sha-0", "sha-1", "sha-2"]
-    assert len(objs) == 3
-    assert truncated is True
-
-    # window EXACTLY 3, cap 3 -> complete (iterator ended at the cap)
-    raw, _objs, truncated = fetch(_FakeRepo(3), 3, "repo-1")
-    assert len(raw) == 3
-    assert truncated is False
-
-    # window 2, under cap 3 -> complete
-    raw, _objs, truncated = fetch(_FakeRepo(2), 3, "repo-1")
-    assert len(raw) == 2
-    assert truncated is False
-
-    # no cap -> never truncated
-    raw, _objs, truncated = fetch(_FakeRepo(10), None, "repo-1")
-    assert len(raw) == 10
-    assert truncated is False
-
-
 class _RecordingSink:
     def __init__(self) -> None:
         self.stats: list[Any] = []
@@ -120,21 +77,24 @@ def _run_sync_commit_stats(monkeypatch, *, raw_commits, since):
     """Drive ``_sync_github_commit_stats`` with a pre-fetched commit list."""
     fetch_calls: list[int] = []
 
-    def _fake_fetch(raw, repo_id, max_stats, window, gate):
+    async def _fake_fetch(
+        connector, owner, repo_name, raw, repo_id, max_stats, window, usage_sink
+    ):
         fetch_calls.append(max_stats)
         return [
             SimpleNamespace(commit_hash=getattr(c, "sha", c)) for c in raw[:max_stats]
         ]
 
-    monkeypatch.setattr(github, "_fetch_github_commit_stats_sync", _fake_fetch)
+    monkeypatch.setattr(github, "_fetch_github_commit_stats_async", _fake_fetch)
     sink = _RecordingSink()
 
     async def _drive():
         return await github._sync_github_commit_stats(
-            gh_repo=object(),
+            connector=object(),
+            owner="acme",
+            repo_name="widgets",
             db_repo=cast(Repo, SimpleNamespace(id="repo-1")),
             ingestion_sink=cast(IngestionSink, sink),
-            loop=asyncio.get_running_loop(),
             max_commits=None,
             since=since,
             raw_commits=list(raw_commits),
@@ -168,3 +128,92 @@ def test_full_history_capped_sample_still_writes_stats(monkeypatch):
     assert fetch_calls == [50]  # capped sample fetched
     assert written == 50
     assert len(stats) == 50
+
+
+def test_fetch_commit_stats_drains_usage_sink_on_rate_limit(monkeypatch):
+    usage_sink: list[dict[str, Any]] = []
+
+    class _FakeClient:
+        async def get_commit_file_stats(self, owner, repo_name, sha):
+            raise RateLimitException("limited", retry_after_seconds=42.0)
+
+        def drain_usage_observations(self):
+            return [{"route_family": "commit_stats", "request_count": 1}]
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(
+        github, "_github_code_client_from_connector", lambda connector: _FakeClient()
+    )
+
+    async def _drive():
+        return await github._fetch_github_commit_stats_async(
+            connector=object(),
+            owner="acme",
+            repo_name="widgets",
+            raw_commits=[SimpleNamespace(sha="sha-1")],
+            repo_id="repo-1",
+            max_stats=1,
+            since=None,
+            usage_sink=usage_sink,
+        )
+
+    try:
+        asyncio.run(_drive())
+    except RateLimitException as exc:
+        assert exc.retry_after_seconds == 42.0
+    else:
+        raise AssertionError("expected RateLimitException")
+
+    assert usage_sink == [{"route_family": "commit_stats", "request_count": 1}]
+
+
+def test_fetch_commit_stats_skips_non_rate_commit_failure(monkeypatch):
+    usage_sink: list[dict[str, Any]] = []
+
+    class _FakeClient:
+        async def get_commit_file_stats(self, owner, repo_name, sha):
+            if sha == "bad-sha":
+                raise RuntimeError("detail failed")
+            return [
+                SimpleNamespace(
+                    commit_hash=sha,
+                    file_path="src/app.py",
+                    additions=2,
+                    deletions=1,
+                    old_file_mode="unknown",
+                    new_file_mode="unknown",
+                )
+            ]
+
+        def drain_usage_observations(self):
+            return [{"route_family": "commit_stats", "request_count": 3}]
+
+        async def close(self):
+            return None
+
+    monkeypatch.setattr(
+        github, "_github_code_client_from_connector", lambda connector: _FakeClient()
+    )
+
+    async def _drive():
+        return await github._fetch_github_commit_stats_async(
+            connector=object(),
+            owner="acme",
+            repo_name="widgets",
+            raw_commits=[
+                SimpleNamespace(sha="good-1"),
+                SimpleNamespace(sha="bad-sha"),
+                SimpleNamespace(sha="good-2"),
+            ],
+            repo_id="repo-1",
+            max_stats=3,
+            since=None,
+            usage_sink=usage_sink,
+        )
+
+    stats = asyncio.run(_drive())
+
+    assert [stat.commit_hash for stat in stats] == ["good-1", "good-2"]
+    assert usage_sink == [{"route_family": "commit_stats", "request_count": 3}]

--- a/tests/test_github_content_backfill.py
+++ b/tests/test_github_content_backfill.py
@@ -257,10 +257,25 @@ class TestPathsOnlyUpgrade:
 
 
 class TestCommitStatsBackfill:
+    @staticmethod
+    def _stat(commit_hash: str, repo_id: object):
+        from dev_health_ops.models.git import GitCommitStat
+
+        return GitCommitStat(
+            repo_id=repo_id,
+            commit_hash=commit_hash,
+            file_path=f"{commit_hash}.py",
+            additions=1,
+            deletions=0,
+            old_file_mode="unknown",
+            new_file_mode="unknown",
+        )
+
     @pytest.mark.asyncio
     async def test_backfill_commit_stats_uses_window_and_persists_when_cap_not_hit(
         self, monkeypatch
     ):
+        from dev_health_ops.processors import github
         from dev_health_ops.processors.github import _backfill_github_missing_data
 
         monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "2")
@@ -282,22 +297,41 @@ class TestCommitStatsBackfill:
         sink.insert_git_commit_stats = AsyncMock(side_effect=insert)
 
         commits = [SimpleNamespace(sha=f"sha-{idx}") for idx in range(2)]
-        details_by_sha = {
-            commit.sha: SimpleNamespace(
-                files=[
-                    SimpleNamespace(
-                        filename=f"{commit.sha}.py",
-                        additions=1,
-                        deletions=0,
-                    )
-                ]
-            )
-            for commit in commits
-        }
+        fetch_args = []
+        stats_args = []
+
+        async def fake_fetch(
+            connector_arg,
+            owner,
+            repo_name,
+            repo_id,
+            max_commits,
+            since_arg,
+            until_arg,
+            usage_sink,
+        ):
+            fetch_args.append((owner, repo_name, max_commits, since_arg, until_arg))
+            return commits, [], False
+
+        async def fake_stats(
+            connector_arg,
+            owner,
+            repo_name,
+            raw_commits,
+            repo_id,
+            max_stats,
+            since_arg,
+            usage_sink,
+        ):
+            stats_args.append((owner, repo_name, max_stats, since_arg))
+            return [
+                self._stat(commit.sha, repo_id) for commit in raw_commits[:max_stats]
+            ]
+
+        monkeypatch.setattr(github, "_fetch_github_commits_async", fake_fetch)
+        monkeypatch.setattr(github, "_fetch_github_commit_stats_async", fake_stats)
 
         gh_repo = Mock()
-        gh_repo.get_commits.return_value = commits
-        gh_repo.get_commit.side_effect = lambda sha: details_by_sha[sha]
 
         connector = Mock()
         connector.github.get_repo.return_value = gh_repo
@@ -319,15 +353,13 @@ class TestCommitStatsBackfill:
             until=until,
         )
 
-        gh_repo.get_commits.assert_called_once_with(since=since, until=until)
-        assert [call.args[0] for call in gh_repo.get_commit.call_args_list] == [
-            "sha-0",
-            "sha-1",
-        ]
+        assert fetch_args == [("octo", "repo", None, since, until)]
+        assert stats_args == [("octo", "repo", 2, since)]
         assert [row.commit_hash for row in written] == ["sha-0", "sha-1"]
 
     @pytest.mark.asyncio
     async def test_backfill_commit_stats_over_cap_writes_nothing(self, monkeypatch):
+        from dev_health_ops.processors import github
         from dev_health_ops.processors.github import _backfill_github_missing_data
 
         monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "2")
@@ -344,22 +376,19 @@ class TestCommitStatsBackfill:
         sink.insert_git_commit_stats = AsyncMock()
 
         commits = [SimpleNamespace(sha=f"sha-{idx}") for idx in range(3)]
-        details_by_sha = {
-            commit.sha: SimpleNamespace(
-                files=[
-                    SimpleNamespace(
-                        filename=f"{commit.sha}.py",
-                        additions=1,
-                        deletions=0,
-                    )
-                ]
-            )
-            for commit in commits
-        }
+        stats_calls = []
+
+        async def fake_fetch(*args, **kwargs):
+            return commits, [], False
+
+        async def fake_stats(*args, **kwargs):
+            stats_calls.append((args, kwargs))
+            return []
+
+        monkeypatch.setattr(github, "_fetch_github_commits_async", fake_fetch)
+        monkeypatch.setattr(github, "_fetch_github_commit_stats_async", fake_stats)
 
         gh_repo = Mock()
-        gh_repo.get_commits.return_value = commits
-        gh_repo.get_commit.side_effect = lambda sha: details_by_sha[sha]
 
         connector = Mock()
         connector.github.get_repo.return_value = gh_repo
@@ -381,14 +410,14 @@ class TestCommitStatsBackfill:
             until=until,
         )
 
-        gh_repo.get_commits.assert_called_once_with(since=since, until=until)
-        gh_repo.get_commit.assert_not_called()
+        assert stats_calls == []
         sink.insert_git_commit_stats.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_backfill_commit_stats_rate_limit_propagates_without_partial_write(
         self, monkeypatch
     ):
+        from dev_health_ops.processors import github
         from dev_health_ops.processors.github import _backfill_github_missing_data
 
         monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "3")
@@ -405,20 +434,17 @@ class TestCommitStatsBackfill:
         sink.insert_git_commit_stats = AsyncMock()
 
         commits = [SimpleNamespace(sha="sha-0"), SimpleNamespace(sha="sha-1")]
+
+        async def fake_fetch(*args, **kwargs):
+            return commits, [], False
+
+        async def fake_stats(*args, **kwargs):
+            raise RateLimitException("limited", retry_after_seconds=42.0)
+
+        monkeypatch.setattr(github, "_fetch_github_commits_async", fake_fetch)
+        monkeypatch.setattr(github, "_fetch_github_commit_stats_async", fake_stats)
+
         gh_repo = Mock()
-        gh_repo.get_commits.return_value = commits
-        gh_repo.get_commit.side_effect = [
-            SimpleNamespace(
-                files=[
-                    SimpleNamespace(
-                        filename="sha-0.py",
-                        additions=1,
-                        deletions=0,
-                    )
-                ]
-            ),
-            RateLimitException("limited", retry_after_seconds=42.0),
-        ]
 
         connector = Mock()
         connector.github.get_repo.return_value = gh_repo
@@ -447,6 +473,7 @@ class TestCommitStatsBackfill:
     @pytest.mark.asyncio
     async def test_backfill_commit_stats_over_cap_still_runs_blame(self, monkeypatch):
         from dev_health_ops.connectors.models import BlameRange, FileBlame
+        from dev_health_ops.processors import github
         from dev_health_ops.processors.github import _backfill_github_missing_data
 
         monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "2")
@@ -470,24 +497,21 @@ class TestCommitStatsBackfill:
         sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
 
         commits = [SimpleNamespace(sha=f"sha-{idx}") for idx in range(3)]
-        details_by_sha = {
-            commit.sha: SimpleNamespace(
-                files=[
-                    SimpleNamespace(
-                        filename=f"{commit.sha}.py",
-                        additions=1,
-                        deletions=0,
-                    )
-                ]
-            )
-            for commit in commits
-        }
+        stats_calls = []
+
+        async def fake_fetch(*args, **kwargs):
+            return commits, [], False
+
+        async def fake_stats(*args, **kwargs):
+            stats_calls.append((args, kwargs))
+            return []
+
+        monkeypatch.setattr(github, "_fetch_github_commits_async", fake_fetch)
+        monkeypatch.setattr(github, "_fetch_github_commit_stats_async", fake_stats)
 
         gh_repo = Mock()
         gh_repo.get_branch.return_value = Mock(commit=Mock(sha="tree-sha"))
         gh_repo.get_git_tree.return_value = Mock(tree=[_FakeTreeEntry("src/app.py")])
-        gh_repo.get_commits.return_value = commits
-        gh_repo.get_commit.side_effect = lambda sha: details_by_sha[sha]
 
         connector = Mock()
         connector.github.get_repo.return_value = gh_repo
@@ -523,7 +547,7 @@ class TestCommitStatsBackfill:
         )
 
         sink.insert_git_commit_stats.assert_not_called()
-        gh_repo.get_commit.assert_not_called()
+        assert stats_calls == []
         connector.get_file_blame.assert_called_once_with(
             owner="octo",
             repo="repo",
@@ -536,6 +560,7 @@ class TestCommitStatsBackfill:
     async def test_backfill_commit_stats_full_history_writes_capped_sample(
         self, monkeypatch
     ):
+        from dev_health_ops.processors import github
         from dev_health_ops.processors.github import _backfill_github_missing_data
 
         monkeypatch.setenv("COMMIT_STATS_MAX_COMMITS", "2")
@@ -555,22 +580,30 @@ class TestCommitStatsBackfill:
         sink.insert_git_commit_stats = AsyncMock(side_effect=insert)
 
         commits = [SimpleNamespace(sha=f"sha-{idx}") for idx in range(3)]
-        details_by_sha = {
-            commit.sha: SimpleNamespace(
-                files=[
-                    SimpleNamespace(
-                        filename=f"{commit.sha}.py",
-                        additions=1,
-                        deletions=0,
-                    )
-                ]
-            )
-            for commit in commits
-        }
+        stats_args = []
+
+        async def fake_fetch(*args, **kwargs):
+            return commits, [], False
+
+        async def fake_stats(
+            connector_arg,
+            owner,
+            repo_name,
+            raw_commits,
+            repo_id,
+            max_stats,
+            since_arg,
+            usage_sink,
+        ):
+            stats_args.append(max_stats)
+            return [
+                self._stat(commit.sha, repo_id) for commit in raw_commits[:max_stats]
+            ]
+
+        monkeypatch.setattr(github, "_fetch_github_commits_async", fake_fetch)
+        monkeypatch.setattr(github, "_fetch_github_commit_stats_async", fake_stats)
 
         gh_repo = Mock()
-        gh_repo.get_commits.return_value = commits
-        gh_repo.get_commit.side_effect = lambda sha: details_by_sha[sha]
 
         connector = Mock()
         connector.github.get_repo.return_value = gh_repo
@@ -590,9 +623,5 @@ class TestCommitStatsBackfill:
             include_blame=False,
         )
 
-        gh_repo.get_commits.assert_called_once_with()
-        assert [call.args[0] for call in gh_repo.get_commit.call_args_list] == [
-            "sha-0",
-            "sha-1",
-        ]
+        assert stats_args == [2]
         assert [row.commit_hash for row in written] == ["sha-0", "sha-1"]

--- a/tests/test_processor_split.py
+++ b/tests/test_processor_split.py
@@ -17,6 +17,14 @@ def _counting(counter: dict[str, Any], key: str, value: Any):
     return _inner
 
 
+def _async_counting(counter: dict[str, Any], key: str, value: Any):
+    async def _inner(*args: Any, **kwargs: Any) -> Any:
+        counter[key] = counter.get(key, 0) + 1
+        return value
+
+    return _inner
+
+
 class _SimpleRepository:
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
@@ -114,13 +122,13 @@ def test_github_commits_run_does_not_fetch_stats_files_or_blame(monkeypatch):
     monkeypatch.setattr(github, "IngestionSink", _FakeSink)
     monkeypatch.setattr(
         github,
-        "_fetch_github_commits_sync",
-        _counting(calls, "commits", (["raw-sha"], ["commit-row"])),
+        "_fetch_github_commits_async",
+        _async_counting(calls, "commits", (["raw-sha"], ["commit-row"], False)),
     )
     monkeypatch.setattr(
         github,
-        "_fetch_github_commit_stats_sync",
-        _counting(calls, "stats", ["stat-row"]),
+        "_fetch_github_commit_stats_async",
+        _async_counting(calls, "stats", ["stat-row"]),
     )
 
     async def fake_backfill(**kwargs):
@@ -158,13 +166,13 @@ def test_github_granular_stats_files_blame_and_legacy_bundle(monkeypatch):
     monkeypatch.setattr(github, "IngestionSink", _FakeSink)
     monkeypatch.setattr(
         github,
-        "_fetch_github_commits_sync",
-        _counting(calls, "commits", (["raw-sha"], ["commit-row"])),
+        "_fetch_github_commits_async",
+        _async_counting(calls, "commits", (["raw-sha"], ["commit-row"], False)),
     )
     monkeypatch.setattr(
         github,
-        "_fetch_github_commit_stats_sync",
-        _counting(calls, "stats", ["stat-row"]),
+        "_fetch_github_commit_stats_async",
+        _async_counting(calls, "stats", ["stat-row"]),
     )
 
     async def fake_backfill(**kwargs):


### PR DESCRIPTION
Summary

migrate GitHub commit listing and commit file stats onto GitHubCodeClient  
drain git and commit_stats usage observations through processor/backfill/batch paths  
mark GitHub git and commit_stats REST-core actuals live and update provider docs

Validation

OTEL_SDK_DISABLED=true bash ci/local_validate.sh  
pre-push: ruff format --check, ruff check, mypy  
LSP diagnostics clean on changed provider/processor files

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.  
