### PR TITLE
fix(metrics): stop lizard import from shadowing alembic (CHAOS-2863)

### DIFF
--- a/src/dev_health_ops/analytics/complexity.py
+++ b/src/dev_health_ops/analytics/complexity.py
@@ -1,11 +1,13 @@
 import fnmatch
+import functools
 import importlib
 import logging
 import os
+import sys
 from dataclasses import dataclass
 from pathlib import Path
+from types import ModuleType
 
-import lizard
 from radon.complexity import cc_visit
 
 logger = logging.getLogger(__name__)
@@ -14,6 +16,25 @@ yaml = importlib.import_module("yaml")
 DEFAULT_COMPLEXITY_CONFIG_PATH = (
     Path(__file__).resolve().parents[1] / "config" / "complexity.yaml"
 )
+
+
+@functools.cache
+def _import_lizard() -> ModuleType:
+    """Import lizard without letting it poison ``sys.path`` (CHAOS-2863).
+
+    lizard's module body runs a script-mode convenience on import: it inserts
+    ``dirname(abspath(sys.argv[0]))`` at ``sys.path[0]``. Under ``python -m
+    dev_health_ops.cli ...`` that directory is the installed package itself,
+    so ``dev_health_ops.alembic`` shadows the real ``alembic`` for every
+    later import and ``dev-hops migrate`` crashes. Import lazily and restore
+    ``sys.path`` exactly as it was.
+    """
+    path_before = list(sys.path)
+    try:
+        return importlib.import_module("lizard")
+    finally:
+        sys.path[:] = path_before
+
 
 #: Extensions the scanner can analyze, mapped to the persisted ``language``
 #: value. Python goes through radon (kept for trend continuity with existing
@@ -206,6 +227,7 @@ class ComplexityScanner:
     def _analyze_with_lizard(
         self, code: str, file_path: str, language: str
     ) -> FileComplexity | None:
+        lizard = _import_lizard()
         try:
             analysis = lizard.analyze_file.analyze_source_code(file_path, code)
         except Exception:

--- a/tests/analytics/test_complexity_scanner.py
+++ b/tests/analytics/test_complexity_scanner.py
@@ -1,3 +1,7 @@
+import subprocess
+import sys
+import textwrap
+
 from dev_health_ops.analytics.complexity import (
     DEFAULT_COMPLEXITY_CONFIG_PATH,
     LANGUAGE_BY_EXTENSION,
@@ -113,3 +117,59 @@ def test_syntactically_broken_source_returns_no_result() -> None:
 
     assert subject.scan_file_contents([("broken.py", "def broken(:\n")]) == []
     assert subject._analyze_content("def broken(:\n", "broken.py") is None
+
+
+def test_lizard_scan_does_not_mutate_sys_path() -> None:
+    subject = scanner()
+    path_before = list(sys.path)
+
+    results = subject.scan_file_contents(
+        [("src/app.ts", "export function f(a: number) { return a ? 1 : 0; }\n")]
+    )
+
+    assert results, "scan must succeed for the invariant to be meaningful"
+    assert sys.path == path_before
+
+
+def test_lizard_import_does_not_shadow_alembic_under_python_m(tmp_path) -> None:
+    """Regression for CHAOS-2863: lizard inserts dirname(sys.argv[0]) at
+    sys.path[0] on import. Under ``python -m dev_health_ops.cli`` that is the
+    installed package directory, whose ``alembic`` subpackage then shadows the
+    real alembic and crashes ``dev-hops migrate``. Reproduce in a fresh
+    interpreter with a poisoned argv[0] and assert the shadow never happens."""
+    shadow_dir = tmp_path / "fake_pkg"
+    (shadow_dir / "alembic").mkdir(parents=True)
+    (shadow_dir / "alembic" / "__init__.py").write_text("SHADOW = True\n")
+
+    script = textwrap.dedent(
+        """
+        import sys
+        sys.argv[0] = sys.argv.pop(1) + "/cli.py"
+        from dev_health_ops.analytics.complexity import (
+            DEFAULT_COMPLEXITY_CONFIG_PATH,
+            ComplexityScanner,
+        )
+        scanner = ComplexityScanner(DEFAULT_COMPLEXITY_CONFIG_PATH)
+        results = scanner.scan_file_contents(
+            [("src/app.ts", "export function f(a: number) { return a ? 1 : 0; }")]
+        )
+        assert results, "lizard analysis must still work"
+        assert sys.argv[0].rsplit("/", 1)[0] not in sys.path, (
+            "argv[0] dirname leaked into sys.path"
+        )
+        from alembic import command  # must be the real alembic
+
+        assert not hasattr(command, "SHADOW")
+        print("OK")
+        """
+    )
+
+    proc = subprocess.run(
+        [sys.executable, "-c", script, str(shadow_dir)],
+        capture_output=True,
+        text=True,
+        timeout=120,
+    )
+
+    assert proc.returncode == 0, proc.stderr
+    assert "OK" in proc.stdout


### PR DESCRIPTION
## Problem

`docker compose up migrate` fails on current main:

```
ImportError: cannot import name 'command' from 'alembic'
(.../site-packages/dev_health_ops/alembic/__init__.py)
```

Regression from CHAOS-2859 (#1183): `analytics/complexity.py` imports `lizard` at module scope, and lizard's module body inserts `dirname(abspath(sys.argv[0]))` at `sys.path[0]` on import (upstream script-mode convenience, `_script_dirs()` in lizard.py). Under `python -m dev_health_ops.cli ...` argv[0] is the installed `cli.py`, so the **package directory itself** lands first on `sys.path` and `dev_health_ops.alembic` shadows the real alembic for every subsequent import. `dev-hops migrate postgres` crashes; the compose `migrate` service exits 1 and blocks api/worker startup.

## Fix

Lazy, cached lizard loader (`_import_lizard()`) that snapshots and restores `sys.path` around the import. No behavior change to analysis.

## Verification

- New fresh-interpreter regression test with a poisoned argv[0] + fake `alembic` shadow package: fails on main, passes here.
- In-process invariant test: scanning TS never mutates `sys.path`.
- Verified red/green by stashing the fix and re-running the test.
- `ci/local_validate.sh` GATE PASSED (full unit suite + argMax live proof).

SCREENSHOT-WAIVER: backend-only change.

Fixes CHAOS-2863. Related: CHAOS-2859.