### PR TITLE
fix(sync): expose backfill freshness timestamp

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -333,6 +333,11 @@ def _aware_datetime(value: datetime | None) -> datetime | None:
     return value
 
 
+def _latest_datetime(*values: datetime | None) -> datetime | None:
+    aware_values = [aware for value in values if (aware := _aware_datetime(value))]
+    return max(aware_values) if aware_values else None
+
+
 def _elapsed_seconds(
     started_at: datetime | None, completed_at: datetime | None
 ) -> int | None:
@@ -540,6 +545,11 @@ def _backfill_job_response(job: object, run_counts: dict[str, Any] | None = None
         run_counts.get("completed_chunks", getattr(job, "completed_chunks"))
     )
     progress_pct = (completed_chunks / total_chunks * 100) if total_chunks > 0 else 0.0
+    job_updated_at = getattr(job, "updated_at")
+    effective_updated_at = _latest_datetime(
+        job_updated_at,
+        run_counts.get("updated_at"),
+    )
     return BackfillJobResponse(
         id=str(getattr(job, "id")),
         sync_config_id=str(getattr(job, "sync_config_id")),
@@ -556,7 +566,9 @@ def _backfill_job_response(job: object, run_counts: dict[str, Any] | None = None
         started_at=getattr(job, "started_at"),
         completed_at=run_counts.get("completed_at", getattr(job, "completed_at")),
         created_at=getattr(job, "created_at"),
-        updated_at=getattr(job, "updated_at"),
+        # Response-level updated_at is effective liveness: the raw BackfillJob
+        # row-write timestamp OR the latest linked fanout unit activity.
+        updated_at=effective_updated_at or job_updated_at,
     )
 
 
@@ -586,6 +598,15 @@ async def _backfill_job_run_counts(
     run = result.scalar_one_or_none()
     if run is None:
         return None
+    activity_stmt = select(
+        func.max(SyncRunUnit.updated_at),
+        func.max(SyncRunUnit.last_heartbeat_at),
+    ).where(
+        SyncRunUnit.sync_run_id == run_uuid,
+        SyncRunUnit.org_id == str(getattr(job, "org_id")),
+    )
+    activity_result = await session.execute(activity_stmt)
+    latest_unit_updated_at, latest_unit_heartbeat_at = activity_result.one()
     return {
         "status": getattr(run, "status"),
         "total_chunks": int(getattr(run, "total_units")),
@@ -593,6 +614,10 @@ async def _backfill_job_run_counts(
         "failed_chunks": int(getattr(run, "failed_units")),
         "completed_at": getattr(run, "completed_at"),
         "error_message": getattr(run, "error"),
+        "updated_at": _latest_datetime(
+            latest_unit_updated_at,
+            latest_unit_heartbeat_at,
+        ),
     }
 
 

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -556,6 +556,7 @@ def _backfill_job_response(job: object, run_counts: dict[str, Any] | None = None
         started_at=getattr(job, "started_at"),
         completed_at=run_counts.get("completed_at", getattr(job, "completed_at")),
         created_at=getattr(job, "created_at"),
+        updated_at=getattr(job, "updated_at"),
     )
 
 

--- a/src/dev_health_ops/api/schemas/backfill.py
+++ b/src/dev_health_ops/api/schemas/backfill.py
@@ -19,6 +19,7 @@ class BackfillJobResponse(BaseModel):
     started_at: datetime | None
     completed_at: datetime | None
     created_at: datetime
+    updated_at: datetime
 
 
 class BackfillJobListResponse(BaseModel):

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -24,7 +24,8 @@ import types
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import cast
 from unittest.mock import MagicMock, patch
@@ -674,6 +675,100 @@ async def test_backfill_paused_config_returns_409_without_dispatch(
 _T0 = datetime(2026, 1, 1, tzinfo=timezone.utc)
 
 
+@dataclass(frozen=True, slots=True)
+class _BackfillFreshnessTimes:
+    job_updated_at: datetime
+    unit_updated_at: datetime
+    unit_heartbeat_at: datetime | None
+
+
+async def _backfill_response_for_unit_activity(
+    session_maker,
+    seeded_state,
+    times: _BackfillFreshnessTimes,
+):
+    config_id = uuid.uuid4()
+    integration_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    sync_run_id = uuid.uuid4()
+
+    async with session_maker() as session:
+        config = SyncConfiguration(
+            name=f"bf-freshness-{config_id}",
+            provider="github",
+            org_id=seeded_state["org_id"],
+            integration_id=integration_id,
+        )
+        config.id = config_id
+        session.add_all(
+            [
+                config,
+                Integration(
+                    id=integration_id,
+                    org_id=seeded_state["org_id"],
+                    provider="github",
+                    name="github-integration",
+                    config={},
+                ),
+                IntegrationSource(
+                    id=source_id,
+                    org_id=seeded_state["org_id"],
+                    integration_id=integration_id,
+                    provider="github",
+                    source_type="repository",
+                    external_id="full-chaos/dev-health",
+                    name="dev-health",
+                    full_name="full-chaos/dev-health",
+                    is_enabled=True,
+                ),
+                SyncRun(
+                    id=sync_run_id,
+                    org_id=seeded_state["org_id"],
+                    integration_id=integration_id,
+                    triggered_by="backfill",
+                    mode="backfill",
+                    status=SyncRunStatus.RUNNING.value,
+                    total_units=2,
+                    completed_units=1,
+                    failed_units=0,
+                ),
+                SyncRunUnit(
+                    org_id=seeded_state["org_id"],
+                    sync_run_id=sync_run_id,
+                    integration_id=integration_id,
+                    source_id=source_id,
+                    provider="github",
+                    dataset_key="commits",
+                    cost_class="rest",
+                    mode="backfill",
+                    status="running",
+                    updated_at=times.unit_updated_at,
+                    last_heartbeat_at=times.unit_heartbeat_at,
+                ),
+                BackfillJob(
+                    id=uuid.uuid4(),
+                    org_id=seeded_state["org_id"],
+                    sync_config_id=config_id,
+                    celery_task_id=f"sync_run:{sync_run_id}",
+                    status="running",
+                    since_date=datetime(2025, 12, 1, tzinfo=timezone.utc).date(),
+                    before_date=datetime(2025, 12, 8, tzinfo=timezone.utc).date(),
+                    total_chunks=2,
+                    completed_chunks=0,
+                    failed_chunks=0,
+                    started_at=times.job_updated_at,
+                    created_at=times.job_updated_at,
+                    updated_at=times.job_updated_at,
+                ),
+            ]
+        )
+        await session.commit()
+
+        job = (await session.execute(select(BackfillJob))).scalar_one()
+        run_counts = await sync_router_module._backfill_job_run_counts(session, job)
+        return sync_router_module._backfill_job_response(job, run_counts)
+
+
 def _fake_unit(**overrides):
     base = dict(
         id=uuid.uuid4(),
@@ -754,6 +849,45 @@ def test_backfill_job_response_includes_updated_at_freshness_timestamp():
     response = sync_router_module._backfill_job_response(job)
 
     assert response.updated_at == updated_at
+
+
+@pytest.mark.asyncio
+async def test_backfill_job_response_uses_linked_unit_activity_for_freshness(
+    session_maker, seeded_state
+):
+    stale_at = _T0 - timedelta(days=2)
+    recent_at = _T0 - timedelta(hours=1)
+    response = await _backfill_response_for_unit_activity(
+        session_maker,
+        seeded_state,
+        _BackfillFreshnessTimes(
+            job_updated_at=stale_at,
+            unit_updated_at=stale_at,
+            unit_heartbeat_at=recent_at,
+        ),
+    )
+
+    assert response.updated_at == recent_at
+    assert response.completed_chunks == 1
+
+
+@pytest.mark.asyncio
+async def test_backfill_job_response_remains_stale_when_linked_units_are_stale(
+    session_maker, seeded_state
+):
+    stale_at = _T0 - timedelta(days=2)
+    response = await _backfill_response_for_unit_activity(
+        session_maker,
+        seeded_state,
+        _BackfillFreshnessTimes(
+            job_updated_at=stale_at,
+            unit_updated_at=stale_at,
+            unit_heartbeat_at=None,
+        ),
+    )
+
+    assert response.updated_at == stale_at
+    assert response.completed_chunks == 1
 
 
 def test_unit_to_response_next_retry_at_derived_from_available_at_when_absent():

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -732,6 +732,30 @@ def test_unit_to_response_projects_all_retry_result_keys():
     assert resp.error_category == "soft_timeout"
 
 
+def test_backfill_job_response_includes_updated_at_freshness_timestamp():
+    """Given a persisted backfill job, the response exposes updated_at freshness."""
+    updated_at = datetime(2026, 1, 1, 0, 5, tzinfo=timezone.utc)
+    job = types.SimpleNamespace(
+        id=uuid.uuid4(),
+        sync_config_id=uuid.uuid4(),
+        status="running",
+        since_date=datetime(2025, 12, 1, tzinfo=timezone.utc).date(),
+        before_date=datetime(2025, 12, 8, tzinfo=timezone.utc).date(),
+        total_chunks=10,
+        completed_chunks=4,
+        failed_chunks=0,
+        error_message=None,
+        started_at=_T0,
+        completed_at=None,
+        created_at=_T0,
+        updated_at=updated_at,
+    )
+
+    response = sync_router_module._backfill_job_response(job)
+
+    assert response.updated_at == updated_at
+
+
 def test_unit_to_response_next_retry_at_derived_from_available_at_when_absent():
     """With no result next_retry_at, a retrying unit derives it from available_at."""
     avail = datetime(2026, 1, 1, 0, 10, tzinfo=timezone.utc)


### PR DESCRIPTION
## Summary
- Add `updated_at` to `BackfillJobResponse` as the serialized freshness signal.
- Populate the response from the existing `BackfillJob.updated_at` model column.
- Cover the serializer so the field presence and source timestamp stay locked.

Linear: CHAOS-2872
Companion WEB PR: https://github.com/full-chaos/dev-health-web/pull/758

## Verification
- `python -m pytest tests/api/admin/test_backfill_jobrun.py -q`
- `ruff check src/dev_health_ops/api/schemas/backfill.py src/dev_health_ops/api/admin/routers/sync.py tests/api/admin/test_backfill_jobrun.py`
- pre-push hook: ruff format/check + mypy
- LSP diagnostics clean on changed files

## Visual evidence
The UI behavior is verified in the companion WEB PR; stale progressed jobs now filter out before rendering the banner.

![chaos-2872-stale-progress-filtered-after.png](https://github.com/user-attachments/assets/5186baf6-f5b4-4d16-a6f5-4d300568db07)
