### PR TITLE
fix(home): expose latest successful sync freshness

### DIFF
--- a/src/dev_health_ops/api/main.py
+++ b/src/dev_health_ops/api/main.py
@@ -8,6 +8,7 @@ from typing import Literal, cast
 
 from fastapi import Depends, FastAPI, HTTPException, Request, Response
 from fastapi.responses import JSONResponse, StreamingResponse
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.logging_config import configure_logging
 from dev_health_ops.metrics.sinks.factory import detect_backend
@@ -62,6 +63,7 @@ from .admin.impersonation import router as impersonation_router
 from .auth import router as auth_router
 from .auth.router import get_current_user
 from .billing import router as billing_router
+from .dependencies import get_postgres_session_dep
 from .graphql.app import create_graphql_app
 from .ingest import router as ingest_router
 from .licensing import router as licensing_router
@@ -389,6 +391,7 @@ async def home_post(
     request: Request,
     payload: HomeRequest,
     current_user: AuthenticatedUser = Depends(get_current_user),
+    semantic_session: AsyncSession = Depends(get_postgres_session_dep),
 ) -> HomeResponse:
     try:
         return await build_home_response(
@@ -396,6 +399,7 @@ async def home_post(
             filters=payload.filters,
             cache=HOME_CACHE,
             org_id=current_user.org_id,
+            semantic_session=semantic_session,
         )
     except Exception as exc:
         raise HTTPException(status_code=503, detail="Data unavailable") from exc
@@ -413,6 +417,7 @@ async def home(
     start_date: date | None = None,
     end_date: date | None = None,
     current_user: AuthenticatedUser = Depends(get_current_user),
+    semantic_session: AsyncSession = Depends(get_postgres_session_dep),
 ) -> HomeResponse:
     try:
         filters = _filters_from_query(
@@ -423,6 +428,7 @@ async def home(
             filters=filters,
             cache=HOME_CACHE,
             org_id=current_user.org_id,
+            semantic_session=semantic_session,
         )
         if response is not None:
             response.headers["X-DevHealth-Deprecated"] = "use POST with filters"

--- a/src/dev_health_ops/api/models/schemas.py
+++ b/src/dev_health_ops/api/models/schemas.py
@@ -14,6 +14,7 @@ class Coverage(BaseModel):
 
 class Freshness(BaseModel):
     last_ingested_at: datetime | None
+    latest_successful_sync_at: datetime | None = None
     sources: dict[str, str]
     coverage: Coverage
 

--- a/src/dev_health_ops/api/queries/sync_freshness.py
+++ b/src/dev_health_ops/api/queries/sync_freshness.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from sqlalchemy import func, select, union_all
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.models.integrations import SyncRun, SyncRunStatus
+from dev_health_ops.models.settings import JobRun, JobRunStatus, ScheduledJob
+
+
+async def fetch_latest_successful_sync_at(
+    session: AsyncSession,
+    *,
+    org_id: str,
+) -> datetime | None:
+    successful_runs = union_all(
+        select(SyncRun.completed_at.label("completed_at")).where(
+            SyncRun.org_id == org_id,
+            SyncRun.status == SyncRunStatus.SUCCESS.value,
+            SyncRun.completed_at.is_not(None),
+        ),
+        select(JobRun.completed_at.label("completed_at"))
+        .join(ScheduledJob, ScheduledJob.id == JobRun.job_id)
+        .where(
+            ScheduledJob.org_id == org_id,
+            ScheduledJob.job_type == "sync",
+            JobRun.status == JobRunStatus.SUCCESS.value,
+            JobRun.completed_at.is_not(None),
+        ),
+    ).subquery()
+    latest = (
+        await session.execute(select(func.max(successful_runs.c.completed_at)))
+    ).scalar_one_or_none()
+    if latest is None:
+        return None
+    if latest.tzinfo is None:
+        return latest.replace(tzinfo=timezone.utc)
+    return latest.astimezone(timezone.utc)

--- a/src/dev_health_ops/api/services/home.py
+++ b/src/dev_health_ops/api/services/home.py
@@ -7,6 +7,9 @@ import re
 from datetime import date, datetime, timezone
 from typing import Any, Literal
 
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
 from dev_health_ops.metrics.sinks.base import BaseMetricsSink
 
 from ..models.filters import MetricFilter
@@ -40,6 +43,7 @@ from ..queries.metrics import (
     fetch_metric_value,
     fetch_rework_theme_allocation,
 )
+from ..queries.sync_freshness import fetch_latest_successful_sync_at
 from ..utils import delta_pct, safe_float, safe_transform
 from .cache import TTLCache
 from .filtering import (
@@ -965,11 +969,38 @@ async def build_home_response(
     filters: MetricFilter,
     cache: TTLCache,
     org_id: str = "",
+    semantic_session: AsyncSession | None = None,
 ) -> HomeResponse:
     cache_key = filter_cache_key("home", org_id, filters)
     cached = cache.get(cache_key)
+    if semantic_session is None:
+        if cached is not None:
+            return HomeResponse.model_validate(cached)
+        latest_successful_sync_at = None
+    else:
+        try:
+            latest_successful_sync_at = await fetch_latest_successful_sync_at(
+                semantic_session,
+                org_id=org_id,
+            )
+        except SQLAlchemyError as exc:
+            logger.warning(
+                "home.sync_freshness_unavailable",
+                extra={"org_id": org_id},
+                exc_info=exc,
+            )
+            if cached is not None:
+                return HomeResponse.model_validate(cached)
+            latest_successful_sync_at = None
     if cached is not None:
-        return HomeResponse.model_validate(cached)
+        response = HomeResponse.model_validate(cached)
+        return response.model_copy(
+            update={
+                "freshness": response.freshness.model_copy(
+                    update={"latest_successful_sync_at": latest_successful_sync_at}
+                )
+            }
+        )
 
     start_day, end_day, compare_start, compare_end = time_window(filters)
 
@@ -1177,6 +1208,7 @@ async def build_home_response(
         response = HomeResponse(
             freshness=Freshness(
                 last_ingested_at=last_ingested,
+                latest_successful_sync_at=latest_successful_sync_at,
                 sources=sources,
                 coverage=Coverage(**coverage),
             ),

--- a/tests/api/queries/test_sync_freshness.py
+++ b/tests/api/queries/test_sync_freshness.py
@@ -1,0 +1,209 @@
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.queries.sync_freshness import fetch_latest_successful_sync_at
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.integrations import SyncRun, SyncRunStatus
+from dev_health_ops.models.settings import JobRun, JobRunStatus, ScheduledJob
+from tests._helpers import tables_of
+
+pytestmark = pytest.mark.anyio
+
+_TABLES = tables_of(ScheduledJob, JobRun, SyncRun)
+
+
+@pytest_asyncio.fixture
+async def session_maker(tmp_path: Path):
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'sync-freshness.db'}"
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection,
+                tables=_TABLES,
+            )
+        )
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+async def test_latest_successful_sync_uses_run_history_and_org_scope(session_maker):
+    org_id = "org-1"
+    legacy_success_at = datetime(2026, 7, 13, 16, 11, tzinfo=UTC)
+
+    async with session_maker() as session:
+        job = ScheduledJob(
+            name="legacy-sync",
+            job_type="sync",
+            schedule_cron="0 * * * *",
+            org_id=org_id,
+            provider="linear",
+        )
+        non_sync_job = ScheduledJob(
+            name="daily-metrics",
+            job_type="metrics",
+            schedule_cron="0 * * * *",
+            org_id=org_id,
+        )
+        other_org_job = ScheduledJob(
+            name="other-org-sync",
+            job_type="sync",
+            schedule_cron="0 * * * *",
+            org_id="org-2",
+            provider="github",
+        )
+        session.add_all([job, non_sync_job, other_org_job])
+        await session.flush()
+
+        legacy_success = JobRun(
+            job_id=job.id,
+            status=JobRunStatus.SUCCESS.value,
+        )
+        legacy_success.completed_at = legacy_success_at
+        legacy_failure = JobRun(
+            job_id=job.id,
+            status=JobRunStatus.FAILED.value,
+        )
+        legacy_failure.completed_at = datetime(2026, 7, 13, 16, 20, tzinfo=UTC)
+        non_sync_success = JobRun(
+            job_id=non_sync_job.id,
+            status=JobRunStatus.SUCCESS.value,
+        )
+        non_sync_success.completed_at = datetime(2026, 7, 13, 16, 40, tzinfo=UTC)
+        other_org_legacy_success = JobRun(
+            job_id=other_org_job.id,
+            status=JobRunStatus.SUCCESS.value,
+        )
+        other_org_legacy_success.completed_at = datetime(
+            2026, 7, 13, 16, 45, tzinfo=UTC
+        )
+
+        planner_success = SyncRun(
+            org_id=org_id,
+            integration_id=uuid.uuid4(),
+            triggered_by="manual",
+            mode="incremental",
+            status=SyncRunStatus.SUCCESS.value,
+            total_units=1,
+            completed_units=1,
+            failed_units=0,
+            completed_at=datetime(2026, 7, 13, 16, 5, tzinfo=UTC),
+        )
+        planner_failure = SyncRun(
+            org_id=org_id,
+            integration_id=uuid.uuid4(),
+            triggered_by="manual",
+            mode="incremental",
+            status=SyncRunStatus.FAILED.value,
+            total_units=1,
+            completed_units=0,
+            failed_units=1,
+            completed_at=datetime(2026, 7, 13, 16, 25, tzinfo=UTC),
+        )
+        other_org_success = SyncRun(
+            org_id="org-2",
+            integration_id=uuid.uuid4(),
+            triggered_by="manual",
+            mode="incremental",
+            status=SyncRunStatus.SUCCESS.value,
+            total_units=1,
+            completed_units=1,
+            failed_units=0,
+            completed_at=datetime(2026, 7, 13, 16, 30, tzinfo=UTC),
+        )
+        session.add_all(
+            [
+                legacy_success,
+                legacy_failure,
+                non_sync_success,
+                other_org_legacy_success,
+                planner_success,
+                planner_failure,
+                other_org_success,
+            ]
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        latest = await fetch_latest_successful_sync_at(session, org_id=org_id)
+        missing = await fetch_latest_successful_sync_at(
+            session, org_id="org-without-runs"
+        )
+
+    assert latest == legacy_success_at
+    assert missing is None
+
+
+async def test_latest_successful_sync_uses_planner_history_without_legacy_runs(
+    session_maker,
+):
+    planner_success_at = datetime(2026, 7, 13, 17, 5, tzinfo=UTC)
+    async with session_maker() as session:
+        session.add(
+            SyncRun(
+                org_id="org-1",
+                integration_id=uuid.uuid4(),
+                triggered_by="scheduler",
+                mode="incremental",
+                status=SyncRunStatus.SUCCESS.value,
+                total_units=1,
+                completed_units=1,
+                failed_units=0,
+                completed_at=planner_success_at,
+            )
+        )
+        await session.commit()
+
+    async with session_maker() as session:
+        latest = await fetch_latest_successful_sync_at(session, org_id="org-1")
+
+    assert latest == planner_success_at
+
+
+async def test_latest_successful_sync_picks_newer_planner_run(session_maker):
+    planner_success_at = datetime(2026, 7, 13, 18, 5, tzinfo=UTC)
+    async with session_maker() as session:
+        job = ScheduledJob(
+            name="legacy-sync",
+            job_type="sync",
+            schedule_cron="0 * * * *",
+            org_id="org-1",
+            provider="linear",
+        )
+        session.add(job)
+        await session.flush()
+
+        legacy_success = JobRun(
+            job_id=job.id,
+            status=JobRunStatus.SUCCESS.value,
+        )
+        legacy_success.completed_at = datetime(2026, 7, 13, 17, 5, tzinfo=UTC)
+        planner_success = SyncRun(
+            org_id="org-1",
+            integration_id=uuid.uuid4(),
+            triggered_by="scheduler",
+            mode="incremental",
+            status=SyncRunStatus.SUCCESS.value,
+            total_units=1,
+            completed_units=1,
+            failed_units=0,
+            completed_at=planner_success_at,
+        )
+        session.add_all([legacy_success, planner_success])
+        await session.commit()
+
+    async with session_maker() as session:
+        latest = await fetch_latest_successful_sync_at(session, org_id="org-1")
+
+    assert latest == planner_success_at

--- a/tests/api/services/test_home_freshness.py
+++ b/tests/api/services/test_home_freshness.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from sqlalchemy.exc import SQLAlchemyError
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.models.filters import MetricFilter, ScopeFilter, TimeFilter
+from dev_health_ops.api.models.schemas import (
+    ConstraintCard,
+    Coverage,
+    Freshness,
+    HomeResponse,
+)
+from dev_health_ops.api.services import home as home_service
+from dev_health_ops.api.services.cache import TTLCache
+from dev_health_ops.api.services.filtering import filter_cache_key
+
+
+@pytest.mark.asyncio
+async def test_cached_home_response_refreshes_latest_successful_sync(monkeypatch):
+    filters = MetricFilter(
+        time=TimeFilter(range_days=14, compare_days=14),
+        scope=ScopeFilter(level="org", ids=[]),
+    )
+    cache = TTLCache(ttl_seconds=60)
+    cached_sync_at = datetime(2026, 7, 13, 15, 5, tzinfo=UTC)
+    latest_sync_at = datetime(2026, 7, 13, 16, 11, tzinfo=UTC)
+    cached_response = HomeResponse(
+        freshness=Freshness(
+            last_ingested_at=datetime(2026, 7, 12, 0, 7, tzinfo=UTC),
+            latest_successful_sync_at=cached_sync_at,
+            sources={},
+            coverage=Coverage(
+                repos_covered_pct=100,
+                prs_linked_to_issues_pct=100,
+                issues_with_cycle_states_pct=100,
+            ),
+        ),
+        deltas=[],
+        summary=[],
+        tiles={},
+        constraint=ConstraintCard(title="", claim="", evidence=[], experiments=[]),
+        events=[],
+    )
+    cache.set(
+        filter_cache_key("home", "org-1", filters),
+        cached_response.model_dump(mode="json"),
+    )
+    semantic_session = MagicMock(spec=AsyncSession)
+
+    async def _fake_latest_successful_sync_at(session, *, org_id):
+        assert session is semantic_session
+        assert org_id == "org-1"
+        return latest_sync_at
+
+    monkeypatch.setattr(
+        home_service,
+        "fetch_latest_successful_sync_at",
+        _fake_latest_successful_sync_at,
+    )
+
+    response = await home_service.build_home_response(
+        db_url="unused-on-cache-hit",
+        filters=filters,
+        cache=cache,
+        org_id="org-1",
+        semantic_session=semantic_session,
+    )
+
+    assert response.freshness.latest_successful_sync_at == latest_sync_at
+    assert (
+        response.freshness.last_ingested_at
+        == cached_response.freshness.last_ingested_at
+    )
+
+
+@pytest.mark.asyncio
+async def test_cached_home_response_survives_sync_freshness_query_failure(monkeypatch):
+    filters = MetricFilter(
+        time=TimeFilter(range_days=14, compare_days=14),
+        scope=ScopeFilter(level="org", ids=[]),
+    )
+    cache = TTLCache(ttl_seconds=60)
+    cached_sync_at = datetime(2026, 7, 13, 15, 5, tzinfo=UTC)
+    cached_response = HomeResponse(
+        freshness=Freshness(
+            last_ingested_at=datetime(2026, 7, 12, 0, 7, tzinfo=UTC),
+            latest_successful_sync_at=cached_sync_at,
+            sources={},
+            coverage=Coverage(
+                repos_covered_pct=100,
+                prs_linked_to_issues_pct=100,
+                issues_with_cycle_states_pct=100,
+            ),
+        ),
+        deltas=[],
+        summary=[],
+        tiles={},
+        constraint=ConstraintCard(title="", claim="", evidence=[], experiments=[]),
+        events=[],
+    )
+    cache.set(
+        filter_cache_key("home", "org-1", filters),
+        cached_response.model_dump(mode="json"),
+    )
+
+    async def _fail_latest_successful_sync_at(session, *, org_id):
+        raise SQLAlchemyError
+
+    monkeypatch.setattr(
+        home_service,
+        "fetch_latest_successful_sync_at",
+        _fail_latest_successful_sync_at,
+    )
+
+    response = await home_service.build_home_response(
+        db_url="unused-on-cache-hit",
+        filters=filters,
+        cache=cache,
+        org_id="org-1",
+        semantic_session=MagicMock(spec=AsyncSession),
+    )
+
+    assert response == cached_response

--- a/tests/test_api_endpoints.py
+++ b/tests/test_api_endpoints.py
@@ -1,9 +1,12 @@
 from datetime import datetime, timezone
+from unittest.mock import MagicMock
 
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.api.auth.router import get_current_user
+from dev_health_ops.api.dependencies import get_postgres_session_dep
 from dev_health_ops.api.main import app
 from dev_health_ops.api.models.filters import MetricFilter
 from dev_health_ops.api.models.schemas import (
@@ -30,6 +33,7 @@ _FAKE_USER = AuthenticatedUser(
     org_id="test-org",
     role="admin",
 )
+_SEMANTIC_SESSION = MagicMock(spec=AsyncSession)
 
 
 def _validate(model, payload):
@@ -41,14 +45,17 @@ def _validate(model, payload):
 @pytest.fixture
 def client():
     app.dependency_overrides[get_current_user] = lambda: _FAKE_USER
+    app.dependency_overrides[get_postgres_session_dep] = lambda: _SEMANTIC_SESSION
     yield TestClient(app)
     app.dependency_overrides.clear()
 
 
 def test_home_endpoint_schema(client, monkeypatch):
+    captured = {}
     sample = HomeResponse(
         freshness=Freshness(
             last_ingested_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
+            latest_successful_sync_at=datetime(2024, 1, 2, tzinfo=timezone.utc),
             sources={"github": "ok", "gitlab": "ok", "jira": "ok", "ci": "ok"},
             coverage=Coverage(
                 repos_covered_pct=90.0,
@@ -94,7 +101,8 @@ def test_home_endpoint_schema(client, monkeypatch):
         ],
     )
 
-    async def _fake_home(**_):
+    async def _fake_home(**kwargs):
+        captured.update(kwargs)
         return sample
 
     monkeypatch.setattr("dev_health_ops.api.main.build_home_response", _fake_home)
@@ -102,14 +110,20 @@ def test_home_endpoint_schema(client, monkeypatch):
     response = client.get("/api/v1/home")
     assert response.status_code == 200
     _validate(HomeResponse, response.json())
+    assert (
+        response.json()["freshness"]["latest_successful_sync_at"]
+        == "2024-01-02T00:00:00Z"
+    )
     assert response.headers.get("X-DevHealth-Deprecated") == "use POST with filters"
+    assert captured["org_id"] == _FAKE_USER.org_id
+    assert captured["semantic_session"] is _SEMANTIC_SESSION
 
 
 def test_home_post_uses_filters(client, monkeypatch):
     captured = {}
 
     async def _fake_home(**kwargs):
-        captured["filters"] = kwargs["filters"]
+        captured.update(kwargs)
         return HomeResponse(
             freshness=Freshness(
                 last_ingested_at=datetime(2024, 1, 1, tzinfo=timezone.utc),
@@ -153,6 +167,8 @@ def test_home_post_uses_filters(client, monkeypatch):
     assert filters.time.compare_days == 7
     assert filters.scope.level == "team"
     assert filters.scope.ids == ["team-a"]
+    assert captured["org_id"] == _FAKE_USER.org_id
+    assert captured["semantic_session"] is _SEMANTIC_SESSION
 
 
 def test_home_query_translation_matches_post(client, monkeypatch):


### PR DESCRIPTION
## Summary

- expose the newest successful provider sync as org-scoped home freshness
- combine planner `SyncRun` history with legacy sync-only `JobRun` history while excluding failed, non-sync, and cross-org rows
- refresh successful-sync freshness independently of the cached Cockpit payload and degrade to cached/null freshness when the query fails
- wire the semantic session through both home endpoints and cover the API contract

## Verification

- `bash ci/local_validate.sh` (ruff, mypy, ClickHouse migration/proof, 7,734 tests)
- pre-commit and pre-push hooks (ruff format/check and mypy)
- all changed files report clean LSP diagnostics

## Companion change

- full-chaos/dev-health-web#777
- The frontend treats the new field as optional and preserves the existing ingestion timestamp as a compatibility fallback.

## Scope note

Graceful degradation covers freshness-query failures. PostgreSQL session acquisition remains the existing endpoint dependency boundary.
