### PR TITLE
fix(llm): avoid computed_at alias collision in spend queries (CHAOS-2876)

### DIFF
--- a/src/dev_health_ops/metrics/sinks/clickhouse/llm_tokens.py
+++ b/src/dev_health_ops/metrics/sinks/clickhouse/llm_tokens.py
@@ -111,13 +111,13 @@ class LLMTokenUsageMixin(_ClickHouseSinkBase):
                 sum(calls) AS calls,
                 sum(input_tokens) AS input_tokens,
                 sum(output_tokens) AS output_tokens,
-                max(computed_at) AS computed_at
+                max(computed_at) AS last_computed_at
             FROM llm_token_usage
             WHERE org_id = {org_id:String}
               AND run_id IN {run_ids:Array(String)}
               AND computed_at >= {since:DateTime}
             GROUP BY run_id, provider, model
-            ORDER BY computed_at DESC, run_id DESC, model ASC
+            ORDER BY last_computed_at DESC, run_id DESC, model ASC
             """,
                 parameters={"org_id": org_id, "since": since, "run_ids": list(run_ids)},
             ).result_rows
@@ -154,13 +154,13 @@ class LLMTokenUsageMixin(_ClickHouseSinkBase):
                 sum(calls) AS calls,
                 sum(input_tokens) AS input_tokens,
                 sum(output_tokens) AS output_tokens,
-                max(computed_at) AS computed_at
+                max(computed_at) AS last_computed_at
             FROM llm_token_usage
             WHERE org_id = {org_id:String}
               AND run_id = ''
               AND computed_at >= {since:DateTime}
             GROUP BY provider, model
-            ORDER BY computed_at DESC, model ASC
+            ORDER BY last_computed_at DESC, model ASC
             """,
                 parameters={"org_id": org_id, "since": since},
             ).result_rows

--- a/tests/metrics/test_llm_token_usage_sink.py
+++ b/tests/metrics/test_llm_token_usage_sink.py
@@ -177,6 +177,25 @@ def test_llm_spend_reader_aggregates_runs_failures_and_caps_limit():
     assert summary.legacy == []
 
 
+def test_llm_spend_reader_does_not_alias_aggregate_as_filtered_column():
+    computed_at = datetime(2026, 1, 2, 3, tzinfo=timezone.utc)
+    client = FakeSpendClient(
+        latest_runs=[("run-new", computed_at)],
+        run_rows=[("run-new", "openai", "gpt-5-mini", 3, 30, 15, computed_at)],
+        legacy_rows=[("openai", "gpt-legacy", 2, 20, 8, computed_at)],
+    )
+    sink = ClickHouseMetricsSink("clickhouse://localhost:9000/default", client=client)
+
+    sink.read_llm_token_spend(org_id="org-a")
+
+    colliding_queries = [
+        query
+        for query, _parameters in client.calls
+        if "max(computed_at) AS computed_at" in query and "AND computed_at >=" in query
+    ]
+    assert colliding_queries == []
+
+
 def test_llm_spend_reader_returns_empty_summary_without_rows():
     client = FakeSpendClient()
     sink = ClickHouseMetricsSink("clickhouse://localhost:9000/default", client=client)


### PR DESCRIPTION
## Summary
- Rename BYO LLM spend aggregate aliases from `computed_at` to `last_computed_at` so ClickHouse does not substitute `max(computed_at)` into `WHERE`.
- Add regression coverage for run and legacy spend query paths.

## Verification
- `uv run pytest tests/metrics/test_llm_token_usage_sink.py::test_llm_spend_reader_does_not_alias_aggregate_as_filtered_column -q` (red before fix, green after)
- `uv run pytest tests/metrics/test_llm_token_usage_sink.py -q`
- `uv run ruff format --check src/dev_health_ops/metrics/sinks/clickhouse/llm_tokens.py tests/metrics/test_llm_token_usage_sink.py`
- `uv run ruff check src/dev_health_ops/metrics/sinks/clickhouse/llm_tokens.py tests/metrics/test_llm_token_usage_sink.py`
- live ClickHouse scratch query: old alias shape failed; renamed run/legacy queries returned expected rows
- `bash ci/local_validate.sh`

Linear: CHAOS-2876

SCREENSHOT-WAIVER: backend-only ClickHouse query fix; no rendered UI changed.