### PR TITLE
feat(licensing): add hosted ACR entitlement (CHAOS-2921)

### DIFF
--- a/docs/architecture/licensing.md
+++ b/docs/architecture/licensing.md
@@ -39,6 +39,33 @@ In the SaaS model, entitlements are managed dynamically through our billing inte
    stripe
 ```
 
+### Hosted Agent Context Runtime
+
+`agent_context_runtime` is a purchased hosted product entitlement, not a tier
+benefit. It is present in the canonical feature registry, but is `false` for
+Community, Team, and Enterprise defaults. A paid tier, trial, or self-hosted
+install must not enable it implicitly.
+
+The billing bridge grants the entitlement only when the organization purchases a
+`FeatureBundle` containing `agent_context_runtime`; it persists the resolved key
+in `OrgLicense.features_override`. A superadmin may also use the existing
+organization-scoped `OrgFeatureOverride` for a support-approved grant or
+revocation. The global `FeatureFlag.is_enabled` kill switch still wins over both
+paths, and expired organization overrides are ignored.
+
+Self-hosted default license payloads also report the key as `false`. A
+self-hosted deployment must not infer hosted ACR access from its license tier.
+
+### ACR Consumer Contract
+
+The future hosted ACR API resolves the entitlement server-side from
+`GET /api/v1/licensing/entitlements/{org_id}`. It may treat only
+`features.agent_context_runtime == true` as product authorization after it has
+independently authenticated the caller and resolved the organization and
+repository scope. `false`, a missing feature row, or an unavailable entitlement
+record denies access. The Dev Health license key is entitlement evidence only;
+it is never an ACR API bearer credential.
+
 ---
 
 ## Self-Hosted Licensing (Secondary)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ dynamic = ["version"]
 description = "Open Source Development Team Operation Analytics"
 readme = "README.md"
 authors = [{ name = "Chris Geo", email = "chris@example.com" }]
-license = { text = "MIT" }
+license = { file = "LICENSE.md" }
 classifiers = [
   "Development Status :: 4 - Beta",
   "Intended Audience :: Developers",
@@ -16,7 +16,7 @@ classifiers = [
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
   "Programming Language :: Python :: 3.14",
-  "License :: OSI Approved :: MIT License",
+  "License :: Other/Proprietary License",
   "Operating System :: OS Independent",
 ]
 keywords = ["metrics", "git", "analytics", "developer-experience"]
@@ -109,6 +109,8 @@ enterprise-sso = ["signxml>=3.0.0"]
 [project.urls]
 Repository = "https://github.com/chrisgeo/dev-health-ops"
 Issues = "https://github.com/chrisgeo/dev-health-ops/issues"
+Documentation = "https://github.com/chrisgeo/dev-health-ops/blob/main/docs/architecture/licensing.md"
+License = "https://github.com/chrisgeo/dev-health-ops/blob/main/LICENSE.md"
 
 [project.scripts]
 dev-health-ops = "dev_health_ops.cli:main"

--- a/src/dev_health_ops/alembic/versions/0037_seed_agent_context_runtime_feature_flag.py
+++ b/src/dev_health_ops/alembic/versions/0037_seed_agent_context_runtime_feature_flag.py
@@ -1,0 +1,60 @@
+"""Seed the hosted Agent Context Runtime entitlement flag.
+
+Revision ID: 0037
+Revises: 0036
+Create Date: 2026-07-10 00:00:00
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0037"
+down_revision: str | None = "0036"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+__all__ = ["revision", "down_revision", "branch_labels", "depends_on"]
+
+_FEATURE_KEY = "agent_context_runtime"
+_FEATURE_NAME = "Agent Context Runtime"
+_FEATURE_CATEGORY = "integrations"
+_FEATURE_MIN_TIER = "community"
+
+
+def upgrade() -> None:
+    conn = op.get_bind()
+    now = datetime.now(timezone.utc)
+
+    conn.execute(
+        sa.text(
+            """
+            INSERT INTO feature_flags
+                (id, key, name, category, min_tier, is_enabled, is_beta,
+                 is_deprecated, created_at, updated_at)
+            SELECT :id, :key, :name, :category, :min_tier,
+                   TRUE, FALSE, FALSE, :created_at, :updated_at
+            WHERE NOT EXISTS (
+                SELECT 1 FROM feature_flags WHERE key = :key
+            )
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "key": _FEATURE_KEY,
+            "name": _FEATURE_NAME,
+            "category": _FEATURE_CATEGORY,
+            "min_tier": _FEATURE_MIN_TIER,
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+
+
+def downgrade() -> None:
+    pass

--- a/src/dev_health_ops/api/licensing/router.py
+++ b/src/dev_health_ops/api/licensing/router.py
@@ -9,6 +9,7 @@ from pydantic import BaseModel, Field
 from dev_health_ops.api.auth.router import get_current_user
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.db import get_postgres_session
+from dev_health_ops.licensing.registry import is_explicit_purchase_feature
 from dev_health_ops.licensing.types import LicenseTier
 
 router = APIRouter(prefix="/api/v1/licensing", tags=["licensing"])
@@ -110,8 +111,12 @@ async def get_entitlements(
     features: dict[str, bool] = {}
     flags_by_key = {str(flag.key): flag for flag in all_flags}
     for flag in all_flags:
+        feature_key = str(flag.key)
+        if is_explicit_purchase_feature(feature_key):
+            features[feature_key] = False
+            continue
         min_tier = _coerce_license_tier(flag.min_tier)
-        features[str(flag.key)] = bool(flag.is_enabled) and org_rank >= TIER_RANK.get(
+        features[feature_key] = bool(flag.is_enabled) and org_rank >= TIER_RANK.get(
             min_tier, 0
         )
 
@@ -120,8 +125,14 @@ async def get_entitlements(
             override_flag = flags_by_key.get(key)
             if override_flag is None:
                 features[key] = (
-                    False if key == _CUSTOMER_PUSH_FEATURE else bool(enabled)
+                    False
+                    if key == _CUSTOMER_PUSH_FEATURE
+                    or is_explicit_purchase_feature(key)
+                    else bool(enabled)
                 )
+                continue
+            if is_explicit_purchase_feature(key):
+                features[key] = bool(enabled) and bool(override_flag.is_enabled)
                 continue
             min_tier = _coerce_license_tier(override_flag.min_tier)
             tier_allowed = org_rank >= TIER_RANK.get(min_tier, 0)
@@ -135,9 +146,15 @@ async def get_entitlements(
                 now = datetime.now().astimezone()
                 if override.expires_at and override.expires_at < now:
                     continue
+                feature_key = str(flag.key)
+                if is_explicit_purchase_feature(feature_key):
+                    features[feature_key] = bool(override.is_enabled) and bool(
+                        flag.is_enabled
+                    )
+                    break
                 min_tier = _coerce_license_tier(flag.min_tier)
                 tier_allowed = org_rank >= TIER_RANK.get(min_tier, 0)
-                features[str(flag.key)] = (
+                features[feature_key] = (
                     bool(override.is_enabled) and bool(flag.is_enabled) and tier_allowed
                 )
                 break

--- a/src/dev_health_ops/api/services/licensing.py
+++ b/src/dev_health_ops/api/services/licensing.py
@@ -13,6 +13,7 @@ from typing import TYPE_CHECKING, Any
 import jwt
 from jwt.exceptions import InvalidTokenError
 
+from dev_health_ops.licensing.registry import is_explicit_purchase_feature
 from dev_health_ops.licensing.types import TIER_ORDER, LicenseTier
 from dev_health_ops.models.licensing import (
     STANDARD_FEATURES,
@@ -351,6 +352,12 @@ class FeatureService:
                         allowed=False,
                         reason="Feature disabled in license",
                     )
+
+        if is_explicit_purchase_feature(feature_key):
+            return FeatureAccess(
+                allowed=False,
+                reason="Requires an explicit organization purchase",
+            )
 
         feature_min_tier = LicenseTier(feature.min_tier)
         tier_order = [

--- a/src/dev_health_ops/licensing/gating.py
+++ b/src/dev_health_ops/licensing/gating.py
@@ -12,7 +12,10 @@ from fastapi import HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from dev_health_ops.licensing.registry import get_features_for_tier
+from dev_health_ops.licensing.registry import (
+    EXPLICIT_PURCHASE_FEATURES,
+    get_features_for_tier,
+)
 from dev_health_ops.licensing.types import (
     DEFAULT_LIMITS,
     TIER_ORDER,
@@ -424,6 +427,31 @@ async def get_org_entitlements_from_db(
                     else False
                 )
         features["customer_push_ingest"] = customer_push_enabled
+
+    for feature_key in EXPLICIT_PURCHASE_FEATURES:
+        explicit_flag_result = await session.execute(
+            select(FeatureFlag).filter_by(key=feature_key)
+        )
+        explicit_flag = explicit_flag_result.scalar_one_or_none()
+        features[feature_key] = False
+        if explicit_flag is None or not explicit_flag.is_enabled:
+            continue
+
+        if org_license is not None and org_license.features_override:
+            feature_overrides = _coerce_bool_map(org_license.features_override)
+            if feature_key in feature_overrides:
+                features[feature_key] = feature_overrides[feature_key]
+
+        org_override_result = await session.execute(
+            select(OrgFeatureOverride).filter_by(
+                org_id=org_id, feature_id=explicit_flag.id
+            )
+        )
+        org_override = org_override_result.scalar_one_or_none()
+        if org_override is not None:
+            now = datetime.now(timezone.utc)
+            if not org_override.expires_at or org_override.expires_at >= now:
+                features[feature_key] = bool(org_override.is_enabled)
 
     subscription_result = await session.execute(
         select(Subscription)

--- a/src/dev_health_ops/licensing/registry.py
+++ b/src/dev_health_ops/licensing/registry.py
@@ -11,6 +11,12 @@ from dev_health_ops.licensing.types import TIER_ORDER, FeatureCategory, LicenseT
 
 STANDARD_FEATURE_ROW = tuple[str, str, FeatureCategory, LicenseTier, str]
 
+EXPLICIT_PURCHASE_FEATURES: frozenset[str] = frozenset({"agent_context_runtime"})
+
+
+def is_explicit_purchase_feature(feature_key: str) -> bool:
+    return feature_key in EXPLICIT_PURCHASE_FEATURES
+
 
 def get_features_for_tier(tier: LicenseTier) -> dict[str, bool]:
     """Return a feature-key → enabled dict for the given tier.
@@ -22,7 +28,7 @@ def get_features_for_tier(tier: LicenseTier) -> dict[str, bool]:
     result: dict[str, bool] = {}
     for key, _name, _category, min_tier, _desc in STANDARD_FEATURES:
         min_index = TIER_ORDER.index(min_tier) if min_tier in TIER_ORDER else 0
-        result[key] = tier_index >= min_index
+        result[key] = tier_index >= min_index and not is_explicit_purchase_feature(key)
     return result
 
 
@@ -138,6 +144,13 @@ STANDARD_FEATURES: list[STANDARD_FEATURE_ROW] = [
         FeatureCategory.INTEGRATIONS,
         LicenseTier.TEAM,
         "Customer-owned external ingestion runners",
+    ),
+    (
+        "agent_context_runtime",
+        "Agent Context Runtime",
+        FeatureCategory.INTEGRATIONS,
+        LicenseTier.COMMUNITY,
+        "Hosted evidence-backed context for authorized coding agents",
     ),
     (
         "scheduled_jobs",

--- a/tests/api/licensing/test_entitlements_auth.py
+++ b/tests/api/licensing/test_entitlements_auth.py
@@ -214,6 +214,106 @@ async def test_entitlements_return_effective_false_when_feature_globally_disable
 
 
 @pytest.mark.asyncio
+async def test_entitlements_keep_acr_false_for_paid_org_without_purchase(
+    session_maker, seeded_org, monkeypatch
+):
+    async with session_maker() as session:
+        session.add(
+            FeatureFlag(
+                key="agent_context_runtime",
+                name="Agent Context Runtime",
+                category="integrations",
+                min_tier="community",
+            )
+        )
+        await session.commit()
+
+    user = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="member@example.com",
+        org_id=seeded_org,
+        role="member",
+        is_superuser=False,
+    )
+
+    app = FastAPI()
+    app.include_router(licensing_router)
+    app.dependency_overrides[get_current_user] = lambda: user
+    monkeypatch.setattr(
+        _licensing_router_module,
+        "get_postgres_session",
+        _make_postgres_patcher(session_maker),
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(f"/api/v1/licensing/entitlements/{seeded_org}")
+
+    assert response.status_code == 200
+    assert response.json()["features"]["agent_context_runtime"] is False
+
+
+@pytest.mark.asyncio
+async def test_billing_entitlements_enable_acr_for_explicit_bundle_grant(
+    session_maker, seeded_org
+):
+    async with session_maker() as session:
+        session.add_all(
+            [
+                FeatureFlag(
+                    key="agent_context_runtime",
+                    name="Agent Context Runtime",
+                    category="integrations",
+                    min_tier="community",
+                ),
+                OrgLicense(
+                    org_id=uuid.UUID(seeded_org),
+                    tier="team",
+                    features_override={"agent_context_runtime": True},
+                ),
+            ]
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        entitlements = await get_org_entitlements_from_db(
+            uuid.UUID(seeded_org), session
+        )
+
+    assert entitlements["features"]["agent_context_runtime"] is True
+
+
+@pytest.mark.asyncio
+async def test_billing_entitlements_enable_acr_for_active_org_override(
+    session_maker, seeded_org
+):
+    async with session_maker() as session:
+        feature_flag = FeatureFlag(
+            key="agent_context_runtime",
+            name="Agent Context Runtime",
+            category="integrations",
+            min_tier="community",
+        )
+        session.add(feature_flag)
+        await session.flush()
+        session.add(
+            OrgFeatureOverride(
+                org_id=uuid.UUID(seeded_org),
+                feature_id=feature_flag.id,
+                is_enabled=True,
+            )
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        entitlements = await get_org_entitlements_from_db(
+            uuid.UUID(seeded_org), session
+        )
+
+    assert entitlements["features"]["agent_context_runtime"] is True
+
+
+@pytest.mark.asyncio
 async def test_entitlements_keep_customer_push_false_below_tier_with_positive_license_override(
     session_maker, seeded_org, monkeypatch
 ):

--- a/tests/test_agent_context_runtime_feature_flag_migration.py
+++ b/tests/test_agent_context_runtime_feature_flag_migration.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+import importlib
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+
+def _load_migration_0037():
+    return importlib.import_module(
+        "dev_health_ops.alembic.versions.0037_seed_agent_context_runtime_feature_flag"
+    )
+
+
+def test_migration_0037_seeds_agent_context_runtime_feature_flag_idempotently():
+    migration = _load_migration_0037()
+    assert migration.revision == "0037"
+    assert migration.down_revision == "0036"
+
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                sa.text(
+                    """
+                    CREATE TABLE feature_flags (
+                        id TEXT PRIMARY KEY,
+                        key TEXT NOT NULL UNIQUE,
+                        name TEXT NOT NULL,
+                        category TEXT NOT NULL,
+                        min_tier TEXT NOT NULL,
+                        is_enabled BOOLEAN NOT NULL,
+                        is_beta BOOLEAN NOT NULL,
+                        is_deprecated BOOLEAN NOT NULL,
+                        created_at DATETIME NOT NULL,
+                        updated_at DATETIME NOT NULL
+                    )
+                    """
+                )
+            )
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.upgrade()
+                migration.upgrade()
+
+                rows = conn.execute(
+                    sa.text(
+                        """
+                        SELECT key, name, category, min_tier, is_enabled
+                        FROM feature_flags
+                        WHERE key = 'agent_context_runtime'
+                        """
+                    )
+                ).all()
+                assert rows == [
+                    (
+                        "agent_context_runtime",
+                        "Agent Context Runtime",
+                        "integrations",
+                        "community",
+                        1,
+                    )
+                ]
+
+                migration.downgrade()
+                rows_after_downgrade = conn.execute(
+                    sa.text("SELECT key FROM feature_flags")
+                ).all()
+                assert rows_after_downgrade == [("agent_context_runtime",)]
+    finally:
+        engine.dispose()

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -833,6 +833,14 @@ def test_validate_bundle_feature_keys_valid():
     validate_bundle_feature_keys(["git_sync", "api_access"])
 
 
+def test_validate_bundle_feature_keys_accepts_acr_purchased_feature():
+    from dev_health_ops.api.billing.bundle_validation import (
+        validate_bundle_feature_keys,
+    )
+
+    validate_bundle_feature_keys(["agent_context_runtime"])
+
+
 def test_validate_bundle_feature_keys_unknown_raises():
     """Creating a bundle with an unknown key raises ValueError naming the key."""
     from dev_health_ops.api.billing.bundle_validation import (

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -26,6 +26,7 @@ from dev_health_ops.licensing.registry import (
 from dev_health_ops.licensing.types import (
     DEFAULT_LIMITS,
     GRACE_DAYS,
+    TIER_ORDER,
     LicenseLimits,
 )
 from dev_health_ops.licensing.validator import ValidationResult
@@ -1224,7 +1225,7 @@ class TestGetFeaturesForTier:
         assert features["capacity_forecast"] is True
 
     def test_agent_context_runtime_requires_explicit_purchase_for_every_tier(self):
-        for tier in LicenseTier:
+        for tier in TIER_ORDER:
             features = get_features_for_tier(tier)
 
             assert features["agent_context_runtime"] is False

--- a/tests/test_licensing.py
+++ b/tests/test_licensing.py
@@ -2,9 +2,11 @@ import argparse
 import base64
 import json
 import time
+from pathlib import Path
 
 import pytest
 import pytest_asyncio
+import tomllib
 from nacl.signing import SigningKey
 
 from dev_health_ops.licensing import (
@@ -17,7 +19,10 @@ from dev_health_ops.licensing import (
     sign_license,
     sign_payload,
 )
-from dev_health_ops.licensing.registry import get_features_for_tier
+from dev_health_ops.licensing.registry import (
+    get_features_for_tier,
+    is_explicit_purchase_feature,
+)
 from dev_health_ops.licensing.types import (
     DEFAULT_LIMITS,
     GRACE_DAYS,
@@ -1218,15 +1223,24 @@ class TestGetFeaturesForTier:
         assert features["scheduled_jobs"] is True
         assert features["capacity_forecast"] is True
 
+    def test_agent_context_runtime_requires_explicit_purchase_for_every_tier(self):
+        for tier in LicenseTier:
+            features = get_features_for_tier(tier)
+
+            assert features["agent_context_runtime"] is False
+
+    def test_agent_context_runtime_is_registered_as_explicit_purchase(self):
+        assert is_explicit_purchase_feature("agent_context_runtime") is True
+
     def test_all_tiers_return_same_key_set(self):
         community = get_features_for_tier(LicenseTier.COMMUNITY)
         team = get_features_for_tier(LicenseTier.TEAM)
         enterprise = get_features_for_tier(LicenseTier.ENTERPRISE)
         assert set(community.keys()) == set(team.keys()) == set(enterprise.keys())
 
-    def test_returns_27_features(self):
+    def test_returns_28_features(self):
         features = get_features_for_tier(LicenseTier.COMMUNITY)
-        assert len(features) == 27
+        assert len(features) == 28
 
     def test_sign_license_uses_canonical_registry(self):
         """sign_license() with no explicit features uses get_features_for_tier."""
@@ -1273,6 +1287,7 @@ class TestGetFeaturesForTier:
             from dev_health_ops.licensing import sign_license
 
             LicenseManager.reset()
+
             real_license = sign_license(
                 kp.private_key, org_id="org-1", tier="enterprise"
             )
@@ -1282,6 +1297,16 @@ class TestGetFeaturesForTier:
             assert result == "ok"
         finally:
             LicenseManager.reset()
+
+
+def test_package_metadata_identifies_bsl_and_links_canonical_docs():
+    project_path = Path(__file__).parents[1] / "pyproject.toml"
+    project = tomllib.loads(project_path.read_text())["project"]
+
+    assert project["license"] == {"file": "LICENSE.md"}
+    assert "License :: Other/Proprietary License" in project["classifiers"]
+    assert project["urls"]["License"].endswith("/LICENSE.md")
+    assert project["urls"]["Documentation"].endswith("/docs/architecture/licensing.md")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- correct package license metadata to the repository BSL license
- add `agent_context_runtime` as an explicit purchased feature, never a tier default
- expose organization-scoped entitlement results with migration and authorization coverage

## Verification
- `bash ci/local_validate.sh` (7,707 passed, 44 skipped; ClickHouse-only stages skipped because the local container was unavailable)
- independent changeset review: APPROVE, no blocking findings

SCREENSHOT-WAIVER: backend licensing and metadata changes; no rendered UI.

Linear: CHAOS-2921