### PR TITLE
fix(work-graph): project persisted dependency edges

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -53,6 +53,37 @@ _INCIDENT_STATUS_LABELS: dict[str, str] = {
     "closed": "Closed",
 }
 
+_DEPENDENCY_EDGE_TYPES: frozenset[str] = frozenset(
+    {
+        "blocks",
+        "is_blocked_by",
+        "relates",
+        "is_related_to",
+        "duplicates",
+        "is_duplicate_of",
+        "parent_of",
+        "child_of",
+    }
+)
+
+_DEPENDENCY_RELATIONSHIP_TYPE_MAP: dict[str, str] = {
+    "blocks": "blocks",
+    "blocked_by": "is_blocked_by",
+    "is_blocked_by": "is_blocked_by",
+    "relates": "relates",
+    "relates_to": "relates",
+    "is_related_to": "is_related_to",
+    "duplicates": "duplicates",
+    "duplicate": "duplicates",
+    "is_duplicate_of": "is_duplicate_of",
+    "parent": "parent_of",
+    "parent_of": "parent_of",
+    "is_parent_of": "parent_of",
+    "child": "child_of",
+    "child_of": "child_of",
+    "is_child_of": "child_of",
+}
+
 
 def _uses_scoped_partial(filters: WorkGraphEdgeFilterInput | None) -> bool:
     return bool(_partial_repo_ids(filters))
@@ -114,6 +145,67 @@ def _map_provenance(value: str) -> WorkGraphProvenance:
         return WorkGraphProvenance(value.lower())
     except ValueError:
         return WorkGraphProvenance.HEURISTIC
+
+
+def _dependency_edge_type_sql() -> str:
+    cases = [
+        f"relationship_type = '{relationship_type}', '{edge_type}'"
+        for relationship_type, edge_type in sorted(
+            _DEPENDENCY_RELATIONSHIP_TYPE_MAP.items()
+        )
+    ]
+    return f"multiIf({', '.join(cases)}, 'relates')"
+
+
+def _dependency_node_type_sql(column_name: str) -> str:
+    return (
+        "multiIf("
+        f"startsWith({column_name}, 'ghpr:') OR "
+        f"(startsWith({column_name}, 'gitlab:') AND position({column_name}, '!') > 0), "
+        "'pr', 'issue')"
+    )
+
+
+def _dependency_theme_membership_exists_clause(
+    filters: WorkGraphEdgeFilterInput | None,
+) -> str:
+    return f"""
+        EXISTS (
+            SELECT 1
+            FROM work_unit_membership AS m
+            INNER JOIN ({_membership_run_subquery(filters)}) AS latest_run
+                ON 1 = 1
+            {_LEGACY_NODE_MAX_JOIN}
+            WHERE m.org_id = %(org_id)s
+              AND latest_run.latest_run_id != ''
+              AND ({_RUN_SCOPE_PREDICATE})
+              AND (
+                (m.node_type, m.node_id) = (source_type, source_work_item_id)
+                OR (m.node_type, m.node_id) = (target_type, target_work_item_id)
+              )
+              AND (m.category_kind, m.category) IN %(category_tuples)s
+            GROUP BY m.node_type, m.node_id
+            HAVING uniqExact((m.category_kind, m.category)) = %(wanted_count)s
+        )
+    """
+
+
+def _dependency_edge_filter_values(
+    filters: WorkGraphEdgeFilterInput | None,
+) -> list[str]:
+    if filters is None:
+        return []
+
+    if filters.edge_type and filters.edge_types:
+        plural_values = {edge_type.value for edge_type in filters.edge_types}
+        requested = {filters.edge_type.value} & plural_values
+    elif filters.edge_type:
+        requested = {filters.edge_type.value}
+    elif filters.edge_types:
+        requested = {edge_type.value for edge_type in filters.edge_types}
+    else:
+        return []
+    return sorted(requested & _DEPENDENCY_EDGE_TYPES)
 
 
 def _display_name_for(
@@ -893,6 +985,94 @@ def _build_work_graph_where(
     return where_sql, params
 
 
+async def _query_dependency_edges(
+    client: Any,
+    org_id: str,
+    filters: WorkGraphEdgeFilterInput | None,
+    limit: int,
+) -> list[dict[str, Any]]:
+    from dev_health_ops.api.queries.client import query_dicts
+
+    edge_types = _dependency_edge_filter_values(filters)
+    if not edge_types:
+        return []
+    if filters and filters.repo_ids:
+        return []
+
+    mapped_edge_type = _dependency_edge_type_sql()
+    source_type = _dependency_node_type_sql("source_work_item_id")
+    target_type = _dependency_node_type_sql("target_work_item_id")
+    where_clauses = ["org_id = %(org_id)s", "mapped_edge_type IN %(edge_types)s"]
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "edge_types": edge_types,
+        "limit": limit,
+    }
+    _add_membership_scope_params(params, filters)
+
+    if filters and filters.source_type:
+        where_clauses.append("source_type = %(source_type)s")
+        params["source_type"] = filters.source_type.value
+    if filters and filters.target_type:
+        where_clauses.append("target_type = %(target_type)s")
+        params["target_type"] = filters.target_type.value
+    if filters and filters.node_id:
+        where_clauses.append(
+            "(source_work_item_id = %(node_id)s OR target_work_item_id = %(node_id)s)"
+        )
+        params["node_id"] = filters.node_id
+    if filters and (filters.theme or filters.subcategory):
+        exists_clause, theme_params = _build_theme_filter(
+            filters.theme, filters.subcategory, filters
+        )
+        if exists_clause:
+            dependency_exists_clause = _dependency_theme_membership_exists_clause(
+                filters
+            )
+            where_clauses.append(dependency_exists_clause)
+            params.update(theme_params)
+
+    where_sql = " AND ".join(where_clauses)
+    return await query_dicts(
+        client,
+        f"""
+        SELECT
+            concat(
+                'wid:',
+                hex(MD5(concat(source_type, ':', source_work_item_id, ':', mapped_edge_type, ':', target_type, ':', target_work_item_id)))
+            ) AS edge_id,
+            source_type,
+            source_work_item_id AS source_id,
+            target_type,
+            target_work_item_id AS target_id,
+            mapped_edge_type AS edge_type,
+            CAST(NULL, 'Nullable(UUID)') AS repo_id,
+            CAST(NULL, 'Nullable(String)') AS provider,
+            'native' AS provenance,
+            1.0 AS confidence,
+            if(relationship_type_raw != '', relationship_type_raw, relationship_type) AS evidence
+        FROM (
+            SELECT
+                org_id,
+                source_work_item_id,
+                target_work_item_id,
+                relationship_type,
+                relationship_type_raw,
+                {mapped_edge_type} AS mapped_edge_type,
+                {source_type} AS source_type,
+                {target_type} AS target_type,
+                last_synced
+            FROM work_item_dependencies FINAL
+            WHERE org_id = %(org_id)s
+        )
+        WHERE {where_sql}
+        ORDER BY last_synced DESC, edge_id ASC
+        LIMIT %(limit)s
+        """,
+        params,
+    )
+
+
 async def resolve_work_graph_edges(
     context: GraphQLContext,
     filters: WorkGraphEdgeFilterInput | None = None,
@@ -995,6 +1175,34 @@ async def resolve_work_graph_edges(
             )
             return _empty_edges_result(MEMBERSHIP_NOT_MATERIALIZED, filters)
         raise
+
+    dependency_rows = await _query_dependency_edges(client, org_id, filters, int(limit))
+    if dependency_rows:
+        existing_edge_keys = {
+            (
+                row.get("source_type"),
+                row.get("source_id"),
+                row.get("edge_type"),
+                row.get("target_type"),
+                row.get("target_id"),
+            )
+            for row in rows
+        }
+        rows = (
+            rows
+            + [
+                row
+                for row in dependency_rows
+                if (
+                    row.get("source_type"),
+                    row.get("source_id"),
+                    row.get("edge_type"),
+                    row.get("target_type"),
+                    row.get("target_id"),
+                )
+                not in existing_edge_keys
+            ]
+        )[: int(limit)]
 
     # Degraded-state signal (CHAOS-2430 rollout): a theme filter that yields zero
     # edges is normally a legitimate empty state, but immediately after deploy it

--- a/tests/graphql/test_work_graph_aggregates.py
+++ b/tests/graphql/test_work_graph_aggregates.py
@@ -85,8 +85,8 @@ class TestEdgeTypesFilter:
             filters = WorkGraphEdgeFilterInput(edge_types=dep_types)
             await resolve_work_graph_edges(mock_context, filters)
 
-            sql = mock_query.call_args[0][1]
-            params = mock_query.call_args[0][2]
+            sql = mock_query.call_args_list[0][0][1]
+            params = mock_query.call_args_list[0][0][2]
 
             assert "edge_type IN %(edge_types)s" in sql
             assert params["edge_types"] == [
@@ -97,6 +97,171 @@ class TestEdgeTypesFilter:
             ]
             # The IN clause precedes the LIMIT — proof it filters before the cap.
             assert sql.index("edge_type IN") < sql.index("LIMIT")
+
+    @pytest.mark.asyncio
+    async def test_dependency_edge_types_project_work_item_dependencies(
+        self, mock_context
+    ):
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [
+                [],
+                [
+                    {
+                        "edge_id": "wid:abc",
+                        "source_type": "pr",
+                        "source_id": "ghpr:full-chaos/dev-health-ops#1171",
+                        "target_type": "issue",
+                        "target_id": "linear:CHAOS-2852",
+                        "edge_type": "relates",
+                        "repo_id": None,
+                        "provider": None,
+                        "provenance": "native",
+                        "confidence": 1.0,
+                        "evidence": "linear_attachment",
+                    }
+                ],
+                [],
+                [],
+            ]
+
+            filters = WorkGraphEdgeFilterInput(
+                edge_types=[WorkGraphEdgeTypeInput.RELATES]
+            )
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+        dependency_sql = mock_query.call_args_list[1][0][1]
+        dependency_params = mock_query.call_args_list[1][0][2]
+        assert "FROM work_item_dependencies FINAL" in dependency_sql
+        assert dependency_params["edge_types"] == ["relates"]
+        assert len(result.edges) == 1
+        edge = result.edges[0]
+        assert edge.source_type == WorkGraphNodeType.PR
+        assert edge.source_id == "ghpr:full-chaos/dev-health-ops#1171"
+        assert edge.target_type == WorkGraphNodeType.ISSUE
+        assert edge.target_id == "linear:CHAOS-2852"
+
+    @pytest.mark.asyncio
+    async def test_dependency_projection_preserves_edge_type_and_semantics(
+        self, mock_context
+    ):
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+
+            filters = WorkGraphEdgeFilterInput(
+                edge_type=WorkGraphEdgeTypeInput.BLOCKS,
+                edge_types=[WorkGraphEdgeTypeInput.RELATES],
+            )
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+        assert result.edges == []
+        assert len(mock_query.call_args_list) == 1
+        assert (
+            "FROM work_item_dependencies FINAL"
+            not in mock_query.call_args_list[0][0][1]
+        )
+
+    @pytest.mark.asyncio
+    async def test_dependency_projection_skips_unscopable_repo_filter(
+        self, mock_context
+    ):
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.return_value = []
+
+            filters = WorkGraphEdgeFilterInput(
+                edge_types=[WorkGraphEdgeTypeInput.RELATES],
+                repo_ids=["00000000-0000-0000-0000-000000000001"],
+            )
+            await resolve_work_graph_edges(mock_context, filters)
+
+        assert all(
+            "FROM work_item_dependencies FINAL" not in call_args[0][1]
+            for call_args in mock_query.call_args_list
+        )
+
+    @pytest.mark.asyncio
+    async def test_dependency_projection_applies_theme_membership_filter(
+        self, mock_context
+    ):
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [
+                [],
+                [],
+                [{"complete_run_markers": 1, "investment_rows": 5}],
+            ]
+
+            filters = WorkGraphEdgeFilterInput(
+                edge_types=[WorkGraphEdgeTypeInput.RELATES],
+                theme="feature_delivery",
+            )
+            await resolve_work_graph_edges(mock_context, filters)
+
+        dependency_sql = mock_query.call_args_list[1][0][1]
+        dependency_params = mock_query.call_args_list[1][0][2]
+        assert "FROM work_item_dependencies FINAL" in dependency_sql
+        assert "FROM work_unit_membership AS m" in dependency_sql
+        assert "source_work_item_id" in dependency_sql
+        assert "target_work_item_id" in dependency_sql
+        assert dependency_params["category_tuples"] == [("theme", "feature_delivery")]
+
+    @pytest.mark.asyncio
+    async def test_dependency_projection_deduplicates_persisted_edges(
+        self, mock_context
+    ):
+        persisted_row = {
+            "edge_id": "edge:persisted",
+            "source_type": "pr",
+            "source_id": "ghpr:full-chaos/dev-health-ops#1171",
+            "target_type": "issue",
+            "target_id": "linear:CHAOS-2852",
+            "edge_type": "relates",
+            "repo_id": None,
+            "provider": None,
+            "provenance": "native",
+            "confidence": 0.9,
+            "evidence": "persisted",
+        }
+        duplicate_dependency_row = persisted_row | {
+            "edge_id": "wid:duplicate",
+            "confidence": 1.0,
+            "evidence": "linear_attachment",
+        }
+        unique_dependency_row = duplicate_dependency_row | {
+            "edge_id": "wid:unique",
+            "target_id": "linear:CHAOS-2853",
+        }
+
+        with patch(
+            "dev_health_ops.api.queries.client.query_dicts",
+            new_callable=AsyncMock,
+        ) as mock_query:
+            mock_query.side_effect = [
+                [persisted_row],
+                [duplicate_dependency_row, unique_dependency_row],
+                [],
+                [],
+            ]
+
+            filters = WorkGraphEdgeFilterInput(
+                edge_types=[WorkGraphEdgeTypeInput.RELATES]
+            )
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+        assert [edge.edge_id for edge in result.edges] == [
+            "edge:persisted",
+            "wid:unique",
+        ]
 
     @pytest.mark.asyncio
     async def test_singular_edge_type_still_works(self, mock_context):
@@ -112,8 +277,8 @@ class TestEdgeTypesFilter:
             )
             await resolve_work_graph_edges(mock_context, filters)
 
-            sql = mock_query.call_args[0][1]
-            params = mock_query.call_args[0][2]
+            sql = mock_query.call_args_list[0][0][1]
+            params = mock_query.call_args_list[0][0][2]
 
             assert "edge_type = %(edge_type)s" in sql
             assert params["edge_type"] == "implements"
@@ -137,8 +302,8 @@ class TestEdgeTypesFilter:
             )
             await resolve_work_graph_edges(mock_context, filters)
 
-            sql = mock_query.call_args[0][1]
-            params = mock_query.call_args[0][2]
+            sql = mock_query.call_args_list[0][0][1]
+            params = mock_query.call_args_list[0][0][2]
 
             assert "edge_type = %(edge_type)s" in sql
             assert "edge_type IN %(edge_types)s" in sql
@@ -164,7 +329,7 @@ class TestEdgeListOrdering:
             mock_query.return_value = []
             await resolve_work_graph_edges(mock_context)
 
-            sql = mock_query.call_args[0][1]
+            sql = mock_query.call_args_list[0][0][1]
             assert "ORDER BY" not in sql
             assert "LIMIT" in sql
 
@@ -179,7 +344,7 @@ class TestEdgeListOrdering:
             mock_query.return_value = []
             await resolve_work_graph_edges(mock_context, WorkGraphEdgeFilterInput())
 
-            sql = mock_query.call_args[0][1]
+            sql = mock_query.call_args_list[0][0][1]
             assert "ORDER BY" not in sql
 
     @pytest.mark.asyncio
@@ -196,7 +361,7 @@ class TestEdgeListOrdering:
             )
             await resolve_work_graph_edges(mock_context, filters)
 
-            sql = mock_query.call_args[0][1]
+            sql = mock_query.call_args_list[0][0][1]
             assert "ORDER BY confidence DESC, edge_id ASC" in sql
             assert sql.index("ORDER BY") < sql.index("LIMIT")
 


### PR DESCRIPTION
## Summary
- project persisted `work_item_dependencies` rows into `WorkGraphEdges` dependency responses when dependency edge types are requested
- preserve singular/plural edge-type AND semantics, theme membership filtering, repo-scope safety, GitLab MR classification, and de-dupe against persisted graph edges
- add regression coverage for dependency projection guardrails

## Validation
- `uv run pytest tests/graphql/test_work_graph.py tests/graphql/test_work_graph_aggregates.py -q` -> 62 passed
- `bash ci/local_validate.sh` -> GATE PASSED
- schema-level GraphQL query against live ClickHouse returned dependency edges for `filters.edgeTypes=[BLOCKS, IS_BLOCKED_BY, RELATES, IS_RELATED_TO, DUPLICATES, IS_DUPLICATE_OF, PARENT_OF, CHILD_OF]`

SCREENSHOT-WAIVER: backend-only GraphQL resolver fix; no web UI or rendered visual changes.

Linear: CHAOS-2866