### PR TITLE
feat(acr): internal ACR service credentials and entitlement/health API (CHAOS-2944)

### DIFF
--- a/ci/run_live_backend_e2e.sh
+++ b/ci/run_live_backend_e2e.sh
@@ -281,6 +281,15 @@ echo "==> generating deterministic ClickHouse fixtures (metrics + work graph)"
     --with-work-graph
 )
 
+echo "==> migrating PostgreSQL for internal credential lifecycle coverage"
+run_dev_hops --db "${POSTGRES_URI}" migrate postgres upgrade
+
+echo "==> running service credential subprocess lifecycle against live PostgreSQL"
+DEV_HEALTH_POSTGRES_TEST_URI="${POSTGRES_URI}" \
+  run_python -m pytest \
+  tests/test_service_credentials_cli.py::test_service_credential_create_emits_only_token_and_db_flag_is_honored \
+  -q
+
 # JWT_SECRET_KEY is now required (no SHA256 derivation fallback) — derive the same
 # value generate_auth_token() uses so tokens match between API and e2e client.
 if [ -z "${JWT_SECRET_KEY:-}" ]; then

--- a/src/dev_health_ops/alembic/versions/0038_add_internal_service_credentials.py
+++ b/src/dev_health_ops/alembic/versions/0038_add_internal_service_credentials.py
@@ -1,0 +1,76 @@
+"""Add dedicated internal service credentials for ACR entitlement lookups.
+
+Revision ID: 0038
+Revises: 0037
+Create Date: 2026-07-13 00:00:00
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects.postgresql import UUID
+
+revision: str = "0038"
+down_revision: str | None = "0037"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "internal_service_credentials",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("service_name", sa.Text(), nullable=False),
+        sa.Column("token_hash", sa.Text(), nullable=False, unique=True),
+        sa.Column("token_prefix", sa.Text(), nullable=False),
+        sa.Column("scopes", sa.JSON(), nullable=False),
+        sa.Column("created_by_user_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_used_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["created_by_user_id"], ["users.id"], ondelete="SET NULL"
+        ),
+    )
+    op.create_index(
+        "ix_internal_service_credentials_service_active",
+        "internal_service_credentials",
+        ["service_name", "revoked_at"],
+    )
+    op.create_index(
+        "ix_internal_service_credentials_token_hash",
+        "internal_service_credentials",
+        ["token_hash"],
+        unique=True,
+    )
+    op.create_table(
+        "internal_service_credential_audits",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column("credential_id", UUID(as_uuid=True), nullable=True),
+        sa.Column("requested_org_id", sa.Text(), nullable=True),
+        sa.Column("action", sa.Text(), nullable=False),
+        sa.Column("outcome", sa.Text(), nullable=False),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["credential_id"], ["internal_service_credentials.id"], ondelete="SET NULL"
+        ),
+    )
+    op.create_index(
+        "ix_internal_service_credential_audits_credential_id",
+        "internal_service_credential_audits",
+        ["credential_id"],
+    )
+    op.create_index(
+        "ix_internal_service_credential_audits_requested_org_id",
+        "internal_service_credential_audits",
+        ["requested_org_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("internal_service_credential_audits")
+    op.drop_table("internal_service_credentials")

--- a/src/dev_health_ops/api/internal/__init__.py
+++ b/src/dev_health_ops/api/internal/__init__.py
@@ -1,0 +1,3 @@
+from .acr import router
+
+__all__ = ["router"]

--- a/src/dev_health_ops/api/internal/acr.py
+++ b/src/dev_health_ops/api/internal/acr.py
@@ -1,0 +1,224 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from fastapi import APIRouter, HTTPException, Request
+from limits import parse as parse_rate_limit
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy import select
+from sqlalchemy.exc import SQLAlchemyError
+
+from dev_health_ops.api.middleware.rate_limit import (
+    INTERNAL_ACR_AUTH_ATTEMPT_IP_LIMIT,
+    get_forwarded_ip,
+    limiter,
+)
+from dev_health_ops.db import get_postgres_session
+from dev_health_ops.licensing.gating import get_org_entitlements_from_db
+from dev_health_ops.models.internal_service_credential import (
+    INTERNAL_SERVICE_TOKEN_PREFIX,
+    InternalServiceCredential,
+    InternalServiceCredentialAudit,
+    hash_internal_service_token,
+)
+from dev_health_ops.models.users import Organization
+
+router = APIRouter(prefix="/api/v1/internal/acr", tags=["internal-acr"])
+_REQUIRED_SCOPE = "entitlements:read"
+_AUTH_ATTEMPT_LIMIT_ITEM = parse_rate_limit(INTERNAL_ACR_AUTH_ATTEMPT_IP_LIMIT)
+
+
+class ACREntitlementResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: str = "acr_entitlement.v1"
+    org_id: str
+    agent_context_runtime: bool
+
+
+class ACRServiceHealthResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    schema_version: str = "acr_service_health.v1"
+    service: str = "dev-health-ops"
+    status: str = "ok"
+
+
+def _extract_token(request: Request) -> str | None:
+    authorization = request.headers.get("Authorization")
+    if authorization is None or not authorization.startswith("Bearer "):
+        return None
+    token = authorization.removeprefix("Bearer ")
+    if not token.startswith(INTERNAL_SERVICE_TOKEN_PREFIX) or len(token) <= len(
+        INTERNAL_SERVICE_TOKEN_PREFIX
+    ):
+        return None
+    return token
+
+
+def _reserve_auth_attempt_or_429(request: Request) -> None:
+    rate_limiter = getattr(limiter, "limiter", None)
+    if rate_limiter is None:
+        return
+    key = f"internal-acr-auth-attempt:{get_forwarded_ip(request)}"
+    if not rate_limiter.hit(_AUTH_ATTEMPT_LIMIT_ITEM, key):
+        raise HTTPException(status_code=429, detail="Too many authentication attempts")
+
+
+async def _audit(
+    credential_id: uuid.UUID | None,
+    requested_org_id: str,
+    outcome: str,
+) -> None:
+    async with get_postgres_session() as session:
+        session.add(
+            InternalServiceCredentialAudit(
+                credential_id=credential_id,
+                requested_org_id=requested_org_id,
+                action="acr_entitlement_lookup",
+                outcome=outcome,
+            )
+        )
+        await session.commit()
+
+
+@router.get("/health", response_model=ACRServiceHealthResponse)
+async def get_acr_service_health(request: Request) -> ACRServiceHealthResponse:
+    _reserve_auth_attempt_or_429(request)
+    token = _extract_token(request)
+    if token is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    try:
+        async with get_postgres_session() as session:
+            result = await session.execute(
+                select(InternalServiceCredential).where(
+                    InternalServiceCredential.token_hash
+                    == hash_internal_service_token(token)
+                )
+            )
+            credential = result.scalar_one_or_none()
+    except (RuntimeError, SQLAlchemyError):
+        raise HTTPException(status_code=503, detail="Service unavailable") from None
+
+    if credential is None:
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    now = datetime.now(timezone.utc)
+    if credential.service_name != "acr" or not credential.is_valid(now):
+        raise HTTPException(status_code=401, detail="Unauthorized")
+    if _REQUIRED_SCOPE not in credential.scopes:
+        raise HTTPException(status_code=403, detail="Forbidden")
+    return ACRServiceHealthResponse()
+
+
+@router.get("/entitlements/{org_id}", response_model=ACREntitlementResponse)
+async def get_acr_entitlement(org_id: str, request: Request) -> ACREntitlementResponse:
+    _reserve_auth_attempt_or_429(request)
+    token = _extract_token(request)
+    if token is None:
+        await _audit(None, org_id, "missing_or_malformed_token")
+        raise HTTPException(status_code=401, detail="Unauthorized")
+
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(InternalServiceCredential).where(
+                InternalServiceCredential.token_hash
+                == hash_internal_service_token(token)
+            )
+        )
+        credential = result.scalar_one_or_none()
+        if credential is None:
+            session.add(
+                InternalServiceCredentialAudit(
+                    credential_id=None,
+                    requested_org_id=org_id,
+                    action="acr_entitlement_lookup",
+                    outcome="unknown_token",
+                )
+            )
+            await session.commit()
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+        credential_id = credential.id
+        now = datetime.now(timezone.utc)
+        if credential.service_name != "acr" or not credential.is_valid(now):
+            session.add(
+                InternalServiceCredentialAudit(
+                    credential_id=credential_id,
+                    requested_org_id=org_id,
+                    action="acr_entitlement_lookup",
+                    outcome="inactive_token",
+                )
+            )
+            await session.commit()
+            raise HTTPException(status_code=401, detail="Unauthorized")
+
+        credential.last_used_at = now
+        if _REQUIRED_SCOPE not in credential.scopes:
+            session.add(
+                InternalServiceCredentialAudit(
+                    credential_id=credential_id,
+                    requested_org_id=org_id,
+                    action="acr_entitlement_lookup",
+                    outcome="insufficient_scope",
+                )
+            )
+            await session.commit()
+            raise HTTPException(status_code=403, detail="Forbidden")
+
+        try:
+            org_uuid = uuid.UUID(org_id)
+        except ValueError:
+            session.add(
+                InternalServiceCredentialAudit(
+                    credential_id=credential.id,
+                    requested_org_id=org_id,
+                    action="acr_entitlement_lookup",
+                    outcome="organization_not_found",
+                )
+            )
+            await session.commit()
+            raise HTTPException(status_code=404, detail="Not found") from None
+
+        org = await session.get(Organization, org_uuid)
+        if org is None:
+            session.add(
+                InternalServiceCredentialAudit(
+                    credential_id=credential.id,
+                    requested_org_id=org_id,
+                    action="acr_entitlement_lookup",
+                    outcome="organization_not_found",
+                )
+            )
+            await session.commit()
+            raise HTTPException(status_code=404, detail="Not found")
+
+        try:
+            entitlements = await get_org_entitlements_from_db(org_uuid, session)
+        except Exception:  # noqa: BLE001 - entitlement provider is an untrusted boundary.
+            await session.rollback()
+            session.add(
+                InternalServiceCredentialAudit(
+                    credential_id=credential_id,
+                    requested_org_id=org_id,
+                    action="acr_entitlement_lookup",
+                    outcome="entitlement_lookup_failed",
+                )
+            )
+            await session.commit()
+            raise HTTPException(status_code=503, detail="Service unavailable") from None
+        session.add(
+            InternalServiceCredentialAudit(
+                credential_id=credential.id,
+                requested_org_id=org_id,
+                action="acr_entitlement_lookup",
+                outcome="success",
+            )
+        )
+        await session.commit()
+    features = entitlements["features"]
+    return ACREntitlementResponse(
+        org_id=org_id,
+        agent_context_runtime=bool(features.get("agent_context_runtime", False)),
+    )

--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -29,6 +29,7 @@ from dev_health_ops.api.external_ingest.errors import (
 from dev_health_ops.api.external_ingest.status import (
     status_router as external_ingest_status_router,
 )
+from dev_health_ops.api.internal import router as internal_acr_router
 from dev_health_ops.api.middleware.rate_limit import limiter
 from dev_health_ops.api.product_telemetry import router as product_telemetry_router
 from dev_health_ops.api.telemetry.router import router as telemetry_router
@@ -215,6 +216,7 @@ app.include_router(product_telemetry_router)
 app.include_router(ingest_router)
 app.include_router(external_ingest_router)
 app.include_router(external_ingest_status_router)
+app.include_router(internal_acr_router)
 app.include_router(orgs_router)
 
 register_observability(app)

--- a/src/dev_health_ops/api/middleware/rate_limit.py
+++ b/src/dev_health_ops/api/middleware/rate_limit.py
@@ -65,6 +65,7 @@ INGEST_AUTH_ATTEMPT_IP_LIMIT = "100/minute"
 # concern (the attempt ceiling already bounds that unconditionally); it
 # exists purely to penalize repeated *wrong credentials* specifically.
 INGEST_AUTH_FAILURE_IP_LIMIT = "30/minute"
+INTERNAL_ACR_AUTH_ATTEMPT_IP_LIMIT = "100/minute"
 
 
 def get_ingest_token_key(request: Request) -> str:

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -367,6 +367,17 @@ def _is_push_invocation(argv: list[str] | None) -> bool:
     return bool(args) and args[0] == "push"
 
 
+def _is_service_credential_invocation(argv: list[str] | None) -> bool:
+    args = sys.argv[1:] if argv is None else argv
+    return "service-credentials" in args
+
+
+def _route_logs_to_stderr() -> None:
+    for handler in logging.getLogger().handlers:
+        if isinstance(handler, logging.StreamHandler):
+            handler.setStream(sys.stderr)
+
+
 @contextlib.contextmanager
 def _suppress_parser_construction_noise():
     previous_disable_level = logging.root.manager.disable
@@ -494,6 +505,10 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("admin", "bundles", "assign-plan"): frozenset({_REQ_POSTGRES}),
     ("admin", "bundles", "assign-org"): frozenset({_REQ_POSTGRES}),
     ("billing", "reconcile"): frozenset({_REQ_POSTGRES}),
+    ("service-credentials", "create"): frozenset({_REQ_POSTGRES}),
+    ("service-credentials", "list"): frozenset({_REQ_POSTGRES}),
+    ("service-credentials", "rotate"): frozenset({_REQ_POSTGRES}),
+    ("service-credentials", "revoke"): frozenset({_REQ_POSTGRES}),
     ("backfill", "run"): frozenset({_REQ_POSTGRES}),
     ("maintenance", "scrub-error-text"): frozenset({_REQ_POSTGRES}),
     # --- migrations that connect to a live database ---
@@ -598,6 +613,10 @@ def run_preflight_checks(
     from dev_health_ops.db import validate_sink_uri_scheme
 
     try:
+        if _REQ_POSTGRES in requires and (uri := getattr(ns, "db", None)):
+            from dev_health_ops.db import validate_postgres_uri_scheme
+
+            validate_postgres_uri_scheme(uri)
         if _REQ_CLICKHOUSE in requires and (uri := _clickhouse_value(ns)):
             validate_sink_uri_scheme(uri)
         if _REQ_SINK_DB in requires and (uri := _sink_db_value(ns)):
@@ -635,6 +654,7 @@ def build_parser() -> argparse.ArgumentParser:
     import dev_health_ops.api.billing.cli as billing_cli
     import dev_health_ops.backfill.cli as backfill_cli
     from dev_health_ops import migrate as migrate_mod
+    from dev_health_ops import service_credentials
     from dev_health_ops.api import runner as api_runner
     from dev_health_ops.api.admin import cli as admin_cli
     from dev_health_ops.audit import (
@@ -738,6 +758,7 @@ def build_parser() -> argparse.ArgumentParser:
     api_runner.register_commands(sub)
 
     billing_cli.register_commands(sub)
+    service_credentials.register_commands(sub)
 
     # ---- admin (user/org management) ----
     admin_cli.register_commands(sub)
@@ -876,12 +897,17 @@ def main(argv: list[str] | None = None) -> int:
     quiet_json_inspect = _is_workers_inspect_json_invocation(
         argv
     ) or _is_push_invocation(argv)
+    service_credentials_output = _is_service_credential_invocation(argv)
     previous_otel_enabled = os.environ.get("OTEL_ENABLED")
     if quiet_json_inspect:
         os.environ["OTEL_ENABLED"] = "false"
 
     try:
-        if _is_help_invocation(argv) or quiet_json_inspect:
+        if (
+            _is_help_invocation(argv)
+            or quiet_json_inspect
+            or service_credentials_output
+        ):
             with _suppress_parser_construction_noise():
                 parser = build_parser()
         else:
@@ -893,6 +919,11 @@ def main(argv: list[str] | None = None) -> int:
             ns.org = _resolve_first_org_id(getattr(ns, "db", None))
 
         run_preflight_checks(parser, ns)
+        if _REQ_POSTGRES in (getattr(ns, "_requires", None) or frozenset()) and ns.db:
+            os.environ["POSTGRES_URI"] = ns.db
+
+        if service_credentials_output:
+            _route_logs_to_stderr()
 
         level_name = str(getattr(ns, "log_level", "") or "INFO").upper()
         level = getattr(logging, level_name, logging.INFO)

--- a/src/dev_health_ops/db.py
+++ b/src/dev_health_ops/db.py
@@ -146,6 +146,12 @@ def get_postgres_uri() -> str | None:
     return None
 
 
+def validate_postgres_uri_scheme(uri: str) -> None:
+    drivername = make_url(uri).drivername
+    if drivername not in {"postgresql", "postgresql+asyncpg"}:
+        raise ValueError("PostgreSQL --db must use a postgresql:// URI")
+
+
 def get_clickhouse_uri() -> str | None:
     """Get ClickHouse connection URI."""
     return os.getenv("CLICKHOUSE_URI")

--- a/src/dev_health_ops/models/internal_service_credential.py
+++ b/src/dev_health_ops/models/internal_service_credential.py
@@ -1,0 +1,143 @@
+from __future__ import annotations
+
+import hashlib
+import secrets
+import uuid
+from datetime import datetime, timezone
+
+from sqlalchemy import JSON, DateTime, ForeignKey, Index, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from dev_health_ops.models.git import GUID, Base
+
+INTERNAL_SERVICE_TOKEN_PREFIX = "svc_acr_"
+
+
+def generate_internal_service_token() -> str:
+    return f"{INTERNAL_SERVICE_TOKEN_PREFIX}{secrets.token_urlsafe(32)}"
+
+
+def hash_internal_service_token(token: str) -> str:
+    return hashlib.sha256(token.encode("utf-8")).hexdigest()
+
+
+class InternalServiceCredential(Base):
+    __tablename__ = "internal_service_credentials"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    service_name: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    token_hash: Mapped[str] = mapped_column(
+        Text, nullable=False, unique=True, index=True
+    )
+    token_prefix: Mapped[str] = mapped_column(Text, nullable=False)
+    scopes: Mapped[list[str]] = mapped_column(JSON, nullable=False, default=list)
+    created_by_user_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID, ForeignKey("users.id", ondelete="SET NULL"), nullable=True
+    )
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    revoked_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    __table_args__ = (
+        Index(
+            "ix_internal_service_credentials_service_active",
+            "service_name",
+            "revoked_at",
+        ),
+    )
+
+    @classmethod
+    def from_plaintext_token(
+        cls,
+        *,
+        token: str,
+        service_name: str,
+        scopes: list[str],
+        expires_at: datetime | None,
+        created_by_user_id: uuid.UUID | None = None,
+    ) -> InternalServiceCredential:
+        return cls(
+            service_name=service_name,
+            token_hash=hash_internal_service_token(token),
+            token_prefix=token[:16],
+            scopes=scopes,
+            expires_at=expires_at,
+            created_by_user_id=created_by_user_id,
+        )
+
+    @classmethod
+    def issue(
+        cls,
+        *,
+        service_name: str,
+        scopes: list[str],
+        created_by_user_id: uuid.UUID | None,
+        expires_at: datetime | None = None,
+    ) -> tuple[InternalServiceCredential, str]:
+        token = generate_internal_service_token()
+        return (
+            cls.from_plaintext_token(
+                token=token,
+                service_name=service_name,
+                scopes=scopes,
+                expires_at=expires_at,
+                created_by_user_id=created_by_user_id,
+            ),
+            token,
+        )
+
+    def is_valid(self, now: datetime) -> bool:
+        if self.revoked_at is not None:
+            return False
+        expires_at = self.expires_at
+        if expires_at is None:
+            return True
+        if expires_at.tzinfo is None:
+            expires_at = expires_at.replace(tzinfo=timezone.utc)
+        return now <= expires_at
+
+    def public_metadata(self) -> dict[str, str | list[str] | None]:
+        return {
+            "id": str(self.id),
+            "service_name": self.service_name,
+            "token_prefix": self.token_prefix,
+            "scopes": self.scopes,
+            "expires_at": self.expires_at.isoformat() if self.expires_at else None,
+            "revoked_at": self.revoked_at.isoformat() if self.revoked_at else None,
+            "last_used_at": self.last_used_at.isoformat()
+            if self.last_used_at
+            else None,
+        }
+
+
+class InternalServiceCredentialAudit(Base):
+    __tablename__ = "internal_service_credential_audits"
+
+    id: Mapped[uuid.UUID] = mapped_column(GUID, primary_key=True, default=uuid.uuid4)
+    credential_id: Mapped[uuid.UUID | None] = mapped_column(
+        GUID,
+        ForeignKey("internal_service_credentials.id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    requested_org_id: Mapped[str | None] = mapped_column(
+        Text, nullable=True, index=True
+    )
+    action: Mapped[str] = mapped_column(Text, nullable=False)
+    outcome: Mapped[str] = mapped_column(Text, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )

--- a/src/dev_health_ops/service_credentials.py
+++ b/src/dev_health_ops/service_credentials.py
@@ -1,0 +1,134 @@
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+
+from sqlalchemy import select
+
+from dev_health_ops.db import get_postgres_session
+from dev_health_ops.models.internal_service_credential import InternalServiceCredential
+
+_ALLOWED_SCOPES = frozenset({"entitlements:read"})
+_MAX_OVERLAP_SECONDS = 3600
+
+
+def register_commands(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "service-credentials", help="Manage internal service credentials."
+    )
+    commands = parser.add_subparsers(dest="service_credentials_command", required=True)
+    create = commands.add_parser("create", help="Create a service credential.")
+    _add_credential_arguments(create)
+    create.set_defaults(func=run_create)
+    listing = commands.add_parser(
+        "list", help="List credential metadata without secrets."
+    )
+    listing.add_argument("--service", default="acr", choices=["acr"])
+    listing.set_defaults(func=run_list)
+    rotate = commands.add_parser("rotate", help="Rotate a service credential.")
+    rotate.add_argument("credential_id")
+    _add_credential_arguments(rotate)
+    rotate.add_argument("--overlap-seconds", type=int, default=0)
+    rotate.set_defaults(func=run_rotate)
+    revoke = commands.add_parser("revoke", help="Revoke a service credential.")
+    revoke.add_argument("credential_id")
+    revoke.set_defaults(func=run_revoke)
+
+
+def _add_credential_arguments(parser: argparse.ArgumentParser) -> None:
+    parser.add_argument("--service", default="acr", choices=["acr"])
+    parser.add_argument("--scope", action="append", required=True)
+    parser.add_argument("--expires-at")
+    parser.add_argument("--created-by-user-id")
+
+
+def _parse_expiry(raw: str | None) -> datetime | None:
+    if raw is None:
+        return None
+    value = datetime.fromisoformat(raw)
+    if value.tzinfo is None:
+        raise ValueError("--expires-at must include a timezone")
+    expiry = value.astimezone(timezone.utc)
+    if expiry <= datetime.now(timezone.utc):
+        raise ValueError("--expires-at must be in the future")
+    return expiry
+
+
+def _parse_creator(raw: str | None) -> uuid.UUID | None:
+    return uuid.UUID(raw) if raw else None
+
+
+def _scopes(raw_scopes: list[str]) -> list[str]:
+    scopes = sorted(set(raw_scopes))
+    if not scopes or not set(scopes).issubset(_ALLOWED_SCOPES):
+        raise ValueError("unsupported internal service credential scope")
+    return scopes
+
+
+async def run_create(ns: argparse.Namespace) -> int:
+    credential, token = InternalServiceCredential.issue(
+        service_name=ns.service,
+        scopes=_scopes(ns.scope),
+        created_by_user_id=_parse_creator(ns.created_by_user_id),
+        expires_at=_parse_expiry(ns.expires_at),
+    )
+    async with get_postgres_session() as session:
+        session.add(credential)
+        await session.commit()
+    print(token)
+    return 0
+
+
+async def run_list(ns: argparse.Namespace) -> int:
+    async with get_postgres_session() as session:
+        result = await session.execute(
+            select(InternalServiceCredential)
+            .where(InternalServiceCredential.service_name == ns.service)
+            .order_by(InternalServiceCredential.created_at)
+        )
+        metadata = [
+            credential.public_metadata() for credential in result.scalars().all()
+        ]
+    print(json.dumps(metadata, sort_keys=True), file=sys.stdout)
+    return 0
+
+
+async def run_rotate(ns: argparse.Namespace) -> int:
+    if ns.overlap_seconds < 0 or ns.overlap_seconds > _MAX_OVERLAP_SECONDS:
+        raise ValueError("--overlap-seconds must be between 0 and 3600")
+    credential_id = uuid.UUID(ns.credential_id)
+    scopes = _scopes(ns.scope)
+    created_by_user_id = _parse_creator(ns.created_by_user_id)
+    expires_at = _parse_expiry(ns.expires_at)
+    async with get_postgres_session() as session:
+        credential = await session.get(InternalServiceCredential, credential_id)
+        if credential is None or credential.service_name != ns.service:
+            raise ValueError("service credential not found")
+        now = datetime.now(timezone.utc)
+        if not credential.is_valid(now):
+            raise ValueError("service credential is not active")
+        credential.expires_at = now + timedelta(seconds=ns.overlap_seconds)
+        replacement, token = InternalServiceCredential.issue(
+            service_name=ns.service,
+            scopes=scopes,
+            created_by_user_id=created_by_user_id,
+            expires_at=expires_at,
+        )
+        session.add(replacement)
+        await session.commit()
+    print(token)
+    return 0
+
+
+async def run_revoke(ns: argparse.Namespace) -> int:
+    credential_id = uuid.UUID(ns.credential_id)
+    async with get_postgres_session() as session:
+        credential = await session.get(InternalServiceCredential, credential_id)
+        if credential is None:
+            raise ValueError("service credential not found")
+        credential.revoked_at = datetime.now(timezone.utc)
+        await session.commit()
+    return 0

--- a/tests/api/internal/test_acr_entitlements.py
+++ b/tests/api/internal/test_acr_entitlements.py
@@ -1,0 +1,277 @@
+from __future__ import annotations
+
+import uuid
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.internal.acr import router
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.internal_service_credential import (
+    InternalServiceCredential,
+    InternalServiceCredentialAudit,
+    generate_internal_service_token,
+)
+from dev_health_ops.models.licensing import FeatureFlag, OrgFeatureOverride, OrgLicense
+from dev_health_ops.models.subscriptions import Subscription
+from dev_health_ops.models.users import Organization
+from tests._helpers import tables_of
+
+_TABLES = tables_of(
+    Organization,
+    OrgLicense,
+    FeatureFlag,
+    OrgFeatureOverride,
+    Subscription,
+    InternalServiceCredential,
+    InternalServiceCredentialAudit,
+)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path):
+    db_path = tmp_path / "acr-entitlements.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def entitled_org(session_maker):
+    org_id = uuid.uuid4()
+    async with session_maker() as session:
+        session.add_all(
+            [
+                Organization(id=org_id, slug="acr-entitled", name="ACR Entitled"),
+                FeatureFlag(
+                    key="agent_context_runtime",
+                    name="Agent Context Runtime",
+                    category="integrations",
+                    min_tier="community",
+                ),
+                OrgLicense(
+                    org_id=org_id,
+                    tier="team",
+                    features_override={"agent_context_runtime": True},
+                ),
+            ]
+        )
+        await session.commit()
+    return str(org_id)
+
+
+async def _create_credential(
+    session: AsyncSession,
+    *,
+    scopes: list[str] | None = None,
+    expires_at: datetime | None = None,
+    revoked_at: datetime | None = None,
+) -> str:
+    token = generate_internal_service_token()
+    credential = InternalServiceCredential.from_plaintext_token(
+        token=token,
+        service_name="acr",
+        scopes=scopes or ["entitlements:read"],
+        expires_at=expires_at,
+    )
+    credential.revoked_at = revoked_at
+    session.add(credential)
+    await session.commit()
+    return token
+
+
+def _patch_session(monkeypatch, session_maker) -> None:
+    from dev_health_ops.api.internal import acr
+
+    @asynccontextmanager
+    async def _session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(acr, "get_postgres_session", _session)
+
+
+@pytest.mark.asyncio
+async def test_acr_entitlement_returns_exact_minimal_contract_for_valid_service_token(
+    session_maker, entitled_org, monkeypatch
+):
+    async with session_maker() as session:
+        token = await _create_credential(session)
+    _patch_session(monkeypatch, session_maker)
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/v1/internal/acr/entitlements/{entitled_org}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 200
+    assert response.json() == {
+        "schema_version": "acr_entitlement.v1",
+        "org_id": entitled_org,
+        "agent_context_runtime": True,
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "authorization",
+    [None, "Basic abc", "Bearer invalid", "Bearer svc_acr_bad"],
+)
+async def test_acr_entitlement_rejects_missing_malformed_or_unknown_tokens(
+    session_maker, entitled_org, monkeypatch, authorization
+):
+    _patch_session(monkeypatch, session_maker)
+    app = FastAPI()
+    app.include_router(router)
+    headers = {} if authorization is None else {"Authorization": authorization}
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/v1/internal/acr/entitlements/{entitled_org}", headers=headers
+        )
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
+    async with session_maker() as session:
+        audits = (
+            (await session.execute(select(InternalServiceCredentialAudit)))
+            .scalars()
+            .all()
+        )
+    assert len(audits) == 1
+    assert audits[0].credential_id is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "credential_kwargs",
+    [
+        {"scopes": ["other:read"]},
+        {"expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)},
+        {"revoked_at": datetime.now(timezone.utc)},
+    ],
+)
+async def test_acr_entitlement_fails_closed_for_insufficient_or_inactive_token(
+    session_maker, entitled_org, monkeypatch, credential_kwargs
+):
+    async with session_maker() as session:
+        token = await _create_credential(session, **credential_kwargs)
+    _patch_session(monkeypatch, session_maker)
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/v1/internal/acr/entitlements/{entitled_org}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    expected_status = 403 if credential_kwargs.get("scopes") else 401
+    assert response.status_code == expected_status
+    assert token not in response.text
+
+
+@pytest.mark.asyncio
+async def test_acr_entitlement_returns_404_for_missing_org_after_service_auth(
+    session_maker, monkeypatch
+):
+    async with session_maker() as session:
+        token = await _create_credential(session)
+    _patch_session(monkeypatch, session_maker)
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/v1/internal/acr/entitlements/{uuid.uuid4()}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_acr_entitlement_audits_and_safely_fails_when_entitlement_lookup_errors(
+    session_maker, entitled_org, monkeypatch
+):
+    async with session_maker() as session:
+        token = await _create_credential(session)
+    _patch_session(monkeypatch, session_maker)
+
+    async def _raise_entitlement_error(_org_id, _session):
+        raise RuntimeError("sensitive upstream failure")
+
+    from dev_health_ops.api.internal import acr
+
+    monkeypatch.setattr(acr, "get_org_entitlements_from_db", _raise_entitlement_error)
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app, raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            f"/api/v1/internal/acr/entitlements/{entitled_org}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Service unavailable"}
+    assert "sensitive upstream failure" not in response.text
+    async with session_maker() as session:
+        audit = (
+            await session.execute(
+                select(InternalServiceCredentialAudit).order_by(
+                    InternalServiceCredentialAudit.created_at.desc()
+                )
+            )
+        ).scalar_one()
+    assert audit.credential_id is not None
+    assert audit.requested_org_id == entitled_org
+    assert audit.outcome == "entitlement_lookup_failed"
+
+
+@pytest.mark.asyncio
+async def test_acr_entitlement_rate_limit_stops_burst_before_auth_audit_writes(
+    session_maker, entitled_org, monkeypatch
+):
+    class Limiter:
+        calls = 0
+
+        def hit(self, _limit, _key):
+            self.calls += 1
+            return self.calls <= 2
+
+    class RateLimiter:
+        limiter = Limiter()
+
+    from dev_health_ops.api.internal import acr
+
+    monkeypatch.setattr(acr, "limiter", RateLimiter())
+    _patch_session(monkeypatch, session_maker)
+    app = FastAPI()
+    app.include_router(router)
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.get(f"/api/v1/internal/acr/entitlements/{entitled_org}")
+        second = await client.get(f"/api/v1/internal/acr/entitlements/{entitled_org}")
+        third = await client.get(f"/api/v1/internal/acr/entitlements/{entitled_org}")
+    assert first.status_code == 401
+    assert second.status_code == 401
+    assert third.status_code == 429
+    async with session_maker() as session:
+        audits = (
+            (await session.execute(select(InternalServiceCredentialAudit)))
+            .scalars()
+            .all()
+        )
+    assert len(audits) == 2

--- a/tests/api/internal/test_acr_health.py
+++ b/tests/api/internal/test_acr_health.py
@@ -1,0 +1,183 @@
+from __future__ import annotations
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.internal.acr import router
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.internal_service_credential import (
+    InternalServiceCredential,
+    InternalServiceCredentialAudit,
+    generate_internal_service_token,
+)
+from tests._helpers import tables_of
+
+_TABLES = tables_of(InternalServiceCredential, InternalServiceCredentialAudit)
+_HEALTH_PATH = "/api/v1/internal/acr/health"
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path):
+    db_path = tmp_path / "acr-health.db"
+    engine = create_async_engine(f"sqlite+aiosqlite:///{db_path}")
+    async with engine.begin() as conn:
+        await conn.run_sync(
+            lambda sync_conn: Base.metadata.create_all(sync_conn, tables=_TABLES)
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def _create_credential(
+    session: AsyncSession,
+    *,
+    scopes: list[str] | None = None,
+    expires_at: datetime | None = None,
+    revoked_at: datetime | None = None,
+) -> str:
+    token = generate_internal_service_token()
+    credential = InternalServiceCredential.from_plaintext_token(
+        token=token,
+        service_name="acr",
+        scopes=scopes or ["entitlements:read"],
+        expires_at=expires_at,
+    )
+    credential.revoked_at = revoked_at
+    session.add(credential)
+    await session.commit()
+    return token
+
+
+def _patch_session(monkeypatch, session_maker) -> None:
+    from dev_health_ops.api.internal import acr
+
+    @asynccontextmanager
+    async def _session():
+        async with session_maker() as session:
+            yield session
+
+    monkeypatch.setattr(acr, "get_postgres_session", _session)
+
+
+def _app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    return app
+
+
+@pytest.mark.asyncio
+async def test_acr_health_returns_exact_contract_for_valid_service_credential(
+    session_maker, monkeypatch
+):
+    async with session_maker() as session:
+        token = await _create_credential(session)
+    _patch_session(monkeypatch, session_maker)
+    transport = ASGITransport(app=_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            _HEALTH_PATH, headers={"Authorization": f"Bearer {token}"}
+        )
+    assert response.status_code == 200
+    assert response.json() == {
+        "schema_version": "acr_service_health.v1",
+        "service": "dev-health-ops",
+        "status": "ok",
+    }
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "authorization",
+    [None, "Basic abc", "Bearer invalid", "Bearer svc_acr_unknown"],
+)
+async def test_acr_health_rejects_missing_malformed_or_unknown_tokens(
+    session_maker, monkeypatch, authorization
+):
+    _patch_session(monkeypatch, session_maker)
+    headers = {} if authorization is None else {"Authorization": authorization}
+    transport = ASGITransport(app=_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(_HEALTH_PATH, headers=headers)
+    assert response.status_code == 401
+    assert response.json() == {"detail": "Unauthorized"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("credential_kwargs", "expected_status"),
+    [
+        ({"scopes": ["other:read"]}, 403),
+        ({"expires_at": datetime.now(timezone.utc) - timedelta(seconds=1)}, 401),
+        ({"revoked_at": datetime.now(timezone.utc)}, 401),
+    ],
+)
+async def test_acr_health_fails_closed_for_insufficient_or_inactive_token(
+    session_maker, monkeypatch, credential_kwargs, expected_status
+):
+    async with session_maker() as session:
+        token = await _create_credential(session, **credential_kwargs)
+    _patch_session(monkeypatch, session_maker)
+    transport = ASGITransport(app=_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            _HEALTH_PATH, headers={"Authorization": f"Bearer {token}"}
+        )
+    assert response.status_code == expected_status
+    assert token not in response.text
+
+
+@pytest.mark.asyncio
+async def test_acr_health_rate_limit_stops_authentication_burst(
+    session_maker, monkeypatch
+):
+    class Limiter:
+        calls = 0
+
+        def hit(self, _limit, _key):
+            self.calls += 1
+            return self.calls <= 2
+
+    class RateLimiter:
+        limiter = Limiter()
+
+    from dev_health_ops.api.internal import acr
+
+    monkeypatch.setattr(acr, "limiter", RateLimiter())
+    _patch_session(monkeypatch, session_maker)
+    transport = ASGITransport(app=_app())
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        first = await client.get(_HEALTH_PATH)
+        second = await client.get(_HEALTH_PATH)
+        third = await client.get(_HEALTH_PATH)
+    assert first.status_code == 401
+    assert second.status_code == 401
+    assert third.status_code == 429
+
+
+@pytest.mark.asyncio
+async def test_acr_health_sanitizes_unavailable_credential_store(monkeypatch):
+    from dev_health_ops.api.internal import acr
+
+    @asynccontextmanager
+    async def _unavailable_session():
+        raise RuntimeError("postgres configuration is unavailable")
+        yield
+
+    monkeypatch.setattr(acr, "get_postgres_session", _unavailable_session)
+    transport = ASGITransport(app=_app(), raise_app_exceptions=False)
+    async with AsyncClient(transport=transport, base_url="http://test") as client:
+        response = await client.get(
+            _HEALTH_PATH, headers={"Authorization": "Bearer svc_acr_valid"}
+        )
+    assert response.status_code == 503
+    assert response.json() == {"detail": "Service unavailable"}
+    assert "postgres configuration is unavailable" not in response.text

--- a/tests/test_cli_preflight.py
+++ b/tests/test_cli_preflight.py
@@ -134,6 +134,7 @@ _MISSING_CASES = [
     # Bare migrate forms default to upgrade and must be guarded too.
     (("migrate", "postgres"), ("PostgreSQL",)),
     (("migrate", "clickhouse"), ("ClickHouse",)),
+    (("service-credentials", "list"), ("PostgreSQL",)),
     # sync teams persists to ClickHouse after generating teams.
     (("sync", "teams", "--provider", "synthetic"), ("ClickHouse",)),
 ]
@@ -189,6 +190,17 @@ def test_work_graph_build_rejects_unsupported_db_scheme_cleanly() -> None:
     assert "Traceback" not in result.stderr
     assert "Unknown or unsupported sink scheme 'sqlite'" in result.stderr
     assert "Only ClickHouse is supported" in result.stderr
+
+
+def test_service_credentials_rejects_non_postgres_db_flag_cleanly(tmp_path) -> None:
+    invalid_db = tmp_path / "not-postgres.db"
+    result = _run_cli("--db", f"sqlite:///{invalid_db}", "service-credentials", "list")
+
+    assert result.returncode == 2, result.stderr
+    assert "Traceback" not in result.stderr
+    assert "PostgreSQL" in result.stderr
+    invalid_db.unlink(missing_ok=True)
+    assert not invalid_db.exists()
 
 
 def test_sync_rejects_unsupported_analytics_scheme_cleanly() -> None:

--- a/tests/test_internal_service_credential_migration.py
+++ b/tests/test_internal_service_credential_migration.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+
+def test_migration_0038_creates_reversible_internal_service_credential_tables():
+    migration = importlib.import_module(
+        "dev_health_ops.alembic.versions.0038_add_internal_service_credentials"
+    )
+    assert migration.revision == "0038"
+    assert migration.down_revision == "0037"
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as conn:
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.upgrade()
+                tables = set(sa.inspect(conn).get_table_names())
+                assert "internal_service_credentials" in tables
+                assert "internal_service_credential_audits" in tables
+                migration.downgrade()
+                assert "internal_service_credentials" not in set(
+                    sa.inspect(conn).get_table_names()
+                )
+                migration.upgrade()
+                assert "internal_service_credentials" in set(
+                    sa.inspect(conn).get_table_names()
+                )
+    finally:
+        engine.dispose()

--- a/tests/test_service_credentials_cli.py
+++ b/tests/test_service_credentials_cli.py
@@ -1,0 +1,222 @@
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import subprocess
+import sys
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from dev_health_ops import cli, service_credentials
+from dev_health_ops.models.internal_service_credential import InternalServiceCredential
+
+
+def _postgres_test_uri() -> str:
+    uri = os.getenv("DEV_HEALTH_POSTGRES_TEST_URI")
+    if uri is None:
+        pytest.skip("DEV_HEALTH_POSTGRES_TEST_URI is not configured")
+    return uri
+
+
+def _run_service_credentials_cli(
+    postgres_uri: str, *args: str
+) -> subprocess.CompletedProcess[str]:
+    env = os.environ.copy()
+    env.update(
+        {
+            "DISABLE_DOTENV": "1",
+            "LOG_LEVEL": "INFO",
+            "OTEL_SDK_DISABLED": "true",
+            "PYTHONPATH": "src",
+        }
+    )
+    return subprocess.run(
+        [
+            sys.executable,
+            "-m",
+            "dev_health_ops.cli",
+            "--db",
+            postgres_uri,
+            "service-credentials",
+            *args,
+        ],
+        check=False,
+        capture_output=True,
+        env=env,
+        text=True,
+        timeout=60,
+    )
+
+
+def test_service_credential_cli_create_reveals_token_once_and_list_redacts_it(
+    monkeypatch, capsys
+):
+    parser = cli.build_parser()
+    create_ns = parser.parse_args(
+        [
+            "service-credentials",
+            "create",
+            "--service",
+            "acr",
+            "--scope",
+            "entitlements:read",
+        ]
+    )
+    created: list[InternalServiceCredential] = []
+
+    async def _create(ns):
+        credential, token = InternalServiceCredential.issue(
+            service_name=ns.service, scopes=ns.scope, created_by_user_id=None
+        )
+        created.append(credential)
+        print(token)
+        return 0
+
+    monkeypatch.setattr(create_ns, "func", _create)
+    assert asyncio.run(create_ns.func(create_ns)) == 0
+    token = capsys.readouterr().out.strip()
+    assert token.startswith("svc_acr_")
+
+    list_ns = parser.parse_args(["service-credentials", "list"])
+
+    async def _list(_ns):
+        print(json.dumps([created[0].public_metadata()]))
+        return 0
+
+    monkeypatch.setattr(list_ns, "func", _list)
+    assert asyncio.run(list_ns.func(list_ns)) == 0
+    assert token not in capsys.readouterr().out
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("inactive_field", ["revoked_at", "expires_at"])
+async def test_rotate_rejects_an_inactive_credential_before_creating_a_replacement(
+    monkeypatch, inactive_field
+):
+    credential, _ = InternalServiceCredential.issue(
+        service_name="acr", scopes=["entitlements:read"], created_by_user_id=None
+    )
+    credential.id = uuid.uuid4()
+    setattr(credential, inactive_field, datetime.now(timezone.utc))
+
+    class Session:
+        async def get(self, _model, _credential_id):
+            return credential
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc_value, _traceback):
+            return None
+
+    monkeypatch.setattr(service_credentials, "get_postgres_session", lambda: Session())
+    parser = cli.build_parser()
+    ns = parser.parse_args(
+        [
+            "service-credentials",
+            "rotate",
+            str(credential.id),
+            "--scope",
+            "entitlements:read",
+        ]
+    )
+    with pytest.raises(ValueError, match="active"):
+        await service_credentials.run_rotate(ns)
+
+
+@pytest.mark.asyncio
+async def test_create_rejects_past_expiry_before_opening_a_database_session(
+    monkeypatch,
+):
+    parser = cli.build_parser()
+    expired_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+    ns = parser.parse_args(
+        [
+            "service-credentials",
+            "create",
+            "--scope",
+            "entitlements:read",
+            "--expires-at",
+            expired_at,
+        ]
+    )
+
+    def _unexpected_session():
+        raise AssertionError("database session must not open for past expiry")
+
+    monkeypatch.setattr(
+        service_credentials, "get_postgres_session", _unexpected_session
+    )
+    with pytest.raises(ValueError, match="future"):
+        await service_credentials.run_create(ns)
+
+
+@pytest.mark.asyncio
+async def test_rotate_rejects_past_expiry_without_mutating_existing_credential(
+    monkeypatch,
+):
+    credential, _ = InternalServiceCredential.issue(
+        service_name="acr", scopes=["entitlements:read"], created_by_user_id=None
+    )
+    credential.id = uuid.uuid4()
+    initial_expiry = credential.expires_at
+    expired_at = (datetime.now(timezone.utc) - timedelta(seconds=1)).isoformat()
+
+    class Session:
+        added: list[InternalServiceCredential] = []
+        commits = 0
+
+        async def get(self, _model, _credential_id):
+            return credential
+
+        def add(self, replacement: InternalServiceCredential) -> None:
+            self.added.append(replacement)
+
+        async def commit(self) -> None:
+            self.commits += 1
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, _exc_type, _exc_value, _traceback):
+            return None
+
+    session = Session()
+    monkeypatch.setattr(service_credentials, "get_postgres_session", lambda: session)
+    parser = cli.build_parser()
+    ns = parser.parse_args(
+        [
+            "service-credentials",
+            "rotate",
+            str(credential.id),
+            "--scope",
+            "entitlements:read",
+            "--expires-at",
+            expired_at,
+        ]
+    )
+    with pytest.raises(ValueError, match="future"):
+        await service_credentials.run_rotate(ns)
+    assert credential.expires_at is initial_expiry
+    assert session.added == []
+    assert session.commits == 0
+
+
+def test_service_credential_create_emits_only_token_and_db_flag_is_honored() -> None:
+    postgres_uri = _postgres_test_uri()
+    created = _run_service_credentials_cli(
+        postgres_uri, "create", "--scope", "entitlements:read"
+    )
+    assert created.returncode == 0, created.stderr
+    token_lines = created.stdout.splitlines()
+    assert len(token_lines) == 1
+    assert token_lines[0].startswith("svc_acr_")
+    assert token_lines[0] not in created.stderr
+
+    listed = _run_service_credentials_cli(postgres_uri, "list")
+    assert listed.returncode == 0, listed.stderr
+    assert token_lines[0] not in listed.stdout
+    assert isinstance(json.loads(listed.stdout), list)


### PR DESCRIPTION
## Summary

Adds the internal, dev-health-ops-side authenticated surface that lets the
separate ACR (`dev-health-acr`) hosted Go service compose its production
runtime dependencies without using the unauthenticated billing entitlement
route or sharing Dev Health operational storage credentials.

Prerequisite for CHAOS-2944 (ACR Platform: compose production `acr-api`
runtime dependencies and adapters).

## What's included

- **`internal_service_credentials` / `internal_service_credential_audits` models**
  (`src/dev_health_ops/models/internal_service_credential.py`, migration
  `0038`, reversible). Tokens are opaque (`svc_acr_` prefix), generated with
  `secrets.token_urlsafe(32)`, and stored only as a SHA-256 hash — the
  plaintext is never persisted or logged.
- **`service-credentials` CLI** (`create` / `list` / `rotate` / `revoke`) —
  requires `--db` (PostgreSQL only, enforced by preflight), prints exactly
  one plaintext token line to stdout on `create`/`rotate`, routes all
  operational logging to stderr, and rejects past-expiry or unsupported
  scopes before opening a database session.
- **Internal API** at `/api/v1/internal/acr` (`src/dev_health_ops/api/internal/acr.py`):
  - `GET /health` — service liveness gated on a valid `acr`-scoped credential.
  - `GET /entitlements/{org_id}` — returns `{schema_version, org_id, agent_context_runtime}`.

### Security properties

- **Fail closed**: 401 for missing/malformed/unknown/expired/revoked
  credentials, 403 for insufficient scope (`entitlements:read` required),
  404 for unknown org, 503 for credential-store or entitlement-provider
  errors — no upstream error text ever reaches the response body.
- **Rate limiting before audit writes**: unauthenticated bursts are
  rejected with 429 by a per-IP limiter (`INTERNAL_ACR_AUTH_ATTEMPT_IP_LIMIT`,
  100/min) *before* touching the audit table, so a flood cannot inflate audit
  volume.
- **Every entitlement lookup is audited** (`internal_service_credential_audits`):
  success, unknown/inactive token, insufficient scope, org-not-found, and
  entitlement-lookup-failure are all recorded with `credential_id` and
  `requested_org_id` (never the token itself).
- **No plaintext token, DB password, or process detail is ever logged.**

## Testing

- `tests/api/internal/test_acr_entitlements.py`,
  `tests/api/internal/test_acr_health.py` — auth matrix (missing/malformed/
  unknown/expired/revoked/wrong-scope), 404 org-not-found, entitlement-lookup
  failure audit + 503 sanitization, and rate-limit-before-audit-write.
- `tests/test_service_credentials_cli.py` — CLI parsing/validation, plus a
  real subprocess test against isolated PostgreSQL asserting `create` emits
  exactly one plaintext token line on stdout and `list` never leaks it.
- `tests/test_internal_service_credential_migration.py` — migration 0038
  round-trips (upgrade → downgrade → upgrade) on SQLite; additionally
  verified by hand: fresh upgrade to head → downgrade to 0037 → upgrade to
  head on real PostgreSQL.
- `bash ci/local_validate.sh` — ruff format/check, mypy, full unit suite,
  live ClickHouse argMax proof: **7757 passed, 45 skipped, GATE PASSED.**

No billing/licensing routes were touched.