### PR TITLE
docs: plan canonical operations, PagerDuty OAuth, migrations, and Push API

### DIFF
--- a/docs/superpowers/plans/2026-07-16-canonical-operations-oauth-migration-push-addendum.md
+++ b/docs/superpowers/plans/2026-07-16-canonical-operations-oauth-migration-push-addendum.md
@@ -1,0 +1,368 @@
+# Canonical Operations Addendum: OAuth, Source Migration, and External Push
+
+**Parent plan:** `2026-07-16-pagerduty-incident-response-provider.md`  
+**Linear epic:** [CHAOS-2954](https://linear.app/fullchaos/issue/CHAOS-2954/canonical-operations-model-and-pagerduty-integration)  
+**Milestone:** Canonical Incident Response and PagerDuty
+
+## Purpose
+
+This addendum corrects and expands the original PagerDuty plan in three ways:
+
+1. PagerDuty authentication is OAuth-first rather than API-token-first.
+2. The canonical operations model must replace or adapt every existing incident producer—not only accept PagerDuty data.
+3. The External Push API must expose the same canonical operational contracts so customer ETL and unsupported incident systems do not create a parallel path.
+
+## 1. PagerDuty authentication
+
+PagerDuty REST access supports scoped OAuth. API keys remain supported, but they are not the preferred hosted connection experience.
+
+### 1.1 Hosted Dev Health
+
+Preferred user-connected flow:
+
+```text
+Dev Health -> PagerDuty authorization endpoint
+           -> user login and consent
+           -> authorization code callback
+           -> short-lived bearer token
+           -> encrypted token lifecycle storage
+```
+
+Implementation requirements:
+
+- register a Dev Health PagerDuty app explicitly;
+- use authorization code and PKCE where supported by the registered app type;
+- protect callback state, PKCE verifier, redirect URI, and account binding;
+- persist access token, refresh/token-lifecycle metadata where returned, granted scopes, account subdomain, and region through the encrypted credential store;
+- rotate/refresh tokens atomically;
+- support disconnect/revocation and expired authorization;
+- request read-only scopes derived from enabled datasets;
+- never log codes, tokens, client secrets, or authorization headers.
+
+PagerDuty does not currently expose Dynamic Client Registration. App/client registration is an explicit setup prerequisite.
+
+### 1.2 Private and self-hosted deployments
+
+Preferred non-interactive flow:
+
+```text
+customer-managed private scoped app
+        -> client ID + client secret
+        -> identity.pagerduty.com OAuth token exchange
+        -> client_credentials
+        -> short-lived scoped bearer token
+```
+
+The requested scope must include the account qualifier and only the enabled read permissions, for example:
+
+```text
+as_account-us.<subdomain>
+incidents.read
+services.read
+schedules.read
+oncalls.read
+users.read
+teams.read
+escalation_policies.read
+```
+
+Exact scope names must be derived from PagerDuty endpoint documentation and frozen in provider capability tests.
+
+Store the client secret encrypted, cache the resulting access token only for its lifetime, and renew before expiry. Region and PagerDuty account subdomain are part of the credential identity.
+
+### 1.3 API-token fallback
+
+Support general/user REST API tokens for compatibility and bootstrap cases:
+
+```http
+Authorization: Token token=<API_KEY>
+```
+
+The provider workflow must display this behind **Use API token instead**. It must not require users to create a long-lived token for the normal hosted flow.
+
+### 1.4 OAuth validation matrix
+
+Tests must cover:
+
+- consent success and denial;
+- invalid callback state and PKCE mismatch;
+- account/region mismatch;
+- token expiry and renewal;
+- atomic token rotation;
+- concurrent refresh attempts;
+- revoked authorization;
+- client-credentials exchange and renewal;
+- insufficient dataset scopes;
+- API-token fallback;
+- secret-safe errors and telemetry.
+
+## 2. Canonical migration of existing incident producers
+
+PagerDuty is not complete until all current incident producers use or migrate into the canonical operational model.
+
+### 2.1 Atlassian / JSM Operations / Opsgenie
+
+Current provider-specific persistence:
+
+```text
+atlassian_ops_incidents
+atlassian_ops_alerts
+atlassian_ops_schedules
+```
+
+Required migration:
+
+- map existing rows into `OperationalIncident`, `OperationalAlert`, and `OnCallSchedule`;
+- populate `OperationalService`, responder, team, escalation, timeline, and on-call relationships when source data exists;
+- preserve external IDs, source URLs, provider identity, raw status/severity, and timestamps;
+- dual-write or backfill plus compatibility views until parity is proven;
+- keep provider-specific storage available for rollback until the removal gate is accepted;
+- move downstream queries to canonical reads only after row-count and lifecycle parity.
+
+### 2.2 GitHub issue-derived incidents
+
+Current path collects issues with configured incident labels and writes the narrow repo-scoped `Incident` model.
+
+Required migration:
+
+- normalize the issue into `OperationalIncident` with `provider=github` and explicit `source_entity_type=issue`;
+- preserve issue ID/number, URL, labels, status, creation, closure/resolution, and repository identity;
+- create or resolve a repository-derived `OperationalService`;
+- persist an explicit `ServiceRepositoryMapping` rather than requiring `repo_id` in the incident primary key;
+- dual-write during parity validation;
+- migrate historical `incidents` rows idempotently;
+- preserve existing incident-correlation, Sankey, DORA/MTTR, and deployment edges through compatibility reads.
+
+### 2.3 GitLab issue-derived incidents
+
+Apply the same contract to GitLab:
+
+- `provider=gitlab`;
+- source issue ID/IID and project instance retained;
+- configured incident-label behavior preserved;
+- repository/project represented as an explicit operational service mapping;
+- historical rows backfilled with stable identities;
+- direct writes to the legacy repo-scoped `Incident` model removed only after consumer cutover.
+
+### 2.4 Stable identity
+
+Canonical identity seed:
+
+```text
+org_id
++ provider_instance_id
++ source_entity_type
++ external_id
+```
+
+Repository or service mappings are relationships and must not alter incident identity.
+
+Migration must not create duplicate work-graph nodes or edges. Every migrated entity retains source provenance and the migration version.
+
+### 2.5 Cutover sequence
+
+```text
+canonical contracts and tables
+    -> compatibility reads
+    -> native dual-write
+    -> historical backfill
+    -> parity checks
+    -> consumer cutover
+    -> stop legacy writes
+    -> rollback window
+    -> legacy removal issue
+```
+
+Removal is never implicit in the initial migration.
+
+## 3. External Push API operational contracts
+
+The External Push API was intentionally designed as a connector-equivalent boundary:
+
+```text
+customer payload
+    -> external-ingest validation
+    -> provider-neutral normalization
+    -> existing sinks
+    -> metrics and graph
+```
+
+Its current `external-ingest.v1` implementation exposes nine work/code record kinds and does not yet support operational incidents. The canonical operations model is now the correct contract for that deferred coverage.
+
+### 3.1 Additive record kinds
+
+Add the following record schemas without creating push-only internal models:
+
+```text
+operational_service.v1
+operational_incident.v1
+operational_alert.v1
+incident_timeline_event.v1
+incident_note.v1
+incident_responder.v1
+escalation_policy.v1
+on_call_schedule.v1
+on_call_assignment.v1
+operational_team.v1
+operational_user.v1
+service_repository_mapping.v1
+```
+
+Whether these remain additive kinds under `external-ingest.v1` or require an envelope version increment is decided through compatibility tests. The preference is additive record-kind versioning when existing clients remain unaffected.
+
+### 3.2 Source systems
+
+Operational records must support at least:
+
+```text
+pagerduty
+atlassian
+github
+gitlab
+custom
+```
+
+`custom` supports incident-response systems without a native connector, but customers must still provide stable source system/instance identity and canonical record fields.
+
+### 3.3 One contract, multiple transports
+
+Equivalent native and pushed facts must normalize to identical canonical entities:
+
+```text
+PagerDuty REST incident --------┐
+PagerDuty webhook incident -----┤
+Customer-pushed incident -------┼-> OperationalIncident
+GitHub incident issue ----------┤
+GitLab incident issue ----------┤
+JSM/Opsgenie incident ----------┘
+```
+
+The transport must not be visible to analytics except as provenance/ownership metadata.
+
+### 3.4 Dataset-level ownership
+
+The existing External Push policy assigns one owner to a complete `source_system + source_instance`. Canonical operations require ownership to be explicit by entity family:
+
+```text
+org_id
++ source_system
++ source_instance
++ entity_family/dataset
+```
+
+Rules:
+
+- one active owner per entity family;
+- native PagerDuty sync and pushed PagerDuty incidents cannot both own incidents for the same provider instance;
+- native code sync may coexist with pushed incident data only when dataset ownership is explicit;
+- registration and preflight reject ambiguous ownership;
+- every canonical row records native-sync versus customer-push provenance;
+- ownership changes require a controlled cutover and watermark reset/reconciliation.
+
+### 3.5 Wire-schema requirements
+
+Operational Push schemas must:
+
+- use strict versioned validation (`extra=forbid`);
+- require stable external IDs and timestamps;
+- preserve raw status/severity/priority beside canonical values;
+- represent services and repositories by references, not implicit scope;
+- include tombstone/deletion semantics where relevant;
+- bound strings, arrays, notes, and structured metadata;
+- treat notes/timeline content as untrusted evidence;
+- allow per-record validation failures without rejecting unrelated valid records;
+- preserve batch and record idempotency.
+
+### 3.6 Processing and recomputation
+
+The External Push worker must:
+
+1. validate the operational record kind;
+2. derive org/provider/source identity;
+3. normalize through shared canonical operational mappers;
+4. write through canonical operational sinks;
+5. update bounded rejected-record diagnostics;
+6. record source ownership and provenance;
+7. enqueue bounded graph/metric recomputation for affected incidents, services, repositories, and time windows.
+
+It must never write final metric tables directly.
+
+### 3.7 Push credentials
+
+PagerDuty OAuth is unrelated to Push API authentication.
+
+- Native PagerDuty connector: PagerDuty OAuth or API-token fallback.
+- External Push producer: Dev Health External Push credential.
+
+Push credentials retain:
+
+```text
+schema:read
+ingest:write
+ingest:status
+```
+
+Optional least-privilege scopes may be added:
+
+```text
+ingest:operations
+ingest:incidents
+```
+
+### 3.8 CLI and schema discovery
+
+Update:
+
+```text
+GET /api/v1/external-ingest/schemas
+GET /api/v1/external-ingest/schemas/{version}
+POST /api/v1/external-ingest/validate
+POST /api/v1/external-ingest/batches
+dev-hops push sample
+dev-hops push validate
+dev-hops push batch
+```
+
+Provide sanitized samples for every operational kind and a multi-record incident lifecycle batch.
+
+## 4. Revised work breakdown
+
+### Wave 1: Canonical contract
+
+- CHAOS-2955 — canonical contracts, identity, storage, and compatibility
+- CHAOS-2956 — OAuth-first PagerDuty client and fallback token support
+
+### Wave 2: Existing source migration and Push API
+
+- CHAOS-2963 — migrate Atlassian, GitHub, and GitLab incident producers
+- CHAOS-2964 — add canonical operational record kinds to External Push
+
+These may proceed in parallel once CHAOS-2955 freezes identity and storage contracts.
+
+### Wave 3: PagerDuty ingestion
+
+- CHAOS-2957 — REST sync, normalization, reconciliation, and sinks
+- CHAOS-2958 — V3 webhooks
+
+### Wave 4: Correlation and setup
+
+- CHAOS-2959 — service/repository mapping and work graph
+- CHAOS-2960 — OAuth-first provider setup workflow
+
+### Wave 5: Cross-provider release gate
+
+- CHAOS-2961 — OAuth, migration, Push, PagerDuty, observability, docs, and live validation
+
+## 5. Updated definition of done
+
+- PagerDuty can be connected through scoped OAuth without requiring a copied API token.
+- Private/self-hosted deployments can obtain scoped app bearer tokens.
+- API-token fallback is supported but secondary.
+- Atlassian/JSM, GitHub, and GitLab incident producers use or migrate into canonical operational entities.
+- Native and pushed operational records normalize into identical canonical entities.
+- Source ownership prevents double-ingestion and ambiguous fact authority.
+- Existing incident analytics and work-graph behavior retain parity during cutover.
+- Push schema discovery, validation, worker processing, CLI samples, and idempotency cover operational records.
+- PagerDuty REST and V3 webhooks share the same canonical sinks.
+- Legacy incident storage has an explicit parity, rollback, and removal gate.
+- No transport- or provider-specific analytics silo is introduced.

--- a/docs/superpowers/plans/2026-07-16-pagerduty-incident-response-provider.md
+++ b/docs/superpowers/plans/2026-07-16-pagerduty-incident-response-provider.md
@@ -1,0 +1,564 @@
+# PagerDuty Incident-Response Provider Integration
+
+**Linear source of truth:** [CHAOS-2954](https://linear.app/fullchaos/issue/CHAOS-2954/pagerduty-incident-response-provider-integration)  
+**Project:** Dev Health Ops  
+**Milestone:** PagerDuty Incident Response Integration  
+**Status:** Planning / implementation-ready
+
+## Executive summary
+
+Add PagerDuty as the first non-Atlassian incident-response provider in Dev Health Ops.
+
+The implementation must not create a PagerDuty-specific analytics silo. PagerDuty should normalize into a provider-neutral operational model shared by Atlassian/JSM Operations and future providers such as incident.io, FireHydrant, Rootly, and ServiceNow.
+
+V1 is read-only:
+
+- REST API backfill and incremental reconciliation;
+- PagerDuty V3 webhook updates;
+- services, business services, incidents, alerts, timeline/log entries, notes, escalation policies, schedules, on-call assignments, users, and teams;
+- explicit service-to-repository mappings;
+- existing work-graph and incident-correlation integration;
+- canonical provider setup, credential preflight, sync/backfill state, tests, docs, and observability.
+
+Do not add PagerDuty incident mutation, acknowledgement, reassignment, resolution, schedule mutation, Event Orchestration management, or status-page publishing in V1.
+
+## Grounded current state
+
+### Atlassian coverage already exists
+
+The custom [`full-chaos/atlassian`](https://github.com/full-chaos/atlassian) library already includes:
+
+- Jira REST and Atlassian GraphQL Gateway clients;
+- generated API models from live schema introspection;
+- canonical Jira, Compass, Teams, and Teamwork Graph models;
+- Compass components, relationships, and scorecards;
+- Atlassian Teams and memberships;
+- Teamwork Graph generated API support;
+- Opsgenie/JSM-oriented project and team relationships.
+
+`dev-health-ops` already imports that library through:
+
+```text
+src/dev_health_ops/providers/jira/atlassian_compat.py
+src/dev_health_ops/providers/jira/provider.py
+```
+
+This plan therefore does **not** add or replace Atlassian Teamwork Graph coverage.
+
+### Existing operational storage is provider-specific
+
+Current Atlassian operational entities live in:
+
+```text
+src/dev_health_ops/models/atlassian_ops.py
+src/dev_health_ops/storage/mixins/atlassian_ops.py
+src/dev_health_ops/migrations/clickhouse/021_atlassian_ops_tables.sql
+```
+
+Current tables:
+
+```text
+atlassian_ops_incidents
+atlassian_ops_alerts
+atlassian_ops_schedules
+```
+
+These tables are insufficient as the permanent cross-provider contract because they:
+
+- are named for one provider family;
+- do not express the full service, escalation, responder, timeline, and on-call graph;
+- do not provide a provider-neutral identity contract;
+- are not the appropriate destination for PagerDuty data.
+
+### The existing generic incident row is too narrow
+
+`src/dev_health_ops/models/git.py` defines a repo-scoped `Incident` with:
+
+```text
+repo_id
+incident_id
+status
+started_at
+resolved_at
+last_synced
+```
+
+This works for GitHub/GitLab incident-like issues, but PagerDuty incidents belong to operational services and may map to zero, one, or many repositories.
+
+PagerDuty incidents must not be forced into a synthetic repository merely to satisfy the current primary key.
+
+### Current provider contract is work-item oriented
+
+`src/dev_health_ops/providers/base.py` defines `ProviderBatch` around work items, transitions, dependencies, comments, sprints, worklogs, and AI attribution.
+
+PagerDuty needs a separate operational ingestion envelope or a broader canonical provider contract. Do not overload the current work-item batch with loosely typed incident fields.
+
+### Existing incident correlation should be reused
+
+GitHub and GitLab processors already create repo-scoped incidents from labeled issues. Existing work-graph and incident-correlation paths include deployment-to-incident relationships.
+
+PagerDuty must feed those canonical analytics and graph surfaces through compatibility queries/edges rather than create a new PagerDuty-only dashboard.
+
+## Product and architecture decisions
+
+### 1. Provider-neutral operational ontology
+
+Define the following canonical entities:
+
+```text
+OperationalService
+OperationalIncident
+OperationalAlert
+IncidentTimelineEvent
+IncidentNote
+IncidentResponder
+EscalationPolicy
+OnCallSchedule
+OnCallAssignment
+OperationalTeam
+OperationalUser
+ServiceRepositoryMapping
+```
+
+All canonical entities must include:
+
+- `org_id`;
+- provider name;
+- provider instance or integration-source identity;
+- stable source external ID;
+- deterministic internal identity;
+- source URL where available;
+- source event timestamp, observed timestamp, and `last_synced`;
+- raw source status/severity/priority values;
+- canonical normalized status/severity/priority;
+- provenance and confidence for derived relationships.
+
+### 2. Repository scope is a relationship
+
+Repositories are connected to operational services using `ServiceRepositoryMapping`.
+
+Supported mapping sources:
+
+1. explicit admin configuration;
+2. exact repository URL or slug from service metadata/integrations;
+3. Compass/service-catalog relationships;
+4. bounded heuristics, clearly marked with lower confidence.
+
+A service may map to multiple repositories. A repository may map to multiple services.
+
+### 3. REST reconciles; webhooks reduce latency
+
+```text
+PagerDuty REST API -----------┐
+                              ├──> provider normalization
+PagerDuty V3 webhooks --------┘              │
+                                             ▼
+                              canonical operational entities
+```
+
+REST sync is authoritative for reconciliation and backfill. V3 webhooks provide low-latency updates but must not be the only source of truth.
+
+### 4. No direct metric-table writes
+
+Provider ingestion writes source entities through canonical sinks. Existing metric jobs and work-graph builders derive analytics and relationships.
+
+### 5. Read-only V1
+
+No PagerDuty write/mutation methods are added to the client or UI in V1.
+
+## PagerDuty REST API coverage
+
+Initial read coverage:
+
+```text
+GET /incidents
+GET /incidents/{id}
+GET /incidents/{id}/alerts
+GET /incidents/{id}/log_entries
+GET /incidents/{id}/notes
+GET /services
+GET /business_services
+GET /escalation_policies
+GET /schedules
+GET /oncalls
+GET /users
+GET /teams
+```
+
+Required request behavior:
+
+- `Accept: application/vnd.pagerduty+json;version=2`;
+- API token and scoped OAuth support;
+- offset/limit pagination and `more` handling;
+- bounded request concurrency and timeouts;
+- route-family provider usage observations;
+- parse `ratelimit-limit`, `ratelimit-remaining`, and `ratelimit-reset`;
+- bounded retry after `429` using PagerDuty reset guidance;
+- no retry for permanent 4xx failures;
+- dataset-specific degradation for missing plan/permission coverage.
+
+Official references:
+
+- [PagerDuty REST API rate limits](https://support.pagerduty.com/main/docs/rest-api-rate-limits)
+- [PagerDuty Webhooks](https://support.pagerduty.com/main/docs/webhooks)
+- [PagerDuty public API collection](https://www.postman.com/pagerduty/pagerduty-public-api-collection/overview)
+
+## PagerDuty V3 webhook coverage
+
+Incident events:
+
+```text
+incident.triggered
+incident.acknowledged
+incident.unacknowledged
+incident.escalated
+incident.reassigned
+incident.delegated
+incident.priority_updated
+incident.resolved
+incident.reopened
+incident.annotated
+incident.responder.added
+incident.responder.replied
+incident.service_updated
+incident.status_update_published
+```
+
+Service events:
+
+```text
+service.created
+service.updated
+service.deleted
+```
+
+Webhook requirements:
+
+- verify `x-pagerduty-signature`;
+- store secrets through the encrypted credential/configuration boundary;
+- validate event type and V3 payload shape;
+- deduplicate by provider instance plus PagerDuty event ID;
+- protect against replay with a bounded event-ID retention window;
+- preserve `occurred_at`, received time, and processed time separately;
+- durable asynchronous processing;
+- targeted REST hydration when payloads omit required state;
+- out-of-order events must not regress a newer canonical state;
+- REST reconciliation repairs dropped events;
+- service deletion uses tombstone/disabled semantics.
+
+Do not support V1/V2 webhook extensions.
+
+## Canonical mapping direction
+
+### Operational service
+
+PagerDuty sources:
+
+- service;
+- business service;
+- teams;
+- escalation policy;
+- integration metadata;
+- service dependencies/impact relationships when available.
+
+Canonical fields should retain:
+
+- service kind (`technical`, `business`, or source-specific unknown);
+- name/summary/description;
+- lifecycle state;
+- escalation-policy reference;
+- team references;
+- source URL;
+- provider metadata needed for mapping without exposing credentials.
+
+### Operational incident
+
+PagerDuty sources:
+
+- incident object;
+- service reference;
+- assignments;
+- escalation policy;
+- urgency and priority;
+- status and lifecycle timestamps;
+- acknowledgement and resolution data;
+- title/summary/description;
+- incident type/custom fields when available and permitted.
+
+Canonical state should distinguish at minimum:
+
+```text
+triggered
+acknowledged
+resolved
+reopened
+unknown
+```
+
+Retain the PagerDuty raw status and urgency separately.
+
+### Alert
+
+Alerts remain distinct from incidents. Preserve:
+
+- alert ID and deduplication key;
+- status;
+- severity/priority;
+- creation and resolution timestamps;
+- service and incident references;
+- source summary/details where safe.
+
+### Timeline event
+
+PagerDuty log entries normalize into typed timeline events:
+
+- trigger;
+- acknowledgement;
+- escalation;
+- assignment/reassignment;
+- responder action;
+- notification/channel action;
+- resolution/reopen;
+- note/status update;
+- workflow start/completion;
+- source-specific unknown.
+
+Store actor/reference/channel metadata as structured data, with raw event type retained.
+
+### Notes and retrieved content
+
+Incident notes are source evidence and untrusted text. They are never interpreted as system/tool instructions.
+
+## Storage and migration strategy
+
+### Preferred direction
+
+Create provider-neutral tables using current ClickHouse/PostgreSQL ownership conventions.
+
+Candidate table family:
+
+```text
+operational_services
+operational_incidents
+operational_alerts
+incident_timeline_events
+incident_notes
+incident_responders
+operational_escalation_policies
+operational_schedules
+operational_on_call_assignments
+operational_users
+operational_teams
+service_repository_mappings
+```
+
+Exact names are decided in CHAOS-2955.
+
+### Existing data compatibility
+
+Implement one of:
+
+1. dual-write existing Atlassian ingestion into legacy and canonical tables until parity;
+2. migrate/backfill Atlassian rows into canonical tables plus compatibility views;
+3. canonical views over provider-specific raw tables as an interim step.
+
+Do not remove `atlassian_ops_*` tables until parity and rollback are proven.
+
+### Existing generic incidents
+
+GitHub/GitLab issue-derived incidents should remain supported. A compatibility adapter or migration may expose them as canonical operational incidents with an explicit repository-derived service/mapping source.
+
+Do not silently rewrite historical IDs or break current incident-correlation queries.
+
+## Sync and backfill design
+
+Reference collections such as services, policies, teams, users, and schedules can be refreshed as bounded complete snapshots when practical.
+
+Incident history is windowed and paginated.
+
+Per-incident enrichment for alerts, log entries, and notes must be controlled through:
+
+- dataset toggles;
+- history limits;
+- per-sync incident caps;
+- concurrency caps;
+- rate-limit budgets;
+- partial/degraded completion reporting.
+
+The provider must integrate with canonical SyncRun, JobRun, backfill, credential preflight, provider usage, and queue telemetry paths.
+
+## Work graph and correlation
+
+Canonical nodes/edges:
+
+```text
+operational_service -> repository
+operational_service -> incident
+incident -> alert
+incident -> timeline_event
+incident -> responder
+incident -> escalation_policy
+incident -> work_item
+incident -> pull_request
+incident -> deployment
+incident -> remediation_work_item
+```
+
+Correlation order:
+
+1. explicit source link;
+2. explicit service-to-repository mapping;
+3. provider/service-catalog relationship;
+4. bounded time/service/environment heuristic.
+
+Rules:
+
+- every edge carries provenance, confidence, evidence, provider, org, and timestamps;
+- temporal proximity alone never proves root cause;
+- heuristic edges use stable rule IDs and lower confidence;
+- duplicate service display names cannot collide;
+- cross-org and unmapped-service data cannot leak into repo-scoped queries.
+
+Existing incident Sankey, deployment→incident graph, DORA/MTTR, AI workflow linkage, and ACR evidence should read the canonical operational model.
+
+## Provider setup workflow
+
+Use the existing Provider workflow:
+
+1. Add Provider → PagerDuty
+2. Enter API/OAuth credential
+3. Run credential and permission preflight
+4. Select datasets and history window
+5. Discover PagerDuty services
+6. Map services to repositories
+7. Configure V3 webhooks or select REST-only mode
+8. Review and start initial sync
+9. Display REST sync/backfill health and webhook health separately
+
+Required states:
+
+- invalid credential;
+- insufficient dataset scope;
+- no accessible services;
+- optional feature unavailable by plan/permission;
+- unmapped services;
+- REST-only;
+- webhook pending/success/failure;
+- rate limited;
+- initial sync partial/failed/complete.
+
+Do not add a PagerDuty-specific dashboard or integration-card design.
+
+## Observability
+
+Required telemetry:
+
+- requests, latency, failures, and rate-limit state by route family;
+- entities fetched/normalized/persisted by dataset;
+- sync/backfill duration and partial-failure reasons;
+- webhook accepted/rejected/duplicate/replayed/out-of-order counts;
+- queue depth/age and processing latency;
+- hydration call count;
+- unmapped service count;
+- mapped-service and correlation coverage;
+- credential preflight results without secret values.
+
+## Test plan
+
+### Deterministic fixtures
+
+Sanitized fixtures for:
+
+- services and business services;
+- incidents and incident lifecycle variants;
+- alerts;
+- log entries/timeline events;
+- notes;
+- escalation policies;
+- schedules and on-call entries;
+- users and teams;
+- V3 webhook events.
+
+Include equivalent Atlassian/JSM fixtures to prove canonical parity.
+
+### Adversarial tests
+
+- 401 and 403;
+- partial dataset permission;
+- 429 and reset behavior;
+- pagination boundary and partial-page failure;
+- invalid signature;
+- duplicate and replayed webhook;
+- out-of-order webhook;
+- unknown event/status fields;
+- cross-org isolation;
+- multi-repo service;
+- duplicate service names;
+- stale webhook versus newer REST state;
+- deleted service;
+- repeated backfill idempotency.
+
+### Live validation
+
+Env-gated live validation must prove:
+
+- credential preflight;
+- at least one service;
+- escalation policy;
+- schedule and on-call assignment;
+- incident lifecycle with alerts/log entries/notes where available;
+- signed V3 test event;
+- REST reconciliation after a missed webhook;
+- service-to-repository mapping;
+- at least one provenance-backed incident work-graph edge.
+
+## Delivery sequence and Linear mapping
+
+### Wave 1 — contracts and client in parallel
+
+- [CHAOS-2955](https://linear.app/fullchaos/issue/CHAOS-2955/pagerduty-foundation-define-canonical-operational-contracts-and): canonical operational contracts and storage migration
+- [CHAOS-2956](https://linear.app/fullchaos/issue/CHAOS-2956/pagerduty-client-implement-auth-pagination-rate-limits-and-typed-api): PagerDuty client, auth, models, pagination, and rate limits
+
+### Wave 2 — REST ingestion
+
+- [CHAOS-2957](https://linear.app/fullchaos/issue/CHAOS-2957/pagerduty-sync-normalize-and-persist-rest-entities-through-canonical): normalization, sync, backfill, and canonical sinks
+
+### Wave 3 — low-latency updates and graph integration
+
+- [CHAOS-2958](https://linear.app/fullchaos/issue/CHAOS-2958/pagerduty-webhooks-ingest-v3-incident-and-service-events-with): V3 webhooks
+- [CHAOS-2959](https://linear.app/fullchaos/issue/CHAOS-2959/pagerduty-correlation-map-services-to-repositories-and-extend-incident): service mapping and work graph
+
+### Wave 4 — product setup
+
+- [CHAOS-2960](https://linear.app/fullchaos/issue/CHAOS-2960/pagerduty-provider-setup-add-canonical-credential-dataset-mapping-and): provider setup workflow
+
+### Wave 5 — release gate
+
+- [CHAOS-2961](https://linear.app/fullchaos/issue/CHAOS-2961/pagerduty-validation-add-fixtures-live-e2e-observability-and-provider): E2E, live validation, observability, and docs
+
+## Risks and mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Provider-specific storage proliferates | Canonical operational contract is a hard prerequisite |
+| PagerDuty data is service-scoped while current incidents are repo-scoped | Explicit service↔repository mapping; repository remains optional |
+| Per-incident enrichment creates N+1 and rate-limit pressure | Dataset toggles, caps, concurrency controls, usage telemetry |
+| Webhooks are missed or arrive out of order | REST reconciliation and event-time ordering |
+| Paid/plan-specific fields cause sync failure | Dataset-specific capability/preflight and graceful degradation |
+| Existing Atlassian incident surfaces regress | Dual-write/compatibility path and shared fixtures |
+| Temporal correlation is mistaken for root cause | Provenance/confidence and explicit non-causal semantics |
+| Sensitive incident text leaks | Sanitized fixtures, secure credentials, bounded raw payload retention, no secret/raw incident logging |
+
+## Definition of done
+
+- Canonical operational contracts support PagerDuty and Atlassian/JSM equivalents.
+- PagerDuty REST client is typed, instrumented, rate-limit safe, and read-only.
+- REST sync/backfill persists all selected V1 datasets idempotently.
+- V3 webhook updates are signed, durable, idempotent, replay-safe, and reconcilable.
+- Services map to repositories without synthetic repo requirements.
+- Existing incident correlation and work-graph surfaces consume PagerDuty entities.
+- Provider setup supports credential preflight, dataset selection, mappings, REST-only, and webhook modes.
+- Deterministic, adversarial, and env-gated live tests pass.
+- Provider telemetry and runbooks make failures diagnosable.
+- Connector inventory and stale Atlassian/Jira coverage statements are corrected.
+- No PagerDuty mutation API or provider-specific analytics silo is introduced.


### PR DESCRIPTION
## Summary

Expands the incident-response architecture from a PagerDuty-only provider plan into a canonical operations program.

The PR now contains:

- the original PagerDuty provider plan;
- an addendum covering OAuth-first authentication;
- migration of existing Atlassian/JSM, GitHub, and GitLab incident producers;
- canonical operational record kinds for the External Push API;
- dataset-level ownership rules preventing native-sync and customer-push double ingestion.

## Key decisions

### OAuth-first PagerDuty connection

- Hosted Dev Health uses a registered PagerDuty OAuth app and user consent flow; authorization code/PKCE is used where supported by the registered app type.
- Private/self-hosted deployments can use a scoped app token obtained through `client_credentials`.
- API tokens remain a compatibility fallback, not the primary setup experience.
- Only read scopes are requested in V1.
- PagerDuty does not currently support Dynamic Client Registration, so app registration is explicit.

### Canonical migration

The canonical operational model must receive data from:

```text
Atlassian / JSM Operations / Opsgenie
GitHub issue-derived incidents
GitLab issue-derived incidents
PagerDuty
External Push API
```

Existing `atlassian_ops_*` tables and the narrow repo-scoped `Incident` row remain compatibility paths during migration, not the final architecture.

### External Push API

Add versioned operational record kinds including:

```text
operational_service.v1
operational_incident.v1
operational_alert.v1
incident_timeline_event.v1
incident_note.v1
incident_responder.v1
escalation_policy.v1
on_call_schedule.v1
on_call_assignment.v1
operational_team.v1
operational_user.v1
service_repository_mapping.v1
```

Pushed and native facts normalize through the same canonical mappers and sinks. Ownership is explicit by organization, source instance, and entity family.

## Documents

- `docs/superpowers/plans/2026-07-16-pagerduty-incident-response-provider.md`
- `docs/superpowers/plans/2026-07-16-canonical-operations-oauth-migration-push-addendum.md`

## Linear

- [CHAOS-2954](https://linear.app/fullchaos/issue/CHAOS-2954/canonical-operations-model-and-pagerduty-integration) — parent epic
- CHAOS-2955 — canonical contracts/storage/compatibility
- CHAOS-2956 — OAuth-first PagerDuty client
- CHAOS-2957 — PagerDuty REST sync
- CHAOS-2958 — PagerDuty V3 webhooks
- CHAOS-2959 — service/repository mapping and graph
- CHAOS-2960 — OAuth-first setup workflow
- CHAOS-2961 — release validation
- CHAOS-2963 — migrate Atlassian, GitHub, and GitLab sources
- CHAOS-2964 — External Push operational record kinds

## Scope of this PR

Documentation and implementation planning only. No runtime behavior changes.