### PR TITLE
feat(providers): instrument GitLab repo metadata and batch orchestration (CHAOS-2817)

### DIFF
--- a/docs/providers/rate-limit-policy.md
+++ b/docs/providers/rate-limit-policy.md
@@ -1194,17 +1194,20 @@ above. GitHub `git` and `commit_stats` REST-core traffic is instrumented as of
   CHAOS-2808, REST `prs` listing / PR commits / incident-label issue
   fetches as of CHAOS-2809, and `repo` metadata/discovery traffic as of
   CHAOS-2810 (CS9); GitLab merge-request and MR-note REST-core traffic
-  is instrumented as of CHAOS-2816 (CS15). The `files`/`blame` `rest_core` tree
-  listing and remaining GitHub/GitLab code-dataset families stay uninstrumented
-  pending their own CHAOS-2773 changesets (see
+  is instrumented as of CHAOS-2816 (CS15), and GitLab repo metadata, project
+  discovery, and batch orchestration as of CHAOS-2817 (CS15b). The
+  `files`/`blame` `rest_core` tree listing and remaining GitHub/GitLab
+  code-dataset families stay uninstrumented pending their own CHAOS-2773
+  changesets (see
   "Frozen `connectors/` path" below). There is also no cross-run
   aggregation/dashboard yet — calibration today is visible per-unit (result +
   structured log), not rolled up over time.
 - **Frozen `connectors/` path.** GitHub repo metadata/listing and batch
-  orchestration now use `GitHubCodeClient` and emit `repo:` usage actuals. The
-  frozen-but-retained GitHub connector PR-commit method (pending CS16
-  retirement), plus the remaining equivalent GitLab code-dataset paths
-  (repo-metadata/batch orchestration among them), remain under the frozen `connectors/` tree
+  orchestration now use `GitHubCodeClient` and emit `repo:` usage actuals, and
+  GitLab repo metadata, project discovery, and batch orchestration now use
+  `GitLabCodeClient` and emit `project:` usage actuals. The frozen-but-retained
+  GitHub connector PR-commit method (pending CS16 retirement) and the GitLab
+  connector (pending CS17 retirement) remain under the frozen `connectors/` tree
   (`connectors/github.py`'s PyGithub-based `GitHubConnector`, `connectors/
   gitlab.py`'s python-gitlab-based `GitLabConnector`). No new code may be added
   there (see [`AGENTS.md`](../../AGENTS.md)); rate-limit/actuals
@@ -1243,10 +1246,10 @@ above. GitHub `git` and `commit_stats` REST-core traffic is instrumented as of
   `merge_requests`/`notes` (`iter_merge_requests`, MR commits, MR approvals,
   MR notes;
   [CHAOS-2816](https://linear.app/fullchaos/issue/CHAOS-2816), CS15)
-  code-dataset families are migrated onto the canonical, instrumented
-  `providers/gitlab/code_client.py::GitLabCodeClient`. GitLab's remaining
-  frozen code-dataset methods (repo-metadata/batch orchestration) stay
-  unmigrated pending their own CHAOS-2773 changesets through CS17.
+  code-dataset families plus repo metadata/project discovery/batch orchestration
+  ([CHAOS-2817](https://linear.app/fullchaos/issue/CHAOS-2817), CS15b) are
+  migrated onto the canonical, instrumented
+  `providers/gitlab/code_client.py::GitLabCodeClient`.
 
 
 ## References

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -170,17 +170,6 @@ async def list_credential_repos(
         except APIException as exc:
             raise HTTPException(status_code=502, detail=str(exc))
     elif provider == "gitlab":
-        from dev_health_ops.connectors.exceptions import (
-            AuthenticationException as GitLabAuthenticationException,
-        )
-        from dev_health_ops.connectors.exceptions import (
-            NotFoundException as GitLabNotFoundException,
-        )
-        from dev_health_ops.connectors.exceptions import (
-            RateLimitException as GitLabRateLimitException,
-        )
-        from dev_health_ops.connectors.gitlab import GitLabConnector
-
         token = decrypted.get("token")
         url = (
             _string_value(decrypted.get("url"))
@@ -196,27 +185,28 @@ async def list_credential_repos(
         is_valid, url_error = _validate_external_url(url)
         if not is_valid:
             raise HTTPException(status_code=400, detail=url_error)
-        gitlab_connector = GitLabConnector(url=url, private_token=token)
         effective_owner = owner or _string_value(config.get("group"))
         try:
-            if not effective_owner:
-                repos = _list_gitlab_membership_repos(
+            if effective_owner:
+                repos = await _list_gitlab_code_client_repos(
                     url=url,
-                    token=token,
+                    token=str(token),
+                    owner=effective_owner,
                     search=search,
                     max_repos=max_repos,
                 )
             else:
-                repos = gitlab_connector.list_repositories(
-                    org_name=effective_owner,
+                repos = await _list_gitlab_membership_repos(
+                    url=url,
+                    token=str(token),
                     search=search,
                     max_repos=max_repos,
                 )
-        except GitLabNotFoundException:
+        except NotFoundException:
             return DiscoveredReposResponse(provider=provider, repos=[], total=0)
-        except GitLabAuthenticationException as exc:
+        except AuthenticationException as exc:
             raise HTTPException(status_code=401, detail=str(exc))
-        except GitLabRateLimitException as exc:
+        except RateLimitException as exc:
             raise HTTPException(status_code=429, detail=str(exc))
     else:
         raise HTTPException(
@@ -486,76 +476,38 @@ async def _list_github_app_installation_repos(
         await client.close()
 
 
-def _list_gitlab_membership_repos(
+async def _list_gitlab_code_client_repos(
+    url: str,
+    token: str,
+    owner: str | None,
+    search: str | None,
+    max_repos: int,
+) -> list[Any]:
+    from dev_health_ops.providers.gitlab.code_client import GitLabCodeClient
+
+    async with GitLabCodeClient(private_token=token, base_url=url) as client:
+        return await client.list_projects(
+            group_name=owner,
+            search=search if owner else None,
+            pattern=f"*{search}*" if search and not owner else None,
+            membership=owner is None,
+            max_projects=max_repos,
+        )
+
+
+async def _list_gitlab_membership_repos(
     url: str,
     token: str,
     search: str | None,
     max_repos: int,
 ) -> list[Any]:
-    """Enumerate GitLab projects the token is a member of (membership=True).
-
-    Bypasses the frozen connector to call python-gitlab directly with
-    membership=True, ensuring only credential-accessible projects are returned.
-    Applies search as a client-side fnmatch filter to avoid a global search.
-    """
-    import fnmatch
-
-    import gitlab
-    from gitlab.exceptions import GitlabAuthenticationError, GitlabError
-
-    from dev_health_ops.connectors.exceptions import (
-        AuthenticationException,
-        RateLimitException,
+    return await _list_gitlab_code_client_repos(
+        url=url,
+        token=token,
+        owner=None,
+        search=search,
+        max_repos=max_repos,
     )
-    from dev_health_ops.connectors.models import Repository
-
-    gl = gitlab.Gitlab(url=url, private_token=token)
-    pattern = f"*{search}*" if search else None
-    repos: list[Any] = []
-    page = 1
-    per_page = 100
-
-    try:
-        while True:
-            gl_projects = gl.projects.list(
-                membership=True,
-                per_page=per_page,
-                page=page,
-            )
-            if not gl_projects:
-                break
-            for p in gl_projects:
-                full_name = str(
-                    getattr(p, "path_with_namespace", None)
-                    or getattr(p, "name", "")
-                    or ""
-                )
-                if pattern and not fnmatch.fnmatch(full_name.lower(), pattern.lower()):
-                    continue
-                repos.append(
-                    Repository(
-                        id=p.id,
-                        name=p.name,
-                        full_name=full_name,
-                        default_branch=getattr(p, "default_branch", None) or "main",
-                        description=getattr(p, "description", None),
-                        url=getattr(p, "web_url", "") or "",
-                    )
-                )
-                if len(repos) >= max_repos:
-                    return repos
-            if len(gl_projects) < per_page:
-                break
-            page += 1
-    except GitlabAuthenticationError as exc:
-        raise AuthenticationException(str(exc)) from exc
-    except GitlabError as exc:
-        msg = str(exc).lower()
-        if "rate" in msg or "429" in msg:
-            raise RateLimitException(str(exc)) from exc
-        raise
-
-    return repos
 
 
 async def _test_github_connection(creds: dict[str, Any]) -> tuple[bool, dict[str, Any]]:

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -1188,6 +1188,15 @@ def _gitlab_group_from_options(sync_options: dict[str, Any]) -> str:
     return str(group).replace("\r", "").replace("\n", "").strip()
 
 
+async def _list_gitlab_group_projects(
+    *, gitlab_url: str, token: str, group: str
+) -> list[Any]:
+    from dev_health_ops.providers.gitlab.code_client import GitLabCodeClient
+
+    async with GitLabCodeClient(private_token=token, base_url=gitlab_url) as client:
+        return await client.list_projects(group_name=group)
+
+
 async def _resolve_gitlab_batch_projects(
     session: AsyncSession,
     org_id: str,
@@ -1264,11 +1273,10 @@ async def _resolve_gitlab_batch_projects(
     # opportunistically when numeric entries could shadow project names.
     should_list = bool(named) or (bool(numeric) and bool(token) and bool(group))
     if should_list:
-        from dev_health_ops.connectors.gitlab import GitLabConnector
-
-        connector = GitLabConnector(url=gitlab_url, private_token=str(token))
         try:
-            projects = connector.list_repositories(org_name=group)
+            projects = await _list_gitlab_group_projects(
+                gitlab_url=gitlab_url, token=str(token), group=group
+            )
         except Exception as exc:
             if named:
                 raise HTTPException(

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -1,15 +1,20 @@
 import asyncio
 import logging
 import zipfile
-from collections.abc import Iterable
 from datetime import datetime, timezone
+from functools import partial
 from typing import TYPE_CHECKING, Any, NamedTuple, cast
 
 from dev_health_ops.analytics.complexity import (
     DEFAULT_COMPLEXITY_CONFIG_PATH,
     ComplexityScanner,
 )
-from dev_health_ops.connectors.models import SecurityAlertData
+from dev_health_ops.connectors.models import (
+    Author,
+    Repository,
+    RepoStats,
+    SecurityAlertData,
+)
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.models import git as git_models
 from dev_health_ops.models.git import (
@@ -87,12 +92,25 @@ def _is_rate_limit_exception(exc: Exception) -> bool:
 # --- GitLab Sync Helpers ---
 
 
-def _fetch_gitlab_project_info_sync(connector, project_id):
+def _fetch_gitlab_project_info_sync(
+    connector, project_id, usage_sink: list[dict[str, Any]] | None = None
+):
     """Sync helper to fetch GitLab project info."""
-    gl_project = connector.gitlab.projects.get(project_id)
-    # Access properties to force load if lazy
-    _ = gl_project.name
-    return gl_project
+    drained_observations: list[dict[str, Any]] = []
+
+    async def _run():
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await client.get_project(project_id)
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+
+    try:
+        return asyncio.run(_run())
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_project_info_sync", drained_observations, usage_sink
+        )
 
 
 def _fetch_gitlab_commits_sync(
@@ -1157,6 +1175,31 @@ def _gitlab_code_client_from_connector(connector):
     )
 
 
+def _gitlab_effective_group(group_name: str | None, pattern: str | None) -> str | None:
+    if group_name or not pattern or "/" not in pattern:
+        return group_name
+    prefix = pattern.split("/", 1)[0]
+    if prefix and "*" not in prefix and "?" not in prefix:
+        logging.info("Extracted group '%s' from pattern '%s'", prefix, pattern)
+        return prefix
+    return None
+
+
+def _repo_stats_from_gitlab_commits(commits: list[Any], stats: list[Any]) -> RepoStats:
+    authors: dict[str, Author] = {}
+    for commit in commits:
+        author_name = str(getattr(commit, "author_name", None) or "Unknown")
+        if author_name not in authors:
+            authors[author_name] = Author(id=0, username=author_name, name=author_name)
+    return RepoStats(
+        total_commits=len(commits),
+        additions=sum(int(getattr(item, "additions", 0)) for item in stats),
+        deletions=sum(int(getattr(item, "deletions", 0)) for item in stats),
+        commits_per_week=0.0,
+        authors=list(authors.values()),
+    )
+
+
 def _fetch_gitlab_security_alerts_sync(
     connector, project_id, repo_id, max_alerts, since, usage_sink=None
 ):
@@ -1235,121 +1278,95 @@ def _fetch_gitlab_security_alerts_sync(
     return alerts
 
 
-def _iter_gitlab_repo_tree(
-    gl_project,
-    *,
-    ref: str,
-    per_page: int = 100,
-    limit: int | None = None,
-) -> Iterable[Any]:
-    page = 1
-    seen = 0
-    # Defensive page cap. GitLab paginates until it returns an empty page, but a
-    # transport/API glitch — or a test double whose ``repository_tree()`` is a
-    # truthy Mock that never yields a falsy page — would otherwise spin forever
-    # (an unbounded REST crawl that hangs the sync; this hung the unit suite to
-    # the CI job timeout). 10k pages at per_page=100 covers ~1M tree entries,
-    # far beyond any real repository.
-    max_pages = 10_000
+def _fetch_gitlab_blame_sync(
+    connector,
+    project_full_name: str,
+    default_branch: str,
+    repo_id,
+    limit: int = 50,
+    usage_sink: list[dict[str, Any]] | None = None,
+):
+    """Sync helper to fetch GitLab blame data via the canonical code client.
 
-    while page <= max_pages:
-        try:
-            page_items = gl_project.repository_tree(
-                ref=ref,
-                recursive=True,
-                per_page=per_page,
-                page=page,
-                get_all=False,
-            )
-        except TypeError:
-            page_items = gl_project.repository_tree(
-                ref=ref,
-                recursive=True,
-                per_page=per_page,
-                page=page,
-                all=False,
-            )
-        # An empty page marks the end. Check the length explicitly: a real
-        # GitLab response is a list (``[]`` is falsy), but a truthy-but-empty
-        # container — e.g. a test Mock with no configured return — is not caught
-        # by ``not page_items`` alone and would loop until ``max_pages``.
-        try:
-            page_len = len(page_items)
-        except TypeError:
-            page_len = 0
-        if not page_items or page_len == 0:
-            break
-        seen += page_len
-        logging.debug(
-            "GitLab repo tree page %d returned %d items (total: %d)",
-            page,
-            page_len,
-            seen,
-        )
-        yield from page_items
-        if limit is not None and seen >= limit:
-            return
-        page += 1
+    CHAOS-2817/CS15b: ``process_gitlab_project``'s optional ``fetch_blame``
+    step used to receive the python-gitlab project object and call its
+    ``.repository_tree()`` / the frozen ``connector.get_file_blame()``. Once
+    ``_fetch_gitlab_project_info_sync`` started returning the plain
+    ``GitLabProjectData`` dataclass (no ``.repository_tree()``), that shape
+    stopped matching -- rewired onto ``GitLabCodeClient.list_repository_tree``
+    / ``get_file_blame`` (project full name + default branch, not a
+    python-gitlab project object).
+    """
+    drained_observations: list[dict[str, Any]] = []
 
-
-def _fetch_gitlab_blame_sync(gl_project, connector, project_id, repo_id, limit=50):
-    """Sync helper to fetch GitLab blame data."""
-    blame_batch = []
-    try:
-        # Get files from repository tree (paged to avoid huge responses)
-        files_to_process = []
-        for item in _iter_gitlab_repo_tree(
-            gl_project,
-            ref=gl_project.default_branch,
-            per_page=100,
-            limit=None,
-        ):
-            if item["type"] == "blob" and not is_skippable(item["path"]):
-                files_to_process.append(item["path"])
-                if len(files_to_process) >= limit:
-                    break
-
-        # Limit files
-        files_to_process = files_to_process[:limit]
-        logging.debug(
-            "GitLab blame: processing %d files (limit %d)",
-            len(files_to_process),
-            limit,
-        )
-
-        for idx, file_path in enumerate(files_to_process, start=1):
+    async def _run() -> list[Any]:
+        async with _gitlab_code_client_from_connector(connector) as client:
             try:
+                try:
+                    tree_items = await client.list_repository_tree(
+                        project_full_name, ref=default_branch
+                    )
+                except Exception as e:
+                    if _is_rate_limit_exception(e):
+                        raise
+                    logging.error("Error fetching files for blame: %s", e)
+                    return []
+
+                files_to_process: list[str] = []
+                for item in tree_items:
+                    if item.get("type") == "blob" and not is_skippable(
+                        item.get("path", "")
+                    ):
+                        files_to_process.append(item["path"])
+                        if len(files_to_process) >= limit:
+                            break
+                files_to_process = files_to_process[:limit]
                 logging.debug(
-                    "GitLab blame fetch %d/%d: %s",
-                    idx,
+                    "GitLab blame: processing %d files (limit %d)",
                     len(files_to_process),
-                    file_path,
+                    limit,
                 )
-                blame = connector.get_file_blame(
-                    project_id=project_id,
-                    file_path=file_path,
-                    ref=gl_project.default_branch,
-                )
-                if blame and blame.ranges:
-                    for r in blame.ranges:
-                        blame_obj = GitBlame(
-                            repo_id=repo_id,
-                            path=file_path,
-                            line_no=r.starting_line,
-                            author_name=r.author,
-                            author_email=r.author_email,
-                            commit_hash=r.commit_sha,
-                            line="<remote>",
-                            author_when=datetime.now(timezone.utc),
+
+                blame_batch: list[Any] = []
+                for idx, file_path in enumerate(files_to_process, start=1):
+                    try:
+                        logging.debug(
+                            "GitLab blame fetch %d/%d: %s",
+                            idx,
+                            len(files_to_process),
+                            file_path,
                         )
-                        blame_batch.append(blame_obj)
-            except Exception as e:
-                logging.warning(f"Failed to get blame for {file_path}: {e}")
+                        blame = await client.get_file_blame(
+                            project_full_name, file_path, ref=default_branch
+                        )
+                        if blame and blame.ranges:
+                            for r in blame.ranges:
+                                blame_batch.append(
+                                    GitBlame(
+                                        repo_id=repo_id,
+                                        path=file_path,
+                                        line_no=r.starting_line,
+                                        author_name=r.author,
+                                        author_email=r.author_email,
+                                        commit_hash=r.commit_sha,
+                                        line="<remote>",
+                                        author_when=datetime.now(timezone.utc),
+                                    )
+                                )
+                    except Exception as e:
+                        if _is_rate_limit_exception(e):
+                            raise
+                        logging.warning("Failed to get blame for %s: %s", file_path, e)
+                return blame_batch
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
 
-    except Exception as e:
-        logging.error(f"Error fetching files for blame: {e}")
-
-    return blame_batch
+    try:
+        return asyncio.run(_run())
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_blame_sync", drained_observations, usage_sink
+        )
 
 
 # Bounds for API-based file-content backfill (parity with the GitHub
@@ -1434,6 +1451,30 @@ async def _fetch_scannable_contents(
         )
 
 
+async def _fetch_gitlab_repository_tree(
+    connector: Any,
+    project_full_name: str,
+    ref: str,
+    usage_sink: list[dict[str, Any]] | None,
+) -> list[dict[str, Any]]:
+    drained_observations: list[dict[str, Any]] = []
+    try:
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await client.list_repository_tree(project_full_name, ref=ref)
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+    except Exception as e:
+        if _is_rate_limit_exception(e):
+            raise
+        logging.warning("Failed to list GitLab files for %s: %s", project_full_name, e)
+        return []
+    finally:
+        _drain_gitlab_code_usage(
+            "_fetch_gitlab_repository_tree", drained_observations, usage_sink
+        )
+
+
 async def _backfill_gitlab_missing_data(
     store: Any,
     ingestion_sink: IngestionSink,
@@ -1480,25 +1521,12 @@ async def _backfill_gitlab_missing_data(
     if not (needs_files or needs_blame or needs_commit_stats):
         return
 
-    try:
-        project = connector.gitlab.projects.get(project_full_name)
-    except Exception as e:
-        logging.warning(f"Failed to load GitLab project {project_full_name}: {e}")
-        return
-
     file_paths: list[str] = []
     blame_paths: list[str] = []
     if needs_files or needs_blame:
-        try:
-            items = _iter_gitlab_repo_tree(
-                project,
-                ref=default_branch,
-                per_page=100,
-                limit=None,
-            )
-        except Exception as e:
-            logging.warning(f"Failed to list GitLab files for {project_full_name}: {e}")
-            items = []
+        items = await _fetch_gitlab_repository_tree(
+            connector, project_full_name, default_branch, usage_sink
+        )
 
         for item in items or []:
             if item.get("type") != "blob":
@@ -1604,7 +1632,7 @@ async def _backfill_gitlab_missing_data(
                         for path in blame_paths:
                             try:
                                 blame_items = await client.get_file_blame(
-                                    project.id, path, ref=default_branch
+                                    project_full_name, path, ref=default_branch
                                 )
                             except Exception as e:
                                 if _is_rate_limit_exception(e):
@@ -2118,7 +2146,7 @@ async def process_gitlab_project(
         # 1. Fetch Project Info
         logging.info("Fetching project information...")
         gl_project = await loop.run_in_executor(
-            None, _fetch_gitlab_project_info_sync, connector, project_id
+            None, _fetch_gitlab_project_info_sync, connector, project_id, usage_sink
         )
 
         logging.info(f"Found project: {gl_project.name}")
@@ -2326,12 +2354,15 @@ async def process_gitlab_project(
             logging.info("Fetching blame data from GitLab (this may take a while)...")
             blame_batch = await loop.run_in_executor(
                 None,
-                _fetch_gitlab_blame_sync,
-                gl_project,
-                connector,
-                project_id,
-                db_repo.id,
-                50,
+                partial(
+                    _fetch_gitlab_blame_sync,
+                    connector,
+                    gl_project.path_with_namespace,
+                    gl_project.default_branch,
+                    db_repo.id,
+                    50,
+                    usage_sink,
+                ),
             )
 
             if blame_batch:
@@ -2407,6 +2438,7 @@ async def process_gitlab_projects_batch(
     blame_only: bool = False,
     backfill_missing: bool = True,
     since: datetime | None = None,
+    usage_sink: list[dict[str, Any]] | None = None,
 ) -> None:
     """
     Process multiple GitLab projects using batch processing with pattern matching.
@@ -2500,7 +2532,7 @@ async def process_gitlab_projects_batch(
             return
 
         gl_project = None
-        usage_sink: list[dict[str, Any]] = []
+        project_usage_sink = usage_sink if usage_sink is not None else []
         if sync_git:
             # Fetch commits and stats to populate git_commits/git_commit_stats.
             if max_commits_per_project is None and since is None:
@@ -2517,7 +2549,7 @@ async def process_gitlab_projects_batch(
                     db_repo.id,
                     since,
                     None,
-                    usage_sink,
+                    project_usage_sink,
                 )
                 if commit_objects:
                     await ingestion_sink.insert_git_commit_data(commit_objects)
@@ -2531,7 +2563,7 @@ async def process_gitlab_projects_batch(
                     db_repo.id,
                     50 if commit_limit is None else min(commit_limit, 50),
                     None,
-                    usage_sink,
+                    project_usage_sink,
                 )
                 if stats_objects:
                     await ingestion_sink.insert_git_commit_stats(stats_objects)
@@ -2565,7 +2597,7 @@ async def process_gitlab_projects_batch(
                         mr_gate,
                         since,
                         None,
-                        usage_sink,
+                        project_usage_sink,
                     )
             except PartialGitLabMrSyncError as e:
                 # Degraded review fetch skipped MR rows for this project. Keep
@@ -2603,7 +2635,7 @@ async def process_gitlab_projects_batch(
                     db_repo.id,
                     BATCH_SIZE,
                     since,
-                    usage_sink,
+                    project_usage_sink,
                 )
                 if pipeline_runs:
                     await ingestion_sink.insert_ci_pipeline_runs(pipeline_runs)
@@ -2617,9 +2649,7 @@ async def process_gitlab_projects_batch(
         if sync_tests:
             try:
                 if gl_project is None:
-                    gl_project = await loop.run_in_executor(
-                        None, connector.gitlab.projects.get, project_info.id
-                    )
+                    gl_project = project_info
                 await _sync_gitlab_test_reports(
                     connector=connector,
                     gl_project=gl_project,
@@ -2630,7 +2660,7 @@ async def process_gitlab_projects_batch(
                     ingestion_sink=ingestion_sink,
                     loop=loop,
                     since=since,
-                    usage_sink=usage_sink,
+                    usage_sink=project_usage_sink,
                 )
             except Exception as e:
                 logging.warning(
@@ -2649,7 +2679,7 @@ async def process_gitlab_projects_batch(
                     db_repo.id,
                     BATCH_SIZE,
                     since,
-                    usage_sink,
+                    project_usage_sink,
                 )
                 if deployments:
                     await ingestion_sink.insert_deployments(deployments)
@@ -2690,6 +2720,7 @@ async def process_gitlab_projects_batch(
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    project_usage_sink,
                 )
                 if security_alerts:
                     insert_security_alerts = getattr(
@@ -2732,7 +2763,7 @@ async def process_gitlab_projects_batch(
                     max_commits=max_commits_per_project,
                     include_blame=True,
                     include_commit_stats=False,
-                    usage_sink=usage_sink,
+                    usage_sink=project_usage_sink,
                 )
             except Exception as e:
                 logging.debug(
@@ -2773,7 +2804,79 @@ async def process_gitlab_projects_batch(
             else:
                 loop.call_soon_threadsafe(_enqueue)
 
+    async def _discover_projects() -> list[Repository]:
+        effective_group = _gitlab_effective_group(group_name, pattern)
+        drained_observations: list[dict[str, Any]] = []
+        try:
+            async with _gitlab_code_client_from_connector(connector) as client:
+                try:
+                    return await client.list_projects(
+                        group_name=effective_group,
+                        pattern=pattern,
+                        max_projects=max_projects,
+                    )
+                finally:
+                    drained_observations.extend(client.drain_usage_observations())
+        finally:
+            _drain_gitlab_code_usage(
+                "process_gitlab_projects_batch[discover]",
+                drained_observations,
+                usage_sink,
+            )
+
+    async def _process_project_stats(project: Repository) -> None:
+        semaphore = project_stats_semaphore
+        async with semaphore:
+            batch_result_cls = cast(Any, BatchResult)
+            try:
+                # Cap the stats-only commit fetch the same way the historical
+                # get_repo_stats_by_project page fetch was implicitly bounded
+                # (~100, GitLab's default page size): an unset
+                # max_commits_per_project must NOT fall through to
+                # GitLabCodeClient.get_commits(max_commits=None), which
+                # paginates up to 10k pages of full project history.
+                commit_limit = max_commits_per_project or 100
+                commits, _commit_objects = await loop.run_in_executor(
+                    None,
+                    _fetch_gitlab_commits_sync,
+                    connector,
+                    project.id,
+                    commit_limit,
+                    None,
+                    since,
+                    None,
+                    usage_sink,
+                )
+                stats_limit = resolve_commit_stats_limit(
+                    len(commits), max_commits_per_project, since
+                )
+                stat_objects = await loop.run_in_executor(
+                    None,
+                    _fetch_gitlab_commit_stats_sync,
+                    connector,
+                    project.id,
+                    commits,
+                    None,
+                    stats_limit,
+                    None,
+                    usage_sink,
+                )
+                result = batch_result_cls(
+                    repository=project,
+                    stats=_repo_stats_from_gitlab_commits(commits, stat_objects),
+                    success=True,
+                )
+            except Exception as e:
+                if _is_rate_limit_exception(e):
+                    raise
+                logging.warning("Failed to get stats for %s: %s", project.full_name, e)
+                result = batch_result_cls(
+                    repository=project, error=str(e), success=False
+                )
+            on_project_complete(result)
+
     try:
+        projects = await _discover_projects()
         if sync_git:
             results_queue = asyncio.Queue(maxsize=max(1, max_concurrent * 2))
 
@@ -2790,30 +2893,11 @@ async def process_gitlab_projects_batch(
 
             consumer_task = asyncio.create_task(_consume_results())
 
-            if use_async:
-                await connector.get_projects_with_stats_async(
-                    group_name=group_name,
-                    pattern=pattern,
-                    batch_size=batch_size,
-                    max_concurrent=max_concurrent,
-                    rate_limit_delay=rate_limit_delay,
-                    max_commits_per_repo=max_commits_per_project,
-                    max_repos=max_projects,
-                    on_project_complete=on_project_complete,
-                )
-            else:
-                await loop.run_in_executor(
-                    None,
-                    lambda: connector.get_projects_with_stats(
-                        group_name=group_name,
-                        pattern=pattern,
-                        batch_size=batch_size,
-                        max_concurrent=max_concurrent,
-                        rate_limit_delay=rate_limit_delay,
-                        max_commits_per_repo=max_commits_per_project,
-                        max_repos=max_projects,
-                        on_project_complete=on_project_complete,
-                    ),
+            project_stats_semaphore = asyncio.Semaphore(max(1, max_concurrent))
+            for batch_start in range(0, len(projects), max(1, batch_size)):
+                batch = projects[batch_start : batch_start + max(1, batch_size)]
+                await asyncio.gather(
+                    *(_process_project_stats(project) for project in batch)
                 )
 
             # Wait for the queue to drain, but bail out if the consumer dies
@@ -2841,14 +2925,6 @@ async def process_gitlab_projects_batch(
                 group_name,
                 pattern,
                 max_projects,
-            )
-            projects = await loop.run_in_executor(
-                None,
-                lambda: connector._get_projects_for_processing(
-                    group_name=group_name,
-                    pattern=pattern,
-                    max_repos=max_projects,
-                ),
             )
             logging.info("Discovered %d GitLab projects for PR sync", len(projects))
             semaphore = asyncio.Semaphore(max(1, max_concurrent))

--- a/src/dev_health_ops/providers/gitlab/code_client.py
+++ b/src/dev_health_ops/providers/gitlab/code_client.py
@@ -59,11 +59,12 @@ import logging
 import urllib.parse
 from dataclasses import dataclass
 from datetime import datetime, timezone
+from fnmatch import fnmatch
 from typing import Any
 
 import httpx
 
-from dev_health_ops.connectors.models import SecurityAlertData
+from dev_health_ops.connectors.models import Repository, SecurityAlertData
 from dev_health_ops.exceptions import (
     APIException,
     NotFoundException,
@@ -155,6 +156,20 @@ class GitLabBlameRange:
 class GitLabFileBlame:
     file_path: str
     ranges: tuple[GitLabBlameRange, ...] = ()
+
+
+@dataclass(frozen=True)
+class GitLabProjectData:
+    id: int
+    name: str
+    path_with_namespace: str
+    web_url: str | None
+    default_branch: str
+    description: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
+    stars: int = 0
+    forks: int = 0
 
 
 class _GitLabSecurityForbidden(APIException):
@@ -395,6 +410,40 @@ def _map_commit_stats(commit_id: str, item: dict[str, Any]) -> GitLabCommitStats
     )
 
 
+def _map_project(item: dict[str, Any]) -> GitLabProjectData:
+    project_id = _coerce_int(item.get("id"))
+    name = str(item.get("name") or project_id)
+    full_name = str(item.get("path_with_namespace") or item.get("path") or name)
+    return GitLabProjectData(
+        id=project_id,
+        name=name,
+        path_with_namespace=full_name,
+        web_url=item.get("web_url"),
+        default_branch=str(item.get("default_branch") or "main"),
+        description=item.get("description"),
+        created_at=_parse_gitlab_datetime(item.get("created_at")),
+        updated_at=_parse_gitlab_datetime(item.get("last_activity_at")),
+        stars=_coerce_int(item.get("star_count")),
+        forks=_coerce_int(item.get("forks_count")),
+    )
+
+
+def _project_to_repository(project: GitLabProjectData) -> Repository:
+    return Repository(
+        id=project.id,
+        name=project.name,
+        full_name=project.path_with_namespace,
+        default_branch=project.default_branch,
+        description=project.description,
+        url=project.web_url,
+        created_at=project.created_at,
+        updated_at=project.updated_at,
+        language=None,
+        stars=project.stars,
+        forks=project.forks,
+    )
+
+
 def _format_gitlab_window_datetime(value: datetime) -> str:
     return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
 
@@ -462,6 +511,85 @@ class GitLabCodeClient:
             transport=transport,
         )
         self._graphql_url = f"{base_url.rstrip('/')}/api/graphql"
+
+    async def get_project(self, project_id: int | str) -> GitLabProjectData:
+        encoded = _encode_project_id(project_id)
+        response = await self._core.request(
+            "GET",
+            f"/projects/{encoded}",
+            operation=f"{_PROJECT_FAMILY_PREFIX}:GET /projects/{{id}}",
+        )
+        payload = response.json()
+        if not isinstance(payload, dict):
+            raise APIException(f"Unexpected GitLab project response: {type(payload)!r}")
+        return _map_project(payload)
+
+    async def list_projects(
+        self,
+        *,
+        group_name: str | int | None = None,
+        search: str | None = None,
+        pattern: str | None = None,
+        membership: bool = False,
+        max_projects: int | None = None,
+        per_page: int = 100,
+    ) -> list[Repository]:
+        params: dict[str, Any] = {}
+        if search:
+            params["search"] = search
+        if membership:
+            params["membership"] = True
+        if group_name is None:
+            path = "/projects"
+            operation = f"{_PROJECT_FAMILY_PREFIX}:GET /projects"
+        else:
+            encoded_group = _encode_project_id(group_name)
+            path = f"/groups/{encoded_group}/projects"
+            operation = f"{_PROJECT_FAMILY_PREFIX}:GET /groups/{{id}}/projects"
+
+        max_items = (
+            1_000_000
+            if pattern and max_projects is not None
+            else max_projects or 1_000_000
+        )
+        raw_projects = await self._get_gitlab_list(
+            path,
+            operation=operation,
+            params=params,
+            per_page=per_page,
+            paginate=True,
+            max_items=max_items,
+        )
+        repositories: list[Repository] = []
+        lowered_pattern = pattern.lower() if pattern else None
+        for raw_project in raw_projects:
+            project = _map_project(raw_project)
+            if lowered_pattern and not fnmatch(
+                project.path_with_namespace.lower(), lowered_pattern
+            ):
+                continue
+            repositories.append(_project_to_repository(project))
+            if max_projects is not None and len(repositories) >= max_projects:
+                break
+        return repositories
+
+    async def list_repository_tree(
+        self,
+        project_id: int | str,
+        *,
+        ref: str,
+        per_page: int = 100,
+        max_items: int = 1_000_000,
+    ) -> list[dict[str, Any]]:
+        encoded = _encode_project_id(project_id)
+        return await self._get_gitlab_list(
+            f"/projects/{encoded}/repository/tree",
+            operation=f"{_PROJECT_FAMILY_PREFIX}:GET /projects/{{id}}/repository/tree",
+            params={"ref": ref, "recursive": True},
+            per_page=per_page,
+            paginate=True,
+            max_items=max_items,
+        )
 
     async def _resolve_project_id(self, project_id_or_path: int | str) -> int:
         """Resolve a project id/path to its numeric id, mirroring the
@@ -1256,4 +1384,5 @@ __all__ = [
     "GitLabCommitStatsData",
     "GitLabDeploymentData",
     "GitLabPipelineData",
+    "GitLabProjectData",
 ]

--- a/tests/api/admin/test_credential_repos.py
+++ b/tests/api/admin/test_credential_repos.py
@@ -187,8 +187,8 @@ _GH_REPO_CLIENT = (
 )
 _GL_CONNECTOR = "dev_health_ops.connectors.gitlab.GitLabConnector"
 _GH_APP_PROVIDER = "dev_health_ops.connectors.utils.github_app.GitHubAppTokenProvider"
-_GL_MEMBERSHIP_HELPER = (
-    "dev_health_ops.api.admin.routers.credentials._list_gitlab_membership_repos"
+_GL_CODE_CLIENT_REPOS = (
+    "dev_health_ops.api.admin.routers.credentials._list_gitlab_code_client_repos"
 )
 
 
@@ -475,7 +475,7 @@ async def test_no_owner_gitlab_enumerates_membership_scoped(client):
             ),
         ) as _,
         patch(_GL_CONNECTOR) as MockGLConnector,
-        patch(_GL_MEMBERSHIP_HELPER, return_value=gl_repos) as MockMembership,
+        patch(_GL_CODE_CLIENT_REPOS, return_value=gl_repos) as MockCodeClientRepos,
     ):
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
@@ -487,8 +487,15 @@ async def test_no_owner_gitlab_enumerates_membership_scoped(client):
     assert body["provider"] == "gitlab"
     assert body["total"] == 1
     assert body["repos"][0]["name"] == "infra"
-    # Must use membership-scoped helper, NOT the connector's unscoped list
-    MockMembership.assert_called_once()
+    # Must use the membership-scoped code-client helper, NOT the connector's
+    # unscoped list
+    MockCodeClientRepos.assert_called_once_with(
+        url="https://gitlab.com",
+        token="glpat_fake",
+        owner=None,
+        search=None,
+        max_repos=100,
+    )
     MockGLConnector.return_value.list_repositories.assert_not_called()
 
 
@@ -605,7 +612,7 @@ async def test_no_owner_gitlab_search_uses_membership_scoped_with_pattern(client
             ),
         ) as _,
         patch(_GL_CONNECTOR) as MockGLConnector,
-        patch(_GL_MEMBERSHIP_HELPER, return_value=gl_repos) as MockMembership,
+        patch(_GL_CODE_CLIENT_REPOS, return_value=gl_repos) as MockCodeClientRepos,
     ):
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
@@ -616,10 +623,12 @@ async def test_no_owner_gitlab_search_uses_membership_scoped_with_pattern(client
     body = resp.json()
     assert body["provider"] == "gitlab"
     assert body["repos"][0]["name"] == "infra-api"
-    # Must use membership-scoped helper with search forwarded for client-side filtering
-    MockMembership.assert_called_once_with(
+    # Must use the membership-scoped code-client helper with search forwarded
+    # for client-side filtering
+    MockCodeClientRepos.assert_called_once_with(
         url="https://gitlab.com",
         token="glpat_fake",
+        owner=None,
         search="api",
         max_repos=100,
     )
@@ -667,7 +676,7 @@ async def test_gitlab_base_url_key_used_for_self_hosted(client):
             ),
         ) as _,
         patch(_GL_CONNECTOR) as MockGLConnector,
-        patch(_GL_MEMBERSHIP_HELPER, return_value=gl_repos) as MockMembership,
+        patch(_GL_CODE_CLIENT_REPOS, return_value=gl_repos) as MockCodeClientRepos,
     ):
         resp = await ac.get(
             f"/api/v1/admin/credentials/{state['cred_id']}/repos",
@@ -677,10 +686,11 @@ async def test_gitlab_base_url_key_used_for_self_hosted(client):
     body = resp.json()
     assert body["total"] == 1
     assert body["repos"][0]["name"] == "self-hosted-repo"
-    # Membership helper must be called with the self-hosted URL, NOT gitlab.com
-    MockMembership.assert_called_once_with(
+    # Code-client helper must be called with the self-hosted URL, NOT gitlab.com
+    MockCodeClientRepos.assert_called_once_with(
         url="https://gitlab.example.com",
         token="glpat_selfhosted",
+        owner=None,
         search=None,
         max_repos=100,
     )
@@ -860,7 +870,7 @@ async def test_gitlab_internal_url_rejected_ssrf(client):
                 ),
             ) as _,
             patch(_GL_CONNECTOR) as MockGLConnector,
-            patch(_GL_MEMBERSHIP_HELPER) as MockMembership,
+            patch(_GL_CODE_CLIENT_REPOS) as MockCodeClientRepos,
         ):
             resp = await ac.get(
                 f"/api/v1/admin/credentials/{state['cred_id']}/repos",
@@ -869,9 +879,9 @@ async def test_gitlab_internal_url_rejected_ssrf(client):
         assert resp.status_code == 400, (
             f"Expected 400 for {internal_url}, got {resp.status_code}"
         )
-        # Connector and membership helper must NOT have been called
+        # Connector and code-client helper must NOT have been called
         MockGLConnector.assert_not_called()
-        MockMembership.assert_not_called()
+        MockCodeClientRepos.assert_not_called()
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -1864,6 +1864,23 @@ def _gitlab_project(project_id: int, name: str, full_name: str):
     )
 
 
+class _FakeGitLabCodeClient:
+    """Async context manager stub for GitLabCodeClient (CHAOS-2817/CS15b).
+
+    Batch-create name resolution now discovers group projects through the
+    canonical httpx code client instead of ``GitLabConnector.list_repositories``.
+    """
+
+    def __init__(self, projects):
+        self.list_projects = AsyncMock(return_value=projects)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc_info):
+        return None
+
+
 @pytest.mark.asyncio
 async def test_batch_create_github_creates_planner_config_without_children(
     client, session_maker
@@ -2078,12 +2095,13 @@ async def test_batch_create_gitlab_children_get_project_id_and_group(
     mock_creds_svc.get_decrypted_credentials_by_id = AsyncMock(
         return_value=({"token": "glpat-test"}, MagicMock(config={}))
     )
-    mock_connector = MagicMock()
-    mock_connector.list_repositories.return_value = [
-        _gitlab_project(101, "alpha", "acme-group/alpha"),
-        _gitlab_project(202, "beta", "acme-group/sub/beta"),
-    ]
-    mock_connector_cls = MagicMock(return_value=mock_connector)
+    fake_client = _FakeGitLabCodeClient(
+        [
+            _gitlab_project(101, "alpha", "acme-group/alpha"),
+            _gitlab_project(202, "beta", "acme-group/sub/beta"),
+        ]
+    )
+    mock_client_cls = MagicMock(return_value=fake_client)
 
     with (
         patch.object(
@@ -2092,8 +2110,8 @@ async def test_batch_create_gitlab_children_get_project_id_and_group(
             return_value=mock_creds_svc,
         ),
         patch(
-            "dev_health_ops.connectors.gitlab.GitLabConnector",
-            mock_connector_cls,
+            "dev_health_ops.providers.gitlab.code_client.GitLabCodeClient",
+            mock_client_cls,
         ),
     ):
         resp = await ac.post(
@@ -2117,10 +2135,10 @@ async def test_batch_create_gitlab_children_get_project_id_and_group(
     assert data["total_created"] == 0
     assert data["children"] == []
 
-    mock_connector_cls.assert_called_once_with(
-        url="https://gitlab.example.com", private_token="glpat-test"
+    mock_client_cls.assert_called_once_with(
+        private_token="glpat-test", base_url="https://gitlab.example.com"
     )
-    mock_connector.list_repositories.assert_called_once_with(org_name="acme-group")
+    fake_client.list_projects.assert_called_once_with(group_name="acme-group")
 
     async with session_maker() as session:
         sources = (await session.execute(select(IntegrationSource))).scalars().all()
@@ -2161,10 +2179,11 @@ async def test_batch_create_gitlab_unknown_project_name_returns_400(client):
     mock_creds_svc.get_decrypted_credentials_by_id = AsyncMock(
         return_value=({"token": "glpat-test"}, MagicMock(config={}))
     )
-    mock_connector = MagicMock()
-    mock_connector.list_repositories.return_value = [
-        _gitlab_project(101, "alpha", "acme-group/alpha"),
-    ]
+    fake_client = _FakeGitLabCodeClient(
+        [
+            _gitlab_project(101, "alpha", "acme-group/alpha"),
+        ]
+    )
 
     with (
         patch.object(
@@ -2173,8 +2192,8 @@ async def test_batch_create_gitlab_unknown_project_name_returns_400(client):
             return_value=mock_creds_svc,
         ),
         patch(
-            "dev_health_ops.connectors.gitlab.GitLabConnector",
-            MagicMock(return_value=mock_connector),
+            "dev_health_ops.providers.gitlab.code_client.GitLabCodeClient",
+            MagicMock(return_value=fake_client),
         ),
     ):
         resp = await ac.post(
@@ -2232,11 +2251,12 @@ async def test_batch_create_gitlab_credential_url_persisted_into_children(
             MagicMock(config={}),
         )
     )
-    mock_connector = MagicMock()
-    mock_connector.list_repositories.return_value = [
-        _gitlab_project(101, "alpha", "acme-group/alpha"),
-    ]
-    mock_connector_cls = MagicMock(return_value=mock_connector)
+    fake_client = _FakeGitLabCodeClient(
+        [
+            _gitlab_project(101, "alpha", "acme-group/alpha"),
+        ]
+    )
+    mock_client_cls = MagicMock(return_value=fake_client)
 
     with (
         patch.object(
@@ -2245,8 +2265,8 @@ async def test_batch_create_gitlab_credential_url_persisted_into_children(
             return_value=mock_creds_svc,
         ),
         patch(
-            "dev_health_ops.connectors.gitlab.GitLabConnector",
-            mock_connector_cls,
+            "dev_health_ops.providers.gitlab.code_client.GitLabCodeClient",
+            mock_client_cls,
         ),
     ):
         resp = await ac.post(
@@ -2265,8 +2285,8 @@ async def test_batch_create_gitlab_credential_url_persisted_into_children(
     data = resp.json()
 
     # Resolution used the credential's self-hosted URL...
-    mock_connector_cls.assert_called_once_with(
-        url="https://gitlab.internal.example.com", private_token="glpat-test"
+    mock_client_cls.assert_called_once_with(
+        private_token="glpat-test", base_url="https://gitlab.internal.example.com"
     )
     # ...and that URL is persisted into both parent and child options.
     assert (
@@ -2292,11 +2312,12 @@ async def test_batch_create_gitlab_numeric_entry_matching_name_resolves_as_name(
     mock_creds_svc.get_decrypted_credentials_by_id = AsyncMock(
         return_value=({"token": "glpat-test"}, MagicMock(config={}))
     )
-    mock_connector = MagicMock()
-    mock_connector.list_repositories.return_value = [
-        _gitlab_project(7007, "007", "acme-group/007"),
-        _gitlab_project(101, "alpha", "acme-group/alpha"),
-    ]
+    fake_client = _FakeGitLabCodeClient(
+        [
+            _gitlab_project(7007, "007", "acme-group/007"),
+            _gitlab_project(101, "alpha", "acme-group/alpha"),
+        ]
+    )
 
     with (
         patch.object(
@@ -2305,8 +2326,8 @@ async def test_batch_create_gitlab_numeric_entry_matching_name_resolves_as_name(
             return_value=mock_creds_svc,
         ),
         patch(
-            "dev_health_ops.connectors.gitlab.GitLabConnector",
-            MagicMock(return_value=mock_connector),
+            "dev_health_ops.providers.gitlab.code_client.GitLabCodeClient",
+            MagicMock(return_value=fake_client),
         ),
     ):
         resp = await ac.post(
@@ -2323,7 +2344,7 @@ async def test_batch_create_gitlab_numeric_entry_matching_name_resolves_as_name(
 
     assert resp.status_code == 201, resp.text
     data = resp.json()
-    mock_connector.list_repositories.assert_called_once_with(org_name="acme-group")
+    fake_client.list_projects.assert_called_once_with(group_name="acme-group")
 
     assert data["children"] == []
     async with session_maker() as session:
@@ -2344,10 +2365,11 @@ async def test_batch_create_gitlab_numeric_entry_not_in_listing_used_as_id(
     mock_creds_svc.get_decrypted_credentials_by_id = AsyncMock(
         return_value=({"token": "glpat-test"}, MagicMock(config={}))
     )
-    mock_connector = MagicMock()
-    mock_connector.list_repositories.return_value = [
-        _gitlab_project(101, "alpha", "acme-group/alpha"),
-    ]
+    fake_client = _FakeGitLabCodeClient(
+        [
+            _gitlab_project(101, "alpha", "acme-group/alpha"),
+        ]
+    )
 
     with (
         patch.object(
@@ -2356,8 +2378,8 @@ async def test_batch_create_gitlab_numeric_entry_not_in_listing_used_as_id(
             return_value=mock_creds_svc,
         ),
         patch(
-            "dev_health_ops.connectors.gitlab.GitLabConnector",
-            MagicMock(return_value=mock_connector),
+            "dev_health_ops.providers.gitlab.code_client.GitLabCodeClient",
+            MagicMock(return_value=fake_client),
         ),
     ):
         resp = await ac.post(
@@ -2375,7 +2397,7 @@ async def test_batch_create_gitlab_numeric_entry_not_in_listing_used_as_id(
     assert resp.status_code == 201, resp.text
     data = resp.json()
     # The listing WAS consulted (credential + group present)...
-    mock_connector.list_repositories.assert_called_once_with(org_name="acme-group")
+    fake_client.list_projects.assert_called_once_with(group_name="acme-group")
 
     assert data["children"] == []
     async with session_maker() as session:

--- a/tests/metrics/test_job_daily_hotspots.py
+++ b/tests/metrics/test_job_daily_hotspots.py
@@ -629,8 +629,9 @@ class _FakeGitLabCodeClientForBlame:
     ``GitLabCodeClient.get_file_blame``, never ``connector.rest_client.
     get_file_blame`` (frozen, un-instrumented)."""
 
-    def __init__(self, blame_fn):
+    def __init__(self, blame_fn, tree_items=None):
         self._blame_fn = blame_fn
+        self._tree_items = tree_items if tree_items is not None else []
 
     async def __aenter__(self):
         return self
@@ -640,6 +641,11 @@ class _FakeGitLabCodeClientForBlame:
 
     async def get_file_blame(self, project_id, file_path, *, ref):
         return self._blame_fn(project_id, file_path, ref)
+
+    async def list_repository_tree(
+        self, project_id, *, ref, per_page=100, max_items=1_000_000
+    ):
+        return self._tree_items
 
     def drain_usage_observations(self):
         return []
@@ -771,7 +777,7 @@ async def test_gitlab_blame_backfill_is_capped(
     connector = Mock()
     connector.gitlab.projects.get.return_value = project
 
-    # _iter_gitlab_repo_tree yields the (oversized) tree of blobs.
+    # list_repository_tree yields the (oversized) tree of blobs.
     tree_items = [{"type": "blob", "path": f"src/f{i}.py"} for i in range(n_files)]
 
     blame_calls: list[str] = []
@@ -786,17 +792,14 @@ async def test_gitlab_blame_backfill_is_capped(
     monkeypatch.setattr(
         gitlab_mod,
         "_gitlab_code_client_from_connector",
-        lambda connector: _FakeGitLabCodeClientForBlame(fake_blame),
+        lambda connector: _FakeGitLabCodeClientForBlame(
+            fake_blame, tree_items=tree_items
+        ),
     )
 
     db_repo = Mock()
     db_repo.id = uuid.uuid4()
     db_repo.settings = {"default_branch": "main"}
-
-    # Patch the module-level tree iterator to return the oversized blob list.
-    monkeypatch.setattr(
-        gitlab_mod, "_iter_gitlab_repo_tree", lambda *a, **k: tree_items
-    )
     await gitlab_mod._backfill_gitlab_missing_data(
         store=store,
         ingestion_sink=sink,
@@ -1088,9 +1091,6 @@ async def test_gitlab_blame_backfill_resumes_on_second_sync(
     store = _StatefulBlameStore(all_paths)
 
     tree_items = [{"type": "blob", "path": f"src/f{i}.py"} for i in range(n_files)]
-    monkeypatch.setattr(
-        gitlab_mod, "_iter_gitlab_repo_tree", lambda *a, **k: tree_items
-    )
 
     project = Mock()
     project.id = 123
@@ -1106,7 +1106,9 @@ async def test_gitlab_blame_backfill_resumes_on_second_sync(
     monkeypatch.setattr(
         gitlab_mod,
         "_gitlab_code_client_from_connector",
-        lambda connector: _FakeGitLabCodeClientForBlame(fake_blame),
+        lambda connector: _FakeGitLabCodeClientForBlame(
+            fake_blame, tree_items=tree_items
+        ),
     )
 
     db_repo = Mock()

--- a/tests/providers/test_gitlab_budget.py
+++ b/tests/providers/test_gitlab_budget.py
@@ -103,6 +103,19 @@ def test_gitlab_budget_has_code_client_family_prefix_markers() -> None:
     assert GITLAB_USAGE_RESOLVER.resolve(
         transport="rest", operation="project:GET /projects/{id}/repository/commits"
     ) == ("project", BudgetDimension.REST_CORE)
+    # CHAOS-2817/CS15b: project metadata + discovery (get_project/list_projects/
+    # list_repository_tree) author the same "project:" prefix, so they resolve
+    # via the explicit-prefix short-circuit without needing new markers.
+    for operation in (
+        "project:GET /projects/{id}",
+        "project:GET /projects",
+        "project:GET /groups/{id}/projects",
+        "project:GET /projects/{id}/repository/tree",
+    ):
+        assert GITLAB_USAGE_RESOLVER.resolve(transport="rest", operation=operation) == (
+            "project",
+            BudgetDimension.REST_CORE,
+        )
 
 
 def test_gitlab_budget_route_family_limits_override_dimension_defaults() -> None:

--- a/tests/providers/test_gitlab_code_client.py
+++ b/tests/providers/test_gitlab_code_client.py
@@ -35,6 +35,7 @@ from dev_health_ops.sync.budget_types import BudgetDimension
 _PROJECT_PATH = "/api/v4/projects/42"
 _FINDINGS_PATH = "/api/v4/projects/42/vulnerability_findings"
 _DEPENDENCIES_PATH = "/api/v4/projects/42/dependencies"
+_PROJECTS_PATH = "/api/v4/projects"
 
 _PROJECT_RESPONSE = {"id": 42, "path_with_namespace": "group/project"}
 
@@ -145,6 +146,112 @@ class TestAuthAndProjectResolution:
 
         with pytest.raises(AuthenticationException):
             await client.get_security_alerts(42)
+
+
+class TestProjectMetadataAndDiscovery:
+    @pytest.mark.asyncio
+    async def test_get_project_maps_metadata_and_records_project_usage(self) -> None:
+        project_path = "/api/v4/projects/group/project"
+        transport, _ = _router_transport(
+            {
+                project_path: _json_response(
+                    200,
+                    {
+                        "id": "42",
+                        "name": "project",
+                        "path_with_namespace": "group/project",
+                        "web_url": "https://gitlab.example.com/group/project",
+                        "default_branch": "trunk",
+                    },
+                )
+            }
+        )
+        client = _client(transport, base_url="https://gitlab.example.com/")
+
+        project = await client.get_project("group/project")
+
+        assert project.id == 42
+        assert project.name == "project"
+        assert project.path_with_namespace == "group/project"
+        assert project.web_url == "https://gitlab.example.com/group/project"
+        assert project.default_branch == "trunk"
+        assert (
+            b"/api/v4/projects/group%2Fproject"
+            in transport.captured_raw_paths[  # type: ignore[attr-defined]
+                project_path
+            ]
+        )
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "project"
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_list_projects_paginates_membership_and_records_per_page_usage(
+        self,
+    ) -> None:
+        transport, calls = _router_transport(
+            {
+                _PROJECTS_PATH: [
+                    _json_response(
+                        200,
+                        [
+                            {
+                                "id": 1,
+                                "name": "alpha",
+                                "path_with_namespace": "group/alpha",
+                                "default_branch": "main",
+                                "web_url": "https://gitlab.example.com/group/alpha",
+                            },
+                            {
+                                "id": "2",
+                                "name": "beta",
+                                "path_with_namespace": "group/beta",
+                                "default_branch": "develop",
+                                "web_url": "https://gitlab.example.com/group/beta",
+                            },
+                        ],
+                        headers={"X-Next-Page": "2"},
+                    ),
+                    _json_response(
+                        200,
+                        [
+                            {
+                                "id": 3,
+                                "name": "gamma",
+                                "path_with_namespace": "group/gamma",
+                                "default_branch": None,
+                                "web_url": "https://gitlab.example.com/group/gamma",
+                            }
+                        ],
+                    ),
+                ]
+            }
+        )
+        client = _client(transport)
+
+        repos = await client.list_projects(
+            membership=True,
+            pattern="group/*a*",
+            max_projects=3,
+            per_page=2,
+        )
+
+        assert [repo.full_name for repo in repos] == [
+            "group/alpha",
+            "group/beta",
+            "group/gamma",
+        ]
+        assert repos[1].id == 2
+        assert repos[2].default_branch == "main"
+        assert calls[_PROJECTS_PATH] == 2
+        first_url = transport.captured_urls[_PROJECTS_PATH]  # type: ignore[attr-defined]
+        assert first_url.params["membership"] == "true"
+        assert first_url.params["per_page"] == "2"
+        observations = client.drain_usage_observations()
+        assert len(observations) == 1
+        assert observations[0]["route_family"] == "project"
+        assert observations[0]["request_count"] == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -43,6 +43,31 @@ def _enable_connector_stubs(monkeypatch) -> None:
     monkeypatch.setattr(processors.gitlab, "RateLimitGate", RateLimitGate)
 
 
+class _GitLabProjectDiscoveryClient:
+    def __init__(self, projects):
+        self._projects = projects
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def list_projects(self, **kwargs):
+        return self._projects
+
+    def drain_usage_observations(self):
+        return [{"route_family": "project"}]
+
+
+def _stub_gitlab_project_discovery(monkeypatch, projects) -> None:
+    monkeypatch.setattr(
+        processors.gitlab,
+        "_gitlab_code_client_from_connector",
+        lambda connector: _GitLabProjectDiscoveryClient(projects),
+    )
+
+
 def _github_commits_async_from_sync(fake_fetch):
     async def _wrapped(
         connector,
@@ -323,6 +348,7 @@ async def test_process_gitlab_projects_batch_upserts_during_sync_processing(
     project.default_branch = "main"
 
     result = BatchResult(repository=project, stats=None, success=True)
+    _stub_gitlab_project_discovery(monkeypatch, [project])
 
     class DummyConnector:
         def __init__(self, url: str, private_token: str):
@@ -411,6 +437,7 @@ async def test_process_gitlab_projects_batch_persists_instance_discriminator(
     project.default_branch = "main"
 
     result = BatchResult(repository=project, stats=None, success=True)
+    _stub_gitlab_project_discovery(monkeypatch, [project])
 
     class DummyConnector:
         def __init__(self, url: str, private_token: str):
@@ -1679,6 +1706,7 @@ async def test_process_gitlab_projects_batch_stores_commits_and_stats(monkeypatc
     project.default_branch = "main"
 
     result = BatchResult(repository=project, stats=None, success=True)
+    _stub_gitlab_project_discovery(monkeypatch, [project])
 
     def fake_fetch_commits(
         connector,
@@ -1784,6 +1812,114 @@ async def test_process_gitlab_projects_batch_stores_commits_and_stats(monkeypatc
 
 
 @pytest.mark.asyncio
+async def test_process_gitlab_projects_batch_since_prepass_persists_aggregate_stats(
+    monkeypatch,
+):
+    _enable_connector_stubs(monkeypatch)
+
+    since = datetime(2026, 5, 13, tzinfo=timezone.utc)
+    recorded_stats: list[GitCommitStat] = []
+
+    class DummyStore:
+        async def insert_repo(self, repo):
+            return
+
+        async def insert_git_commit_data(self, commit_data):
+            return
+
+        async def insert_git_commit_stats(self, commit_stats):
+            recorded_stats.extend(commit_stats)
+
+        async def insert_git_pull_requests(self, pr_data):
+            return
+
+    project = Mock()
+    project.id = 457
+    project.full_name = "group/windowed-stats"
+    project.url = "https://example.com/group/windowed-stats"
+    project.default_branch = "main"
+
+    class DummyConnector:
+        def __init__(self, url: str, private_token: str):
+            self.url = url
+            self.private_token = private_token
+
+        def close(self):
+            return
+
+    class DummyCodeClient:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return None
+
+        async def list_projects(self, **kwargs):
+            return [project]
+
+        async def get_commit_stats(self, project_id, commit_hash):
+            assert project_id == project.id
+            assert commit_hash == "gitlab-windowed"
+            return SimpleNamespace(additions=7, deletions=2)
+
+        def drain_usage_observations(self):
+            return []
+
+    def fake_fetch_commits(
+        connector,
+        project_id,
+        max_commits,
+        repo_id,
+        since=None,
+        until=None,
+        usage_sink=None,
+    ):
+        assert project_id == project.id
+        assert since is not None
+        return ["gitlab-windowed"], []
+
+    monkeypatch.setattr(processors.gitlab, "GitLabConnector", DummyConnector)
+    monkeypatch.setattr(
+        processors.gitlab,
+        "_gitlab_code_client_from_connector",
+        lambda connector: DummyCodeClient(),
+    )
+    monkeypatch.setattr(
+        processors.gitlab, "_fetch_gitlab_commits_sync", fake_fetch_commits
+    )
+
+    await processors.gitlab.process_gitlab_projects_batch(
+        store=DummyStore(),
+        token="test_token",
+        gitlab_url="https://gitlab.com",
+        group_name="group",
+        pattern="group/*",
+        batch_size=1,
+        max_concurrent=1,
+        rate_limit_delay=0,
+        use_async=True,
+        sync_git=True,
+        sync_prs=False,
+        sync_cicd=False,
+        sync_deployments=False,
+        sync_incidents=False,
+        sync_security=False,
+        sync_tests=False,
+        backfill_missing=False,
+        since=since,
+    )
+
+    aggregate_stats = [
+        stat
+        for stat in recorded_stats
+        if stat.commit_hash == processors.gitlab.AGGREGATE_STATS_MARKER
+    ]
+    assert len(aggregate_stats) == 1
+    assert aggregate_stats[0].additions == 7
+    assert aggregate_stats[0].deletions == 2
+
+
+@pytest.mark.asyncio
 async def test_process_gitlab_projects_batch_commit_rate_limit_propagates(
     monkeypatch,
 ):
@@ -1818,6 +1954,7 @@ async def test_process_gitlab_projects_batch_commit_rate_limit_propagates(
     project.default_branch = "main"
 
     result = BatchResult(repository=project, stats=None, success=True)
+    _stub_gitlab_project_discovery(monkeypatch, [project])
 
     def fake_fetch_commits(*args, **kwargs):
         raise RateLimitException("limited", retry_after_seconds=42.0)
@@ -1899,6 +2036,9 @@ async def test_process_gitlab_projects_batch_multi_project_rate_limit_does_not_h
         return BatchResult(repository=project, stats=None, success=True)
 
     results = [make_result(index) for index in range(3)]
+    _stub_gitlab_project_discovery(
+        monkeypatch, [result.repository for result in results]
+    )
 
     def fake_fetch_commits(*args, **kwargs):
         raise RateLimitException("limited", retry_after_seconds=42.0)
@@ -1972,6 +2112,7 @@ async def test_process_gitlab_projects_batch_threads_code_usage_sink(monkeypatch
     project.url = "https://example.com/group/proj-usage"
     project.default_branch = "main"
     result = BatchResult(repository=project, stats=None, success=True)
+    _stub_gitlab_project_discovery(monkeypatch, [project])
 
     class DummyConnector:
         def __init__(self, url: str, private_token: str):

--- a/tests/test_gitlab_content_backfill.py
+++ b/tests/test_gitlab_content_backfill.py
@@ -15,7 +15,6 @@ from datetime import datetime, timezone
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
-import httpx
 import pytest
 
 # Initialize the connectors package before processors.gitlab to avoid the
@@ -32,7 +31,6 @@ from dev_health_ops.processors.gitlab import (
 )
 from dev_health_ops.providers.gitlab.code_client import (
     GitLabBlameRange,
-    GitLabCodeClient,
     GitLabCommitData,
     GitLabCommitStatsData,
     GitLabFileBlame,
@@ -222,12 +220,14 @@ class _FakeGitLabCodeClientForFiles:
         contents_error=None,
         blame_by_path=None,
         blame_error_paths=None,
+        tree_items=None,
         observations=None,
     ):
         self.contents = contents or {}
         self.contents_error = contents_error
         self.blame_by_path = blame_by_path or {}
         self.blame_error_paths = blame_error_paths or {}
+        self.tree_items = tree_items if tree_items is not None else []
         self.observations = observations or []
         self.get_file_contents_calls: list[Any] = []
         self.get_file_blame_calls: list[Any] = []
@@ -251,6 +251,11 @@ class _FakeGitLabCodeClientForFiles:
         if file_path in self.blame_error_paths:
             raise self.blame_error_paths[file_path]
         return self.blame_by_path.get(file_path, GitLabFileBlame(file_path=file_path))
+
+    async def list_repository_tree(
+        self, project_id, *, ref, per_page=100, max_items=1_000_000
+    ):
+        return self.tree_items
 
     def drain_usage_observations(self):
         observations = list(self.observations)
@@ -342,7 +347,14 @@ class TestGitLabBackfillContents:
         connector = Mock()
         connector.gitlab.projects.get.return_value = project
 
-        fake_client = _FakeGitLabCodeClientForFiles(contents={"src/app.py": "x = 1\n"})
+        tree_items = [
+            {"type": "blob", "path": "src/app.py"},
+            {"type": "blob", "path": "README.md"},
+            {"type": "tree", "path": "src"},
+        ]
+        fake_client = _FakeGitLabCodeClientForFiles(
+            contents={"src/app.py": "x = 1\n"}, tree_items=tree_items
+        )
         monkeypatch.setattr(
             "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
             lambda connector: fake_client,
@@ -351,26 +363,17 @@ class TestGitLabBackfillContents:
         db_repo = Mock()
         db_repo.id = uuid.uuid4()
 
-        tree_items = [
-            {"type": "blob", "path": "src/app.py"},
-            {"type": "blob", "path": "README.md"},
-            {"type": "tree", "path": "src"},
-        ]
-        with patch(
-            "dev_health_ops.processors.gitlab._iter_gitlab_repo_tree",
-            return_value=tree_items,
-        ):
-            await _backfill_gitlab_missing_data(
-                store=store,
-                ingestion_sink=sink,
-                connector=connector,
-                db_repo=db_repo,
-                project_full_name="group/proj",
-                default_branch="main",
-                max_commits=None,
-                include_blame=False,
-                include_commit_stats=False,
-            )
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_blame=False,
+            include_commit_stats=False,
+        )
 
         by_path = {f.path: f.contents for f in written}
         assert by_path == {"src/app.py": "x = 1\n", "README.md": None}
@@ -603,46 +606,40 @@ class TestGitLabBackfillBlame:
             )
         )
 
-        blame_payloads = {
-            "/api/v4/projects/42/repository/files/src/a.py/blame": [
-                {
-                    "commit": {
-                        "id": "sha1",
-                        "author_name": "Ada",
-                        "author_email": "ada@example.com",
-                    },
-                    "lines": ["a = 1", "a = 2"],
-                },
-                {
-                    "commit": {
-                        "id": "sha3",
-                        "author_name": "Linus",
-                        "author_email": "linus@example.com",
-                    },
-                    "lines": ["a = 3"],
-                },
-            ],
-            "/api/v4/projects/42/repository/files/src/b.py/blame": [
-                {
-                    "commit": {
-                        "id": "sha2",
-                        "author_name": "Grace",
-                        "author_email": "grace@example.com",
-                    },
-                    "lines": ["b = 1"],
-                }
-            ],
-        }
-        blame_calls: dict[str, int] = {}
-
-        def blame_handler(request: httpx.Request) -> httpx.Response:
-            path = request.url.path
-            blame_calls[path] = blame_calls.get(path, 0) + 1
-            return httpx.Response(200, json=blame_payloads[path])
-
-        fake_client = GitLabCodeClient(
-            private_token="tok",
-            transport=httpx.MockTransport(blame_handler),
+        tree_items = [
+            {"type": "blob", "path": "src/a.py"},
+            {"type": "blob", "path": "src/b.py"},
+        ]
+        fake_client = _FakeGitLabCodeClientForFiles(
+            blame_by_path={
+                "src/a.py": GitLabFileBlame(
+                    file_path="src/a.py",
+                    ranges=(
+                        GitLabBlameRange(
+                            1,
+                            2,
+                            "sha1",
+                            "Ada",
+                            "ada@example.com",
+                            0,
+                            ("a = 1", "a = 2"),
+                        ),
+                        GitLabBlameRange(
+                            3, 3, "sha3", "Linus", "linus@example.com", 0, ("a = 3",)
+                        ),
+                    ),
+                ),
+                "src/b.py": GitLabFileBlame(
+                    file_path="src/b.py",
+                    ranges=(
+                        GitLabBlameRange(
+                            1, 1, "sha2", "Grace", "grace@example.com", 0, ("b = 1",)
+                        ),
+                    ),
+                ),
+            },
+            tree_items=tree_items,
+            observations=[{"route_family": "project"}],
         )
         monkeypatch.setattr(
             "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
@@ -653,31 +650,19 @@ class TestGitLabBackfillBlame:
         db_repo.id = uuid.uuid4()
         usage_sink: list[dict[str, Any]] = []
 
-        tree_items = [
-            {"type": "blob", "path": "src/a.py"},
-            {"type": "blob", "path": "src/b.py"},
-        ]
-        with patch(
-            "dev_health_ops.processors.gitlab._iter_gitlab_repo_tree",
-            return_value=tree_items,
-        ):
-            await _backfill_gitlab_missing_data(
-                store=store,
-                ingestion_sink=sink,
-                connector=connector,
-                db_repo=db_repo,
-                project_full_name="group/proj",
-                default_branch="main",
-                max_commits=None,
-                include_files=False,
-                include_commit_stats=False,
-                usage_sink=usage_sink,
-            )
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_files=False,
+            include_commit_stats=False,
+            usage_sink=usage_sink,
+        )
 
-        assert blame_calls == {
-            "/api/v4/projects/42/repository/files/src/a.py/blame": 1,
-            "/api/v4/projects/42/repository/files/src/b.py/blame": 1,
-        }
         assert connector.rest_client.get_file_blame.call_count == 0
         assert [
             (row.path, row.line_no, row.line, row.commit_hash, row.author_name)
@@ -709,6 +694,10 @@ class TestGitLabBackfillBlame:
         connector = Mock()
         connector.gitlab.projects.get.return_value = project
 
+        tree_items = [
+            {"type": "blob", "path": "src/a.py"},
+            {"type": "blob", "path": "src/b.py"},
+        ]
         fake_client = _FakeGitLabCodeClientForFiles(
             blame_by_path={
                 "src/b.py": GitLabFileBlame(
@@ -719,6 +708,7 @@ class TestGitLabBackfillBlame:
                 ),
             },
             blame_error_paths={"src/a.py": RuntimeError("boom")},
+            tree_items=tree_items,
         )
         monkeypatch.setattr(
             "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
@@ -728,25 +718,17 @@ class TestGitLabBackfillBlame:
         db_repo = Mock()
         db_repo.id = uuid.uuid4()
 
-        tree_items = [
-            {"type": "blob", "path": "src/a.py"},
-            {"type": "blob", "path": "src/b.py"},
-        ]
-        with patch(
-            "dev_health_ops.processors.gitlab._iter_gitlab_repo_tree",
-            return_value=tree_items,
-        ):
-            await _backfill_gitlab_missing_data(
-                store=store,
-                ingestion_sink=sink,
-                connector=connector,
-                db_repo=db_repo,
-                project_full_name="group/proj",
-                default_branch="main",
-                max_commits=None,
-                include_files=False,
-                include_commit_stats=False,
-            )
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_files=False,
+            include_commit_stats=False,
+        )
 
         assert {row.path for row in written} == {"src/b.py"}
 
@@ -760,8 +742,10 @@ class TestGitLabBackfillBlame:
         project.id = 42
         connector = Mock()
         connector.gitlab.projects.get.return_value = project
+        tree_items = [{"type": "blob", "path": path} for path in sorted(paths)]
         fake_client = _FakeGitLabCodeClientForFiles(
             blame_error_paths={path: RuntimeError("boom") for path in paths},
+            tree_items=tree_items,
         )
         monkeypatch.setattr(
             "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
@@ -769,24 +753,19 @@ class TestGitLabBackfillBlame:
         )
         db_repo = Mock()
         db_repo.id = uuid.uuid4()
-        tree_items = [{"type": "blob", "path": path} for path in sorted(paths)]
 
-        with patch(
-            "dev_health_ops.processors.gitlab._iter_gitlab_repo_tree",
-            return_value=tree_items,
-        ):
-            with caplog.at_level(logging.WARNING):
-                await _backfill_gitlab_missing_data(
-                    store=store,
-                    ingestion_sink=sink,
-                    connector=connector,
-                    db_repo=db_repo,
-                    project_full_name="group/proj",
-                    default_branch="main",
-                    max_commits=None,
-                    include_files=False,
-                    include_commit_stats=False,
-                )
+        with caplog.at_level(logging.WARNING):
+            await _backfill_gitlab_missing_data(
+                store=store,
+                ingestion_sink=sink,
+                connector=connector,
+                db_repo=db_repo,
+                project_full_name="group/proj",
+                default_branch="main",
+                max_commits=None,
+                include_files=False,
+                include_commit_stats=False,
+            )
 
         messages = [record.getMessage() for record in caplog.records]
         assert sum("Failed GitLab blame fetch" in message for message in messages) == 5
@@ -812,8 +791,13 @@ class TestGitLabBackfillBlame:
         connector = Mock()
         connector.gitlab.projects.get.return_value = project
 
+        tree_items = [
+            {"type": "blob", "path": "src/a.py"},
+            {"type": "blob", "path": "src/b.py"},
+        ]
         fake_client = _FakeGitLabCodeClientForFiles(
             blame_error_paths={"src/a.py": RateLimitException("rate limited")},
+            tree_items=tree_items,
             observations=[{"route_family": "project"}],
         )
         monkeypatch.setattr(
@@ -825,27 +809,19 @@ class TestGitLabBackfillBlame:
         db_repo.id = uuid.uuid4()
         usage_sink: list[dict[str, Any]] = []
 
-        tree_items = [
-            {"type": "blob", "path": "src/a.py"},
-            {"type": "blob", "path": "src/b.py"},
-        ]
-        with patch(
-            "dev_health_ops.processors.gitlab._iter_gitlab_repo_tree",
-            return_value=tree_items,
-        ):
-            with pytest.raises(RateLimitException):
-                await _backfill_gitlab_missing_data(
-                    store=store,
-                    ingestion_sink=sink,
-                    connector=connector,
-                    db_repo=db_repo,
-                    project_full_name="group/proj",
-                    default_branch="main",
-                    max_commits=None,
-                    include_files=False,
-                    include_commit_stats=False,
-                    usage_sink=usage_sink,
-                )
+        with pytest.raises(RateLimitException):
+            await _backfill_gitlab_missing_data(
+                store=store,
+                ingestion_sink=sink,
+                connector=connector,
+                db_repo=db_repo,
+                project_full_name="group/proj",
+                default_branch="main",
+                max_commits=None,
+                include_files=False,
+                include_commit_stats=False,
+                usage_sink=usage_sink,
+            )
 
         # Partial observations gathered before the raise still reach the sink
         # (CHAOS-2754/2803 partial-observations-on-exception contract).

--- a/tests/test_gitlab_mr_reviews.py
+++ b/tests/test_gitlab_mr_reviews.py
@@ -1133,6 +1133,23 @@ class _FakeBatchConnector:
         self.closed = True
 
 
+class _FakeBatchDiscoveryClient:
+    def __init__(self, projects):
+        self._projects = projects
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return None
+
+    async def list_projects(self, **_kwargs):
+        return list(self._projects)
+
+    def drain_usage_observations(self):
+        return []
+
+
 def _patch_batch(monkeypatch, projects, sync_behavior):
     """Wire process_gitlab_projects_batch to fakes.
 
@@ -1143,6 +1160,11 @@ def _patch_batch(monkeypatch, projects, sync_behavior):
         gitlab_processor,
         "GitLabConnector",
         lambda **kw: _FakeBatchConnector(projects, **kw),
+    )
+    monkeypatch.setattr(
+        gitlab_processor,
+        "_gitlab_code_client_from_connector",
+        lambda _connector: _FakeBatchDiscoveryClient(projects),
     )
     monkeypatch.setattr(gitlab_processor, "IngestionSink", _FakeBatchSink)
     monkeypatch.setattr(gitlab_processor, "CONNECTORS_AVAILABLE", True)

--- a/tests/test_processor_split.py
+++ b/tests/test_processor_split.py
@@ -97,6 +97,20 @@ class _FakeGitLabConnector:
         return None
 
 
+class _FakeGitLabProjectInfoClient:
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        return None
+
+    async def get_project(self, project_id):
+        return _fake_gitlab_project()
+
+    def drain_usage_observations(self):
+        return []
+
+
 def _fake_github_repo():
     return SimpleNamespace(
         id=1,
@@ -131,6 +145,14 @@ def _disable_non_git_flags() -> dict[str, Any]:
         sync_incidents=False,
         sync_security=False,
         sync_tests=False,
+    )
+
+
+def _patch_gitlab_project_info(monkeypatch) -> None:
+    monkeypatch.setattr(
+        gitlab,
+        "_gitlab_code_client_from_connector",
+        lambda _connector: _FakeGitLabProjectInfoClient(),
     )
 
 
@@ -285,6 +307,7 @@ def test_gitlab_commits_run_does_not_fetch_stats_files_or_blame(monkeypatch):
 
     monkeypatch.setattr(gitlab, "CONNECTORS_AVAILABLE", True)
     monkeypatch.setattr(gitlab, "GitLabConnector", _FakeGitLabConnector)
+    _patch_gitlab_project_info(monkeypatch)
     monkeypatch.setattr(gitlab, "IngestionSink", _FakeSink)
     monkeypatch.setattr(
         gitlab,
@@ -328,6 +351,7 @@ def test_gitlab_granular_stats_files_blame_and_legacy_bundle(monkeypatch):
 
     monkeypatch.setattr(gitlab, "CONNECTORS_AVAILABLE", True)
     monkeypatch.setattr(gitlab, "GitLabConnector", _FakeGitLabConnector)
+    _patch_gitlab_project_info(monkeypatch)
     monkeypatch.setattr(gitlab, "IngestionSink", _FakeSink)
     monkeypatch.setattr(
         gitlab,

--- a/tests/test_processors_gitlab.py
+++ b/tests/test_processors_gitlab.py
@@ -13,6 +13,8 @@ from dev_health_ops.processors.gitlab import (
     _fetch_gitlab_incidents_sync,
     _fetch_gitlab_mrs_sync,
     _fetch_gitlab_pipelines_sync,
+    _fetch_gitlab_project_info_sync,
+    _fetch_gitlab_repository_tree,
     _fetch_gitlab_test_reports_sync,
     process_gitlab_project,
 )
@@ -21,6 +23,7 @@ from dev_health_ops.providers.gitlab.code_client import (
     GitLabCommitStatsData,
     GitLabDeploymentData,
     GitLabPipelineData,
+    GitLabProjectData,
 )
 
 
@@ -40,6 +43,8 @@ class _FakeGitLabCodeClient:
         test_reports=None,
         jobs=None,
         artifacts=None,
+        project=None,
+        tree_items=None,
     ):
         self.pipelines = pipelines or []
         self.deployments = deployments or []
@@ -55,6 +60,8 @@ class _FakeGitLabCodeClient:
         self.test_reports = test_reports or {}
         self.jobs = jobs or {}
         self.artifacts = artifacts or {}
+        self.project = project
+        self.tree_items = tree_items if tree_items is not None else []
         self.iter_merge_requests_calls: list[tuple[Any, str, int, int | None]] = []
         self.get_merge_requests_page_calls: list[tuple[Any, int, str, int]] = []
 
@@ -117,6 +124,14 @@ class _FakeGitLabCodeClient:
 
     async def download_job_artifact(self, project_id, job_id, *, max_bytes=None):
         return self.artifacts.get(job_id, b"")
+
+    async def get_project(self, project_id):
+        return self.project
+
+    async def list_repository_tree(
+        self, project_id, *, ref, per_page=100, max_items=1_000_000
+    ):
+        return self.tree_items
 
     def drain_usage_observations(self):
         observations = list(self.observations)
@@ -471,6 +486,72 @@ def test_fetch_gitlab_commits_sync(monkeypatch):
     assert commit_objects[0].message == "ship it"
     assert commit_objects[0].parents == 1
     assert commit_objects[0].committer_when == committed_at
+    assert usage_sink == [{"route_family": "project"}]
+
+
+def test_fetch_gitlab_project_info_sync_uses_code_client(monkeypatch):
+    usage_sink: list[dict[str, Any]] = []
+    project = GitLabProjectData(
+        id=42,
+        name="proj",
+        path_with_namespace="group/proj",
+        web_url="https://gitlab.com/group/proj",
+        default_branch="main",
+    )
+    fake_client = _FakeGitLabCodeClient(
+        project=project, observations=[{"route_family": "project"}]
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+
+    result = _fetch_gitlab_project_info_sync(Mock(), 42, usage_sink=usage_sink)
+
+    assert result is project
+    assert result.name == "proj"
+    assert usage_sink == [{"route_family": "project"}]
+
+
+@pytest.mark.asyncio
+async def test_fetch_gitlab_repository_tree_uses_code_client(monkeypatch):
+    usage_sink: list[dict[str, Any]] = []
+    tree_items = [{"type": "blob", "path": "src/a.py"}]
+    fake_client = _FakeGitLabCodeClient(
+        tree_items=tree_items, observations=[{"route_family": "project"}]
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+
+    items = await _fetch_gitlab_repository_tree(
+        Mock(), "group/proj", "main", usage_sink
+    )
+
+    assert items == tree_items
+    assert usage_sink == [{"route_family": "project"}]
+
+
+@pytest.mark.asyncio
+async def test_fetch_gitlab_repository_tree_reraises_rate_limit(monkeypatch):
+    usage_sink: list[dict[str, Any]] = []
+
+    class _RateLimitedClient(_FakeGitLabCodeClient):
+        async def list_repository_tree(
+            self, project_id, *, ref, per_page=100, max_items=1_000_000
+        ):
+            raise RateLimitException("limited")
+
+    fake_client = _RateLimitedClient(observations=[{"route_family": "project"}])
+    monkeypatch.setattr(
+        "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+        lambda connector: fake_client,
+    )
+
+    with pytest.raises(RateLimitException):
+        await _fetch_gitlab_repository_tree(Mock(), "group/proj", "main", usage_sink)
+
     assert usage_sink == [{"route_family": "project"}]
 
 


### PR DESCRIPTION
## CHAOS-2773 CS15b — GitLab repo metadata + batch orchestration + admin batch/repo-list

Migrates GitLab project metadata, batch orchestration, and the admin GitLab batch-create + credential repo-list off the frozen connector/python-gitlab machinery onto the canonical httpx `GitLabCodeClient` (final GitLab family changeset before LV-B).

### Changes
- **`GitLabCodeClient`**: adds `get_project` (single-project metadata) and `list_projects` (group/pattern/membership scoped) with `project:` operation labels and usage recording via `InstrumentedRESTCore`.
- **Processor**: `process_gitlab_project` metadata fetch and `process_gitlab_projects_batch` discovery/fan-out rewired to bounded-async over the code client; `usage_sink` threaded through the batch path; `RateLimitException` propagation preserved (both swallow layers kept re-raising). The batch stats prepass caps the commit fetch (`max_commits_per_project or 100`) so an unset window can't paginate 10k pages.
- **Admin**: GitLab batch-create repo listing and the credential repo-list endpoint migrated off `GitLabConnector`, preserving status codes and membership/group scoping.
- **Budget**: `project` family prefix resolution confirmed; compressed estimator vocabulary `{project, merge_requests, notes, pipelines}` unchanged.
- Docs (`rate-limit-policy.md`) updated; code-client/batch/admin/content-backfill/processor tests added/updated.

`connectors/utils/rest.py` and the GitLab feature-flag path stay frozen in tree (retained for CS17); no connector code deleted. No runtime legacy flag.

### Validation
- Full gate `OTEL_SDK_DISABLED=true SCRATCH_DB=ci_local_validate_2817 bash ci/local_validate.sh` → `GATE PASSED` (`6947 passed, 44 skipped`).
- Adversarial review (Oracle) caught a real bug the gate missed: the batch stats prepass passed a `since` datetime where a rate-limit `gate` was expected (`_fetch_gitlab_commit_stats_sync`), silently failing aggregate stats on windowed syncs. Fixed (pass `gate=None`) and locked with a regression test (`test_process_gitlab_projects_batch_since_prepass_persists_aggregate_stats`, red/green proven). A full sibling arg-order audit of the diff found no other mismatches.

> Rebased onto current main; resolved conflicts with main's blame-dataset refactor (CHAOS-2861) — GitLab blame uses the local `GitLabFileBlame`/`GitLabBlameRange` types.

SCREENSHOT-WAIVER: backend/provider-only change; no rendered UI.