### PR TITLE
feat(testops): expose persisted delivery risk resolver (CHAOS-2854)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/testops_risk.py
+++ b/src/dev_health_ops/api/graphql/resolvers/testops_risk.py
@@ -1,0 +1,254 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+
+from dev_health_ops.api.queries.client import query_dicts
+
+from ..authz import require_org_id
+from ..context import GraphQLContext
+from ..types.testops_risk import (
+    TestOpsRiskBreakdownItem,
+    TestOpsRiskInput,
+    TestOpsRiskQuadrantPoint,
+    TestOpsRiskResult,
+    TestOpsRiskSparkPoint,
+    TestOpsRiskTrendPoint,
+)
+
+
+def _require_client(context: GraphQLContext) -> Any:
+    if context.client is None:
+        raise RuntimeError("Database client not available for TestOps Risk resolver")
+    return context.client
+
+
+def _float_or_none(value: str | int | float | None) -> float | None:
+    if value is None:
+        return None
+    return float(value)
+
+
+def _delta(points: list[TestOpsRiskSparkPoint]) -> float | None:
+    if len(points) < 2:
+        return None
+    previous = points[0].value
+    current = points[-1].value
+    if previous == 0:
+        return None
+    return ((current - previous) / abs(previous)) * 100
+
+
+async def _fetch_daily_rows(
+    client: Any, org_id: str, risk_input: TestOpsRiskInput
+) -> list[dict[str, Any]]:
+    query = """
+        WITH
+        release_daily AS (
+            SELECT
+                day,
+                avg(confidence_score) AS release_confidence
+            FROM (
+                SELECT
+                    day,
+                    repo_id,
+                    argMax(confidence_score, computed_at) AS confidence_score
+                FROM testops_release_confidence
+                WHERE org_id = {org_id:String}
+                  AND day >= {start:Date}
+                  AND day <= {end:Date}
+                GROUP BY day, repo_id
+            )
+            GROUP BY day
+        ),
+        drag_daily AS (
+            SELECT
+                day,
+                sum(drag_hours) AS quality_drag_hours,
+                sum(failure_rework_hours) AS failure_rework_hours,
+                sum(flake_investigation_hours) AS flake_investigation_hours,
+                sum(queue_wait_hours) AS queue_wait_hours,
+                sum(retry_overhead_hours) AS retry_overhead_hours
+            FROM (
+                SELECT
+                    day,
+                    repo_id,
+                    argMax(drag_hours, computed_at) AS drag_hours,
+                    argMax(failure_rework_hours, computed_at) AS failure_rework_hours,
+                    argMax(flake_investigation_hours, computed_at) AS flake_investigation_hours,
+                    argMax(queue_wait_hours, computed_at) AS queue_wait_hours,
+                    argMax(retry_overhead_hours, computed_at) AS retry_overhead_hours
+                FROM testops_quality_drag
+                WHERE org_id = {org_id:String}
+                  AND day >= {start:Date}
+                  AND day <= {end:Date}
+                GROUP BY day, repo_id
+            )
+            GROUP BY day
+        ),
+        stability_daily AS (
+            SELECT
+                day,
+                avg(stability_index) AS pipeline_stability
+            FROM (
+                SELECT
+                    day,
+                    repo_id,
+                    argMax(stability_index, computed_at) AS stability_index
+                FROM testops_pipeline_stability
+                WHERE org_id = {org_id:String}
+                  AND day >= {start:Date}
+                  AND day <= {end:Date}
+                GROUP BY day, repo_id
+            )
+            GROUP BY day
+        )
+        SELECT
+            day AS day,
+            release_confidence,
+            quality_drag_hours,
+            failure_rework_hours,
+            flake_investigation_hours,
+            queue_wait_hours,
+            retry_overhead_hours,
+            pipeline_stability
+        FROM release_daily
+        FULL OUTER JOIN drag_daily USING (day)
+        FULL OUTER JOIN stability_daily USING (day)
+        ORDER BY day ASC
+        SETTINGS join_use_nulls = 1
+        """
+    return await query_dicts(
+        client,
+        query,
+        {"org_id": org_id, "start": risk_input.start_date, "end": risk_input.end_date},
+    )
+
+
+async def _fetch_quadrant_rows(
+    client: Any, org_id: str, risk_input: TestOpsRiskInput
+) -> list[dict[str, Any]]:
+    query = """
+        SELECT
+            coalesce(nullIf(repos.repo, ''), toString(latest.repo_id)) AS repo_label,
+            latest.pipeline_success_rate,
+            latest.test_pass_rate
+        FROM (
+            SELECT
+                repo_id,
+                argMax(
+                    JSONExtractFloat(factors_json, 'pipeline_success_rate'),
+                    (day, computed_at)
+                ) AS pipeline_success_rate,
+                argMax(
+                    JSONExtractFloat(factors_json, 'test_pass_rate'),
+                    (day, computed_at)
+                ) AS test_pass_rate,
+                argMax(confidence_score, (day, computed_at)) AS confidence_score
+            FROM testops_release_confidence
+            WHERE org_id = {org_id:String}
+              AND day >= {start:Date}
+              AND day <= {end:Date}
+            GROUP BY repo_id
+        ) AS latest
+        LEFT JOIN repos
+          ON repos.org_id = {org_id:String}
+         AND repos.id = latest.repo_id
+        ORDER BY latest.confidence_score ASC
+        LIMIT 50
+        """
+    return await query_dicts(
+        client,
+        query,
+        {"org_id": org_id, "start": risk_input.start_date, "end": risk_input.end_date},
+    )
+
+
+def _latest_with(rows: list[dict[str, Any]], field: str) -> dict[str, Any]:
+    return next((row for row in reversed(rows) if row.get(field) is not None), {})
+
+
+async def resolve_testops_risk(
+    context: GraphQLContext, org_id: str, input: TestOpsRiskInput
+) -> TestOpsRiskResult:
+    context_org_id = require_org_id(context)
+    client = _require_client(context)
+    rows = await _fetch_daily_rows(client, context_org_id, input)
+    quadrant_rows = await _fetch_quadrant_rows(client, context_org_id, input)
+
+    timeseries = [
+        TestOpsRiskTrendPoint(
+            date=row["day"],
+            risk_score=max(0.0, min(1.0, 1.0 - float(row["release_confidence"]))),
+        )
+        for row in rows
+        if isinstance(row.get("day"), date)
+        and row.get("release_confidence") is not None
+    ]
+    confidence_spark = [
+        TestOpsRiskSparkPoint(ts=point.date, value=(1.0 - point.risk_score) * 100.0)
+        for point in timeseries
+    ]
+    drag_spark = [
+        TestOpsRiskSparkPoint(ts=row["day"], value=float(row["quality_drag_hours"]))
+        for row in rows
+        if isinstance(row.get("day"), date)
+        and row.get("quality_drag_hours") is not None
+    ]
+    stability_spark = [
+        TestOpsRiskSparkPoint(
+            ts=row["day"], value=float(row["pipeline_stability"]) * 100.0
+        )
+        for row in rows
+        if isinstance(row.get("day"), date)
+        and row.get("pipeline_stability") is not None
+    ]
+
+    latest_release = _latest_with(rows, "release_confidence")
+    latest_drag = _latest_with(rows, "quality_drag_hours")
+    latest_stability = _latest_with(rows, "pipeline_stability")
+    breakdown = (
+        [
+            TestOpsRiskBreakdownItem(
+                category="Failure Rework",
+                hours=float(latest_drag.get("failure_rework_hours") or 0.0),
+            ),
+            TestOpsRiskBreakdownItem(
+                category="Flake Investigation",
+                hours=float(latest_drag.get("flake_investigation_hours") or 0.0),
+            ),
+            TestOpsRiskBreakdownItem(
+                category="Queue Wait",
+                hours=float(latest_drag.get("queue_wait_hours") or 0.0),
+            ),
+            TestOpsRiskBreakdownItem(
+                category="Retry Overhead",
+                hours=float(latest_drag.get("retry_overhead_hours") or 0.0),
+            ),
+        ]
+        if latest_drag
+        else []
+    )
+
+    return TestOpsRiskResult(
+        org_id=context_org_id,
+        release_confidence=_float_or_none(latest_release.get("release_confidence")),
+        quality_drag_hours=_float_or_none(latest_drag.get("quality_drag_hours")),
+        pipeline_stability=_float_or_none(latest_stability.get("pipeline_stability")),
+        timeseries=timeseries,
+        quality_drag_breakdown=breakdown,
+        quadrant_data=[
+            TestOpsRiskQuadrantPoint(
+                id=str(row["repo_label"]),
+                pipeline_success_rate=_float_or_none(row.get("pipeline_success_rate")),
+                test_pass_rate=_float_or_none(row.get("test_pass_rate")),
+            )
+            for row in quadrant_rows
+        ],
+        confidence_spark=confidence_spark,
+        confidence_delta=_delta(confidence_spark),
+        drag_spark=drag_spark,
+        drag_delta=_delta(drag_spark),
+        stability_spark=stability_spark,
+        stability_delta=_delta(stability_spark),
+    )

--- a/src/dev_health_ops/api/graphql/schema.py
+++ b/src/dev_health_ops/api/graphql/schema.py
@@ -126,6 +126,7 @@ from .types.review_edges import (
     ReviewEdgesInput,
     ReviewEdgesResult,
 )
+from .types.testops_risk import TestOpsRiskInput, TestOpsRiskResult
 
 logger = logging.getLogger(__name__)
 
@@ -540,6 +541,23 @@ class Query:
     ) -> CompoundingRiskResult:
         context = get_context(info)
         return await resolve_compounding_risk(context, org_id, filter)
+
+    @strawberry.field(
+        description=(
+            "Persisted TestOps Delivery Risk metrics from release confidence, "
+            "quality drag, and pipeline stability tables."
+        )
+    )
+    async def testops_risk(
+        self,
+        info: Info,
+        org_id: str,
+        input: TestOpsRiskInput,
+    ) -> TestOpsRiskResult:
+        from .resolvers.testops_risk import resolve_testops_risk
+
+        context = get_context(info)
+        return await resolve_testops_risk(context, org_id, input)
 
     @strawberry.field(
         description=(

--- a/src/dev_health_ops/api/graphql/types/testops_risk.py
+++ b/src/dev_health_ops/api/graphql/types/testops_risk.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+from datetime import date
+
+import strawberry
+
+
+@strawberry.input
+class TestOpsRiskInput:
+    start_date: date = strawberry.field(name="startDate")
+    end_date: date = strawberry.field(name="endDate")
+
+
+@strawberry.type
+class TestOpsRiskTrendPoint:
+    date: date
+    risk_score: float = strawberry.field(name="riskScore")
+
+
+@strawberry.type
+class TestOpsRiskBreakdownItem:
+    category: str
+    hours: float
+
+
+@strawberry.type
+class TestOpsRiskQuadrantPoint:
+    id: str
+    pipeline_success_rate: float | None = strawberry.field(name="pipelineSuccessRate")
+    test_pass_rate: float | None = strawberry.field(name="testPassRate")
+
+
+@strawberry.type
+class TestOpsRiskSparkPoint:
+    ts: date
+    value: float
+
+
+@strawberry.type
+class TestOpsRiskResult:
+    org_id: str = strawberry.field(name="orgId")
+    release_confidence: float | None = strawberry.field(name="releaseConfidence")
+    quality_drag_hours: float | None = strawberry.field(name="qualityDragHours")
+    pipeline_stability: float | None = strawberry.field(name="pipelineStability")
+    timeseries: list[TestOpsRiskTrendPoint]
+    quality_drag_breakdown: list[TestOpsRiskBreakdownItem] = strawberry.field(
+        name="qualityDragBreakdown"
+    )
+    quadrant_data: list[TestOpsRiskQuadrantPoint] = strawberry.field(
+        name="quadrantData"
+    )
+    confidence_spark: list[TestOpsRiskSparkPoint] = strawberry.field(
+        name="confidenceSpark"
+    )
+    confidence_delta: float | None = strawberry.field(name="confidenceDelta")
+    drag_spark: list[TestOpsRiskSparkPoint] = strawberry.field(name="dragSpark")
+    drag_delta: float | None = strawberry.field(name="dragDelta")
+    stability_spark: list[TestOpsRiskSparkPoint] = strawberry.field(
+        name="stabilitySpark"
+    )
+    stability_delta: float | None = strawberry.field(name="stabilityDelta")

--- a/tests/api/graphql/_sql_explain_helpers.py
+++ b/tests/api/graphql/_sql_explain_helpers.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from dev_health_ops.api.graphql.context import GraphQLContext
+
 
 class CapturingSink:
     """Minimal sink stand-in that records ``(sql, params)`` instead of executing.
@@ -46,7 +48,7 @@ class CapturingSink:
 
 
 @dataclass
-class FakeGraphQLContext:
+class FakeGraphQLContext(GraphQLContext):
     """Stand-in for ``GraphQLContext`` accepted by helpers that take a context.
 
     Carries the capturing client and a stable sample org_id. Other context
@@ -55,18 +57,8 @@ class FakeGraphQLContext:
     starts depending on additional attributes, add them here.
     """
 
-    client: Any
     org_id: str = "00000000-0000-0000-0000-000000000001"
     db_url: str = "clickhouse://test/test"
-    request_id: str = "test-explain-request"
-    persisted_query_id: str | None = None
-    loaders: Any = None
-    team_loader: Any = None
-    team_by_name_loader: Any = None
-    repo_loader: Any = None
-    repo_by_name_loader: Any = None
-    cache: Any = None
-    user: Any = None
     db_session: Any = None
     session: Any = None
     extra: dict[str, Any] = field(default_factory=dict)

--- a/tests/api/graphql/sql_explain_fixtures.py
+++ b/tests/api/graphql/sql_explain_fixtures.py
@@ -100,6 +100,31 @@ async def _fixture_compounding_risk(sink: CapturingSink) -> None:
     await _load_team_assignments(sink, SAMPLE_ORG_ID)
 
 
+async def _fixture_testops_risk(sink: CapturingSink) -> None:
+    from dev_health_ops.api.graphql.resolvers.testops_risk import (
+        _fetch_daily_rows,
+        _fetch_quadrant_rows,
+    )
+    from dev_health_ops.api.graphql.types.testops_risk import TestOpsRiskInput
+
+    await _fetch_daily_rows(
+        sink,
+        SAMPLE_ORG_ID,
+        TestOpsRiskInput(
+            start_date=SAMPLE_DAY - timedelta(days=14),
+            end_date=SAMPLE_DAY,
+        ),
+    )
+    await _fetch_quadrant_rows(
+        sink,
+        SAMPLE_ORG_ID,
+        TestOpsRiskInput(
+            start_date=SAMPLE_DAY - timedelta(days=14),
+            end_date=SAMPLE_DAY,
+        ),
+    )
+
+
 # ---------------------------------------------------------------------------
 # forecast
 # ---------------------------------------------------------------------------
@@ -552,6 +577,7 @@ async def _fixture_analytics(sink: CapturingSink) -> None:
 
 ALL_RESOLVER_SQL_FIXTURES: list[tuple[str, ResolverSQLFixture]] = [
     ("compounding_risk", _fixture_compounding_risk),
+    ("testops_risk", _fixture_testops_risk),
     ("forecast", _fixture_forecast),
     ("home", _fixture_home),
     ("capacity", _fixture_capacity),

--- a/tests/api/graphql/test_testops_risk_resolver.py
+++ b/tests/api/graphql/test_testops_risk_resolver.py
@@ -1,0 +1,153 @@
+from __future__ import annotations
+
+from datetime import date
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.resolvers.testops_risk import resolve_testops_risk
+from dev_health_ops.api.graphql.types.testops_risk import TestOpsRiskInput
+
+ORG_ID = "org-test"
+START = date(2026, 5, 19)
+END = date(2026, 5, 20)
+
+
+def _ctx() -> GraphQLContext:
+    ctx = GraphQLContext(org_id=ORG_ID, db_url="clickhouse://localhost:8123/d")
+    ctx.client = MagicMock(spec=["query"])
+    return ctx
+
+
+def _qresult(columns: list[str], rows: list[list[Any]]) -> Any:
+    result = MagicMock()
+    result.column_names = columns
+    result.result_rows = rows
+    return result
+
+
+@pytest.mark.asyncio
+async def test_returns_empty_persisted_risk_when_tables_have_no_window_rows() -> None:
+    ctx = _ctx()
+    ctx.client.query.side_effect = [
+        _qresult([], []),
+        _qresult([], []),
+    ]
+
+    result = await resolve_testops_risk(
+        ctx, ORG_ID, TestOpsRiskInput(start_date=START, end_date=END)
+    )
+
+    assert result.release_confidence is None
+    assert result.quality_drag_hours is None
+    assert result.pipeline_stability is None
+    assert result.timeseries == []
+    assert result.quality_drag_breakdown == []
+    assert result.quadrant_data == []
+
+
+@pytest.mark.asyncio
+async def test_maps_persisted_risk_rows_without_recomputing_components() -> None:
+    ctx = _ctx()
+    ctx.client.query.side_effect = [
+        _qresult(
+            [
+                "day",
+                "release_confidence",
+                "quality_drag_hours",
+                "failure_rework_hours",
+                "flake_investigation_hours",
+                "queue_wait_hours",
+                "retry_overhead_hours",
+                "pipeline_stability",
+            ],
+            [
+                [START, 0.60, 20.0, 8.0, 6.0, 4.0, 2.0, 0.80],
+                [END, 0.75, 10.0, 3.0, 2.5, 1.5, 3.0, 0.90],
+            ],
+        ),
+        _qresult(
+            ["repo_label", "pipeline_success_rate", "test_pass_rate"],
+            [["web", 0.92, 0.98], ["ops", 0.84, 0.95]],
+        ),
+    ]
+
+    result = await resolve_testops_risk(
+        ctx, "client-supplied-org", TestOpsRiskInput(start_date=START, end_date=END)
+    )
+
+    assert result.org_id == ORG_ID
+    assert result.release_confidence == 0.75
+    assert result.quality_drag_hours == 10.0
+    assert result.pipeline_stability == 0.90
+    assert [(point.date, point.risk_score) for point in result.timeseries] == [
+        (START, 0.4),
+        (END, 0.25),
+    ]
+    assert [(point.ts, point.value) for point in result.confidence_spark] == [
+        (START, 60.0),
+        (END, 75.0),
+    ]
+    assert result.confidence_delta == 25.0
+    assert [(item.category, item.hours) for item in result.quality_drag_breakdown] == [
+        ("Failure Rework", 3.0),
+        ("Flake Investigation", 2.5),
+        ("Queue Wait", 1.5),
+        ("Retry Overhead", 3.0),
+    ]
+    assert [
+        (point.id, point.pipeline_success_rate, point.test_pass_rate)
+        for point in result.quadrant_data
+    ] == [
+        ("web", 0.92, 0.98),
+        ("ops", 0.84, 0.95),
+    ]
+
+    daily_sql = ctx.client.query.call_args_list[0].args[0]
+    quadrant_sql = ctx.client.query.call_args_list[1].args[0]
+    assert "testops_release_confidence" in daily_sql
+    assert "testops_quality_drag" in daily_sql
+    assert "testops_pipeline_stability" in daily_sql
+    assert "argMax(confidence_score, computed_at)" in daily_sql
+    assert "SETTINGS join_use_nulls = 1" in daily_sql
+    assert "JSONExtractFloat(factors_json, 'pipeline_success_rate')" in quadrant_sql
+
+
+@pytest.mark.asyncio
+async def test_uses_latest_non_null_row_for_each_headline_metric() -> None:
+    ctx = _ctx()
+    ctx.client.query.side_effect = [
+        _qresult(
+            [
+                "day",
+                "release_confidence",
+                "quality_drag_hours",
+                "failure_rework_hours",
+                "flake_investigation_hours",
+                "queue_wait_hours",
+                "retry_overhead_hours",
+                "pipeline_stability",
+            ],
+            [
+                [START, 0.60, None, None, None, None, None, None],
+                [END, None, 10.0, 3.0, 2.5, 1.5, 3.0, 0.90],
+            ],
+        ),
+        _qresult(["repo_label", "pipeline_success_rate", "test_pass_rate"], []),
+    ]
+
+    result = await resolve_testops_risk(
+        ctx, ORG_ID, TestOpsRiskInput(start_date=START, end_date=END)
+    )
+
+    assert result.release_confidence == 0.60
+    assert result.quality_drag_hours == 10.0
+    assert result.pipeline_stability == 0.90
+    assert [(item.category, item.hours) for item in result.quality_drag_breakdown] == [
+        ("Failure Rework", 3.0),
+        ("Flake Investigation", 2.5),
+        ("Queue Wait", 1.5),
+        ("Retry Overhead", 3.0),
+    ]


### PR DESCRIPTION
## Summary
- Add `testopsRisk` GraphQL field backed by persisted `testops_release_confidence`, `testops_quality_drag`, and `testops_pipeline_stability` ClickHouse tables.
- Preserve org isolation by resolving from the authorized GraphQL context, not the client-supplied org id.
- Add SQL explain fixture coverage and resolver regressions for `join_use_nulls` and latest-non-null KPI selection.

## Validation
- `pytest tests/api/graphql/test_testops_risk_resolver.py`
- `ruff check ...` and `ruff format --check ...` on changed ops files
- `SCRATCH_DB=ci_local_validate_chaos2854b bash ci/local_validate.sh`
- Oracle review: PASS

Linear: CHAOS-2854
