### PR TITLE
feat(providers): instrument GitLab files and blame actuals (CHAOS-2815)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -882,8 +882,9 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
 - **GitLab.** `process_gitlab_project` accepts the same `usage_sink`
   parameter for a uniform cross-provider adapter contract. Migrated
   GitLabCodeClient-backed families drain into it on both success and failure:
-  `security` (CS10), `pipelines`/`deployments` (CS11), `tests` (CS12), and
-  commits + aggregate commit stats under the existing `project` family (CS13).
+  `security` (CS10), `pipelines`/`deployments` (CS11), `tests` (CS12),
+  commits + aggregate commit stats (CS13), and `files`/`blame` (CS14) --
+  all under the existing `project` family.
   Frozen connector-only paths still leave the sink untouched until their own
   migration changeset lands.
 
@@ -1192,14 +1193,17 @@ paper over:
   `pipelines`+`deployments`
   ([CHAOS-2812](https://linear.app/fullchaos/issue/CHAOS-2812), CS11), and
   `tests` (+CI adapter usage draining;
-  [CHAOS-2813](https://linear.app/fullchaos/issue/CHAOS-2813), CS12), and
-  commits + aggregate commit stats under the `project` family
-  ([CHAOS-2814](https://linear.app/fullchaos/issue/CHAOS-2814), CS13)
+  [CHAOS-2813](https://linear.app/fullchaos/issue/CHAOS-2813), CS12),
+  commits + aggregate commit stats
+  ([CHAOS-2814](https://linear.app/fullchaos/issue/CHAOS-2814), CS13), and
+  `files`/`blame` (`get_file_contents` batched GraphQL blob fetch +
+  `get_file_blame` REST, both under the `project` family;
+  [CHAOS-2815](https://linear.app/fullchaos/issue/CHAOS-2815), CS14)
   code-dataset families are migrated onto the canonical, instrumented
   `providers/gitlab/code_client.py::GitLabCodeClient`. GitLab's remaining
-  frozen code-dataset methods (`files`/`blame`/
-  `merge_requests` listing + repo-metadata/batch orchestration) stay
-  unmigrated pending their own CHAOS-2773 changesets through CS17.
+  frozen code-dataset methods (`merge_requests` listing + repo-metadata/batch
+  orchestration) stay unmigrated pending their own CHAOS-2773 changesets
+  through CS17.
 
 
 ## References

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -1267,13 +1267,24 @@ async def _fetch_scannable_contents(
     project_full_name: str,
     ref: str,
     file_paths: list[str],
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> dict[str, str]:
     """Fetch text for scanner-eligible files via batched GraphQL blob queries.
 
-    Only paths matching the complexity scanner's include/exclude globs are
-    fetched, keeping API volume proportional to what the metrics jobs can
-    actually use. Errors degrade to a paths-only backfill (contents stay
-    NULL) rather than failing the sync.
+    CHAOS-2815/CS14: fetches via the canonical, instrumented
+    ``providers.gitlab.code_client.GitLabCodeClient`` (built on the shared
+    ``InstrumentedRESTCore``) instead of the frozen
+    ``GitLabConnector.get_file_contents`` (``connectors/gitlab.py``, riding
+    un-instrumented ``requests`` GraphQL calls). Only paths matching the
+    complexity scanner's include/exclude globs are fetched, keeping API
+    volume proportional to what the metrics jobs can actually use.
+
+    ``usage_sink`` (CHAOS-2803/CS2) receives the client's drained
+    per-request usage observations in a ``finally:`` on both the success and
+    failure path, mirroring every other GitLabCodeClient helper in this
+    file. A ``RateLimitException`` propagates (an exhausted rate limit must
+    fail the sync, not silently truncate file coverage); any other fetch
+    failure degrades to a paths-only backfill (contents stay NULL).
     """
     scanner = ComplexityScanner(config_path=DEFAULT_COMPLEXITY_CONFIG_PATH)
     scannable: list[str] = []
@@ -1292,22 +1303,29 @@ async def _fetch_scannable_contents(
     if not scannable:
         return {}
 
-    loop = asyncio.get_running_loop()
+    drained_observations: list[dict[str, Any]] = []
     try:
-        return await loop.run_in_executor(
-            None,
-            lambda: connector.get_file_contents(
-                project_full_name,
-                scannable,
-                ref=ref,
-                max_bytes=CONTENT_FETCH_MAX_BYTES,
-            ),
-        )
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await client.get_file_contents(
+                    project_full_name,
+                    scannable,
+                    ref=ref,
+                    max_bytes=CONTENT_FETCH_MAX_BYTES,
+                )
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
     except Exception as e:
+        if _is_rate_limit_exception(e):
+            raise
         logging.warning(
             "Failed to fetch file contents for %s: %s", project_full_name, e
         )
         return {}
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_scannable_contents", drained_observations, usage_sink
+        )
 
 
 async def _backfill_gitlab_missing_data(
@@ -1390,6 +1408,7 @@ async def _backfill_gitlab_missing_data(
                 project_full_name,
                 default_branch,
                 file_paths,
+                usage_sink=usage_sink,
             )
             await backfill_file_records(
                 ingestion_sink,
@@ -1458,42 +1477,60 @@ async def _backfill_gitlab_missing_data(
             project_full_name,
             BLAME_BACKFILL_MAX_FILES,
         )
-        async with AsyncBatchCollector(
-            ingestion_sink.insert_blame_data
-        ) as blame_collector:
-            for path in blame_paths:
+        # CHAOS-2815/CS14: fetch blame via the canonical, instrumented
+        # GitLabCodeClient (built on the shared InstrumentedRESTCore) instead
+        # of the frozen ``connector.rest_client.get_file_blame`` (un-
+        # instrumented ``connectors/utils/rest.py``). One client is built for
+        # the whole capped crawl and drained once, mirroring
+        # ``_fetch_gitlab_commit_stats_sync``'s per-commit-loop shape. A
+        # ``RateLimitException`` on any file propagates -- an exhausted rate
+        # limit must fail the sync, not silently strand the remaining files
+        # in this batch as per-file warnings -- while any other per-file
+        # failure is logged and the crawl continues (bounded, best-effort).
+        drained_observations: list[dict[str, Any]] = []
+        try:
+            async with _gitlab_code_client_from_connector(connector) as client:
                 try:
-                    blame_items = connector.rest_client.get_file_blame(
-                        project.id,
-                        path,
-                        default_branch,
-                    )
-                except Exception as e:
-                    logging.debug(
-                        f"Failed blame fetch for {project_full_name}:{path}: {e}"
-                    )
-                    continue
+                    async with AsyncBatchCollector(
+                        ingestion_sink.insert_blame_data
+                    ) as blame_collector:
+                        for path in blame_paths:
+                            try:
+                                blame_items = await client.get_file_blame(
+                                    project.id, path, ref=default_branch
+                                )
+                            except Exception as e:
+                                if _is_rate_limit_exception(e):
+                                    raise
+                                logging.debug(
+                                    f"Failed blame fetch for {project_full_name}:{path}: {e}"
+                                )
+                                continue
 
-                line_no = 1
-                for item in blame_items or []:
-                    commit = item.get("commit", {})
-                    for line in item.get("lines", []) or []:
-                        blame_collector.add(
-                            GitBlame(
-                                repo_id=db_repo.id,
-                                path=path,
-                                line_no=line_no,
-                                author_email=commit.get("author_email"),
-                                author_name=commit.get("author_name"),
-                                author_when=None,
-                                commit_hash=commit.get("id"),
-                                line=line.rstrip("\n")
-                                if isinstance(line, str)
-                                else None,
-                            )
-                        )
-                        line_no += 1
-                        await blame_collector.maybe_flush()
+                            for rng in blame_items.ranges:
+                                for line_no in range(
+                                    rng.starting_line,
+                                    rng.ending_line + 1,
+                                ):
+                                    blame_collector.add(
+                                        GitBlame(
+                                            repo_id=db_repo.id,
+                                            path=path,
+                                            line_no=line_no,
+                                            author_email=rng.author_email,
+                                            author_name=rng.author,
+                                            author_when=None,
+                                            commit_hash=rng.commit_sha,
+                                            line=None,
+                                        )
+                                    )
+                                    await blame_collector.maybe_flush()
+                finally:
+                    drained_observations.extend(client.drain_usage_observations())
+        finally:
+            _drain_gitlab_code_usage(
+                "_backfill_gitlab_missing_data blame", drained_observations, usage_sink
+            )
 
 
 async def _sync_gitlab_commits(
@@ -2019,6 +2056,7 @@ async def process_gitlab_project(
                 default_branch=db_repo.settings.get("default_branch", "main"),
                 max_commits=max_commits,
                 blame_only=True,
+                usage_sink=usage_sink,
             )
             logging.info("Completed blame-only sync for GitLab project: %s", project_id)
             return
@@ -2196,8 +2234,15 @@ async def process_gitlab_project(
                     include_files=run_files,
                     include_blame=run_blame,
                     include_commit_stats=False,
+                    usage_sink=usage_sink,
                 )
             except Exception as e:
+                if _is_rate_limit_exception(e):
+                    # CHAOS-2815/CS14: an exhausted rate limit must propagate
+                    # so the batch/job is marked failed and retried, not
+                    # swallowed as a per-project warning (mirrors CS13's
+                    # commit-stats precedent).
+                    raise
                 logging.warning(
                     "Backfill failed for GitLab project %s: %s", full_name, e
                 )
@@ -2557,6 +2602,7 @@ async def process_gitlab_projects_batch(
                     max_commits=max_commits_per_project,
                     include_blame=True,
                     include_commit_stats=False,
+                    usage_sink=usage_sink,
                 )
             except Exception as e:
                 logging.debug(

--- a/src/dev_health_ops/providers/gitlab/code_client.py
+++ b/src/dev_health_ops/providers/gitlab/code_client.py
@@ -63,8 +63,12 @@ from typing import Any
 
 import httpx
 
-from dev_health_ops.connectors.models import SecurityAlertData
-from dev_health_ops.exceptions import APIException, NotFoundException
+from dev_health_ops.connectors.models import BlameRange, FileBlame, SecurityAlertData
+from dev_health_ops.exceptions import (
+    APIException,
+    NotFoundException,
+    RateLimitException,
+)
 from dev_health_ops.providers._http import (
     GITLAB_DIAGNOSTIC_HEADER_NAMES,
     InstrumentedRESTCore,
@@ -258,6 +262,47 @@ def _map_dependency_alert(
     )
 
 
+def _parse_gitlab_blame_datetime(value: object) -> datetime | None:
+    if not isinstance(value, str) or not value:
+        return None
+    try:
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError:
+        logger.debug("Failed to parse GitLab blame authored date: %s", value)
+        return None
+
+
+def _map_file_blame(file_path: str, items: list[Any]) -> FileBlame:
+    now = datetime.now(timezone.utc)
+    line_no = 1
+    ranges: list[BlameRange] = []
+    for item in items:
+        if not isinstance(item, dict):
+            continue
+        raw_lines = item.get("lines") or []
+        lines = [line for line in raw_lines if isinstance(line, str)]
+        if not lines:
+            continue
+        commit = item.get("commit") or {}
+        if not isinstance(commit, dict):
+            commit = {}
+        authored_at = _parse_gitlab_blame_datetime(commit.get("authored_date"))
+        age_seconds = int((now - authored_at).total_seconds()) if authored_at else 0
+        ending_line = line_no + len(lines) - 1
+        ranges.append(
+            BlameRange(
+                starting_line=line_no,
+                ending_line=ending_line,
+                commit_sha=str(commit.get("id") or ""),
+                author=str(commit.get("author_name") or "Unknown"),
+                author_email=str(commit.get("author_email") or ""),
+                age_seconds=age_seconds,
+            )
+        )
+        line_no = ending_line + 1
+    return FileBlame(file_path=file_path, ranges=ranges)
+
+
 def _parse_gitlab_datetime(value: object) -> datetime | None:
     if not isinstance(value, str) or not value:
         return None
@@ -396,6 +441,7 @@ class GitLabCodeClient:
             classify_error=_classify_error,
             transport=transport,
         )
+        self._graphql_url = f"{base_url.rstrip('/')}/api/graphql"
 
     async def _resolve_project_id(self, project_id_or_path: int | str) -> int:
         """Resolve a project id/path to its numeric id, mirroring the
@@ -612,6 +658,197 @@ class GitLabCodeClient:
         if not isinstance(payload, dict):
             raise APIException(f"Unexpected GitLab commit response: {type(payload)!r}")
         return _map_commit_stats(commit_sha, payload)
+
+    async def get_file_contents(
+        self,
+        project_full_path: str,
+        paths: list[str],
+        *,
+        ref: str = "HEAD",
+        batch_size: int = 50,
+        max_bytes: int | None = 1_000_000,
+    ) -> dict[str, str]:
+        """Fetch text contents for many files via batched GraphQL blob queries.
+
+        Mirrors ``GitLabConnector.get_file_contents`` (``connectors/gitlab.py``,
+        FROZEN) field-for-field: GitLab's GraphQL API resolves multiple blobs
+        natively through ``repository.blobs(ref:, paths:)``; ``rawTextBlob``
+        is null for binary blobs, so those (and missing paths) are omitted
+        from the result. When ``max_bytes`` is set, a cheap ``rawSize``-only
+        pass filters oversized blobs first so their text never crosses the
+        wire.
+
+        Per-chunk resilience mirrors ``get_commit_stats``'s per-commit caller
+        contract (CHAOS-2814/CS13 precedent): a ``RateLimitException`` from
+        any chunk PROPAGATES (an exhausted rate limit must fail the sync,
+        not silently truncate file coverage); any other chunk failure
+        degrades -- a failed size-pass chunk falls back to an unfiltered
+        text fetch, a failed text-pass chunk is logged and skipped,
+        preserving earlier chunks' results.
+
+        :param project_full_path: Project full path (``group/project``).
+        :param paths: Repository-relative file paths.
+        :param ref: Git reference the paths are resolved against.
+        :param batch_size: Number of blobs to resolve per GraphQL request.
+        :param max_bytes: Skip blobs larger than this (None disables).
+        :return: Mapping of path -> file text for blobs with usable text.
+        """
+        if not paths:
+            return {}
+
+        eligible = paths
+        if max_bytes is not None:
+            eligible = []
+            for start in range(0, len(paths), batch_size):
+                chunk = paths[start : start + batch_size]
+                try:
+                    nodes = await self._graphql_blobs(
+                        project_full_path, ref, chunk, "path rawSize"
+                    )
+                except RateLimitException:
+                    raise
+                except Exception as exc:
+                    logger.warning(
+                        "Size pass failed for %d paths in %s (%s); "
+                        "fetching text without size filter",
+                        len(chunk),
+                        project_full_path,
+                        exc,
+                    )
+                    eligible.extend(chunk)
+                    continue
+                for node in nodes:
+                    path = node.get("path")
+                    raw_size = node.get("rawSize")
+                    if not path:
+                        continue
+                    if raw_size is not None and int(raw_size) > max_bytes:
+                        continue
+                    eligible.append(path)
+
+        contents: dict[str, str] = {}
+        for start in range(0, len(eligible), batch_size):
+            chunk = eligible[start : start + batch_size]
+            try:
+                nodes = await self._graphql_blobs(
+                    project_full_path, ref, chunk, "path rawTextBlob"
+                )
+            except RateLimitException:
+                raise
+            except Exception as exc:
+                logger.warning(
+                    "Content fetch failed for %d paths in %s: %s",
+                    len(chunk),
+                    project_full_path,
+                    exc,
+                )
+                continue
+            for node in nodes:
+                text = node.get("rawTextBlob")
+                path = node.get("path")
+                if path and text is not None:
+                    contents[path] = text
+
+        return contents
+
+    async def _graphql_blobs(
+        self,
+        project_full_path: str,
+        ref: str,
+        paths: list[str],
+        fields: str,
+    ) -> list[dict[str, Any]]:
+        """Resolve one chunk of blobs via GitLab GraphQL.
+
+        Mirrors ``GitLabConnector._graphql_blobs`` (``connectors/gitlab.py``,
+        FROZEN): one POST per chunk to the instance's GraphQL endpoint
+        (``{base_url}/api/graphql`` -- distinct from the REST v4 base every
+        other method on this client targets). Routed through the SAME
+        ``InstrumentedRESTCore`` -- retry, rate-limit classification, and
+        usage recording included -- because httpx treats an absolute URL
+        passed to a base-url-configured client as an override, not a join,
+        so ``self._graphql_url`` reaches the GraphQL endpoint unchanged
+        regardless of the core's REST ``base_url``. Labeled with the
+        ``project:`` prefix like ``get_commits``/``get_commit_stats`` above:
+        ``providers/gitlab/budget.py`` buckets FILES/BLAME datasets under
+        the existing ``project`` route family (CHAOS-2815/CS14), not a new
+        one.
+        """
+        query = (
+            "query($fullPath: ID!, $ref: String!, $paths: [String!]!) {\n"
+            "  project(fullPath: $fullPath) {\n"
+            "    repository {\n"
+            "      blobs(ref: $ref, paths: $paths) {\n"
+            f"        nodes {{ {fields} }}\n"
+            "      }\n"
+            "    }\n"
+            "  }\n"
+            "}"
+        )
+        response = await self._core.request(
+            "POST",
+            self._graphql_url,
+            operation=f"{_PROJECT_FAMILY_PREFIX}:POST /api/graphql blobs",
+            json={
+                "query": query,
+                "variables": {
+                    "fullPath": project_full_path,
+                    "ref": ref,
+                    "paths": paths,
+                },
+            },
+        )
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise APIException(f"Unexpected GitLab GraphQL response: {type(payload)!r}")
+        errors = payload.get("errors")
+        if errors:
+            messages = "; ".join(
+                str(item.get("message", item)) if isinstance(item, dict) else str(item)
+                for item in errors
+            )
+            raise APIException(f"GitLab GraphQL errors: {messages}")
+        project_data = (payload.get("data") or {}).get("project") or {}
+        repository = project_data.get("repository") or {}
+        nodes = (repository.get("blobs") or {}).get("nodes")
+        return [node for node in nodes or [] if isinstance(node, dict)]
+
+    async def get_file_blame(
+        self,
+        project_id: int | str,
+        file_path: str,
+        *,
+        ref: str = "HEAD",
+    ) -> FileBlame:
+        """Fetch normalized GitLab blame ranges for one file.
+
+        Mirrors ``GitLabRESTClient.get_file_blame``
+        (``connectors/utils/rest.py``, FROZEN): ``GET
+        /projects/{id}/repository/files/{path}/blame`` returns GitLab's raw
+        ``{"lines": [...], "commit": {...}}`` ranges, and this provider
+        normalizes them to the shared ``FileBlame`` DTO before the processor
+        sees them. GitLab's blame endpoint
+        returns the full per-file breakdown in one response (no pagination
+        concept), so this is a single request. Errors -- INCLUDING a 404
+        (no blame for this ref/path) -- propagate; callers handle
+        best-effort per-file (pre-existing behavior, mirroring
+        ``get_pipeline_test_report``).
+        """
+        encoded_project_id = _encode_project_id(project_id)
+        encoded_path = urllib.parse.quote(file_path, safe="")
+        response = await self._core.request(
+            "GET",
+            f"/projects/{encoded_project_id}/repository/files/{encoded_path}/blame",
+            operation=(
+                f"{_PROJECT_FAMILY_PREFIX}:GET "
+                "/projects/{id}/repository/files/{path}/blame"
+            ),
+            params={"ref": ref},
+        )
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise APIException(f"Unexpected GitLab blame response: {type(payload)!r}")
+        return _map_file_blame(file_path, payload)
 
     async def get_deployment_merge_requests(
         self, project_id: int | str, sha: str

--- a/tests/metrics/test_job_daily_hotspots.py
+++ b/tests/metrics/test_job_daily_hotspots.py
@@ -605,6 +605,28 @@ class _FakeTreeEntry:
         self.type = type_
 
 
+class _FakeGitLabCodeClientForBlame:
+    """Minimal instrumented GitLabCodeClient stand-in for the blame backfill
+    branch (CHAOS-2815/CS14): the real backfill now fetches blame via
+    ``GitLabCodeClient.get_file_blame``, never ``connector.rest_client.
+    get_file_blame`` (frozen, un-instrumented)."""
+
+    def __init__(self, blame_fn):
+        self._blame_fn = blame_fn
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get_file_blame(self, project_id, file_path, *, ref):
+        return self._blame_fn(project_id, file_path, ref)
+
+    def drain_usage_observations(self):
+        return []
+
+
 @pytest.mark.asyncio
 async def test_github_blame_backfill_is_capped() -> None:
     """Onboarding blame must stop at BLAME_BACKFILL_MAX_FILES files.
@@ -695,6 +717,7 @@ async def test_gitlab_blame_backfill_is_capped(
 ) -> None:
     """Onboarding blame must stop at BLAME_BACKFILL_MAX_FILES files (GitLab)."""
     import dev_health_ops.processors.gitlab as gitlab_mod
+    from dev_health_ops.connectors.models import BlameRange, FileBlame
 
     n_files = gitlab_mod.BLAME_BACKFILL_MAX_FILES + 9
 
@@ -727,11 +750,18 @@ async def test_gitlab_blame_backfill_is_capped(
 
     blame_calls: list[str] = []
 
-    def fake_rest_blame(project_id: int, path: str, ref: str) -> list[dict[str, Any]]:
+    def fake_blame(project_id: int, path: str, ref: str) -> FileBlame:
         blame_calls.append(path)
-        return [{"commit": {"author_email": "a@ex.com"}, "lines": ["x = 1"]}]
+        return FileBlame(
+            file_path=path,
+            ranges=[BlameRange(1, 1, "sha", "Ada", "a@ex.com", 0)],
+        )
 
-    connector.rest_client.get_file_blame = Mock(side_effect=fake_rest_blame)
+    monkeypatch.setattr(
+        gitlab_mod,
+        "_gitlab_code_client_from_connector",
+        lambda connector: _FakeGitLabCodeClientForBlame(fake_blame),
+    )
 
     db_repo = Mock()
     db_repo.id = uuid.uuid4()
@@ -1015,6 +1045,7 @@ async def test_gitlab_blame_backfill_resumes_on_second_sync(
 ) -> None:
     """A second GitLab sync blames the files the first sync left uncovered."""
     import dev_health_ops.processors.gitlab as gitlab_mod
+    from dev_health_ops.connectors.models import BlameRange, FileBlame
 
     n_files = gitlab_mod.BLAME_BACKFILL_MAX_FILES + 11
     all_paths = {f"src/f{i}.py" for i in range(n_files)}
@@ -1030,10 +1061,17 @@ async def test_gitlab_blame_backfill_resumes_on_second_sync(
     connector = Mock()
     connector.gitlab.projects.get.return_value = project
 
-    def fake_rest_blame(project_id: int, path: str, ref: str) -> list[dict[str, Any]]:
-        return [{"commit": {"author_email": "a@ex.com"}, "lines": ["x = 1"]}]
+    def fake_blame(project_id: int, path: str, ref: str) -> FileBlame:
+        return FileBlame(
+            file_path=path,
+            ranges=[BlameRange(1, 1, "sha", "Ada", "a@ex.com", 0)],
+        )
 
-    connector.rest_client.get_file_blame = Mock(side_effect=fake_rest_blame)
+    monkeypatch.setattr(
+        gitlab_mod,
+        "_gitlab_code_client_from_connector",
+        lambda connector: _FakeGitLabCodeClientForBlame(fake_blame),
+    )
 
     db_repo = Mock()
     db_repo.id = uuid.uuid4()

--- a/tests/providers/test_gitlab_code_client.py
+++ b/tests/providers/test_gitlab_code_client.py
@@ -24,6 +24,7 @@ import httpx
 import pytest
 
 from dev_health_ops.exceptions import (
+    APIException,
     AuthenticationException,
     NotFoundException,
     RateLimitException,
@@ -1174,3 +1175,243 @@ class TestLifecycle:
         )
         async with _client(transport) as client:
             await client.get_security_alerts(42)
+
+
+# ---------------------------------------------------------------------------
+# ``files`` dataset (CHAOS-2815/CS14): batched GraphQL blob-content fetch --
+# parity with the legacy ``GitLabConnector.get_file_contents`` /
+# ``_graphql_blobs`` (``connectors/gitlab.py``, FROZEN).
+# ---------------------------------------------------------------------------
+
+_GRAPHQL_PATH = "/api/graphql"
+
+
+def _graphql_response(data: dict) -> httpx.Response:
+    return httpx.Response(200, json={"data": data}, headers={})
+
+
+class TestFileContentsParity:
+    @pytest.mark.asyncio
+    async def test_size_pass_then_text_pass_filters_oversized(self) -> None:
+        responses = [
+            _graphql_response(
+                {
+                    "project": {
+                        "repository": {
+                            "blobs": {
+                                "nodes": [
+                                    {"path": "src/a.py", "rawSize": 7},
+                                    {"path": "big.py", "rawSize": 2_000_000},
+                                ]
+                            }
+                        }
+                    }
+                }
+            ),
+            _graphql_response(
+                {
+                    "project": {
+                        "repository": {
+                            "blobs": {
+                                "nodes": [
+                                    {"path": "src/a.py", "rawTextBlob": "x = 1\n"},
+                                ]
+                            }
+                        }
+                    }
+                }
+            ),
+        ]
+        transport, calls = _router_transport({_GRAPHQL_PATH: responses})
+        client = _client(transport, private_token="secret-tok")
+
+        result = await client.get_file_contents(
+            "group/project", ["src/a.py", "big.py"], ref="main"
+        )
+
+        assert result == {"src/a.py": "x = 1\n"}
+        assert calls[_GRAPHQL_PATH] == 2
+        assert (
+            transport.captured_headers[_GRAPHQL_PATH]["PRIVATE-TOKEN"]  # type: ignore[attr-defined]
+            == "secret-tok"
+        )
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "project"
+        assert observations[0]["request_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_no_size_pass_when_max_bytes_disabled(self) -> None:
+        transport, calls = _router_transport(
+            {
+                _GRAPHQL_PATH: _graphql_response(
+                    {
+                        "project": {
+                            "repository": {
+                                "blobs": {
+                                    "nodes": [{"path": "a.py", "rawTextBlob": "a"}]
+                                }
+                            }
+                        }
+                    }
+                )
+            }
+        )
+        client = _client(transport)
+
+        result = await client.get_file_contents(
+            "group/project", ["a.py"], ref="main", max_bytes=None
+        )
+
+        assert result == {"a.py": "a"}
+        assert calls[_GRAPHQL_PATH] == 1
+
+    @pytest.mark.asyncio
+    async def test_empty_paths_makes_no_request(self) -> None:
+        transport, calls = _router_transport({})
+        client = _client(transport)
+
+        result = await client.get_file_contents("group/project", [], ref="main")
+
+        assert result == {}
+        assert calls == {}
+
+    @pytest.mark.asyncio
+    async def test_graphql_errors_degrade_to_empty_for_that_chunk(self) -> None:
+        """A GraphQL ``errors`` payload on the text pass is per-chunk
+        resilience, not a hard failure -- mirrors the legacy connector's own
+        ``except Exception`` degrade-and-continue contract."""
+        transport, _ = _router_transport(
+            {
+                _GRAPHQL_PATH: httpx.Response(
+                    200, json={"errors": [{"message": "boom"}]}, headers={}
+                )
+            }
+        )
+        client = _client(transport, max_retries=1)
+
+        result = await client.get_file_contents(
+            "group/project", ["a.py"], ref="main", max_bytes=None
+        )
+
+        assert result == {}
+
+    @pytest.mark.asyncio
+    async def test_graphql_blobs_raises_api_exception_on_errors(self) -> None:
+        """The private ``_graphql_blobs`` helper itself DOES raise on a
+        GraphQL ``errors`` payload -- ``get_file_contents`` is the layer that
+        chooses to degrade per-chunk."""
+        transport, _ = _router_transport(
+            {
+                _GRAPHQL_PATH: httpx.Response(
+                    200, json={"errors": [{"message": "boom"}]}, headers={}
+                )
+            }
+        )
+        client = _client(transport, max_retries=1)
+
+        with pytest.raises(APIException):
+            await client._graphql_blobs(
+                "group/project", "main", ["a.py"], "path rawTextBlob"
+            )
+
+    @pytest.mark.asyncio
+    async def test_429_raises_rate_limit_exception(self) -> None:
+        transport, calls = _router_transport(
+            {_GRAPHQL_PATH: _empty_response(429, {"Retry-After": "0"})}
+        )
+        client = _client(transport, max_retries=2)
+
+        with pytest.raises(RateLimitException) as excinfo:
+            await client.get_file_contents(
+                "group/project", ["a.py"], ref="main", max_bytes=None
+            )
+
+        assert calls[_GRAPHQL_PATH] == 2
+        assert excinfo.value.signal is not None
+        assert excinfo.value.signal.dimension is BudgetDimension.REST_CORE
+
+
+# ---------------------------------------------------------------------------
+# ``blame`` dataset (CHAOS-2815/CS14): parity with the legacy
+# ``GitLabRESTClient.get_file_blame`` (``connectors/utils/rest.py``, FROZEN).
+# ---------------------------------------------------------------------------
+
+
+class TestFileBlameParity:
+    @pytest.mark.asyncio
+    async def test_returns_normalized_blame_ranges_and_usage_family(self) -> None:
+        blame_path = "/api/v4/projects/42/repository/files/app.py/blame"
+        transport, calls = _router_transport(
+            {
+                blame_path: _json_response(
+                    200,
+                    [
+                        {
+                            "commit": {
+                                "id": "sha1",
+                                "author_name": "Ada",
+                                "author_email": "ada@example.com",
+                            },
+                            "lines": ["x = 1", "y = 2"],
+                        }
+                    ],
+                )
+            }
+        )
+        client = _client(transport)
+
+        blame = await client.get_file_blame(42, "app.py", ref="main")
+
+        assert blame.file_path == "app.py"
+        assert [
+            (rng.starting_line, rng.ending_line, rng.commit_sha, rng.author)
+            for rng in blame.ranges
+        ] == [(1, 2, "sha1", "Ada")]
+        assert blame.ranges[0].author_email == "ada@example.com"
+        assert calls[blame_path] == 1
+        query = dict(transport.captured_urls[blame_path].params)  # type: ignore[attr-defined]
+        assert query == {"ref": "main"}
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "project"
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_404_propagates(self) -> None:
+        blame_path = "/api/v4/projects/42/repository/files/missing.py/blame"
+        transport, _ = _router_transport({blame_path: _empty_response(404)})
+        client = _client(transport)
+
+        with pytest.raises(NotFoundException):
+            await client.get_file_blame(42, "missing.py", ref="main")
+
+    @pytest.mark.asyncio
+    async def test_429_raises_rate_limit_exception(self) -> None:
+        blame_path = "/api/v4/projects/42/repository/files/app.py/blame"
+        transport, calls = _router_transport(
+            {blame_path: _empty_response(429, {"Retry-After": "0"})}
+        )
+        client = _client(transport, max_retries=2)
+
+        with pytest.raises(RateLimitException):
+            await client.get_file_blame(42, "app.py", ref="main")
+
+        assert calls[blame_path] == 2
+
+    @pytest.mark.asyncio
+    async def test_encodes_file_path_containing_slash(self) -> None:
+        raw_file_path = "src/nested/app.py"
+        decoded_path = "/api/v4/projects/42/repository/files/src/nested/app.py/blame"
+        transport, calls = _router_transport({decoded_path: _json_response(200, [])})
+        client = _client(transport)
+
+        blame = await client.get_file_blame(42, raw_file_path, ref="HEAD")
+
+        assert blame.file_path == raw_file_path
+        assert blame.ranges == []
+        assert calls[decoded_path] == 1
+        raw_path = transport.captured_raw_paths[decoded_path]  # type: ignore[attr-defined]
+        expected_segment = quote(raw_file_path, safe="")
+        assert (
+            raw_path.split(b"?")[0]
+            == f"/api/v4/projects/42/repository/files/{expected_segment}/blame".encode()
+        )

--- a/tests/test_gitlab_content_backfill.py
+++ b/tests/test_gitlab_content_backfill.py
@@ -20,6 +20,7 @@ import pytest
 # is collected in isolation.
 import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.connectors import GitLabConnector
+from dev_health_ops.connectors.models import BlameRange, FileBlame
 from dev_health_ops.processors.gitlab import (
     _backfill_gitlab_missing_data,
     _fetch_scannable_contents,
@@ -198,28 +199,93 @@ class TestGetFileContents:
         post.assert_not_called()
 
 
+class _FakeGitLabCodeClientForFiles:
+    """Minimal instrumented GitLabCodeClient stand-in for the file-content /
+    blame backfill branches (CHAOS-2815/CS14). The real backfill fetches
+    through ``GitLabCodeClient.get_file_contents`` /
+    ``GitLabCodeClient.get_file_blame``, never the frozen
+    ``connector.get_file_contents`` / ``connector.rest_client.get_file_blame``.
+    """
+
+    def __init__(
+        self,
+        *,
+        contents=None,
+        contents_error=None,
+        blame_by_path=None,
+        blame_error_paths=None,
+        observations=None,
+    ):
+        self.contents = contents or {}
+        self.contents_error = contents_error
+        self.blame_by_path = blame_by_path or {}
+        self.blame_error_paths = blame_error_paths or {}
+        self.observations = observations or []
+        self.get_file_contents_calls: list[Any] = []
+        self.get_file_blame_calls: list[Any] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def get_file_contents(self, project_full_path, paths, *, ref, max_bytes=None):
+        self.get_file_contents_calls.append(
+            (project_full_path, tuple(paths), ref, max_bytes)
+        )
+        if self.contents_error is not None:
+            raise self.contents_error
+        return self.contents
+
+    async def get_file_blame(self, project_id, file_path, *, ref):
+        self.get_file_blame_calls.append((project_id, file_path, ref))
+        if file_path in self.blame_error_paths:
+            raise self.blame_error_paths[file_path]
+        return self.blame_by_path.get(file_path, FileBlame(file_path=file_path))
+
+    def drain_usage_observations(self):
+        observations = list(self.observations)
+        self.observations.clear()
+        return observations
+
+
 class TestFetchScannableContents:
     @pytest.mark.asyncio
-    async def test_filters_by_scanner_globs(self):
+    async def test_filters_by_scanner_globs(self, monkeypatch):
+        fake_client = _FakeGitLabCodeClientForFiles(
+            contents={"src/app.py": "x = 1\n"},
+            observations=[{"route_family": "project"}],
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
         connector = Mock()
-        connector.get_file_contents = Mock(return_value={"src/app.py": "x = 1\n"})
+        usage_sink: list[dict[str, Any]] = []
 
         result = await _fetch_scannable_contents(
             connector,
             "group/proj",
             "main",
             ["src/app.py", "README.md", "pkg/__init__.py"],
+            usage_sink=usage_sink,
         )
 
         assert result == {"src/app.py": "x = 1\n"}
-        connector.get_file_contents.assert_called_once_with(
-            "group/proj", ["src/app.py"], ref="main", max_bytes=1_000_000
-        )
+        assert fake_client.get_file_contents_calls == [
+            ("group/proj", ("src/app.py",), "main", 1_000_000)
+        ]
+        assert usage_sink == [{"route_family": "project"}]
 
     @pytest.mark.asyncio
-    async def test_api_error_degrades_to_empty(self):
+    async def test_api_error_degrades_to_empty(self, monkeypatch):
+        fake_client = _FakeGitLabCodeClientForFiles(contents_error=RuntimeError("boom"))
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
         connector = Mock()
-        connector.get_file_contents = Mock(side_effect=RuntimeError("boom"))
 
         result = await _fetch_scannable_contents(
             connector, "group/proj", "main", ["src/app.py"]
@@ -227,10 +293,28 @@ class TestFetchScannableContents:
 
         assert result == {}
 
+    @pytest.mark.asyncio
+    async def test_rate_limit_exception_propagates(self, monkeypatch):
+        from dev_health_ops.exceptions import RateLimitException
+
+        fake_client = _FakeGitLabCodeClientForFiles(
+            contents_error=RateLimitException("rate limited")
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+        connector = Mock()
+
+        with pytest.raises(RateLimitException):
+            await _fetch_scannable_contents(
+                connector, "group/proj", "main", ["src/app.py"]
+            )
+
 
 class TestGitLabBackfillContents:
     @pytest.mark.asyncio
-    async def test_backfill_writes_contents_for_paths_only_repos(self):
+    async def test_backfill_writes_contents_for_paths_only_repos(self, monkeypatch):
         """Projects with paths-only git_files rows get upgraded."""
         store = Mock()
         store.has_any_git_files = AsyncMock(return_value=True)
@@ -249,7 +333,12 @@ class TestGitLabBackfillContents:
         project = Mock()
         connector = Mock()
         connector.gitlab.projects.get.return_value = project
-        connector.get_file_contents = Mock(return_value={"src/app.py": "x = 1\n"})
+
+        fake_client = _FakeGitLabCodeClientForFiles(contents={"src/app.py": "x = 1\n"})
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
 
         db_repo = Mock()
         db_repo.id = uuid.uuid4()
@@ -463,3 +552,212 @@ class TestGitLabBackfillCommitStats:
 
         client_factory.assert_not_called()
         sink.insert_git_commit_stats.assert_not_called()
+
+
+class TestGitLabBackfillBlame:
+    """CHAOS-2815/CS14: the blame backfill branch must fetch through the
+    canonical, instrumented ``GitLabCodeClient.get_file_blame`` -- never the
+    frozen, un-instrumented ``connector.rest_client.get_file_blame``.
+    """
+
+    @staticmethod
+    def _store(all_paths: set[str]) -> Mock:
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=True)
+        store.has_any_git_blame = AsyncMock(return_value=False)
+        store.get_blamed_paths = AsyncMock(return_value=set())
+        store.has_unblamed_files = AsyncMock(return_value=bool(all_paths))
+        return store
+
+    @pytest.mark.asyncio
+    async def test_backfill_writes_blame_via_gitlab_code_client(self, monkeypatch):
+        store = self._store({"src/a.py", "src/b.py"})
+
+        written: list[Any] = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_blame_data = AsyncMock(side_effect=insert)
+
+        project = Mock()
+        project.id = 42
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = project
+        # The legacy, frozen REST helper must never be invoked by the fixed
+        # blame backfill path.
+        connector.rest_client.get_file_blame = Mock(
+            side_effect=AssertionError(
+                "legacy connector.rest_client.get_file_blame must not be called"
+            )
+        )
+
+        fake_client = _FakeGitLabCodeClientForFiles(
+            blame_by_path={
+                "src/a.py": FileBlame(
+                    file_path="src/a.py",
+                    ranges=[BlameRange(1, 2, "sha1", "Ada", "ada@example.com", 0)],
+                ),
+                "src/b.py": FileBlame(
+                    file_path="src/b.py",
+                    ranges=[BlameRange(1, 1, "sha2", "Grace", "grace@example.com", 0)],
+                ),
+            },
+            observations=[{"route_family": "project"}],
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+        usage_sink: list[dict[str, Any]] = []
+
+        tree_items = [
+            {"type": "blob", "path": "src/a.py"},
+            {"type": "blob", "path": "src/b.py"},
+        ]
+        with patch(
+            "dev_health_ops.processors.gitlab._iter_gitlab_repo_tree",
+            return_value=tree_items,
+        ):
+            await _backfill_gitlab_missing_data(
+                store=store,
+                ingestion_sink=sink,
+                connector=connector,
+                db_repo=db_repo,
+                project_full_name="group/proj",
+                default_branch="main",
+                max_commits=None,
+                include_files=False,
+                include_commit_stats=False,
+                usage_sink=usage_sink,
+            )
+
+        assert {(pc[1]) for pc in fake_client.get_file_blame_calls} == {
+            "src/a.py",
+            "src/b.py",
+        }
+        assert connector.rest_client.get_file_blame.call_count == 0
+        by_path = {row.path: row for row in written}
+        assert by_path["src/a.py"].commit_hash == "sha1"
+        assert by_path["src/a.py"].author_name == "Ada"
+        assert by_path["src/b.py"].commit_hash == "sha2"
+        assert usage_sink == [{"route_family": "project"}]
+
+    @pytest.mark.asyncio
+    async def test_per_file_failure_is_skipped_but_crawl_continues(self, monkeypatch):
+        """A single file's fetch failure logs and continues -- bounded
+        per-file resilience is preserved after the GitLabCodeClient rewire."""
+        store = self._store({"src/a.py", "src/b.py"})
+
+        written: list[Any] = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_blame_data = AsyncMock(side_effect=insert)
+
+        project = Mock()
+        project.id = 42
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = project
+
+        fake_client = _FakeGitLabCodeClientForFiles(
+            blame_by_path={
+                "src/b.py": FileBlame(
+                    file_path="src/b.py",
+                    ranges=[BlameRange(1, 1, "sha2", "Grace", "", 0)],
+                ),
+            },
+            blame_error_paths={"src/a.py": RuntimeError("boom")},
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        tree_items = [
+            {"type": "blob", "path": "src/a.py"},
+            {"type": "blob", "path": "src/b.py"},
+        ]
+        with patch(
+            "dev_health_ops.processors.gitlab._iter_gitlab_repo_tree",
+            return_value=tree_items,
+        ):
+            await _backfill_gitlab_missing_data(
+                store=store,
+                ingestion_sink=sink,
+                connector=connector,
+                db_repo=db_repo,
+                project_full_name="group/proj",
+                default_branch="main",
+                max_commits=None,
+                include_files=False,
+                include_commit_stats=False,
+            )
+
+        assert {row.path for row in written} == {"src/b.py"}
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_exception_propagates_and_stops_crawl(self, monkeypatch):
+        """An exhausted rate limit on one file must propagate -- never be
+        swallowed as a per-file warning like other errors."""
+        from dev_health_ops.exceptions import RateLimitException
+
+        store = self._store({"src/a.py", "src/b.py"})
+
+        sink = Mock()
+        sink.insert_blame_data = AsyncMock()
+
+        project = Mock()
+        project.id = 42
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = project
+
+        fake_client = _FakeGitLabCodeClientForFiles(
+            blame_error_paths={"src/a.py": RateLimitException("rate limited")},
+            observations=[{"route_family": "project"}],
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+        usage_sink: list[dict[str, Any]] = []
+
+        tree_items = [
+            {"type": "blob", "path": "src/a.py"},
+            {"type": "blob", "path": "src/b.py"},
+        ]
+        with patch(
+            "dev_health_ops.processors.gitlab._iter_gitlab_repo_tree",
+            return_value=tree_items,
+        ):
+            with pytest.raises(RateLimitException):
+                await _backfill_gitlab_missing_data(
+                    store=store,
+                    ingestion_sink=sink,
+                    connector=connector,
+                    db_repo=db_repo,
+                    project_full_name="group/proj",
+                    default_branch="main",
+                    max_commits=None,
+                    include_files=False,
+                    include_commit_stats=False,
+                    usage_sink=usage_sink,
+                )
+
+        # Partial observations gathered before the raise still reach the sink
+        # (CHAOS-2754/2803 partial-observations-on-exception contract).
+        assert usage_sink == [{"route_family": "project"}]


### PR DESCRIPTION
## Summary
- route GitLab file contents and blame through GitLabCodeClient
- normalize GitLab blame inside the provider before processor consumption
- document GitLab files/blame actuals under the project route family

## Validation
- uv run --extra dev pytest tests/providers/test_gitlab_code_client.py tests/test_gitlab_content_backfill.py
- uv run --extra dev pytest tests/metrics/test_job_daily_hotspots.py::test_gitlab_blame_backfill_is_capped tests/metrics/test_job_daily_hotspots.py::test_gitlab_blame_backfill_resumes_on_second_sync
- uv run --extra dev ruff format --check .
- uv run --extra dev ruff check .
- uv run --extra dev mypy --install-types --non-interactive .
- OTEL_SDK_DISABLED=true bash ci/local_validate.sh

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.