### PR TITLE
fix(sync): reject over-cap plans at plan time and cascade unit failure on dispatch deny (CHAOS-2867)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -1989,22 +1989,29 @@ async def trigger_sync_config_backfill(
         lambda sync_session: _preflight_planner_credential(sync_session, config)
     )
     try:
-        trigger = await session.run_sync(
-            lambda sync_session: create_sync_execution_trigger(
-                sync_session,
-                config,
-                org_id,
-                triggered_by="backfill",
-                mode="backfill",
-                since=datetime.combine(
-                    payload.since, datetime.min.time(), tzinfo=timezone.utc
-                ),
-                before=datetime.combine(
-                    payload.before, datetime.max.time(), tzinfo=timezone.utc
-                ),
-                initial_job_result={"planner_managed": True},
+        # Planner ValueErrors (e.g. SyncPlanUnitCapExceededError when the
+        # window expands past the org's run unit cap) are client-fixable:
+        # surface them as 400 like the /trigger endpoint does, instead of
+        # letting the generic handler below report 503.
+        try:
+            trigger = await session.run_sync(
+                lambda sync_session: create_sync_execution_trigger(
+                    sync_session,
+                    config,
+                    org_id,
+                    triggered_by="backfill",
+                    mode="backfill",
+                    since=datetime.combine(
+                        payload.since, datetime.min.time(), tzinfo=timezone.utc
+                    ),
+                    before=datetime.combine(
+                        payload.before, datetime.max.time(), tzinfo=timezone.utc
+                    ),
+                    initial_job_result={"planner_managed": True},
+                )
             )
-        )
+        except ValueError as plan_exc:
+            raise HTTPException(status_code=400, detail=sanitize_error_text(plan_exc))
         if trigger is None:
             raise HTTPException(
                 status_code=400,

--- a/src/dev_health_ops/sync/planner.py
+++ b/src/dev_health_ops/sync/planner.py
@@ -67,6 +67,7 @@ from dev_health_ops.sync.dispatch_outbox import (
     OUTBOX_KIND_DISCOVERY,
     upsert_outbox_wakeup,
 )
+from dev_health_ops.sync.guard import _resolve_total_unit_cap
 from dev_health_ops.sync.watermarks import get_watermark_with_overlap
 
 if TYPE_CHECKING:
@@ -129,6 +130,26 @@ class SyncRunPlan:
     unit_ids: tuple[str, ...]
 
 
+class SyncPlanUnitCapExceededError(ValueError):
+    """Plan-time guard: the expanded plan exceeds the org's run unit cap.
+
+    Raised BEFORE any SyncRun/SyncRunUnit row is persisted so an oversized
+    backfill/sync fails fast at the API boundary instead of being accepted
+    (202) and then hard-denied asynchronously by ``DispatchGuard`` — which
+    would terminalize the run as FAILED after the fact. Subclasses
+    ``ValueError`` so existing planner error handling (admin routers map
+    ``ValueError`` -> HTTP 400) surfaces it without extra wiring.
+    """
+
+    def __init__(self, *, planned_units: int, total_cap: int) -> None:
+        self.planned_units = planned_units
+        self.total_cap = total_cap
+        super().__init__(
+            f"sync plan exceeds the run unit cap: {planned_units}/{total_cap} "
+            "units; reduce the backfill date range or narrow sources/datasets"
+        )
+
+
 def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
     """Expand an integration into persisted SyncRun + SyncRunUnit rows.
 
@@ -161,6 +182,16 @@ def plan_sync_run(session: Session, request: SyncPlanRequest) -> SyncRunPlan:
         mode=mode,
         now=now,
     )
+
+    # Plan-time mirror of DispatchGuard's total-unit cap (CHAOS-2512): deny
+    # oversized plans BEFORE persisting anything. Without this, the run and
+    # all its units are persisted, dispatch hard-denies asynchronously, and
+    # the caller only learns from a FAILED run after the fact.
+    total_cap = _resolve_total_unit_cap(session, str(integration.org_id))
+    if len(planned_units) > total_cap:
+        raise SyncPlanUnitCapExceededError(
+            planned_units=len(planned_units), total_cap=total_cap
+        )
 
     sync_run = SyncRun(
         org_id=integration.org_id,

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -782,10 +782,19 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                     "failed_stale_dispatching_units": failed_stale_dispatching,
                 }
             else:
+                # No unit is DISPATCHING/RUNNING, so every remaining
+                # non-terminal unit (PLANNED / RETRYING) can never legally
+                # dispatch again — the guard re-denies every redispatch.
+                # Fail them NOW: leaving them stranded under a terminal run
+                # is invisible to the reconciler (it skips terminal runs)
+                # and pollutes coverage as permanent requested-but-uncovered
+                # windows.
                 completed_at = datetime.now(timezone.utc)
+                failed_planned = _fail_planned_units(session, run_uuid, error)
                 run.status = SyncRunStatus.FAILED.value
                 run.completed_at = completed_at
                 run.error = error
+                run.failed_units = int(run.failed_units or 0) + failed_planned
                 run.result = {"capped_unit_ids": list(decision.capped_unit_ids)}
                 sync_observers_for_terminal_sync_run(session, run)
                 session.flush()
@@ -794,9 +803,14 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
                     extra={
                         "sync_run_id": sync_run_id,
                         "reason": run.error,
+                        "failed_planned_units": failed_planned,
                     },
                 )
-                return {"status": "denied", "reason": run.error}
+                return {
+                    "status": "denied",
+                    "reason": run.error,
+                    "failed_planned_units": failed_planned,
+                }
 
         if not decision.allowed:
             logger.warning(
@@ -2107,12 +2121,24 @@ def sync_observers_for_terminal_sync_run(session, run: SyncRun) -> None:
 
 
 def _fail_planned_units(session, run_uuid: uuid.UUID, error: str) -> int:
+    """Fail every unit of the run that is not dispatched and never will be.
+
+    Covers PLANNED and RETRYING: on a total-cap hard deny the guard re-denies
+    every future redispatch, so a deferred RETRYING unit is just as stranded
+    as a PLANNED one — and a lingering RETRYING unit blocks finalize_sync_run
+    (it requires all units terminal) forever.
+    """
     now = datetime.now(timezone.utc)
     result = (
         session.query(SyncRunUnit)
         .filter(
             SyncRunUnit.sync_run_id == run_uuid,
-            SyncRunUnit.status == SyncRunUnitStatus.PLANNED.value,
+            SyncRunUnit.status.in_(
+                {
+                    SyncRunUnitStatus.PLANNED.value,
+                    SyncRunUnitStatus.RETRYING.value,
+                }
+            ),
         )
         .update(
             {

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -340,6 +340,76 @@ async def test_backfill_fanout_creates_job_run_anchor(
 
 
 @pytest.mark.asyncio
+async def test_backfill_over_unit_cap_rejected_before_persisting(
+    client, session_maker, seeded_state, monkeypatch
+):
+    """A backfill whose plan exceeds the run unit cap is a 400, not a 202.
+
+    Regression for the '1872/1000' bug: without the plan-time cap check the
+    endpoint accepted the backfill, persisted the run + every unit, and the
+    dispatch guard hard-denied asynchronously — failing the run after the
+    fact and stranding all its PLANNED units.
+    """
+    ac, _ = client
+
+    create_resp = await _create_sync_config(ac, name="bf-cap", provider="github")
+    assert create_resp.status_code == 201
+    config_id = create_resp.json()["id"]
+    integration_id = await _link_migrated_integration(
+        session_maker, seeded_state["org_id"], config_id
+    )
+    async with session_maker() as session:
+        # Plain-created configs are planner-managed: the planner scopes the
+        # run to sources tagged with this config id, so tag the seeded one.
+        source = (
+            await session.execute(
+                select(IntegrationSource).where(
+                    IntegrationSource.integration_id == integration_id
+                )
+            )
+        ).scalar_one()
+        source.metadata_ = {"planner_managed_sync_config_id": config_id}
+        session.add_all(
+            [
+                IntegrationDataset(
+                    org_id=seeded_state["org_id"],
+                    integration_id=integration_id,
+                    dataset_key=dataset_key,
+                    is_enabled=True,
+                    options={},
+                )
+                for dataset_key in ("commits", "prs")
+            ]
+        )
+        await session.commit()
+
+    # Patch the resolved cap directly: the org here is a real UUID, so the
+    # tier-limit path (max_sync_units) would win over the SYNC_RUN_MAX_UNITS
+    # env fallback. Cap resolution itself is covered in test_sync_planner.py.
+    monkeypatch.setattr(
+        "dev_health_ops.sync.planner._resolve_total_unit_cap",
+        lambda session, org_id: 1,
+    )
+    with _patch_dispatch() as mock_dispatch:
+        resp = await ac.post(
+            f"/api/v1/admin/sync-configs/{config_id}/backfill",
+            json={"since": "2026-01-01", "before": "2026-01-15"},
+        )
+
+    assert resp.status_code == 400, resp.text
+    assert "unit cap" in resp.json()["detail"]
+    mock_dispatch.apply_async.assert_not_called()
+
+    # Fail-fast means NOTHING was persisted: no run, no units, no backfill
+    # job, and no stranded PENDING JobRun anchor.
+    async with session_maker() as session:
+        assert (await session.execute(select(SyncRun))).scalars().all() == []
+        assert (await session.execute(select(SyncRunUnit))).scalars().all() == []
+        assert (await session.execute(select(BackfillJob))).scalars().all() == []
+        assert (await session.execute(select(JobRun))).scalars().all() == []
+
+
+@pytest.mark.asyncio
 async def test_backfill_fanout_commits_backfill_job_before_dispatch(
     client, session_maker, seeded_state
 ):

--- a/tests/test_sync_planner.py
+++ b/tests/test_sync_planner.py
@@ -164,6 +164,44 @@ def test_enabled_sources_and_enabled_datasets_fan_out_to_units(db_session):
     assert discovery.org_id == ORG_ID
 
 
+def test_plan_sync_run_rejects_plan_over_unit_cap(db_session, monkeypatch):
+    """An oversized plan is rejected BEFORE anything is persisted.
+
+    Without the plan-time cap check the run + all its units are persisted,
+    DispatchGuard hard-denies asynchronously, and the caller only learns
+    from a FAILED run after the 202 (the '1872/1000' backfill bug).
+    """
+    from dev_health_ops.sync.planner import SyncPlanUnitCapExceededError
+
+    monkeypatch.setenv("SYNC_RUN_MAX_UNITS", "3")
+    integration = _create_integration(db_session)
+    _create_source(db_session, integration, external_id="full-chaos/dev-health")
+    _create_source(db_session, integration, external_id="full-chaos/dev-health-web")
+    _create_dataset(db_session, integration, "commits")
+    _create_dataset(db_session, integration, "prs")
+
+    with pytest.raises(SyncPlanUnitCapExceededError) as excinfo:
+        plan_sync_run(
+            db_session,
+            SyncPlanRequest(
+                integration_id=str(integration.id),
+                org_id=ORG_ID,
+                mode=SyncRunMode.INCREMENTAL.value,
+                triggered_by="manual",
+                before=datetime(2026, 6, 17, 12, 0, tzinfo=timezone.utc),
+            ),
+        )
+
+    assert excinfo.value.planned_units == 4
+    assert excinfo.value.total_cap == 3
+    assert "4/3" in str(excinfo.value)
+    # Fail-fast means NOTHING was persisted: no run, no units, no outbox row.
+    assert db_session.query(SyncRun).count() == 0
+    assert db_session.query(SyncRunUnit).count() == 0
+    assert db_session.query(SyncDispatchOutbox).count() == 0
+    assert db_session.query(SyncRunReferenceDiscovery).count() == 0
+
+
 def test_planner_stamps_single_credential_per_run(db_session):
     """CHAOS-2755: plan_sync_run stamps credential_id + fingerprint + auth_source
     ONCE on the SyncRun, and neither PlannedUnit nor SyncRunUnit gains a

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -2754,6 +2754,24 @@ def test_total_cap_hard_deny_terminalizes_linked_job_run(db_session, monkeypatch
     from dev_health_ops.workers import sync_units
 
     run, unit = _seed_run(db_session)
+    now = datetime.now(timezone.utc)
+    retrying = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=unit.integration_id,
+        source_id=unit.source_id,
+        provider="github",
+        dataset_key="issues",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.RETRYING.value,
+        attempts=1,
+        available_at=now + timedelta(minutes=10),
+        processor_flags={"sync_issues": True},
+    )
+    run.total_units = 2
+    db_session.add(retrying)
+    db_session.flush()
     scheduled = ScheduledJob(
         org_id=run.org_id,
         name=f"sync-config-{uuid.uuid4()}",
@@ -2787,11 +2805,27 @@ def test_total_cap_hard_deny_terminalizes_linked_job_run(db_session, monkeypatch
 
     db_session.refresh(run)
     db_session.refresh(job_run)
-    assert result == {"status": "denied", "reason": reason}
+    db_session.refresh(unit)
+    db_session.refresh(retrying)
+    assert result == {
+        "status": "denied",
+        "reason": reason,
+        "failed_planned_units": 2,
+    }
     assert run.status == SyncRunStatus.FAILED.value
+    # The stranded units cascade to FAILED with the deny reason — a hard-
+    # denied run can never legally redispatch them, and the reconciler
+    # skips terminal runs, so leaving them PLANNED/RETRYING strands them
+    # forever (and blocks any later finalize on the RETRYING one).
+    assert unit.status == SyncRunUnitStatus.FAILED.value
+    assert unit.error == reason
+    assert retrying.status == SyncRunUnitStatus.FAILED.value
+    assert retrying.error == reason
+    assert run.failed_units == 2
     assert job_run.status == JobRunStatus.FAILED.value
     assert job_run.error == reason
     assert job_run.completed_at is not None
+    assert job_run.result["failed_units"] == 2
 
 
 def test_dispatch_sync_run_continues_accepted_run_after_child_config_pause(


### PR DESCRIPTION
Fixes CHAOS-2867

## Bug

A backfill whose plan exceeded the org's sync run unit cap (`sync run unit cap exceeded: 1872/1000`) was **accepted with 202**, fully persisted, then hard-denied asynchronously by `DispatchGuard`:

1. The run failed after the fact with no actionable feedback at request time.
2. `dispatch_sync_run`'s hard-deny branch (no active units) marked the `SyncRun` FAILED but stranded every `SyncRunUnit` in PLANNED (and deferred RETRYING units) forever — the reconciler skips terminal runs, so the displaced units never received status updates.
3. `run.failed_units` stayed 0, so `BackfillJob.failed_chunks` / `JobRun` observer counts reported zero failures, and the stranded PLANNED windows polluted coverage as permanent requested-but-uncovered ranges.

## Fix

**Fail fast at plan time** — `plan_sync_run` now raises a typed `SyncPlanUnitCapExceededError` (a `ValueError`) *before persisting anything* when the expanded plan exceeds the same cap the dispatch guard enforces (`_resolve_total_unit_cap`: tier `max_sync_units`, else `SYNC_RUN_MAX_UNITS`). Covers every caller:

- `POST /sync-configs/{id}/backfill` — new narrow `except ValueError` → HTTP 400 with "reduce the date range" guidance (previously swallowed into the generic 503 handler)
- `POST /sync-configs/{id}/trigger` and `POST /integrations/{id}/{sync,backfill}` — already map `ValueError` → 400, covered via subclassing
- scheduler — existing rollback-and-skip handler covers it

**Cascade on dispatch deny (defense-in-depth** for tier caps shrinking after planning**)** — the total-cap hard-deny branch in `workers/sync_units.py` now fails all PLANNED **and RETRYING** units via `_fail_planned_units` and sets `run.failed_units` before `sync_observers_for_terminal_sync_run`, so backfill jobs / job runs report true failed counts and nothing is left stranded. Including RETRYING also unblocks the denied-active branch's finalize, which could previously hang forever on a deferred retry.

## Tests

- `tests/test_sync_units.py::test_total_cap_hard_deny_terminalizes_linked_job_run` — extended: PLANNED + future-RETRYING units cascade to FAILED with the deny reason, `run.failed_units == 2`, JobRun observer result carries the counts
- `tests/test_sync_planner.py::test_plan_sync_run_rejects_plan_over_unit_cap` — oversized plan raises and persists nothing (no run/units/outbox/discovery rows)
- `tests/api/admin/test_backfill_jobrun.py::test_backfill_over_unit_cap_rejected_before_persisting` — endpoint returns 400 through the real FastAPI app; no BackfillJob, no SyncRun/units, no stranded PENDING JobRun anchor; dispatch never enqueued

Local: 278 tests green across sync/planner/backfill/reconciler suites; `ruff format --check` + `ruff check` clean; mypy clean on changed files. Full suite deferred to CI gates per reviewer request.
