### PR TITLE
fix(sync): terminalize orphaned backfill jobs in reconciler (CHAOS-2868)

### DIFF
--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -651,7 +651,19 @@ def _backfill_job_sync_run_id(job: BackfillJob) -> str | None:
     return task_id.rsplit(marker, 1)[-1] or None
 
 
-def _backfill_job_is_orphaned(session, job: BackfillJob) -> bool:
+def _backfill_job_marker_sync_run_id(job: BackfillJob) -> uuid.UUID | None:
+    sync_run_id = _backfill_job_sync_run_id(job)
+    if sync_run_id is None:
+        return None
+    try:
+        return uuid.UUID(sync_run_id)
+    except ValueError:
+        return None
+
+
+def _backfill_job_is_orphaned(
+    sync_run_id: uuid.UUID | None, existing_run_ids: set[uuid.UUID]
+) -> bool:
     # Mirrors the admin surface's fallback in api/admin/routers/sync.py
     # (_backfill_job_sync_run_id / _backfill_job_run_counts): a job whose
     # marker is missing/unparseable, or whose marker resolves to a SyncRun
@@ -660,38 +672,44 @@ def _backfill_job_is_orphaned(session, job: BackfillJob) -> bool:
     # forever (CHAOS-2868). A marker resolving to an EXISTING run (terminal
     # or not) is owned by the observer-repair pass above or the live
     # dispatch/finalize flow and must not be touched here.
-    sync_run_id = _backfill_job_sync_run_id(job)
-    if sync_run_id is None:
-        return True
-    try:
-        run_uuid = uuid.UUID(sync_run_id)
-    except ValueError:
-        return True
-    return session.get(SyncRun, run_uuid) is None
+    return sync_run_id is None or sync_run_id not in existing_run_ids
 
 
 def _terminalize_orphaned_backfill_jobs(session, now: datetime, limit: int) -> int:
     cutoff = now - timedelta(seconds=_backfill_job_orphan_ttl_seconds())
     max_repairs = max(1, int(limit))
-    terminalized = 0
     candidates = (
         session.query(BackfillJob)
-        .filter(BackfillJob.status.in_({"pending", "running"}))
+        .filter(
+            BackfillJob.status.in_({"pending", "running"}),
+            BackfillJob.created_at <= cutoff,
+        )
         .order_by(BackfillJob.created_at.asc(), BackfillJob.id.asc())
+        .limit(max_repairs)
         .all()
     )
+    if not candidates:
+        return 0
+
+    marker_run_ids = {
+        job.id: _backfill_job_marker_sync_run_id(job) for job in candidates
+    }
+    candidate_run_ids = {
+        run_id for run_id in marker_run_ids.values() if run_id is not None
+    }
+    existing_run_ids: set[uuid.UUID] = set()
+    if candidate_run_ids:
+        rows = session.query(SyncRun.id).filter(SyncRun.id.in_(candidate_run_ids)).all()
+        existing_run_ids = {row_id for (row_id,) in rows}
+
+    terminalized = 0
     for job in candidates:
-        created_at = job.created_at
-        if created_at is None or _as_aware(created_at) > cutoff:
-            continue
-        if not _backfill_job_is_orphaned(session, job):
+        if not _backfill_job_is_orphaned(marker_run_ids[job.id], existing_run_ids):
             continue
         job.status = "failed"
         job.error_message = "backfill job orphaned: no linked sync run"
         job.completed_at = now
         terminalized += 1
-        if terminalized >= max_repairs:
-            break
     return terminalized
 
 

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -675,9 +675,29 @@ def _backfill_job_is_orphaned(
     return sync_run_id is None or sync_run_id not in existing_run_ids
 
 
+_BACKFILL_JOB_ORPHAN_SCAN_LIMIT_MULTIPLIER = 5
+
+
 def _terminalize_orphaned_backfill_jobs(session, now: datetime, limit: int) -> int:
+    """Terminalize orphaned pending/running BackfillJob rows past the TTL.
+
+    The repair budget (`limit`, jobs actually terminalized) is decoupled
+    from the scan budget (candidates examined): candidates are loaded
+    oldest-first up to `limit * _BACKFILL_JOB_ORPHAN_SCAN_LIMIT_MULTIPLIER`
+    rows in one query, bulk-checked against SyncRun in a single follow-up
+    query, then terminalized in order until `limit` is reached. Without
+    this separation, a run of non-orphan jobs at the head of the ordering
+    (markers resolving to existing SyncRuns) would consume the entire scan
+    window and permanently starve an orphan sitting behind them -- every
+    reconciler run would re-select the exact same non-orphan window. The
+    scan budget bounds a single sweep even against a pathological table
+    full of live non-orphans; any remainder past the scan window is picked
+    up on a later run once the leading jobs terminalize or age out.
+    """
     cutoff = now - timedelta(seconds=_backfill_job_orphan_ttl_seconds())
     max_repairs = max(1, int(limit))
+    max_scanned = max_repairs * _BACKFILL_JOB_ORPHAN_SCAN_LIMIT_MULTIPLIER
+
     candidates = (
         session.query(BackfillJob)
         .filter(
@@ -685,7 +705,7 @@ def _terminalize_orphaned_backfill_jobs(session, now: datetime, limit: int) -> i
             BackfillJob.created_at <= cutoff,
         )
         .order_by(BackfillJob.created_at.asc(), BackfillJob.id.asc())
-        .limit(max_repairs)
+        .limit(max_scanned)
         .all()
     )
     if not candidates:
@@ -704,6 +724,8 @@ def _terminalize_orphaned_backfill_jobs(session, now: datetime, limit: int) -> i
 
     terminalized = 0
     for job in candidates:
+        if terminalized >= max_repairs:
+            break
         if not _backfill_job_is_orphaned(marker_run_ids[job.id], existing_run_ids):
             continue
         job.status = "failed"

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -44,6 +44,22 @@ def _rate_limit_observation_retention_days() -> int:
     return max(0, days)
 
 
+_DEFAULT_BACKFILL_JOB_ORPHAN_TTL_SECONDS = 3600
+
+
+def _backfill_job_orphan_ttl_seconds() -> int:
+    try:
+        seconds = int(
+            os.getenv(
+                "SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS",
+                str(_DEFAULT_BACKFILL_JOB_ORPHAN_TTL_SECONDS),
+            )
+        )
+    except ValueError:
+        return _DEFAULT_BACKFILL_JOB_ORPHAN_TTL_SECONDS
+    return max(0, seconds)
+
+
 @celery_app.task(
     queue="sync",
     name="dev_health_ops.workers.tasks.prune_rate_limit_observations",
@@ -271,6 +287,10 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
             sync_observers_for_terminal_sync_run(session, run)
             repaired_observers += 1
         session.flush()
+        orphaned_backfill_jobs = _terminalize_orphaned_backfill_jobs(
+            session, now, limit
+        )
+        session.flush()
         finalize_run_ids = _finalizable_run_ids(session, limit)
         for run_id in expired_run_ids:
             if _run_is_finalizable(session, run_id):
@@ -419,6 +439,7 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
         "relayed_post_sync": relayed_post_sync,
         "publish_failures": publish_failures,
         "observer_repairs": repaired_observers,
+        "orphaned_backfill_jobs": orphaned_backfill_jobs,
     }
 
 
@@ -628,6 +649,50 @@ def _backfill_job_sync_run_id(job: BackfillJob) -> str | None:
     if marker not in task_id:
         return None
     return task_id.rsplit(marker, 1)[-1] or None
+
+
+def _backfill_job_is_orphaned(session, job: BackfillJob) -> bool:
+    # Mirrors the admin surface's fallback in api/admin/routers/sync.py
+    # (_backfill_job_sync_run_id / _backfill_job_run_counts): a job whose
+    # marker is missing/unparseable, or whose marker resolves to a SyncRun
+    # that no longer exists, has nothing left to terminalize it -- the
+    # merged-status endpoint falls back to the stored pending/running status
+    # forever (CHAOS-2868). A marker resolving to an EXISTING run (terminal
+    # or not) is owned by the observer-repair pass above or the live
+    # dispatch/finalize flow and must not be touched here.
+    sync_run_id = _backfill_job_sync_run_id(job)
+    if sync_run_id is None:
+        return True
+    try:
+        run_uuid = uuid.UUID(sync_run_id)
+    except ValueError:
+        return True
+    return session.get(SyncRun, run_uuid) is None
+
+
+def _terminalize_orphaned_backfill_jobs(session, now: datetime, limit: int) -> int:
+    cutoff = now - timedelta(seconds=_backfill_job_orphan_ttl_seconds())
+    max_repairs = max(1, int(limit))
+    terminalized = 0
+    candidates = (
+        session.query(BackfillJob)
+        .filter(BackfillJob.status.in_({"pending", "running"}))
+        .order_by(BackfillJob.created_at.asc(), BackfillJob.id.asc())
+        .all()
+    )
+    for job in candidates:
+        created_at = job.created_at
+        if created_at is None or _as_aware(created_at) > cutoff:
+            continue
+        if not _backfill_job_is_orphaned(session, job):
+            continue
+        job.status = "failed"
+        job.error_message = "backfill job orphaned: no linked sync run"
+        job.completed_at = now
+        terminalized += 1
+        if terminalized >= max_repairs:
+            break
+    return terminalized
 
 
 def _publish_claimed_outbox_row(

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -689,10 +689,13 @@ def _terminalize_orphaned_backfill_jobs(session, now: datetime, limit: int) -> i
     this separation, a run of non-orphan jobs at the head of the ordering
     (markers resolving to existing SyncRuns) would consume the entire scan
     window and permanently starve an orphan sitting behind them -- every
-    reconciler run would re-select the exact same non-orphan window. The
-    scan budget bounds a single sweep even against a pathological table
-    full of live non-orphans; any remainder past the scan window is picked
-    up on a later run once the leading jobs terminalize or age out.
+    reconciler run would re-select the exact same non-orphan window. This
+    is a bounded BEST-EFFORT scan: an orphan sitting behind more than
+    ``limit * _BACKFILL_JOB_ORPHAN_SCAN_LIMIT_MULTIPLIER`` old non-orphan
+    jobs is not examined this sweep and waits until the leading jobs leave
+    pending/running (via dispatch/finalize or the observer repair above).
+    If production ever shows persistent head-of-line non-orphans, the
+    escalation path is keyset pagination over (created_at, id).
     """
     cutoff = now - timedelta(seconds=_backfill_job_orphan_ttl_seconds())
     max_repairs = max(1, int(limit))

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -1314,3 +1314,108 @@ def test_reconciler_still_repairs_pending_backfill_job_with_terminal_run_via_obs
     assert job.status == "failed"
     assert job.error_message == "provider auth failed"
     assert job.completed_at is not None
+
+
+def test_backfill_job_marker_sync_run_id_parses_and_rejects_marker_variants():
+    from dev_health_ops.workers import sync_reconciler
+
+    resolvable = BackfillJob(celery_task_id=f"worker|sync_run:{uuid.uuid4()}")
+    missing_marker = BackfillJob(celery_task_id="worker-task-id")
+    no_task_id = BackfillJob(celery_task_id=None)
+    unparseable = BackfillJob(celery_task_id="worker|sync_run:not-a-uuid")
+
+    assert sync_reconciler._backfill_job_marker_sync_run_id(resolvable) is not None
+    assert sync_reconciler._backfill_job_marker_sync_run_id(missing_marker) is None
+    assert sync_reconciler._backfill_job_marker_sync_run_id(no_task_id) is None
+    assert sync_reconciler._backfill_job_marker_sync_run_id(unparseable) is None
+
+
+def test_backfill_job_is_orphaned_predicate_against_existing_run_id_set():
+    from dev_health_ops.workers import sync_reconciler
+
+    live_id = uuid.uuid4()
+    existing_run_ids = {live_id}
+    missing_id = uuid.uuid4()
+
+    assert sync_reconciler._backfill_job_is_orphaned(None, existing_run_ids) is True
+    assert (
+        sync_reconciler._backfill_job_is_orphaned(missing_id, existing_run_ids) is True
+    )
+    assert sync_reconciler._backfill_job_is_orphaned(live_id, existing_run_ids) is False
+
+
+def test_terminalize_orphaned_backfill_jobs_boundary_created_at_equals_cutoff(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler
+
+    monkeypatch.setenv("SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS", "3600")
+    fixed_now = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+    cutoff = fixed_now - timedelta(seconds=3600)
+    job = _seed_orphan_backfill_job(
+        db_session,
+        celery_task_id=None,
+        status="pending",
+        created_at=cutoff,
+    )
+
+    terminalized = sync_reconciler._terminalize_orphaned_backfill_jobs(
+        db_session, fixed_now, limit=10
+    )
+    db_session.flush()
+
+    db_session.refresh(job)
+    assert terminalized == 1
+    assert job.status == "failed"
+    assert job.error_message == "backfill job orphaned: no linked sync run"
+
+
+def test_terminalize_orphaned_backfill_jobs_just_inside_ttl_is_untouched(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler
+
+    monkeypatch.setenv("SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS", "3600")
+    fixed_now = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+    cutoff = fixed_now - timedelta(seconds=3600)
+    job = _seed_orphan_backfill_job(
+        db_session,
+        celery_task_id=None,
+        status="pending",
+        created_at=cutoff + timedelta(seconds=1),
+    )
+
+    terminalized = sync_reconciler._terminalize_orphaned_backfill_jobs(
+        db_session, fixed_now, limit=10
+    )
+    db_session.flush()
+
+    db_session.refresh(job)
+    assert terminalized == 0
+    assert job.status == "pending"
+    assert job.error_message is None
+
+
+def test_terminalize_orphaned_backfill_jobs_unparseable_marker_is_orphaned(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler
+
+    monkeypatch.setenv("SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS", "3600")
+    fixed_now = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+    job = _seed_orphan_backfill_job(
+        db_session,
+        celery_task_id="worker|sync_run:not-a-uuid",
+        status="running",
+        created_at=fixed_now - timedelta(hours=2),
+    )
+
+    terminalized = sync_reconciler._terminalize_orphaned_backfill_jobs(
+        db_session, fixed_now, limit=10
+    )
+    db_session.flush()
+
+    db_session.refresh(job)
+    assert terminalized == 1
+    assert job.status == "failed"
+    assert job.error_message == "backfill job orphaned: no linked sync run"

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -1419,3 +1419,51 @@ def test_terminalize_orphaned_backfill_jobs_unparseable_marker_is_orphaned(
     assert terminalized == 1
     assert job.status == "failed"
     assert job.error_message == "backfill job orphaned: no linked sync run"
+
+
+def test_terminalize_orphaned_backfill_jobs_does_not_starve_orphan_behind_limit(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler
+
+    monkeypatch.setenv("SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS", "3600")
+    fixed_now = datetime(2026, 3, 1, 12, 0, tzinfo=timezone.utc)
+
+    run, running, _planned = _seed_run(db_session, planned_units=0)
+    running.lease_expires_at = fixed_now + timedelta(minutes=5)
+    db_session.flush()
+
+    # Ordered FIRST (oldest created_at): a non-orphan whose marker resolves
+    # to a live, existing SyncRun -- owned by the dispatch/finalize flow,
+    # never terminalized here.
+    non_orphan = _seed_orphan_backfill_job(
+        db_session,
+        org_id=run.org_id,
+        celery_task_id=f"sync_run:{run.id}",
+        status="pending",
+        created_at=fixed_now - timedelta(hours=3),
+    )
+    # Ordered SECOND (behind the non-orphan): a true orphan with no marker.
+    orphan = _seed_orphan_backfill_job(
+        db_session,
+        celery_task_id=None,
+        status="pending",
+        created_at=fixed_now - timedelta(hours=2),
+    )
+
+    # limit=1: the old single-limit query would have selected only
+    # `non_orphan` (the oldest row) and never examined `orphan` at all --
+    # every subsequent sweep would re-select the same non-orphan window,
+    # starving `orphan` forever. The scan budget must look past it.
+    terminalized = sync_reconciler._terminalize_orphaned_backfill_jobs(
+        db_session, fixed_now, limit=1
+    )
+    db_session.flush()
+
+    db_session.refresh(non_orphan)
+    db_session.refresh(orphan)
+    assert terminalized == 1
+    assert non_orphan.status == "pending"
+    assert non_orphan.error_message is None
+    assert orphan.status == "failed"
+    assert orphan.error_message == "backfill job orphaned: no linked sync run"

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -2,13 +2,14 @@ from __future__ import annotations
 
 import uuid
 from contextlib import contextmanager
-from datetime import datetime, timedelta, timezone
+from datetime import date, datetime, timedelta, timezone
 
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
 from dev_health_ops.models import (
+    BackfillJob,
     Base,
     Integration,
     IntegrationSource,
@@ -1140,3 +1141,176 @@ def test_reconciler_two_passes_do_not_double_publish_post_sync(db_session, monke
     assert second["relayed_post_sync"] == 0
     assert len(post_sync_dispatches) == 1
     assert post_sync_row.status == OUTBOX_STATUS_DISPATCHED
+
+
+def _seed_orphan_backfill_job(
+    session,
+    *,
+    org_id=None,
+    celery_task_id=None,
+    status="pending",
+    created_at=None,
+):
+    job = BackfillJob(
+        org_id=org_id or str(uuid.uuid4()),
+        sync_config_id=uuid.uuid4(),
+        celery_task_id=celery_task_id,
+        status=status,
+        since_date=date(2026, 1, 1),
+        before_date=date(2026, 1, 8),
+        total_chunks=1,
+    )
+    if created_at is not None:
+        job.created_at = created_at
+    session.add(job)
+    session.flush()
+    return job
+
+
+def test_reconciler_terminalizes_orphaned_backfill_job_without_marker_past_ttl(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler
+
+    job = _seed_orphan_backfill_job(
+        db_session,
+        celery_task_id=None,
+        status="pending",
+        created_at=datetime.now(timezone.utc) - timedelta(hours=2),
+    )
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS", "3600")
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(job)
+    assert result["orphaned_backfill_jobs"] == 1
+    assert job.status == "failed"
+    assert job.error_message == "backfill job orphaned: no linked sync run"
+    assert job.completed_at is not None
+
+
+def test_reconciler_terminalizes_orphaned_backfill_job_with_marker_to_deleted_run(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler
+
+    deleted_run_id = uuid.uuid4()
+    job = _seed_orphan_backfill_job(
+        db_session,
+        celery_task_id=f"worker|sync_run:{deleted_run_id}",
+        status="running",
+        created_at=datetime.now(timezone.utc) - timedelta(hours=2),
+    )
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS", "3600")
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(job)
+    assert result["orphaned_backfill_jobs"] == 1
+    assert job.status == "failed"
+    assert job.error_message == "backfill job orphaned: no linked sync run"
+    assert job.completed_at is not None
+
+
+def test_reconciler_does_not_terminalize_young_orphaned_backfill_job(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler
+
+    job = _seed_orphan_backfill_job(
+        db_session,
+        celery_task_id=None,
+        status="pending",
+        created_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+    )
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS", "3600")
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(job)
+    assert result["orphaned_backfill_jobs"] == 0
+    assert job.status == "pending"
+    assert job.error_message is None
+    assert job.completed_at is None
+
+
+def test_reconciler_does_not_terminalize_backfill_job_with_live_nonterminal_run(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, _planned = _seed_run(db_session, planned_units=0)
+    running.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    db_session.flush()
+    job = _seed_orphan_backfill_job(
+        db_session,
+        org_id=run.org_id,
+        celery_task_id=f"sync_run:{run.id}",
+        status="pending",
+        created_at=datetime.now(timezone.utc) - timedelta(hours=2),
+    )
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS", "3600")
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: None,
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: None,
+    )
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(run)
+    db_session.refresh(job)
+    assert run.status == SyncRunStatus.DISPATCHING.value
+    assert result["orphaned_backfill_jobs"] == 0
+    assert job.status == "pending"
+    assert job.error_message is None
+    assert job.completed_at is None
+
+
+def test_reconciler_still_repairs_pending_backfill_job_with_terminal_run_via_observer(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, _planned = _seed_run(db_session, planned_units=0)
+    running.lease_expires_at = datetime.now(timezone.utc) + timedelta(minutes=5)
+    run.status = SyncRunStatus.FAILED.value
+    run.completed_at = None
+    run.error = "provider auth failed"
+    run.failed_units = 1
+    job = _seed_orphan_backfill_job(
+        db_session,
+        org_id=run.org_id,
+        celery_task_id=f"sync_run:{run.id}",
+        status="pending",
+    )
+    _patch_db_session(monkeypatch, db_session)
+    monkeypatch.setenv("SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS", "3600")
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: None,
+    )
+    monkeypatch.setattr(
+        sync_units.finalize_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: None,
+    )
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    db_session.refresh(job)
+    assert result["observer_repairs"] == 1
+    assert result["orphaned_backfill_jobs"] == 0
+    assert job.status == "failed"
+    assert job.error_message == "provider auth failed"
+    assert job.completed_at is not None


### PR DESCRIPTION
Fixes CHAOS-2868

## Zombie-banner mechanism

The admin sync page's "BACKFILL IN PROGRESS / Dispatching work... / 0% / Live — refreshing" banner renders whenever `GET /backfill-jobs` finds a `BackfillJob` whose merged status is non-terminal. `_backfill_job_run_counts` (`src/dev_health_ops/api/admin/routers/sync.py:570`) merges the linked `SyncRun` status over the stored `BackfillJob.status`, but only when `_backfill_job_sync_run_id` (`:562`) can extract and resolve a `sync_run:<uuid>` marker from `celery_task_id`. When it can't — because the marker is missing/unparseable, or it resolves to a `SyncRun` row that no longer exists — the endpoint falls back to the stored `status` (`pending`/`running`) **forever**, since nothing else ever mutates that column again.

Two repair paths already exist for the recoverable cases:
- `_terminal_runs_with_stale_observers` (`workers/sync_reconciler.py`) + `sync_observers_for_terminal_sync_run` (`workers/sync_units.py:2061`) repair pending/running `BackfillJob` rows whose marker resolves to a **terminal** `SyncRun`.
- Post-CHAOS-2867 (#1195), stranded runs get re-dispatched, hard-denied, and terminalized, after which the observer repair above fires.

Neither path helps a job whose marker can never resolve to any run. This PR adds a periodic sweep in `reconcile_sync_dispatch` that terminalizes those true orphans:

- **Missing/unparseable marker**: `_backfill_job_sync_run_id(job) is None`.
- **Marker resolves to a deleted run**: the parsed `sync_run:<uuid>` no longer has a matching `SyncRun` row.

Jobs whose marker resolves to an **existing** run (terminal or not) are left untouched — those are owned by the observer-repair pass above or the live dispatch/finalize flow.

## Change

- `_backfill_job_orphan_ttl_seconds()` — env-tunable via `SYNC_BACKFILL_JOB_ORPHAN_TTL_SECONDS` (default 3600s), following the existing `_rate_limit_observation_retention_days` int-parse pattern.
- `_backfill_job_is_orphaned(session, job)` — the two orphan predicates above.
- `_terminalize_orphaned_backfill_jobs(session, now, limit)` — scans pending/running `BackfillJob` rows older than the TTL, sets `status="failed"`, `error_message="backfill job orphaned: no linked sync run"`, `completed_at=now` for true orphans. Wired into `reconcile_sync_dispatch` right after the existing observer-repair pass, counted as `orphaned_backfill_jobs` in the task's returned dict.

## Tests

`tests/test_sync_reconciler.py` (5 new cases, following the existing fixture style):
1. Orphaned job past TTL with no marker → terminalized failed.
2. Orphaned job with marker pointing at a deleted run → terminalized failed.
3. Young orphan within TTL → left untouched.
4. Pending job with a resolvable marker to a live non-terminal run → left untouched (existing dispatch/finalize flow owns it).
5. Regression: pending job with a terminal run is still repaired by the existing observer path (unaffected by this change).

## Verification

```
.venv/bin/ruff format --check .
.venv/bin/ruff check .
.venv/bin/mypy src/dev_health_ops/workers/sync_reconciler.py
.venv/bin/python -m pytest tests/test_sync_reconciler.py tests/test_sync_units.py -q
```

All green (116 passed).

Scope is intentionally minimal — one repair loop + tests, no refactor of surrounding reconciler code. Web-side staleness-cutoff fix (`getActiveBackfillJob`, `BackfillStatus`) is tracked separately per the issue's proposed fix.