### PR TITLE
fix(coverage): align backfill coverage lookback clock (CHAOS-2873)

### DIFF
--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -391,6 +391,7 @@ async def _has_schedule_row(
 async def _terminal_unit_windows(
     session: AsyncSession,
     org_id: str,
+    config: SyncConfiguration,
     scope: EffectiveScope,
     truncated_before: datetime,
 ) -> list[UnitWindow]:
@@ -412,6 +413,27 @@ async def _terminal_unit_windows(
         .join(SyncRun, SyncRun.id == SyncRunUnit.sync_run_id)
         .where(*base_filters, SyncRunUnit.updated_at >= truncated_before)
     )
+    recent_backfill_stmt = select(BackfillJob).where(
+        BackfillJob.org_id == org_id,
+        BackfillJob.sync_config_id == config.id,
+        BackfillJob.created_at >= truncated_before,
+    )
+    recent_backfill_run_ids: set[uuid.UUID] = set()
+    for job in (await session.execute(recent_backfill_stmt)).scalars().all():
+        run_id_str = _backfill_job_sync_run_id(job)
+        if run_id_str is None:
+            continue
+        try:
+            recent_backfill_run_ids.add(uuid.UUID(run_id_str))
+        except ValueError:
+            continue
+    backfill_unit_stmt = None
+    if recent_backfill_run_ids:
+        backfill_unit_stmt = (
+            select(SyncRunUnit, SyncRun)
+            .join(SyncRun, SyncRun.id == SyncRunUnit.sync_run_id)
+            .where(*base_filters, SyncRunUnit.sync_run_id.in_(recent_backfill_run_ids))
+        )
     latest_success_ranked = (
         select(
             SyncRunUnit.id.label("unit_id"),
@@ -448,6 +470,12 @@ async def _terminal_unit_windows(
         if key not in seen:
             rows.append((unit, run))
             seen.add(key)
+    if backfill_unit_stmt is not None:
+        for unit, run in (await session.execute(backfill_unit_stmt)).all():
+            key = (unit.id, run.id)
+            if key not in seen:
+                rows.append((unit, run))
+                seen.add(key)
     windows: list[UnitWindow] = []
     for unit, run in rows:
         window = _unit_window_from_row(unit, run)
@@ -951,7 +979,9 @@ async def build_sync_coverage_summary(
     scope = await resolve_effective_scope(session, org_id, config)
     schedule = await _active_schedule(session, org_id, config)
     has_schedule = await _has_schedule_row(session, org_id, config)
-    windows = await _terminal_unit_windows(session, org_id, scope, truncated_before)
+    windows = await _terminal_unit_windows(
+        session, org_id, config, scope, truncated_before
+    )
     active_pairs = await _active_run_ids(session, org_id, scope)
     backfill_requested = await _backfill_requested_ranges(
         session, org_id, config, scope, truncated_before

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -12,6 +12,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.sync_coverage import build_sync_coverage_summary
 from dev_health_ops.models.backfill import BackfillJob
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.integrations import (
@@ -266,6 +267,7 @@ async def _seed_run_unit(
     status: str = "success",
     source_id: str | None = None,
     dataset_key: str = "commits",
+    updated_at: datetime | None = None,
 ) -> None:
     async with session_maker() as session:
         unit = SyncRunUnit(
@@ -282,8 +284,28 @@ async def _seed_run_unit(
             status=status,
             attempts=1,
         )
+        if updated_at is not None:
+            unit.updated_at = updated_at
         session.add(unit)
         await session.commit()
+
+
+async def _coverage_summary_at(
+    session_maker,
+    scope: dict,
+    *,
+    org_id: str,
+    generated_at: datetime,
+) -> dict:
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, uuid.UUID(scope["config_id"]))
+        assert config is not None
+        return await build_sync_coverage_summary(
+            session,
+            org_id,
+            config,
+            generated_at=generated_at,
+        )
 
 
 @pytest.mark.asyncio
@@ -596,6 +618,188 @@ async def test_sync_coverage_api_success_matching_backfill_range_clears_gap(
     data = resp.json()
     assert data["overall"]["health"] == "healthy"
     assert data["datasets"][0]["gaps"] == []
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_recent_backfill_success_stays_cleared_after_unit_ages_out(
+    session_maker, seeded_state
+):
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    generated_at = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    old_unit_updated_at = generated_at - timedelta(days=181)
+    backfill_created_at = generated_at - timedelta(days=179)
+
+    backfill_run_id = await _seed_run(session_maker, scope, status="success")
+    await _seed_run_unit(
+        session_maker,
+        scope,
+        backfill_run_id,
+        since=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        before=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        status="success",
+        updated_at=old_unit_updated_at,
+    )
+    latest_run_id = await _seed_run(session_maker, scope, status="success")
+    await _seed_run_unit(
+        session_maker,
+        scope,
+        latest_run_id,
+        since=generated_at - timedelta(hours=2),
+        before=generated_at - timedelta(hours=1),
+        status="success",
+        updated_at=generated_at - timedelta(hours=1),
+    )
+    async with session_maker() as session:
+        session.add(
+            BackfillJob(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(scope["config_id"]),
+                status="success",
+                since_date=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                before_date=datetime(2026, 1, 2, tzinfo=timezone.utc).date(),
+                total_chunks=1,
+                completed_chunks=1,
+                celery_task_id=f"sync_run:{backfill_run_id}",
+                created_at=backfill_created_at,
+                updated_at=backfill_created_at,
+            )
+        )
+        await session.commit()
+
+    data = await _coverage_summary_at(
+        session_maker,
+        scope,
+        org_id=seeded_state["org_id"],
+        generated_at=generated_at,
+    )
+
+    assert data["overall"]["health"] == "healthy"
+    assert data["datasets"][0]["gaps"] == []
+    assert data["sources"][0]["gap_count"] == 0
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_recent_backfill_uncovered_range_still_reports_gap(
+    session_maker, seeded_state
+):
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    generated_at = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    old_unit_updated_at = generated_at - timedelta(days=181)
+    backfill_created_at = generated_at - timedelta(days=179)
+
+    backfill_run_id = await _seed_run(session_maker, scope, status="running")
+    await _seed_run_unit(
+        session_maker,
+        scope,
+        backfill_run_id,
+        since=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        before=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        status="planned",
+        updated_at=old_unit_updated_at,
+    )
+    latest_run_id = await _seed_run(session_maker, scope, status="success")
+    await _seed_run_unit(
+        session_maker,
+        scope,
+        latest_run_id,
+        since=generated_at - timedelta(hours=2),
+        before=generated_at - timedelta(hours=1),
+        status="success",
+        updated_at=generated_at - timedelta(hours=1),
+    )
+    async with session_maker() as session:
+        session.add(
+            BackfillJob(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(scope["config_id"]),
+                status="running",
+                since_date=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                before_date=datetime(2026, 1, 2, tzinfo=timezone.utc).date(),
+                total_chunks=1,
+                completed_chunks=0,
+                celery_task_id=f"sync_run:{backfill_run_id}",
+                created_at=backfill_created_at,
+                updated_at=backfill_created_at,
+            )
+        )
+        await session.commit()
+
+    data = await _coverage_summary_at(
+        session_maker,
+        scope,
+        org_id=seeded_state["org_id"],
+        generated_at=generated_at,
+    )
+
+    assert data["overall"]["health"] == "gaps"
+    assert [(gap["since"], gap["before"]) for gap in data["datasets"][0]["gaps"]] == [
+        (
+            datetime(2026, 1, 1, tzinfo=timezone.utc),
+            datetime(2026, 1, 2, tzinfo=timezone.utc),
+        )
+    ]
+    assert data["sources"][0]["gap_count"] == 1
+
+
+@pytest.mark.asyncio
+async def test_sync_coverage_recent_backfill_clock_alignment_remains_pair_scoped(
+    session_maker, seeded_state
+):
+    scope = await _seed_scope(session_maker, seeded_state["org_id"])
+    async with session_maker() as session:
+        extra_source = IntegrationSource(
+            org_id=scope["org_id"],
+            integration_id=uuid.UUID(scope["integration_id"]),
+            provider="github",
+            source_type="repository",
+            external_id="acme/clock-pair-scope",
+            name="clock-pair-scope",
+            full_name="acme/clock-pair-scope",
+            metadata_={"planner_managed_sync_config_id": scope["config_id"]},
+            is_enabled=True,
+        )
+        session.add(extra_source)
+        await session.commit()
+        extra_source_id = str(extra_source.id)
+    generated_at = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    backfill_run_id = await _seed_run(session_maker, scope, status="success")
+    await _seed_run_unit(
+        session_maker,
+        scope,
+        backfill_run_id,
+        since=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        before=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        status="success",
+        updated_at=generated_at - timedelta(days=181),
+    )
+    async with session_maker() as session:
+        session.add(
+            BackfillJob(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(scope["config_id"]),
+                status="success",
+                since_date=datetime(2026, 1, 1, tzinfo=timezone.utc).date(),
+                before_date=datetime(2026, 1, 2, tzinfo=timezone.utc).date(),
+                total_chunks=1,
+                completed_chunks=1,
+                celery_task_id=f"sync_run:{backfill_run_id}",
+                created_at=generated_at - timedelta(days=179),
+                updated_at=generated_at - timedelta(days=179),
+            )
+        )
+        await session.commit()
+
+    data = await _coverage_summary_at(
+        session_maker,
+        scope,
+        org_id=seeded_state["org_id"],
+        generated_at=generated_at,
+    )
+
+    sources = {source["source_id"]: source for source in data["sources"]}
+    assert sources[scope["source_id"]]["gap_count"] == 0
+    assert sources[extra_source_id]["gap_count"] == 0
+    assert sources[extra_source_id]["status"] == "insufficient_data"
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Aligns pair-aware backfill coverage with the backfill job clock so a cleared requested range does not resurrect when its linked unit `updated_at` crosses the lookback boundary first.
- Keeps CHAOS-2869 marker-state behavior intact: unmarked/unparseable jobs still use the legacy all-pairs fallback, zero-unit marked jobs contribute nothing, and populated marked jobs stay pair-scoped.
- Adds clock-boundary regression coverage for filled gaps, genuinely uncovered gaps, and pair-scoped behavior.

## Anchor decision
Use `BackfillJob.created_at` as the authoritative lookback anchor for pair-aware backfill comparisons. Backfill requested intent is persisted and retained by the job row, so coverage produced by that job's linked `SyncRunUnit` rows must be retained on the same clock while the job remains in lookback. Anchoring requested intent to `SyncRunUnit.updated_at` would hide genuinely uncovered recent backfill jobs; anchoring the linked coverage to `BackfillJob.created_at` keeps real gaps visible while preventing already-cleared gaps from reappearing.

## Tests
- `python -m pytest tests/api/admin/test_sync_coverage_api.py -q`
- `ruff check src/dev_health_ops/api/services/sync_coverage.py tests/api/admin/test_sync_coverage_api.py`
- LSP diagnostics clean for changed files
- Commit/pre-push hooks: ruff + mypy

Refs CHAOS-2873.
