### PR TITLE
feat(providers): instrument GitHub prs and incidents actuals (CHAOS-2809)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -875,12 +875,10 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
   `tests/providers/test_github_pr_social_batch.py` (N physical GraphQL
   requests → one aggregated `pr_social`/`graphql_cost` observation with
   `request_count == N`; a mid-pagination failure leaves the prior successful
-  request(s) drained). The REST `prs` listing itself (raw PyGithub
-  `get_pulls`) stays on the frozen connector, unlabeled, until CHAOS-2773 CS8
-  — `providers/github/budget.py`'s `prs` marker is therefore left empty
-  (never flip a marker before its traffic exists, per the migration
-  strategy above), while `pr_social`'s GRAPHQL_COST marker is flipped to
-  document it as now-instrumented.
+  request(s) drained). CS8 moves the REST `prs` listing and PR-commit fetches
+  onto `GitHubCodeClient`, labels them with the `prs:` prefix, and flips the
+  `providers/github/budget.py` `prs` REST-core marker; `pr_social` remains the
+  separate GRAPHQL_COST family for review/social enrichment.
 - **GitLab.** `process_gitlab_project` accepts the same `usage_sink`
   parameter for a uniform cross-provider adapter contract. Migrated
   GitLabCodeClient-backed families drain into it on both success and failure:
@@ -924,8 +922,8 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
   primary (`graphql_cost`) traffic IS now measured as of
   [CHAOS-2803](https://linear.app/fullchaos/issue/CHAOS-2803) (CS2, see
   [Usage drain wiring](#usage-drain-wiring-first-re-bucketing-chaos-2773-cs2)
-  above) for the PR review-batch enrichment; the REST `prs` listing itself
-  remains on the frozen connector, unmeasured, pending CHAOS-2773 CS8. See
+  above) for the PR review-batch enrichment; REST `prs` listing/PR commits and
+  incident-label issue fetches are measured as of CHAOS-2809 (CS8). See
   [Known gaps](#known-gaps).
 - **Actuals instrumentation (CHAOS-2807).** Commit listing (`git`) and
   per-commit file stats (`commit_stats`) now fetch through
@@ -945,6 +943,13 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
   `rest_core` reservation stays estimate-only -- it belongs to the
   repository tree listing that discovers candidate paths, which remains on
   the frozen PyGithub connector (out of CS7 scope).
+- **Actuals instrumentation (CHAOS-2809).** Pull-request listing and PR commits
+  (`prs`) now fetch through `GitHubCodeClient` REST pagers and resolve through
+  explicit `prs:` operation prefixes. Incident-label issue fetches also use
+  `GitHubCodeClient` and emit an `incidents:` prefix; `incidents` is a
+  resolver/actuals-only family so the estimator vocabulary stays frozen while
+  real incident issue traffic still appears in calibration output as an
+  unbudgeted actual when present.
 
 #### Route families
 <!-- route-families:github -->
@@ -956,7 +961,8 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
 | `commit_stats` | `rest_core`, `contents_blob` | Per-commit file/stat expansion (`GitHubCodeClient` REST core, CHAOS-2773 CS6; contents/blob still estimate-only) | low |
 | `files` | `rest_core`, `contents_blob` | Repository tree listing (`rest_core`, frozen/estimate-only) + blob-text reads (`contents_blob`, `GitHubCodeClient` GraphQL, CHAOS-2773 CS7) | low |
 | `blame` | `rest_core`, `contents_blob` | Blame expansion (file-count dependent; `contents_blob` via `GitHubCodeClient` GraphQL, CHAOS-2773 CS7) | low |
-| `prs` | `rest_core` | Pull requests / reviews / comments core | medium |
+| `prs` | `rest_core` | Pull-request listing + PR commits (`GitHubCodeClient`, CHAOS-2773 CS8) | medium |
+| `incidents` | `rest_core` | Incident-label issue fetches (`GitHubCodeClient`, resolver-only actuals family, CHAOS-2773 CS8) | low |
 | `pr_social` | `graphql_cost`, `secondary_abuse_risk` | PR timeline/social expansion | medium |
 | `cicd` | `rest_core`, `contents_blob` | CI/CD workflow runs + artifact expansion | low |
 | `tests` | `rest_core`, `contents_blob` | Test report ingestion | low |
@@ -1177,18 +1183,18 @@ paper over:
   (CS2) — see
   [Usage drain wiring](#usage-drain-wiring-first-re-bucketing-chaos-2773-cs2)
   above. GitHub `git` and `commit_stats` REST-core traffic is instrumented as of
-  CHAOS-2807, and `files`/`blame` `contents_blob` traffic (GraphQL) as of
-  CHAOS-2808; GitLab merge-request and MR-note REST-core traffic is
-  instrumented as of CHAOS-2816 (CS15). The REST `prs` listing, the
-  `files`/`blame` `rest_core` tree listing, and remaining GitHub/GitLab
-  code-dataset families stay
-  uninstrumented pending their own CHAOS-2773 changesets (see
+  CHAOS-2807, `files`/`blame` `contents_blob` traffic (GraphQL) as of
+  CHAOS-2808, and REST `prs` listing / PR commits / incident-label issue
+  fetches as of CHAOS-2809; GitLab merge-request and MR-note REST-core traffic
+  is instrumented as of CHAOS-2816 (CS15). The `files`/`blame` `rest_core` tree
+  listing and remaining GitHub/GitLab code-dataset families stay uninstrumented
+  pending their own CHAOS-2773 changesets (see
   "Frozen `connectors/` path" below). There is also no cross-run
   aggregation/dashboard yet — calibration today is visible per-unit (result +
   structured log), not rolled up over time.
-- **Frozen `connectors/` path.** GitHub's `prs` and repo metadata/batch
-  orchestration, plus the remaining equivalent GitLab code-dataset paths,
-  remain under the frozen `connectors/` tree
+- **Frozen `connectors/` path.** GitHub's repo metadata/batch orchestration,
+  the frozen-but-retained connector PR-commit method pending CS16 retirement,
+  plus the remaining equivalent GitLab code-dataset paths, remain under the frozen `connectors/` tree
   (`connectors/github.py`'s PyGithub-based `GitHubConnector`, `connectors/
   gitlab.py`'s python-gitlab-based `GitLabConnector`). No new code may be added
   there (see [`AGENTS.md`](../../AGENTS.md)); rate-limit/actuals
@@ -1208,7 +1214,10 @@ paper over:
   `files`/`blame` ([CHAOS-2808](https://linear.app/fullchaos/issue/CHAOS-2808),
   CS7 -- the file-contents/blame GraphQL fetch relocated onto
   `providers/github/graphql.py`) moved to
-  `providers/github/code_client.py::GitHubCodeClient`; GitLab's `security`
+  `providers/github/code_client.py::GitHubCodeClient`; GitHub `prs` REST
+  listing, PR commits, and incident-label issue fetches
+  ([CHAOS-2809](https://linear.app/fullchaos/issue/CHAOS-2809), CS8) also moved
+  onto `GitHubCodeClient`. GitLab's `security`
   ([CHAOS-2811](https://linear.app/fullchaos/issue/CHAOS-2811), CS10),
   `pipelines`+`deployments`
   ([CHAOS-2812](https://linear.app/fullchaos/issue/CHAOS-2812), CS11), and

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -39,7 +39,6 @@ from dev_health_ops.processors.base_git import (
 from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
     SyncBatchCollector,
-    extract_retry_after,
 )
 from dev_health_ops.processors.fetch_utils import (
     safe_parse_datetime as _coerce_datetime,
@@ -421,55 +420,75 @@ async def _fetch_github_deployments_async(
         await client.close()
 
 
-def _fetch_github_incidents_sync(gh_repo, repo_id, max_issues, since):
+async def _fetch_github_incidents_async(
+    connector,
+    owner: str,
+    repo_name: str,
+    repo_id,
+    max_issues: int,
+    since: datetime | None,
+    usage_sink: list[dict[str, Any]] | None = None,
+) -> list[Incident]:
     incidents: list[Incident] = []
-    if not hasattr(gh_repo, "get_issues"):
-        return incidents
     labels = resolve_incident_labels()
     raw_issues = []
     seen_issue_ids: set = set()
-    for label in labels:
-        try:
-            label_issues = list(
-                gh_repo.get_issues(state="all", labels=[label])[:max_issues]
-            )
-        except Exception as exc:
-            logging.debug(
-                "Failed to fetch incident issues for label %r: %s", label, exc
-            )
-            continue
-        for issue in label_issues:
-            # The GitHub issues API returns PRs alongside issues; a PR
-            # carrying an incident label is not an incident.
-            if getattr(issue, "pull_request", None) is not None:
+    client = _github_code_client_from_connector(connector)
+    try:
+        for label in labels:
+            try:
+                label_issues = await client.iter_issues(
+                    owner,
+                    repo_name,
+                    state="all",
+                    labels=[label],
+                    max_issues=max_issues,
+                )
+            except (RateLimitException, RateLimitExceededException):
+                raise
+            except Exception as exc:
+                logging.debug(
+                    "Failed to fetch incident issues for label %r: %s", label, exc
+                )
                 continue
-            issue_id = getattr(issue, "id", None)
-            if issue_id in seen_issue_ids:
-                continue
-            seen_issue_ids.add(issue_id)
-            raw_issues.append(issue)
-    logging.info(
-        "Fetched %d incident issue(s) (labels searched: %s)",
-        len(raw_issues),
-        ", ".join(labels),
-    )
-
-    for issue in raw_issues:
-        created_at = getattr(issue, "created_at", None)
-        if not isinstance(created_at, datetime):
-            continue
-        if since is not None and created_at.astimezone(timezone.utc) < since:
-            continue
-        incidents.append(
-            Incident(
-                repo_id=repo_id,
-                incident_id=str(getattr(issue, "id", "")),
-                status=getattr(issue, "state", None),
-                started_at=created_at,
-                resolved_at=getattr(issue, "closed_at", None),
-            )
+            for issue in label_issues:
+                issue_id = getattr(issue, "issue_id", None)
+                if issue_id in seen_issue_ids:
+                    continue
+                seen_issue_ids.add(issue_id)
+                raw_issues.append(issue)
+        logging.info(
+            "Fetched %d incident issue(s) (labels searched: %s)",
+            len(raw_issues),
+            ", ".join(labels),
         )
-    return incidents
+
+        for issue in raw_issues:
+            created_at = getattr(issue, "created_at", None)
+            if not isinstance(created_at, datetime):
+                continue
+            if since is not None and created_at.astimezone(timezone.utc) < since:
+                continue
+            incidents.append(
+                Incident(
+                    repo_id=repo_id,
+                    incident_id=str(getattr(issue, "issue_id", "")),
+                    status=getattr(issue, "state", None),
+                    started_at=created_at,
+                    resolved_at=getattr(issue, "closed_at", None),
+                )
+            )
+        return incidents
+    finally:
+        observations = client.drain_usage_observations()
+        await client.close()
+        if usage_sink is not None:
+            usage_sink.extend(observations)
+        elif observations:
+            logging.debug(
+                "_fetch_github_incidents_async: drained %d incidents usage observations",
+                len(observations),
+            )
 
 
 def _github_code_client_from_connector(connector) -> GitHubCodeClient:
@@ -574,16 +593,15 @@ async def _fetch_github_security_alerts_async(
         await client.close()
 
 
-def _collect_github_pr_objects(
+async def _collect_github_pr_objects(
     connector,
     owner: str,
     repo_name: str,
     repo_id,
-    gh_repo,
-    gate: "RateLimitGate",
     state: str = "all",
     since: datetime | None = None,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> tuple[list[GitPullRequest], list[Any]]:
     """Collect raw PR objects and build GitPullRequest records without per-PR review/comment API calls.
 
@@ -593,94 +611,89 @@ def _collect_github_pr_objects(
     pr_objects: list[GitPullRequest] = []
     raw_gh_prs: list[Any] = []
 
-    sorted_by_updated = True
+    client = _github_code_client_from_connector(connector)
     try:
-        pr_iter = iter(gh_repo.get_pulls(state=state, sort="updated", direction="desc"))
-    except TypeError:
-        sorted_by_updated = False
-        pr_iter = iter(gh_repo.get_pulls(state=state))
-
-    while True:
-        try:
-            gate.wait_sync()
-            gh_pr = next(pr_iter)
-            gate.reset()
-        except StopIteration:
-            break
-        except RateLimitExceededException as e:
-            retry_after = extract_retry_after(e, connector)
-            applied = gate.penalize(retry_after)
-            logging.info(
-                "GitHub rate limited fetching PRs; backoff %.1fs (%s)",
-                applied,
-                e,
-            )
-            continue
-        except Exception as e:
-            retry_after = extract_retry_after(e, connector=None)
-            if retry_after is not None:
-                applied = gate.penalize(retry_after)
-                logging.info(
-                    "GitHub rate limited fetching PRs; backoff %.1fs (%s)",
-                    applied,
-                    e,
-                )
-                continue
-            raise
-
-        if until is not None:
-            updated_at = getattr(gh_pr, "updated_at", None)
-            if (
-                isinstance(updated_at, datetime)
-                and updated_at.astimezone(timezone.utc) > until
-            ):
-                continue
-
-        if since is not None and sorted_by_updated:
-            updated_at = getattr(gh_pr, "updated_at", None)
-            if (
-                isinstance(updated_at, datetime)
-                and updated_at.astimezone(timezone.utc) < since
-            ):
-                break
-
-        author_name = "Unknown"
-        author_email = None
-        if getattr(gh_pr, "user", None):
-            author_name = getattr(gh_pr.user, "login", None) or author_name
-
-        merged_at = getattr(gh_pr, "merged_at", None)
-        closed_at = getattr(gh_pr, "closed_at", None)
-        additions = getattr(gh_pr, "additions", 0)
-        deletions = getattr(gh_pr, "deletions", 0)
-        changed_files = getattr(gh_pr, "changed_files", 0)
-        comments_count = getattr(gh_pr, "comments", 0)
-
-        pr_objects.append(
-            build_git_pull_request(
-                repo_id=repo_id,
-                number=int(getattr(gh_pr, "number", 0) or 0),
-                title=getattr(gh_pr, "title", None),
-                body=getattr(gh_pr, "body", None),
-                state=normalize_pr_state(getattr(gh_pr, "state", None), merged_at),
-                author_name=author_name,
-                author_email=author_email,
-                created_at=getattr(gh_pr, "created_at", None),
-                merged_at=merged_at,
-                closed_at=closed_at,
-                head_branch=getattr(getattr(gh_pr, "head", None), "ref", None),
-                base_branch=getattr(getattr(gh_pr, "base", None), "ref", None),
-                additions=additions,
-                deletions=deletions,
-                changed_files=changed_files,
-                first_review_at=None,
-                first_comment_at=None,
-                changes_requested_count=0,
-                reviews_count=0,
-                comments_count=comments_count,
-            )
+        raw_pulls = await client.iter_pulls(
+            owner,
+            repo_name,
+            state=state,
+            sort="updated",
+            direction="desc",
+            since=since,
         )
-        raw_gh_prs.append(gh_pr)
+        for listed_pr in raw_pulls:
+            if until is not None:
+                updated_at = getattr(listed_pr, "updated_at", None)
+                if (
+                    isinstance(updated_at, datetime)
+                    and updated_at.astimezone(timezone.utc) > until
+                ):
+                    continue
+
+            if since is not None:
+                updated_at = getattr(listed_pr, "updated_at", None)
+                if (
+                    isinstance(updated_at, datetime)
+                    and updated_at.astimezone(timezone.utc) < since
+                ):
+                    break
+
+            gh_pr = await client.get_pull_detail(
+                owner,
+                repo_name,
+                int(getattr(listed_pr, "number", 0) or 0),
+            )
+
+            author_name = "Unknown"
+            author_email = None
+            if getattr(gh_pr, "author_login", None):
+                author_name = getattr(gh_pr, "author_login", None) or author_name
+            merged_at = getattr(gh_pr, "merged_at", None)
+            closed_at = getattr(gh_pr, "closed_at", None)
+            additions = getattr(gh_pr, "additions", 0)
+            deletions = getattr(gh_pr, "deletions", 0)
+            changed_files = getattr(gh_pr, "changed_files", 0)
+            comments_count = getattr(gh_pr, "comments_count", None)
+            if comments_count is None:
+                comments_count = getattr(gh_pr, "comments", 0)
+
+            pr_objects.append(
+                build_git_pull_request(
+                    repo_id=repo_id,
+                    number=int(getattr(gh_pr, "number", 0) or 0),
+                    title=getattr(gh_pr, "title", None),
+                    body=getattr(gh_pr, "body", None),
+                    state=normalize_pr_state(getattr(gh_pr, "state", None), merged_at),
+                    author_name=author_name,
+                    author_email=author_email,
+                    created_at=getattr(gh_pr, "created_at", None),
+                    merged_at=merged_at,
+                    closed_at=closed_at,
+                    head_branch=getattr(gh_pr, "head_ref", None)
+                    or getattr(getattr(gh_pr, "head", None), "ref", None),
+                    base_branch=getattr(gh_pr, "base_ref", None)
+                    or getattr(getattr(gh_pr, "base", None), "ref", None),
+                    additions=additions,
+                    deletions=deletions,
+                    changed_files=changed_files,
+                    first_review_at=None,
+                    first_comment_at=None,
+                    changes_requested_count=0,
+                    reviews_count=0,
+                    comments_count=comments_count,
+                )
+            )
+            raw_gh_prs.append(gh_pr)
+    finally:
+        observations = client.drain_usage_observations()
+        await client.close()
+        if usage_sink is not None:
+            usage_sink.extend(observations)
+        elif observations:
+            logging.debug(
+                "_collect_github_pr_objects: drained %d prs usage observations",
+                len(observations),
+            )
 
     return pr_objects, raw_gh_prs
 
@@ -850,7 +863,7 @@ def _github_work_client_from_connector(
     return client
 
 
-def _sync_github_prs_to_store(
+async def _sync_github_prs_to_store_async(
     connector,
     owner: str,
     repo_name: str,
@@ -866,33 +879,29 @@ def _sync_github_prs_to_store(
 ) -> int:
     """Fetch all PRs for a repo and insert them in batches.
 
-    Runs in a worker thread; uses run_coroutine_threadsafe to write batches.
     Reviews are fetched in a single batch pass after all PRs are collected,
-    avoiding N+1 API calls. ``usage_sink`` is threaded through to
-    ``_enrich_prs_with_reviews_batch`` (CHAOS-2803/CS2) -- see its docstring.
+    avoiding N+1 API calls. ``usage_sink`` is threaded through to the PR list
+    code client and ``_enrich_prs_with_reviews_batch``.
     """
     logging.info(
         "Fetching PRs for %s/%s...",
         owner,
         repo_name,
     )
-    gh_repo = connector.github.get_repo(f"{owner}/{repo_name}")
-
     gate = BaseGitProcessor.ensure_gate(gate)
     if gate is None:
         raise RuntimeError("Rate limit gate unavailable")
 
     # Phase 1: collect all PR objects without per-PR review/comment API calls
-    pr_objects, raw_gh_prs = _collect_github_pr_objects(
+    pr_objects, raw_gh_prs = await _collect_github_pr_objects(
         connector=connector,
         owner=owner,
         repo_name=repo_name,
         repo_id=repo_id,
-        gh_repo=gh_repo,
-        gate=gate,
         state=state,
         since=since,
         until=until,
+        usage_sink=usage_sink,
     )
     total = len(pr_objects)
 
@@ -912,10 +921,7 @@ def _sync_github_prs_to_store(
 
     # Phase 3: persist reviews in one bulk insert
     if review_objects:
-        BaseGitProcessor.persist_batch_threadsafe(
-            ingestion_sink.insert_git_pull_request_reviews(review_objects),
-            loop,
-        )
+        await ingestion_sink.insert_git_pull_request_reviews(review_objects)
         logging.debug(
             "Stored %d reviews for %s/%s",
             len(review_objects),
@@ -926,10 +932,7 @@ def _sync_github_prs_to_store(
     # Phase 4: persist PRs in batches
     for i in range(0, len(pr_objects), batch_size):
         batch = pr_objects[i : i + batch_size]
-        BaseGitProcessor.persist_batch_threadsafe(
-            ingestion_sink.insert_git_pull_requests(batch),
-            loop,
-        )
+        await ingestion_sink.insert_git_pull_requests(batch)
         logging.debug(
             "Stored batch of %d PRs for %s/%s (total so far: %d)",
             len(batch),
@@ -946,6 +949,38 @@ def _sync_github_prs_to_store(
     )
 
     return total
+
+
+def _sync_github_prs_to_store(
+    connector,
+    owner: str,
+    repo_name: str,
+    repo_id,
+    ingestion_sink: IngestionSink,
+    loop: asyncio.AbstractEventLoop,
+    batch_size: int,
+    state: str = "all",
+    gate: RateLimitGate | None = None,
+    since: datetime | None = None,
+    until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
+) -> int:
+    return asyncio.run(
+        _sync_github_prs_to_store_async(
+            connector=connector,
+            owner=owner,
+            repo_name=repo_name,
+            repo_id=repo_id,
+            ingestion_sink=ingestion_sink,
+            loop=loop,
+            batch_size=batch_size,
+            state=state,
+            gate=gate,
+            since=since,
+            until=until,
+            usage_sink=usage_sink,
+        )
+    )
 
 
 def _fetch_github_blame_sync(gh_repo, repo_id, limit=50):
@@ -1795,21 +1830,19 @@ async def process_github_repo(
             if sync_prs:
                 # 4. Fetch PRs
                 logging.info("Fetching pull requests from GitHub...")
-                pr_total = await loop.run_in_executor(
-                    None,
-                    _sync_github_prs_to_store,
-                    connector,
-                    owner,
-                    repo_name,
-                    db_repo.id,
-                    ingestion_sink,
-                    loop,
-                    BATCH_SIZE,
-                    "all",
-                    None,
-                    since,
-                    until,
-                    usage_sink,
+                pr_total = await _sync_github_prs_to_store_async(
+                    connector=connector,
+                    owner=owner,
+                    repo_name=repo_name,
+                    repo_id=db_repo.id,
+                    ingestion_sink=ingestion_sink,
+                    loop=loop,
+                    batch_size=BATCH_SIZE,
+                    state="all",
+                    gate=None,
+                    since=since,
+                    until=until,
+                    usage_sink=usage_sink,
                 )
                 logging.info(f"Stored {pr_total} pull requests from GitHub")
 
@@ -1864,13 +1897,14 @@ async def process_github_repo(
 
             if sync_incidents:
                 logging.info("Fetching incident issues from GitHub...")
-                incidents = await loop.run_in_executor(
-                    None,
-                    _fetch_github_incidents_sync,
-                    gh_repo,
+                incidents = await _fetch_github_incidents_async(
+                    connector,
+                    owner,
+                    repo_name,
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink=usage_sink,
                 )
                 incidents = _filter_after(incidents, until, "started_at")
                 if incidents:
@@ -2125,19 +2159,18 @@ async def process_github_repos_batch(
                 if pr_semaphore_active is None:
                     raise RuntimeError("PR semaphore unavailable")
                 async with pr_semaphore_active:
-                    await loop.run_in_executor(
-                        None,
-                        _sync_github_prs_to_store,
-                        connector,
-                        owner,
-                        repo_name,
-                        db_repo.id,
-                        ingestion_sink,
-                        loop,
-                        BATCH_SIZE,
-                        "all",
-                        pr_gate,
-                        since,
+                    await _sync_github_prs_to_store_async(
+                        connector=connector,
+                        owner=owner,
+                        repo_name=repo_name,
+                        repo_id=db_repo.id,
+                        ingestion_sink=ingestion_sink,
+                        loop=loop,
+                        batch_size=BATCH_SIZE,
+                        state="all",
+                        gate=pr_gate,
+                        since=since,
+                        usage_sink=usage_sink,
                     )
             except Exception as e:
                 logging.error(
@@ -2215,18 +2248,20 @@ async def process_github_repos_batch(
 
         if sync_incidents:
             try:
-                if gh_repo is None:
-                    gh_repo = connector.github.get_repo(repo_info.full_name)
-                incidents = await loop.run_in_executor(
-                    None,
-                    _fetch_github_incidents_sync,
-                    gh_repo,
+                batch_owner, _, batch_repo = repo_info.full_name.partition("/")
+                incidents = await _fetch_github_incidents_async(
+                    connector,
+                    batch_owner,
+                    batch_repo,
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    usage_sink=usage_sink,
                 )
                 if incidents:
                     await ingestion_sink.insert_incidents(incidents)
+            except (RateLimitException, RateLimitExceededException):
+                raise
             except Exception as e:
                 logging.warning(
                     "Failed to fetch incidents for GitHub repo %s: %s",

--- a/src/dev_health_ops/providers/github/budget.py
+++ b/src/dev_health_ops/providers/github/budget.py
@@ -340,14 +340,10 @@ def _fallback_credential_scope(
 # `"pr_social:"` prefix (CS1's resolver short-circuit, `providers/usage.py`),
 # so this marker documents that the family is now live rather than driving
 # resolution itself -- the short-circuit matches on `route_family` alone,
-# irrespective of `operation_markers`. The REST `prs` listing (raw PyGithub
-# `get_pulls`, `_collect_github_pr_objects`) and the `pr_social`
-# SECONDARY_ABUSE_RISK dimension remain uninstrumented/estimate-only: no
-# client observes a distinct secondary-limit signal on success responses (an
-# abstract reservation, like `work_item_prs`' SECONDARY_ABUSE_RISK sibling),
-# and the REST prs traffic itself stays on the frozen connector pending
-# CHAOS-2773 CS8 -- so their markers stay empty per the plan's "never flip a
-# marker before its traffic" rule (§3).
+# irrespective of `operation_markers`. The `pr_social` SECONDARY_ABUSE_RISK
+# dimension remains uninstrumented/estimate-only: no client observes a distinct
+# secondary-limit signal on success responses (an abstract reservation, like
+# `work_item_prs`' SECONDARY_ABUSE_RISK sibling), so its marker stays empty.
 #
 # `git` (REST_CORE), `commit_stats` (REST_CORE), `security` (REST_CORE), and
 # deployments REST_CORE now fetch through
@@ -368,6 +364,11 @@ def _fallback_credential_scope(
 # label resolve to the instrumented dimension instead of the still-frozen
 # REST_CORE one (the repository tree listing that discovers candidate paths
 # stays on the frozen PyGithub connector, uninstrumented, out of CS7 scope).
+# `prs` REST_CORE and the processor's incident-label issue fetches (CHAOS-2809/
+# CS8) now share the same `GitHubCodeClient` REST core as git/commit_stats and
+# emit explicit `prs:`/`incidents:` labels. `incidents` is a resolver-only
+# actuals family: the estimator constants remain frozen, and incident issue
+# traffic is attached to observed actuals without adding a new planned estimate.
 GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
     UsageRouteFamily("repo", BudgetDimension.REST_CORE),
     UsageRouteFamily("git", BudgetDimension.REST_CORE, operation_markers=("git:",)),
@@ -383,7 +384,10 @@ GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
         "blame", BudgetDimension.CONTENTS_BLOB, operation_markers=("blame:",)
     ),
     UsageRouteFamily("blame", BudgetDimension.REST_CORE),
-    UsageRouteFamily("prs", BudgetDimension.REST_CORE),
+    UsageRouteFamily("prs", BudgetDimension.REST_CORE, operation_markers=("prs:",)),
+    UsageRouteFamily(
+        "incidents", BudgetDimension.REST_CORE, operation_markers=("incidents:",)
+    ),
     UsageRouteFamily(
         "pr_social", BudgetDimension.GRAPHQL_COST, operation_markers=("pr_social:",)
     ),

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -31,6 +31,7 @@ import httpx
 
 from dev_health_ops.connectors.models import FileBlame, SecurityAlertData
 from dev_health_ops.exceptions import (
+    APIException,
     AuthenticationException,
     NotFoundException,
     RateLimitException,
@@ -71,6 +72,8 @@ GIT_ROUTE_FAMILY = "git"
 COMMIT_STATS_ROUTE_FAMILY = "commit_stats"
 FILES_ROUTE_FAMILY = "files"
 BLAME_ROUTE_FAMILY = "blame"
+PRS_ROUTE_FAMILY = "prs"
+INCIDENTS_ROUTE_FAMILY = "incidents"
 _GITHUB_DEPLOYMENTS_PER_PAGE = 100
 
 
@@ -123,6 +126,35 @@ class GitHubCommitFileStatData:
     deletions: int
     old_file_mode: str = "unknown"
     new_file_mode: str = "unknown"
+
+
+@dataclass(frozen=True)
+class GitHubPullData:
+    pull_id: str
+    number: int
+    title: str | None
+    body: str | None
+    state: str | None
+    author_login: str | None
+    created_at: datetime | None
+    updated_at: datetime | None
+    merged_at: datetime | None
+    closed_at: datetime | None
+    head_ref: str | None
+    base_ref: str | None
+    additions: int
+    deletions: int
+    changed_files: int
+    comments_count: int
+
+
+@dataclass(frozen=True)
+class GitHubIssueData:
+    issue_id: str
+    number: int
+    state: str | None
+    created_at: datetime | None
+    closed_at: datetime | None
 
 
 def _lowered_github_headers(response: httpx.Response) -> dict[str, str]:
@@ -236,6 +268,28 @@ def _parse_alert_datetime(value: object) -> datetime | None:
     except ValueError:
         logger.debug("Failed to parse GitHub datetime: %s", value)
         return None
+
+
+def _int_or_zero(value: object) -> int:
+    if isinstance(value, int):
+        return value
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return 0
+    if isinstance(value, float):
+        return int(value)
+    return 0
+
+
+def _repo_path(owner: str, repo: str, *segments: object) -> str:
+    encoded = [
+        urllib.parse.quote(str(owner), safe=""),
+        urllib.parse.quote(str(repo), safe=""),
+    ]
+    encoded.extend(urllib.parse.quote(str(segment), safe="") for segment in segments)
+    return "/repos/" + "/".join(encoded)
 
 
 def _dependabot_alert_from_item(item: dict[str, Any]) -> SecurityAlertData:
@@ -387,6 +441,46 @@ def _commit_stat_from_file(
         file_path=str(file_item.get("filename") or ""),
         additions=int(file_item.get("additions") or 0),
         deletions=int(file_item.get("deletions") or 0),
+    )
+
+
+def _pull_from_item(item: Mapping[str, Any]) -> GitHubPullData:
+    user = item.get("user")
+    head = item.get("head")
+    base = item.get("base")
+    return GitHubPullData(
+        pull_id=str(item.get("id") or ""),
+        number=_int_or_zero(item.get("number")),
+        title=str(item["title"]) if item.get("title") is not None else None,
+        body=str(item["body"]) if item.get("body") is not None else None,
+        state=str(item["state"]) if item.get("state") is not None else None,
+        author_login=str(user["login"])
+        if isinstance(user, Mapping) and user.get("login") is not None
+        else None,
+        created_at=_parse_alert_datetime(item.get("created_at")),
+        updated_at=_parse_alert_datetime(item.get("updated_at")),
+        merged_at=_parse_alert_datetime(item.get("merged_at")),
+        closed_at=_parse_alert_datetime(item.get("closed_at")),
+        head_ref=str(head["ref"])
+        if isinstance(head, Mapping) and head.get("ref") is not None
+        else None,
+        base_ref=str(base["ref"])
+        if isinstance(base, Mapping) and base.get("ref") is not None
+        else None,
+        additions=_int_or_zero(item.get("additions")),
+        deletions=_int_or_zero(item.get("deletions")),
+        changed_files=_int_or_zero(item.get("changed_files")),
+        comments_count=_int_or_zero(item.get("comments")),
+    )
+
+
+def _issue_from_item(item: Mapping[str, Any]) -> GitHubIssueData:
+    return GitHubIssueData(
+        issue_id=str(item.get("id") or ""),
+        number=_int_or_zero(item.get("number")),
+        state=str(item["state"]) if item.get("state") is not None else None,
+        created_at=_parse_alert_datetime(item.get("created_at")),
+        closed_at=_parse_alert_datetime(item.get("closed_at")),
     )
 
 
@@ -603,6 +697,149 @@ class GitHubCodeClient:
             if isinstance(item, Mapping) and item.get("sha")
         ]
         return commits, window_truncated
+
+    async def iter_pulls(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        state: str = "all",
+        sort: str = "updated",
+        direction: str = "desc",
+        max_pulls: int | None = None,
+        since: datetime | None = None,
+    ) -> list[GitHubPullData]:
+        params: dict[str, Any] = {
+            "state": state,
+            "sort": sort,
+            "direction": direction,
+            "per_page": _GITHUB_DEPLOYMENTS_PER_PAGE,
+        }
+        max_pages = None if max_pulls is None else _page_cap_for_limit(max_pulls)
+        operation = f"{PRS_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/pulls"
+        pulls: list[GitHubPullData] = []
+        next_url: str | None = _repo_path(owner, repo, "pulls")
+        next_params: dict[str, Any] | None = params
+        pages = 0
+        while next_url is not None:
+            if max_pages is not None and pages >= max_pages:
+                logger.warning(
+                    "%s pagination hit the %d-page cap for %s",
+                    "github",
+                    max_pages,
+                    operation,
+                )
+                break
+            response = await self._core.request(
+                "GET",
+                next_url,
+                operation=operation,
+                params=next_params,
+            )
+            pages += 1
+            payload = response.json()
+            if not isinstance(payload, list):
+                raise APIException(
+                    f"Unexpected paginated response for {operation}: {type(payload)!r}"
+                )
+
+            crossed_since_boundary = False
+            for item in payload:
+                if not isinstance(item, Mapping):
+                    continue
+                pull = _pull_from_item(item)
+                if (
+                    since is not None
+                    and pull.updated_at is not None
+                    and pull.updated_at < since
+                ):
+                    crossed_since_boundary = True
+                    break
+                pulls.append(pull)
+                if max_pulls is not None and len(pulls) >= max_pulls:
+                    return pulls
+            if crossed_since_boundary:
+                break
+            next_url = response.links.get("next", {}).get("url")
+            next_params = None
+        return pulls
+
+    async def get_pull_detail(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+    ) -> GitHubPullData:
+        operation = f"{PRS_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/pulls/{{number}}"
+        response = await self._core.request(
+            "GET",
+            _repo_path(owner, repo, "pulls", number),
+            operation=operation,
+        )
+        payload = response.json()
+        if not isinstance(payload, Mapping):
+            raise APIException(
+                f"Unexpected pull detail response for {operation}: {type(payload)!r}"
+            )
+        return _pull_from_item(payload)
+
+    async def iter_pull_commits(
+        self,
+        owner: str,
+        repo: str,
+        number: int,
+        *,
+        max_commits: int | None = None,
+    ) -> list[GitHubCommitData]:
+        params: dict[str, Any] = {"per_page": _GITHUB_DEPLOYMENTS_PER_PAGE}
+        max_pages = None if max_commits is None else _page_cap_for_limit(max_commits)
+        operation = (
+            f"{PRS_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/pulls/{{number}}/commits"
+        )
+        items = await self._core.paginate_link_header(
+            _repo_path(owner, repo, "pulls", number, "commits"),
+            operation=operation,
+            params=params,
+            max_pages=max_pages,
+        )
+        if max_commits is not None:
+            items = items[:max_commits]
+        return [
+            _commit_from_item(item)
+            for item in items
+            if isinstance(item, Mapping) and item.get("sha") is not None
+        ]
+
+    async def iter_issues(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        state: str = "all",
+        labels: list[str] | None = None,
+        max_issues: int | None = None,
+    ) -> list[GitHubIssueData]:
+        params: dict[str, Any] = {
+            "state": state,
+            "per_page": _GITHUB_DEPLOYMENTS_PER_PAGE,
+        }
+        if labels:
+            params["labels"] = ",".join(labels)
+        max_pages = None if max_issues is None else _page_cap_for_limit(max_issues)
+        operation = f"{INCIDENTS_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/issues"
+        items = await self._core.paginate_link_header(
+            f"{_repo_path(owner, repo)}/issues",
+            operation=operation,
+            params=params,
+            max_pages=max_pages,
+        )
+        if max_issues is not None:
+            items = items[:max_issues]
+        return [
+            _issue_from_item(item)
+            for item in items
+            if isinstance(item, Mapping) and item.get("pull_request") is None
+        ]
 
     async def get_commit_file_stats(
         self,
@@ -854,11 +1091,15 @@ __all__ = [
     "DEPLOYMENTS_ROUTE_FAMILY",
     "FILES_ROUTE_FAMILY",
     "GIT_ROUTE_FAMILY",
+    "INCIDENTS_ROUTE_FAMILY",
     "GitHubCodeClient",
     "GitHubCommitData",
     "GitHubCommitFileStatData",
     "GitHubDeploymentData",
+    "GitHubIssueData",
+    "GitHubPullData",
     "GitHubWorkflowRunData",
     "GitHubReleaseData",
+    "PRS_ROUTE_FAMILY",
     "SECURITY_ROUTE_FAMILY",
 ]

--- a/tests/providers/test_github_budget.py
+++ b/tests/providers/test_github_budget.py
@@ -100,6 +100,16 @@ def test_github_files_and_blame_contents_blob_actuals_markers_are_live() -> None
     assert markers[("blame", BudgetDimension.REST_CORE)] == ()
 
 
+def test_github_prs_and_incidents_rest_core_actuals_markers_are_live() -> None:
+    markers = {
+        (family.route_family, family.dimension): family.operation_markers
+        for family in GITHUB_USAGE_ROUTE_FAMILIES
+    }
+
+    assert markers[("prs", BudgetDimension.REST_CORE)] == ("prs:",)
+    assert markers[("incidents", BudgetDimension.REST_CORE)] == ("incidents:",)
+
+
 def test_github_budget_estimator_splits_pr_social_pressure() -> None:
     estimates = GitHubBudgetEstimator().estimate(_context(dataset_key="pr-comments"))
 

--- a/tests/providers/test_github_code_client_prs.py
+++ b/tests/providers/test_github_code_client_prs.py
@@ -1,0 +1,360 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+from dev_health_ops.exceptions import APIException, NotFoundException
+from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.code_client import GitHubCodeClient
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+
+def _client(transport: httpx.AsyncBaseTransport) -> GitHubCodeClient:
+    return GitHubCodeClient(auth=GitHubAuth(token="unit-test-pat"), transport=transport)
+
+
+def test_iter_pulls_normalizes_fields_and_utc_datetimes() -> None:
+    asyncio.run(_test_iter_pulls_normalizes_fields_and_utc_datetimes())
+
+
+async def _test_iter_pulls_normalizes_fields_and_utc_datetimes() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 123,
+                    "number": "42",
+                    "title": "Fix widgets",
+                    "body": "Details",
+                    "state": "closed",
+                    "user": {"login": "octocat"},
+                    "created_at": "2026-01-01T00:00:00Z",
+                    "updated_at": "2026-01-02T00:00:00Z",
+                    "merged_at": "2026-01-03T00:00:00Z",
+                    "closed_at": "2026-01-04T00:00:00Z",
+                    "head": {"ref": "feature"},
+                    "base": {"ref": "main"},
+                    "additions": "5",
+                    "deletions": 2,
+                    "changed_files": "3",
+                    "comments": "7",
+                }
+            ],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    pulls = await client.iter_pulls("acme", "widgets", state="all")
+    await client.close()
+
+    assert len(seen) == 1
+    assert seen[0].url.params["state"] == "all"
+    assert seen[0].url.params["sort"] == "updated"
+    assert seen[0].url.params["direction"] == "desc"
+    pull = pulls[0]
+    assert pull.pull_id == "123"
+    assert pull.number == 42
+    assert pull.author_login == "octocat"
+    assert pull.created_at == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert pull.updated_at == datetime(2026, 1, 2, tzinfo=timezone.utc)
+    assert pull.merged_at == datetime(2026, 1, 3, tzinfo=timezone.utc)
+    assert pull.closed_at == datetime(2026, 1, 4, tzinfo=timezone.utc)
+    assert pull.additions == 5
+    assert pull.deletions == 2
+    assert pull.changed_files == 3
+    assert pull.comments_count == 7
+
+
+def test_iter_pulls_follows_link_header_until_absent_last_page() -> None:
+    asyncio.run(_test_iter_pulls_follows_link_header_until_absent_last_page())
+
+
+async def _test_iter_pulls_follows_link_header_until_absent_last_page() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if len(seen) == 1:
+            return httpx.Response(
+                200,
+                json=[{"id": 1, "number": 1}],
+                headers={
+                    "Link": (
+                        "<https://api.github.com/repos/acme/widgets/pulls?page=2>; "
+                        'rel="next"'
+                    )
+                },
+            )
+        return httpx.Response(200, json=[{"id": 2, "number": 2}])
+
+    client = _client(httpx.MockTransport(handler))
+    pulls = await client.iter_pulls("acme", "widgets")
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert [pull.number for pull in pulls] == [1, 2]
+    assert len(seen) == 2
+    assert observations[0]["route_family"] == "prs"
+    assert observations[0]["dimension"] == BudgetDimension.REST_CORE.value
+    assert observations[0]["request_count"] == 2
+    assert observations[0]["example_operation"].startswith("prs:")
+
+
+def test_iter_pulls_stops_at_since_boundary_without_fetching_later_pages() -> None:
+    asyncio.run(_test_iter_pulls_stops_at_since_boundary_without_fetching_later_pages())
+
+
+async def _test_iter_pulls_stops_at_since_boundary_without_fetching_later_pages() -> (
+    None
+):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if len(seen) == 1:
+            return httpx.Response(
+                200,
+                json=[
+                    {"id": 1, "number": 1, "updated_at": "2026-01-03T00:00:00Z"},
+                    {"id": 2, "number": 2, "updated_at": "2026-01-01T00:00:00Z"},
+                ],
+                headers={
+                    "Link": (
+                        "<https://api.github.com/repos/acme/widgets/pulls?page=2>; "
+                        'rel="next"'
+                    )
+                },
+            )
+        return httpx.Response(
+            200,
+            json=[{"id": 3, "number": 3, "updated_at": "2025-12-31T00:00:00Z"}],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    pulls = await client.iter_pulls(
+        "acme",
+        "widgets",
+        since=datetime(2026, 1, 2, tzinfo=timezone.utc),
+    )
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert [pull.number for pull in pulls] == [1]
+    assert len(seen) == 1
+    assert observations[0]["route_family"] == "prs"
+    assert observations[0]["request_count"] == 1
+
+
+def test_get_pull_detail_records_prs_usage_and_normalizes_stats() -> None:
+    asyncio.run(_test_get_pull_detail_records_prs_usage_and_normalizes_stats())
+
+
+async def _test_get_pull_detail_records_prs_usage_and_normalizes_stats() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": 42,
+                "number": 7,
+                "updated_at": "2026-01-03T00:00:00Z",
+                "additions": 123,
+                "deletions": 45,
+                "changed_files": 6,
+                "comments": 8,
+            },
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    pull = await client.get_pull_detail("acme", "widgets", 7)
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert seen[0].url.path == "/repos/acme/widgets/pulls/7"
+    assert pull.additions == 123
+    assert pull.deletions == 45
+    assert pull.changed_files == 6
+    assert pull.comments_count == 8
+    assert observations[0]["route_family"] == "prs"
+    assert observations[0]["request_count"] == 1
+    assert observations[0]["example_operation"].startswith("prs:")
+
+
+def test_iter_pulls_empty_first_page_stops_without_followup() -> None:
+    asyncio.run(_test_iter_pulls_empty_first_page_stops_without_followup())
+
+
+async def _test_iter_pulls_empty_first_page_stops_without_followup() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=[])
+
+    client = _client(httpx.MockTransport(handler))
+    pulls = await client.iter_pulls("acme", "widgets")
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert pulls == []
+    assert len(seen) == 1
+    assert observations[0]["request_count"] == 1
+
+
+def test_iter_pulls_404_is_not_treated_as_empty() -> None:
+    asyncio.run(_test_iter_pulls_404_is_not_treated_as_empty())
+
+
+async def _test_iter_pulls_404_is_not_treated_as_empty() -> None:
+    client = _client(httpx.MockTransport(lambda r: httpx.Response(404, json={})))
+
+    with pytest.raises(NotFoundException):
+        await client.iter_pulls("acme", "missing")
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert observations[0]["route_family"] == "prs"
+    assert observations[0]["request_count"] == 1
+
+
+def test_iter_pull_commits_normalizes_and_encodes_path_segments() -> None:
+    asyncio.run(_test_iter_pull_commits_normalizes_and_encodes_path_segments())
+
+
+async def _test_iter_pull_commits_normalizes_and_encodes_path_segments() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "sha": 123,
+                    "commit": {
+                        "message": "msg",
+                        "author": {
+                            "name": "Ada",
+                            "email": "a@example.com",
+                            "date": "2026-02-01T00:00:00Z",
+                        },
+                        "committer": {
+                            "name": "Grace",
+                            "email": "g@example.com",
+                            "date": "2026-02-02T00:00:00Z",
+                        },
+                    },
+                    "parents": [{"sha": "p"}],
+                }
+            ],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    commits = await client.iter_pull_commits("acme/evil", "widgets?x=1", 42)
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert commits[0].sha == "123"
+    assert commits[0].author_when == datetime(2026, 2, 1, tzinfo=timezone.utc)
+    assert commits[0].committer_when == datetime(2026, 2, 2, tzinfo=timezone.utc)
+    assert commits[0].parent_count == 1
+    assert (
+        seen[0]
+        .url.raw_path.decode()
+        .startswith("/repos/acme%2Fevil/widgets%3Fx%3D1/pulls/42/commits?")
+    )
+    assert seen[0].url.params.get("x") is None
+    assert observations[0]["route_family"] == "prs"
+    assert observations[0]["request_count"] == 1
+
+
+def test_iter_issues_sends_label_filter_and_skips_pull_requests() -> None:
+    asyncio.run(_test_iter_issues_sends_label_filter_and_skips_pull_requests())
+
+
+async def _test_iter_issues_sends_label_filter_and_skips_pull_requests() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "id": "100",
+                    "number": "5",
+                    "state": "closed",
+                    "created_at": "2026-03-01T00:00:00Z",
+                    "closed_at": "2026-03-02T00:00:00Z",
+                },
+                {
+                    "id": 101,
+                    "number": 6,
+                    "state": "open",
+                    "created_at": "2026-03-03T00:00:00Z",
+                    "pull_request": {"url": "https://api.github.com/pulls/6"},
+                },
+            ],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+    issues = await client.iter_issues(
+        "acme", "widgets", state="all", labels=["incident"]
+    )
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert seen[0].url.params["labels"] == "incident"
+    assert [issue.issue_id for issue in issues] == ["100"]
+    assert issues[0].created_at == datetime(2026, 3, 1, tzinfo=timezone.utc)
+    assert issues[0].closed_at == datetime(2026, 3, 2, tzinfo=timezone.utc)
+    assert observations[0]["route_family"] == "incidents"
+    assert observations[0]["dimension"] == BudgetDimension.REST_CORE.value
+    assert observations[0]["example_operation"].startswith("incidents:")
+
+
+def test_iter_issues_failure_mid_pagination_preserves_partial_observations() -> None:
+    asyncio.run(
+        _test_iter_issues_failure_mid_pagination_preserves_partial_observations()
+    )
+
+
+async def _test_iter_issues_failure_mid_pagination_preserves_partial_observations() -> (
+    None
+):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if len(seen) == 1:
+            return httpx.Response(
+                200,
+                json=[{"id": 1, "number": 1, "created_at": "2026-01-01T00:00:00Z"}],
+                headers={
+                    "Link": (
+                        "<https://api.github.com/repos/acme/widgets/issues?page=2>; "
+                        'rel="next"'
+                    )
+                },
+            )
+        return httpx.Response(500, json={"message": "boom"})
+
+    client = _client(httpx.MockTransport(handler))
+
+    with pytest.raises(APIException):
+        await client.iter_issues("acme", "widgets", state="all", labels=["incident"])
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert len(seen) == 6
+    assert observations[0]["route_family"] == "incidents"
+    assert observations[0]["request_count"] == len(seen)
+    assert observations[0]["latest_status"] == 500

--- a/tests/providers/test_usage_resolver_prefix.py
+++ b/tests/providers/test_usage_resolver_prefix.py
@@ -199,6 +199,35 @@ def test_github_files_blame_prefixed_labels_resolve_to_contents_blob(
     )
 
 
+GITHUB_CS8_PREFIXED_LABELS: tuple[tuple[str, str, tuple[str, BudgetDimension]], ...] = (
+    (
+        "rest",
+        "prs:GET /repos/acme/widgets/pulls",
+        ("prs", BudgetDimension.REST_CORE),
+    ),
+    (
+        "rest",
+        "prs:GET /repos/acme/widgets/pulls/{number}/commits",
+        ("prs", BudgetDimension.REST_CORE),
+    ),
+    (
+        "rest",
+        "incidents:GET /repos/acme/widgets/issues",
+        ("incidents", BudgetDimension.REST_CORE),
+    ),
+)
+
+
+@pytest.mark.parametrize("transport,operation,expected", GITHUB_CS8_PREFIXED_LABELS)
+def test_github_prs_incidents_prefixed_labels_resolve_to_rest_core(
+    transport: str, operation: str, expected: tuple[str, BudgetDimension]
+) -> None:
+    assert (
+        GITHUB_USAGE_RESOLVER.resolve(transport=transport, operation=operation)
+        == expected
+    )
+
+
 # ---------------------------------------------------------------------------
 # 2. Representative prefixed labels per registered family short-circuit.
 # ---------------------------------------------------------------------------

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -79,6 +79,20 @@ def _github_commit_stats_async_from_sync(fake_fetch):
     return _wrapped
 
 
+class _EmptyGithubPrCodeClient:
+    async def iter_pulls(self, owner, repo, *, state, sort, direction, since=None):
+        return []
+
+    async def get_pull_detail(self, owner, repo, number):
+        raise AssertionError(f"unexpected pull detail request for {number}")
+
+    def drain_usage_observations(self):
+        return []
+
+    async def close(self):
+        return None
+
+
 @pytest.mark.asyncio
 async def test_github_async_batch_callback_fires_as_completed(monkeypatch):
     """Fast repos should invoke callback before slow repos in same batch."""
@@ -457,6 +471,11 @@ async def test_process_github_repos_batch_upserts_during_async_processing(monkey
             self.close()
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _EmptyGithubPrCodeClient(),
+    )
 
     await processors.github.process_github_repos_batch(
         store=store,
@@ -565,6 +584,11 @@ async def test_process_github_repos_batch_stores_commits_and_stats(monkeypatch):
             self.close()
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _EmptyGithubPrCodeClient(),
+    )
     monkeypatch.setattr(
         processors.github,
         "_fetch_github_commits_async",
@@ -1408,6 +1432,96 @@ async def test_process_github_repos_batch_commit_detail_rate_limit_propagates(
 
     assert exc_info.value.retry_after_seconds == 43.0
     assert recorded_stats == []
+
+
+@pytest.mark.asyncio
+async def test_process_github_repos_batch_incident_rate_limit_propagates(
+    monkeypatch,
+):
+    _enable_connector_stubs(monkeypatch)
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_incidents(self, incidents):
+            raise AssertionError("incidents must not persist after a rate limit")
+
+    repo = Mock()
+    repo.id = 1003
+    repo.full_name = "org/incident-rate-limited"
+    repo.url = "https://example.com/org/incident-rate-limited"
+    repo.default_branch = "main"
+    repo.language = "Python"
+    result = BatchResult(repository=repo, stats=None, success=True)
+
+    class DummyGithub:
+        def get_repo(self, full_name: str):
+            raise AssertionError("legacy repo object must not be fetched")
+
+    class DummyConnector:
+        def __init__(self, token: str):
+            self.github = DummyGithub()
+
+        async def get_repos_with_stats_async(self, **kwargs):
+            on_repo_complete = kwargs.get("on_repo_complete")
+            if on_repo_complete:
+                on_repo_complete(result)
+            return [result]
+
+        def get_rate_limit(self):
+            return {"remaining": 0, "limit": 0}
+
+        def close(self):
+            return
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            self.close()
+
+    async def fake_fetch_incidents(*args, **kwargs):
+        raise RateLimitException("limited", retry_after_seconds=44.0)
+
+    async def fake_fetch_commits(*args, **kwargs):
+        return [], [], False
+
+    monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github,
+        "_fetch_github_commits_async",
+        fake_fetch_commits,
+    )
+    monkeypatch.setattr(
+        processors.github,
+        "_fetch_github_incidents_async",
+        fake_fetch_incidents,
+    )
+
+    with pytest.raises(RateLimitException) as exc_info:
+        await processors.github.process_github_repos_batch(
+            store=DummyStore(),
+            token="test_token",
+            org_name="org",
+            pattern="org/*",
+            batch_size=1,
+            max_concurrent=1,
+            rate_limit_delay=0,
+            use_async=True,
+            sync_prs=False,
+            sync_cicd=False,
+            sync_deployments=False,
+            sync_incidents=True,
+            sync_security=False,
+            sync_tests=False,
+            backfill_missing=False,
+        )
+
+    assert exc_info.value.retry_after_seconds == 44.0
 
 
 @pytest.mark.asyncio

--- a/tests/test_deployment_pr_inference.py
+++ b/tests/test_deployment_pr_inference.py
@@ -23,7 +23,7 @@ from dev_health_ops.connectors.utils.rest import GitLabRESTClient
 from dev_health_ops.processors.base_git import resolve_incident_labels
 from dev_health_ops.processors.github import (
     _fetch_github_deployments_async,
-    _fetch_github_incidents_sync,
+    _fetch_github_incidents_async,
 )
 from dev_health_ops.processors.gitlab import (
     _fetch_gitlab_incidents_sync,
@@ -32,6 +32,23 @@ from dev_health_ops.processors.gitlab import (
 
 REPO_ID = uuid.uuid4()
 NOW = datetime(2026, 6, 12, tzinfo=timezone.utc)
+
+
+class _IssueClient:
+    def __init__(self, issues_by_label):
+        self.issues_by_label = issues_by_label
+        self.calls = []
+        self.close_called = False
+
+    async def iter_issues(self, owner, repo, *, state, labels, max_issues):
+        self.calls.append((owner, repo, state, labels, max_issues))
+        return self.issues_by_label[labels[0]][:max_issues]
+
+    def drain_usage_observations(self):
+        return []
+
+    async def close(self):
+        self.close_called = True
 
 
 class _NoWaitGate:
@@ -140,34 +157,45 @@ class TestIncidentLabels:
         monkeypatch.setenv("INCIDENT_LABELS", " , ")
         assert resolve_incident_labels() == ["incident"]
 
-    def test_github_queries_each_label_and_dedupes(self, monkeypatch) -> None:
-        monkeypatch.setenv("INCIDENT_LABELS", "incident,outage")
-        shared = Mock(id=1, state="closed", created_at=NOW, closed_at=NOW)
-        shared.pull_request = None
-        outage_only = Mock(id=2, state="open", created_at=NOW, closed_at=None)
-        outage_only.pull_request = None
-        gh_repo = Mock()
-        gh_repo.get_issues.side_effect = [[shared], [shared, outage_only]]
+    @pytest.mark.asyncio
+    async def test_github_queries_each_label_and_dedupes(self, monkeypatch) -> None:
+        from dev_health_ops.processors import github
 
-        incidents = _fetch_github_incidents_sync(gh_repo, REPO_ID, 10, None)
+        monkeypatch.setenv("INCIDENT_LABELS", "incident,outage")
+        shared = Mock(issue_id="1", state="closed", created_at=NOW, closed_at=NOW)
+        outage_only = Mock(issue_id="2", state="open", created_at=NOW, closed_at=None)
+        client = _IssueClient({"incident": [shared], "outage": [shared, outage_only]})
+        monkeypatch.setattr(
+            github, "_github_code_client_from_connector", lambda _connector: client
+        )
+
+        incidents = await _fetch_github_incidents_async(
+            Mock(), "octo", "repo", REPO_ID, 10, None
+        )
 
         assert {i.incident_id for i in incidents} == {"1", "2"}
-        assert gh_repo.get_issues.call_count == 2
-        labels_queried = [
-            call.kwargs["labels"] for call in gh_repo.get_issues.call_args_list
+        assert client.calls == [
+            ("octo", "repo", "all", ["incident"], 10),
+            ("octo", "repo", "all", ["outage"], 10),
         ]
-        assert labels_queried == [["incident"], ["outage"]]
+        assert client.close_called is True
 
-    def test_github_filters_prs_carrying_incident_label(self, monkeypatch) -> None:
+    @pytest.mark.asyncio
+    async def test_github_filters_prs_carrying_incident_label(
+        self, monkeypatch
+    ) -> None:
+        from dev_health_ops.processors import github
+
         monkeypatch.delenv("INCIDENT_LABELS", raising=False)
-        real_issue = Mock(id=1, state="closed", created_at=NOW, closed_at=NOW)
-        real_issue.pull_request = None
-        labeled_pr = Mock(id=2, state="open", created_at=NOW, closed_at=None)
-        labeled_pr.pull_request = Mock()  # the issues API includes PRs
-        gh_repo = Mock()
-        gh_repo.get_issues.return_value = [real_issue, labeled_pr]
+        real_issue = Mock(issue_id="1", state="closed", created_at=NOW, closed_at=NOW)
+        client = _IssueClient({"incident": [real_issue]})
+        monkeypatch.setattr(
+            github, "_github_code_client_from_connector", lambda _connector: client
+        )
 
-        incidents = _fetch_github_incidents_sync(gh_repo, REPO_ID, 10, None)
+        incidents = await _fetch_github_incidents_async(
+            Mock(), "octo", "repo", REPO_ID, 10, None
+        )
 
         assert [i.incident_id for i in incidents] == ["1"]
 

--- a/tests/test_github_content_backfill.py
+++ b/tests/test_github_content_backfill.py
@@ -35,12 +35,14 @@ class _FakeCodeClient:
     tests double the CLIENT, never ``connector.get_file_contents``/
     ``connector.get_file_blame`` (which the processor no longer calls)."""
 
-    def __init__(self, *, contents=None, blame=None, side_effect=None):
+    def __init__(self, *, contents=None, blame=None, issues=None, side_effect=None):
         self.contents = contents if contents is not None else {}
         self.blame = blame
+        self.issues = issues if issues is not None else []
         self.side_effect = side_effect
         self.file_content_calls: list[tuple[str, str, list[str], str]] = []
         self.file_blame_calls: list[tuple[str, str, str, str]] = []
+        self.issue_calls: list[tuple[str, str, str, list[str], int | None]] = []
         self.drain_usage_observations = Mock(return_value=[])
         self.close = AsyncMock()
 
@@ -71,6 +73,20 @@ class _FakeCodeClient:
         if self.side_effect is not None:
             raise self.side_effect
         return self.blame
+
+    async def iter_issues(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        state: str = "all",
+        labels: list[str] | None = None,
+        max_issues: int | None = None,
+    ):
+        self.issue_calls.append((owner, repo, state, labels or [], max_issues))
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.issues[:max_issues]
 
 
 class TestFetchScannableContents:
@@ -136,6 +152,52 @@ class TestFetchScannableContents:
             )
 
         assert exc_info.value.retry_after_seconds == 7.0
+
+
+class TestGithubIncidentsClientSeam:
+    @pytest.mark.asyncio
+    async def test_incidents_fetch_uses_code_client_and_not_legacy_repo(
+        self, monkeypatch
+    ):
+        from dev_health_ops.processors import github
+        from dev_health_ops.processors.github import _fetch_github_incidents_async
+
+        since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+        issue = SimpleNamespace(
+            issue_id="issue-1",
+            state="closed",
+            created_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            closed_at=datetime(2026, 1, 3, tzinfo=timezone.utc),
+        )
+        code_client = _FakeCodeClient(issues=[issue])
+        monkeypatch.setattr(github, "resolve_incident_labels", lambda: ["incident"])
+        monkeypatch.setattr(
+            github, "_github_code_client_from_connector", lambda _connector: code_client
+        )
+
+        connector = Mock()
+        connector.github.get_repo.side_effect = AssertionError(
+            "legacy PyGithub repo path must not be called"
+        )
+        repo_id = uuid.uuid4()
+        usage_sink: list[dict[str, object]] = []
+
+        incidents = await _fetch_github_incidents_async(
+            connector,
+            "octo",
+            "repo",
+            repo_id,
+            10,
+            since,
+            usage_sink=usage_sink,
+        )
+
+        assert [(row.incident_id, row.status, row.started_at) for row in incidents] == [
+            ("issue-1", "closed", datetime(2026, 1, 2, tzinfo=timezone.utc))
+        ]
+        assert code_client.issue_calls == [("octo", "repo", "all", ["incident"], 10)]
+        code_client.close.assert_awaited_once()
+        connector.github.get_repo.assert_not_called()
 
 
 class TestBackfillFileRecordsContents:

--- a/tests/test_github_pr_changes_requested_sync.py
+++ b/tests/test_github_pr_changes_requested_sync.py
@@ -87,16 +87,21 @@ class _FakePR:
         self.title = f"PR {number}"
         self.body = None
         self.state = "closed"
+        self.author_login = "octo"
         self.user = _FakePRUser()
         self.created_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        self.updated_at = datetime(2020, 1, 2, tzinfo=timezone.utc)
         self.merged_at = None
         self.closed_at = None
+        self.head_ref = "feature"
+        self.base_ref = "main"
         self.head = _FakePRRef("feature")
         self.base = _FakePRRef("main")
         self.additions = 0
         self.deletions = 0
         self.changed_files = 0
         self.comments = 0
+        self.comments_count = 0
 
 
 class _FakeRepo:
@@ -104,7 +109,36 @@ class _FakeRepo:
         self._pull_items = pull_items
 
     def get_pulls(self, state="all", sort=None, direction=None):
-        return _PRIter(self._pull_items)
+        raise AssertionError("legacy PyGithub get_pulls must not be called")
+
+
+class _ListingCodeClient:
+    def __init__(self, pulls):
+        self._pulls = list(pulls)
+
+    async def iter_pulls(self, owner, repo, *, state, sort, direction, since=None):
+        assert (owner, repo, state, sort, direction) == (
+            "o",
+            "r",
+            "all",
+            "updated",
+            "desc",
+        )
+        self.since = since
+        return list(self._pulls)
+
+    async def get_pull_detail(self, owner, repo, number):
+        assert (owner, repo) == ("o", "r")
+        for pull in self._pulls:
+            if pull.number == number:
+                return pull
+        raise AssertionError(f"unexpected pull detail request for {number}")
+
+    def drain_usage_observations(self):
+        return []
+
+    async def close(self):
+        return None
 
 
 class _FakeReview:
@@ -165,9 +199,15 @@ async def test_github_pr_sync_writes_changes_requested_count_from_reviews():
             for pr in prs:
                 yield pr.number, tuple(reviews_by_pr.get(pr.number, []))
 
-    with patch(
-        "dev_health_ops.processors.github.GitHubWorkClient",
-        _BatchReviewClient,
+    with (
+        patch(
+            "dev_health_ops.processors.github.GitHubWorkClient",
+            _BatchReviewClient,
+        ),
+        patch(
+            "dev_health_ops.processors.github._github_code_client_from_connector",
+            lambda _connector: _ListingCodeClient(fake_repo._pull_items),
+        ),
     ):
         total = await loop.run_in_executor(
             None,

--- a/tests/test_github_pr_usage_drain.py
+++ b/tests/test_github_pr_usage_drain.py
@@ -86,21 +86,35 @@ class _FakePRRef:
 
 
 class _FakePR:
-    def __init__(self, number: int):
+    def __init__(
+        self,
+        number: int,
+        *,
+        additions: int = 0,
+        deletions: int = 0,
+        changed_files: int = 0,
+        comments_count: int = 0,
+    ):
+        self.pull_id = str(number)
         self.number = number
         self.title = f"PR {number}"
         self.body = None
         self.state = "closed"
+        self.author_login = "octo"
         self.user = _FakePRUser()
         self.created_at = datetime(2020, 1, 1, tzinfo=timezone.utc)
+        self.updated_at = datetime(2020, 1, 2, tzinfo=timezone.utc)
         self.merged_at = None
         self.closed_at = None
+        self.head_ref = "feature"
+        self.base_ref = "main"
         self.head = _FakePRRef("feature")
         self.base = _FakePRRef("main")
-        self.additions = 0
-        self.deletions = 0
-        self.changed_files = 0
-        self.comments = 0
+        self.additions = additions
+        self.deletions = deletions
+        self.changed_files = changed_files
+        self.comments = comments_count
+        self.comments_count = comments_count
 
 
 class _FakeRepo:
@@ -108,7 +122,7 @@ class _FakeRepo:
         self._pull_items = pull_items
 
     def get_pulls(self, state="all", sort=None, direction=None):
-        return _PRIter(self._pull_items)
+        raise AssertionError("legacy PyGithub get_pulls must not be called")
 
 
 class _Connector:
@@ -120,6 +134,53 @@ class _Connector:
 
     def _rest_base_url(self):
         return "https://api.github.com"
+
+
+_PR_LISTING_RECORD = {
+    "transport": "rest",
+    "route_family": "prs",
+    "dimension": "rest_core",
+    "request_count": 1,
+    "example_operation": "prs:GET /repos/o/r/pulls",
+}
+
+
+class _ListingCodeClient:
+    instances: list["_ListingCodeClient"] = []
+
+    def __init__(self, pulls, details=None):
+        self._pulls = list(pulls)
+        self._details = list(details) if details is not None else list(pulls)
+        self.closed = False
+        self.drained = False
+        self.detail_numbers: list[int] = []
+        type(self).instances.append(self)
+
+    async def iter_pulls(self, owner, repo, *, state, sort, direction, since=None):
+        assert (owner, repo, state, sort, direction) == (
+            "o",
+            "r",
+            "all",
+            "updated",
+            "desc",
+        )
+        self.since = since
+        return list(self._pulls)
+
+    async def get_pull_detail(self, owner, repo, number):
+        assert (owner, repo) == ("o", "r")
+        self.detail_numbers.append(number)
+        for pull in self._details:
+            if pull.number == number:
+                return pull
+        raise AssertionError(f"unexpected pull detail request for {number}")
+
+    def drain_usage_observations(self) -> list[dict[str, Any]]:
+        self.drained = True
+        return [dict(_PR_LISTING_RECORD)]
+
+    async def close(self) -> None:
+        self.closed = True
 
 
 class _DrainingBatchReviewClient:
@@ -156,8 +217,10 @@ class _DrainingBatchReviewClient:
 @pytest.fixture(autouse=True)
 def _reset_instances():
     _DrainingBatchReviewClient.instances = []
+    _ListingCodeClient.instances = []
     yield
     _DrainingBatchReviewClient.instances = []
+    _ListingCodeClient.instances = []
 
 
 @pytest.mark.asyncio
@@ -170,9 +233,15 @@ async def test_sync_prs_drains_review_client_into_adapter_owned_sink():
     fake_repo = _FakeRepo([_FakePR(1), _FakePR(2)])
     usage_sink: list[dict[str, Any]] = []
 
-    with patch(
-        "dev_health_ops.processors.github.GitHubWorkClient",
-        _DrainingBatchReviewClient,
+    with (
+        patch(
+            "dev_health_ops.processors.github.GitHubWorkClient",
+            _DrainingBatchReviewClient,
+        ),
+        patch(
+            "dev_health_ops.processors.github._github_code_client_from_connector",
+            lambda _connector: _ListingCodeClient(fake_repo._pull_items),
+        ),
     ):
         total = await loop.run_in_executor(
             None,
@@ -194,15 +263,70 @@ async def test_sync_prs_drains_review_client_into_adapter_owned_sink():
     assert total == 2
     assert len(_DrainingBatchReviewClient.instances) == 1
     assert _DrainingBatchReviewClient.instances[0].drained is True
+    assert _ListingCodeClient.instances[0].drained is True
+    assert _ListingCodeClient.instances[0].closed is True
     assert usage_sink == [
+        _PR_LISTING_RECORD,
         {
             "transport": "graphql",
             "route_family": "pr_social",
             "dimension": "graphql_cost",
             "request_count": 1,
             "example_operation": "pr_social:POST /graphql PR social data",
-        }
+        },
     ]
+
+
+@pytest.mark.asyncio
+async def test_sync_prs_hydrates_detail_stats_before_persisting_pr_rows():
+    loop = asyncio.get_running_loop()
+    repo_id = uuid.uuid4()
+    store = _FakeStore()
+    listed_pr = _FakePR(1)
+    detailed_pr = _FakePR(
+        1,
+        additions=123,
+        deletions=45,
+        changed_files=6,
+        comments_count=8,
+    )
+    fake_repo = _FakeRepo([listed_pr])
+    usage_sink: list[dict[str, Any]] = []
+
+    with (
+        patch(
+            "dev_health_ops.processors.github.GitHubWorkClient",
+            _DrainingBatchReviewClient,
+        ),
+        patch(
+            "dev_health_ops.processors.github._github_code_client_from_connector",
+            lambda _connector: _ListingCodeClient([listed_pr], [detailed_pr]),
+        ),
+    ):
+        total = await loop.run_in_executor(
+            None,
+            cast(Any, _sync_github_prs_to_store),
+            _Connector(fake_repo),
+            "o",
+            "r",
+            repo_id,
+            store,
+            loop,
+            50,
+            "all",
+            _NoSleepGate(),
+            None,
+            None,
+            usage_sink,
+        )
+
+    assert total == 1
+    assert _ListingCodeClient.instances[0].detail_numbers == [1]
+    persisted_pr = store.pr_batches[0][0]
+    assert persisted_pr.additions == 123
+    assert persisted_pr.deletions == 45
+    assert persisted_pr.changed_files == 6
+    assert persisted_pr.comments_count == 8
 
 
 @pytest.mark.asyncio
@@ -222,6 +346,10 @@ async def test_sync_prs_without_sink_drains_client_but_logs_only(caplog):
             "dev_health_ops.processors.github.GitHubWorkClient",
             _DrainingBatchReviewClient,
         ),
+        patch(
+            "dev_health_ops.processors.github._github_code_client_from_connector",
+            lambda _connector: _ListingCodeClient(fake_repo._pull_items),
+        ),
         caplog.at_level("DEBUG", logger="root"),
     ):
         # usage_sink omitted entirely -- exercises the default (None) path.
@@ -240,6 +368,8 @@ async def test_sync_prs_without_sink_drains_client_but_logs_only(caplog):
         )
 
     assert total == 1
+    assert _ListingCodeClient.instances[0].drained is True
+    assert _ListingCodeClient.instances[0].closed is True
     assert len(_DrainingBatchReviewClient.instances) == 1
     assert _DrainingBatchReviewClient.instances[0].drained is True
     assert any(
@@ -329,9 +459,15 @@ async def test_sync_prs_rate_limit_propagates_after_partial_drain():
     fake_repo = _FakeRepo([_FakePR(1), _FakePR(2)])
     usage_sink: list[dict[str, Any]] = []
 
-    with patch(
-        "dev_health_ops.processors.github.GitHubWorkClient",
-        _RateLimitedAfterOneRequestClient,
+    with (
+        patch(
+            "dev_health_ops.processors.github.GitHubWorkClient",
+            _RateLimitedAfterOneRequestClient,
+        ),
+        patch(
+            "dev_health_ops.processors.github._github_code_client_from_connector",
+            lambda _connector: _ListingCodeClient(fake_repo._pull_items),
+        ),
     ):
         with pytest.raises(RateLimitException) as exc_info:
             await loop.run_in_executor(
@@ -355,7 +491,7 @@ async def test_sync_prs_rate_limit_propagates_after_partial_drain():
     # The drain ran BEFORE the exception unwound past the processor.
     assert len(_RateLimitedAfterOneRequestClient.instances) == 1
     assert _RateLimitedAfterOneRequestClient.instances[0].drained is True
-    assert usage_sink == [_PARTIAL_PR_SOCIAL_RECORD]
+    assert usage_sink == [_PR_LISTING_RECORD, _PARTIAL_PR_SOCIAL_RECORD]
     # No success-path persistence happened: the unit defers, nothing stamped.
     assert store.pr_batches == []
     assert store.review_batches == []
@@ -373,9 +509,15 @@ async def test_sync_prs_non_rate_limit_error_still_degrades_gracefully():
     fake_repo = _FakeRepo([_FakePR(1), _FakePR(2)])
     usage_sink: list[dict[str, Any]] = []
 
-    with patch(
-        "dev_health_ops.processors.github.GitHubWorkClient",
-        _FailingBatchReviewClient,
+    with (
+        patch(
+            "dev_health_ops.processors.github.GitHubWorkClient",
+            _FailingBatchReviewClient,
+        ),
+        patch(
+            "dev_health_ops.processors.github._github_code_client_from_connector",
+            lambda _connector: _ListingCodeClient(fake_repo._pull_items),
+        ),
     ):
         total = await loop.run_in_executor(
             None,
@@ -397,7 +539,7 @@ async def test_sync_prs_non_rate_limit_error_still_degrades_gracefully():
     assert total == 2
     assert len(_FailingBatchReviewClient.instances) == 1
     assert _FailingBatchReviewClient.instances[0].drained is True
-    assert usage_sink == [_PARTIAL_PR_SOCIAL_RECORD]
+    assert usage_sink == [_PR_LISTING_RECORD, _PARTIAL_PR_SOCIAL_RECORD]
     # PRs persisted despite the failed (optional) review enrichment.
     persisted_prs = [pr for batch in store.pr_batches for pr in batch]
     assert len(persisted_prs) == 2

--- a/tests/test_processors_pr_mr_rate_limit.py
+++ b/tests/test_processors_pr_mr_rate_limit.py
@@ -1,6 +1,9 @@
 import asyncio
 import uuid
+from datetime import datetime, timezone
+from types import SimpleNamespace
 from typing import Any, cast
+from unittest.mock import patch
 
 import pytest
 
@@ -37,111 +40,116 @@ class _FakeStore:
         self.pr_batches.append(list(batch))
 
 
-class _FakeGithub:
-    def __init__(self, repo):
-        self._repo = repo
-
-    def get_repo(self, _full_name: str):
-        return self._repo
-
-
-class _RetryAfterException(Exception):
-    def __init__(self, headers):
-        super().__init__("rate limited")
-        self.headers = headers
-
-
-class _PRIter:
-    def __init__(self, items):
-        self._items = list(items)
-        self._idx = 0
-
-    def __iter__(self):
-        return self
-
-    def __next__(self):
-        if self._idx >= len(self._items):
-            raise StopIteration
-        item = self._items[self._idx]
-        self._idx += 1
-        if isinstance(item, Exception):
-            raise item
-        return item
+def _fake_pr(number: int):
+    return SimpleNamespace(
+        number=number,
+        title=f"PR {number}",
+        body=None,
+        state="closed",
+        author_login="octo",
+        created_at=datetime(2020, 1, 1, tzinfo=timezone.utc),
+        updated_at=datetime(2020, 1, 2, tzinfo=timezone.utc),
+        merged_at=None,
+        closed_at=None,
+        head_ref="feature",
+        base_ref="main",
+        additions=0,
+        deletions=0,
+        changed_files=0,
+        comments_count=0,
+    )
 
 
-class _FakePRUser:
-    def __init__(self, login="octo", email=None):
-        self.login = login
-        self.email = email
+class _FakeCodeClient:
+    def __init__(self, pulls):
+        self._pulls = list(pulls)
+
+    async def iter_pulls(self, owner, repo, *, state, sort, direction, since=None):
+        assert (owner, repo, state, sort, direction) == (
+            "o",
+            "r",
+            "all",
+            "updated",
+            "desc",
+        )
+        self.since = since
+        return list(self._pulls)
+
+    async def get_pull_detail(self, owner, repo, number):
+        assert (owner, repo) == ("o", "r")
+        for pull in self._pulls:
+            if pull.number == number:
+                return pull
+        raise AssertionError(f"unexpected pull detail request for {number}")
+
+    def drain_usage_observations(self):
+        return []
+
+    async def close(self):
+        return None
 
 
-class _FakePRRef:
-    def __init__(self, ref):
-        self.ref = ref
+class _NoReviewClient:
+    def __init__(self, **_kwargs):
+        self.graphql = None
 
+    def iter_pr_reviews_batch(self, *, owner, repo, prs, limit, operation_family=None):
+        for pr in prs:
+            yield pr.number, ()
 
-class _FakePR:
-    def __init__(self, number: int):
-        self.number = number
-        self.title = f"PR {number}"
-        self.state = "closed"
-        self.user = _FakePRUser()
-        self.created_at = None
-        self.merged_at = None
-        self.closed_at = None
-        self.head = _FakePRRef("feature")
-        self.base = _FakePRRef("main")
-
-
-class _FakeRepo:
-    def __init__(self, pull_items):
-        self._pull_items = pull_items
-
-    def get_pulls(self, state="all"):
-        assert state == "all"
-        return _PRIter(self._pull_items)
+    def drain_usage_observations(self):
+        return []
 
 
 @pytest.mark.asyncio
-async def test_github_pr_sync_retries_on_retry_after_and_persists():
+async def test_github_pr_sync_uses_code_client_and_persists():
     loop = asyncio.get_running_loop()
     repo_id = uuid.uuid4()
     store = _FakeStore()
 
-    # First call hits a Retry-After style limit, then we yield two PRs.
-    fake_repo = _FakeRepo(
-        [
-            _RetryAfterException({"Retry-After": "0"}),
-            _FakePR(1),
-            _FakePR(2),
-        ]
-    )
-
     class _Connector:
         def __init__(self):
-            self.github = _FakeGithub(fake_repo)
+            self.github = SimpleNamespace(
+                get_repo=lambda _full_name: (_ for _ in ()).throw(
+                    AssertionError("legacy PyGithub get_repo must not be called")
+                )
+            )
+            self.token = "token"
+            self.per_page = 100
+            self.graphql = object()
+
+        def _rest_base_url(self):
+            return "https://api.github.com"
 
     connector = _Connector()
     gate = _NoSleepGate()
 
-    total = await loop.run_in_executor(
-        None,
-        cast(Any, _sync_github_prs_to_store),
-        connector,
-        "o",
-        "r",
-        repo_id,
-        store,
-        loop,
-        1,  # batch_size
-        "all",
-        gate,
-    )
+    pulls = [_fake_pr(1), _fake_pr(2)]
+    with (
+        patch(
+            "dev_health_ops.processors.github._github_code_client_from_connector",
+            lambda _connector: _FakeCodeClient(pulls),
+        ),
+        patch("dev_health_ops.processors.github.GitHubWorkClient", _NoReviewClient),
+    ):
+        total = await loop.run_in_executor(
+            None,
+            cast(Any, _sync_github_prs_to_store),
+            connector,
+            "o",
+            "r",
+            repo_id,
+            store,
+            loop,
+            1,  # batch_size
+            "all",
+            gate,
+        )
 
     assert total == 2
     assert len(store.pr_batches) == 2
     assert [b[0].number for b in store.pr_batches] == [1, 2]
-    assert gate.penalties and gate.penalties[0] == pytest.approx(0.0)
+    assert gate.penalties == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## CHAOS-2773 CS8 — GitHub prs family + incidents

Migrates the GitHub `prs` route family and incident-label issue fetches off raw PyGithub onto the canonical httpx `GitHubCodeClient`, following the merged CS7 (files+blame) template.

### Changes
- **`GitHubCodeClient`**: adds `iter_pulls` (windowed — stops at the `since` boundary instead of eager full-history pagination), `iter_pull_commits`, `iter_issues` (per-label cap, skips PR-shaped issues), and `get_pull_detail` (hydrates `additions`/`deletions`/`changed_files`/`comments` via `GET /pulls/{number}` so persisted PR rows keep the same shape the PyGithub path lazily produced).
- **Processor**: PR listing + incident fetches rewired to the async client; usage observations drain on success and failure; `RateLimitException` re-raised from batch incident sync instead of being swallowed.
- **Budget**: `prs` marker flipped to the explicit `prs:` prefix; resolver-only `incidents` family added. Estimator constants/types/family names stay frozen.
- Docs (`rate-limit-policy.md`) updated in this changeset; code-client, resolver-prefix, budget, and processor-seam tests added.

The connector prs/incidents methods stay frozen in-tree until CS16 retirement. No runtime legacy flag.

### Validation
- Full gate `OTEL_SDK_DISABLED=true SCRATCH_DB=ci_local_validate_2809 bash ci/local_validate.sh` → `GATE PASSED` (`6905 passed, 44 skipped`).
- Adversarial review (Oracle) found 3 blockers (PR row-shape drift, windowed-pagination budget blowout, batch incident rate-limit swallow); all fixed with regression tests.

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.