### PR TITLE
feat(ops): Wave 1 — migrate producers + External Push operational kinds (CHAOS-2963, CHAOS-2964)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -216,6 +216,7 @@ SOCIAL_GITLAB_CLIENT_SECRET=
 # ATLASSIAN_CLIENT_ENABLED="false"  # Enable new atlassian-client (Phase 1+)
 # ATLASSIAN_GQL_ENABLED="false"     # Enable AGG GraphQL enrichment
 # JIRA_USE_PROVIDER="false"         # Use JiraProvider in work_items pipeline
+# OPERATIONAL_INCIDENT_DUAL_WRITE="false"  # Write canonical incident rows alongside legacy producers
 
 # ----------------------------------------------------------------------------
 # Observability — SigNoz (distributed tracing + metrics)

--- a/docs/api/external-ingest/v1/schema.json
+++ b/docs/api/external-ingest/v1/schema.json
@@ -152,6 +152,228 @@
       "title": "CommitV1",
       "type": "object"
     },
+    "EscalationPolicyV1": {
+      "additionalProperties": false,
+      "properties": {
+        "deletedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deletedat"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "maxLength": 20000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "isDeleted": {
+          "default": false,
+          "title": "Isdeleted",
+          "type": "boolean"
+        },
+        "name": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "name"
+      ],
+      "title": "EscalationPolicyV1",
+      "type": "object"
+    },
     "IdentityV1": {
       "additionalProperties": false,
       "properties": {
@@ -220,6 +442,775 @@
       "title": "IdentityV1",
       "type": "object"
     },
+    "IncidentNoteV1": {
+      "additionalProperties": false,
+      "properties": {
+        "authorUserExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Authoruserexternalid"
+        },
+        "body": {
+          "maxLength": 20000,
+          "minLength": 1,
+          "title": "Body",
+          "type": "string"
+        },
+        "createdAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Createdat"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "incidentExternalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Incidentexternalid",
+          "type": "string"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "incidentExternalId",
+        "body"
+      ],
+      "title": "IncidentNoteV1",
+      "type": "object"
+    },
+    "IncidentResponderV1": {
+      "additionalProperties": false,
+      "properties": {
+        "acknowledgedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Acknowledgedat"
+        },
+        "assignedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Assignedat"
+        },
+        "completedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Completedat"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "incidentExternalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Incidentexternalid",
+          "type": "string"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "requestedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Requestedat"
+        },
+        "responderAssignmentId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Responderassignmentid"
+        },
+        "responderName": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Respondername"
+        },
+        "role": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Role"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        },
+        "userExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Userexternalid"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "incidentExternalId"
+      ],
+      "title": "IncidentResponderV1",
+      "type": "object"
+    },
+    "IncidentTimelineEventV1": {
+      "additionalProperties": false,
+      "properties": {
+        "actorExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Actorexternalid"
+        },
+        "actorType": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Actortype"
+        },
+        "body": {
+          "anyOf": [
+            {
+              "maxLength": 20000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Body"
+        },
+        "eventType": {
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Eventtype",
+          "type": "string"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "incidentExternalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Incidentexternalid",
+          "type": "string"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "occurredAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Occurredat"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "incidentExternalId",
+        "eventType"
+      ],
+      "title": "IncidentTimelineEventV1",
+      "type": "object"
+    },
     "IngestWindow": {
       "additionalProperties": false,
       "properties": {
@@ -239,6 +1230,1770 @@
         "endedAt"
       ],
       "title": "IngestWindow",
+      "type": "object"
+    },
+    "OnCallAssignmentV1": {
+      "additionalProperties": false,
+      "properties": {
+        "endsAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Endsat"
+        },
+        "escalationLevel": {
+          "anyOf": [
+            {
+              "maximum": 100,
+              "minimum": 0,
+              "type": "integer"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Escalationlevel"
+        },
+        "escalationPolicyExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Escalationpolicyexternalid"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "scheduleExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Scheduleexternalid"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        },
+        "startsAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Startsat"
+        },
+        "userExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Userexternalid"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt"
+      ],
+      "title": "OnCallAssignmentV1",
+      "type": "object"
+    },
+    "OnCallScheduleV1": {
+      "additionalProperties": false,
+      "properties": {
+        "deletedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deletedat"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "maxLength": 20000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "isDeleted": {
+          "default": false,
+          "title": "Isdeleted",
+          "type": "boolean"
+        },
+        "name": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        },
+        "timezone": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Timezone"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "name"
+      ],
+      "title": "OnCallScheduleV1",
+      "type": "object"
+    },
+    "OperationalAlertV1": {
+      "additionalProperties": false,
+      "properties": {
+        "acknowledgedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Acknowledgedat"
+        },
+        "deletedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deletedat"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "maxLength": 20000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "incidentExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Incidentexternalid"
+        },
+        "isDeleted": {
+          "default": false,
+          "title": "Isdeleted",
+          "type": "boolean"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "resolvedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Resolvedat"
+        },
+        "serviceExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Serviceexternalid"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        },
+        "title": {
+          "maxLength": 1024,
+          "minLength": 1,
+          "title": "Title",
+          "type": "string"
+        },
+        "triggeredAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Triggeredat"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "title"
+      ],
+      "title": "OperationalAlertV1",
+      "type": "object"
+    },
+    "OperationalIncidentV1": {
+      "additionalProperties": false,
+      "properties": {
+        "deletedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deletedat"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "maxLength": 20000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "escalationPolicyExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Escalationpolicyexternalid"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "isDeleted": {
+          "default": false,
+          "title": "Isdeleted",
+          "type": "boolean"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "resolvedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Resolvedat"
+        },
+        "serviceExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Serviceexternalid"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        },
+        "startedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Startedat"
+        },
+        "title": {
+          "maxLength": 1024,
+          "minLength": 1,
+          "title": "Title",
+          "type": "string"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "title"
+      ],
+      "title": "OperationalIncidentV1",
+      "type": "object"
+    },
+    "OperationalServiceV1": {
+      "additionalProperties": false,
+      "properties": {
+        "deletedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deletedat"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "maxLength": 20000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "escalationPolicyExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Escalationpolicyexternalid"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "isDeleted": {
+          "default": false,
+          "title": "Isdeleted",
+          "type": "boolean"
+        },
+        "name": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "owningTeamExternalId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Owningteamexternalid"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "serviceType": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Servicetype"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "name"
+      ],
+      "title": "OperationalServiceV1",
+      "type": "object"
+    },
+    "OperationalTeamV1": {
+      "additionalProperties": false,
+      "properties": {
+        "deletedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deletedat"
+        },
+        "description": {
+          "anyOf": [
+            {
+              "maxLength": 20000,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Description"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "isDeleted": {
+          "default": false,
+          "title": "Isdeleted",
+          "type": "boolean"
+        },
+        "name": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Name",
+          "type": "string"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "name"
+      ],
+      "title": "OperationalTeamV1",
+      "type": "object"
+    },
+    "OperationalUserV1": {
+      "additionalProperties": false,
+      "properties": {
+        "deletedAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Deletedat"
+        },
+        "displayName": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Displayname",
+          "type": "string"
+        },
+        "email": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Email"
+        },
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "isDeleted": {
+          "default": false,
+          "title": "Isdeleted",
+          "type": "boolean"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "displayName"
+      ],
+      "title": "OperationalUserV1",
       "type": "object"
     },
     "PullRequestV1": {
@@ -504,10 +3259,22 @@
         "kind": {
           "enum": [
             "commit.v1",
+            "escalation_policy.v1",
             "identity.v1",
+            "incident_note.v1",
+            "incident_responder.v1",
+            "incident_timeline_event.v1",
+            "on_call_assignment.v1",
+            "on_call_schedule.v1",
+            "operational_alert.v1",
+            "operational_incident.v1",
+            "operational_service.v1",
+            "operational_team.v1",
+            "operational_user.v1",
             "pull_request.v1",
             "repository.v1",
             "review.v1",
+            "service_repository_mapping.v1",
             "team.v1",
             "work_item.v1",
             "work_item_dependency.v1",
@@ -645,9 +3412,294 @@
       "title": "ReviewV1",
       "type": "object"
     },
+    "ServiceRepositoryMappingV1": {
+      "additionalProperties": false,
+      "properties": {
+        "externalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Externalid",
+          "type": "string"
+        },
+        "isActive": {
+          "default": true,
+          "title": "Isactive",
+          "type": "boolean"
+        },
+        "mappingKind": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Mappingkind"
+        },
+        "normalizedPriority": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedpriority"
+        },
+        "normalizedSeverity": {
+          "anyOf": [
+            {
+              "enum": [
+                "critical",
+                "high",
+                "medium",
+                "low",
+                "info"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedseverity"
+        },
+        "normalizedStatus": {
+          "anyOf": [
+            {
+              "enum": [
+                "active",
+                "open",
+                "acknowledged",
+                "resolved",
+                "closed",
+                "suppressed"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Normalizedstatus"
+        },
+        "rawPriority": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawpriority"
+        },
+        "rawSeverity": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawseverity"
+        },
+        "rawStatus": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Rawstatus"
+        },
+        "relationshipConfidence": {
+          "anyOf": [
+            {
+              "maximum": 1,
+              "minimum": 0,
+              "type": "number"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipconfidence"
+        },
+        "relationshipProvenance": {
+          "anyOf": [
+            {
+              "maxLength": 255,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Relationshipprovenance"
+        },
+        "repoFullName": {
+          "anyOf": [
+            {
+              "maxLength": 1024,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repofullname"
+        },
+        "repoProvider": {
+          "anyOf": [
+            {
+              "enum": [
+                "github",
+                "gitlab",
+                "custom"
+              ],
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Repoprovider"
+        },
+        "ruleId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Ruleid"
+        },
+        "serviceExternalId": {
+          "maxLength": 512,
+          "minLength": 1,
+          "title": "Serviceexternalid",
+          "type": "string"
+        },
+        "sourceEventAt": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventat"
+        },
+        "sourceEventId": {
+          "anyOf": [
+            {
+              "maxLength": 512,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceeventid"
+        },
+        "sourceUrl": {
+          "anyOf": [
+            {
+              "maxLength": 2048,
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Sourceurl"
+        },
+        "sourceVersionAt": {
+          "format": "date-time",
+          "title": "Sourceversionat",
+          "type": "string"
+        },
+        "validFrom": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Validfrom"
+        },
+        "validTo": {
+          "anyOf": [
+            {
+              "format": "date-time",
+              "type": "string"
+            },
+            {
+              "type": "null"
+            }
+          ],
+          "default": null,
+          "title": "Validto"
+        }
+      },
+      "required": [
+        "externalId",
+        "sourceVersionAt",
+        "serviceExternalId"
+      ],
+      "title": "ServiceRepositoryMappingV1",
+      "type": "object"
+    },
     "SourceDescriptor": {
       "additionalProperties": false,
       "properties": {
+        "entityFamily": {
+          "default": "legacy",
+          "maxLength": 255,
+          "minLength": 1,
+          "title": "Entityfamily",
+          "type": "string"
+        },
         "instance": {
           "maxLength": 255,
           "minLength": 1,
@@ -684,6 +3736,8 @@
             "gitlab",
             "jira",
             "linear",
+            "pagerduty",
+            "atlassian",
             "custom"
           ],
           "title": "System",
@@ -1358,6 +4412,16 @@
         }
       ]
     },
+    "escalation_policy.v1": {
+      "$ref": "#/$defs/EscalationPolicyV1",
+      "examples": [
+        {
+          "externalId": "policy-1",
+          "name": "Payments escalation",
+          "sourceVersionAt": "2026-07-17T00:00:00Z"
+        }
+      ]
+    },
     "identity.v1": {
       "$ref": "#/$defs/IdentityV1",
       "examples": [
@@ -1378,6 +4442,126 @@
             "team-platform"
           ],
           "updatedAt": "2026-06-25T00:00:00Z"
+        }
+      ]
+    },
+    "incident_note.v1": {
+      "$ref": "#/$defs/IncidentNoteV1",
+      "examples": [
+        {
+          "body": "Investigating latency.",
+          "createdAt": "2026-07-17T00:02:00Z",
+          "externalId": "note-1",
+          "incidentExternalId": "inc-1",
+          "sourceVersionAt": "2026-07-17T00:00:00Z"
+        }
+      ]
+    },
+    "incident_responder.v1": {
+      "$ref": "#/$defs/IncidentResponderV1",
+      "examples": [
+        {
+          "assignedAt": "2026-07-17T00:02:00Z",
+          "externalId": "responder-1",
+          "incidentExternalId": "inc-1",
+          "responderName": "On-call",
+          "sourceVersionAt": "2026-07-17T00:00:00Z"
+        }
+      ]
+    },
+    "incident_timeline_event.v1": {
+      "$ref": "#/$defs/IncidentTimelineEventV1",
+      "examples": [
+        {
+          "eventType": "acknowledged",
+          "externalId": "event-1",
+          "incidentExternalId": "inc-1",
+          "normalizedStatus": "acknowledged",
+          "occurredAt": "2026-07-17T00:01:00Z",
+          "sourceVersionAt": "2026-07-17T00:00:00Z"
+        }
+      ]
+    },
+    "on_call_assignment.v1": {
+      "$ref": "#/$defs/OnCallAssignmentV1",
+      "examples": [
+        {
+          "endsAt": "2026-07-18T00:00:00Z",
+          "externalId": "assignment-1",
+          "scheduleExternalId": "schedule-1",
+          "sourceVersionAt": "2026-07-17T00:00:00Z",
+          "startsAt": "2026-07-17T00:00:00Z"
+        }
+      ]
+    },
+    "on_call_schedule.v1": {
+      "$ref": "#/$defs/OnCallScheduleV1",
+      "examples": [
+        {
+          "externalId": "schedule-1",
+          "name": "Payments on-call",
+          "sourceVersionAt": "2026-07-17T00:00:00Z",
+          "timezone": "UTC"
+        }
+      ]
+    },
+    "operational_alert.v1": {
+      "$ref": "#/$defs/OperationalAlertV1",
+      "examples": [
+        {
+          "externalId": "alert-1",
+          "incidentExternalId": "inc-1",
+          "normalizedStatus": "active",
+          "serviceExternalId": "payments",
+          "sourceVersionAt": "2026-07-17T00:00:00Z",
+          "title": "Latency alert",
+          "triggeredAt": "2026-07-17T00:00:00Z"
+        }
+      ]
+    },
+    "operational_incident.v1": {
+      "$ref": "#/$defs/OperationalIncidentV1",
+      "examples": [
+        {
+          "externalId": "inc-1",
+          "normalizedSeverity": "high",
+          "normalizedStatus": "open",
+          "serviceExternalId": "payments",
+          "sourceVersionAt": "2026-07-17T00:00:00Z",
+          "startedAt": "2026-07-17T00:00:00Z",
+          "title": "Payments latency"
+        }
+      ]
+    },
+    "operational_service.v1": {
+      "$ref": "#/$defs/OperationalServiceV1",
+      "examples": [
+        {
+          "externalId": "payments",
+          "name": "Payments",
+          "normalizedStatus": "active",
+          "sourceVersionAt": "2026-07-17T00:00:00Z"
+        }
+      ]
+    },
+    "operational_team.v1": {
+      "$ref": "#/$defs/OperationalTeamV1",
+      "examples": [
+        {
+          "externalId": "team-ops",
+          "name": "Operations",
+          "sourceVersionAt": "2026-07-17T00:00:00Z"
+        }
+      ]
+    },
+    "operational_user.v1": {
+      "$ref": "#/$defs/OperationalUserV1",
+      "examples": [
+        {
+          "displayName": "Alex Operator",
+          "email": "alex@example.test",
+          "externalId": "user-1",
+          "sourceVersionAt": "2026-07-17T00:00:00Z"
         }
       ]
     },
@@ -1431,6 +4615,19 @@
           "reviewer": "bob@acme.example",
           "state": "APPROVED",
           "submittedAt": "2026-06-22T14:00:00Z"
+        }
+      ]
+    },
+    "service_repository_mapping.v1": {
+      "$ref": "#/$defs/ServiceRepositoryMappingV1",
+      "examples": [
+        {
+          "externalId": "payments-repository",
+          "mappingKind": "primary",
+          "repoFullName": "acme/payments",
+          "repoProvider": "github",
+          "serviceExternalId": "payments",
+          "sourceVersionAt": "2026-07-17T00:00:00Z"
         }
       ]
     },

--- a/docs/api/external-ingest/v1/schema.json
+++ b/docs/api/external-ingest/v1/schema.json
@@ -3695,8 +3695,10 @@
       "properties": {
         "entityFamily": {
           "default": "legacy",
-          "maxLength": 255,
-          "minLength": 1,
+          "enum": [
+            "legacy",
+            "operational"
+          ],
           "title": "Entityfamily",
           "type": "string"
         },

--- a/docs/architecture/canonical-operational-model.md
+++ b/docs/architecture/canonical-operational-model.md
@@ -107,4 +107,31 @@ tombstones. Resolved windows are for MTTR and DORA. Started windows are for inci
 creation analysis. Overlap windows are for lifecycle and active-incident analysis.
 `load_operational_incidents()` remains a resolved-window compatibility alias. These
 reads intentionally coexist with legacy `incidents` and `atlassian_ops_*` readers.
-CHAOS-2963 migrates producers and metric consumers without changing these guarantees.
+## Producer migration rollout
+
+CHAOS-2963 adds an opt-in, additive producer seam for GitHub and GitLab
+issue-derived incidents and for historical Atlassian Ops rows. Set
+`OPERATIONAL_INCIDENT_DUAL_WRITE=true` to write canonical rows alongside the
+legacy `incidents` write; this flag never suppresses the legacy write.
+
+`providers.operational_migration` maps GitHub and GitLab records with
+`source_entity_type="issue"`, a repository-derived `OperationalService`, and a
+`ServiceRepositoryMapping`. The incident has no `repo_id`; repository linkage is
+the explicit mapping edge. Atlassian Ops backfill maps its legacy incidents,
+alerts, and schedules with `provider="atlassian"` and their native source entity
+types. Deterministic canonical ids make repeated source snapshots idempotent.
+
+The migration does not change incident-correlation, Sankey, DORA, MTTR, or
+deployment-edge consumers. Those consumers continue reading legacy tables until
+their explicit cutover gate. Historical migration runs through
+`dev-health-ops backfill operational --org <org-id>` and joins `incidents` to
+`repos` on `repo_id` before mapping GitHub/GitLab issue incidents. The CLI accepts
+explicit provider-instance ids because the legacy incident row does not carry
+instance provenance. Atlassian Ops incidents, alerts, and schedules are read from
+their legacy tables and mapped through the same canonical writer.
+
+Historical GitHub/GitLab rows retain status and lifecycle timestamps, but legacy
+`incidents` has no labels, issue URL, number, title, or description; those canonical
+fields are null or empty after backfill. Enabled live dual-write supplies that richer
+issue metadata going forward. The backfill's deterministic canonical ids make
+repeated runs idempotent under ClickHouse `FINAL` reads.

--- a/docs/architecture/external-ingest-idempotency-ownership.md
+++ b/docs/architecture/external-ingest-idempotency-ownership.md
@@ -154,6 +154,18 @@ Instance matching is per-provider (master-spec CC5) because
 | linear | org-wide placeholder (`external_id == "linear"` or `metadata.org_wide_placeholder`) matches **any** instance; else `external_id`/`full_name`/`name` |
 | custom | never conflicts |
 
+For operational GitHub/GitLab ownership, an instance host in `Integration.config`
+is authoritative and avoids credential reads. When no configured host is present,
+the resolver may read the linked credential. A missing credential link still uses
+the provider public default (`github.com` / `gitlab.com`). In contrast, an active
+managed source with a linked credential that is unreadable, invalid, missing, or
+decrypts without an instance host makes **self-hosted** ownership indeterminate.
+Registration fails with **409** `ownership_resolution_unavailable`; accept fails
+with **403** `ownership_resolution_unavailable`. Public-default hosts retain normal
+default-host matching. This conservative rejection is scoped to the same org and
+provider with an active managed source, so configured unrelated hosts continue to
+coexist.
+
 Provider comparison is `func.lower()`d on both sides (managed rows may
 carry `"GitHub"`), and instance comparison is case-insensitive on both
 sides (adversarial-review finding): GitHub full names, GitLab paths, and
@@ -189,6 +201,7 @@ unreachable at accept time; the load-bearing outcome is the
 | 403 | `source_not_registered` | resolved mode `unclaimed` |
 | 403 | `source_disabled` | resolved mode `disabled` |
 | 403 | `source_owned_by_fullchaos_sync` | resolved mode `fullchaos_sync` |
+| 403 | `ownership_resolution_unavailable` | a linked active managed credential leaves a self-hosted GitHub/GitLab host indeterminate |
 
 All via `ExternalIngestError` (`{"error": {code, message}}`), not
 HTTPException detail-dicts (brief D13 overruled by reconciliation).

--- a/docs/customer-push-ingestion/examples.md
+++ b/docs/customer-push-ingestion/examples.md
@@ -147,3 +147,23 @@ A `completed` (or `partial`) status with `itemsAccepted >= 1` means the records 
 persisted and will surface in the product once the debounced metric recompute runs. The
 same validate → push → poll sequence is what you wire into a GitHub Actions / GitLab CI /
 generic runner job to push on a schedule.
+
+## Operational record examples
+
+Operational batches declare `source.entityFamily` as `operational` and contain only one
+operational record family.
+
+```json
+--8<-- "operational_service.v1.json"
+--8<-- "operational_incident.v1.json"
+--8<-- "operational_alert.v1.json"
+--8<-- "incident_timeline_event.v1.json"
+--8<-- "incident_note.v1.json"
+--8<-- "incident_responder.v1.json"
+--8<-- "escalation_policy.v1.json"
+--8<-- "on_call_schedule.v1.json"
+--8<-- "on_call_assignment.v1.json"
+--8<-- "operational_team.v1.json"
+--8<-- "operational_user.v1.json"
+--8<-- "service_repository_mapping.v1.json"
+```

--- a/src/dev_health_ops/alembic/versions/0040_external_ingest_source_entity_family.py
+++ b/src/dev_health_ops/alembic/versions/0040_external_ingest_source_entity_family.py
@@ -1,0 +1,68 @@
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "0040"
+down_revision: str | None = "0039"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_TABLE = "external_ingest_sources"
+_LEGACY_CONSTRAINT = "uq_external_ingest_sources_org_system_instance"
+_FAMILY_CONSTRAINT = "uq_external_ingest_sources_org_system_instance_family"
+
+
+def upgrade() -> None:
+    if not _table_exists():
+        return
+    if "entity_family" not in _column_names():
+        with op.batch_alter_table(_TABLE) as batch:
+            batch.add_column(
+                sa.Column(
+                    "entity_family", sa.Text(), nullable=False, server_default="legacy"
+                )
+            )
+    if _LEGACY_CONSTRAINT in _unique_constraint_names():
+        with op.batch_alter_table(_TABLE) as batch:
+            batch.drop_constraint(_LEGACY_CONSTRAINT, type_="unique")
+    if _FAMILY_CONSTRAINT not in _unique_constraint_names():
+        with op.batch_alter_table(_TABLE) as batch:
+            batch.create_unique_constraint(
+                _FAMILY_CONSTRAINT, ["org_id", "system", "instance", "entity_family"]
+            )
+
+
+def downgrade() -> None:
+    if not _table_exists():
+        return
+    if _FAMILY_CONSTRAINT in _unique_constraint_names():
+        with op.batch_alter_table(_TABLE) as batch:
+            batch.drop_constraint(_FAMILY_CONSTRAINT, type_="unique")
+    if _LEGACY_CONSTRAINT not in _unique_constraint_names():
+        with op.batch_alter_table(_TABLE) as batch:
+            batch.create_unique_constraint(
+                _LEGACY_CONSTRAINT, ["org_id", "system", "instance"]
+            )
+    if "entity_family" in _column_names():
+        with op.batch_alter_table(_TABLE) as batch:
+            batch.drop_column("entity_family")
+
+
+def _table_exists() -> bool:
+    return _TABLE in sa.inspect(op.get_bind()).get_table_names()
+
+
+def _column_names() -> set[str]:
+    return {column["name"] for column in sa.inspect(op.get_bind()).get_columns(_TABLE)}
+
+
+def _unique_constraint_names() -> set[str]:
+    return {
+        constraint["name"]
+        for constraint in sa.inspect(op.get_bind()).get_unique_constraints(_TABLE)
+        if constraint["name"] is not None
+    }

--- a/src/dev_health_ops/alembic/versions/0040_external_ingest_source_entity_family.py
+++ b/src/dev_health_ops/alembic/versions/0040_external_ingest_source_entity_family.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 from collections.abc import Sequence
 
 import sqlalchemy as sa
-
 from alembic import op
 
 revision: str = "0040"
@@ -12,6 +11,7 @@ branch_labels: str | Sequence[str] | None = None
 depends_on: str | Sequence[str] | None = None
 
 _TABLE = "external_ingest_sources"
+_BATCHES_TABLE = "external_ingest_batches"
 _LEGACY_CONSTRAINT = "uq_external_ingest_sources_org_system_instance"
 _FAMILY_CONSTRAINT = "uq_external_ingest_sources_org_system_instance_family"
 
@@ -34,6 +34,7 @@ def upgrade() -> None:
             batch.create_unique_constraint(
                 _FAMILY_CONSTRAINT, ["org_id", "system", "instance", "entity_family"]
             )
+    _upgrade_batches()
 
 
 def downgrade() -> None:
@@ -49,6 +50,75 @@ def downgrade() -> None:
             )
     if "entity_family" in _column_names():
         with op.batch_alter_table(_TABLE) as batch:
+            batch.drop_column("entity_family")
+    _downgrade_batches()
+
+
+def _upgrade_batches() -> None:
+    if _BATCHES_TABLE not in sa.inspect(op.get_bind()).get_table_names():
+        return
+    columns = {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns(_BATCHES_TABLE)
+    }
+    if "entity_family" not in columns:
+        with op.batch_alter_table(_BATCHES_TABLE) as batch:
+            batch.add_column(
+                sa.Column(
+                    "entity_family", sa.Text(), nullable=False, server_default="legacy"
+                )
+            )
+    constraints = {
+        constraint["name"]
+        for constraint in sa.inspect(op.get_bind()).get_unique_constraints(
+            _BATCHES_TABLE
+        )
+        if constraint["name"] is not None
+    }
+    if "uq_external_ingest_batches_idem" in constraints:
+        with op.batch_alter_table(_BATCHES_TABLE) as batch:
+            batch.drop_constraint("uq_external_ingest_batches_idem", type_="unique")
+    if "uq_external_ingest_batches_idem_family" not in constraints:
+        with op.batch_alter_table(_BATCHES_TABLE) as batch:
+            batch.create_unique_constraint(
+                "uq_external_ingest_batches_idem_family",
+                [
+                    "org_id",
+                    "source_system",
+                    "source_instance",
+                    "entity_family",
+                    "idempotency_key",
+                ],
+            )
+
+
+def _downgrade_batches() -> None:
+    if _BATCHES_TABLE not in sa.inspect(op.get_bind()).get_table_names():
+        return
+    constraints = {
+        constraint["name"]
+        for constraint in sa.inspect(op.get_bind()).get_unique_constraints(
+            _BATCHES_TABLE
+        )
+        if constraint["name"] is not None
+    }
+    if "uq_external_ingest_batches_idem_family" in constraints:
+        with op.batch_alter_table(_BATCHES_TABLE) as batch:
+            batch.drop_constraint(
+                "uq_external_ingest_batches_idem_family", type_="unique"
+            )
+    if "uq_external_ingest_batches_idem" not in constraints:
+        with op.batch_alter_table(_BATCHES_TABLE) as batch:
+            batch.create_unique_constraint(
+                "uq_external_ingest_batches_idem",
+                ["org_id", "source_system", "source_instance", "idempotency_key"],
+            )
+    columns = {
+        column["name"]
+        for column in sa.inspect(op.get_bind()).get_columns(_BATCHES_TABLE)
+    }
+    if "entity_family" in columns:
+        with op.batch_alter_table(_BATCHES_TABLE) as batch:
             batch.drop_column("entity_family")
 
 

--- a/src/dev_health_ops/api/admin/routers/customer_push.py
+++ b/src/dev_health_ops/api/admin/routers/customer_push.py
@@ -47,7 +47,11 @@ from dev_health_ops.api.external_ingest.schemas import (
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.licensing import feature_flag_state, resolve_org_tier
 from dev_health_ops.api.utils.audit import emit_audit_log
-from dev_health_ops.external_ingest.ownership import find_matching_managed_sources
+from dev_health_ops.external_ingest.ownership import (
+    OWNERSHIP_RESOLUTION_UNAVAILABLE_MESSAGE,
+    OperationalOwnershipResolutionUnavailableError,
+    find_matching_managed_sources,
+)
 from dev_health_ops.external_ingest.validate import validate_records
 from dev_health_ops.licensing.types import TIER_ORDER, LicenseTier
 from dev_health_ops.models.audit import AuditAction, AuditResourceType
@@ -301,13 +305,22 @@ async def _resolve_ownership(
     if system == "custom":
         return matched_id, warnings
 
-    matches = await find_matching_managed_sources(
-        session,
-        org_id=org_id,
-        system=system,
-        instance=instance,
-        entity_family=entity_family,
-    )
+    try:
+        matches = await find_matching_managed_sources(
+            session,
+            org_id=org_id,
+            system=system,
+            instance=instance,
+            entity_family=entity_family,
+        )
+    except OperationalOwnershipResolutionUnavailableError as exc:
+        raise HTTPException(
+            status_code=409,
+            detail={
+                "code": "ownership_resolution_unavailable",
+                "message": OWNERSHIP_RESOLUTION_UNAVAILABLE_MESSAGE,
+            },
+        ) from exc
     enabled_match = next(
         (
             source

--- a/src/dev_health_ops/api/admin/routers/customer_push.py
+++ b/src/dev_health_ops/api/admin/routers/customer_push.py
@@ -70,7 +70,15 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter()
 
-_VALID_SYSTEMS = {"github", "gitlab", "jira", "linear", "custom"}
+_VALID_SYSTEMS = {
+    "github",
+    "gitlab",
+    "jira",
+    "linear",
+    "pagerduty",
+    "atlassian",
+    "custom",
+}
 _CUSTOMER_PUSH_FEATURE = "customer_push_ingest"
 _CUSTOMER_PUSH_REQUIRED_TIER = LicenseTier.TEAM
 
@@ -136,6 +144,7 @@ def _source_to_response(
         org_id=source.org_id,
         system=source.system,
         instance=source.instance,
+        entity_family=source.entity_family,
         display_name=source.display_name,
         mode=source.mode,
         enabled=source.enabled,
@@ -260,7 +269,11 @@ async def _require_customer_push_access(session: AsyncSession, org_id: str) -> N
 
 
 async def _resolve_ownership(
-    session: AsyncSession, org_id: str, system: str, instance: str
+    session: AsyncSession,
+    org_id: str,
+    system: str,
+    instance: str,
+    entity_family: str,
 ) -> tuple[uuid.UUID | None, list[str]]:
     """Run CC5 per-provider ownership matching against managed integration_sources.
 
@@ -289,7 +302,11 @@ async def _resolve_ownership(
         return matched_id, warnings
 
     matches = await find_matching_managed_sources(
-        session, org_id=org_id, system=system, instance=instance
+        session,
+        org_id=org_id,
+        system=system,
+        instance=instance,
+        entity_family=entity_family,
     )
     enabled_match = next(
         (
@@ -424,6 +441,7 @@ async def create_source(
                     IngestSource.system == system,
                     func.lower(IngestSource.instance)
                     == payload.instance.strip().lower(),
+                    IngestSource.entity_family == payload.entity_family,
                 )
             )
         )
@@ -444,13 +462,14 @@ async def create_source(
     warnings: list[str] = []
     if mode == IngestSourceMode.CUSTOMER_PUSH:
         matched_id, warnings = await _resolve_ownership(
-            session, org_id, system, payload.instance
+            session, org_id, system, payload.instance, payload.entity_family
         )
 
     source = IngestSource(
         org_id=org_id,
         system=system,
         instance=payload.instance,
+        entity_family=payload.entity_family,
         display_name=payload.display_name,
         mode=mode.value,
         enabled=True,
@@ -479,7 +498,12 @@ async def create_source(
         resource_id=str(source.id),
         user_id=_user_uuid(current_user.user_id),
         description=f"Registered customer-push source {system}/{payload.instance}",
-        changes={"system": system, "instance": payload.instance, "mode": mode.value},
+        changes={
+            "system": system,
+            "instance": payload.instance,
+            "entity_family": payload.entity_family,
+            "mode": mode.value,
+        },
         request=request,
     )
     await session.commit()
@@ -555,7 +579,7 @@ async def patch_source(
     warnings: list[str] = []
     if source.is_write_eligible() and ("mode" in changes or "enabled" in changes):
         matched_id, warnings = await _resolve_ownership(
-            session, org_id, source.system, source.instance
+            session, org_id, source.system, source.instance, source.entity_family
         )
         source.matched_integration_source_id = matched_id
 

--- a/src/dev_health_ops/api/admin/schemas/customer_push.py
+++ b/src/dev_health_ops/api/admin/schemas/customer_push.py
@@ -8,6 +8,7 @@ deliberate divergence from the camelCase data-plane batch envelope.
 from __future__ import annotations
 
 from datetime import datetime
+from typing import Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
@@ -43,7 +44,7 @@ def _validate_webhook_mode(value: str | None) -> str | None:
 class IngestSourceCreate(BaseModel):
     system: str = Field(..., min_length=1)
     instance: str = Field(..., min_length=1)
-    entity_family: str = Field(default="legacy", min_length=1, max_length=255)
+    entity_family: Literal["legacy", "operational"] = "legacy"
     display_name: str | None = None
     mode: str = "customer_push"
     webhook_mode: str = "disabled"

--- a/src/dev_health_ops/api/admin/schemas/customer_push.py
+++ b/src/dev_health_ops/api/admin/schemas/customer_push.py
@@ -43,6 +43,7 @@ def _validate_webhook_mode(value: str | None) -> str | None:
 class IngestSourceCreate(BaseModel):
     system: str = Field(..., min_length=1)
     instance: str = Field(..., min_length=1)
+    entity_family: str = Field(default="legacy", min_length=1, max_length=255)
     display_name: str | None = None
     mode: str = "customer_push"
     webhook_mode: str = "disabled"
@@ -72,6 +73,7 @@ class IngestSourceResponse(BaseModel):
     org_id: str
     system: str
     instance: str
+    entity_family: str
     display_name: str | None
     mode: str
     enabled: bool

--- a/src/dev_health_ops/api/external_ingest/auth.py
+++ b/src/dev_health_ops/api/external_ingest/auth.py
@@ -358,7 +358,10 @@ def require_ingest_scope(scope: str):
 
 
 def require_matching_source(
-    ctx: IngestAuthContext, system: str, instance: str
+    ctx: IngestAuthContext,
+    system: str,
+    instance: str,
+    entity_family: str = "legacy",
 ) -> IngestSource:
     """Enforce that a write request's declared source matches the token's
     bound source (Design Decision 7 / master-spec CC16 ``source_mismatch``).
@@ -378,7 +381,12 @@ def require_matching_source(
     a mismatch, not a pass-through.
     """
     source = ctx.source
-    if source is None or source.system != system or source.instance != instance:
+    if (
+        source is None
+        or source.system != system
+        or source.instance != instance
+        or (source.entity_family or "legacy") != entity_family
+    ):
         raise ExternalIngestError(
             403,
             "source_mismatch",

--- a/src/dev_health_ops/api/external_ingest/examples/escalation_policy.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/escalation_policy.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"policy-1","sourceVersionAt":"2026-07-17T00:00:00Z","name":"Payments escalation"}

--- a/src/dev_health_ops/api/external_ingest/examples/incident_note.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/incident_note.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"note-1","sourceVersionAt":"2026-07-17T00:00:00Z","incidentExternalId":"inc-1","body":"Investigating latency.","createdAt":"2026-07-17T00:02:00Z"}

--- a/src/dev_health_ops/api/external_ingest/examples/incident_responder.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/incident_responder.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"responder-1","sourceVersionAt":"2026-07-17T00:00:00Z","incidentExternalId":"inc-1","responderName":"On-call","assignedAt":"2026-07-17T00:02:00Z"}

--- a/src/dev_health_ops/api/external_ingest/examples/incident_timeline_event.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/incident_timeline_event.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"event-1","sourceVersionAt":"2026-07-17T00:00:00Z","incidentExternalId":"inc-1","eventType":"acknowledged","occurredAt":"2026-07-17T00:01:00Z","normalizedStatus":"acknowledged"}

--- a/src/dev_health_ops/api/external_ingest/examples/on_call_assignment.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/on_call_assignment.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"assignment-1","sourceVersionAt":"2026-07-17T00:00:00Z","scheduleExternalId":"schedule-1","startsAt":"2026-07-17T00:00:00Z","endsAt":"2026-07-18T00:00:00Z"}

--- a/src/dev_health_ops/api/external_ingest/examples/on_call_schedule.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/on_call_schedule.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"schedule-1","sourceVersionAt":"2026-07-17T00:00:00Z","name":"Payments on-call","timezone":"UTC"}

--- a/src/dev_health_ops/api/external_ingest/examples/operational_alert.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/operational_alert.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"alert-1","sourceVersionAt":"2026-07-17T00:00:00Z","title":"Latency alert","serviceExternalId":"payments","incidentExternalId":"inc-1","triggeredAt":"2026-07-17T00:00:00Z","normalizedStatus":"active"}

--- a/src/dev_health_ops/api/external_ingest/examples/operational_incident.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/operational_incident.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"inc-1","sourceVersionAt":"2026-07-17T00:00:00Z","title":"Payments latency","serviceExternalId":"payments","startedAt":"2026-07-17T00:00:00Z","normalizedStatus":"open","normalizedSeverity":"high"}

--- a/src/dev_health_ops/api/external_ingest/examples/operational_service.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/operational_service.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"payments","sourceVersionAt":"2026-07-17T00:00:00Z","name":"Payments","normalizedStatus":"active"}

--- a/src/dev_health_ops/api/external_ingest/examples/operational_team.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/operational_team.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"team-ops","sourceVersionAt":"2026-07-17T00:00:00Z","name":"Operations"}

--- a/src/dev_health_ops/api/external_ingest/examples/operational_user.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/operational_user.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"user-1","sourceVersionAt":"2026-07-17T00:00:00Z","displayName":"Alex Operator","email":"alex@example.test"}

--- a/src/dev_health_ops/api/external_ingest/examples/service_repository_mapping.v1.json
+++ b/src/dev_health_ops/api/external_ingest/examples/service_repository_mapping.v1.json
@@ -1,0 +1,1 @@
+{"externalId":"payments-repository","sourceVersionAt":"2026-07-17T00:00:00Z","serviceExternalId":"payments","repoFullName":"acme/payments","repoProvider":"github","mappingKind":"primary"}

--- a/src/dev_health_ops/api/external_ingest/idempotency.py
+++ b/src/dev_health_ops/api/external_ingest/idempotency.py
@@ -134,8 +134,12 @@ def compute_payload_hash(envelope: BaseModel) -> str:
     envelope is hashed, ``records`` in given order — record order is
     position-significant by design (brief decisions 3-4).
     """
+    payload = envelope.model_dump(mode="json")
+    source = payload.get("source")
+    if isinstance(source, dict) and source.get("entity_family") == "legacy":
+        source.pop("entity_family")
     canonical = json.dumps(
-        envelope.model_dump(mode="json"),
+        payload,
         sort_keys=True,
         separators=(",", ":"),
         ensure_ascii=True,
@@ -171,6 +175,7 @@ async def resolve_batch_idempotency(
     window_started_at: datetime | None,
     window_ended_at: datetime | None,
     items_received: int,
+    entity_family: str = "legacy",
 ) -> IdempotencyOutcome:
     """Resolve NEW / REPLAY / CONFLICT / RETRY for a batch identity.
 
@@ -190,6 +195,7 @@ async def resolve_batch_idempotency(
         org_id=org_id,
         source_system=source_system,
         source_instance=source_instance,
+        entity_family=entity_family,
         idempotency_key=idempotency_key,
     )
     if existing is not None:
@@ -204,6 +210,7 @@ async def resolve_batch_idempotency(
             payload_hash=payload_hash,
             source_system=source_system,
             source_instance=source_instance,
+            entity_family=entity_family,
             producer=producer,
             producer_version=producer_version,
             schema_version=schema_version,
@@ -217,6 +224,7 @@ async def resolve_batch_idempotency(
             org_id=org_id,
             source_system=source_system,
             source_instance=source_instance,
+            entity_family=entity_family,
             idempotency_key=idempotency_key,
         )
         if raced is None:

--- a/src/dev_health_ops/api/external_ingest/router.py
+++ b/src/dev_health_ops/api/external_ingest/router.py
@@ -61,6 +61,7 @@ from .schemas import (
     BatchAcceptedResponse,
     BatchEnvelope,
     ValidationResponse,
+    entity_family_for_record_kinds,
 )
 from .status import (
     BatchRow,
@@ -97,6 +98,18 @@ def _max_body_bytes() -> int:
 
 def _limits_payload() -> dict[str, int]:
     return {"maxRecordsPerBatch": _max_records(), "maxBodyBytes": _max_body_bytes()}
+
+
+def _check_entity_family_or_400(envelope: BatchEnvelope) -> None:
+    expected_family = entity_family_for_record_kinds(
+        [record.kind for record in envelope.records]
+    )
+    if expected_family != envelope.source.entity_family:
+        raise ExternalIngestError(
+            400,
+            "entity_family_mismatch",
+            "source.entityFamily must match the submitted record kinds",
+        )
 
 
 async def _read_body_enforcing_size_limit(request: Request) -> bytes:
@@ -337,6 +350,7 @@ async def accept_batch(
     _check_idempotency_header_matches_body(envelope, idempotency_key_header)
     _check_schema_version_or_400(envelope)
     _check_all_kinds_known_or_400(envelope)
+    _check_entity_family_or_400(envelope)
     _check_batch_size_or_400(envelope)
     # Adversarial-review fix: require_ingest_scope resolves before the body
     # is parsed, so it can't check payload source vs. token-bound source
@@ -367,9 +381,6 @@ async def accept_batch(
 
     window = envelope.window
     payload_hash = compute_payload_hash(envelope)
-    idempotency_key = envelope.idempotency_key
-    if envelope.source.entity_family != "legacy":
-        idempotency_key = f"{envelope.source.entity_family}:{idempotency_key}"
     try:
         # FIRST Postgres write of the accept sequence (CC22) -- the unique
         # idempotency index is the serialization point for concurrent
@@ -379,8 +390,9 @@ async def accept_batch(
             org_id=ctx.org_id,
             source_system=envelope.source.system,
             source_instance=envelope.source.instance,
-            idempotency_key=idempotency_key,
+            idempotency_key=envelope.idempotency_key,
             payload_hash=payload_hash,
+            entity_family=envelope.source.entity_family,
             schema_version=envelope.schema_version,
             producer=envelope.source.producer,
             producer_version=envelope.source.producer_version,

--- a/src/dev_health_ops/api/external_ingest/router.py
+++ b/src/dev_health_ops/api/external_ingest/router.py
@@ -37,7 +37,9 @@ from dev_health_ops.api.middleware.rate_limit import (
     limiter,
 )
 from dev_health_ops.external_ingest.ownership import (
+    OWNERSHIP_RESOLUTION_UNAVAILABLE_MESSAGE,
     EffectiveMode,
+    OperationalOwnershipResolutionUnavailableError,
     resolve_effective_mode,
 )
 from dev_health_ops.external_ingest.payload_store import upsert_payload
@@ -369,13 +371,20 @@ async def accept_batch(
     # write-eligible source row -- it cannot see a managed sync source that
     # was connected to the SAME instance AFTER registration (nothing on the
     # api/admin/routers/sync.py side knows about external_ingest_sources).
-    mode = await resolve_effective_mode(
-        session,
-        org_id=ctx.org_id,
-        system=envelope.source.system,
-        instance=envelope.source.instance,
-        entity_family=envelope.source.entity_family,
-    )
+    try:
+        mode = await resolve_effective_mode(
+            session,
+            org_id=ctx.org_id,
+            system=envelope.source.system,
+            instance=envelope.source.instance,
+            entity_family=envelope.source.entity_family,
+        )
+    except OperationalOwnershipResolutionUnavailableError as exc:
+        raise ExternalIngestError(
+            403,
+            "ownership_resolution_unavailable",
+            OWNERSHIP_RESOLUTION_UNAVAILABLE_MESSAGE,
+        ) from exc
     if mode != "customer_push":
         raise _ownership_error(mode, envelope.source.system, envelope.source.instance)
 

--- a/src/dev_health_ops/api/external_ingest/router.py
+++ b/src/dev_health_ops/api/external_ingest/router.py
@@ -343,7 +343,12 @@ async def accept_batch(
     # itself -- a source-bound ingest:write token must not be able to push
     # data for a different source instance in the same org (CC16
     # source_mismatch / source_disabled).
-    require_matching_source(ctx, envelope.source.system, envelope.source.instance)
+    require_matching_source(
+        ctx,
+        envelope.source.system,
+        envelope.source.instance,
+        envelope.source.entity_family,
+    )
 
     # One-active-owner re-check at accept time (CC5/CC14 defense in depth):
     # require_matching_source only proves the token binds to a registered,
@@ -355,12 +360,16 @@ async def accept_batch(
         org_id=ctx.org_id,
         system=envelope.source.system,
         instance=envelope.source.instance,
+        entity_family=envelope.source.entity_family,
     )
     if mode != "customer_push":
         raise _ownership_error(mode, envelope.source.system, envelope.source.instance)
 
     window = envelope.window
     payload_hash = compute_payload_hash(envelope)
+    idempotency_key = envelope.idempotency_key
+    if envelope.source.entity_family != "legacy":
+        idempotency_key = f"{envelope.source.entity_family}:{idempotency_key}"
     try:
         # FIRST Postgres write of the accept sequence (CC22) -- the unique
         # idempotency index is the serialization point for concurrent
@@ -370,7 +379,7 @@ async def accept_batch(
             org_id=ctx.org_id,
             source_system=envelope.source.system,
             source_instance=envelope.source.instance,
-            idempotency_key=envelope.idempotency_key,
+            idempotency_key=idempotency_key,
             payload_hash=payload_hash,
             schema_version=envelope.schema_version,
             producer=envelope.source.producer,

--- a/src/dev_health_ops/api/external_ingest/schemas.py
+++ b/src/dev_health_ops/api/external_ingest/schemas.py
@@ -12,13 +12,15 @@ REST-boundary/ownership-model rationale.
 from __future__ import annotations
 
 from datetime import datetime
-from typing import Literal
+from typing import Final, Literal
 
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 SCHEMA_VERSION = "external-ingest.v1"
 MAX_RECORDS_DEFAULT = 1000
 MAX_BODY_BYTES_DEFAULT = 10_000_000
+LEGACY_ENTITY_FAMILY: Final = "legacy"
+OPERATIONAL_ENTITY_FAMILY: Final = "operational"
 
 _WORK_ITEM_STATUS = Literal[
     "backlog",
@@ -41,8 +43,8 @@ class SourceDescriptor(BaseModel):
         "github", "gitlab", "jira", "linear", "pagerduty", "atlassian", "custom"
     ]
     instance: str = Field(..., min_length=1, max_length=255)
-    entity_family: str = Field(
-        default="legacy", alias="entityFamily", min_length=1, max_length=255
+    entity_family: Literal["legacy", "operational"] = Field(
+        default=LEGACY_ENTITY_FAMILY, alias="entityFamily"
     )
     producer: str | None = None
     producer_version: str | None = Field(default=None, alias="producerVersion")
@@ -541,6 +543,34 @@ RECORD_KIND_MODELS: dict[str, type[BaseModel]] = {
     "service_repository_mapping.v1": ServiceRepositoryMappingV1,
 }
 
+OPERATIONAL_RECORD_KINDS: Final[frozenset[str]] = frozenset(
+    {
+        "operational_service.v1",
+        "operational_incident.v1",
+        "operational_alert.v1",
+        "incident_timeline_event.v1",
+        "incident_note.v1",
+        "incident_responder.v1",
+        "escalation_policy.v1",
+        "on_call_schedule.v1",
+        "on_call_assignment.v1",
+        "operational_team.v1",
+        "operational_user.v1",
+        "service_repository_mapping.v1",
+    }
+)
+
+
+def entity_family_for_record_kinds(record_kinds: list[str]) -> str | None:
+    """Return the single family required by the submitted record kinds."""
+    families = {
+        OPERATIONAL_ENTITY_FAMILY
+        if kind in OPERATIONAL_RECORD_KINDS
+        else LEGACY_ENTITY_FAMILY
+        for kind in record_kinds
+    }
+    return families.pop() if len(families) == 1 else None
+
 
 __all__ = [
     "SCHEMA_VERSION",
@@ -576,4 +606,8 @@ __all__ = [
     "OperationalUserV1",
     "ServiceRepositoryMappingV1",
     "RECORD_KIND_MODELS",
+    "OPERATIONAL_RECORD_KINDS",
+    "LEGACY_ENTITY_FAMILY",
+    "OPERATIONAL_ENTITY_FAMILY",
+    "entity_family_for_record_kinds",
 ]

--- a/src/dev_health_ops/api/external_ingest/schemas.py
+++ b/src/dev_health_ops/api/external_ingest/schemas.py
@@ -37,8 +37,13 @@ class SourceDescriptor(BaseModel):
     model_config = ConfigDict(populate_by_name=True, extra="forbid")
 
     type: Literal["customer_push"] = "customer_push"
-    system: Literal["github", "gitlab", "jira", "linear", "custom"]
+    system: Literal[
+        "github", "gitlab", "jira", "linear", "pagerduty", "atlassian", "custom"
+    ]
     instance: str = Field(..., min_length=1, max_length=255)
+    entity_family: str = Field(
+        default="legacy", alias="entityFamily", min_length=1, max_length=255
+    )
     producer: str | None = None
     producer_version: str | None = Field(default=None, alias="producerVersion")
 
@@ -121,7 +126,6 @@ class BatchAcceptedResponse(BaseModel):
 
 
 # ---------------------------------------------------------------------------
-# The 9 record-kind payload schemas
 #
 # All models: extra="forbid" — this is a versioned, external, customer-SDK
 # contract, not an internal analytics event. A customer typo should be a
@@ -331,6 +335,188 @@ class CommitV1(BaseModel):
     parents: int = Field(default=1, ge=0)
 
 
+_OPERATIONAL_STATUS = Literal[
+    "active", "open", "acknowledged", "resolved", "closed", "suppressed"
+]
+_OPERATIONAL_SEVERITY = Literal["critical", "high", "medium", "low", "info"]
+_OPERATIONAL_PRIORITY = Literal["critical", "high", "medium", "low"]
+
+
+class OperationalRecordV1(BaseModel):
+    model_config = ConfigDict(populate_by_name=True, extra="forbid")
+
+    external_id: str = Field(..., alias="externalId", min_length=1, max_length=512)
+    source_version_at: datetime = Field(..., alias="sourceVersionAt")
+    source_url: str | None = Field(default=None, alias="sourceUrl", max_length=2048)
+    source_event_at: datetime | None = Field(default=None, alias="sourceEventAt")
+    source_event_id: str | None = Field(
+        default=None, alias="sourceEventId", max_length=512
+    )
+    raw_status: str | None = Field(default=None, alias="rawStatus", max_length=255)
+    raw_severity: str | None = Field(default=None, alias="rawSeverity", max_length=255)
+    raw_priority: str | None = Field(default=None, alias="rawPriority", max_length=255)
+    normalized_status: _OPERATIONAL_STATUS | None = Field(
+        default=None, alias="normalizedStatus"
+    )
+    normalized_severity: _OPERATIONAL_SEVERITY | None = Field(
+        default=None, alias="normalizedSeverity"
+    )
+    normalized_priority: _OPERATIONAL_PRIORITY | None = Field(
+        default=None, alias="normalizedPriority"
+    )
+    relationship_provenance: str | None = Field(
+        default=None, alias="relationshipProvenance", max_length=255
+    )
+    relationship_confidence: float | None = Field(
+        default=None, alias="relationshipConfidence", ge=0, le=1
+    )
+
+
+class OperationalServiceV1(OperationalRecordV1):
+    name: str = Field(..., min_length=1, max_length=512)
+    description: str | None = Field(default=None, max_length=20_000)
+    service_type: str | None = Field(default=None, alias="serviceType", max_length=255)
+    owning_team_external_id: str | None = Field(
+        default=None, alias="owningTeamExternalId", max_length=512
+    )
+    escalation_policy_external_id: str | None = Field(
+        default=None, alias="escalationPolicyExternalId", max_length=512
+    )
+    is_deleted: bool = Field(default=False, alias="isDeleted")
+    deleted_at: datetime | None = Field(default=None, alias="deletedAt")
+
+
+class OperationalIncidentV1(OperationalRecordV1):
+    title: str = Field(..., min_length=1, max_length=1024)
+    description: str | None = Field(default=None, max_length=20_000)
+    service_external_id: str | None = Field(
+        default=None, alias="serviceExternalId", max_length=512
+    )
+    escalation_policy_external_id: str | None = Field(
+        default=None, alias="escalationPolicyExternalId", max_length=512
+    )
+    started_at: datetime | None = Field(default=None, alias="startedAt")
+    resolved_at: datetime | None = Field(default=None, alias="resolvedAt")
+    is_deleted: bool = Field(default=False, alias="isDeleted")
+    deleted_at: datetime | None = Field(default=None, alias="deletedAt")
+
+
+class OperationalAlertV1(OperationalRecordV1):
+    title: str = Field(..., min_length=1, max_length=1024)
+    description: str | None = Field(default=None, max_length=20_000)
+    service_external_id: str | None = Field(
+        default=None, alias="serviceExternalId", max_length=512
+    )
+    incident_external_id: str | None = Field(
+        default=None, alias="incidentExternalId", max_length=512
+    )
+    triggered_at: datetime | None = Field(default=None, alias="triggeredAt")
+    acknowledged_at: datetime | None = Field(default=None, alias="acknowledgedAt")
+    resolved_at: datetime | None = Field(default=None, alias="resolvedAt")
+    is_deleted: bool = Field(default=False, alias="isDeleted")
+    deleted_at: datetime | None = Field(default=None, alias="deletedAt")
+
+
+class IncidentTimelineEventV1(OperationalRecordV1):
+    incident_external_id: str = Field(
+        ..., alias="incidentExternalId", min_length=1, max_length=512
+    )
+    event_type: str = Field(..., alias="eventType", min_length=1, max_length=255)
+    body: str | None = Field(default=None, max_length=20_000)
+    actor_type: str | None = Field(default=None, alias="actorType", max_length=255)
+    actor_external_id: str | None = Field(
+        default=None, alias="actorExternalId", max_length=512
+    )
+    occurred_at: datetime | None = Field(default=None, alias="occurredAt")
+
+
+class IncidentNoteV1(OperationalRecordV1):
+    incident_external_id: str = Field(
+        ..., alias="incidentExternalId", min_length=1, max_length=512
+    )
+    body: str = Field(..., min_length=1, max_length=20_000)
+    author_user_external_id: str | None = Field(
+        default=None, alias="authorUserExternalId", max_length=512
+    )
+    created_at: datetime | None = Field(default=None, alias="createdAt")
+
+
+class IncidentResponderV1(OperationalRecordV1):
+    incident_external_id: str = Field(
+        ..., alias="incidentExternalId", min_length=1, max_length=512
+    )
+    user_external_id: str | None = Field(
+        default=None, alias="userExternalId", max_length=512
+    )
+    responder_name: str | None = Field(
+        default=None, alias="responderName", max_length=512
+    )
+    role: str | None = Field(default=None, max_length=255)
+    responder_assignment_id: str | None = Field(
+        default=None, alias="responderAssignmentId", max_length=512
+    )
+    requested_at: datetime | None = Field(default=None, alias="requestedAt")
+    assigned_at: datetime | None = Field(default=None, alias="assignedAt")
+    acknowledged_at: datetime | None = Field(default=None, alias="acknowledgedAt")
+    completed_at: datetime | None = Field(default=None, alias="completedAt")
+
+
+class EscalationPolicyV1(OperationalRecordV1):
+    name: str = Field(..., min_length=1, max_length=512)
+    description: str | None = Field(default=None, max_length=20_000)
+    is_deleted: bool = Field(default=False, alias="isDeleted")
+    deleted_at: datetime | None = Field(default=None, alias="deletedAt")
+
+
+class OnCallScheduleV1(EscalationPolicyV1):
+    timezone: str | None = Field(default=None, max_length=255)
+
+
+class OnCallAssignmentV1(OperationalRecordV1):
+    schedule_external_id: str | None = Field(
+        default=None, alias="scheduleExternalId", max_length=512
+    )
+    user_external_id: str | None = Field(
+        default=None, alias="userExternalId", max_length=512
+    )
+    escalation_policy_external_id: str | None = Field(
+        default=None, alias="escalationPolicyExternalId", max_length=512
+    )
+    escalation_level: int | None = Field(
+        default=None, alias="escalationLevel", ge=0, le=100
+    )
+    starts_at: datetime | None = Field(default=None, alias="startsAt")
+    ends_at: datetime | None = Field(default=None, alias="endsAt")
+
+
+class OperationalTeamV1(EscalationPolicyV1):
+    pass
+
+
+class OperationalUserV1(OperationalRecordV1):
+    display_name: str = Field(..., alias="displayName", min_length=1, max_length=512)
+    email: str | None = Field(default=None, max_length=512)
+    is_deleted: bool = Field(default=False, alias="isDeleted")
+    deleted_at: datetime | None = Field(default=None, alias="deletedAt")
+
+
+class ServiceRepositoryMappingV1(OperationalRecordV1):
+    service_external_id: str = Field(
+        ..., alias="serviceExternalId", min_length=1, max_length=512
+    )
+    repo_full_name: str | None = Field(
+        default=None, alias="repoFullName", max_length=1024
+    )
+    repo_provider: Literal["github", "gitlab", "custom"] | None = Field(
+        default=None, alias="repoProvider"
+    )
+    mapping_kind: str | None = Field(default=None, alias="mappingKind", max_length=255)
+    rule_id: str | None = Field(default=None, alias="ruleId", max_length=512)
+    valid_from: datetime | None = Field(default=None, alias="validFrom")
+    valid_to: datetime | None = Field(default=None, alias="validTo")
+    is_active: bool = Field(default=True, alias="isActive")
+
+
 RECORD_KIND_MODELS: dict[str, type[BaseModel]] = {
     "repository.v1": RepositoryV1,
     "identity.v1": IdentityV1,
@@ -341,6 +527,18 @@ RECORD_KIND_MODELS: dict[str, type[BaseModel]] = {
     "pull_request.v1": PullRequestV1,
     "review.v1": ReviewV1,
     "commit.v1": CommitV1,
+    "operational_service.v1": OperationalServiceV1,
+    "operational_incident.v1": OperationalIncidentV1,
+    "operational_alert.v1": OperationalAlertV1,
+    "incident_timeline_event.v1": IncidentTimelineEventV1,
+    "incident_note.v1": IncidentNoteV1,
+    "incident_responder.v1": IncidentResponderV1,
+    "escalation_policy.v1": EscalationPolicyV1,
+    "on_call_schedule.v1": OnCallScheduleV1,
+    "on_call_assignment.v1": OnCallAssignmentV1,
+    "operational_team.v1": OperationalTeamV1,
+    "operational_user.v1": OperationalUserV1,
+    "service_repository_mapping.v1": ServiceRepositoryMappingV1,
 }
 
 
@@ -364,5 +562,18 @@ __all__ = [
     "PullRequestV1",
     "ReviewV1",
     "CommitV1",
+    "OperationalRecordV1",
+    "OperationalServiceV1",
+    "OperationalIncidentV1",
+    "OperationalAlertV1",
+    "IncidentTimelineEventV1",
+    "IncidentNoteV1",
+    "IncidentResponderV1",
+    "EscalationPolicyV1",
+    "OnCallScheduleV1",
+    "OnCallAssignmentV1",
+    "OperationalTeamV1",
+    "OperationalUserV1",
+    "ServiceRepositoryMappingV1",
     "RECORD_KIND_MODELS",
 ]

--- a/src/dev_health_ops/api/external_ingest/status.py
+++ b/src/dev_health_ops/api/external_ingest/status.py
@@ -117,6 +117,7 @@ class BatchRow:
     payload_hash: str
     source_system: str
     source_instance: str
+    entity_family: str
     producer: str | None
     producer_version: str | None
     schema_version: str
@@ -193,6 +194,7 @@ def _row_to_batch(m: RowMapping) -> BatchRow:
         payload_hash=m["payload_hash"],
         source_system=m["source_system"],
         source_instance=m["source_instance"],
+        entity_family=m["entity_family"],
         producer=m["producer"],
         producer_version=m["producer_version"],
         schema_version=m["schema_version"],
@@ -258,6 +260,7 @@ async def find_existing_batch(
     source_system: str,
     source_instance: str,
     idempotency_key: str,
+    entity_family: str = "legacy",
 ) -> BatchRow | None:
     """Idempotency-key lookup. Consumed by CHAOS-2695's conflict policy
     BEFORE calling ``create_batch()`` -- this is the primary dedupe path; the
@@ -268,12 +271,14 @@ async def find_existing_batch(
         text(
             f"SELECT * FROM {_BATCHES_TABLE} WHERE org_id = :org_id "
             "AND source_system = :source_system AND source_instance = :source_instance "
+            "AND entity_family = :entity_family "
             "AND idempotency_key = :idempotency_key"
         ),
         {
             "org_id": org_id,
             "source_system": source_system,
             "source_instance": source_instance,
+            "entity_family": entity_family,
             "idempotency_key": idempotency_key,
         },
     )
@@ -296,6 +301,7 @@ async def create_batch(
     window_started_at: datetime | None,
     window_ended_at: datetime | None,
     items_received: int,
+    entity_family: str = "legacy",
 ) -> BatchRow:
     """INSERT a new ``status='accepted'`` row. This is the FIRST write in
     the accept sequence (master-spec CC22: idempotency row -> payload row ->
@@ -316,6 +322,7 @@ async def create_batch(
         "payload_hash": payload_hash,
         "source_system": source_system,
         "source_instance": source_instance,
+        "entity_family": entity_family,
         "producer": producer,
         "producer_version": producer_version,
         "schema_version": schema_version,
@@ -346,7 +353,7 @@ async def create_batch(
         f"""
         INSERT INTO {_BATCHES_TABLE} (
             ingestion_id, org_id, idempotency_key, payload_hash, source_system,
-            source_instance, producer, producer_version, schema_version,
+            source_instance, entity_family, producer, producer_version, schema_version,
             window_started_at, window_ended_at, status, attempts,
             items_received, items_accepted, items_rejected, record_counts,
             error_summary, created_at, updated_at, completed_at,
@@ -354,7 +361,7 @@ async def create_batch(
             recompute_completed_at, recompute_error
         ) VALUES (
             :ingestion_id, :org_id, :idempotency_key, :payload_hash, :source_system,
-            :source_instance, :producer, :producer_version, :schema_version,
+            :source_instance, :entity_family, :producer, :producer_version, :schema_version,
             :window_started_at, :window_ended_at, :status, :attempts,
             :items_received, :items_accepted, :items_rejected, :record_counts,
             :error_summary, :created_at, :updated_at, :completed_at,
@@ -381,6 +388,7 @@ async def create_batch(
         payload_hash=payload_hash,
         source_system=source_system,
         source_instance=source_instance,
+        entity_family=entity_family,
         producer=producer,
         producer_version=producer_version,
         schema_version=schema_version,

--- a/src/dev_health_ops/backfill/cli.py
+++ b/src/dev_health_ops/backfill/cli.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import asyncio
 import logging
 from datetime import timedelta
 
@@ -12,6 +13,7 @@ from dev_health_ops.utils.cli import (
     validate_sink,
 )
 
+from .operational_clickhouse import run_canonical_operational_backfill
 from .runner import run_backfill_for_config
 
 logger = logging.getLogger(__name__)
@@ -34,6 +36,27 @@ def register_backfill_commands(subparsers: argparse._SubParsersAction) -> None:
     add_date_range_args(run_parser)
     add_sink_arg(run_parser)
     run_parser.set_defaults(func=_cmd_backfill_run)
+
+    operational_parser = backfill_subparsers.add_parser(
+        "operational",
+        help="Migrate legacy incident producers into canonical operational tables.",
+    )
+    operational_parser.add_argument("--org", required=True, help="Organization id")
+    operational_parser.add_argument(
+        "--github-provider-instance-id", default="github.com", help="GitHub instance"
+    )
+    operational_parser.add_argument(
+        "--gitlab-provider-instance-id",
+        default="https://gitlab.com",
+        help="GitLab instance",
+    )
+    operational_parser.add_argument(
+        "--atlassian-provider-instance-id",
+        default="atlassian-ops",
+        help="Atlassian Ops instance",
+    )
+    add_sink_arg(operational_parser)
+    operational_parser.set_defaults(func=_cmd_backfill_operational)
 
 
 def _cmd_backfill_run(ns: argparse.Namespace) -> int:
@@ -64,4 +87,28 @@ def _cmd_backfill_run(ns: argparse.Namespace) -> int:
         return 0
     except Exception as exc:
         logger.error("Backfill failed: %s", exc)
+        return 1
+
+
+def _cmd_backfill_operational(ns: argparse.Namespace) -> int:
+    try:
+        validate_sink(ns)
+        result = asyncio.run(
+            run_canonical_operational_backfill(
+                clickhouse_uri=resolve_sink_uri(ns),
+                org_id=ns.org,
+                github_provider_instance_id=ns.github_provider_instance_id,
+                gitlab_provider_instance_id=ns.gitlab_provider_instance_id,
+                atlassian_provider_instance_id=ns.atlassian_provider_instance_id,
+            )
+        )
+        print(
+            "Migrated canonical operational rows: "
+            f"services={result.services}, incidents={result.incidents}, "
+            f"alerts={result.alerts}, schedules={result.schedules}, "
+            f"service_repository_mappings={result.service_repository_mappings}"
+        )
+        return 0
+    except Exception as exc:
+        logger.error("Canonical operational backfill failed: %s", exc)
         return 1

--- a/src/dev_health_ops/backfill/cli.py
+++ b/src/dev_health_ops/backfill/cli.py
@@ -43,12 +43,12 @@ def register_backfill_commands(subparsers: argparse._SubParsersAction) -> None:
     )
     operational_parser.add_argument("--org", required=True, help="Organization id")
     operational_parser.add_argument(
-        "--github-provider-instance-id", default="github.com", help="GitHub instance"
+        "--github-provider-instance-id",
+        help="Explicit GitHub instance override for legacy rows without a persisted host",
     )
     operational_parser.add_argument(
         "--gitlab-provider-instance-id",
-        default="https://gitlab.com",
-        help="GitLab instance",
+        help="Explicit GitLab instance override for legacy rows without a persisted host",
     )
     operational_parser.add_argument(
         "--atlassian-provider-instance-id",

--- a/src/dev_health_ops/backfill/operational.py
+++ b/src/dev_health_ops/backfill/operational.py
@@ -1,0 +1,59 @@
+"""Pure mappings for migrating legacy incident rows into canonical operations."""
+
+from __future__ import annotations
+
+from collections import defaultdict
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from dev_health_ops.models.operational import OperationalBatch
+from dev_health_ops.providers.operational_migration import (
+    IssueIncidentSource,
+    map_issue_incidents,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class LegacyIncidentRepositoryRow:
+    """A legacy incident row enriched with its source repository identity."""
+
+    org_id: str
+    repo_id: UUID
+    repo_full_name: str
+    provider: str
+    provider_instance_id: str
+    incident_id: str
+    status: str | None
+    started_at: datetime
+    resolved_at: datetime | None
+    source_version_at: datetime
+
+
+def map_legacy_issue_incident_batches(
+    rows: Iterable[LegacyIncidentRepositoryRow],
+) -> tuple[OperationalBatch, ...]:
+    """Group repository-enriched legacy incident rows into canonical batches."""
+    grouped: dict[tuple[str, str, str], list[IssueIncidentSource]] = defaultdict(list)
+    for row in rows:
+        grouped[(row.org_id, row.provider, row.provider_instance_id)].append(
+            IssueIncidentSource(
+                org_id=row.org_id,
+                provider=row.provider,
+                provider_instance_id=row.provider_instance_id,
+                repo_id=row.repo_id,
+                repo_full_name=row.repo_full_name,
+                external_id=row.incident_id,
+                issue_number=None,
+                source_url=None,
+                labels=(),
+                raw_status=row.status,
+                title="",
+                description=None,
+                created_at=row.started_at,
+                resolved_at=row.resolved_at,
+                source_version_at=row.source_version_at,
+            )
+        )
+    return tuple(map_issue_incidents(sources) for sources in grouped.values())

--- a/src/dev_health_ops/backfill/operational.py
+++ b/src/dev_health_ops/backfill/operational.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections import defaultdict
 from collections.abc import Iterable
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 from uuid import UUID
 
 from dev_health_ops.models.operational import OperationalBatch
@@ -53,7 +53,7 @@ def map_legacy_issue_incident_batches(
                 description=None,
                 created_at=row.started_at,
                 resolved_at=row.resolved_at,
-                source_version_at=row.source_version_at,
+                source_version_at=row.source_version_at - timedelta(seconds=1),
             )
         )
     return tuple(map_issue_incidents(sources) for sources in grouped.values())

--- a/src/dev_health_ops/backfill/operational_clickhouse.py
+++ b/src/dev_health_ops/backfill/operational_clickhouse.py
@@ -178,24 +178,32 @@ def _recover_provider_instance_id(
     )
     for candidate in candidates:
         if candidate:
-            return normalized_operational_provider_instance(provider, candidate)
+            normalized = normalized_operational_provider_instance(provider, candidate)
+            if normalized is not None:
+                return normalized
     return None
 
 
 def _repo_settings(value: object) -> dict[str, str]:
     if isinstance(value, dict):
-        return {str(key): str(item) for key, item in value.items()}
+        return {
+            str(key): item.strip()
+            for key, item in value.items()
+            if isinstance(item, str) and item.strip()
+        }
     if not isinstance(value, str) or not value:
         return {}
     try:
         parsed = json.loads(value)
     except json.JSONDecodeError:
         return {}
-    return (
-        {str(key): str(item) for key, item in parsed.items()}
-        if isinstance(parsed, dict)
-        else {}
-    )
+    if not isinstance(parsed, dict):
+        return {}
+    return {
+        str(key): item.strip()
+        for key, item in parsed.items()
+        if isinstance(item, str) and item.strip()
+    }
 
 
 async def _load_atlassian_ops_batch(

--- a/src/dev_health_ops/backfill/operational_clickhouse.py
+++ b/src/dev_health_ops/backfill/operational_clickhouse.py
@@ -4,7 +4,8 @@ from __future__ import annotations
 
 import asyncio
 import json
-from dataclasses import dataclass
+import logging
+from dataclasses import dataclass, replace
 from datetime import datetime
 from uuid import UUID
 
@@ -16,6 +17,10 @@ from dev_health_ops.models.atlassian_ops import (
     AtlassianOpsAlert,
     AtlassianOpsIncident,
     AtlassianOpsSchedule,
+)
+from dev_health_ops.models.operational import OperationalBatch
+from dev_health_ops.models.operational_identity import (
+    normalized_operational_provider_instance,
 )
 from dev_health_ops.providers.operational_migration import (
     AtlassianOpsRows,
@@ -41,8 +46,8 @@ async def run_canonical_operational_backfill(
     *,
     clickhouse_uri: str,
     org_id: str,
-    github_provider_instance_id: str = "github.com",
-    gitlab_provider_instance_id: str = "https://gitlab.com",
+    github_provider_instance_id: str | None = None,
+    gitlab_provider_instance_id: str | None = None,
     atlassian_provider_instance_id: str = "atlassian-ops",
 ) -> OperationalBackfillResult:
     """Join legacy rows and persist their deterministic canonical replacements."""
@@ -54,7 +59,9 @@ async def run_canonical_operational_backfill(
             github_provider_instance_id=github_provider_instance_id,
             gitlab_provider_instance_id=gitlab_provider_instance_id,
         )
-        issue_batches = map_legacy_issue_incident_batches(legacy_rows)
+        issue_batches = await _without_existing_incidents(
+            store, map_legacy_issue_incident_batches(legacy_rows)
+        )
         atlassian_batch = await _load_atlassian_ops_batch(
             store,
             org_id=org_id,
@@ -74,12 +81,35 @@ async def run_canonical_operational_backfill(
     )
 
 
+async def _without_existing_incidents(
+    store: ClickHouseStore, batches: tuple[OperationalBatch, ...]
+) -> tuple[OperationalBatch, ...]:
+    assert store.client is not None
+    result = await asyncio.to_thread(
+        store.client.query,
+        "SELECT id FROM operational_incidents FINAL WHERE org_id = {org_id:String}",
+        parameters={"org_id": store.org_id},
+    )
+    existing_ids = {str(row[0]) for row in result.result_rows}
+    return tuple(
+        replace(
+            batch,
+            incidents=tuple(
+                incident
+                for incident in batch.incidents
+                if incident.id not in existing_ids
+            ),
+        )
+        for batch in batches
+    )
+
+
 async def _load_legacy_incident_repository_rows(
     store: ClickHouseStore,
     *,
     org_id: str,
-    github_provider_instance_id: str,
-    gitlab_provider_instance_id: str,
+    github_provider_instance_id: str | None,
+    gitlab_provider_instance_id: str | None,
 ) -> tuple[LegacyIncidentRepositoryRow, ...]:
     assert store.client is not None
     result = await asyncio.to_thread(
@@ -88,8 +118,8 @@ async def _load_legacy_incident_repository_rows(
         SELECT
             i.repo_id, i.incident_id, i.status, i.started_at, i.resolved_at,
             r.repo, r.provider, r.settings
-        FROM incidents FINAL AS i
-        INNER JOIN repos FINAL AS r ON i.repo_id = r.id
+        FROM incidents AS i FINAL
+        INNER JOIN repos AS r FINAL ON i.repo_id = r.id
         WHERE i.org_id = {org_id:String}
           AND r.org_id = {org_id:String}
           AND r.provider IN ('github', 'gitlab')
@@ -100,14 +130,20 @@ async def _load_legacy_incident_repository_rows(
     for row in result.result_rows:
         provider = str(row[6])
         settings = _repo_settings(row[7])
-        provider_instance_id = str(
-            settings.get(f"{provider}_instance_url")
-            or (
-                github_provider_instance_id
-                if provider == "github"
-                else gitlab_provider_instance_id
-            )
+        provider_instance_id = _recover_provider_instance_id(
+            provider,
+            settings,
+            github_provider_instance_id
+            if provider == "github"
+            else gitlab_provider_instance_id,
         )
+        if provider_instance_id is None:
+            logging.warning(
+                "Skipping operational incident backfill without recoverable %s host for repo %s",
+                provider,
+                row[5],
+            )
+            continue
         started_at = row[3]
         if not isinstance(started_at, datetime):
             continue
@@ -128,6 +164,22 @@ async def _load_legacy_incident_repository_rows(
             )
         )
     return tuple(rows)
+
+
+def _recover_provider_instance_id(
+    provider: str, settings: dict[str, str], configured_instance: str | None
+) -> str | None:
+    candidates = (
+        settings.get(f"{provider}_instance_url"),
+        settings.get("html_url"),
+        settings.get("api_url"),
+        settings.get("url"),
+        configured_instance,
+    )
+    for candidate in candidates:
+        if candidate:
+            return normalized_operational_provider_instance(provider, candidate)
+    return None
 
 
 def _repo_settings(value: object) -> dict[str, str]:
@@ -156,20 +208,20 @@ async def _load_atlassian_ops_batch(
     incidents_result = await asyncio.to_thread(
         store.client.query,
         "SELECT id, url, summary, description, status, severity, created_at, "
-        "provider_id, last_synced FROM atlassian_ops_incidents "
+        "provider_id, last_synced FROM atlassian_ops_incidents FINAL "
         "WHERE org_id = {org_id:String}",
         parameters={"org_id": org_id},
     )
     alerts_result = await asyncio.to_thread(
         store.client.query,
         "SELECT id, status, priority, created_at, acknowledged_at, snoozed_at, "
-        "closed_at, last_synced FROM atlassian_ops_alerts "
+        "closed_at, last_synced FROM atlassian_ops_alerts FINAL "
         "WHERE org_id = {org_id:String}",
         parameters={"org_id": org_id},
     )
     schedules_result = await asyncio.to_thread(
         store.client.query,
-        "SELECT id, name, timezone, last_synced FROM atlassian_ops_schedules "
+        "SELECT id, name, timezone, last_synced FROM atlassian_ops_schedules FINAL "
         "WHERE org_id = {org_id:String}",
         parameters={"org_id": org_id},
     )

--- a/src/dev_health_ops/backfill/operational_clickhouse.py
+++ b/src/dev_health_ops/backfill/operational_clickhouse.py
@@ -1,0 +1,201 @@
+"""ClickHouse reader and writer for canonical operational migration backfills."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+from uuid import UUID
+
+from dev_health_ops.backfill.operational import (
+    LegacyIncidentRepositoryRow,
+    map_legacy_issue_incident_batches,
+)
+from dev_health_ops.models.atlassian_ops import (
+    AtlassianOpsAlert,
+    AtlassianOpsIncident,
+    AtlassianOpsSchedule,
+)
+from dev_health_ops.providers.operational_migration import (
+    AtlassianOpsRows,
+    AtlassianOpsSource,
+    map_atlassian_ops_batch,
+    write_operational_batch,
+)
+from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalBackfillResult:
+    """Counts written by one canonical operational migration invocation."""
+
+    services: int
+    incidents: int
+    alerts: int
+    schedules: int
+    service_repository_mappings: int
+
+
+async def run_canonical_operational_backfill(
+    *,
+    clickhouse_uri: str,
+    org_id: str,
+    github_provider_instance_id: str = "github.com",
+    gitlab_provider_instance_id: str = "https://gitlab.com",
+    atlassian_provider_instance_id: str = "atlassian-ops",
+) -> OperationalBackfillResult:
+    """Join legacy rows and persist their deterministic canonical replacements."""
+    async with ClickHouseStore(clickhouse_uri) as store:
+        store.org_id = org_id
+        legacy_rows = await _load_legacy_incident_repository_rows(
+            store,
+            org_id=org_id,
+            github_provider_instance_id=github_provider_instance_id,
+            gitlab_provider_instance_id=gitlab_provider_instance_id,
+        )
+        issue_batches = map_legacy_issue_incident_batches(legacy_rows)
+        atlassian_batch = await _load_atlassian_ops_batch(
+            store,
+            org_id=org_id,
+            provider_instance_id=atlassian_provider_instance_id,
+        )
+        all_batches = (*issue_batches, atlassian_batch)
+        for batch in all_batches:
+            await write_operational_batch(store, batch)
+    return OperationalBackfillResult(
+        services=sum(len(batch.services) for batch in all_batches),
+        incidents=sum(len(batch.incidents) for batch in all_batches),
+        alerts=sum(len(batch.alerts) for batch in all_batches),
+        schedules=sum(len(batch.on_call_schedules) for batch in all_batches),
+        service_repository_mappings=sum(
+            len(batch.service_repository_mappings) for batch in all_batches
+        ),
+    )
+
+
+async def _load_legacy_incident_repository_rows(
+    store: ClickHouseStore,
+    *,
+    org_id: str,
+    github_provider_instance_id: str,
+    gitlab_provider_instance_id: str,
+) -> tuple[LegacyIncidentRepositoryRow, ...]:
+    assert store.client is not None
+    result = await asyncio.to_thread(
+        store.client.query,
+        """
+        SELECT
+            i.repo_id, i.incident_id, i.status, i.started_at, i.resolved_at,
+            i.last_synced, r.repo, r.provider
+        FROM incidents AS i
+        INNER JOIN repos AS r ON i.repo_id = r.id
+        WHERE i.org_id = {org_id:String}
+          AND r.org_id = {org_id:String}
+          AND r.provider IN ('github', 'gitlab')
+        """,
+        parameters={"org_id": org_id},
+    )
+    rows: list[LegacyIncidentRepositoryRow] = []
+    for row in result.result_rows:
+        provider = str(row[7])
+        provider_instance_id = (
+            github_provider_instance_id
+            if provider == "github"
+            else gitlab_provider_instance_id
+        )
+        started_at = row[3]
+        source_version_at = row[5]
+        if not isinstance(started_at, datetime):
+            continue
+        rows.append(
+            LegacyIncidentRepositoryRow(
+                org_id=org_id,
+                repo_id=UUID(str(row[0])),
+                repo_full_name=str(row[6]),
+                provider=provider,
+                provider_instance_id=provider_instance_id,
+                incident_id=str(row[1]),
+                status=str(row[2]) if row[2] is not None else None,
+                started_at=started_at,
+                resolved_at=row[4] if isinstance(row[4], datetime) else None,
+                source_version_at=(
+                    source_version_at
+                    if isinstance(source_version_at, datetime)
+                    else started_at
+                ),
+            )
+        )
+    return tuple(rows)
+
+
+async def _load_atlassian_ops_batch(
+    store: ClickHouseStore,
+    *,
+    org_id: str,
+    provider_instance_id: str,
+):
+    assert store.client is not None
+    incidents_result = await asyncio.to_thread(
+        store.client.query,
+        "SELECT id, url, summary, description, status, severity, created_at, "
+        "provider_id, last_synced FROM atlassian_ops_incidents "
+        "WHERE org_id = {org_id:String}",
+        parameters={"org_id": org_id},
+    )
+    alerts_result = await asyncio.to_thread(
+        store.client.query,
+        "SELECT id, status, priority, created_at, acknowledged_at, snoozed_at, "
+        "closed_at, last_synced FROM atlassian_ops_alerts "
+        "WHERE org_id = {org_id:String}",
+        parameters={"org_id": org_id},
+    )
+    schedules_result = await asyncio.to_thread(
+        store.client.query,
+        "SELECT id, name, timezone, last_synced FROM atlassian_ops_schedules "
+        "WHERE org_id = {org_id:String}",
+        parameters={"org_id": org_id},
+    )
+    incidents = tuple(
+        AtlassianOpsIncident(
+            id=str(row[0]),
+            url=str(row[1]) if row[1] is not None else None,
+            summary=str(row[2]),
+            description=str(row[3]) if row[3] is not None else None,
+            status=str(row[4]),
+            severity=str(row[5]),
+            created_at=row[6],
+            provider_id=str(row[7]) if row[7] is not None else None,
+            last_synced=row[8],
+        )
+        for row in incidents_result.result_rows
+    )
+    alerts = tuple(
+        AtlassianOpsAlert(
+            id=str(row[0]),
+            status=str(row[1]),
+            priority=str(row[2]),
+            created_at=row[3],
+            acknowledged_at=row[4],
+            snoozed_at=row[5],
+            closed_at=row[6],
+            last_synced=row[7],
+        )
+        for row in alerts_result.result_rows
+    )
+    schedules = tuple(
+        AtlassianOpsSchedule(
+            id=str(row[0]), name=str(row[1]), timezone=row[2], last_synced=row[3]
+        )
+        for row in schedules_result.result_rows
+    )
+    return map_atlassian_ops_batch(
+        AtlassianOpsSource(
+            org_id=org_id,
+            provider_instance_id=provider_instance_id,
+            rows=AtlassianOpsRows(
+                incidents=incidents,
+                alerts=alerts,
+                schedules=schedules,
+            ),
+        )
+    )

--- a/src/dev_health_ops/backfill/operational_clickhouse.py
+++ b/src/dev_health_ops/backfill/operational_clickhouse.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from dataclasses import dataclass
 from datetime import datetime
 from uuid import UUID
@@ -86,9 +87,9 @@ async def _load_legacy_incident_repository_rows(
         """
         SELECT
             i.repo_id, i.incident_id, i.status, i.started_at, i.resolved_at,
-            i.last_synced, r.repo, r.provider
-        FROM incidents AS i
-        INNER JOIN repos AS r ON i.repo_id = r.id
+            r.repo, r.provider, r.settings
+        FROM incidents FINAL AS i
+        INNER JOIN repos FINAL AS r ON i.repo_id = r.id
         WHERE i.org_id = {org_id:String}
           AND r.org_id = {org_id:String}
           AND r.provider IN ('github', 'gitlab')
@@ -97,21 +98,24 @@ async def _load_legacy_incident_repository_rows(
     )
     rows: list[LegacyIncidentRepositoryRow] = []
     for row in result.result_rows:
-        provider = str(row[7])
-        provider_instance_id = (
-            github_provider_instance_id
-            if provider == "github"
-            else gitlab_provider_instance_id
+        provider = str(row[6])
+        settings = _repo_settings(row[7])
+        provider_instance_id = str(
+            settings.get(f"{provider}_instance_url")
+            or (
+                github_provider_instance_id
+                if provider == "github"
+                else gitlab_provider_instance_id
+            )
         )
         started_at = row[3]
-        source_version_at = row[5]
         if not isinstance(started_at, datetime):
             continue
         rows.append(
             LegacyIncidentRepositoryRow(
                 org_id=org_id,
                 repo_id=UUID(str(row[0])),
-                repo_full_name=str(row[6]),
+                repo_full_name=str(row[5]),
                 provider=provider,
                 provider_instance_id=provider_instance_id,
                 incident_id=str(row[1]),
@@ -119,13 +123,27 @@ async def _load_legacy_incident_repository_rows(
                 started_at=started_at,
                 resolved_at=row[4] if isinstance(row[4], datetime) else None,
                 source_version_at=(
-                    source_version_at
-                    if isinstance(source_version_at, datetime)
-                    else started_at
+                    row[4] if isinstance(row[4], datetime) else started_at
                 ),
             )
         )
     return tuple(rows)
+
+
+def _repo_settings(value: object) -> dict[str, str]:
+    if isinstance(value, dict):
+        return {str(key): str(item) for key, item in value.items()}
+    if not isinstance(value, str) or not value:
+        return {}
+    try:
+        parsed = json.loads(value)
+    except json.JSONDecodeError:
+        return {}
+    return (
+        {str(key): str(item) for key, item in parsed.items()}
+        if isinstance(parsed, dict)
+        else {}
+    )
 
 
 async def _load_atlassian_ops_batch(

--- a/src/dev_health_ops/cli.py
+++ b/src/dev_health_ops/cli.py
@@ -510,6 +510,7 @@ _COMMAND_REQUIREMENTS: dict[tuple[str, ...], frozenset[str]] = {
     ("service-credentials", "rotate"): frozenset({_REQ_POSTGRES}),
     ("service-credentials", "revoke"): frozenset({_REQ_POSTGRES}),
     ("backfill", "run"): frozenset({_REQ_POSTGRES}),
+    ("backfill", "operational"): frozenset({_REQ_CLICKHOUSE}),
     ("maintenance", "scrub-error-text"): frozenset({_REQ_POSTGRES}),
     # --- migrations that connect to a live database ---
     ("migrate", "clickhouse", "upgrade"): frozenset({_REQ_CLICKHOUSE}),

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -67,6 +67,16 @@ PROVIDER_CREDENTIAL_TYPES: dict[str, type[ProviderCredentials]] = {
 }
 
 
+def environment_base_url(provider: str) -> str | None:
+    """Return the provider base URL declared in the environment, if any."""
+    environment_variable = PROVIDER_ENV_VARS.get(provider.casefold(), {}).get(
+        "base_url"
+    )
+    if environment_variable is None:
+        return None
+    return os.getenv(environment_variable)
+
+
 class CredentialResolutionError(Exception):
     def __init__(
         self,

--- a/src/dev_health_ops/external_ingest/normalize.py
+++ b/src/dev_health_ops/external_ingest/normalize.py
@@ -33,15 +33,44 @@ from __future__ import annotations
 import logging
 import uuid
 from dataclasses import dataclass, field
+from typing import Any
 
 from pydantic import BaseModel, ValidationError
 
 from dev_health_ops.api.external_ingest.schemas import (
     RECORD_KIND_MODELS,
+    EscalationPolicyV1,
+    IncidentNoteV1,
+    IncidentResponderV1,
+    IncidentTimelineEventV1,
+    OnCallAssignmentV1,
+    OnCallScheduleV1,
+    OperationalAlertV1,
+    OperationalIncidentV1,
+    OperationalRecordV1,
+    OperationalServiceV1,
+    OperationalTeamV1,
+    OperationalUserV1,
     RecordEnvelope,
+    ServiceRepositoryMappingV1,
 )
 from dev_health_ops.external_ingest.types import NormalizedBatch
 from dev_health_ops.external_ingest.validate import validate_records
+from dev_health_ops.models.operational import (
+    EscalationPolicy,
+    IncidentNote,
+    IncidentResponder,
+    IncidentTimelineEvent,
+    OnCallAssignment,
+    OnCallSchedule,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+    ServiceRepositoryMapping,
+    canonical_operational_id,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -52,15 +81,39 @@ _WORK_ITEM_FAMILY_KINDS = frozenset(
     {"work_item.v1", "work_item_transition.v1", "work_item_dependency.v1"}
 )
 _ORG_SCOPED_KINDS = frozenset({"team.v1", "identity.v1"})
+_OPERATIONAL_KINDS = frozenset(
+    {
+        "operational_service.v1",
+        "operational_incident.v1",
+        "operational_alert.v1",
+        "incident_timeline_event.v1",
+        "incident_note.v1",
+        "incident_responder.v1",
+        "escalation_policy.v1",
+        "on_call_schedule.v1",
+        "on_call_assignment.v1",
+        "operational_team.v1",
+        "operational_user.v1",
+        "service_repository_mapping.v1",
+    }
+)
 
 #: Master-spec CC6 kind x system matrix. ``custom`` excludes the work_item
 #: family in v1 (would widen the ``WorkItem.provider`` Literal vocabulary).
 ALLOWED_KINDS_BY_SYSTEM: dict[str, frozenset[str]] = {
-    "github": _GIT_FAMILY_KINDS | _WORK_ITEM_FAMILY_KINDS | _ORG_SCOPED_KINDS,
-    "gitlab": _GIT_FAMILY_KINDS | _WORK_ITEM_FAMILY_KINDS | _ORG_SCOPED_KINDS,
+    "github": _GIT_FAMILY_KINDS
+    | _WORK_ITEM_FAMILY_KINDS
+    | _ORG_SCOPED_KINDS
+    | _OPERATIONAL_KINDS,
+    "gitlab": _GIT_FAMILY_KINDS
+    | _WORK_ITEM_FAMILY_KINDS
+    | _ORG_SCOPED_KINDS
+    | _OPERATIONAL_KINDS,
     "jira": _WORK_ITEM_FAMILY_KINDS | _ORG_SCOPED_KINDS,
     "linear": _WORK_ITEM_FAMILY_KINDS | _ORG_SCOPED_KINDS,
-    "custom": _GIT_FAMILY_KINDS | _ORG_SCOPED_KINDS,
+    "custom": _GIT_FAMILY_KINDS | _ORG_SCOPED_KINDS | _OPERATIONAL_KINDS,
+    "pagerduty": _OPERATIONAL_KINDS | _ORG_SCOPED_KINDS,
+    "atlassian": _OPERATIONAL_KINDS | _ORG_SCOPED_KINDS,
 }
 
 #: CC6: systems whose git-family records must reference the batch's own
@@ -84,6 +137,27 @@ _KIND_DISPATCH: dict[str, tuple[str, str, bool]] = {
         "work_item_dependencies",
         "work_item_dependency",
         False,
+    ),
+}
+
+_OPERATIONAL_KIND_DISPATCH: dict[str, tuple[str, str]] = {
+    "operational_service.v1": ("operational_services", "operational_service"),
+    "operational_incident.v1": ("operational_incidents", "operational_incident"),
+    "operational_alert.v1": ("operational_alerts", "operational_alert"),
+    "incident_timeline_event.v1": (
+        "incident_timeline_events",
+        "incident_timeline_event",
+    ),
+    "incident_note.v1": ("incident_notes", "incident_note"),
+    "incident_responder.v1": ("incident_responders", "incident_responder"),
+    "escalation_policy.v1": ("escalation_policies", "escalation_policy"),
+    "on_call_schedule.v1": ("on_call_schedules", "on_call_schedule"),
+    "on_call_assignment.v1": ("on_call_assignments", "on_call_assignment"),
+    "operational_team.v1": ("operational_teams", "operational_team"),
+    "operational_user.v1": ("operational_users", "operational_user"),
+    "service_repository_mapping.v1": (
+        "service_repository_mappings",
+        "service_repository_mapping",
     ),
 }
 
@@ -132,6 +206,218 @@ def _git_family_repo_identifier(kind: str, payload_model: BaseModel) -> str:
     if kind == "repository.v1":
         return str(getattr(payload_model, "external_id", "") or "")
     return str(getattr(payload_model, "repository_external_id", "") or "")
+
+
+def _operational_reference_id(
+    batch: NormalizedBatch, entity_family: str, external_id: str | None
+) -> str | None:
+    if external_id is None:
+        return None
+    return canonical_operational_id(
+        batch.org_id,
+        batch.source_system,
+        batch.source_instance,
+        entity_family,
+        external_id,
+    )
+
+
+def _operational_common(
+    payload: OperationalRecordV1, batch: NormalizedBatch, kind: str
+) -> dict[str, Any]:
+    return {
+        "org_id": batch.org_id,
+        "provider": batch.source_system,
+        "provider_instance_id": batch.source_instance,
+        "source_entity_type": f"external_push.{kind.rsplit('.', 1)[0]}",
+        "external_id": payload.external_id,
+        "source_version_at": payload.source_version_at,
+        "source_id": batch.source_id,
+        "source_url": payload.source_url,
+        "source_event_at": payload.source_event_at,
+        "source_event_id": payload.source_event_id,
+        "raw_status": payload.raw_status,
+        "raw_severity": payload.raw_severity,
+        "raw_priority": payload.raw_priority,
+        "normalized_status": payload.normalized_status,
+        "normalized_severity": payload.normalized_severity,
+        "normalized_priority": payload.normalized_priority,
+        "relationship_provenance": payload.relationship_provenance,
+        "relationship_confidence": payload.relationship_confidence,
+    }
+
+
+def _normalize_operational_record(
+    kind: str, payload: OperationalRecordV1, batch: NormalizedBatch
+) -> object:
+    common = _operational_common(payload, batch, kind)
+    match payload:
+        case OperationalServiceV1():
+            return OperationalService(
+                **common,
+                name=payload.name,
+                description=payload.description,
+                service_type=payload.service_type,
+                owning_team_id=_operational_reference_id(
+                    batch, "operational_team", payload.owning_team_external_id
+                ),
+                escalation_policy_id=_operational_reference_id(
+                    batch,
+                    "operational_escalation_policy",
+                    payload.escalation_policy_external_id,
+                ),
+                is_deleted=payload.is_deleted,
+                deleted_at=payload.deleted_at,
+            )
+        case OperationalIncidentV1():
+            return OperationalIncident(
+                **common,
+                service_id=_operational_reference_id(
+                    batch, "operational_service", payload.service_external_id
+                ),
+                service_external_id=payload.service_external_id,
+                escalation_policy_id=_operational_reference_id(
+                    batch,
+                    "operational_escalation_policy",
+                    payload.escalation_policy_external_id,
+                ),
+                title=payload.title,
+                description=payload.description,
+                started_at=payload.started_at,
+                resolved_at=payload.resolved_at,
+                is_deleted=payload.is_deleted,
+                deleted_at=payload.deleted_at,
+            )
+        case OperationalAlertV1():
+            return OperationalAlert(
+                **common,
+                service_id=_operational_reference_id(
+                    batch, "operational_service", payload.service_external_id
+                ),
+                incident_id=_operational_reference_id(
+                    batch, "operational_incident", payload.incident_external_id
+                ),
+                title=payload.title,
+                description=payload.description,
+                triggered_at=payload.triggered_at,
+                acknowledged_at=payload.acknowledged_at,
+                resolved_at=payload.resolved_at,
+                is_deleted=payload.is_deleted,
+                deleted_at=payload.deleted_at,
+            )
+        case IncidentTimelineEventV1():
+            return IncidentTimelineEvent(
+                **common,
+                incident_id=_operational_reference_id(
+                    batch, "operational_incident", payload.incident_external_id
+                )
+                or "",
+                event_type=payload.event_type,
+                body=payload.body,
+                actor_type=payload.actor_type,
+                actor_id=_operational_reference_id(
+                    batch, "operational_user", payload.actor_external_id
+                ),
+                occurred_at=payload.occurred_at,
+            )
+        case IncidentNoteV1():
+            return IncidentNote(
+                **common,
+                incident_id=_operational_reference_id(
+                    batch, "operational_incident", payload.incident_external_id
+                )
+                or "",
+                body=payload.body,
+                author_user_id=_operational_reference_id(
+                    batch, "operational_user", payload.author_user_external_id
+                ),
+                created_at=payload.created_at,
+            )
+        case IncidentResponderV1():
+            return IncidentResponder(
+                **common,
+                incident_id=_operational_reference_id(
+                    batch, "operational_incident", payload.incident_external_id
+                )
+                or "",
+                user_id=_operational_reference_id(
+                    batch, "operational_user", payload.user_external_id
+                ),
+                responder_name=payload.responder_name,
+                role=payload.role,
+                responder_assignment_id=payload.responder_assignment_id,
+                requested_at=payload.requested_at,
+                assigned_at=payload.assigned_at,
+                acknowledged_at=payload.acknowledged_at,
+                completed_at=payload.completed_at,
+            )
+        case OnCallScheduleV1():
+            return OnCallSchedule(
+                **common,
+                name=payload.name,
+                description=payload.description,
+                timezone=payload.timezone,
+                is_deleted=payload.is_deleted,
+                deleted_at=payload.deleted_at,
+            )
+        case OperationalTeamV1():
+            return OperationalTeam(
+                **common,
+                name=payload.name,
+                description=payload.description,
+                is_deleted=payload.is_deleted,
+                deleted_at=payload.deleted_at,
+            )
+        case EscalationPolicyV1():
+            return EscalationPolicy(
+                **common,
+                name=payload.name,
+                description=payload.description,
+                is_deleted=payload.is_deleted,
+                deleted_at=payload.deleted_at,
+            )
+        case OnCallAssignmentV1():
+            return OnCallAssignment(
+                **common,
+                schedule_id=_operational_reference_id(
+                    batch, "operational_on_call_schedule", payload.schedule_external_id
+                ),
+                user_id=_operational_reference_id(
+                    batch, "operational_user", payload.user_external_id
+                ),
+                escalation_policy_id=_operational_reference_id(
+                    batch,
+                    "operational_escalation_policy",
+                    payload.escalation_policy_external_id,
+                ),
+                escalation_level=payload.escalation_level,
+                starts_at=payload.starts_at,
+                ends_at=payload.ends_at,
+            )
+        case OperationalUserV1():
+            return OperationalUser(
+                **common,
+                display_name=payload.display_name,
+                email=payload.email,
+                is_deleted=payload.is_deleted,
+                deleted_at=payload.deleted_at,
+            )
+        case ServiceRepositoryMappingV1():
+            return ServiceRepositoryMapping(
+                **common,
+                service_id=_operational_reference_id(
+                    batch, "operational_service", payload.service_external_id
+                )
+                or "",
+                repo_full_name=payload.repo_full_name,
+                repo_provider=payload.repo_provider,
+                mapping_kind=payload.mapping_kind,
+                rule_id=payload.rule_id,
+                valid_from=payload.valid_from,
+                valid_to=payload.valid_to,
+                is_active=payload.is_active,
+            )
+    raise AssertionError(f"unsupported operational payload {type(payload)!r}")
 
 
 def normalize_batch(
@@ -245,9 +531,18 @@ def normalize_batch(
                 )
                 continue
 
-        attr, index_key, as_dict = _KIND_DISPATCH[record.kind]
-        target: list = getattr(batch, attr)
-        target.append(payload_model.model_dump() if as_dict else payload_model)
+        operational_dispatch = _OPERATIONAL_KIND_DISPATCH.get(record.kind)
+        if operational_dispatch is not None:
+            assert isinstance(payload_model, OperationalRecordV1)
+            attr, index_key = operational_dispatch
+            target = getattr(batch, attr)
+            target.append(
+                _normalize_operational_record(record.kind, payload_model, batch)
+            )
+        else:
+            attr, index_key, as_dict = _KIND_DISPATCH[record.kind]
+            target = getattr(batch, attr)
+            target.append(payload_model.model_dump() if as_dict else payload_model)
         batch.record_index_by_kind.setdefault(index_key, []).append(index)
         result.record_counts[record.kind] = result.record_counts.get(record.kind, 0) + 1
 

--- a/src/dev_health_ops/external_ingest/normalize.py
+++ b/src/dev_health_ops/external_ingest/normalize.py
@@ -71,6 +71,7 @@ from dev_health_ops.models.operational import (
     ServiceRepositoryMapping,
     canonical_operational_id,
 )
+from dev_health_ops.models.operational_identity import operational_source_coordinates
 
 logger = logging.getLogger(__name__)
 
@@ -161,6 +162,36 @@ _OPERATIONAL_KIND_DISPATCH: dict[str, tuple[str, str]] = {
     ),
 }
 
+_OPERATIONAL_ENTITY_TYPES = {
+    "operational_service": OperationalService,
+    "operational_incident": OperationalIncident,
+    "operational_alert": OperationalAlert,
+    "operational_incident_timeline_event": IncidentTimelineEvent,
+    "operational_incident_note": IncidentNote,
+    "operational_incident_responder": IncidentResponder,
+    "operational_escalation_policy": EscalationPolicy,
+    "operational_on_call_schedule": OnCallSchedule,
+    "operational_on_call_assignment": OnCallAssignment,
+    "operational_team": OperationalTeam,
+    "operational_user": OperationalUser,
+    "operational_service_repository_mapping": ServiceRepositoryMapping,
+}
+
+_OPERATIONAL_KIND_ENTITY_TYPES = {
+    "operational_service.v1": OperationalService,
+    "operational_incident.v1": OperationalIncident,
+    "operational_alert.v1": OperationalAlert,
+    "incident_timeline_event.v1": IncidentTimelineEvent,
+    "incident_note.v1": IncidentNote,
+    "incident_responder.v1": IncidentResponder,
+    "escalation_policy.v1": EscalationPolicy,
+    "on_call_schedule.v1": OnCallSchedule,
+    "on_call_assignment.v1": OnCallAssignment,
+    "operational_team.v1": OperationalTeam,
+    "operational_user.v1": OperationalUser,
+    "service_repository_mapping.v1": ServiceRepositoryMapping,
+}
+
 
 @dataclass(frozen=True)
 class RecordRejection:
@@ -209,28 +240,52 @@ def _git_family_repo_identifier(kind: str, payload_model: BaseModel) -> str:
 
 
 def _operational_reference_id(
-    batch: NormalizedBatch, entity_family: str, external_id: str | None
+    batch: NormalizedBatch,
+    entity_family: str,
+    external_id: str | None,
 ) -> str | None:
     if external_id is None:
         return None
+    entity_type = _OPERATIONAL_ENTITY_TYPES[entity_family]
+    coordinates = operational_source_coordinates(
+        entity_type,
+        provider=batch.source_system,
+        provider_instance_id=batch.source_instance,
+        external_id=external_id,
+    )
     return canonical_operational_id(
         batch.org_id,
-        batch.source_system,
-        batch.source_instance,
-        entity_family,
-        external_id,
+        coordinates.provider,
+        coordinates.provider_instance_id,
+        coordinates.entity_family,
+        coordinates.external_id,
     )
 
 
 def _operational_common(
     payload: OperationalRecordV1, batch: NormalizedBatch, kind: str
 ) -> dict[str, Any]:
+    entity_type = _OPERATIONAL_KIND_ENTITY_TYPES[kind]
+    issue_repo = (
+        payload.service_external_id
+        if isinstance(payload, OperationalIncidentV1)
+        and batch.source_system in {"github", "gitlab"}
+        else None
+    )
+    coordinates = operational_source_coordinates(
+        entity_type,
+        provider=batch.source_system,
+        provider_instance_id=batch.source_instance,
+        external_id=payload.external_id,
+        repo_full_name=issue_repo,
+        issue_number=payload.source_event_id,
+    )
     return {
         "org_id": batch.org_id,
-        "provider": batch.source_system,
-        "provider_instance_id": batch.source_instance,
+        "provider": coordinates.provider,
+        "provider_instance_id": coordinates.provider_instance_id,
         "source_entity_type": f"external_push.{kind.rsplit('.', 1)[0]}",
-        "external_id": payload.external_id,
+        "external_id": coordinates.external_id,
         "source_version_at": payload.source_version_at,
         "source_id": batch.source_id,
         "source_url": payload.source_url,
@@ -530,6 +585,21 @@ def normalize_batch(
                     )
                 )
                 continue
+
+        if isinstance(payload_model, ServiceRepositoryMappingV1) and (
+            payload_model.repo_full_name is None or payload_model.repo_provider is None
+        ):
+            result.rejections.append(
+                RecordRejection(
+                    index=index,
+                    kind=record.kind,
+                    external_id=record.external_id,
+                    code="repository_identity_required",
+                    message="service_repository_mapping requires repoFullName and repoProvider",
+                    path=f"records[{index}].payload",
+                )
+            )
+            continue
 
         operational_dispatch = _OPERATIONAL_KIND_DISPATCH.get(record.kind)
         if operational_dispatch is not None:

--- a/src/dev_health_ops/external_ingest/ownership.py
+++ b/src/dev_health_ops/external_ingest/ownership.py
@@ -21,7 +21,9 @@ See docs/architecture/external-ingest-idempotency-ownership.md.
 from __future__ import annotations
 
 from collections.abc import Mapping
-from typing import Any, Literal
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any, Final, Literal
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -32,12 +34,44 @@ from dev_health_ops.api.services.configuration.integration_credentials import (
 from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
 from dev_health_ops.models.integrations import Integration, IntegrationSource
 from dev_health_ops.models.operational import OperationalIncident
-from dev_health_ops.models.operational_identity import operational_source_coordinates
+from dev_health_ops.models.operational_identity import (
+    normalized_operational_provider_instance,
+    operational_source_coordinates,
+)
 
 EffectiveMode = Literal["fullchaos_sync", "customer_push", "disabled", "unclaimed"]
 
+OWNERSHIP_RESOLUTION_UNAVAILABLE_MESSAGE: Final = (
+    "Ownership could not be determined because a linked managed credential is "
+    "unreadable or does not declare an instance host. Repair the managed "
+    "integration before enabling customer push."
+)
+
+
+class _CredentialHostState(StrEnum):
+    RESOLVED = "resolved"
+    UNREADABLE = "unreadable"
+    MISSING_BASE_URL = "missing_base_url"
+
+
+@dataclass(frozen=True, slots=True)
+class _CredentialHostResolution:
+    state: _CredentialHostState
+    base_url: str | None
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalOwnershipResolutionUnavailableError(Exception):
+    provider: str
+
+    def __str__(self) -> str:
+        return "Operational ownership resolution is unavailable"
+
+
 __all__ = [
     "EffectiveMode",
+    "OWNERSHIP_RESOLUTION_UNAVAILABLE_MESSAGE",
+    "OperationalOwnershipResolutionUnavailableError",
     "find_active_managed_owner",
     "find_matching_managed_sources",
     "linear_is_org_wide_placeholder",
@@ -125,29 +159,40 @@ def matches_instance(
     return False
 
 
-async def _credential_base_url(
+async def _credential_host_resolution(
     session: AsyncSession, *, org_id: str, system: str, integration: Integration
-) -> str | None:
+) -> _CredentialHostResolution:
+    """Resolve a linked credential host without conflating unreadable and absent hosts."""
     credential_id = integration.credential_id
     if credential_id is None:
-        return None
+        return _CredentialHostResolution(_CredentialHostState.UNREADABLE, None)
     credentials, credential = await IntegrationCredentialsService(
         session, org_id
     ).get_decrypted_credentials_by_id(str(credential_id))
     if credential is None or credential.provider.casefold() != system:
-        return None
+        return _CredentialHostResolution(_CredentialHostState.UNREADABLE, None)
+    if credentials is not None and not isinstance(credentials, Mapping):
+        return _CredentialHostResolution(_CredentialHostState.UNREADABLE, None)
+    credential_values: Mapping[str, Any] = credentials or {}
     credential_config = credential.config or {}
+    invalid_host = False
     for candidate in (
-        (credentials or {}).get(f"{system}_url"),
-        (credentials or {}).get("url"),
-        (credentials or {}).get("base_url"),
+        credential_values.get(f"{system}_url"),
+        credential_values.get("url"),
+        credential_values.get("base_url"),
         credential_config.get(f"{system}_url"),
         credential_config.get("url"),
         credential_config.get("base_url"),
     ):
         if isinstance(candidate, str) and candidate.strip():
-            return candidate
-    return None
+            if normalized_operational_provider_instance(system, candidate) is not None:
+                return _CredentialHostResolution(
+                    _CredentialHostState.RESOLVED, candidate
+                )
+            invalid_host = True
+    if credentials is None or invalid_host:
+        return _CredentialHostResolution(_CredentialHostState.UNREADABLE, None)
+    return _CredentialHostResolution(_CredentialHostState.MISSING_BASE_URL, None)
 
 
 async def find_matching_managed_sources(
@@ -181,7 +226,7 @@ async def find_matching_managed_sources(
             )
         )
     ).all()
-    credential_hosts: dict[str, str | None] = {}
+    credential_hosts: dict[str, _CredentialHostResolution] = {}
     matches: list[tuple[IntegrationSource, bool]] = []
     for source, integration in candidate_rows:
         credential_base_url: str | None = None
@@ -189,6 +234,7 @@ async def find_matching_managed_sources(
         configured_host = config.get(f"{system}_instance_url") or config.get(
             f"{system}_url"
         )
+        default_host = "github.com" if system == "github" else "gitlab.com"
         credential_id = integration.credential_id
         if (
             entity_family in {"operational", "operational_incident"}
@@ -198,10 +244,19 @@ async def find_matching_managed_sources(
         ):
             credential_key = str(credential_id)
             if credential_key not in credential_hosts:
-                credential_hosts[credential_key] = await _credential_base_url(
+                credential_hosts[credential_key] = await _credential_host_resolution(
                     session, org_id=org_id, system=system, integration=integration
                 )
-            credential_base_url = credential_hosts[credential_key]
+            credential_host = credential_hosts[credential_key]
+            credential_base_url = credential_host.base_url
+            if (
+                credential_host.state is not _CredentialHostState.RESOLVED
+                and _operational_host(system, instance)
+                != _operational_host(system, default_host)
+                and source.is_enabled
+                and integration.is_active
+            ):
+                raise OperationalOwnershipResolutionUnavailableError(system)
         if matches_instance(
             system,
             instance,

--- a/src/dev_health_ops/external_ingest/ownership.py
+++ b/src/dev_health_ops/external_ingest/ownership.py
@@ -106,9 +106,6 @@ async def find_matching_managed_sources(
     """
     if system == "custom":
         return []
-    if entity_family == "operational" and system in {"github", "gitlab"}:
-        return []
-
     candidate_rows = (
         await session.execute(
             select(IntegrationSource, Integration.is_active)

--- a/src/dev_health_ops/external_ingest/ownership.py
+++ b/src/dev_health_ops/external_ingest/ownership.py
@@ -86,7 +86,12 @@ def matches_instance(system: str, instance: str, source: IntegrationSource) -> b
 
 
 async def find_matching_managed_sources(
-    session: AsyncSession, *, org_id: str, system: str, instance: str
+    session: AsyncSession,
+    *,
+    org_id: str,
+    system: str,
+    instance: str,
+    entity_family: str = "legacy",
 ) -> list[tuple[IntegrationSource, bool]]:
     """All managed ``integration_sources`` rows matching (org, system, instance).
 
@@ -100,6 +105,8 @@ async def find_matching_managed_sources(
     indexed SQL predicate.
     """
     if system == "custom":
+        return []
+    if entity_family == "operational" and system in {"github", "gitlab"}:
         return []
 
     candidate_rows = (
@@ -120,7 +127,12 @@ async def find_matching_managed_sources(
 
 
 async def find_active_managed_owner(
-    session: AsyncSession, *, org_id: str, system: str, instance: str
+    session: AsyncSession,
+    *,
+    org_id: str,
+    system: str,
+    instance: str,
+    entity_family: str = "legacy",
 ) -> IntegrationSource | None:
     """The managed source that ACTIVELY owns this instance, if any.
 
@@ -129,7 +141,11 @@ async def find_active_managed_owner(
     left enabled under a since-deactivated integration no longer counts.
     """
     matches = await find_matching_managed_sources(
-        session, org_id=org_id, system=system, instance=instance
+        session,
+        org_id=org_id,
+        system=system,
+        instance=instance,
+        entity_family=entity_family,
     )
     return next(
         (
@@ -142,7 +158,12 @@ async def find_active_managed_owner(
 
 
 async def resolve_effective_mode(
-    session: AsyncSession, *, org_id: str, system: str, instance: str
+    session: AsyncSession,
+    *,
+    org_id: str,
+    system: str,
+    instance: str,
+    entity_family: str = "legacy",
 ) -> EffectiveMode:
     """Resolve the single active ingestion owner for (org, system, instance).
 
@@ -171,6 +192,7 @@ async def resolve_effective_mode(
                 IngestSource.org_id == org_id,
                 IngestSource.system == system,
                 IngestSource.instance == instance,
+                IngestSource.entity_family == entity_family,
             )
         )
     ).scalar_one_or_none()
@@ -181,14 +203,22 @@ async def resolve_effective_mode(
         if explicit.mode == IngestSourceMode.FULLCHAOS_SYNC.value:
             return "fullchaos_sync"
         owner = await find_active_managed_owner(
-            session, org_id=org_id, system=system, instance=instance
+            session,
+            org_id=org_id,
+            system=system,
+            instance=instance,
+            entity_family=entity_family,
         )
         if owner is not None:
             return "fullchaos_sync"
         return "customer_push"
 
     owner = await find_active_managed_owner(
-        session, org_id=org_id, system=system, instance=instance
+        session,
+        org_id=org_id,
+        system=system,
+        instance=instance,
+        entity_family=entity_family,
     )
     if owner is not None:
         return "fullchaos_sync"

--- a/src/dev_health_ops/external_ingest/ownership.py
+++ b/src/dev_health_ops/external_ingest/ownership.py
@@ -31,6 +31,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from dev_health_ops.api.services.configuration.integration_credentials import (
     IntegrationCredentialsService,
 )
+from dev_health_ops.credentials.resolver import environment_base_url
 from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
 from dev_health_ops.models.integrations import Integration, IntegrationSource
 from dev_health_ops.models.operational import OperationalIncident
@@ -195,6 +196,16 @@ async def _credential_host_resolution(
     return _CredentialHostResolution(_CredentialHostState.MISSING_BASE_URL, None)
 
 
+def _environment_host_resolution(system: str) -> _CredentialHostResolution:
+    """Resolve a credentialless managed integration host from runtime environment."""
+    base_url = environment_base_url(system)
+    if base_url is None or not base_url.strip():
+        return _CredentialHostResolution(_CredentialHostState.MISSING_BASE_URL, None)
+    if normalized_operational_provider_instance(system, base_url) is None:
+        return _CredentialHostResolution(_CredentialHostState.UNREADABLE, None)
+    return _CredentialHostResolution(_CredentialHostState.RESOLVED, base_url)
+
+
 async def find_matching_managed_sources(
     session: AsyncSession,
     *,
@@ -253,6 +264,20 @@ async def find_matching_managed_sources(
                 credential_host.state is not _CredentialHostState.RESOLVED
                 and _operational_host(system, instance)
                 != _operational_host(system, default_host)
+                and source.is_enabled
+                and integration.is_active
+            ):
+                raise OperationalOwnershipResolutionUnavailableError(system)
+        elif (
+            entity_family in {"operational", "operational_incident"}
+            and system in {"github", "gitlab"}
+            and not (isinstance(configured_host, str) and configured_host.strip())
+            and credential_id is None
+        ):
+            environment_host = _environment_host_resolution(system)
+            credential_base_url = environment_host.base_url
+            if (
+                environment_host.state is _CredentialHostState.UNREADABLE
                 and source.is_enabled
                 and integration.is_active
             ):

--- a/src/dev_health_ops/external_ingest/ownership.py
+++ b/src/dev_health_ops/external_ingest/ownership.py
@@ -26,6 +26,9 @@ from typing import Any, Literal
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from dev_health_ops.api.services.configuration.integration_credentials import (
+    IntegrationCredentialsService,
+)
 from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
 from dev_health_ops.models.integrations import Integration, IntegrationSource
 from dev_health_ops.models.operational import OperationalIncident
@@ -76,6 +79,7 @@ def matches_instance(
     *,
     entity_family: str = "legacy",
     integration_config: Mapping[str, Any] | None = None,
+    credential_base_url: str | None = None,
 ) -> bool:
     """CC5 per-provider matching (see docs/architecture/customer-push-authz.md).
 
@@ -99,8 +103,13 @@ def matches_instance(
             f"{system}_url"
         )
         default_host = "github.com" if system == "github" else "gitlab.com"
+        managed_host = (
+            configured_host
+            if isinstance(configured_host, str) and configured_host.strip()
+            else credential_base_url or default_host
+        )
         return _operational_host(system, instance) == _operational_host(
-            system, str(configured_host or default_host)
+            system, managed_host
         )
     if system in ("github", "jira"):
         return inst in _candidate_set(source.external_id, source.full_name)
@@ -114,6 +123,31 @@ def matches_instance(
             return True
         return inst in _candidate_set(source.external_id, source.full_name, source.name)
     return False
+
+
+async def _credential_base_url(
+    session: AsyncSession, *, org_id: str, system: str, integration: Integration
+) -> str | None:
+    credential_id = integration.credential_id
+    if credential_id is None:
+        return None
+    credentials, credential = await IntegrationCredentialsService(
+        session, org_id
+    ).get_decrypted_credentials_by_id(str(credential_id))
+    if credential is None or credential.provider.casefold() != system:
+        return None
+    credential_config = credential.config or {}
+    for candidate in (
+        (credentials or {}).get(f"{system}_url"),
+        (credentials or {}).get("url"),
+        (credentials or {}).get("base_url"),
+        credential_config.get(f"{system}_url"),
+        credential_config.get("url"),
+        credential_config.get("base_url"),
+    ):
+        if isinstance(candidate, str) and candidate.strip():
+            return candidate
+    return None
 
 
 async def find_matching_managed_sources(
@@ -147,17 +181,37 @@ async def find_matching_managed_sources(
             )
         )
     ).all()
-    return [
-        (source, bool(integration.is_active))
-        for source, integration in candidate_rows
+    credential_hosts: dict[str, str | None] = {}
+    matches: list[tuple[IntegrationSource, bool]] = []
+    for source, integration in candidate_rows:
+        credential_base_url: str | None = None
+        config = integration.config or {}
+        configured_host = config.get(f"{system}_instance_url") or config.get(
+            f"{system}_url"
+        )
+        credential_id = integration.credential_id
+        if (
+            entity_family in {"operational", "operational_incident"}
+            and system in {"github", "gitlab"}
+            and not (isinstance(configured_host, str) and configured_host.strip())
+            and credential_id is not None
+        ):
+            credential_key = str(credential_id)
+            if credential_key not in credential_hosts:
+                credential_hosts[credential_key] = await _credential_base_url(
+                    session, org_id=org_id, system=system, integration=integration
+                )
+            credential_base_url = credential_hosts[credential_key]
         if matches_instance(
             system,
             instance,
             source,
             entity_family=entity_family,
             integration_config=integration.config,
-        )
-    ]
+            credential_base_url=credential_base_url,
+        ):
+            matches.append((source, bool(integration.is_active)))
+    return matches
 
 
 async def find_active_managed_owner(

--- a/src/dev_health_ops/external_ingest/ownership.py
+++ b/src/dev_health_ops/external_ingest/ownership.py
@@ -20,13 +20,16 @@ See docs/architecture/external-ingest-idempotency-ownership.md.
 
 from __future__ import annotations
 
-from typing import Literal
+from collections.abc import Mapping
+from typing import Any, Literal
 
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
 from dev_health_ops.models.integrations import Integration, IntegrationSource
+from dev_health_ops.models.operational import OperationalIncident
+from dev_health_ops.models.operational_identity import operational_source_coordinates
 
 EffectiveMode = Literal["fullchaos_sync", "customer_push", "disabled", "unclaimed"]
 
@@ -57,7 +60,23 @@ def _candidate_set(*values: object) -> set[str]:
     return {v.strip().lower() for v in values if isinstance(v, str) and v.strip()}
 
 
-def matches_instance(system: str, instance: str, source: IntegrationSource) -> bool:
+def _operational_host(system: str, instance: str) -> str:
+    return operational_source_coordinates(
+        OperationalIncident,
+        provider=system,
+        provider_instance_id=instance,
+        external_id="ownership",
+    ).provider_instance_id
+
+
+def matches_instance(
+    system: str,
+    instance: str,
+    source: IntegrationSource,
+    *,
+    entity_family: str = "legacy",
+    integration_config: Mapping[str, Any] | None = None,
+) -> bool:
     """CC5 per-provider matching (see docs/architecture/customer-push-authz.md).
 
     Comparisons are case-insensitive on BOTH sides (adversarial-review
@@ -71,6 +90,18 @@ def matches_instance(system: str, instance: str, source: IntegrationSource) -> b
     inst = instance.strip().lower()
     if not inst:
         return False
+    if entity_family in {"operational", "operational_incident"} and system in {
+        "github",
+        "gitlab",
+    }:
+        config = integration_config or {}
+        configured_host = config.get(f"{system}_instance_url") or config.get(
+            f"{system}_url"
+        )
+        default_host = "github.com" if system == "github" else "gitlab.com"
+        return _operational_host(system, instance) == _operational_host(
+            system, str(configured_host or default_host)
+        )
     if system in ("github", "jira"):
         return inst in _candidate_set(source.external_id, source.full_name)
     if system == "gitlab":
@@ -108,7 +139,7 @@ async def find_matching_managed_sources(
         return []
     candidate_rows = (
         await session.execute(
-            select(IntegrationSource, Integration.is_active)
+            select(IntegrationSource, Integration)
             .join(Integration, IntegrationSource.integration_id == Integration.id)
             .where(
                 IntegrationSource.org_id == org_id,
@@ -117,9 +148,15 @@ async def find_matching_managed_sources(
         )
     ).all()
     return [
-        (source, bool(integration_is_active))
-        for source, integration_is_active in candidate_rows
-        if matches_instance(system, instance, source)
+        (source, bool(integration.is_active))
+        for source, integration in candidate_rows
+        if matches_instance(
+            system,
+            instance,
+            source,
+            entity_family=entity_family,
+            integration_config=integration.config,
+        )
     ]
 
 

--- a/src/dev_health_ops/external_ingest/processor.py
+++ b/src/dev_health_ops/external_ingest/processor.py
@@ -96,7 +96,12 @@ def _parse_ingestion_uuid(value: str) -> uuid.UUID:
 
 
 async def _resolve_source_id(
-    session: AsyncSession, *, org_id: str, source_system: str, source_instance: str
+    session: AsyncSession,
+    *,
+    org_id: str,
+    source_system: str,
+    source_instance: str,
+    entity_family: str = "legacy",
 ) -> uuid.UUID:
     """The registered source's UUID, stamped as row provenance (CC8
     ``source_id`` column). Case-insensitive match on both system and
@@ -115,6 +120,7 @@ async def _resolve_source_id(
                     func.lower(IngestSource.system) == source_system.strip().lower(),
                     func.lower(IngestSource.instance)
                     == source_instance.strip().lower(),
+                    IngestSource.entity_family == entity_family,
                 )
                 .order_by(IngestSource.created_at)
             )
@@ -321,14 +327,14 @@ async def process_batch(
                 f"payload row for batch {ingestion_id} is missing (pruned or "
                 "already cleaned up) — batch cannot be processed"
             )
+        envelope = _parse_envelope(payload, ingestion_id=ingestion_id)
         source_id = await _resolve_source_id(
             session,
             org_id=org_id,
             source_system=source_system,
             source_instance=source_instance,
+            entity_family=envelope.source.entity_family,
         )
-
-        envelope = _parse_envelope(payload, ingestion_id=ingestion_id)
         if (
             envelope.source.system != source_system
             or envelope.source.instance != source_instance

--- a/src/dev_health_ops/external_ingest/recompute.py
+++ b/src/dev_health_ops/external_ingest/recompute.py
@@ -38,6 +38,22 @@ _WORK_ITEM_KINDS = frozenset(
     {"work_item.v1", "work_item_transition.v1", "work_item_dependency.v1"}
 )
 _TEAM_KINDS = frozenset({"identity.v1", "team.v1"})
+_OPERATIONAL_KINDS = frozenset(
+    {
+        "operational_service.v1",
+        "operational_incident.v1",
+        "operational_alert.v1",
+        "incident_timeline_event.v1",
+        "incident_note.v1",
+        "incident_responder.v1",
+        "escalation_policy.v1",
+        "on_call_schedule.v1",
+        "on_call_assignment.v1",
+        "operational_team.v1",
+        "operational_user.v1",
+        "service_repository_mapping.v1",
+    }
+)
 _REPO_ONLY_KINDS = frozenset({"repository.v1"})
 _RECOMPUTE_TRIGGER_KINDS = _GIT_KINDS | _WORK_ITEM_KINDS
 
@@ -189,8 +205,9 @@ def plan_recompute(scope: RecomputeScope) -> RecomputePlan:
     has_git = bool(scope.record_kinds & _GIT_KINDS)
     has_work_items = bool(scope.record_kinds & _WORK_ITEM_KINDS)
     has_team = bool(scope.record_kinds & _TEAM_KINDS)
+    has_operational = bool(scope.record_kinds & _OPERATIONAL_KINDS)
 
-    if not (has_git or has_work_items or has_team):
+    if not (has_git or has_work_items or has_team or has_operational):
         return RecomputePlan(
             org_id=scope.org_id,
             trigger=False,

--- a/src/dev_health_ops/external_ingest/sinks.py
+++ b/src/dev_health_ops/external_ingest/sinks.py
@@ -104,6 +104,15 @@ def _track_scope_timestamp(scope: AffectedScope, value: Any) -> None:
         scope.max_timestamp = dt
 
 
+def _track_operational_scope(scope: AffectedScope, records: list[Any]) -> None:
+    for record in records:
+        _track_scope_timestamp(scope, record.source_version_at)
+        if record.entity_family == "operational_service":
+            scope.service_ids.add(record.id)
+        if record.entity_family == "operational_incident":
+            scope.incident_ids.add(record.id)
+
+
 def _resolve_customer_identity(system: str, raw: str | None) -> str | None:
     """D4: resolve a work-item-family raw assignee/reporter/actor string.
 
@@ -643,6 +652,18 @@ async def write_batch(
         or batch.reviews
         or batch.teams
         or batch.identities
+        or batch.operational_services
+        or batch.operational_incidents
+        or batch.operational_alerts
+        or batch.incident_timeline_events
+        or batch.incident_notes
+        or batch.incident_responders
+        or batch.escalation_policies
+        or batch.on_call_schedules
+        or batch.on_call_assignments
+        or batch.operational_teams
+        or batch.operational_users
+        or batch.service_repository_mappings
     )
 
     async with _maybe_store(clickhouse_dsn, batch.org_id, needs_async_store) as store:
@@ -813,6 +834,73 @@ async def write_batch(
                     SinkWriteError(
                         record_index=-1,
                         kind="identity",
+                        external_id=None,
+                        code="clickhouse_insert_failed",
+                        message=str(exc),
+                    )
+                )
+
+        operational_writes = (
+            (
+                "operational_services",
+                "operational_service",
+                "insert_operational_services",
+            ),
+            (
+                "operational_incidents",
+                "operational_incident",
+                "insert_operational_incidents",
+            ),
+            ("operational_alerts", "operational_alert", "insert_operational_alerts"),
+            (
+                "incident_timeline_events",
+                "incident_timeline_event",
+                "insert_operational_incident_timeline_events",
+            ),
+            ("incident_notes", "incident_note", "insert_operational_incident_notes"),
+            (
+                "incident_responders",
+                "incident_responder",
+                "insert_operational_incident_responders",
+            ),
+            (
+                "escalation_policies",
+                "escalation_policy",
+                "insert_operational_escalation_policies",
+            ),
+            (
+                "on_call_schedules",
+                "on_call_schedule",
+                "insert_operational_on_call_schedules",
+            ),
+            (
+                "on_call_assignments",
+                "on_call_assignment",
+                "insert_operational_on_call_assignments",
+            ),
+            ("operational_teams", "operational_team", "insert_operational_teams"),
+            ("operational_users", "operational_user", "insert_operational_users"),
+            (
+                "service_repository_mappings",
+                "service_repository_mapping",
+                "insert_operational_service_repository_mappings",
+            ),
+        )
+        for attribute, kind, writer_name in operational_writes:
+            records = getattr(batch, attribute)
+            if not records:
+                continue
+            try:
+                await getattr(store, writer_name)(records)
+                counts[kind] = len(records)
+                scope.record_kinds.add(kind)
+                _track_operational_scope(scope, records)
+            except Exception as exc:  # noqa: BLE001
+                logger.exception("write_batch: %s sink write failed", kind)
+                errors.append(
+                    SinkWriteError(
+                        record_index=-1,
+                        kind=kind,
                         external_id=None,
                         code="clickhouse_insert_failed",
                         message=str(exc),

--- a/src/dev_health_ops/external_ingest/types.py
+++ b/src/dev_health_ops/external_ingest/types.py
@@ -16,6 +16,21 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any
 
+from dev_health_ops.models.operational import (
+    EscalationPolicy,
+    IncidentNote,
+    IncidentResponder,
+    IncidentTimelineEvent,
+    OnCallAssignment,
+    OnCallSchedule,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+    ServiceRepositoryMapping,
+)
+
 __all__ = [
     "NormalizedBatch",
     "SinkWriteError",
@@ -54,6 +69,20 @@ class NormalizedBatch:
     pull_requests: list[dict[str, Any]] = field(default_factory=list)
     reviews: list[dict[str, Any]] = field(default_factory=list)
     commits: list[dict[str, Any]] = field(default_factory=list)
+    operational_services: list[OperationalService] = field(default_factory=list)
+    operational_incidents: list[OperationalIncident] = field(default_factory=list)
+    operational_alerts: list[OperationalAlert] = field(default_factory=list)
+    incident_timeline_events: list[IncidentTimelineEvent] = field(default_factory=list)
+    incident_notes: list[IncidentNote] = field(default_factory=list)
+    incident_responders: list[IncidentResponder] = field(default_factory=list)
+    escalation_policies: list[EscalationPolicy] = field(default_factory=list)
+    on_call_schedules: list[OnCallSchedule] = field(default_factory=list)
+    on_call_assignments: list[OnCallAssignment] = field(default_factory=list)
+    operational_teams: list[OperationalTeam] = field(default_factory=list)
+    operational_users: list[OperationalUser] = field(default_factory=list)
+    service_repository_mappings: list[ServiceRepositoryMapping] = field(
+        default_factory=list
+    )
     # Per-kind list of the record's original index in the accepted envelope's
     # `records` array, for error/warning correlation back to CHAOS-2694's
     # rejection diagnostics. Falls back to in-batch position when absent or
@@ -89,6 +118,8 @@ class AffectedScope:
     repo_ids: set[uuid.UUID] = field(default_factory=set)
     team_ids: set[str] = field(default_factory=set)
     work_item_ids: set[str] = field(default_factory=set)
+    incident_ids: set[str] = field(default_factory=set)
+    service_ids: set[str] = field(default_factory=set)
     min_timestamp: datetime | None = None
     max_timestamp: datetime | None = None
     record_kinds: set[str] = field(default_factory=set)

--- a/src/dev_health_ops/metrics/sinks/ingestion.py
+++ b/src/dev_health_ops/metrics/sinks/ingestion.py
@@ -22,6 +22,8 @@ from dev_health_ops.models.git import (
     Repo,
     SecurityAlert,
 )
+from dev_health_ops.models.operational import OperationalBatch
+from dev_health_ops.providers.operational_migration import write_operational_batch
 
 
 class IngestionSink:
@@ -92,6 +94,9 @@ class IngestionSink:
 
     async def insert_incidents(self, incidents: list[Incident]) -> None:
         await self._store.insert_incidents(incidents)
+
+    async def insert_operational_batch(self, batch: OperationalBatch) -> None:
+        await write_operational_batch(self._store, batch)
 
     async def insert_security_alerts(self, alerts: list[SecurityAlert]) -> None:
         await self._store.insert_security_alerts(alerts)

--- a/src/dev_health_ops/models/external_ingest.py
+++ b/src/dev_health_ops/models/external_ingest.py
@@ -75,6 +75,9 @@ class ExternalIngestBatch(Base):
     payload_hash: Mapped[str] = mapped_column(Text, nullable=False)
     source_system: Mapped[str] = mapped_column(Text, nullable=False)
     source_instance: Mapped[str] = mapped_column(Text, nullable=False)
+    entity_family: Mapped[str] = mapped_column(
+        Text, nullable=False, default="legacy", server_default="legacy"
+    )
     producer: Mapped[str | None] = mapped_column(Text, nullable=True)
     producer_version: Mapped[str | None] = mapped_column(Text, nullable=True)
     schema_version: Mapped[str] = mapped_column(Text, nullable=False)
@@ -132,6 +135,7 @@ class ExternalIngestBatch(Base):
             "org_id",
             "source_system",
             "source_instance",
+            "entity_family",
             "idempotency_key",
             name="uq_external_ingest_batches_idem",
         ),

--- a/src/dev_health_ops/models/ingest_auth.py
+++ b/src/dev_health_ops/models/ingest_auth.py
@@ -73,7 +73,7 @@ def hash_ingest_token(token: str) -> str:
 
 
 class IngestSource(Base):
-    """One row per ``(org_id, system, instance)``.
+    """One row per ``(org_id, system, instance, entity_family)``.
 
     Tracks which of ``fullchaos_sync | customer_push | disabled`` currently
     owns that source instance -- the single registry the one-active-owner XOR
@@ -86,6 +86,7 @@ class IngestSource(Base):
     org_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
     system: Mapped[str] = mapped_column(Text, nullable=False)
     instance: Mapped[str] = mapped_column(Text, nullable=False)
+    entity_family: Mapped[str] = mapped_column(Text, nullable=False, default="legacy")
     display_name: Mapped[str | None] = mapped_column(Text, nullable=True)
     mode: Mapped[str] = mapped_column(
         Text, nullable=False, default=IngestSourceMode.DISABLED.value
@@ -120,7 +121,8 @@ class IngestSource(Base):
             "org_id",
             "system",
             "instance",
-            name="uq_external_ingest_sources_org_system_instance",
+            "entity_family",
+            name="uq_external_ingest_sources_org_system_instance_family",
         ),
     )
 

--- a/src/dev_health_ops/models/operational_identity.py
+++ b/src/dev_health_ops/models/operational_identity.py
@@ -1,0 +1,60 @@
+"""Canonical provider coordinates for operational entity identities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from urllib.parse import urlsplit
+
+from dev_health_ops.models.operational import CanonicalOperationalEntity
+
+
+@dataclass(frozen=True, slots=True)
+class OperationalSourceCoordinates:
+    """The immutable source coordinates used by canonical operational ids."""
+
+    provider: str
+    provider_instance_id: str
+    entity_family: str
+    external_id: str
+
+
+def _normalized_instance(provider: str, provider_instance_id: str) -> str:
+    """Normalize account or host identity without admitting repository scope."""
+    raw_instance = provider_instance_id.strip()
+    if provider not in {"github", "gitlab", "atlassian"}:
+        return raw_instance.casefold()
+    parsed = urlsplit(raw_instance if "://" in raw_instance else f"//{raw_instance}")
+    host = parsed.hostname
+    if host is None:
+        return raw_instance.casefold().rstrip("/")
+    port = f":{parsed.port}" if parsed.port is not None else ""
+    return f"{host.casefold()}{port}"
+
+
+def operational_source_coordinates(
+    entity_type: type[CanonicalOperationalEntity],
+    *,
+    provider: str,
+    provider_instance_id: str,
+    external_id: str,
+    repo_full_name: str | None = None,
+    issue_number: str | None = None,
+) -> OperationalSourceCoordinates:
+    """Return the only allowed source coordinates for an operational entity.
+
+    Issue-derived incidents are unique per repository, rather than per host-wide
+    issue number. The entity family always comes from the canonical dataclass.
+    """
+    normalized_provider = provider.strip().casefold()
+    normalized_external_id = external_id.strip()
+    if entity_type.entity_family == "operational_incident" and repo_full_name:
+        number = (issue_number or normalized_external_id).strip()
+        normalized_external_id = f"{repo_full_name}#{number}"
+    return OperationalSourceCoordinates(
+        provider=normalized_provider,
+        provider_instance_id=_normalized_instance(
+            normalized_provider, provider_instance_id
+        ),
+        entity_family=entity_type.entity_family,
+        external_id=normalized_external_id,
+    )

--- a/src/dev_health_ops/models/operational_identity.py
+++ b/src/dev_health_ops/models/operational_identity.py
@@ -18,17 +18,30 @@ class OperationalSourceCoordinates:
     external_id: str
 
 
-def _normalized_instance(provider: str, provider_instance_id: str) -> str:
-    """Normalize account or host identity without admitting repository scope."""
+def normalized_operational_provider_instance(
+    provider: str, provider_instance_id: str
+) -> str:
+    """Normalize an operational provider host without repository scope."""
     raw_instance = provider_instance_id.strip()
     if provider not in {"github", "gitlab", "atlassian"}:
         return raw_instance.casefold()
-    parsed = urlsplit(raw_instance if "://" in raw_instance else f"//{raw_instance}")
+    try:
+        parsed = urlsplit(
+            raw_instance if "://" in raw_instance else f"//{raw_instance}"
+        )
+        port = parsed.port
+    except ValueError:
+        return raw_instance.casefold().rstrip("/")
     host = parsed.hostname
     if host is None:
         return raw_instance.casefold().rstrip("/")
-    port = f":{parsed.port}" if parsed.port is not None else ""
-    return f"{host.casefold()}{port}"
+    normalized_host = host.casefold()
+    if provider == "github" and normalized_host in {"api.github.com", "github.com"}:
+        return "github.com"
+    scheme = parsed.scheme.casefold() or "https"
+    default_port = 443 if scheme == "https" else 80 if scheme == "http" else None
+    port_suffix = f":{port}" if port is not None and port != default_port else ""
+    return f"{normalized_host}{port_suffix}"
 
 
 def operational_source_coordinates(
@@ -42,17 +55,15 @@ def operational_source_coordinates(
 ) -> OperationalSourceCoordinates:
     """Return the only allowed source coordinates for an operational entity.
 
-    Issue-derived incidents are unique per repository, rather than per host-wide
-    issue number. The entity family always comes from the canonical dataclass.
+    Provider-global issue ids are recoverable from legacy incidents, native
+    producers, and external push. The entity family always comes from the
+    canonical dataclass.
     """
     normalized_provider = provider.strip().casefold()
     normalized_external_id = external_id.strip()
-    if entity_type.entity_family == "operational_incident" and repo_full_name:
-        number = (issue_number or normalized_external_id).strip()
-        normalized_external_id = f"{repo_full_name}#{number}"
     return OperationalSourceCoordinates(
         provider=normalized_provider,
-        provider_instance_id=_normalized_instance(
+        provider_instance_id=normalized_operational_provider_instance(
             normalized_provider, provider_instance_id
         ),
         entity_family=entity_type.entity_family,

--- a/src/dev_health_ops/models/operational_identity.py
+++ b/src/dev_health_ops/models/operational_identity.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+from ipaddress import ip_address
 from urllib.parse import urlsplit
 
 from dev_health_ops.models.operational import CanonicalOperationalEntity
@@ -18,23 +19,42 @@ class OperationalSourceCoordinates:
     external_id: str
 
 
+class InvalidOperationalProviderInstanceError(ValueError):
+    pass
+
+
 def normalized_operational_provider_instance(
     provider: str, provider_instance_id: str
-) -> str:
+) -> str | None:
     """Normalize an operational provider host without repository scope."""
     raw_instance = provider_instance_id.strip()
-    if provider not in {"github", "gitlab", "atlassian"}:
+    if provider not in {"github", "gitlab"}:
         return raw_instance.casefold()
     try:
-        parsed = urlsplit(
-            raw_instance if "://" in raw_instance else f"//{raw_instance}"
-        )
+        has_scheme = "://" in raw_instance
+        parsed = urlsplit(raw_instance if has_scheme else f"//{raw_instance}")
         port = parsed.port
     except ValueError:
-        return raw_instance.casefold().rstrip("/")
+        return None
     host = parsed.hostname
-    if host is None:
-        return raw_instance.casefold().rstrip("/")
+    if (
+        host is None
+        or host.casefold() in {"none", "null"}
+        or (not has_scheme and parsed.path)
+    ):
+        return None
+    try:
+        ip_address(host)
+    except ValueError:
+        labels = host.split(".")
+        if not all(
+            label
+            and label[0].isalnum()
+            and label[-1].isalnum()
+            and all(character.isalnum() or character == "-" for character in label)
+            for label in labels
+        ):
+            return None
     normalized_host = host.casefold()
     if provider == "github" and normalized_host in {"api.github.com", "github.com"}:
         return "github.com"
@@ -61,11 +81,16 @@ def operational_source_coordinates(
     """
     normalized_provider = provider.strip().casefold()
     normalized_external_id = external_id.strip()
+    normalized_instance = normalized_operational_provider_instance(
+        normalized_provider, provider_instance_id
+    )
+    if normalized_instance is None:
+        raise InvalidOperationalProviderInstanceError(
+            f"Invalid {normalized_provider} provider instance"
+        )
     return OperationalSourceCoordinates(
         provider=normalized_provider,
-        provider_instance_id=normalized_operational_provider_instance(
-            normalized_provider, provider_instance_id
-        ),
+        provider_instance_id=normalized_instance,
         entity_family=entity_type.entity_family,
         external_id=normalized_external_id,
     )

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -576,14 +576,20 @@ def _github_code_client_from_connector(connector) -> "GitHubCodeClient":
 def _github_provider_instance_id(connector) -> str:
     """Return a stable public or enterprise GitHub instance identifier."""
     from dev_health_ops.models.operational_identity import (
+        InvalidOperationalProviderInstanceError,
         normalized_operational_provider_instance,
     )
 
     rest_base_url = getattr(connector, "_rest_base_url", None)
     raw_base_url = rest_base_url() if callable(rest_base_url) else None
-    return normalized_operational_provider_instance(
+    provider_instance_id = normalized_operational_provider_instance(
         "github", str(raw_base_url or "https://api.github.com")
     )
+    if provider_instance_id is None:
+        raise InvalidOperationalProviderInstanceError(
+            "Invalid GitHub provider instance"
+        )
+    return provider_instance_id
 
 
 async def _list_github_repositories_for_batch(
@@ -2240,6 +2246,7 @@ async def process_github_repos_batch(
             provider="github",
             settings={
                 "source": "github",
+                "github_instance_url": _github_provider_instance_id(connector),
                 "repo_id": repo_info.id,
                 "url": repo_info.url,
                 "default_branch": repo_info.default_branch,

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -578,10 +578,11 @@ def _github_provider_instance_id(connector) -> str:
     """Return a stable public or enterprise GitHub instance identifier."""
     rest_base_url = getattr(connector, "_rest_base_url", None)
     raw_base_url = rest_base_url() if callable(rest_base_url) else None
-    host = urlparse(str(raw_base_url or "https://api.github.com")).hostname
+    parsed = urlparse(str(raw_base_url or "https://api.github.com"))
+    host = parsed.hostname
     if host is None or host in {"api.github.com", "github.com"}:
         return "github.com"
-    return host
+    return f"{host}:{parsed.port}" if parsed.port is not None else host
 
 
 async def _list_github_repositories_for_batch(

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -3,6 +3,7 @@ import logging
 import zipfile
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Protocol
+from urllib.parse import urlparse
 
 from dev_health_ops.analytics.complexity import (
     DEFAULT_COMPLEXITY_CONFIG_PATH,
@@ -52,6 +53,11 @@ from dev_health_ops.processors.testops_ingest import (
     ingest_report_members,
 )
 from dev_health_ops.providers.github.client import GitHubAuth, GitHubWorkClient
+from dev_health_ops.providers.operational_migration import (
+    IssueIncidentSource,
+    map_issue_incidents,
+    operational_dual_write_enabled,
+)
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.providers.usage import drain_provider_usage
 from dev_health_ops.utils import (
@@ -447,6 +453,9 @@ async def _fetch_github_incidents_async(
     max_issues: int,
     since: datetime | None,
     usage_sink: list[dict[str, Any]] | None = None,
+    canonical_sources: list[IssueIncidentSource] | None = None,
+    canonical_org_id: str | None = None,
+    canonical_provider_instance_id: str | None = None,
 ) -> list[Incident]:
     incidents: list[Incident] = []
     labels = resolve_incident_labels()
@@ -488,15 +497,52 @@ async def _fetch_github_incidents_async(
                 continue
             if since is not None and created_at.astimezone(timezone.utc) < since:
                 continue
+            issue_id = str(getattr(issue, "issue_id", ""))
             incidents.append(
                 Incident(
                     repo_id=repo_id,
-                    incident_id=str(getattr(issue, "issue_id", "")),
+                    incident_id=issue_id,
                     status=getattr(issue, "state", None),
                     started_at=created_at,
                     resolved_at=getattr(issue, "closed_at", None),
                 )
             )
+            if (
+                canonical_sources is not None
+                and canonical_org_id
+                and canonical_provider_instance_id
+                and issue_id
+            ):
+                labels_value = getattr(issue, "labels", ())
+                canonical_labels = (
+                    tuple(str(label) for label in labels_value)
+                    if isinstance(labels_value, (list, tuple))
+                    else ()
+                )
+                updated_at = getattr(issue, "updated_at", None)
+                canonical_sources.append(
+                    IssueIncidentSource(
+                        org_id=canonical_org_id,
+                        provider="github",
+                        provider_instance_id=canonical_provider_instance_id,
+                        repo_id=repo_id,
+                        repo_full_name=f"{owner}/{repo_name}",
+                        external_id=issue_id,
+                        issue_number=str(getattr(issue, "number", "")) or None,
+                        source_url=getattr(issue, "source_url", None),
+                        labels=canonical_labels,
+                        raw_status=getattr(issue, "state", None),
+                        title=getattr(issue, "title", None) or "",
+                        description=getattr(issue, "description", None),
+                        created_at=created_at,
+                        resolved_at=getattr(issue, "closed_at", None),
+                        source_version_at=(
+                            updated_at
+                            if isinstance(updated_at, datetime)
+                            else created_at
+                        ),
+                    )
+                )
         return incidents
     finally:
         observations = client.drain_usage_observations()
@@ -526,6 +572,16 @@ def _github_code_client_from_connector(connector) -> "GitHubCodeClient":
     from dev_health_ops.providers.github.code_client import GitHubCodeClient
 
     return GitHubCodeClient(auth=GitHubAuth(token=token, base_url=base_url))
+
+
+def _github_provider_instance_id(connector) -> str:
+    """Return a stable public or enterprise GitHub instance identifier."""
+    rest_base_url = getattr(connector, "_rest_base_url", None)
+    raw_base_url = rest_base_url() if callable(rest_base_url) else None
+    host = urlparse(str(raw_base_url or "https://api.github.com")).hostname
+    if host is None or host in {"api.github.com", "github.com"}:
+        return "github.com"
+    return host
 
 
 async def _list_github_repositories_for_batch(
@@ -2015,6 +2071,9 @@ async def process_github_repo(
 
             if sync_incidents:
                 logging.info("Fetching incident issues from GitHub...")
+                canonical_sources: list[IssueIncidentSource] | None = (
+                    [] if operational_dual_write_enabled() else None
+                )
                 incidents = await _fetch_github_incidents_async(
                     connector,
                     owner,
@@ -2023,10 +2082,19 @@ async def process_github_repo(
                     BATCH_SIZE,
                     since,
                     usage_sink=usage_sink,
+                    canonical_sources=canonical_sources,
+                    canonical_org_id=getattr(store, "org_id", "") or None,
+                    canonical_provider_instance_id=_github_provider_instance_id(
+                        connector
+                    ),
                 )
                 incidents = _filter_after(incidents, until, "started_at")
                 if incidents:
                     await ingestion_sink.insert_incidents(incidents)
+                    if canonical_sources:
+                        await ingestion_sink.insert_operational_batch(
+                            map_issue_incidents(canonical_sources)
+                        )
                     logging.info("Stored %d incidents", len(incidents))
 
             if sync_security:
@@ -2365,6 +2433,9 @@ async def process_github_repos_batch(
         if sync_incidents:
             try:
                 batch_owner, _, batch_repo = repo_info.full_name.partition("/")
+                canonical_sources: list[IssueIncidentSource] | None = (
+                    [] if operational_dual_write_enabled() else None
+                )
                 incidents = await _fetch_github_incidents_async(
                     connector,
                     batch_owner,
@@ -2373,9 +2444,18 @@ async def process_github_repos_batch(
                     BATCH_SIZE,
                     since,
                     usage_sink=usage_sink,
+                    canonical_sources=canonical_sources,
+                    canonical_org_id=getattr(store, "org_id", "") or None,
+                    canonical_provider_instance_id=_github_provider_instance_id(
+                        connector
+                    ),
                 )
                 if incidents:
                     await ingestion_sink.insert_incidents(incidents)
+                    if canonical_sources:
+                        await ingestion_sink.insert_operational_batch(
+                            map_issue_incidents(canonical_sources)
+                        )
             except (RateLimitException, RateLimitExceededException):
                 raise
             except Exception as e:

--- a/src/dev_health_ops/processors/github.py
+++ b/src/dev_health_ops/processors/github.py
@@ -3,7 +3,6 @@ import logging
 import zipfile
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any, Protocol
-from urllib.parse import urlparse
 
 from dev_health_ops.analytics.complexity import (
     DEFAULT_COMPLEXITY_CONFIG_PATH,
@@ -576,13 +575,15 @@ def _github_code_client_from_connector(connector) -> "GitHubCodeClient":
 
 def _github_provider_instance_id(connector) -> str:
     """Return a stable public or enterprise GitHub instance identifier."""
+    from dev_health_ops.models.operational_identity import (
+        normalized_operational_provider_instance,
+    )
+
     rest_base_url = getattr(connector, "_rest_base_url", None)
     raw_base_url = rest_base_url() if callable(rest_base_url) else None
-    parsed = urlparse(str(raw_base_url or "https://api.github.com"))
-    host = parsed.hostname
-    if host is None or host in {"api.github.com", "github.com"}:
-        return "github.com"
-    return f"{host}:{parsed.port}" if parsed.port is not None else host
+    return normalized_operational_provider_instance(
+        "github", str(raw_base_url or "https://api.github.com")
+    )
 
 
 async def _list_github_repositories_for_batch(
@@ -1935,6 +1936,7 @@ async def process_github_repo(
                 provider="github",
                 settings={
                     "source": "github",
+                    "github_instance_url": _github_provider_instance_id(connector),
                     "repo_id": repo_info.id,
                     "url": repo_info.url,
                     "default_branch": repo_info.default_branch,

--- a/src/dev_health_ops/processors/gitlab.py
+++ b/src/dev_health_ops/processors/gitlab.py
@@ -55,6 +55,11 @@ from dev_health_ops.processors.testops_ingest import (
 )
 from dev_health_ops.processors.testops_tests import process_gitlab_test_report
 from dev_health_ops.providers.gitlab.instance import normalize_gitlab_instance
+from dev_health_ops.providers.operational_migration import (
+    IssueIncidentSource,
+    map_issue_incidents,
+    operational_dual_write_enabled,
+)
 from dev_health_ops.providers.pr_state import normalize_pr_state
 from dev_health_ops.utils import (
     AGGREGATE_STATS_MARKER,
@@ -1102,7 +1107,17 @@ def _fetch_gitlab_deployments_sync(
     return deployments
 
 
-def _fetch_gitlab_incidents_sync(connector, project_id, repo_id, max_issues, since):
+def _fetch_gitlab_incidents_sync(
+    connector,
+    project_id,
+    repo_id,
+    max_issues,
+    since,
+    canonical_sources: list[IssueIncidentSource] | None = None,
+    canonical_org_id: str | None = None,
+    canonical_provider_instance_id: str | None = None,
+    repo_full_name: str | None = None,
+):
     """Sync helper to fetch GitLab incidents (configurable incident labels)."""
     incidents: list[Incident] = []
     labels = resolve_incident_labels()
@@ -1150,15 +1165,49 @@ def _fetch_gitlab_incidents_sync(connector, project_id, repo_id, max_issues, sin
         if closed_at_str:
             resolved_at = safe_parse_datetime(closed_at_str)
 
+        issue_id = str(issue.get("id", ""))
         incidents.append(
             Incident(
                 repo_id=repo_id,
-                incident_id=str(issue.get("id", "")),
+                incident_id=issue_id,
                 status=issue.get("state", None),
                 started_at=created_at,
                 resolved_at=resolved_at,
             )
         )
+        if (
+            canonical_sources is not None
+            and canonical_org_id
+            and canonical_provider_instance_id
+            and repo_full_name
+            and issue_id
+        ):
+            raw_labels = issue.get("labels")
+            canonical_labels = (
+                tuple(str(label) for label in raw_labels)
+                if isinstance(raw_labels, list)
+                else ()
+            )
+            updated_at = safe_parse_datetime(issue.get("updated_at"))
+            canonical_sources.append(
+                IssueIncidentSource(
+                    org_id=canonical_org_id,
+                    provider="gitlab",
+                    provider_instance_id=canonical_provider_instance_id,
+                    repo_id=repo_id,
+                    repo_full_name=repo_full_name,
+                    external_id=issue_id,
+                    issue_number=str(issue.get("iid", "")) or None,
+                    source_url=issue.get("web_url") or issue.get("url"),
+                    labels=canonical_labels,
+                    raw_status=issue.get("state"),
+                    title=issue.get("title") or "",
+                    description=issue.get("description"),
+                    created_at=created_at,
+                    resolved_at=resolved_at,
+                    source_version_at=updated_at or created_at,
+                )
+            )
 
     return incidents
 
@@ -2375,6 +2424,9 @@ async def process_gitlab_project(
 
         if sync_incidents:
             logging.info("Fetching incidents from GitLab...")
+            canonical_sources: list[IssueIncidentSource] | None = (
+                [] if operational_dual_write_enabled() else None
+            )
             incidents = await loop.run_in_executor(
                 None,
                 _fetch_gitlab_incidents_sync,
@@ -2383,10 +2435,18 @@ async def process_gitlab_project(
                 db_repo.id,
                 BATCH_SIZE,
                 since,
+                canonical_sources,
+                getattr(store, "org_id", "") or None,
+                normalize_gitlab_instance(gitlab_url) or "https://gitlab.com",
+                full_name,
             )
             incidents = _filter_after(incidents, until, "started_at")
             if incidents:
                 await ingestion_sink.insert_incidents(incidents)
+                if canonical_sources:
+                    await ingestion_sink.insert_operational_batch(
+                        map_issue_incidents(canonical_sources)
+                    )
                 logging.info(f"Stored {len(incidents)} incidents from GitLab")
 
         if sync_security:
@@ -2756,6 +2816,9 @@ async def process_gitlab_projects_batch(
 
         if sync_incidents:
             try:
+                canonical_sources: list[IssueIncidentSource] | None = (
+                    [] if operational_dual_write_enabled() else None
+                )
                 incidents = await loop.run_in_executor(
                     None,
                     _fetch_gitlab_incidents_sync,
@@ -2764,9 +2827,17 @@ async def process_gitlab_projects_batch(
                     db_repo.id,
                     BATCH_SIZE,
                     since,
+                    canonical_sources,
+                    getattr(store, "org_id", "") or None,
+                    normalize_gitlab_instance(gitlab_url) or "https://gitlab.com",
+                    project_info.full_name,
                 )
                 if incidents:
                     await ingestion_sink.insert_incidents(incidents)
+                    if canonical_sources:
+                        await ingestion_sink.insert_operational_batch(
+                            map_issue_incidents(canonical_sources)
+                        )
             except Exception as e:
                 logging.warning(
                     "Failed to fetch incidents for GitLab project %s: %s",

--- a/src/dev_health_ops/providers/github/code_client.py
+++ b/src/dev_health_ops/providers/github/code_client.py
@@ -157,6 +157,11 @@ class GitHubIssueData:
     state: str | None
     created_at: datetime | None
     closed_at: datetime | None
+    updated_at: datetime | None = None
+    source_url: str | None = None
+    title: str | None = None
+    description: str | None = None
+    labels: tuple[str, ...] = ()
 
 
 @dataclass(frozen=True)
@@ -492,12 +497,27 @@ def _pull_from_item(item: Mapping[str, Any]) -> GitHubPullData:
 
 
 def _issue_from_item(item: Mapping[str, Any]) -> GitHubIssueData:
+    raw_labels = item.get("labels")
+    labels = (
+        tuple(
+            str(label["name"])
+            for label in raw_labels
+            if isinstance(label, Mapping) and label.get("name") is not None
+        )
+        if isinstance(raw_labels, list)
+        else ()
+    )
     return GitHubIssueData(
         issue_id=str(item.get("id") or ""),
         number=_int_or_zero(item.get("number")),
         state=str(item["state"]) if item.get("state") is not None else None,
         created_at=_parse_alert_datetime(item.get("created_at")),
         closed_at=_parse_alert_datetime(item.get("closed_at")),
+        updated_at=_parse_alert_datetime(item.get("updated_at")),
+        source_url=str(item.get("html_url") or item.get("url") or "") or None,
+        title=str(item["title"]) if item.get("title") is not None else None,
+        description=str(item["body"]) if item.get("body") is not None else None,
+        labels=labels,
     )
 
 

--- a/src/dev_health_ops/providers/operational_migration.py
+++ b/src/dev_health_ops/providers/operational_migration.py
@@ -1,0 +1,306 @@
+"""Provider-neutral mappings for legacy operational producers.
+
+The mappers in this module preserve the legacy write path while supplying the
+canonical ClickHouse operational contract during the reversible migration.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol
+from uuid import UUID
+
+from dev_health_ops.models.atlassian_ops import (
+    AtlassianOpsAlert,
+    AtlassianOpsIncident,
+    AtlassianOpsSchedule,
+)
+from dev_health_ops.models.operational import (
+    OnCallSchedule,
+    OperationalAlert,
+    OperationalBatch,
+    OperationalIncident,
+    OperationalService,
+    ServiceRepositoryMapping,
+)
+
+
+@dataclass(frozen=True, slots=True)
+class IssueIncidentSource:
+    """Provider issue data retained until its canonical incident is persisted."""
+
+    org_id: str
+    provider: str
+    provider_instance_id: str
+    repo_id: UUID
+    repo_full_name: str
+    external_id: str
+    issue_number: str | None
+    source_url: str | None
+    labels: tuple[str, ...]
+    raw_status: str | None
+    title: str
+    description: str | None
+    created_at: datetime
+    resolved_at: datetime | None
+    source_version_at: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class AtlassianOpsRows:
+    """Legacy Atlassian Ops rows for one provider instance."""
+
+    incidents: tuple[AtlassianOpsIncident, ...] = ()
+    alerts: tuple[AtlassianOpsAlert, ...] = ()
+    schedules: tuple[AtlassianOpsSchedule, ...] = ()
+
+
+@dataclass(frozen=True, slots=True)
+class AtlassianOpsSource:
+    """Canonical identity context for an Atlassian Ops legacy batch."""
+
+    org_id: str
+    provider_instance_id: str
+    rows: AtlassianOpsRows
+
+
+class OperationalWriteStore(Protocol):
+    """Canonical operational sink capability used by producer orchestration."""
+
+    async def insert_operational_services(
+        self, services: list[OperationalService]
+    ) -> None: ...
+
+    async def insert_operational_incidents(
+        self, incidents: list[OperationalIncident]
+    ) -> None: ...
+
+    async def insert_operational_alerts(
+        self, alerts: list[OperationalAlert]
+    ) -> None: ...
+
+    async def insert_operational_on_call_schedules(
+        self, schedules: list[OnCallSchedule]
+    ) -> None: ...
+
+    async def insert_operational_service_repository_mappings(
+        self, mappings: list[ServiceRepositoryMapping]
+    ) -> None: ...
+
+
+def operational_dual_write_enabled() -> bool:
+    """Return whether additive canonical operational writes are enabled."""
+    return os.getenv("OPERATIONAL_INCIDENT_DUAL_WRITE", "false").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _normalized_status(raw_status: str | None) -> str | None:
+    normalized = {
+        "active": "active",
+        "acknowledged": "acknowledged",
+        "closed": "resolved",
+        "open": "open",
+        "opened": "open",
+        "resolved": "resolved",
+        "suppressed": "suppressed",
+    }
+    return normalized.get((raw_status or "").strip().lower())
+
+
+def _normalized_priority(raw_priority: str | None) -> str | None:
+    normalized = {
+        "critical": "critical",
+        "high": "high",
+        "low": "low",
+        "medium": "medium",
+        "p1": "critical",
+        "p2": "high",
+        "p3": "medium",
+        "p4": "low",
+    }
+    return normalized.get((raw_priority or "").strip().lower())
+
+
+def _normalized_severity(raw_severity: str | None) -> str | None:
+    normalized = {
+        "critical": "critical",
+        "high": "high",
+        "info": "info",
+        "low": "low",
+        "medium": "medium",
+        "sev1": "critical",
+        "sev2": "high",
+        "sev3": "medium",
+        "sev4": "low",
+    }
+    return normalized.get((raw_severity or "").strip().lower().replace("-", ""))
+
+
+def map_issue_incidents(sources: Sequence[IssueIncidentSource]) -> OperationalBatch:
+    """Map labelled GitHub or GitLab issues into canonical incident records."""
+    if not sources:
+        raise ValueError("at least one issue incident source is required")
+
+    first = sources[0]
+    services: dict[str, OperationalService] = {}
+    mappings: dict[str, ServiceRepositoryMapping] = {}
+    incidents: dict[str, OperationalIncident] = {}
+    for source in sources:
+        if (
+            source.org_id != first.org_id
+            or source.provider != first.provider
+            or source.provider_instance_id != first.provider_instance_id
+        ):
+            raise ValueError(
+                "issue incident sources must share canonical identity context"
+            )
+
+        service = services.setdefault(
+            source.repo_full_name,
+            OperationalService(
+                org_id=source.org_id,
+                provider=source.provider,
+                provider_instance_id=source.provider_instance_id,
+                source_entity_type="repository",
+                external_id=source.repo_full_name,
+                source_version_at=source.source_version_at,
+                source_url=None,
+                name=source.repo_full_name,
+                service_type="repository",
+            ),
+        )
+        mapping = ServiceRepositoryMapping(
+            org_id=source.org_id,
+            provider=source.provider,
+            provider_instance_id=source.provider_instance_id,
+            source_entity_type="repository_mapping",
+            external_id=f"{source.repo_full_name}:{source.repo_id}",
+            source_version_at=source.source_version_at,
+            service_id=service.id,
+            repo_id=source.repo_id,
+            repo_full_name=source.repo_full_name,
+            repo_provider=source.provider,
+            mapping_kind="repository_derived",
+            relationship_provenance="native_repository_context",
+            relationship_confidence=1.0,
+        )
+        mappings.setdefault(mapping.id, mapping)
+        incident = OperationalIncident(
+            org_id=source.org_id,
+            provider=source.provider,
+            provider_instance_id=source.provider_instance_id,
+            source_entity_type="issue",
+            external_id=source.external_id,
+            source_version_at=source.source_version_at,
+            source_url=source.source_url,
+            source_event_id=source.issue_number,
+            raw_status=source.raw_status,
+            normalized_status=_normalized_status(source.raw_status),
+            service_id=service.id,
+            service_external_id=source.repo_full_name,
+            title=source.title,
+            description=source.description,
+            started_at=source.created_at,
+            resolved_at=source.resolved_at,
+        )
+        incidents.setdefault(incident.id, incident)
+
+    return OperationalBatch(
+        org_id=first.org_id,
+        provider=first.provider,
+        provider_instance_id=first.provider_instance_id,
+        services=tuple(services.values()),
+        incidents=tuple(incidents.values()),
+        service_repository_mappings=tuple(mappings.values()),
+    )
+
+
+def map_atlassian_ops_batch(source: AtlassianOpsSource) -> OperationalBatch:
+    """Map one legacy Atlassian Ops provider instance into canonical entities."""
+    incidents = tuple(
+        OperationalIncident(
+            org_id=source.org_id,
+            provider="atlassian",
+            provider_instance_id=source.provider_instance_id,
+            source_entity_type="atlassian_ops_incident",
+            external_id=row.id,
+            source_version_at=row.last_synced,
+            source_url=row.url,
+            raw_status=row.status,
+            raw_severity=row.severity,
+            normalized_status=_normalized_status(row.status),
+            normalized_severity=_normalized_severity(row.severity),
+            title=row.summary,
+            description=row.description,
+            started_at=row.created_at,
+            resolved_at=row.last_synced
+            if _normalized_status(row.status) == "resolved"
+            else None,
+        )
+        for row in source.rows.incidents
+    )
+    alerts = tuple(
+        OperationalAlert(
+            org_id=source.org_id,
+            provider="atlassian",
+            provider_instance_id=source.provider_instance_id,
+            source_entity_type="atlassian_ops_alert",
+            external_id=row.id,
+            source_version_at=row.last_synced,
+            raw_status=row.status,
+            raw_priority=row.priority,
+            normalized_status=_normalized_status(row.status),
+            normalized_priority=_normalized_priority(row.priority),
+            triggered_at=row.created_at,
+            acknowledged_at=row.acknowledged_at,
+            resolved_at=row.closed_at,
+        )
+        for row in source.rows.alerts
+    )
+    schedules = tuple(
+        OnCallSchedule(
+            org_id=source.org_id,
+            provider="atlassian",
+            provider_instance_id=source.provider_instance_id,
+            source_entity_type="atlassian_ops_schedule",
+            external_id=row.id,
+            source_version_at=row.last_synced,
+            name=row.name,
+            timezone=row.timezone,
+        )
+        for row in source.rows.schedules
+    )
+    return OperationalBatch(
+        org_id=source.org_id,
+        provider="atlassian",
+        provider_instance_id=source.provider_instance_id,
+        services=(),
+        incidents=incidents,
+        alerts=alerts,
+        on_call_schedules=schedules,
+    )
+
+
+async def write_operational_batch(
+    store: OperationalWriteStore, batch: OperationalBatch
+) -> None:
+    """Persist a homogeneous canonical batch through typed ClickHouse writers."""
+    if batch.services:
+        await store.insert_operational_services(list(batch.services))
+    if batch.service_repository_mappings:
+        await store.insert_operational_service_repository_mappings(
+            list(batch.service_repository_mappings)
+        )
+    if batch.incidents:
+        await store.insert_operational_incidents(list(batch.incidents))
+    if batch.alerts:
+        await store.insert_operational_alerts(list(batch.alerts))
+    if batch.on_call_schedules:
+        await store.insert_operational_on_call_schedules(list(batch.on_call_schedules))

--- a/src/dev_health_ops/providers/operational_migration.py
+++ b/src/dev_health_ops/providers/operational_migration.py
@@ -26,6 +26,7 @@ from dev_health_ops.models.operational import (
     OperationalService,
     ServiceRepositoryMapping,
 )
+from dev_health_ops.models.operational_identity import operational_source_coordinates
 
 
 @dataclass(frozen=True, slots=True)
@@ -149,27 +150,52 @@ def map_issue_incidents(sources: Sequence[IssueIncidentSource]) -> OperationalBa
         raise ValueError("at least one issue incident source is required")
 
     first = sources[0]
+    first_coordinates = operational_source_coordinates(
+        OperationalIncident,
+        provider=first.provider,
+        provider_instance_id=first.provider_instance_id,
+        external_id=first.external_id,
+        repo_full_name=first.repo_full_name,
+        issue_number=first.issue_number,
+    )
     services: dict[str, OperationalService] = {}
     mappings: dict[str, ServiceRepositoryMapping] = {}
     incidents: dict[str, OperationalIncident] = {}
     for source in sources:
-        if (
-            source.org_id != first.org_id
-            or source.provider != first.provider
-            or source.provider_instance_id != first.provider_instance_id
+        source_coordinates = operational_source_coordinates(
+            OperationalIncident,
+            provider=source.provider,
+            provider_instance_id=source.provider_instance_id,
+            external_id=source.external_id,
+            repo_full_name=source.repo_full_name,
+            issue_number=source.issue_number,
+        )
+        if source.org_id != first.org_id or (
+            source_coordinates.provider,
+            source_coordinates.provider_instance_id,
+        ) != (
+            first_coordinates.provider,
+            first_coordinates.provider_instance_id,
         ):
             raise ValueError(
                 "issue incident sources must share canonical identity context"
             )
 
+        service_coordinates = operational_source_coordinates(
+            OperationalService,
+            provider=source.provider,
+            provider_instance_id=source.provider_instance_id,
+            external_id=source.repo_full_name,
+        )
+        incident_coordinates = source_coordinates
         service = services.setdefault(
             source.repo_full_name,
             OperationalService(
                 org_id=source.org_id,
-                provider=source.provider,
-                provider_instance_id=source.provider_instance_id,
+                provider=service_coordinates.provider,
+                provider_instance_id=service_coordinates.provider_instance_id,
                 source_entity_type="repository",
-                external_id=source.repo_full_name,
+                external_id=service_coordinates.external_id,
                 source_version_at=source.source_version_at,
                 source_url=None,
                 name=source.repo_full_name,
@@ -178,8 +204,8 @@ def map_issue_incidents(sources: Sequence[IssueIncidentSource]) -> OperationalBa
         )
         mapping = ServiceRepositoryMapping(
             org_id=source.org_id,
-            provider=source.provider,
-            provider_instance_id=source.provider_instance_id,
+            provider=service_coordinates.provider,
+            provider_instance_id=service_coordinates.provider_instance_id,
             source_entity_type="repository_mapping",
             external_id=f"{source.repo_full_name}:{source.repo_id}",
             source_version_at=source.source_version_at,
@@ -194,10 +220,10 @@ def map_issue_incidents(sources: Sequence[IssueIncidentSource]) -> OperationalBa
         mappings.setdefault(mapping.id, mapping)
         incident = OperationalIncident(
             org_id=source.org_id,
-            provider=source.provider,
-            provider_instance_id=source.provider_instance_id,
+            provider=incident_coordinates.provider,
+            provider_instance_id=incident_coordinates.provider_instance_id,
             source_entity_type="issue",
-            external_id=source.external_id,
+            external_id=incident_coordinates.external_id,
             source_version_at=source.source_version_at,
             source_url=source.source_url,
             source_event_id=source.issue_number,
@@ -214,8 +240,8 @@ def map_issue_incidents(sources: Sequence[IssueIncidentSource]) -> OperationalBa
 
     return OperationalBatch(
         org_id=first.org_id,
-        provider=first.provider,
-        provider_instance_id=first.provider_instance_id,
+        provider=first_coordinates.provider,
+        provider_instance_id=first_coordinates.provider_instance_id,
         services=tuple(services.values()),
         incidents=tuple(incidents.values()),
         service_repository_mappings=tuple(mappings.values()),

--- a/src/dev_health_ops/push/cli.py
+++ b/src/dev_health_ops/push/cli.py
@@ -355,6 +355,21 @@ def _derive_correlation_external_id(kind: str, payload: dict[str, Any]) -> str:
         )
     if base_kind == "commit":
         return f"{payload['repositoryExternalId']}@{payload['hash']}"
+    if base_kind in {
+        "operational_service",
+        "operational_incident",
+        "operational_alert",
+        "incident_timeline_event",
+        "incident_note",
+        "incident_responder",
+        "escalation_policy",
+        "on_call_schedule",
+        "on_call_assignment",
+        "operational_team",
+        "operational_user",
+        "service_repository_mapping",
+    }:
+        return str(payload["externalId"])
     raise ValueError(f"no correlation-id rule for kind: {kind!r}")
 
 

--- a/tests/api/admin/test_customer_push.py
+++ b/tests/api/admin/test_customer_push.py
@@ -421,6 +421,198 @@ async def test_operational_registration_rejects_linked_credential_host(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("provider", "instance", "environment_url"),
+    (
+        ("github", "https://ghe.acme.test:8443/api/v3", "GITHUB_URL"),
+        ("gitlab", "https://gitlab.acme.test:8443/api/v4", "GITLAB_URL"),
+    ),
+)
+async def test_operational_registration_rejects_environment_auth_host(
+    session_maker,
+    client,
+    monkeypatch,
+    provider: str,
+    instance: str,
+    environment_url: str,
+):
+    # Given: a credentialless managed integration authenticated from its environment.
+    ac, state = client
+    monkeypatch.setenv(f"{provider.upper()}_TOKEN", "test-token")
+    monkeypatch.setenv(environment_url, instance)
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider=provider,
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+
+    # When: a customer push registers the operational family for that host.
+    response = await _create_source(
+        ac,
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+    )
+
+    # Then: environment-auth ownership prevents a second owner.
+    assert response.status_code != 201
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "source_owned_by_fullchaos_sync"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance", "environment_url"),
+    (
+        ("github", "https://ghe.acme.test:8443/api/v3", "GITHUB_URL"),
+        ("gitlab", "https://gitlab.acme.test:8443/api/v4", "GITLAB_URL"),
+    ),
+)
+async def test_operational_registration_rejects_invalid_environment_auth_host(
+    session_maker,
+    client,
+    monkeypatch,
+    provider: str,
+    instance: str,
+    environment_url: str,
+):
+    # Given: an active credentialless integration with an invalid declared environment host.
+    ac, state = client
+    monkeypatch.setenv(f"{provider.upper()}_TOKEN", "test-token")
+    monkeypatch.setenv(environment_url, "not a valid host")
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider=provider,
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+
+    # When: a customer push registers an operational source for the same provider and org.
+    response = await _create_source(
+        ac,
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+    )
+
+    # Then: ownership fails closed instead of defaulting the bad declaration to public.
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "ownership_resolution_unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance", "environment_url"),
+    (
+        ("github", "https://ghe.other.test:8443/api/v3", "GITHUB_URL"),
+        ("gitlab", "https://gitlab.other.test:8443/api/v4", "GITLAB_URL"),
+    ),
+)
+async def test_operational_registration_allows_unrelated_host_without_environment_url(
+    session_maker,
+    client,
+    monkeypatch,
+    provider: str,
+    instance: str,
+    environment_url: str,
+):
+    # Given: a credentialless public managed integration with no declared environment host.
+    ac, state = client
+    monkeypatch.delenv(environment_url, raising=False)
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider=provider,
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+
+    # When: a customer push registers an unrelated self-hosted operational source.
+    response = await _create_source(
+        ac,
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+    )
+
+    # Then: no declared environment host preserves the public default without over-blocking.
+    assert response.status_code == 201
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "environment_url"),
+    (("github", "GITHUB_URL"), ("gitlab", "GITLAB_URL")),
+)
+async def test_invalid_environment_auth_host_does_not_block_another_org(
+    session_maker, client, monkeypatch, provider: str, environment_url: str
+):
+    # Given: an invalid environment host belonging only to another organization.
+    ac, _ = client
+    monkeypatch.setenv(environment_url, "not a valid host")
+    await _seed_integration_source(
+        session_maker,
+        str(uuid.uuid4()),
+        provider=provider,
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+
+    # When: this organization registers the same provider for a self-hosted instance.
+    response = await _create_source(
+        ac,
+        system=provider,
+        instance="https://ghe.other.test:8443/api/v3",
+        entity_family="operational",
+    )
+
+    # Then: another organization's unavailable resolution does not block this source.
+    assert response.status_code == 201
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("managed_provider", "requested_provider", "environment_url"),
+    (
+        ("github", "gitlab", "GITHUB_URL"),
+        ("gitlab", "github", "GITLAB_URL"),
+    ),
+)
+async def test_invalid_environment_auth_host_does_not_block_another_provider(
+    session_maker,
+    client,
+    monkeypatch,
+    managed_provider: str,
+    requested_provider: str,
+    environment_url: str,
+):
+    # Given: this organization has an invalid environment host for a different provider.
+    ac, state = client
+    monkeypatch.setenv(environment_url, "not a valid host")
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider=managed_provider,
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+
+    # When: the other provider registers its operational source.
+    response = await _create_source(
+        ac,
+        system=requested_provider,
+        instance="https://ghe.other.test:8443/api/v3",
+        entity_family="operational",
+    )
+
+    # Then: provider-scoped resolution does not over-block.
+    assert response.status_code == 201
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("provider", "instance"),
     (
         ("github", "https://ghe.acme.test:8443/api/v3"),

--- a/tests/api/admin/test_customer_push.py
+++ b/tests/api/admin/test_customer_push.py
@@ -137,18 +137,20 @@ async def _seed_integration_source(
     name: str | None = None,
     metadata_: dict | None = None,
     credential_base_url: str | None = None,
+    credential_encrypted_override: str | None = None,
     is_enabled: bool = True,
     integration_is_active: bool = True,
 ) -> None:
     integration_id = uuid.uuid4()
     async with session_maker() as session:
         credential_id = None
-        if credential_base_url is not None:
+        if credential_base_url is not None or credential_encrypted_override is not None:
             credential = IntegrationCredential(
                 org_id=org_id,
                 provider=provider,
                 name=f"{provider}-credential",
-                credentials_encrypted=encrypt_value(
+                credentials_encrypted=credential_encrypted_override
+                or encrypt_value(
                     json.dumps({"token": "test-token", "base_url": credential_base_url})
                 ),
             )
@@ -415,6 +417,113 @@ async def test_operational_registration_rejects_linked_credential_host(
     # Then: the managed integration remains the only owner.
     assert response.status_code == 409
     assert response.json()["detail"]["code"] == "source_owned_by_fullchaos_sync"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance"),
+    (
+        ("github", "https://ghe.acme.test:8443/api/v3"),
+        ("gitlab", "https://gitlab.acme.test:8443/api/v4"),
+    ),
+)
+async def test_operational_registration_rejects_undecryptable_linked_credential_host(
+    session_maker, client, monkeypatch, provider: str, instance: str
+):
+    # Given: an active managed self-hosted provider whose linked credential is unreadable.
+    ac, state = client
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider=provider,
+        external_id="acme/api",
+        full_name="acme/api",
+        credential_encrypted_override="undecryptable",
+    )
+
+    # When: a customer push registers the operational family for a self-hosted host.
+    response = await _create_source(
+        ac,
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+    )
+
+    # Then: registration fails closed instead of assuming the public default host.
+    assert response.status_code != 201
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "ownership_resolution_unavailable"
+    assert "linked managed credential" in response.json()["detail"]["message"]
+    assert "undecryptable" not in response.json()["detail"]["message"]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance"),
+    (
+        ("github", "https://ghe.acme.test:8443/api/v3"),
+        ("gitlab", "https://gitlab.acme.test:8443/api/v4"),
+    ),
+)
+async def test_operational_registration_rejects_linked_credential_without_base_url(
+    session_maker, client, monkeypatch, provider: str, instance: str
+):
+    # Given: an active managed self-hosted provider with a readable credential lacking a host.
+    ac, state = client
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider=provider,
+        external_id="acme/api",
+        full_name="acme/api",
+        credential_encrypted_override=encrypt_value(
+            json.dumps({"token": "test-token"})
+        ),
+    )
+
+    # When: a customer push registers the operational family for a self-hosted host.
+    response = await _create_source(
+        ac,
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+    )
+
+    # Then: the incomplete credential is also conservative for self-hosted ownership.
+    assert response.status_code != 201
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "ownership_resolution_unavailable"
+
+
+@pytest.mark.asyncio
+async def test_operational_registration_rejects_non_mapping_linked_credential(
+    session_maker, client, monkeypatch
+):
+    # Given: an active managed GitHub integration with a decryptable but invalid credential shape.
+    ac, state = client
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+        credential_encrypted_override=encrypt_value(json.dumps("not-a-mapping")),
+    )
+
+    # When: a customer push registers a self-hosted operational source.
+    response = await _create_source(
+        ac,
+        system="github",
+        instance="https://ghe.acme.test:8443/api/v3",
+        entity_family="operational",
+    )
+
+    # Then: malformed credential content returns the controlled ownership error.
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "ownership_resolution_unavailable"
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_customer_push.py
+++ b/tests/api/admin/test_customer_push.py
@@ -8,6 +8,7 @@ established by tests/api/admin/test_integrations.py.
 from __future__ import annotations
 
 import importlib
+import json
 import uuid
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
@@ -21,11 +22,13 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 
 from dev_health_ops.api.external_ingest.schemas import SCHEMA_VERSION
 from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.core.encryption import encrypt_value
 from dev_health_ops.models.audit import AuditLog
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.ingest_auth import IngestSource, IngestToken
 from dev_health_ops.models.integrations import Integration, IntegrationSource
 from dev_health_ops.models.licensing import FeatureFlag, OrgFeatureOverride, OrgLicense
+from dev_health_ops.models.settings import IntegrationCredential
 from dev_health_ops.models.users import Organization, User
 from tests._helpers import tables_of
 
@@ -37,6 +40,7 @@ _TABLES = tables_of(
     Organization,
     Integration,
     IntegrationSource,
+    IntegrationCredential,
     IngestSource,
     IngestToken,
     FeatureFlag,
@@ -132,16 +136,31 @@ async def _seed_integration_source(
     full_name: str,
     name: str | None = None,
     metadata_: dict | None = None,
+    credential_base_url: str | None = None,
     is_enabled: bool = True,
     integration_is_active: bool = True,
 ) -> None:
     integration_id = uuid.uuid4()
     async with session_maker() as session:
+        credential_id = None
+        if credential_base_url is not None:
+            credential = IntegrationCredential(
+                org_id=org_id,
+                provider=provider,
+                name=f"{provider}-credential",
+                credentials_encrypted=encrypt_value(
+                    json.dumps({"token": "test-token", "base_url": credential_base_url})
+                ),
+            )
+            session.add(credential)
+            await session.flush()
+            credential_id = credential.id
         session.add(
             Integration(
                 id=integration_id,
                 org_id=org_id,
                 provider=provider,
+                credential_id=credential_id,
                 name=f"{provider}-integration",
                 is_active=integration_is_active,
             )
@@ -360,6 +379,97 @@ async def test_github_enabled_managed_match_by_external_id_409(session_maker, cl
     resp = await _create_source(ac, system="github", instance="acme/api")
     assert resp.status_code == 409
     assert resp.json()["detail"]["code"] == "source_owned_by_fullchaos_sync"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance"),
+    (
+        ("github", "https://ghe.acme.test:8443/api/v3"),
+        ("gitlab", "https://gitlab.acme.test:8443/api/v4"),
+    ),
+)
+async def test_operational_registration_rejects_linked_credential_host(
+    session_maker, client, monkeypatch, provider: str, instance: str
+):
+    # Given: a managed self-hosted provider with its host only on its credential.
+    ac, state = client
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider=provider,
+        external_id="acme/api",
+        full_name="acme/api",
+        credential_base_url=instance,
+    )
+
+    # When: a customer push registers the operational family for that host.
+    response = await _create_source(
+        ac,
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+    )
+
+    # Then: the managed integration remains the only owner.
+    assert response.status_code == 409
+    assert response.json()["detail"]["code"] == "source_owned_by_fullchaos_sync"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance"),
+    (
+        ("github", "https://github.com"),
+        ("gitlab", "https://gitlab.com"),
+    ),
+)
+async def test_operational_registration_rejects_public_default_host(
+    session_maker, client, provider: str, instance: str
+):
+    ac, state = client
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider=provider,
+        external_id="acme/api",
+        full_name="acme/api",
+    )
+
+    response = await _create_source(
+        ac,
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+    )
+
+    assert response.status_code == 409
+
+
+@pytest.mark.asyncio
+async def test_operational_registration_allows_unrelated_credential_host(
+    session_maker, client, monkeypatch
+):
+    ac, state = client
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+    await _seed_integration_source(
+        session_maker,
+        state["org_id"],
+        provider="github",
+        external_id="acme/api",
+        full_name="acme/api",
+        credential_base_url="https://ghe.acme.test:8443/api/v3",
+    )
+
+    response = await _create_source(
+        ac,
+        system="github",
+        instance="https://ghe.other.test:8443/api/v3",
+        entity_family="operational",
+    )
+
+    assert response.status_code == 201
 
 
 @pytest.mark.asyncio

--- a/tests/api/external_ingest/test_schema_registry.py
+++ b/tests/api/external_ingest/test_schema_registry.py
@@ -33,15 +33,29 @@ def test_get_bundle_unsupported_version_returns_none():
     assert registry.get_bundle("external-ingest.v99") is None
 
 
-def test_list_versions_has_one_entry_with_all_nine_kinds_no_duplicates():
+def test_list_versions_has_one_entry_with_all_record_kinds_no_duplicates():
     versions = registry.list_versions()
 
     assert len(versions) == 1
     entry = versions[0]
     assert entry["schemaVersion"] == SCHEMA_VERSION
     kinds = entry["recordKinds"]
-    assert len(kinds) == 9
+    assert len(kinds) == 21
     assert len(set(kinds)) == len(kinds)
+    assert {
+        "operational_service.v1",
+        "operational_incident.v1",
+        "operational_alert.v1",
+        "incident_timeline_event.v1",
+        "incident_note.v1",
+        "incident_responder.v1",
+        "escalation_policy.v1",
+        "on_call_schedule.v1",
+        "on_call_assignment.v1",
+        "operational_team.v1",
+        "operational_user.v1",
+        "service_repository_mapping.v1",
+    }.issubset(kinds)
 
 
 def test_etag_is_stable_and_shaped_like_a_quoted_sha256():

--- a/tests/api/test_external_ingest_router.py
+++ b/tests/api/test_external_ingest_router.py
@@ -758,6 +758,254 @@ async def test_operational_accept_rejects_linked_credential_host(
 
 @pytest.mark.asyncio
 @pytest.mark.parametrize(
+    ("provider", "instance", "environment_url"),
+    (
+        ("github", "https://ghe.acme.test:8443/api/v3", "GITHUB_URL"),
+        ("gitlab", "https://gitlab.acme.test:8443/api/v4", "GITLAB_URL"),
+    ),
+)
+async def test_operational_accept_rejects_environment_auth_host(
+    client,
+    session_maker,
+    monkeypatch,
+    provider: str,
+    instance: str,
+    environment_url: str,
+):
+    # Given: a registered source and credentialless managed integration sharing an environment host.
+    source = IngestSource(
+        org_id="test-org",
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+        mode=IngestSourceMode.CUSTOMER_PUSH.value,
+        enabled=True,
+    )
+    monkeypatch.setenv(f"{provider.upper()}_TOKEN", "test-token")
+    monkeypatch.setenv(environment_url, instance)
+    async with session_maker() as session:
+        integration = Integration(
+            org_id="test-org",
+            provider=provider,
+            name=f"managed-{provider}",
+        )
+        session.add_all((source, integration))
+        await session.flush()
+        session.add(
+            IntegrationSource(
+                org_id="test-org",
+                integration_id=integration.id,
+                provider=provider,
+                source_type="repository",
+                external_id="acme/api",
+                name="api",
+                full_name="acme/api",
+            )
+        )
+        await session.commit()
+    operational_context = IngestAuthContext(
+        org_id="test-org",
+        scopes=frozenset({"ingest:write"}),
+        source=source,
+    )
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: (
+        operational_context
+    )
+    envelope = _envelope(
+        [
+            _record(
+                "operational_incident.v1",
+                "incident-1",
+                {
+                    "externalId": "incident-1",
+                    "sourceVersionAt": "2026-07-17T00:00:00Z",
+                    "title": "Database unavailable",
+                },
+            )
+        ]
+    )
+    envelope["source"] = {
+        "type": "customer_push",
+        "system": provider,
+        "instance": instance,
+        "entityFamily": "operational",
+    }
+
+    # When: the environment-auth source submits an operational incident.
+    response = await client.post(f"{BASE}/batches", json=envelope)
+
+    # Then: accept-time ownership prevents a duplicate operational writer.
+    assert response.status_code != 202
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "source_owned_by_fullchaos_sync"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance", "environment_url"),
+    (
+        ("github", "https://ghe.acme.test:8443/api/v3", "GITHUB_URL"),
+        ("gitlab", "https://gitlab.acme.test:8443/api/v4", "GITLAB_URL"),
+    ),
+)
+async def test_operational_accept_rejects_invalid_environment_auth_host(
+    client,
+    session_maker,
+    monkeypatch,
+    provider: str,
+    instance: str,
+    environment_url: str,
+):
+    # Given: a registered source and managed integration with an invalid environment host.
+    source = IngestSource(
+        org_id="test-org",
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+        mode=IngestSourceMode.CUSTOMER_PUSH.value,
+        enabled=True,
+    )
+    monkeypatch.setenv(f"{provider.upper()}_TOKEN", "test-token")
+    monkeypatch.setenv(environment_url, "not a valid host")
+    async with session_maker() as session:
+        integration = Integration(
+            org_id="test-org",
+            provider=provider,
+            name=f"managed-{provider}",
+        )
+        session.add_all((source, integration))
+        await session.flush()
+        session.add(
+            IntegrationSource(
+                org_id="test-org",
+                integration_id=integration.id,
+                provider=provider,
+                source_type="repository",
+                external_id="acme/api",
+                name="api",
+                full_name="acme/api",
+            )
+        )
+        await session.commit()
+    operational_context = IngestAuthContext(
+        org_id="test-org",
+        scopes=frozenset({"ingest:write"}),
+        source=source,
+    )
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: (
+        operational_context
+    )
+    envelope = _envelope(
+        [
+            _record(
+                "operational_incident.v1",
+                "incident-1",
+                {
+                    "externalId": "incident-1",
+                    "sourceVersionAt": "2026-07-17T00:00:00Z",
+                    "title": "Database unavailable",
+                },
+            )
+        ]
+    )
+    envelope["source"] = {
+        "type": "customer_push",
+        "system": provider,
+        "instance": instance,
+        "entityFamily": "operational",
+    }
+
+    # When: the source submits an operational incident for the same provider and org.
+    response = await client.post(f"{BASE}/batches", json=envelope)
+
+    # Then: accept fails closed instead of treating the invalid declaration as public.
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "ownership_resolution_unavailable"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance", "environment_url"),
+    (
+        ("github", "https://ghe.other.test:8443/api/v3", "GITHUB_URL"),
+        ("gitlab", "https://gitlab.other.test:8443/api/v4", "GITLAB_URL"),
+    ),
+)
+async def test_operational_accept_allows_unrelated_host_without_environment_url(
+    client,
+    session_maker,
+    monkeypatch,
+    provider: str,
+    instance: str,
+    environment_url: str,
+):
+    # Given: a registered self-hosted source and a credentialless public managed integration.
+    source = IngestSource(
+        org_id="test-org",
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+        mode=IngestSourceMode.CUSTOMER_PUSH.value,
+        enabled=True,
+    )
+    monkeypatch.delenv(environment_url, raising=False)
+    async with session_maker() as session:
+        integration = Integration(
+            org_id="test-org",
+            provider=provider,
+            name=f"managed-{provider}",
+        )
+        session.add_all((source, integration))
+        await session.flush()
+        session.add(
+            IntegrationSource(
+                org_id="test-org",
+                integration_id=integration.id,
+                provider=provider,
+                source_type="repository",
+                external_id="acme/api",
+                name="api",
+                full_name="acme/api",
+            )
+        )
+        await session.commit()
+    operational_context = IngestAuthContext(
+        org_id="test-org",
+        scopes=frozenset({"ingest:write"}),
+        source=source,
+    )
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: (
+        operational_context
+    )
+    envelope = _envelope(
+        [
+            _record(
+                "operational_incident.v1",
+                "incident-1",
+                {
+                    "externalId": "incident-1",
+                    "sourceVersionAt": "2026-07-17T00:00:00Z",
+                    "title": "Database unavailable",
+                },
+            )
+        ]
+    )
+    envelope["source"] = {
+        "type": "customer_push",
+        "system": provider,
+        "instance": instance,
+        "entityFamily": "operational",
+    }
+
+    # When: the unrelated self-hosted source submits an operational incident.
+    response = await client.post(f"{BASE}/batches", json=envelope)
+
+    # Then: no environment host preserves public ownership without blocking this push.
+    assert response.status_code == 202
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
     ("provider", "instance"),
     (
         ("github", "https://ghe.acme.test:8443/api/v3"),

--- a/tests/api/test_external_ingest_router.py
+++ b/tests/api/test_external_ingest_router.py
@@ -14,6 +14,7 @@ dependencies for every test below.
 from __future__ import annotations
 
 import importlib
+import json
 import sys
 import uuid as uuid_mod
 from pathlib import Path
@@ -31,6 +32,7 @@ from dev_health_ops.api.external_ingest.schemas import (
 )
 from dev_health_ops.api.external_ingest.streams import StreamUnavailableError
 from dev_health_ops.api.main import app
+from dev_health_ops.core.encryption import encrypt_value
 from dev_health_ops.external_ingest.payload_store import payload_exists
 from dev_health_ops.models.external_ingest import (
     ExternalIngestBatch,
@@ -41,6 +43,7 @@ from dev_health_ops.models.external_ingest import (
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.ingest_auth import IngestSource, IngestSourceMode
 from dev_health_ops.models.integrations import Integration, IntegrationSource
+from dev_health_ops.models.settings import IntegrationCredential
 from tests._helpers import tables_of
 
 # __init__.py exports the APIRouter as "router", shadowing the module name —
@@ -78,6 +81,7 @@ _TABLES = tables_of(
     IngestSource,
     Integration,
     IntegrationSource,
+    IntegrationCredential,
 )
 
 
@@ -662,6 +666,94 @@ async def test_accept_rejected_when_fullchaos_actively_owns_instance(
 
     assert resp.status_code == 403
     assert resp.json()["error"]["code"] == "source_owned_by_fullchaos_sync"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance"),
+    (
+        ("github", "https://ghe.acme.test:8443/api/v3"),
+        ("gitlab", "https://gitlab.acme.test:8443/api/v4"),
+    ),
+)
+async def test_operational_accept_rejects_linked_credential_host(
+    client, session_maker, monkeypatch, provider: str, instance: str
+):
+    # Given: a registered operational source and managed integration sharing only a credential host.
+    source = IngestSource(
+        org_id="test-org",
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+        mode=IngestSourceMode.CUSTOMER_PUSH.value,
+        enabled=True,
+    )
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+    async with session_maker() as session:
+        credential = IntegrationCredential(
+            org_id="test-org",
+            provider=provider,
+            name=f"{provider}-credential",
+            credentials_encrypted=encrypt_value(
+                json.dumps({"token": "test-token", "base_url": instance})
+            ),
+        )
+        session.add(credential)
+        await session.flush()
+        integration = Integration(
+            org_id="test-org",
+            provider=provider,
+            credential_id=credential.id,
+            name=f"managed-{provider}",
+        )
+        session.add_all((source, integration))
+        await session.flush()
+        session.add(
+            IntegrationSource(
+                org_id="test-org",
+                integration_id=integration.id,
+                provider=provider,
+                source_type="repository",
+                external_id="acme/api",
+                name="api",
+                full_name="acme/api",
+            )
+        )
+        await session.commit()
+    operational_context = IngestAuthContext(
+        org_id="test-org",
+        scopes=frozenset({"ingest:write"}),
+        source=source,
+    )
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: (
+        operational_context
+    )
+    envelope = _envelope(
+        [
+            _record(
+                "operational_incident.v1",
+                "incident-1",
+                {
+                    "externalId": "incident-1",
+                    "sourceVersionAt": "2026-07-17T00:00:00Z",
+                    "title": "Database unavailable",
+                },
+            )
+        ]
+    )
+    envelope["source"] = {
+        "type": "customer_push",
+        "system": provider,
+        "instance": instance,
+        "entityFamily": "operational",
+    }
+
+    # When: the credential-host source submits an operational incident.
+    response = await client.post(f"{BASE}/batches", json=envelope)
+
+    # Then: accept-time ownership prevents a duplicate operational writer.
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "source_owned_by_fullchaos_sync"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_external_ingest_router.py
+++ b/tests/api/test_external_ingest_router.py
@@ -757,6 +757,95 @@ async def test_operational_accept_rejects_linked_credential_host(
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("provider", "instance"),
+    (
+        ("github", "https://ghe.acme.test:8443/api/v3"),
+        ("gitlab", "https://gitlab.acme.test:8443/api/v4"),
+    ),
+)
+async def test_operational_accept_rejects_undecryptable_linked_credential_host(
+    client, session_maker, monkeypatch, provider: str, instance: str
+):
+    # Given: a registered operational source and an active managed integration with no readable host.
+    source = IngestSource(
+        org_id="test-org",
+        system=provider,
+        instance=instance,
+        entity_family="operational",
+        mode=IngestSourceMode.CUSTOMER_PUSH.value,
+        enabled=True,
+    )
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+    async with session_maker() as session:
+        credential = IntegrationCredential(
+            org_id="test-org",
+            provider=provider,
+            name=f"{provider}-credential",
+            credentials_encrypted="undecryptable",
+        )
+        session.add(credential)
+        await session.flush()
+        integration = Integration(
+            org_id="test-org",
+            provider=provider,
+            credential_id=credential.id,
+            name=f"managed-{provider}",
+        )
+        session.add_all((source, integration))
+        await session.flush()
+        session.add(
+            IntegrationSource(
+                org_id="test-org",
+                integration_id=integration.id,
+                provider=provider,
+                source_type="repository",
+                external_id="acme/api",
+                name="api",
+                full_name="acme/api",
+            )
+        )
+        await session.commit()
+    operational_context = IngestAuthContext(
+        org_id="test-org",
+        scopes=frozenset({"ingest:write"}),
+        source=source,
+    )
+    app.dependency_overrides[router_mod._require_ingest_write] = lambda: (
+        operational_context
+    )
+    envelope = _envelope(
+        [
+            _record(
+                "operational_incident.v1",
+                "incident-1",
+                {
+                    "externalId": "incident-1",
+                    "sourceVersionAt": "2026-07-17T00:00:00Z",
+                    "title": "Database unavailable",
+                },
+            )
+        ]
+    )
+    envelope["source"] = {
+        "type": "customer_push",
+        "system": provider,
+        "instance": instance,
+        "entityFamily": "operational",
+    }
+
+    # When: the customer source submits an operational incident.
+    response = await client.post(f"{BASE}/batches", json=envelope)
+
+    # Then: accept fails closed while ownership cannot be resolved.
+    assert response.status_code != 202
+    assert response.status_code == 403
+    assert response.json()["error"]["code"] == "ownership_resolution_unavailable"
+    assert "linked managed credential" in response.json()["error"]["message"]
+    assert "undecryptable" not in response.json()["error"]["message"]
+
+
+@pytest.mark.asyncio
 async def test_unexpected_exception_falls_through_to_generic_handler(
     client, monkeypatch
 ):

--- a/tests/external_ingest/test_idempotency.py
+++ b/tests/external_ingest/test_idempotency.py
@@ -123,6 +123,26 @@ def test_canonicalization_timestamp_format_invariant():
     assert compute_payload_hash(zulu) == compute_payload_hash(offset)
 
 
+def test_legacy_payload_hash_matches_the_pre_entity_family_wire_shape():
+    legacy_payload = _envelope_dict()
+    envelope = BatchEnvelope.model_validate(legacy_payload)
+    import hashlib
+    import json as json_mod
+
+    pre_deploy_payload = envelope.model_dump(mode="json")
+    pre_deploy_payload["source"].pop("entity_family")
+    expected = hashlib.sha256(
+        json_mod.dumps(
+            pre_deploy_payload,
+            sort_keys=True,
+            separators=(",", ":"),
+            ensure_ascii=True,
+        ).encode("utf-8")
+    ).hexdigest()
+
+    assert compute_payload_hash(envelope) == expected
+
+
 def test_record_order_is_position_significant():
     """Brief decision 3: records are NOT sorted before hashing -- swapping
     two records is a different payload (CONFLICT), by design."""

--- a/tests/external_ingest/test_normalize.py
+++ b/tests/external_ingest/test_normalize.py
@@ -19,6 +19,10 @@ from dev_health_ops.external_ingest.normalize import (
     ALLOWED_KINDS_BY_SYSTEM,
     normalize_batch,
 )
+from dev_health_ops.models.operational import (
+    OperationalIncident,
+    canonical_operational_id,
+)
 
 ORG = "org-1"
 SOURCE_ID = uuid.uuid4()
@@ -141,6 +145,34 @@ class TestHappyPath:
         assert result.batch.source_system == "github"
         assert result.batch.source_instance == INSTANCE
 
+    def test_operational_incident_uses_canonical_identity_and_source_provenance(
+        self,
+    ) -> None:
+        result = _normalize(
+            [
+                RecordEnvelope(
+                    kind="operational_incident.v1",
+                    external_id="inc-1",
+                    payload={
+                        "externalId": "inc-1",
+                        "sourceVersionAt": "2026-07-01T00:00:00Z",
+                        "title": "Payments latency",
+                        "serviceExternalId": "payments",
+                    },
+                )
+            ],
+            source_system="pagerduty",
+            source_instance="pd-example",
+        )
+
+        assert result.items_rejected == 0
+        (incident,) = result.batch.operational_incidents
+        assert isinstance(incident, OperationalIncident)
+        assert incident.source_id == SOURCE_ID
+        assert incident.id == canonical_operational_id(
+            ORG, "pagerduty", "pd-example", "operational_incident", "inc-1"
+        )
+
 
 class TestShapeRejections:
     def test_invalid_payload_rejected_with_validate_py_code(self) -> None:
@@ -214,11 +246,27 @@ class TestKindSystemMatrix:
         git = {"repository.v1", "pull_request.v1", "review.v1", "commit.v1"}
         wi = {"work_item.v1", "work_item_transition.v1", "work_item_dependency.v1"}
         org = {"team.v1", "identity.v1"}
-        assert ALLOWED_KINDS_BY_SYSTEM["github"] == git | wi | org
-        assert ALLOWED_KINDS_BY_SYSTEM["gitlab"] == git | wi | org
+        operational = {
+            "operational_service.v1",
+            "operational_incident.v1",
+            "operational_alert.v1",
+            "incident_timeline_event.v1",
+            "incident_note.v1",
+            "incident_responder.v1",
+            "escalation_policy.v1",
+            "on_call_schedule.v1",
+            "on_call_assignment.v1",
+            "operational_team.v1",
+            "operational_user.v1",
+            "service_repository_mapping.v1",
+        }
+        assert ALLOWED_KINDS_BY_SYSTEM["github"] == git | wi | org | operational
+        assert ALLOWED_KINDS_BY_SYSTEM["gitlab"] == git | wi | org | operational
         assert ALLOWED_KINDS_BY_SYSTEM["jira"] == wi | org
         assert ALLOWED_KINDS_BY_SYSTEM["linear"] == wi | org
-        assert ALLOWED_KINDS_BY_SYSTEM["custom"] == git | org
+        assert ALLOWED_KINDS_BY_SYSTEM["custom"] == git | org | operational
+        assert ALLOWED_KINDS_BY_SYSTEM["pagerduty"] == org | operational
+        assert ALLOWED_KINDS_BY_SYSTEM["atlassian"] == org | operational
         # Every kind the wire schema knows is reachable through some system.
         reachable = frozenset().union(*ALLOWED_KINDS_BY_SYSTEM.values())
         assert reachable == set(RECORD_KIND_MODELS)

--- a/tests/external_ingest/test_normalize.py
+++ b/tests/external_ingest/test_normalize.py
@@ -173,6 +173,26 @@ class TestHappyPath:
             ORG, "pagerduty", "pd-example", "operational_incident", "inc-1"
         )
 
+    def test_mapping_without_repository_identity_is_rejected(self) -> None:
+        result = _normalize(
+            [
+                RecordEnvelope(
+                    kind="service_repository_mapping.v1",
+                    external_id="mapping-1",
+                    payload={
+                        "externalId": "mapping-1",
+                        "sourceVersionAt": "2026-07-01T00:00:00Z",
+                        "serviceExternalId": "payments",
+                    },
+                )
+            ],
+            source_system="pagerduty",
+            source_instance="pd-example",
+        )
+
+        assert result.items_accepted == 0
+        assert result.rejections[0].code == "repository_identity_required"
+
 
 class TestShapeRejections:
     def test_invalid_payload_rejected_with_validate_py_code(self) -> None:

--- a/tests/external_ingest/test_ownership.py
+++ b/tests/external_ingest/test_ownership.py
@@ -52,6 +52,7 @@ async def _seed_managed(
     full_name: str,
     name: str | None = None,
     metadata_: dict | None = None,
+    config: dict | None = None,
     source_enabled: bool = True,
     integration_active: bool = True,
     org_id: str = ORG,
@@ -64,6 +65,7 @@ async def _seed_managed(
                 org_id=org_id,
                 provider=provider,
                 name=f"{provider}-integration",
+                config=config or {},
                 is_active=integration_active,
             )
         )
@@ -100,10 +102,20 @@ async def _seed_explicit(
         await session.commit()
 
 
-async def _mode(session_maker, *, system: str = "github", instance: str = "acme/api"):
+async def _mode(
+    session_maker,
+    *,
+    system: str = "github",
+    instance: str = "acme/api",
+    entity_family: str = "legacy",
+):
     async with session_maker() as session:
         return await resolve_effective_mode(
-            session, org_id=ORG, system=system, instance=instance
+            session,
+            org_id=ORG,
+            system=system,
+            instance=instance,
+            entity_family=entity_family,
         )
 
 
@@ -217,6 +229,48 @@ async def test_gitlab_metadata_path_case_insensitive(session_maker):
     assert (
         await _mode(session_maker, system="gitlab", instance="group/project")
         == "fullchaos_sync"
+    )
+
+
+@pytest.mark.asyncio
+async def test_operational_family_is_owned_by_managed_github_host(session_maker):
+    await _seed_managed(
+        session_maker, provider="github", external_id="acme/api", full_name="acme/api"
+    )
+
+    assert (
+        await _mode(
+            session_maker,
+            instance="https://github.com/api/v3",
+            entity_family="operational",
+        )
+        == "fullchaos_sync"
+    )
+
+
+@pytest.mark.asyncio
+async def test_operational_family_keeps_unrelated_host_and_legacy_path_independent(
+    session_maker,
+):
+    await _seed_managed(
+        session_maker,
+        provider="gitlab",
+        external_id="12345",
+        full_name="group/project",
+        config={"gitlab_url": "https://gitlab.acme.test:8443/api/v4"},
+    )
+
+    assert (
+        await _mode(
+            session_maker,
+            system="gitlab",
+            instance="gitlab.other.test:8443",
+            entity_family="operational",
+        )
+        == "unclaimed"
+    )
+    assert await _mode(session_maker, system="gitlab", instance="group/project") == (
+        "fullchaos_sync"
     )
 
 

--- a/tests/providers/test_operational_migration.py
+++ b/tests/providers/test_operational_migration.py
@@ -46,7 +46,7 @@ def test_issue_incident_mapper_creates_repository_service_and_mapping() -> None:
     # Then: incident provenance and repository linkage are explicit.
     assert len(batch.incidents) == 1
     assert batch.incidents[0].source_entity_type == "issue"
-    assert batch.incidents[0].external_id == "12345"
+    assert batch.incidents[0].external_id == "acme/api#17"
     assert batch.incidents[0].normalized_status == "resolved"
     assert batch.incidents[0].service_id == batch.services[0].id
     assert batch.incidents[0].service_external_id == "acme/api"

--- a/tests/providers/test_operational_migration.py
+++ b/tests/providers/test_operational_migration.py
@@ -46,7 +46,7 @@ def test_issue_incident_mapper_creates_repository_service_and_mapping() -> None:
     # Then: incident provenance and repository linkage are explicit.
     assert len(batch.incidents) == 1
     assert batch.incidents[0].source_entity_type == "issue"
-    assert batch.incidents[0].external_id == "acme/api#17"
+    assert batch.incidents[0].external_id == "12345"
     assert batch.incidents[0].normalized_status == "resolved"
     assert batch.incidents[0].service_id == batch.services[0].id
     assert batch.incidents[0].service_external_id == "acme/api"

--- a/tests/providers/test_operational_migration.py
+++ b/tests/providers/test_operational_migration.py
@@ -1,0 +1,212 @@
+from datetime import datetime, timezone
+from uuid import UUID
+
+import pytest
+
+from dev_health_ops.models.atlassian_ops import (
+    AtlassianOpsAlert,
+    AtlassianOpsIncident,
+    AtlassianOpsSchedule,
+)
+from dev_health_ops.providers.operational_migration import (
+    AtlassianOpsRows,
+    AtlassianOpsSource,
+    IssueIncidentSource,
+    map_atlassian_ops_batch,
+    map_issue_incidents,
+)
+
+_AT = datetime(2026, 7, 17, tzinfo=timezone.utc)
+_REPO_ID = UUID("00000000-0000-0000-0000-000000000101")
+
+
+def test_issue_incident_mapper_creates_repository_service_and_mapping() -> None:
+    # Given: an issue-labelled incident from a GitHub repository.
+    source = IssueIncidentSource(
+        org_id="org-a",
+        provider="github",
+        provider_instance_id="github.com",
+        repo_id=_REPO_ID,
+        repo_full_name="acme/api",
+        external_id="12345",
+        issue_number="17",
+        source_url="https://github.com/acme/api/issues/17",
+        labels=("incident", "sev-1"),
+        raw_status="closed",
+        title="Database unavailable",
+        description="Primary database was unavailable.",
+        created_at=_AT,
+        resolved_at=_AT,
+        source_version_at=_AT,
+    )
+
+    # When: the source is normalized into the canonical envelope.
+    batch = map_issue_incidents((source,))
+
+    # Then: incident provenance and repository linkage are explicit.
+    assert len(batch.incidents) == 1
+    assert batch.incidents[0].source_entity_type == "issue"
+    assert batch.incidents[0].external_id == "12345"
+    assert batch.incidents[0].normalized_status == "resolved"
+    assert batch.incidents[0].service_id == batch.services[0].id
+    assert batch.incidents[0].service_external_id == "acme/api"
+    assert batch.services[0].name == "acme/api"
+    assert batch.service_repository_mappings[0].repo_id == _REPO_ID
+    assert batch.service_repository_mappings[0].service_id == batch.services[0].id
+
+
+def test_issue_incident_mapper_isolated_by_provider_and_organization() -> None:
+    # Given: equivalent issue ids in distinct provider and organization scopes.
+    github = IssueIncidentSource(
+        org_id="org-a",
+        provider="github",
+        provider_instance_id="github.com",
+        repo_id=_REPO_ID,
+        repo_full_name="acme/api",
+        external_id="12345",
+        issue_number="17",
+        source_url=None,
+        labels=("incident",),
+        raw_status="open",
+        title="Database unavailable",
+        description=None,
+        created_at=_AT,
+        resolved_at=None,
+        source_version_at=_AT,
+    )
+    gitlab = IssueIncidentSource(
+        org_id="org-a",
+        provider="gitlab",
+        provider_instance_id="gitlab.com",
+        repo_id=_REPO_ID,
+        repo_full_name="acme/api",
+        external_id="12345",
+        issue_number="17",
+        source_url=None,
+        labels=("incident",),
+        raw_status="opened",
+        title="Database unavailable",
+        description=None,
+        created_at=_AT,
+        resolved_at=None,
+        source_version_at=_AT,
+    )
+    other_org = IssueIncidentSource(
+        org_id="org-b",
+        provider="github",
+        provider_instance_id="github.com",
+        repo_id=_REPO_ID,
+        repo_full_name="acme/api",
+        external_id="12345",
+        issue_number="17",
+        source_url=None,
+        labels=("incident",),
+        raw_status="open",
+        title="Database unavailable",
+        description=None,
+        created_at=_AT,
+        resolved_at=None,
+        source_version_at=_AT,
+    )
+
+    # When: each source is mapped within its own canonical envelope.
+    github_incident = map_issue_incidents((github,)).incidents[0]
+    gitlab_incident = map_issue_incidents((gitlab,)).incidents[0]
+    other_org_incident = map_issue_incidents((other_org,)).incidents[0]
+
+    # Then: deterministic identities do not cross tenant or provider boundaries.
+    assert github_incident.id != gitlab_incident.id
+    assert github_incident.id != other_org_incident.id
+    assert gitlab_incident.source_entity_type == "issue"
+
+
+def test_atlassian_mapper_preserves_incident_alert_and_schedule_lifecycles() -> None:
+    # Given: legacy Atlassian Ops rows.
+    incident = AtlassianOpsIncident(
+        id="incident-1",
+        url="https://acme.atlassian.net/ops/incident-1",
+        summary="Database unavailable",
+        description="Primary database was unavailable.",
+        status="closed",
+        severity="critical",
+        created_at=_AT,
+        provider_id="acme-atlassian",
+        last_synced=_AT,
+    )
+    alert = AtlassianOpsAlert(
+        id="alert-1",
+        status="closed",
+        priority="high",
+        created_at=_AT,
+        acknowledged_at=_AT,
+        closed_at=_AT,
+        last_synced=_AT,
+    )
+    schedule = AtlassianOpsSchedule(
+        id="schedule-1",
+        name="Primary response",
+        timezone="UTC",
+        last_synced=_AT,
+    )
+
+    # When: legacy rows are mapped for canonical backfill.
+    batch = map_atlassian_ops_batch(
+        AtlassianOpsSource(
+            org_id="org-a",
+            provider_instance_id="acme-atlassian",
+            rows=AtlassianOpsRows(
+                incidents=(incident,),
+                alerts=(alert,),
+                schedules=(schedule,),
+            ),
+        )
+    )
+
+    # Then: each canonical family retains its lifecycle timestamps and provenance.
+    assert batch.provider == "atlassian"
+    assert batch.incidents[0].source_entity_type == "atlassian_ops_incident"
+    assert batch.incidents[0].resolved_at == _AT
+    assert batch.alerts[0].acknowledged_at == _AT
+    assert batch.alerts[0].resolved_at == _AT
+    assert batch.on_call_schedules[0].timezone == "UTC"
+
+
+@pytest.mark.parametrize(
+    ("provider", "provider_instance_id"),
+    (("github", "github.com"), ("gitlab", "https://gitlab.com")),
+)
+def test_issue_mappers_preserve_equivalent_incident_lifecycle(
+    provider: str, provider_instance_id: str
+) -> None:
+    # Given: equivalent issue incidents from each repository provider.
+    source = IssueIncidentSource(
+        org_id="org-a",
+        provider=provider,
+        provider_instance_id=provider_instance_id,
+        repo_id=_REPO_ID,
+        repo_full_name="acme/api",
+        external_id="12345",
+        issue_number="17",
+        source_url=None,
+        labels=("incident",),
+        raw_status="closed",
+        title="Database unavailable",
+        description=None,
+        created_at=_AT,
+        resolved_at=_AT,
+        source_version_at=_AT,
+    )
+
+    # When: each issue is mapped through the common canonical family mapper.
+    batch = map_issue_incidents((source,))
+
+    # Then: canonical count and lifecycle semantics are provider-neutral.
+    assert (
+        len(batch.services)
+        == len(batch.incidents)
+        == len(batch.service_repository_mappings)
+        == 1
+    )
+    assert batch.incidents[0].started_at == _AT
+    assert batch.incidents[0].resolved_at == _AT
+    assert batch.incidents[0].source_entity_type == "issue"

--- a/tests/test_batch_processing.py
+++ b/tests/test_batch_processing.py
@@ -383,6 +383,7 @@ async def test_process_gitlab_projects_batch_persists_instance_discriminator(
 async def test_process_github_repos_batch_upserts_during_async_processing(monkeypatch):
     """Ensure async batch mode upserts as repos complete."""
     _enable_connector_stubs(monkeypatch)
+    inserted_repos = []
 
     monkeypatch.setattr(
         processors.github,
@@ -400,6 +401,7 @@ async def test_process_github_repos_batch_upserts_during_async_processing(monkey
 
     class DummyStore:
         async def insert_repo(self, repo):
+            inserted_repos.append(repo)
             inserted_event.set()
 
         async def insert_git_commit_data(self, commit_data):
@@ -458,6 +460,9 @@ async def test_process_github_repos_batch_upserts_during_async_processing(monkey
         def get_rate_limit(self):
             return {"remaining": 0, "limit": 0}
 
+        def _rest_base_url(self):
+            return "https://ghe.acme.test:8443/api/v3"
+
         def close(self):
             return
 
@@ -484,6 +489,8 @@ async def test_process_github_repos_batch_upserts_during_async_processing(monkey
         rate_limit_delay=0,
         use_async=True,
     )
+
+    assert inserted_repos[0].settings["github_instance_url"] == "ghe.acme.test:8443"
 
 
 @pytest.mark.asyncio

--- a/tests/test_migration_0040_external_ingest_source_entity_family.py
+++ b/tests/test_migration_0040_external_ingest_source_entity_family.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import importlib
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+
+def test_migration_0040_adds_family_scoped_source_uniqueness() -> None:
+    migration = importlib.import_module(
+        "dev_health_ops.alembic.versions.0040_external_ingest_source_entity_family"
+    )
+    engine = create_engine("sqlite:///:memory:")
+    try:
+        with engine.connect() as conn:
+            conn.execute(
+                sa.text(
+                    "CREATE TABLE external_ingest_sources ("
+                    "id TEXT PRIMARY KEY, org_id TEXT NOT NULL, system TEXT NOT NULL, "
+                    "instance TEXT NOT NULL, "
+                    "CONSTRAINT uq_external_ingest_sources_org_system_instance "
+                    "UNIQUE (org_id, system, instance))"
+                )
+            )
+            ctx = MigrationContext.configure(conn)
+            with Operations.context(ctx):
+                migration.upgrade()
+                inspector = sa.inspect(conn)
+                assert "entity_family" in {
+                    column["name"]
+                    for column in inspector.get_columns("external_ingest_sources")
+                }
+                assert {
+                    constraint["name"]
+                    for constraint in inspector.get_unique_constraints(
+                        "external_ingest_sources"
+                    )
+                } == {"uq_external_ingest_sources_org_system_instance_family"}
+                migration.upgrade()
+                migration.downgrade()
+                assert "entity_family" not in {
+                    column["name"]
+                    for column in sa.inspect(conn).get_columns(
+                        "external_ingest_sources"
+                    )
+                }
+    finally:
+        engine.dispose()

--- a/tests/test_operational_backfill.py
+++ b/tests/test_operational_backfill.py
@@ -11,8 +11,8 @@ from dev_health_ops.backfill.operational import (
 _AT = datetime(2026, 7, 17, tzinfo=timezone.utc)
 
 
-def test_legacy_incident_backfill_joins_repository_identity_without_collision() -> None:
-    # Given: equal legacy incident ids from separate repositories in one organization.
+def test_legacy_incident_backfill_preserves_distinct_global_issue_ids() -> None:
+    # Given: distinct provider-global issue ids from separate repositories in one organization.
     rows = (
         LegacyIncidentRepositoryRow(
             org_id="org-a",
@@ -20,7 +20,7 @@ def test_legacy_incident_backfill_joins_repository_identity_without_collision() 
             repo_full_name="acme/api",
             provider="github",
             provider_instance_id="github.com",
-            incident_id="incident-1",
+            incident_id="incident-2",
             status="closed",
             started_at=_AT,
             resolved_at=_AT,
@@ -43,7 +43,7 @@ def test_legacy_incident_backfill_joins_repository_identity_without_collision() 
     # When: legacy incident and repository rows are mapped into canonical batches.
     batches = map_legacy_issue_incident_batches(rows)
 
-    # Then: repository-qualified incident identities remain distinct.
+    # Then: provider-global incident identities remain distinct.
     assert len(batches) == 1
     assert len(batches[0].incidents) == 2
     assert len(batches[0].services) == 2

--- a/tests/test_operational_backfill.py
+++ b/tests/test_operational_backfill.py
@@ -43,9 +43,9 @@ def test_legacy_incident_backfill_joins_repository_identity_without_collision() 
     # When: legacy incident and repository rows are mapped into canonical batches.
     batches = map_legacy_issue_incident_batches(rows)
 
-    # Then: globally stable incident identity dedupes while repository edges remain distinct.
+    # Then: repository-qualified incident identities remain distinct.
     assert len(batches) == 1
-    assert len(batches[0].incidents) == 1
+    assert len(batches[0].incidents) == 2
     assert len(batches[0].services) == 2
     assert {
         mapping.repo_full_name for mapping in batches[0].service_repository_mappings
@@ -93,7 +93,7 @@ def test_legacy_incident_backfill_separates_organizations_and_provider_instances
     assert len(batches) == 2
     assert {batch.org_id for batch in batches} == {"org-a", "org-b"}
     assert {batch.provider_instance_id for batch in batches} == {
-        "https://gitlab.com",
-        "https://gitlab.example.com",
+        "gitlab.com",
+        "gitlab.example.com",
     }
     assert len({batch.incidents[0].id for batch in batches}) == 2

--- a/tests/test_operational_backfill.py
+++ b/tests/test_operational_backfill.py
@@ -1,0 +1,99 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID
+
+from dev_health_ops.backfill.operational import (
+    LegacyIncidentRepositoryRow,
+    map_legacy_issue_incident_batches,
+)
+
+_AT = datetime(2026, 7, 17, tzinfo=timezone.utc)
+
+
+def test_legacy_incident_backfill_joins_repository_identity_without_collision() -> None:
+    # Given: equal legacy incident ids from separate repositories in one organization.
+    rows = (
+        LegacyIncidentRepositoryRow(
+            org_id="org-a",
+            repo_id=UUID("00000000-0000-0000-0000-000000000101"),
+            repo_full_name="acme/api",
+            provider="github",
+            provider_instance_id="github.com",
+            incident_id="incident-1",
+            status="closed",
+            started_at=_AT,
+            resolved_at=_AT,
+            source_version_at=_AT,
+        ),
+        LegacyIncidentRepositoryRow(
+            org_id="org-a",
+            repo_id=UUID("00000000-0000-0000-0000-000000000102"),
+            repo_full_name="acme/worker",
+            provider="github",
+            provider_instance_id="github.com",
+            incident_id="incident-1",
+            status="closed",
+            started_at=_AT,
+            resolved_at=_AT,
+            source_version_at=_AT,
+        ),
+    )
+
+    # When: legacy incident and repository rows are mapped into canonical batches.
+    batches = map_legacy_issue_incident_batches(rows)
+
+    # Then: globally stable incident identity dedupes while repository edges remain distinct.
+    assert len(batches) == 1
+    assert len(batches[0].incidents) == 1
+    assert len(batches[0].services) == 2
+    assert {
+        mapping.repo_full_name for mapping in batches[0].service_repository_mappings
+    } == {
+        "acme/api",
+        "acme/worker",
+    }
+
+
+def test_legacy_incident_backfill_separates_organizations_and_provider_instances() -> (
+    None
+):
+    # Given: matching legacy identity fields across organization and provider-instance boundaries.
+    rows = (
+        LegacyIncidentRepositoryRow(
+            org_id="org-a",
+            repo_id=UUID("00000000-0000-0000-0000-000000000101"),
+            repo_full_name="acme/api",
+            provider="gitlab",
+            provider_instance_id="https://gitlab.com",
+            incident_id="incident-1",
+            status="opened",
+            started_at=_AT,
+            resolved_at=None,
+            source_version_at=_AT,
+        ),
+        LegacyIncidentRepositoryRow(
+            org_id="org-b",
+            repo_id=UUID("00000000-0000-0000-0000-000000000101"),
+            repo_full_name="acme/api",
+            provider="gitlab",
+            provider_instance_id="https://gitlab.example.com",
+            incident_id="incident-1",
+            status="opened",
+            started_at=_AT,
+            resolved_at=None,
+            source_version_at=_AT,
+        ),
+    )
+
+    # When: rows are grouped into homogeneous canonical batches.
+    batches = map_legacy_issue_incident_batches(rows)
+
+    # Then: each canonical identity remains isolated by source context.
+    assert len(batches) == 2
+    assert {batch.org_id for batch in batches} == {"org-a", "org-b"}
+    assert {batch.provider_instance_id for batch in batches} == {
+        "https://gitlab.com",
+        "https://gitlab.example.com",
+    }
+    assert len({batch.incidents[0].id for batch in batches}) == 2

--- a/tests/test_operational_backfill.py
+++ b/tests/test_operational_backfill.py
@@ -1,11 +1,18 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from unittest.mock import Mock
 from uuid import UUID
+
+import pytest
 
 from dev_health_ops.backfill.operational import (
     LegacyIncidentRepositoryRow,
     map_legacy_issue_incident_batches,
+)
+from dev_health_ops.backfill.operational_clickhouse import (
+    _load_legacy_incident_repository_rows,
+    _recover_provider_instance_id,
 )
 
 _AT = datetime(2026, 7, 17, tzinfo=timezone.utc)
@@ -97,3 +104,87 @@ def test_legacy_incident_backfill_separates_organizations_and_provider_instances
         "gitlab.example.com",
     }
     assert len({batch.incidents[0].id for batch in batches}) == 2
+
+
+def test_backfill_recovery_skips_path_only_github_host() -> None:
+    # Given: a legacy repository whose only host recovery value is path-only.
+    settings = {"github_instance_url": "acme/api"}
+
+    # When: the ClickHouse backfill recovers its provider instance.
+    provider_instance_id = _recover_provider_instance_id("github", settings, None)
+
+    # Then: no bogus canonical identity can be fabricated for the repository.
+    assert provider_instance_id is None
+
+
+@pytest.mark.asyncio
+async def test_clickhouse_backfill_skips_repo_with_path_only_github_host() -> None:
+    # Given: a legacy incident repository row with no recoverable GitHub host.
+    store = Mock()
+    store.client.query.return_value = Mock(
+        result_rows=(
+            (
+                "00000000-0000-0000-0000-000000000101",
+                "incident-1",
+                "open",
+                _AT,
+                None,
+                "acme/api",
+                "github",
+                '{"github_instance_url": "acme/api"}',
+            ),
+        )
+    )
+
+    # When: canonical backfill reads the legacy repository row.
+    rows = await _load_legacy_incident_repository_rows(
+        store,
+        org_id="org-a",
+        github_provider_instance_id=None,
+        gitlab_provider_instance_id=None,
+    )
+
+    # Then: the malformed repository is skipped instead of receiving a bogus identity.
+    assert rows == ()
+
+
+@pytest.mark.asyncio
+async def test_clickhouse_backfill_uses_configured_host_after_null_url() -> None:
+    # Given: legacy settings with a null URL and a valid configured GitHub host.
+    store = Mock()
+    store.client.query.return_value = Mock(
+        result_rows=(
+            (
+                "00000000-0000-0000-0000-000000000101",
+                "incident-1",
+                "open",
+                _AT,
+                None,
+                "acme/api",
+                "github",
+                '{"url": null}',
+            ),
+        )
+    )
+
+    # When: canonical backfill reads the legacy repository row.
+    rows = await _load_legacy_incident_repository_rows(
+        store,
+        org_id="org-a",
+        github_provider_instance_id="https://ghe.acme.test:8443/api/v3",
+        gitlab_provider_instance_id=None,
+    )
+
+    # Then: it uses the configured host rather than fabricating a null identity.
+    assert rows[0].provider_instance_id == "ghe.acme.test:8443"
+
+
+def test_backfill_recovery_normalizes_enterprise_github_host_like_native_path() -> None:
+    # Given: an enterprise API URL persisted by the native GitHub path.
+    settings = {"github_instance_url": "https://GHE.Acme.test:8443/api/v3"}
+
+    # When: the legacy ClickHouse backfill recovers the provider instance.
+    provider_instance_id = _recover_provider_instance_id("github", settings, None)
+
+    # Then: it is the same canonical host emitted by the native mapper.
+    assert provider_instance_id == "ghe.acme.test:8443"

--- a/tests/test_operational_clickhouse_live.py
+++ b/tests/test_operational_clickhouse_live.py
@@ -162,7 +162,7 @@ def test_operational_dual_write_and_legacy_backfill_are_idempotent(sink) -> None
             )
             legacy_incident = Incident(
                 repo_id=repo_id,
-                incident_id="github-incident-1",
+                incident_id="17",
                 status="closed",
                 started_at=source_version,
                 resolved_at=source_version,
@@ -206,7 +206,7 @@ def test_operational_dual_write_and_legacy_backfill_are_idempotent(sink) -> None
                             provider_instance_id="github.com",
                             repo_id=repo_id,
                             repo_full_name="acme/api",
-                            external_id="github-incident-1",
+                            external_id="17",
                             issue_number="17",
                             source_url="https://github.com/acme/api/issues/17",
                             labels=("incident",),
@@ -215,7 +215,7 @@ def test_operational_dual_write_and_legacy_backfill_are_idempotent(sink) -> None
                             description=None,
                             created_at=source_version,
                             resolved_at=source_version,
-                            source_version_at=source_version,
+                            source_version_at=source_version + timedelta(seconds=1),
                         ),
                     )
                 )
@@ -274,11 +274,17 @@ def test_operational_dual_write_and_legacy_backfill_are_idempotent(sink) -> None
         }
         assert counts == {
             "operational_services": 1,
-            "operational_incidents": 2,
+            "operational_incidents": 1,
             "operational_alerts": 1,
             "operational_on_call_schedules": 1,
             "operational_service_repository_mappings": 1,
         }
+        incident = sink.client.query(
+            "SELECT title FROM operational_incidents FINAL "
+            "WHERE org_id = {org_id:String}",
+            parameters={"org_id": org_id},
+        ).result_rows
+        assert incident == [("Database unavailable",)]
     finally:
         for table in (
             "operational_services",

--- a/tests/test_operational_clickhouse_live.py
+++ b/tests/test_operational_clickhouse_live.py
@@ -157,7 +157,7 @@ def test_operational_dual_write_and_legacy_backfill_are_idempotent(sink) -> None
                 id=repo_id,
                 repo="acme/api",
                 provider="github",
-                settings={"source": "github"},
+                settings={"source": "github", "github_instance_url": "github.com"},
                 tags=["github"],
             )
             legacy_incident = Incident(
@@ -215,7 +215,7 @@ def test_operational_dual_write_and_legacy_backfill_are_idempotent(sink) -> None
                             description=None,
                             created_at=source_version,
                             resolved_at=source_version,
-                            source_version_at=source_version + timedelta(seconds=1),
+                            source_version_at=source_version,
                         ),
                     )
                 )
@@ -258,7 +258,7 @@ def test_operational_dual_write_and_legacy_backfill_are_idempotent(sink) -> None
         ):
             sink.client.command(f"OPTIMIZE TABLE {table} FINAL")
 
-        # Then: FINAL reads retain one deterministic canonical row per source identity.
+        # Then: native content wins even when the legacy backfill has the same source time.
         counts = {
             table: sink.client.query(
                 f"SELECT count() FROM {table} FINAL WHERE org_id = {{org_id:String}}",
@@ -274,14 +274,14 @@ def test_operational_dual_write_and_legacy_backfill_are_idempotent(sink) -> None
         }
         assert counts == {
             "operational_services": 1,
-            "operational_incidents": 1,
+            "operational_incidents": 2,
             "operational_alerts": 1,
             "operational_on_call_schedules": 1,
             "operational_service_repository_mappings": 1,
         }
         incident = sink.client.query(
             "SELECT title FROM operational_incidents FINAL "
-            "WHERE org_id = {org_id:String}",
+            "WHERE org_id = {org_id:String} AND provider = 'github'",
             parameters={"org_id": org_id},
         ).result_rows
         assert incident == [("Database unavailable",)]

--- a/tests/test_operational_clickhouse_live.py
+++ b/tests/test_operational_clickhouse_live.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import os
 from dataclasses import asdict, fields, replace
 from datetime import datetime, timedelta, timezone
@@ -26,11 +27,12 @@ pytestmark = [
 def sink():
     from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 
-    assert CLICKHOUSE_URI is not None
-    database = (urlparse(CLICKHOUSE_URI).path or "").lstrip("/")
+    clickhouse_uri = CLICKHOUSE_URI
+    assert clickhouse_uri is not None
+    database = (urlparse(clickhouse_uri).path or "").lstrip("/")
     if database in ("", "default"):
         pytest.skip("refusing to run ClickHouse schema setup against default")
-    result = ClickHouseMetricsSink(CLICKHOUSE_URI)
+    result = ClickHouseMetricsSink(clickhouse_uri)
     result.ensure_schema(force=True)
     yield result
     result.close()
@@ -118,3 +120,180 @@ def test_operational_incident_columns_match_the_live_schema(sink) -> None:
 
     # Then: live writes use the complete current contract.
     assert columns == expected
+
+
+def test_operational_dual_write_and_legacy_backfill_are_idempotent(sink) -> None:
+    # Given: live and legacy incident sources scoped to an isolated organization.
+    from dev_health_ops.backfill.operational_clickhouse import (
+        run_canonical_operational_backfill,
+    )
+    from dev_health_ops.metrics.sinks.ingestion import IngestionSink
+    from dev_health_ops.models.atlassian_ops import (
+        AtlassianOpsAlert,
+        AtlassianOpsIncident,
+        AtlassianOpsSchedule,
+    )
+    from dev_health_ops.models.git import Incident, Repo
+    from dev_health_ops.providers.operational_migration import (
+        AtlassianOpsRows,
+        AtlassianOpsSource,
+        IssueIncidentSource,
+        map_atlassian_ops_batch,
+        map_issue_incidents,
+    )
+    from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+    clickhouse_uri = CLICKHOUSE_URI
+    assert clickhouse_uri is not None
+    org_id = f"test-chaos-2963-{uuid4()}"
+    repo_id = uuid4()
+    source_version = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+
+    async def seed_dual_write() -> None:
+        async with ClickHouseStore(clickhouse_uri) as store:
+            store.org_id = org_id
+            ingestion_sink = IngestionSink(store)
+            repo = Repo(
+                id=repo_id,
+                repo="acme/api",
+                provider="github",
+                settings={"source": "github"},
+                tags=["github"],
+            )
+            legacy_incident = Incident(
+                repo_id=repo_id,
+                incident_id="github-incident-1",
+                status="closed",
+                started_at=source_version,
+                resolved_at=source_version,
+            )
+            atlassian_incident = AtlassianOpsIncident(
+                id="atlassian-incident-1",
+                url="https://acme.atlassian.net/ops/incident-1",
+                summary="Pager incident",
+                description=None,
+                status="closed",
+                severity="high",
+                created_at=source_version,
+                provider_id="acme-atlassian",
+                last_synced=source_version,
+            )
+            atlassian_alert = AtlassianOpsAlert(
+                id="atlassian-alert-1",
+                status="closed",
+                priority="high",
+                created_at=source_version,
+                closed_at=source_version,
+                last_synced=source_version,
+            )
+            atlassian_schedule = AtlassianOpsSchedule(
+                id="atlassian-schedule-1",
+                name="Primary response",
+                timezone="UTC",
+                last_synced=source_version,
+            )
+            await store.insert_repo(repo)
+            await store.insert_incidents([legacy_incident])
+            await store.insert_atlassian_ops_incidents([atlassian_incident])
+            await store.insert_atlassian_ops_alerts([atlassian_alert])
+            await store.insert_atlassian_ops_schedules([atlassian_schedule])
+            await ingestion_sink.insert_operational_batch(
+                map_issue_incidents(
+                    (
+                        IssueIncidentSource(
+                            org_id=org_id,
+                            provider="github",
+                            provider_instance_id="github.com",
+                            repo_id=repo_id,
+                            repo_full_name="acme/api",
+                            external_id="github-incident-1",
+                            issue_number="17",
+                            source_url="https://github.com/acme/api/issues/17",
+                            labels=("incident",),
+                            raw_status="closed",
+                            title="Database unavailable",
+                            description=None,
+                            created_at=source_version,
+                            resolved_at=source_version,
+                            source_version_at=source_version,
+                        ),
+                    )
+                )
+            )
+            await ingestion_sink.insert_operational_batch(
+                map_atlassian_ops_batch(
+                    AtlassianOpsSource(
+                        org_id=org_id,
+                        provider_instance_id="atlassian-ops",
+                        rows=AtlassianOpsRows(
+                            incidents=(atlassian_incident,),
+                            alerts=(atlassian_alert,),
+                            schedules=(atlassian_schedule,),
+                        ),
+                    )
+                )
+            )
+
+    try:
+        # When: dual-write and repeated legacy backfills populate canonical tables.
+        asyncio.run(seed_dual_write())
+        asyncio.run(
+            run_canonical_operational_backfill(
+                clickhouse_uri=clickhouse_uri,
+                org_id=org_id,
+            )
+        )
+        asyncio.run(
+            run_canonical_operational_backfill(
+                clickhouse_uri=clickhouse_uri,
+                org_id=org_id,
+            )
+        )
+        for table in (
+            "operational_services",
+            "operational_incidents",
+            "operational_alerts",
+            "operational_on_call_schedules",
+            "operational_service_repository_mappings",
+        ):
+            sink.client.command(f"OPTIMIZE TABLE {table} FINAL")
+
+        # Then: FINAL reads retain one deterministic canonical row per source identity.
+        counts = {
+            table: sink.client.query(
+                f"SELECT count() FROM {table} FINAL WHERE org_id = {{org_id:String}}",
+                parameters={"org_id": org_id},
+            ).result_rows[0][0]
+            for table in (
+                "operational_services",
+                "operational_incidents",
+                "operational_alerts",
+                "operational_on_call_schedules",
+                "operational_service_repository_mappings",
+            )
+        }
+        assert counts == {
+            "operational_services": 1,
+            "operational_incidents": 2,
+            "operational_alerts": 1,
+            "operational_on_call_schedules": 1,
+            "operational_service_repository_mappings": 1,
+        }
+    finally:
+        for table in (
+            "operational_services",
+            "operational_incidents",
+            "operational_alerts",
+            "operational_on_call_schedules",
+            "operational_service_repository_mappings",
+            "atlassian_ops_incidents",
+            "atlassian_ops_alerts",
+            "atlassian_ops_schedules",
+            "incidents",
+            "repos",
+        ):
+            sink.client.command(
+                f"ALTER TABLE {table} DELETE WHERE org_id = {{org_id:String}} "
+                "SETTINGS mutations_sync=2",
+                parameters={"org_id": org_id},
+            )

--- a/tests/test_operational_identity_parity.py
+++ b/tests/test_operational_identity_parity.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from uuid import UUID, uuid4
+
+import pytest
+
+from dev_health_ops.api.external_ingest.schemas import RecordEnvelope
+from dev_health_ops.backfill.operational import (
+    LegacyIncidentRepositoryRow,
+    map_legacy_issue_incident_batches,
+)
+from dev_health_ops.external_ingest.normalize import normalize_batch
+from dev_health_ops.providers.operational_migration import (
+    IssueIncidentSource,
+    map_issue_incidents,
+)
+
+_AT = datetime(2026, 7, 17, tzinfo=timezone.utc)
+_REPO_ID = UUID("00000000-0000-0000-0000-000000000101")
+
+
+@pytest.mark.parametrize(
+    ("provider", "instance"),
+    (("github", "https://github.com"), ("gitlab", "https://gitlab.example.com")),
+)
+def test_operational_incident_identity_matches_native_backfill_and_push(
+    provider: str, instance: str
+) -> None:
+    # Given: one logical issue incident represented by all three ingestion paths.
+    native = IssueIncidentSource(
+        org_id="org-a",
+        provider=provider,
+        provider_instance_id=instance,
+        repo_id=_REPO_ID,
+        repo_full_name="acme/api",
+        external_id="17",
+        issue_number="17",
+        source_url=None,
+        labels=("incident",),
+        raw_status="open",
+        title="Database unavailable",
+        description=None,
+        created_at=_AT,
+        resolved_at=None,
+        source_version_at=_AT,
+    )
+    backfill = LegacyIncidentRepositoryRow(
+        org_id="org-a",
+        repo_id=_REPO_ID,
+        repo_full_name="acme/api",
+        provider=provider,
+        provider_instance_id=instance,
+        incident_id="17",
+        status="open",
+        started_at=_AT,
+        resolved_at=None,
+        source_version_at=_AT,
+    )
+    push_record = RecordEnvelope(
+        kind="operational_incident.v1",
+        external_id="17",
+        payload={
+            "externalId": "17",
+            "sourceVersionAt": _AT.isoformat(),
+            "sourceEventId": "17",
+            "serviceExternalId": "acme/api",
+            "title": "Database unavailable",
+        },
+    )
+
+    # When: each representation is mapped into canonical operational records.
+    native_id = map_issue_incidents((native,)).incidents[0].id
+    backfill_id = map_legacy_issue_incident_batches((backfill,))[0].incidents[0].id
+    push_id = (
+        normalize_batch(
+            org_id="org-a",
+            source_id=uuid4(),
+            source_system=provider,
+            source_instance=instance,
+            ingestion_id=uuid4(),
+            records=[push_record],
+        )
+        .batch.operational_incidents[0]
+        .id
+    )
+
+    # Then: all producer paths use the same canonical source coordinates.
+    assert native_id == backfill_id == push_id

--- a/tests/test_operational_identity_parity.py
+++ b/tests/test_operational_identity_parity.py
@@ -21,20 +21,45 @@ _REPO_ID = UUID("00000000-0000-0000-0000-000000000101")
 
 
 @pytest.mark.parametrize(
-    ("provider", "instance"),
-    (("github", "https://github.com"), ("gitlab", "https://gitlab.example.com")),
+    (
+        "provider",
+        "native_instance",
+        "backfill_instance",
+        "push_instance",
+        "global_issue_id",
+    ),
+    (
+        (
+            "github",
+            "https://GHE.Acme.test:8443/api/v3",
+            "ghe.acme.test:8443",
+            "https://ghe.acme.test:8443/api/v3",
+            "100000001",
+        ),
+        (
+            "gitlab",
+            "https://GitLab.Acme.test:8443/api/v4",
+            "gitlab.acme.test:8443",
+            "https://gitlab.acme.test:8443/api/v4",
+            "200000001",
+        ),
+    ),
 )
 def test_operational_incident_identity_matches_native_backfill_and_push(
-    provider: str, instance: str
+    provider: str,
+    native_instance: str,
+    backfill_instance: str,
+    push_instance: str,
+    global_issue_id: str,
 ) -> None:
     # Given: one logical issue incident represented by all three ingestion paths.
     native = IssueIncidentSource(
         org_id="org-a",
         provider=provider,
-        provider_instance_id=instance,
+        provider_instance_id=native_instance,
         repo_id=_REPO_ID,
-        repo_full_name="acme/api",
-        external_id="17",
+        repo_full_name="AcMe/API",
+        external_id=global_issue_id,
         issue_number="17",
         source_url=None,
         labels=("incident",),
@@ -48,10 +73,10 @@ def test_operational_incident_identity_matches_native_backfill_and_push(
     backfill = LegacyIncidentRepositoryRow(
         org_id="org-a",
         repo_id=_REPO_ID,
-        repo_full_name="acme/api",
+        repo_full_name="AcMe/API",
         provider=provider,
-        provider_instance_id=instance,
-        incident_id="17",
+        provider_instance_id=backfill_instance,
+        incident_id=global_issue_id,
         status="open",
         started_at=_AT,
         resolved_at=None,
@@ -59,12 +84,12 @@ def test_operational_incident_identity_matches_native_backfill_and_push(
     )
     push_record = RecordEnvelope(
         kind="operational_incident.v1",
-        external_id="17",
+        external_id=global_issue_id,
         payload={
-            "externalId": "17",
+            "externalId": global_issue_id,
             "sourceVersionAt": _AT.isoformat(),
             "sourceEventId": "17",
-            "serviceExternalId": "acme/api",
+            "serviceExternalId": "AcMe/API",
             "title": "Database unavailable",
         },
     )
@@ -77,7 +102,7 @@ def test_operational_incident_identity_matches_native_backfill_and_push(
             org_id="org-a",
             source_id=uuid4(),
             source_system=provider,
-            source_instance=instance,
+            source_instance=push_instance,
             ingestion_id=uuid4(),
             records=[push_record],
         )

--- a/tests/test_operational_incident_producers.py
+++ b/tests/test_operational_incident_producers.py
@@ -1,0 +1,123 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+from uuid import UUID
+
+import pytest
+
+from dev_health_ops.processors.github import _fetch_github_incidents_async
+from dev_health_ops.processors.gitlab import _fetch_gitlab_incidents_sync
+from dev_health_ops.providers.operational_migration import IssueIncidentSource
+
+_AT = datetime(2026, 7, 17, tzinfo=timezone.utc)
+_REPO_ID = UUID("00000000-0000-0000-0000-000000000101")
+
+
+class _GitHubIssueClient:
+    def __init__(self, issue: SimpleNamespace) -> None:
+        self._issue = issue
+        self.close = AsyncMock()
+
+    async def iter_issues(
+        self, _owner: str, _repo: str, **_kwargs: object
+    ) -> list[SimpleNamespace]:
+        return [self._issue]
+
+    def drain_usage_observations(self) -> list[dict[str, str]]:
+        return []
+
+
+@pytest.mark.asyncio
+async def test_github_incident_fetch_retains_full_issue_for_canonical_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given: a live GitHub issue with the metadata absent from legacy incidents.
+    from dev_health_ops.processors import github
+
+    issue = SimpleNamespace(
+        issue_id="github-incident-1",
+        number=17,
+        state="closed",
+        created_at=_AT,
+        closed_at=_AT,
+        updated_at=_AT,
+        source_url="https://github.com/acme/api/issues/17",
+        title="Database unavailable",
+        description="The primary database was unavailable.",
+        labels=("incident", "sev-1"),
+    )
+    client = _GitHubIssueClient(issue)
+    monkeypatch.setattr(github, "resolve_incident_labels", lambda: ["incident"])
+    monkeypatch.setattr(
+        github, "_github_code_client_from_connector", lambda _connector: client
+    )
+    sources: list[IssueIncidentSource] = []
+
+    # When: the legacy producer fetches its incident row.
+    incidents = await _fetch_github_incidents_async(
+        Mock(),
+        "acme",
+        "api",
+        _REPO_ID,
+        10,
+        None,
+        canonical_sources=sources,
+        canonical_org_id="org-a",
+        canonical_provider_instance_id="github.com",
+    )
+
+    # Then: the additive canonical source retains lifecycle and issue metadata.
+    assert [incident.incident_id for incident in incidents] == ["github-incident-1"]
+    assert len(sources) == 1
+    assert sources[0].source_url == "https://github.com/acme/api/issues/17"
+    assert sources[0].issue_number == "17"
+    assert sources[0].labels == ("incident", "sev-1")
+    assert sources[0].resolved_at == _AT
+
+
+def test_gitlab_incident_fetch_retains_full_issue_for_canonical_mapping(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Given: a live GitLab issue with metadata absent from legacy incidents.
+    from dev_health_ops.processors import gitlab
+
+    connector = Mock()
+    connector.rest_client.get_issues.return_value = [
+        {
+            "id": "gitlab-incident-1",
+            "iid": 17,
+            "state": "closed",
+            "created_at": "2026-07-17T00:00:00Z",
+            "closed_at": "2026-07-17T00:00:00Z",
+            "updated_at": "2026-07-17T00:00:00Z",
+            "web_url": "https://gitlab.com/acme/api/-/issues/17",
+            "title": "Database unavailable",
+            "description": "The primary database was unavailable.",
+            "labels": ["incident", "severity::high"],
+        }
+    ]
+    monkeypatch.setattr(gitlab, "resolve_incident_labels", lambda: ["incident"])
+    sources: list[IssueIncidentSource] = []
+
+    # When: the legacy producer fetches its incident row.
+    incidents = _fetch_gitlab_incidents_sync(
+        connector,
+        123,
+        _REPO_ID,
+        10,
+        None,
+        canonical_sources=sources,
+        canonical_org_id="org-a",
+        canonical_provider_instance_id="https://gitlab.com",
+        repo_full_name="acme/api",
+    )
+
+    # Then: the additive canonical source retains lifecycle and issue metadata.
+    assert [incident.incident_id for incident in incidents] == ["gitlab-incident-1"]
+    assert len(sources) == 1
+    assert sources[0].source_url == "https://gitlab.com/acme/api/-/issues/17"
+    assert sources[0].issue_number == "17"
+    assert sources[0].labels == ("incident", "severity::high")
+    assert sources[0].resolved_at == _AT


### PR DESCRIPTION
## Wave 1 — Migrate native producers + External Push operational record kinds

Second implementation wave of the canonical operations program ([CHAOS-2954](https://linear.app/fullchaos/issue/CHAOS-2954/canonical-operations-model-and-pagerduty-integration)), building on the Wave 0 canonical contract (#1233). Two changes that share one identity/ownership contract:

- **[CHAOS-2963](https://linear.app/fullchaos/issue/CHAOS-2963)** — migrate Atlassian/JSM, GitHub, and GitLab incident producers into the canonical operational model via dual-write + idempotent historical backfill, keeping the legacy path fully intact.
- **[CHAOS-2964](https://linear.app/fullchaos/issue/CHAOS-2964)** — add 12 canonical operational record kinds to the External Push API (`/api/v1/external-ingest`) with entity-family dataset ownership.

Additive and reversible: legacy incident storage/reads and the existing 9 push record kinds are untouched; downstream analytics (DORA/MTTR, incident correlation, Sankey, deployment edges) are **not** cut over here — that is CHAOS-2959.

### The shared identity contract (the crux)

A single helper `models/operational_identity.py::operational_source_coordinates(...)` derives `(provider, provider_instance_id, entity_family, external_id)` for **every** path — native dual-write, historical backfill, and customer push — so the same logical incident yields the **identical** `canonical_operational_id` regardless of transport. Key rules:
- `external_id` uses the provider-**global** issue id (recoverable from legacy `incidents`, present natively, suppliable by push) — not the repo-local number.
- `provider_instance_id` is account/host grain (github.com / enterprise host / self-hosted GitLab instance), consistently normalized (case, ports, GHE `/api/v3`, GitLab `:443`); repository is a service via `ServiceRepositoryMapping`, never in the incident identity.

### Dataset-family ownership (prevents double-ingestion)

Ownership key is now `(org_id, source_system, source_instance, entity_family)`. Native sync and customer push cannot both own the same operational family for an instance. Host resolution is source-aware across **all** deployment modes — config host, linked credential `base_url` (GHE / self-hosted), and env-auth (`GITHUB_URL`/`GITLAB_URL` for null-credential integrations) — and **fails closed** (409 registration / 403 accept, secret-safe) when a host cannot be determined (undecryptable credential or declared-but-invalid env host). Additive record kinds keep existing legacy client hashes byte-for-byte identical.

### Backfill safety

Historical backfill versions rows by real source-event time (not ingestion time), reads legacy `ReplacingMergeTree` inputs with `FINAL`, and can never outrank a genuine native row for the same id (equal-timestamp precedence proven by a live-ClickHouse test).

### Review + validation

This wave went through **6 adversarial Oracle reviews** (blocker count 7 → 4 → 2 → 1 → 1 → 0) hardening the identity/ownership boundary across public, enterprise, self-hosted-credential, undecryptable-credential, and environment-auth vectors. Final Oracle verdict: **PASS, 0 critical / 0 warning, no regressions.** The full standing pre-push gate (`ci/local_validate.sh`) is green: ruff + mypy, ClickHouse scratch migrate, the full unit suite, and the live-engine argMax proof. Includes live-ClickHouse identity-parity + backfill-precedence + tombstone tests.

### Deferred (tracked)

- **[CHAOS-2965](https://linear.app/fullchaos/issue/CHAOS-2965)** — dedicated live External-Push operational idempotency + tombstone test (before production enablement).
- **[CHAOS-2966](https://linear.app/fullchaos/issue/CHAOS-2966)** — native snapshot incident tombstones on label removal/disappearance (before consumer cutover, CHAOS-2959).

### Scope boundaries (later waves)

PagerDuty REST sync (CHAOS-2957) + V3 webhooks (CHAOS-2958), correlation/service-repo work-graph cutover (CHAOS-2959), setup UX (CHAOS-2960), and release validation (CHAOS-2961) are **not** in this PR.

SCREENSHOT-WAIVER: backend-only, no rendered UI in this wave.

Closes CHAOS-2963, CHAOS-2964.
