### PR TITLE
fix(cockpit): use dynamic connected source statuses

### DIFF
--- a/ci/run_live_backend_e2e.sh
+++ b/ci/run_live_backend_e2e.sh
@@ -7,6 +7,9 @@ EXIT_FAILURE=10
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "${ROOT_DIR}" || exit "${EXIT_FAILURE}"
 
+PYTHONPATH="${ROOT_DIR}/src${PYTHONPATH:+:${PYTHONPATH}}"
+export PYTHONPATH
+
 require_cmd() {
   local cmd="$1"
   if ! command -v "${cmd}" >/dev/null 2>&1; then
@@ -58,6 +61,8 @@ POSTGRES_URI_DEFAULT="postgresql+asyncpg://postgres:postgres@127.0.0.1:5432/test
 CLICKHOUSE_URI="${CLICKHOUSE_URI:-${CLICKHOUSE_URI_DEFAULT}}"
 POSTGRES_URI="${POSTGRES_URI:-${POSTGRES_URI_DEFAULT}}"
 DATABASE_URI="${POSTGRES_URI}"
+export CLICKHOUSE_URI POSTGRES_URI DATABASE_URI
+export DISABLE_DOTENV=1
 
 API_HOST="${LIVE_E2E_API_HOST:-127.0.0.1}"
 API_PORT="${LIVE_E2E_API_PORT:-18080}"
@@ -66,8 +71,10 @@ BASE_URL="http://${API_HOST}:${API_PORT}"
 FIXTURE_SEED="${LIVE_E2E_FIXTURE_SEED:-20260219}"
 FIXTURE_DAYS="${LIVE_E2E_FIXTURE_DAYS:-14}"
 FIXTURE_REPO_NAME="${LIVE_E2E_FIXTURE_REPO_NAME:-acme/live-e2e}"
+FIXTURE_PROVIDER="${LIVE_E2E_FIXTURE_PROVIDER:-github}"
 FIXTURE_COMMITS_PER_DAY="${LIVE_E2E_COMMITS_PER_DAY:-6}"
 FIXTURE_PR_COUNT="${LIVE_E2E_PR_COUNT:-24}"
+export FIXTURE_PROVIDER
 
 
 # Must match the org_id used in generate_auth_token() below.
@@ -219,7 +226,6 @@ PY
 
 echo "==> generating deterministic ClickHouse fixtures (metrics + work graph)"
 (
-  export DISABLE_DOTENV=1
   export ORG_ID="${E2E_ORG_ID}"
   unset POSTGRES_URI
   unset DATABASE_URI
@@ -228,6 +234,7 @@ echo "==> generating deterministic ClickHouse fixtures (metrics + work graph)"
     --sink "${CLICKHOUSE_URI}" \
     --db-type clickhouse \
     --repo-name "${FIXTURE_REPO_NAME}" \
+    --provider "${FIXTURE_PROVIDER}" \
     --days "${FIXTURE_DAYS}" \
     --commits-per-day "${FIXTURE_COMMITS_PER_DAY}" \
     --pr-count "${FIXTURE_PR_COUNT}" \
@@ -251,7 +258,6 @@ fi
 
 echo "==> starting API at ${BASE_URL}"
 (
-  export DISABLE_DOTENV=1
   export DATABASE_URI="${DATABASE_URI}"
   export CLICKHOUSE_URI="${CLICKHOUSE_URI}"
   export POSTGRES_URI="${POSTGRES_URI}"
@@ -305,6 +311,7 @@ HOME_FILE="${TMP_DIR}/home.json"
 fetch_json "/api/v1/home" "${HOME_FILE}" "200"
 run_python - "${HOME_FILE}" <<'PY'
 import json
+import os
 import pathlib
 import sys
 
@@ -312,8 +319,13 @@ payload = json.loads(pathlib.Path(sys.argv[1]).read_text())
 freshness = payload.get("freshness", {})
 assert "last_ingested_at" in freshness, freshness
 sources = freshness.get("sources", {})
-allowed_states = {"ok", "down", "stale", "unknown", "not_configured", "error"}
-for key in ("github", "gitlab", "jira", "ci"):
+allowed_states = {"ok", "degraded", "down", "stale", "unknown", "not_configured", "error"}
+fixture_provider = os.environ.get("FIXTURE_PROVIDER", "github")
+expected_sources = {"ci"}
+if fixture_provider != "synthetic":
+    expected_sources.add(fixture_provider)
+assert set(sources) == expected_sources, sources
+for key in expected_sources:
     assert key in sources, sources
     assert str(sources.get(key, "")).lower() in allowed_states, sources
 coverage = freshness.get("coverage", {})

--- a/src/dev_health_ops/api/queries/freshness.py
+++ b/src/dev_health_ops/api/queries/freshness.py
@@ -7,6 +7,27 @@ from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 from .client import query_dicts
 
 
+def _coerce_datetime(value: datetime | str | None) -> datetime | None:
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        try:
+            normalized = value.replace(" ", "T")
+            return datetime.fromisoformat(normalized.replace("Z", "+00:00"))
+        except ValueError:
+            return None
+    return None
+
+
+def _source_status(value: datetime | str | None, *, start_day: date) -> str:
+    seen_at = _coerce_datetime(value)
+    if seen_at is None:
+        return "down"
+    if seen_at.date() < start_day:
+        return "degraded"
+    return "ok"
+
+
 async def fetch_last_ingested_at(
     sink: BaseMetricsSink, org_id: str = ""
 ) -> datetime | None:
@@ -97,4 +118,45 @@ async def fetch_coverage(
         "repos_covered_pct": repos_covered_pct,
         "prs_linked_to_issues_pct": prs_linked_pct,
         "issues_with_cycle_states_pct": issues_cycle_pct,
+    }
+
+
+async def fetch_source_statuses(
+    sink: BaseMetricsSink,
+    *,
+    start_day: date,
+    org_id: str = "",
+) -> dict[str, str]:
+    query = """
+        SELECT source, max(last_seen_at) AS last_seen_at
+        FROM (
+            SELECT lower(provider) AS source, max(last_synced) AS last_seen_at
+            FROM repos
+            WHERE org_id = %(org_id)s
+              AND lower(provider) NOT IN ('', 'unknown', 'synthetic')
+            GROUP BY source
+
+            UNION ALL
+
+            SELECT lower(provider) AS source, max(last_synced) AS last_seen_at
+            FROM work_items
+            WHERE org_id = %(org_id)s
+              AND lower(provider) NOT IN ('', 'unknown', 'synthetic')
+            GROUP BY source
+
+            UNION ALL
+
+            SELECT 'ci' AS source, max(last_synced) AS last_seen_at
+            FROM ci_pipeline_runs
+            WHERE org_id = %(org_id)s
+            HAVING count() > 0
+        )
+        GROUP BY source
+        ORDER BY source
+    """
+    rows = await query_dicts(sink, query, {"org_id": org_id})
+    return {
+        str(row["source"]): _source_status(row.get("last_seen_at"), start_day=start_day)
+        for row in rows
+        if row.get("source")
     }

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -29,7 +29,11 @@ from ..models.schemas import (
 )
 from ..queries.client import clickhouse_client, query_dicts
 from ..queries.explain import fetch_metric_driver_delta
-from ..queries.freshness import fetch_coverage, fetch_last_ingested_at
+from ..queries.freshness import (
+    fetch_coverage,
+    fetch_last_ingested_at,
+    fetch_source_statuses,
+)
 from ..queries.metrics import (
     fetch_blocked_hours,
     fetch_metric_series,
@@ -987,6 +991,7 @@ async def build_home_response(
         (
             last_ingested,
             coverage,
+            sources,
             deltas,
             rework_theme_allocation_rows,
         ) = await asyncio.gather(
@@ -995,6 +1000,11 @@ async def build_home_response(
                 sink,
                 start_day=start_day,
                 end_day=end_day,
+                org_id=org_id,
+            ),
+            fetch_source_statuses(
+                sink,
+                start_day=start_day,
                 org_id=org_id,
             ),
             _metric_deltas(
@@ -1031,12 +1041,6 @@ async def build_home_response(
             for row in rework_theme_allocation_rows
         ]
 
-        sources = {
-            "github": "ok" if last_ingested else "down",
-            "gitlab": "ok" if last_ingested else "down",
-            "jira": "ok" if last_ingested else "down",
-            "ci": "ok" if last_ingested else "down",
-        }
         data_confidence = build_data_confidence(coverage=coverage, sources=sources)
         metric_signals = build_metric_signals(deltas, filters, data_confidence)
         recommendation_signals, risk_signals = await asyncio.gather(

--- a/tests/api/queries/test_freshness_source_statuses.py
+++ b/tests/api/queries/test_freshness_source_statuses.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.api.queries import freshness as freshness_queries
+from dev_health_ops.api.queries.freshness import fetch_source_statuses
+from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+
+
+@pytest.mark.asyncio
+async def test_source_statuses_derive_from_ingested_provider_rows(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_query_dicts(
+        sink: BaseMetricsSink,
+        query: str,
+        parameters: dict[str, Any],
+    ) -> list[dict[str, Any]]:
+        assert "repos" in query
+        assert "work_items" in query
+        assert "ci_pipeline_runs" in query
+        assert parameters == {"org_id": "org-test"}
+        return [
+            {
+                "source": "github",
+                "last_seen_at": datetime(2026, 6, 10, tzinfo=timezone.utc),
+            },
+            {
+                "source": "jira",
+                "last_seen_at": datetime(2026, 5, 20, tzinfo=timezone.utc),
+            },
+            {"source": "ci", "last_seen_at": None},
+        ]
+
+    monkeypatch.setattr(freshness_queries, "query_dicts", fake_query_dicts)
+
+    statuses = await fetch_source_statuses(
+        MagicMock(spec=BaseMetricsSink),
+        start_day=date(2026, 6, 1),
+        org_id="org-test",
+    )
+
+    assert statuses == {"ci": "down", "github": "ok", "jira": "degraded"}

--- a/tests/test_api_sanitization.py
+++ b/tests/test_api_sanitization.py
@@ -51,6 +51,9 @@ async def test_home_response_sanitizes_non_finite_values(monkeypatch):
             "issues_with_cycle_states_pct": 0.0,
         }
 
+    async def _fake_fetch_source_statuses(*_args, **_kwargs):
+        return {"github": "ok"}
+
     async def _fake_fetch_metric_driver_delta(*_args, **_kwargs):
         return []
 
@@ -79,6 +82,9 @@ async def test_home_response_sanitizes_non_finite_values(monkeypatch):
         home_service, "fetch_last_ingested_at", _fake_fetch_last_ingested_at
     )
     monkeypatch.setattr(home_service, "fetch_coverage", _fake_fetch_coverage)
+    monkeypatch.setattr(
+        home_service, "fetch_source_statuses", _fake_fetch_source_statuses
+    )
     monkeypatch.setattr(
         home_service, "fetch_metric_driver_delta", _fake_fetch_metric_driver_delta
     )


### PR DESCRIPTION
## Summary
- derive connected source status from ingested `repos`, `work_items`, and `ci_pipeline_runs` provider data
- wire the Home/Cockpit response to use those dynamic statuses instead of static source names
- add regression coverage for provider-derived source freshness and update the sanitization test seam

## Validation
- `bash ci/local_validate.sh` in a clean detached worktree: PASS
  - ruff format/check, mypy, scratch ClickHouse migrate, full unit suite, live argMax proof
  - full unit suite: 6958 passed, 46 skipped
- targeted home/source tests: 13 passed
- manual browser QA: Cockpit showed ci, github, linear; absent gitlab no longer appeared

## Notes
- No Linear issue ID was found in the branch name, so this PR is not auto-linked to Linear.