### PR TITLE
fix(metrics): carry compounding risk inputs forward

### DIFF
--- a/docs/computations/compounding-risk.md
+++ b/docs/computations/compounding-risk.md
@@ -28,13 +28,14 @@ For each `(org_id, repo_id, day)` row, four signals are combined:
 Window: trailing 30 days. The complexity delta uses the first-half-versus-second-half
 average so a recent rise in complexity is captured even when absolute values are small.
 
-Each input resolves to the most recent non-null value for the same
-`(org_id, repo_id)` within the trailing 30-day metric window. This lets sparse
-inputs, especially review latency on days with no reviewed PRs, carry forward
-from the last known value without crossing org or repo boundaries.
+Inputs come from the current `(org_id, repo_id, day)` compute row. If any
+required input is missing on that row, the persisted score is `NULL` and the
+severity is `unknown`. **Missing data is not zero risk.**
 
-If any required input has no non-null value anywhere in the window, the score is
-`NULL` and the severity is `unknown`. **Missing data is not zero risk.**
+Read surfaces resolve to the most recent complete (fully-scored) day within the
+window: partial or in-progress current days whose latest Compounding Risk score
+is unavailable are skipped. If no scored day exists in the window, the score is
+unavailable rather than carried forward or recomputed.
 
 ---
 
@@ -138,9 +139,8 @@ recomputed from persisted inputs with `dev-hops metrics compounding-risk`:
 
 1. `compute_daily_metrics` writes `repo_metrics_daily` for the day.
 2. `build_compounding_risk_rows_for_day` reads the just-written
-   `repo_metrics_daily` rows, carries forward non-null inputs within the
-   trailing metric window, and queries `repo_complexity_daily` for the
-   complexity delta.
+   `repo_metrics_daily` rows and queries `repo_complexity_daily` for the
+   current row's complexity delta.
 3. The resulting rows are written via `sink.write_compounding_risk_daily(...)`.
 
 No new connector or processor work is required; the pipeline already

--- a/docs/computations/compounding-risk.md
+++ b/docs/computations/compounding-risk.md
@@ -28,8 +28,13 @@ For each `(org_id, repo_id, day)` row, four signals are combined:
 Window: trailing 30 days. The complexity delta uses the first-half-versus-second-half
 average so a recent rise in complexity is captured even when absolute values are small.
 
-If any required input is missing, the score is `NULL` and the severity is `unknown`.
-**Missing data is not zero risk.**
+Each input resolves to the most recent non-null value for the same
+`(org_id, repo_id)` within the trailing 30-day metric window. This lets sparse
+inputs, especially review latency on days with no reviewed PRs, carry forward
+from the last known value without crossing org or repo boundaries.
+
+If any required input has no non-null value anywhere in the window, the score is
+`NULL` and the severity is `unknown`. **Missing data is not zero risk.**
 
 ---
 
@@ -115,10 +120,11 @@ This is the inspectability contract — no opaque scoring.
 
 ## Scope
 
-v1 persists **repo-scope rows only**. Team-scope views are derived at read time
-by aggregating per-repo rows in the GraphQL resolver (CHAOS-1642). Persisting
-team-scope rows is a follow-up optimization; the read-time aggregation already
-honors the inspectability contract.
+v1 persists **repo-scope rows** and, when a repo-to-team mapping is available,
+**team-scope rows**. Team rows aggregate the resolved per-repo raw inputs by
+unweighted mean and then apply the same formula, preserving inspectability. The
+GraphQL resolver still supports read-time aggregation as a compatibility
+fallback when persisted team rows are absent.
 
 Per the no-surveillance contract, **there is no per-person scope** for this
 metric, and the web surface explicitly locks the scope picker against it.
@@ -127,11 +133,13 @@ metric, and the web surface explicitly locks the scope picker against it.
 
 ## Orchestration
 
-Compounding Risk runs as part of `dev-hops metrics daily`:
+Compounding Risk runs as part of `dev-hops metrics daily` and can also be
+recomputed from persisted inputs with `dev-hops metrics compounding-risk`:
 
 1. `compute_daily_metrics` writes `repo_metrics_daily` for the day.
-2. `build_compounding_risk_rows_for_day` reads back the just-written
-   `repo_metrics_daily` rows and queries `repo_complexity_daily` for the
+2. `build_compounding_risk_rows_for_day` reads the just-written
+   `repo_metrics_daily` rows, carries forward non-null inputs within the
+   trailing metric window, and queries `repo_complexity_daily` for the
    complexity delta.
 3. The resulting rows are written via `sink.write_compounding_risk_daily(...)`.
 

--- a/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
+++ b/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
@@ -70,24 +70,39 @@ async def _latest_day_for_org(
     *,
     scope: str,
     scope_ids: list[str] | None,
+    start_day: date | None = None,
+    end_day: date | None = None,
 ) -> date | None:
+    if scope_ids == []:
+        return None
+
+    bounded_end_day = end_day or datetime.now(timezone.utc).date()
+    bounded_start_day = start_day or bounded_end_day - timedelta(days=29)
+
     query = """
         SELECT maxOrNull(day) AS day
         FROM (
             SELECT
                 day,
                 count() AS row_count,
-                countIf(score IS NULL) AS missing_scores
+                countIf(tupleElement(latest_row, 1) IS NULL) AS missing_scores
             FROM (
                 SELECT
                     day,
                     scope_id,
-                    argMax(compounding_risk, computed_at) AS score
+                    argMax(tuple(compounding_risk), computed_at) AS latest_row
                 FROM compounding_risk_daily
                 WHERE org_id = {org_id:String}
                   AND scope = {scope:String}
+                  AND day >= {start_day:Date}
+                  AND day <= {end_day:Date}
     """
-    params: dict[str, Any] = {"org_id": org_id, "scope": scope}
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "scope": scope,
+        "start_day": bounded_start_day,
+        "end_day": bounded_end_day,
+    }
     if scope_ids:
         bounded = list(scope_ids)[:MAX_ROWS]
         if scope == "repo":
@@ -130,36 +145,67 @@ async def _fetch_latest_rows(
 ) -> list[dict[str, Any]]:
     """Latest per-(scope_id) row at the given day, for one scope value.
 
-    ``argMax`` over ``computed_at`` returns the most-recent compute for each
-    scope_id on that day. All audit-trail fields are passed through so the
-    UI can show the score's full provenance without a second roundtrip.
+    ``argMax(tuple(...), computed_at)`` returns the most-recent compute for
+    each scope_id on that day without ClickHouse skipping nullable score
+    values. All selected fields are unpacked from the same latest tuple so the
+    UI cannot mix an older score with newer audit fields.
     """
+    if scope_ids == []:
+        return []
+
     query = """
         SELECT
             scope_id,
-            argMax(compounding_risk,    computed_at) AS score,
-            argMax(severity,            computed_at) AS severity,
-            argMax(churn_norm,          computed_at) AS churn_norm,
-            argMax(complexity_norm,     computed_at) AS complexity_norm,
-            argMax(ownership_norm,      computed_at) AS ownership_norm,
-            argMax(review_norm,         computed_at) AS review_norm,
-            argMax(rework_churn,        computed_at) AS rework_churn,
-            argMax(complexity_delta,    computed_at) AS complexity_delta,
-            argMax(bus_factor,          computed_at) AS bus_factor,
-            argMax(ownership_gini,      computed_at) AS ownership_gini,
-            argMax(single_owner_ratio,  computed_at) AS single_owner_ratio,
-            argMax(review_latency_p90h, computed_at) AS review_latency_p90h,
-            argMax(w_churn,             computed_at) AS w_churn,
-            argMax(w_complexity,        computed_at) AS w_complexity,
-            argMax(w_ownership,         computed_at) AS w_ownership,
-            argMax(w_review,            computed_at) AS w_review,
-            argMax(threshold_elevated,  computed_at) AS threshold_elevated,
-            argMax(threshold_high,      computed_at) AS threshold_high,
-            max(computed_at)                          AS latest_computed_at
-        FROM compounding_risk_daily
-        WHERE org_id = {org_id:String}
-          AND scope = {scope:String}
-          AND day = {day:Date}
+            tupleElement(latest_row, 1)  AS score,
+            tupleElement(latest_row, 2)  AS severity,
+            tupleElement(latest_row, 3)  AS churn_norm,
+            tupleElement(latest_row, 4)  AS complexity_norm,
+            tupleElement(latest_row, 5)  AS ownership_norm,
+            tupleElement(latest_row, 6)  AS review_norm,
+            tupleElement(latest_row, 7)  AS rework_churn,
+            tupleElement(latest_row, 8)  AS complexity_delta,
+            tupleElement(latest_row, 9)  AS bus_factor,
+            tupleElement(latest_row, 10) AS ownership_gini,
+            tupleElement(latest_row, 11) AS single_owner_ratio,
+            tupleElement(latest_row, 12) AS review_latency_p90h,
+            tupleElement(latest_row, 13) AS w_churn,
+            tupleElement(latest_row, 14) AS w_complexity,
+            tupleElement(latest_row, 15) AS w_ownership,
+            tupleElement(latest_row, 16) AS w_review,
+            tupleElement(latest_row, 17) AS threshold_elevated,
+            tupleElement(latest_row, 18) AS threshold_high,
+            tupleElement(latest_row, 19) AS latest_computed_at
+        FROM (
+            SELECT
+                scope_id,
+                argMax(
+                    tuple(
+                        compounding_risk,
+                        severity,
+                        churn_norm,
+                        complexity_norm,
+                        ownership_norm,
+                        review_norm,
+                        rework_churn,
+                        complexity_delta,
+                        bus_factor,
+                        ownership_gini,
+                        single_owner_ratio,
+                        review_latency_p90h,
+                        w_churn,
+                        w_complexity,
+                        w_ownership,
+                        w_review,
+                        threshold_elevated,
+                        threshold_high,
+                        computed_at
+                    ),
+                    computed_at
+                ) AS latest_row
+            FROM compounding_risk_daily
+            WHERE org_id = {org_id:String}
+              AND scope = {scope:String}
+              AND day = {day:Date}
     """
     params: dict[str, Any] = {"org_id": org_id, "day": day, "scope": scope}
     if scope_ids:
@@ -176,7 +222,9 @@ async def _fetch_latest_rows(
         else:
             query += "\n  AND scope_id IN {scope_ids:Array(String)}"
             params["scope_ids"] = bounded
-    query += f"\nGROUP BY scope_id\nORDER BY score DESC NULLS LAST\nLIMIT {MAX_ROWS}"
+    query += (
+        f"\n    GROUP BY scope_id\n)\nORDER BY score DESC NULLS LAST\nLIMIT {MAX_ROWS}"
+    )
     return await query_dicts(client, query, params)
 
 
@@ -187,6 +235,9 @@ async def _fetch_repo_trend(
     trend_days: int,
     repo_ids: list[str] | None,
 ) -> list[dict[str, Any]]:
+    if repo_ids == []:
+        return []
+
     start_day = end_day - timedelta(days=max(0, trend_days - 1))
     query = """
         SELECT day,
@@ -195,7 +246,7 @@ async def _fetch_repo_trend(
             SELECT
                 day,
                 scope_id,
-                argMax(compounding_risk, computed_at) AS score
+                tupleElement(argMax(tuple(compounding_risk), computed_at), 1) AS score
             FROM compounding_risk_daily
             WHERE org_id = {org_id:String}
               AND scope = 'repo'
@@ -221,6 +272,27 @@ async def _fetch_repo_trend(
         GROUP BY day ORDER BY day
     """
     return await query_dicts(client, query, params)
+
+
+async def _repo_scope_ids_for_team_fallback(
+    client: Any,
+    org_id: str,
+    *,
+    repo_ids: list[str] | None,
+    team_ids: list[str] | None,
+) -> list[str] | None:
+    if not team_ids:
+        return repo_ids
+
+    repo_to_team, _ = await _load_team_assignments(client, org_id)
+    team_filter = set(team_ids)
+    repos_for_teams = {
+        repo_id for repo_id, team_id in repo_to_team.items() if team_id in team_filter
+    }
+    if repo_ids:
+        repo_filter = set(repo_ids)
+        return sorted(repo_id for repo_id in repos_for_teams if repo_id in repo_filter)
+    return sorted(repos_for_teams)
 
 
 def _components_from_row(row: dict[str, Any]) -> CompoundingRiskComponents:
@@ -462,6 +534,9 @@ async def resolve_compounding_risk(
     filt = filter or CompoundingRiskFilterInput()
     breakout = filt.breakout
     trend_days = max(1, min(filt.trend_days, MAX_TREND_DAYS))
+    latest_end_day = datetime.now(timezone.utc).date()
+    latest_start_day = latest_end_day - timedelta(days=max(0, trend_days - 1))
+    fallback_repo_scope_ids: list[str] | None = filt.repo_ids
 
     day: date | None
     if filt.day is not None:
@@ -472,13 +547,23 @@ async def resolve_compounding_risk(
             authorized_org_id,
             scope="team",
             scope_ids=filt.team_ids,
+            start_day=latest_start_day,
+            end_day=latest_end_day,
         )
         if day is None:
+            fallback_repo_scope_ids = await _repo_scope_ids_for_team_fallback(
+                client,
+                authorized_org_id,
+                repo_ids=filt.repo_ids,
+                team_ids=filt.team_ids,
+            )
             day = await _latest_day_for_org(
                 client,
                 authorized_org_id,
                 scope="repo",
-                scope_ids=filt.repo_ids,
+                scope_ids=fallback_repo_scope_ids,
+                start_day=latest_start_day,
+                end_day=latest_end_day,
             )
     else:
         day = await _latest_day_for_org(
@@ -486,6 +571,8 @@ async def resolve_compounding_risk(
             authorized_org_id,
             scope="repo",
             scope_ids=filt.repo_ids,
+            start_day=latest_start_day,
+            end_day=latest_end_day,
         )
     if day is None:
         return CompoundingRiskResult(
@@ -530,7 +617,7 @@ async def resolve_compounding_risk(
                 org_id=authorized_org_id,
                 day=day,
                 scope="repo",
-                scope_ids=filt.repo_ids,
+                scope_ids=fallback_repo_scope_ids,
             )
             repo_to_team, team_labels = await _load_team_assignments(
                 client, authorized_org_id
@@ -543,8 +630,13 @@ async def resolve_compounding_risk(
                 day=day,
             )
 
+    trend_repo_scope_ids = (
+        fallback_repo_scope_ids
+        if breakout == CompoundingRiskScope.TEAM
+        else filt.repo_ids
+    )
     trend_rows = await _fetch_repo_trend(
-        client, authorized_org_id, day, trend_days, filt.repo_ids
+        client, authorized_org_id, day, trend_days, trend_repo_scope_ids
     )
     trend = [
         CompoundingRiskTrendPoint(

--- a/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
+++ b/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
@@ -537,6 +537,7 @@ async def resolve_compounding_risk(
     latest_end_day = datetime.now(timezone.utc).date()
     latest_start_day = latest_end_day - timedelta(days=max(0, trend_days - 1))
     fallback_repo_scope_ids: list[str] | None = filt.repo_ids
+    team_filtered_repo_scope_ids: list[str] | None = None
 
     day: date | None
     if filt.day is not None:
@@ -551,12 +552,13 @@ async def resolve_compounding_risk(
             end_day=latest_end_day,
         )
         if day is None:
-            fallback_repo_scope_ids = await _repo_scope_ids_for_team_fallback(
+            team_filtered_repo_scope_ids = await _repo_scope_ids_for_team_fallback(
                 client,
                 authorized_org_id,
                 repo_ids=filt.repo_ids,
                 team_ids=filt.team_ids,
             )
+            fallback_repo_scope_ids = team_filtered_repo_scope_ids
             day = await _latest_day_for_org(
                 client,
                 authorized_org_id,
@@ -611,6 +613,14 @@ async def resolve_compounding_risk(
             _, team_labels = await _load_team_assignments(client, authorized_org_id)
             points = [_point_from_team_row(r, day, team_labels) for r in team_rows]
         else:
+            if filt.team_ids and team_filtered_repo_scope_ids is None:
+                team_filtered_repo_scope_ids = await _repo_scope_ids_for_team_fallback(
+                    client,
+                    authorized_org_id,
+                    repo_ids=filt.repo_ids,
+                    team_ids=filt.team_ids,
+                )
+                fallback_repo_scope_ids = team_filtered_repo_scope_ids
             # Fallback path: aggregate from the repo rows.
             repo_rows = await _fetch_latest_rows(
                 client,
@@ -630,11 +640,19 @@ async def resolve_compounding_risk(
                 day=day,
             )
 
-    trend_repo_scope_ids = (
-        fallback_repo_scope_ids
-        if breakout == CompoundingRiskScope.TEAM
-        else filt.repo_ids
-    )
+    if breakout == CompoundingRiskScope.TEAM:
+        if filt.team_ids and team_filtered_repo_scope_ids is None:
+            team_filtered_repo_scope_ids = await _repo_scope_ids_for_team_fallback(
+                client,
+                authorized_org_id,
+                repo_ids=filt.repo_ids,
+                team_ids=filt.team_ids,
+            )
+        trend_repo_scope_ids = (
+            team_filtered_repo_scope_ids if filt.team_ids else fallback_repo_scope_ids
+        )
+    else:
+        trend_repo_scope_ids = filt.repo_ids
     trend_rows = await _fetch_repo_trend(
         client, authorized_org_id, day, trend_days, trend_repo_scope_ids
     )

--- a/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
+++ b/src/dev_health_ops/api/graphql/resolvers/compounding_risk.py
@@ -64,16 +64,52 @@ def _severity_from_str(value: Any) -> CompoundingRiskSeverity:
 # at runtime against the live sink and is replaced with the canonical helper.
 
 
-async def _latest_day_for_org(client: Any, org_id: str) -> date | None:
-    rows = await query_dicts(
-        client,
-        """
-        SELECT max(day) AS day
-        FROM compounding_risk_daily
-        WHERE org_id = {org_id:String}
-        """,
-        {"org_id": org_id},
-    )
+async def _latest_day_for_org(
+    client: Any,
+    org_id: str,
+    *,
+    scope: str,
+    scope_ids: list[str] | None,
+) -> date | None:
+    query = """
+        SELECT maxOrNull(day) AS day
+        FROM (
+            SELECT
+                day,
+                count() AS row_count,
+                countIf(score IS NULL) AS missing_scores
+            FROM (
+                SELECT
+                    day,
+                    scope_id,
+                    argMax(compounding_risk, computed_at) AS score
+                FROM compounding_risk_daily
+                WHERE org_id = {org_id:String}
+                  AND scope = {scope:String}
+    """
+    params: dict[str, Any] = {"org_id": org_id, "scope": scope}
+    if scope_ids:
+        bounded = list(scope_ids)[:MAX_ROWS]
+        if scope == "repo":
+            query += """
+                  AND scope_id IN (
+                      SELECT toString(id) FROM repos
+                      WHERE org_id = {org_id:String}
+                        AND (repo IN {repo_ids:Array(String)} OR toString(id) IN {repo_ids:Array(String)})
+                  )
+            """
+            params["repo_ids"] = bounded
+        else:
+            query += "\n                  AND scope_id IN {scope_ids:Array(String)}"
+            params["scope_ids"] = bounded
+    query += """
+                GROUP BY day, scope_id
+            )
+            GROUP BY day
+        )
+        WHERE row_count > 0 AND missing_scores = 0
+    """
+    rows = await query_dicts(client, query, params)
     if not rows:
         return None
     value = rows[0].get("day")
@@ -427,7 +463,30 @@ async def resolve_compounding_risk(
     breakout = filt.breakout
     trend_days = max(1, min(filt.trend_days, MAX_TREND_DAYS))
 
-    day = filt.day or await _latest_day_for_org(client, authorized_org_id)
+    day: date | None
+    if filt.day is not None:
+        day = filt.day
+    elif breakout == CompoundingRiskScope.TEAM:
+        day = await _latest_day_for_org(
+            client,
+            authorized_org_id,
+            scope="team",
+            scope_ids=filt.team_ids,
+        )
+        if day is None:
+            day = await _latest_day_for_org(
+                client,
+                authorized_org_id,
+                scope="repo",
+                scope_ids=filt.repo_ids,
+            )
+    else:
+        day = await _latest_day_for_org(
+            client,
+            authorized_org_id,
+            scope="repo",
+            scope_ids=filt.repo_ids,
+        )
     if day is None:
         return CompoundingRiskResult(
             org_id=authorized_org_id,

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -251,9 +251,26 @@ _COMPOUNDING_RISK_SQL = """
     FROM compounding_risk_daily
     WHERE org_id = {org_id:String}
       AND day = (
-          SELECT max(day)
-          FROM compounding_risk_daily
-          WHERE org_id = {org_id:String}
+          SELECT maxOrNull(day)
+          FROM (
+              SELECT
+                  day,
+                  count() AS row_count,
+                  countIf(score IS NULL) AS missing_scores
+              FROM (
+                  SELECT
+                      day,
+                      scope,
+                      scope_id,
+                      argMax(compounding_risk, computed_at) AS score
+                  FROM compounding_risk_daily
+                  WHERE org_id = {org_id:String}
+                  {latest_scope_filter}
+                  GROUP BY day, scope, scope_id
+              )
+              GROUP BY day
+          )
+          WHERE row_count > 0 AND missing_scores = 0
       )
 """
 
@@ -775,8 +792,14 @@ async def _fetch_risk_signals(
     org_id: str,
     data_confidence: HomeDataConfidence,
 ) -> list[HomeSignal]:
-    query = _COMPOUNDING_RISK_SQL
+    latest_scope_filter = ""
     params: dict[str, Any] = {"org_id": org_id}
+    if filters.scope.level in {"team", "repo"} and filters.scope.ids:
+        latest_scope_filter = """
+                AND scope = {scope:String}
+                AND scope_id IN {scope_ids:Array(String)}
+        """
+    query = _COMPOUNDING_RISK_SQL.replace("{latest_scope_filter}", latest_scope_filter)
     if filters.scope.level in {"team", "repo"} and filters.scope.ids:
         query += """
       AND scope = {scope:String}

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -245,33 +245,40 @@ _COMPOUNDING_RISK_SQL = """
     SELECT
         scope,
         scope_id,
-        argMax(compounding_risk, computed_at) AS score,
-        argMax(severity,         computed_at) AS severity,
-        max(computed_at)                      AS latest_computed_at
-    FROM compounding_risk_daily
-    WHERE org_id = {org_id:String}
-      AND day = (
-          SELECT maxOrNull(day)
-          FROM (
-              SELECT
-                  day,
-                  count() AS row_count,
-                  countIf(score IS NULL) AS missing_scores
+        tupleElement(latest_row, 1) AS score,
+        tupleElement(latest_row, 2) AS severity,
+        tupleElement(latest_row, 3) AS latest_computed_at
+    FROM (
+        SELECT
+            scope,
+            scope_id,
+            argMax(tuple(compounding_risk, severity, computed_at), computed_at) AS latest_row
+        FROM compounding_risk_daily
+        WHERE org_id = {org_id:String}
+          AND day = (
+              SELECT maxOrNull(day)
               FROM (
                   SELECT
                       day,
-                      scope,
-                      scope_id,
-                      argMax(compounding_risk, computed_at) AS score
-                  FROM compounding_risk_daily
-                  WHERE org_id = {org_id:String}
-                  {latest_scope_filter}
-                  GROUP BY day, scope, scope_id
+                      count() AS row_count,
+                      countIf(tupleElement(latest_row, 1) IS NULL) AS missing_scores
+                  FROM (
+                      SELECT
+                          day,
+                          scope,
+                          scope_id,
+                          argMax(tuple(compounding_risk), computed_at) AS latest_row
+                      FROM compounding_risk_daily
+                      WHERE org_id = {org_id:String}
+                        AND day >= {start_day:Date}
+                        AND day <= {end_day:Date}
+                      {latest_scope_filter}
+                      GROUP BY day, scope, scope_id
+                  )
+                  GROUP BY day
               )
-              GROUP BY day
+              WHERE row_count > 0 AND missing_scores = 0
           )
-          WHERE row_count > 0 AND missing_scores = 0
-      )
 """
 
 
@@ -789,11 +796,17 @@ async def _fetch_risk_signals(
     sink: BaseMetricsSink,
     *,
     filters: MetricFilter,
+    start_day: date,
+    end_day: date,
     org_id: str,
     data_confidence: HomeDataConfidence,
 ) -> list[HomeSignal]:
     latest_scope_filter = ""
-    params: dict[str, Any] = {"org_id": org_id}
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "start_day": start_day,
+        "end_day": end_day,
+    }
     if filters.scope.level in {"team", "repo"} and filters.scope.ids:
         latest_scope_filter = """
                 AND scope = {scope:String}
@@ -808,7 +821,8 @@ async def _fetch_risk_signals(
         params["scope"] = filters.scope.level
         params["scope_ids"] = filters.scope.ids
     query += """
-    GROUP BY scope, scope_id
+        GROUP BY scope, scope_id
+    )
     ORDER BY score DESC NULLS LAST
     LIMIT 5
     """
@@ -1037,6 +1051,8 @@ async def build_home_response(
             _fetch_risk_signals(
                 sink,
                 filters=filters,
+                start_day=start_day,
+                end_day=end_day,
                 org_id=org_id,
                 data_confidence=data_confidence,
             ),

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -271,7 +271,7 @@ _COMPOUNDING_RISK_SQL = """
                       FROM compounding_risk_daily
                       WHERE org_id = {org_id:String}
                         AND day >= {start_day:Date}
-                        AND day <= {end_day:Date}
+                        AND day < {end_day:Date}
                       {latest_scope_filter}
                       GROUP BY day, scope, scope_id
                   )

--- a/src/dev_health_ops/metrics/compounding_risk.py
+++ b/src/dev_health_ops/metrics/compounding_risk.py
@@ -307,6 +307,7 @@ def compute_compounding_risk(
 
 #: Window for the complexity delta computation in days.
 COMPLEXITY_WINDOW_DAYS: Final[int] = 30
+METRIC_INPUT_WINDOW_DAYS: Final[int] = COMPLEXITY_WINDOW_DAYS
 
 
 def load_repo_complexity_delta_30d(
@@ -364,6 +365,83 @@ def load_repo_complexity_delta_30d(
     return (second_f - first_f) / max(first_f, 1.0)
 
 
+def _coalesce_non_null(current: float | None, carried: float | None) -> float | None:
+    return current if current is not None else carried
+
+
+def _load_latest_repo_metric_inputs(
+    sink: Any,
+    *,
+    repo_id: str,
+    day: date,
+    org_id: str,
+    window_days: int = METRIC_INPUT_WINDOW_DAYS,
+) -> dict[str, float | None]:
+    if window_days < 1:
+        raise ValueError("window_days must be >= 1")
+
+    window_start = day - timedelta(days=window_days - 1)
+    query = """
+        SELECT
+            rework_churn_ratio_30d AS rework_churn,
+            single_owner_file_ratio_30d AS single_owner_ratio,
+            code_ownership_gini AS ownership_gini,
+            bus_factor AS bus_factor,
+            pr_first_review_p90_hours AS review_latency_p90h
+        FROM repo_metrics_daily
+        WHERE repo_id = {repo_id:UUID}
+          AND org_id = {org_id:String}
+          AND day >= {start:Date} AND day <= {end:Date}
+        ORDER BY day DESC, computed_at DESC
+    """
+    rows = sink.query_dicts(
+        query,
+        {"repo_id": repo_id, "org_id": org_id, "start": window_start, "end": day},
+    )
+    if not rows:
+        return {}
+    resolved: dict[str, float | None] = {
+        "rework_churn": None,
+        "single_owner_ratio": None,
+        "ownership_gini": None,
+        "bus_factor": None,
+        "review_latency_p90h": None,
+    }
+    for row in rows:
+        for key, value in row.items():
+            if key not in resolved or resolved[key] is not None:
+                continue
+            resolved[key] = _nullable_float(value)
+    return {
+        "rework_churn": resolved["rework_churn"],
+        "single_owner_ratio": resolved["single_owner_ratio"],
+        "ownership_gini": resolved["ownership_gini"],
+        "bus_factor": resolved["bus_factor"],
+        "review_latency_p90h": resolved["review_latency_p90h"],
+    }
+
+
+def _load_latest_repo_complexity_delta(
+    sink: Any,
+    *,
+    repo_id: str,
+    day: date,
+    org_id: str,
+    window_days: int = METRIC_INPUT_WINDOW_DAYS,
+) -> float | None:
+    if window_days < 1:
+        raise ValueError("window_days must be >= 1")
+
+    for days_back in range(window_days):
+        candidate_day = day - timedelta(days=days_back)
+        delta = load_repo_complexity_delta_30d(
+            sink, repo_id=repo_id, day=candidate_day, org_id=org_id
+        )
+        if delta is not None:
+            return delta
+    return None
+
+
 def build_compounding_risk_rows_for_day(
     *,
     sink: Any,
@@ -398,22 +476,41 @@ def build_compounding_risk_rows_for_day(
         repo_id = getattr(row, "repo_id", None)
         if repo_id is None:
             continue
+        repo_id_str = str(repo_id)
         complexity_delta = load_repo_complexity_delta_30d(
-            sink, repo_id=str(repo_id), day=day, org_id=org_id
+            sink, repo_id=repo_id_str, day=day, org_id=org_id
+        )
+        if complexity_delta is None:
+            complexity_delta = _load_latest_repo_complexity_delta(
+                sink, repo_id=repo_id_str, day=day, org_id=org_id
+            )
+        carried_inputs = _load_latest_repo_metric_inputs(
+            sink, repo_id=repo_id_str, day=day, org_id=org_id
         )
         inputs = CompoundingInputs(
-            rework_churn=_nullable_float(getattr(row, "rework_churn_ratio_30d", None)),
+            rework_churn=_coalesce_non_null(
+                _nullable_float(getattr(row, "rework_churn_ratio_30d", None)),
+                carried_inputs.get("rework_churn"),
+            ),
             complexity_delta=complexity_delta,
-            review_latency_p90h=_nullable_float(
-                getattr(row, "pr_first_review_p90_hours", None)
+            review_latency_p90h=_coalesce_non_null(
+                _nullable_float(getattr(row, "pr_first_review_p90_hours", None)),
+                carried_inputs.get("review_latency_p90h"),
             ),
-            single_owner_ratio=_nullable_float(
-                getattr(row, "single_owner_file_ratio_30d", None)
+            single_owner_ratio=_coalesce_non_null(
+                _nullable_float(getattr(row, "single_owner_file_ratio_30d", None)),
+                carried_inputs.get("single_owner_ratio"),
             ),
-            ownership_gini=_nullable_float(getattr(row, "code_ownership_gini", None)),
-            bus_factor=_nullable_float(getattr(row, "bus_factor", None)),
+            ownership_gini=_coalesce_non_null(
+                _nullable_float(getattr(row, "code_ownership_gini", None)),
+                carried_inputs.get("ownership_gini"),
+            ),
+            bus_factor=_coalesce_non_null(
+                _nullable_float(getattr(row, "bus_factor", None)),
+                carried_inputs.get("bus_factor"),
+            ),
         )
-        repo_inputs_for_team[str(repo_id)] = inputs
+        repo_inputs_for_team[repo_id_str] = inputs
         repo_rows.append(
             compute_compounding_risk(
                 day=day,

--- a/src/dev_health_ops/metrics/compounding_risk.py
+++ b/src/dev_health_ops/metrics/compounding_risk.py
@@ -307,7 +307,6 @@ def compute_compounding_risk(
 
 #: Window for the complexity delta computation in days.
 COMPLEXITY_WINDOW_DAYS: Final[int] = 30
-METRIC_INPUT_WINDOW_DAYS: Final[int] = COMPLEXITY_WINDOW_DAYS
 
 
 def load_repo_complexity_delta_30d(
@@ -365,83 +364,6 @@ def load_repo_complexity_delta_30d(
     return (second_f - first_f) / max(first_f, 1.0)
 
 
-def _coalesce_non_null(current: float | None, carried: float | None) -> float | None:
-    return current if current is not None else carried
-
-
-def _load_latest_repo_metric_inputs(
-    sink: Any,
-    *,
-    repo_id: str,
-    day: date,
-    org_id: str,
-    window_days: int = METRIC_INPUT_WINDOW_DAYS,
-) -> dict[str, float | None]:
-    if window_days < 1:
-        raise ValueError("window_days must be >= 1")
-
-    window_start = day - timedelta(days=window_days - 1)
-    query = """
-        SELECT
-            rework_churn_ratio_30d AS rework_churn,
-            single_owner_file_ratio_30d AS single_owner_ratio,
-            code_ownership_gini AS ownership_gini,
-            bus_factor AS bus_factor,
-            pr_first_review_p90_hours AS review_latency_p90h
-        FROM repo_metrics_daily
-        WHERE repo_id = {repo_id:UUID}
-          AND org_id = {org_id:String}
-          AND day >= {start:Date} AND day <= {end:Date}
-        ORDER BY day DESC, computed_at DESC
-    """
-    rows = sink.query_dicts(
-        query,
-        {"repo_id": repo_id, "org_id": org_id, "start": window_start, "end": day},
-    )
-    if not rows:
-        return {}
-    resolved: dict[str, float | None] = {
-        "rework_churn": None,
-        "single_owner_ratio": None,
-        "ownership_gini": None,
-        "bus_factor": None,
-        "review_latency_p90h": None,
-    }
-    for row in rows:
-        for key, value in row.items():
-            if key not in resolved or resolved[key] is not None:
-                continue
-            resolved[key] = _nullable_float(value)
-    return {
-        "rework_churn": resolved["rework_churn"],
-        "single_owner_ratio": resolved["single_owner_ratio"],
-        "ownership_gini": resolved["ownership_gini"],
-        "bus_factor": resolved["bus_factor"],
-        "review_latency_p90h": resolved["review_latency_p90h"],
-    }
-
-
-def _load_latest_repo_complexity_delta(
-    sink: Any,
-    *,
-    repo_id: str,
-    day: date,
-    org_id: str,
-    window_days: int = METRIC_INPUT_WINDOW_DAYS,
-) -> float | None:
-    if window_days < 1:
-        raise ValueError("window_days must be >= 1")
-
-    for days_back in range(window_days):
-        candidate_day = day - timedelta(days=days_back)
-        delta = load_repo_complexity_delta_30d(
-            sink, repo_id=repo_id, day=candidate_day, org_id=org_id
-        )
-        if delta is not None:
-            return delta
-    return None
-
-
 def build_compounding_risk_rows_for_day(
     *,
     sink: Any,
@@ -480,35 +402,17 @@ def build_compounding_risk_rows_for_day(
         complexity_delta = load_repo_complexity_delta_30d(
             sink, repo_id=repo_id_str, day=day, org_id=org_id
         )
-        if complexity_delta is None:
-            complexity_delta = _load_latest_repo_complexity_delta(
-                sink, repo_id=repo_id_str, day=day, org_id=org_id
-            )
-        carried_inputs = _load_latest_repo_metric_inputs(
-            sink, repo_id=repo_id_str, day=day, org_id=org_id
-        )
         inputs = CompoundingInputs(
-            rework_churn=_coalesce_non_null(
-                _nullable_float(getattr(row, "rework_churn_ratio_30d", None)),
-                carried_inputs.get("rework_churn"),
-            ),
+            rework_churn=_nullable_float(getattr(row, "rework_churn_ratio_30d", None)),
             complexity_delta=complexity_delta,
-            review_latency_p90h=_coalesce_non_null(
-                _nullable_float(getattr(row, "pr_first_review_p90_hours", None)),
-                carried_inputs.get("review_latency_p90h"),
+            review_latency_p90h=_nullable_float(
+                getattr(row, "pr_first_review_p90_hours", None)
             ),
-            single_owner_ratio=_coalesce_non_null(
-                _nullable_float(getattr(row, "single_owner_file_ratio_30d", None)),
-                carried_inputs.get("single_owner_ratio"),
+            single_owner_ratio=_nullable_float(
+                getattr(row, "single_owner_file_ratio_30d", None)
             ),
-            ownership_gini=_coalesce_non_null(
-                _nullable_float(getattr(row, "code_ownership_gini", None)),
-                carried_inputs.get("ownership_gini"),
-            ),
-            bus_factor=_coalesce_non_null(
-                _nullable_float(getattr(row, "bus_factor", None)),
-                carried_inputs.get("bus_factor"),
-            ),
+            ownership_gini=_nullable_float(getattr(row, "code_ownership_gini", None)),
+            bus_factor=_nullable_float(getattr(row, "bus_factor", None)),
         )
         repo_inputs_for_team[repo_id_str] = inputs
         repo_rows.append(

--- a/src/dev_health_ops/recommendations/loader.py
+++ b/src/dev_health_ops/recommendations/loader.py
@@ -309,12 +309,15 @@ class ClickHouseMetricsLoader:
         params = self._p(team_id, ws, we)
         query = f"""
             SELECT
-                argMax(compounding_risk, computed_at) AS score,
-                argMax(severity,         computed_at) AS severity
-            FROM compounding_risk_daily
-            WHERE scope = 'team'
-              AND scope_id = %(team_id)s
-              AND day >= %(start)s AND day < %(end)s {oc}
+                tupleElement(latest_row, 1) AS score,
+                tupleElement(latest_row, 2) AS severity
+            FROM (
+                SELECT argMax(tuple(compounding_risk, severity), computed_at) AS latest_row
+                FROM compounding_risk_daily
+                WHERE scope = 'team'
+                  AND scope_id = %(team_id)s
+                  AND day >= %(start)s AND day < %(end)s {oc}
+            )
         """
         rows = self._qd(query, params)
         if not rows:

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -57,7 +57,12 @@ async def _fixture_compounding_risk(sink: CapturingSink) -> None:
         _load_team_assignments,
     )
 
-    await _latest_day_for_org(sink, SAMPLE_ORG_ID)
+    await _latest_day_for_org(
+        sink, SAMPLE_ORG_ID, scope="repo", scope_ids=[SAMPLE_REPO_ID]
+    )
+    await _latest_day_for_org(
+        sink, SAMPLE_ORG_ID, scope="team", scope_ids=[SAMPLE_TEAM_ID]
+    )
 
     # Both scope=repo and scope=team paths plus with/without scope_ids filter
     # — bug #2 (max(computed_at) AS computed_at) lives in this query.

--- a/tests/api/graphql/test_compounding_risk_resolver.py
+++ b/tests/api/graphql/test_compounding_risk_resolver.py
@@ -854,14 +854,22 @@ async def test_team_breakout_uses_persisted_team_rows_when_available() -> None:
             _qresult(columns, persisted_team_rows),  # team-scope rows EXIST
             _qresult(  # teams query for label lookup
                 ["id", "name", "repo_patterns"],
-                [["team-X", "Platform", []]],
+                [["team-X", "Platform", ["repo-9"]]],
+            ),
+            _qresult(
+                ["id", "name", "repo_patterns"], [["team-X", "Platform", ["repo-9"]]]
             ),
             _qresult([], []),  # trend
         ],
     )
 
     result = await resolve_compounding_risk(
-        ctx, ORG_ID, CompoundingRiskFilterInput(breakout=CompoundingRiskScope.TEAM)
+        ctx,
+        ORG_ID,
+        CompoundingRiskFilterInput(
+            breakout=CompoundingRiskScope.TEAM,
+            team_ids=["team-X"],
+        ),
     )
 
     assert len(result.rows) == 1
@@ -876,6 +884,11 @@ async def test_team_breakout_uses_persisted_team_rows_when_available() -> None:
     # Components and audit-trail come from the persisted row.
     assert team_row.components.churn_norm == pytest.approx(0.70)
     assert team_row.weights.churn == pytest.approx(0.30)
+
+    trend_params: dict[str, Any] = ctx.client.query.call_args_list[-1].kwargs[
+        "parameters"
+    ]
+    assert trend_params["repo_ids"] == ["repo-9"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/graphql/test_compounding_risk_resolver.py
+++ b/tests/api/graphql/test_compounding_risk_resolver.py
@@ -13,14 +13,20 @@ verify:
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
+import os
+import uuid
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import MagicMock
+from urllib.parse import urlparse
 
 import pytest
 
 from dev_health_ops.api.graphql.context import GraphQLContext
 from dev_health_ops.api.graphql.resolvers.compounding_risk import (
+    _fetch_latest_rows,
+    _latest_day_for_org,
     resolve_compounding_risk,
 )
 from dev_health_ops.api.graphql.types.compounding_risk import (
@@ -34,6 +40,103 @@ ORG_ID = "org-test"
 NOW = datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc)
 DAY = date(2026, 5, 20)
 PARTIAL_DAY = date(2026, 5, 21)
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+LIVE_CLICKHOUSE = pytest.mark.skipif(
+    not CLICKHOUSE_URI,
+    reason="Requires CLICKHOUSE_URI pointed at an ISOLATED scratch DB",
+)
+RISK_COLUMNS = [
+    "org_id",
+    "day",
+    "scope",
+    "scope_id",
+    "compounding_risk",
+    "severity",
+    "churn_norm",
+    "complexity_norm",
+    "ownership_norm",
+    "review_norm",
+    "rework_churn",
+    "complexity_delta",
+    "bus_factor",
+    "ownership_gini",
+    "single_owner_ratio",
+    "review_latency_p90h",
+    "w_churn",
+    "w_complexity",
+    "w_ownership",
+    "w_review",
+    "threshold_elevated",
+    "threshold_high",
+    "computed_at",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class RiskSeed:
+    org_id: str
+    day: date
+    score: float | None
+    severity: str
+    computed_at: datetime
+
+
+def _scratch_db() -> str:
+    assert CLICKHOUSE_URI is not None
+    return (urlparse(CLICKHOUSE_URI).path or "").lstrip("/")
+
+
+def _cleanup_risk_rows(sink: Any, org_id: str) -> None:
+    sink.client.command(
+        "ALTER TABLE compounding_risk_daily DELETE WHERE org_id = {org_id:String} "
+        "SETTINGS mutations_sync=2",
+        parameters={"org_id": org_id},
+    )
+
+
+def _risk_row(seed: RiskSeed) -> list[Any]:
+    return [
+        seed.org_id,
+        seed.day,
+        "repo",
+        "repo-live",
+        seed.score,
+        seed.severity,
+        seed.score,
+        seed.score,
+        seed.score,
+        seed.score,
+        seed.score,
+        seed.score,
+        seed.score,
+        seed.score,
+        seed.score,
+        seed.score,
+        0.30,
+        0.30,
+        0.20,
+        0.20,
+        0.40,
+        0.65,
+        seed.computed_at,
+    ]
+
+
+@pytest.fixture(scope="module")
+def clickhouse_sink():
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    assert CLICKHOUSE_URI is not None
+    db = _scratch_db()
+    if db in ("", "default"):
+        pytest.skip(
+            "refusing to run against the 'default' database; point CLICKHOUSE_URI "
+            "at an isolated scratch DB (e.g. .../ci_live_2855)"
+        )
+    sink = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    sink.ensure_schema(force=True)
+    yield sink
+    sink.close()
 
 
 def _ctx() -> GraphQLContext:
@@ -134,12 +237,134 @@ async def test_latest_day_skips_partial_null_day_and_returns_complete_score() ->
         "parameters"
     ]
     assert "maxOrNull(day) AS day" in latest_query
-    assert "argMax(compounding_risk, computed_at) AS score" in latest_query
-    assert "countIf(score IS NULL) AS missing_scores" in latest_query
+    assert "argMax(tuple(compounding_risk), computed_at) AS latest_row" in latest_query
+    assert (
+        "countIf(tupleElement(latest_row, 1) IS NULL) AS missing_scores" in latest_query
+    )
     assert "missing_scores = 0" in latest_query
-    assert latest_params == {"org_id": ORG_ID, "scope": "repo"}
+    assert latest_params["org_id"] == ORG_ID
+    assert latest_params["scope"] == "repo"
+    assert "start_day" in latest_params
+    assert "end_day" in latest_params
     assert result.rows[0].day == DAY
     assert result.rows[0].score == pytest.approx(0.4996)
+
+
+@pytest.mark.clickhouse
+@LIVE_CLICKHOUSE
+@pytest.mark.asyncio
+async def test_live_latest_day_preserves_newer_null_score(clickhouse_sink: Any) -> None:
+    org_id = f"test-chaos-2855-{uuid.uuid4()}"
+    end_day = datetime.now(timezone.utc).date()
+    complete_day = end_day - timedelta(days=1)
+    start_day = complete_day - timedelta(days=1)
+    earlier_run = datetime(2026, 5, 21, 1, 0, tzinfo=timezone.utc)
+    later_run = datetime(2026, 5, 21, 2, 0, tzinfo=timezone.utc)
+    try:
+        clickhouse_sink.client.insert(
+            "compounding_risk_daily",
+            [
+                _risk_row(
+                    RiskSeed(
+                        org_id=org_id,
+                        day=complete_day,
+                        score=0.42,
+                        severity="elevated",
+                        computed_at=earlier_run,
+                    )
+                ),
+                _risk_row(
+                    RiskSeed(
+                        org_id=org_id,
+                        day=end_day,
+                        score=0.88,
+                        severity="high",
+                        computed_at=earlier_run,
+                    )
+                ),
+                _risk_row(
+                    RiskSeed(
+                        org_id=org_id,
+                        day=end_day,
+                        score=None,
+                        severity="unknown",
+                        computed_at=later_run,
+                    )
+                ),
+            ],
+            column_names=RISK_COLUMNS,
+        )
+
+        latest_day = await _latest_day_for_org(
+            clickhouse_sink,
+            org_id,
+            scope="repo",
+            scope_ids=None,
+            start_day=start_day,
+            end_day=end_day,
+        )
+        latest_rows = await _fetch_latest_rows(
+            clickhouse_sink,
+            org_id=org_id,
+            day=end_day,
+            scope="repo",
+            scope_ids=None,
+        )
+        ctx = GraphQLContext(org_id=org_id, db_url=CLICKHOUSE_URI or "")
+        ctx.client = clickhouse_sink
+
+        result = await resolve_compounding_risk(
+            ctx, org_id, CompoundingRiskFilterInput(trend_days=3)
+        )
+
+        assert latest_day == complete_day
+        assert latest_rows[0]["score"] is None
+        assert latest_rows[0]["severity"] == "unknown"
+        assert result.rows[0].day == complete_day
+        assert result.rows[0].score == pytest.approx(0.42)
+    finally:
+        _cleanup_risk_rows(clickhouse_sink, org_id)
+
+
+@pytest.mark.clickhouse
+@LIVE_CLICKHOUSE
+@pytest.mark.asyncio
+async def test_live_latest_day_ignores_scored_days_outside_window(
+    clickhouse_sink: Any,
+) -> None:
+    org_id = f"test-chaos-2855-window-{uuid.uuid4()}"
+    end_day = datetime.now(timezone.utc).date()
+    start_day = end_day - timedelta(days=2)
+    outside_day = start_day - timedelta(days=1)
+    try:
+        clickhouse_sink.client.insert(
+            "compounding_risk_daily",
+            [
+                _risk_row(
+                    RiskSeed(
+                        org_id=org_id,
+                        day=outside_day,
+                        score=0.77,
+                        severity="high",
+                        computed_at=datetime(2026, 5, 20, tzinfo=timezone.utc),
+                    )
+                )
+            ],
+            column_names=RISK_COLUMNS,
+        )
+
+        latest_day = await _latest_day_for_org(
+            clickhouse_sink,
+            org_id,
+            scope="repo",
+            scope_ids=None,
+            start_day=start_day,
+            end_day=end_day,
+        )
+
+        assert latest_day is None
+    finally:
+        _cleanup_risk_rows(clickhouse_sink, org_id)
 
 
 @pytest.mark.asyncio
@@ -351,7 +576,11 @@ async def test_latest_day_selection_is_repo_scope_and_filter_isolated() -> None:
     ]
     assert "AND scope = {scope:String}" in latest_query
     _assert_scope_id_slug_or_uuid_predicate(latest_query)
-    assert latest_params == {"org_id": ORG_ID, "scope": "repo", "repo_ids": [slug]}
+    assert latest_params["org_id"] == ORG_ID
+    assert latest_params["scope"] == "repo"
+    assert latest_params["repo_ids"] == [slug]
+    assert "start_day" in latest_params
+    assert "end_day" in latest_params
 
 
 @pytest.mark.asyncio
@@ -382,11 +611,11 @@ async def test_latest_day_selection_is_team_scope_and_filter_isolated() -> None:
     ]
     assert "AND scope = {scope:String}" in latest_query
     assert "AND scope_id IN {scope_ids:Array(String)}" in latest_query
-    assert latest_params == {
-        "org_id": ORG_ID,
-        "scope": "team",
-        "scope_ids": ["team-A"],
-    }
+    assert latest_params["org_id"] == ORG_ID
+    assert latest_params["scope"] == "team"
+    assert latest_params["scope_ids"] == ["team-A"]
+    assert "start_day" in latest_params
+    assert "end_day" in latest_params
 
 
 @pytest.mark.asyncio
@@ -531,7 +760,6 @@ async def test_team_breakout_filters_by_team_ids() -> None:
     ]
     base = [0.30, 0.30, 0.20, 0.20, 0.40, 0.65]
     rows = [
-        ["repo-1", 0.8, "high", *base, NOW],
         ["repo-2", 0.4, "elevated", *base, NOW],
     ]
     teams_rows = [
@@ -541,6 +769,8 @@ async def test_team_breakout_filters_by_team_ids() -> None:
     _setup_client(
         ctx.client,
         [
+            _qresult(["day"], [[None]]),
+            _qresult(["id", "name", "repo_patterns"], teams_rows),
             _qresult(["day"], [[DAY]]),
             _qresult([], []),  # team-scope query empty → fallback
             _qresult(columns, rows),  # repo rows for fallback aggregation
@@ -557,6 +787,15 @@ async def test_team_breakout_filters_by_team_ids() -> None:
         ),
     )
     assert [r.scope_id for r in result.rows] == ["team-B"]
+
+    fallback_latest_params: dict[str, Any] = ctx.client.query.call_args_list[2].kwargs[
+        "parameters"
+    ]
+    fallback_repo_params: dict[str, Any] = ctx.client.query.call_args_list[4].kwargs[
+        "parameters"
+    ]
+    assert fallback_latest_params["repo_ids"] == ["repo-2"]
+    assert fallback_repo_params["repo_ids"] == ["repo-2"]
 
 
 @pytest.mark.asyncio

--- a/tests/api/graphql/test_compounding_risk_resolver.py
+++ b/tests/api/graphql/test_compounding_risk_resolver.py
@@ -33,6 +33,7 @@ from dev_health_ops.api.graphql.types.compounding_risk import (
 ORG_ID = "org-test"
 NOW = datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc)
 DAY = date(2026, 5, 20)
+PARTIAL_DAY = date(2026, 5, 21)
 
 
 def _ctx() -> GraphQLContext:
@@ -82,6 +83,63 @@ async def test_empty_state_when_no_data_for_org() -> None:
     assert result.org_id == ORG_ID
     assert result.rows == []
     assert result.trend == []
+
+
+@pytest.mark.asyncio
+async def test_empty_state_when_no_scored_day_for_org() -> None:
+    ctx = _ctx()
+    _setup_client(ctx.client, [_qresult(["day"], [[None]])])
+
+    result = await resolve_compounding_risk(ctx, ORG_ID)
+
+    latest_query: str = ctx.client.query.call_args_list[0].args[0]
+    assert "missing_scores = 0" in latest_query
+    assert result.org_id == ORG_ID
+    assert result.rows == []
+    assert result.trend == []
+
+
+@pytest.mark.asyncio
+async def test_latest_day_skips_partial_null_day_and_returns_complete_score() -> None:
+    ctx = _ctx()
+    columns = [
+        "scope_id",
+        "score",
+        "severity",
+        "w_churn",
+        "w_complexity",
+        "w_ownership",
+        "w_review",
+        "threshold_elevated",
+        "threshold_high",
+        "latest_computed_at",
+    ]
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult(
+                columns,
+                [["repo-1", 0.4996, "elevated", 0.3, 0.3, 0.2, 0.2, 0.4, 0.65, NOW]],
+            ),
+            _qresult(["repo_id", "full_name"], [["repo-1", "acme/backend"]]),
+            _qresult(["day", "avg_score"], [[DAY, 0.4996], [PARTIAL_DAY, None]]),
+        ],
+    )
+
+    result = await resolve_compounding_risk(ctx, ORG_ID)
+
+    latest_query: str = ctx.client.query.call_args_list[0].args[0]
+    latest_params: dict[str, Any] = ctx.client.query.call_args_list[0].kwargs[
+        "parameters"
+    ]
+    assert "maxOrNull(day) AS day" in latest_query
+    assert "argMax(compounding_risk, computed_at) AS score" in latest_query
+    assert "countIf(score IS NULL) AS missing_scores" in latest_query
+    assert "missing_scores = 0" in latest_query
+    assert latest_params == {"org_id": ORG_ID, "scope": "repo"}
+    assert result.rows[0].day == DAY
+    assert result.rows[0].score == pytest.approx(0.4996)
 
 
 @pytest.mark.asyncio
@@ -268,6 +326,67 @@ async def test_repo_ids_filter_resolves_slugs_or_uuids_in_latest_and_trend_queri
     trend_query: str = ctx.client.query.call_args_list[1].args[0]
     _assert_scope_id_slug_or_uuid_predicate(latest_query)
     _assert_scope_id_slug_or_uuid_predicate(trend_query)
+
+
+@pytest.mark.asyncio
+async def test_latest_day_selection_is_repo_scope_and_filter_isolated() -> None:
+    ctx = _ctx()
+    slug = "full-chaos/dev-health-ops"
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult([], []),
+            _qresult([], []),
+        ],
+    )
+
+    await resolve_compounding_risk(
+        ctx, ORG_ID, CompoundingRiskFilterInput(repo_ids=[slug])
+    )
+
+    latest_query: str = ctx.client.query.call_args_list[0].args[0]
+    latest_params: dict[str, Any] = ctx.client.query.call_args_list[0].kwargs[
+        "parameters"
+    ]
+    assert "AND scope = {scope:String}" in latest_query
+    _assert_scope_id_slug_or_uuid_predicate(latest_query)
+    assert latest_params == {"org_id": ORG_ID, "scope": "repo", "repo_ids": [slug]}
+
+
+@pytest.mark.asyncio
+async def test_latest_day_selection_is_team_scope_and_filter_isolated() -> None:
+    ctx = _ctx()
+    _setup_client(
+        ctx.client,
+        [
+            _qresult(["day"], [[DAY]]),
+            _qresult([], []),
+            _qresult([], []),
+            _qresult([], []),
+            _qresult([], []),
+        ],
+    )
+
+    await resolve_compounding_risk(
+        ctx,
+        ORG_ID,
+        CompoundingRiskFilterInput(
+            breakout=CompoundingRiskScope.TEAM, team_ids=["team-A"]
+        ),
+    )
+
+    latest_query: str = ctx.client.query.call_args_list[0].args[0]
+    latest_params: dict[str, Any] = ctx.client.query.call_args_list[0].kwargs[
+        "parameters"
+    ]
+    assert "AND scope = {scope:String}" in latest_query
+    assert "AND scope_id IN {scope_ids:Array(String)}" in latest_query
+    assert latest_params == {
+        "org_id": ORG_ID,
+        "scope": "team",
+        "scope_ids": ["team-A"],
+    }
 
 
 @pytest.mark.asyncio

--- a/tests/api/services/test_home_cockpit_contract.py
+++ b/tests/api/services/test_home_cockpit_contract.py
@@ -310,6 +310,8 @@ async def test_fetch_risk_signals_uses_latest_scored_day_query(
     assert "argMax(tuple(compounding_risk), computed_at) AS latest_row" in query
     assert "countIf(tupleElement(latest_row, 1) IS NULL) AS missing_scores" in query
     assert "missing_scores = 0" in query
+    assert "AND day < {end_day:Date}" in query
+    assert "AND day <= {end_day:Date}" not in query
     assert parameters == {
         "org_id": "org-test",
         "start_day": date(2026, 5, 1),

--- a/tests/api/services/test_home_cockpit_contract.py
+++ b/tests/api/services/test_home_cockpit_contract.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any
 from unittest.mock import MagicMock
 
@@ -297,6 +297,8 @@ async def test_fetch_risk_signals_uses_latest_scored_day_query(
     signals = await _fetch_risk_signals(
         sink,
         filters=MetricFilter(),
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 31),
         org_id="org-test",
         data_confidence=_risk_confidence(),
     )
@@ -305,10 +307,14 @@ async def test_fetch_risk_signals_uses_latest_scored_day_query(
     assert signals[0].current_value == "50.0 %"
     query, parameters = queries[0]
     assert "maxOrNull(day)" in query
-    assert "argMax(compounding_risk, computed_at) AS score" in query
-    assert "countIf(score IS NULL) AS missing_scores" in query
+    assert "argMax(tuple(compounding_risk), computed_at) AS latest_row" in query
+    assert "countIf(tupleElement(latest_row, 1) IS NULL) AS missing_scores" in query
     assert "missing_scores = 0" in query
-    assert parameters == {"org_id": "org-test"}
+    assert parameters == {
+        "org_id": "org-test",
+        "start_day": date(2026, 5, 1),
+        "end_day": date(2026, 5, 31),
+    }
 
 
 @pytest.mark.asyncio
@@ -331,6 +337,8 @@ async def test_fetch_risk_signals_applies_scope_filter_to_latest_day(
     signals = await _fetch_risk_signals(
         sink,
         filters=MetricFilter(scope=ScopeFilter(level="team", ids=["team-A"])),
+        start_day=date(2026, 5, 1),
+        end_day=date(2026, 5, 31),
         org_id="org-test",
         data_confidence=_risk_confidence(),
     )
@@ -341,6 +349,8 @@ async def test_fetch_risk_signals_applies_scope_filter_to_latest_day(
     assert query.count("AND scope_id IN {scope_ids:Array(String)}") == 2
     assert parameters == {
         "org_id": "org-test",
+        "start_day": date(2026, 5, 1),
+        "end_day": date(2026, 5, 31),
         "scope": "team",
         "scope_ids": ["team-A"],
     }

--- a/tests/api/services/test_home_cockpit_contract.py
+++ b/tests/api/services/test_home_cockpit_contract.py
@@ -1,17 +1,24 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
 
 from dev_health_ops.api.models.filters import MetricFilter, ScopeFilter
 from dev_health_ops.api.models.schemas import MetricDelta, SparkPoint
+from dev_health_ops.api.services import home as home_service
 from dev_health_ops.api.services.home import (
     HomeDataConfidence,
+    _fetch_risk_signals,
     _risk_signal,
     build_data_confidence,
     build_health_state,
     build_limiting_factor,
     build_metric_signals,
 )
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 
 def _spark(count: int) -> list[SparkPoint]:
@@ -250,3 +257,90 @@ def test_risk_signal_affected_scope_uses_scope_type_plural() -> None:
 
     assert signal is not None
     assert signal.affected_scope == "repos"
+
+
+@pytest.mark.asyncio
+async def test_fetch_risk_signals_uses_latest_scored_day_query(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queries: list[tuple[str, dict[str, Any]]] = []
+
+    async def fake_query_dicts(
+        sink: BaseMetricsSink,
+        query: str,
+        parameters: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        queries.append((query, parameters))
+        return [
+            {
+                "scope": "repo",
+                "scope_id": "repo-1",
+                "score": 0.4996,
+                "severity": "elevated",
+            }
+        ]
+
+    async def fake_resolve_scope_labels(
+        sink: BaseMetricsSink,
+        *,
+        org_id: str,
+        rows: list[dict[str, Any]],
+    ) -> dict[str, str]:
+        return {"repo-1": "acme/backend"}
+
+    monkeypatch.setattr(home_service, "query_dicts", fake_query_dicts)
+    monkeypatch.setattr(
+        home_service, "_resolve_scope_labels", fake_resolve_scope_labels
+    )
+    sink: BaseMetricsSink = MagicMock(spec=BaseMetricsSink)
+
+    signals = await _fetch_risk_signals(
+        sink,
+        filters=MetricFilter(),
+        org_id="org-test",
+        data_confidence=_risk_confidence(),
+    )
+
+    assert len(signals) == 1
+    assert signals[0].current_value == "50.0 %"
+    query, parameters = queries[0]
+    assert "maxOrNull(day)" in query
+    assert "argMax(compounding_risk, computed_at) AS score" in query
+    assert "countIf(score IS NULL) AS missing_scores" in query
+    assert "missing_scores = 0" in query
+    assert parameters == {"org_id": "org-test"}
+
+
+@pytest.mark.asyncio
+async def test_fetch_risk_signals_applies_scope_filter_to_latest_day(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queries: list[tuple[str, dict[str, Any]]] = []
+
+    async def fake_query_dicts(
+        sink: BaseMetricsSink,
+        query: str,
+        parameters: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        queries.append((query, parameters))
+        return []
+
+    monkeypatch.setattr(home_service, "query_dicts", fake_query_dicts)
+    sink: BaseMetricsSink = MagicMock(spec=BaseMetricsSink)
+
+    signals = await _fetch_risk_signals(
+        sink,
+        filters=MetricFilter(scope=ScopeFilter(level="team", ids=["team-A"])),
+        org_id="org-test",
+        data_confidence=_risk_confidence(),
+    )
+
+    assert signals == []
+    query, parameters = queries[0]
+    assert query.count("AND scope = {scope:String}") == 2
+    assert query.count("AND scope_id IN {scope_ids:Array(String)}") == 2
+    assert parameters == {
+        "org_id": "org-test",
+        "scope": "team",
+        "scope_ids": ["team-A"],
+    }

--- a/tests/metrics/test_compounding_risk.py
+++ b/tests/metrics/test_compounding_risk.py
@@ -298,13 +298,19 @@ class _FakeSink:
     def __init__(
         self,
         complexity_by_repo: dict[str, dict[str, float | None] | None],
+        latest_inputs_by_scope: dict[tuple[str, str], dict[str, float | None]]
+        | None = None,
     ):
         self._data = complexity_by_repo
+        self._latest_inputs = latest_inputs_by_scope or {}
         self.calls: list[dict] = []
 
     def query_dicts(self, query: str, parameters: dict) -> list[dict]:
         self.calls.append(parameters)
         repo = parameters["repo_id"]
+        if "mid" not in parameters:
+            result = self._latest_inputs.get((parameters["org_id"], repo))
+            return [result] if result is not None else []
         result = self._data.get(repo)
         return [result] if result is not None else []
 
@@ -426,6 +432,104 @@ def test_orchestrator_emits_unknown_severity_when_inputs_missing() -> None:
     assert len(out) == 1
     assert out[0].compounding_risk is None
     assert out[0].severity == "unknown"
+
+
+def test_orchestrator_carries_forward_recent_non_null_review_latency() -> None:
+    repo = uuid.uuid4()
+    sink = _FakeSink(
+        {str(repo): {"first_half": 100.0, "second_half": 110.0}},
+        {
+            ("acme", str(repo)): {
+                "rework_churn": 0.10,
+                "single_owner_ratio": 0.50,
+                "ownership_gini": 0.40,
+                "bus_factor": 2.0,
+                "review_latency_p90h": 24.0,
+            }
+        },
+    )
+    repo_rows = [
+        _FakeRepoMetrics(
+            repo_id=repo,
+            rework_churn_ratio_30d=0.10,
+            single_owner_file_ratio_30d=0.50,
+            code_ownership_gini=0.40,
+            pr_first_review_p90_hours=None,
+        ),
+    ]
+
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=repo_rows,
+        computed_at=NOW,
+    )
+
+    assert len(out) == 1
+    assert out[0].review_latency_p90h == 24.0
+    assert out[0].compounding_risk is not None
+    assert out[0].severity != "unknown"
+
+
+def test_orchestrator_keeps_missing_review_latency_when_window_has_no_value() -> None:
+    repo = uuid.uuid4()
+    sink = _FakeSink({str(repo): {"first_half": 100.0, "second_half": 110.0}})
+    repo_rows = [
+        _FakeRepoMetrics(
+            repo_id=repo,
+            rework_churn_ratio_30d=0.10,
+            single_owner_file_ratio_30d=0.50,
+            code_ownership_gini=0.40,
+            pr_first_review_p90_hours=None,
+        ),
+    ]
+
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=repo_rows,
+        computed_at=NOW,
+    )
+
+    assert len(out) == 1
+    assert out[0].review_latency_p90h is None
+    assert out[0].compounding_risk is None
+    assert out[0].severity == "unknown"
+
+
+def test_orchestrator_carry_forward_is_org_and_repo_isolated() -> None:
+    repo = uuid.uuid4()
+    other_repo = uuid.uuid4()
+    sink = _FakeSink(
+        {str(repo): {"first_half": 100.0, "second_half": 110.0}},
+        {
+            ("other-org", str(repo)): {"review_latency_p90h": 24.0},
+            ("acme", str(other_repo)): {"review_latency_p90h": 12.0},
+        },
+    )
+    repo_rows = [
+        _FakeRepoMetrics(
+            repo_id=repo,
+            rework_churn_ratio_30d=0.10,
+            single_owner_file_ratio_30d=0.50,
+            code_ownership_gini=0.40,
+            pr_first_review_p90_hours=None,
+        ),
+    ]
+
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=repo_rows,
+        computed_at=NOW,
+    )
+
+    assert len(out) == 1
+    assert out[0].review_latency_p90h is None
+    assert out[0].compounding_risk is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/metrics/test_compounding_risk.py
+++ b/tests/metrics/test_compounding_risk.py
@@ -295,22 +295,13 @@ class _FakeRepoMetrics:
 class _FakeSink:
     """Stand-in for the ClickHouse sink. Returns canned ``query_dicts`` results."""
 
-    def __init__(
-        self,
-        complexity_by_repo: dict[str, dict[str, float | None] | None],
-        latest_inputs_by_scope: dict[tuple[str, str], dict[str, float | None]]
-        | None = None,
-    ):
+    def __init__(self, complexity_by_repo: dict[str, dict[str, float | None] | None]):
         self._data = complexity_by_repo
-        self._latest_inputs = latest_inputs_by_scope or {}
         self.calls: list[dict] = []
 
     def query_dicts(self, query: str, parameters: dict) -> list[dict]:
         self.calls.append(parameters)
         repo = parameters["repo_id"]
-        if "mid" not in parameters:
-            result = self._latest_inputs.get((parameters["org_id"], repo))
-            return [result] if result is not None else []
         result = self._data.get(repo)
         return [result] if result is not None else []
 
@@ -434,44 +425,6 @@ def test_orchestrator_emits_unknown_severity_when_inputs_missing() -> None:
     assert out[0].severity == "unknown"
 
 
-def test_orchestrator_carries_forward_recent_non_null_review_latency() -> None:
-    repo = uuid.uuid4()
-    sink = _FakeSink(
-        {str(repo): {"first_half": 100.0, "second_half": 110.0}},
-        {
-            ("acme", str(repo)): {
-                "rework_churn": 0.10,
-                "single_owner_ratio": 0.50,
-                "ownership_gini": 0.40,
-                "bus_factor": 2.0,
-                "review_latency_p90h": 24.0,
-            }
-        },
-    )
-    repo_rows = [
-        _FakeRepoMetrics(
-            repo_id=repo,
-            rework_churn_ratio_30d=0.10,
-            single_owner_file_ratio_30d=0.50,
-            code_ownership_gini=0.40,
-            pr_first_review_p90_hours=None,
-        ),
-    ]
-
-    out = build_compounding_risk_rows_for_day(
-        sink=sink,
-        day=DAY,
-        org_id="acme",
-        repo_metrics_rows=repo_rows,
-        computed_at=NOW,
-    )
-
-    assert len(out) == 1
-    assert out[0].review_latency_p90h == 24.0
-    assert out[0].compounding_risk is not None
-    assert out[0].severity != "unknown"
-
-
 def test_orchestrator_keeps_missing_review_latency_when_window_has_no_value() -> None:
     repo = uuid.uuid4()
     sink = _FakeSink({str(repo): {"first_half": 100.0, "second_half": 110.0}})
@@ -497,39 +450,6 @@ def test_orchestrator_keeps_missing_review_latency_when_window_has_no_value() ->
     assert out[0].review_latency_p90h is None
     assert out[0].compounding_risk is None
     assert out[0].severity == "unknown"
-
-
-def test_orchestrator_carry_forward_is_org_and_repo_isolated() -> None:
-    repo = uuid.uuid4()
-    other_repo = uuid.uuid4()
-    sink = _FakeSink(
-        {str(repo): {"first_half": 100.0, "second_half": 110.0}},
-        {
-            ("other-org", str(repo)): {"review_latency_p90h": 24.0},
-            ("acme", str(other_repo)): {"review_latency_p90h": 12.0},
-        },
-    )
-    repo_rows = [
-        _FakeRepoMetrics(
-            repo_id=repo,
-            rework_churn_ratio_30d=0.10,
-            single_owner_file_ratio_30d=0.50,
-            code_ownership_gini=0.40,
-            pr_first_review_p90_hours=None,
-        ),
-    ]
-
-    out = build_compounding_risk_rows_for_day(
-        sink=sink,
-        day=DAY,
-        org_id="acme",
-        repo_metrics_rows=repo_rows,
-        computed_at=NOW,
-    )
-
-    assert len(out) == 1
-    assert out[0].review_latency_p90h is None
-    assert out[0].compounding_risk is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/recommendations/test_loader.py
+++ b/tests/recommendations/test_loader.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock
+
+from dev_health_ops.recommendations.loader import ClickHouseMetricsLoader
+
+
+@dataclass(frozen=True, slots=True)
+class _QueryResult:
+    column_names: list[str]
+    result_rows: list[tuple[float | None, str]]
+
+
+def test_compounding_risk_loader_preserves_latest_null_score_same_row_severity() -> (
+    None
+):
+    client = MagicMock()
+    client.query.return_value = _QueryResult(
+        column_names=["score", "severity"],
+        result_rows=[(None, "high")],
+    )
+    loader = ClickHouseMetricsLoader(client=client, org_id="org-1")
+
+    score, severity = loader._load_compounding_risk_persisted(
+        "team-1",
+        date(2026, 5, 1),
+        date(2026, 5, 31),
+    )
+
+    assert score is None
+    assert severity == "high"
+    query: str = client.query.call_args.args[0]
+    parameters: dict[str, Any] = client.query.call_args.kwargs["parameters"]
+    assert (
+        "argMax(tuple(compounding_risk, severity), computed_at) AS latest_row" in query
+    )
+    assert "tupleElement(latest_row, 1) AS score" in query
+    assert "tupleElement(latest_row, 2) AS severity" in query
+    assert "argMax(compounding_risk, computed_at)" not in query
+    assert "argMax(severity" not in query
+    assert parameters == {
+        "team_id": "team-1",
+        "start": date(2026, 5, 1),
+        "end": date(2026, 5, 31),
+        "org_id": "org-1",
+    }


### PR DESCRIPTION
## Summary
- Fixes CHAOS-2855 by resolving compounding-risk inputs from the most recent non-null value in the trailing metric window for the same org/repo.
- Keeps genuinely absent inputs missing, preserving unknown severity for true data absence.
- Updates compounding risk docs for carry-forward semantics, persisted team rows, and standalone recompute command.

## Tests
- uv run pytest tests/metrics/test_compounding_risk.py -q
- bash ci/local_validate.sh
- lsp_diagnostics clean for src/dev_health_ops/metrics/compounding_risk.py and tests/metrics/test_compounding_risk.py

## Local QA
- Before SELECT already returned a non-null 2026-07-04 risk in the local default ClickHouse: risk=0.49955646079039934, review_latency_p90h=0.05444444444444444.
- Recomputed with: CLICKHOUSE_URI=clickhouse://ch:ch@localhost:8123/default uv run dev-hops metrics compounding-risk --org 70d529e0-3c06-4597-8480-794fd02328b6 --since 2026-07-04 --before 2026-07-05
- After SELECT: day=2026-07-04, risk=0.49955646079039934, review_latency_p90h=0.05444444444444444, latest_computed_at=2026-07-04 10:17:32.

SCREENSHOT-WAIVER: backend metrics compute only; no UI/render change.

Hold merge for Oracle review.