### PR TITLE
fix(metrics): dispatch capacity forecasts per org (CHAOS-2878)

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/capacity.py
+++ b/src/dev_health_ops/api/graphql/resolvers/capacity.py
@@ -81,7 +81,7 @@ async def resolve_capacity_forecast(
     )
     from dev_health_ops.metrics.sinks.factory import create_sink
 
-    require_org_id(context)
+    org_id = require_org_id(context)
 
     if context.client is None:
         raise RuntimeError("Database client not available")
@@ -95,6 +95,7 @@ async def resolve_capacity_forecast(
 
     sink = create_sink(context.db_url)
     try:
+        setattr(sink, "org_id", org_id)
         history = await load_throughput_from_sink(
             sink,
             team_id=team_id,
@@ -148,15 +149,15 @@ async def resolve_capacity_forecasts(
 ) -> CapacityForecastConnection:
     from dev_health_ops.api.queries.client import query_dicts
 
-    require_org_id(context)
+    org_id = require_org_id(context)
     client = context.client
 
     if client is None:
         raise RuntimeError("Database client not available")
 
     limit = filters.limit if filters else 10
-    params: dict[str, Any] = {"limit": int(limit)}
-    where_clauses: list[str] = []
+    params: dict[str, Any] = {"limit": int(limit), "org_id": org_id}
+    where_clauses: list[str] = ["org_id = %(org_id)s"]
 
     if filters:
         if filters.team_id:

--- a/src/dev_health_ops/metrics/capacity_queries.py
+++ b/src/dev_health_ops/metrics/capacity_queries.py
@@ -1,0 +1,154 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import date, timedelta
+from typing import Any, Protocol
+
+from dev_health_ops.metrics.compute_capacity import ThroughputHistory, ThroughputSample
+from dev_health_ops.utils.datetime import utc_today
+
+
+class CapacityQuerySink(Protocol):
+    @property
+    def backend_type(self) -> str: ...
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]: ...
+
+
+async def load_throughput_from_sink(
+    sink: CapacityQuerySink,
+    team_id: str | None = None,
+    work_scope_id: str | None = None,
+    history_days: int = 90,
+) -> ThroughputHistory:
+    backend = sink.backend_type
+    start_date = utc_today() - timedelta(days=history_days)
+
+    conditions = [f"day >= '{start_date.isoformat()}'"]
+    params = {}
+    org_id = str(getattr(sink, "org_id", "") or "")
+
+    if org_id:
+        if backend == "clickhouse":
+            conditions.append("org_id = {org_id:String}")
+        else:
+            conditions.append("org_id = :org_id")
+        params["org_id"] = org_id
+
+    if team_id:
+        if backend == "clickhouse":
+            conditions.append("team_id = {team_id:String}")
+        else:
+            conditions.append("team_id = :team_id")
+        params["team_id"] = team_id
+    if work_scope_id:
+        if backend == "clickhouse":
+            conditions.append("work_scope_id = {work_scope_id:String}")
+        else:
+            conditions.append("work_scope_id = :work_scope_id")
+        params["work_scope_id"] = work_scope_id
+
+    where_clause = " AND ".join(conditions)
+
+    query = f"""
+        SELECT day, SUM(items_completed) as items_completed
+        FROM work_item_metrics_daily FINAL
+        WHERE {where_clause}
+        GROUP BY day
+        ORDER BY day
+    """
+
+    rows = await asyncio.to_thread(sink.query_dicts, query, params)
+
+    samples = [
+        ThroughputSample(
+            day=row["day"]
+            if isinstance(row["day"], date)
+            else date.fromisoformat(str(row["day"])),
+            items_completed=int(row["items_completed"]),
+            team_id=team_id,
+            work_scope_id=work_scope_id,
+        )
+        for row in rows
+    ]
+
+    return ThroughputHistory(samples)
+
+
+async def get_backlog_from_sink(
+    sink: CapacityQuerySink,
+    team_id: str | None = None,
+    work_scope_id: str | None = None,
+) -> int:
+    backend = sink.backend_type
+    conditions = []
+    params = {}
+    org_id = str(getattr(sink, "org_id", "") or "")
+
+    if org_id:
+        if backend == "clickhouse":
+            conditions.append("org_id = {org_id:String}")
+        else:
+            conditions.append("org_id = :org_id")
+        params["org_id"] = org_id
+
+    if team_id:
+        if backend == "clickhouse":
+            conditions.append("team_id = {team_id:String}")
+        else:
+            conditions.append("team_id = :team_id")
+        params["team_id"] = team_id
+    if work_scope_id:
+        if backend == "clickhouse":
+            conditions.append("work_scope_id = {work_scope_id:String}")
+        else:
+            conditions.append("work_scope_id = :work_scope_id")
+        params["work_scope_id"] = work_scope_id
+
+    where_clause = " AND ".join(conditions) if conditions else "1=1"
+
+    query = f"""
+        SELECT wip_count_end_of_day
+        FROM work_item_metrics_daily FINAL
+        WHERE {where_clause}
+        ORDER BY day DESC
+        LIMIT 1
+    """
+
+    rows = await asyncio.to_thread(sink.query_dicts, query, params)
+    if rows:
+        return int(rows[0].get("wip_count_end_of_day", 0))
+    return 0
+
+
+async def discover_team_scopes(
+    sink: CapacityQuerySink,
+) -> list[tuple[str | None, str | None]]:
+    backend = sink.backend_type
+    org_id = str(getattr(sink, "org_id", "") or "")
+
+    if backend == "clickhouse":
+        org_filter = "AND org_id = {org_id:String}" if org_id else ""
+    else:
+        org_filter = "AND org_id = :org_id" if org_id else ""
+    params = {"org_id": org_id} if org_id else {}
+
+    query = f"""
+        SELECT DISTINCT team_id, work_scope_id
+        FROM work_item_metrics_daily FINAL
+        WHERE day >= today() - 30
+        {org_filter}
+    """
+
+    rows = await asyncio.to_thread(sink.query_dicts, query, params)
+    return [
+        (
+            str(row.get("team_id")) if row.get("team_id") is not None else None,
+            str(row.get("work_scope_id"))
+            if row.get("work_scope_id") is not None
+            else None,
+        )
+        for row in rows
+    ]

--- a/src/dev_health_ops/metrics/job_capacity.py
+++ b/src/dev_health_ops/metrics/job_capacity.py
@@ -4,18 +4,19 @@ import argparse
 import asyncio
 import logging
 from dataclasses import replace
-from datetime import date, timedelta
-from typing import Any
+from datetime import date
 
+from dev_health_ops.metrics.capacity_queries import (
+    discover_team_scopes,
+    get_backlog_from_sink,
+    load_throughput_from_sink,
+)
 from dev_health_ops.metrics.compute_capacity import (
     ForecastResult,
-    ThroughputHistory,
-    ThroughputSample,
     forecast_capacity,
 )
 from dev_health_ops.metrics.schemas import CapacityForecastRecord
 from dev_health_ops.metrics.sinks.factory import create_sink
-from dev_health_ops.utils.datetime import utc_today
 
 logger = logging.getLogger(__name__)
 
@@ -47,122 +48,6 @@ def _result_to_record(result: ForecastResult) -> CapacityForecastRecord:
     )
 
 
-async def load_throughput_from_sink(
-    sink: Any,
-    team_id: str | None = None,
-    work_scope_id: str | None = None,
-    history_days: int = 90,
-) -> ThroughputHistory:
-    backend = sink.backend_type
-    start_date = utc_today() - timedelta(days=history_days)
-
-    conditions = [f"day >= '{start_date.isoformat()}'"]
-    params = {}
-
-    if team_id:
-        if backend == "clickhouse":
-            conditions.append("team_id = {team_id:String}")
-        else:
-            conditions.append("team_id = :team_id")
-        params["team_id"] = team_id
-    if work_scope_id:
-        if backend == "clickhouse":
-            conditions.append("work_scope_id = {work_scope_id:String}")
-        else:
-            conditions.append("work_scope_id = :work_scope_id")
-        params["work_scope_id"] = work_scope_id
-
-    where_clause = " AND ".join(conditions)
-
-    query = f"""
-        SELECT day, SUM(items_completed) as items_completed
-        FROM work_item_metrics_daily FINAL
-        WHERE {where_clause}
-        GROUP BY day
-        ORDER BY day
-    """
-
-    if backend == "clickhouse":
-        result = await asyncio.to_thread(sink.client.query, query, parameters=params)
-        rows = result.result_rows or []
-    else:
-        rows = sink.query_dicts(query, params)
-        rows = [(r["day"], r["items_completed"]) for r in rows]
-
-    samples = [
-        ThroughputSample(
-            day=row[0] if isinstance(row[0], date) else date.fromisoformat(str(row[0])),
-            items_completed=int(row[1]),
-            team_id=team_id,
-            work_scope_id=work_scope_id,
-        )
-        for row in rows
-    ]
-
-    return ThroughputHistory(samples)
-
-
-async def get_backlog_from_sink(
-    sink: Any,
-    team_id: str | None = None,
-    work_scope_id: str | None = None,
-) -> int:
-    backend = sink.backend_type
-    conditions = []
-    params = {}
-
-    if team_id:
-        if backend == "clickhouse":
-            conditions.append("team_id = {team_id:String}")
-        else:
-            conditions.append("team_id = :team_id")
-        params["team_id"] = team_id
-    if work_scope_id:
-        if backend == "clickhouse":
-            conditions.append("work_scope_id = {work_scope_id:String}")
-        else:
-            conditions.append("work_scope_id = :work_scope_id")
-        params["work_scope_id"] = work_scope_id
-
-    where_clause = " AND ".join(conditions) if conditions else "1=1"
-
-    query = f"""
-        SELECT wip_count_end_of_day
-        FROM work_item_metrics_daily FINAL
-        WHERE {where_clause}
-        ORDER BY day DESC
-        LIMIT 1
-    """
-
-    if backend == "clickhouse":
-        result = await asyncio.to_thread(sink.client.query, query, parameters=params)
-        if result.result_rows:
-            return int(result.result_rows[0][0])
-        return 0
-    else:
-        rows = sink.query_dicts(query, params)
-        if rows:
-            return int(rows[0].get("wip_count_end_of_day", 0))
-        return 0
-
-
-async def discover_team_scopes(sink: Any) -> list[tuple[str | None, str | None]]:
-    backend = sink.backend_type
-
-    query = """
-        SELECT DISTINCT team_id, work_scope_id
-        FROM work_item_metrics_daily FINAL
-        WHERE day >= today() - 30
-    """
-
-    if backend == "clickhouse":
-        result = await asyncio.to_thread(sink.client.query, query)
-        return [(row[0], row[1]) for row in (result.result_rows or [])]
-    else:
-        rows = sink.query_dicts(query, {})
-        return [(r.get("team_id"), r.get("work_scope_id")) for r in rows]
-
-
 async def run_capacity_forecast(
     db_url: str,
     org_id: str,
@@ -175,6 +60,9 @@ async def run_capacity_forecast(
     all_teams: bool = False,
     persist: bool = True,
 ) -> list[ForecastResult]:
+    if not org_id:
+        raise ValueError("org_id is required for capacity forecast")
+
     sink = create_sink(db_url)
     try:
         setattr(sink, "org_id", org_id)
@@ -268,11 +156,13 @@ def _print_forecast(result: ForecastResult) -> None:
 
 
 async def _run_cli(args: argparse.Namespace) -> int:
+    from dev_health_ops.metrics.sinks.factory import detect_backend
+
+    detect_backend(args.db)
+
     target_date = None
     if args.target_date:
         target_date = date.fromisoformat(args.target_date)
-
-    org_id = getattr(args, "org", None) or ""
 
     results = await run_capacity_forecast(
         db_url=args.db,
@@ -284,7 +174,7 @@ async def _run_cli(args: argparse.Namespace) -> int:
         simulations=args.simulations,
         all_teams=args.all_teams,
         persist=not args.dry_run,
-        org_id=org_id,
+        org_id=args.org or "",
     )
 
     if not results:
@@ -306,6 +196,10 @@ def register_commands(subparsers: argparse._SubParsersAction) -> None:
         "--db",
         required=True,
         help="Database connection string",
+    )
+    capacity_parser.add_argument(
+        "--org",
+        help="Organization ID for tenant-scoped forecast queries",
     )
     capacity_parser.add_argument(
         "--team-id",

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -38,6 +38,7 @@ late_ack_excluded_tasks = (
     "dev_health_ops.workers.tasks.dispatch_scheduled_metrics",
     "dev_health_ops.workers.tasks.dispatch_daily_metrics_partitioned",
     "dev_health_ops.workers.tasks.dispatch_daily_metrics_for_all_orgs",
+    "dev_health_ops.workers.tasks.dispatch_capacity_forecast",
     "dev_health_ops.workers.tasks.dispatch_complexity_job",
     "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned",
     "dev_health_ops.workers.tasks.dispatch_release_impact",
@@ -186,10 +187,9 @@ beat_schedule = {
         "options": {"queue": "sync"},
     },
     "run-capacity-forecast": {
-        "task": "dev_health_ops.workers.tasks.run_capacity_forecast_job",
+        "task": "dev_health_ops.workers.tasks.dispatch_capacity_forecast",
         "schedule": crontab(hour=4, minute=0, day_of_week="monday"),
-        "kwargs": {"all_teams": True},
-        "options": {"queue": "metrics"},
+        "options": {"queue": "default"},
     },
     "process-ingest-streams": {
         "task": "dev_health_ops.workers.tasks.run_ingest_consumer",

--- a/src/dev_health_ops/workers/product_tasks.py
+++ b/src/dev_health_ops/workers/product_tasks.py
@@ -77,3 +77,36 @@ def run_capacity_forecast_job(
     except Exception as exc:
         logger.exception("Capacity forecast task failed: %s", exc)
         raise self.retry(exc=exc, countdown=120 * (2**self.request.retries))
+
+
+@celery_app.task(
+    bind=True,
+    max_retries=3,
+    queue="default",
+    name="dev_health_ops.workers.tasks.dispatch_capacity_forecast",
+)
+def dispatch_capacity_forecast(
+    self,
+    db_url: str | None = None,
+) -> dict:
+    from dev_health_ops.workers.recommendations_tasks import _discover_active_org_ids
+
+    try:
+        org_ids = _discover_active_org_ids(strict=True)
+    except Exception as exc:
+        logger.exception("dispatch_capacity_forecast failed to enumerate orgs")
+        raise self.retry(exc=exc, countdown=60 * (2**self.request.retries))
+
+    dispatched: list[str] = []
+    for org_id in org_ids:
+        celery_app.send_task(
+            "dev_health_ops.workers.tasks.run_capacity_forecast_job",
+            kwargs={"db_url": db_url, "org_id": org_id, "all_teams": True},
+            queue="metrics",
+        )
+        dispatched.append(org_id)
+
+    logger.info(
+        "Capacity forecast dispatch: dispatched=%d organizations", len(dispatched)
+    )
+    return {"dispatched": dispatched}

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -12,6 +12,7 @@ from dev_health_ops.workers.metrics_tasks import (
     run_release_impact_job,
 )
 from dev_health_ops.workers.product_tasks import (
+    dispatch_capacity_forecast,
     run_capacity_forecast_job,
 )
 from dev_health_ops.workers.queue_monitor import monitor_queue_depths
@@ -65,6 +66,7 @@ __all__ = [
     "dispatch_daily_metrics_partitioned",
     "dispatch_investment_materialize_partitioned",
     "dispatch_release_impact",
+    "dispatch_capacity_forecast",
     "dispatch_scheduled_metrics",
     "dispatch_scheduled_reports",
     "dispatch_scheduled_syncs",

--- a/tests/test_capacity_forecast_schedule.py
+++ b/tests/test_capacity_forecast_schedule.py
@@ -1,0 +1,321 @@
+"""CHAOS-2878: capacity forecast beat must fan out per active org."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from datetime import date, datetime, timezone
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import MagicMock, patch
+from uuid import uuid4
+
+import pytest
+from celery.schedules import crontab
+
+from dev_health_ops.metrics.compute_capacity import (
+    ForecastResult,
+    ThroughputHistory,
+    ThroughputSample,
+)
+from dev_health_ops.metrics.schemas import CapacityForecastRecord
+
+
+class FakeClickHouseSink:
+    backend_type = "clickhouse"
+    org_id: str
+
+    def __init__(self) -> None:
+        self.client = MagicMock()
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        result = self.client.query(query, parameters=parameters)
+        rows = result.result_rows or []
+        if "SELECT DISTINCT team_id, work_scope_id" in query:
+            return [{"team_id": row[0], "work_scope_id": row[1]} for row in rows]
+        if "wip_count_end_of_day" in query:
+            return [{"wip_count_end_of_day": row[0]} for row in rows]
+        return [{"day": row[0], "items_completed": row[1]} for row in rows]
+
+
+class FakeSqlSink:
+    backend_type = "postgres"
+    org_id: str
+
+    def __init__(self) -> None:
+        self.queries: list[tuple[str, dict[str, str]]] = []
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        self.queries.append((query, parameters))
+        return []
+
+
+class FakeCapacitySink:
+    backend_type = "clickhouse"
+    org_id: str
+
+    def __init__(self) -> None:
+        self.closed = False
+        self.written: list[CapacityForecastRecord] = []
+
+    def write_capacity_forecasts(self, rows: Sequence[CapacityForecastRecord]) -> None:
+        self.written.extend(rows)
+
+    def close(self) -> None:
+        self.closed = True
+
+
+class TestCapacityForecastTaskRegistered:
+    def test_tasks_exported_from_tasks_module(self) -> None:
+        """Given the worker task module, When imported, Then both capacity tasks exist."""
+        from dev_health_ops.workers import tasks
+
+        assert "run_capacity_forecast_job" in tasks.__all__
+        assert hasattr(tasks, "run_capacity_forecast_job")
+        assert "dispatch_capacity_forecast" in tasks.__all__
+        assert hasattr(tasks, "dispatch_capacity_forecast")
+
+    def test_dispatcher_is_celery_task(self) -> None:
+        """Given the dispatcher, When inspected, Then it is registered on default."""
+        from dev_health_ops.workers.celery_app import celery_app
+
+        dispatch_capacity_forecast = celery_app.tasks[
+            "dev_health_ops.workers.tasks.dispatch_capacity_forecast"
+        ]
+        assert (
+            getattr(dispatch_capacity_forecast, "name")
+            == "dev_health_ops.workers.tasks.dispatch_capacity_forecast"
+        )
+        assert getattr(dispatch_capacity_forecast, "queue") == "default"
+
+
+class TestCapacityForecastBeatSchedule:
+    def test_beat_schedule_dispatches_per_org(self) -> None:
+        """Given beat config, When due, Then it targets the per-org dispatcher."""
+        from dev_health_ops.workers.config import beat_schedule
+
+        entry = beat_schedule["run-capacity-forecast"]
+        assert (
+            entry["task"] == "dev_health_ops.workers.tasks.dispatch_capacity_forecast"
+        )
+        assert entry["options"]["queue"] == "default"
+        assert "kwargs" not in entry
+
+    def test_beat_schedule_uses_weekly_crontab(self) -> None:
+        """Given beat config, When inspected, Then cadence remains weekly."""
+        from dev_health_ops.workers.config import beat_schedule
+
+        schedule = beat_schedule["run-capacity-forecast"]["schedule"]
+        assert isinstance(schedule, crontab)
+
+    def test_beat_schedule_call_shape_is_signature_valid(self) -> None:
+        """Given beat config, When Celery validates args, Then no org_id is missing."""
+        from dev_health_ops.workers.celery_app import celery_app
+        from dev_health_ops.workers.config import beat_schedule
+
+        entry = beat_schedule["run-capacity-forecast"]
+        dispatch_capacity_forecast = celery_app.tasks[entry["task"]]
+        kwargs = entry.get("kwargs", {})
+        getattr(dispatch_capacity_forecast, "__header__")(**kwargs)
+
+
+class TestCapacityForecastDispatcherFansOutPerOrg:
+    def test_dispatcher_enqueues_one_task_per_active_org(self) -> None:
+        """Given active orgs, When dispatcher runs, Then each task has org_id."""
+        from dev_health_ops.workers import product_tasks
+
+        org_a = str(uuid4())
+        org_b = str(uuid4())
+
+        with (
+            patch(
+                "dev_health_ops.workers.recommendations_tasks._discover_active_org_ids",
+                return_value=[org_a, org_b],
+            ),
+            patch.object(product_tasks.celery_app, "send_task") as mock_send_task,
+        ):
+            result = getattr(product_tasks.dispatch_capacity_forecast, "run")(
+                db_url="clickhouse://fake"
+            )
+
+        assert mock_send_task.call_count == 2
+        dispatched_orgs = {
+            call.kwargs["kwargs"]["org_id"] for call in mock_send_task.call_args_list
+        }
+        assert dispatched_orgs == {org_a, org_b}
+        worker_task = product_tasks.celery_app.tasks[
+            "dev_health_ops.workers.tasks.run_capacity_forecast_job"
+        ]
+        for call in mock_send_task.call_args_list:
+            assert (
+                call.args[0] == "dev_health_ops.workers.tasks.run_capacity_forecast_job"
+            )
+            assert call.kwargs["queue"] == "metrics"
+            assert call.kwargs["kwargs"]["db_url"] == "clickhouse://fake"
+            assert call.kwargs["kwargs"]["all_teams"] is True
+            getattr(worker_task, "__header__")(**call.kwargs["kwargs"])
+        assert set(result["dispatched"]) == {org_a, org_b}
+
+
+@pytest.mark.asyncio
+async def test_run_capacity_forecast_persists_rows_with_requested_org_id() -> None:
+    from dev_health_ops.metrics import job_capacity
+
+    sink = FakeCapacitySink()
+    forecast = ForecastResult(
+        forecast_id="forecast-1",
+        computed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        team_id="team-a",
+        work_scope_id="scope-a",
+        backlog_size=7,
+        target_items=7,
+        target_date=None,
+        history_days=30,
+        simulation_count=10,
+        p50_days=1,
+        p85_days=2,
+        p95_days=3,
+        p50_date=date(2026, 1, 2),
+        p85_date=date(2026, 1, 3),
+        p95_date=date(2026, 1, 4),
+        p50_items=None,
+        p85_items=None,
+        p95_items=None,
+        throughput_mean=1.0,
+        throughput_stddev=0.0,
+    )
+    history = ThroughputHistory(
+        [ThroughputSample(day=date(2025, 12, 31), items_completed=1)]
+    )
+
+    with (
+        patch("dev_health_ops.metrics.job_capacity.create_sink", return_value=sink),
+        patch(
+            "dev_health_ops.metrics.job_capacity.load_throughput_from_sink",
+            return_value=history,
+        ),
+        patch(
+            "dev_health_ops.metrics.job_capacity.get_backlog_from_sink", return_value=7
+        ),
+        patch(
+            "dev_health_ops.metrics.job_capacity.forecast_capacity",
+            return_value=forecast,
+        ),
+    ):
+        results = await job_capacity.run_capacity_forecast(
+            db_url="clickhouse://fake",
+            org_id="org-1",
+            team_id="team-a",
+            work_scope_id="scope-a",
+            target_items=7,
+            simulations=10,
+            persist=True,
+        )
+
+    assert results == [forecast]
+    assert [row.org_id for row in sink.written] == ["org-1"]
+    assert sink.closed is True
+
+
+@pytest.mark.asyncio
+async def test_run_capacity_forecast_rejects_empty_org_id_before_querying() -> None:
+    from dev_health_ops.metrics import job_capacity
+
+    with patch("dev_health_ops.metrics.job_capacity.create_sink") as mock_create_sink:
+        with pytest.raises(ValueError, match="org_id is required"):
+            await job_capacity.run_capacity_forecast(
+                db_url="clickhouse://fake",
+                org_id="",
+                all_teams=True,
+            )
+
+    mock_create_sink.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_discover_team_scopes_filters_clickhouse_by_org_id() -> None:
+    """Given an org-scoped sink, When discovering scopes, Then query filters org."""
+    from dev_health_ops.metrics.job_capacity import discover_team_scopes
+
+    sink = FakeClickHouseSink()
+    sink.org_id = "org-1"
+    sink.client.query.return_value = SimpleNamespace(
+        result_rows=[("team-a", "scope-a")]
+    )
+
+    result = await discover_team_scopes(sink)
+
+    assert result == [("team-a", "scope-a")]
+    query = sink.client.query.call_args.args[0]
+    params = sink.client.query.call_args.kwargs["parameters"]
+    assert "org_id = {org_id:String}" in query
+    assert params == {"org_id": "org-1"}
+
+
+@pytest.mark.asyncio
+async def test_load_throughput_filters_sql_sink_by_org_id() -> None:
+    """Given an org-scoped SQL sink, When loading history, Then query filters org."""
+    from dev_health_ops.metrics.job_capacity import load_throughput_from_sink
+
+    sink = FakeSqlSink()
+    sink.org_id = "org-1"
+
+    history = await load_throughput_from_sink(
+        sink,
+        team_id="team-a",
+        work_scope_id="scope-a",
+        history_days=30,
+    )
+
+    assert history.daily_throughputs == []
+    query, params = sink.queries[0]
+    assert "org_id = :org_id" in query
+    assert params == {
+        "org_id": "org-1",
+        "team_id": "team-a",
+        "work_scope_id": "scope-a",
+    }
+
+
+@pytest.mark.asyncio
+async def test_get_backlog_filters_clickhouse_by_org_id() -> None:
+    """Given an org-scoped ClickHouse sink, When loading backlog, Then filters org."""
+    from dev_health_ops.metrics.job_capacity import get_backlog_from_sink
+
+    sink = FakeClickHouseSink()
+    sink.org_id = "org-1"
+    sink.client.query.return_value = SimpleNamespace(result_rows=[(7,)])
+
+    backlog = await get_backlog_from_sink(sink, team_id="team-a")
+
+    assert backlog == 7
+    query = sink.client.query.call_args.args[0]
+    params = sink.client.query.call_args.kwargs["parameters"]
+    assert "org_id = {org_id:String}" in query
+    assert params == {"org_id": "org-1", "team_id": "team-a"}
+
+
+@pytest.mark.asyncio
+async def test_capacity_forecasts_resolver_filters_persisted_rows_by_org_id() -> None:
+    """Given persisted forecasts, When resolving, Then query is tenant-scoped."""
+    from dev_health_ops.api.graphql.context import GraphQLContext
+    from dev_health_ops.api.graphql.resolvers.capacity import resolve_capacity_forecasts
+
+    context = GraphQLContext(
+        org_id="org-1", db_url="clickhouse://fake", client=MagicMock()
+    )
+
+    with patch(
+        "dev_health_ops.api.queries.client.query_dicts",
+        return_value=[],
+    ) as mock_query:
+        result = await resolve_capacity_forecasts(context, filters=None)
+
+    assert result.total_count == 0
+    query = mock_query.call_args.args[1]
+    params = mock_query.call_args.args[2]
+    assert "org_id = %(org_id)s" in query
+    assert params["org_id"] == "org-1"


### PR DESCRIPTION
## Summary
- route the weekly capacity forecast beat through a default-queue dispatcher
- fan out `run_capacity_forecast_job` per active org with explicit `org_id`
- scope capacity helper queries and persisted forecast reads by org
- reject empty `org_id` before capacity forecast sink creation

## Verification
- `ruff format --check .`
- `ruff check .`
- `mypy --install-types --non-interactive .`
- `pytest tests -m "not benchmark and not clickhouse" --ignore=tests/test_connectors_integration.py --ignore=tests/test_private_repo_access.py --ignore=tests/api/admin/test_org_deletion.py -n 4 --dist loadscope -ra --tb=short -q`
- focused capacity/CLI regression tests
- manual Celery surface script for beat target and worker payload header validation

## Notes
- `ci/local_validate.sh` itself was not run because this worktree lacks its own `.venv`; the equivalent pure-Python stages were run with the existing ops dev environment.
- live ClickHouse validation was not run.

Linear: CHAOS-2878