### PR TITLE
fix(admin/sync): derive backfill status from units

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -338,6 +338,32 @@ def _latest_datetime(*values: datetime | None) -> datetime | None:
     return max(aware_values) if aware_values else None
 
 
+def _effective_backfill_run_status(
+    run_status: str, status_counts: dict[str, int], total_units: int
+) -> str:
+    success_count = status_counts.get(SyncRunUnitStatus.SUCCESS.value, 0)
+    failed_count = status_counts.get(SyncRunUnitStatus.FAILED.value, 0)
+    settled_count = success_count + failed_count
+    if total_units > 0 and settled_count >= total_units:
+        if failed_count == 0:
+            return SyncRunStatus.SUCCESS.value
+        if success_count == 0:
+            return SyncRunStatus.FAILED.value
+        return SyncRunStatus.PARTIAL_FAILED.value
+
+    if (
+        settled_count > 0
+        or status_counts.get(SyncRunUnitStatus.RUNNING.value, 0) > 0
+        or status_counts.get(SyncRunUnitStatus.RETRYING.value, 0) > 0
+    ):
+        return SyncRunStatus.RUNNING.value
+    if status_counts.get(SyncRunUnitStatus.DISPATCHING.value, 0) > 0:
+        return SyncRunStatus.DISPATCHING.value
+    if status_counts.get(SyncRunUnitStatus.PLANNED.value, 0) > 0:
+        return SyncRunStatus.PLANNED.value
+    return run_status
+
+
 def _elapsed_seconds(
     started_at: datetime | None, completed_at: datetime | None
 ) -> int | None:
@@ -460,6 +486,22 @@ def _sync_run_unit_range(
     )
 
 
+def _sync_run_unit_rollup(
+    sync_run: SyncRun, units: Sequence[SyncRunUnit]
+) -> tuple[int, int, int, str]:
+    status_counts: dict[str, int] = {}
+    for unit in units:
+        status_counts[unit.status] = status_counts.get(unit.status, 0) + 1
+
+    total_units = max(sum(status_counts.values()), int(sync_run.total_units))
+    completed_units = status_counts.get(SyncRunUnitStatus.SUCCESS.value, 0)
+    failed_units = status_counts.get(SyncRunUnitStatus.FAILED.value, 0)
+    effective_status = _effective_backfill_run_status(
+        str(sync_run.status), status_counts, total_units
+    )
+    return total_units, completed_units, failed_units, effective_status
+
+
 def _sync_run_job_enrichment(
     sync_run: SyncRun | None, units: Sequence[SyncRunUnit]
 ) -> SyncRunJobEnrichment | None:
@@ -470,14 +512,17 @@ def _sync_run_job_enrichment(
     triggered_by = getattr(sync_run, "triggered_by", None)
     if sync_run_id is None or mode is None or triggered_by is None:
         return None
+    total_units, completed_units, failed_units, _ = _sync_run_unit_rollup(
+        sync_run, units
+    )
     return SyncRunJobEnrichment(
         mode=str(mode),
         triggered_by=str(triggered_by),
         requested_range=_sync_run_unit_range(units),
         covered_range=_sync_run_unit_range(units, success_only=True),
-        total_units=int(sync_run.total_units),
-        completed_units=int(sync_run.completed_units),
-        failed_units=int(sync_run.failed_units),
+        total_units=total_units,
+        completed_units=completed_units,
+        failed_units=failed_units,
         sync_run_id=str(sync_run_id),
     )
 
@@ -501,20 +546,23 @@ def _job_run_response(
         # Planner-managed JobRun rows are visibility anchors for Job History.
         # The linked SyncRun owns execution lifecycle and runtime stats.
         sync_result = getattr(planner_sync_run, "result")
+        total_units, completed_units, failed_units, effective_status = (
+            _sync_run_unit_rollup(planner_sync_run, planner_sync_run_units)
+        )
         result = {
             **(result if isinstance(result, dict) else {}),
             **(sync_result if isinstance(sync_result, dict) else {}),
-            "sync_run_status": str(getattr(planner_sync_run, "status")),
-            "total_units": int(getattr(planner_sync_run, "total_units")),
-            "completed_units": int(getattr(planner_sync_run, "completed_units")),
-            "failed_units": int(getattr(planner_sync_run, "failed_units")),
+            "sync_run_status": effective_status,
+            "total_units": total_units,
+            "completed_units": completed_units,
+            "failed_units": failed_units,
         }
-        status_value = _planner_job_run_status(str(getattr(planner_sync_run, "status")))
+        status_value = _planner_job_run_status(effective_status)
         started_at = getattr(planner_sync_run, "started_at")
         completed_at = getattr(planner_sync_run, "completed_at")
         duration_seconds = _elapsed_seconds(started_at, completed_at)
         error = getattr(planner_sync_run, "error") or error
-        items_synced = int(getattr(planner_sync_run, "completed_units"))
+        items_synced = completed_units
 
     return JobRunResponse.model_validate(
         {
@@ -544,6 +592,7 @@ def _backfill_job_response(job: object, run_counts: dict[str, Any] | None = None
     completed_chunks = int(
         run_counts.get("completed_chunks", getattr(job, "completed_chunks"))
     )
+    failed_chunks = int(run_counts.get("failed_chunks", getattr(job, "failed_chunks")))
     progress_pct = (completed_chunks / total_chunks * 100) if total_chunks > 0 else 0.0
     job_updated_at = getattr(job, "updated_at")
     effective_updated_at = _latest_datetime(
@@ -558,9 +607,7 @@ def _backfill_job_response(job: object, run_counts: dict[str, Any] | None = None
         before_date=getattr(job, "before_date"),
         total_chunks=total_chunks,
         completed_chunks=completed_chunks,
-        failed_chunks=int(
-            run_counts.get("failed_chunks", getattr(job, "failed_chunks"))
-        ),
+        failed_chunks=failed_chunks,
         progress_pct=progress_pct,
         error_message=run_counts.get("error_message", getattr(job, "error_message")),
         started_at=getattr(job, "started_at"),
@@ -607,11 +654,27 @@ async def _backfill_job_run_counts(
     )
     activity_result = await session.execute(activity_stmt)
     latest_unit_updated_at, latest_unit_heartbeat_at = activity_result.one()
+    status_counts_result = await session.execute(
+        select(SyncRunUnit.status, func.count())
+        .where(
+            SyncRunUnit.sync_run_id == run_uuid,
+            SyncRunUnit.org_id == str(getattr(job, "org_id")),
+        )
+        .group_by(SyncRunUnit.status)
+    )
+    status_counts = {
+        str(status): int(count) for status, count in status_counts_result.all()
+    }
+    total_chunks = max(sum(status_counts.values()), int(getattr(run, "total_units")))
+    completed_chunks = status_counts.get(SyncRunUnitStatus.SUCCESS.value, 0)
+    failed_chunks = status_counts.get(SyncRunUnitStatus.FAILED.value, 0)
     return {
-        "status": getattr(run, "status"),
-        "total_chunks": int(getattr(run, "total_units")),
-        "completed_chunks": int(getattr(run, "completed_units")),
-        "failed_chunks": int(getattr(run, "failed_units")),
+        "status": _effective_backfill_run_status(
+            str(getattr(run, "status")), status_counts, total_chunks
+        ),
+        "total_chunks": total_chunks,
+        "completed_chunks": completed_chunks,
+        "failed_chunks": failed_chunks,
         "completed_at": getattr(run, "completed_at"),
         "error_message": getattr(run, "error"),
         "updated_at": _latest_datetime(

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -51,6 +51,7 @@ from dev_health_ops.models.integrations import (
     SyncRunReferenceDiscovery,
     SyncRunStatus,
     SyncRunUnit,
+    SyncRunUnitStatus,
 )
 from dev_health_ops.models.licensing import OrgLicense
 from dev_health_ops.models.settings import (
@@ -741,7 +742,7 @@ async def _backfill_response_for_unit_activity(
                     dataset_key="commits",
                     cost_class="rest",
                     mode="backfill",
-                    status="running",
+                    status=SyncRunUnitStatus.SUCCESS.value,
                     updated_at=times.unit_updated_at,
                     last_heartbeat_at=times.unit_heartbeat_at,
                 ),
@@ -890,6 +891,102 @@ async def test_backfill_job_response_remains_stale_when_linked_units_are_stale(
     assert response.completed_chunks == 1
 
 
+@pytest.mark.asyncio
+async def test_backfill_job_response_counts_actual_linked_unit_statuses(
+    session_maker, seeded_state
+):
+    config_id = uuid.uuid4()
+    integration_id = uuid.uuid4()
+    source_id = uuid.uuid4()
+    sync_run_id = uuid.uuid4()
+
+    async with session_maker() as session:
+        config = SyncConfiguration(
+            name="bf-live-unit-statuses",
+            provider="github",
+            org_id=seeded_state["org_id"],
+            integration_id=integration_id,
+        )
+        config.id = config_id
+        session.add_all(
+            [
+                config,
+                Integration(
+                    id=integration_id,
+                    org_id=seeded_state["org_id"],
+                    provider="github",
+                    name="github-integration",
+                    config={},
+                ),
+                IntegrationSource(
+                    id=source_id,
+                    org_id=seeded_state["org_id"],
+                    integration_id=integration_id,
+                    provider="github",
+                    source_type="repository",
+                    external_id="full-chaos/dev-health",
+                    name="dev-health",
+                    full_name="full-chaos/dev-health",
+                    is_enabled=True,
+                ),
+                SyncRun(
+                    id=sync_run_id,
+                    org_id=seeded_state["org_id"],
+                    integration_id=integration_id,
+                    triggered_by="backfill",
+                    mode="backfill",
+                    status=SyncRunStatus.DISPATCHING.value,
+                    total_units=3,
+                    completed_units=0,
+                    failed_units=0,
+                ),
+                BackfillJob(
+                    id=uuid.uuid4(),
+                    org_id=seeded_state["org_id"],
+                    sync_config_id=config_id,
+                    celery_task_id=f"sync_run:{sync_run_id}",
+                    status="dispatching",
+                    since_date=datetime(2025, 12, 1, tzinfo=timezone.utc).date(),
+                    before_date=datetime(2025, 12, 8, tzinfo=timezone.utc).date(),
+                    total_chunks=3,
+                    completed_chunks=0,
+                    failed_chunks=0,
+                    started_at=_T0,
+                    created_at=_T0,
+                    updated_at=_T0,
+                ),
+            ]
+        )
+        session.add_all(
+            SyncRunUnit(
+                org_id=seeded_state["org_id"],
+                sync_run_id=sync_run_id,
+                integration_id=integration_id,
+                source_id=source_id,
+                provider="github",
+                dataset_key=f"dataset-{status.value}",
+                cost_class="rest",
+                mode="backfill",
+                status=status.value,
+                updated_at=_T0,
+            )
+            for status in (
+                SyncRunUnitStatus.SUCCESS,
+                SyncRunUnitStatus.FAILED,
+            )
+        )
+        await session.commit()
+
+        job = (await session.execute(select(BackfillJob))).scalar_one()
+        run_counts = await sync_router_module._backfill_job_run_counts(session, job)
+        response = sync_router_module._backfill_job_response(job, run_counts)
+
+    assert response.status == SyncRunStatus.RUNNING.value
+    assert response.completed_chunks == 1
+    assert response.failed_chunks == 1
+    assert response.progress_pct == pytest.approx(1 / 3 * 100)
+
+
 def test_unit_to_response_next_retry_at_derived_from_available_at_when_absent():
     """With no result next_retry_at, a retrying unit derives it from available_at."""
     avail = datetime(2026, 1, 1, 0, 10, tzinfo=timezone.utc)
@@ -966,13 +1063,22 @@ def test_job_run_response_distinguishes_partial_failed_and_forwards_retry_aggreg
         status=SyncRunStatus.PARTIAL_FAILED.value,
         result={"retry_exhausted_units": 1, "retrying_units": 0},
         total_units=3,
-        completed_units=2,
-        failed_units=1,
+        completed_units=0,
+        failed_units=0,
         started_at=_T0,
         completed_at=datetime(2026, 1, 1, 0, 30, tzinfo=timezone.utc),
         error=None,
     )
-    resp = _job_run_response(run, cast(SyncRun, planner))
+    units = [
+        _fake_unit(status=SyncRunUnitStatus.SUCCESS.value),
+        _fake_unit(status=SyncRunUnitStatus.SUCCESS.value),
+        _fake_unit(status=SyncRunUnitStatus.FAILED.value),
+    ]
+
+    resp = _job_run_response(
+        run, cast(SyncRun, planner), cast(list[SyncRunUnit], units)
+    )
+
     # JobRunStatus enum/labels are unchanged: PARTIAL_FAILED collapses to the
     # 'failed' label, but the literal run state stays distinguishable in result.
     assert resp.status == "failed"
@@ -981,3 +1087,97 @@ def test_job_run_response_distinguishes_partial_failed_and_forwards_retry_aggreg
     assert resp.result["retry_exhausted_units"] == 1
     assert resp.result["retrying_units"] == 0
     assert resp.result["failed_units"] == 1
+    assert resp.result["completed_units"] == 2
+    assert resp.items_synced == 2
+
+
+def test_job_run_response_uses_unit_statuses_when_sync_run_counters_are_stale():
+    run = types.SimpleNamespace(
+        id=uuid.uuid4(),
+        job_id=uuid.uuid4(),
+        status=JobRunStatus.RUNNING.value,
+        started_at=None,
+        completed_at=None,
+        duration_seconds=None,
+        error=None,
+        result={"sync_run_id": str(uuid.uuid4()), "planner_managed": True},
+        triggered_by="sync",
+        created_at=_T0,
+    )
+    planner = types.SimpleNamespace(
+        id=uuid.uuid4(),
+        status=SyncRunStatus.RUNNING.value,
+        result={},
+        mode="incremental",
+        triggered_by="sync",
+        total_units=4,
+        completed_units=0,
+        failed_units=0,
+        started_at=_T0,
+        completed_at=None,
+        error=None,
+    )
+    units = [
+        _fake_unit(status=SyncRunUnitStatus.SUCCESS.value),
+        _fake_unit(status=SyncRunUnitStatus.SUCCESS.value),
+        _fake_unit(status=SyncRunUnitStatus.SUCCESS.value),
+        _fake_unit(status=SyncRunUnitStatus.FAILED.value),
+    ]
+
+    resp = _job_run_response(
+        run, cast(SyncRun, planner), cast(list[SyncRunUnit], units)
+    )
+
+    assert resp.status == "failed"
+    assert resp.items_synced == 3
+    assert resp.result is not None
+    assert resp.result["sync_run_status"] == SyncRunStatus.PARTIAL_FAILED.value
+    assert resp.result["completed_units"] == 3
+    assert resp.result["failed_units"] == 1
+    assert resp.sync_run is not None
+    assert resp.sync_run.completed_units == 3
+    assert resp.sync_run.failed_units == 1
+
+
+def test_job_run_response_uses_unit_statuses_when_run_status_is_stale_terminal():
+    run = types.SimpleNamespace(
+        id=uuid.uuid4(),
+        job_id=uuid.uuid4(),
+        status=JobRunStatus.SUCCESS.value,
+        started_at=None,
+        completed_at=None,
+        duration_seconds=None,
+        error=None,
+        result={"sync_run_id": str(uuid.uuid4()), "planner_managed": True},
+        triggered_by="sync",
+        created_at=_T0,
+    )
+    planner = types.SimpleNamespace(
+        id=uuid.uuid4(),
+        status=SyncRunStatus.SUCCESS.value,
+        result={},
+        mode="incremental",
+        triggered_by="sync",
+        total_units=4,
+        completed_units=4,
+        failed_units=0,
+        started_at=_T0,
+        completed_at=None,
+        error=None,
+    )
+    units = [
+        _fake_unit(status=SyncRunUnitStatus.SUCCESS.value),
+        _fake_unit(status=SyncRunUnitStatus.RUNNING.value),
+        _fake_unit(status=SyncRunUnitStatus.RUNNING.value),
+        _fake_unit(status=SyncRunUnitStatus.RUNNING.value),
+    ]
+
+    resp = _job_run_response(
+        run, cast(SyncRun, planner), cast(list[SyncRunUnit], units)
+    )
+
+    assert resp.status == "running"
+    assert resp.items_synced == 1
+    assert resp.result is not None
+    assert resp.result["sync_run_status"] == SyncRunStatus.RUNNING.value
+    assert resp.result["completed_units"] == 1


### PR DESCRIPTION
## Summary
- Derive backfill job and job-history progress/status from linked `SyncRunUnit.status` rows instead of stale `SyncRun` counters.
- Keep completed-only `progress_pct` semantics for backfill responses while still surfacing failed unit counts.
- Add regressions for stale counters and stale terminal run status being overridden by live unit rows.

Companion web PR: https://github.com/full-chaos/dev-health-web/pull/771

## Validation
- `.venv/bin/python -m pytest tests/api/admin/test_backfill_jobrun.py -q` → 21 passed
- `.venv/bin/python -m ruff check src/dev_health_ops/api/admin/routers/sync.py tests/api/admin/test_backfill_jobrun.py`
- `.venv/bin/python -m ruff format --check src/dev_health_ops/api/admin/routers/sync.py tests/api/admin/test_backfill_jobrun.py`
- `bash ci/local_validate.sh`
- pre-push hook: ruff format/check + mypy passed
