### PR TITLE
fix(metrics): avoid FINAL on repo flow detector query

### DIFF
--- a/src/dev_health_ops/metrics/opportunities/flow_detector.py
+++ b/src/dev_health_ops/metrics/opportunities/flow_detector.py
@@ -28,6 +28,7 @@ import asyncio
 import logging
 from typing import Any
 
+from dev_health_ops.clickhouse_dedup import dedup_from
 from dev_health_ops.metrics.opportunities.models import (
     FlowScopeInput,
     ImproveOpportunity,
@@ -419,7 +420,7 @@ class FlowOpportunityDetector:
             avg(rework_churn_ratio_30d) AS rework_churn_ratio_30d,
             avg(change_failure_rate) AS change_failure_rate,
             sum(total_loc_touched) AS total_loc_touched
-        FROM repo_metrics_daily FINAL
+        FROM repo_metrics_daily
         WHERE {where_clause}
         GROUP BY repo_id
         HAVING data_days >= {_MIN_DATA_DAYS}
@@ -461,7 +462,7 @@ class FlowOpportunityDetector:
             avg(wip_congestion_ratio) AS wip_congestion_ratio,
             sum(items_completed) AS items_completed,
             avg(defect_intro_rate) AS defect_intro_rate
-        FROM work_item_metrics_daily FINAL
+        FROM {dedup_from("work_item_metrics_daily")}
         WHERE {where_clause}
           AND team_id != ''
         GROUP BY team_id

--- a/tests/metrics/opportunities/test_flow_detector_clickhouse_sql.py
+++ b/tests/metrics/opportunities/test_flow_detector_clickhouse_sql.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from dev_health_ops.metrics.opportunities.flow_detector import FlowOpportunityDetector
+
+
+@pytest.mark.asyncio
+async def test_detector_metric_queries_dedup_only_replacing_merge_tree_tables(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    queries: list[str] = []
+
+    async def fake_query_dicts(
+        _client: Any, query: str, _params: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        queries.append(" ".join(query.split()))
+        return []
+
+    monkeypatch.setattr(
+        "dev_health_ops.api.queries.client.query_dicts", fake_query_dicts
+    )
+
+    await FlowOpportunityDetector(MagicMock()).detect("org-test")
+
+    repo_query = next(query for query in queries if "FROM repo_metrics_daily" in query)
+    work_item_query = next(
+        query for query in queries if "FROM work_item_metrics_daily" in query
+    )
+
+    assert "FROM repo_metrics_daily FINAL" not in repo_query
+    assert "FROM work_item_metrics_daily FINAL" in work_item_query


### PR DESCRIPTION
## Summary
- remove unsupported `FINAL` from the `repo_metrics_daily` query used by `ImproveOpportunities`
- keep rerun deduplication for `work_item_metrics_daily` through `dedup_from(...)`
- add a regression test for the split ClickHouse table contract

## Verification
- `uv run --extra dev pytest tests/metrics/opportunities/test_flow_detector_clickhouse_sql.py tests/metrics/opportunities/test_flow_detector.py tests/test_rerun_dedup_guard.py`
- `bash ci/local_validate.sh`
- manual GraphQL `ImproveOpportunities` resolver QA against scratch ClickHouse returned `detector_ready=True total_count=0`
- LSP diagnostics clean on changed files
- Oracle review: no SQL/dedup correctness blocker

## Notes
- An initial push attempt was rejected because local upstream tracking still pointed at `origin/main`; the branch was then pushed explicitly to `origin/fix/flow-detector-no-final`. No protected branch was changed.