### PR TITLE
fix(work-graph): resolve repo slug/UUID refs before edge filtering

### DIFF
--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -7,6 +7,7 @@ import re
 from collections import defaultdict
 from typing import Any
 
+from dev_health_ops.api.queries.scopes import resolve_repo_ids
 from dev_health_ops.api.services.identity import looks_like_uuid
 
 from ..authz import require_org_id
@@ -119,6 +120,33 @@ def _add_membership_scope_params(
         return
     params["scoped_repo_ids"] = scoped_repo_ids
     params["scoped_repo_count"] = len(scoped_repo_ids)
+
+
+async def _resolve_filter_repo_scope(
+    client: Any,
+    filters: WorkGraphEdgeFilterInput | None,
+    org_id: str,
+) -> bool:
+    """Resolve ``filters.repo_ids`` (repo slugs OR UUID strings) to verified
+    repo UUIDs IN PLACE, through the org-scoped ``repos`` catalog — the same
+    ``resolve_repo_ids`` choke point every other repo-scoped surface uses.
+
+    The web global filter bar sends repo slugs (``org/repo``), but every
+    ``work_graph_edges`` / membership column is a UUID. A raw slug reaching SQL
+    throws ClickHouse ``CANNOT_PARSE_UUID`` and empties the graph, so refs MUST
+    be resolved here before they touch any query.
+
+    Returns True when repos WERE requested but NONE resolved to a known repo:
+    the caller MUST short-circuit to an empty result rather than fall through to
+    an unscoped (whole-org) query.
+    """
+    if filters is None or not filters.repo_ids:
+        return False
+    resolved = await resolve_repo_ids(client, filters.repo_ids, org_id=org_id)
+    if not resolved:
+        return True
+    filters.repo_ids = resolved
+    return False
 
 
 def _incident_label(status: str) -> str:
@@ -1085,6 +1113,12 @@ async def resolve_work_graph_edges(
     if client is None:
         raise RuntimeError("Database client not available")
 
+    # Resolve repo slug/UUID refs to catalog UUIDs BEFORE any query (the web
+    # global filter bar sends slugs). If none resolve, the scope is empty —
+    # return an empty result rather than an unscoped whole-org query.
+    if await _resolve_filter_repo_scope(client, filters, org_id):
+        return _empty_edges_result(filters=filters)
+
     limit = filters.limit if filters else 1000
 
     theme_filter = filters.theme if filters else None
@@ -1262,6 +1296,10 @@ async def resolve_work_graph_flow(
     if client is None:
         raise RuntimeError("Database client not available")
 
+    # Resolve repo slug/UUID refs to catalog UUIDs before any query.
+    if await _resolve_filter_repo_scope(client, filters, org_id):
+        return _empty_flow_result(filters=filters)
+
     theme_filter = filters.theme if filters else None
     subcategory_filter = filters.subcategory if filters else None
     theme_filter_active = bool(theme_filter or subcategory_filter)
@@ -1368,6 +1406,10 @@ async def resolve_work_graph_artifacts(
 
     if client is None:
         raise RuntimeError("Database client not available")
+
+    # Resolve repo slug/UUID refs to catalog UUIDs before any query.
+    if await _resolve_filter_repo_scope(client, filters, org_id):
+        return _empty_artifacts_result(filters=filters)
 
     limit = filters.limit if filters else 1000
 

--- a/tests/graphql/conftest.py
+++ b/tests/graphql/conftest.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+from unittest.mock import patch
+
+import pytest
+
+
+@pytest.fixture(autouse=True)
+def _passthrough_resolve_repo_ids():
+    """Stub work-graph repo-ref resolution with an identity pass-through.
+
+    The work-graph resolvers pre-resolve ``filters.repo_ids`` (repo slugs OR
+    UUID strings) to catalog UUIDs via ``resolve_repo_ids`` — a real ClickHouse
+    round-trip against the ``repos`` table. Unit tests here mock only
+    ``query_dicts``, so without this the resolver would hit a live DB.
+
+    The identity stub returns the refs unchanged, so ``repo_ids`` reach the SQL
+    exactly as passed (tests assert the resulting param list) and no DB call is
+    made. Tests that need real slug→UUID mapping or the empty-scope
+    short-circuit patch ``resolve_repo_ids`` themselves; that inner patch
+    overrides this fixture for the duration of the test.
+    """
+
+    async def _identity(
+        sink: Any, repo_refs: Iterable[str], *, org_id: str = ""
+    ) -> list[str]:
+        return [str(ref) for ref in repo_refs if ref]
+
+    with patch(
+        "dev_health_ops.api.graphql.resolvers.work_graph.resolve_repo_ids",
+        side_effect=_identity,
+    ):
+        yield

--- a/tests/graphql/test_work_graph.py
+++ b/tests/graphql/test_work_graph.py
@@ -16,7 +16,11 @@ from dev_health_ops.api.graphql.models.outputs import (
     WorkGraphNodeType,
     WorkGraphProvenance,
 )
-from dev_health_ops.api.graphql.resolvers.work_graph import resolve_work_graph_edges
+from dev_health_ops.api.graphql.resolvers.work_graph import (
+    resolve_work_graph_artifacts,
+    resolve_work_graph_edges,
+    resolve_work_graph_flow,
+)
 
 
 class MockClient:
@@ -121,21 +125,65 @@ class TestResolveWorkGraphEdges:
 
     @pytest.mark.asyncio
     async def test_applies_repo_ids_filter(self, mock_context):
-        with patch(
-            "dev_health_ops.api.queries.client.query_dicts",
-            new_callable=AsyncMock,
-        ) as mock_query:
+        # The web global filter bar sends repo *slugs* ("org/repo"), not UUIDs.
+        # The resolver MUST resolve them to catalog UUIDs (via resolve_repo_ids)
+        # BEFORE they reach SQL: a raw slug against the UUID repo_id column
+        # throws CANNOT_PARSE_UUID and empties the graph. After resolution the
+        # SQL filters the UUID column directly.
+        resolved_uuid = "920f9442-07df-4217-4dc4-c5833c0b8268"
+        with (
+            patch(
+                "dev_health_ops.api.graphql.resolvers.work_graph.resolve_repo_ids",
+                new_callable=AsyncMock,
+                return_value=[resolved_uuid],
+            ) as mock_resolve,
+            patch(
+                "dev_health_ops.api.queries.client.query_dicts",
+                new_callable=AsyncMock,
+            ) as mock_query,
+        ):
             mock_query.return_value = []
 
-            filters = WorkGraphEdgeFilterInput(repo_ids=["repo-1", "repo-2"])
+            filters = WorkGraphEdgeFilterInput(repo_ids=["full-chaos/dev-health-ops"])
             await resolve_work_graph_edges(mock_context, filters)
+
+            # Resolution happened, org-scoped, on the raw slug ref.
+            mock_resolve.assert_awaited_once()
+            assert mock_resolve.await_args is not None
+            assert mock_resolve.await_args.args[1] == ["full-chaos/dev-health-ops"]
+            assert mock_resolve.await_args.kwargs.get("org_id") == "test-org"
 
             call_args = mock_query.call_args
             sql = call_args[0][1]
             params = call_args[0][2]
 
+            # Raw UUID-column filter (inputs are already resolved UUIDs).
             assert "repo_id IN %(repo_ids)s" in sql
-            assert params["repo_ids"] == ["repo-1", "repo-2"]
+            # The RESOLVED UUID reaches SQL, never the slug.
+            assert params["repo_ids"] == [resolved_uuid]
+
+    @pytest.mark.asyncio
+    async def test_unresolvable_repo_ids_returns_empty(self, mock_context):
+        # A repo filter whose refs resolve to NO known repo must yield an empty
+        # result, NOT fall through to an unscoped whole-org query.
+        with (
+            patch(
+                "dev_health_ops.api.graphql.resolvers.work_graph.resolve_repo_ids",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+            patch(
+                "dev_health_ops.api.queries.client.query_dicts",
+                new_callable=AsyncMock,
+            ) as mock_query,
+        ):
+            filters = WorkGraphEdgeFilterInput(repo_ids=["nonexistent/repo"])
+            result = await resolve_work_graph_edges(mock_context, filters)
+
+            assert result.total_count == 0
+            assert result.edges == []
+            # Short-circuited before any edge query touched SQL.
+            mock_query.assert_not_called()
 
     @pytest.mark.asyncio
     async def test_applies_source_type_filter(self, mock_context):
@@ -736,3 +784,45 @@ class TestWorkGraphEdgeLookupResolution:
         pr_lookup_params = mock_query.call_args_list[1][0][2]
         assert "pr_numbers" in pr_lookup_params
         assert 42 in pr_lookup_params["pr_numbers"]
+
+
+class TestRepoScopeResolutionContract:
+    """Guardrail: EVERY work-graph resolver must route repo refs through the
+    shared ``resolve_repo_ids`` choke point (slug/UUID -> org-scoped catalog
+    UUID) BEFORE they reach SQL. A resolver that filters ``repo_id`` on a raw
+    slug reintroduces the CANNOT_PARSE_UUID / empty-graph regression. This test
+    fails if any resolver stops calling the shared resolver or drops org_id."""
+
+    @pytest.mark.asyncio
+    @pytest.mark.parametrize(
+        "resolver",
+        [
+            resolve_work_graph_edges,
+            resolve_work_graph_flow,
+            resolve_work_graph_artifacts,
+        ],
+    )
+    async def test_resolver_routes_repo_refs_through_shared_resolver(
+        self, resolver, mock_context
+    ):
+        with (
+            patch(
+                "dev_health_ops.api.graphql.resolvers.work_graph.resolve_repo_ids",
+                new_callable=AsyncMock,
+                return_value=["920f9442-07df-4217-4dc4-c5833c0b8268"],
+            ) as mock_resolve,
+            patch(
+                "dev_health_ops.api.queries.client.query_dicts",
+                new_callable=AsyncMock,
+                return_value=[],
+            ),
+        ):
+            filters = WorkGraphEdgeFilterInput(repo_ids=["full-chaos/dev-health-ops"])
+            await resolver(mock_context, filters)
+
+            # The shared choke point was invoked exactly once, org-scoped, on the
+            # raw ref (NOT a bespoke inline SQL subquery, NOT a raw slug in SQL).
+            mock_resolve.assert_awaited_once()
+            assert mock_resolve.await_args is not None
+            assert mock_resolve.await_args.args[1] == ["full-chaos/dev-health-ops"]
+            assert mock_resolve.await_args.kwargs.get("org_id") == "test-org"


### PR DESCRIPTION
## Problem

The web global filter bar sends repo **slugs** (`org/repo`), but the work-graph
resolvers filtered the UUID `work_graph_edges.repo_id` column directly
(`repo_id IN %(repo_ids)s`). A slug reaching that predicate makes ClickHouse
throw `CANNOT_PARSE_UUID`, so **any repo-filtered work-graph query (edges, flow,
artifacts) errored out to an empty graph.**

Every other repo-scoped surface (investment, work-units, metrics) already
resolves refs through the shared `resolve_repo_ids` choke point — work-graph was
the one surface that bypassed it.

## Fix

- Pre-resolve `filters.repo_ids` (slug **or** UUID) to org-scoped catalog UUIDs
  via the shared `resolve_repo_ids`, once per resolver, before any query.
- Keep the SQL on the raw UUID `repo_id IN %(repo_ids)s` (inputs are UUIDs by the
  time they reach SQL).
- Unresolvable refs short-circuit to a clean empty result instead of an unscoped
  whole-org query.
- New `_resolve_filter_repo_scope` helper wired into the edges / flow / artifacts
  resolvers.

## Tests

- Autouse `tests/graphql/conftest.py` pass-through for `resolve_repo_ids` (keeps
  unit tests DB-free).
- Explicit slug→UUID resolution test + empty-scope short-circuit test.
- **Guardrail:** a parametrized contract test locking all three resolvers to the
  shared choke point — fails if any resolver reintroduces a raw-slug filter or
  drops `org_id`.

## Verification

- `ci/local_validate.sh` **GATE PASSED** — ruff + mypy + full unit suite
  (6977 passed) + live argMax proof.
- Live end-to-end: repo-slug filter returns 704 edges with `repoId` populated
  (previously empty/errored).
- Browser QA: work-graph renders edges with the repo filter applied; the
  Investment view (same global filter) is unaffected.

## Follow-up (separate, filed)

CHAOS-2879 — the investment services (`api/services/investment.py`,
`api/services/investment_flow.py`) call `resolve_repo_filter_ids` without
`org_id`, silently unscoping their repo filter to whole-org data. Not addressed
in this PR.
