### PR TITLE
fix(admin/sync): roll up job units in SQL

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 import os
 import uuid
-from collections.abc import Callable, Sequence
+from collections.abc import Callable, Mapping, Sequence
+from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol, cast
 
@@ -243,6 +244,13 @@ class _MutableSyncConfiguration(Protocol):
     is_active: bool
 
 
+@dataclass(frozen=True, slots=True)
+class _SyncRunUnitRollup:
+    status_counts: Mapping[str, int]
+    requested_range: SyncCoverageRange | None
+    covered_range: SyncCoverageRange | None
+
+
 async def _integration_credential_id_for_config(
     session: AsyncSession, config: object, org_id: str
 ) -> uuid.UUID | None:
@@ -339,7 +347,7 @@ def _latest_datetime(*values: datetime | None) -> datetime | None:
 
 
 def _effective_backfill_run_status(
-    run_status: str, status_counts: dict[str, int], total_units: int
+    run_status: str, status_counts: Mapping[str, int], total_units: int
 ) -> str:
     success_count = status_counts.get(SyncRunUnitStatus.SUCCESS.value, 0)
     failed_count = status_counts.get(SyncRunUnitStatus.FAILED.value, 0)
@@ -436,9 +444,9 @@ async def _planner_sync_runs_for_job_runs(
     return {str(sync_run.id): sync_run for sync_run in result.scalars().all()}
 
 
-async def _planner_sync_run_units_for_job_runs(
+async def _planner_sync_run_unit_rollups_for_job_runs(
     session: AsyncSession, runs: Sequence[object], org_id: str
-) -> dict[str, list[SyncRunUnit]]:
+) -> dict[str, _SyncRunUnitRollup]:
     sync_run_ids = {
         sync_run_id
         for run in runs
@@ -446,16 +454,87 @@ async def _planner_sync_run_units_for_job_runs(
     }
     if not sync_run_ids:
         return {}
-    result = await session.execute(
-        select(SyncRunUnit).where(
+
+    status_result = await session.execute(
+        select(
+            SyncRunUnit.sync_run_id,
+            SyncRunUnit.status,
+            func.count(SyncRunUnit.id),
+        )
+        .where(
             SyncRunUnit.sync_run_id.in_(sync_run_ids),
             SyncRunUnit.org_id == org_id,
         )
+        .group_by(SyncRunUnit.sync_run_id, SyncRunUnit.status)
     )
-    units_by_run: dict[str, list[SyncRunUnit]] = {}
-    for unit in result.scalars().all():
-        units_by_run.setdefault(str(unit.sync_run_id), []).append(unit)
-    return units_by_run
+    status_counts_by_run: dict[str, dict[str, int]] = {}
+    for sync_run_id, status, count in status_result.all():
+        status_counts_by_run.setdefault(str(sync_run_id), {})[str(status)] = int(count)
+
+    requested_ranges = await _planner_sync_run_unit_ranges(
+        session, sync_run_ids, org_id, success_only=False
+    )
+    covered_ranges = await _planner_sync_run_unit_ranges(
+        session, sync_run_ids, org_id, success_only=True
+    )
+    return {
+        str(sync_run_id): _SyncRunUnitRollup(
+            status_counts=status_counts_by_run.get(str(sync_run_id), {}),
+            requested_range=requested_ranges.get(str(sync_run_id)),
+            covered_range=covered_ranges.get(str(sync_run_id)),
+        )
+        for sync_run_id in sync_run_ids
+    }
+
+
+async def _planner_sync_run_unit_ranges(
+    session: AsyncSession,
+    sync_run_ids: set[uuid.UUID],
+    org_id: str,
+    *,
+    success_only: bool,
+) -> dict[str, SyncCoverageRange]:
+    range_stmt = (
+        select(
+            SyncRunUnit.sync_run_id,
+            SyncRunUnit.source_id,
+            func.min(SyncRunUnit.since_at),
+            func.max(SyncRunUnit.before_at),
+        )
+        .where(
+            SyncRunUnit.sync_run_id.in_(sync_run_ids),
+            SyncRunUnit.org_id == org_id,
+            SyncRunUnit.since_at.is_not(None),
+            SyncRunUnit.before_at.is_not(None),
+        )
+        .group_by(SyncRunUnit.sync_run_id, SyncRunUnit.source_id)
+    )
+    if success_only:
+        range_stmt = range_stmt.where(
+            SyncRunUnit.status == SyncRunUnitStatus.SUCCESS.value
+        )
+
+    range_result = await session.execute(range_stmt)
+    since_by_run: dict[str, datetime] = {}
+    before_by_run: dict[str, datetime] = {}
+    source_ids_by_run: dict[str, set[str]] = {}
+    for sync_run_id, source_id, since_at, before_at in range_result.all():
+        run_id = str(sync_run_id)
+        since = ensure_utc(since_at)
+        before = ensure_utc(before_at)
+        since_by_run[run_id] = min(since_by_run.get(run_id, since), since)
+        before_by_run[run_id] = max(before_by_run.get(run_id, before), before)
+        source_ids_by_run.setdefault(run_id, set()).add(str(source_id))
+
+    return {
+        run_id: SyncCoverageRange(
+            since=since,
+            before=before_by_run[run_id],
+            source_ids=sorted(source_ids_by_run.get(run_id, set())),
+            run_ids=[run_id],
+        )
+        for run_id, since in since_by_run.items()
+    }
 
 
 def _sync_run_unit_range(
@@ -487,12 +566,8 @@ def _sync_run_unit_range(
 
 
 def _sync_run_unit_rollup(
-    sync_run: SyncRun, units: Sequence[SyncRunUnit]
+    sync_run: SyncRun, status_counts: Mapping[str, int]
 ) -> tuple[int, int, int, str]:
-    status_counts: dict[str, int] = {}
-    for unit in units:
-        status_counts[unit.status] = status_counts.get(unit.status, 0) + 1
-
     total_units = max(sum(status_counts.values()), int(sync_run.total_units))
     completed_units = status_counts.get(SyncRunUnitStatus.SUCCESS.value, 0)
     failed_units = status_counts.get(SyncRunUnitStatus.FAILED.value, 0)
@@ -503,7 +578,7 @@ def _sync_run_unit_rollup(
 
 
 def _sync_run_job_enrichment(
-    sync_run: SyncRun | None, units: Sequence[SyncRunUnit]
+    sync_run: SyncRun | None, unit_rollup: _SyncRunUnitRollup | None
 ) -> SyncRunJobEnrichment | None:
     if sync_run is None:
         return None
@@ -512,14 +587,15 @@ def _sync_run_job_enrichment(
     triggered_by = getattr(sync_run, "triggered_by", None)
     if sync_run_id is None or mode is None or triggered_by is None:
         return None
+    status_counts = unit_rollup.status_counts if unit_rollup is not None else {}
     total_units, completed_units, failed_units, _ = _sync_run_unit_rollup(
-        sync_run, units
+        sync_run, status_counts
     )
     return SyncRunJobEnrichment(
         mode=str(mode),
         triggered_by=str(triggered_by),
-        requested_range=_sync_run_unit_range(units),
-        covered_range=_sync_run_unit_range(units, success_only=True),
+        requested_range=unit_rollup.requested_range if unit_rollup else None,
+        covered_range=unit_rollup.covered_range if unit_rollup else None,
         total_units=total_units,
         completed_units=completed_units,
         failed_units=failed_units,
@@ -530,7 +606,7 @@ def _sync_run_job_enrichment(
 def _job_run_response(
     run: object,
     planner_sync_run: SyncRun | None = None,
-    planner_sync_run_units: Sequence[SyncRunUnit] = (),
+    planner_sync_run_unit_rollup: _SyncRunUnitRollup | None = None,
 ) -> JobRunResponse:
     status_value = int(getattr(run, "status"))
     started_at = getattr(run, "started_at")
@@ -547,7 +623,12 @@ def _job_run_response(
         # The linked SyncRun owns execution lifecycle and runtime stats.
         sync_result = getattr(planner_sync_run, "result")
         total_units, completed_units, failed_units, effective_status = (
-            _sync_run_unit_rollup(planner_sync_run, planner_sync_run_units)
+            _sync_run_unit_rollup(
+                planner_sync_run,
+                planner_sync_run_unit_rollup.status_counts
+                if planner_sync_run_unit_rollup
+                else {},
+            )
         )
         result = {
             **(result if isinstance(result, dict) else {}),
@@ -577,7 +658,7 @@ def _job_run_response(
             "error": error,
             "triggered_by": getattr(run, "triggered_by"),
             "sync_run": _sync_run_job_enrichment(
-                planner_sync_run, planner_sync_run_units
+                planner_sync_run, planner_sync_run_unit_rollup
             ),
             "created_at": getattr(run, "created_at"),
         }
@@ -2216,7 +2297,7 @@ async def list_sync_config_jobs(
     runs_result = await session.execute(runs_stmt)
     runs = list(runs_result.scalars().all())
     planner_sync_runs = await _planner_sync_runs_for_job_runs(session, runs, org_id)
-    planner_sync_run_units = await _planner_sync_run_units_for_job_runs(
+    planner_sync_run_unit_rollups = await _planner_sync_run_unit_rollups_for_job_runs(
         session, runs, org_id
     )
 
@@ -2224,7 +2305,9 @@ async def list_sync_config_jobs(
         _job_run_response(
             run,
             planner_sync_runs.get(str(sync_run_id)) if sync_run_id else None,
-            planner_sync_run_units.get(str(sync_run_id), ()) if sync_run_id else (),
+            planner_sync_run_unit_rollups.get(str(sync_run_id))
+            if sync_run_id
+            else None,
         )
         for run in runs
         for sync_run_id in [_planner_job_run_sync_run_id(run)]

--- a/tests/api/admin/test_backfill_jobrun.py
+++ b/tests/api/admin/test_backfill_jobrun.py
@@ -38,7 +38,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.admin.routers.integrations import _unit_to_response
-from dev_health_ops.api.admin.routers.sync import _job_run_response
+from dev_health_ops.api.admin.routers.sync import _job_run_response, _SyncRunUnitRollup
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.models.backfill import BackfillJob
 from dev_health_ops.models.git import Base
@@ -799,6 +799,18 @@ def _fake_unit(**overrides):
     return types.SimpleNamespace(**base)
 
 
+def _unit_rollup(units) -> _SyncRunUnitRollup:
+    status_counts: dict[str, int] = {}
+    for unit in units:
+        status = str(unit.status)
+        status_counts[status] = status_counts.get(status, 0) + 1
+    return _SyncRunUnitRollup(
+        status_counts=status_counts,
+        requested_range=None,
+        covered_range=None,
+    )
+
+
 def test_unit_to_response_projects_all_retry_result_keys():
     """All 8 worker-emitted retry/timeout result keys project onto the response."""
     resp = _unit_to_response(
@@ -1075,9 +1087,7 @@ def test_job_run_response_distinguishes_partial_failed_and_forwards_retry_aggreg
         _fake_unit(status=SyncRunUnitStatus.FAILED.value),
     ]
 
-    resp = _job_run_response(
-        run, cast(SyncRun, planner), cast(list[SyncRunUnit], units)
-    )
+    resp = _job_run_response(run, cast(SyncRun, planner), _unit_rollup(units))
 
     # JobRunStatus enum/labels are unchanged: PARTIAL_FAILED collapses to the
     # 'failed' label, but the literal run state stays distinguishable in result.
@@ -1124,9 +1134,7 @@ def test_job_run_response_uses_unit_statuses_when_sync_run_counters_are_stale():
         _fake_unit(status=SyncRunUnitStatus.FAILED.value),
     ]
 
-    resp = _job_run_response(
-        run, cast(SyncRun, planner), cast(list[SyncRunUnit], units)
-    )
+    resp = _job_run_response(run, cast(SyncRun, planner), _unit_rollup(units))
 
     assert resp.status == "failed"
     assert resp.items_synced == 3
@@ -1172,9 +1180,7 @@ def test_job_run_response_uses_unit_statuses_when_run_status_is_stale_terminal()
         _fake_unit(status=SyncRunUnitStatus.RUNNING.value),
     ]
 
-    resp = _job_run_response(
-        run, cast(SyncRun, planner), cast(list[SyncRunUnit], units)
-    )
+    resp = _job_run_response(run, cast(SyncRun, planner), _unit_rollup(units))
 
     assert resp.status == "running"
     assert resp.items_synced == 1

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -10,7 +10,7 @@ import pytest
 import pytest_asyncio
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
-from sqlalchemy import select
+from sqlalchemy import event, select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
@@ -1576,6 +1576,109 @@ async def test_list_sync_config_jobs_enriches_planner_run_and_paginates(
     second = second_page.json()
     assert len(second) == 1
     assert second[0]["sync_run"] is None
+
+
+@pytest.mark.asyncio
+async def test_list_sync_config_jobs_uses_rollups_without_loading_unit_rows(
+    client, session_maker
+):
+    ac, _ = client
+    create_resp = await _create_sync_config(ac, name="jobs-large-rollup")
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = create_resp.json()["id"]
+    unit_count = 201
+
+    async with session_maker() as session:
+        config = (
+            await session.execute(
+                select(SyncConfiguration).where(
+                    SyncConfiguration.id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+        job = (
+            await session.execute(
+                select(ScheduledJob).where(
+                    ScheduledJob.sync_config_id == uuid.UUID(config_id)
+                )
+            )
+        ).scalar_one()
+        source = IntegrationSource(
+            org_id=config.org_id,
+            integration_id=config.integration_id,
+            provider="github",
+            source_type="repository",
+            external_id="acme/large-repo",
+            name="large-repo",
+            full_name="acme/large-repo",
+            metadata_={"planner_managed_sync_config_id": str(config.id)},
+            is_enabled=True,
+        )
+        session.add(source)
+        await session.flush()
+        sync_run = SyncRun(
+            org_id=config.org_id,
+            integration_id=config.integration_id,
+            triggered_by="manual",
+            mode="incremental",
+            status="success",
+            total_units=unit_count,
+            completed_units=unit_count,
+            failed_units=0,
+            started_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+            completed_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+        )
+        session.add(sync_run)
+        await session.flush()
+        session.add_all(
+            SyncRunUnit(
+                org_id=config.org_id,
+                sync_run_id=sync_run.id,
+                integration_id=config.integration_id,
+                source_id=source.id,
+                provider="github",
+                dataset_key="commits",
+                cost_class="standard",
+                mode="incremental",
+                since_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+                before_at=datetime(2026, 1, 2, tzinfo=timezone.utc),
+                status="success",
+                attempts=1,
+            )
+            for _ in range(unit_count)
+        )
+        enriched_run = JobRun(
+            job.id, triggered_by="manual", status=JobRunStatus.RUNNING.value
+        )
+        enriched_run.created_at = datetime(2026, 1, 3, tzinfo=timezone.utc)
+        enriched_run.result = {"sync_run_id": str(sync_run.id)}
+        session.add(enriched_run)
+        await session.commit()
+
+    loaded_unit_rows = 0
+
+    def count_loaded_unit_row(_target, _context) -> None:
+        nonlocal loaded_unit_rows
+        loaded_unit_rows += 1
+
+    event.listen(SyncRunUnit, "load", count_loaded_unit_row)
+    try:
+        resp = await ac.get(f"/api/v1/admin/sync-configs/{config_id}/jobs?limit=1")
+    finally:
+        event.remove(SyncRunUnit, "load", count_loaded_unit_row)
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    assert data[0]["sync_run"]["total_units"] == unit_count
+    assert data[0]["sync_run"]["completed_units"] == unit_count
+    assert data[0]["sync_run"]["failed_units"] == 0
+    assert data[0]["sync_run"]["requested_range"] == {
+        "since": "2026-01-01T00:00:00Z",
+        "before": "2026-01-02T00:00:00Z",
+        "source_ids": [str(source.id)],
+        "run_ids": [str(sync_run.id)],
+    }
+    assert loaded_unit_rows == 0
 
 
 def test_sync_run_unit_range_normalizes_naive_datetimes_to_utc():


### PR DESCRIPTION
## Summary

Fixes CHAOS-2881 by removing the unbounded `SyncRunUnit` ORM materialization path from the admin sync jobs endpoint.

- Replaces `/api/v1/admin/sync-configs/{config_id}/jobs` unit-row loading with grouped SQL rollups for status counts and requested/covered ranges.
- Preserves the existing job history response contract for effective status, unit counts, `items_synced`, and sync run enrichment ranges.
- Adds a regression that creates hundreds of unit rows and asserts the endpoint returns correct rollups without loading `SyncRunUnit` ORM instances.
- Updates backfill job response helper tests for the new rollup input shape.

## Verification

- `python -m pytest tests/api/admin/test_sync_configs.py tests/api/admin/test_backfill_jobrun.py::test_job_run_response_distinguishes_partial_failed_and_forwards_retry_aggregates tests/api/admin/test_backfill_jobrun.py::test_job_run_response_uses_unit_statuses_when_sync_run_counters_are_stale tests/api/admin/test_backfill_jobrun.py::test_job_run_response_uses_unit_statuses_when_run_status_is_stale_terminal -q`
- `bash ci/local_validate.sh`
  - ruff format/check passed
  - mypy passed
  - full unit suite passed: 6975 passed, 43 skipped
  - ClickHouse scratch stages skipped locally because `dev-health-clickhouse-1` was not running

## Visual evidence

SCREENSHOT-WAIVER: backend API/test-only change; no rendered UI changes.

## Linear

CHAOS-2881