### PR TITLE
fix(admin/sync): expand work-item coverage flags (CHAOS-2895)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ dist/
 index.txt
 .omo/**
 .worktrees/**
+.codegraph/

--- a/docs/architecture/data-pipeline.md
+++ b/docs/architecture/data-pipeline.md
@@ -293,6 +293,8 @@ Backfill depth is gated by organization billing tier:
 
 > Unit decomposition and reference-data cardinality: see [Sync Unit Model](sync-unit-model.md). The work-item-family collapse writes per-dataset watermarks only for incremental/full-resync units, preserving the invariant below.
 
+Coverage summaries are a separate consumer path from ClickHouse reader collapse. They must expand any composite work-item-family `SyncRunUnit` using its `family_dataset_*` flags before summarizing comments, history, projects, or labels coverage. That rule applies to admin coverage and observability views, not to the retry-idempotency matrix.
+
 Backfill **never seeds the watermark** (CHAOS-2514), so the first incremental
 sync after a backfill cold-starts. Continuity across the seam is provided by the
 incremental **cold-start depth** (CHAOS-2569): with no watermark, the planner

--- a/docs/architecture/sync-unit-model.md
+++ b/docs/architecture/sync-unit-model.md
@@ -1,6 +1,6 @@
 # Sync Unit Model
 
-> **What this documents:** how a sync run is decomposed into executable units, and why **reference data** (teams, orgs, members, projects, boards/cycles/sprints) belongs on a different axis than **work items** (issues, PRs/MRs). This conceptual page was missing, which is why a structural request-amplification went unnoticed (CHAOS-2719). Target-state behavior is labeled where it is not yet shipped.
+> **What this documents:** how a sync run is decomposed into executable units, and why **reference data** (teams, orgs, members, projects, boards/cycles/sprints) belongs on a different axis than **work items** (issues, PRs/MRs). This conceptual page was missing, which is why a structural request-amplification went unnoticed (CHAOS-2719). Shipped behavior is described here, and any remaining gaps are called out explicitly.
 
 ## Overview
 
@@ -10,17 +10,17 @@ A sync run is decomposed by the planner (`sync/planner.py` `_build_planned_units
 source × dataset × date-window
 ```
 
-Each `PlannedUnit` becomes one `SyncRunUnit` row and one `run_sync_unit` Celery task (see [Durable Dispatch Outbox](dispatch-outbox.md) for the task hierarchy). This axis is **correct for work items**, which are per-source and time-sliced: a 90-day backfill of issues legitimately splits into windows, and each window legitimately scopes to one source.
+Each `PlannedUnit` becomes one `SyncRunUnit` row and one `run_sync_unit` Celery task (see [Durable Dispatch Outbox](dispatch-outbox.md) for the task hierarchy). This axis is **correct for work items**, which are per-source and time-sliced: a 90-day backfill of issues legitimately splits into windows, and each window legitimately scopes to one source. The work-item-family datasets are the shipped exception: enabled family keys collapse into one composite `work-items` unit per `(source, window)` and are carried as `family_dataset_*` flags.
 
 The axis is **wrong for reference entities**. Teams, orgs, members, projects, and boards/cycles/sprints are **source-independent and time-independent** — their true cardinality is *once per integration per run*. When a provider fetches reference data *inside* a work-item unit, it pays for that data `windows × datasets × sources` times.
 
 ```mermaid
 graph TD
     Run[SyncRun] --> Plan[plan_sync_run: _build_planned_units]
-    Plan -->|source × dataset × window| U1[unit: src A · work-items · win1]
-    Plan --> U2[unit: src A · work-items · win2]
-    Plan --> U3[unit: src A · work-item-labels · win1]
-    Plan --> U4[unit: src B · work-items · win1]
+    Plan -->|source × dataset/window| U1[unit: src A · work-items composite · win1<br/>flags: work-items, labels, projects, history, comments]
+    Plan --> U2[unit: src A · work-items composite · win2]
+    Plan --> U3[unit: src B · work-items composite · win1]
+    Plan --> U4[unit: src B · commits · win1]
 
     subgraph WT [Work-item tier — correct on this axis]
         U1
@@ -45,7 +45,7 @@ graph TD
     style RT fill:#bbf,stroke:#333
 ```
 
-For a 90-day Linear backfill: `ceil(90/14)=7 windows × 5 work-item-family datasets = 35 units`, each running the **complete** Linear ingest, each calling `iter_teams()` (all teams) plus `iter_cycles()` per team. The teams/cycles cardinality should be *one fetch per run*; instead it is `35× (× team count)`. This is the unmeasured amplifier behind Linear backfill request saturation, and it is **not Linear-specific**.
+For a 90-day backfill, `ceil(90/14)=7` windows. When the work-item family is enabled, each `(source, window)` now becomes **one** composite `SyncRunUnit`, not 5 separate dataset units, so the family executes once per source/window and carries `family_dataset_*` flags for the enabled child datasets. The same collapse applies to GitHub, GitLab, Jira, and Linear. This is the shipped fix for the work-item-family amplifier, and it is **not Linear-specific**.
 
 ## The two tiers
 
@@ -72,7 +72,7 @@ The ⚠️ cells are the work this epic removes. GitHub/GitLab already solved th
 ## The three amplifiers and their fixes
 
 1. **Per-unit reference re-fetch** (Linear teams+cycles; Jira sprints). The dominant fixed overhead. **Fix (P2):** read teams/cycles/sprints from the persisted store via a once-per-run resolver; add a `get_all_sprints` loader and a cycle/sprint producer; bounded source-scoped API fallback on a store miss.
-2. **Work-item-family redundancy.** The 5 family datasets (`work-items`, `work-item-labels`, `work-item-projects`, `work-item-history`, `work-item-comments`) each re-run the *full* ingest, so enabling the family multiplies cost ×5 per source/window. **Fix (P3, target-state):** plan-time collapse to **one** composite ingest per `(source, window)`, writing per-dataset watermarks for each enabled family key.
+2. **Work-item-family redundancy.** The 5 family datasets (`work-items`, `work-item-labels`, `work-item-projects`, `work-item-history`, `work-item-comments`) used to re-run the *full* ingest, so enabling the family multiplied cost ×5 per source/window. **Shipped:** plan-time collapse now produces **one** composite ingest per `(source, window)`, with raw `dataset_key='work-items'` plus boolean `family_dataset_*` flags for each enabled child dataset.
 3. **Source fan-out.** Work-item units that ignore their own source — Linear `IngestionContext(repo=None)` → all teams; GitHub `discover_repos` without a repo filter → all org repos; GitLab likewise (its `repo_name` is a numeric project id, not the `path_with_namespace` on `repos.repo`, so a naive filter can't reuse the GitHub match). **Fix (P1, shipped on the source-scoping branch):** thread the unit's `source_external_id` so a unit syncs only its one source; preserve the no-source CLI/org-wide path. GitHub shipped first (CHAOS-2720); GitLab shipped via a separate match branch keyed on the discovered repo's `settings.project_id` (CHAOS-2763), since the id spaces don't overlap.
 
 **Target acceptance:** total provider API requests for a backfill scale `O(issues + teams + cycles/projects)`, not `O(windows × datasets × sources)`, across all four providers.
@@ -149,6 +149,7 @@ PR #1143. GitHub-path behavior is unaffected.
 ## Invariants this model must preserve
 
 - **Backfill never writes watermarks.** Backfill units (`mode="backfill"`) must never update `sync_watermarks`; see [Data Pipeline](data-pipeline.md) and the planner module contract (CHAOS-2514). The work-item-family collapse writes per-dataset watermarks only for incremental/full-resync units.
+- **Coverage and observability consumers must expand family flags.** Any consumer that reads `SyncRunUnit` rows for coverage or observability must expand `family_dataset_*` flags before interpreting a composite work-item-family unit. Raw `dataset_key='work-items'` alone does **not** prove coverage for comments, history, projects, or labels.
 - **Provider coverage matrix.** Behavior stays green across `{jira, gitlab, github, linear} × {teams, projects, members, issues}` — see [Team Attribution](team-attribution.md). Never make a fix Linear-only.
 - **ClickHouse idempotency.** Reference reads and collapsed/scoped writes stay idempotent (`teams FINAL`, `sprints FINAL`).
 - **No Postgres team/identity attribution.** Reference data is read from ClickHouse, never a Postgres attribution bridge.

--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import uuid
 from collections import defaultdict
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from datetime import datetime, time, timedelta, timezone
 from typing import Any
@@ -22,6 +22,7 @@ from dev_health_ops.models.integrations import (
 )
 from dev_health_ops.models.settings import JobStatus, ScheduledJob, SyncConfiguration
 from dev_health_ops.sync.datasets import supported_datasets
+from dev_health_ops.sync.planner import family_dataset_keys_from_flags
 
 HISTORY_LOOKBACK_DAYS = 180
 STALE_MINIMUM_GRACE = timedelta(hours=6)
@@ -269,7 +270,14 @@ def _range_to_dict(interval: CoverageInterval) -> dict[str, Any]:
     return payload
 
 
-def _unit_window_from_row(unit: SyncRunUnit, run: SyncRun) -> UnitWindow | None:
+def _unit_window_from_row(
+    unit: SyncRunUnit, run: SyncRun, dataset_key: str | None = None
+) -> UnitWindow | None:
+    """Build a ``UnitWindow`` for one row, optionally under an effective
+    dataset key (CHAOS-2721 work-item-family expansion) instead of the raw
+    persisted ``unit.dataset_key``. Run id/source id/status/timestamps always
+    reflect the raw unit -- only the reported dataset key changes.
+    """
     since_at = unit.since_at
     before_at = unit.before_at
     if since_at is None or before_at is None:
@@ -279,11 +287,78 @@ def _unit_window_from_row(unit: SyncRunUnit, run: SyncRun) -> UnitWindow | None:
         since=ensure_utc(since_at),
         before=ensure_utc(before_at),
         source_id=str(unit.source_id),
-        dataset_key=str(unit.dataset_key),
+        dataset_key=dataset_key if dataset_key is not None else str(unit.dataset_key),
         run_id=str(unit.sync_run_id),
         status=str(unit.status),
         run_time=ensure_utc(run_time),
     )
+
+
+# CHAOS-2721 collapses the enabled work-item-family datasets (work-items,
+# work-item-labels, work-item-projects, work-item-history, work-item-comments)
+# into ONE composite SyncRunUnit per (source, window) with canonical
+# dataset_key="work-items" and boolean family_dataset_<key> processor flags
+# per enabled child dataset. Coverage math must expand a persisted unit into
+# its effective child dataset keys before doing interval/status math, or a
+# later successful composite run never supersedes stale child-dataset gaps or
+# failures. This mirrors the identical expansion in
+# ``workers/sync_units.py::_watermark_dataset_keys``/``_family_dataset_audit_metadata``.
+_WORK_ITEMS_CANONICAL_DATASET_KEY = "work-items"
+
+
+def _effective_dataset_keys(
+    dataset_key: str, processor_flags: Mapping[str, object] | None
+) -> list[str]:
+    """Expand a raw ``dataset_key``/``processor_flags`` pair into effective
+    coverage dataset keys.
+
+    Only the canonical composite key (``"work-items"``) is ever expanded --
+    a raw, non-composite ``dataset_key`` is returned as-is even if stray
+    ``family_dataset_*`` flags are present, since a plain unit never carries
+    a real work-item-family collapse. For the canonical key, returns the
+    enabled work-item-family child keys (canonical order) decoded from
+    ``processor_flags`` when any are true; otherwise falls back to the raw
+    ``dataset_key`` (missing/false/unknown flags never advance coverage for a
+    dataset that was not actually run).
+    """
+    if str(dataset_key) != _WORK_ITEMS_CANONICAL_DATASET_KEY:
+        return [str(dataset_key)]
+    family_keys = family_dataset_keys_from_flags(processor_flags)
+    return family_keys or [str(dataset_key)]
+
+
+def _effective_dataset_keys_for_unit(unit: SyncRunUnit) -> list[str]:
+    """Expand a persisted ``SyncRunUnit`` into its effective coverage dataset keys."""
+    return _effective_dataset_keys(unit.dataset_key, unit.processor_flags)
+
+
+def _is_work_item_family_dataset_key(dataset_key: str) -> bool:
+    """True when ``dataset_key`` is one of the work-item-family child datasets.
+
+    Probes the public ``family_dataset_keys_from_flags`` helper with that key's
+    own synthetic flag rather than importing planner's private
+    ``_WORK_ITEM_FAMILY_DATASETS`` constant, keeping this fix localized to
+    coverage math (mirrors the family-flag naming convention already relied on
+    by ``workers/sync_units.py``).
+    """
+    probe_flag = "family_dataset_" + dataset_key.replace("-", "_")
+    return dataset_key in family_dataset_keys_from_flags({probe_flag: True})
+
+
+def _query_dataset_keys_for_scope(dataset_keys: Sequence[str]) -> tuple[str, ...]:
+    """Expand scope dataset keys with the canonical work-item-family key.
+
+    Persisted ``SyncRunUnit`` rows carry the collapsed composite key
+    ``"work-items"`` for every enabled work-item-family dataset (CHAOS-2721).
+    A scope covering any family child key (e.g. ``work-item-comments``) must
+    therefore also query for rows keyed ``"work-items"``, or the composite row
+    is invisible to per-dataset coverage queries entirely. Non-family scopes
+    are returned unchanged.
+    """
+    keys = set(dataset_keys)
+    if any(_is_work_item_family_dataset_key(key) for key in dataset_keys):
+        keys.add(_WORK_ITEMS_CANONICAL_DATASET_KEY)
+    return tuple(sorted(keys))
 
 
 def _dataset_keys_for_config(config: SyncConfiguration) -> tuple[str, ...]:
@@ -398,11 +473,12 @@ async def _terminal_unit_windows(
     if scope.integration_id is None or not scope.sources or not scope.dataset_keys:
         return []
     source_ids = [source.id for source in scope.sources]
+    query_dataset_keys = _query_dataset_keys_for_scope(scope.dataset_keys)
     base_filters = [
         SyncRunUnit.org_id == org_id,
         SyncRunUnit.integration_id == scope.integration_id,
         SyncRunUnit.source_id.in_(source_ids),
-        SyncRunUnit.dataset_key.in_(scope.dataset_keys),
+        SyncRunUnit.dataset_key.in_(query_dataset_keys),
         SyncRunUnit.status.in_(REQUESTED_UNIT_STATUSES),
         SyncRunUnit.since_at.is_not(None),
         SyncRunUnit.before_at.is_not(None),
@@ -478,9 +554,12 @@ async def _terminal_unit_windows(
                 seen.add(key)
     windows: list[UnitWindow] = []
     for unit, run in rows:
-        window = _unit_window_from_row(unit, run)
-        if window is not None:
-            windows.append(window)
+        for effective_key in _effective_dataset_keys_for_unit(unit):
+            if effective_key not in scope.dataset_keys:
+                continue
+            window = _unit_window_from_row(unit, run, effective_key)
+            if window is not None:
+                windows.append(window)
     return windows
 
 
@@ -489,8 +568,13 @@ async def _active_run_ids(
 ) -> set[tuple[str, str]]:
     if scope.integration_id is None or not scope.sources or not scope.dataset_keys:
         return set()
+    query_dataset_keys = _query_dataset_keys_for_scope(scope.dataset_keys)
     stmt = (
-        select(SyncRunUnit.source_id, SyncRunUnit.dataset_key)
+        select(
+            SyncRunUnit.source_id,
+            SyncRunUnit.dataset_key,
+            SyncRunUnit.processor_flags,
+        )
         .select_from(SyncRun)
         .join(SyncRunUnit, SyncRunUnit.sync_run_id == SyncRun.id)
         .where(
@@ -499,14 +583,20 @@ async def _active_run_ids(
             SyncRun.status.in_(ACTIVE_RUN_STATUSES),
             SyncRunUnit.org_id == org_id,
             SyncRunUnit.source_id.in_([source.id for source in scope.sources]),
-            SyncRunUnit.dataset_key.in_(scope.dataset_keys),
+            SyncRunUnit.dataset_key.in_(query_dataset_keys),
         )
-        .distinct()
     )
-    return {
-        (str(source_id), str(dataset_key))
-        for source_id, dataset_key in (await session.execute(stmt)).all()
-    }
+    # No SQL-level .distinct(): SyncRunUnit.processor_flags is a plain JSON
+    # column (not JSONB), which Postgres cannot compare for DISTINCT. Dedup
+    # happens naturally by building a set of expanded (source_id,
+    # effective_dataset_key) pairs below.
+    pairs: set[tuple[str, str]] = set()
+    for source_id, dataset_key, processor_flags in (await session.execute(stmt)).all():
+        for effective_key in _effective_dataset_keys(dataset_key, processor_flags):
+            if effective_key not in scope.dataset_keys:
+                continue
+            pairs.add((str(source_id), effective_key))
+    return pairs
 
 
 def _backfill_interval(job: BackfillJob) -> CoverageInterval:
@@ -538,6 +628,12 @@ async def _backfill_job_run_pair_windows(
     MUST treat that as "this job requested nothing", not as "unresolvable"
     (see ``_backfill_requested_ranges``): a run that legitimately planned zero
     units must not be conflated with a marker we simply couldn't parse.
+
+    Pairs are keyed by effective dataset key (CHAOS-2721 work-item-family
+    expansion via ``_effective_dataset_keys_for_unit``), not the raw persisted
+    ``dataset_key``, so a collapsed composite unit's window is attributed to
+    each of its actually-enabled child datasets rather than the invisible
+    canonical "work-items" key.
     """
     stmt = select(SyncRunUnit).where(
         SyncRunUnit.org_id == org_id,
@@ -551,10 +647,12 @@ async def _backfill_job_run_pair_windows(
         before_at = unit.before_at
         if since_at is None or before_at is None:
             continue
-        pair = (str(unit.source_id), str(unit.dataset_key))
-        raw_windows[pair].append(
-            CoverageInterval(since=ensure_utc(since_at), before=ensure_utc(before_at))
+        interval = CoverageInterval(
+            since=ensure_utc(since_at), before=ensure_utc(before_at)
         )
+        for effective_key in _effective_dataset_keys_for_unit(unit):
+            pair = (str(unit.source_id), effective_key)
+            raw_windows[pair].append(interval)
     return {pair: merge_intervals(intervals) for pair, intervals in raw_windows.items()}
 
 

--- a/tests/api/admin/test_sync_coverage_api.py
+++ b/tests/api/admin/test_sync_coverage_api.py
@@ -112,13 +112,20 @@ async def client(session_maker, seeded_state):
     app.dependency_overrides.clear()
 
 
-async def _seed_scope(session_maker, org_id: str, *, other_org: bool = False) -> dict:
+async def _seed_scope(
+    session_maker,
+    org_id: str,
+    *,
+    other_org: bool = False,
+    provider: str = "github",
+    source_external_id: str = "acme/repo",
+) -> dict:
     row_org_id = str(uuid.uuid4()) if other_org else org_id
     async with session_maker() as session:
         integration = Integration(
             org_id=row_org_id,
-            provider="github",
-            name="GitHub",
+            provider=provider,
+            name=f"{provider.title()} Integration",
             config={},
             is_active=True,
         )
@@ -127,7 +134,7 @@ async def _seed_scope(session_maker, org_id: str, *, other_org: bool = False) ->
         config = SyncConfiguration(
             org_id=row_org_id,
             name="Coverage",
-            provider="github",
+            provider=provider,
             sync_targets=["git"],
             sync_options={"schedule_cron": "0 * * * *"},
             integration_id=integration.id,
@@ -138,11 +145,11 @@ async def _seed_scope(session_maker, org_id: str, *, other_org: bool = False) ->
         source = IntegrationSource(
             org_id=row_org_id,
             integration_id=integration.id,
-            provider="github",
+            provider=provider,
             source_type="repository",
-            external_id="acme/repo",
+            external_id=source_external_id,
             name="repo",
-            full_name="acme/repo",
+            full_name=source_external_id,
             metadata_={"planner_managed_sync_config_id": str(config.id)},
             is_enabled=True,
         )
@@ -157,7 +164,7 @@ async def _seed_scope(session_maker, org_id: str, *, other_org: bool = False) ->
             org_id=row_org_id,
             name="sync-config-coverage",
             job_type="sync",
-            provider="github",
+            provider=provider,
             schedule_cron="0 * * * *",
             sync_config_id=config.id,
             status=JobStatus.ACTIVE.value,
@@ -171,6 +178,7 @@ async def _seed_scope(session_maker, org_id: str, *, other_org: bool = False) ->
             "config_id": str(config.id),
             "integration_id": str(integration.id),
             "source_id": str(source.id),
+            "provider": provider,
         }
 
 
@@ -199,6 +207,8 @@ async def _seed_unit(
     status: str = "success",
     updated_at: datetime | None = None,
     source_id: str | None = None,
+    dataset_key: str = "commits",
+    processor_flags: dict | None = None,
 ) -> str:
     async with session_maker() as session:
         run_status = "success"
@@ -225,14 +235,15 @@ async def _seed_unit(
             sync_run_id=run.id,
             integration_id=uuid.UUID(scope["integration_id"]),
             source_id=uuid.UUID(source_id or scope["source_id"]),
-            provider="github",
-            dataset_key="commits",
+            provider=scope.get("provider", "github"),
+            dataset_key=dataset_key,
             cost_class="standard",
             mode="incremental",
             since_at=since,
             before_at=before,
             status=status,
             attempts=1,
+            processor_flags=processor_flags,
         )
         if updated_at is not None:
             unit.updated_at = updated_at
@@ -268,6 +279,7 @@ async def _seed_run_unit(
     source_id: str | None = None,
     dataset_key: str = "commits",
     updated_at: datetime | None = None,
+    processor_flags: dict | None = None,
 ) -> None:
     async with session_maker() as session:
         unit = SyncRunUnit(
@@ -275,7 +287,7 @@ async def _seed_run_unit(
             sync_run_id=uuid.UUID(run_id),
             integration_id=uuid.UUID(scope["integration_id"]),
             source_id=uuid.UUID(source_id or scope["source_id"]),
-            provider="github",
+            provider=scope.get("provider", "github"),
             dataset_key=dataset_key,
             cost_class="standard",
             mode="incremental",
@@ -283,6 +295,7 @@ async def _seed_run_unit(
             before_at=before,
             status=status,
             attempts=1,
+            processor_flags=processor_flags,
         )
         if updated_at is not None:
             unit.updated_at = updated_at
@@ -902,3 +915,74 @@ async def test_sync_coverage_api_backfill_marker_resolved_zero_units_contributes
     assert sources[scope["source_id"]]["gap_count"] == 0
     assert sources[extra_source_id]["gap_count"] == 0
     assert data["overall"]["health"] == "insufficient_data"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("provider", ["jira", "gitlab", "github", "linear"])
+async def test_sync_coverage_api_backfill_requested_range_expands_by_family_flag(
+    client, session_maker, provider
+):
+    """CHAOS-2721/coverage-fix core repro: a pair-scoped backfill's linked
+    collapsed composite work-items run unit must only request coverage for
+    the work-item-family child dataset(s) whose ``family_dataset_*`` flag was
+    true on that unit. A disabled child dataset in the same scope must NOT
+    inherit a requested range from the same composite unit -- provider
+    agnostic across jira/gitlab/github/linear."""
+    ac, seeded_state = client
+    scope = await _seed_scope(session_maker, seeded_state["org_id"], provider=provider)
+    async with session_maker() as session:
+        for dataset_key in ("work-item-comments", "work-item-labels"):
+            session.add(
+                IntegrationDataset(
+                    org_id=scope["org_id"],
+                    integration_id=uuid.UUID(scope["integration_id"]),
+                    dataset_key=dataset_key,
+                    is_enabled=True,
+                    options={},
+                )
+            )
+        await session.commit()
+
+    now = datetime.now(timezone.utc)
+    since = now - timedelta(days=2)
+    before = now - timedelta(minutes=5)
+    run_id = await _seed_run(session_maker, scope, status="success")
+    await _seed_run_unit(
+        session_maker,
+        scope,
+        run_id,
+        since=since,
+        before=before,
+        status="success",
+        dataset_key="work-items",
+        processor_flags={"family_dataset_work_item_comments": True},
+    )
+    async with session_maker() as session:
+        session.add(
+            BackfillJob(
+                org_id=seeded_state["org_id"],
+                sync_config_id=uuid.UUID(scope["config_id"]),
+                status="success",
+                since_date=(now - timedelta(days=3)).date(),
+                before_date=(now + timedelta(days=1)).date(),
+                total_chunks=1,
+                completed_chunks=1,
+                celery_task_id=f"sync_run:{run_id}",
+            )
+        )
+        await session.commit()
+
+    resp = await ac.get(f"/api/v1/admin/sync-configs/{scope['config_id']}/coverage")
+
+    assert resp.status_code == 200, resp.text
+    data = resp.json()
+    datasets = {dataset["dataset_key"]: dataset for dataset in data["datasets"]}
+    # Flagged child: the composite run's actual window resolves the pair
+    # clean, with no gap and no phantom failed range.
+    assert datasets["work-item-comments"]["status"] == "healthy"
+    assert datasets["work-item-comments"]["gaps"] == []
+    # Unflagged child in the same scope must not inherit any requested range
+    # from the composite unit -- it stays at insufficient_data, not gapped.
+    assert datasets["work-item-labels"]["requested_ranges"] == []
+    assert datasets["work-item-labels"]["gaps"] == []
+    assert datasets["work-item-labels"]["status"] == "insufficient_data"

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -3,10 +3,14 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timedelta, timezone
 
+import pytest
+
 from dev_health_ops.api.services.sync_coverage import (
     CoverageInterval,
     EffectiveScope,
     UnitWindow,
+    _effective_dataset_keys_for_unit,
+    _query_dataset_keys_for_scope,
     build_coverage_summary_payload,
     classify_staleness,
     ensure_utc,
@@ -14,7 +18,7 @@ from dev_health_ops.api.services.sync_coverage import (
     merge_intervals,
     subtract_intervals,
 )
-from dev_health_ops.models.integrations import IntegrationSource
+from dev_health_ops.models.integrations import IntegrationSource, SyncRunUnit
 from dev_health_ops.models.settings import ScheduledJob, SyncConfiguration
 
 
@@ -103,6 +107,55 @@ def _summary(
         has_schedule_row=True,
         generated_at=now,
     )
+
+
+_WORK_ITEM_FAMILY_PROVIDERS = ("jira", "gitlab", "github", "linear")
+
+
+def _composite_unit(
+    *,
+    provider: str = "github",
+    dataset_key: str = "work-items",
+    processor_flags: dict[str, bool] | None = None,
+    source_id: uuid.UUID | None = None,
+    status: str = "success",
+) -> SyncRunUnit:
+    return SyncRunUnit(
+        org_id="org-1",
+        sync_run_id=uuid.uuid4(),
+        integration_id=uuid.uuid4(),
+        source_id=source_id or uuid.uuid4(),
+        provider=provider,
+        dataset_key=dataset_key,
+        cost_class="standard",
+        mode="incremental",
+        status=status,
+        attempts=1,
+        processor_flags=processor_flags,
+    )
+
+
+def _expand_unit_to_windows(
+    unit: SyncRunUnit,
+    *,
+    since: datetime,
+    before: datetime,
+    run_time: datetime,
+) -> list[UnitWindow]:
+    """Mirror the terminal-window expansion: one ``UnitWindow`` per effective
+    dataset key decoded from the unit's work-item-family flags (CHAOS-2721)."""
+    return [
+        UnitWindow(
+            since=since,
+            before=before,
+            source_id=str(unit.source_id),
+            dataset_key=effective_key,
+            run_id=str(unit.sync_run_id),
+            status=str(unit.status),
+            run_time=run_time,
+        )
+        for effective_key in _effective_dataset_keys_for_unit(unit)
+    ]
 
 
 def test_merge_intervals_collapses_overlap_and_adjacency():
@@ -351,3 +404,179 @@ def test_backfill_interval_without_pair_scope_applies_to_all_scope_pairs():
     sources = {source["source_id"]: source for source in summary["sources"]}
     assert sources[str(source_a)]["gap_count"] == 1
     assert sources[str(source_b)]["gap_count"] == 1
+
+
+@pytest.mark.parametrize("provider", _WORK_ITEM_FAMILY_PROVIDERS)
+def test_effective_dataset_keys_expands_true_family_flags_in_canonical_order(
+    provider,
+):
+    # CHAOS-2721/coverage-fix: a collapsed composite unit's true family flags
+    # decode to only the enabled child keys, in canonical order -- never every
+    # work-item-family key regardless of which flags are set.
+    unit = _composite_unit(
+        provider=provider,
+        processor_flags={
+            "family_dataset_work_item_comments": True,
+            "family_dataset_work_item_labels": True,
+        },
+    )
+
+    assert list(_effective_dataset_keys_for_unit(unit)) == [
+        "work-item-labels",
+        "work-item-comments",
+    ]
+
+
+@pytest.mark.parametrize("provider", _WORK_ITEM_FAMILY_PROVIDERS)
+def test_effective_dataset_keys_falls_back_to_raw_key_when_no_family_flag_true(
+    provider,
+):
+    unit = _composite_unit(
+        provider=provider,
+        processor_flags={"family_dataset_work_item_comments": False},
+    )
+
+    assert list(_effective_dataset_keys_for_unit(unit)) == ["work-items"]
+
+
+def test_effective_dataset_keys_missing_flags_falls_back_to_raw_key():
+    unit = _composite_unit(processor_flags=None)
+
+    assert list(_effective_dataset_keys_for_unit(unit)) == ["work-items"]
+
+
+def test_effective_dataset_keys_ignores_unknown_flags():
+    # An unrecognized family_dataset_* flag must never advance coverage for a
+    # dataset key that isn't in the canonical work-item-family set.
+    unit = _composite_unit(processor_flags={"family_dataset_bogus": True})
+
+    assert list(_effective_dataset_keys_for_unit(unit)) == ["work-items"]
+
+
+def test_effective_dataset_keys_non_family_dataset_ignores_flags():
+    # A raw, non-composite dataset_key must never be expanded even if stray
+    # family_dataset_* flags are present on its processor_flags.
+    unit = _composite_unit(
+        dataset_key="commits",
+        processor_flags={"family_dataset_work_item_comments": True},
+    )
+
+    assert list(_effective_dataset_keys_for_unit(unit)) == ["commits"]
+
+
+def test_query_dataset_keys_for_scope_includes_canonical_work_items_for_family_child():
+    keys = _query_dataset_keys_for_scope(("work-item-comments",))
+
+    assert "work-items" in keys
+    assert "work-item-comments" in keys
+
+
+def test_query_dataset_keys_for_scope_unchanged_for_non_family_scope():
+    keys = _query_dataset_keys_for_scope(("commits", "prs"))
+
+    assert set(keys) == {"commits", "prs"}
+
+
+@pytest.mark.parametrize("provider", _WORK_ITEM_FAMILY_PROVIDERS)
+def test_composite_success_supersedes_old_failed_child_only_when_flag_true(
+    provider,
+):
+    # CHAOS-2721/coverage-fix core repro: a later successful composite
+    # work-items unit must supersede an old failed child dataset ONLY for the
+    # child whose family_dataset_* flag was true on that composite run. A
+    # disabled child dataset must remain failed/gapped.
+    source_id = uuid.uuid4()
+    config = _config()
+    scope = EffectiveScope(
+        integration_id=config.integration_id,
+        sources=(_source(source_id),),
+        dataset_keys=("work-item-comments", "work-item-labels"),
+    )
+
+    old_failed_comments = _window(
+        _dt(1),
+        _dt(2),
+        source_id=source_id,
+        dataset_key="work-item-comments",
+        status="failed",
+        run_time=_dt(2),
+    )
+    old_failed_labels = _window(
+        _dt(1),
+        _dt(2),
+        source_id=source_id,
+        dataset_key="work-item-labels",
+        status="failed",
+        run_time=_dt(2),
+    )
+    composite = _composite_unit(
+        provider=provider,
+        source_id=source_id,
+        processor_flags={"family_dataset_work_item_comments": True},
+        status="success",
+    )
+    later_success_windows = _expand_unit_to_windows(
+        composite, since=_dt(1), before=_dt(2), run_time=_dt(3)
+    )
+
+    summary = _summary(
+        [old_failed_comments, old_failed_labels, *later_success_windows],
+        config=config,
+        scope=scope,
+    )
+
+    datasets = {dataset["dataset_key"]: dataset for dataset in summary["datasets"]}
+    assert datasets["work-item-comments"]["failed_ranges"] == []
+    assert datasets["work-item-comments"]["status"] == "healthy"
+    assert datasets["work-item-labels"]["failed_ranges"] != []
+    assert datasets["work-item-labels"]["status"] == "failed"
+
+
+@pytest.mark.parametrize("provider", _WORK_ITEM_FAMILY_PROVIDERS)
+def test_active_composite_run_marks_only_flagged_child_pair_running(provider):
+    # An in-flight composite work-items unit must mark ONLY the flagged
+    # child dataset pair as running; an unflagged child pair falls back to
+    # the ordinary stale/gap/insufficient_data rollup rules.
+    source_id = uuid.uuid4()
+    config = _config()
+    scope = EffectiveScope(
+        integration_id=config.integration_id,
+        sources=(_source(source_id),),
+        dataset_keys=("work-item-comments", "work-item-labels"),
+    )
+    comments_window = _window(
+        _dt(1),
+        _dt(2),
+        source_id=source_id,
+        dataset_key="work-item-comments",
+        status="success",
+    )
+    labels_window = _window(
+        _dt(1),
+        _dt(2),
+        source_id=source_id,
+        dataset_key="work-item-labels",
+        status="success",
+    )
+    running_composite = _composite_unit(
+        provider=provider,
+        source_id=source_id,
+        processor_flags={"family_dataset_work_item_comments": True},
+        status="running",
+    )
+    active_pairs = {
+        (str(source_id), key)
+        for key in _effective_dataset_keys_for_unit(running_composite)
+    }
+
+    summary = _summary(
+        [comments_window, labels_window],
+        active_pairs=active_pairs,
+        now=_dt(5),
+        config=config,
+        scope=scope,
+    )
+
+    datasets = {dataset["dataset_key"]: dataset for dataset in summary["datasets"]}
+    assert datasets["work-item-comments"]["status"] == "running"
+    assert datasets["work-item-labels"]["status"] != "running"


### PR DESCRIPTION
## Summary
- expand composite work-item-family `SyncRunUnit` rows by `family_dataset_*` flags before coverage/status math
- scope work-item family coverage queries to include the canonical `work-items` unit key without granting coverage to unflagged children
- document the coverage/observability invariant for collapsed work-item-family units

## Verification
- `bash ci/local_validate.sh`
- LSP diagnostics clean on changed Python files

Linear: CHAOS-2895

SCREENSHOT-WAIVER: backend/docs-only change; no rendered web UI changed.