### PR TITLE
feat(providers): instrument GitHub files and blame actuals (CHAOS-2808)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -99,6 +99,7 @@ cooperating layers:
    | --- | --- | --- |
    | GitHub REST connector | 3 (`retry_with_backoff(max_retries=3)`) | `connectors/github.py` |
    | GitHub GraphQL client | 5 (`max_retries=5`) | `connectors/utils/graphql.py` |
+   | GitHub code client (canonical: git/commit_stats/security/deployments REST, files/blame GraphQL) | 5 (`InstrumentedRESTCore` default) | `providers/github/code_client.py` + `providers/github/graphql.py` |
    | GitLab REST connector | 3 (`retry_with_backoff(max_retries=3)`) | `connectors/gitlab.py` |
    | GitLab feature-flags (canonical) | 5 (`max_retries=5`) | `providers/gitlab/feature_flags.py` |
    | Jira client (JQL + enrichment) | 4 (`max_retries_429=3` → `+1` initial) | `providers/jira/client.py` |
@@ -931,6 +932,17 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
   `commit_stats:` operation prefixes. The `commit_stats` `contents_blob`
   reservation remains estimate-only because the migrated REST commit-detail call
   reports as `rest_core`.
+- **Actuals instrumentation (CHAOS-2808).** File contents (`files`) and blame
+  (`blame`) now fetch via GraphQL through the SAME
+  `providers/github/code_client.py::GitHubCodeClient`, over provider-owned
+  GraphQL support relocated from the frozen connector's GraphQL client onto
+  `providers/github/graphql.py`, and drain into the shared `usage_sink`,
+  resolving through explicit `files:` / `blame:` operation prefixes. Unlike
+  `commit_stats` (where `rest_core` is the live dimension), `files`/`blame`
+  traffic is 100% GraphQL, so `contents_blob` carries the marker; their
+  `rest_core` reservation stays estimate-only -- it belongs to the
+  repository tree listing that discovers candidate paths, which remains on
+  the frozen PyGithub connector (out of CS7 scope).
 
 #### Route families
 <!-- route-families:github -->
@@ -940,8 +952,8 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
 | `repo` | `rest_core` | Repository metadata | high |
 | `git` | `rest_core` | Commit listing (`GitHubCodeClient`, CHAOS-2773 CS6) | medium |
 | `commit_stats` | `rest_core`, `contents_blob` | Per-commit file/stat expansion (`GitHubCodeClient` REST core, CHAOS-2773 CS6; contents/blob still estimate-only) | low |
-| `files` | `rest_core`, `contents_blob` | Repository tree/blob reads | low |
-| `blame` | `rest_core`, `contents_blob` | Blame expansion (file-count dependent) | low |
+| `files` | `rest_core`, `contents_blob` | Repository tree listing (`rest_core`, frozen/estimate-only) + blob-text reads (`contents_blob`, `GitHubCodeClient` GraphQL, CHAOS-2773 CS7) | low |
+| `blame` | `rest_core`, `contents_blob` | Blame expansion (file-count dependent; `contents_blob` via `GitHubCodeClient` GraphQL, CHAOS-2773 CS7) | low |
 | `prs` | `rest_core` | Pull requests / reviews / comments core | medium |
 | `pr_social` | `graphql_cost`, `secondary_abuse_risk` | PR timeline/social expansion | medium |
 | `cicd` | `rest_core`, `contents_blob` | CI/CD workflow runs + artifact expansion | low |
@@ -1163,14 +1175,16 @@ paper over:
   (CS2) — see
   [Usage drain wiring](#usage-drain-wiring-first-re-bucketing-chaos-2773-cs2)
   above. GitHub `git` and `commit_stats` REST-core traffic is instrumented as of
-  CHAOS-2807; the REST `prs` listing and remaining GitHub/GitLab code-dataset
-  families stay uninstrumented pending their own CHAOS-2773 changesets (see
+  CHAOS-2807, and `files`/`blame` `contents_blob` traffic (GraphQL) as of
+  CHAOS-2808; the REST `prs` listing, the `files`/`blame` `rest_core` tree
+  listing, and remaining GitHub/GitLab code-dataset families stay
+  uninstrumented pending their own CHAOS-2773 changesets (see
   "Frozen `connectors/` path" below). There is also no cross-run
   aggregation/dashboard yet — calibration today is visible per-unit (result +
   structured log), not rolled up over time.
-- **Frozen `connectors/` path.** GitHub's `files`/`blame`/`prs` and repo
-  metadata/batch orchestration, plus the remaining equivalent GitLab
-  code-dataset paths, remain under the frozen `connectors/` tree
+- **Frozen `connectors/` path.** GitHub's `prs` and repo metadata/batch
+  orchestration, plus the remaining equivalent GitLab code-dataset paths,
+  remain under the frozen `connectors/` tree
   (`connectors/github.py`'s PyGithub-based `GitHubConnector`, `connectors/
   gitlab.py`'s python-gitlab-based `GitLabConnector`). No new code may be added
   there (see [`AGENTS.md`](../../AGENTS.md)); rate-limit/actuals
@@ -1186,7 +1200,10 @@ paper over:
   (`get_feature_flags` / `get_project_name`) is likewise closed as of
   [CHAOS-2785](https://linear.app/fullchaos/issue/CHAOS-2785) — see
   [GitLab](#gitlab) above. GitHub's `git`/`commit_stats`
-  ([CHAOS-2807](https://linear.app/fullchaos/issue/CHAOS-2807), CS6) moved to
+  ([CHAOS-2807](https://linear.app/fullchaos/issue/CHAOS-2807), CS6) and
+  `files`/`blame` ([CHAOS-2808](https://linear.app/fullchaos/issue/CHAOS-2808),
+  CS7 -- the file-contents/blame GraphQL fetch relocated onto
+  `providers/github/graphql.py`) moved to
   `providers/github/code_client.py::GitHubCodeClient`; GitLab's `security`
   ([CHAOS-2811](https://linear.app/fullchaos/issue/CHAOS-2811), CS10),
   `pipelines`+`deployments`

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import zipfile
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Protocol
 
 from dev_health_ops.analytics.complexity import (
     DEFAULT_COMPLEXITY_CONFIG_PATH,
@@ -994,8 +994,20 @@ CONTENT_FETCH_MAX_FILES = 2_000
 BLAME_BACKFILL_MAX_FILES = 500
 
 
+class _GitHubFileContentClient(Protocol):
+    async def get_file_contents(
+        self,
+        owner: str,
+        repo: str,
+        paths: list[str],
+        *,
+        ref: str = "HEAD",
+        batch_size: int = 50,
+    ) -> dict[str, str]: ...
+
+
 async def _fetch_scannable_contents(
-    connector: GitHubConnector,
+    client: _GitHubFileContentClient,
     owner: str,
     repo_name: str,
     ref: str,
@@ -1007,8 +1019,12 @@ async def _fetch_scannable_contents(
 
     Only paths matching the complexity scanner's include/exclude globs are
     fetched, keeping API volume proportional to what the metrics jobs can
-    actually use. Errors degrade to a paths-only backfill (contents stay
-    NULL) rather than failing the sync.
+    actually use. A non-rate-limit fetch failure degrades to a paths-only
+    backfill (contents stay NULL) rather than failing the sync; a
+    ``RateLimitException``/``RateLimitExceededException`` propagates so the
+    caller's deferral semantics apply, mirroring the commit-stats fetch path
+    (CHAOS-2773 CS7 -- previously this degraded a rate limit to empty too,
+    silently masking it for the files dataset).
     """
     scanner = ComplexityScanner(config_path=DEFAULT_COMPLEXITY_CONFIG_PATH)
     scannable: list[str] = []
@@ -1030,12 +1046,10 @@ async def _fetch_scannable_contents(
     if not scannable:
         return {}
 
-    loop = asyncio.get_running_loop()
     try:
-        return await loop.run_in_executor(
-            None,
-            lambda: connector.get_file_contents(owner, repo_name, scannable, ref=ref),
-        )
+        return await client.get_file_contents(owner, repo_name, scannable, ref=ref)
+    except (RateLimitException, RateLimitExceededException):
+        raise
     except Exception as e:
         logging.warning("Failed to fetch file contents for %s: %s", repo_full_name, e)
         return {}
@@ -1100,150 +1114,179 @@ async def _backfill_github_missing_data(
 
     file_paths: list[str] = []
     blame_paths: list[str] = []
+    # Files and blame share ONE ``GitHubCodeClient`` (built once, drained and
+    # closed in the ``finally`` below) since both fetch over the same
+    # provider-owned GraphQL support (``providers/github/graphql.py``,
+    # CHAOS-2773 CS7) -- mirrors the commit/commit-stats helpers' one-client-
+    # per-fetch lifecycle, just shared across two call sites instead of one.
+    code_client: GitHubCodeClient | None = None
     if needs_files or needs_blame:
-        try:
-            branch = gh_repo.get_branch(default_branch)
-            tree = gh_repo.get_git_tree(branch.commit.sha, recursive=True)
-            blob_sizes: dict[str, int | None] = {}
-            for entry in getattr(tree, "tree", []) or []:
-                if getattr(entry, "type", None) != "blob":
-                    continue
-                path = getattr(entry, "path", None)
-                if not path:
-                    continue
-                file_paths.append(path)
-                blob_sizes[path] = getattr(entry, "size", None)
+        code_client = _github_code_client_from_connector(connector)
+    try:
+        if needs_files or needs_blame:
+            try:
+                branch = gh_repo.get_branch(default_branch)
+                tree = gh_repo.get_git_tree(branch.commit.sha, recursive=True)
+                blob_sizes: dict[str, int | None] = {}
+                for entry in getattr(tree, "tree", []) or []:
+                    if getattr(entry, "type", None) != "blob":
+                        continue
+                    path = getattr(entry, "path", None)
+                    if not path:
+                        continue
+                    file_paths.append(path)
+                    blob_sizes[path] = getattr(entry, "size", None)
 
-            if needs_files and file_paths:
-                contents_by_path = await _fetch_scannable_contents(
+                if needs_files and file_paths:
+                    assert code_client is not None
+                    contents_by_path = await _fetch_scannable_contents(
+                        code_client,
+                        owner,
+                        repo_name,
+                        default_branch,
+                        file_paths,
+                        blob_sizes,
+                        repo_full_name,
+                    )
+                    await backfill_file_records(
+                        ingestion_sink,
+                        db_repo.id,
+                        file_paths,
+                        repo_full_name,
+                        contents_by_path=contents_by_path,
+                    )
+            except (RateLimitException, RateLimitExceededException):
+                raise
+            except Exception as e:
+                logging.warning(
+                    f"Failed to backfill GitHub files for {repo_full_name}: {e}"
+                )
+
+        if needs_commit_stats:
+            try:
+                logging.info(
+                    "Backfilling commit stats for %s...",
+                    repo_full_name,
+                )
+                raw_commits, _, window_truncated = await _fetch_github_commits_async(
                     connector,
                     owner,
                     repo_name,
-                    default_branch,
-                    file_paths,
-                    blob_sizes,
-                    repo_full_name,
-                )
-                await backfill_file_records(
-                    ingestion_sink,
                     db_repo.id,
-                    file_paths,
-                    repo_full_name,
-                    contents_by_path=contents_by_path,
+                    max_commits,
+                    since,
+                    until,
+                    usage_sink,
                 )
-        except Exception as e:
-            logging.warning(
-                f"Failed to backfill GitHub files for {repo_full_name}: {e}"
-            )
+                stats_count = await _sync_github_commit_stats(
+                    connector=connector,
+                    owner=owner,
+                    repo_name=repo_name,
+                    db_repo=db_repo,
+                    ingestion_sink=ingestion_sink,
+                    max_commits=max_commits,
+                    since=since,
+                    until=until,
+                    raw_commits=raw_commits,
+                    window_truncated=window_truncated,
+                    usage_sink=usage_sink,
+                )
+                logging.info(
+                    "Backfilled %d commit-stat rows in %s",
+                    stats_count,
+                    repo_full_name,
+                )
+            except (RateLimitException, RateLimitExceededException):
+                raise
+            except Exception as e:
+                logging.warning(
+                    "Failed to backfill GitHub commit stats for %s: %s",
+                    repo_full_name,
+                    e,
+                )
 
-    if needs_commit_stats:
-        try:
-            logging.info(
-                "Backfilling commit stats for %s...",
-                repo_full_name,
+        if needs_blame and file_paths:
+            # Bound the blame crawl: one GraphQL call per file, so cap the number
+            # of files we blame on a single sync to avoid quota exhaustion /
+            # timeouts on large repos (CHAOS-2376). Select the *next* unblamed batch
+            # (diffing the live tree against already-blamed paths) so each rerun
+            # advances coverage instead of reblaming the same capped prefix; the
+            # capped prefix is used only as a fallback when the store lacks per-path
+            # coverage.
+            blame_paths = await select_unblamed_paths(
+                store, db_repo.id, file_paths, BLAME_BACKFILL_MAX_FILES
             )
-            raw_commits, _, window_truncated = await _fetch_github_commits_async(
-                connector,
-                owner,
-                repo_name,
-                db_repo.id,
-                max_commits,
-                since,
-                until,
-                usage_sink,
-            )
-            stats_count = await _sync_github_commit_stats(
-                connector=connector,
-                owner=owner,
-                repo_name=repo_name,
-                db_repo=db_repo,
-                ingestion_sink=ingestion_sink,
-                max_commits=max_commits,
-                since=since,
-                until=until,
-                raw_commits=raw_commits,
-                window_truncated=window_truncated,
-                usage_sink=usage_sink,
-            )
-            logging.info(
-                "Backfilled %d commit-stat rows in %s",
-                stats_count,
-                repo_full_name,
-            )
-        except (RateLimitException, RateLimitExceededException):
-            raise
-        except Exception as e:
-            logging.warning(
-                "Failed to backfill GitHub commit stats for %s: %s",
-                repo_full_name,
-                e,
-            )
-
-    if needs_blame and file_paths:
-        # Bound the blame crawl: one GraphQL call per file, so cap the number
-        # of files we blame on a single sync to avoid quota exhaustion /
-        # timeouts on large repos (CHAOS-2376). Select the *next* unblamed batch
-        # (diffing the live tree against already-blamed paths) so each rerun
-        # advances coverage instead of reblaming the same capped prefix; the
-        # capped prefix is used only as a fallback when the store lacks per-path
-        # coverage.
-        blame_paths = await select_unblamed_paths(
-            store, db_repo.id, file_paths, BLAME_BACKFILL_MAX_FILES
-        )
-    if needs_blame and blame_paths:
-        processed_files = 0
-        try:
-            logging.info(
-                "Backfilling blame for %d unblamed files in %s (cap %d)...",
-                len(blame_paths),
-                repo_full_name,
-                BLAME_BACKFILL_MAX_FILES,
-            )
-            async with AsyncBatchCollector(
-                ingestion_sink.insert_blame_data
-            ) as blame_collector:
-                for path in blame_paths:
-                    try:
-                        blame = connector.get_file_blame(
-                            owner=owner,
-                            repo=repo_name,
-                            path=path,
-                            ref=default_branch,
-                        )
-                        processed_files += 1
-                    except Exception as e:
-                        logging.debug(
-                            f"Failed blame fetch for {repo_full_name}:{path}: {e}"
-                        )
-                        continue
-
-                    for rng in blame.ranges:
-                        for line_no in range(
-                            rng.starting_line,
-                            rng.ending_line + 1,
-                        ):
-                            blame_collector.add(
-                                GitBlame(
-                                    repo_id=db_repo.id,
-                                    path=path,
-                                    line_no=line_no,
-                                    author_email=rng.author_email,
-                                    author_name=rng.author,
-                                    author_when=None,
-                                    commit_hash=rng.commit_sha,
-                                    line=None,
-                                )
+        if needs_blame and blame_paths:
+            assert code_client is not None
+            processed_files = 0
+            try:
+                logging.info(
+                    "Backfilling blame for %d unblamed files in %s (cap %d)...",
+                    len(blame_paths),
+                    repo_full_name,
+                    BLAME_BACKFILL_MAX_FILES,
+                )
+                async with AsyncBatchCollector(
+                    ingestion_sink.insert_blame_data
+                ) as blame_collector:
+                    for path in blame_paths:
+                        try:
+                            blame = await code_client.get_file_blame(
+                                owner=owner,
+                                repo=repo_name,
+                                path=path,
+                                ref=default_branch,
                             )
-                            await blame_collector.maybe_flush()
-            logging.info(
-                "Backfilled blame for %d files in %s",
-                processed_files,
-                repo_full_name,
-            )
-        except Exception as e:
-            logging.warning(
-                f"Failed to backfill GitHub blame for {repo_full_name}: {e}"
-            )
+                            processed_files += 1
+                        except (RateLimitException, RateLimitExceededException):
+                            raise
+                        except Exception as e:
+                            logging.debug(
+                                f"Failed blame fetch for {repo_full_name}:{path}: {e}"
+                            )
+                            continue
+
+                        for rng in blame.ranges:
+                            for line_no in range(
+                                rng.starting_line,
+                                rng.ending_line + 1,
+                            ):
+                                blame_collector.add(
+                                    GitBlame(
+                                        repo_id=db_repo.id,
+                                        path=path,
+                                        line_no=line_no,
+                                        author_email=rng.author_email,
+                                        author_name=rng.author,
+                                        author_when=None,
+                                        commit_hash=rng.commit_sha,
+                                        line=None,
+                                    )
+                                )
+                                await blame_collector.maybe_flush()
+                logging.info(
+                    "Backfilled blame for %d files in %s",
+                    processed_files,
+                    repo_full_name,
+                )
+            except (RateLimitException, RateLimitExceededException):
+                raise
+            except Exception as e:
+                logging.warning(
+                    f"Failed to backfill GitHub blame for {repo_full_name}: {e}"
+                )
+    finally:
+        if code_client is not None:
+            observations = code_client.drain_usage_observations()
+            await code_client.close()
+            if usage_sink is not None:
+                usage_sink.extend(observations)
+            elif observations:
+                logging.debug(
+                    "_backfill_github_missing_data: drained %d files/blame usage "
+                    "observations",
+                    len(observations),
+                )
 
 
 async def _sync_github_commits(

--- a/src/dev_health_ops/providers/github/budget.py
+++ b/src/dev_health_ops/providers/github/budget.py
@@ -356,6 +356,18 @@ def _fallback_credential_scope(
 # directly. `commit_stats` CONTENTS_BLOB and deployments CONTENTS_BLOB remain
 # empty/deferred until a distinct blob/content path is migrated; markers are
 # populated only for live instrumented traffic.
+#
+# `files`/`blame` CONTENTS_BLOB (CHAOS-2808/CS7) now fetch through the SAME
+# `GitHubCodeClient`, over its GraphQL support (`providers/github/graphql.py`),
+# labeled with explicit `files:`/`blame:` prefixes -- listed BEFORE their
+# sibling REST_CORE entry (unlike `commit_stats`, where REST_CORE is the
+# live dimension) because `files`/`blame`'s actual traffic is 100% GraphQL
+# blob/blame queries, never REST; the resolver's prefix short-circuit matches
+# route_family literally (not dimension), so the FIRST family sharing that
+# name wins -- ordering CONTENTS_BLOB first is what makes a `files:`/`blame:`
+# label resolve to the instrumented dimension instead of the still-frozen
+# REST_CORE one (the repository tree listing that discovers candidate paths
+# stays on the frozen PyGithub connector, uninstrumented, out of CS7 scope).
 GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("repo", BudgetDimension.REST_CORE),
     UsageRouteFamily("git", BudgetDimension.REST_CORE, operation_markers=("git:",)),
@@ -363,10 +375,14 @@ GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
         "commit_stats", BudgetDimension.REST_CORE, operation_markers=("commit_stats:",)
     ),
     UsageRouteFamily("commit_stats", BudgetDimension.CONTENTS_BLOB),
+    UsageRouteFamily(
+        "files", BudgetDimension.CONTENTS_BLOB, operation_markers=("files:",)
+    ),
     UsageRouteFamily("files", BudgetDimension.REST_CORE),
-    UsageRouteFamily("files", BudgetDimension.CONTENTS_BLOB),
+    UsageRouteFamily(
+        "blame", BudgetDimension.CONTENTS_BLOB, operation_markers=("blame:",)
+    ),
     UsageRouteFamily("blame", BudgetDimension.REST_CORE),
-    UsageRouteFamily("blame", BudgetDimension.CONTENTS_BLOB),
     UsageRouteFamily("prs", BudgetDimension.REST_CORE),
     UsageRouteFamily(
         "pr_social", BudgetDimension.GRAPHQL_COST, operation_markers=("pr_social:",)

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -22,14 +22,14 @@ from __future__ import annotations
 import logging
 import urllib.parse
 from collections.abc import Mapping
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from math import ceil
 from typing import Any
 
 import httpx
 
-from dev_health_ops.connectors.models import SecurityAlertData
+from dev_health_ops.connectors.models import FileBlame, SecurityAlertData
 from dev_health_ops.exceptions import (
     AuthenticationException,
     NotFoundException,
@@ -42,10 +42,20 @@ from dev_health_ops.providers._http import (
     github_rest_base_url,
 )
 from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.graphql import (
+    BLAME_QUERY,
+    blame_variables,
+    build_blob_texts_query,
+    github_graphql_url,
+    parse_blame_response,
+    parse_blob_texts_response,
+    raise_for_graphql_errors,
+)
 from dev_health_ops.providers.github.ratelimit import (
     classify_github_403,
     github_retry_after_seconds,
 )
+from dev_health_ops.sync.budget_types import BudgetDimension
 from dev_health_ops.sync.rate_limit_signal import RateLimitSignal
 
 logger = logging.getLogger(__name__)
@@ -59,6 +69,8 @@ DEPLOYMENTS_ROUTE_FAMILY = "deployments"
 CICD_ROUTE_FAMILY = "cicd"
 GIT_ROUTE_FAMILY = "git"
 COMMIT_STATS_ROUTE_FAMILY = "commit_stats"
+FILES_ROUTE_FAMILY = "files"
+BLAME_ROUTE_FAMILY = "blame"
 _GITHUB_DEPLOYMENTS_PER_PAGE = 100
 
 
@@ -436,6 +448,7 @@ class GitHubCodeClient:
         if not auth.token:
             raise ValueError("GitHubCodeClient requires a resolved token")
         self.auth = auth
+        self._graphql_url = github_graphql_url(github_rest_base_url(auth.base_url))
 
         # Deferred import mirrors providers/github/client.py: budget.py is the
         # source of truth for the route-family vocabulary, imported lazily to
@@ -618,6 +631,101 @@ class GitHubCodeClient:
             if isinstance(file_item, Mapping) and file_item.get("filename")
         ]
 
+    async def get_file_contents(
+        self,
+        owner: str,
+        repo: str,
+        paths: list[str],
+        *,
+        ref: str = "HEAD",
+        batch_size: int = 50,
+    ) -> dict[str, str]:
+        """Fetch text contents for many files via batched GraphQL blob
+        queries (CHAOS-2773 CS7) -- ports ``connectors/github.py::
+        GitHubConnector.get_file_contents`` onto this client's owned
+        ``InstrumentedRESTCore``, using ``providers/github/graphql.py``'s
+        query builder/parser. Binary, truncated, or missing blobs are
+        omitted from the result so callers can treat absence as "no usable
+        text". A GraphQL-level error mid-batch (an APIException, not a rate
+        limit) discards only the unresolved chunks; batches already merged
+        into ``contents`` are lost with it since the caller treats this as
+        one atomic fetch, matching the connector's own all-or-raise contract.
+        """
+        contents: dict[str, str] = {}
+        for start in range(0, len(paths), batch_size):
+            chunk = paths[start : start + batch_size]
+            operation = (
+                f"{FILES_ROUTE_FAMILY}:POST /graphql (get_blob_texts x{len(chunk)})"
+            )
+            response = await self._request_graphql_contents_blob(
+                "POST",
+                self._graphql_url,
+                operation=operation,
+                json={
+                    "query": build_blob_texts_query(ref, chunk),
+                    "variables": {"owner": owner, "repo": repo},
+                },
+            )
+            envelope = response.json()
+            raise_for_graphql_errors(envelope, operation=operation)
+            batch = parse_blob_texts_response(envelope.get("data") or {}, chunk)
+            contents.update(
+                {path: text for path, text in batch.items() if text is not None}
+            )
+        return contents
+
+    async def get_file_blame(
+        self,
+        owner: str,
+        repo: str,
+        path: str,
+        *,
+        ref: str = "HEAD",
+    ) -> FileBlame:
+        """Get blame information for a file via the GitHub GraphQL API
+        (CHAOS-2773 CS7) -- ports ``connectors/github.py::GitHubConnector.
+        get_file_blame`` onto this client's owned ``InstrumentedRESTCore``.
+        """
+        operation = f"{BLAME_ROUTE_FAMILY}:POST /graphql (get_blame)"
+        response = await self._request_graphql_contents_blob(
+            "POST",
+            self._graphql_url,
+            operation=operation,
+            json={
+                "query": BLAME_QUERY,
+                "variables": blame_variables(owner, repo, path, ref),
+            },
+        )
+        envelope = response.json()
+        raise_for_graphql_errors(envelope, operation=operation)
+        return parse_blame_response(envelope.get("data") or {}, file_path=path)
+
+    async def _request_graphql_contents_blob(
+        self,
+        method: str,
+        url: str,
+        *,
+        operation: str,
+        json: Mapping[str, Any],
+    ) -> httpx.Response:
+        try:
+            return await self._core.request(
+                method,
+                url,
+                operation=operation,
+                headers={"Authorization": f"Bearer {self.auth.token}"},
+                json=json,
+            )
+        except RateLimitException as exc:
+            signal = exc.signal
+            if signal is None:
+                raise
+            raise RateLimitException(
+                str(exc),
+                retry_after_seconds=exc.retry_after_seconds,
+                signal=replace(signal, dimension=BudgetDimension.CONTENTS_BLOB),
+            ) from exc
+
     async def get_deployments(
         self,
         owner: str,
@@ -741,8 +849,10 @@ class GitHubCodeClient:
 
 __all__ = [
     "COMMIT_STATS_ROUTE_FAMILY",
+    "BLAME_ROUTE_FAMILY",
     "CICD_ROUTE_FAMILY",
     "DEPLOYMENTS_ROUTE_FAMILY",
+    "FILES_ROUTE_FAMILY",
     "GIT_ROUTE_FAMILY",
     "GitHubCodeClient",
     "GitHubCommitData",

--- a/src/dev_health_ops/providers/github/graphql.py
+++ b/src/dev_health_ops/providers/github/graphql.py
@@ -1,0 +1,194 @@
+"""GitHub GraphQL query builders + response parsers (CHAOS-2773 CS7).
+
+Relocates the file-contents and blame GraphQL shapes off the frozen
+``connectors/utils/graphql.py::GitHubGraphQLClient`` (``get_blob_texts`` /
+``get_blame``) onto the canonical ``providers/github/`` tree, per the epic's
+provider-boundary contract: raw fetch/auth/pagination/retry/rate-limit stays
+inside the provider, never in a processor.
+
+This module owns ONLY pure query construction and response parsing --
+transport (retry/backoff, 403 triage, usage recording) stays on
+``GitHubCodeClient``'s single owned ``InstrumentedRESTCore``
+(``providers/github/code_client.py``), which POSTs these queries via its
+existing ``request()`` method (a relative ``/graphql`` path joins correctly
+against the default ``https://api.github.com`` base -- the same base every
+other CS3-CS6 code-client method already uses) exactly like its paginators
+reuse ``request()`` for REST calls. This is deliberate: the epic's "one
+``InstrumentedRESTCore`` per client, never a second transport primitive"
+rule (see ``code_client.py``'s module docstring) means GraphQL support is
+new QUERY/PARSE code, not a new transport.
+
+Response-shape parity with the legacy client is pinned by
+``tests/providers/test_github_graphql.py``.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import Mapping
+from datetime import datetime, timezone
+from typing import Any
+from urllib.parse import urlsplit, urlunsplit
+
+from dev_health_ops.connectors.models import BlameRange, FileBlame
+from dev_health_ops.exceptions import APIException
+
+logger = logging.getLogger(__name__)
+
+GITHUB_GRAPHQL_PATH = "/graphql"
+GITHUB_ENTERPRISE_GRAPHQL_PATH = "/api/graphql"
+
+
+def github_graphql_url(rest_base_url: str) -> str:
+    """Resolve the GitHub GraphQL endpoint from a REST API base URL.
+
+    Public GitHub uses ``https://api.github.com/graphql``. GitHub Enterprise
+    REST bases include ``/api/v3`` and GraphQL lives at sibling path
+    ``/api/graphql`` on the same host.
+    """
+    parsed = urlsplit(rest_base_url.rstrip("/"))
+    base_path = parsed.path.rstrip("/")
+    path = (
+        f"{base_path[: -len('/api/v3')]}/api/graphql"
+        if base_path.endswith("/api/v3")
+        else f"{base_path}/graphql"
+    )
+    return urlunsplit((parsed.scheme, parsed.netloc, path, "", ""))
+
+
+BLAME_QUERY = """
+query($owner: String!, $repo: String!, $path: String!, $ref: String!) {
+  repository(owner: $owner, name: $repo) {
+    object(expression: $ref) {
+      ... on Commit {
+        blame(path: $path) {
+          ranges {
+            startingLine
+            endingLine
+            commit {
+              oid
+              authoredDate
+              author {
+                name
+                email
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+
+
+def blame_variables(owner: str, repo: str, path: str, ref: str) -> dict[str, str]:
+    return {"owner": owner, "repo": repo, "path": path, "ref": ref}
+
+
+def build_blob_texts_query(ref: str, paths: list[str]) -> str:
+    """Build one query resolving up to ``len(paths)`` blobs via field
+    aliases -- byte-for-byte port of ``connectors/utils/graphql.py::
+    GitHubGraphQLClient.get_blob_texts``'s query construction."""
+    fields = []
+    for i, path in enumerate(paths):
+        expression = json.dumps(f"{ref}:{path}")
+        fields.append(
+            f"f{i}: object(expression: {expression}) "
+            "{ ... on Blob { text isBinary isTruncated } }"
+        )
+    return (
+        "query($owner: String!, $repo: String!) {\n"
+        "  repository(owner: $owner, name: $repo) {\n" + "\n".join(fields) + "\n  }\n}"
+    )
+
+
+def raise_for_graphql_errors(envelope: Mapping[str, Any], *, operation: str) -> None:
+    """Raise ``APIException`` for a GraphQL-level ``errors`` array.
+
+    A GraphQL application error rides on an HTTP 200 (no status-code
+    classification catches it), so the transport core's retry/classification
+    loop never sees it -- this must be checked explicitly by the caller after
+    a successful ``request()``, mirroring ``connectors/utils/graphql.py``'s
+    ``"errors" in data`` check.
+    """
+    errors = envelope.get("errors") if isinstance(envelope, Mapping) else None
+    if not errors:
+        return
+    error_messages = [
+        e.get("message", str(e)) if isinstance(e, Mapping) else str(e) for e in errors
+    ]
+    raise APIException(
+        f"GitHub GraphQL errors on {operation}: {'; '.join(error_messages)}"
+    )
+
+
+def parse_blob_texts_response(
+    payload: Mapping[str, Any], paths: list[str]
+) -> dict[str, str | None]:
+    """Byte-for-byte port of ``GitHubGraphQLClient.get_blob_texts``'s result
+    parsing: binary/truncated/missing blobs resolve to ``None`` so callers
+    can treat absence as "no usable text"."""
+    repo_data = payload.get("repository") or {}
+    contents: dict[str, str | None] = {}
+    for i, path in enumerate(paths):
+        blob = repo_data.get(f"f{i}") or {}
+        text = blob.get("text")
+        if blob.get("isBinary") or blob.get("isTruncated") or text is None:
+            contents[path] = None
+        else:
+            contents[path] = text
+    return contents
+
+
+def _parse_blame_commit_datetime(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        logger.debug("Failed to parse GitHub blame commit datetime: %s", value)
+        return None
+
+
+def parse_blame_response(payload: Mapping[str, Any], *, file_path: str) -> FileBlame:
+    """Byte-for-byte port of ``connectors/github.py::GitHubConnector.
+    get_file_blame``'s response parsing, including its per-call
+    ``age_seconds`` calculation (measured against "now" at parse time)."""
+    repo_data = payload.get("repository") or {}
+    obj_data = repo_data.get("object") or {}
+    blame_data = obj_data.get("blame") or {}
+    ranges_data = blame_data.get("ranges") or []
+
+    now = datetime.now(timezone.utc)
+    ranges: list[BlameRange] = []
+    for range_item in ranges_data:
+        commit = range_item.get("commit") or {}
+        author_info = commit.get("author") or {}
+        authored_date = _parse_blame_commit_datetime(commit.get("authoredDate"))
+        age_seconds = int((now - authored_date).total_seconds()) if authored_date else 0
+        ranges.append(
+            BlameRange(
+                starting_line=range_item.get("startingLine", 0),
+                ending_line=range_item.get("endingLine", 0),
+                commit_sha=commit.get("oid", ""),
+                author=author_info.get("name", "Unknown"),
+                author_email=author_info.get("email", ""),
+                age_seconds=age_seconds,
+            )
+        )
+    return FileBlame(file_path=file_path, ranges=ranges)
+
+
+__all__ = [
+    "BLAME_QUERY",
+    "GITHUB_ENTERPRISE_GRAPHQL_PATH",
+    "GITHUB_GRAPHQL_PATH",
+    "blame_variables",
+    "build_blob_texts_query",
+    "github_graphql_url",
+    "parse_blame_response",
+    "parse_blob_texts_response",
+    "raise_for_graphql_errors",
+]

--- a/tests/metrics/test_job_daily_hotspots.py
+++ b/tests/metrics/test_job_daily_hotspots.py
@@ -605,8 +605,26 @@ class _FakeTreeEntry:
         self.type = type_
 
 
+class _FakeGitHubCodeClient:
+    """Stand-in for ``GitHubCodeClient`` (CHAOS-2773 CS7): the processor now
+    fetches blame through this client's async ``get_file_blame`` instead of
+    the frozen connector's sync ``get_file_blame`` (no longer called)."""
+
+    def __init__(self, *, blame_fn: Any) -> None:
+        self._blame_fn = blame_fn
+        self.close = AsyncMock()
+
+    async def get_file_blame(
+        self, *, owner: str, repo: str, path: str, ref: str
+    ) -> Any:
+        return self._blame_fn(owner=owner, repo=repo, path=path, ref=ref)
+
+    def drain_usage_observations(self) -> list[Any]:
+        return []
+
+
 @pytest.mark.asyncio
-async def test_github_blame_backfill_is_capped() -> None:
+async def test_github_blame_backfill_is_capped(monkeypatch: pytest.MonkeyPatch) -> None:
     """Onboarding blame must stop at BLAME_BACKFILL_MAX_FILES files.
 
     Drives the real ``_backfill_github_missing_data`` blame branch with a tree
@@ -615,6 +633,7 @@ async def test_github_blame_backfill_is_capped() -> None:
     onboarding into an unbounded GraphQL crawl (CHAOS-2376 / Codex no-ship).
     """
     from dev_health_ops.connectors.models import BlameRange, FileBlame
+    from dev_health_ops.processors import github as github_module
     from dev_health_ops.processors.github import (
         BLAME_BACKFILL_MAX_FILES,
         _backfill_github_missing_data,
@@ -666,7 +685,11 @@ async def test_github_blame_backfill_is_capped() -> None:
 
     connector = Mock()
     connector.github.get_repo.return_value = gh_repo
-    connector.get_file_blame = Mock(side_effect=fake_blame)
+    monkeypatch.setattr(
+        github_module,
+        "_github_code_client_from_connector",
+        lambda _connector: _FakeGitHubCodeClient(blame_fn=fake_blame),
+    )
 
     db_repo = Mock()
     db_repo.id = uuid.uuid4()
@@ -920,7 +943,9 @@ def test_blame_backfill_needed_probe_failure_defers_not_aborts() -> None:
 
 
 @pytest.mark.asyncio
-async def test_github_blame_backfill_resumes_on_second_sync() -> None:
+async def test_github_blame_backfill_resumes_on_second_sync(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """A second GitHub sync blames the files the first sync left uncovered.
 
     Proves the cap is not a permanent dead-end: across two runs every file in
@@ -928,6 +953,7 @@ async def test_github_blame_backfill_resumes_on_second_sync() -> None:
     round-3 / Codex no-ship).
     """
     from dev_health_ops.connectors.models import BlameRange, FileBlame
+    from dev_health_ops.processors import github as github_module
     from dev_health_ops.processors.github import (
         BLAME_BACKFILL_MAX_FILES,
         _backfill_github_missing_data,
@@ -970,7 +996,11 @@ async def test_github_blame_backfill_resumes_on_second_sync() -> None:
 
     connector = Mock()
     connector.github.get_repo.return_value = gh_repo
-    connector.get_file_blame = Mock(side_effect=fake_blame)
+    monkeypatch.setattr(
+        github_module,
+        "_github_code_client_from_connector",
+        lambda _connector: _FakeGitHubCodeClient(blame_fn=fake_blame),
+    )
 
     db_repo = Mock()
     db_repo.id = uuid.uuid4()
@@ -1075,13 +1105,16 @@ async def test_gitlab_blame_backfill_resumes_on_second_sync(
 
 
 @pytest.mark.asyncio
-async def test_github_blame_gate_alive_when_files_present_blame_partial() -> None:
+async def test_github_blame_gate_alive_when_files_present_blame_partial(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """needs.blame=False but has_unblamed_files=True still triggers the crawl.
 
     Models a rerun where the any-row gate would say "blame exists, skip" but
     coverage is partial; the coverage gate must keep the blame branch alive.
     """
     from dev_health_ops.connectors.models import BlameRange, FileBlame
+    from dev_health_ops.processors import github as github_module
     from dev_health_ops.processors.github import _backfill_github_missing_data
 
     all_paths = {"src/a.py", "src/b.py", "src/c.py"}
@@ -1120,7 +1153,11 @@ async def test_github_blame_gate_alive_when_files_present_blame_partial() -> Non
 
     connector = Mock()
     connector.github.get_repo.return_value = gh_repo
-    connector.get_file_blame = Mock(side_effect=fake_blame)
+    monkeypatch.setattr(
+        github_module,
+        "_github_code_client_from_connector",
+        lambda _connector: _FakeGitHubCodeClient(blame_fn=fake_blame),
+    )
 
     db_repo = Mock()
     db_repo.id = uuid.uuid4()

--- a/tests/providers/test_github_budget.py
+++ b/tests/providers/test_github_budget.py
@@ -83,6 +83,23 @@ def test_github_git_and_commit_stats_actuals_markers_are_live() -> None:
     assert markers[("commit_stats", BudgetDimension.CONTENTS_BLOB)] == ()
 
 
+def test_github_files_and_blame_contents_blob_actuals_markers_are_live() -> None:
+    """CHAOS-2808/CS7: files/blame GraphQL content+blame fetch (`GitHubCodeClient`,
+    `providers/github/graphql.py`) is the instrumented dimension -- unlike
+    `commit_stats` (where REST_CORE is live), `files`/`blame` traffic is 100%
+    GraphQL, so `contents_blob` carries the marker and `rest_core` (the still-
+    frozen tree-listing REST call) stays empty."""
+    markers = {
+        (family.route_family, family.dimension): family.operation_markers
+        for family in GITHUB_USAGE_ROUTE_FAMILIES
+    }
+
+    assert markers[("files", BudgetDimension.CONTENTS_BLOB)] == ("files:",)
+    assert markers[("files", BudgetDimension.REST_CORE)] == ()
+    assert markers[("blame", BudgetDimension.CONTENTS_BLOB)] == ("blame:",)
+    assert markers[("blame", BudgetDimension.REST_CORE)] == ()
+
+
 def test_github_budget_estimator_splits_pr_social_pressure() -> None:
     estimates = GitHubBudgetEstimator().estimate(_context(dataset_key="pr-comments"))
 

--- a/tests/providers/test_github_code_client_files_blame.py
+++ b/tests/providers/test_github_code_client_files_blame.py
@@ -1,0 +1,252 @@
+"""``GitHubCodeClient.get_file_contents`` / ``get_file_blame`` tests
+(CHAOS-2773 CS7).
+
+Proves the GraphQL content/blame methods POST through the client's owned
+``InstrumentedRESTCore``, label operations with the explicit ``files:``/
+``blame:`` route-family prefix (the CS1 resolver short-circuit), and drain
+usage observations under the ``contents_blob`` dimension -- mirroring
+``test_github_code_client_commits.py``'s pattern for the git/commit_stats
+families.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from collections.abc import Mapping
+
+import httpx
+import pytest
+
+from dev_health_ops.exceptions import APIException, RateLimitException
+from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.code_client import GitHubCodeClient
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+
+def _client(transport: httpx.AsyncBaseTransport) -> GitHubCodeClient:
+    return GitHubCodeClient(auth=GitHubAuth(token="unit-test-pat"), transport=transport)
+
+
+def _mock_sleep(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No-op ``asyncio.sleep`` so retry backoff (a rate-limited 403 gets
+    retried before the terminal ``RateLimitException``) does not actually
+    block the test -- mirrors ``test_github_code_client_security.py``."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers._http.asyncio.sleep",
+        AsyncMock(return_value=None),
+    )
+
+
+def _blob_response(fields: Mapping[str, Mapping[str, object] | None]) -> httpx.Response:
+    return httpx.Response(200, json={"data": {"repository": fields}})
+
+
+def test_get_file_contents_posts_graphql_and_omits_binary_and_truncated() -> None:
+    asyncio.run(_test_get_file_contents_posts_graphql_and_omits_binary_and_truncated())
+
+
+async def _test_get_file_contents_posts_graphql_and_omits_binary_and_truncated() -> (
+    None
+):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return _blob_response(
+            {
+                "f0": {"text": "print(1)\n", "isBinary": False, "isTruncated": False},
+                "f1": {"text": None, "isBinary": True, "isTruncated": False},
+            }
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    result = await client.get_file_contents(
+        "acme", "widgets", ["src/app.py", "src/logo.png"], ref="main"
+    )
+    await client.close()
+
+    assert result == {"src/app.py": "print(1)\n"}
+    assert len(seen) == 1
+    assert str(seen[0].url).endswith("/graphql")
+    assert seen[0].headers["Authorization"] == "Bearer unit-test-pat"
+    body = json.loads(seen[0].content)
+    assert body["variables"] == {"owner": "acme", "repo": "widgets"}
+    assert "f0:" in body["query"]
+    assert "f1:" in body["query"]
+
+
+def test_get_file_contents_batches_across_batch_size() -> None:
+    asyncio.run(_test_get_file_contents_batches_across_batch_size())
+
+
+async def _test_get_file_contents_batches_across_batch_size() -> None:
+    calls: list[dict[str, object]] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        body = json.loads(request.content)
+        calls.append(body)
+        # Reply with contents for however many aliased fields were requested.
+        n = body["query"].count("object(expression:")
+        fields = {
+            f"f{i}": {"text": f"text-{i}", "isBinary": False, "isTruncated": False}
+            for i in range(n)
+        }
+        return _blob_response(fields)
+
+    client = _client(httpx.MockTransport(handler))
+    paths = [f"src/f{i}.py" for i in range(5)]
+    result = await client.get_file_contents(
+        "acme", "widgets", paths, ref="main", batch_size=2
+    )
+    await client.close()
+
+    # 5 paths at batch_size=2 -> 3 physical GraphQL requests.
+    assert len(calls) == 3
+    assert set(result.keys()) <= set(paths)
+
+
+def test_get_file_contents_usage_resolves_to_files_contents_blob_family() -> None:
+    asyncio.run(_test_get_file_contents_usage_resolves_to_files_contents_blob_family())
+
+
+async def _test_get_file_contents_usage_resolves_to_files_contents_blob_family() -> (
+    None
+):
+    client = _client(
+        httpx.MockTransport(
+            lambda r: _blob_response(
+                {"f0": {"text": "x", "isBinary": False, "isTruncated": False}}
+            )
+        )
+    )
+
+    await client.get_file_contents("acme", "widgets", ["src/app.py"], ref="main")
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert len(observations) == 1
+    assert observations[0]["route_family"] == "files"
+    assert observations[0]["dimension"] == BudgetDimension.CONTENTS_BLOB.value
+    assert observations[0]["request_count"] == 1
+    assert observations[0]["example_operation"].startswith("files:")
+
+
+def test_get_file_contents_raises_api_exception_on_graphql_errors() -> None:
+    asyncio.run(_test_get_file_contents_raises_api_exception_on_graphql_errors())
+
+
+async def _test_get_file_contents_raises_api_exception_on_graphql_errors() -> None:
+    client = _client(
+        httpx.MockTransport(
+            lambda r: httpx.Response(
+                200, json={"errors": [{"message": "field does not exist"}]}
+            )
+        )
+    )
+
+    with pytest.raises(APIException, match="field does not exist"):
+        await client.get_file_contents("acme", "widgets", ["src/app.py"], ref="main")
+    await client.close()
+
+
+def test_get_file_blame_posts_graphql_and_parses_ranges() -> None:
+    asyncio.run(_test_get_file_blame_posts_graphql_and_parses_ranges())
+
+
+async def _test_get_file_blame_posts_graphql_and_parses_ranges() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "data": {
+                    "repository": {
+                        "object": {
+                            "blame": {
+                                "ranges": [
+                                    {
+                                        "startingLine": 1,
+                                        "endingLine": 2,
+                                        "commit": {
+                                            "oid": "sha1",
+                                            "authoredDate": "2020-01-01T00:00:00Z",
+                                            "author": {
+                                                "name": "Ada",
+                                                "email": "ada@example.com",
+                                            },
+                                        },
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                }
+            },
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    blame = await client.get_file_blame("acme", "widgets", "src/app.py", ref="main")
+    await client.close()
+
+    assert len(seen) == 1
+    body = json.loads(seen[0].content)
+    assert body["variables"] == {
+        "owner": "acme",
+        "repo": "widgets",
+        "path": "src/app.py",
+        "ref": "main",
+    }
+    assert blame.file_path == "src/app.py"
+    assert [
+        (rng.starting_line, rng.ending_line, rng.commit_sha, rng.author)
+        for rng in blame.ranges
+    ] == [(1, 2, "sha1", "Ada")]
+
+
+def test_get_file_blame_usage_resolves_to_blame_contents_blob_family() -> None:
+    asyncio.run(_test_get_file_blame_usage_resolves_to_blame_contents_blob_family())
+
+
+async def _test_get_file_blame_usage_resolves_to_blame_contents_blob_family() -> None:
+    client = _client(
+        httpx.MockTransport(lambda r: httpx.Response(200, json={"data": {}}))
+    )
+
+    await client.get_file_blame("acme", "widgets", "src/app.py", ref="main")
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert len(observations) == 1
+    assert observations[0]["route_family"] == "blame"
+    assert observations[0]["dimension"] == BudgetDimension.CONTENTS_BLOB.value
+    assert observations[0]["example_operation"].startswith("blame:")
+
+
+def test_get_file_blame_raises_rate_limit_exception_on_primary_403(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _mock_sleep(monkeypatch)
+    asyncio.run(_test_get_file_blame_raises_rate_limit_exception_on_primary_403())
+
+
+async def _test_get_file_blame_raises_rate_limit_exception_on_primary_403() -> None:
+    def handler(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(
+            403,
+            headers={"x-ratelimit-remaining": "0", "x-ratelimit-reset": "0"},
+            json={"message": "API rate limit exceeded"},
+        )
+
+    client = _client(httpx.MockTransport(handler))
+
+    with pytest.raises(RateLimitException) as exc_info:
+        await client.get_file_blame("acme", "widgets", "src/app.py", ref="main")
+    await client.close()
+
+    assert exc_info.value.signal is not None
+    assert exc_info.value.signal.dimension == BudgetDimension.CONTENTS_BLOB

--- a/tests/providers/test_github_graphql.py
+++ b/tests/providers/test_github_graphql.py
@@ -1,0 +1,173 @@
+"""``providers/github/graphql.py`` query builder + response parser tests
+(CHAOS-2773 CS7).
+
+Pins byte-for-byte parity with the legacy ``connectors/utils/graphql.py::
+GitHubGraphQLClient.get_blame`` / ``get_blob_texts`` response-shape handling
+this module relocates, plus the GraphQL-level error contract that the
+transport core's status-code classification never sees (a GraphQL error
+rides on an HTTP 200).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from dev_health_ops.exceptions import APIException
+from dev_health_ops.providers.github.graphql import (
+    blame_variables,
+    build_blob_texts_query,
+    github_graphql_url,
+    parse_blame_response,
+    parse_blob_texts_response,
+    raise_for_graphql_errors,
+)
+
+
+def test_blame_variables_carries_all_four_fields() -> None:
+    assert blame_variables("acme", "widgets", "src/app.py", "main") == {
+        "owner": "acme",
+        "repo": "widgets",
+        "path": "src/app.py",
+        "ref": "main",
+    }
+
+
+def test_github_graphql_url_uses_public_github_endpoint() -> None:
+    assert (
+        github_graphql_url("https://api.github.com") == "https://api.github.com/graphql"
+    )
+
+
+def test_github_graphql_url_uses_enterprise_graphql_endpoint() -> None:
+    assert (
+        github_graphql_url("https://ghe.example.com/api/v3")
+        == "https://ghe.example.com/api/graphql"
+    )
+
+
+def test_github_graphql_url_preserves_enterprise_prefix() -> None:
+    assert (
+        github_graphql_url("https://ghe.example.com/source/api/v3")
+        == "https://ghe.example.com/source/api/graphql"
+    )
+
+
+def test_build_blob_texts_query_aliases_one_field_per_path() -> None:
+    query = build_blob_texts_query("main", ["src/app.py", "README.md"])
+
+    assert 'f0: object(expression: "main:src/app.py")' in query
+    assert 'f1: object(expression: "main:README.md")' in query
+    assert "isBinary" in query
+    assert "isTruncated" in query
+
+
+def test_build_blob_texts_query_json_escapes_path_special_characters() -> None:
+    # A path containing a quote/backslash must not break out of the
+    # GraphQL string literal -- json.dumps is the escaping mechanism.
+    query = build_blob_texts_query("main", ['weird"path.py'])
+    assert '\\"path.py' in query
+
+
+def test_raise_for_graphql_errors_noop_when_no_errors_key() -> None:
+    raise_for_graphql_errors({"data": {}}, operation="files:test")
+    raise_for_graphql_errors({}, operation="files:test")
+
+
+def test_raise_for_graphql_errors_raises_api_exception_with_joined_messages() -> None:
+    with pytest.raises(APIException) as exc_info:
+        raise_for_graphql_errors(
+            {"errors": [{"message": "Field 'x' doesn't exist"}, {"message": "boom"}]},
+            operation="blame:POST /graphql",
+        )
+    assert "Field 'x' doesn't exist" in str(exc_info.value)
+    assert "boom" in str(exc_info.value)
+    assert "blame:POST /graphql" in str(exc_info.value)
+
+
+def test_parse_blob_texts_response_omits_binary_truncated_and_missing() -> None:
+    payload = {
+        "repository": {
+            "f0": {"text": "hello\n", "isBinary": False, "isTruncated": False},
+            "f1": {"text": None, "isBinary": True, "isTruncated": False},
+            "f2": {"text": "big", "isBinary": False, "isTruncated": True},
+            "f3": None,
+        }
+    }
+    result = parse_blob_texts_response(payload, ["a.py", "b.bin", "c.py", "d.py"])
+
+    assert result == {
+        "a.py": "hello\n",
+        "b.bin": None,
+        "c.py": None,
+        "d.py": None,
+    }
+
+
+def test_parse_blame_response_builds_ranges_and_computes_age() -> None:
+    payload = {
+        "repository": {
+            "object": {
+                "blame": {
+                    "ranges": [
+                        {
+                            "startingLine": 1,
+                            "endingLine": 3,
+                            "commit": {
+                                "oid": "abc123",
+                                "authoredDate": "2020-01-01T00:00:00Z",
+                                "author": {"name": "Ada", "email": "ada@example.com"},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    blame = parse_blame_response(payload, file_path="src/app.py")
+
+    assert blame.file_path == "src/app.py"
+    assert len(blame.ranges) == 1
+    rng = blame.ranges[0]
+    assert rng.starting_line == 1
+    assert rng.ending_line == 3
+    assert rng.commit_sha == "abc123"
+    assert rng.author == "Ada"
+    assert rng.author_email == "ada@example.com"
+    # Authored in 2020 -- age is a large positive number of seconds.
+    assert rng.age_seconds > 0
+
+
+def test_parse_blame_response_defaults_on_missing_shape() -> None:
+    blame = parse_blame_response({}, file_path="src/app.py")
+
+    assert blame.file_path == "src/app.py"
+    assert blame.ranges == []
+
+
+def test_parse_blame_response_unparseable_date_falls_back_to_zero_age() -> None:
+    payload = {
+        "repository": {
+            "object": {
+                "blame": {
+                    "ranges": [
+                        {
+                            "startingLine": 1,
+                            "endingLine": 1,
+                            "commit": {
+                                "oid": "abc",
+                                "authoredDate": "not-a-date",
+                                "author": {},
+                            },
+                        }
+                    ]
+                }
+            }
+        }
+    }
+
+    blame = parse_blame_response(payload, file_path="src/app.py")
+
+    assert blame.ranges[0].age_seconds == 0
+    assert blame.ranges[0].author == "Unknown"
+    assert blame.ranges[0].author_email == ""

--- a/tests/providers/test_usage_resolver_prefix.py
+++ b/tests/providers/test_usage_resolver_prefix.py
@@ -167,6 +167,39 @@ def test_github_review_batch_unprefixed_label_still_resolves_to_work_item_prs() 
 
 
 # ---------------------------------------------------------------------------
+# CHAOS-2808/CS7: files/blame GraphQL content+blame fetch is the SECOND
+# intentional re-bucketing. Both families carry TWO dimension entries
+# (contents_blob live, rest_core still frozen/empty); the prefix
+# short-circuit only matches on route_family, so ORDERING within
+# GITHUB_USAGE_ROUTE_FAMILIES (contents_blob listed first) is what resolves
+# a "files:"/"blame:" label to the live dimension instead of the frozen one.
+# ---------------------------------------------------------------------------
+
+GITHUB_CS7_PREFIXED_LABELS: tuple[tuple[str, str, tuple[str, BudgetDimension]], ...] = (
+    (
+        "rest",
+        "files:POST /graphql (get_blob_texts x3)",
+        ("files", BudgetDimension.CONTENTS_BLOB),
+    ),
+    (
+        "rest",
+        "blame:POST /graphql (get_blame)",
+        ("blame", BudgetDimension.CONTENTS_BLOB),
+    ),
+)
+
+
+@pytest.mark.parametrize("transport,operation,expected", GITHUB_CS7_PREFIXED_LABELS)
+def test_github_files_blame_prefixed_labels_resolve_to_contents_blob(
+    transport: str, operation: str, expected: tuple[str, BudgetDimension]
+) -> None:
+    assert (
+        GITHUB_USAGE_RESOLVER.resolve(transport=transport, operation=operation)
+        == expected
+    )
+
+
+# ---------------------------------------------------------------------------
 # 2. Representative prefixed labels per registered family short-circuit.
 # ---------------------------------------------------------------------------
 

--- a/tests/test_github_content_backfill.py
+++ b/tests/test_github_content_backfill.py
@@ -28,11 +28,55 @@ from dev_health_ops.processors.github import (
 )
 
 
+class _FakeCodeClient:
+    """Stand-in for ``GitHubCodeClient`` (CHAOS-2773 CS7): the processor now
+    fetches files/blame through this client's async ``get_file_contents``/
+    ``get_file_blame`` instead of the frozen connector's sync methods, so
+    tests double the CLIENT, never ``connector.get_file_contents``/
+    ``connector.get_file_blame`` (which the processor no longer calls)."""
+
+    def __init__(self, *, contents=None, blame=None, side_effect=None):
+        self.contents = contents if contents is not None else {}
+        self.blame = blame
+        self.side_effect = side_effect
+        self.file_content_calls: list[tuple[str, str, list[str], str]] = []
+        self.file_blame_calls: list[tuple[str, str, str, str]] = []
+        self.drain_usage_observations = Mock(return_value=[])
+        self.close = AsyncMock()
+
+    async def get_file_contents(
+        self,
+        owner: str,
+        repo: str,
+        paths: list[str],
+        *,
+        ref: str = "HEAD",
+        batch_size: int = 50,
+    ) -> dict[str, str]:
+        del batch_size
+        self.file_content_calls.append((owner, repo, paths, ref))
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.contents
+
+    async def get_file_blame(
+        self,
+        owner: str,
+        repo: str,
+        path: str,
+        *,
+        ref: str = "HEAD",
+    ):
+        self.file_blame_calls.append((owner, repo, path, ref))
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.blame
+
+
 class TestFetchScannableContents:
     @pytest.mark.asyncio
     async def test_filters_by_scanner_globs_and_size(self):
-        connector = Mock()
-        connector.get_file_contents = Mock(return_value={"src/app.py": "x = 1\n"})
+        client = _FakeCodeClient(contents={"src/app.py": "x = 1\n"})
 
         file_paths = [
             "src/app.py",
@@ -50,36 +94,48 @@ class TestFetchScannableContents:
         }
 
         result = await _fetch_scannable_contents(
-            connector, "octo", "repo", "main", file_paths, blob_sizes, "octo/repo"
+            client, "octo", "repo", "main", file_paths, blob_sizes, "octo/repo"
         )
 
         assert result == {"src/app.py": "x = 1\n"}
-        connector.get_file_contents.assert_called_once_with(
-            "octo", "repo", ["src/app.py"], ref="main"
-        )
+        assert client.file_content_calls == [("octo", "repo", ["src/app.py"], "main")]
 
     @pytest.mark.asyncio
     async def test_no_scannable_paths_skips_api(self):
-        connector = Mock()
-        connector.get_file_contents = Mock()
+        client = _FakeCodeClient()
 
         result = await _fetch_scannable_contents(
-            connector, "octo", "repo", "main", ["README.md"], {}, "octo/repo"
+            client, "octo", "repo", "main", ["README.md"], {}, "octo/repo"
         )
 
         assert result == {}
-        connector.get_file_contents.assert_not_called()
+        assert client.file_content_calls == []
 
     @pytest.mark.asyncio
     async def test_api_error_degrades_to_empty(self):
-        connector = Mock()
-        connector.get_file_contents = Mock(side_effect=RuntimeError("boom"))
+        client = _FakeCodeClient(side_effect=RuntimeError("boom"))
 
         result = await _fetch_scannable_contents(
-            connector, "octo", "repo", "main", ["src/app.py"], {}, "octo/repo"
+            client, "octo", "repo", "main", ["src/app.py"], {}, "octo/repo"
         )
 
         assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_propagates_without_degrading(self):
+        """CHAOS-2773 CS7: unlike a generic fetch error, a rate limit must NOT
+        degrade to empty -- it propagates so the caller's deferral semantics
+        apply, exactly like the commit-stats fetch path."""
+        client = _FakeCodeClient(
+            side_effect=RateLimitException("limited", retry_after_seconds=7.0)
+        )
+
+        with pytest.raises(RateLimitException) as exc_info:
+            await _fetch_scannable_contents(
+                client, "octo", "repo", "main", ["src/app.py"], {}, "octo/repo"
+            )
+
+        assert exc_info.value.retry_after_seconds == 7.0
 
 
 class TestBackfillFileRecordsContents:
@@ -180,8 +236,9 @@ class _FakeTreeEntry:
 
 class TestPathsOnlyUpgrade:
     @pytest.mark.asyncio
-    async def test_backfill_refetches_contents_for_paths_only_repos(self):
+    async def test_backfill_refetches_contents_for_paths_only_repos(self, monkeypatch):
         """Repos with paths-only git_files rows (pre-content-sync) get upgraded."""
+        from dev_health_ops.processors import github
         from dev_health_ops.processors.github import _backfill_github_missing_data
 
         store = Mock()
@@ -205,7 +262,11 @@ class TestPathsOnlyUpgrade:
         )
         connector = Mock()
         connector.github.get_repo.return_value = gh_repo
-        connector.get_file_contents = Mock(return_value={"src/app.py": "x = 1\n"})
+
+        code_client = _FakeCodeClient(contents={"src/app.py": "x = 1\n"})
+        monkeypatch.setattr(
+            github, "_github_code_client_from_connector", lambda _connector: code_client
+        )
 
         db_repo = Mock()
         db_repo.id = uuid.uuid4()
@@ -224,6 +285,11 @@ class TestPathsOnlyUpgrade:
 
         by_path = {f.path: f.contents for f in written}
         assert by_path == {"src/app.py": "x = 1\n", "README.md": None}
+        assert code_client.file_content_calls == [
+            ("octo", "repo", ["src/app.py"], "main")
+        ]
+        code_client.close.assert_awaited_once()
+        connector.get_file_contents.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_backfill_skips_when_contents_already_present(self):
@@ -515,18 +581,24 @@ class TestCommitStatsBackfill:
 
         connector = Mock()
         connector.github.get_repo.return_value = gh_repo
-        connector.get_file_blame.return_value = FileBlame(
-            file_path="src/app.py",
-            ranges=[
-                BlameRange(
-                    starting_line=1,
-                    ending_line=1,
-                    commit_sha="sha-0",
-                    author="A",
-                    author_email="a@example.com",
-                    age_seconds=0,
-                )
-            ],
+
+        code_client = _FakeCodeClient(
+            blame=FileBlame(
+                file_path="src/app.py",
+                ranges=[
+                    BlameRange(
+                        starting_line=1,
+                        ending_line=1,
+                        commit_sha="sha-0",
+                        author="A",
+                        author_email="a@example.com",
+                        age_seconds=0,
+                    )
+                ],
+            )
+        )
+        monkeypatch.setattr(
+            github, "_github_code_client_from_connector", lambda _connector: code_client
         )
 
         db_repo = Mock()
@@ -548,12 +620,9 @@ class TestCommitStatsBackfill:
 
         sink.insert_git_commit_stats.assert_not_called()
         assert stats_calls == []
-        connector.get_file_blame.assert_called_once_with(
-            owner="octo",
-            repo="repo",
-            path="src/app.py",
-            ref="main",
-        )
+        assert code_client.file_blame_calls == [("octo", "repo", "src/app.py", "main")]
+        code_client.close.assert_awaited_once()
+        connector.get_file_blame.assert_not_called()
         assert [row.path for row in blame_rows] == ["src/app.py"]
 
     @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- route GitHub file contents and blame through GitHubCodeClient
- relocate GitHub GraphQL file/blame query and parser support under providers/github
- classify files/blame usage as contents_blob actuals and document the policy

## Validation
- uv run --extra dev pytest tests/providers/test_github_code_client_files_blame.py tests/providers/test_github_graphql.py tests/test_github_content_backfill.py
- uv run --extra dev ruff format --check .
- uv run --extra dev ruff check .
- uv run --extra dev mypy --install-types --non-interactive .
- OTEL_SDK_DISABLED=true bash ci/local_validate.sh

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.