### PR TITLE
docs(github-app): add security-alert read permissions (CHAOS-2856)

### DIFF
--- a/docs/user-guide/github-app-auth.md
+++ b/docs/user-guide/github-app-auth.md
@@ -10,7 +10,8 @@ Grant only the permissions needed for the sync target you run:
 - Metadata: read
 - Pull requests: read (for `sync prs`)
 - Issues: read (for GitHub work item sync)
-- Actions / deployments / security events: read when using the corresponding sync targets
+- Actions / Deployments: read (for the corresponding sync targets)
+- Dependabot alerts / Code scanning alerts / Secret scanning alerts: read (required for security alert sync)
 
 Install the app on the organization or repositories you want Dev Health to ingest.
 

--- a/docs/user-guide/github-app-setup.md
+++ b/docs/user-guide/github-app-setup.md
@@ -75,6 +75,11 @@ The same secret must be set as `GITHUB_WEBHOOK_SECRET` on the ops backend; the
 | Actions | Read‑only | Workflow runs (CI/CD, DORA) |
 | Deployments | Read‑only | Delivery / change‑failure signals |
 | Commit statuses | Read‑only | CI status (optional) |
+| Dependabot alerts | Read‑only | Security view / compounding‑risk security signals |
+| Code scanning alerts | Read‑only | Security view / compounding‑risk security signals |
+| Secret scanning alerts | Read‑only | Security view / compounding‑risk security signals |
+
+Dependabot alerts, Code scanning alerts, and Secret scanning alerts are distinct from the **Repository security advisories** permission and the **Security advisory** event (see [Subscribe to events](#subscribe-to-events)) — neither of those enables `security_alerts` sync. After changing permissions on an already‑installed App, the organization must **approve the pending permission request** before the installation token receives the new scopes.
 
 **Organization**
 


### PR DESCRIPTION
## Summary

Fixes CHAOS-2856. The GitHub App setup docs omitted the security-alert read permissions required for `security_alerts` to sync, so App installs created by following the docs cannot fetch Dependabot / code-scanning / secret-scanning alerts (providers silently degrade the 403/404 to empty). Confirmed root cause of prod "security not syncing" — local stack (with the perms granted) flows 288 `security_alerts` (241 code_scanning + 47 dependabot); prod has none.

This is a **docs-only** change.

## Changes

- `docs/user-guide/github-app-setup.md`
  - Adds three missing rows to the Repository permissions table: **Dependabot alerts**, **Code scanning alerts**, **Secret scanning alerts** (all Read-only).
  - Adds a note clarifying these are distinct from the **Repository security advisories** permission and the **Security advisory** event (neither of which enables `security_alerts` sync), and that changing permissions on an already-installed App requires the org to approve the pending permission request before the token receives the new scopes.
- `docs/user-guide/github-app-auth.md`
  - Replaces the imprecise line "Actions / deployments / security events: read when using the corresponding sync targets" with specific, correct permission names: Actions/Deployments, and a separate line for Dependabot alerts / Code scanning alerts / Secret scanning alerts.

## Verification

- `mkdocs build --strict` passes cleanly (no warnings/errors).
- Manually checked both edited Markdown tables render with aligned columns and balanced pipes.

## Not in scope

- No code changes.
- Does not touch CHAOS-2855 (metrics/resolver) branch or files.
- Not merging this PR.