### PR TITLE
fix(sync): stamp watermarks from planned window end (CHAOS-2880)

### DIFF
--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -1157,6 +1157,17 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 computed_at=budget_audit_computed_at,
             )
         )
+        watermark_at: datetime | None = None
+        if ctx.mode in {
+            SyncRunMode.INCREMENTAL.value,
+            SyncRunMode.FULL_RESYNC.value,
+        }:
+            watermark_at = ctx.window_end
+            if watermark_at is None:
+                raise ValueError(
+                    "sync unit cannot stamp watermark without before_at: "
+                    f"unit_id={unit_id} mode={ctx.mode}"
+                )
 
         completed_at = datetime.now(timezone.utc)
         duration_seconds = max(0, int((completed_at - started_at).total_seconds()))
@@ -1209,17 +1220,14 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
                 available_at=completed_at,
                 now=completed_at,
             )
-            if ctx.mode in {
-                SyncRunMode.INCREMENTAL.value,
-                SyncRunMode.FULL_RESYNC.value,  # full_resync stamps watermark on success
-            }:
+            if watermark_at is not None:
                 for watermark_dataset_key in _watermark_dataset_keys(ctx):
                     set_watermark(
                         session,
                         ctx.org_id,
                         ctx.source_external_id,
                         watermark_dataset_key,
-                        started_at,
+                        watermark_at,
                     )
             session.flush()
             should_finalize = True

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -341,6 +341,8 @@ def test_run_sync_unit_success_persists_status_and_incremental_watermark(
     from dev_health_ops.workers.sync_units import run_sync_unit
 
     run, unit = _seed_run(db_session)
+    planned_before = datetime(2026, 6, 1, 12, 0, tzinfo=timezone.utc)
+    unit.before_at = planned_before
     _mark_dispatching(db_session, unit)
     _patch_db_session(monkeypatch, db_session)
     _patch_runtime(monkeypatch)
@@ -396,6 +398,7 @@ def test_run_sync_unit_success_persists_status_and_incremental_watermark(
     assert watermark.org_id == run.org_id
     assert watermark.source_id == "full-chaos/dev-health"
     assert watermark.dataset_key == "commits"
+    assert _aware(watermark.last_synced_at) == planned_before
     finalize_outbox = (
         db_session.query(SyncDispatchOutbox)
         .filter_by(sync_run_id=run.id, kind=OUTBOX_KIND_FINALIZE)


### PR DESCRIPTION
## Summary
- stamp successful incremental/full-resync sync watermarks from the planned window end (`ctx.window_end`) instead of worker start time
- fail visibly if a watermark-writing unit has no `before_at`
- add a regression assertion that `SyncWatermark.last_synced_at` equals the planned `before_at`

Linear: CHAOS-2880 https://linear.app/fullchaos/issue/CHAOS-2880/sync-watermarks-advance-to-worker-start-time-creating-coverage-gaps

## Verification
- `uv run pytest tests/test_sync_units.py -q`
- `uv run ruff check src/dev_health_ops/workers/sync_units.py tests/test_sync_units.py`
- `uv run ruff format --check src/dev_health_ops/workers/sync_units.py tests/test_sync_units.py`
- pre-commit hook: ruff format, ruff check, mypy
- pre-push hook: ruff check, ruff format check, mypy