### PR TITLE
feat(providers): instrument GitLab merge-requests and notes actuals (CHAOS-2816)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -99,9 +99,10 @@ cooperating layers:
    | --- | --- | --- |
    | GitHub REST connector | 3 (`retry_with_backoff(max_retries=3)`) | `connectors/github.py` |
    | GitHub GraphQL client | 5 (`max_retries=5`) | `connectors/utils/graphql.py` |
-   | GitHub code client (canonical: git/commit_stats/security/deployments REST, files/blame GraphQL) | 5 (`InstrumentedRESTCore` default) | `providers/github/code_client.py` + `providers/github/graphql.py` |
-   | GitLab REST connector | 3 (`retry_with_backoff(max_retries=3)`) | `connectors/gitlab.py` |
-   | GitLab feature-flags (canonical) | 5 (`max_retries=5`) | `providers/gitlab/feature_flags.py` |
+| GitHub code client (canonical: git/commit_stats/security/deployments REST, files/blame GraphQL) | 5 (`InstrumentedRESTCore` default) | `providers/github/code_client.py` + `providers/github/graphql.py` |
+| GitLab REST connector | 3 (`retry_with_backoff(max_retries=3)`) | `connectors/gitlab.py` |
+| GitLab code client (canonical: security/pipelines/deployments/tests/commits/files/blame/merge_requests/notes) | 5 (`InstrumentedRESTCore` default) | `providers/gitlab/code_client.py` |
+| GitLab feature-flags (canonical) | 5 (`max_retries=5`) | `providers/gitlab/feature_flags.py` |
    | Jira client (JQL + enrichment) | 4 (`max_retries_429=3` → `+1` initial) | `providers/jira/client.py` |
    | Jira Atlassian REST compat | 5 (`RESTClient(max_retries=5)`) | `connectors/utils/rest.py` |
    | Linear | 5 (`DEFAULT_MAX_ATTEMPTS`) | `providers/linear/client.py` |
@@ -1012,8 +1013,8 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
 | Route family | Dimension(s) | Covers | Confidence |
 | --- | --- | --- | --- |
 | `project` | `rest_core` | Project metadata, commits, files/blame, feature-flags | high–low |
-| `merge_requests` | `rest_core` | Merge request iterators (pagination-heavy) | medium |
-| `notes` | `rest_core` | MR/issue note + discussion expansion | low |
+| `merge_requests` | `rest_core` | Merge request iterators, MR commits, approvals (`GitLabCodeClient`, CHAOS-2816/CS15) | medium |
+| `notes` | `rest_core` | MR note + discussion expansion (`GitLabCodeClient`, CHAOS-2816/CS15); issue notes still use work-item paths | low |
 | `pipelines` | `rest_core` | CI/CD pipeline listing + job expansion (`GitLabCodeClient.get_pipelines`) | low |
 | `deployments` | `rest_core` | Deployments, releases, deployment→MR resolution (`GitLabCodeClient`, CHAOS-2773 CS11) | low |
 | `security` | `rest_core` | Vulnerability findings + dependency-scan alerts (`GitLabCodeClient`, CHAOS-2773 CS10) | low |
@@ -1177,8 +1178,10 @@ paper over:
   [Usage drain wiring](#usage-drain-wiring-first-re-bucketing-chaos-2773-cs2)
   above. GitHub `git` and `commit_stats` REST-core traffic is instrumented as of
   CHAOS-2807, and `files`/`blame` `contents_blob` traffic (GraphQL) as of
-  CHAOS-2808; the REST `prs` listing, the `files`/`blame` `rest_core` tree
-  listing, and remaining GitHub/GitLab code-dataset families stay
+  CHAOS-2808; GitLab merge-request and MR-note REST-core traffic is
+  instrumented as of CHAOS-2816 (CS15). The REST `prs` listing, the
+  `files`/`blame` `rest_core` tree listing, and remaining GitHub/GitLab
+  code-dataset families stay
   uninstrumented pending their own CHAOS-2773 changesets (see
   "Frozen `connectors/` path" below). There is also no cross-run
   aggregation/dashboard yet — calibration today is visible per-unit (result +
@@ -1215,12 +1218,14 @@ paper over:
   ([CHAOS-2814](https://linear.app/fullchaos/issue/CHAOS-2814), CS13), and
   `files`/`blame` (`get_file_contents` batched GraphQL blob fetch +
   `get_file_blame` REST, both under the `project` family;
-  [CHAOS-2815](https://linear.app/fullchaos/issue/CHAOS-2815), CS14)
+  [CHAOS-2815](https://linear.app/fullchaos/issue/CHAOS-2815), CS14), and
+  `merge_requests`/`notes` (`iter_merge_requests`, MR commits, MR approvals,
+  MR notes;
+  [CHAOS-2816](https://linear.app/fullchaos/issue/CHAOS-2816), CS15)
   code-dataset families are migrated onto the canonical, instrumented
   `providers/gitlab/code_client.py::GitLabCodeClient`. GitLab's remaining
-  frozen code-dataset methods (`merge_requests` listing + repo-metadata/batch
-  orchestration) stay unmigrated pending their own CHAOS-2773 changesets
-  through CS17.
+  frozen code-dataset methods (repo-metadata/batch orchestration) stay
+  unmigrated pending their own CHAOS-2773 changesets through CS17.
 
 
 ## References

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -28,7 +28,6 @@ from dev_health_ops.processors.base_git import (
     backfill_file_records,
     blame_backfill_needed,
     build_ci_pipeline_run,
-    build_connector_pull_request,
     build_deployment,
     build_git_pull_request,
     check_backfill_needs,
@@ -212,22 +211,61 @@ def _fetch_gitlab_commit_stats_sync(
         )
 
 
-def _fetch_gitlab_mrs_sync(connector, project_id, repo_id, max_mrs):
+def _fetch_gitlab_mrs_sync(
+    connector,
+    project_id,
+    repo_id,
+    max_mrs,
+    usage_sink: list[dict[str, Any]] | None = None,
+):
     """Sync helper to fetch GitLab Merge Requests."""
     logging.info(
         "Fetching merge requests for project %d...",
         project_id,
     )
-    mrs = connector.get_merge_requests(
-        project_id=project_id, state="all", max_mrs=max_mrs
-    )
+    drained_observations: list[dict[str, Any]] = []
+
+    async def _run():
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await client.iter_merge_requests(
+                    project_id,
+                    state="all",
+                    per_page=int(getattr(connector, "per_page", 100) or 100),
+                    max_items=max_mrs,
+                )
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+
+    try:
+        mrs = asyncio.run(_run())
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_mrs_sync", drained_observations, usage_sink
+        )
+
     pr_objects = []
     for mr in mrs:
-        git_pr = build_connector_pull_request(
-            mr,
+        merged_at = safe_parse_datetime(mr.get("merged_at"))
+        closed_at = safe_parse_datetime(mr.get("closed_at"))
+        author_data = mr.get("author")
+        git_pr = build_git_pull_request(
             repo_id=repo_id,
-            state=normalize_pr_state(mr.state, mr.merged_at),
+            number=int(mr.get("iid") or 0),
+            title=mr.get("title") or None,
+            body=mr.get("description"),
+            state=normalize_pr_state(mr.get("state"), merged_at),
+            author_name=(
+                author_data.get("username")
+                if isinstance(author_data, dict) and author_data.get("username")
+                else "Unknown"
+            ),
             author_email=None,
+            created_at=safe_parse_datetime(mr.get("created_at")),
+            merged_at=merged_at,
+            closed_at=closed_at,
+            head_branch=mr.get("source_branch"),
+            base_branch=mr.get("target_branch"),
         )
         pr_objects.append(git_pr)
     logging.info(
@@ -466,11 +504,22 @@ class _MrReviewFetch(NamedTuple):
     known: bool
 
 
+async def _fetch_all_mr_notes_async(
+    client: Any,
+    project_id: int,
+    iid: int,
+    *,
+    per_page: int,
+) -> list[dict[str, Any]]:
+    return await client.iter_mr_notes(project_id, iid, per_page=per_page)
+
+
 def _fetch_all_mr_notes(
     connector,
     project_id: int,
     iid: int,
     gate: Any = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
     """Fetch *every* page of an MR's notes, not just the first.
 
@@ -485,49 +534,38 @@ def _fetch_all_mr_notes(
     failed first page — both must avoid clobbering correct metrics).
     """
     per_page = int(getattr(connector, "per_page", 100) or 100)
-    all_notes: list[dict[str, Any]] = []
-    page = 1
-    while True:
-        if gate is not None:
-            gate.wait_sync()
-        try:
-            page_notes = connector.rest_client.get_merge_request_notes(
-                project_id,
-                iid,
-                page=page,
-                per_page=per_page,
-            )
-            if gate is not None:
-                gate.reset()
-        except Exception as exc:
-            retry_after = getattr(exc, "retry_after_seconds", None)
-            if retry_after is not None and gate is not None:
-                applied = gate.penalize(retry_after)
-                logging.info(
-                    "GitLab rate limited fetching notes for MR !%d; backoff %.1fs (%s)",
-                    iid,
-                    applied,
-                    exc,
+    drained_observations: list[dict[str, Any]] = []
+
+    async def _run() -> list[dict[str, Any]]:
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await _fetch_all_mr_notes_async(
+                    client, project_id, iid, per_page=per_page
                 )
-                continue
-            raise
-        if not page_notes:
-            break
-        all_notes.extend(page_notes)
-        # Final page when the server returns fewer than a full page.
-        if len(page_notes) < per_page:
-            break
-        page += 1
-    return all_notes
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+
+    if gate is not None:
+        gate.wait_sync()
+    try:
+        notes = asyncio.run(_run())
+        if gate is not None:
+            gate.reset()
+        return notes
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_all_mr_notes", drained_observations, usage_sink
+        )
 
 
-def _fetch_gitlab_mr_reviews(
-    connector,
+async def _fetch_gitlab_mr_reviews_async(
+    client: Any,
     project_id: int,
     mr: dict[str, Any],
     repo_id: Any,
     created_at: datetime | None,
-    gate: Any = None,
+    *,
+    per_page: int,
 ) -> _MrReviewFetch:
     """Best-effort fetch + map of one MR's reviews (approvals + notes).
 
@@ -549,15 +587,21 @@ def _fetch_gitlab_mr_reviews(
 
     approvals: dict[str, Any] | None = None
     try:
-        approvals = connector.rest_client.get_merge_request_approvals(project_id, iid)
+        approvals = await client.get_mr_approvals(project_id, iid)
     except Exception as exc:  # noqa: BLE001 - best-effort, some tiers lack approvals
+        if _is_rate_limit_exception(exc):
+            raise
         logging.debug("Failed to fetch approvals for MR !%d: %s", iid, exc)
 
     notes: list[dict[str, Any]] = []
     notes_known = True
     try:
-        notes = _fetch_all_mr_notes(connector, project_id, iid, gate=gate)
+        notes = await _fetch_all_mr_notes_async(
+            client, project_id, iid, per_page=per_page
+        )
     except Exception as exc:  # noqa: BLE001 - best-effort
+        if _is_rate_limit_exception(exc):
+            raise
         notes_known = False
         logging.warning(
             "Could not fetch notes for MR !%d (project %s); preserving existing "
@@ -589,6 +633,48 @@ def _fetch_gitlab_mr_reviews(
     return _MrReviewFetch(reviews, first_review_at, changes_requested_count, known=True)
 
 
+def _fetch_gitlab_mr_reviews(
+    connector,
+    project_id: int,
+    mr: dict[str, Any],
+    repo_id: Any,
+    created_at: datetime | None,
+    gate: Any = None,
+    usage_sink: list[dict[str, Any]] | None = None,
+) -> _MrReviewFetch:
+    iid = int(mr.get("iid") or 0)
+    if iid <= 0:
+        return _MrReviewFetch([], None, 0, known=True)
+
+    drained_observations: list[dict[str, Any]] = []
+
+    async def _run() -> _MrReviewFetch:
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await _fetch_gitlab_mr_reviews_async(
+                    client,
+                    project_id,
+                    mr,
+                    repo_id,
+                    created_at,
+                    per_page=int(getattr(connector, "per_page", 100) or 100),
+                )
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+
+    if gate is not None:
+        gate.wait_sync()
+    try:
+        fetched = asyncio.run(_run())
+        if gate is not None:
+            gate.reset()
+        return fetched
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_mr_reviews", drained_observations, usage_sink
+        )
+
+
 def _sync_gitlab_mrs_to_store(
     connector,
     project_id: int,
@@ -600,6 +686,7 @@ def _sync_gitlab_mrs_to_store(
     gate: Any = None,
     since: datetime | None = None,
     until: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> int:
     """Fetch all MRs for a project and insert them in batches.
 
@@ -621,6 +708,16 @@ def _sync_gitlab_mrs_to_store(
 
     gate = BaseGitProcessor.ensure_gate(gate)
     assert gate is not None
+    per_page = int(getattr(connector, "per_page", 100) or 100)
+    drained_observations: list[dict[str, Any]] = []
+
+    def _flush_prs() -> None:
+        if batch:
+            BaseGitProcessor.persist_batch_threadsafe(
+                ingestion_sink.insert_git_pull_requests(list(batch)),
+                loop,
+            )
+            batch.clear()
 
     def _flush_reviews() -> None:
         if review_batch:
@@ -630,152 +727,160 @@ def _sync_gitlab_mrs_to_store(
             )
             review_batch.clear()
 
-    while True:
-        try:
-            gate.wait_sync()
-            logging.debug(
-                "GitLab MRs page %d (per_page=%d) for project %d",
-                page,
-                connector.per_page,
+    def _append_fetched_mr(mr: dict[str, Any], fetched: _MrReviewFetch) -> None:
+        nonlocal total
+
+        author_name = "Unknown"
+        author_email = None
+        author_data = mr.get("author")
+        if author_data:
+            author_name = author_data.get("username") or author_name
+
+        merged_at = safe_parse_datetime(mr.get("merged_at"))
+        closed_at = safe_parse_datetime(mr.get("closed_at"))
+        created_at = safe_parse_datetime(mr.get("created_at"))
+
+        comments_count = int(mr.get("user_notes_count") or 0)
+
+        if not fetched.known:
+            # Authoritative review source (MR notes) was unavailable for
+            # this MR. The PR row is ReplacingMergeTree-replaced on write,
+            # so persisting it now with zeroed review metrics would clobber
+            # previously-correct first_review_at / reviews_count /
+            # changes_requested_count. Skip this MR's row this cycle so the
+            # prior values are preserved, and record the iid so the run
+            # fails loud (no watermark advancement) and is retried — a
+            # silent skip would let the watermark move past this MR and
+            # strand it until a full resync (CHAOS-2378).
+            skipped_iid = int(mr.get("iid") or 0)
+            skipped_iids.append(skipped_iid)
+            logging.warning(
+                "Skipping PR row for MR !%d (project %d): review fetch "
+                "degraded; run will not advance watermark and will retry",
+                skipped_iid,
                 project_id,
             )
-            mrs = connector.rest_client.get_merge_requests(
-                project_id=project_id,
-                state=state,
-                page=page,
-                per_page=connector.per_page,
-                order_by="updated_at",
-                sort="desc",
-            )
-            gate.reset()
-        except Exception as e:
-            retry_after = getattr(e, "retry_after_seconds", None)
-            if retry_after is None:
-                raise
-            applied = gate.penalize(retry_after)
-            logging.info(
-                "GitLab rate limited while fetching MRs; backoff %.1fs (%s)",
-                applied,
-                e,
-            )
-            continue
-        if not mrs:
-            break
-        logging.debug(
-            "GitLab MRs page %d returned %d items (total: %d)",
-            page,
-            len(mrs),
-            total,
-        )
+            return
 
-        for mr in mrs:
-            author_name = "Unknown"
-            author_email = None
-            author_data = mr.get("author")
-            if author_data:
-                author_name = author_data.get("username") or author_name
+        review_batch.extend(fetched.reviews)
 
-            merged_at = safe_parse_datetime(mr.get("merged_at"))
-            closed_at = safe_parse_datetime(mr.get("closed_at"))
-            updated_at = safe_parse_datetime(mr.get("updated_at"))
-            created_at = safe_parse_datetime(mr.get("created_at"))
-
-            comments_count = int(mr.get("user_notes_count") or 0)
-
-            if (
-                until is not None
-                and isinstance(updated_at, datetime)
-                and updated_at.astimezone(timezone.utc) > until
-            ):
-                continue
-
-            if (
-                since is not None
-                and isinstance(updated_at, datetime)
-                and updated_at.astimezone(timezone.utc) < since
-            ):
-                mrs = []
-                break
-
-            # Reconstruct reviews (approvals + notes) so GitLab orgs populate
-            # git_pull_request_reviews like GitHub does (CHAOS-2378).
-            fetched = _fetch_gitlab_mr_reviews(
-                connector=connector,
-                project_id=project_id,
-                mr=mr,
+        batch.append(
+            build_git_pull_request(
                 repo_id=repo_id,
+                number=int(mr.get("iid") or 0),
+                title=mr.get("title") or None,
+                body=mr.get("description"),
+                state=normalize_pr_state(mr.get("state"), merged_at),
+                author_name=author_name,
+                author_email=author_email,
                 created_at=created_at,
-                gate=gate,
+                merged_at=merged_at,
+                closed_at=closed_at,
+                head_branch=mr.get("source_branch"),
+                base_branch=mr.get("target_branch"),
+                first_review_at=fetched.first_review_at,
+                changes_requested_count=fetched.changes_requested_count,
+                reviews_count=len(fetched.reviews),
+                comments_count=comments_count,
             )
-
-            if not fetched.known:
-                # Authoritative review source (MR notes) was unavailable for
-                # this MR. The PR row is ReplacingMergeTree-replaced on write,
-                # so persisting it now with zeroed review metrics would clobber
-                # previously-correct first_review_at / reviews_count /
-                # changes_requested_count. Skip this MR's row this cycle so the
-                # prior values are preserved, and record the iid so the run
-                # fails loud (no watermark advancement) and is retried — a
-                # silent skip would let the watermark move past this MR and
-                # strand it until a full resync (CHAOS-2378).
-                skipped_iid = int(mr.get("iid") or 0)
-                skipped_iids.append(skipped_iid)
-                logging.warning(
-                    "Skipping PR row for MR !%d (project %d): review fetch "
-                    "degraded; run will not advance watermark and will retry",
-                    skipped_iid,
-                    project_id,
-                )
-                continue
-
-            review_batch.extend(fetched.reviews)
-
-            batch.append(
-                build_git_pull_request(
-                    repo_id=repo_id,
-                    number=int(mr.get("iid") or 0),
-                    title=mr.get("title") or None,
-                    body=mr.get("description"),
-                    state=normalize_pr_state(mr.get("state"), merged_at),
-                    author_name=author_name,
-                    author_email=author_email,
-                    created_at=created_at,
-                    merged_at=merged_at,
-                    closed_at=closed_at,
-                    head_branch=mr.get("source_branch"),
-                    base_branch=mr.get("target_branch"),
-                    first_review_at=fetched.first_review_at,
-                    changes_requested_count=fetched.changes_requested_count,
-                    reviews_count=len(fetched.reviews),
-                    comments_count=comments_count,
-                )
-            )
-            total += 1
-
-            if len(batch) >= batch_size:
-                BaseGitProcessor.persist_batch_threadsafe(
-                    ingestion_sink.insert_git_pull_requests(batch),
-                    loop,
-                )
-                logging.debug(
-                    "Stored batch of %d MRs for project %d (total: %d)",
-                    len(batch),
-                    project_id,
-                    total,
-                )
-                batch.clear()
-                _flush_reviews()
-
-        page += 1
-        if not mrs:
-            break
-
-    if batch:
-        BaseGitProcessor.persist_batch_threadsafe(
-            ingestion_sink.insert_git_pull_requests(batch),
-            loop,
         )
-    _flush_reviews()
+        total += 1
+
+        if len(batch) >= batch_size:
+            _flush_prs()
+            logging.debug(
+                "Stored batch of %d MRs for project %d (total: %d)",
+                batch_size,
+                project_id,
+                total,
+            )
+            _flush_reviews()
+
+    async def _sync_pages() -> None:
+        nonlocal page
+
+        async def _fetch_page_with_retry(
+            client, current_page: int
+        ) -> list[dict[str, Any]]:
+            while True:
+                try:
+                    gate.wait_sync()
+                    page_items = await client.get_merge_requests_page(
+                        project_id=project_id,
+                        page=current_page,
+                        state=state,
+                        per_page=per_page,
+                    )
+                    gate.reset()
+                    return page_items
+                except Exception as exc:  # noqa: BLE001 - legacy retry-after seam
+                    if _is_rate_limit_exception(exc):
+                        raise
+                    retry_after = getattr(exc, "retry_after_seconds", None)
+                    if retry_after is None:
+                        raise
+                    applied = gate.penalize(retry_after)
+                    logging.info(
+                        "GitLab rate limited while fetching MRs; backoff %.1fs (%s)",
+                        applied,
+                        exc,
+                    )
+
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                while True:
+                    mrs = await _fetch_page_with_retry(client, page)
+                    logging.debug(
+                        "GitLab MRs page %d returned %d items for project %d (total: %d)",
+                        page,
+                        len(mrs),
+                        project_id,
+                        total,
+                    )
+                    if not mrs:
+                        return
+
+                    stop_pagination = False
+                    for mr in mrs:
+                        updated_at = safe_parse_datetime(mr.get("updated_at"))
+                        if (
+                            until is not None
+                            and isinstance(updated_at, datetime)
+                            and updated_at.astimezone(timezone.utc) > until
+                        ):
+                            continue
+                        if (
+                            since is not None
+                            and isinstance(updated_at, datetime)
+                            and updated_at.astimezone(timezone.utc) < since
+                        ):
+                            stop_pagination = True
+                            break
+                        created_at = safe_parse_datetime(mr.get("created_at"))
+                        fetched = await _fetch_gitlab_mr_reviews_async(
+                            client,
+                            project_id,
+                            mr,
+                            repo_id,
+                            created_at,
+                            per_page=per_page,
+                        )
+                        _append_fetched_mr(mr, fetched)
+
+                    if stop_pagination:
+                        return
+                    page += 1
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+
+    try:
+        asyncio.run(_sync_pages())
+    finally:
+        _flush_prs()
+        _flush_reviews()
+        _drain_gitlab_code_usage(
+            "_sync_gitlab_mrs_to_store", drained_observations, usage_sink
+        )
 
     logging.info(
         "Fetched %d merge requests for project %d",
@@ -2105,6 +2210,7 @@ async def process_gitlab_project(
                 None,
                 since,
                 until,
+                usage_sink,
             )
             logging.info(f"Stored {mr_total} merge requests from GitLab")
 
@@ -2438,6 +2544,8 @@ async def process_gitlab_projects_batch(
                         "all",
                         mr_gate,
                         since,
+                        None,
+                        usage_sink,
                     )
             except PartialGitLabMrSyncError as e:
                 # Degraded review fetch skipped MR rows for this project. Keep
@@ -2457,6 +2565,8 @@ async def process_gitlab_projects_batch(
                 )
                 degraded_mr_errors.append(e)
             except Exception as e:
+                if _is_rate_limit_exception(e):
+                    raise
                 logging.warning(
                     "Failed to fetch/store MRs for GitLab project %s: %s",
                     project_info.full_name,
@@ -2734,6 +2844,8 @@ async def process_gitlab_projects_batch(
                     try:
                         await store_result(result)
                     except Exception as e:
+                        if _is_rate_limit_exception(e):
+                            raise
                         result = batch_result_cls(
                             repository=project_info,
                             stats=None,

--- a/src/dev_health_ops/providers/gitlab/budget.py
+++ b/src/dev_health_ops/providers/gitlab/budget.py
@@ -385,8 +385,18 @@ GITLAB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
         ),
     ),
     UsageRouteFamily("issues", BudgetDimension.REST_CORE),
-    UsageRouteFamily("merge_requests", BudgetDimension.REST_CORE),
-    UsageRouteFamily("notes", BudgetDimension.REST_CORE),
+    UsageRouteFamily(
+        "merge_requests",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("merge_requests:",),
+    ),
+    UsageRouteFamily(
+        "notes",
+        BudgetDimension.REST_CORE,
+        transport="rest",
+        operation_markers=("notes:",),
+    ),
     UsageRouteFamily(
         "pipelines",
         BudgetDimension.REST_CORE,

--- a/src/dev_health_ops/providers/gitlab/code_client.py
+++ b/src/dev_health_ops/providers/gitlab/code_client.py
@@ -97,6 +97,8 @@ _PROJECT_FAMILY_PREFIX = "project"
 _PIPELINES_FAMILY_PREFIX = "pipelines"
 _DEPLOYMENTS_FAMILY_PREFIX = "deployments"
 _TESTS_FAMILY_PREFIX = "tests"
+_MERGE_REQUESTS_FAMILY_PREFIX = "merge_requests"
+_NOTES_FAMILY_PREFIX = "notes"
 
 
 @dataclass(frozen=True)
@@ -865,6 +867,163 @@ class GitLabCodeClient:
             paginate=False,
             max_items=100,
         )
+
+    async def iter_merge_requests(
+        self,
+        project_id: int | str,
+        *,
+        state: str = "all",
+        per_page: int = 100,
+        max_pages: int = 10_000,
+        max_items: int | None = None,
+    ) -> list[dict[str, Any]]:
+        """List GitLab merge requests newest-updated first.
+
+        Mirrors the processor's legacy ``GitLabRESTClient.get_merge_requests``
+        loop: ``state=all``, ``order_by=updated_at``, ``sort=desc``, and
+        GitLab page/per_page pagination. ``max_items`` is reserved for callers
+        that intentionally cap the scan (the legacy ``connector.get_merge_requests``
+        helper); the full sync path exhausts ``X-Next-Page``.
+        """
+        encoded_project_id = _encode_project_id(project_id)
+        path = f"/projects/{encoded_project_id}/merge_requests"
+        operation = (
+            f"{_MERGE_REQUESTS_FAMILY_PREFIX}:GET /projects/{{id}}/merge_requests"
+        )
+        params = {"state": state, "order_by": "updated_at", "sort": "desc"}
+        if max_items is not None:
+            if max_items <= 0:
+                return []
+            effective_per_page = min(max_items, per_page)
+            return await self._get_gitlab_list(
+                path,
+                operation=operation,
+                params=params,
+                per_page=effective_per_page,
+                paginate=max_items > effective_per_page,
+                max_items=max_items,
+            )
+        payload = await self._core.paginate_page_param(
+            path,
+            operation=operation,
+            params=params,
+            per_page=per_page,
+            max_pages=max_pages,
+        )
+        return [item for item in payload if isinstance(item, dict)]
+
+    async def get_merge_requests_page(
+        self,
+        project_id: int | str,
+        *,
+        page: int,
+        state: str = "all",
+        per_page: int = 100,
+    ) -> list[dict[str, Any]]:
+        encoded_project_id = _encode_project_id(project_id)
+        response = await self._core.request(
+            "GET",
+            f"/projects/{encoded_project_id}/merge_requests",
+            operation=(
+                f"{_MERGE_REQUESTS_FAMILY_PREFIX}:GET /projects/{{id}}/merge_requests"
+            ),
+            params={
+                "state": state,
+                "order_by": "updated_at",
+                "sort": "desc",
+                "page": page,
+                "per_page": per_page,
+            },
+        )
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise APIException(
+                f"Unexpected GitLab merge requests response: {type(payload)!r}"
+            )
+        return [item for item in payload if isinstance(item, dict)]
+
+    async def iter_mr_commits(
+        self,
+        project_id: int | str,
+        iid: int | str,
+        *,
+        per_page: int = 100,
+        max_pages: int = 10_000,
+    ) -> list[dict[str, Any]]:
+        """List raw commits attached to one merge request.
+
+        Added with the MR-family migration for parity with the frozen
+        ``GitLabConnector.get_merge_request_commits`` helper. No processor path
+        consumes it today, but keeping the canonical method ready prevents new
+        python-gitlab usage while the connector remains frozen until CS17.
+        """
+        encoded_project_id = _encode_project_id(project_id)
+        encoded_iid = urllib.parse.quote(str(iid), safe="")
+        payload = await self._core.paginate_page_param(
+            f"/projects/{encoded_project_id}/merge_requests/{encoded_iid}/commits",
+            operation=(
+                f"{_MERGE_REQUESTS_FAMILY_PREFIX}:GET "
+                "/projects/{id}/merge_requests/{iid}/commits"
+            ),
+            params={},
+            per_page=per_page,
+            max_pages=max_pages,
+        )
+        return [item for item in payload if isinstance(item, dict)]
+
+    async def iter_mr_notes(
+        self,
+        project_id: int | str,
+        iid: int | str,
+        *,
+        per_page: int = 100,
+        max_pages: int = 10_000,
+    ) -> list[dict[str, Any]]:
+        """Fetch every note page for one merge request.
+
+        The processor treats notes as the authoritative review-event source, so
+        this method exhausts pagination instead of preserving the frozen REST
+        client's one-page convenience helper.
+        """
+        encoded_project_id = _encode_project_id(project_id)
+        encoded_iid = urllib.parse.quote(str(iid), safe="")
+        payload = await self._core.paginate_page_param(
+            f"/projects/{encoded_project_id}/merge_requests/{encoded_iid}/notes",
+            operation=(
+                f"{_NOTES_FAMILY_PREFIX}:GET "
+                "/projects/{id}/merge_requests/{iid}/notes"
+            ),
+            params={"sort": "asc", "order_by": "created_at"},
+            per_page=per_page,
+            max_pages=max_pages,
+        )
+        return [item for item in payload if isinstance(item, dict)]
+
+    async def get_mr_approvals(
+        self, project_id: int | str, iid: int | str
+    ) -> dict[str, Any]:
+        """Fetch raw approvals for one merge request.
+
+        GitLab's approvals endpoint is a single object response, not a list.
+        Tier/permission errors propagate to the caller, which decides whether a
+        non-rate failure is best-effort for its dataset.
+        """
+        encoded_project_id = _encode_project_id(project_id)
+        encoded_iid = urllib.parse.quote(str(iid), safe="")
+        response = await self._core.request(
+            "GET",
+            f"/projects/{encoded_project_id}/merge_requests/{encoded_iid}/approvals",
+            operation=(
+                f"{_MERGE_REQUESTS_FAMILY_PREFIX}:GET "
+                "/projects/{id}/merge_requests/{iid}/approvals"
+            ),
+        )
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise APIException(
+                f"Unexpected GitLab MR approvals response: {type(payload)!r}"
+            )
+        return payload
 
     async def iter_pipelines_since(
         self,

--- a/tests/providers/test_gitlab_budget.py
+++ b/tests/providers/test_gitlab_budget.py
@@ -96,6 +96,8 @@ def test_gitlab_budget_has_code_client_family_prefix_markers() -> None:
 
     assert families["pipelines"].operation_markers == ("pipelines:",)
     assert families["deployments"].operation_markers == ("deployments:",)
+    assert families["merge_requests"].operation_markers == ("merge_requests:",)
+    assert families["notes"].operation_markers == ("notes:",)
     assert families["security"].operation_markers == ("security:",)
     assert families["tests"].operation_markers == ("tests:",)
     assert GITLAB_USAGE_RESOLVER.resolve(

--- a/tests/providers/test_gitlab_code_client.py
+++ b/tests/providers/test_gitlab_code_client.py
@@ -1415,3 +1415,218 @@ class TestFileBlameParity:
             raw_path.split(b"?")[0]
             == f"/api/v4/projects/42/repository/files/{expected_segment}/blame".encode()
         )
+
+
+# ---------------------------------------------------------------------------
+# ``merge_requests`` / ``notes`` datasets (CHAOS-2816/CS15): parity with the
+# legacy GitLab REST client MR list, MR commits, approvals, and notes helpers.
+# ---------------------------------------------------------------------------
+
+
+class TestMergeRequestsAndNotesParity:
+    @pytest.mark.asyncio
+    async def test_iter_merge_requests_uses_expected_query_and_usage_family(
+        self,
+    ) -> None:
+        mr_path = "/api/v4/projects/42/merge_requests"
+        mr = {
+            "id": "1001",
+            "iid": "7",
+            "title": "Ship it",
+            "updated_at": "2026-01-02T03:04:05Z",
+        }
+        transport, calls = _router_transport({mr_path: _json_response(200, [mr])})
+        client = _client(transport)
+
+        result = await client.iter_merge_requests(42, per_page=50)
+
+        assert result == [mr]
+        assert calls[mr_path] == 1
+        query = dict(cast(Any, transport).captured_urls[mr_path].params)
+        assert query == {
+            "state": "all",
+            "order_by": "updated_at",
+            "sort": "desc",
+            "page": "1",
+            "per_page": "50",
+        }
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "merge_requests"
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_get_merge_requests_page_uses_expected_page_query(self) -> None:
+        mr_path = "/api/v4/projects/42/merge_requests"
+        mr = {"iid": "7", "title": "Ship it"}
+        transport, calls = _router_transport({mr_path: _json_response(200, [mr])})
+        client = _client(transport)
+
+        result = await client.get_merge_requests_page(42, page=3, per_page=50)
+
+        assert result == [mr]
+        assert calls[mr_path] == 1
+        query = dict(cast(Any, transport).captured_urls[mr_path].params)
+        assert query == {
+            "state": "all",
+            "order_by": "updated_at",
+            "sort": "desc",
+            "page": "3",
+            "per_page": "50",
+        }
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "merge_requests"
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_iter_merge_requests_exhausts_empty_last_page(self) -> None:
+        mr_path = "/api/v4/projects/42/merge_requests"
+        transport, calls = _router_transport(
+            {
+                mr_path: [
+                    _json_response(200, [{"iid": 1}], {"X-Next-Page": "2"}),
+                    _json_response(200, []),
+                ]
+            }
+        )
+        client = _client(transport)
+
+        result = await client.iter_merge_requests(42, per_page=1)
+
+        assert result == [{"iid": 1}]
+        assert calls[mr_path] == 2
+        observations = client.drain_usage_observations()
+        assert observations[0]["request_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_iter_merge_requests_empty_first_page_records_one_request(
+        self,
+    ) -> None:
+        mr_path = "/api/v4/projects/42/merge_requests"
+        transport, calls = _router_transport({mr_path: _json_response(200, [])})
+        client = _client(transport)
+
+        result = await client.iter_merge_requests(42)
+
+        assert result == []
+        assert calls[mr_path] == 1
+        observations = client.drain_usage_observations()
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_iter_merge_requests_item_cap_uses_min_per_page(self) -> None:
+        mr_path = "/api/v4/projects/42/merge_requests"
+        transport, calls = _router_transport(
+            {mr_path: _json_response(200, [{"iid": 1}, {"iid": 2}])}
+        )
+        client = _client(transport)
+
+        result = await client.iter_merge_requests(42, max_items=2, per_page=100)
+
+        assert result == [{"iid": 1}, {"iid": 2}]
+        assert calls[mr_path] == 1
+        query = dict(cast(Any, transport).captured_urls[mr_path].params)
+        assert query["per_page"] == "2"
+
+    @pytest.mark.asyncio
+    async def test_iter_merge_requests_failure_preserves_partial_observations(
+        self,
+    ) -> None:
+        mr_path = "/api/v4/projects/42/merge_requests"
+        transport, calls = _router_transport(
+            {
+                mr_path: [
+                    _json_response(200, [{"iid": 1}], {"X-Next-Page": "2"}),
+                    _empty_response(500),
+                ]
+            }
+        )
+        client = _client(transport, max_retries=1)
+
+        with pytest.raises(APIException):
+            await client.iter_merge_requests(42, per_page=1)
+
+        assert calls[mr_path] == 2
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "merge_requests"
+        assert observations[0]["request_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_iter_merge_requests_encodes_project_path_segment(self) -> None:
+        project_id = "group/sub.project?x=1"
+        decoded_path = f"/api/v4/projects/{project_id}/merge_requests"
+        transport, calls = _router_transport({decoded_path: _json_response(200, [])})
+        client = _client(transport)
+
+        result = await client.iter_merge_requests(project_id)
+
+        assert result == []
+        assert calls[decoded_path] == 1
+        raw_path = cast(Any, transport).captured_raw_paths[decoded_path]
+        assert raw_path.split(b"?")[0] == (
+            f"/api/v4/projects/{quote(project_id, safe='')}/merge_requests".encode()
+        )
+
+    @pytest.mark.asyncio
+    async def test_iter_mr_commits_coerces_int_and_str_ids_in_path(self) -> None:
+        commits_path = "/api/v4/projects/42/merge_requests/7/commits"
+        commit = {"id": "abc123", "created_at": "2026-01-02T03:04:05Z"}
+        transport, calls = _router_transport(
+            {commits_path: _json_response(200, [commit])}
+        )
+        client = _client(transport)
+
+        result = await client.iter_mr_commits("42", 7)
+
+        assert result == [commit]
+        assert calls[commits_path] == 1
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "merge_requests"
+
+    @pytest.mark.asyncio
+    async def test_iter_mr_notes_exhausts_pages_and_records_notes_family(self) -> None:
+        notes_path = "/api/v4/projects/42/merge_requests/7/notes"
+        notes = [
+            {"id": 1, "created_at": "2026-01-02T03:04:05Z"},
+            {"id": 2, "created_at": "2026-01-02T03:05:05Z"},
+        ]
+        transport, calls = _router_transport(
+            {
+                notes_path: [
+                    _json_response(200, [notes[0]], {"X-Next-Page": "2"}),
+                    _json_response(200, [notes[1]]),
+                ]
+            }
+        )
+        client = _client(transport)
+
+        result = await client.iter_mr_notes(42, "7", per_page=2)
+
+        assert result == notes
+        assert calls[notes_path] == 2
+        query = dict(cast(Any, transport).captured_urls[notes_path].params)
+        assert query == {
+            "sort": "asc",
+            "order_by": "created_at",
+            "page": "2",
+            "per_page": "2",
+        }
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "notes"
+        assert observations[0]["request_count"] == 2
+
+    @pytest.mark.asyncio
+    async def test_get_mr_approvals_uses_single_request(self) -> None:
+        approvals_path = "/api/v4/projects/42/merge_requests/7/approvals"
+        approvals = {"approved_by": [{"user": {"id": "5", "username": "ada"}}]}
+        transport, calls = _router_transport(
+            {approvals_path: _json_response(200, approvals)}
+        )
+        client = _client(transport)
+
+        result = await client.get_mr_approvals(42, 7)
+
+        assert result == approvals
+        assert calls[approvals_path] == 1
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "merge_requests"
+        assert observations[0]["request_count"] == 1

--- a/tests/providers/test_usage_resolver_prefix.py
+++ b/tests/providers/test_usage_resolver_prefix.py
@@ -244,6 +244,30 @@ def test_gitlab_pipelines_prefix_not_swallowed_by_broad_project_marker() -> None
     assert unprefixed_family == "project"
 
 
+@pytest.mark.parametrize(
+    ("operation", "expected_family"),
+    (
+        (
+            "merge_requests:GET /projects/:id/merge_requests",
+            "merge_requests",
+        ),
+        (
+            "notes:GET /projects/:id/merge_requests/:iid/notes",
+            "notes",
+        ),
+    ),
+)
+def test_gitlab_mr_notes_prefixes_not_swallowed_by_broad_project_marker(
+    operation: str, expected_family: str
+) -> None:
+    route_family, dimension = GITLAB_USAGE_RESOLVER.resolve(
+        transport="rest", operation=operation
+    )
+
+    assert route_family == expected_family
+    assert dimension is BudgetDimension.REST_CORE
+
+
 # ---------------------------------------------------------------------------
 # 3. False-trigger regression guard: no existing label accidentally
 #    prefix-matches a registered family.

--- a/tests/test_gitlab_content_backfill.py
+++ b/tests/test_gitlab_content_backfill.py
@@ -8,9 +8,10 @@ upgrade through ``_backfill_gitlab_missing_data``.
 
 from __future__ import annotations
 
+import asyncio
 import uuid
 from datetime import datetime, timezone
-from typing import Any
+from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
@@ -21,9 +22,12 @@ import pytest
 import dev_health_ops.connectors  # noqa: F401
 from dev_health_ops.connectors import GitLabConnector
 from dev_health_ops.connectors.models import BlameRange, FileBlame
+from dev_health_ops.metrics.sinks.ingestion import IngestionSink
+from dev_health_ops.processors import gitlab as gitlab_processor
 from dev_health_ops.processors.gitlab import (
     _backfill_gitlab_missing_data,
     _fetch_scannable_contents,
+    _sync_gitlab_mrs_to_store,
 )
 from dev_health_ops.providers.gitlab.code_client import (
     GitLabCommitData,
@@ -761,3 +765,281 @@ class TestGitLabBackfillBlame:
         # Partial observations gathered before the raise still reach the sink
         # (CHAOS-2754/2803 partial-observations-on-exception contract).
         assert usage_sink == [{"route_family": "project"}]
+
+
+class _FakeGitLabCodeClientForMergeRequests:
+    def __init__(
+        self, *, mrs=None, pages=None, approvals=None, notes=None, observations=None
+    ):
+        self.mrs = mrs or []
+        self.pages = pages or {1: self.mrs, 2: []}
+        self.approvals = approvals or {}
+        self.notes = notes or {}
+        self.observations = observations or []
+        self.iter_merge_requests_calls: list[Any] = []
+        self.get_merge_requests_page_calls: list[Any] = []
+        self.get_mr_approvals_calls: list[Any] = []
+        self.iter_mr_notes_calls: list[Any] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def iter_merge_requests(self, *, project_id, state, per_page):
+        self.iter_merge_requests_calls.append((project_id, state, per_page))
+        return self.mrs
+
+    async def get_merge_requests_page(self, *, project_id, page, state, per_page):
+        self.get_merge_requests_page_calls.append((project_id, page, state, per_page))
+        val = self.pages.get(page, [])
+        if isinstance(val, Exception):
+            raise val
+        return list(val)
+
+    async def get_mr_approvals(self, project_id, iid):
+        self.get_mr_approvals_calls.append((project_id, iid))
+        return self.approvals.get(iid)
+
+    async def iter_mr_notes(self, project_id, iid, *, per_page):
+        self.iter_mr_notes_calls.append((project_id, iid, per_page))
+        return self.notes.get(iid, [])
+
+    def drain_usage_observations(self):
+        observations = list(self.observations)
+        self.observations.clear()
+        return observations
+
+
+class _FakeMrSink:
+    def __init__(self):
+        self.prs: list[Any] = []
+        self.reviews: list[Any] = []
+
+    def insert_git_pull_requests(self, batch):
+        self.prs.extend(batch)
+
+        async def _noop():
+            return None
+
+        return _noop()
+
+    def insert_git_pull_request_reviews(self, batch):
+        self.reviews.extend(batch)
+
+        async def _noop():
+            return None
+
+        return _noop()
+
+
+class _NoSleepGitLabGate:
+    def wait_sync(self) -> None:
+        return
+
+    def penalize(self, delay_seconds=None) -> float:
+        return float(delay_seconds or 0)
+
+    def reset(self) -> None:
+        return
+
+
+def test_gitlab_mr_sync_uses_code_client_and_drains_usage() -> None:
+    mr = {
+        "iid": 42,
+        "title": "Ship",
+        "description": "desc",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": "2026-01-04T11:00:00Z",
+        "source_branch": "feat",
+        "target_branch": "main",
+        "user_notes_count": 1,
+    }
+    fake_client = _FakeGitLabCodeClientForMergeRequests(
+        mrs=[mr],
+        approvals={42: {"approved_by": []}},
+        notes={
+            42: [
+                {
+                    "id": 300,
+                    "system": True,
+                    "body": "approved this merge request",
+                    "author": {"username": "alice"},
+                    "created_at": "2026-01-04T10:00:00Z",
+                }
+            ]
+        },
+        observations=[
+            {"route_family": "merge_requests", "request_count": 2},
+            {"route_family": "notes", "request_count": 1},
+        ],
+    )
+    connector = Mock()
+    connector.per_page = 100
+    connector.rest_client.get_merge_requests.side_effect = AssertionError(
+        "legacy MR list path must not be called"
+    )
+    connector.rest_client.get_merge_request_approvals.side_effect = AssertionError(
+        "legacy approvals path must not be called"
+    )
+    connector.rest_client.get_merge_request_notes.side_effect = AssertionError(
+        "legacy notes path must not be called"
+    )
+
+    sink = _FakeMrSink()
+    usage_sink: list[dict[str, Any]] = []
+
+    async def _driver() -> int:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: _sync_gitlab_mrs_to_store(
+                connector,
+                99,
+                uuid.uuid4(),
+                cast(IngestionSink, sink),
+                loop,
+                50,
+                gate=_NoSleepGitLabGate(),
+                usage_sink=usage_sink,
+            ),
+        )
+
+    with patch.object(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda _connector: fake_client,
+    ):
+        total = asyncio.run(_driver())
+
+    assert total == 1
+    assert [pr.number for pr in sink.prs] == [42]
+    assert [review.state for review in sink.reviews] == ["APPROVED"]
+    assert fake_client.get_merge_requests_page_calls == [
+        (99, 1, "all", 100),
+        (99, 2, "all", 100),
+    ]
+    assert fake_client.get_mr_approvals_calls == [(99, 42)]
+    assert fake_client.iter_mr_notes_calls == [(99, 42, 100)]
+    connector.rest_client.get_merge_requests.assert_not_called()
+    connector.rest_client.get_merge_request_approvals.assert_not_called()
+    connector.rest_client.get_merge_request_notes.assert_not_called()
+    assert usage_sink == [
+        {"route_family": "merge_requests", "request_count": 2},
+        {"route_family": "notes", "request_count": 1},
+    ]
+
+
+def test_gitlab_mr_sync_stops_pagination_at_since_boundary() -> None:
+    recent_mr = {
+        "iid": 10,
+        "title": "Recent",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-03T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": "2026-01-05T13:00:00Z",
+        "source_branch": "feat",
+        "target_branch": "main",
+    }
+    older_mr = {
+        "iid": 9,
+        "title": "Older",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-01T12:00:00Z",
+        "merged_at": "2026-01-01T13:00:00Z",
+        "source_branch": "old",
+        "target_branch": "main",
+    }
+    fake_client = _FakeGitLabCodeClientForMergeRequests(
+        pages={1: [recent_mr, older_mr], 2: [older_mr]},
+        approvals={10: {"approved_by": []}},
+    )
+    connector = Mock()
+    connector.per_page = 100
+    sink = _FakeMrSink()
+
+    async def _driver() -> int:
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(
+            None,
+            lambda: _sync_gitlab_mrs_to_store(
+                connector,
+                99,
+                uuid.uuid4(),
+                cast(IngestionSink, sink),
+                loop,
+                50,
+                gate=_NoSleepGitLabGate(),
+                since=datetime(2026, 1, 2, tzinfo=timezone.utc),
+            ),
+        )
+
+    with patch.object(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda _connector: fake_client,
+    ):
+        total = asyncio.run(_driver())
+
+    assert total == 1
+    assert [pr.number for pr in sink.prs] == [10]
+    assert fake_client.get_merge_requests_page_calls == [(99, 1, "all", 100)]
+
+
+def test_gitlab_mr_sync_flushes_rows_before_terminal_rate_limit() -> None:
+    from dev_health_ops.exceptions import RateLimitException
+
+    mr = {
+        "iid": 77,
+        "title": "Persist before limit",
+        "state": "merged",
+        "author": {"username": "author"},
+        "created_at": "2026-01-03T12:00:00Z",
+        "updated_at": "2026-01-05T12:00:00Z",
+        "merged_at": "2026-01-05T13:00:00Z",
+        "source_branch": "feat",
+        "target_branch": "main",
+    }
+    fake_client = _FakeGitLabCodeClientForMergeRequests(
+        pages={1: [mr], 2: RateLimitException("limited")},
+        approvals={77: {"approved_by": []}},
+    )
+    connector = Mock()
+    connector.per_page = 100
+    sink = _FakeMrSink()
+
+    async def _driver() -> None:
+        loop = asyncio.get_running_loop()
+        await loop.run_in_executor(
+            None,
+            lambda: _sync_gitlab_mrs_to_store(
+                connector,
+                99,
+                uuid.uuid4(),
+                cast(IngestionSink, sink),
+                loop,
+                50,
+                gate=_NoSleepGitLabGate(),
+            ),
+        )
+
+    with patch.object(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda _connector: fake_client,
+    ):
+        with pytest.raises(RateLimitException):
+            asyncio.run(_driver())
+
+    assert [pr.number for pr in sink.prs] == [77]
+    assert fake_client.get_merge_requests_page_calls == [
+        (99, 1, "all", 100),
+        (99, 2, "all", 100),
+    ]

--- a/tests/test_gitlab_mr_reviews.py
+++ b/tests/test_gitlab_mr_reviews.py
@@ -9,7 +9,7 @@ import asyncio
 import uuid
 from datetime import datetime, timedelta, timezone
 from typing import Any, cast
-from unittest.mock import Mock
+from unittest.mock import Mock, patch
 
 import pytest
 
@@ -17,6 +17,7 @@ import pytest
 # pre-existing providers._base <-> connectors circular import when this file
 # is collected in isolation (mirrors tests/test_deployment_pr_inference.py).
 import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models.git import GitPullRequestReview
 from dev_health_ops.processors import gitlab as gitlab_processor
@@ -40,6 +41,76 @@ def _approvals(*usernames_ids):
             {"user": {"id": uid, "username": name}} for name, uid in usernames_ids
         ]
     }
+
+
+class _FakeGitLabMrCodeClient:
+    def __init__(self, *, mrs=None, approvals_by_iid=None, notes_by_iid=None):
+        self.mrs = mrs or []
+        self.approvals_by_iid = approvals_by_iid or {}
+        self.notes_by_iid = notes_by_iid or {}
+        self.iter_merge_requests_calls: list[dict[str, Any]] = []
+        self.get_merge_requests_page_calls: list[dict[str, Any]] = []
+        self.get_mr_approvals_calls: list[tuple[int, int]] = []
+        self.iter_mr_notes_calls: list[tuple[int, int, int]] = []
+        self.observations = [
+            {"route_family": "merge_requests", "request_count": 1},
+            {"route_family": "notes", "request_count": 1},
+        ]
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def iter_merge_requests(self, *, project_id, state, per_page):
+        self.iter_merge_requests_calls.append(
+            {"project_id": project_id, "state": state, "per_page": per_page}
+        )
+        return list(self.mrs)
+
+    async def get_merge_requests_page(self, *, project_id, page, state, per_page):
+        self.get_merge_requests_page_calls.append(
+            {
+                "project_id": project_id,
+                "page": page,
+                "state": state,
+                "per_page": per_page,
+            }
+        )
+        if page > 1:
+            return []
+        return list(self.mrs)
+
+    async def get_mr_approvals(self, project_id, iid):
+        self.get_mr_approvals_calls.append((project_id, iid))
+        val = self.approvals_by_iid.get(iid)
+        if isinstance(val, Exception):
+            raise val
+        return val
+
+    async def iter_mr_notes(self, project_id, iid, *, per_page):
+        self.iter_mr_notes_calls.append((project_id, iid, per_page))
+        val = self.notes_by_iid.get(iid)
+        if isinstance(val, Exception):
+            raise val
+        return list(val or [])
+
+    def drain_usage_observations(self):
+        observations = list(self.observations)
+        self.observations.clear()
+        return observations
+
+
+class _NoSleepGitLabGate:
+    def wait_sync(self) -> None:
+        return
+
+    def penalize(self, delay_seconds=None) -> float:
+        return float(delay_seconds or 0)
+
+    def reset(self) -> None:
+        return
 
 
 def test_approval_maps_to_approved_state_and_org_scope():
@@ -335,36 +406,49 @@ def test_empty_payloads_yield_no_rows():
     assert map_gitlab_mr_reviews(REPO_ID, 42, {"approved_by": []}, []) == ([], None)
 
 
-def test_fetch_calls_rest_endpoints_and_maps():
-    """The fetch helper wires the REST approvals + notes calls into the mapper."""
+def test_fetch_calls_code_client_endpoints_and_maps():
+    """The fetch helper wires the code-client approvals + notes calls into the mapper."""
     connector = Mock()
     connector.per_page = 100
-    connector.rest_client.get_merge_request_approvals.return_value = _approvals(
-        ("alice", 7)
+    connector.rest_client.get_merge_request_approvals.side_effect = AssertionError(
+        "legacy approvals path must not be called"
     )
-    connector.rest_client.get_merge_request_notes.return_value = [
-        {
-            "id": 200,
-            "system": False,
-            "type": "DiffNote",
-            "body": "looks good",
-            "author": {"username": "carol"},
-            "created_at": "2026-01-03T08:00:00Z",
-        }
-    ]
+    connector.rest_client.get_merge_request_notes.side_effect = AssertionError(
+        "legacy notes path must not be called"
+    )
+    fake_client = _FakeGitLabMrCodeClient(
+        approvals_by_iid={42: _approvals(("alice", 7))},
+        notes_by_iid={
+            42: [
+                {
+                    "id": 200,
+                    "system": False,
+                    "type": "DiffNote",
+                    "body": "looks good",
+                    "author": {"username": "carol"},
+                    "created_at": "2026-01-03T08:00:00Z",
+                }
+            ]
+        },
+    )
 
-    fetched = _fetch_gitlab_mr_reviews(
-        connector=connector,
-        project_id=99,
-        mr={"iid": 42, "author": {"username": "author"}},
-        repo_id=REPO_ID,
-        created_at=CREATED_AT,
-    )
+    with patch.object(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda _connector: fake_client,
+    ):
+        fetched = _fetch_gitlab_mr_reviews(
+            connector=connector,
+            project_id=99,
+            mr={"iid": 42, "author": {"username": "author"}},
+            repo_id=REPO_ID,
+            created_at=CREATED_AT,
+        )
 
-    connector.rest_client.get_merge_request_approvals.assert_called_once_with(99, 42)
-    connector.rest_client.get_merge_request_notes.assert_called_once_with(
-        99, 42, page=1, per_page=100
-    )
+    assert fake_client.get_mr_approvals_calls == [(99, 42)]
+    assert fake_client.iter_mr_notes_calls == [(99, 42, 100)]
+    connector.rest_client.get_merge_request_approvals.assert_not_called()
+    connector.rest_client.get_merge_request_notes.assert_not_called()
     assert fetched.known is True
     assert sorted(r.state for r in fetched.reviews) == ["APPROVED", "COMMENTED"]
     assert fetched.first_review_at == datetime(2026, 1, 3, 8, 0, tzinfo=timezone.utc)
@@ -374,16 +458,22 @@ def test_fetch_is_resilient_to_missing_approvals_endpoint():
     """MRs whose approvals endpoint 404s still ingest notes (skip cleanly)."""
     connector = Mock()
     connector.per_page = 100
-    connector.rest_client.get_merge_request_approvals.side_effect = Exception("404")
-    connector.rest_client.get_merge_request_notes.return_value = []
-
-    fetched = _fetch_gitlab_mr_reviews(
-        connector=connector,
-        project_id=99,
-        mr={"iid": 42},
-        repo_id=REPO_ID,
-        created_at=CREATED_AT,
+    fake_client = _FakeGitLabMrCodeClient(
+        approvals_by_iid={42: Exception("404")}, notes_by_iid={42: []}
     )
+
+    with patch.object(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda _connector: fake_client,
+    ):
+        fetched = _fetch_gitlab_mr_reviews(
+            connector=connector,
+            project_id=99,
+            mr={"iid": 42},
+            repo_id=REPO_ID,
+            created_at=CREATED_AT,
+        )
 
     # Notes are authoritative and succeeded (empty) -> known, no reviews.
     assert fetched.known is True
@@ -396,18 +486,23 @@ def test_fetch_notes_failure_reports_unknown():
     result is flagged unknown so the caller will NOT zero out review metrics."""
     connector = Mock()
     connector.per_page = 100
-    connector.rest_client.get_merge_request_approvals.return_value = _approvals(
-        ("alice", 7)
+    fake_client = _FakeGitLabMrCodeClient(
+        approvals_by_iid={42: _approvals(("alice", 7))},
+        notes_by_iid={42: Exception("timeout")},
     )
-    connector.rest_client.get_merge_request_notes.side_effect = Exception("timeout")
 
-    fetched = _fetch_gitlab_mr_reviews(
-        connector=connector,
-        project_id=99,
-        mr={"iid": 42},
-        repo_id=REPO_ID,
-        created_at=CREATED_AT,
-    )
+    with patch.object(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda _connector: fake_client,
+    ):
+        fetched = _fetch_gitlab_mr_reviews(
+            connector=connector,
+            project_id=99,
+            mr={"iid": 42},
+            repo_id=REPO_ID,
+            created_at=CREATED_AT,
+        )
 
     assert fetched.known is False
     assert fetched.reviews == []
@@ -457,34 +552,22 @@ class _FakeSink:
 
 
 def _make_connector(mrs_page, approvals_by_iid, notes_by_iid):
-    """Build a Mock GitLab connector whose REST client returns the given data."""
     connector = Mock()
     connector.per_page = 100
-
-    pages = {1: mrs_page}
-
-    def _get_merge_requests(*, project_id, state, page, per_page, order_by, sort):
-        return pages.get(page, [])
-
-    connector.rest_client.get_merge_requests.side_effect = _get_merge_requests
-
-    def _approvals_for(project_id, iid):
-        val = approvals_by_iid.get(iid)
-        if isinstance(val, Exception):
-            raise val
-        return val
-
-    def _notes_for(project_id, iid, page=1, per_page=100):
-        val = notes_by_iid.get(iid)
-        if isinstance(val, Exception):
-            raise val
-        all_notes = val or []
-        # Emulate real GitLab note pagination so the exhaustion loop is exercised.
-        start = (page - 1) * per_page
-        return all_notes[start : start + per_page]
-
-    connector.rest_client.get_merge_request_approvals.side_effect = _approvals_for
-    connector.rest_client.get_merge_request_notes.side_effect = _notes_for
+    connector.code_client = _FakeGitLabMrCodeClient(
+        mrs=mrs_page,
+        approvals_by_iid=approvals_by_iid,
+        notes_by_iid=notes_by_iid,
+    )
+    connector.rest_client.get_merge_requests.side_effect = AssertionError(
+        "legacy MR list path must not be called"
+    )
+    connector.rest_client.get_merge_request_approvals.side_effect = AssertionError(
+        "legacy approvals path must not be called"
+    )
+    connector.rest_client.get_merge_request_notes.side_effect = AssertionError(
+        "legacy notes path must not be called"
+    )
     return connector
 
 
@@ -505,12 +588,17 @@ def _run_sync(connector, since=None):
                 loop,
                 50,  # batch_size
                 "all",  # state
-                None,  # gate
+                _NoSleepGitLabGate(),  # gate
                 since,
             ),
         )
 
-    total = asyncio.run(_driver())
+    with patch.object(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda connector: connector.code_client,
+    ):
+        total = asyncio.run(_driver())
     return total, sink
 
 
@@ -660,11 +748,17 @@ def test_live_sync_partial_failure_flushes_good_rows_before_raising():
                 cast(IngestionSink, sink),
                 loop,
                 50,
+                gate=_NoSleepGitLabGate(),
             ),
         )
 
-    with pytest.raises(PartialGitLabMrSyncError) as exc_info:
-        asyncio.run(_driver())
+    with patch.object(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda connector: connector.code_client,
+    ):
+        with pytest.raises(PartialGitLabMrSyncError) as exc_info:
+            asyncio.run(_driver())
 
     # The good MR (41) is persisted; the degraded MR (42) is not.
     assert [pr.number for pr in sink.prs] == [41]
@@ -813,21 +907,23 @@ def test_fetch_all_mr_notes_exhausts_pages():
 
     connector = Mock()
     connector.per_page = 100
+    connector.code_client = _FakeGitLabMrCodeClient(notes_by_iid={42: all_notes})
+    connector.rest_client.get_merge_request_notes.side_effect = AssertionError(
+        "legacy notes path must not be called"
+    )
 
-    def _notes(project_id, iid, page=1, per_page=100):
-        start = (page - 1) * per_page
-        return all_notes[start : start + per_page]
-
-    connector.rest_client.get_merge_request_notes.side_effect = _notes
-
-    fetched = _fetch_all_mr_notes(connector, project_id=99, iid=42)
+    with patch.object(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda connector: connector.code_client,
+    ):
+        fetched = _fetch_all_mr_notes(connector, project_id=99, iid=42)
 
     assert len(fetched) == 101
     # The page-2 approval note survived pagination.
     assert any(n["id"] == 1000 for n in fetched)
-    # Two full-size fetches + one short page would also be valid; here page 2
-    # is short (1 item) so the loop stops after 2 calls.
-    assert connector.rest_client.get_merge_request_notes.call_count == 2
+    assert connector.code_client.iter_mr_notes_calls == [(99, 42, 100)]
+    connector.rest_client.get_merge_request_notes.assert_not_called()
 
 
 def test_live_sync_approval_after_first_note_page_is_counted():
@@ -1054,7 +1150,17 @@ def _patch_batch(monkeypatch, projects, sync_behavior):
     calls: list[int] = []
 
     def _fake_sync_mrs(
-        connector, project_id, repo_id, sink, loop, batch_size, state, gate, since
+        connector,
+        project_id,
+        repo_id,
+        sink,
+        loop,
+        batch_size,
+        state,
+        gate,
+        since,
+        until=None,
+        usage_sink=None,
     ):
         calls.append(project_id)
         outcome = sync_behavior[project_id]
@@ -1115,6 +1221,38 @@ def test_batch_degraded_mr_fetch_raises_and_does_not_report_success(monkeypatch)
     # skipped iids are surfaced, not lost.
     assert [e.project_id for e in exc_info.value.errors] == [2]
     assert exc_info.value.errors[0].skipped_iids == [42, 43]
+
+
+def test_batch_rate_limited_mr_fetch_propagates(monkeypatch):
+    projects = [
+        _FakeProjectInfo(1, "group/healthy"),
+        _FakeProjectInfo(2, "group/limited"),
+        _FakeProjectInfo(3, "group/not-reached"),
+    ]
+    calls = _patch_batch(
+        monkeypatch,
+        projects,
+        sync_behavior={
+            1: 5,
+            2: RateLimitException("limited"),
+            3: 5,
+        },
+    )
+
+    store = Mock()
+    with pytest.raises(RateLimitException):
+        asyncio.run(
+            process_gitlab_projects_batch(
+                store=store,
+                token="tok",
+                group_name="group",
+                pattern="*",
+                max_concurrent=1,
+                **_BATCH_PRS_ONLY,
+            )
+        )
+
+    assert calls[:2] == [1, 2]
 
 
 def test_batch_flushes_healthy_repos_before_raising(monkeypatch):

--- a/tests/test_processors_gitlab.py
+++ b/tests/test_processors_gitlab.py
@@ -11,6 +11,7 @@ from dev_health_ops.processors.gitlab import (
     _fetch_gitlab_commits_sync,
     _fetch_gitlab_deployments_sync,
     _fetch_gitlab_incidents_sync,
+    _fetch_gitlab_mrs_sync,
     _fetch_gitlab_pipelines_sync,
     _fetch_gitlab_test_reports_sync,
     process_gitlab_project,
@@ -54,6 +55,8 @@ class _FakeGitLabCodeClient:
         self.test_reports = test_reports or {}
         self.jobs = jobs or {}
         self.artifacts = artifacts or {}
+        self.iter_merge_requests_calls: list[tuple[Any, str, int, int | None]] = []
+        self.get_merge_requests_page_calls: list[tuple[Any, int, str, int]] = []
 
     async def __aenter__(self):
         return self
@@ -72,6 +75,26 @@ class _FakeGitLabCodeClient:
 
     async def get_deployment_merge_requests(self, project_id, sha):
         return self.merge_requests
+
+    async def iter_merge_requests(self, project_id, *, state, per_page, max_items=None):
+        self.iter_merge_requests_calls.append((project_id, state, per_page, max_items))
+        return (
+            self.merge_requests[:max_items]
+            if max_items is not None
+            else self.merge_requests
+        )
+
+    async def get_merge_requests_page(self, project_id, *, page, state, per_page):
+        self.get_merge_requests_page_calls.append((project_id, page, state, per_page))
+        if page > 1:
+            return []
+        return self.merge_requests
+
+    async def get_mr_approvals(self, project_id, iid):
+        return {"approved_by": []}
+
+    async def iter_mr_notes(self, project_id, iid, *, per_page):
+        return []
 
     async def get_commits(
         self, project_id, *, max_commits, since=None, until=None, per_page=100
@@ -509,6 +532,52 @@ def test_fetch_gitlab_commit_stats_sync_reraises_rate_limit(monkeypatch):
         )
 
     assert usage_sink == [{"route_family": "project"}]
+
+
+def test_fetch_gitlab_mrs_sync_uses_code_client(monkeypatch):
+    usage_sink: list[dict[str, Any]] = []
+    mr = {
+        "iid": "42",
+        "title": "Ship MR",
+        "description": "desc",
+        "state": "merged",
+        "author": {"username": "ada"},
+        "created_at": "2026-01-01T12:00:00Z",
+        "updated_at": "2026-01-02T12:00:00Z",
+        "merged_at": "2026-01-03T12:00:00Z",
+        "closed_at": None,
+        "source_branch": "feat",
+        "target_branch": "main",
+    }
+    fake_client = _FakeGitLabCodeClient(
+        merge_requests=[mr], observations=[{"route_family": "merge_requests"}]
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+    connector = Mock()
+    connector.per_page = 50
+    connector.get_merge_requests.side_effect = AssertionError(
+        "legacy connector.get_merge_requests must not be called"
+    )
+
+    prs = _fetch_gitlab_mrs_sync(
+        connector,
+        project_id=99,
+        repo_id=None,
+        max_mrs=10,
+        usage_sink=usage_sink,
+    )
+
+    assert fake_client.iter_merge_requests_calls == [(99, "all", 50, 10)]
+    connector.get_merge_requests.assert_not_called()
+    assert len(prs) == 1
+    assert prs[0].number == 42
+    assert prs[0].author_name == "ada"
+    assert prs[0].created_at == datetime(2026, 1, 1, 12, tzinfo=timezone.utc)
+    assert prs[0].merged_at == datetime(2026, 1, 3, 12, tzinfo=timezone.utc)
+    assert usage_sink == [{"route_family": "merge_requests"}]
 
 
 def test_fetch_gitlab_deployments_sync(monkeypatch):

--- a/tests/test_processors_pr_mr_rate_limit.py
+++ b/tests/test_processors_pr_mr_rate_limit.py
@@ -8,6 +8,7 @@ import pytest
 # pre-existing providers._base <-> connectors circular import when this file
 # is collected in isolation (mirrors tests/test_deployment_pr_inference.py).
 import dev_health_ops.connectors  # noqa: F401
+import dev_health_ops.processors.gitlab as gitlab_processor
 from dev_health_ops.processors.github import _sync_github_prs_to_store
 from dev_health_ops.processors.gitlab import _sync_gitlab_mrs_to_store
 
@@ -144,36 +145,43 @@ async def test_github_pr_sync_retries_on_retry_after_and_persists():
 
 
 @pytest.mark.asyncio
-async def test_gitlab_mr_sync_retries_on_retry_after_and_persists():
+async def test_gitlab_mr_sync_retries_on_retry_after_and_persists(
+    monkeypatch: pytest.MonkeyPatch,
+):
     loop = asyncio.get_running_loop()
     repo_id = uuid.uuid4()
     store = _FakeStore()
 
-    class _RateLimit(Exception):
-        def __init__(self, retry_after_seconds):
-            super().__init__("rate limited")
-            self.retry_after_seconds = retry_after_seconds
+    class _RetryAfter(Exception):
+        def __init__(self):
+            super().__init__("retry later")
+            self.retry_after_seconds = 0
 
-    class _Rest:
+    class _CodeClient:
         def __init__(self):
             self.calls = 0
+            self.pages: list[int] = []
 
-        def get_merge_requests(
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def get_merge_requests_page(
             self,
-            project_id=None,
-            state=None,
-            page=None,
-            per_page=None,
-            **_kwargs,
+            *,
+            project_id,
+            page,
+            state,
+            per_page,
         ):
             assert project_id is not None
-            assert page is not None
             assert per_page is not None
             assert state == "all"
+            self.pages.append(page)
             self.calls += 1
             if self.calls == 1:
-                raise _RateLimit(0)
-            if self.calls == 2:
                 return [
                     {
                         "iid": 7,
@@ -187,25 +195,30 @@ async def test_gitlab_mr_sync_retries_on_retry_after_and_persists():
                         "author": {"username": "alice"},
                     }
                 ]
+            if self.calls == 2:
+                raise _RetryAfter()
             return []
 
-        # MR-review reconstruction (CHAOS-2378) calls these per in-window MR.
-        # This test exercises rate-limit retry on get_merge_requests, not
-        # reviews, so they return empty (the legitimate "no reviews" path).
-        def get_merge_request_approvals(self, project_id, iid):
+        async def get_mr_approvals(self, project_id, iid):
             return {"approved_by": []}
 
-        def get_merge_request_notes(
-            self, project_id, iid, page=1, per_page=100, **_kwargs
-        ):
+        async def iter_mr_notes(self, project_id, iid, *, per_page):
+            return []
+
+        def drain_usage_observations(self):
             return []
 
     class _Connector:
         def __init__(self):
             self.per_page = 100
-            self.rest_client = _Rest()
 
+    client = _CodeClient()
     connector = _Connector()
+    monkeypatch.setattr(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda _connector: client,
+    )
     gate = _NoSleepGate()
 
     total = await loop.run_in_executor(
@@ -224,4 +237,5 @@ async def test_gitlab_mr_sync_retries_on_retry_after_and_persists():
     assert total == 1
     assert len(store.pr_batches) == 1
     assert store.pr_batches[0][0].number == 7
+    assert client.pages == [1, 2, 2]
     assert gate.penalties and gate.penalties[0] == 0.0


### PR DESCRIPTION
## CHAOS-2773 CS15 — GitLab merge-requests + notes families

Migrates the GitLab `merge_requests` and `notes` route families off the legacy connector/python-gitlab paths onto the canonical httpx `GitLabCodeClient`, following the merged CS14 (files+blame) template.

### Changes
- **`GitLabCodeClient`**: adds `iter_merge_requests`, `get_merge_requests_page` (page-level fetch so the processor retries the same page on Retry-After and stops at the `since` boundary), `iter_mr_commits`, `iter_mr_notes` (preserves the legacy `sort=asc`/`order_by=created_at` note ordering), and `get_mr_approvals`.
- **Processor**: MR listing / notes / approvals rewired to the async client with page-by-page processing, per-page gate handling, `since`-boundary early stop, `finally`-drain of usage observations, and partial-row flush before terminal rate limits. Canonical `RateLimitException` now re-raised from both the MR batch `store_result` and the PR-only batch wrapper instead of being swallowed.
- **Budget**: `merge_requests`/`notes` markers flipped to explicit prefixes; the compressed estimator vocabulary `{project, merge_requests, notes, pipelines}` stays frozen.
- Docs (`rate-limit-policy.md`) updated in this changeset; code-client, resolver, budget, content-backfill, mr-reviews, and processor tests added.

The connector MR methods and `connectors/utils/rest.py` stay frozen in-tree until CS17 retirement (rest.py retained for feature flags). No runtime legacy flag.

### Validation
- Full gate `OTEL_SDK_DISABLED=true SCRATCH_DB=ci_local_validate_2816 bash ci/local_validate.sh` → `GATE PASSED` (`6905 passed, 44 skipped`).
- Adversarial review (Oracle) found 3 blockers (batch MR rate-limit swallow, eager full-history pagination breaking windowed-sync/retry/partial-persistence, notes ordering drift); all fixed with regression tests, plus a second swallow layer in the PR-only batch wrapper.

> Note: shares two files with CS8/#1181 (`rate-limit-policy.md`, `test_processors_pr_mr_rate_limit.py`). This PR is based on `main` @ 025a68d6a; after #1181 merges it will be rebased to resolve those two files.

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.