### PR TITLE
fix(metrics): aggregate org-wide capacity backlog

### DIFF
--- a/src/dev_health_ops/metrics/capacity_queries.py
+++ b/src/dev_health_ops/metrics/capacity_queries.py
@@ -110,16 +110,19 @@ async def get_backlog_from_sink(
     where_clause = " AND ".join(conditions) if conditions else "1=1"
 
     query = f"""
-        SELECT wip_count_end_of_day
+        SELECT sum(wip_count_end_of_day) AS wip_count_end_of_day
         FROM work_item_metrics_daily FINAL
         WHERE {where_clause}
-        ORDER BY day DESC
-        LIMIT 1
+          AND day = (
+              SELECT max(day)
+              FROM work_item_metrics_daily FINAL
+              WHERE {where_clause}
+          )
     """
 
     rows = await asyncio.to_thread(sink.query_dicts, query, params)
     if rows:
-        return int(rows[0].get("wip_count_end_of_day", 0))
+        return int(rows[0].get("wip_count_end_of_day") or 0)
     return 0
 
 

--- a/tests/test_capacity_queries.py
+++ b/tests/test_capacity_queries.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from datetime import date
+
+import pytest
+
+
+class FakeClickHouseSink:
+    backend_type = "clickhouse"
+    org_id: str
+
+    def __init__(self, rows: list[tuple[date, int]]) -> None:
+        self.rows = rows
+        self.query = ""
+        self.parameters: dict[str, str] = {}
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, str]
+    ) -> list[dict[str, int]]:
+        self.query = query
+        self.parameters = parameters
+
+        if "sum(wip_count_end_of_day)" not in query.lower():
+            return [{"wip_count_end_of_day": self.rows[0][1]}]
+
+        latest_day = max(row[0] for row in self.rows)
+        return [
+            {
+                "wip_count_end_of_day": sum(
+                    backlog for day, backlog in self.rows if day == latest_day
+                )
+            }
+        ]
+
+
+@pytest.mark.asyncio
+async def test_get_backlog_aggregates_latest_day_for_org_scope() -> None:
+    from dev_health_ops.metrics.job_capacity import get_backlog_from_sink
+
+    sink = FakeClickHouseSink(
+        rows=[
+            (date(2026, 1, 1), 3),
+            (date(2026, 1, 2), 0),
+            (date(2026, 1, 2), 7),
+        ]
+    )
+    sink.org_id = "org-1"
+
+    backlog = await get_backlog_from_sink(sink)
+
+    assert backlog == 7
+    assert "sum(wip_count_end_of_day)" in sink.query.lower()
+    assert "max(day)" in sink.query.lower()
+    assert sink.parameters == {"org_id": "org-1"}


### PR DESCRIPTION
## Summary
- Aggregate latest-day WIP rows for org-wide capacity backlog forecasts instead of selecting one arbitrary row.
- Add a focused regression for org-wide latest-day backlog aggregation.

## Verification
- Oracle review: no blocking findings.
- uv run pytest tests/test_capacity_queries.py tests/test_capacity_forecast_schedule.py tests/api/graphql/test_capacity_resolver.py -q
- uv run ruff format --check src/dev_health_ops/metrics/capacity_queries.py tests/test_capacity_queries.py tests/test_capacity_forecast_schedule.py
- uv run ruff check src/dev_health_ops/metrics/capacity_queries.py tests/test_capacity_queries.py tests/test_capacity_forecast_schedule.py
- uv run mypy src/dev_health_ops/metrics/capacity_queries.py
- Live authenticated browser GraphQL capacityForecast returned non-null forecast with backlogSize=36 and targetItems=36.

## Notes
- Full ci/local_validate.sh was not run.
