### PR TITLE
fix(admin): hide platform LLM spend for inactive BYO (CHAOS-2896)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/settings.py
+++ b/src/dev_health_ops/api/admin/routers/settings.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from dataclasses import asdict
 from datetime import datetime, timedelta, timezone
 
@@ -35,7 +35,7 @@ from dev_health_ops.llm.credentials import (
     evaluate_org_llm_status,
     latest_recent_org_byo_base_url_fallback_at,
 )
-from dev_health_ops.metrics.sinks.base import BaseMetricsSink
+from dev_health_ops.metrics.schemas import LLMTokenSpendSummaryRecord
 from dev_health_ops.metrics.sinks.factory import create_sink
 from dev_health_ops.models.settings import SettingCategory
 
@@ -43,13 +43,21 @@ from .common import get_session
 
 router = APIRouter()
 
+LLMSpendReader = Callable[..., LLMTokenSpendSummaryRecord | None]
 
-def get_metrics_sink() -> Iterator[BaseMetricsSink]:
+
+def read_llm_token_spend_summary(
+    *, org_id: str, limit: int, since: datetime | None
+) -> LLMTokenSpendSummaryRecord | None:
     sink = create_sink(require_clickhouse_uri())
     try:
-        yield sink
+        return sink.read_llm_token_spend(org_id=org_id, limit=limit, since=since)
     finally:
         sink.close()
+
+
+def get_llm_spend_reader() -> Iterator[LLMSpendReader]:
+    yield read_llm_token_spend_summary
 
 
 def _setting_response(setting: object) -> SettingResponse:
@@ -152,15 +160,18 @@ async def get_llm_settings_spend(
     since: datetime | None = None,
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
-    sink: BaseMetricsSink = Depends(get_metrics_sink),
+    spend_reader: LLMSpendReader = Depends(get_llm_spend_reader),
 ) -> LLMSpendResponse:
     await _require_byo_llm_tier(session, org_id)
-    summary = sink.read_llm_token_spend(org_id=org_id, limit=limit, since=since)
+    response_since = since or datetime.now(timezone.utc) - timedelta(days=30)
+    response_limit = min(max(1, limit), 100)
+    svc = SettingsService(session, org_id)
+    evaluation = await evaluate_org_llm_status(org_id, svc)
+    if not evaluation.active:
+        return LLMSpendResponse(since=response_since, limit=response_limit)
+    summary = spend_reader(org_id=org_id, limit=limit, since=since)
     if summary is None:
-        return LLMSpendResponse(
-            since=since or datetime.now(timezone.utc) - timedelta(days=30),
-            limit=min(max(1, limit), 100),
-        )
+        return LLMSpendResponse(since=response_since, limit=response_limit)
     return LLMSpendResponse.model_validate(asdict(summary))
 
 

--- a/tests/api/admin/test_llm_settings_spend.py
+++ b/tests/api/admin/test_llm_settings_spend.py
@@ -13,6 +13,7 @@ from httpx import ASGITransport, AsyncClient
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.configuration import SettingsService
 from dev_health_ops.metrics.schemas import (
     LLMTokenSpendLegacyRecord,
     LLMTokenSpendRunRecord,
@@ -20,6 +21,7 @@ from dev_health_ops.metrics.schemas import (
 )
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.licensing import FeatureFlag, OrgFeatureOverride, OrgLicense
+from dev_health_ops.models.settings import Setting, SettingCategory
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
@@ -37,6 +39,7 @@ _TABLES = tables_of(
     OrgLicense,
     FeatureFlag,
     OrgFeatureOverride,
+    Setting,
 )
 
 
@@ -97,6 +100,14 @@ async def _seed_org(
     return {"org_id": str(org_id), "user_id": str(user_id)}
 
 
+async def _seed_active_llm_settings(session_maker, org_id: str) -> None:
+    async with session_maker() as session:
+        svc = SettingsService(session, org_id)
+        await svc.set("provider", "openai", SettingCategory.LLM.value)
+        await svc.set("api_key", "sk-org", SettingCategory.LLM.value, encrypt=True)
+        await session.commit()
+
+
 class FakeSpendSink:
     def __init__(self, summary: LLMTokenSpendSummaryRecord) -> None:
         self.summary = summary
@@ -138,11 +149,13 @@ def _make_app(
             await session.commit()
 
     def _sink_override():
-        yield sink
+        yield sink.read_llm_token_spend
 
     app.dependency_overrides[auth_router_module.get_current_user] = lambda: admin_user
     app.dependency_overrides[admin_router_module.get_session] = _session_override
-    app.dependency_overrides[settings_router_module.get_metrics_sink] = _sink_override
+    app.dependency_overrides[settings_router_module.get_llm_spend_reader] = (
+        _sink_override
+    )
     return app
 
 
@@ -180,6 +193,7 @@ def _summary() -> LLMTokenSpendSummaryRecord:
 @pytest.mark.asyncio
 async def test_admin_llm_settings_spend_returns_org_scoped_summary(session_maker):
     state = await _seed_org(session_maker, tier="team", flag_enabled=True)
+    await _seed_active_llm_settings(session_maker, state["org_id"])
     sink = FakeSpendSink(_summary())
     app = _make_app(session_maker, state, sink)
 
@@ -209,6 +223,7 @@ async def test_admin_llm_settings_spend_returns_org_scoped_summary(session_maker
 @pytest.mark.asyncio
 async def test_admin_llm_settings_spend_returns_empty_summary(session_maker):
     state = await _seed_org(session_maker, tier="team", flag_enabled=True)
+    await _seed_active_llm_settings(session_maker, state["org_id"])
     empty = LLMTokenSpendSummaryRecord(
         since=datetime(2025, 12, 3, 3, tzinfo=timezone.utc),
         limit=20,
@@ -225,6 +240,25 @@ async def test_admin_llm_settings_spend_returns_empty_summary(session_maker):
     assert resp.status_code == 200, resp.text
     assert resp.json()["runs"] == []
     assert resp.json()["legacy"] == []
+
+
+@pytest.mark.asyncio
+async def test_admin_llm_settings_spend_hides_platform_usage_without_active_byo(
+    session_maker,
+):
+    state = await _seed_org(session_maker, tier="team", flag_enabled=True)
+    sink = FakeSpendSink(_summary())
+    app = _make_app(session_maker, state, sink)
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as ac:
+        resp = await ac.get("/api/v1/admin/llm-settings/spend")
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["runs"] == []
+    assert body["legacy"] == []
+    assert sink.org_ids == []
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary
- Gate the BYO-LLM spend endpoint on active org BYO settings before returning spend rows.
- Make ClickHouse spend-reader creation lazy so inactive BYO orgs do not touch ClickHouse.
- Add regression coverage for not-configured BYO orgs returning empty spend and preserving active BYO behavior.

Linear: CHAOS-2896

## Verification
- `bash ci/local_validate.sh`
- Targeted API/manual QA during implementation: inactive BYO returned `200` with empty `runs`/`legacy` and no sink read; active BYO returned the seeded run.

SCREENSHOT-WAIVER: backend-only admin API behavior change; no rendered UI changes.