### PR TITLE
feat(providers): instrument GitHub repo metadata and batch orchestration (CHAOS-2810)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -99,7 +99,7 @@ cooperating layers:
    | --- | --- | --- |
    | GitHub REST connector | 3 (`retry_with_backoff(max_retries=3)`) | `connectors/github.py` |
    | GitHub GraphQL client | 5 (`max_retries=5`) | `connectors/utils/graphql.py` |
-| GitHub code client (canonical: git/commit_stats/security/deployments REST, files/blame GraphQL) | 5 (`InstrumentedRESTCore` default) | `providers/github/code_client.py` + `providers/github/graphql.py` |
+| GitHub code client (canonical: repo metadata/listing, git/commit_stats/security/deployments REST, files/blame GraphQL) | 5 (`InstrumentedRESTCore` default) | `providers/github/code_client.py` + `providers/github/graphql.py` |
 | GitLab REST connector | 3 (`retry_with_backoff(max_retries=3)`) | `connectors/gitlab.py` |
 | GitLab code client (canonical: security/pipelines/deployments/tests/commits/files/blame/merge_requests/notes) | 5 (`InstrumentedRESTCore` default) | `providers/gitlab/code_client.py` |
 | GitLab feature-flags (canonical) | 5 (`max_retries=5`) | `providers/gitlab/feature_flags.py` |
@@ -950,13 +950,20 @@ proof-of-pipe that the plumbing actually reaches a `budget_comparison` row:
   resolver/actuals-only family so the estimator vocabulary stays frozen while
   real incident issue traffic still appears in calibration output as an
   unbudgeted actual when present.
+- **Actuals instrumentation (CHAOS-2810).** Repository metadata (`get_repo`)
+  and discovery/listing (`list_repositories`, `list_installation_repositories`)
+  now fetch through `GitHubCodeClient`, resolving through an explicit `repo:`
+  operation prefix; `process_github_repos_batch`'s repo discovery/metadata
+  fan-out and the admin credential repo-list endpoint
+  (`api/admin/routers/credentials.py`) both moved off `GitHubConnector`/PyGithub
+  onto the same client.
 
 #### Route families
 <!-- route-families:github -->
 
 | Route family | Dimension(s) | Covers | Confidence |
 | --- | --- | --- | --- |
-| `repo` | `rest_core` | Repository metadata | high |
+| `repo` | `rest_core` | Repository metadata + discovery (`GitHubCodeClient`, CHAOS-2773 CS9) | high |
 | `git` | `rest_core` | Commit listing (`GitHubCodeClient`, CHAOS-2773 CS6) | medium |
 | `commit_stats` | `rest_core`, `contents_blob` | Per-commit file/stat expansion (`GitHubCodeClient` REST core, CHAOS-2773 CS6; contents/blob still estimate-only) | low |
 | `files` | `rest_core`, `contents_blob` | Repository tree listing (`rest_core`, frozen/estimate-only) + blob-text reads (`contents_blob`, `GitHubCodeClient` GraphQL, CHAOS-2773 CS7) | low |
@@ -1182,19 +1189,22 @@ paper over:
   instrumented as of [CHAOS-2803](https://linear.app/fullchaos/issue/CHAOS-2803)
   (CS2) — see
   [Usage drain wiring](#usage-drain-wiring-first-re-bucketing-chaos-2773-cs2)
-  above. GitHub `git` and `commit_stats` REST-core traffic is instrumented as of
+above. GitHub `git` and `commit_stats` REST-core traffic is instrumented as of
   CHAOS-2807, `files`/`blame` `contents_blob` traffic (GraphQL) as of
-  CHAOS-2808, and REST `prs` listing / PR commits / incident-label issue
-  fetches as of CHAOS-2809; GitLab merge-request and MR-note REST-core traffic
+  CHAOS-2808, REST `prs` listing / PR commits / incident-label issue
+  fetches as of CHAOS-2809, and `repo` metadata/discovery traffic as of
+  CHAOS-2810 (CS9); GitLab merge-request and MR-note REST-core traffic
   is instrumented as of CHAOS-2816 (CS15). The `files`/`blame` `rest_core` tree
   listing and remaining GitHub/GitLab code-dataset families stay uninstrumented
   pending their own CHAOS-2773 changesets (see
   "Frozen `connectors/` path" below). There is also no cross-run
   aggregation/dashboard yet — calibration today is visible per-unit (result +
   structured log), not rolled up over time.
-- **Frozen `connectors/` path.** GitHub's repo metadata/batch orchestration,
-  the frozen-but-retained connector PR-commit method pending CS16 retirement,
-  plus the remaining equivalent GitLab code-dataset paths, remain under the frozen `connectors/` tree
+- **Frozen `connectors/` path.** GitHub repo metadata/listing and batch
+  orchestration now use `GitHubCodeClient` and emit `repo:` usage actuals. The
+  frozen-but-retained GitHub connector PR-commit method (pending CS16
+  retirement), plus the remaining equivalent GitLab code-dataset paths
+  (repo-metadata/batch orchestration among them), remain under the frozen `connectors/` tree
   (`connectors/github.py`'s PyGithub-based `GitHubConnector`, `connectors/
   gitlab.py`'s python-gitlab-based `GitLabConnector`). No new code may be added
   there (see [`AGENTS.md`](../../AGENTS.md)); rate-limit/actuals
@@ -1216,7 +1226,9 @@ paper over:
   `providers/github/graphql.py`) moved to
   `providers/github/code_client.py::GitHubCodeClient`; GitHub `prs` REST
   listing, PR commits, and incident-label issue fetches
-  ([CHAOS-2809](https://linear.app/fullchaos/issue/CHAOS-2809), CS8) also moved
+  ([CHAOS-2809](https://linear.app/fullchaos/issue/CHAOS-2809), CS8), and
+  GitHub repo metadata + batch discovery/orchestration
+  ([CHAOS-2810](https://linear.app/fullchaos/issue/CHAOS-2810), CS9) also moved
   onto `GitHubCodeClient`. GitLab's `security`
   ([CHAOS-2811](https://linear.app/fullchaos/issue/CHAOS-2811), CS10),
   `pipelines`+`deployments`

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -21,6 +21,14 @@ from dev_health_ops.api.admin.schemas import (
 )
 from dev_health_ops.api.services.configuration import IntegrationCredentialsService
 from dev_health_ops.credentials.resolver import github_credentials_from_mapping
+from dev_health_ops.exceptions import (
+    APIException,
+    AuthenticationException,
+    NotFoundException,
+    RateLimitException,
+)
+from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.code_client import GitHubCodeClient
 from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
 from .common import get_session
@@ -118,15 +126,7 @@ async def list_credential_repos(
     provider = str(getattr(credential, "provider"))
     config: dict[str, Any] = getattr(credential, "config") or {}
 
-    from dev_health_ops.connectors.exceptions import (
-        AuthenticationException,
-        NotFoundException,
-        RateLimitException,
-    )
-
     if provider == "github":
-        from dev_health_ops.connectors.github import GitHubConnector
-
         github_credentials = _github_credentials_or_400(
             {
                 **decrypted,
@@ -140,44 +140,45 @@ async def list_credential_repos(
             or _string_value(decrypted.get("org"))
         )
         try:
-            github_connector = GitHubConnector(credentials=github_credentials)
-        except Exception as exc:
-            raise HTTPException(
-                status_code=401, detail="GitHub App authentication failed"
-            ) from exc
-        try:
             if not effective_owner and github_credentials.is_app_auth:
-                # GitHub App installation tokens have no user surface.
-                # Enumerate installation repos directly via the REST API,
-                # then apply search as a client-side name filter.
                 repos = await _list_github_app_installation_repos(
                     github_credentials=github_credentials,
                     base_url=github_credentials.base_url or "https://api.github.com",
                     search=search,
                     max_repos=max_repos,
                 )
-            elif not effective_owner and search:
-                # Blank owner + search: enumerate token-wide repos and filter
-                # client-side via pattern to avoid a global GitHub search.
-                repos = github_connector.list_repositories(
-                    org_name=None,
-                    search=None,
-                    pattern=f"*{search}*",
-                    max_repos=max_repos,
-                )
             else:
-                repos = github_connector.list_repositories(
-                    org_name=effective_owner or None,
-                    search=search,
-                    max_repos=max_repos,
-                )
+                client = await _github_repo_list_client(github_credentials)
+                try:
+                    repos = await client.list_repositories(
+                        org_name=effective_owner or None,
+                        search=search if effective_owner else None,
+                        pattern=f"*{search}*"
+                        if search and not effective_owner
+                        else None,
+                        max_repos=max_repos,
+                    )
+                finally:
+                    client.drain_usage_observations()
+                    await client.close()
         except NotFoundException:
             return DiscoveredReposResponse(provider=provider, repos=[], total=0)
         except AuthenticationException as exc:
             raise HTTPException(status_code=401, detail=str(exc))
         except RateLimitException as exc:
             raise HTTPException(status_code=429, detail=str(exc))
+        except APIException as exc:
+            raise HTTPException(status_code=502, detail=str(exc))
     elif provider == "gitlab":
+        from dev_health_ops.connectors.exceptions import (
+            AuthenticationException as GitLabAuthenticationException,
+        )
+        from dev_health_ops.connectors.exceptions import (
+            NotFoundException as GitLabNotFoundException,
+        )
+        from dev_health_ops.connectors.exceptions import (
+            RateLimitException as GitLabRateLimitException,
+        )
         from dev_health_ops.connectors.gitlab import GitLabConnector
 
         token = decrypted.get("token")
@@ -199,10 +200,6 @@ async def list_credential_repos(
         effective_owner = owner or _string_value(config.get("group"))
         try:
             if not effective_owner:
-                # Blank owner: enumerate only membership-scoped projects to
-                # avoid returning globally-visible public projects the token
-                # is not a member of. Bypass the connector (frozen) and call
-                # python-gitlab directly with membership=True.
                 repos = _list_gitlab_membership_repos(
                     url=url,
                     token=token,
@@ -215,11 +212,11 @@ async def list_credential_repos(
                     search=search,
                     max_repos=max_repos,
                 )
-        except NotFoundException:
+        except GitLabNotFoundException:
             return DiscoveredReposResponse(provider=provider, repos=[], total=0)
-        except AuthenticationException as exc:
+        except GitLabAuthenticationException as exc:
             raise HTTPException(status_code=401, detail=str(exc))
-        except RateLimitException as exc:
+        except GitLabRateLimitException as exc:
             raise HTTPException(status_code=429, detail=str(exc))
     else:
         raise HTTPException(
@@ -435,6 +432,29 @@ def _build_safe_url(validated_base: str, path: str) -> str:
     return urlunparse((parsed.scheme, parsed.netloc, safe_path, "", "", ""))
 
 
+async def _github_repo_list_client(github_credentials: Any) -> GitHubCodeClient:
+    if github_credentials.is_app_auth:
+        from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
+
+        assert github_credentials.app_id is not None
+        assert github_credentials.private_key is not None
+        assert github_credentials.installation_id is not None
+        try:
+            token = GitHubAppTokenProvider(
+                app_id=github_credentials.app_id,
+                private_key=github_credentials.private_key,
+                installation_id=github_credentials.installation_id,
+                api_base_url=github_credentials.base_url or "https://api.github.com",
+            ).get_token()
+        except Exception as exc:
+            raise AuthenticationException("GitHub App authentication failed") from exc
+    else:
+        token = github_credentials.token
+    return GitHubCodeClient(
+        auth=GitHubAuth(token=token, base_url=github_credentials.base_url)
+    )
+
+
 async def _list_github_app_installation_repos(
     github_credentials: Any,
     base_url: str,
@@ -448,107 +468,22 @@ async def _list_github_app_installation_repos(
     Applies search as a client-side name filter (fnmatch) to avoid a global
     GitHub search.
     """
-    import fnmatch
-
-    import httpx
-
-    from dev_health_ops.connectors.models import Repository
-    from dev_health_ops.connectors.utils.github_app import GitHubAppTokenProvider
-
-    assert github_credentials.app_id is not None
-    assert github_credentials.private_key is not None
-    assert github_credentials.installation_id is not None
-
-    token = GitHubAppTokenProvider(
-        app_id=github_credentials.app_id,
-        private_key=github_credentials.private_key,
-        installation_id=github_credentials.installation_id,
-        api_base_url=base_url,
-    ).get_token()
-
-    pattern = f"*{search}*" if search else None
-    repos: list[Any] = []
-    page = 1
-    per_page = 100
-
-    async with httpx.AsyncClient() as client:
-        while True:
-            resp = await client.get(
-                _build_safe_url(base_url, "installation/repositories"),
-                headers={
-                    "Authorization": f"Bearer {token}",
-                    "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
-                },
-                params={"per_page": per_page, "page": page},
-                timeout=10,
-            )
-            if resp.status_code == 401:
-                raise HTTPException(
-                    status_code=401,
-                    detail="GitHub App authentication failed",
-                )
-            if resp.status_code == 403:
-                body_lower = resp.text.lower()
-                remaining = resp.headers.get("x-ratelimit-remaining")
-                retry_after = resp.headers.get("retry-after")
-                is_rate_limit = (
-                    remaining == "0"
-                    or retry_after is not None
-                    or "rate limit" in body_lower
-                    or "abuse" in body_lower
-                    or "secondary" in body_lower
-                )
-                if is_rate_limit:
-                    raise HTTPException(
-                        status_code=429,
-                        detail="GitHub API rate limit exceeded",
-                    )
-                raise HTTPException(
-                    status_code=403,
-                    detail="GitHub App permission denied",
-                )
-            if resp.status_code == 429:
-                raise HTTPException(
-                    status_code=429,
-                    detail="GitHub API rate limit exceeded",
-                )
-            if resp.status_code >= 500:
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"GitHub API error: {resp.status_code}",
-                )
-            if resp.status_code != 200:
-                raise HTTPException(
-                    status_code=502,
-                    detail=f"GitHub API error: {resp.status_code}",
-                )
-            data = resp.json()
-            page_repos = data.get("repositories", [])
-            if not page_repos:
-                break
-            for r in page_repos:
-                if pattern and not fnmatch.fnmatch(
-                    (r.get("full_name") or "").lower(), pattern.lower()
-                ):
-                    continue
-                repos.append(
-                    Repository(
-                        id=r["id"],
-                        name=r["name"],
-                        full_name=r["full_name"],
-                        default_branch=r.get("default_branch") or "main",
-                        description=r.get("description"),
-                        url=r.get("html_url") or "",
-                    )
-                )
-                if len(repos) >= max_repos:
-                    return repos
-            if len(page_repos) < per_page:
-                break
-            page += 1
-
-    return repos
+    _validated_github_base_url(base_url)
+    client = await _github_repo_list_client(github_credentials)
+    try:
+        return await client.list_installation_repositories(
+            search=search,
+            max_repos=max_repos,
+        )
+    except AuthenticationException as exc:
+        raise HTTPException(status_code=401, detail=str(exc)) from exc
+    except RateLimitException as exc:
+        raise HTTPException(status_code=429, detail=str(exc)) from exc
+    except APIException as exc:
+        raise HTTPException(status_code=502, detail=str(exc)) from exc
+    finally:
+        client.drain_usage_observations()
+        await client.close()
 
 
 def _list_gitlab_membership_repos(

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -51,7 +51,6 @@ from dev_health_ops.processors.testops_ingest import (
     ingest_report_members,
 )
 from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
-from dev_health_ops.providers.github.code_client import GitHubCodeClient
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.providers.usage import drain_provider_usage
 from dev_health_ops.utils import (
@@ -73,6 +72,10 @@ if TYPE_CHECKING:
     )
     from dev_health_ops.connectors.models import Repository
     from dev_health_ops.connectors.utils import RateLimitConfig, RateLimitGate
+    from dev_health_ops.providers.github.code_client import (
+        GitHubCodeClient,
+        GitHubRepositoryData,
+    )
 elif CONNECTORS_AVAILABLE:
     from github import RateLimitExceededException
 
@@ -100,11 +103,41 @@ else:
 # --- GitHub Sync Helpers ---
 
 
-def _fetch_github_repo_info_sync(connector, owner, repo_name):
-    """Sync helper to fetch GitHub repository info."""
-    gh_repo = connector.github.get_repo(f"{owner}/{repo_name}")
-    _ = gh_repo.id
-    return gh_repo
+def _repository_from_code_repo(repo: "GitHubRepositoryData") -> Repository:
+    return Repository(
+        id=repo.id,
+        name=repo.name,
+        full_name=repo.full_name,
+        default_branch=repo.default_branch,
+        description=repo.description,
+        url=repo.url,
+        created_at=repo.created_at,
+        updated_at=repo.updated_at,
+        language=repo.language,
+        stars=repo.stars,
+        forks=repo.forks,
+    )
+
+
+async def _fetch_github_repo_info_async(
+    connector,
+    owner: str,
+    repo_name: str,
+    usage_sink: list[dict[str, Any]] | None = None,
+) -> Repository:
+    client = _github_code_client_from_connector(connector)
+    try:
+        return _repository_from_code_repo(await client.get_repo(owner, repo_name))
+    finally:
+        observations = client.drain_usage_observations()
+        await client.close()
+        if usage_sink is not None:
+            usage_sink.extend(observations)
+        elif observations:
+            logging.debug(
+                "_fetch_github_repo_info_async: drained %d repo usage observations",
+                len(observations),
+            )
 
 
 def _github_commit_to_model(commit: Any, repo_id: Any) -> GitCommit:
@@ -491,7 +524,7 @@ async def _fetch_github_incidents_async(
             )
 
 
-def _github_code_client_from_connector(connector) -> GitHubCodeClient:
+def _github_code_client_from_connector(connector) -> "GitHubCodeClient":
     """Build a ``GitHubCodeClient`` from an already-authenticated connector.
 
     Mirrors ``_github_work_client_from_connector`` (below): the connector has
@@ -504,7 +537,47 @@ def _github_code_client_from_connector(connector) -> GitHubCodeClient:
     raw_base_url = rest_base_url() if callable(rest_base_url) else None
     base_url = raw_base_url if isinstance(raw_base_url, str) else None
     token = getattr(connector, "token", None)
+    from dev_health_ops.providers.github.code_client import GitHubCodeClient
+
     return GitHubCodeClient(auth=GitHubAuth(token=token, base_url=base_url))
+
+
+async def _list_github_repositories_for_batch(
+    connector,
+    *,
+    org_name: str | None,
+    user_name: str | None,
+    pattern: str | None,
+    max_repos: int | None,
+    usage_sink: list[dict[str, Any]] | None,
+) -> list[Repository]:
+    effective_org = org_name
+    effective_user = user_name
+    if not org_name and not user_name and pattern and "/" in pattern:
+        owner_part = pattern.split("/", 1)[0]
+        if owner_part and "*" not in owner_part and "?" not in owner_part:
+            effective_user = owner_part
+            logging.info("Extracted owner '%s' from pattern '%s'", owner_part, pattern)
+
+    client = _github_code_client_from_connector(connector)
+    try:
+        repos = await client.list_repositories(
+            org_name=effective_org,
+            user_name=effective_user,
+            pattern=pattern,
+            max_repos=max_repos,
+        )
+        return [_repository_from_code_repo(repo) for repo in repos]
+    finally:
+        observations = client.drain_usage_observations()
+        await client.close()
+        if usage_sink is not None:
+            usage_sink.extend(observations)
+        elif observations:
+            logging.debug(
+                "_list_github_repositories_for_batch: drained %d repo usage observations",
+                len(observations),
+            )
 
 
 async def _fetch_github_security_alerts_async(
@@ -1765,25 +1838,11 @@ async def process_github_repo(
         with connector:
             # 1. Fetch Repo Info
             logging.info("Fetching repository information...")
-            gh_repo = await loop.run_in_executor(
-                None, _fetch_github_repo_info_sync, connector, owner, repo_name
+            repo_info = await _fetch_github_repo_info_async(
+                connector, owner, repo_name, usage_sink=usage_sink
             )
 
             # Create/Insert Repo
-            repo_info = Repository(
-                id=gh_repo.id,
-                name=gh_repo.name,
-                full_name=gh_repo.full_name,
-                default_branch=gh_repo.default_branch,
-                description=gh_repo.description,
-                url=gh_repo.html_url,
-                created_at=gh_repo.created_at,
-                updated_at=gh_repo.updated_at,
-                language=gh_repo.language,
-                stars=gh_repo.stargazers_count,
-                forks=gh_repo.forks_count,
-            )
-
             db_repo = Repo(
                 repo_path=None,
                 repo=repo_info.full_name,
@@ -1892,6 +1951,7 @@ async def process_github_repo(
                     logging.info("Stored %d workflow runs", len(pipeline_runs))
 
             if sync_tests:
+                gh_repo = connector.github.get_repo(repo_info.full_name)
                 await _sync_github_test_reports(
                     connector=connector,
                     gh_repo=gh_repo,
@@ -1962,6 +2022,7 @@ async def process_github_repo(
             # 5. Fetch Blame (Optional & Stubbed)
             if fetch_blame:
                 logging.info("Fetching blame data (file list) from GitHub...")
+                gh_repo = connector.github.get_repo(repo_info.full_name)
                 await loop.run_in_executor(
                     None, _fetch_github_blame_sync, gh_repo, db_repo.id
                 )
@@ -2065,9 +2126,6 @@ async def process_github_repos_batch(
     # Track results for summary and incremental storage
     all_results: list[BatchResult] = []
     stored_count = 0
-
-    results_queue: asyncio.Queue | None = None
-    _queue_sentinel = object()
 
     async def store_result(result: BatchResult) -> None:
         """Store a single result in the database (upsert)."""
@@ -2382,118 +2440,41 @@ async def process_github_repos_batch(
                 f"  ✗ Failed: {result.repository.full_name}: {result.error}"
             )
 
-        if results_queue is not None:
-            try:
-                running_loop = asyncio.get_running_loop()
-            except RuntimeError:
-                running_loop = None
-
-            def _enqueue() -> None:
-                assert results_queue is not None
-                try:
-                    results_queue.put_nowait(result)
-                except asyncio.QueueFull:
-                    asyncio.create_task(results_queue.put(result))
-
-            if running_loop is loop:
-                _enqueue()
-            else:
-                loop.call_soon_threadsafe(_enqueue)
-
     try:
         with connector:
-            if sync_git:
-                results_queue = asyncio.Queue(maxsize=max(1, max_concurrent * 2))
+            repos = await _list_github_repositories_for_batch(
+                connector,
+                org_name=org_name,
+                user_name=user_name,
+                pattern=pattern,
+                max_repos=max_repos,
+                usage_sink=usage_sink,
+            )
+            semaphore = asyncio.Semaphore(max(1, max_concurrent))
 
-                async def _consume_results() -> None:
-                    assert results_queue is not None
-                    while True:
-                        item = await results_queue.get()
-                        try:
-                            if item is _queue_sentinel:
-                                return
-                            await store_result(item)
-                        finally:
-                            results_queue.task_done()
-
-                consumer_task = asyncio.create_task(_consume_results())
-
-                if use_async:
-                    await connector.get_repos_with_stats_async(
-                        org_name=org_name,
-                        user_name=user_name,
-                        pattern=pattern,
-                        batch_size=batch_size,
-                        max_concurrent=max_concurrent,
-                        rate_limit_delay=rate_limit_delay,
-                        max_commits_per_repo=max_commits_per_repo,
-                        max_repos=max_repos,
-                        on_repo_complete=on_repo_complete,
+            async def _process_repo(repo_info) -> None:
+                async with semaphore:
+                    result = BatchResult(
+                        repository=repo_info,
+                        stats=None,
+                        success=True,
                     )
-                else:
-                    await loop.run_in_executor(
-                        None,
-                        lambda: connector.get_repos_with_stats(
-                            org_name=org_name,
-                            user_name=user_name,
-                            pattern=pattern,
-                            batch_size=batch_size,
-                            max_concurrent=max_concurrent,
-                            rate_limit_delay=rate_limit_delay,
-                            max_commits_per_repo=max_commits_per_repo,
-                            max_repos=max_repos,
-                            on_repo_complete=on_repo_complete,
-                        ),
-                    )
-
-                # Wait for the queue to drain, but bail out if the consumer dies
-                # first: store_result may propagate a RateLimitException, leaving
-                # un-task_done()'d items so results_queue.join() would hang forever.
-                # FIRST_COMPLETED lets us detect that and re-raise instead.
-                join_task = asyncio.create_task(results_queue.join())
-                done, _pending = await asyncio.wait(
-                    {join_task, consumer_task}, return_when=asyncio.FIRST_COMPLETED
-                )
-                if consumer_task in done:
-                    join_task.cancel()
                     try:
-                        await join_task
-                    except asyncio.CancelledError:
-                        pass
-                    await consumer_task  # re-raises the consumer's exception
-                await results_queue.put(_queue_sentinel)
-                await consumer_task
-            else:
-                repos = await loop.run_in_executor(
-                    None,
-                    lambda: connector.list_repositories(
-                        org_name=org_name,
-                        user_name=user_name,
-                        pattern=pattern,
-                        max_repos=max_repos,
-                    ),
-                )
-                semaphore = asyncio.Semaphore(max(1, max_concurrent))
-
-                async def _process_repo(repo_info) -> None:
-                    async with semaphore:
+                        await store_result(result)
+                    except (RateLimitException, RateLimitExceededException):
+                        raise
+                    except Exception as e:
                         result = BatchResult(
                             repository=repo_info,
                             stats=None,
-                            success=True,
+                            error=str(e),
+                            success=False,
                         )
-                        try:
-                            await store_result(result)
-                        except Exception as e:
-                            result = BatchResult(
-                                repository=repo_info,
-                                stats=None,
-                                error=str(e),
-                                success=False,
-                            )
-                        on_repo_complete(result)
+                    on_repo_complete(result)
 
-                tasks = [asyncio.create_task(_process_repo(repo)) for repo in repos]
+            for batch_start in range(0, len(repos), max(1, batch_size)):
+                batch = repos[batch_start : batch_start + max(1, batch_size)]
+                tasks = [asyncio.create_task(_process_repo(repo)) for repo in batch]
                 if tasks:
                     await asyncio.gather(*tasks)
 

--- a/src/dev_health_ops/providers/github/budget.py
+++ b/src/dev_health_ops/providers/github/budget.py
@@ -345,8 +345,8 @@ def _fallback_credential_scope(
 # secondary-limit signal on success responses (an abstract reservation, like
 # `work_item_prs`' SECONDARY_ABUSE_RISK sibling), so its marker stays empty.
 #
-# `git` (REST_CORE), `commit_stats` (REST_CORE), `security` (REST_CORE), and
-# deployments REST_CORE now fetch through
+# `repo` (REST_CORE), `git` (REST_CORE), `commit_stats` (REST_CORE), `security`
+# (REST_CORE), and deployments REST_CORE now fetch through
 # `providers/github/code_client.py::GitHubCodeClient`, labeling operations
 # with explicit family prefixes so CS1's resolver short-circuit resolves them
 # directly. `commit_stats` CONTENTS_BLOB and deployments CONTENTS_BLOB remain
@@ -364,13 +364,14 @@ def _fallback_credential_scope(
 # label resolve to the instrumented dimension instead of the still-frozen
 # REST_CORE one (the repository tree listing that discovers candidate paths
 # stays on the frozen PyGithub connector, uninstrumented, out of CS7 scope).
-# `prs` REST_CORE and the processor's incident-label issue fetches (CHAOS-2809/
-# CS8) now share the same `GitHubCodeClient` REST core as git/commit_stats and
-# emit explicit `prs:`/`incidents:` labels. `incidents` is a resolver-only
-# actuals family: the estimator constants remain frozen, and incident issue
-# traffic is attached to observed actuals without adding a new planned estimate.
+# `repo` REST_CORE (metadata/listing), `prs` REST_CORE, and the processor's
+# incident-label issue fetches now share the same `GitHubCodeClient` REST core as
+# git/commit_stats and emit explicit `repo:`/`prs:`/`incidents:` labels.
+# `incidents` is a resolver-only actuals family: the estimator constants remain
+# frozen, and incident issue traffic is attached to observed actuals without
+# adding a new planned estimate.
 GITHUB_USAGE_ROUTE_FAMILIES: tuple[UsageRouteFamily, ...] = (
-    UsageRouteFamily("repo", BudgetDimension.REST_CORE),
+    UsageRouteFamily("repo", BudgetDimension.REST_CORE, operation_markers=("repo:",)),
     UsageRouteFamily("git", BudgetDimension.REST_CORE, operation_markers=("git:",)),
     UsageRouteFamily(
         "commit_stats", BudgetDimension.REST_CORE, operation_markers=("commit_stats:",)

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -24,6 +24,7 @@ import urllib.parse
 from collections.abc import Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime
+from fnmatch import fnmatchcase
 from math import ceil
 from typing import Any
 
@@ -74,6 +75,7 @@ FILES_ROUTE_FAMILY = "files"
 BLAME_ROUTE_FAMILY = "blame"
 PRS_ROUTE_FAMILY = "prs"
 INCIDENTS_ROUTE_FAMILY = "incidents"
+REPO_ROUTE_FAMILY = "repo"
 _GITHUB_DEPLOYMENTS_PER_PAGE = 100
 
 
@@ -155,6 +157,21 @@ class GitHubIssueData:
     state: str | None
     created_at: datetime | None
     closed_at: datetime | None
+
+
+@dataclass(frozen=True)
+class GitHubRepositoryData:
+    id: int
+    name: str
+    full_name: str
+    default_branch: str
+    description: str | None = None
+    url: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    language: str | None = None
+    stars: int = 0
+    forks: int = 0
 
 
 def _lowered_github_headers(response: httpx.Response) -> dict[str, str]:
@@ -484,6 +501,30 @@ def _issue_from_item(item: Mapping[str, Any]) -> GitHubIssueData:
     )
 
 
+def _repo_from_item(item: Mapping[str, Any]) -> GitHubRepositoryData:
+    return GitHubRepositoryData(
+        id=_int_or_zero(item.get("id")),
+        name=str(item.get("name") or ""),
+        full_name=str(item.get("full_name") or ""),
+        default_branch=str(item.get("default_branch") or "main"),
+        description=str(item["description"])
+        if item.get("description") is not None
+        else None,
+        url=str(item.get("html_url") or item.get("url") or ""),
+        created_at=_parse_alert_datetime(item.get("created_at")),
+        updated_at=_parse_alert_datetime(item.get("updated_at")),
+        language=str(item["language"]) if item.get("language") is not None else None,
+        stars=_int_or_zero(item.get("stargazers_count")),
+        forks=_int_or_zero(item.get("forks_count")),
+    )
+
+
+def _matches_repo_pattern(full_name: str, pattern: str | None) -> bool:
+    if pattern is None:
+        return True
+    return fnmatchcase(full_name.lower(), pattern.lower())
+
+
 def _pull_request_merged_at(item: Mapping[str, Any]) -> datetime | None:
     return _parse_alert_datetime(item.get("merged_at"))
 
@@ -563,6 +604,148 @@ class GitHubCodeClient:
             is_retryable_status=_github_is_retryable_status,
             transport=transport,
         )
+
+    async def get_repo(self, owner: str, repo: str) -> GitHubRepositoryData:
+        operation = f"{REPO_ROUTE_FAMILY}:GET /repos/{owner}/{repo}"
+        response = await self._core.request(
+            "GET",
+            _repo_path(owner, repo),
+            operation=operation,
+        )
+        payload = response.json()
+        if not isinstance(payload, Mapping):
+            raise APIException(
+                f"Unexpected repository response for {operation}: {type(payload)!r}"
+            )
+        return _repo_from_item(payload)
+
+    async def list_repositories(
+        self,
+        *,
+        org_name: str | None = None,
+        user_name: str | None = None,
+        search: str | None = None,
+        pattern: str | None = None,
+        max_repos: int | None = None,
+    ) -> list[GitHubRepositoryData]:
+        if search:
+            return await self._search_repositories(
+                org_name=org_name,
+                user_name=user_name,
+                search=search,
+                pattern=pattern,
+                max_repos=max_repos,
+            )
+
+        if org_name:
+            encoded_org = urllib.parse.quote(str(org_name), safe="")
+            path = f"/orgs/{encoded_org}/repos"
+            operation = f"{REPO_ROUTE_FAMILY}:GET /orgs/{org_name}/repos"
+        elif user_name:
+            encoded_user = urllib.parse.quote(str(user_name), safe="")
+            path = f"/users/{encoded_user}/repos"
+            operation = f"{REPO_ROUTE_FAMILY}:GET /users/{user_name}/repos"
+        else:
+            path = "/user/repos"
+            operation = f"{REPO_ROUTE_FAMILY}:GET /user/repos"
+
+        return await self._list_repo_page_payloads(
+            path=path,
+            operation=operation,
+            data_key=None,
+            pattern=pattern,
+            max_repos=max_repos,
+        )
+
+    async def list_installation_repositories(
+        self,
+        *,
+        search: str | None = None,
+        max_repos: int | None = None,
+    ) -> list[GitHubRepositoryData]:
+        pattern = f"*{search}*" if search else None
+        return await self._list_repo_page_payloads(
+            path="/installation/repositories",
+            operation=f"{REPO_ROUTE_FAMILY}:GET /installation/repositories",
+            data_key="repositories",
+            pattern=pattern,
+            max_repos=max_repos,
+        )
+
+    async def _search_repositories(
+        self,
+        *,
+        org_name: str | None,
+        user_name: str | None,
+        search: str,
+        pattern: str | None,
+        max_repos: int | None,
+    ) -> list[GitHubRepositoryData]:
+        query_parts = [search]
+        if org_name:
+            query_parts.append(f"org:{org_name}")
+        elif user_name:
+            query_parts.append(f"user:{user_name}")
+        return await self._list_repo_page_payloads(
+            path="/search/repositories",
+            operation=f"{REPO_ROUTE_FAMILY}:GET /search/repositories",
+            params={"q": " ".join(query_parts)},
+            data_key="items",
+            pattern=pattern,
+            max_repos=max_repos,
+        )
+
+    async def _list_repo_page_payloads(
+        self,
+        *,
+        path: str,
+        operation: str,
+        data_key: str | None,
+        pattern: str | None,
+        max_repos: int | None,
+        params: dict[str, Any] | None = None,
+    ) -> list[GitHubRepositoryData]:
+        request_params: dict[str, Any] = {"per_page": _GITHUB_DEPLOYMENTS_PER_PAGE}
+        if params:
+            request_params.update(params)
+        repos: list[GitHubRepositoryData] = []
+        next_url: str | None = path
+        next_params: dict[str, Any] | None = request_params
+        pages = 0
+        max_pages = 100
+        while next_url is not None:
+            if pages >= max_pages:
+                logger.warning(
+                    "%s pagination hit the %d-page cap for %s",
+                    "github",
+                    max_pages,
+                    operation,
+                )
+                break
+            response = await self._core.request(
+                "GET",
+                next_url,
+                operation=operation,
+                params=next_params,
+            )
+            pages += 1
+            payload = response.json()
+            page_items = payload.get(data_key, []) if data_key else payload
+            if not isinstance(page_items, list):
+                raise APIException(
+                    f"Unexpected paginated response for {operation}: {type(page_items)!r}"
+                )
+            for item in page_items:
+                if not isinstance(item, Mapping):
+                    continue
+                if not _matches_repo_pattern(str(item.get("full_name") or ""), pattern):
+                    continue
+                repos.append(_repo_from_item(item))
+                if max_repos is not None and len(repos) >= max_repos:
+                    return repos
+            next_url = response.links.get("next", {}).get("url")
+            next_params = None
+        return repos
 
     async def get_dependabot_alerts(
         self,
@@ -1092,12 +1275,14 @@ __all__ = [
     "FILES_ROUTE_FAMILY",
     "GIT_ROUTE_FAMILY",
     "INCIDENTS_ROUTE_FAMILY",
+    "REPO_ROUTE_FAMILY",
     "GitHubCodeClient",
     "GitHubCommitData",
     "GitHubCommitFileStatData",
     "GitHubDeploymentData",
     "GitHubIssueData",
     "GitHubPullData",
+    "GitHubRepositoryData",
     "GitHubWorkflowRunData",
     "GitHubReleaseData",
     "PRS_ROUTE_FAMILY",

--- a/tests/api/admin/test_credential_repos.py
+++ b/tests/api/admin/test_credential_repos.py
@@ -29,6 +29,7 @@ from dev_health_ops.connectors.exceptions import (
     RateLimitException,
 )
 from dev_health_ops.connectors.models import Repository
+from dev_health_ops.exceptions import APIException
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import IntegrationCredential
@@ -181,6 +182,9 @@ _FAKE_REPOS = [
 
 _DECRYPT_PATCH = "dev_health_ops.api.services.configuration.IntegrationCredentialsService.get_decrypted_credentials_by_id"
 _GH_CONNECTOR = "dev_health_ops.connectors.github.GitHubConnector"
+_GH_REPO_CLIENT = (
+    "dev_health_ops.api.admin.routers.credentials._github_repo_list_client"
+)
 _GL_CONNECTOR = "dev_health_ops.connectors.gitlab.GitLabConnector"
 _GH_APP_PROVIDER = "dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider"
 _GL_MEMBERSHIP_HELPER = (
@@ -196,6 +200,31 @@ def _mock_credential(provider="github", config=None, credentials=None):
     return credentials or {"token": "ghp_fake123"}, cred
 
 
+class _FakeGithubRepoClient:
+    def __init__(self, repos=None, exc=None):
+        self.repos = list(_FAKE_REPOS if repos is None else repos)
+        self.exc = exc
+        self.calls = []
+
+    async def list_repositories(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.exc is not None:
+            raise self.exc
+        return list(self.repos)
+
+    async def list_installation_repositories(self, **kwargs):
+        self.calls.append(kwargs)
+        if self.exc is not None:
+            raise self.exc
+        return list(self.repos)
+
+    def drain_usage_observations(self):
+        return []
+
+    async def close(self):
+        return None
+
+
 # ---------------------------------------------------------------------------
 # Tests — Happy path
 # ---------------------------------------------------------------------------
@@ -203,15 +232,13 @@ def _mock_credential(provider="github", config=None, credentials=None):
 
 @pytest.mark.asyncio
 async def test_list_repos_success(client):
-    """Connector returns repos → 200 with DiscoveredReposResponse."""
     ac, state = client
+    fake_client = _FakeGithubRepoClient()
 
     with (
         patch(_DECRYPT_PATCH, return_value=_mock_credential()) as _,
-        patch(_GH_CONNECTOR) as MockConnector,
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockConnector.return_value.list_repositories.return_value = _FAKE_REPOS
-
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             params={"owner": "my-org"},
@@ -228,6 +255,7 @@ async def test_list_repos_success(client):
 @pytest.mark.asyncio
 async def test_list_repos_accepts_github_app_credentials(client):
     ac, state = client
+    fake_client = _FakeGithubRepoClient()
     app_credentials = {
         "app_id": "12345",
         "private_key": "not-a-real-github-app-private-key",
@@ -239,10 +267,8 @@ async def test_list_repos_accepts_github_app_credentials(client):
             _DECRYPT_PATCH,
             return_value=_mock_credential(credentials=app_credentials),
         ),
-        patch(_GH_CONNECTOR) as MockConnector,
+        patch(_GH_REPO_CLIENT, return_value=fake_client) as MockRepoClient,
     ):
-        MockConnector.return_value.list_repositories.return_value = _FAKE_REPOS
-
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             params={"owner": "my-org"},
@@ -250,9 +276,9 @@ async def test_list_repos_accepts_github_app_credentials(client):
 
     assert resp.status_code == 200
     assert resp.json()["total"] == 2
-    _, kwargs = MockConnector.call_args
-    assert kwargs["credentials"].is_app_auth is True
-    assert kwargs["credentials"].installation_id == "67890"
+    passed_credentials = MockRepoClient.call_args.args[0]
+    assert passed_credentials.is_app_auth is True
+    assert passed_credentials.installation_id == "67890"
 
 
 @pytest.mark.asyncio
@@ -303,17 +329,15 @@ async def test_github_app_test_connection_accepts_camel_case_fields():
 
 @pytest.mark.asyncio
 async def test_not_found_returns_empty_list(client):
-    """NotFoundException (invalid/partial org name) → 200 with empty repos."""
     ac, state = client
+    fake_client = _FakeGithubRepoClient(
+        exc=NotFoundException("GitHub resource not found (404)")
+    )
 
     with (
         patch(_DECRYPT_PATCH, return_value=_mock_credential()) as _,
-        patch(_GH_CONNECTOR) as MockConnector,
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockConnector.return_value.list_repositories.side_effect = NotFoundException(
-            "GitHub resource not found (404)"
-        )
-
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             params={"owner": "full-"},
@@ -328,17 +352,13 @@ async def test_not_found_returns_empty_list(client):
 
 @pytest.mark.asyncio
 async def test_auth_exception_returns_401(client):
-    """AuthenticationException (bad/revoked token) → HTTP 401."""
     ac, state = client
+    fake_client = _FakeGithubRepoClient(exc=AuthenticationException("Bad credentials"))
 
     with (
         patch(_DECRYPT_PATCH, return_value=_mock_credential()) as _,
-        patch(_GH_CONNECTOR) as MockConnector,
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockConnector.return_value.list_repositories.side_effect = (
-            AuthenticationException("Bad credentials")
-        )
-
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             params={"owner": "my-org"},
@@ -350,17 +370,15 @@ async def test_auth_exception_returns_401(client):
 
 @pytest.mark.asyncio
 async def test_rate_limit_returns_429(client):
-    """RateLimitException (GitHub API rate limit) → HTTP 429."""
     ac, state = client
+    fake_client = _FakeGithubRepoClient(
+        exc=RateLimitException("API rate limit exceeded")
+    )
 
     with (
         patch(_DECRYPT_PATCH, return_value=_mock_credential()) as _,
-        patch(_GH_CONNECTOR) as MockConnector,
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockConnector.return_value.list_repositories.side_effect = RateLimitException(
-            "API rate limit exceeded"
-        )
-
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             params={"owner": "my-org"},
@@ -382,15 +400,15 @@ async def test_no_owner_github_enumerates_token_wide(client):
     CHAOS-2449: previously returned empty list; now enumerates all accessible repos.
     """
     ac, state = client
+    fake_client = _FakeGithubRepoClient()
 
     with (
         patch(
             _DECRYPT_PATCH,
             return_value=_mock_credential(config={}),  # no org in config
         ) as _,
-        patch(_GH_CONNECTOR) as MockConnector,
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockConnector.return_value.list_repositories.return_value = _FAKE_REPOS
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             # no owner query param
@@ -400,23 +418,21 @@ async def test_no_owner_github_enumerates_token_wide(client):
     body = resp.json()
     assert body["total"] == 2
     assert body["repos"][0]["name"] == "api-gateway"
-    # Connector must be called without org_name (None → token-wide)
-    MockConnector.return_value.list_repositories.assert_called_once_with(
-        org_name=None, search=None, max_repos=100
-    )
+    assert fake_client.calls == [
+        {"org_name": None, "search": None, "pattern": None, "max_repos": 100}
+    ]
 
 
 @pytest.mark.asyncio
 async def test_owner_falls_back_to_config_org(client):
     """When owner param is missing, uses config.org from credential."""
     ac, state = client
+    fake_client = _FakeGithubRepoClient()
 
     with (
         patch(_DECRYPT_PATCH, return_value=_mock_credential()) as _,
-        patch(_GH_CONNECTOR) as MockConnector,
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockConnector.return_value.list_repositories.return_value = _FAKE_REPOS
-
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             # no owner param — should fall back to config["org"] = "my-org"
@@ -424,9 +440,9 @@ async def test_owner_falls_back_to_config_org(client):
 
     assert resp.status_code == 200
     assert resp.json()["total"] == 2
-    MockConnector.return_value.list_repositories.assert_called_once_with(
-        org_name="my-org", search=None, max_repos=100
-    )
+    assert fake_client.calls == [
+        {"org_name": "my-org", "search": None, "pattern": None, "max_repos": 100}
+    ]
 
 
 @pytest.mark.asyncio
@@ -490,30 +506,24 @@ async def test_no_owner_github_search_uses_pattern_not_global_search(client):
     Fix: enumerate token-wide repos and apply search as a pattern filter.
     """
     ac, state = client
+    fake_client = _FakeGithubRepoClient()
 
     with (
         patch(
             _DECRYPT_PATCH,
             return_value=_mock_credential(config={}),  # no org in config
         ) as _,
-        patch(_GH_CONNECTOR) as MockConnector,
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockConnector.return_value.list_repositories.return_value = _FAKE_REPOS
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             params={"search": "api"},  # search but no owner
         )
 
     assert resp.status_code == 200
-    # Must NOT have called search_repositories (global search)
-    MockConnector.return_value.search_repositories = MagicMock()
-    MockConnector.return_value.search_repositories.assert_not_called()
-    # Must have called list_repositories with pattern= (client-side filter), search=None
-    call_kwargs = MockConnector.return_value.list_repositories.call_args
-    assert call_kwargs is not None
-    assert call_kwargs.kwargs.get("search") is None or call_kwargs.args[1:2] == ()
-    assert call_kwargs.kwargs.get("pattern") == "*api*"
-    assert call_kwargs.kwargs.get("org_name") is None
+    assert fake_client.calls == [
+        {"org_name": None, "search": None, "pattern": "*api*", "max_repos": 100}
+    ]
 
 
 @pytest.mark.asyncio
@@ -530,34 +540,18 @@ async def test_no_owner_github_app_uses_installation_repos(client):
         "private_key": "not-a-real-github-app-private-key",
         "installation_id": "67890",
     }
-
-    class _FakeResp:
-        status_code = 200
-
-        def json(self):
-            return {
-                "repositories": [
-                    {
-                        "id": 1,
-                        "name": "install-repo",
-                        "full_name": "org/install-repo",
-                        "default_branch": "main",
-                        "description": "Installation repo",
-                        "html_url": "https://github.com/org/install-repo",
-                    }
-                ],
-                "total_count": 1,
-            }
-
-    class _FakeAsyncClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def get(self, *args, **kwargs):
-            return _FakeResp()
+    fake_client = _FakeGithubRepoClient(
+        repos=[
+            Repository(
+                id=1,
+                name="install-repo",
+                full_name="org/install-repo",
+                default_branch="main",
+                description="Installation repo",
+                url="https://github.com/org/install-repo",
+            )
+        ]
+    )
 
     with (
         patch(
@@ -565,10 +559,8 @@ async def test_no_owner_github_app_uses_installation_repos(client):
             return_value=_mock_credential(config={}, credentials=app_credentials),
         ) as _,
         patch(_GH_CONNECTOR) as MockConnector,
-        patch(_GH_APP_PROVIDER) as MockProvider,
-        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockProvider.return_value.get_token.return_value = "ghs_installation_token"
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
             # no owner — App auth blank-owner path
@@ -578,9 +570,8 @@ async def test_no_owner_github_app_uses_installation_repos(client):
     body = resp.json()
     assert body["total"] == 1
     assert body["repos"][0]["name"] == "install-repo"
-    # The connector's list_repositories must NOT have been called
-    # (we bypass it for App auth + blank owner)
     MockConnector.return_value.list_repositories.assert_not_called()
+    assert fake_client.calls == [{"search": None, "max_repos": 100}]
 
 
 @pytest.mark.asyncio
@@ -703,31 +694,15 @@ async def test_gitlab_base_url_key_used_for_self_hosted(client):
 
 @pytest.mark.asyncio
 async def test_github_app_installation_401_raises_auth_error(client):
-    """App installation helper: 401 response → HTTP 401, not a silent empty list."""
     ac, state = client
     app_credentials = {
         "app_id": "12345",
         "private_key": "not-a-real-github-app-private-key",
         "installation_id": "67890",
     }
-
-    class _FakeResp:
-        status_code = 401
-        text = "Bad credentials"
-        headers: dict = {}
-
-        def json(self):
-            return {"message": "Bad credentials"}
-
-    class _FakeAsyncClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def get(self, *args, **kwargs):
-            return _FakeResp()
+    fake_client = _FakeGithubRepoClient(
+        exc=AuthenticationException("GitHub App authentication failed")
+    )
 
     with (
         patch(
@@ -735,10 +710,8 @@ async def test_github_app_installation_401_raises_auth_error(client):
             return_value=_mock_credential(config={}, credentials=app_credentials),
         ) as _,
         patch(_GH_CONNECTOR),
-        patch(_GH_APP_PROVIDER) as MockProvider,
-        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockProvider.return_value.get_token.return_value = "ghs_bad_token"
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
         )
@@ -749,31 +722,13 @@ async def test_github_app_installation_401_raises_auth_error(client):
 
 @pytest.mark.asyncio
 async def test_github_app_installation_429_raises_rate_limit(client):
-    """App installation helper: 429 response → HTTP 429, not a silent empty list."""
     ac, state = client
     app_credentials = {
         "app_id": "12345",
         "private_key": "not-a-real-github-app-private-key",
         "installation_id": "67890",
     }
-
-    class _FakeResp:
-        status_code = 429
-        text = "rate limit exceeded"
-        headers: dict = {}
-
-        def json(self):
-            return {"message": "rate limit exceeded"}
-
-    class _FakeAsyncClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def get(self, *args, **kwargs):
-            return _FakeResp()
+    fake_client = _FakeGithubRepoClient(exc=RateLimitException("rate limit exceeded"))
 
     with (
         patch(
@@ -781,10 +736,8 @@ async def test_github_app_installation_429_raises_rate_limit(client):
             return_value=_mock_credential(config={}, credentials=app_credentials),
         ) as _,
         patch(_GH_CONNECTOR),
-        patch(_GH_APP_PROVIDER) as MockProvider,
-        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockProvider.return_value.get_token.return_value = "ghs_token"
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
         )
@@ -795,31 +748,13 @@ async def test_github_app_installation_429_raises_rate_limit(client):
 
 @pytest.mark.asyncio
 async def test_github_app_installation_5xx_raises_502(client):
-    """App installation helper: 5xx response → HTTP 502, not a silent empty list."""
     ac, state = client
     app_credentials = {
         "app_id": "12345",
         "private_key": "not-a-real-github-app-private-key",
         "installation_id": "67890",
     }
-
-    class _FakeResp:
-        status_code = 503
-        text = "Service Unavailable"
-        headers: dict = {}
-
-        def json(self):
-            return {}
-
-    class _FakeAsyncClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def get(self, *args, **kwargs):
-            return _FakeResp()
+    fake_client = _FakeGithubRepoClient(exc=APIException("GitHub API error: 503"))
 
     with (
         patch(
@@ -827,10 +762,8 @@ async def test_github_app_installation_5xx_raises_502(client):
             return_value=_mock_credential(config={}, credentials=app_credentials),
         ) as _,
         patch(_GH_CONNECTOR),
-        patch(_GH_APP_PROVIDER) as MockProvider,
-        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockProvider.return_value.get_token.return_value = "ghs_token"
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
         )
@@ -958,24 +891,9 @@ async def test_github_app_403_permission_not_rate_limit(client):
         "private_key": "not-a-real-github-app-private-key",
         "installation_id": "67890",
     }
-
-    class _FakeResp:
-        status_code = 403
-        text = "Resource not accessible by integration"
-        headers = {"x-ratelimit-remaining": "4999"}
-
-        def json(self):
-            return {"message": "Resource not accessible by integration"}
-
-    class _FakeAsyncClient:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *args):
-            return None
-
-        async def get(self, *args, **kwargs):
-            return _FakeResp()
+    fake_client = _FakeGithubRepoClient(
+        exc=AuthenticationException("Resource not accessible by integration")
+    )
 
     with (
         patch(
@@ -983,10 +901,8 @@ async def test_github_app_403_permission_not_rate_limit(client):
             return_value=_mock_credential(config={}, credentials=app_credentials),
         ) as _,
         patch(_GH_CONNECTOR),
-        patch(_GH_APP_PROVIDER) as MockProvider,
-        patch("httpx.AsyncClient", return_value=_FakeAsyncClient()),
+        patch(_GH_REPO_CLIENT, return_value=fake_client),
     ):
-        MockProvider.return_value.get_token.return_value = "ghs_token"
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
         )

--- a/tests/providers/test_github_budget.py
+++ b/tests/providers/test_github_budget.py
@@ -78,6 +78,7 @@ def test_github_git_and_commit_stats_actuals_markers_are_live() -> None:
         for family in GITHUB_USAGE_ROUTE_FAMILIES
     }
 
+    assert markers[("repo", BudgetDimension.REST_CORE)] == ("repo:",)
     assert markers[("git", BudgetDimension.REST_CORE)] == ("git:",)
     assert markers[("commit_stats", BudgetDimension.REST_CORE)] == ("commit_stats:",)
     assert markers[("commit_stats", BudgetDimension.CONTENTS_BLOB)] == ()

--- a/tests/providers/test_github_code_client_repos.py
+++ b/tests/providers/test_github_code_client_repos.py
@@ -1,0 +1,278 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+
+import httpx
+
+from dev_health_ops.providers.github.client import GitHubAuth
+from dev_health_ops.providers.github.code_client import GitHubCodeClient
+from dev_health_ops.sync.budget_types import BudgetDimension
+
+
+def _client(transport: httpx.AsyncBaseTransport) -> GitHubCodeClient:
+    return GitHubCodeClient(auth=GitHubAuth(token="unit-test-pat"), transport=transport)
+
+
+def test_get_repo_normalizes_metadata_and_records_repo_usage() -> None:
+    asyncio.run(_test_get_repo_normalizes_metadata_and_records_repo_usage())
+
+
+async def _test_get_repo_normalizes_metadata_and_records_repo_usage() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": "123",
+                "name": "widgets",
+                "full_name": "acme/widgets",
+                "default_branch": "trunk",
+                "description": "Widget service",
+                "html_url": "https://github.com/acme/widgets",
+                "created_at": "2026-01-01T00:00:00Z",
+                "updated_at": "2026-01-02T00:00:00Z",
+                "language": "Python",
+                "stargazers_count": "5",
+                "forks_count": 2,
+            },
+        )
+
+    client = _client(httpx.MockTransport(handler))
+
+    repo = await client.get_repo("acme", "widgets")
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert seen[0].url.path == "/repos/acme/widgets"
+    assert repo.id == 123
+    assert repo.name == "widgets"
+    assert repo.full_name == "acme/widgets"
+    assert repo.default_branch == "trunk"
+    assert repo.url == "https://github.com/acme/widgets"
+    assert repo.created_at == datetime(2026, 1, 1, tzinfo=timezone.utc)
+    assert repo.updated_at == datetime(2026, 1, 2, tzinfo=timezone.utc)
+    assert repo.language == "Python"
+    assert repo.stars == 5
+    assert repo.forks == 2
+    assert len(observations) == 1
+    assert observations[0]["route_family"] == "repo"
+    assert observations[0]["dimension"] == BudgetDimension.REST_CORE.value
+    assert observations[0]["request_count"] == 1
+    assert observations[0]["example_operation"].startswith("repo:")
+
+
+def test_get_repo_percent_encodes_owner_and_repo_path_segments() -> None:
+    asyncio.run(_test_get_repo_percent_encodes_owner_and_repo_path_segments())
+
+
+async def _test_get_repo_percent_encodes_owner_and_repo_path_segments() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "id": 1,
+                "name": "widgets",
+                "full_name": "acme/widgets",
+                "default_branch": "main",
+            },
+        )
+
+    client = _client(httpx.MockTransport(handler))
+
+    await client.get_repo("acme/evil", "widgets?x=1")
+    await client.close()
+
+    assert seen[0].url.raw_path.decode() == "/repos/acme%2Fevil/widgets%3Fx%3D1"
+    assert seen[0].url.params.get("x") is None
+
+
+def test_list_repositories_follows_link_header_applies_pattern_and_records_pages() -> (
+    None
+):
+    asyncio.run(
+        _test_list_repositories_follows_link_header_applies_pattern_and_records_pages()
+    )
+
+
+async def _test_list_repositories_follows_link_header_applies_pattern_and_records_pages() -> (
+    None
+):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if len(seen) == 1:
+            return httpx.Response(
+                200,
+                headers={
+                    "Link": (
+                        '<https://api.github.com/orgs/acme/repos?page=2>; rel="next"'
+                    )
+                },
+                json=[
+                    {
+                        "id": 1,
+                        "name": "api",
+                        "full_name": "acme/api",
+                        "default_branch": "main",
+                    },
+                    {
+                        "id": 2,
+                        "name": "web",
+                        "full_name": "acme/web",
+                        "default_branch": "main",
+                    },
+                ],
+            )
+        return httpx.Response(
+            200,
+            json=[
+                {
+                    "id": 3,
+                    "name": "api-admin",
+                    "full_name": "acme/api-admin",
+                    "default_branch": "main",
+                }
+            ],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+
+    repos = await client.list_repositories(
+        org_name="acme", pattern="*/api*", max_repos=2
+    )
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert [repo.full_name for repo in repos] == ["acme/api", "acme/api-admin"]
+    assert len(seen) == 2
+    assert seen[0].url.path == "/orgs/acme/repos"
+    assert seen[0].url.params["per_page"] == "100"
+    assert observations[0]["route_family"] == "repo"
+    assert observations[0]["request_count"] == 2
+
+
+def test_list_repositories_stops_pagination_when_max_matching_repos_reached() -> None:
+    asyncio.run(
+        _test_list_repositories_stops_pagination_when_max_matching_repos_reached()
+    )
+
+
+async def _test_list_repositories_stops_pagination_when_max_matching_repos_reached() -> (
+    None
+):
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        if len(seen) > 1:
+            raise AssertionError("max_repos should stop before fetching page 2")
+        return httpx.Response(
+            200,
+            headers={
+                "Link": '<https://api.github.com/orgs/acme/repos?page=2>; rel="next"'
+            },
+            json=[
+                {
+                    "id": 1,
+                    "name": "api",
+                    "full_name": "acme/api",
+                    "default_branch": "main",
+                },
+                {
+                    "id": 2,
+                    "name": "web",
+                    "full_name": "acme/web",
+                    "default_branch": "main",
+                },
+                {
+                    "id": 3,
+                    "name": "api-admin",
+                    "full_name": "acme/api-admin",
+                    "default_branch": "main",
+                },
+            ],
+        )
+
+    client = _client(httpx.MockTransport(handler))
+
+    repos = await client.list_repositories(
+        org_name="acme", pattern="*/api*", max_repos=2
+    )
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert [repo.full_name for repo in repos] == ["acme/api", "acme/api-admin"]
+    assert len(seen) == 1
+    assert observations[0]["request_count"] == 1
+
+
+def test_list_repositories_search_uses_scoped_search_and_data_key() -> None:
+    asyncio.run(_test_list_repositories_search_uses_scoped_search_and_data_key())
+
+
+async def _test_list_repositories_search_uses_scoped_search_and_data_key() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "items": [
+                    {
+                        "id": "4",
+                        "name": "api",
+                        "full_name": "acme/api",
+                        "default_branch": "main",
+                    }
+                ]
+            },
+        )
+
+    client = _client(httpx.MockTransport(handler))
+
+    repos = await client.list_repositories(org_name="acme", search="api")
+    await client.close()
+
+    assert [repo.id for repo in repos] == [4]
+    assert seen[0].url.path == "/search/repositories"
+    assert seen[0].url.params["q"] == "api org:acme"
+
+
+def test_list_installation_repositories_uses_installation_endpoint() -> None:
+    asyncio.run(_test_list_installation_repositories_uses_installation_endpoint())
+
+
+async def _test_list_installation_repositories_uses_installation_endpoint() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(
+            200,
+            json={
+                "repositories": [
+                    {
+                        "id": 5,
+                        "name": "install-repo",
+                        "full_name": "acme/install-repo",
+                        "default_branch": "main",
+                    }
+                ]
+            },
+        )
+
+    client = _client(httpx.MockTransport(handler))
+
+    repos = await client.list_installation_repositories(search="install")
+    await client.close()
+
+    assert [repo.full_name for repo in repos] == ["acme/install-repo"]
+    assert seen[0].url.path == "/installation/repositories"

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -80,6 +80,14 @@ def _github_commit_stats_async_from_sync(fake_fetch):
 
 
 class _EmptyGithubPrCodeClient:
+    def __init__(self, repos=None):
+        self._repos = list(repos or [])
+        self.list_repository_calls = []
+
+    async def list_repositories(self, **kwargs):
+        self.list_repository_calls.append(kwargs)
+        return list(self._repos)
+
     async def iter_pulls(self, owner, repo, *, state, sort, direction, since=None):
         return []
 
@@ -91,6 +99,80 @@ class _EmptyGithubPrCodeClient:
 
     async def close(self):
         return None
+
+
+def _repo_client_for(*repos):
+    return _EmptyGithubPrCodeClient(repos)
+
+
+@pytest.mark.asyncio
+async def test_process_github_repos_batch_uses_pattern_owner_for_repo_discovery(
+    monkeypatch,
+):
+    _enable_connector_stubs(monkeypatch)
+
+    inserted_repos = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            inserted_repos.append(repo)
+
+    class DummyConnector:
+        def __init__(self, token: str):
+            self.token = token
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, exc_type, exc, tb):
+            return None
+
+    repo = SimpleNamespace(
+        id=1,
+        name="service",
+        full_name="org/service",
+        default_branch="main",
+        description=None,
+        url="https://github.com/org/service",
+        created_at=None,
+        updated_at=None,
+        language="Python",
+        stars=0,
+        forks=0,
+    )
+    code_client = _repo_client_for(repo)
+
+    monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: code_client,
+    )
+
+    await processors.github.process_github_repos_batch(
+        store=DummyStore(),
+        token="test_token",
+        pattern="org/*",
+        batch_size=1,
+        max_concurrent=1,
+        rate_limit_delay=0,
+        sync_git=False,
+        sync_prs=False,
+        sync_cicd=False,
+        sync_deployments=False,
+        sync_incidents=False,
+        sync_security=False,
+    )
+
+    assert len(inserted_repos) == 1
+    assert code_client.list_repository_calls == [
+        {
+            "org_name": None,
+            "user_name": "org",
+            "pattern": "org/*",
+            "max_repos": None,
+        }
+    ]
 
 
 @pytest.mark.asyncio
@@ -474,7 +556,7 @@ async def test_process_github_repos_batch_upserts_during_async_processing(monkey
     monkeypatch.setattr(
         processors.github,
         "_github_code_client_from_connector",
-        lambda _connector: _EmptyGithubPrCodeClient(),
+        lambda _connector: _repo_client_for(repo),
     )
 
     await processors.github.process_github_repos_batch(
@@ -591,6 +673,11 @@ async def test_process_github_repos_batch_stores_commits_and_stats(monkeypatch):
     )
     monkeypatch.setattr(
         processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _repo_client_for(repo),
+    )
+    monkeypatch.setattr(
+        processors.github,
         "_fetch_github_commits_async",
         _github_commits_async_from_sync(fake_fetch_commits),
     )
@@ -701,6 +788,11 @@ async def test_process_github_repos_batch_over_cap_window_skips_stats(monkeypatc
             self.close()
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _repo_client_for(repo),
+    )
     monkeypatch.setattr(
         processors.github,
         "_fetch_github_commits_async",
@@ -818,6 +910,11 @@ async def test_process_github_repos_batch_truncated_window_skips_stats(monkeypat
             self.close()
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _repo_client_for(repo),
+    )
     monkeypatch.setattr(
         processors.github,
         "_fetch_github_commits_async",
@@ -945,6 +1042,11 @@ async def test_process_github_repos_batch_undersized_window_writes_stats(monkeyp
             self.close()
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _repo_client_for(repo),
+    )
     monkeypatch.setattr(
         processors.github,
         "_fetch_github_commits_async",
@@ -1080,6 +1182,11 @@ async def test_process_github_repos_batch_exact_complete_window_writes_stats(
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
         processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _repo_client_for(repo),
+    )
+    monkeypatch.setattr(
+        processors.github,
         "_fetch_github_commits_async",
         _github_commits_async_from_sync(fake_fetch_commits),
     )
@@ -1185,6 +1292,11 @@ async def test_process_github_repos_batch_commit_stats_rate_limit_propagates(
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
         processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _repo_client_for(repo),
+    )
+    monkeypatch.setattr(
+        processors.github,
         "_fetch_github_commits_async",
         _github_commits_async_from_sync(fake_fetch_commits),
     )
@@ -1285,6 +1397,11 @@ async def test_process_github_repos_batch_multi_repo_rate_limit_does_not_hang(
             self.close()
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _repo_client_for(*[result.repository for result in results]),
+    )
     monkeypatch.setattr(
         processors.github,
         "_fetch_github_commits_async",
@@ -1397,6 +1514,11 @@ async def test_process_github_repos_batch_commit_detail_rate_limit_propagates(
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
     monkeypatch.setattr(
         processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _repo_client_for(repo),
+    )
+    monkeypatch.setattr(
+        processors.github,
         "_fetch_github_commits_async",
         _github_commits_async_from_sync(fake_fetch_commits),
     )
@@ -1491,6 +1613,11 @@ async def test_process_github_repos_batch_incident_rate_limit_propagates(
         return [], [], False
 
     monkeypatch.setattr(processors.github, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.github,
+        "_github_code_client_from_connector",
+        lambda _connector: _repo_client_for(repo),
+    )
     monkeypatch.setattr(
         processors.github,
         "_fetch_github_commits_async",

--- a/tests/test_github_batch_deployments_usage_sink.py
+++ b/tests/test_github_batch_deployments_usage_sink.py
@@ -40,9 +40,6 @@ async def _test_batch_deployments_threads_usage_sink(
         def __init__(self, token: str) -> None:
             self.token = token
 
-        def list_repositories(self, **kwargs: object) -> list[object]:
-            return [repo]
-
         def close(self) -> None:
             return None
 
@@ -66,8 +63,18 @@ async def _test_batch_deployments_threads_usage_sink(
             usage_sink.append({"route_family": "deployments", "request_count": 1})
         return []
 
+    async def fake_list_repos_for_batch(
+        connector: object, **kwargs: object
+    ) -> list[object]:
+        return [repo]
+
     monkeypatch.setattr(github_processor, "CONNECTORS_AVAILABLE", True)
     monkeypatch.setattr(github_processor, "GitHubConnector", DummyConnector)
+    monkeypatch.setattr(
+        github_processor,
+        "_list_github_repositories_for_batch",
+        fake_list_repos_for_batch,
+    )
     monkeypatch.setattr(
         github_processor, "_fetch_github_deployments_async", fake_fetch_deployments
     )

--- a/tests/test_processor_split.py
+++ b/tests/test_processor_split.py
@@ -25,6 +25,27 @@ def _async_counting(counter: dict[str, Any], key: str, value: Any):
     return _inner
 
 
+async def _fake_fetch_github_repo_info(connector, owner, repo_name, usage_sink=None):
+    """Mirror ``_fetch_github_repo_info_async``'s field mapping so tests keep
+    exercising ``_FakeGitHubConnector.github.get_repo`` without a real
+    ``GitHubCodeClient`` (these fixtures pin PyGithub-shaped attribute names).
+    """
+    gh_repo = connector.github.get_repo(f"{owner}/{repo_name}")
+    return github.Repository(
+        id=gh_repo.id,
+        name=gh_repo.name,
+        full_name=gh_repo.full_name,
+        default_branch=gh_repo.default_branch,
+        description=gh_repo.description,
+        url=gh_repo.html_url,
+        created_at=gh_repo.created_at,
+        updated_at=gh_repo.updated_at,
+        language=gh_repo.language,
+        stars=gh_repo.stargazers_count,
+        forks=gh_repo.forks_count,
+    )
+
+
 class _SimpleRepository:
     def __init__(self, **kwargs):
         self.__dict__.update(kwargs)
@@ -121,6 +142,9 @@ def test_github_commits_run_does_not_fetch_stats_files_or_blame(monkeypatch):
     monkeypatch.setattr(github, "Repository", _SimpleRepository)
     monkeypatch.setattr(github, "IngestionSink", _FakeSink)
     monkeypatch.setattr(
+        github, "_fetch_github_repo_info_async", _fake_fetch_github_repo_info
+    )
+    monkeypatch.setattr(
         github,
         "_fetch_github_commits_async",
         _async_counting(calls, "commits", (["raw-sha"], ["commit-row"], False)),
@@ -164,6 +188,9 @@ def test_github_granular_stats_files_blame_and_legacy_bundle(monkeypatch):
     monkeypatch.setattr(github, "GitHubConnector", _FakeGitHubConnector)
     monkeypatch.setattr(github, "Repository", _SimpleRepository)
     monkeypatch.setattr(github, "IngestionSink", _FakeSink)
+    monkeypatch.setattr(
+        github, "_fetch_github_repo_info_async", _fake_fetch_github_repo_info
+    )
     monkeypatch.setattr(
         github,
         "_fetch_github_commits_async",

--- a/tests/test_provider_usage.py
+++ b/tests/test_provider_usage.py
@@ -117,6 +117,12 @@ def test_recorder_separates_transports_into_distinct_route_families() -> None:
     assert by_family["work_item_prs"]["dimension"] == "graphql_cost"
 
 
+def test_github_resolver_maps_repo_prefix_to_repo_family() -> None:
+    assert GITHUB_USAGE_RESOLVER.resolve(
+        transport="rest", operation="repo:GET /repos/acme/widgets"
+    ) == ("repo", BudgetDimension.REST_CORE)
+
+
 def test_recorder_skips_empty_observations() -> None:
     recorder = UsageRecorder(resolver=GITHUB_USAGE_RESOLVER)
     recorder.record(


### PR DESCRIPTION
## CHAOS-2773 CS9 — GitHub repo metadata + batch orchestration + admin repo-list

Migrates GitHub repo metadata, batch orchestration, and the admin credential repo-list off the frozen connector/PyGithub machinery onto the canonical httpx `GitHubCodeClient` (final GitHub family changeset before LV-A).

### Changes
- **`GitHubCodeClient`**: adds `get_repo` (single-repo metadata) and `list_repositories` (user/org/search/App-installation scoped) with `repo:` operation labels and usage recording via `InstrumentedRESTCore`. `list_repositories` **streams** Link-header pages and stops as soon as `max_repos` matching repos are collected (no drain-then-slice rate-budget blowout).
- **Processor**: `process_github_repo` repo-info fetch and `process_github_repos_batch` discovery rewired to bounded-async over the code client; `usage_sink` threaded through the batch path; `RateLimitException` propagation preserved. Batch discovery derives the effective owner from the pattern prefix (e.g. `org/*` → the `org` repos endpoint), preserving the old scoping instead of falling back to `/user/repos`.
- **Admin**: the credential GitHub repo-list endpoint migrated off `GitHubConnector`, preserving 401/404/429 and response shape.
- **Budget**: `repo` family flipped to the explicit `repo:` prefix marker.
- Docs (`rate-limit-policy.md`) updated; code-client/batch/admin/budget/resolver tests added.

The connector repo methods and GitHub App installation-token minting stay frozen in tree (retirement is CS16; token minting is a retained auth surface). No runtime legacy flag.

### Validation
- Full gate `OTEL_SDK_DISABLED=true SCRATCH_DB=ci_local_validate_2810 bash ci/local_validate.sh` → `GATE PASSED` (`6948 passed, 44 skipped`).
- Oracle adversarial review found 2 blockers (batch discovery lost pattern-owner scoping; `list_repositories` eager-paginated before `max_repos`); both fixed with regression tests and re-gated green.

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.