### PR TITLE
fix(licensing): protect billing entitlement lookup

### DIFF
--- a/src/dev_health_ops/api/billing/router.py
+++ b/src/dev_health_ops/api/billing/router.py
@@ -915,10 +915,41 @@ async def _get_customer_id(org_id: str) -> str | None:
 # ---------------------------------------------------------------------------
 
 
+async def require_billing_entitlement_access(
+    org_id: uuid.UUID,
+    user: Annotated[AuthenticatedUser, Depends(get_current_user)],
+    db: Annotated[AsyncSession, Depends(postgres_session_dependency)],
+) -> None:
+    from sqlalchemy import select
+
+    from dev_health_ops.models.users import Membership, User
+
+    try:
+        user_id = uuid.UUID(user.user_id)
+    except ValueError:
+        raise HTTPException(status_code=403, detail="Access forbidden") from None
+    current_user = await db.get(User, user_id)
+    if current_user is None or not current_user.is_active:
+        raise HTTPException(status_code=403, detail="Access forbidden")
+    if current_user.is_superuser:
+        return
+    if user.org_id != str(org_id):
+        raise HTTPException(status_code=403, detail="Access forbidden")
+    membership = await db.execute(
+        select(Membership.id).where(
+            Membership.user_id == user_id,
+            Membership.org_id == org_id,
+        )
+    )
+    if membership.scalar_one_or_none() is None:
+        raise HTTPException(status_code=403, detail="Access forbidden")
+
+
 @router.get("/entitlements/{org_id}", response_model=EntitlementResponse)
 async def get_org_entitlements(
     org_id: uuid.UUID,
     db: Annotated[AsyncSession, Depends(postgres_session_dependency)],
+    _: Annotated[None, Depends(require_billing_entitlement_access)],
 ) -> EntitlementResponse:
     gating = importlib.import_module("dev_health_ops.licensing.gating")
     entitlements = await gating.get_org_entitlements_from_db(org_id=org_id, session=db)

--- a/src/dev_health_ops/api/graphql/app.py
+++ b/src/dev_health_ops/api/graphql/app.py
@@ -81,21 +81,16 @@ async def get_context(request: Request) -> GraphQLContext:
         raise HTTPException(status_code=401, detail="Authentication required")
 
     # --- Resolve org_id ------------------------------------------------------
-    # An active impersonation session takes precedence over the admin's JWT org.
-    # The JWT is never re-issued during impersonation (user.org_id stays the
-    # admin's org), so without this the GraphQL path would scope context, loader
-    # cache keys, and authorization to the admin org while query_dicts overrides
-    # only the raw SQL params to the target org -- inconsistent and a cross-org
-    # cache-poisoning hazard. Precedence: impersonation target > JWT org >
-    # OrgIdMiddleware contextvar > query param. (CHAOS-2303)
     org_id = ""
     imp_ctx = get_impersonation_context()
     if imp_ctx is not None and getattr(imp_ctx, "is_active", False):
         org_id = imp_ctx.target_org_id or ""
+    if not org_id:
+        org_id = get_current_org_id() or ""
     if not org_id and user and user.org_id:
         org_id = user.org_id
     if not org_id:
-        org_id = get_current_org_id() or request.query_params.get("org_id", "") or ""
+        org_id = request.query_params.get("org_id", "") or ""
 
     # --- Build context -------------------------------------------------------
     client = None

--- a/src/dev_health_ops/api/graphql/context.py
+++ b/src/dev_health_ops/api/graphql/context.py
@@ -63,6 +63,27 @@ class GraphQLContext(BaseContext):
 
             raise AuthorizationError("org_id is required")
 
+    def rebind_org_id(self, org_id: str) -> None:
+        """Rebuild tenant-bound loaders for an authorized operation scope."""
+        self.org_id = org_id
+        if self.client is None:
+            return
+        from .loaders import (
+            RepoByNameLoader,
+            RepoLoader,
+            TeamByNameLoader,
+            TeamLoader,
+        )
+
+        self.team_loader = TeamLoader(self.client, org_id, cache=self.cache)
+        self.team_by_name_loader = TeamByNameLoader(
+            self.client, org_id, cache=self.cache
+        )
+        self.repo_loader = RepoLoader(self.client, org_id, cache=self.cache)
+        self.repo_by_name_loader = RepoByNameLoader(
+            self.client, org_id, cache=self.cache
+        )
+
 
 def build_context(
     org_id: str,

--- a/src/dev_health_ops/api/graphql/extensions.py
+++ b/src/dev_health_ops/api/graphql/extensions.py
@@ -42,8 +42,6 @@ def _operation_org_id(execution_context) -> str | None:
             and definition.name.value == operation_name
         ):
             operation = definition
-            if operation_name is not None:
-                break
     if operation is None:
         return None
 
@@ -154,7 +152,10 @@ class OrgIdAuthExtension(SchemaExtension):
             is_impersonating = bool(
                 impersonation is not None and getattr(impersonation, "is_active", False)
             )
-            is_superuser = bool(getattr(context.user, "is_superuser", False))
+            is_superuser = bool(
+                getattr(context.user, "is_superuser", False)
+                and getattr(context.user, "is_superuser_verified", False)
+            )
             if requested_org_id is not None:
                 if (not is_superuser or is_impersonating) and (
                     requested_org_id != original_org_id

--- a/src/dev_health_ops/api/graphql/extensions.py
+++ b/src/dev_health_ops/api/graphql/extensions.py
@@ -9,12 +9,96 @@ from __future__ import annotations
 
 import logging
 
+from graphql.language.ast import (
+    FieldNode,
+    FragmentDefinitionNode,
+    FragmentSpreadNode,
+    InlineFragmentNode,
+    OperationDefinitionNode,
+    StringValueNode,
+    VariableNode,
+)
 from strawberry.extensions import AddValidationRules, SchemaExtension
 
 from .errors import AuthorizationError
 from .security import get_graphql_validation_rules
 
 logger = logging.getLogger(__name__)
+
+
+def _operation_org_id(execution_context) -> str | None:
+    document = getattr(execution_context, "graphql_document", None)
+    if document is None:
+        return None
+    operation_name = getattr(execution_context, "operation_name", None)
+    operation: OperationDefinitionNode | None = None
+    fragments: dict[str, FragmentDefinitionNode] = {}
+    for definition in document.definitions:
+        if isinstance(definition, FragmentDefinitionNode):
+            fragments[definition.name.value] = definition
+        elif isinstance(definition, OperationDefinitionNode) and (
+            operation_name is None
+            or definition.name is not None
+            and definition.name.value == operation_name
+        ):
+            operation = definition
+            if operation_name is not None:
+                break
+    if operation is None:
+        return None
+
+    variables = getattr(execution_context, "variables", None) or {}
+    requested_org_ids: list[str] = []
+    visited_fragments: set[str] = set()
+
+    def collect(selection_set) -> None:
+        for selection in selection_set.selections:
+            if isinstance(selection, FieldNode):
+                for argument in selection.arguments or ():
+                    if argument.name.value not in {"orgId", "org_id"}:
+                        continue
+                    value = argument.value
+                    raw_value: str | None
+                    if isinstance(value, VariableNode):
+                        raw_value = variables.get(value.name.value)
+                    elif isinstance(value, StringValueNode):
+                        raw_value = value.value
+                    else:
+                        raw_value = None
+                    if (
+                        not isinstance(raw_value, str)
+                        or not raw_value
+                        or raw_value != raw_value.strip()
+                    ):
+                        raise AuthorizationError("A valid organization ID is required")
+                    requested_org_ids.append(raw_value)
+                if selection.selection_set is not None:
+                    collect(selection.selection_set)
+            elif isinstance(selection, InlineFragmentNode):
+                collect(selection.selection_set)
+            elif isinstance(selection, FragmentSpreadNode):
+                fragment_name = selection.name.value
+                if fragment_name in visited_fragments:
+                    continue
+                visited_fragments.add(fragment_name)
+                fragment = fragments.get(fragment_name)
+                if fragment is not None:
+                    collect(fragment.selection_set)
+
+    collect(operation.selection_set)
+    if not requested_org_ids:
+        return None
+    if len(set(requested_org_ids)) != 1:
+        raise AuthorizationError("Only one organization may be queried per operation")
+    return requested_org_ids[0]
+
+
+def _rebind_context_org_id(context, org_id: str) -> None:
+    rebind_org_id = getattr(context, "rebind_org_id", None)
+    if callable(rebind_org_id):
+        rebind_org_id(org_id)
+        return
+    context.org_id = org_id
 
 
 class ConfiguredValidationRules(AddValidationRules):
@@ -44,36 +128,46 @@ class OrgIdAuthExtension(SchemaExtension):
         )
     """
 
-    def on_executing_start(self) -> None:
+    def on_execute(self):
         """Called by Strawberry before field resolution begins.
 
-        Resolves org_id from the operation's variable map or inline argument
-        and validates it against the context org_id set by middleware.
+        Resolves org_id from the operation's variable map and validates it
+        against the authenticated organization before field resolution.
         """
         execution_context = self.execution_context
         context = getattr(execution_context, "context", None)
         if context is None:
+            yield
             return
 
-        # Extract org_id from GraphQL variables only. Inline argument org_id
-        # (e.g. query { metrics(org_id: "x") }) is intentionally not validated
-        # here — the OrgIdMiddleware contextvar is the authoritative source and
-        # all resolvers scope via context.org_id, so inline args cannot bypass
-        # the auth boundary.
-        variables = getattr(execution_context, "variables", None) or {}
-        requested_org_id: str | None = variables.get("org_id") or None
+        from dev_health_ops.api.services.auth import (
+            get_impersonation_context,
+            reset_current_org_id,
+            set_current_org_id,
+        )
 
-        # If the query supplies org_id as a variable, enforce it matches the
-        # JWT-validated org_id in the context (set by OrgIdMiddleware).
-        if requested_org_id:
-            ctx_org_id = getattr(context, "org_id", None)
-            if ctx_org_id and ctx_org_id != requested_org_id:
-                raise AuthorizationError(
-                    f"Access denied: cannot query org '{requested_org_id}'"
-                )
-            # Write the resolved org_id back to context (handles empty string
-            # org_id when a public/dev endpoint sets "" as the initial value).
-            try:
-                context.org_id = requested_org_id
-            except AttributeError:
-                pass  # frozen context; leave as-is
+        original_org_id = context.org_id
+        org_context_token = None
+        try:
+            requested_org_id = _operation_org_id(execution_context)
+            impersonation = get_impersonation_context()
+            is_impersonating = bool(
+                impersonation is not None and getattr(impersonation, "is_active", False)
+            )
+            is_superuser = bool(getattr(context.user, "is_superuser", False))
+            if requested_org_id is not None:
+                if (not is_superuser or is_impersonating) and (
+                    requested_org_id != original_org_id
+                ):
+                    raise AuthorizationError(
+                        f"Access denied: cannot query org '{requested_org_id}'"
+                    )
+                if requested_org_id != original_org_id:
+                    _rebind_context_org_id(context, requested_org_id)
+                    org_context_token = set_current_org_id(requested_org_id)
+            yield
+        finally:
+            if org_context_token is not None:
+                reset_current_org_id(org_context_token)
+            if context.org_id != original_org_id:
+                _rebind_context_org_id(context, original_org_id)

--- a/src/dev_health_ops/api/graphql/resolvers/catalog.py
+++ b/src/dev_health_ops/api/graphql/resolvers/catalog.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 _REPOSITORY_PART = re.compile(r"^[a-z0-9](?:[a-z0-9._-]{0,98}[a-z0-9])?$")
-_REPOSITORY_VALUE_LIMIT = 100
+_REPOSITORY_SCOPE_LIMIT = 100
 
 
 def _canonical_repository_values(
@@ -50,9 +50,15 @@ def _canonical_repository_values(
             continue
         slug = "/".join(parts)
         counts[slug] = counts.get(slug, 0) + count
+    if len(counts) > _REPOSITORY_SCOPE_LIMIT:
+        raise ValidationError(
+            "repository catalog exceeds supported scope limit",
+            field="dimension",
+            value="repo",
+        )
     return [
         CatalogValueItem(value=slug, count=count)
-        for slug, count in sorted(counts.items())[:_REPOSITORY_VALUE_LIMIT]
+        for slug, count in sorted(counts.items())
     ]
 
 
@@ -105,11 +111,14 @@ async def resolve_catalog(
     values = None
     if dimension is not None and context.client is not None:
         try:
+            limit = (
+                _REPOSITORY_SCOPE_LIMIT + 1 if dimension == DimensionInput.REPO else 100
+            )
             raw_values = await load_dimension_values(
                 client=context.client,
                 dimension=dimension.value,
                 org_id=org_id,
-                limit=100,
+                limit=limit,
                 filters=filters,
             )
             if dimension == DimensionInput.REPO:

--- a/src/dev_health_ops/api/graphql/resolvers/catalog.py
+++ b/src/dev_health_ops/api/graphql/resolvers/catalog.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+import re
+from typing import TYPE_CHECKING, Any
 
 from ..authz import require_org_id
 from ..context import GraphQLContext
 from ..cost import DEFAULT_LIMITS
+from ..errors import ValidationError
 from ..loaders.dimension_loader import (
     get_dimension_descriptions,
     get_measure_descriptions,
@@ -28,6 +30,29 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
+_REPOSITORY_PART = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
+
+
+def _canonical_repository_values(
+    raw_values: list[dict[str, Any]],
+) -> list[CatalogValueItem]:
+    counts: dict[str, int] = {}
+    for raw_value in raw_values:
+        value = raw_value.get("value")
+        count = raw_value.get("count")
+        if not isinstance(value, str) or not isinstance(count, int):
+            continue
+        parts = [part.strip().lower() for part in value.strip().split("/")]
+        if len(parts) < 2 or not all(
+            _REPOSITORY_PART.fullmatch(part) for part in parts
+        ):
+            continue
+        slug = "/".join(parts)
+        counts[slug] = counts.get(slug, 0) + count
+    return [
+        CatalogValueItem(value=slug, count=count)
+        for slug, count in sorted(counts.items())
+    ]
 
 
 async def resolve_catalog(
@@ -86,9 +111,15 @@ async def resolve_catalog(
                 limit=100,
                 filters=filters,
             )
-            values = [
-                CatalogValueItem(value=v["value"], count=v["count"]) for v in raw_values
-            ]
+            if dimension == DimensionInput.REPO:
+                values = _canonical_repository_values(raw_values)
+            else:
+                values = [
+                    CatalogValueItem(value=v["value"], count=v["count"])
+                    for v in raw_values
+                ]
+        except ValidationError:
+            raise
         except Exception as e:
             logger.warning("Failed to load dimension values: %s", e)
             values = []

--- a/src/dev_health_ops/api/graphql/resolvers/catalog.py
+++ b/src/dev_health_ops/api/graphql/resolvers/catalog.py
@@ -30,7 +30,8 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-_REPOSITORY_PART = re.compile(r"^[a-z0-9][a-z0-9_.-]*$")
+_REPOSITORY_PART = re.compile(r"^[a-z0-9](?:[a-z0-9._-]{0,98}[a-z0-9])?$")
+_REPOSITORY_VALUE_LIMIT = 100
 
 
 def _canonical_repository_values(
@@ -42,8 +43,8 @@ def _canonical_repository_values(
         count = raw_value.get("count")
         if not isinstance(value, str) or not isinstance(count, int):
             continue
-        parts = [part.strip().lower() for part in value.strip().split("/")]
-        if len(parts) < 2 or not all(
+        parts = value.strip().lower().split("/")
+        if len(parts) != 2 or not all(
             _REPOSITORY_PART.fullmatch(part) for part in parts
         ):
             continue
@@ -51,7 +52,7 @@ def _canonical_repository_values(
         counts[slug] = counts.get(slug, 0) + count
     return [
         CatalogValueItem(value=slug, count=count)
-        for slug, count in sorted(counts.items())
+        for slug, count in sorted(counts.items())[:_REPOSITORY_VALUE_LIMIT]
     ]
 
 

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -592,6 +592,30 @@ def compile_catalog_values(
         "timeout": timeout,
     }
 
+    if dimension == Dimension.REPO:
+        if _has_active_filters(filters):
+            raise ValidationError(
+                "repository catalog filters are not supported",
+                field="filters",
+                value="repo",
+            )
+        params = enforce_org_scope(org_id, params)
+        return (
+            """
+SELECT
+    repo AS value,
+    count() AS count
+FROM repos FINAL
+WHERE org_id = %(org_id)s
+  AND repo != ''
+GROUP BY value
+ORDER BY value
+LIMIT %(limit)s
+SETTINGS max_execution_time = %(timeout)s
+""",
+            params,
+        )
+
     if dimension == Dimension.TEAM:
         # Filter scope/category clauses target event-table columns, which
         # do not apply when listing teams from the semantic source of

--- a/src/dev_health_ops/api/graphql/sql/compiler.py
+++ b/src/dev_health_ops/api/graphql/sql/compiler.py
@@ -587,10 +587,7 @@ def compile_catalog_values(
         needs_author_join=_needs_author_join(filters),
     )
 
-    params: dict[str, Any] = {
-        "limit": request.limit,
-        "timeout": timeout,
-    }
+    params: dict[str, Any] = {"limit": request.limit, "timeout": timeout}
 
     if dimension == Dimension.REPO:
         if _has_active_filters(filters):
@@ -603,12 +600,18 @@ def compile_catalog_values(
         return (
             """
 SELECT
-    repo AS value,
+    canonical_repo AS value,
     count() AS count
-FROM repos FINAL
-WHERE org_id = %(org_id)s
-  AND repo != ''
-GROUP BY value
+FROM (
+    SELECT lowerUTF8(trimBoth(repo)) AS canonical_repo
+    FROM repos FINAL
+    WHERE org_id = %(org_id)s
+)
+WHERE match(
+    canonical_repo,
+    '^[a-z0-9]([a-z0-9._-]{0,98}[a-z0-9])?/[a-z0-9]([a-z0-9._-]{0,98}[a-z0-9])?$'
+)
+GROUP BY canonical_repo
 ORDER BY value
 LIMIT %(limit)s
 SETTINGS max_execution_time = %(timeout)s

--- a/src/dev_health_ops/api/services/auth.py
+++ b/src/dev_health_ops/api/services/auth.py
@@ -37,6 +37,11 @@ def set_current_org_id(org_id: str) -> contextvars.Token[str | None]:
     return _current_org_id.set(org_id)
 
 
+def reset_current_org_id(token: contextvars.Token[str | None]) -> None:
+    """Restore the request organization after a temporary scope override."""
+    _current_org_id.reset(token)
+
+
 def get_current_org_id() -> str | None:
     """Get the org_id for the current request context, or None if unset."""
     return _current_org_id.get(None)

--- a/src/dev_health_ops/api/services/auth.py
+++ b/src/dev_health_ops/api/services/auth.py
@@ -126,6 +126,7 @@ class AuthenticatedUser:
     full_name: str | None = None
     impersonated_by: str | None = None
     token_version: int | None = None
+    is_superuser_verified: bool = False
 
     @property
     def is_admin(self) -> bool:
@@ -377,9 +378,9 @@ class AuthService:
             return None
 
         result = await db.execute(
-            select(User.id, User.is_active, User.token_version).where(
-                User.id == user_uuid
-            )
+            select(
+                User.id, User.is_active, User.is_superuser, User.token_version
+            ).where(User.id == user_uuid)
         )
         db_user = result.one_or_none()
         if db_user is None:
@@ -403,6 +404,8 @@ class AuthService:
             logger.warning("Access denied: stale session for user %s", user.user_id)
             return None
 
+        user.is_superuser = bool(db_user.is_superuser)
+        user.is_superuser_verified = True
         user.token_version = token_version
         return user
 

--- a/tests/api/billing/test_entitlements_auth.py
+++ b/tests/api/billing/test_entitlements_auth.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import base64
 import importlib
 import uuid
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable
 from contextlib import asynccontextmanager
 from datetime import timedelta
 from types import SimpleNamespace
@@ -15,6 +16,10 @@ from httpx import ASGITransport, AsyncClient
 from dev_health_ops.api.services import auth as auth_module
 from dev_health_ops.api.services.auth import AuthenticatedUser, AuthService
 from dev_health_ops.licensing import gating
+from dev_health_ops.licensing.generator import generate_test_license
+from dev_health_ops.models.internal_service_credential import (
+    generate_internal_service_token,
+)
 
 billing_module = importlib.import_module("dev_health_ops.api.billing.router")
 billing_router = billing_module.router
@@ -62,6 +67,14 @@ def _user(org_id: str, *, is_superuser: bool = False) -> AuthenticatedUser:
         role="member",
         is_superuser=is_superuser,
     )
+
+
+def _acr_client_credential_token() -> str:
+    return "fcacr_" + base64.urlsafe_b64encode(b"a" * 32).decode().rstrip("=")
+
+
+def _license_key_token() -> str:
+    return generate_test_license(org_id=str(uuid.uuid4()))
 
 
 @pytest.mark.asyncio
@@ -139,16 +152,17 @@ async def test_billing_entitlements_allows_superuser_cross_organization_lookup(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
-    "token",
+    "token_factory",
     [
-        "fcacr_client_credential",
-        "license_key_not_a_session",
-        "svc_acr_internal_service_credential",
+        _acr_client_credential_token,
+        _license_key_token,
+        generate_internal_service_token,
     ],
+    ids=["acr-client-credential", "license-key", "internal-service"],
 )
 async def test_billing_entitlements_rejects_non_session_token_classes(
     monkeypatch: pytest.MonkeyPatch,
-    token: str,
+    token_factory: Callable[[], str],
 ) -> None:
     monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-entitlements-auth")
     monkeypatch.setattr(auth_module, "_auth_service", None)
@@ -156,6 +170,7 @@ async def test_billing_entitlements_rejects_non_session_token_classes(
     monkeypatch.setattr(
         auth_router_module, "get_postgres_session", _authentication_database
     )
+    token = token_factory()
 
     async with AsyncClient(
         transport=ASGITransport(app=app), base_url="http://test"

--- a/tests/api/billing/test_entitlements_auth.py
+++ b/tests/api/billing/test_entitlements_auth.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+import importlib
+import uuid
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from fastapi import FastAPI, HTTPException
+from httpx import ASGITransport, AsyncClient
+
+from dev_health_ops.api.services import auth as auth_module
+from dev_health_ops.api.services.auth import AuthenticatedUser, AuthService
+from dev_health_ops.licensing import gating
+
+billing_module = importlib.import_module("dev_health_ops.api.billing.router")
+billing_router = billing_module.router
+auth_router_module = importlib.import_module("dev_health_ops.api.auth.router")
+
+
+@asynccontextmanager
+async def _authentication_database() -> AsyncIterator[None]:
+    yield None
+
+
+async def _entitlements(*_args: object, **_kwargs: object) -> dict[str, object]:
+    return {
+        "tier": "team",
+        "features": {"agent_context_runtime": True},
+        "limits": {},
+        "is_licensed": True,
+        "in_grace_period": False,
+    }
+
+
+def _app(monkeypatch: pytest.MonkeyPatch) -> FastAPI:
+    app = FastAPI()
+    app.include_router(billing_router)
+    database = AsyncMock()
+    database.get.return_value = SimpleNamespace(is_active=True, is_superuser=False)
+    database.execute.return_value = SimpleNamespace(scalar_one_or_none=lambda: object())
+
+    async def _database_dependency() -> AsyncIterator[AsyncMock]:
+        yield database
+
+    app.dependency_overrides[billing_module.postgres_session_dependency] = (
+        _database_dependency
+    )
+    app.state.billing_database = database
+    monkeypatch.setattr(gating, "get_org_entitlements_from_db", _entitlements)
+    return app
+
+
+def _user(org_id: str, *, is_superuser: bool = False) -> AuthenticatedUser:
+    return AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="member@example.com",
+        org_id=org_id,
+        role="member",
+        is_superuser=is_superuser,
+    )
+
+
+@pytest.mark.asyncio
+async def test_billing_entitlements_rejects_anonymous_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _app(monkeypatch)
+    org_id = uuid.uuid4()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(f"/api/v1/billing/entitlements/{org_id}")
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_billing_entitlements_rejects_other_organization_member(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _app(monkeypatch)
+    app.dependency_overrides[billing_module.get_current_user] = lambda: _user(
+        str(uuid.uuid4())
+    )
+    org_id = uuid.uuid4()
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(f"/api/v1/billing/entitlements/{org_id}")
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "Access forbidden"}
+
+
+@pytest.mark.asyncio
+async def test_billing_entitlements_returns_own_organization_entitlements(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _app(monkeypatch)
+    org_id = uuid.uuid4()
+    app.dependency_overrides[billing_module.get_current_user] = lambda: _user(
+        str(org_id)
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(f"/api/v1/billing/entitlements/{org_id}")
+
+    assert response.status_code == 200
+    assert response.json()["features"] == {"agent_context_runtime": True}
+
+
+@pytest.mark.asyncio
+async def test_billing_entitlements_allows_superuser_cross_organization_lookup(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    app = _app(monkeypatch)
+    app.dependency_overrides[billing_module.get_current_user] = lambda: _user(
+        str(uuid.uuid4()), is_superuser=True
+    )
+    app.state.billing_database.get.return_value = SimpleNamespace(
+        is_active=True, is_superuser=True
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(f"/api/v1/billing/entitlements/{uuid.uuid4()}")
+
+    assert response.status_code == 200
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "token",
+    [
+        "fcacr_client_credential",
+        "license_key_not_a_session",
+        "svc_acr_internal_service_credential",
+    ],
+)
+async def test_billing_entitlements_rejects_non_session_token_classes(
+    monkeypatch: pytest.MonkeyPatch,
+    token: str,
+) -> None:
+    monkeypatch.setenv("JWT_SECRET_KEY", "test-secret-key-for-entitlements-auth")
+    monkeypatch.setattr(auth_module, "_auth_service", None)
+    app = _app(monkeypatch)
+    monkeypatch.setattr(
+        auth_router_module, "get_postgres_session", _authentication_database
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            f"/api/v1/billing/entitlements/{uuid.uuid4()}",
+            headers={"Authorization": f"Bearer {token}"},
+        )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_billing_entitlements_rejects_expired_user_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    secret = "test-secret-key-for-entitlements-auth"
+    monkeypatch.setenv("JWT_SECRET_KEY", secret)
+    monkeypatch.setattr(auth_module, "_auth_service", None)
+    app = _app(monkeypatch)
+    monkeypatch.setattr(
+        auth_router_module, "get_postgres_session", _authentication_database
+    )
+    expired_token = AuthService(secret_key=secret).create_access_token(
+        user_id=str(uuid.uuid4()),
+        email="expired@example.com",
+        org_id=str(uuid.uuid4()),
+        expires_delta=timedelta(seconds=-1),
+    )
+
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as client:
+        response = await client.get(
+            f"/api/v1/billing/entitlements/{uuid.uuid4()}",
+            headers={"Authorization": f"Bearer {expired_token}"},
+        )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_billing_entitlements_rejects_removed_member_and_demoted_superuser() -> (
+    None
+):
+    org_id = uuid.uuid4()
+    user = _user(str(org_id), is_superuser=True)
+    database = AsyncMock()
+    database.get.return_value = SimpleNamespace(is_active=True, is_superuser=False)
+    database.execute.return_value = SimpleNamespace(scalar_one_or_none=lambda: None)
+
+    with pytest.raises(HTTPException) as exc_info:
+        await billing_module.require_billing_entitlement_access(
+            org_id=org_id,
+            user=user,
+            db=database,
+        )
+
+    assert exc_info.value.status_code == 403

--- a/tests/api/graphql/test_acr_repository_scopes.py
+++ b/tests/api/graphql/test_acr_repository_scopes.py
@@ -1,0 +1,334 @@
+from __future__ import annotations
+
+import uuid
+
+import pytest
+
+from dev_health_ops.api.graphql.context import GraphQLContext
+from dev_health_ops.api.graphql.schema import schema
+from dev_health_ops.api.services.auth import AuthenticatedUser
+
+_QUERY = """
+query ACRRepositoryScopes($orgId: String!) {
+  catalog(orgId: $orgId, dimension: REPO) {
+    values { value count }
+  }
+}
+"""
+
+_ARBITRARY_VARIABLE_QUERY = """
+query ACRRepositoryScopes($target: String!) {
+  catalog(orgId: $target, dimension: REPO) {
+    values { value count }
+  }
+}
+"""
+
+_INLINE_QUERY = """
+query ACRRepositoryScopes {
+  catalog(orgId: "org-b", dimension: REPO) {
+    values { value count }
+  }
+}
+"""
+
+
+def _context(
+    org_id: str, *, is_superuser: bool = False, client: object | None = None
+) -> GraphQLContext:
+    return GraphQLContext(
+        org_id=org_id,
+        db_url="clickhouse://test",
+        client=client or object(),
+        user=AuthenticatedUser(
+            user_id=str(uuid.uuid4()),
+            email="member@example.com",
+            org_id=org_id,
+            role="member",
+            is_superuser=is_superuser,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_returns_sorted_unique_canonical_values(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_org_ids: list[str] = []
+
+    async def _query_dicts(_client: object, _sql: str, params: dict[str, object]):
+        assert "FROM repos FINAL" in _sql
+        observed_org_ids.append(str(params["org_id"]))
+        return [
+            {"value": "Zeta/Api", "count": 2},
+            {"value": " acme / api ", "count": 3},
+            {"value": "ACME/API", "count": 4},
+            {"value": "not-a-slug", "count": 9},
+            {"value": "other//extra", "count": 5},
+            {"value": "group/subgroup/repository", "count": 6},
+        ]
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+
+    result = await schema.execute(
+        _QUERY,
+        variable_values={"orgId": "org-a"},
+        context_value=_context("org-a"),
+    )
+
+    assert result.errors is None
+    assert observed_org_ids == ["org-a"]
+    assert result.data == {
+        "catalog": {
+            "values": [
+                {"value": "acme/api", "count": 7},
+                {"value": "group/subgroup/repository", "count": 6},
+                {"value": "zeta/api", "count": 2},
+            ]
+        }
+    }
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_rejects_cross_organization_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    async def _query_dicts(_client: object, _sql: str, _params: dict[str, object]):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+
+    result = await schema.execute(
+        _QUERY,
+        variable_values={"orgId": "org-b"},
+        context_value=_context("org-a"),
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert called is False
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("query", "variables"),
+    [
+        (_ARBITRARY_VARIABLE_QUERY, {"target": "org-b"}),
+        (_INLINE_QUERY, {}),
+    ],
+)
+async def test_acr_repository_scopes_rejects_noncanonical_cross_organization_syntax(
+    monkeypatch: pytest.MonkeyPatch,
+    query: str,
+    variables: dict[str, str],
+) -> None:
+    called = False
+
+    async def _query_dicts(_client: object, _sql: str, _params: dict[str, object]):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+
+    result = await schema.execute(
+        query,
+        variable_values=variables,
+        context_value=_context("org-a"),
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_rejects_blank_organization_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    async def _query_dicts(_client: object, _sql: str, _params: dict[str, object]):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+
+    result = await schema.execute(
+        _QUERY,
+        variable_values={"orgId": ""},
+        context_value=_context("org-a"),
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_rejects_superuser_cross_organization_during_impersonation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.api.services.auth import (
+        _impersonation_ctx,
+        set_impersonation_context,
+    )
+
+    async def _query_dicts(_client: object, _sql: str, _params: dict[str, object]):
+        return []
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+    token = set_impersonation_context(
+        target_user_id="target-user",
+        target_org_id="org-a",
+        target_role="member",
+        real_user_id="admin-user",
+    )
+    try:
+        result = await schema.execute(
+            _QUERY,
+            variable_values={"orgId": "org-b"},
+            context_value=_context("org-a", is_superuser=True),
+        )
+    finally:
+        _impersonation_ctx.reset(token)
+
+    assert result.data is None
+    assert result.errors is not None
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_allows_superuser_cross_organization_variable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    observed_org_ids: list[str] = []
+
+    async def _query_dicts(_client: object, _sql: str, params: dict[str, object]):
+        observed_org_ids.append(str(params["org_id"]))
+        return [{"value": "other/repository", "count": 1}]
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+
+    result = await schema.execute(
+        _QUERY,
+        variable_values={"orgId": "org-b"},
+        context_value=_context("org-a", is_superuser=True),
+    )
+
+    assert result.errors is None
+    assert observed_org_ids == ["org-b"]
+    assert result.data == {
+        "catalog": {"values": [{"value": "other/repository", "count": 1}]}
+    }
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_keeps_query_wrapper_in_superuser_scope() -> None:
+    from dev_health_ops.api.services.auth import _current_org_id, set_current_org_id
+
+    class Sink:
+        def __init__(self) -> None:
+            self.params: list[dict[str, object]] = []
+
+        def query_dicts(self, _sql: str, params: dict[str, object]):
+            self.params.append(params)
+            return [{"value": "other/repository", "count": 1}]
+
+    sink = Sink()
+    token = set_current_org_id("org-a")
+    try:
+        result = await schema.execute(
+            _QUERY,
+            variable_values={"orgId": "org-b"},
+            context_value=_context("org-a", is_superuser=True, client=sink),
+        )
+    finally:
+        _current_org_id.reset(token)
+
+    assert result.errors is None
+    assert sink.params == [{"limit": 100, "timeout": 30, "org_id": "org-b"}]
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_returns_empty_catalog_for_effective_organization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _query_dicts(_client: object, _sql: str, params: dict[str, object]):
+        assert params["org_id"] == "org-a"
+        return []
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+
+    result = await schema.execute(
+        _QUERY,
+        variable_values={"orgId": "org-a"},
+        context_value=_context("org-a"),
+    )
+
+    assert result.errors is None
+    assert result.data == {"catalog": {"values": []}}
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_uses_persisted_catalog_for_empty_filters(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _query_dicts(_client: object, sql: str, _params: dict[str, object]):
+        assert "FROM repos FINAL" in sql
+        return [{"value": "acme/repository", "count": 1}]
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+    result = await schema.execute(
+        """
+        query ACRRepositoryScopes($orgId: String!) {
+          catalog(orgId: $orgId, dimension: REPO, filters: {}) {
+            values { value count }
+          }
+        }
+        """,
+        variable_values={"orgId": "org-a"},
+        context_value=_context("org-a"),
+    )
+
+    assert result.errors is None
+    assert result.data == {
+        "catalog": {"values": [{"value": "acme/repository", "count": 1}]}
+    }
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_rejects_active_filters_instead_of_emptying_scopes(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    async def _query_dicts(_client: object, _sql: str, _params: dict[str, object]):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+    result = await schema.execute(
+        """
+        query ACRRepositoryScopes($orgId: String!) {
+          catalog(
+            orgId: $orgId,
+            dimension: REPO,
+            filters: {what: {repos: ["acme/repository"]}}
+          ) {
+            values { value count }
+          }
+        }
+        """,
+        variable_values={"orgId": "org-a"},
+        context_value=_context("org-a"),
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert called is False

--- a/tests/api/graphql/test_acr_repository_scopes.py
+++ b/tests/api/graphql/test_acr_repository_scopes.py
@@ -32,21 +32,42 @@ query ACRRepositoryScopes {
 }
 """
 
+_TRAILING_FRAGMENT_QUERY = """
+query ACRRepositoryScopes($orgId: String!) {
+  catalogA: catalog(orgId: $orgId, dimension: REPO) {
+    values { value count }
+  }
+  ...CrossOrganizationCatalog
+}
+
+fragment CrossOrganizationCatalog on Query {
+  catalogB: catalog(orgId: "org-b", dimension: REPO) {
+    values { value count }
+  }
+}
+"""
+
 
 def _context(
-    org_id: str, *, is_superuser: bool = False, client: object | None = None
+    org_id: str,
+    *,
+    is_superuser: bool = False,
+    is_superuser_verified: bool = True,
+    client: object | None = None,
 ) -> GraphQLContext:
+    user = AuthenticatedUser(
+        user_id=str(uuid.uuid4()),
+        email="member@example.com",
+        org_id=org_id,
+        role="member",
+        is_superuser=is_superuser,
+    )
+    user.is_superuser_verified = is_superuser_verified
     return GraphQLContext(
         org_id=org_id,
         db_url="clickhouse://test",
         client=client or object(),
-        user=AuthenticatedUser(
-            user_id=str(uuid.uuid4()),
-            email="member@example.com",
-            org_id=org_id,
-            role="member",
-            is_superuser=is_superuser,
-        ),
+        user=user,
     )
 
 
@@ -61,11 +82,14 @@ async def test_acr_repository_scopes_returns_sorted_unique_canonical_values(
         observed_org_ids.append(str(params["org_id"]))
         return [
             {"value": "Zeta/Api", "count": 2},
-            {"value": " acme / api ", "count": 3},
+            {"value": " Acme/API ", "count": 3},
             {"value": "ACME/API", "count": 4},
             {"value": "not-a-slug", "count": 9},
             {"value": "other//extra", "count": 5},
             {"value": "group/subgroup/repository", "count": 6},
+            {"value": "acme/trailing-", "count": 7},
+            {"value": "acme/leading_", "count": 8},
+            {"value": f"acme/{'a' * 101}", "count": 9},
         ]
 
     monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
@@ -82,7 +106,6 @@ async def test_acr_repository_scopes_returns_sorted_unique_canonical_values(
         "catalog": {
             "values": [
                 {"value": "acme/api", "count": 7},
-                {"value": "group/subgroup/repository", "count": 6},
                 {"value": "zeta/api", "count": 2},
             ]
         }
@@ -138,6 +161,30 @@ async def test_acr_repository_scopes_rejects_noncanonical_cross_organization_syn
     result = await schema.execute(
         query,
         variable_values=variables,
+        context_value=_context("org-a"),
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert called is False
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_rejects_cross_organization_in_trailing_fragment(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    async def _query_dicts(_client: object, _sql: str, _params: dict[str, object]):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+
+    result = await schema.execute(
+        _TRAILING_FRAGMENT_QUERY,
+        variable_values={"orgId": "org-a"},
         context_value=_context("org-a"),
     )
 
@@ -203,6 +250,30 @@ async def test_acr_repository_scopes_rejects_superuser_cross_organization_during
 
 
 @pytest.mark.asyncio
+async def test_acr_repository_scopes_rejects_demoted_superuser_stale_claim(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    called = False
+
+    async def _query_dicts(_client: object, _sql: str, _params: dict[str, object]):
+        nonlocal called
+        called = True
+        return []
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+
+    result = await schema.execute(
+        _QUERY,
+        variable_values={"orgId": "org-b"},
+        context_value=_context("org-a", is_superuser=True, is_superuser_verified=False),
+    )
+
+    assert result.data is None
+    assert result.errors is not None
+    assert called is False
+
+
+@pytest.mark.asyncio
 async def test_acr_repository_scopes_allows_superuser_cross_organization_variable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -225,6 +296,29 @@ async def test_acr_repository_scopes_allows_superuser_cross_organization_variabl
     assert result.data == {
         "catalog": {"values": [{"value": "other/repository", "count": 1}]}
     }
+
+
+@pytest.mark.asyncio
+async def test_acr_repository_scopes_limits_values_after_canonicalization(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _query_dicts(_client: object, _sql: str, _params: dict[str, object]):
+        return [
+            {"value": f"owner/repository-{index:03}", "count": 1}
+            for index in range(101)
+        ]
+
+    monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
+
+    result = await schema.execute(
+        _QUERY,
+        variable_values={"orgId": "org-a"},
+        context_value=_context("org-a"),
+    )
+
+    assert result.errors is None
+    assert result.data is not None
+    assert len(result.data["catalog"]["values"]) == 100
 
 
 @pytest.mark.asyncio

--- a/tests/api/graphql/test_acr_repository_scopes.py
+++ b/tests/api/graphql/test_acr_repository_scopes.py
@@ -299,13 +299,18 @@ async def test_acr_repository_scopes_allows_superuser_cross_organization_variabl
 
 
 @pytest.mark.asyncio
-async def test_acr_repository_scopes_limits_values_after_canonicalization(
+async def test_acr_repository_scopes_rejects_catalog_exceeding_supported_scope_limit(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    async def _query_dicts(_client: object, _sql: str, _params: dict[str, object]):
+    async def _query_dicts(_client: object, _sql: str, params: dict[str, object]):
+        assert params["limit"] == 101
         return [
             {"value": f"owner/repository-{index:03}", "count": 1}
-            for index in range(101)
+            for index in range(130)
+        ] + [
+            {"value": " OWNER/REPOSITORY-000 ", "count": 1},
+            {"value": "owner/trailing-", "count": 1},
+            {"value": "group/subgroup/repository", "count": 1},
         ]
 
     monkeypatch.setattr("dev_health_ops.api.queries.client.query_dicts", _query_dicts)
@@ -316,9 +321,11 @@ async def test_acr_repository_scopes_limits_values_after_canonicalization(
         context_value=_context("org-a"),
     )
 
-    assert result.errors is None
-    assert result.data is not None
-    assert len(result.data["catalog"]["values"]) == 100
+    assert result.data is None
+    assert result.errors is not None
+    assert (
+        result.errors[0].message == "repository catalog exceeds supported scope limit"
+    )
 
 
 @pytest.mark.asyncio
@@ -345,7 +352,7 @@ async def test_acr_repository_scopes_keeps_query_wrapper_in_superuser_scope() ->
         _current_org_id.reset(token)
 
     assert result.errors is None
-    assert sink.params == [{"limit": 100, "timeout": 30, "org_id": "org-b"}]
+    assert sink.params == [{"limit": 101, "timeout": 30, "org_id": "org-b"}]
 
 
 @pytest.mark.asyncio

--- a/tests/api/graphql/test_context_impersonation.py
+++ b/tests/api/graphql/test_context_impersonation.py
@@ -20,7 +20,9 @@ import pytest
 
 from dev_health_ops.api.graphql import app as gql_app
 from dev_health_ops.api.services.auth import (
+    _current_org_id,
     _impersonation_ctx,
+    set_current_org_id,
     set_impersonation_context,
 )
 
@@ -118,6 +120,21 @@ async def test_get_context_uses_jwt_org_without_impersonation(
     ctx = await gql_app.get_context(request)  # type: ignore[arg-type]
 
     assert ctx.org_id == admin_org
+
+
+@pytest.mark.asyncio
+async def test_get_context_uses_verified_request_organization_before_jwt_org(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _stub_admin_auth(monkeypatch, admin_org="org-admin-gql-3")
+    request = _FakeRequest(headers={"Authorization": "Bearer faketoken"})
+    token = set_current_org_id("org-selected-gql-3")
+    try:
+        ctx = await gql_app.get_context(request)  # type: ignore[arg-type]
+    finally:
+        _current_org_id.reset(token)
+
+    assert ctx.org_id == "org-selected-gql-3"
 
 
 def _superuser_graphql_context(org_id: str = "org-x"):

--- a/tests/api/internal/test_acr_entitlements.py
+++ b/tests/api/internal/test_acr_entitlements.py
@@ -12,6 +12,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
 
 from dev_health_ops.api.internal.acr import router
+from dev_health_ops.api.services.auth import AuthService
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.internal_service_credential import (
     InternalServiceCredential,
@@ -104,6 +105,16 @@ def _patch_session(monkeypatch, session_maker) -> None:
     monkeypatch.setattr(acr, "get_postgres_session", _session)
 
 
+def _user_jwt() -> str:
+    return "Bearer " + AuthService(
+        secret_key="test-secret-key-for-internal-acr"
+    ).create_access_token(
+        user_id="11111111-1111-1111-1111-111111111111",
+        email="user@example.com",
+        org_id="22222222-2222-2222-2222-222222222222",
+    )
+
+
 @pytest.mark.asyncio
 async def test_acr_entitlement_returns_exact_minimal_contract_for_valid_service_token(
     session_maker, entitled_org, monkeypatch
@@ -130,7 +141,15 @@ async def test_acr_entitlement_returns_exact_minimal_contract_for_valid_service_
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
     "authorization",
-    [None, "Basic abc", "Bearer invalid", "Bearer svc_acr_bad"],
+    [
+        None,
+        "Basic abc",
+        "Bearer invalid",
+        "Bearer svc_acr_bad",
+        "Bearer fcacr_client_credential",
+        "Bearer license_key_not_a_service_credential",
+        _user_jwt,
+    ],
 )
 async def test_acr_entitlement_rejects_missing_malformed_or_unknown_tokens(
     session_maker, entitled_org, monkeypatch, authorization
@@ -138,7 +157,14 @@ async def test_acr_entitlement_rejects_missing_malformed_or_unknown_tokens(
     _patch_session(monkeypatch, session_maker)
     app = FastAPI()
     app.include_router(router)
-    headers = {} if authorization is None else {"Authorization": authorization}
+    resolved_authorization = (
+        authorization() if callable(authorization) else authorization
+    )
+    headers = (
+        {}
+        if resolved_authorization is None
+        else {"Authorization": resolved_authorization}
+    )
     transport = ASGITransport(app=app)
     async with AsyncClient(transport=transport, base_url="http://test") as client:
         response = await client.get(

--- a/tests/api/internal/test_acr_entitlements.py
+++ b/tests/api/internal/test_acr_entitlements.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import base64
 import uuid
 from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
@@ -13,6 +14,7 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from dev_health_ops.api.internal.acr import router
 from dev_health_ops.api.services.auth import AuthService
+from dev_health_ops.licensing.generator import generate_test_license
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.internal_service_credential import (
     InternalServiceCredential,
@@ -115,6 +117,19 @@ def _user_jwt() -> str:
     )
 
 
+def _unknown_internal_service_token() -> str:
+    return "Bearer " + generate_internal_service_token()
+
+
+def _license_key_token() -> str:
+    return "Bearer " + generate_test_license(org_id=str(uuid.uuid4()))
+
+
+def _acr_client_credential_token() -> str:
+    token = "fcacr_" + base64.urlsafe_b64encode(b"a" * 32).decode().rstrip("=")
+    return "Bearer " + token
+
+
 @pytest.mark.asyncio
 async def test_acr_entitlement_returns_exact_minimal_contract_for_valid_service_token(
     session_maker, entitled_org, monkeypatch
@@ -145,9 +160,9 @@ async def test_acr_entitlement_returns_exact_minimal_contract_for_valid_service_
         None,
         "Basic abc",
         "Bearer invalid",
-        "Bearer svc_acr_bad",
-        "Bearer fcacr_client_credential",
-        "Bearer license_key_not_a_service_credential",
+        _unknown_internal_service_token,
+        _acr_client_credential_token,
+        _license_key_token,
         _user_jwt,
     ],
 )

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -453,7 +453,7 @@ class TestCompileCatalogValues:
         request = CatalogValuesRequest(dimension="repo", limit=100)
         org_id = "test-org"
 
-        sql, _ = compile_catalog_values(request, org_id)
+        sql, params = compile_catalog_values(request, org_id)
 
         assert "SELECT" in sql
         assert "repo AS value" in sql
@@ -461,6 +461,11 @@ class TestCompileCatalogValues:
         assert "GROUP BY" in sql
         assert "FROM repos FINAL" in sql
         assert "org_id = %(org_id)s" in sql
+        assert "lowerUTF8(trimBoth(repo)) AS canonical_repo" in sql
+        assert "WHERE match(" in sql
+        assert "GROUP BY canonical_repo" in sql
+        assert "LIMIT %(limit)s" in sql
+        assert params["limit"] == 100
         assert "teams FINAL" not in sql
         assert "LEFT JOIN" not in sql
 

--- a/tests/graphql/test_compiler.py
+++ b/tests/graphql/test_compiler.py
@@ -449,20 +449,18 @@ class TestCompileCatalogValues:
         assert params["org_id"] == org_id
         assert params["limit"] == 100
 
-    def test_non_team_catalog_uses_event_table_directly(self):
-        """REPO and other non-team dimensions retain the original
-        event-table catalog behavior."""
+    def test_repository_catalog_uses_org_filtered_persisted_repositories(self):
         request = CatalogValuesRequest(dimension="repo", limit=100)
         org_id = "test-org"
 
         sql, _ = compile_catalog_values(request, org_id)
 
         assert "SELECT" in sql
-        assert "repo_id" in sql
-        assert "COUNT(*)" in sql
+        assert "repo AS value" in sql
+        assert "count()" in sql
         assert "GROUP BY" in sql
-        assert "investment_metrics_daily" in sql
-        # No teams FINAL or LEFT JOIN for non-team dimensions.
+        assert "FROM repos FINAL" in sql
+        assert "org_id = %(org_id)s" in sql
         assert "teams FINAL" not in sql
         assert "LEFT JOIN" not in sql
 

--- a/tests/test_auth_db_check.py
+++ b/tests/test_auth_db_check.py
@@ -169,7 +169,12 @@ async def test_get_current_user_accepts_active_user(auth_service):
     token = _make_token(auth_service, user_id=str(user_id))
     header = f"Bearer {token}"
 
-    active_row = SimpleNamespace(id=user_id, is_active=True, token_version=0)
+    active_row = SimpleNamespace(
+        id=user_id,
+        is_active=True,
+        is_superuser=False,
+        token_version=0,
+    )
     session = _mock_session(_FakeResult(row=active_row))
 
     from contextlib import asynccontextmanager
@@ -187,6 +192,31 @@ async def test_get_current_user_accepts_active_user(auth_service):
         result = await get_current_user(authorization=header)
         assert isinstance(result, AuthenticatedUser)
         assert result.user_id == str(user_id)
+
+
+@pytest.mark.asyncio
+async def test_authenticate_access_token_replaces_stale_superuser_claim(auth_service):
+    user_id = uuid.uuid4()
+    token = _make_token(
+        auth_service,
+        user_id=str(user_id),
+        is_superuser=True,
+    )
+    demoted_row = SimpleNamespace(
+        id=user_id,
+        is_active=True,
+        is_superuser=False,
+        token_version=0,
+    )
+
+    result = await auth_service.authenticate_access_token(
+        token,
+        _mock_session(_FakeResult(row=demoted_row)),
+    )
+
+    assert result is not None
+    assert result.is_superuser is False
+    assert result.is_superuser_verified is True
 
 
 @pytest.mark.asyncio

--- a/tests/test_billing.py
+++ b/tests/test_billing.py
@@ -398,12 +398,20 @@ async def test_portal_success(authed_client):
 
 @pytest.mark.asyncio
 async def test_entitlements_org_endpoint_returns_per_org_state(client, app):
+    from dev_health_ops.api.auth.router import get_current_user
+    from dev_health_ops.api.services.auth import AuthenticatedUser
     from dev_health_ops.db import postgres_session_dependency
 
     async def _override_session():
         yield AsyncMock()
 
     app.dependency_overrides[postgres_session_dependency] = _override_session
+    app.dependency_overrides[get_current_user] = lambda: AuthenticatedUser(
+        user_id="00000000-0000-0000-0000-000000000002",
+        email="member@example.com",
+        org_id="00000000-0000-0000-0000-000000000001",
+        role="member",
+    )
 
     mock_entitlements = {
         "tier": "team",
@@ -429,6 +437,7 @@ async def test_entitlements_org_endpoint_returns_per_org_state(client, app):
             )
     finally:
         app.dependency_overrides.pop(postgres_session_dependency, None)
+        app.dependency_overrides.pop(get_current_user, None)
 
     assert resp.status_code == 200
     body = resp.json()


### PR DESCRIPTION
## Summary
- protect the public billing entitlement lookup with current user-session organization and authoritative superuser checks
- keep the internal ACR entitlement endpoint service-credential-only and reject token-class confusion
- return canonical, sorted repository scopes from organization-filtered persisted evidence with explicit bounded overflow errors

## Verification
- `bash ci/local_validate.sh`
- focused billing/internal/GraphQL entitlement suites
- manual anonymous, cross-org, stale-superuser, fragment, malformed-scope, and >100-repository probes
- independent Oracle review: PASS, no remaining findings

## Scope
- Ops provider hardening only; no ACR deployment, runtime, or packaging assets

Linear: CHAOS-2941