### PR TITLE
fix(sync): harden backfill metrics diagnostics (CHAOS-2888)

### DIFF
--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -401,6 +401,8 @@ dev-hops metrics dora --backfill 30 --metrics deployment_frequency,lead_time
 
 Compute file complexity and hotspot metrics from persisted `git_files`/`git_blame` data. Uses `CLICKHOUSE_URI`.
 
+> **Note (CHAOS-2850/CHAOS-2888):** `--backfill N` must not fabricate N days of historical complexity from current file contents. There is no persisted historical file-content snapshot, so the DB complexity path writes complexity only when it has a real target-day input contract; run it daily (or let the scheduled `dispatch_complexity_job` cadence run) to build a genuine trend. Historical API backfills skip complexity recompute unless a future real historical source of truth is added.
+
 ```bash
 dev-hops metrics complexity --backfill 30
 
@@ -483,6 +485,8 @@ dev-hops metrics validate-flags --lookback 30
 ### `metrics compounding-risk`
 
 Compute the Compounding Risk composite from persisted inputs (`repo_metrics_daily` + `repo_complexity_daily`) and write `compounding_risk_daily`. Requires `CLICKHOUSE_URI` **and** an organization id.
+
+> **Note (CHAOS-2888):** this command exits `0` whenever the compounding-risk query and write both complete, even if some rows have `severity="unknown"` due to missing required inputs — it exits non-zero only for configuration, validation, or infrastructure failures. Missing-input reason counts (`missing_rework_churn`, `missing_complexity_delta`, `missing_review_latency`, `missing_ownership_signal`) are logged per run. For API-triggered backfills, the same missing-input counts and per-day table coverage are surfaced on `GET /backfill-jobs/{job_id}` via `metrics_diagnostics`.
 
 ```bash
 dev-hops metrics compounding-risk --org "$ORG_ID"

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -166,6 +166,9 @@ The system registers Celery tasks under the `workers/` directory. The primary re
 | `run_daily_metrics_finalize_task` | None | `default` | Finalizes daily metrics computation. Source: `metrics_partitioned.py`. |
 | `run_complexity_job` | None | `metrics` | Analyzes code complexity for repositories. Source: `metrics_extra.py:16-319`. |
 | `dispatch_complexity_job` | None | `default` | Fans out `run_complexity_job` per active organization on an independent daily cadence (CHAOS-2850), so complexity refreshes even for orgs with infrequent syncs. Source: `metrics_extra.py`. |
+
+> ⚠️ **Limitation (CHAOS-2888):** `run_complexity_job` computes complexity only from current `git_files`/`git_blame` contents — there is no historical file-content snapshot store. Post-sync dispatch (`post_sync_dispatch.py`) therefore enqueues it only for a current single-day sync (`metrics_backfill_days` in `(None, 1)` and `metrics_day` absent or equal to `utc_today()`); historical single-day and multi-day sync windows skip the complexity enqueue entirely and log a `historical_complexity_unsupported` diagnostic instead of fabricating a misleading flat historical trend. Daily metrics, work-graph build, and investment materialization continue to run over the full requested historical window regardless.
+
 | `run_dora_metrics` | None | `metrics` | Computes DORA metrics. Source: `metrics_extra.py:16-319`. |
 | `run_release_impact_job` | None | `metrics` | Computes release impact metrics. Source: `metrics_extra.py:16-319`. |
 | `dispatch_release_impact` | None | `default` | Fans out release impact computation. Source: `metrics_extra.py`. |

--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import logging
 import os
 import uuid
-from collections.abc import Callable, Mapping, Sequence
+from collections.abc import AsyncIterator, Callable, Mapping, Sequence
+from contextlib import AbstractAsyncContextManager, asynccontextmanager
 from dataclasses import dataclass
 from datetime import datetime, timezone
 from typing import Any, Protocol, cast
@@ -665,7 +666,11 @@ def _job_run_response(
     )
 
 
-def _backfill_job_response(job: object, run_counts: dict[str, Any] | None = None):
+def _backfill_job_response(
+    job: object,
+    run_counts: dict[str, Any] | None = None,
+    metrics_diagnostics: Any | None = None,
+):
     from dev_health_ops.api.schemas.backfill import BackfillJobResponse
 
     run_counts = run_counts or {}
@@ -697,6 +702,7 @@ def _backfill_job_response(job: object, run_counts: dict[str, Any] | None = None
         # Response-level updated_at is effective liveness: the raw BackfillJob
         # row-write timestamp OR the latest linked fanout unit activity.
         updated_at=effective_updated_at or job_updated_at,
+        metrics_diagnostics=metrics_diagnostics,
     )
 
 
@@ -763,6 +769,44 @@ async def _backfill_job_run_counts(
             latest_unit_heartbeat_at,
         ),
     }
+
+
+async def _open_backfill_metrics_sink() -> AsyncIterator[Any | None]:
+    """Open a ClickHouse metrics sink for backfill diagnostics reads.
+
+    ``GET /backfill-jobs/{job_id}`` populates ``metrics_diagnostics`` from
+    ClickHouse analytics tables only -- no Postgres shortcuts (CHAOS-2888).
+    Yields ``None`` when ClickHouse is not configured so the detail
+    endpoint can omit diagnostics instead of failing.
+    """
+    from dev_health_ops.db import get_clickhouse_uri
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    uri = get_clickhouse_uri()
+    if not uri:
+        yield None
+        return
+    sink = ClickHouseMetricsSink(dsn=uri)
+    try:
+        yield sink
+    finally:
+        sink.close()
+
+
+def get_backfill_metrics_sink() -> Callable[
+    [], AbstractAsyncContextManager[Any | None]
+]:
+    """Return a lazy factory for the backfill-diagnostics ClickHouse sink.
+
+    Returns the factory itself -- not an opened sink -- so resolving this
+    FastAPI dependency performs no I/O. ``GET /backfill-jobs/{job_id}``
+    only calls the factory (opening ClickHouse) after confirming the job
+    exists; a 404 for a missing job never opens a ClickHouse client
+    (CHAOS-2888 Workstream C review fix). Tests override this dependency
+    with a factory returning their fake sink -- the same structural
+    contract ``metrics/compounding_risk.py`` already uses.
+    """
+    return asynccontextmanager(_open_backfill_metrics_sink)
 
 
 # Canonical mapping of provider → supported sync targets.
@@ -2343,6 +2387,9 @@ async def get_backfill_job(
     job_id: str,
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
+    metrics_sink_factory: Callable[
+        [], AbstractAsyncContextManager[Any | None]
+    ] = Depends(get_backfill_metrics_sink),
 ):
     from dev_health_ops.api.services.backfill import BackfillJobService
 
@@ -2351,4 +2398,22 @@ async def get_backfill_job(
     if job is None:
         raise HTTPException(status_code=404, detail="Backfill job not found")
     run_counts = await _backfill_job_run_counts(session, job)
-    return _backfill_job_response(job, run_counts)
+    metrics_diagnostics = None
+    # The sink is opened lazily, only now that the job is confirmed to
+    # exist -- a 404 above never triggers a ClickHouse connection
+    # (CHAOS-2888 Workstream C review fix).
+    async with metrics_sink_factory() as metrics_sink:
+        if metrics_sink is not None:
+            from dev_health_ops.api.services.backfill_diagnostics import (
+                build_backfill_metrics_diagnostics,
+            )
+
+            metrics_diagnostics = build_backfill_metrics_diagnostics(
+                metrics_sink,
+                org_id=org_id,
+                range_start=getattr(job, "since_date"),
+                range_end=getattr(job, "before_date"),
+            )
+    return _backfill_job_response(
+        job, run_counts, metrics_diagnostics=metrics_diagnostics
+    )

--- a/src/dev_health_ops/api/schemas/backfill.py
+++ b/src/dev_health_ops/api/schemas/backfill.py
@@ -5,6 +5,43 @@ from datetime import date, datetime
 from pydantic import BaseModel
 
 
+class BackfillMetricsDiagnosticsBucket(BaseModel):
+    """Row-count/missing-input summary for one day or an aggregate window.
+
+    Shared shape for the CHAOS-2888 backfill diagnostics contract: the same
+    fields appear per-day (``BackfillMetricsDiagnosticsDay``) and rolled up
+    (``BackfillMetricsDiagnostics.aggregate``). ``reason_counts`` keys are
+    the fixed vocabulary from ``metrics.compounding_risk``
+    (``missing_rework_churn``, ``missing_complexity_delta``,
+    ``missing_review_latency``, ``missing_ownership_signal``).
+    """
+
+    repo_metrics_rows: int
+    repo_complexity_rows: int
+    compounding_risk_rows: int
+    compounding_risk_non_null_rows: int
+    compounding_risk_unknown_rows: int
+    reason_counts: dict[str, int]
+
+
+class BackfillMetricsDiagnosticsDay(BackfillMetricsDiagnosticsBucket):
+    day: date
+
+
+class BackfillMetricsDiagnostics(BaseModel):
+    """Metrics observability for one backfill job's date window.
+
+    Populated for the detail endpoint (``GET /backfill-jobs/{job_id}``)
+    from ClickHouse analytics reads only. List responses leave this
+    ``None`` to stay cheap.
+    """
+
+    range_start: date
+    range_end: date
+    aggregate: BackfillMetricsDiagnosticsBucket
+    per_day: list[BackfillMetricsDiagnosticsDay]
+
+
 class BackfillJobResponse(BaseModel):
     id: str
     sync_config_id: str
@@ -20,6 +57,7 @@ class BackfillJobResponse(BaseModel):
     completed_at: datetime | None
     created_at: datetime
     updated_at: datetime
+    metrics_diagnostics: BackfillMetricsDiagnostics | None = None
 
 
 class BackfillJobListResponse(BaseModel):

--- a/src/dev_health_ops/api/services/backfill_diagnostics.py
+++ b/src/dev_health_ops/api/services/backfill_diagnostics.py
@@ -1,0 +1,208 @@
+"""Backfill metrics diagnostics (CHAOS-2888 Workstream C).
+
+Read-only ClickHouse aggregation feeding
+``BackfillJobResponse.metrics_diagnostics`` for the backfill-job detail
+endpoint (``GET /backfill-jobs/{job_id}``). Reuses the fixed reason-name
+vocabulary from ``metrics/compounding_risk.py`` (Workstream B) so the API
+surface and the metrics job report identical missing-input semantics.
+
+ClickHouse analytics reads only -- no Postgres shortcuts, no persistence.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from typing import Any, Protocol
+
+from dev_health_ops.metrics.compounding_risk import (
+    REASON_MISSING_COMPLEXITY_DELTA,
+    REASON_MISSING_OWNERSHIP_SIGNAL,
+    REASON_MISSING_REVIEW_LATENCY,
+    REASON_MISSING_REWORK_CHURN,
+)
+
+from ..schemas.backfill import (
+    BackfillMetricsDiagnostics,
+    BackfillMetricsDiagnosticsBucket,
+    BackfillMetricsDiagnosticsDay,
+)
+
+_REASON_KEYS: tuple[str, ...] = (
+    REASON_MISSING_REWORK_CHURN,
+    REASON_MISSING_COMPLEXITY_DELTA,
+    REASON_MISSING_REVIEW_LATENCY,
+    REASON_MISSING_OWNERSHIP_SIGNAL,
+)
+
+
+class MetricsDiagnosticsSink(Protocol):
+    """Structural sink contract -- the same one ``compounding_risk.py``'s
+    ``load_repo_complexity_delta_30d`` already uses (``ClickHouseMetricsSink``
+    in production, a canned fake in tests).
+    """
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]: ...
+
+
+def _day_range(start: date, end: date) -> list[date]:
+    if end < start:
+        return []
+    return [start + timedelta(days=i) for i in range((end - start).days + 1)]
+
+
+def _rows_per_day_query(table: str) -> str:
+    # DISTINCT repo_id rather than a raw row count: both tables are
+    # append-only MergeTree (no dedup engine), so a recomputed day would
+    # otherwise double-count. "Rows" here means "repos with data for this day".
+    return f"""
+        SELECT day, count(DISTINCT repo_id) AS row_count
+        FROM {table}
+        WHERE org_id = {{org_id:String}}
+          AND day >= {{start:Date}} AND day <= {{end:Date}}
+        GROUP BY day
+    """
+
+
+_COMPOUNDING_RISK_QUERY = """
+    WITH latest AS (
+        SELECT
+            day,
+            scope,
+            scope_id,
+            argMax(compounding_risk, computed_at) AS compounding_risk,
+            argMax(severity, computed_at) AS severity,
+            argMax(rework_churn, computed_at) AS rework_churn,
+            argMax(complexity_delta, computed_at) AS complexity_delta,
+            argMax(review_latency_p90h, computed_at) AS review_latency_p90h,
+            argMax(single_owner_ratio, computed_at) AS single_owner_ratio,
+            argMax(ownership_gini, computed_at) AS ownership_gini
+        FROM compounding_risk_daily
+        WHERE org_id = {org_id:String}
+          AND day >= {start:Date} AND day <= {end:Date}
+          -- Rows are persisted per (day, scope, scope_id): 'repo' rows and
+          -- 'team' rows both cover the same org/day, so counting both scopes
+          -- here would double-count. Diagnostics report the repo-scope view;
+          -- the DTO has no scope split (CHAOS-2888 Workstream C review fix).
+          AND scope = 'repo'
+        GROUP BY day, scope, scope_id
+    )
+    SELECT
+        day,
+        count() AS total_rows,
+        countIf(compounding_risk IS NOT NULL) AS non_null_rows,
+        countIf(severity = 'unknown') AS unknown_rows,
+        countIf(rework_churn IS NULL) AS missing_rework_churn,
+        countIf(complexity_delta IS NULL) AS missing_complexity_delta,
+        countIf(review_latency_p90h IS NULL) AS missing_review_latency,
+        countIf(single_owner_ratio IS NULL AND ownership_gini IS NULL)
+            AS missing_ownership_signal
+    FROM latest
+    GROUP BY day
+"""
+
+
+def _empty_bucket() -> dict[str, Any]:
+    return {
+        "repo_metrics_rows": 0,
+        "repo_complexity_rows": 0,
+        "compounding_risk_rows": 0,
+        "compounding_risk_non_null_rows": 0,
+        "compounding_risk_unknown_rows": 0,
+        "reason_counts": dict.fromkeys(_REASON_KEYS, 0),
+    }
+
+
+def _int_rows_by_day(rows: list[dict[str, Any]]) -> dict[date, int]:
+    return {
+        row["day"]: int(row.get("row_count") or 0)
+        for row in rows
+        if isinstance(row.get("day"), date)
+    }
+
+
+def build_backfill_metrics_diagnostics(
+    sink: MetricsDiagnosticsSink,
+    *,
+    org_id: str,
+    range_start: date,
+    range_end: date,
+) -> BackfillMetricsDiagnostics:
+    """Aggregate ClickHouse row counts and missing-input reasons for a backfill window.
+
+    Reads ``repo_metrics_daily``, ``repo_complexity_daily``, and
+    ``compounding_risk_daily`` directly. Per-day rows are required by the
+    CHAOS-2888 shared diagnostics contract because the underlying failure
+    mode (historical complexity unsupported) is window-specific.
+    """
+    params = {"org_id": org_id, "start": range_start, "end": range_end}
+
+    metrics_by_day = _int_rows_by_day(
+        sink.query_dicts(_rows_per_day_query("repo_metrics_daily"), params)
+    )
+    complexity_by_day = _int_rows_by_day(
+        sink.query_dicts(_rows_per_day_query("repo_complexity_daily"), params)
+    )
+    risk_by_day: dict[date, dict[str, Any]] = {
+        row["day"]: row
+        for row in sink.query_dicts(_COMPOUNDING_RISK_QUERY, params)
+        if isinstance(row.get("day"), date)
+    }
+
+    per_day: list[BackfillMetricsDiagnosticsDay] = []
+    agg = _empty_bucket()
+
+    for day in _day_range(range_start, range_end):
+        bucket = _empty_bucket()
+        bucket["repo_metrics_rows"] = metrics_by_day.get(day, 0)
+        bucket["repo_complexity_rows"] = complexity_by_day.get(day, 0)
+
+        risk_row = risk_by_day.get(day)
+        if risk_row is not None:
+            bucket["compounding_risk_rows"] = int(risk_row.get("total_rows") or 0)
+            bucket["compounding_risk_non_null_rows"] = int(
+                risk_row.get("non_null_rows") or 0
+            )
+            bucket["compounding_risk_unknown_rows"] = int(
+                risk_row.get("unknown_rows") or 0
+            )
+            bucket["reason_counts"] = {
+                REASON_MISSING_REWORK_CHURN: int(
+                    risk_row.get("missing_rework_churn") or 0
+                ),
+                REASON_MISSING_COMPLEXITY_DELTA: int(
+                    risk_row.get("missing_complexity_delta") or 0
+                ),
+                REASON_MISSING_REVIEW_LATENCY: int(
+                    risk_row.get("missing_review_latency") or 0
+                ),
+                REASON_MISSING_OWNERSHIP_SIGNAL: int(
+                    risk_row.get("missing_ownership_signal") or 0
+                ),
+            }
+
+        agg["repo_metrics_rows"] += bucket["repo_metrics_rows"]
+        agg["repo_complexity_rows"] += bucket["repo_complexity_rows"]
+        agg["compounding_risk_rows"] += bucket["compounding_risk_rows"]
+        agg["compounding_risk_non_null_rows"] += bucket[
+            "compounding_risk_non_null_rows"
+        ]
+        agg["compounding_risk_unknown_rows"] += bucket["compounding_risk_unknown_rows"]
+        for reason, count in bucket["reason_counts"].items():
+            agg["reason_counts"][reason] += count
+
+        per_day.append(BackfillMetricsDiagnosticsDay(day=day, **bucket))
+
+    return BackfillMetricsDiagnostics(
+        range_start=range_start,
+        range_end=range_end,
+        aggregate=BackfillMetricsDiagnosticsBucket(**agg),
+        per_day=per_day,
+    )
+
+
+__all__ = [
+    "MetricsDiagnosticsSink",
+    "build_backfill_metrics_diagnostics",
+]

--- a/src/dev_health_ops/metrics/compounding_risk.py
+++ b/src/dev_health_ops/metrics/compounding_risk.py
@@ -31,7 +31,7 @@ from __future__ import annotations
 from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import date, datetime, timedelta
-from typing import Any, Final
+from typing import Any, Final, Protocol
 
 from dev_health_ops.metrics.schemas import CompoundingRiskDailyRecord
 
@@ -126,6 +126,107 @@ class CompoundingInputs:
         if self.single_owner_ratio is None and self.ownership_gini is None:
             return False
         return True
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics (CHAOS-2888): fixed reason names for missing required inputs
+# ---------------------------------------------------------------------------
+
+#: Shared reason names for missing-input diagnostics (CHAOS-2888 contract).
+#: Fixed across workstreams -- do not rename or add ad hoc variants.
+REASON_MISSING_REWORK_CHURN: Final[str] = "missing_rework_churn"
+REASON_MISSING_COMPLEXITY_DELTA: Final[str] = "missing_complexity_delta"
+REASON_MISSING_REVIEW_LATENCY: Final[str] = "missing_review_latency"
+REASON_MISSING_OWNERSHIP_SIGNAL: Final[str] = "missing_ownership_signal"
+
+#: Ordered, fixed set of all missing-input reason names. Callers seed
+#: aggregate/report dicts from this tuple so output shape and key order are
+#: stable regardless of which reasons actually occur in a given batch.
+MISSING_INPUT_REASONS: Final[tuple[str, ...]] = (
+    REASON_MISSING_REWORK_CHURN,
+    REASON_MISSING_COMPLEXITY_DELTA,
+    REASON_MISSING_REVIEW_LATENCY,
+    REASON_MISSING_OWNERSHIP_SIGNAL,
+)
+
+
+class _RiskSignalSource(Protocol):
+    """Structural shape shared by ``CompoundingInputs`` and the persisted
+    ``CompoundingRiskDailyRecord`` -- both carry the same five raw signal
+    fields, so diagnostics can inspect either without importing one from
+    the other.
+    """
+
+    @property
+    def rework_churn(self) -> float | None: ...
+    @property
+    def complexity_delta(self) -> float | None: ...
+    @property
+    def review_latency_p90h(self) -> float | None: ...
+    @property
+    def single_owner_ratio(self) -> float | None: ...
+    @property
+    def ownership_gini(self) -> float | None: ...
+
+
+def missing_input_reasons(source: _RiskSignalSource) -> list[str]:
+    """Return the fixed reason name for each required input that is absent.
+
+    Mirrors ``CompoundingInputs.has_required_inputs()`` but names *which*
+    signal is missing instead of collapsing to a single boolean. Works on
+    both ``CompoundingInputs`` (pre-compute) and ``CompoundingRiskDailyRecord``
+    (post-compute, e.g. rows read back from a sink).
+    """
+    reasons: list[str] = []
+    if source.rework_churn is None:
+        reasons.append(REASON_MISSING_REWORK_CHURN)
+    if source.complexity_delta is None:
+        reasons.append(REASON_MISSING_COMPLEXITY_DELTA)
+    if source.review_latency_p90h is None:
+        reasons.append(REASON_MISSING_REVIEW_LATENCY)
+    if source.single_owner_ratio is None and source.ownership_gini is None:
+        reasons.append(REASON_MISSING_OWNERSHIP_SIGNAL)
+    return reasons
+
+
+@dataclass(frozen=True)
+class CompoundingRiskDiagnostics:
+    """Row-level input-completeness summary for a batch of computed rows.
+
+    Pure aggregation -- no I/O. Callers (the standalone job, backfill
+    observability) decide how to log or expose it. Field names and the
+    reason vocabulary are the fixed CHAOS-2888 shared diagnostics contract
+    consumed by the backfill observability workstream.
+    """
+
+    total_rows: int
+    non_null_rows: int
+    unknown_rows: int
+    reason_counts: dict[str, int]
+
+
+def summarize_compounding_risk_diagnostics(
+    rows: Iterable[CompoundingRiskDailyRecord],
+) -> CompoundingRiskDiagnostics:
+    """Aggregate missing-input reasons across already-computed rows."""
+    reason_counts: dict[str, int] = {reason: 0 for reason in MISSING_INPUT_REASONS}
+    total = 0
+    non_null = 0
+    unknown = 0
+    for row in rows:
+        total += 1
+        if row.compounding_risk is not None:
+            non_null += 1
+        if row.severity == "unknown":
+            unknown += 1
+        for reason in missing_input_reasons(row):
+            reason_counts[reason] += 1
+    return CompoundingRiskDiagnostics(
+        total_rows=total,
+        non_null_rows=non_null,
+        unknown_rows=unknown,
+        reason_counts=reason_counts,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -515,13 +616,21 @@ def _nullable_float(value: Any) -> float | None:
 __all__ = [
     "COMPLEXITY_WINDOW_DAYS",
     "CompoundingInputs",
+    "CompoundingRiskDiagnostics",
     "CompoundingThresholds",
     "CompoundingWeights",
     "DEFAULT_THRESHOLDS",
     "DEFAULT_WEIGHTS",
+    "MISSING_INPUT_REASONS",
+    "REASON_MISSING_COMPLEXITY_DELTA",
+    "REASON_MISSING_OWNERSHIP_SIGNAL",
+    "REASON_MISSING_REVIEW_LATENCY",
+    "REASON_MISSING_REWORK_CHURN",
     "REFERENCE_VALUES",
     "build_compounding_risk_rows_for_day",
     "compute_compounding_risk",
     "load_repo_complexity_delta_30d",
+    "missing_input_reasons",
     "severity_for",
+    "summarize_compounding_risk_diagnostics",
 ]

--- a/src/dev_health_ops/metrics/job_compounding_risk.py
+++ b/src/dev_health_ops/metrics/job_compounding_risk.py
@@ -19,7 +19,9 @@ from typing import Any
 
 from dev_health_ops.db import resolve_sink_uri
 from dev_health_ops.metrics.compounding_risk import (
+    MISSING_INPUT_REASONS,
     build_compounding_risk_rows_for_day,
+    summarize_compounding_risk_diagnostics,
 )
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 from dev_health_ops.providers.teams import build_repo_pattern_resolver
@@ -136,9 +138,16 @@ async def run_compounding_risk_job(
     computed_at = datetime.now(timezone.utc)
 
     total_rows = 0
+    aggregate_non_null = 0
+    aggregate_unknown = 0
+    # Seed every fixed reason key at 0 so the aggregate has a stable shape
+    # and key order regardless of which reasons actually occur (CHAOS-2888).
+    aggregate_reason_counts: dict[str, int] = dict.fromkeys(MISSING_INPUT_REASONS, 0)
+    days_with_no_repo_rows: list[str] = []
     for d in _date_range(day, backfill_days):
         repo_rows = _fetch_repo_metrics_for_day(sink, org_id, d)
         if not repo_rows:
+            days_with_no_repo_rows.append(d.isoformat())
             logger.info(
                 "compounding-risk: no repo_metrics_daily rows for day=%s org_id=%s",
                 d.isoformat(),
@@ -156,18 +165,34 @@ async def run_compounding_risk_job(
         if rows:
             sink.write_compounding_risk_daily(rows)
             total_rows += len(rows)
+            diagnostics = summarize_compounding_risk_diagnostics(rows)
+            aggregate_non_null += diagnostics.non_null_rows
+            aggregate_unknown += diagnostics.unknown_rows
+            for reason, count in diagnostics.reason_counts.items():
+                aggregate_reason_counts[reason] = (
+                    aggregate_reason_counts.get(reason, 0) + count
+                )
             logger.info(
-                "compounding-risk: wrote %d rows for day=%s (repos=%d, teams=%d)",
+                "compounding-risk: wrote %d rows for day=%s (repos=%d, teams=%d, "
+                "non_null=%d, unknown=%d, reasons=%s)",
                 len(rows),
                 d.isoformat(),
                 sum(1 for r in rows if r.scope == "repo"),
                 sum(1 for r in rows if r.scope == "team"),
+                diagnostics.non_null_rows,
+                diagnostics.unknown_rows,
+                diagnostics.reason_counts,
             )
 
     logger.info(
-        "compounding-risk: done, %d rows written across %d day(s)",
+        "compounding-risk: done, %d rows written across %d day(s) "
+        "(non_null=%d, unknown=%d, reasons=%s, days_with_no_repo_rows=%s)",
         total_rows,
         max(1, backfill_days),
+        aggregate_non_null,
+        aggregate_unknown,
+        aggregate_reason_counts,
+        days_with_no_repo_rows,
     )
     return 0
 

--- a/src/dev_health_ops/processors/base_git.py
+++ b/src/dev_health_ops/processors/base_git.py
@@ -16,9 +16,14 @@ import asyncio
 import logging
 import os
 from collections.abc import Coroutine
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import TYPE_CHECKING, Any
 
+from dev_health_ops.analytics.complexity import (
+    DEFAULT_COMPLEXITY_CONFIG_PATH,
+    ComplexityScanner,
+)
+from dev_health_ops.metrics.schemas import FileComplexitySnapshot, RepoComplexityDaily
 from dev_health_ops.models.git import (
     CiPipelineRun,
     Deployment,
@@ -524,6 +529,114 @@ async def backfill_file_records(
         len(contents_by_path),
         repo_full_name,
     )
+
+
+def build_complexity_records_from_contents(
+    *,
+    repo_id: Any,
+    day: date,
+    ref_value: str,
+    contents_by_path: dict[str, str],
+    org_id: str,
+) -> tuple[list[FileComplexitySnapshot], RepoComplexityDaily] | None:
+    scanner = ComplexityScanner(config_path=DEFAULT_COMPLEXITY_CONFIG_PATH)
+    file_results = scanner.scan_file_contents(sorted(contents_by_path.items()))
+    if not file_results:
+        return None
+
+    computed_at = datetime.now(timezone.utc)
+    snapshots: list[FileComplexitySnapshot] = []
+    total_loc = 0
+    total_cc = 0
+    total_high = 0
+    total_very_high = 0
+
+    for file_result in file_results:
+        snapshots.append(
+            FileComplexitySnapshot(
+                repo_id=repo_id,
+                as_of_day=day,
+                ref=ref_value,
+                file_path=file_result.file_path,
+                language=file_result.language,
+                loc=file_result.loc,
+                functions_count=file_result.functions_count,
+                cyclomatic_total=file_result.cyclomatic_total,
+                cyclomatic_avg=file_result.cyclomatic_avg,
+                high_complexity_functions=file_result.high_complexity_functions,
+                very_high_complexity_functions=file_result.very_high_complexity_functions,
+                computed_at=computed_at,
+                org_id=org_id,
+            )
+        )
+        total_loc += file_result.loc
+        total_cc += file_result.cyclomatic_total
+        total_high += file_result.high_complexity_functions
+        total_very_high += file_result.very_high_complexity_functions
+
+    repo_daily = RepoComplexityDaily(
+        repo_id=repo_id,
+        day=day,
+        loc_total=total_loc,
+        cyclomatic_total=total_cc,
+        cyclomatic_per_kloc=(total_cc / (total_loc / 1000.0)) if total_loc > 0 else 0.0,
+        high_complexity_functions=total_high,
+        very_high_complexity_functions=total_very_high,
+        computed_at=computed_at,
+        org_id=org_id,
+    )
+    return snapshots, repo_daily
+
+
+def historical_backfill_day(until: datetime | None) -> date | None:
+    if until is None:
+        return None
+    return until.astimezone(timezone.utc).date()
+
+
+def _new_complexity_sink(store: Any) -> Any | None:
+    conn_string = getattr(store, "conn_string", None)
+    if not isinstance(conn_string, str) or not conn_string:
+        return None
+    from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+
+    sink = ClickHouseMetricsSink(dsn=conn_string)
+    sink.ensure_tables()
+    setattr(sink, "org_id", getattr(store, "org_id", None) or "")
+    return sink
+
+
+def write_historical_complexity(
+    *,
+    store: Any,
+    metrics_sink: Any | None,
+    repo_id: Any,
+    day: date | None,
+    ref_value: str,
+    contents_by_path: dict[str, str],
+) -> None:
+    if day is None or not contents_by_path:
+        return
+    records = build_complexity_records_from_contents(
+        repo_id=repo_id,
+        day=day,
+        ref_value=ref_value,
+        contents_by_path=contents_by_path,
+        org_id=getattr(store, "org_id", None) or "",
+    )
+    if records is None:
+        return
+    snapshots, repo_daily = records
+    sink = metrics_sink or _new_complexity_sink(store)
+    if sink is None:
+        return
+    close_sink = metrics_sink is None
+    try:
+        sink.write_file_complexity_snapshots(snapshots)
+        sink.write_repo_complexity_daily([repo_daily])
+    finally:
+        if close_sink:
+            sink.close()
 
 
 async def backfill_commit_stat_records(

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -31,9 +31,11 @@ from dev_health_ops.processors.base_git import (
     build_deployment,
     build_git_pull_request,
     check_backfill_needs,
+    historical_backfill_day,
     resolve_commit_stats_limit,
     resolve_incident_labels,
     select_unblamed_paths,
+    write_historical_complexity,
 )
 from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
@@ -1116,6 +1118,15 @@ class _BoundedBlameFailureLogger:
 
 
 class _GitHubFileContentClient(Protocol):
+    async def get_latest_commit_sha(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        ref: str,
+        until: datetime,
+    ) -> str | None: ...
+
     async def get_file_contents(
         self,
         owner: str,
@@ -1191,6 +1202,7 @@ async def _backfill_github_missing_data(
     since: datetime | None = None,
     until: datetime | None = None,
     usage_sink: list[dict[str, Any]] | None = None,
+    metrics_sink: Any | None = None,
 ) -> None:
     # Logic matches the CLI sync orchestration.
     logging.info(
@@ -1208,7 +1220,11 @@ async def _backfill_github_missing_data(
     # (contents NULL), which has_any_git_files treats as "done". Upgrade
     # them by re-running the files backfill when no contents exist yet;
     # ReplacingMergeTree(last_synced) supersedes the stale rows.
-    needs_files = needs.files if include_files else False
+    historical_day = historical_backfill_day(until)
+    needs_historical_complexity = include_files and historical_day is not None
+    needs_files = (
+        needs.files if include_files else False
+    ) or needs_historical_complexity
     if (
         include_files
         and not needs_files
@@ -1243,39 +1259,68 @@ async def _backfill_github_missing_data(
     code_client: GitHubCodeClient | None = None
     if needs_files or needs_blame:
         code_client = _github_code_client_from_connector(connector)
+    tree_ref = default_branch
     try:
         if needs_files or needs_blame:
             try:
-                branch = gh_repo.get_branch(default_branch)
-                tree = gh_repo.get_git_tree(branch.commit.sha, recursive=True)
-                blob_sizes: dict[str, int | None] = {}
-                for entry in getattr(tree, "tree", []) or []:
-                    if getattr(entry, "type", None) != "blob":
-                        continue
-                    path = getattr(entry, "path", None)
-                    if not path:
-                        continue
-                    file_paths.append(path)
-                    blob_sizes[path] = getattr(entry, "size", None)
+                assert code_client is not None
+                tree_ref = default_branch
+                if until is not None:
+                    resolved_ref = await code_client.get_latest_commit_sha(
+                        owner, repo_name, ref=default_branch, until=until
+                    )
+                    if resolved_ref is None:
+                        logging.warning(
+                            "No GitHub commit found for %s at or before %s; "
+                            "skipping file backfill",
+                            repo_full_name,
+                            until.isoformat(),
+                        )
+                        needs_files = False
+                        needs_blame = False
+                    else:
+                        tree_ref = resolved_ref
+                else:
+                    branch = gh_repo.get_branch(default_branch)
+                    tree_ref = branch.commit.sha
+                if needs_files or needs_blame:
+                    tree = gh_repo.get_git_tree(tree_ref, recursive=True)
+                    blob_sizes: dict[str, int | None] = {}
+                    for entry in getattr(tree, "tree", []) or []:
+                        if getattr(entry, "type", None) != "blob":
+                            continue
+                        path = getattr(entry, "path", None)
+                        if not path:
+                            continue
+                        file_paths.append(path)
+                        blob_sizes[path] = getattr(entry, "size", None)
 
-                if needs_files and file_paths:
-                    assert code_client is not None
-                    contents_by_path = await _fetch_scannable_contents(
-                        code_client,
-                        owner,
-                        repo_name,
-                        default_branch,
-                        file_paths,
-                        blob_sizes,
-                        repo_full_name,
-                    )
-                    await backfill_file_records(
-                        ingestion_sink,
-                        db_repo.id,
-                        file_paths,
-                        repo_full_name,
-                        contents_by_path=contents_by_path,
-                    )
+                    if needs_files and file_paths:
+                        contents_by_path = await _fetch_scannable_contents(
+                            code_client,
+                            owner,
+                            repo_name,
+                            tree_ref,
+                            file_paths,
+                            blob_sizes,
+                            repo_full_name,
+                        )
+                        if historical_day is None:
+                            await backfill_file_records(
+                                ingestion_sink,
+                                db_repo.id,
+                                file_paths,
+                                repo_full_name,
+                                contents_by_path=contents_by_path,
+                            )
+                        write_historical_complexity(
+                            store=store,
+                            metrics_sink=metrics_sink,
+                            repo_id=db_repo.id,
+                            day=historical_day,
+                            ref_value=tree_ref,
+                            contents_by_path=contents_by_path,
+                        )
             except (RateLimitException, RateLimitExceededException):
                 raise
             except Exception as e:
@@ -1357,7 +1402,7 @@ async def _backfill_github_missing_data(
                                 owner=owner,
                                 repo=repo_name,
                                 path=path,
-                                ref=default_branch,
+                                ref=tree_ref,
                             )
                             processed_files += 1
                         except (RateLimitException, RateLimitExceededException):

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -36,9 +36,11 @@ from dev_health_ops.processors.base_git import (
     build_deployment,
     build_git_pull_request,
     check_backfill_needs,
+    historical_backfill_day,
     resolve_commit_stats_limit,
     resolve_incident_labels,
     select_unblamed_paths,
+    write_historical_complexity,
 )
 from dev_health_ops.processors.fetch_utils import (
     AsyncBatchCollector,
@@ -1475,6 +1477,33 @@ async def _fetch_gitlab_repository_tree(
         )
 
 
+async def _resolve_gitlab_backfill_ref(
+    connector: Any,
+    project_full_name: str,
+    default_branch: str,
+    until: datetime | None,
+    usage_sink: list[dict[str, Any]] | None,
+) -> str | None:
+    if until is None:
+        return default_branch
+
+    drained_observations: list[dict[str, Any]] = []
+    try:
+        async with _gitlab_code_client_from_connector(connector) as client:
+            try:
+                return await client.get_latest_commit_sha(
+                    project_full_name,
+                    ref=default_branch,
+                    until=until,
+                )
+            finally:
+                drained_observations.extend(client.drain_usage_observations())
+    finally:
+        _drain_gitlab_code_usage(
+            "_resolve_gitlab_backfill_ref", drained_observations, usage_sink
+        )
+
+
 async def _backfill_gitlab_missing_data(
     store: Any,
     ingestion_sink: IngestionSink,
@@ -1487,7 +1516,10 @@ async def _backfill_gitlab_missing_data(
     include_files: bool = True,
     include_blame: bool = True,
     include_commit_stats: bool = True,
+    since: datetime | None = None,
+    until: datetime | None = None,
     usage_sink: list[dict[str, Any]] | None = None,
+    metrics_sink: Any | None = None,
 ) -> None:
     # check_backfill_needs's blame_only flag doubles as "skip commit stats".
     needs = await check_backfill_needs(
@@ -1498,7 +1530,11 @@ async def _backfill_gitlab_missing_data(
     # (contents NULL), which has_any_git_files treats as "done". Upgrade
     # them by re-running the files backfill when no contents exist yet;
     # ReplacingMergeTree(last_synced) supersedes the stale rows.
-    needs_files = needs.files if include_files else False
+    historical_day = historical_backfill_day(until)
+    needs_historical_complexity = include_files and historical_day is not None
+    needs_files = (
+        needs.files if include_files else False
+    ) or needs_historical_complexity
     if (
         include_files
         and not needs_files
@@ -1523,10 +1559,25 @@ async def _backfill_gitlab_missing_data(
 
     file_paths: list[str] = []
     blame_paths: list[str] = []
+    backfill_ref = default_branch
     if needs_files or needs_blame:
-        items = await _fetch_gitlab_repository_tree(
-            connector, project_full_name, default_branch, usage_sink
+        resolved_ref = await _resolve_gitlab_backfill_ref(
+            connector, project_full_name, default_branch, until, usage_sink
         )
+        if resolved_ref is None:
+            logging.warning(
+                "No GitLab commit found for %s at or before %s; skipping file backfill",
+                project_full_name,
+                until.isoformat() if until is not None else "unknown",
+            )
+            needs_files = False
+            needs_blame = False
+            items = []
+        else:
+            backfill_ref = resolved_ref
+            items = await _fetch_gitlab_repository_tree(
+                connector, project_full_name, backfill_ref, usage_sink
+            )
 
         for item in items or []:
             if item.get("type") != "blob":
@@ -1540,15 +1591,24 @@ async def _backfill_gitlab_missing_data(
             contents_by_path = await _fetch_scannable_contents(
                 connector,
                 project_full_name,
-                default_branch,
+                backfill_ref,
                 file_paths,
                 usage_sink=usage_sink,
             )
-            await backfill_file_records(
-                ingestion_sink,
-                db_repo.id,
-                file_paths,
-                project_full_name,
+            if historical_day is None:
+                await backfill_file_records(
+                    ingestion_sink,
+                    db_repo.id,
+                    file_paths,
+                    project_full_name,
+                    contents_by_path=contents_by_path,
+                )
+            write_historical_complexity(
+                store=store,
+                metrics_sink=metrics_sink,
+                repo_id=db_repo.id,
+                day=historical_day,
+                ref_value=backfill_ref,
                 contents_by_path=contents_by_path,
             )
 
@@ -1570,11 +1630,11 @@ async def _backfill_gitlab_missing_data(
             project_full_name,
             max_commits,
             db_repo.id,
-            None,
-            None,
+            since,
+            until,
             usage_sink,
         )
-        stats_limit = resolve_commit_stats_limit(len(commit_hashes), max_commits, None)
+        stats_limit = resolve_commit_stats_limit(len(commit_hashes), max_commits, since)
         stats_objects = await loop.run_in_executor(
             None,
             _fetch_gitlab_commit_stats_sync,
@@ -1632,7 +1692,7 @@ async def _backfill_gitlab_missing_data(
                         for path in blame_paths:
                             try:
                                 blame_items = await client.get_file_blame(
-                                    project_full_name, path, ref=default_branch
+                                    project_full_name, path, ref=backfill_ref
                                 )
                             except Exception as e:
                                 if _is_rate_limit_exception(e):
@@ -2209,6 +2269,8 @@ async def process_gitlab_project(
                 default_branch=db_repo.settings.get("default_branch", "main"),
                 max_commits=max_commits,
                 blame_only=True,
+                since=since,
+                until=until,
                 usage_sink=usage_sink,
             )
             logging.info("Completed blame-only sync for GitLab project: %s", project_id)
@@ -2391,6 +2453,8 @@ async def process_gitlab_project(
                     include_files=run_files,
                     include_blame=run_blame,
                     include_commit_stats=False,
+                    since=since,
+                    until=until,
                     usage_sink=usage_sink,
                 )
             except Exception as e:

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -881,6 +881,41 @@ class GitHubCodeClient:
         ]
         return commits, window_truncated
 
+    async def get_latest_commit_sha(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        ref: str,
+        until: datetime,
+    ) -> str | None:
+        params: dict[str, Any] = {
+            "per_page": 1,
+            "sha": ref,
+            "until": until.isoformat(),
+        }
+        operation = f"{GIT_ROUTE_FAMILY}:GET /repos/{owner}/{repo}/commits latest"
+        encoded_owner = urllib.parse.quote(str(owner), safe="")
+        encoded_repo = urllib.parse.quote(str(repo), safe="")
+        response = await self._core.request(
+            "GET",
+            f"/repos/{encoded_owner}/{encoded_repo}/commits",
+            operation=operation,
+            params=params,
+        )
+        payload = response.json()
+        if not isinstance(payload, list):
+            raise APIException(
+                f"Unexpected latest commit response for {operation}: {type(payload)!r}"
+            )
+        if not payload:
+            return None
+        first = payload[0]
+        if not isinstance(first, Mapping):
+            return None
+        sha = first.get("sha")
+        return sha if isinstance(sha, str) and sha else None
+
     async def iter_pulls(
         self,
         owner: str,

--- a/src/dev_health_ops/providers/gitlab/code_client.py
+++ b/src/dev_health_ops/providers/gitlab/code_client.py
@@ -789,6 +789,29 @@ class GitLabCodeClient:
         )
         return [_map_commit(item) for item in raw_items[:max_commits]]
 
+    async def get_latest_commit_sha(
+        self,
+        project_id: int | str,
+        *,
+        ref: str,
+        until: datetime,
+    ) -> str | None:
+        encoded_project_id = _encode_project_id(project_id)
+        raw_items = await self._get_gitlab_list(
+            f"/projects/{encoded_project_id}/repository/commits",
+            operation=f"{_PROJECT_FAMILY_PREFIX}:GET /projects/{{id}}/repository/commits latest",
+            params={
+                "ref_name": ref,
+                "until": _format_gitlab_window_datetime(until),
+            },
+            per_page=1,
+            paginate=False,
+            max_items=1,
+        )
+        if not raw_items:
+            return None
+        return _map_commit(raw_items[0]).commit_id or None
+
     async def get_commit_stats(
         self, project_id: int | str, commit_sha: str
     ) -> GitLabCommitStatsData:

--- a/src/dev_health_ops/workers/post_sync_dispatch.py
+++ b/src/dev_health_ops/workers/post_sync_dispatch.py
@@ -9,6 +9,7 @@ from typing import Any
 from celery import chain
 
 from dev_health_ops.models import SyncRun, SyncRunUnit, SyncRunUnitStatus
+from dev_health_ops.utils.datetime import utc_today
 from dev_health_ops.workers.celery_app import celery_app
 from dev_health_ops.workers.task_utils import _GIT_TARGETS, _WORK_ITEM_TARGETS
 
@@ -186,15 +187,40 @@ def _dispatch_post_sync_tasks(
     # downstream steps would fail anyway; daily also degrades gracefully on a
     # missing snapshot, so the next cycle recovers. If hard isolation is ever
     # needed, decouple via a non-raising wrapper task rather than link_error.
+    # Historical backfills must not enqueue complexity implicitly: run_complexity_db_job
+    # scans CURRENT persisted file contents/blame, so writing it across a
+    # historical window (or a past single day) would fabricate a flat/incorrect
+    # historical complexity trend rather than reflecting real historical state
+    # (CHAOS-2888). Complexity is safe to enqueue only for a current single-day
+    # sync: backfill_days in (None, 1) and day absent or == utc_today().
     complexity_sig = None
     if has_git:
-        complexity_sig = celery_app.signature(
-            "dev_health_ops.workers.tasks.run_complexity_job",
-            kwargs={"org_id": org_id},
-            queue="metrics",
-            immutable=True,
+        is_current_single_day = metrics_backfill_days in (None, 1) and (
+            metrics_day is None or metrics_day == utc_today().isoformat()
         )
-        dispatched.append("run_complexity_job")
+        if is_current_single_day:
+            complexity_kwargs: dict[str, Any] = {"org_id": org_id}
+            if metrics_day is not None:
+                complexity_kwargs["day"] = metrics_day
+                complexity_kwargs["backfill_days"] = 1
+            complexity_sig = celery_app.signature(
+                "dev_health_ops.workers.tasks.run_complexity_job",
+                kwargs=complexity_kwargs,
+                queue="metrics",
+                immutable=True,
+            )
+            dispatched.append("run_complexity_job")
+        else:
+            logger.warning(
+                "historical_complexity_unsupported: skipping run_complexity_job "
+                "org_id=%s from_date=%s to_date=%s metrics_day=%s "
+                "metrics_backfill_days=%s",
+                org_id,
+                from_date,
+                to_date,
+                metrics_day,
+                metrics_backfill_days,
+            )
 
     if has_git or has_work_items:
         build_kwargs: dict[str, Any] = {"org_id": org_id}

--- a/tests/_complexity_readiness_fixtures.py
+++ b/tests/_complexity_readiness_fixtures.py
@@ -1,0 +1,88 @@
+"""Shared ClickHouse-query fake for CHAOS-2888 Workstream D complexity-
+readiness regression tests.
+
+Both ``tests/test_github_content_backfill.py`` and
+``tests/test_gitlab_content_backfill.py`` prove that persisted ``git_files``
+content -- fetched through the provider-specific code-host backfill path --
+satisfies ``job_complexity_db.run_complexity_db_job``'s readiness contract.
+This fake answers each of the job's queries from its actual persisted shape
+(git_files counts, non-empty contents, missing-content paths, the
+``git_blame`` usable-line-text probe, and ``maxOrNull`` last-synced lookups)
+instead of a blanket substring match, and raises loudly on any query shape
+neither test exercises so a future job change that adds or renames a query
+is caught here instead of silently returning an empty result set.
+"""
+
+from __future__ import annotations
+
+
+class ComplexityReadinessClient:
+    """Minimal ClickHouse client stand-in that answers
+    ``job_complexity_db``'s queries purely from the ``(path, contents)`` rows
+    a code-host content backfill just wrote -- proving persisted
+    ``git_files`` content satisfies the complexity job's readiness contract
+    end-to-end (CHAOS-2888 Workstream D)."""
+
+    def __init__(self, files: list[tuple[str, str | None]]):
+        self._total = len(files)
+        self._non_empty = [[path, contents] for path, contents in files if contents]
+        self._missing_paths = [path for path, contents in files if not contents]
+
+    def query(self, query, parameters=None):
+        del parameters
+
+        class _Result:
+            result_rows: list = []
+
+        result = _Result()
+        is_git_files = "FROM git_files" in query
+        is_git_blame = "FROM git_blame" in query
+
+        if is_git_files and "count()" in query:
+            # job_complexity_db._git_file_counts
+            result.result_rows = [[self._total, len(self._non_empty)]]
+        elif is_git_files and "contents IS NOT NULL" in query:
+            # job_complexity_db._load_git_files
+            result.result_rows = [list(row) for row in self._non_empty]
+        elif is_git_files and "contents IS NULL" in query:
+            # job_complexity_db._load_missing_paths
+            result.result_rows = [[path] for path in self._missing_paths]
+        elif is_git_blame and "line IS NOT NULL" in query:
+            # job_complexity_db._has_blame_line_text -- this fixture never
+            # seeds usable blame line text, so the probe always reports
+            # "unusable", matching every real GitHub/GitLab sync today
+            # (CHAOS-2861/CHAOS-2860).
+            result.result_rows = []
+        elif is_git_blame:
+            # job_complexity_db._load_blame_contents -- no blame fallback
+            # rows in this fixture.
+            result.result_rows = []
+        elif "maxOrNull" in query:
+            # job_complexity_db._max_last_synced (git_files/git_blame probes).
+            result.result_rows = [[None]]
+        else:
+            raise AssertionError(
+                "ComplexityReadinessClient received an unrecognized query "
+                "shape -- update this fixture to handle it explicitly "
+                f"instead of silently returning empty rows: {query!r}"
+            )
+        return result
+
+
+class ComplexityReadinessSink:
+    def __init__(self, client: ComplexityReadinessClient):
+        self.client = client
+        self.snapshots: list = []
+        self.dailies: list = []
+
+    def ensure_tables(self) -> None:
+        return None
+
+    def write_file_complexity_snapshots(self, rows) -> None:
+        self.snapshots.extend(rows)
+
+    def write_repo_complexity_daily(self, rows) -> None:
+        self.dailies.extend(rows)
+
+    def close(self) -> None:
+        return None

--- a/tests/metrics/test_compounding_risk.py
+++ b/tests/metrics/test_compounding_risk.py
@@ -9,12 +9,19 @@ import pytest
 from dev_health_ops.metrics.compounding_risk import (
     DEFAULT_THRESHOLDS,
     DEFAULT_WEIGHTS,
+    REASON_MISSING_COMPLEXITY_DELTA,
+    REASON_MISSING_OWNERSHIP_SIGNAL,
+    REASON_MISSING_REVIEW_LATENCY,
+    REASON_MISSING_REWORK_CHURN,
     REFERENCE_VALUES,
     CompoundingInputs,
+    CompoundingRiskDiagnostics,
     CompoundingThresholds,
     CompoundingWeights,
     compute_compounding_risk,
+    missing_input_reasons,
     severity_for,
+    summarize_compounding_risk_diagnostics,
 )
 
 NOW = datetime(2026, 5, 21, 12, 0, 0, tzinfo=timezone.utc)
@@ -571,3 +578,119 @@ def test_orchestrator_team_rows_inherit_weights_and_thresholds() -> None:
     team_row = next(r for r in out if r.scope == "team")
     assert team_row.w_churn == DEFAULT_WEIGHTS.churn
     assert team_row.threshold_elevated == DEFAULT_THRESHOLDS.elevated
+
+
+# ---------------------------------------------------------------------------
+# Diagnostics contract (CHAOS-2888)
+# ---------------------------------------------------------------------------
+
+
+def test_missing_input_reasons_empty_when_all_required_inputs_present() -> None:
+    assert missing_input_reasons(_inputs()) == []
+
+
+def test_missing_input_reasons_names_each_missing_signal() -> None:
+    inputs = CompoundingInputs(
+        rework_churn=None,
+        complexity_delta=None,
+        review_latency_p90h=None,
+        single_owner_ratio=None,
+        ownership_gini=None,
+    )
+    assert missing_input_reasons(inputs) == [
+        REASON_MISSING_REWORK_CHURN,
+        REASON_MISSING_COMPLEXITY_DELTA,
+        REASON_MISSING_REVIEW_LATENCY,
+        REASON_MISSING_OWNERSHIP_SIGNAL,
+    ]
+
+
+def test_missing_input_reasons_ownership_needs_both_signals_absent() -> None:
+    present = _inputs(single_owner_ratio=0.4, ownership_gini=None)
+    assert missing_input_reasons(present) == []
+    absent = _inputs(single_owner_ratio=None, ownership_gini=None)
+    assert missing_input_reasons(absent) == [REASON_MISSING_OWNERSHIP_SIGNAL]
+
+
+def test_summarize_diagnostics_full_input_row_is_non_null_and_reason_free() -> None:
+    row = _compute(_inputs())
+    diagnostics = summarize_compounding_risk_diagnostics([row])
+    assert diagnostics == CompoundingRiskDiagnostics(
+        total_rows=1,
+        non_null_rows=1,
+        unknown_rows=0,
+        reason_counts={
+            REASON_MISSING_REWORK_CHURN: 0,
+            REASON_MISSING_COMPLEXITY_DELTA: 0,
+            REASON_MISSING_REVIEW_LATENCY: 0,
+            REASON_MISSING_OWNERSHIP_SIGNAL: 0,
+        },
+    )
+
+
+def test_summarize_diagnostics_counts_missing_complexity_delta() -> None:
+    row = _compute(_inputs(complexity_delta=None))
+    diagnostics = summarize_compounding_risk_diagnostics([row])
+    assert diagnostics.non_null_rows == 0
+    assert diagnostics.unknown_rows == 1
+    assert diagnostics.reason_counts[REASON_MISSING_COMPLEXITY_DELTA] == 1
+
+
+def test_summarize_diagnostics_aggregates_across_multiple_rows() -> None:
+    full_row = _compute(_inputs())
+    missing_review_row = _compute(_inputs(review_latency_p90h=None))
+    diagnostics = summarize_compounding_risk_diagnostics([full_row, missing_review_row])
+    assert diagnostics.total_rows == 2
+    assert diagnostics.non_null_rows == 1
+    assert diagnostics.unknown_rows == 1
+    assert diagnostics.reason_counts[REASON_MISSING_REVIEW_LATENCY] == 1
+    assert diagnostics.reason_counts[REASON_MISSING_COMPLEXITY_DELTA] == 0
+
+
+def test_summarize_diagnostics_empty_rows_seeds_all_reasons_at_zero() -> None:
+    diagnostics = summarize_compounding_risk_diagnostics([])
+    assert diagnostics == CompoundingRiskDiagnostics(
+        total_rows=0,
+        non_null_rows=0,
+        unknown_rows=0,
+        reason_counts={
+            REASON_MISSING_REWORK_CHURN: 0,
+            REASON_MISSING_COMPLEXITY_DELTA: 0,
+            REASON_MISSING_REVIEW_LATENCY: 0,
+            REASON_MISSING_OWNERSHIP_SIGNAL: 0,
+        },
+    )
+
+
+def test_summarize_diagnostics_counts_missing_ownership_signal() -> None:
+    row = _compute(_inputs(single_owner_ratio=None, ownership_gini=None))
+    diagnostics = summarize_compounding_risk_diagnostics([row])
+    assert diagnostics.non_null_rows == 0
+    assert diagnostics.unknown_rows == 1
+    assert diagnostics.reason_counts[REASON_MISSING_OWNERSHIP_SIGNAL] == 1
+
+
+def test_orchestrator_rows_summarize_missing_complexity_delta_when_history_absent() -> (
+    None
+):
+    repo = uuid.uuid4()
+    sink = _FakeSink({})  # no persisted repo_complexity_daily history
+    repo_rows = [
+        _FakeRepoMetrics(
+            repo_id=repo,
+            rework_churn_ratio_30d=0.1,
+            single_owner_file_ratio_30d=0.5,
+            code_ownership_gini=0.5,
+            pr_first_review_p90_hours=24.0,
+        ),
+    ]
+    out = build_compounding_risk_rows_for_day(
+        sink=sink,
+        day=DAY,
+        org_id="acme",
+        repo_metrics_rows=repo_rows,
+        computed_at=NOW,
+    )
+    diagnostics = summarize_compounding_risk_diagnostics(out)
+    assert diagnostics.reason_counts[REASON_MISSING_COMPLEXITY_DELTA] == 1
+    assert diagnostics.unknown_rows == 1

--- a/tests/metrics/test_job_compounding_risk.py
+++ b/tests/metrics/test_job_compounding_risk.py
@@ -1,0 +1,227 @@
+"""Unit tests for the standalone compounding-risk job (CHAOS-2888).
+
+Covers the Workstream B contract: full-input recompute produces a non-null
+score, missing complexity history is surfaced via the shared
+``missing_complexity_delta`` reason, and repeated recompute with unchanged
+persisted inputs is deterministic (append-only writes, equivalent
+score/severity across recomputes).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import uuid
+from datetime import date, timedelta
+from typing import Any
+
+from dev_health_ops.metrics import job_compounding_risk
+from dev_health_ops.metrics.compounding_risk import (
+    MISSING_INPUT_REASONS,
+    REASON_MISSING_COMPLEXITY_DELTA,
+)
+from dev_health_ops.metrics.job_compounding_risk import run_compounding_risk_job
+
+DAY = date(2026, 5, 20)
+
+
+class _FakeSink:
+    """Duck-typed stand-in for ``ClickHouseMetricsSink`` used by the job.
+
+    Only implements the surface ``run_compounding_risk_job`` actually calls:
+    ``ensure_tables``, ``get_all_teams`` (async), ``query_dicts``, and
+    ``write_compounding_risk_daily``.
+    """
+
+    def __init__(
+        self,
+        *,
+        repo_metrics_by_day: dict[date, list[dict[str, Any]]],
+        complexity_by_repo: dict[str, dict[str, float | None] | None] | None = None,
+    ) -> None:
+        self._repo_metrics_by_day = repo_metrics_by_day
+        self._complexity_by_repo = complexity_by_repo or {}
+        self.written: list[Any] = []
+
+    def ensure_tables(self) -> None:
+        return None
+
+    async def get_all_teams(self) -> list[Any]:
+        return []
+
+    def query_dicts(
+        self, query: str, parameters: dict[str, Any]
+    ) -> list[dict[str, Any]]:
+        if "FROM repos" in query:
+            return []
+        if "FROM repo_metrics_daily" in query:
+            return list(self._repo_metrics_by_day.get(parameters["day"], []))
+        if "FROM repo_complexity_daily" in query:
+            result = self._complexity_by_repo.get(parameters["repo_id"])
+            return [result] if result is not None else []
+        raise AssertionError(f"unexpected query: {query}")
+
+    def write_compounding_risk_daily(self, rows: list[Any]) -> None:
+        self.written.extend(rows)
+
+
+def _run(*, day: date = DAY, backfill_days: int = 1) -> int:
+    return asyncio.run(
+        run_compounding_risk_job(
+            db_url="clickhouse://localhost:8123/default",
+            day=day,
+            backfill_days=backfill_days,
+            org_id="acme",
+        )
+    )
+
+
+def test_full_input_recompute_writes_non_null_non_unknown_row(
+    monkeypatch: Any,
+) -> None:
+    repo_id = uuid.uuid4()
+    sink = _FakeSink(
+        repo_metrics_by_day={
+            DAY: [
+                {
+                    "repo_id": str(repo_id),
+                    "rework_churn_ratio_30d": 0.12,
+                    "single_owner_file_ratio_30d": 0.5,
+                    "code_ownership_gini": 0.4,
+                    "bus_factor": 2,
+                    "pr_first_review_p90_hours": 18.0,
+                }
+            ]
+        },
+        complexity_by_repo={str(repo_id): {"first_half": 100.0, "second_half": 118.0}},
+    )
+    monkeypatch.setattr(
+        job_compounding_risk, "ClickHouseMetricsSink", lambda db_url: sink
+    )
+
+    exit_code = _run()
+
+    assert exit_code == 0
+    assert len(sink.written) == 1
+    row = sink.written[0]
+    assert row.compounding_risk is not None
+    assert row.severity != "unknown"
+
+
+def test_missing_complexity_history_reports_missing_complexity_delta_reason(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    repo_id = uuid.uuid4()
+    sink = _FakeSink(
+        repo_metrics_by_day={
+            DAY: [
+                {
+                    "repo_id": str(repo_id),
+                    "rework_churn_ratio_30d": 0.10,
+                    "single_owner_file_ratio_30d": 0.4,
+                    "code_ownership_gini": 0.3,
+                    "bus_factor": 3,
+                    "pr_first_review_p90_hours": 20.0,
+                }
+            ]
+        },
+        complexity_by_repo={},  # no persisted repo_complexity_daily history
+    )
+    monkeypatch.setattr(
+        job_compounding_risk, "ClickHouseMetricsSink", lambda db_url: sink
+    )
+
+    with caplog.at_level("INFO", logger=job_compounding_risk.logger.name):
+        exit_code = _run()
+
+    assert exit_code == 0
+    row = sink.written[0]
+    assert row.compounding_risk is None
+    assert row.severity == "unknown"
+    assert any(
+        REASON_MISSING_COMPLEXITY_DELTA in message for message in caplog.messages
+    )
+
+
+def test_repeated_recompute_with_same_inputs_is_idempotent(monkeypatch: Any) -> None:
+    repo_id = uuid.uuid4()
+    sink = _FakeSink(
+        repo_metrics_by_day={
+            DAY: [
+                {
+                    "repo_id": str(repo_id),
+                    "rework_churn_ratio_30d": 0.15,
+                    "single_owner_file_ratio_30d": 0.6,
+                    "code_ownership_gini": 0.5,
+                    "bus_factor": 2,
+                    "pr_first_review_p90_hours": 30.0,
+                }
+            ]
+        },
+        complexity_by_repo={str(repo_id): {"first_half": 100.0, "second_half": 125.0}},
+    )
+    monkeypatch.setattr(
+        job_compounding_risk, "ClickHouseMetricsSink", lambda db_url: sink
+    )
+
+    _run()
+    _run()  # recompute: persisted inputs unchanged, second write is appended
+
+    # Append-only: both rows are present (no overwrite/dedup of the first
+    # write), and the second row's computed_at is never earlier than the
+    # first's -- each recompute stamps its own compute moment rather than
+    # mutating the prior row in place.
+    assert len(sink.written) == 2
+    first, second = sink.written
+    assert first.scope_id == second.scope_id == str(repo_id)
+    assert second.computed_at >= first.computed_at
+    # Recompute with unchanged inputs must not drift the score/severity
+    # between the two writes (a reader resolves the latest row via
+    # argMax(computed_at)).
+    assert first.compounding_risk == second.compounding_risk
+    assert first.severity == second.severity
+
+
+def test_backfill_day_with_no_repo_metrics_rows_is_named_in_final_summary(
+    monkeypatch: Any, caplog: Any
+) -> None:
+    repo_id = uuid.uuid4()
+    sink = _FakeSink(
+        repo_metrics_by_day={
+            DAY: [
+                {
+                    "repo_id": str(repo_id),
+                    "rework_churn_ratio_30d": 0.12,
+                    "single_owner_file_ratio_30d": 0.5,
+                    "code_ownership_gini": 0.4,
+                    "bus_factor": 2,
+                    "pr_first_review_p90_hours": 18.0,
+                }
+            ]
+            # DAY - 1 intentionally has no repo_metrics_daily rows.
+        },
+        complexity_by_repo={str(repo_id): {"first_half": 100.0, "second_half": 118.0}},
+    )
+    monkeypatch.setattr(
+        job_compounding_risk, "ClickHouseMetricsSink", lambda db_url: sink
+    )
+
+    empty_day = DAY - timedelta(days=1)
+    with caplog.at_level("INFO", logger=job_compounding_risk.logger.name):
+        exit_code = _run(backfill_days=2)
+
+    assert exit_code == 0
+    assert len(sink.written) == 1  # only the day with rows produced output
+
+    done_messages = [
+        m for m in caplog.messages if m.startswith("compounding-risk: done")
+    ]
+    assert len(done_messages) == 1
+    done_message = done_messages[0]
+    # The zero-row day is named in the final summary, so operators can
+    # distinguish "no repos synced this day" from "repos synced but all
+    # required inputs were null".
+    assert empty_day.isoformat() in done_message
+    # Fixed reason keys are always present, in stable order, even though
+    # only one of the two backfilled days actually produced diagnostics.
+    for reason in MISSING_INPUT_REASONS:
+        assert f"'{reason}': 0" in done_message

--- a/tests/providers/test_github_code_client_commits.py
+++ b/tests/providers/test_github_code_client_commits.py
@@ -125,6 +125,32 @@ async def _test_commits_usage_resolves_to_git_family() -> None:
     assert observations[0]["request_count"] == 1
 
 
+def test_latest_commit_sha_sends_ref_and_until_window() -> None:
+    asyncio.run(_test_latest_commit_sha_sends_ref_and_until_window())
+
+
+async def _test_latest_commit_sha_sends_ref_and_until_window() -> None:
+    seen: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen.append(request)
+        return httpx.Response(200, json=[{"sha": "abc123"}])
+
+    client = _client(httpx.MockTransport(handler))
+    until = datetime(2026, 1, 2, tzinfo=timezone.utc)
+
+    sha = await client.get_latest_commit_sha("acme", "widgets", ref="main", until=until)
+    observations = client.drain_usage_observations()
+    await client.close()
+
+    assert sha == "abc123"
+    assert seen[0].url.params["sha"] == "main"
+    assert seen[0].url.params["until"] == until.isoformat()
+    assert seen[0].url.params["per_page"] == "1"
+    assert observations[0]["route_family"] == "git"
+    assert observations[0]["request_count"] == 1
+
+
 def test_uncapped_commits_follow_all_link_pages() -> None:
     asyncio.run(_test_uncapped_commits_follow_all_link_pages())
 

--- a/tests/providers/test_gitlab_code_client.py
+++ b/tests/providers/test_gitlab_code_client.py
@@ -902,6 +902,30 @@ class TestCommitsParity:
         assert calls[_COMMITS_PATH] == 2
 
     @pytest.mark.asyncio
+    async def test_latest_commit_sha_sends_ref_and_until_window(self) -> None:
+        commit = {"id": "abc123", "committed_date": "2026-01-10T00:00:00Z"}
+        transport, calls = _router_transport(
+            {_COMMITS_PATH: _json_response(200, [commit])}
+        )
+        client = _client(transport)
+        until = datetime(2026, 1, 31, tzinfo=timezone.utc)
+
+        sha = await client.get_latest_commit_sha(42, ref="main", until=until)
+
+        assert sha == "abc123"
+        assert calls[_COMMITS_PATH] == 1
+        query = dict(transport.captured_urls[_COMMITS_PATH].params)  # type: ignore[attr-defined]
+        assert query == {
+            "ref_name": "main",
+            "until": "2026-01-31T00:00:00Z",
+            "page": "1",
+            "per_page": "1",
+        }
+        observations = client.drain_usage_observations()
+        assert observations[0]["route_family"] == "project"
+        assert observations[0]["request_count"] == 1
+
+    @pytest.mark.asyncio
     async def test_commit_stats_maps_aggregate_stats_and_usage_family(self) -> None:
         detail = {"id": "abc123", "stats": {"additions": 12, "deletions": 3}}
         transport, calls = _router_transport(

--- a/tests/test_backfill_observability.py
+++ b/tests/test_backfill_observability.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import importlib
 import uuid
+from contextlib import asynccontextmanager
 from datetime import date
 from pathlib import Path
 
@@ -13,6 +14,15 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.backfill import BackfillJobService
+from dev_health_ops.api.services.backfill_diagnostics import (
+    build_backfill_metrics_diagnostics,
+)
+from dev_health_ops.metrics.compounding_risk import (
+    REASON_MISSING_COMPLEXITY_DELTA,
+    REASON_MISSING_OWNERSHIP_SIGNAL,
+    REASON_MISSING_REVIEW_LATENCY,
+    REASON_MISSING_REWORK_CHURN,
+)
 from dev_health_ops.models.backfill import BackfillJob
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.settings import SyncConfiguration
@@ -20,7 +30,40 @@ from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
 admin_router_module = importlib.import_module("dev_health_ops.api.admin")
+sync_router_module = importlib.import_module("dev_health_ops.api.admin.routers.sync")
 auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+
+class _FakeMetricsSink:
+    """Fake ClickHouse metrics sink for backfill diagnostics tests.
+
+    Rows are dispatched by matching a table-name substring in the query
+    text -- mirrors the real diagnostics builder, which issues one query
+    per table (``repo_metrics_daily``, ``repo_complexity_daily``,
+    ``compounding_risk_daily``).
+    """
+
+    def __init__(self) -> None:
+        self.repo_metrics_rows: list[dict] = []
+        self.repo_complexity_rows: list[dict] = []
+        self.compounding_risk_rows: list[dict] = []
+        self.calls: list[dict] = []
+        self.queries: list[str] = []
+        self.open_calls: int = 0
+
+    def query_dicts(self, query: str, parameters: dict) -> list[dict]:
+        self.calls.append(parameters)
+        self.queries.append(query)
+        if "repo_metrics_daily" in query:
+            return self.repo_metrics_rows
+        if "repo_complexity_daily" in query:
+            return self.repo_complexity_rows
+        if "compounding_risk_daily" in query:
+            return self.compounding_risk_rows
+        # Fail loudly rather than silently returning no rows: an unrecognized
+        # query means the diagnostics builder changed and this fake is stale.
+        raise ValueError(f"_FakeMetricsSink received unexpected query: {query!r}")
+
 
 _TABLES = tables_of(User, Organization, SyncConfiguration, BackfillJob)
 
@@ -92,12 +135,28 @@ async def client(session_maker, seeded_state):
             yield session
             await session.commit()
 
+    metrics_sink = _FakeMetricsSink()
+
+    @asynccontextmanager
+    async def _metrics_sink_cm():
+        # Counts how many times the lazy sink factory is actually entered,
+        # so tests can prove a 404 detail response never opens the sink
+        # (CHAOS-2888 Workstream C review fix).
+        metrics_sink.open_calls += 1
+        yield metrics_sink
+
+    def _metrics_sink_factory_override():
+        return _metrics_sink_cm
+
     app.dependency_overrides[auth_router_module.get_current_user] = lambda: admin_user
     app.dependency_overrides[admin_router_module.get_session] = _session_override
+    app.dependency_overrides[sync_router_module.get_backfill_metrics_sink] = (
+        _metrics_sink_factory_override
+    )
 
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as ac:
-        yield ac, seeded_state
+        yield ac, seeded_state, metrics_sink
 
     app.dependency_overrides.clear()
 
@@ -218,7 +277,7 @@ async def test_backfill_job_service_status_transitions(session_maker, seeded_sta
 
 @pytest.mark.asyncio
 async def test_backfill_job_endpoints_return_expected_schema(client, session_maker):
-    ac, seeded_state = client
+    ac, seeded_state, _metrics_sink = client
 
     async with session_maker() as session:
         svc = BackfillJobService(session, seeded_state["org_id"])
@@ -255,10 +314,223 @@ async def test_backfill_job_endpoints_return_expected_schema(client, session_mak
     assert detail_data["completed_chunks"] == 2
     assert detail_data["failed_chunks"] == 1
     assert detail_data["progress_pct"] == 40.0
+    assert detail_data["metrics_diagnostics"] is not None
+    assert detail_data["metrics_diagnostics"]["range_start"] == "2026-03-01"
+    assert detail_data["metrics_diagnostics"]["range_end"] == "2026-03-05"
+
+    list_item = next(item for item in list_data["items"] if item["id"] == job_id)
+    assert list_item["metrics_diagnostics"] is None
 
 
 @pytest.mark.asyncio
 async def test_backfill_job_detail_not_found_returns_404(client):
-    ac, _ = client
+    ac, _seeded_state, metrics_sink = client
     resp = await ac.get(f"/api/v1/admin/backfill-jobs/{uuid.uuid4()}")
     assert resp.status_code == 404
+    # A missing job must never open the ClickHouse diagnostics sink
+    # (CHAOS-2888 Workstream C review fix): the factory is only entered
+    # after the job-existence check passes.
+    assert metrics_sink.open_calls == 0
+    assert metrics_sink.calls == []
+
+
+# ---------------------------------------------------------------------------
+# Metrics diagnostics builder (CHAOS-2888 Workstream C, pure aggregation)
+# ---------------------------------------------------------------------------
+
+
+def test_build_backfill_metrics_diagnostics_aggregates_row_counts_and_reasons() -> None:
+    sink = _FakeMetricsSink()
+    sink.repo_metrics_rows = [
+        {"day": date(2026, 4, 1), "row_count": 2},
+        {"day": date(2026, 4, 2), "row_count": 1},
+    ]
+    sink.repo_complexity_rows = [
+        {"day": date(2026, 4, 1), "row_count": 2},
+    ]
+    sink.compounding_risk_rows = [
+        {
+            "day": date(2026, 4, 1),
+            "total_rows": 2,
+            "non_null_rows": 1,
+            "unknown_rows": 1,
+            "missing_rework_churn": 0,
+            "missing_complexity_delta": 1,
+            "missing_review_latency": 0,
+            "missing_ownership_signal": 0,
+        },
+        {
+            "day": date(2026, 4, 2),
+            "total_rows": 1,
+            "non_null_rows": 1,
+            "unknown_rows": 0,
+            "missing_rework_churn": 0,
+            "missing_complexity_delta": 0,
+            "missing_review_latency": 0,
+            "missing_ownership_signal": 0,
+        },
+    ]
+
+    diagnostics = build_backfill_metrics_diagnostics(
+        sink,
+        org_id="acme",
+        range_start=date(2026, 4, 1),
+        range_end=date(2026, 4, 2),
+    )
+
+    assert diagnostics.range_start == date(2026, 4, 1)
+    assert diagnostics.range_end == date(2026, 4, 2)
+    assert diagnostics.aggregate.repo_metrics_rows == 3
+    assert diagnostics.aggregate.repo_complexity_rows == 2
+    assert diagnostics.aggregate.compounding_risk_rows == 3
+    assert diagnostics.aggregate.compounding_risk_non_null_rows == 2
+    assert diagnostics.aggregate.compounding_risk_unknown_rows == 1
+    assert diagnostics.aggregate.reason_counts[REASON_MISSING_COMPLEXITY_DELTA] == 1
+    assert diagnostics.aggregate.reason_counts[REASON_MISSING_REWORK_CHURN] == 0
+    assert len(diagnostics.per_day) == 2
+    day1, day2 = diagnostics.per_day
+    assert day1.day == date(2026, 4, 1)
+    assert day1.repo_complexity_rows == 2
+    assert day1.compounding_risk_unknown_rows == 1
+    assert day2.day == date(2026, 4, 2)
+    assert day2.repo_complexity_rows == 0
+    assert day2.compounding_risk_unknown_rows == 0
+
+
+def test_build_backfill_metrics_diagnostics_reports_unsupported_historical_complexity() -> (
+    None
+):
+    sink = _FakeMetricsSink()
+    sink.repo_metrics_rows = [
+        {"day": date(2026, 5, 1), "row_count": 3},
+        {"day": date(2026, 5, 2), "row_count": 3},
+    ]
+    # No repo_complexity_daily rows at all: historical complexity is
+    # unsupported for this window (CHAOS-2888 behavior contract item 3-5).
+    sink.compounding_risk_rows = [
+        {
+            "day": day,
+            "total_rows": 3,
+            "non_null_rows": 0,
+            "unknown_rows": 3,
+            "missing_rework_churn": 0,
+            "missing_complexity_delta": 3,
+            "missing_review_latency": 0,
+            "missing_ownership_signal": 0,
+        }
+        for day in (date(2026, 5, 1), date(2026, 5, 2))
+    ]
+
+    diagnostics = build_backfill_metrics_diagnostics(
+        sink,
+        org_id="acme",
+        range_start=date(2026, 5, 1),
+        range_end=date(2026, 5, 2),
+    )
+
+    assert diagnostics.aggregate.repo_complexity_rows == 0
+    assert diagnostics.aggregate.compounding_risk_non_null_rows == 0
+    assert diagnostics.aggregate.compounding_risk_unknown_rows == 6
+    assert diagnostics.aggregate.reason_counts[REASON_MISSING_COMPLEXITY_DELTA] == 6
+    for day in diagnostics.per_day:
+        assert day.repo_complexity_rows == 0
+        assert day.compounding_risk_non_null_rows == 0
+        assert (
+            day.reason_counts[REASON_MISSING_COMPLEXITY_DELTA]
+            == day.compounding_risk_rows
+        )
+
+
+def test_build_backfill_metrics_diagnostics_zero_fills_days_without_data() -> None:
+    sink = _FakeMetricsSink()  # no data anywhere
+    diagnostics = build_backfill_metrics_diagnostics(
+        sink, org_id="acme", range_start=date(2026, 6, 1), range_end=date(2026, 6, 3)
+    )
+    assert len(diagnostics.per_day) == 3
+    fixed_reasons = {
+        REASON_MISSING_REWORK_CHURN,
+        REASON_MISSING_COMPLEXITY_DELTA,
+        REASON_MISSING_REVIEW_LATENCY,
+        REASON_MISSING_OWNERSHIP_SIGNAL,
+    }
+    for day in diagnostics.per_day:
+        assert day.repo_metrics_rows == 0
+        assert day.repo_complexity_rows == 0
+        assert day.compounding_risk_rows == 0
+        assert set(day.reason_counts) == fixed_reasons
+        assert all(count == 0 for count in day.reason_counts.values())
+    assert diagnostics.aggregate.repo_metrics_rows == 0
+
+
+def test_build_backfill_metrics_diagnostics_scopes_compounding_risk_to_repo() -> None:
+    """The compounding_risk_daily read must filter to scope='repo'.
+
+    Rows are persisted per (day, scope, scope_id): a 'repo' row and a
+    'team' row both cover the same org/day. Without a scope filter, the
+    aggregate query's ``GROUP BY day`` sums across both scopes and
+    double-counts row/reason counts for orgs with team mappings
+    (CHAOS-2888 Workstream C review fix).
+    """
+    sink = _FakeMetricsSink()
+    build_backfill_metrics_diagnostics(
+        sink,
+        org_id="acme",
+        range_start=date(2026, 4, 1),
+        range_end=date(2026, 4, 2),
+    )
+    risk_queries = [q for q in sink.queries if "compounding_risk_daily" in q]
+    assert risk_queries, "compounding_risk_daily was never queried"
+    assert all("scope = 'repo'" in q for q in risk_queries)
+
+
+# ---------------------------------------------------------------------------
+# Detail endpoint wiring (CHAOS-2888 Workstream C, API surface)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_backfill_job_detail_reports_missing_complexity_delta_for_unsupported_historical_window(
+    client, session_maker
+):
+    ac, seeded_state, metrics_sink = client
+
+    async with session_maker() as session:
+        svc = BackfillJobService(session, seeded_state["org_id"])
+        job = await svc.create_job(
+            sync_config_id=seeded_state["sync_config_id"],
+            since=date(2026, 7, 1),
+            before=date(2026, 7, 2),
+            total_chunks=2,
+        )
+        await session.commit()
+        job_id = str(job.id)
+
+    metrics_sink.repo_metrics_rows = [
+        {"day": date(2026, 7, 1), "row_count": 2},
+        {"day": date(2026, 7, 2), "row_count": 2},
+    ]
+    metrics_sink.compounding_risk_rows = [
+        {
+            "day": day,
+            "total_rows": 2,
+            "non_null_rows": 0,
+            "unknown_rows": 2,
+            "missing_rework_churn": 0,
+            "missing_complexity_delta": 2,
+            "missing_review_latency": 0,
+            "missing_ownership_signal": 0,
+        }
+        for day in (date(2026, 7, 1), date(2026, 7, 2))
+    ]
+
+    resp = await ac.get(f"/api/v1/admin/backfill-jobs/{job_id}")
+    assert resp.status_code == 200
+    diagnostics = resp.json()["metrics_diagnostics"]
+    assert diagnostics["aggregate"]["repo_complexity_rows"] == 0
+    assert diagnostics["aggregate"]["compounding_risk_non_null_rows"] == 0
+    assert diagnostics["aggregate"]["compounding_risk_unknown_rows"] == 4
+    assert diagnostics["aggregate"]["reason_counts"]["missing_complexity_delta"] == 4
+    assert len(diagnostics["per_day"]) == 2
+    for day in diagnostics["per_day"]:
+        assert day["repo_complexity_rows"] == 0
+        assert day["reason_counts"]["missing_complexity_delta"] == 2

--- a/tests/test_github_content_backfill.py
+++ b/tests/test_github_content_backfill.py
@@ -26,6 +26,10 @@ from dev_health_ops.processors.github import (
     CONTENT_FETCH_MAX_BYTES,
     _fetch_scannable_contents,
 )
+from tests._complexity_readiness_fixtures import (
+    ComplexityReadinessClient,
+    ComplexityReadinessSink,
+)
 
 
 class _FakeCodeClient:
@@ -822,3 +826,254 @@ class TestCommitStatsBackfill:
 
         assert stats_args == [2]
         assert [row.commit_hash for row in written] == ["sha-0", "sha-1"]
+
+
+class TestGithubBackfillFeedsComplexityReadiness:
+    """CHAOS-2888 Workstream D: the whole point of scanner-driven content
+    backfill (CHAOS-2859) is that persisted ``git_files`` rows are enough for
+    ``job_complexity_db.run_complexity_db_job`` to succeed. These regression
+    tests wire the GitHub-specific fetch+persist path directly into the
+    complexity job's readiness contract, so a change on either side that
+    breaks the contract fails loudly here -- not only in production."""
+
+    @pytest.mark.asyncio
+    async def test_github_scanner_backfilled_contents_satisfy_complexity_job(
+        self, monkeypatch
+    ):
+        client = _FakeCodeClient(
+            contents={
+                "src/alpha.py": "def alpha():\n    return 1\n",
+                "src/beta.py": (
+                    "def beta(x):\n    if x:\n        return x\n    return 0\n"
+                ),
+            }
+        )
+        file_paths = ["src/alpha.py", "src/beta.py"]
+        blob_sizes: dict[str, int | None] = {"src/alpha.py": 40, "src/beta.py": 70}
+
+        contents_by_path = await _fetch_scannable_contents(
+            client, "octo", "repo", "main", file_paths, blob_sizes, "octo/repo"
+        )
+
+        written: list = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+        repo_id = uuid.uuid4()
+
+        await backfill_file_records(
+            sink,
+            repo_id,
+            file_paths,
+            "octo/repo",
+            contents_by_path=contents_by_path,
+        )
+
+        ch_client = ComplexityReadinessClient([(f.path, f.contents) for f in written])
+        ch_sink = ComplexityReadinessSink(ch_client)
+        monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: ch_sink)
+
+        rc = job.run_complexity_db_job(
+            repo_id=repo_id,
+            db_url="clickhouse://localhost:8123/default",
+            date=date(2026, 6, 12),
+            backfill_days=1,
+            language_globs=None,
+            max_files=None,
+            org_id="test-org",
+        )
+
+        assert rc == 0
+        assert client.file_content_calls == [
+            ("octo", "repo", ["src/alpha.py", "src/beta.py"], "main")
+        ]
+        assert {snap.file_path for snap in ch_sink.snapshots} == {
+            "src/alpha.py",
+            "src/beta.py",
+        }
+        assert sum(snap.functions_count for snap in ch_sink.snapshots) == 2
+        assert len(ch_sink.dailies) == 1
+        daily = ch_sink.dailies[0]
+        assert daily.day == date(2026, 6, 12)
+        assert daily.org_id == "test-org"
+        assert daily.loc_total > 0
+        assert daily.cyclomatic_total > 0
+
+    @pytest.mark.asyncio
+    async def test_github_paths_only_records_do_not_satisfy_complexity_job(
+        self, monkeypatch
+    ):
+        """A GitHub sync that has only written path rows (content backfill
+        not yet run, CHAOS-2859) must NOT let the complexity job silently
+        report success -- it must fail loudly per the job's existing
+        readiness contract."""
+        written: list = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+        repo_id = uuid.uuid4()
+
+        await backfill_file_records(
+            sink, repo_id, ["src/alpha.py", "src/beta.py"], "octo/repo"
+        )
+
+        assert [f.contents for f in written] == [None, None]
+
+        ch_client = ComplexityReadinessClient([(f.path, f.contents) for f in written])
+        ch_sink = ComplexityReadinessSink(ch_client)
+        monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: ch_sink)
+
+        rc = job.run_complexity_db_job(
+            repo_id=repo_id,
+            db_url="clickhouse://localhost:8123/default",
+            date=date(2026, 6, 12),
+            backfill_days=1,
+            language_globs=None,
+            max_files=None,
+            org_id="test-org",
+        )
+
+        assert rc == 1
+        assert not ch_sink.snapshots
+        assert not ch_sink.dailies
+
+    @pytest.mark.asyncio
+    async def test_partial_content_backfill_still_computes_complexity_for_available_files(
+        self, monkeypatch
+    ):
+        """A repo where content backfill only hydrated some paths (mixed
+        content / paths-only rows -- e.g. an in-progress CHAOS-2859 upgrade)
+        must still compute complexity from the files that DO have contents.
+        This exercises the complexity job's missing-paths query and
+        git_blame usable-line-text probe branches that the full-content and
+        empty-content cases above never reach."""
+        client = _FakeCodeClient(
+            contents={
+                "src/alpha.py": "def alpha():\n    return 1\n",
+                "src/beta.py": (
+                    "def beta(x):\n    if x:\n        return x\n    return 0\n"
+                ),
+            }
+        )
+        file_paths = ["src/alpha.py", "src/beta.py", "src/gamma.py"]
+        blob_sizes: dict[str, int | None] = {
+            "src/alpha.py": 40,
+            "src/beta.py": 70,
+            "src/gamma.py": 30,
+        }
+
+        contents_by_path = await _fetch_scannable_contents(
+            client, "octo", "repo", "main", file_paths, blob_sizes, "octo/repo"
+        )
+
+        written: list = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+        repo_id = uuid.uuid4()
+
+        await backfill_file_records(
+            sink,
+            repo_id,
+            file_paths,
+            "octo/repo",
+            contents_by_path=contents_by_path,
+        )
+
+        by_path = {f.path: f.contents for f in written}
+        assert by_path == {
+            "src/alpha.py": "def alpha():\n    return 1\n",
+            "src/beta.py": "def beta(x):\n    if x:\n        return x\n    return 0\n",
+            "src/gamma.py": None,
+        }
+
+        ch_client = ComplexityReadinessClient([(f.path, f.contents) for f in written])
+        ch_sink = ComplexityReadinessSink(ch_client)
+        monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: ch_sink)
+
+        rc = job.run_complexity_db_job(
+            repo_id=repo_id,
+            db_url="clickhouse://localhost:8123/default",
+            date=date(2026, 6, 12),
+            backfill_days=1,
+            language_globs=None,
+            max_files=None,
+            org_id="test-org",
+        )
+
+        assert rc == 0
+        assert {snap.file_path for snap in ch_sink.snapshots} == {
+            "src/alpha.py",
+            "src/beta.py",
+        }
+        assert len(ch_sink.dailies) == 1
+        assert ch_sink.dailies[0].loc_total > 0
+
+    @pytest.mark.asyncio
+    async def test_backfill_days_greater_than_one_does_not_fabricate_historical_rows(
+        self, monkeypatch
+    ):
+        """CHAOS-2850/2888: even when a historical multi-day window is
+        requested, the job has no historical content snapshot store, so it
+        must write exactly ONE ``repo_complexity_daily`` row -- for the
+        requested ``date`` only -- never ``backfill_days`` duplicate flat
+        rows that would fabricate a misleading historical trend."""
+        client = _FakeCodeClient(
+            contents={
+                "src/alpha.py": "def alpha():\n    return 1\n",
+                "src/beta.py": (
+                    "def beta(x):\n    if x:\n        return x\n    return 0\n"
+                ),
+            }
+        )
+        file_paths = ["src/alpha.py", "src/beta.py"]
+        blob_sizes: dict[str, int | None] = {"src/alpha.py": 40, "src/beta.py": 70}
+
+        contents_by_path = await _fetch_scannable_contents(
+            client, "octo", "repo", "main", file_paths, blob_sizes, "octo/repo"
+        )
+
+        written: list = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+        repo_id = uuid.uuid4()
+
+        await backfill_file_records(
+            sink,
+            repo_id,
+            file_paths,
+            "octo/repo",
+            contents_by_path=contents_by_path,
+        )
+
+        ch_client = ComplexityReadinessClient([(f.path, f.contents) for f in written])
+        ch_sink = ComplexityReadinessSink(ch_client)
+        monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: ch_sink)
+
+        rc = job.run_complexity_db_job(
+            repo_id=repo_id,
+            db_url="clickhouse://localhost:8123/default",
+            date=date(2026, 6, 12),
+            backfill_days=5,
+            language_globs=None,
+            max_files=None,
+            org_id="test-org",
+        )
+
+        assert rc == 0
+        assert len(ch_sink.dailies) == 1
+        assert ch_sink.dailies[0].day == date(2026, 6, 12)
+        assert len({snap.as_of_day for snap in ch_sink.snapshots}) == 1

--- a/tests/test_github_content_backfill.py
+++ b/tests/test_github_content_backfill.py
@@ -39,16 +39,39 @@ class _FakeCodeClient:
     tests double the CLIENT, never ``connector.get_file_contents``/
     ``connector.get_file_blame`` (which the processor no longer calls)."""
 
-    def __init__(self, *, contents=None, blame=None, issues=None, side_effect=None):
+    def __init__(
+        self,
+        *,
+        contents=None,
+        blame=None,
+        issues=None,
+        latest_commit_sha="resolved-sha",
+        side_effect=None,
+    ):
         self.contents = contents if contents is not None else {}
         self.blame = blame
         self.issues = issues if issues is not None else []
+        self.latest_commit_sha = latest_commit_sha
         self.side_effect = side_effect
+        self.latest_commit_calls: list[tuple[str, str, str, datetime]] = []
         self.file_content_calls: list[tuple[str, str, list[str], str]] = []
         self.file_blame_calls: list[tuple[str, str, str, str]] = []
         self.issue_calls: list[tuple[str, str, str, list[str], int | None]] = []
         self.drain_usage_observations = Mock(return_value=[])
         self.close = AsyncMock()
+
+    async def get_latest_commit_sha(
+        self,
+        owner: str,
+        repo: str,
+        *,
+        ref: str,
+        until: datetime,
+    ) -> str | None:
+        self.latest_commit_calls.append((owner, repo, ref, until))
+        if self.side_effect is not None:
+            raise self.side_effect
+        return self.latest_commit_sha
 
     async def get_file_contents(
         self,
@@ -417,7 +440,7 @@ class TestPathsOnlyUpgrade:
         by_path = {f.path: f.contents for f in written}
         assert by_path == {"src/app.py": "x = 1\n", "README.md": None}
         assert code_client.file_content_calls == [
-            ("octo", "repo", ["src/app.py"], "main")
+            ("octo", "repo", ["src/app.py"], "abc")
         ]
         code_client.close.assert_awaited_once()
         connector.get_file_contents.assert_not_called()
@@ -751,11 +774,108 @@ class TestCommitStatsBackfill:
 
         sink.insert_git_commit_stats.assert_not_called()
         assert stats_calls == []
-        assert code_client.file_blame_calls == [("octo", "repo", "src/app.py", "main")]
+        assert code_client.file_blame_calls == [
+            ("octo", "repo", "src/app.py", "resolved-sha")
+        ]
         code_client.close.assert_awaited_once()
         connector.get_file_blame.assert_not_called()
         assert [row.path for row in blame_rows] == ["src/app.py"]
         assert [row.line for row in blame_rows] == [None]
+
+    @pytest.mark.asyncio
+    async def test_historical_backfill_uses_resolved_ref_for_tree_content_blame_and_complexity(
+        self, monkeypatch
+    ):
+        from dev_health_ops.connectors.models import BlameRange, FileBlame
+        from dev_health_ops.processors import github
+        from dev_health_ops.processors.github import _backfill_github_missing_data
+
+        until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+
+        store = Mock()
+        store.org_id = "test-org"
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=True)
+        store.has_any_git_blame = AsyncMock(return_value=False)
+        store.get_blamed_paths = AsyncMock(return_value={"README.md"})
+
+        written_files = []
+        written_blame = []
+
+        async def insert_files(batch):
+            written_files.extend(batch)
+
+        async def insert_blame(batch):
+            written_blame.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert_files)
+        sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
+
+        metrics_sink = ComplexityReadinessSink(ComplexityReadinessClient([]))
+
+        gh_repo = Mock()
+        gh_repo.get_git_tree.return_value = Mock(
+            tree=[_FakeTreeEntry("src/app.py"), _FakeTreeEntry("README.md")]
+        )
+        connector = Mock()
+        connector.github.get_repo.return_value = gh_repo
+
+        code_client = _FakeCodeClient(
+            contents={"src/app.py": "def app():\n    return 1\n"},
+            blame=FileBlame(
+                file_path="src/app.py",
+                ranges=[
+                    BlameRange(
+                        starting_line=1,
+                        ending_line=1,
+                        commit_sha="resolved-sha",
+                        author="Ada",
+                        author_email="ada@example.com",
+                        age_seconds=0,
+                    )
+                ],
+            ),
+            latest_commit_sha="resolved-sha",
+        )
+        monkeypatch.setattr(
+            github, "_github_code_client_from_connector", lambda _connector: code_client
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_github_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            repo_full_name="octo/repo",
+            default_branch="main",
+            max_commits=None,
+            include_blame=True,
+            include_commit_stats=False,
+            until=until,
+            metrics_sink=metrics_sink,
+        )
+
+        assert code_client.latest_commit_calls == [("octo", "repo", "main", until)]
+        gh_repo.get_branch.assert_not_called()
+        gh_repo.get_git_tree.assert_called_once_with("resolved-sha", recursive=True)
+        assert code_client.file_content_calls == [
+            ("octo", "repo", ["src/app.py"], "resolved-sha")
+        ]
+        assert code_client.file_blame_calls == [
+            ("octo", "repo", "src/app.py", "resolved-sha")
+        ]
+        sink.insert_git_file_data.assert_not_called()
+        assert written_files == []
+        assert [row.commit_hash for row in written_blame] == ["resolved-sha"]
+        assert [snap.ref for snap in metrics_sink.snapshots] == ["resolved-sha"]
+        assert [snap.as_of_day for snap in metrics_sink.snapshots] == [until.date()]
+        assert [daily.day for daily in metrics_sink.dailies] == [until.date()]
+        assert metrics_sink.dailies[0].org_id == "test-org"
 
     @pytest.mark.asyncio
     async def test_backfill_commit_stats_full_history_writes_capped_sample(

--- a/tests/test_gitlab_content_backfill.py
+++ b/tests/test_gitlab_content_backfill.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import date, datetime, timezone
 from typing import Any, cast
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -21,6 +21,7 @@ import pytest
 # pre-existing providers._base <-> connectors circular import when this file
 # is collected in isolation.
 import dev_health_ops.connectors  # noqa: F401
+import dev_health_ops.metrics.job_complexity_db as job
 from dev_health_ops.metrics.sinks.ingestion import IngestionSink
 from dev_health_ops.processors import gitlab as gitlab_processor
 from dev_health_ops.processors.gitlab import (
@@ -33,6 +34,10 @@ from dev_health_ops.providers.gitlab.code_client import (
     GitLabCommitData,
     GitLabCommitStatsData,
     GitLabFileBlame,
+)
+from tests._complexity_readiness_fixtures import (
+    ComplexityReadinessClient,
+    ComplexityReadinessSink,
 )
 
 
@@ -935,3 +940,327 @@ def test_gitlab_mr_sync_flushes_rows_before_terminal_rate_limit() -> None:
         (99, 1, "all", 100),
         (99, 2, "all", 100),
     ]
+
+
+class TestGitLabBackfillFeedsComplexityReadiness:
+    """CHAOS-2888 Workstream D: mirrors the GitHub-side regression in
+    ``tests/test_github_content_backfill.py`` -- proves persisted
+    GitLab-backfilled ``git_files`` content satisfies the complexity job's
+    readiness contract end-to-end."""
+
+    @staticmethod
+    def _store() -> Mock:
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=False)
+        store.has_any_git_commit_stats = AsyncMock(return_value=True)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+        return store
+
+    @pytest.mark.asyncio
+    async def test_gitlab_scanner_backfilled_contents_satisfy_complexity_job(
+        self, monkeypatch
+    ):
+        store = self._store()
+        written: list = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+
+        project = Mock()
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = project
+
+        tree_items = [
+            {"type": "blob", "path": "src/alpha.py"},
+            {"type": "blob", "path": "src/beta.py"},
+        ]
+        fake_client = _FakeGitLabCodeClientForFiles(
+            contents={
+                "src/alpha.py": "def alpha():\n    return 1\n",
+                "src/beta.py": (
+                    "def beta(x):\n    if x:\n        return x\n    return 0\n"
+                ),
+            },
+            tree_items=tree_items,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_blame=False,
+            include_commit_stats=False,
+        )
+
+        ch_client = ComplexityReadinessClient([(f.path, f.contents) for f in written])
+        ch_sink = ComplexityReadinessSink(ch_client)
+        monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: ch_sink)
+
+        rc = job.run_complexity_db_job(
+            repo_id=db_repo.id,
+            db_url="clickhouse://localhost:8123/default",
+            date=date(2026, 6, 12),
+            backfill_days=1,
+            language_globs=None,
+            max_files=None,
+            org_id="test-org",
+        )
+
+        assert rc == 0
+        assert fake_client.get_file_contents_calls == [
+            ("group/proj", ("src/alpha.py", "src/beta.py"), "main", 1_000_000)
+        ]
+        assert {snap.file_path for snap in ch_sink.snapshots} == {
+            "src/alpha.py",
+            "src/beta.py",
+        }
+        assert sum(snap.functions_count for snap in ch_sink.snapshots) == 2
+        assert len(ch_sink.dailies) == 1
+        daily = ch_sink.dailies[0]
+        assert daily.day == date(2026, 6, 12)
+        assert daily.org_id == "test-org"
+        assert daily.loc_total > 0
+        assert daily.cyclomatic_total > 0
+
+    @pytest.mark.asyncio
+    async def test_gitlab_paths_only_records_do_not_satisfy_complexity_job(
+        self, monkeypatch
+    ):
+        """A GitLab sync that discovered file paths but whose content fetch
+        degraded to empty (content backfill not effectively run) must NOT
+        let the complexity job silently report success -- it must fail
+        loudly per the job's existing readiness contract."""
+        store = self._store()
+        written: list = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+
+        project = Mock()
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = project
+
+        tree_items = [
+            {"type": "blob", "path": "src/alpha.py"},
+            {"type": "blob", "path": "src/beta.py"},
+        ]
+        fake_client = _FakeGitLabCodeClientForFiles(
+            contents={},
+            tree_items=tree_items,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_blame=False,
+            include_commit_stats=False,
+        )
+
+        assert [f.contents for f in written] == [None, None]
+
+        ch_client = ComplexityReadinessClient([(f.path, f.contents) for f in written])
+        ch_sink = ComplexityReadinessSink(ch_client)
+        monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: ch_sink)
+
+        rc = job.run_complexity_db_job(
+            repo_id=db_repo.id,
+            db_url="clickhouse://localhost:8123/default",
+            date=date(2026, 6, 12),
+            backfill_days=1,
+            language_globs=None,
+            max_files=None,
+            org_id="test-org",
+        )
+
+        assert rc == 1
+        assert not ch_sink.snapshots
+        assert not ch_sink.dailies
+
+    @pytest.mark.asyncio
+    async def test_partial_content_backfill_still_computes_complexity_for_available_files(
+        self, monkeypatch
+    ):
+        """A GitLab project where content backfill only hydrated some paths
+        (mixed content / paths-only rows) must still compute complexity from
+        the files that DO have contents. This exercises the complexity job's
+        missing-paths query and git_blame usable-line-text probe branches
+        that the full-content and empty-content cases above never reach."""
+        store = self._store()
+        written: list = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+
+        project = Mock()
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = project
+
+        tree_items = [
+            {"type": "blob", "path": "src/alpha.py"},
+            {"type": "blob", "path": "src/beta.py"},
+            {"type": "blob", "path": "src/gamma.py"},
+        ]
+        fake_client = _FakeGitLabCodeClientForFiles(
+            contents={
+                "src/alpha.py": "def alpha():\n    return 1\n",
+                "src/beta.py": (
+                    "def beta(x):\n    if x:\n        return x\n    return 0\n"
+                ),
+            },
+            tree_items=tree_items,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_blame=False,
+            include_commit_stats=False,
+        )
+
+        by_path = {f.path: f.contents for f in written}
+        assert by_path == {
+            "src/alpha.py": "def alpha():\n    return 1\n",
+            "src/beta.py": "def beta(x):\n    if x:\n        return x\n    return 0\n",
+            "src/gamma.py": None,
+        }
+
+        ch_client = ComplexityReadinessClient([(f.path, f.contents) for f in written])
+        ch_sink = ComplexityReadinessSink(ch_client)
+        monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: ch_sink)
+
+        rc = job.run_complexity_db_job(
+            repo_id=db_repo.id,
+            db_url="clickhouse://localhost:8123/default",
+            date=date(2026, 6, 12),
+            backfill_days=1,
+            language_globs=None,
+            max_files=None,
+            org_id="test-org",
+        )
+
+        assert rc == 0
+        assert {snap.file_path for snap in ch_sink.snapshots} == {
+            "src/alpha.py",
+            "src/beta.py",
+        }
+        assert len(ch_sink.dailies) == 1
+        assert ch_sink.dailies[0].loc_total > 0
+
+    @pytest.mark.asyncio
+    async def test_backfill_days_greater_than_one_does_not_fabricate_historical_rows(
+        self, monkeypatch
+    ):
+        """CHAOS-2850/2888: even when a historical multi-day window is
+        requested, the job has no historical content snapshot store, so it
+        must write exactly ONE ``repo_complexity_daily`` row -- for the
+        requested ``date`` only -- never ``backfill_days`` duplicate flat
+        rows that would fabricate a misleading historical trend."""
+        store = self._store()
+        written: list = []
+
+        async def insert(batch):
+            written.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert)
+
+        project = Mock()
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = project
+
+        tree_items = [
+            {"type": "blob", "path": "src/alpha.py"},
+            {"type": "blob", "path": "src/beta.py"},
+        ]
+        fake_client = _FakeGitLabCodeClientForFiles(
+            contents={
+                "src/alpha.py": "def alpha():\n    return 1\n",
+                "src/beta.py": (
+                    "def beta(x):\n    if x:\n        return x\n    return 0\n"
+                ),
+            },
+            tree_items=tree_items,
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_blame=False,
+            include_commit_stats=False,
+        )
+
+        ch_client = ComplexityReadinessClient([(f.path, f.contents) for f in written])
+        ch_sink = ComplexityReadinessSink(ch_client)
+        monkeypatch.setattr(job, "ClickHouseMetricsSink", lambda _dsn: ch_sink)
+
+        rc = job.run_complexity_db_job(
+            repo_id=db_repo.id,
+            db_url="clickhouse://localhost:8123/default",
+            date=date(2026, 6, 12),
+            backfill_days=5,
+            language_globs=None,
+            max_files=None,
+            org_id="test-org",
+        )
+
+        assert rc == 0
+        assert len(ch_sink.dailies) == 1
+        assert ch_sink.dailies[0].day == date(2026, 6, 12)
+        assert len({snap.as_of_day for snap in ch_sink.snapshots}) == 1

--- a/tests/test_gitlab_content_backfill.py
+++ b/tests/test_gitlab_content_backfill.py
@@ -58,6 +58,7 @@ class _FakeGitLabCodeClientForFiles:
         blame_error_paths=None,
         tree_items=None,
         observations=None,
+        latest_commit_sha="resolved-sha",
     ):
         self.contents = contents or {}
         self.contents_error = contents_error
@@ -65,8 +66,11 @@ class _FakeGitLabCodeClientForFiles:
         self.blame_error_paths = blame_error_paths or {}
         self.tree_items = tree_items if tree_items is not None else []
         self.observations = observations or []
+        self.latest_commit_sha = latest_commit_sha
+        self.get_latest_commit_sha_calls: list[Any] = []
         self.get_file_contents_calls: list[Any] = []
         self.get_file_blame_calls: list[Any] = []
+        self.list_repository_tree_calls: list[Any] = []
 
     async def __aenter__(self):
         return self
@@ -88,9 +92,14 @@ class _FakeGitLabCodeClientForFiles:
             raise self.blame_error_paths[file_path]
         return self.blame_by_path.get(file_path, GitLabFileBlame(file_path=file_path))
 
+    async def get_latest_commit_sha(self, project_id, *, ref, until):
+        self.get_latest_commit_sha_calls.append((project_id, ref, until))
+        return self.latest_commit_sha
+
     async def list_repository_tree(
         self, project_id, *, ref, per_page=100, max_items=1_000_000
     ):
+        self.list_repository_tree_calls.append((project_id, ref, per_page, max_items))
         return self.tree_items
 
     def drain_usage_observations(self):
@@ -252,6 +261,7 @@ class _FakeGitLabCodeClientForStats:
         self.commit_stats = commit_stats or {}
         self.observations = observations or []
         self.get_commits_calls: list[Any] = []
+        self.get_commits_window_calls: list[Any] = []
         self.get_commit_stats_calls: list[Any] = []
 
     async def __aenter__(self):
@@ -264,6 +274,7 @@ class _FakeGitLabCodeClientForStats:
         self, project_id, *, max_commits, since=None, until=None, per_page=100
     ):
         self.get_commits_calls.append(project_id)
+        self.get_commits_window_calls.append((project_id, max_commits, since, until))
         return self.commits[:max_commits] if max_commits is not None else self.commits
 
     async def get_commit_stats(self, project_id, commit_sha):
@@ -360,6 +371,165 @@ class TestGitLabBackfillCommitStats:
         # usage_sink plumbing (CHAOS-2803/CS2): the client's drained per-request
         # observations must reach the caller-supplied sink.
         assert usage_sink == [{"route_family": "project"}]
+
+    @pytest.mark.asyncio
+    async def test_historical_commit_stats_backfill_fetches_entire_window(
+        self, monkeypatch
+    ):
+        since = datetime(2026, 1, 10, tzinfo=timezone.utc)
+        until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+        commits = [
+            GitLabCommitData(
+                commit_id=f"sha-{idx}",
+                message="ship it",
+                author_name="Ada",
+                authored_date=since,
+                committer_name="Ada",
+                committed_date=since,
+                parent_ids=(),
+            )
+            for idx in range(60)
+        ]
+        fake_client = _FakeGitLabCodeClientForStats(
+            commits=commits,
+            commit_stats={
+                commit.commit_id: GitLabCommitStatsData(commit.commit_id, 1, 0)
+                for commit in commits
+            },
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        store = Mock()
+        store.has_any_git_files = AsyncMock(return_value=True)
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.has_any_git_commit_stats = AsyncMock(return_value=False)
+        store.has_any_git_blame = AsyncMock(return_value=True)
+
+        recorded_stats: list[Any] = []
+        sink = Mock()
+        sink.insert_git_commit_stats = AsyncMock(side_effect=recorded_stats.extend)
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=Mock(),
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_files=False,
+            include_blame=False,
+            include_commit_stats=True,
+            since=since,
+            until=until,
+        )
+
+        assert fake_client.get_commits_window_calls == [
+            ("group/proj", None, since, until)
+        ]
+        assert len(fake_client.get_commit_stats_calls) == 60
+        assert [row.commit_hash for row in recorded_stats] == [
+            f"sha-{idx}" for idx in range(60)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_historical_backfill_uses_resolved_ref_for_tree_content_blame_and_complexity(
+        self, monkeypatch
+    ):
+        until = datetime(2026, 1, 12, tzinfo=timezone.utc)
+        store = TestGitLabBackfillBlame._store({"src/app.py"})
+        store.org_id = "test-org"
+        store.has_any_git_file_contents = AsyncMock(return_value=True)
+        store.get_blamed_paths = AsyncMock(return_value={"README.md"})
+
+        written_files: list[Any] = []
+        written_blame: list[Any] = []
+
+        async def insert_files(batch):
+            written_files.extend(batch)
+
+        async def insert_blame(batch):
+            written_blame.extend(batch)
+
+        sink = Mock()
+        sink.insert_git_file_data = AsyncMock(side_effect=insert_files)
+        sink.insert_blame_data = AsyncMock(side_effect=insert_blame)
+        metrics_sink = ComplexityReadinessSink(ComplexityReadinessClient([]))
+
+        connector = Mock()
+        connector.gitlab.projects.get.return_value = Mock(id=42)
+        tree_items = [
+            {"type": "blob", "path": "src/app.py"},
+            {"type": "blob", "path": "README.md"},
+        ]
+        fake_client = _FakeGitLabCodeClientForFiles(
+            contents={"src/app.py": "def app():\n    return 1\n"},
+            blame_by_path={
+                "src/app.py": GitLabFileBlame(
+                    file_path="src/app.py",
+                    ranges=(
+                        GitLabBlameRange(
+                            1,
+                            1,
+                            "resolved-sha",
+                            "Ada",
+                            "ada@example.com",
+                            0,
+                            ("def app():",),
+                        ),
+                    ),
+                )
+            },
+            tree_items=tree_items,
+            latest_commit_sha="resolved-sha",
+        )
+        monkeypatch.setattr(
+            "dev_health_ops.processors.gitlab._gitlab_code_client_from_connector",
+            lambda connector: fake_client,
+        )
+
+        db_repo = Mock()
+        db_repo.id = uuid.uuid4()
+
+        await _backfill_gitlab_missing_data(
+            store=store,
+            ingestion_sink=sink,
+            connector=connector,
+            db_repo=db_repo,
+            project_full_name="group/proj",
+            default_branch="main",
+            max_commits=None,
+            include_blame=True,
+            include_commit_stats=False,
+            until=until,
+            metrics_sink=metrics_sink,
+        )
+
+        assert fake_client.get_latest_commit_sha_calls == [
+            ("group/proj", "main", until)
+        ]
+        assert fake_client.list_repository_tree_calls == [
+            ("group/proj", "resolved-sha", 100, 1_000_000)
+        ]
+        assert fake_client.get_file_contents_calls == [
+            ("group/proj", ("src/app.py",), "resolved-sha", 1_000_000)
+        ]
+        assert fake_client.get_file_blame_calls == [
+            ("group/proj", "src/app.py", "resolved-sha")
+        ]
+        sink.insert_git_file_data.assert_not_called()
+        assert written_files == []
+        assert [row.commit_hash for row in written_blame] == ["resolved-sha"]
+        assert [snap.ref for snap in metrics_sink.snapshots] == ["resolved-sha"]
+        assert [snap.as_of_day for snap in metrics_sink.snapshots] == [until.date()]
+        assert [daily.day for daily in metrics_sink.dailies] == [until.date()]
+        assert metrics_sink.dailies[0].org_id == "test-org"
 
     @pytest.mark.asyncio
     async def test_backfill_skips_commit_stats_when_already_present(self, monkeypatch):

--- a/tests/test_post_sync_complexity_dispatch.py
+++ b/tests/test_post_sync_complexity_dispatch.py
@@ -1,0 +1,223 @@
+"""Unit tests for the post-sync complexity historical-window contract (CHAOS-2888).
+
+``run_complexity_db_job`` scans *current* persisted file contents/blame and
+writes ``repo_complexity_daily`` for every day in the requested backfill
+window. Before this change, ``_dispatch_post_sync_tasks`` always enqueued
+``run_complexity_job`` with only ``{"org_id": org_id}`` for any git sync,
+including historical backfills. Because ``run_complexity_job`` defaults
+``day``/``backfill_days`` to today/1 when absent, a historical backfill sync
+silently wrote *today's* file-content complexity across the historical date
+range it did not intend to touch -- fabricating a flat/incorrect historical
+complexity trend.
+
+The corrected contract (CHAOS-2888 plan, Workstream A):
+
+- Complexity is enqueued only for a *current single-day* sync:
+  ``metrics_backfill_days in (None, 1)`` and ``metrics_day`` is either absent
+  or equals ``utc_today()``. When enqueued for an explicit window, the
+  signature carries the explicit ``day``/``backfill_days=1`` rather than
+  relying on the task's implicit today/1 defaults.
+- Any other window (multi-day, or single-day but not today) is a historical
+  backfill: complexity is skipped and a ``historical_complexity_unsupported``
+  warning is logged with the requested date range. ``run_daily_metrics``
+  still receives the full historical window -- only complexity is gated.
+
+These tests prove the seam without a live ClickHouse: they patch the same
+Celery ``chain`` / ``signature`` factories the sibling dispatch tests patch.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import date
+from unittest.mock import MagicMock, patch
+
+# Import connectors first to defuse the providers._base <-> connectors circular
+# import that otherwise ERRORs isolated collection (mirrors CHAOS-2370).
+import dev_health_ops.connectors  # noqa: F401
+from dev_health_ops.workers.post_sync_dispatch import _dispatch_post_sync_tasks
+
+_COMPLEXITY_TASK = "dev_health_ops.workers.tasks.run_complexity_job"
+_DAILY_METRICS_TASK = "dev_health_ops.workers.tasks.run_daily_metrics"
+_WORK_GRAPH_TASK = "dev_health_ops.workers.tasks.run_work_graph_build"
+_INVESTMENT_TASK = (
+    "dev_health_ops.workers.tasks.dispatch_investment_materialize_partitioned"
+)
+
+
+def _run_dispatch(**kwargs):
+    """Drive _dispatch_post_sync_tasks with chain/signature/send_task patched.
+
+    Returns (signature_mock, chain_mock, chain_instance_mock, send_task_mock).
+    """
+    with (
+        patch(
+            "dev_health_ops.workers.post_sync_dispatch.celery_app.signature"
+        ) as mock_signature,
+        patch("dev_health_ops.workers.post_sync_dispatch.chain") as mock_chain,
+        patch(
+            "dev_health_ops.workers.post_sync_dispatch.celery_app.send_task"
+        ) as mock_send_task,
+    ):
+
+        def _make_sig(name, **sig_kwargs):
+            sig = MagicMock(name=f"sig:{name}")
+            sig.task_name = name
+            sig.sig_kwargs = sig_kwargs
+            return sig
+
+        mock_signature.side_effect = _make_sig
+        chain_instance = MagicMock(name="chain_instance")
+        mock_chain.return_value = chain_instance
+        _dispatch_post_sync_tasks(**kwargs)
+    return mock_signature, mock_chain, chain_instance, mock_send_task
+
+
+def _freeze_today(monkeypatch, today: date) -> None:
+    monkeypatch.setattr(
+        "dev_health_ops.workers.post_sync_dispatch.utc_today",
+        lambda: today,
+    )
+
+
+def test_current_single_day_sync_enqueues_complexity_with_explicit_date(
+    monkeypatch,
+) -> None:
+    """A current single-day sync (from_date == to_date == today) enqueues
+    complexity with the explicit day/backfill_days=1, not the task's
+    implicit-today defaults."""
+    _freeze_today(monkeypatch, date(2026, 3, 5))
+
+    _, mock_chain, chain_instance, _ = _run_dispatch(
+        provider="github",
+        sync_targets=["git"],
+        org_id="org-123",
+        from_date="2026-03-05",
+        to_date="2026-03-05",
+    )
+
+    complexity_sig, daily_sig, build_sig, materialize_sig = mock_chain.call_args.args
+    assert complexity_sig.task_name == _COMPLEXITY_TASK
+    assert complexity_sig.sig_kwargs["kwargs"] == {
+        "org_id": "org-123",
+        "day": "2026-03-05",
+        "backfill_days": 1,
+    }
+    assert complexity_sig.sig_kwargs["queue"] == "metrics"
+    assert complexity_sig.sig_kwargs.get("immutable") is True
+    assert daily_sig.task_name == _DAILY_METRICS_TASK
+    assert daily_sig.sig_kwargs["kwargs"] == {
+        "org_id": "org-123",
+        "day": "2026-03-05",
+        "backfill_days": 1,
+    }
+    chain_instance.apply_async.assert_called_once_with()
+
+
+def test_current_sync_without_explicit_window_still_enqueues_complexity(
+    monkeypatch,
+) -> None:
+    """No from_date/to_date/metrics_day at all is still "current" (regression
+    guard): complexity keeps enqueuing with just org_id, matching the task's
+    own implicit today/1 defaults."""
+    _freeze_today(monkeypatch, date(2026, 3, 5))
+
+    _, mock_chain, chain_instance, _ = _run_dispatch(
+        provider="github",
+        sync_targets=["git", "prs"],
+        org_id="org-123",
+    )
+
+    complexity_sig, daily_sig, build_sig, materialize_sig = mock_chain.call_args.args
+    assert complexity_sig.task_name == _COMPLEXITY_TASK
+    assert complexity_sig.sig_kwargs["kwargs"] == {"org_id": "org-123"}
+    chain_instance.apply_async.assert_called_once_with()
+
+
+def test_historical_single_day_sync_skips_complexity_dispatch(
+    monkeypatch, caplog
+) -> None:
+    """A single historical day (from_date == to_date, but not today) must not
+    enqueue complexity -- it would write today's file contents onto that past
+    date. Daily metrics still receives the historical day/backfill_days=1."""
+    _freeze_today(monkeypatch, date(2026, 3, 5))
+
+    with caplog.at_level(logging.WARNING):
+        _, mock_chain, chain_instance, _ = _run_dispatch(
+            provider="github",
+            sync_targets=["git"],
+            org_id="org-123",
+            from_date="2026-01-01",
+            to_date="2026-01-01",
+        )
+
+    chain_sigs = mock_chain.call_args.args
+    task_names = [sig.task_name for sig in chain_sigs]
+    assert _COMPLEXITY_TASK not in task_names
+    daily_sig = chain_sigs[0]
+    assert daily_sig.task_name == _DAILY_METRICS_TASK
+    assert daily_sig.sig_kwargs["kwargs"] == {
+        "org_id": "org-123",
+        "day": "2026-01-01",
+        "backfill_days": 1,
+    }
+    chain_instance.apply_async.assert_called_once_with()
+    assert "historical_complexity_unsupported" in caplog.text
+    assert "2026-01-01" in caplog.text
+
+
+def test_historical_multi_day_backfill_skips_complexity_but_keeps_daily_window(
+    caplog,
+) -> None:
+    """A multi-day historical backfill must not enqueue complexity (it would
+    fabricate a flat historical trend from current file contents), but
+    run_daily_metrics keeps the full requested historical window."""
+    with caplog.at_level(logging.WARNING):
+        _, mock_chain, chain_instance, _ = _run_dispatch(
+            provider="github",
+            sync_targets=["git"],
+            org_id="org-123",
+            from_date="2026-01-01",
+            to_date="2026-01-14",
+        )
+
+    chain_sigs = mock_chain.call_args.args
+    task_names = [sig.task_name for sig in chain_sigs]
+    assert _COMPLEXITY_TASK not in task_names
+    daily_sig = chain_sigs[0]
+    assert daily_sig.task_name == _DAILY_METRICS_TASK
+    assert daily_sig.sig_kwargs["kwargs"] == {
+        "org_id": "org-123",
+        "day": "2026-01-14",
+        "backfill_days": 14,
+    }
+    build_sig, materialize_sig = chain_sigs[1], chain_sigs[2]
+    assert build_sig.task_name == _WORK_GRAPH_TASK
+    assert materialize_sig.task_name == _INVESTMENT_TASK
+    chain_instance.apply_async.assert_called_once_with()
+    assert "historical_complexity_unsupported" in caplog.text
+    assert "2026-01-01" in caplog.text
+    assert "2026-01-14" in caplog.text
+
+
+def test_historical_backfill_skips_complexity_for_explicit_metrics_kwargs(
+    monkeypatch, caplog
+) -> None:
+    """The historical/current determination is based on the final
+    metrics_day/metrics_backfill_days values -- including when a caller
+    passes them explicitly (bypassing from_date/to_date window derivation)."""
+    _freeze_today(monkeypatch, date(2026, 3, 5))
+
+    with caplog.at_level(logging.WARNING):
+        _, mock_chain, _, _ = _run_dispatch(
+            provider="github",
+            sync_targets=["git"],
+            org_id="org-123",
+            metrics_day="2026-01-14",
+            metrics_backfill_days=14,
+        )
+
+    chain_sigs = mock_chain.call_args.args
+    task_names = [sig.task_name for sig in chain_sigs]
+    assert _COMPLEXITY_TASK not in task_names
+    assert "historical_complexity_unsupported" in caplog.text


### PR DESCRIPTION
## Summary
- skip historical complexity dispatch when only current file/blame state is available
- add compounding-risk missing-input diagnostics in jobs and backfill detail responses
- harden GitHub/GitLab complexity readiness regression coverage
- document backfill metrics limitations and compounding-risk exit semantics

## Verification
- lsp_diagnostics clean on changed Python source/test files
- targeted pytest: 105 passed
- bash ci/local_validate.sh: GATE PASSED, including ruff, mypy, full unit suite (7018 passed, 44 skipped), scratch ClickHouse migration, and live argMax proof
- pre-push hook: ruff format check, ruff check, mypy passed

SCREENSHOT-WAIVER: backend/API/docs-only change; no rendered web UI changed