### PR TITLE
fix(complexity): probe blame line text before fallback (CHAOS-2861)

### DIFF
--- a/src/dev_health_ops/metrics/job_complexity_db.py
+++ b/src/dev_health_ops/metrics/job_complexity_db.py
@@ -159,6 +159,35 @@ def _load_blame_contents(
     return [(row[0], row[1]) for row in rows]
 
 
+def _has_blame_line_text(client: Any, repo_id: uuid.UUID, org_id: str) -> bool:
+    """Cheap existence probe: does this repo's git_blame carry any usable
+    (non-null, non-empty) line text?
+
+    GitHub's Blame API does not return line text at all, so ``git_blame.line``
+    is NULL for every GitHub-synced repo today (CHAOS-2861 root cause).
+    GitLab currently discards line text too (pending CHAOS-2860). Only
+    local-sync repos populate it today. Attempting reconstruction against
+    textless rows silently yields newline-only strings via
+    ``_load_blame_contents``'s ``ifNull(line, '')`` concat, so callers should
+    check this probe first and log an actionable message instead of the
+    dead-end fallback.
+    """
+    rows = _query_rows(
+        client,
+        """
+        SELECT 1
+        FROM git_blame
+        WHERE repo_id = {repo_id:UUID}
+          AND org_id = {org_id:String}
+          AND line IS NOT NULL
+          AND line != ''
+        LIMIT 1
+        """,
+        {"repo_id": str(repo_id), "org_id": org_id},
+    )
+    return bool(rows)
+
+
 def _max_last_synced(
     client: Any, table: str, repo_id: uuid.UUID, org_id: str
 ) -> datetime | None:
@@ -277,6 +306,7 @@ def run_complexity_db_job(
 
             files: list[tuple[str, str]] = []
             remaining = max_files
+            blame_unusable = False
 
             if non_empty > 0:
                 git_files = _load_git_files(sink.client, repo_uuid, org_id, remaining)
@@ -286,12 +316,6 @@ def run_complexity_db_job(
 
                 missing = max(total_files - non_empty, 0)
                 if missing > 0 and (remaining is None or remaining > 0):
-                    logger.info(
-                        "Repo %s missing %s/%s git_files contents; filling with blame.",
-                        repo_label,
-                        missing,
-                        total_files,
-                    )
                     missing_paths = _load_missing_paths(
                         sink.client, repo_uuid, org_id, remaining
                     )
@@ -299,27 +323,83 @@ def run_complexity_db_job(
                         path for path in missing_paths if scanner.should_process(path)
                     ]
                     if missing_paths:
-                        blame_files = _load_blame_contents(
-                            sink.client,
-                            repo_uuid,
-                            org_id,
-                            missing_paths,
-                            remaining,
-                        )
-                        files.extend(blame_files)
+                        if _has_blame_line_text(sink.client, repo_uuid, org_id):
+                            logger.info(
+                                "Repo %s missing %s/%s git_files contents; filling with blame.",
+                                repo_label,
+                                missing,
+                                total_files,
+                            )
+                            blame_files = _load_blame_contents(
+                                sink.client,
+                                repo_uuid,
+                                org_id,
+                                missing_paths,
+                                remaining,
+                            )
+                            files.extend(blame_files)
+                        else:
+                            blame_unusable = True
+                            logger.warning(
+                                "Repo %s is missing %s/%s git_files contents and "
+                                "git_blame has no usable line text for those paths, "
+                                "so the blame fallback cannot recover them. "
+                                "Remedies: (1) file contents were never hydrated -- "
+                                "check the scanner include/exclude globs or run a "
+                                "content backfill (CHAOS-2859); (2) GitHub's Blame "
+                                "API does not return line text by design; (3) "
+                                "GitLab blame line text is pending CHAOS-2860; (4) "
+                                "consider enabling the BLAME dataset (CHAOS-2862).",
+                                repo_label,
+                                missing,
+                                total_files,
+                            )
             else:
+                has_blame_text = _has_blame_line_text(sink.client, repo_uuid, org_id)
                 if total_files > 0:
-                    logger.warning(
-                        "Repo %s has no git_files contents; falling back to git_blame.",
-                        repo_label,
+                    if has_blame_text:
+                        logger.warning(
+                            "Repo %s has no git_files contents; falling back to git_blame.",
+                            repo_label,
+                        )
+                    else:
+                        blame_unusable = True
+                        logger.warning(
+                            "Repo %s has no git_files contents and git_blame has "
+                            "no usable line text either, so the blame fallback "
+                            "cannot recover them. Remedies: (1) file contents "
+                            "were never hydrated -- check the scanner "
+                            "include/exclude globs or run a content backfill "
+                            "(CHAOS-2859); (2) GitHub's Blame API does not "
+                            "return line text by design; (3) GitLab blame line "
+                            "text is pending CHAOS-2860; (4) consider enabling "
+                            "the BLAME dataset (CHAOS-2862).",
+                            repo_label,
+                        )
+                if has_blame_text:
+                    files = _load_blame_contents(
+                        sink.client, repo_uuid, org_id, None, remaining
                     )
-                files = _load_blame_contents(
-                    sink.client, repo_uuid, org_id, None, remaining
-                )
 
             files = _filter_files(scanner, files, max_files)
             if not files:
-                logger.warning("No scannable contents found for repo %s.", repo_label)
+                if blame_unusable:
+                    logger.warning(
+                        "No scannable contents found for repo %s: git_blame "
+                        "exists but carries no usable line text (see prior "
+                        "warning for remedies).",
+                        repo_label,
+                    )
+                elif total_files == 0:
+                    logger.warning(
+                        "No scannable contents found for repo %s: no git_files "
+                        "or git_blame rows exist for this repo.",
+                        repo_label,
+                    )
+                else:
+                    logger.warning(
+                        "No scannable contents found for repo %s.", repo_label
+                    )
                 continue
 
             ref_value = _build_ref(sink.client, repo_uuid, org_id)

--- a/src/dev_health_ops/metrics/job_complexity_db.py
+++ b/src/dev_health_ops/metrics/job_complexity_db.py
@@ -341,13 +341,14 @@ def run_complexity_db_job(
                         else:
                             blame_unusable = True
                             logger.warning(
-                                "Repo %s is missing %s/%s git_files contents and "
-                                "git_blame has no usable line text for those paths, "
-                                "so the blame fallback cannot recover them. "
-                                "Remedies: (1) file contents were never hydrated -- "
-                                "check the scanner include/exclude globs or run a "
-                                "content backfill (CHAOS-2859); (2) GitHub's Blame "
-                                "API does not return line text by design; (3) "
+                                "Repo %s is missing %s/%s git_files contents, and "
+                                "git_blame has no usable line text for those paths "
+                                "(either no blame rows were synced, or the provider "
+                                "returned no line text), so the blame fallback cannot "
+                                "recover them. Remedies: (1) file contents were never "
+                                "hydrated -- check the scanner include/exclude globs "
+                                "or run a content backfill (CHAOS-2859); (2) GitHub's "
+                                "Blame API does not return line text by design; (3) "
                                 "GitLab blame line text is pending CHAOS-2860; (4) "
                                 "consider enabling the BLAME dataset (CHAOS-2862).",
                                 repo_label,
@@ -365,10 +366,11 @@ def run_complexity_db_job(
                     else:
                         blame_unusable = True
                         logger.warning(
-                            "Repo %s has no git_files contents and git_blame has "
-                            "no usable line text either, so the blame fallback "
-                            "cannot recover them. Remedies: (1) file contents "
-                            "were never hydrated -- check the scanner "
+                            "Repo %s has no git_files contents, and git_blame has "
+                            "no usable line text either (either no blame rows were "
+                            "synced, or the provider returned no line text), so the "
+                            "blame fallback cannot recover them. Remedies: (1) file "
+                            "contents were never hydrated -- check the scanner "
                             "include/exclude globs or run a content backfill "
                             "(CHAOS-2859); (2) GitHub's Blame API does not "
                             "return line text by design; (3) GitLab blame line "
@@ -385,9 +387,10 @@ def run_complexity_db_job(
             if not files:
                 if blame_unusable:
                     logger.warning(
-                        "No scannable contents found for repo %s: git_blame "
-                        "exists but carries no usable line text (see prior "
-                        "warning for remedies).",
+                        "No scannable contents found for repo %s: git_blame has no "
+                        "usable line text (either no blame rows were synced, or the "
+                        "provider returned no line text) -- see prior warning for "
+                        "remedies.",
                         repo_label,
                     )
                 elif total_files == 0:

--- a/tests/metrics/test_complexity_blame_fallback.py
+++ b/tests/metrics/test_complexity_blame_fallback.py
@@ -166,6 +166,13 @@ def test_zero_contents_textless_blame_skips_fallback_and_logs_actionable_warning
     assert "CHAOS-2860" in combined
     assert "CHAOS-2862" in combined
     assert "GitHub" in combined
+    assert "either no blame rows were synced" in combined, (
+        "message must not assume blame rows exist -- a repo can have zero "
+        "git_blame rows and still hit this branch"
+    )
+    assert "git_blame exists" not in combined, (
+        "message must not assert git_blame rows exist when they may not"
+    )
 
 
 def test_zero_contents_real_blame_text_reconstruction_unchanged(monkeypatch):
@@ -224,6 +231,10 @@ def test_missing_paths_textless_blame_skips_fill_and_logs_actionable_warning(
     assert actionable, (
         f"expected an actionable no-usable-line-text warning, got: {warnings}"
     )
+    assert any("either no blame rows were synced" in msg for msg in actionable), (
+        "message must not assume blame rows exist for the missing paths"
+    )
+    assert not any("git_blame exists" in msg for msg in actionable)
 
 
 def test_missing_paths_real_blame_text_fill_unchanged(monkeypatch):

--- a/tests/metrics/test_complexity_blame_fallback.py
+++ b/tests/metrics/test_complexity_blame_fallback.py
@@ -1,0 +1,300 @@
+"""Tests for CHAOS-2861 (CS-C): honest git_blame fallback gating.
+
+``job_complexity_db``'s blame-reconstruction fallback (``_load_blame_contents``)
+is structurally dead for provider-synced repos today: GitHub's Blame API does
+not return line text at all, and GitLab currently discards it too (pending
+CHAOS-2860), so ``git_blame.line`` is NULL. Reconstructing text from all-NULL
+lines silently produces newline-only strings, and the job used to log a
+misleading "falling back to git_blame" / "No scannable contents" message that
+promised a recovery path which could not exist.
+
+These tests exercise ``_has_blame_line_text`` and its two call sites in
+``run_complexity_db_job``:
+  (a) repos with SOME git_files contents, filling missing paths from blame.
+  (b) repos with ZERO git_files contents, going all-blame.
+
+The fake ClickHouse client below follows the same pattern as
+``tests/test_github_content_backfill.py::_EmptyClickHouseClient`` /
+``tests/test_metrics_complexity_db.py::FakeClickHouseClient`` -- a query-text
+dispatcher that returns canned ``result_rows`` for each query shape the job
+issues.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import date
+
+import dev_health_ops.metrics.job_complexity_db as job
+
+
+class _FakeQueryResult:
+    def __init__(self, rows):
+        self.result_rows = rows
+
+
+class _FakeSink:
+    """Minimal ``ClickHouseMetricsSink`` stand-in, same shape as the other
+    complexity-job tests' fake sinks."""
+
+    def __init__(self, client):
+        self.client = client
+        self.snapshots = []
+        self.dailies = []
+
+    def ensure_tables(self):
+        return None
+
+    def write_file_complexity_snapshots(self, rows):
+        self.snapshots.extend(rows)
+
+    def write_repo_complexity_daily(self, rows):
+        self.dailies.extend(rows)
+
+    def close(self):
+        return None
+
+
+class _BlameFallbackClient:
+    """Query-text dispatcher covering every query shape
+    ``run_complexity_db_job`` issues for a single repo:
+
+    - ``count()`` over ``git_files`` -> (total, non_empty)
+    - ``maxOrNull(last_synced)`` over ``git_files`` / ``git_blame``
+    - ``SELECT path, contents FROM git_files`` (non-empty contents)
+    - ``SELECT path FROM git_files`` (missing/NULL contents)
+    - the CHAOS-2861 probe: ``SELECT 1 FROM git_blame ... line IS NOT NULL``
+    - the reconstruction query: ``SELECT path, arrayStringConcat(...)``
+
+    ``blame_has_text`` controls whether the probe (and, if reached, the
+    reconstruction query) reports usable line text.
+    """
+
+    def __init__(
+        self,
+        *,
+        total_files: int,
+        non_empty_files: int,
+        missing_paths: list[str] | None = None,
+        blame_has_text: bool,
+        blame_reconstructed: list[tuple[str, str]] | None = None,
+        non_empty_rows: list[tuple[str, str]] | None = None,
+    ):
+        self.total_files = total_files
+        self.non_empty_files = non_empty_files
+        self.missing_paths = missing_paths or []
+        self.blame_has_text = blame_has_text
+        self.blame_reconstructed = blame_reconstructed or []
+        self.non_empty_rows = non_empty_rows or []
+        self.queries: list[tuple[str, dict]] = []
+
+    def query(self, query: str, parameters=None):
+        params = parameters or {}
+        self.queries.append((query, params))
+
+        if "count()" in query and "FROM git_files" in query:
+            return _FakeQueryResult([[self.total_files, self.non_empty_files]])
+
+        if "maxOrNull(last_synced)" in query:
+            return _FakeQueryResult([[None]])
+
+        if "FROM git_files" in query and "contents" in query and "IS NULL" not in query:
+            return _FakeQueryResult(self.non_empty_rows)
+
+        if "FROM git_files" in query and "contents" in query and "IS NULL" in query:
+            return _FakeQueryResult([[p] for p in self.missing_paths])
+
+        # CHAOS-2861 probe: cheap existence check for usable blame line text.
+        if "SELECT 1" in query and "FROM git_blame" in query:
+            return _FakeQueryResult([[1]] if self.blame_has_text else [])
+
+        # Reconstruction query (arrayStringConcat over groupArray).
+        if "FROM git_blame" in query:
+            return _FakeQueryResult(self.blame_reconstructed)
+
+        if "FROM repos" in query:
+            return _FakeQueryResult([])
+
+        raise AssertionError(f"Unexpected query: {query}")
+
+
+def _run(client, monkeypatch, *, repo_id=None):
+    sink = _FakeSink(client)
+    monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: sink)
+    rc = job.run_complexity_db_job(
+        repo_id=repo_id or uuid.uuid4(),
+        db_url="clickhouse://localhost:8123/default",
+        date=date(2026, 6, 12),
+        backfill_days=1,
+        language_globs=None,
+        max_files=None,
+        org_id="test-org",
+    )
+    return rc, sink
+
+
+def test_zero_contents_textless_blame_skips_fallback_and_logs_actionable_warning(
+    monkeypatch, caplog
+):
+    """(a) Repo has zero git_files contents; git_blame rows exist but every
+    ``line`` is NULL. The fallback must NOT attempt reconstruction, and must
+    log a warning naming the real remedies instead of the dead-end
+    "falling back to git_blame" message."""
+    client = _BlameFallbackClient(
+        total_files=2,
+        non_empty_files=0,
+        blame_has_text=False,
+    )
+
+    with caplog.at_level("WARNING"):
+        rc, sink = _run(client, monkeypatch)
+
+    assert rc == 1
+    assert not sink.snapshots
+    assert not sink.dailies
+
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert not any("falling back to git_blame" in msg for msg in warnings), (
+        "must not claim a blame fallback is happening when blame has no usable text"
+    )
+    actionable = [msg for msg in warnings if "no usable line text" in msg]
+    assert actionable, (
+        f"expected an actionable no-usable-line-text warning, got: {warnings}"
+    )
+    combined = " ".join(actionable)
+    assert "CHAOS-2859" in combined
+    assert "CHAOS-2860" in combined
+    assert "CHAOS-2862" in combined
+    assert "GitHub" in combined
+
+
+def test_zero_contents_real_blame_text_reconstruction_unchanged(monkeypatch):
+    """(b) Repo has zero git_files contents; git_blame carries real line
+    text. Reconstruction must still happen and produce snapshots -- byte
+    identical to pre-CHAOS-2861 behavior."""
+    blame_rows = [
+        ("src/alpha.py", "def alpha():\n    return 1\n"),
+        ("src/beta.py", "def beta(x):\n    if x:\n        return x\n    return 0\n"),
+    ]
+    client = _BlameFallbackClient(
+        total_files=0,
+        non_empty_files=0,
+        blame_has_text=True,
+        blame_reconstructed=blame_rows,
+    )
+
+    rc, sink = _run(client, monkeypatch)
+
+    assert rc == 0
+    assert sink.snapshots
+    assert sink.dailies
+    assert {snap.file_path for snap in sink.snapshots} == {
+        "src/alpha.py",
+        "src/beta.py",
+    }
+
+
+def test_missing_paths_textless_blame_skips_fill_and_logs_actionable_warning(
+    monkeypatch, caplog
+):
+    """(a) Repo has SOME git_files contents but is missing others; git_blame
+    exists for the missing paths but carries no usable text. The fill must be
+    skipped (not fabricated from NULL lines) and an actionable warning
+    logged, while the files that DO have contents still get scanned."""
+    client = _BlameFallbackClient(
+        total_files=2,
+        non_empty_files=1,
+        missing_paths=["src/beta.py"],
+        blame_has_text=False,
+        non_empty_rows=[("src/alpha.py", "def alpha():\n    return 1\n")],
+    )
+
+    with caplog.at_level("WARNING"):
+        rc, sink = _run(client, monkeypatch)
+
+    assert rc == 0
+    assert {snap.file_path for snap in sink.snapshots} == {"src/alpha.py"}, (
+        "the file with real contents must still be scanned even though the "
+        "blame fill for the missing path was skipped"
+    )
+
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    assert not any("filling with blame" in msg for msg in warnings)
+    actionable = [msg for msg in warnings if "no usable line text" in msg]
+    assert actionable, (
+        f"expected an actionable no-usable-line-text warning, got: {warnings}"
+    )
+
+
+def test_missing_paths_real_blame_text_fill_unchanged(monkeypatch):
+    """(a) Repo has SOME git_files contents and missing paths with real blame
+    text. The existing fill-from-blame behavior must be unchanged."""
+    client = _BlameFallbackClient(
+        total_files=2,
+        non_empty_files=1,
+        missing_paths=["src/beta.py"],
+        blame_has_text=True,
+        blame_reconstructed=[
+            ("src/beta.py", "def beta(x):\n    if x:\n        return x\n    return 0\n")
+        ],
+        non_empty_rows=[("src/alpha.py", "def alpha():\n    return 1\n")],
+    )
+
+    rc, sink = _run(client, monkeypatch)
+
+    assert rc == 0
+    assert {snap.file_path for snap in sink.snapshots} == {
+        "src/alpha.py",
+        "src/beta.py",
+    }
+
+
+def test_zero_rows_repo_distinguishable_message(monkeypatch, caplog):
+    """(c) A repo with NO git_files rows and NO git_blame rows at all must
+    log a distinguishable "no rows exist" message, not the generic fallback
+    warning or the textless-blame remedy message (there is nothing to
+    remedy -- the repo was simply never synced)."""
+    client = _BlameFallbackClient(
+        total_files=0,
+        non_empty_files=0,
+        blame_has_text=False,
+    )
+
+    with caplog.at_level("WARNING"):
+        rc, sink = _run(client, monkeypatch)
+
+    assert rc == 1
+    assert not sink.snapshots
+
+    warnings = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    scannable = [msg for msg in warnings if "No scannable contents found" in msg]
+    assert scannable, f"expected a final no-scannable-contents warning, got: {warnings}"
+    assert any("no git_files or git_blame rows exist" in msg for msg in scannable), (
+        f"expected the zero-rows-specific message, got: {scannable}"
+    )
+    assert not any("no usable line text" in msg for msg in scannable), (
+        "a repo with zero rows entirely should not get the "
+        "blame-exists-but-textless message"
+    )
+
+
+def test_probe_query_is_org_scoped(monkeypatch):
+    """The CHAOS-2861 probe must be scoped by both repo_id and org_id, like
+    every other query in this job (multi-tenant safety)."""
+    client = _BlameFallbackClient(
+        total_files=0,
+        non_empty_files=0,
+        blame_has_text=False,
+    )
+    repo_id = uuid.uuid4()
+
+    _run(client, monkeypatch, repo_id=repo_id)
+
+    probe_queries = [
+        (q, p) for q, p in client.queries if "SELECT 1" in q and "FROM git_blame" in q
+    ]
+    assert probe_queries, "expected the CHAOS-2861 probe query to run"
+    for query, params in probe_queries:
+        assert "org_id = {org_id:String}" in query
+        assert params["org_id"] == "test-org"
+        assert params["repo_id"] == str(repo_id)


### PR DESCRIPTION
## Summary

The complexity job's `git_blame` fallback reconstructs file text from `git_blame.line`, but GitHub's Blame API never returns line text and GitLab currently discards it (pending CHAOS-2860), so `line` is NULL for every provider-synced repo today. Reconstructing against all-NULL lines silently produced newline-only strings, and the job then logged a misleading "falling back to git_blame" / "No scannable contents" message that promised a recovery path which could not exist — confusing debugging on CHAOS-2857/2850.

## Changes

- `metrics/job_complexity_db.py`: add `_has_blame_line_text()`, a cheap per-repo `SELECT 1 ... WHERE line IS NOT NULL AND line != '' LIMIT 1` existence probe (repo + org scoped), and gate **both** fallback call sites on it:
  - repos missing *some* `git_files` contents (fill-from-blame path)
  - repos with *zero* `git_files` contents (all-blame path)
- When blame has no usable text: skip the reconstruction attempt and log **one** actionable warning naming the real remedies (content hydration / scanner globs, CHAOS-2859; GitHub Blame API limitation by design; GitLab line text pending CHAOS-2860; BLAME dataset CHAOS-2862).
- When blame has real text: behavior is byte-identical to before (same log line, same reconstruction call).
- The final "No scannable contents found" warning now distinguishes a repo with zero `git_files`/`git_blame` rows at all from one where blame exists but carries no usable text.
- No changes to scoring, row counts, exit codes, or the CHAOS-2850 single-row backfill contract.

## Tests

New file `tests/metrics/test_complexity_blame_fallback.py` (fake-client pattern matching `tests/test_github_content_backfill.py::_EmptyClickHouseClient`):
- textless blame + zero contents → fallback skipped, actionable warning, rc unchanged
- textless blame + some contents missing → fill skipped, actionable warning, non-missing files still scanned
- real blame text (both call sites) → reconstruction unchanged, snapshots produced
- zero-rows repo → distinguishable message
- probe query is org/repo scoped

Existing complexity suites (`tests/test_metrics_complexity_db.py`, `tests/metrics/test_complexity_org_id_propagation.py`, `tests/test_github_content_backfill.py`, `tests/test_cli_metrics_complexity.py`) pass unmodified.

`bash ci/local_validate.sh` is green (lint, mypy, full unit suite, live-ClickHouse argMax proof).

## Linear

CHAOS-2861 (CS-C, part of CHAOS-2858 plan). Mergeable independently of sibling CHAOS-2859/2860/2862 changesets.

Marked In Progress at start; will link this PR on the issue but leaving it open (not marking Done) per task instructions.