### PR TITLE
fix(admin/sync): cap coverage boundary at generation time

### DIFF
--- a/src/dev_health_ops/api/services/sync_coverage.py
+++ b/src/dev_health_ops/api/services/sync_coverage.py
@@ -887,7 +887,13 @@ def build_coverage_summary_payload(
             failed_ranges = failed_ranges_not_superseded(failures, successes)
             gaps = subtract_intervals(requested, covered)
             covered_through = max(
-                (interval.before for interval in covered), default=None
+                (
+                    clipped_before
+                    for interval in covered
+                    if ensure_utc(interval.since)
+                    < (clipped_before := min(ensure_utc(interval.before), now))
+                ),
+                default=None,
             )
             stale = classify_staleness(
                 covered_through,

--- a/tests/test_sync_coverage.py
+++ b/tests/test_sync_coverage.py
@@ -204,6 +204,41 @@ def test_complete_summary_is_healthy():
     assert summary["datasets"][0]["gaps"] == []
 
 
+def test_summary_caps_covered_through_at_generation_time():
+    source_id = uuid.uuid4()
+    now = datetime(2026, 7, 8, 19, 2, tzinfo=timezone.utc)
+    summary = _summary(
+        [
+            _window(
+                datetime(2026, 7, 8, tzinfo=timezone.utc),
+                datetime(2026, 7, 9, 6, 59, 59, tzinfo=timezone.utc),
+                source_id=source_id,
+            )
+        ],
+        now=now,
+    )
+
+    assert summary["overall"]["latest_covered_through"] == now
+    assert summary["datasets"][0]["covered_through"] == now
+    assert summary["sources"][0]["covered_through"] == now
+
+
+def test_future_only_success_does_not_mask_stale_coverage():
+    source_id = uuid.uuid4()
+    summary = _summary(
+        [
+            _window(_dt(1), _dt(2), source_id=source_id),
+            _window(_dt(5), _dt(6), source_id=source_id),
+        ],
+        now=_dt(4),
+    )
+
+    assert summary["overall"]["latest_covered_through"] == _dt(2)
+    assert summary["overall"]["health"] == "stale"
+    assert summary["datasets"][0]["covered_through"] == _dt(2)
+    assert summary["datasets"][0]["status"] == "stale"
+
+
 def test_failed_window_without_later_success_marks_failed():
     source_id = uuid.uuid4()
     summary = _summary([_window(_dt(1), _dt(2), source_id=source_id, status="failed")])


### PR DESCRIPTION
## Summary
- cap sync coverage `covered_through` values at the report generation timestamp
- ignore future-only successful intervals so stale coverage is not masked
- add regression coverage for boundary clipping and future-only success rows

## Verification
- `uv run pytest tests/test_sync_coverage.py tests/api/admin/test_sync_coverage_api.py`
- `uv run ruff format --check src/dev_health_ops/api/services/sync_coverage.py tests/test_sync_coverage.py`
- `uv run ruff check src/dev_health_ops/api/services/sync_coverage.py tests/test_sync_coverage.py`
- `uv run mypy src/dev_health_ops/api/services/sync_coverage.py tests/test_sync_coverage.py`
- `bash ci/local_validate.sh`
- pre-commit and pre-push lefthook checks

SCREENSHOT-WAIVER: backend-only API coverage-boundary fix; no rendered UI changed.

Linear: CHAOS-2897