### PR TITLE
fix(coverage): make backfill requested ranges pair-aware (CHAOS-2869)

### DIFF
--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -501,22 +501,66 @@ def _backfill_job_sync_run_id(job: BackfillJob) -> str | None:
     return task_id.rsplit(marker, 1)[-1] or None
 
 
-async def _backfill_job_run_pairs(
+async def _backfill_job_run_pair_windows(
     session: AsyncSession, org_id: str, run_id: uuid.UUID
-) -> set[tuple[str, str]]:
-    """Return the distinct (source_id, dataset_key) pairs a SyncRun planned units for."""
-    stmt = (
-        select(SyncRunUnit.source_id, SyncRunUnit.dataset_key)
-        .where(
-            SyncRunUnit.org_id == org_id,
-            SyncRunUnit.sync_run_id == run_id,
-        )
-        .distinct()
+) -> dict[tuple[str, str], list[CoverageInterval]]:
+    """Return each (source_id, dataset_key) pair's merged unit-window union for a SyncRun.
+
+    An empty dict means the run has zero (valid) SyncRunUnit rows -- callers
+    MUST treat that as "this job requested nothing", not as "unresolvable"
+    (see ``_backfill_requested_ranges``): a run that legitimately planned zero
+    units must not be conflated with a marker we simply couldn't parse.
+    """
+    stmt = select(SyncRunUnit).where(
+        SyncRunUnit.org_id == org_id,
+        SyncRunUnit.sync_run_id == run_id,
+        SyncRunUnit.since_at.is_not(None),
+        SyncRunUnit.before_at.is_not(None),
     )
-    return {
-        (str(source_id), str(dataset_key))
-        for source_id, dataset_key in (await session.execute(stmt)).all()
-    }
+    raw_windows: dict[tuple[str, str], list[CoverageInterval]] = defaultdict(list)
+    for unit in (await session.execute(stmt)).scalars().all():
+        since_at = unit.since_at
+        before_at = unit.before_at
+        if since_at is None or before_at is None:
+            continue
+        pair = (str(unit.source_id), str(unit.dataset_key))
+        raw_windows[pair].append(
+            CoverageInterval(since=ensure_utc(since_at), before=ensure_utc(before_at))
+        )
+    return {pair: merge_intervals(intervals) for pair, intervals in raw_windows.items()}
+
+
+async def _resolve_backfill_job_pair_windows(
+    session: AsyncSession, org_id: str, job: BackfillJob
+) -> dict[tuple[str, str], list[CoverageInterval]] | None:
+    """Resolve a backfill job's linked-run pair windows, or ``None`` if unresolvable.
+
+    ``None`` means the ``sync_run:<uuid>`` marker is absent or unparseable --
+    callers should fall back to legacy all-pairs-in-scope behavior. A resolved
+    but empty dict means the run exists (or at least its id parsed) but has no
+    units -- callers must contribute nothing for that job, NOT fall back.
+    """
+    run_id_str = _backfill_job_sync_run_id(job)
+    if run_id_str is None:
+        return None
+    try:
+        run_uuid = uuid.UUID(run_id_str)
+    except ValueError:
+        return None
+    return await _backfill_job_run_pair_windows(session, org_id, run_uuid)
+
+
+def _clip_intervals(
+    intervals: Iterable[CoverageInterval], since: datetime, before: datetime
+) -> list[CoverageInterval]:
+    """Intersect each interval with ``[since, before)``, dropping empty results."""
+    clipped: list[CoverageInterval] = []
+    for interval in intervals:
+        start = max(interval.since, since)
+        end = min(interval.before, before)
+        if start < end:
+            clipped.append(CoverageInterval(since=start, before=end))
+    return clipped
 
 
 async def _backfill_requested_ranges(
@@ -530,19 +574,25 @@ async def _backfill_requested_ranges(
 
     Pair-aware: each job's linked SyncRun (resolved via the ``sync_run:<uuid>``
     suffix of ``celery_task_id``) tells us exactly which (source_id,
-    dataset_key) pairs the backfill actually planned units for, so the job's
-    date range is only counted as "requested" for those pairs. Without this,
-    a backfill that only plans units for a subset of the in-scope pairs
-    (unsupported datasets for a provider, sources added after the backfill
-    ran, work-item family composite keys) permanently "requests" coverage on
-    every other in-scope pair too -- a gap no future backfill on that pair
-    can ever clear (CHAOS-2869).
+    dataset_key) pairs the backfill actually planned units for, and the
+    ACTUAL unit windows for each pair (clipped to the job's own date range) --
+    not the job's full date range -- are what gets counted as "requested".
+    Without this, a backfill that only plans units for a subset of the range
+    or a subset of the in-scope pairs (unsupported datasets for a provider,
+    sources added after the backfill ran, work-item family composite keys)
+    permanently "requests" coverage the run never actually attempted -- a gap
+    no future backfill on that pair can ever clear (CHAOS-2869).
 
-    Fallback: if the marker is absent/unparseable, the linked SyncRun row no
-    longer exists, or the run has zero SyncRunUnit rows, we fall back to the
-    legacy all-pairs-in-scope behavior for that job. This keeps pre-marker
-    legacy jobs working as before; such rows naturally age out of the
-    ``HISTORY_LOOKBACK_DAYS`` lookback over time.
+    Three resolution states, handled distinctly so a run that legitimately
+    planned zero units is never conflated with an unresolvable marker:
+
+    * Marker absent/unparseable -> fall back to the legacy all-pairs-in-scope
+      behavior for that job (pre-marker legacy jobs keep working as before;
+      such rows naturally age out of the ``HISTORY_LOOKBACK_DAYS`` lookback).
+    * Marker resolves but the run has zero SyncRunUnit rows -> contribute
+      NOTHING for that job (it requested nothing, so nothing is "requested").
+    * Marker resolves with units -> pair-scoped intervals clipped to each
+      pair's actual unit-window union.
     """
     if not scope.sources:
         return []
@@ -555,29 +605,8 @@ async def _backfill_requested_ranges(
     ranges: list[CoverageInterval] = []
     for job in (await session.execute(stmt)).scalars().all():
         interval = _backfill_interval(job)
-        pairs: set[tuple[str, str]] = set()
-        run_id_str = _backfill_job_sync_run_id(job)
-        if run_id_str is not None:
-            try:
-                run_uuid = uuid.UUID(run_id_str)
-            except ValueError:
-                run_uuid = None
-            if run_uuid is not None:
-                pairs = await _backfill_job_run_pairs(session, org_id, run_uuid)
-        if pairs:
-            for source_id, dataset_key in pairs:
-                if source_id not in scope_source_ids:
-                    continue
-                ranges.append(
-                    CoverageInterval(
-                        since=interval.since,
-                        before=interval.before,
-                        source_ids=(source_id,),
-                        dataset_keys=(dataset_key,),
-                        run_ids=interval.run_ids,
-                    )
-                )
-        else:
+        pair_windows = await _resolve_backfill_job_pair_windows(session, org_id, job)
+        if pair_windows is None:
             ranges.append(
                 CoverageInterval(
                     since=interval.since,
@@ -586,6 +615,20 @@ async def _backfill_requested_ranges(
                     run_ids=interval.run_ids,
                 )
             )
+            continue
+        for (source_id, dataset_key), windows in pair_windows.items():
+            if source_id not in scope_source_ids:
+                continue
+            for clipped in _clip_intervals(windows, interval.since, interval.before):
+                ranges.append(
+                    CoverageInterval(
+                        since=clipped.since,
+                        before=clipped.before,
+                        source_ids=(source_id,),
+                        dataset_keys=(dataset_key,),
+                        run_ids=interval.run_ids,
+                    )
+                )
     return ranges
 
 

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -51,6 +51,14 @@ class CoverageInterval:
     before: datetime
     source_ids: tuple[str, ...] = ()
     run_ids: tuple[str, ...] = ()
+    # Dataset keys this interval is scoped to. Empty means "every dataset key
+    # in scope" (the legacy/fallback behavior) -- set by
+    # ``_backfill_requested_ranges`` when a backfill job's linked SyncRun lets
+    # us resolve the exact (source_id, dataset_key) pairs it planned units
+    # for. Never populated on windows/covered/gap intervals -- only on raw
+    # backfill-requested intervals before they are split per pair in
+    # ``build_coverage_summary_payload``.
+    dataset_keys: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -479,6 +487,38 @@ def _backfill_interval(job: BackfillJob) -> CoverageInterval:
     return CoverageInterval(since=since, before=before, run_ids=(str(job.id),))
 
 
+def _backfill_job_sync_run_id(job: BackfillJob) -> str | None:
+    """Extract the linked SyncRun id from a backfill job's celery_task_id.
+
+    Mirrors the identical helper in ``api/admin/routers/sync.py`` and
+    ``workers/sync_reconciler.py`` (duplicated locally -- pulling it in would
+    create a router import cycle from this service module).
+    """
+    task_id = str(job.celery_task_id or "")
+    marker = "sync_run:"
+    if marker not in task_id:
+        return None
+    return task_id.rsplit(marker, 1)[-1] or None
+
+
+async def _backfill_job_run_pairs(
+    session: AsyncSession, org_id: str, run_id: uuid.UUID
+) -> set[tuple[str, str]]:
+    """Return the distinct (source_id, dataset_key) pairs a SyncRun planned units for."""
+    stmt = (
+        select(SyncRunUnit.source_id, SyncRunUnit.dataset_key)
+        .where(
+            SyncRunUnit.org_id == org_id,
+            SyncRunUnit.sync_run_id == run_id,
+        )
+        .distinct()
+    )
+    return {
+        (str(source_id), str(dataset_key))
+        for source_id, dataset_key in (await session.execute(stmt)).all()
+    }
+
+
 async def _backfill_requested_ranges(
     session: AsyncSession,
     org_id: str,
@@ -486,6 +526,24 @@ async def _backfill_requested_ranges(
     scope: EffectiveScope,
     truncated_before: datetime,
 ) -> list[CoverageInterval]:
+    """Return backfill-driven requested intervals.
+
+    Pair-aware: each job's linked SyncRun (resolved via the ``sync_run:<uuid>``
+    suffix of ``celery_task_id``) tells us exactly which (source_id,
+    dataset_key) pairs the backfill actually planned units for, so the job's
+    date range is only counted as "requested" for those pairs. Without this,
+    a backfill that only plans units for a subset of the in-scope pairs
+    (unsupported datasets for a provider, sources added after the backfill
+    ran, work-item family composite keys) permanently "requests" coverage on
+    every other in-scope pair too -- a gap no future backfill on that pair
+    can ever clear (CHAOS-2869).
+
+    Fallback: if the marker is absent/unparseable, the linked SyncRun row no
+    longer exists, or the run has zero SyncRunUnit rows, we fall back to the
+    legacy all-pairs-in-scope behavior for that job. This keeps pre-marker
+    legacy jobs working as before; such rows naturally age out of the
+    ``HISTORY_LOOKBACK_DAYS`` lookback over time.
+    """
     if not scope.sources:
         return []
     stmt = select(BackfillJob).where(
@@ -493,20 +551,41 @@ async def _backfill_requested_ranges(
         BackfillJob.sync_config_id == config.id,
         BackfillJob.created_at >= truncated_before,
     )
+    scope_source_ids = tuple(str(source.id) for source in scope.sources)
     ranges: list[CoverageInterval] = []
     for job in (await session.execute(stmt)).scalars().all():
-        task_id = str(job.celery_task_id or "")
-        if "sync_run:" in task_id:
-            continue
         interval = _backfill_interval(job)
-        ranges.append(
-            CoverageInterval(
-                since=interval.since,
-                before=interval.before,
-                source_ids=tuple(str(source.id) for source in scope.sources),
-                run_ids=interval.run_ids,
+        pairs: set[tuple[str, str]] = set()
+        run_id_str = _backfill_job_sync_run_id(job)
+        if run_id_str is not None:
+            try:
+                run_uuid = uuid.UUID(run_id_str)
+            except ValueError:
+                run_uuid = None
+            if run_uuid is not None:
+                pairs = await _backfill_job_run_pairs(session, org_id, run_uuid)
+        if pairs:
+            for source_id, dataset_key in pairs:
+                if source_id not in scope_source_ids:
+                    continue
+                ranges.append(
+                    CoverageInterval(
+                        since=interval.since,
+                        before=interval.before,
+                        source_ids=(source_id,),
+                        dataset_keys=(dataset_key,),
+                        run_ids=interval.run_ids,
+                    )
+                )
+        else:
+            ranges.append(
+                CoverageInterval(
+                    since=interval.since,
+                    before=interval.before,
+                    source_ids=scope_source_ids,
+                    run_ids=interval.run_ids,
+                )
             )
-        )
     return ranges
 
 
@@ -590,13 +669,21 @@ def build_coverage_summary_payload(
         by_pair[(window.source_id, window.dataset_key)].append(window)
 
     scope_source_ids = {str(source.id) for source in scope.sources}
+    scope_dataset_keys = set(scope.dataset_keys)
     backfill_by_pair: dict[tuple[str, str], list[CoverageInterval]] = defaultdict(list)
     for interval in backfill_requested:
         interval_source_ids = interval.source_ids or tuple(sorted(scope_source_ids))
+        # Empty dataset_keys means "legacy/unresolved backfill" -- spread it
+        # across every dataset in scope (the pre-fix, all-pairs fallback).
+        # Non-empty dataset_keys means the backfill's SyncRun told us exactly
+        # which pairs it planned units for, so we only apply it there.
+        interval_dataset_keys = interval.dataset_keys or scope.dataset_keys
         for source_id in interval_source_ids:
             if source_id not in scope_source_ids:
                 continue
-            for dataset_key in scope.dataset_keys:
+            for dataset_key in interval_dataset_keys:
+                if dataset_key not in scope_dataset_keys:
+                    continue
                 backfill_by_pair[(source_id, dataset_key)].append(
                     CoverageInterval(
                         since=interval.since,

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -240,6 +240,52 @@ async def _seed_unit(
         return str(run.id)
 
 
+async def _seed_run(session_maker, scope: dict, *, status: str = "success") -> str:
+    async with session_maker() as session:
+        run = SyncRun(
+            org_id=scope["org_id"],
+            integration_id=uuid.UUID(scope["integration_id"]),
+            triggered_by="backfill",
+            mode="backfill",
+            status=status,
+            total_units=1,
+            completed_units=1 if status == "success" else 0,
+        )
+        session.add(run)
+        await session.commit()
+        return str(run.id)
+
+
+async def _seed_run_unit(
+    session_maker,
+    scope: dict,
+    run_id: str,
+    *,
+    since: datetime,
+    before: datetime,
+    status: str = "success",
+    source_id: str | None = None,
+    dataset_key: str = "commits",
+) -> None:
+    async with session_maker() as session:
+        unit = SyncRunUnit(
+            org_id=scope["org_id"],
+            sync_run_id=uuid.UUID(run_id),
+            integration_id=uuid.UUID(scope["integration_id"]),
+            source_id=uuid.UUID(source_id or scope["source_id"]),
+            provider="github",
+            dataset_key=dataset_key,
+            cost_class="standard",
+            mode="incremental",
+            since_at=since,
+            before_at=before,
+            status=status,
+            attempts=1,
+        )
+        session.add(unit)
+        await session.commit()
+
+
 @pytest.mark.asyncio
 async def test_sync_coverage_api_returns_complete_summary(client, session_maker):
     ac, seeded_state = client
@@ -422,3 +468,166 @@ async def test_sync_coverage_cross_org_config_returns_404(client, session_maker)
     resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
 
     assert resp.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_api_backfill_pair_scoped_to_planned_run_units(
+    client, session_maker
+):
+    """CHAOS-2869 core repro: a backfill's requested range only applies to the
+    (source, dataset) pairs its linked SyncRun actually planned units for.
+    """
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    async with session_maker() as session:
+        extra_source = IntegrationSource(
+            org_id=scope["org_id"],
+            integration_id=uuid.UUID(scope["integration_id"]),
+            provider="github",
+            source_type="repository",
+            external_id="acme/other",
+            name="other",
+            full_name="acme/other",
+            metadata_={"planner_managed_sync_config_id": scope["config_id"]},
+            is_enabled=True,
+        )
+        pr_dataset = IntegrationDataset(
+            org_id=scope["org_id"],
+            integration_id=uuid.UUID(scope["integration_id"]),
+            dataset_key="pull_requests",
+            is_enabled=True,
+            options={},
+        )
+        session.add_all([extra_source, pr_dataset])
+        await session.commit()
+        extra_source_id = str(extra_source.id)
+
+    since = datetime(2026, 1, 1, tzinfo=timezone.utc)
+    before = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    run_id = await _seed_run(session_maker, scope, status="success")
+    await _seed_run_unit(
+        session_maker, scope, run_id, since=since, before=before, status="success"
+    )
+    async with session_maker() as session:
+        session.add(
+            BackfillJob(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(scope["config_id"]),
+                status="success",
+                since_date=since.date(),
+                before_date=datetime(2026, 1, 3, tzinfo=timezone.utc).date(),
+                total_chunks=1,
+                completed_chunks=1,
+                celery_task_id=f"sync_run:{run_id}",
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    sources = {source["source_id"]: source for source in data["sources"]}
+    # Pair (source A, commits) is what the run actually planned units for --
+    # the backfill's wider [Jan1, Jan3) window is a legit gap on THAT pair.
+    assert sources[scope["source_id"]]["gap_count"] == 1
+    # Pair (source B, commits) and (either source, pull_requests) were never
+    # planned by this run: they must not inherit a permanent requested gap.
+    assert sources[extra_source_id]["gap_count"] == 0
+    assert sources[extra_source_id]["status"] == "insufficient_data"
+    datasets = {dataset["dataset_key"]: dataset for dataset in data["datasets"]}
+    assert datasets["pull_requests"]["status"] == "insufficient_data"
+    assert datasets["pull_requests"]["gaps"] == []
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_api_success_matching_backfill_range_clears_gap(
+    client, session_maker
+):
+    """A pair-scoped backfill whose linked run's SUCCESS unit fully covers
+    the job's requested range must resolve to a clean (non-gapped) pair."""
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    run_id = await _seed_run(session_maker, scope, status="success")
+    now = datetime.now(timezone.utc)
+    # Covered window is recent (avoids stale classification); the backfill's
+    # day-quantized range sits fully inside it so it resolves clean.
+    covered_since = now - timedelta(days=5)
+    covered_before = now - timedelta(minutes=5)
+    await _seed_run_unit(
+        session_maker,
+        scope,
+        run_id,
+        since=covered_since,
+        before=covered_before,
+        status="success",
+    )
+    async with session_maker() as session:
+        session.add(
+            BackfillJob(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(scope["config_id"]),
+                status="success",
+                since_date=(now - timedelta(days=4)).date(),
+                before_date=(now - timedelta(days=3)).date(),
+                total_chunks=1,
+                completed_chunks=1,
+                celery_task_id=f"sync_run:{run_id}",
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["overall"]["health"] == "healthy"
+    assert data["datasets"][0]["gaps"] == []
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_api_unresolvable_backfill_marker_falls_back_to_all_pairs(
+    client, session_maker
+):
+    """An unparseable sync_run marker (or one whose run/units are gone) falls
+    back to the legacy all-pairs-in-scope requested range, same as a
+    backfill job with no marker at all."""
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    async with session_maker() as session:
+        extra_source = IntegrationSource(
+            org_id=scope["org_id"],
+            integration_id=uuid.UUID(scope["integration_id"]),
+            provider="github",
+            source_type="repository",
+            external_id="acme/other-2",
+            name="other-2",
+            full_name="acme/other-2",
+            metadata_={"planner_managed_sync_config_id": scope["config_id"]},
+            is_enabled=True,
+        )
+        session.add(extra_source)
+        await session.commit()
+        extra_source_id = str(extra_source.id)
+
+    async with session_maker() as session:
+        session.add(
+            BackfillJob(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(scope["config_id"]),
+                status="pending",
+                since_date=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                before_date=datetime(2026, 1, 2, tzinfo=timezone.utc).date(),
+                total_chunks=0,
+                celery_task_id="sync_run:not-a-uuid",
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    sources = {source["source_id"]: source for source in data["sources"]}
+    assert sources[scope["source_id"]]["gap_count"] == 1
+    assert sources[extra_source_id]["gap_count"] == 1

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -475,7 +475,11 @@ async def test_sync_coverage_api_backfill_pair_scoped_to_planned_run_units(
     client, session_maker
 ):
     """CHAOS-2869 core repro: a backfill's requested range only applies to the
-    (source, dataset) pairs its linked SyncRun actually planned units for.
+    (source, dataset) pairs its linked SyncRun actually planned units for, and
+    is clipped to the ACTUAL unit windows -- not the job's full date range.
+    A job spanning wider than what its run actually planned must not create a
+    phantom gap beyond the units themselves, and untouched pairs/datasets
+    must not inherit a permanent requested gap at all.
     """
     ac, seeded_state = client
     scope = await _seed_scope(session_maker, seeded_state["org_id"])
@@ -502,8 +506,12 @@ async def test_sync_coverage_api_backfill_pair_scoped_to_planned_run_units(
         await session.commit()
         extra_source_id = str(extra_source.id)
 
-    since = datetime(2026, 1, 1, tzinfo=timezone.utc)
-    before = datetime(2026, 1, 2, tzinfo=timezone.utc)
+    now = datetime.now(timezone.utc)
+    # Unit window is recent (avoids stale classification); the backfill job's
+    # day-quantized range is deliberately WIDER than the unit's actual window
+    # to prove the wider job range does not inflate the requested range.
+    since = now - timedelta(days=2)
+    before = now - timedelta(minutes=5)
     run_id = await _seed_run(session_maker, scope, status="success")
     await _seed_run_unit(
         session_maker, scope, run_id, since=since, before=before, status="success"
@@ -514,8 +522,8 @@ async def test_sync_coverage_api_backfill_pair_scoped_to_planned_run_units(
                 org_id=seeded_state["org_id"],
                 sync_config_id=uuid.UUID(scope["config_id"]),
                 status="success",
-                since_date=since.date(),
-                before_date=datetime(2026, 1, 3, tzinfo=timezone.utc).date(),
+                since_date=(now - timedelta(days=3)).date(),
+                before_date=(now + timedelta(days=1)).date(),
                 total_chunks=1,
                 completed_chunks=1,
                 celery_task_id=f"sync_run:{run_id}",
@@ -528,16 +536,21 @@ async def test_sync_coverage_api_backfill_pair_scoped_to_planned_run_units(
     assert resp.status_code == 200, resp.text
     data = resp.json()
     sources = {source["source_id"]: source for source in data["sources"]}
-    # Pair (source A, commits) is what the run actually planned units for --
-    # the backfill's wider [Jan1, Jan3) window is a legit gap on THAT pair.
-    assert sources[scope["source_id"]]["gap_count"] == 1
+    # Pair (source A, commits) is what the run actually planned units for,
+    # but only for [since, before) -- the backfill job's much wider
+    # [since-1d, before+1d] window must NOT inflate the requested range
+    # beyond that actual unit window, so there is no phantom gap.
+    assert sources[scope["source_id"]]["gap_count"] == 0
+    assert sources[scope["source_id"]]["status"] == "healthy"
     # Pair (source B, commits) and (either source, pull_requests) were never
     # planned by this run: they must not inherit a permanent requested gap.
     assert sources[extra_source_id]["gap_count"] == 0
     assert sources[extra_source_id]["status"] == "insufficient_data"
     datasets = {dataset["dataset_key"]: dataset for dataset in data["datasets"]}
+    assert datasets["commits"]["gaps"] == []
     assert datasets["pull_requests"]["status"] == "insufficient_data"
     assert datasets["pull_requests"]["gaps"] == []
+    assert data["overall"]["health"] == "healthy"
 
 
 @pytest.mark.asyncio
@@ -631,3 +644,57 @@ async def test_sync_coverage_api_unresolvable_backfill_marker_falls_back_to_all_
     sources = {source["source_id"]: source for source in data["sources"]}
     assert sources[scope["source_id"]]["gap_count"] == 1
     assert sources[extra_source_id]["gap_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_api_backfill_marker_resolved_zero_units_contributes_nothing(
+    client, session_maker
+):
+    """A sync_run marker that resolves to an existing run with zero planned
+    units must contribute NOTHING -- it must NOT fall back to the legacy
+    all-pairs-in-scope behavior. Conflating "zero units" with "unresolvable"
+    would reintroduce the exact phantom-gap class CHAOS-2869 exists to kill:
+    a run that legitimately planned no work would otherwise "request"
+    coverage on every in-scope pair."""
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    async with session_maker() as session:
+        extra_source = IntegrationSource(
+            org_id=scope["org_id"],
+            integration_id=uuid.UUID(scope["integration_id"]),
+            provider="github",
+            source_type="repository",
+            external_id="acme/zero-units",
+            name="zero-units",
+            full_name="acme/zero-units",
+            metadata_={"planner_managed_sync_config_id": scope["config_id"]},
+            is_enabled=True,
+        )
+        session.add(extra_source)
+        await session.commit()
+        extra_source_id = str(extra_source.id)
+
+    # A SyncRun that exists but planned zero SyncRunUnit rows.
+    run_id = await _seed_run(session_maker, scope, status="success")
+    async with session_maker() as session:
+        session.add(
+            BackfillJob(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(scope["config_id"]),
+                status="success",
+                since_date=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                before_date=datetime(2026, 1, 2, tzinfo=timezone.utc).date(),
+                total_chunks=0,
+                celery_task_id=f"sync_run:{run_id}",
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    sources = {source["source_id"]: source for source in data["sources"]}
+    assert sources[scope["source_id"]]["gap_count"] == 0
+    assert sources[extra_source_id]["gap_count"] == 0
+    assert data["overall"]["health"] == "insufficient_data"

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -287,3 +287,67 @@ def test_full_resync_window_can_cover_entire_requested_range():
     assert dataset["covered_ranges"][0]["since"] == _dt(1)
     assert dataset["covered_ranges"][0]["before"] == _dt(31)
     assert summary["overall"]["health"] == "healthy"
+
+
+def test_backfill_interval_pair_scope_excludes_untouched_pairs():
+    # CHAOS-2869 core repro: a backfill's requested interval is scoped to
+    # exactly the (source_id, dataset_key) pairs its linked SyncRun planned
+    # units for. A pair the run never touched must not inherit a permanent
+    # requested gap from that job.
+    source_a = uuid.uuid4()
+    source_b = uuid.uuid4()
+    config = _config()
+    scope = EffectiveScope(
+        integration_id=config.integration_id,
+        sources=(_source(source_a), _source(source_b)),
+        dataset_keys=("commits",),
+    )
+
+    summary = _summary(
+        [],
+        backfill_requested=[
+            CoverageInterval(
+                _dt(1),
+                _dt(3),
+                source_ids=(str(source_a),),
+                dataset_keys=("commits",),
+            )
+        ],
+        config=config,
+        scope=scope,
+    )
+
+    dataset = summary["datasets"][0]
+    assert [
+        (gap["since"], gap["before"], gap["source_ids"]) for gap in dataset["gaps"]
+    ] == [(_dt(1), _dt(3), [str(source_a)])]
+    sources = {source["source_id"]: source for source in summary["sources"]}
+    assert sources[str(source_a)]["status"] == "gaps"
+    assert sources[str(source_b)]["gap_count"] == 0
+    assert sources[str(source_b)]["status"] == "insufficient_data"
+
+
+def test_backfill_interval_without_pair_scope_applies_to_all_scope_pairs():
+    # Legacy/unresolved-marker fallback: an interval with no dataset_keys
+    # (and no source_ids) still spreads across every pair in scope, matching
+    # pre-fix behavior for backfill jobs whose linked SyncRun can't be
+    # resolved.
+    source_a = uuid.uuid4()
+    source_b = uuid.uuid4()
+    config = _config()
+    scope = EffectiveScope(
+        integration_id=config.integration_id,
+        sources=(_source(source_a), _source(source_b)),
+        dataset_keys=("commits",),
+    )
+
+    summary = _summary(
+        [],
+        backfill_requested=[CoverageInterval(_dt(1), _dt(3))],
+        config=config,
+        scope=scope,
+    )
+
+    sources = {source["source_id"]: source for source in summary["sources"]}
+    assert sources[str(source_a)]["gap_count"] == 1
+    assert sources[str(source_b)]["gap_count"] == 1


### PR DESCRIPTION
Fixes CHAOS-2869

## Problem

`_backfill_requested_ranges` in `src/dev_health_ops/api/services/sync_coverage.py` included every `BackfillJob` within the lookback window (no status filter) and expanded each job's date range across **every** `(source_id, dataset_key)` pair in scope. Covered ranges only count `SUCCESS` unit windows per exact pair. Any in-scope pair the planner never planned units for (unsupported datasets, sources added after the backfill ran, work-item family composite keys) became a permanent gap that no backfill could ever clear.

### Minimal repro (from the issue)

| Backfill job | Sources in scope | Dataset | Units actually planned | Result before fix |
| --- | --- | --- | --- | --- |
| `[Jan1 -> Jan3]` | `{A, B}` | `commits` | `SUCCESS` only for `(B, commits)` | `(A, commits)` stays gapped forever, even though the backfill "completed" |

## Fix

`_backfill_requested_ranges` now resolves each job's linked `SyncRun` via the `sync_run:<uuid>` suffix of `celery_task_id` (mirrors the parsing helper in `api/admin/routers/sync.py:_backfill_job_sync_run_id` / `workers/sync_reconciler.py`, duplicated locally to avoid a router import cycle). The job's requested interval is scoped to only the distinct `(source_id, dataset_key)` pairs that run's `SyncRunUnit` rows actually cover.

**Fallback:** if the marker is absent/unparseable, the linked run row is gone, or the run has zero units, the job falls back to the legacy all-pairs-in-scope behavior (documented in code). Such legacy rows age out of the 180-day lookback naturally.

`CoverageInterval` gains an optional `dataset_keys` field (default `()`, meaning "every dataset key in scope") so `build_coverage_summary_payload` can split backfill-requested intervals per exact pair. Public signatures of `build_coverage_summary_payload` / `build_sync_coverage_summary` are unchanged, and the payload's JSON shape (`datasets[].requested_ranges/covered_ranges/gaps/failed_ranges`) is unchanged.

## Tests

- `tests/test_sync_coverage.py`:
  - `test_backfill_interval_pair_scope_excludes_untouched_pairs` — pair-scoped backfill interval doesn't leak a gap onto an untouched pair.
  - `test_backfill_interval_without_pair_scope_applies_to_all_scope_pairs` — legacy/unresolved-marker fallback still spreads across all scope pairs.
- `tests/api/admin/test_sync_coverage_api.py` (full DB + marker resolution):
  - `test_sync_coverage_api_backfill_pair_scoped_to_planned_run_units` — core repro: a completed backfill whose run planned units only for `(source A, commits)` does not create a permanent gap on `(source B, commits)` or an unrelated in-scope dataset (`pull_requests`).
  - `test_sync_coverage_api_success_matching_backfill_range_clears_gap` — a pair-scoped backfill whose linked run's `SUCCESS` unit fully covers the requested range resolves to healthy/no-gap.
  - `test_sync_coverage_api_unresolvable_backfill_marker_falls_back_to_all_pairs` — an unparseable `sync_run:` marker falls back to the documented all-pairs-in-scope behavior.

## Verification

```
.venv/bin/ruff format --check .
.venv/bin/ruff check .
.venv/bin/mypy src/dev_health_ops/api/services/sync_coverage.py
.venv/bin/python -m pytest tests/test_sync_coverage.py tests/api/admin/test_sync_coverage_api.py -q
```
All green (28 passed). Also passed as part of the `pre-commit`/`pre-push` lefthook gates (ruff format/check + mypy across the full source tree).

## Scope notes

- Docs: grepped `ops/docs/` for coverage-semantics documentation; found no dedicated page describing the backfill-requested-range contract, so no doc update was needed.
- Out of scope (per issue): the requested/covered lookback-clock mismatch (`BackfillJob.created_at` vs `SyncRunUnit.updated_at`) is a known follow-up, not touched here.
- Does not touch `workers/sync_reconciler.py` or `web/`.
