### PR TITLE
fix(sync): relay post-sync metrics backfill window

### DIFF
--- a/src/dev_health_ops/workers/post_sync_dispatch.py
+++ b/src/dev_health_ops/workers/post_sync_dispatch.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass
-from datetime import datetime, time, timedelta, timezone
+from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
 from celery import chain
@@ -154,6 +154,14 @@ def _dispatch_post_sync_tasks(
     has_work_items = bool(target_set & _WORK_ITEM_TARGETS)
     has_dora = bool(target_set & _DORA_TARGETS)
     dispatched: list[str] = []
+
+    if from_date is not None and to_date is not None:
+        metrics_window_start = date.fromisoformat(from_date)
+        metrics_window_end = date.fromisoformat(to_date)
+        if metrics_day is None:
+            metrics_day = metrics_window_end.isoformat()
+        if metrics_backfill_days is None:
+            metrics_backfill_days = (metrics_window_end - metrics_window_start).days + 1
 
     daily_metrics_kwargs: dict[str, Any] = {"org_id": org_id}
     if metrics_day is not None:

--- a/tests/test_post_sync_investment_dispatch.py
+++ b/tests/test_post_sync_investment_dispatch.py
@@ -222,6 +222,44 @@ def test_post_sync_dispatch_forwards_backfill_window() -> None:
     }
 
 
+def test_post_sync_dispatch_derives_metrics_window_from_sync_window() -> None:
+    from dev_health_ops.workers.post_sync_dispatch import _dispatch_post_sync_tasks
+
+    with (
+        patch(
+            "dev_health_ops.workers.post_sync_dispatch.celery_app.signature"
+        ) as window_signature,
+        patch("dev_health_ops.workers.post_sync_dispatch.chain") as window_chain,
+        patch(
+            "dev_health_ops.workers.post_sync_dispatch.celery_app.send_task"
+        ) as window_send_task,
+    ):
+
+        def _make_sig(name, **kwargs):
+            sig = MagicMock(name=f"sig:{name}")
+            sig.task_name = name
+            sig.sig_kwargs = kwargs
+            return sig
+
+        window_signature.side_effect = _make_sig
+        _dispatch_post_sync_tasks(
+            provider="linear",
+            sync_targets=["work-items"],
+            org_id="org-123",
+            from_date="2026-01-01",
+            to_date="2026-01-14",
+        )
+
+    window_send_task.assert_not_called()
+    daily_sig, *_ = window_chain.call_args.args
+    assert daily_sig.task_name == _DAILY_METRICS_TASK
+    assert daily_sig.sig_kwargs["kwargs"] == {
+        "org_id": "org-123",
+        "day": "2026-01-14",
+        "backfill_days": 14,
+    }
+
+
 def test_post_sync_dispatch_does_not_serialize_llm_api_key(monkeypatch) -> None:
     monkeypatch.setenv("LLM_API_KEY", "sk-worker-secret")
 


### PR DESCRIPTION
## Summary
- Derives post-sync daily metrics backfill parameters from the bounded sync window when explicit metrics options are absent.
- Preserves explicit metrics_day and metrics_backfill_days precedence.
- Adds regression coverage for deriving the target day and inclusive backfill span from from_date/to_date.

Linear: CHAOS-2875

## Testing
- uv run pytest tests/test_sync_units.py::test_post_sync_dispatch_includes_window tests/test_post_sync_investment_dispatch.py::test_post_sync_dispatch_forwards_backfill_window tests/test_post_sync_investment_dispatch.py::test_post_sync_dispatch_derives_metrics_window_from_sync_window
- uv run ruff check src/dev_health_ops/workers/post_sync_dispatch.py tests/test_post_sync_investment_dispatch.py
- uv run ruff format --check src/dev_health_ops/workers/post_sync_dispatch.py tests/test_post_sync_investment_dispatch.py
- bash ci/local_validate.sh
- pre-push hook: ruff-check, ruff-format-check, mypy
