### PR TITLE
fix(admin/sync): expose first-sync completion state (CHAOS-2877)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/setup.py
+++ b/src/dev_health_ops/api/admin/routers/setup.py
@@ -171,6 +171,31 @@ def _sync_status_from_job_run(run: JobRun) -> SyncStatus:
     return sync_status
 
 
+async def _has_completed_parent_sync(
+    session: AsyncSession, org_id: str, configs: list[SyncConfiguration]
+) -> bool:
+    parent_config_ids = [
+        getattr(config, "id")
+        for config in configs
+        if getattr(config, "parent_id") is None
+    ]
+    if not parent_config_ids:
+        return False
+
+    stmt = (
+        select(JobRun)
+        .join(ScheduledJob, JobRun.job_id == ScheduledJob.id)
+        .where(
+            ScheduledJob.org_id == org_id,
+            ScheduledJob.sync_config_id.in_(parent_config_ids),
+            JobRun.status == JobRunStatus.SUCCESS.value,
+        )
+        .order_by(JobRun.created_at.desc())
+    )
+    result = await session.execute(stmt)
+    return any(_sync_status_from_job_run(run) == "complete" for run in result.scalars())
+
+
 @router.get("/setup/status", response_model=SetupStatusResponse)
 async def get_setup_status(
     session: AsyncSession = Depends(get_session),
@@ -189,6 +214,15 @@ async def get_setup_status(
     sync_config_id: str | None = None
     sync_status: SyncStatus = "none"
     first_sync_started = False
+    first_sync_completed = any(
+        getattr(config, "parent_id") is None
+        and getattr(config, "last_sync_success") is True
+        for config in configs
+    )
+    if not first_sync_completed:
+        first_sync_completed = await _has_completed_parent_sync(
+            session, org_id, configs
+        )
     selected_repositories_count = 0
     last_sync_error: str | None = None
     can_start_sync = False
@@ -218,6 +252,8 @@ async def get_setup_status(
         if latest is not None:
             first_sync_started = True
             sync_status = _sync_status_from_job_run(latest)
+            if sync_status == "complete":
+                first_sync_completed = True
             if sync_status == "failed":
                 last_sync_error = getattr(latest, "error") or getattr(
                     latest_config, "last_sync_error"
@@ -228,6 +264,7 @@ async def get_setup_status(
             if getattr(primary, "last_sync_success") is True:
                 sync_status = "complete"
                 first_sync_started = True
+                first_sync_completed = True
             elif (
                 getattr(primary, "last_sync_error")
                 or getattr(primary, "last_sync_success") is False
@@ -272,6 +309,7 @@ async def get_setup_status(
         has_sync_config=has_sync_config,
         sync_config_id=sync_config_id,
         first_sync_started=first_sync_started,
+        first_sync_completed=first_sync_completed,
         sync_status=sync_status,
         selected_repositories_count=selected_repositories_count,
         last_sync_error=last_sync_error,

--- a/src/dev_health_ops/api/admin/schemas_flat.py
+++ b/src/dev_health_ops/api/admin/schemas_flat.py
@@ -977,6 +977,7 @@ class SetupStatusResponse(BaseModel):
     has_sync_config: bool
     sync_config_id: str | None = None
     first_sync_started: bool
+    first_sync_completed: bool = False
     sync_status: Literal[
         "none", "pending", "running", "partial", "complete", "failed"
     ] = "none"

--- a/tests/api/admin/test_setup_status.py
+++ b/tests/api/admin/test_setup_status.py
@@ -17,6 +17,7 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
@@ -198,16 +199,24 @@ async def _add_job_run(
     error: str | None = None,
 ) -> None:
     async with session_maker() as session:
-        job = ScheduledJob(
-            name=f"sync-config-{config_id}",
-            job_type="sync",
-            schedule_cron="0 * * * *",
-            org_id=org_id,
-            provider="github",
-            sync_config_id=uuid.UUID(config_id),
+        job = await session.scalar(
+            select(ScheduledJob).where(
+                ScheduledJob.org_id == org_id,
+                ScheduledJob.sync_config_id == uuid.UUID(config_id),
+                ScheduledJob.job_type == "sync",
+            )
         )
-        session.add(job)
-        await session.flush()
+        if job is None:
+            job = ScheduledJob(
+                name=f"sync-config-{config_id}",
+                job_type="sync",
+                schedule_cron="0 * * * *",
+                org_id=org_id,
+                provider="github",
+                sync_config_id=uuid.UUID(config_id),
+            )
+            session.add(job)
+            await session.flush()
         run = JobRun(job_id=job.id, triggered_by="manual", status=status)
         run.error = error
         run.created_at = datetime.now(timezone.utc)
@@ -282,6 +291,7 @@ async def test_setup_status_config_ready_to_start(client, session_maker):
     assert data["sync_config_id"] == config_id
     assert data["selected_repositories_count"] == 1
     assert data["first_sync_started"] is False
+    assert data["first_sync_completed"] is False
     assert data["sync_status"] == "none"
     assert data["can_start_sync"] is True
     assert data["next_action"] == "start_sync"
@@ -366,6 +376,7 @@ async def test_setup_status_sync_running(client, session_maker, status, expected
     assert resp.status_code == 200, resp.text
     data = resp.json()
     assert data["first_sync_started"] is True
+    assert data["first_sync_completed"] is False
     assert data["sync_status"] == expected
     assert data["can_start_sync"] is False
     assert data["next_action"] == "complete"
@@ -397,6 +408,7 @@ async def test_setup_status_sync_running_on_non_primary_config_blocks_start(
     data = resp.json()
     assert data["sync_config_id"] == newer_config_id
     assert data["first_sync_started"] is True
+    assert data["first_sync_completed"] is False
     assert data["sync_status"] == "running"
     assert data["can_start_sync"] is False
     assert data["next_action"] == "complete"
@@ -420,7 +432,75 @@ async def test_setup_status_sync_complete(client, session_maker):
     data = resp.json()
     assert data["sync_status"] == "complete"
     assert data["first_sync_started"] is True
+    assert data["first_sync_completed"] is True
     assert data["next_action"] == "complete"
+
+
+@pytest.mark.asyncio
+async def test_setup_status_marks_setup_complete_during_later_sync(
+    client, session_maker
+):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"])
+    config_id = await _add_config(
+        session_maker,
+        seeded_state["org_id"],
+        last_sync_success=True,
+    )
+    await _add_job_run(
+        session_maker,
+        seeded_state["org_id"],
+        config_id,
+        status=JobRunStatus.RUNNING.value,
+    )
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["first_sync_started"] is True
+    assert data["first_sync_completed"] is True
+    assert data["sync_status"] == "running"
+    assert data["next_action"] == "complete"
+    assert data["blocker"] is None
+
+
+@pytest.mark.asyncio
+async def test_setup_status_keeps_setup_complete_after_later_failed_sync(
+    client, session_maker
+):
+    ac, seeded_state = client
+    await _add_credential(session_maker, seeded_state["org_id"])
+    config_id = await _add_config(
+        session_maker,
+        seeded_state["org_id"],
+        last_sync_success=False,
+        last_sync_error="later failure",
+    )
+    await _add_job_run(
+        session_maker,
+        seeded_state["org_id"],
+        config_id,
+        status=JobRunStatus.SUCCESS.value,
+    )
+    await _add_job_run(
+        session_maker,
+        seeded_state["org_id"],
+        config_id,
+        status=JobRunStatus.FAILED.value,
+        error="later failure",
+    )
+
+    resp = await ac.get("/api/v1/admin/setup/status")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data["first_sync_started"] is True
+    assert data["first_sync_completed"] is True
+    assert data["sync_status"] == "failed"
+    assert data["last_sync_error"] == "later failure"
+    assert data["next_action"] == "start_sync"
+    assert data["blocker"] == "later failure"
 
 
 @pytest.mark.asyncio

--- a/tests/api/auth/test_onboarding_foundation.py
+++ b/tests/api/auth/test_onboarding_foundation.py
@@ -76,6 +76,7 @@ def test_setup_status_response_contract_defaults() -> None:
         next_action="connect_integration",
     )
     assert resp.providers == []
+    assert resp.first_sync_completed is False
     assert resp.sync_status == "none"
     assert resp.selected_repositories_count == 0
     assert resp.can_start_sync is False


### PR DESCRIPTION
## Summary
- Adds sticky `first_sync_completed` to the admin setup-status response.
- Preserves raw/latest `sync_status` while using historical parent sync success to mark setup completion.
- Adds API regressions for later running and later failed syncs after the first sync has completed.

Linear: CHAOS-2877

## Test plan
- `bash ci/local_validate.sh`
- LSP diagnostics clean on changed files.

## Notes
- Full local validation passed: ruff format/check, mypy, ClickHouse scratch migration/status, full non-clickhouse unit suite, and live argMax proof.