### PR TITLE
feat(ops): Wave 2 — PagerDuty REST sync into canonical operational sinks (CHAOS-2957)

### DIFF
--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -378,6 +378,7 @@ def _run_gitlab_dataset(
 def _run_pagerduty_dataset(
     context: SyncTaskContext, runtime: ProviderRuntime
 ) -> dict[str, Any]:
+    from dev_health_ops.providers.pagerduty.enrichment import PagerDutyEnrichmentToggles
     from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
     from dev_health_ops.providers.pagerduty.sync import (
         PagerDutyOperationalSync,
@@ -386,6 +387,12 @@ def _run_pagerduty_dataset(
 
     client, provider_instance_id = _pagerduty_client(context)
     usage_sink: list[dict[str, Any]] = []
+    enrichment_cap = context.dataset_options.get("enrichment_cap", 100)
+    if not isinstance(enrichment_cap, int) or isinstance(enrichment_cap, bool):
+        enrichment_cap = 100
+    enrichment = PagerDutyEnrichmentToggles.from_dataset_options(
+        context.dataset_key, context.dataset_options
+    )
 
     async def _handler(store: Any) -> dict[str, Any]:
         result = await PagerDutyOperationalSync(
@@ -404,6 +411,8 @@ def _run_pagerduty_dataset(
                 window_start=context.window_start,
                 window_end=context.window_end,
                 resume_after=context.resume_cursor,
+                enrichment_cap=enrichment_cap,
+                enrichment=enrichment,
             )
         )
         usage_sink.extend(result.observations)

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -401,12 +401,16 @@ def _run_pagerduty_dataset(
                 dataset_key=context.dataset_key,
                 window_start=context.window_start,
                 window_end=context.window_end,
+                resume_after=context.resume_cursor,
             )
         )
         usage_sink.extend(result.observations)
         return {
             "persisted": result.persisted,
             "degraded": result.degraded,
+            "watermark_at": result.watermark_at.isoformat()
+            if result.watermark_at is not None
+            else None,
         }
 
     try:

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -424,14 +424,22 @@ def _run_pagerduty_dataset(
             else None,
         }
 
+    sync_error: Exception | None = None
     try:
         sync_result = run_async(
             _run_with_reused_or_new_store(context, runtime, _handler)
         )
     except Exception as exc:
+        sync_error = exc
         usage_sink.extend(client.drain_usage_observations())
         _attach_usage_sink_to_exception(exc, usage_sink)
         raise
+    finally:
+        try:
+            run_async(client.close())
+        except Exception:
+            if sync_error is None:
+                raise
     result: dict[str, Any] = {
         "provider": context.provider,
         "dataset": context.dataset_key,

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -173,7 +173,9 @@ def _pagerduty_client(context: SyncTaskContext) -> tuple[Any, str]:
         auth = ApiTokenAuth(credentials.api_token)
     else:
         raise ValueError("PagerDuty dataset unit requires an access token or API token")
-    provider_instance_id = credentials.subdomain or context.source_external_id
+    provider_instance_id = (
+        credentials.subdomain.strip() if credentials.subdomain else ""
+    )
     if not provider_instance_id:
         raise ValueError("PagerDuty dataset unit requires an account subdomain")
     return PagerDutyClient(auth, region=credentials.region), provider_instance_id

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -7,6 +7,7 @@ from typing import Any
 from dev_health_ops.credentials.resolver import (
     github_credentials_from_mapping,
     gitlab_credentials_from_mapping,
+    pagerduty_credentials_from_mapping,
     resolve_gitlab_url,
 )
 from dev_health_ops.providers.usage import (
@@ -58,6 +59,22 @@ _WORK_ITEM_DATASETS = frozenset(
         DatasetKey.WORK_ITEM_PROJECTS.value,
         DatasetKey.WORK_ITEM_HISTORY.value,
         DatasetKey.WORK_ITEM_COMMENTS.value,
+    }
+)
+
+_PAGERDUTY_DATASETS = frozenset(
+    {
+        DatasetKey.SERVICES.value,
+        DatasetKey.BUSINESS_SERVICES.value,
+        DatasetKey.ESCALATION_POLICIES.value,
+        DatasetKey.SCHEDULES.value,
+        DatasetKey.ON_CALLS.value,
+        DatasetKey.USERS.value,
+        DatasetKey.TEAMS.value,
+        DatasetKey.INCIDENTS.value,
+        DatasetKey.INCIDENT_ALERTS.value,
+        DatasetKey.INCIDENT_LOG_ENTRIES.value,
+        DatasetKey.INCIDENT_NOTES.value,
     }
 )
 
@@ -136,6 +153,30 @@ def _gitlab_project_id(source_external_id: str) -> int:
     raise ValueError(
         "GitLab dataset unit requires numeric source_external_id project id"
     )
+
+
+def _pagerduty_client(context: SyncTaskContext) -> tuple[Any, str]:
+    from dev_health_ops.providers.pagerduty.auth import (
+        ApiTokenAuth,
+        OAuthBearerAuth,
+        PagerDutyAuth,
+    )
+    from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+
+    credentials = pagerduty_credentials_from_mapping(_credentials_mapping(context))
+    if credentials is None:
+        raise ValueError("Missing PagerDuty credentials for dataset unit")
+    auth: PagerDutyAuth
+    if credentials.access_token:
+        auth = OAuthBearerAuth(credentials.access_token)
+    elif credentials.api_token:
+        auth = ApiTokenAuth(credentials.api_token)
+    else:
+        raise ValueError("PagerDuty dataset unit requires an access token or API token")
+    provider_instance_id = credentials.subdomain or context.source_external_id
+    if not provider_instance_id:
+        raise ValueError("PagerDuty dataset unit requires an account subdomain")
+    return PagerDutyClient(auth, region=credentials.region), provider_instance_id
 
 
 def _window_backfill_days(context: SyncTaskContext) -> int:
@@ -332,6 +373,68 @@ def _run_gitlab_dataset(
     return result
 
 
+def _run_pagerduty_dataset(
+    context: SyncTaskContext, runtime: ProviderRuntime
+) -> dict[str, Any]:
+    from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
+    from dev_health_ops.providers.pagerduty.sync import (
+        PagerDutyOperationalSync,
+        PagerDutySyncOptions,
+    )
+
+    client, provider_instance_id = _pagerduty_client(context)
+    usage_sink: list[dict[str, Any]] = []
+
+    async def _handler(store: Any) -> dict[str, Any]:
+        result = await PagerDutyOperationalSync(
+            client=client,
+            store=store,
+            normalizer=PagerDutyNormalizer(
+                org_id=context.org_id,
+                provider_instance_id=provider_instance_id,
+                observed_at=context.window_end
+                or context.window_start
+                or datetime.now(timezone.utc),
+            ),
+        ).run(
+            PagerDutySyncOptions(
+                dataset_key=context.dataset_key,
+                window_start=context.window_start,
+                window_end=context.window_end,
+            )
+        )
+        usage_sink.extend(result.observations)
+        return {
+            "persisted": result.persisted,
+            "degraded": result.degraded,
+        }
+
+    try:
+        sync_result = run_async(
+            _run_with_reused_or_new_store(context, runtime, _handler)
+        )
+    except Exception as exc:
+        usage_sink.extend(client.drain_usage_observations())
+        _attach_usage_sink_to_exception(exc, usage_sink)
+        raise
+    result: dict[str, Any] = {
+        "provider": context.provider,
+        "dataset": context.dataset_key,
+        "source": context.source_external_id,
+        "provider_instance_id": provider_instance_id,
+        "window_start": context.window_start.isoformat()
+        if context.window_start is not None
+        else None,
+        "window_end": context.window_end.isoformat()
+        if context.window_end is not None
+        else None,
+        **sync_result,
+    }
+    if usage_sink:
+        result["observations"] = {PROVIDER_USAGE_OBSERVATION_KEY: usage_sink}
+    return result
+
+
 def _attach_usage_sink_to_exception(
     exc: BaseException, usage_sink: list[dict[str, Any]]
 ) -> None:
@@ -425,6 +528,9 @@ def run_dataset_unit(
 ) -> dict[str, Any]:
     provider = context.provider.lower()
     dataset_key = context.dataset_key
+
+    if provider == "pagerduty" and dataset_key in _PAGERDUTY_DATASETS:
+        return _run_pagerduty_dataset(context, runtime)
 
     if dataset_key in _CODE_DATASETS:
         if provider == "github":

--- a/src/dev_health_ops/providers/pagerduty/budget.py
+++ b/src/dev_health_ops/providers/pagerduty/budget.py
@@ -10,6 +10,25 @@ from dev_health_ops.sync.budget_types import (
     BudgetEstimate,
 )
 
+_DEFAULT_ENRICHMENT_CAP = 100
+_ESTIMATED_INCIDENT_PAGES = 2
+_PAGERDUTY_PAGE_SIZE = 100
+_DATASET_ROUTE_FAMILIES = {
+    "incidents": "pagerduty_incidents",
+    "services": "pagerduty_services",
+    "business-services": "pagerduty_business_services",
+    "escalation-policies": "pagerduty_escalation_policies",
+    "schedules": "pagerduty_schedules",
+    "on-calls": "pagerduty_oncalls",
+    "users": "pagerduty_users",
+    "teams": "pagerduty_teams",
+}
+_ENRICHMENT_ROUTE_FAMILIES = {
+    "incident-alerts": "pagerduty_alerts",
+    "incident-log-entries": "pagerduty_log_entries",
+    "incident-notes": "pagerduty_notes",
+}
+
 PAGERDUTY_ROUTE_FAMILIES = tuple(
     UsageRouteFamily(
         name, BudgetDimension.REST_CORE, "rest", (name.replace("pagerduty_", ""),)
@@ -23,6 +42,9 @@ PAGERDUTY_ROUTE_FAMILIES = tuple(
         "pagerduty_oncalls",
         "pagerduty_users",
         "pagerduty_teams",
+        "pagerduty_alerts",
+        "pagerduty_log_entries",
+        "pagerduty_notes",
     )
 )
 PAGERDUTY_OPERATION_RESOLVER = OperationResolver(
@@ -52,12 +74,50 @@ class PagerDutyBudgetEstimator:
             BudgetDimension.REST_CORE,
         )
         dataset = str(getattr(context, "dataset_key", "read"))
+        enrichment_route_family = _ENRICHMENT_ROUTE_FAMILIES.get(dataset)
+        if enrichment_route_family is not None:
+            options = getattr(context, "dataset_options", {})
+            enrichment_cap = (
+                options.get("enrichment_cap", _DEFAULT_ENRICHMENT_CAP)
+                if isinstance(options, Mapping)
+                else _DEFAULT_ENRICHMENT_CAP
+            )
+            if not isinstance(enrichment_cap, int) or isinstance(enrichment_cap, bool):
+                enrichment_cap = _DEFAULT_ENRICHMENT_CAP
+            if enrichment_cap < 0:
+                enrichment_cap = _DEFAULT_ENRICHMENT_CAP
+            estimates = [
+                BudgetEstimate(
+                    bucket,
+                    _ESTIMATED_INCIDENT_PAGES,
+                    "medium",
+                    _DATASET_ROUTE_FAMILIES["incidents"],
+                    ("PagerDuty incident pagination",),
+                )
+            ]
+            if enrichment_cap > 0:
+                child_pages_per_incident = -(-enrichment_cap // _PAGERDUTY_PAGE_SIZE)
+                estimates.append(
+                    BudgetEstimate(
+                        bucket,
+                        (
+                            _ESTIMATED_INCIDENT_PAGES
+                            * _PAGERDUTY_PAGE_SIZE
+                            * child_pages_per_incident
+                        ),
+                        "low",
+                        enrichment_route_family,
+                        ("PagerDuty enrichment fan-out capped per sync unit",),
+                    )
+                )
+            return tuple(estimates)
+
         return (
             BudgetEstimate(
                 bucket,
-                2,
+                _ESTIMATED_INCIDENT_PAGES,
                 "medium",
-                f"pagerduty_{dataset}",
+                _DATASET_ROUTE_FAMILIES.get(dataset, f"pagerduty_{dataset}"),
                 ("PagerDuty offset pagination",),
             ),
         )

--- a/src/dev_health_ops/providers/pagerduty/client.py
+++ b/src/dev_health_ops/providers/pagerduty/client.py
@@ -1,5 +1,6 @@
 """Read-only PagerDuty REST V2 client composed over InstrumentedRESTCore."""
 
+from collections.abc import AsyncIterator
 from typing import TypeVar
 
 import httpx
@@ -70,6 +71,12 @@ class PagerDutyClient:
     ) -> list[Incident]:
         return await self._many("/incidents", "incidents", Incident, params)
 
+    async def iter_incident_pages(
+        self, *, params: dict[str, str] | None = None
+    ) -> AsyncIterator[list[Incident]]:
+        async for page in self._iter_many("/incidents", "incidents", Incident, params):
+            yield page
+
     async def list_incident_alerts(self, incident_id: str) -> list[Alert]:
         return await self._many(
             f"/incidents/{incident_id}/alerts", "alerts", Alert, None
@@ -120,8 +127,15 @@ class PagerDutyClient:
     async def _many(
         self, path: str, key: str, model: type[T], params: dict[str, str] | None
     ) -> list[T]:
-        offset = 0
         values: list[T] = []
+        async for page in self._iter_many(path, key, model, params):
+            values.extend(page)
+        return values
+
+    async def _iter_many(
+        self, path: str, key: str, model: type[T], params: dict[str, str] | None
+    ) -> AsyncIterator[list[T]]:
+        offset = 0
         while True:
             query = {**(params or {}), "limit": "100", "offset": str(offset)}
             response = await self._core.request(
@@ -132,8 +146,10 @@ class PagerDutyClient:
                 headers=self._auth.headers(),
             )
             payload = response.json()
-            page = payload.get(key, [])
-            values.extend(model.model_validate(value) for value in page)
+            page = [model.model_validate(value) for value in payload.get(key, [])]
+            yield page
             if not payload.get("more", False):
-                return values
+                return
+            if not page:
+                raise RuntimeError(f"PagerDuty pagination made no progress for {path}")
             offset += len(page)

--- a/src/dev_health_ops/providers/pagerduty/client.py
+++ b/src/dev_health_ops/providers/pagerduty/client.py
@@ -28,7 +28,18 @@ from dev_health_ops.providers.pagerduty.models import (
 )
 
 T = TypeVar("T", bound=BaseModel)
+PageT = TypeVar("PageT")
 _ACCEPT = "application/vnd.pagerduty+json;version=2"
+
+
+class PagerDutyPage(list[PageT]):
+    """A mutable page of typed PagerDuty resources with completion metadata."""
+
+    more: bool
+
+    def __init__(self, values: list[PageT], *, more: bool) -> None:
+        super().__init__(values)
+        self.more = more
 
 
 def pagerduty_base_url(*, region: str) -> str:
@@ -99,7 +110,7 @@ class PagerDutyClient:
 
     async def iter_incident_alert_pages(
         self, incident_id: str
-    ) -> AsyncIterator[list[Alert]]:
+    ) -> AsyncIterator[PagerDutyPage[Alert]]:
         async for page in self._iter_many(
             f"/incidents/{incident_id}/alerts", "alerts", Alert, None
         ):
@@ -112,7 +123,7 @@ class PagerDutyClient:
 
     async def iter_incident_log_entry_pages(
         self, incident_id: str
-    ) -> AsyncIterator[list[LogEntry]]:
+    ) -> AsyncIterator[PagerDutyPage[LogEntry]]:
         async for page in self._iter_many(
             f"/incidents/{incident_id}/log_entries", "log_entries", LogEntry, None
         ):
@@ -123,7 +134,7 @@ class PagerDutyClient:
 
     async def iter_incident_note_pages(
         self, incident_id: str
-    ) -> AsyncIterator[list[Note]]:
+    ) -> AsyncIterator[PagerDutyPage[Note]]:
         async for page in self._iter_many(
             f"/incidents/{incident_id}/notes", "notes", Note, None
         ):
@@ -173,7 +184,7 @@ class PagerDutyClient:
 
     async def _iter_many(
         self, path: str, key: str, model: type[T], params: dict[str, str] | None
-    ) -> AsyncIterator[list[T]]:
+    ) -> AsyncIterator[PagerDutyPage[T]]:
         offset = 0
         while True:
             query = {**(params or {}), "limit": "100", "offset": str(offset)}
@@ -195,7 +206,9 @@ class PagerDutyClient:
                 raise PaginationException(
                     f"PagerDuty pagination envelope for {path} is malformed"
                 )
-            page = [model.model_validate(value) for value in raw_page]
+            page = PagerDutyPage(
+                [model.model_validate(value) for value in raw_page], more=more
+            )
             yield page
             if not more:
                 return

--- a/src/dev_health_ops/providers/pagerduty/client.py
+++ b/src/dev_health_ops/providers/pagerduty/client.py
@@ -6,9 +6,13 @@ from typing import TypeVar
 import httpx
 from pydantic import BaseModel
 
+from dev_health_ops.exceptions import PaginationException
 from dev_health_ops.providers._http import InstrumentedRESTCore
 from dev_health_ops.providers.pagerduty.auth import PagerDutyAuth
 from dev_health_ops.providers.pagerduty.budget import PAGERDUTY_OPERATION_RESOLVER
+from dev_health_ops.providers.pagerduty.degradation import (
+    PagerDutyInsufficientScopeError,
+)
 from dev_health_ops.providers.pagerduty.models import (
     Alert,
     BusinessService,
@@ -34,6 +38,13 @@ def pagerduty_base_url(*, region: str) -> str:
     return "https://api.pagerduty.com"
 
 
+def _classify_pagerduty_error(response: httpx.Response, operation: str) -> None:
+    if response.status_code == 403:
+        raise PagerDutyInsufficientScopeError(
+            f"PagerDuty insufficient scope on {operation}: {response.text}"
+        )
+
+
 class PagerDutyClient:
     """Only exposes PagerDuty GET endpoints approved for V1."""
 
@@ -57,11 +68,15 @@ class PagerDutyClient:
                 "ratelimit-reset",
                 "retry-after",
             ),
+            classify_error=_classify_pagerduty_error,
             transport=transport,
         )
 
     def drain_usage_observations(self) -> list[dict[str, object]]:
         return self._core.drain_usage_observations()
+
+    async def close(self) -> None:
+        await self._core.close()
 
     async def get_incident(self, incident_id: str) -> Incident:
         return await self._one(f"/incidents/{incident_id}", "incident", Incident)
@@ -175,5 +190,7 @@ class PagerDutyClient:
             if not payload.get("more", False):
                 return
             if not page:
-                raise RuntimeError(f"PagerDuty pagination made no progress for {path}")
+                raise PaginationException(
+                    f"PagerDuty pagination made no progress for {path}"
+                )
             offset += len(page)

--- a/src/dev_health_ops/providers/pagerduty/client.py
+++ b/src/dev_health_ops/providers/pagerduty/client.py
@@ -185,9 +185,19 @@ class PagerDutyClient:
                 headers=self._auth.headers(),
             )
             payload = response.json()
-            page = [model.model_validate(value) for value in payload.get(key, [])]
+            if not isinstance(payload, dict):
+                raise PaginationException(
+                    f"PagerDuty pagination envelope for {path} must be an object"
+                )
+            raw_page = payload.get(key)
+            more = payload.get("more")
+            if not isinstance(raw_page, list) or not isinstance(more, bool):
+                raise PaginationException(
+                    f"PagerDuty pagination envelope for {path} is malformed"
+                )
+            page = [model.model_validate(value) for value in raw_page]
             yield page
-            if not payload.get("more", False):
+            if not more:
                 return
             if not page:
                 raise PaginationException(

--- a/src/dev_health_ops/providers/pagerduty/client.py
+++ b/src/dev_health_ops/providers/pagerduty/client.py
@@ -82,13 +82,37 @@ class PagerDutyClient:
             f"/incidents/{incident_id}/alerts", "alerts", Alert, None
         )
 
+    async def iter_incident_alert_pages(
+        self, incident_id: str
+    ) -> AsyncIterator[list[Alert]]:
+        async for page in self._iter_many(
+            f"/incidents/{incident_id}/alerts", "alerts", Alert, None
+        ):
+            yield page
+
     async def list_incident_log_entries(self, incident_id: str) -> list[LogEntry]:
         return await self._many(
             f"/incidents/{incident_id}/log_entries", "log_entries", LogEntry, None
         )
 
+    async def iter_incident_log_entry_pages(
+        self, incident_id: str
+    ) -> AsyncIterator[list[LogEntry]]:
+        async for page in self._iter_many(
+            f"/incidents/{incident_id}/log_entries", "log_entries", LogEntry, None
+        ):
+            yield page
+
     async def list_incident_notes(self, incident_id: str) -> list[Note]:
         return await self._many(f"/incidents/{incident_id}/notes", "notes", Note, None)
+
+    async def iter_incident_note_pages(
+        self, incident_id: str
+    ) -> AsyncIterator[list[Note]]:
+        async for page in self._iter_many(
+            f"/incidents/{incident_id}/notes", "notes", Note, None
+        ):
+            yield page
 
     async def list_services(self) -> list[Service]:
         return await self._many("/services", "services", Service, None)

--- a/src/dev_health_ops/providers/pagerduty/degradation.py
+++ b/src/dev_health_ops/providers/pagerduty/degradation.py
@@ -1,13 +1,11 @@
 from dev_health_ops.exceptions import (
     APIException,
-    AuthenticationException,
     NotFoundException,
     PaginationException,
 )
 
 DATASET_FETCH_ERRORS = (
     APIException,
-    AuthenticationException,
     NotFoundException,
     PaginationException,
 )
@@ -16,3 +14,7 @@ DATASET_FETCH_ERRORS = (
 class PagerDutyDatasetDegradedError(APIException):
     def __init__(self, dataset_key: str, cause: Exception) -> None:
         super().__init__(f"PagerDuty dataset {dataset_key} degraded: {cause}")
+
+
+class PagerDutyInsufficientScopeError(APIException):
+    pass

--- a/src/dev_health_ops/providers/pagerduty/degradation.py
+++ b/src/dev_health_ops/providers/pagerduty/degradation.py
@@ -1,0 +1,18 @@
+from dev_health_ops.exceptions import (
+    APIException,
+    AuthenticationException,
+    NotFoundException,
+    PaginationException,
+)
+
+DATASET_FETCH_ERRORS = (
+    APIException,
+    AuthenticationException,
+    NotFoundException,
+    PaginationException,
+)
+
+
+class PagerDutyDatasetDegradedError(APIException):
+    def __init__(self, dataset_key: str, cause: Exception) -> None:
+        super().__init__(f"PagerDuty dataset {dataset_key} degraded: {cause}")

--- a/src/dev_health_ops/providers/pagerduty/enrichment.py
+++ b/src/dev_health_ops/providers/pagerduty/enrichment.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from collections.abc import Mapping
 from dataclasses import dataclass
 
 
@@ -19,3 +20,20 @@ class PagerDutyEnrichmentToggles:
                 return self.notes
             case _:
                 return True
+
+    @classmethod
+    def from_dataset_options(
+        cls, dataset_key: str, options: Mapping[str, object]
+    ) -> PagerDutyEnrichmentToggles:
+        enabled = options.get("enabled")
+        if not isinstance(enabled, bool):
+            return cls()
+        match dataset_key:
+            case "incident-alerts":
+                return cls(alerts=enabled)
+            case "incident-log-entries":
+                return cls(log_entries=enabled)
+            case "incident-notes":
+                return cls(notes=enabled)
+            case _:
+                return cls()

--- a/src/dev_health_ops/providers/pagerduty/enrichment.py
+++ b/src/dev_health_ops/providers/pagerduty/enrichment.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class PagerDutyEnrichmentToggles:
+    alerts: bool = True
+    log_entries: bool = True
+    notes: bool = True
+
+    def enabled(self, dataset_key: str) -> bool:
+        match dataset_key:
+            case "incident-alerts":
+                return self.alerts
+            case "incident-log-entries":
+                return self.log_entries
+            case "incident-notes":
+                return self.notes
+            case _:
+                return True

--- a/src/dev_health_ops/providers/pagerduty/enrichment.py
+++ b/src/dev_health_ops/providers/pagerduty/enrichment.py
@@ -13,27 +13,31 @@ class PagerDutyEnrichmentToggles:
     def enabled(self, dataset_key: str) -> bool:
         match dataset_key:
             case "incident-alerts":
-                return self.alerts
+                enabled = self.alerts
             case "incident-log-entries":
-                return self.log_entries
+                enabled = self.log_entries
             case "incident-notes":
-                return self.notes
+                enabled = self.notes
             case _:
-                return True
+                enabled = True
+        return enabled
 
     @classmethod
     def from_dataset_options(
         cls, dataset_key: str, options: Mapping[str, object]
     ) -> PagerDutyEnrichmentToggles:
         enabled = options.get("enabled")
-        if not isinstance(enabled, bool):
-            return cls()
-        match dataset_key:
-            case "incident-alerts":
-                return cls(alerts=enabled)
-            case "incident-log-entries":
-                return cls(log_entries=enabled)
-            case "incident-notes":
-                return cls(notes=enabled)
+        match enabled:
+            case bool() as is_enabled:
+                match dataset_key:
+                    case "incident-alerts":
+                        toggles = cls(alerts=is_enabled)
+                    case "incident-log-entries":
+                        toggles = cls(log_entries=is_enabled)
+                    case "incident-notes":
+                        toggles = cls(notes=is_enabled)
+                    case _:
+                        toggles = cls()
             case _:
-                return cls()
+                toggles = cls()
+        return toggles

--- a/src/dev_health_ops/providers/pagerduty/enrichment.py
+++ b/src/dev_health_ops/providers/pagerduty/enrichment.py
@@ -11,33 +11,23 @@ class PagerDutyEnrichmentToggles:
     notes: bool = True
 
     def enabled(self, dataset_key: str) -> bool:
-        match dataset_key:
-            case "incident-alerts":
-                enabled = self.alerts
-            case "incident-log-entries":
-                enabled = self.log_entries
-            case "incident-notes":
-                enabled = self.notes
-            case _:
-                enabled = True
-        return enabled
+        return {
+            "incident-alerts": self.alerts,
+            "incident-log-entries": self.log_entries,
+            "incident-notes": self.notes,
+        }.get(dataset_key, True)
 
     @classmethod
     def from_dataset_options(
         cls, dataset_key: str, options: Mapping[str, object]
     ) -> PagerDutyEnrichmentToggles:
         enabled = options.get("enabled")
-        match enabled:
-            case bool() as is_enabled:
-                match dataset_key:
-                    case "incident-alerts":
-                        toggles = cls(alerts=is_enabled)
-                    case "incident-log-entries":
-                        toggles = cls(log_entries=is_enabled)
-                    case "incident-notes":
-                        toggles = cls(notes=is_enabled)
-                    case _:
-                        toggles = cls()
-            case _:
-                toggles = cls()
-        return toggles
+        if not isinstance(enabled, bool):
+            return cls()
+        if dataset_key == "incident-alerts":
+            return cls(alerts=enabled)
+        if dataset_key == "incident-log-entries":
+            return cls(log_entries=enabled)
+        if dataset_key == "incident-notes":
+            return cls(notes=enabled)
+        return cls()

--- a/src/dev_health_ops/providers/pagerduty/incident_cursor.py
+++ b/src/dev_health_ops/providers/pagerduty/incident_cursor.py
@@ -14,13 +14,16 @@ class IncidentCursorOptions(Protocol):
     """Pagination fields required to resume an incident collection."""
 
     @property
-    def window_start(self) -> datetime | None: ...
+    def window_start(self) -> datetime | None:
+        """Earliest incident created-at timestamp to include, or None for no lower bound."""
 
     @property
-    def window_end(self) -> datetime | None: ...
+    def window_end(self) -> datetime | None:
+        """Latest incident created-at timestamp to include, or None for no upper bound."""
 
     @property
-    def resume_after(self) -> datetime | None: ...
+    def resume_after(self) -> datetime | None:
+        """Inclusive created-at watermark for resuming incident iteration, or None."""
 
 
 async def iter_resumable_incidents(

--- a/src/dev_health_ops/providers/pagerduty/incident_cursor.py
+++ b/src/dev_health_ops/providers/pagerduty/incident_cursor.py
@@ -27,7 +27,9 @@ async def iter_resumable_incidents(
     client: PagerDutyClient,
     options: IncidentCursorOptions,
 ) -> AsyncIterator[Incident]:
-    """Yield every incident in a fixed window, inclusively from its watermark."""
+    """Yield every incident in a created-at window, inclusively from its watermark."""
+    # PagerDuty filters since/until by created_at; updates to older incidents are
+    # captured by Wave 3 webhooks and periodic full reconciliation.
     params: dict[str, str] = {}
     if options.window_start is not None:
         params["since"] = options.window_start.isoformat()
@@ -46,5 +48,5 @@ async def iter_resumable_incidents(
 
 
 def incident_source_time(incident: Incident) -> datetime | None:
-    """Return the provider event time used for PagerDuty incident cursors."""
-    return incident.updated_at or incident.created_at
+    """Return the created-at time used for PagerDuty incident cursors."""
+    return incident.created_at

--- a/src/dev_health_ops/providers/pagerduty/incident_cursor.py
+++ b/src/dev_health_ops/providers/pagerduty/incident_cursor.py
@@ -22,34 +22,27 @@ class IncidentCursorOptions(Protocol):
     @property
     def resume_after(self) -> datetime | None: ...
 
-    @property
-    def incident_cap(self) -> int: ...
-
 
 async def iter_resumable_incidents(
     client: PagerDutyClient,
     options: IncidentCursorOptions,
 ) -> AsyncIterator[Incident]:
-    """Yield a fixed window without replaying records at its stored watermark."""
+    """Yield every incident in a fixed window, inclusively from its watermark."""
     params: dict[str, str] = {}
     if options.window_start is not None:
         params["since"] = options.window_start.isoformat()
     if options.window_end is not None:
         params["until"] = options.window_end.isoformat()
-    emitted = 0
     async for page in client.iter_incident_pages(params=params):
         for incident in page:
             source_time = incident_source_time(incident)
             if (
                 options.resume_after is not None
                 and source_time is not None
-                and source_time <= options.resume_after
+                and source_time < options.resume_after
             ):
                 continue
-            if emitted >= options.incident_cap:
-                return
             yield incident
-            emitted += 1
 
 
 def incident_source_time(incident: Incident) -> datetime | None:

--- a/src/dev_health_ops/providers/pagerduty/incident_cursor.py
+++ b/src/dev_health_ops/providers/pagerduty/incident_cursor.py
@@ -1,0 +1,57 @@
+"""Boundary-safe PagerDuty incident pagination for incremental syncs."""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime
+from typing import Protocol
+
+from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+from dev_health_ops.providers.pagerduty.models import Incident
+
+
+class IncidentCursorOptions(Protocol):
+    """Pagination fields required to resume an incident collection."""
+
+    @property
+    def window_start(self) -> datetime | None: ...
+
+    @property
+    def window_end(self) -> datetime | None: ...
+
+    @property
+    def resume_after(self) -> datetime | None: ...
+
+    @property
+    def incident_cap(self) -> int: ...
+
+
+async def iter_resumable_incidents(
+    client: PagerDutyClient,
+    options: IncidentCursorOptions,
+) -> AsyncIterator[Incident]:
+    """Yield a fixed window without replaying records at its stored watermark."""
+    params: dict[str, str] = {}
+    if options.window_start is not None:
+        params["since"] = options.window_start.isoformat()
+    if options.window_end is not None:
+        params["until"] = options.window_end.isoformat()
+    emitted = 0
+    async for page in client.iter_incident_pages(params=params):
+        for incident in page:
+            source_time = incident_source_time(incident)
+            if (
+                options.resume_after is not None
+                and source_time is not None
+                and source_time <= options.resume_after
+            ):
+                continue
+            if emitted >= options.incident_cap:
+                return
+            yield incident
+            emitted += 1
+
+
+def incident_source_time(incident: Incident) -> datetime | None:
+    """Return the provider event time used for PagerDuty incident cursors."""
+    return incident.updated_at or incident.created_at

--- a/src/dev_health_ops/providers/pagerduty/models.py
+++ b/src/dev_health_ops/providers/pagerduty/models.py
@@ -2,13 +2,14 @@
 
 from datetime import datetime
 
-from pydantic import BaseModel, ConfigDict, Field, JsonValue
+from pydantic import BaseModel, ConfigDict, Field, JsonValue, model_validator
+from pydantic_core import to_jsonable_python
 
 
 class PagerDutyModel(BaseModel):
-    """Strict API model retaining explicitly supplied forward-compatible values."""
+    """PagerDuty REST payload retaining the untrusted source representation."""
 
-    model_config = ConfigDict(extra="forbid", populate_by_name=True)
+    model_config = ConfigDict(extra="ignore", populate_by_name=True)
 
     id: str
     type: str | None = None
@@ -18,6 +19,13 @@ class PagerDutyModel(BaseModel):
     created_at: datetime | None = None
     updated_at: datetime | None = None
     raw: dict[str, JsonValue] = Field(default_factory=dict)
+
+    @model_validator(mode="before")
+    @classmethod
+    def preserve_raw_payload(cls, values: dict[str, JsonValue]) -> dict[str, JsonValue]:
+        """Retain every source key before accepting undeclared API fields."""
+        raw = to_jsonable_python(values)
+        return {**values, "raw": raw}
 
 
 class Service(PagerDutyModel):
@@ -37,7 +45,10 @@ class Incident(PagerDutyModel):
     status: str | None = None
     urgency: str | None = None
     created_at: datetime | None = None
+    resolved_at: datetime | None = None
+    last_status_change_at: datetime | None = None
     service: PagerDutyModel | None = None
+    priority: PagerDutyModel | None = None
 
 
 class Alert(PagerDutyModel):
@@ -70,8 +81,10 @@ class Schedule(PagerDutyModel):
 
 
 class Oncall(PagerDutyModel):
+    id: str = ""
     start: datetime | None = None
     end: datetime | None = None
+    escalation_level: int | None = None
     user: PagerDutyModel | None = None
     schedule: PagerDutyModel | None = None
     escalation_policy: PagerDutyModel | None = None

--- a/src/dev_health_ops/providers/pagerduty/models.py
+++ b/src/dev_health_ops/providers/pagerduty/models.py
@@ -15,6 +15,8 @@ class PagerDutyModel(BaseModel):
     summary: str | None = None
     self_url: str | None = Field(default=None, alias="self")
     html_url: str | None = None
+    created_at: datetime | None = None
+    updated_at: datetime | None = None
     raw: dict[str, JsonValue] = Field(default_factory=dict)
 
 

--- a/src/dev_health_ops/providers/pagerduty/normalize.py
+++ b/src/dev_health_ops/providers/pagerduty/normalize.py
@@ -92,12 +92,18 @@ class PagerDutyNormalizer:
 
     def oncall(self, row: Oncall) -> OnCallAssignment:
         return OnCallAssignment(
-            **self._common(OnCallAssignment, row, "oncall"),
+            **self._common(
+                OnCallAssignment,
+                row,
+                "oncall",
+                external_id=self._oncall_external_id(row),
+            ),
             schedule_id=self._reference_id(OnCallSchedule, row.schedule),
             user_id=self._reference_id(OperationalUser, row.user),
             escalation_policy_id=self._reference_id(
                 CanonicalEscalationPolicy, row.escalation_policy
             ),
+            escalation_level=row.escalation_level,
             starts_at=row.start,
             ends_at=row.end,
         )
@@ -123,13 +129,17 @@ class PagerDutyNormalizer:
             source_event_id=str(row.incident_number) if row.incident_number else None,
             raw_status=row.status,
             raw_severity=row.urgency,
+            raw_priority=_priority(row.priority),
             normalized_status=_incident_status(row.status),
             normalized_severity=_urgency_severity(row.urgency),
+            normalized_priority=_priority_level(row.priority),
             service_id=self._reference_id(OperationalService, row.service),
             service_external_id=row.service.id if row.service else None,
             title=row.title or row.summary or row.id,
             started_at=row.created_at,
-            resolved_at=self._source_time(row) if row.status == "resolved" else None,
+            resolved_at=self._incident_resolution_time(row)
+            if row.status == "resolved"
+            else None,
         )
 
     def alert(self, row: Alert, incident_id: str) -> OperationalAlert:
@@ -169,19 +179,14 @@ class PagerDutyNormalizer:
         entity_type: type[CanonicalOperationalEntity],
         row: PagerDutyModel,
         source_entity_type: str,
+        external_id: str | None = None,
     ) -> OperationalCommonKwargs:
+        source_external_id = external_id or row.id
         coordinates = operational_source_coordinates(
             entity_type,
             provider="pagerduty",
             provider_instance_id=self.provider_instance_id,
-            external_id=row.id,
-        )
-        canonical_operational_id(
-            self.org_id,
-            coordinates.provider,
-            coordinates.provider_instance_id,
-            coordinates.entity_family,
-            coordinates.external_id,
+            external_id=source_external_id,
         )
         return {
             "org_id": self.org_id,
@@ -221,6 +226,33 @@ class PagerDutyNormalizer:
             coordinates.external_id,
         )
 
+    def _oncall_external_id(self, row: Oncall) -> str:
+        if (
+            row.escalation_policy is None
+            or row.schedule is None
+            or row.user is None
+            or not row.escalation_policy.id
+            or not row.schedule.id
+            or not row.user.id
+            or row.escalation_level is None
+            or row.start is None
+            or row.end is None
+        ):
+            raise ValueError("PagerDuty on-call assignment requires stable dimensions")
+        return "|".join(
+            (
+                row.escalation_policy.id,
+                row.schedule.id,
+                row.user.id,
+                str(row.escalation_level),
+                row.start.isoformat(),
+                row.end.isoformat(),
+            )
+        )
+
+    def _incident_resolution_time(self, row: Incident) -> datetime | None:
+        return row.resolved_at or row.last_status_change_at
+
     def _source_time(self, row: PagerDutyModel) -> datetime:
         return row.updated_at or row.created_at or self.observed_at
 
@@ -243,6 +275,21 @@ def _alert_status(raw_status: str | None) -> str | None:
 
 def _urgency_severity(raw_urgency: str | None) -> str | None:
     return {"high": "high", "low": "low"}.get(raw_urgency or "")
+
+
+def _priority(priority: PagerDutyModel | None) -> str | None:
+    if priority is None:
+        return None
+    return priority.summary or priority.id
+
+
+def _priority_level(priority: PagerDutyModel | None) -> str | None:
+    return {
+        "P1": "high",
+        "P2": "medium",
+        "P3": "low",
+        "P4": "low",
+    }.get(_priority(priority) or "")
 
 
 def _severity(raw_severity: str | None) -> str | None:

--- a/src/dev_health_ops/providers/pagerduty/normalize.py
+++ b/src/dev_health_ops/providers/pagerduty/normalize.py
@@ -1,0 +1,254 @@
+"""Normalize PagerDuty REST resources into canonical operational entities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from typing import TypedDict
+
+from dev_health_ops.models.operational import (
+    CanonicalOperationalEntity,
+    IncidentNote,
+    IncidentTimelineEvent,
+    OnCallAssignment,
+    OnCallSchedule,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+    canonical_operational_id,
+)
+from dev_health_ops.models.operational import (
+    EscalationPolicy as CanonicalEscalationPolicy,
+)
+from dev_health_ops.models.operational_identity import operational_source_coordinates
+from dev_health_ops.providers.pagerduty.models import (
+    Alert,
+    BusinessService,
+    EscalationPolicy,
+    Incident,
+    LogEntry,
+    Note,
+    Oncall,
+    PagerDutyModel,
+    Schedule,
+    Service,
+    Team,
+    User,
+)
+
+
+class OperationalCommonKwargs(TypedDict):
+    org_id: str
+    provider: str
+    provider_instance_id: str
+    source_entity_type: str
+    external_id: str
+    source_version_at: datetime
+    source_url: str | None
+    observed_at: datetime
+    last_synced: datetime
+
+
+@dataclass(frozen=True, slots=True)
+class PagerDutyNormalizer:
+    """Map one PagerDuty account's resources using canonical source coordinates."""
+
+    org_id: str
+    provider_instance_id: str
+    observed_at: datetime
+
+    def service(self, row: Service) -> OperationalService:
+        return OperationalService(
+            **self._common(OperationalService, row, "service"),
+            name=row.name or row.summary or row.id,
+            service_type="technical",
+            escalation_policy_id=self._reference_id(
+                CanonicalEscalationPolicy, row.escalation_policy
+            ),
+        )
+
+    def business_service(self, row: BusinessService) -> OperationalService:
+        return OperationalService(
+            **self._common(OperationalService, row, "business_service"),
+            name=row.name or row.summary or row.id,
+            description=row.description,
+            service_type="business",
+        )
+
+    def escalation_policy(self, row: EscalationPolicy) -> CanonicalEscalationPolicy:
+        return CanonicalEscalationPolicy(
+            **self._common(CanonicalEscalationPolicy, row, "escalation_policy"),
+            name=row.name or row.summary or row.id,
+        )
+
+    def schedule(self, row: Schedule) -> OnCallSchedule:
+        return OnCallSchedule(
+            **self._common(OnCallSchedule, row, "schedule"),
+            name=row.name or row.summary or row.id,
+            timezone=row.time_zone,
+        )
+
+    def oncall(self, row: Oncall) -> OnCallAssignment:
+        return OnCallAssignment(
+            **self._common(OnCallAssignment, row, "oncall"),
+            schedule_id=self._reference_id(OnCallSchedule, row.schedule),
+            user_id=self._reference_id(OperationalUser, row.user),
+            escalation_policy_id=self._reference_id(
+                CanonicalEscalationPolicy, row.escalation_policy
+            ),
+            starts_at=row.start,
+            ends_at=row.end,
+        )
+
+    def user(self, row: User) -> OperationalUser:
+        return OperationalUser(
+            **self._common(OperationalUser, row, "user"),
+            display_name=row.name or row.summary or row.id,
+            email=row.email,
+        )
+
+    def team(self, row: Team) -> OperationalTeam:
+        return OperationalTeam(
+            **self._common(OperationalTeam, row, "team"),
+            name=row.name or row.summary or row.id,
+            description=row.description,
+        )
+
+    def incident(self, row: Incident) -> OperationalIncident:
+        return OperationalIncident(
+            **self._common(OperationalIncident, row, "incident"),
+            source_event_at=row.created_at,
+            source_event_id=str(row.incident_number) if row.incident_number else None,
+            raw_status=row.status,
+            raw_severity=row.urgency,
+            normalized_status=_incident_status(row.status),
+            normalized_severity=_urgency_severity(row.urgency),
+            service_id=self._reference_id(OperationalService, row.service),
+            service_external_id=row.service.id if row.service else None,
+            title=row.title or row.summary or row.id,
+            started_at=row.created_at,
+            resolved_at=self._source_time(row) if row.status == "resolved" else None,
+        )
+
+    def alert(self, row: Alert, incident_id: str) -> OperationalAlert:
+        return OperationalAlert(
+            **self._common(OperationalAlert, row, "alert"),
+            raw_status=row.status,
+            raw_severity=row.severity,
+            normalized_status=_alert_status(row.status),
+            normalized_severity=_severity(row.severity),
+            incident_id=incident_id,
+            title=row.summary or row.id,
+            triggered_at=row.created_at,
+            resolved_at=self._source_time(row) if row.status == "resolved" else None,
+        )
+
+    def log_entry(self, row: LogEntry, incident_id: str) -> IncidentTimelineEvent:
+        return IncidentTimelineEvent(
+            **self._common(IncidentTimelineEvent, row, "log_entry"),
+            incident_id=incident_id,
+            event_type=row.type or "pagerduty_log_entry",
+            body=row.summary,
+            actor_type="pagerduty",
+            occurred_at=row.created_at,
+        )
+
+    def note(self, row: Note, incident_id: str) -> IncidentNote:
+        return IncidentNote(
+            **self._common(IncidentNote, row, "note"),
+            incident_id=incident_id,
+            body=row.content or "",
+            author_user_id=self._reference_id(OperationalUser, row.user),
+            created_at=row.created_at,
+        )
+
+    def _common(
+        self,
+        entity_type: type[CanonicalOperationalEntity],
+        row: PagerDutyModel,
+        source_entity_type: str,
+    ) -> OperationalCommonKwargs:
+        coordinates = operational_source_coordinates(
+            entity_type,
+            provider="pagerduty",
+            provider_instance_id=self.provider_instance_id,
+            external_id=row.id,
+        )
+        canonical_operational_id(
+            self.org_id,
+            coordinates.provider,
+            coordinates.provider_instance_id,
+            coordinates.entity_family,
+            coordinates.external_id,
+        )
+        return {
+            "org_id": self.org_id,
+            "provider": coordinates.provider,
+            "provider_instance_id": coordinates.provider_instance_id,
+            "source_entity_type": source_entity_type,
+            "external_id": coordinates.external_id,
+            "source_version_at": self._source_time(row),
+            "source_url": row.html_url or row.self_url,
+            "observed_at": self.observed_at,
+            "last_synced": self.observed_at,
+        }
+
+    def _reference_id(
+        self,
+        entity_type: type[
+            OperationalService
+            | CanonicalEscalationPolicy
+            | OnCallSchedule
+            | OperationalUser
+        ],
+        row: PagerDutyModel | None,
+    ) -> str | None:
+        if row is None:
+            return None
+        coordinates = operational_source_coordinates(
+            entity_type,
+            provider="pagerduty",
+            provider_instance_id=self.provider_instance_id,
+            external_id=row.id,
+        )
+        return canonical_operational_id(
+            self.org_id,
+            coordinates.provider,
+            coordinates.provider_instance_id,
+            coordinates.entity_family,
+            coordinates.external_id,
+        )
+
+    def _source_time(self, row: PagerDutyModel) -> datetime:
+        return row.updated_at or row.created_at or self.observed_at
+
+
+def _incident_status(raw_status: str | None) -> str | None:
+    return {
+        "triggered": "open",
+        "acknowledged": "acknowledged",
+        "resolved": "resolved",
+    }.get(raw_status or "")
+
+
+def _alert_status(raw_status: str | None) -> str | None:
+    return {
+        "triggered": "open",
+        "acknowledged": "acknowledged",
+        "resolved": "resolved",
+    }.get(raw_status or "")
+
+
+def _urgency_severity(raw_urgency: str | None) -> str | None:
+    return {"high": "high", "low": "low"}.get(raw_urgency or "")
+
+
+def _severity(raw_severity: str | None) -> str | None:
+    return {
+        "critical": "critical",
+        "error": "high",
+        "warning": "medium",
+        "info": "info",
+    }.get(raw_severity or "")

--- a/src/dev_health_ops/providers/pagerduty/operational_store.py
+++ b/src/dev_health_ops/providers/pagerduty/operational_store.py
@@ -1,0 +1,54 @@
+from __future__ import annotations
+
+from typing import Protocol
+
+from dev_health_ops.models.operational import (
+    EscalationPolicy,
+    IncidentNote,
+    IncidentTimelineEvent,
+    OnCallAssignment,
+    OnCallSchedule,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+)
+
+
+class PagerDutyOperationalStore(Protocol):
+    async def insert_operational_services(
+        self, values: list[OperationalService]
+    ) -> None: ...
+
+    async def insert_operational_incidents(
+        self, values: list[OperationalIncident]
+    ) -> None: ...
+
+    async def insert_operational_alerts(
+        self, values: list[OperationalAlert]
+    ) -> None: ...
+
+    async def insert_operational_incident_timeline_events(
+        self, values: list[IncidentTimelineEvent]
+    ) -> None: ...
+
+    async def insert_operational_incident_notes(
+        self, values: list[IncidentNote]
+    ) -> None: ...
+
+    async def insert_operational_escalation_policies(
+        self, values: list[EscalationPolicy]
+    ) -> None: ...
+
+    async def insert_operational_on_call_schedules(
+        self, values: list[OnCallSchedule]
+    ) -> None: ...
+
+    async def insert_operational_on_call_assignments(
+        self, values: list[OnCallAssignment]
+    ) -> None: ...
+
+    async def insert_operational_teams(self, values: list[OperationalTeam]) -> None: ...
+
+    async def insert_operational_users(self, values: list[OperationalUser]) -> None: ...

--- a/src/dev_health_ops/providers/pagerduty/operational_store.py
+++ b/src/dev_health_ops/providers/pagerduty/operational_store.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, TypeVar
 
 from dev_health_ops.models.operational import (
+    CanonicalOperationalEntity,
     EscalationPolicy,
     IncidentNote,
     IncidentTimelineEvent,
@@ -15,8 +16,20 @@ from dev_health_ops.models.operational import (
     OperationalUser,
 )
 
+T = TypeVar("T", bound=CanonicalOperationalEntity)
+
 
 class PagerDutyOperationalStore(Protocol):
+    async def load_active_operational_entities(
+        self,
+        entity_type: type[T],
+        *,
+        org_id: str,
+        provider: str,
+        provider_instance_id: str,
+        source_entity_type: str,
+    ) -> list[T]: ...
+
     async def insert_operational_services(
         self, values: list[OperationalService]
     ) -> None: ...

--- a/src/dev_health_ops/providers/pagerduty/operational_store.py
+++ b/src/dev_health_ops/providers/pagerduty/operational_store.py
@@ -28,40 +28,50 @@ class PagerDutyOperationalStore(Protocol):
         provider: str,
         provider_instance_id: str,
         source_entity_type: str,
-    ) -> list[T]: ...
+    ) -> list[T]:
+        """Load active canonical operational entities for the requested provider source."""
+        raise NotImplementedError
 
     async def insert_operational_services(
         self, values: list[OperationalService]
-    ) -> None: ...
+    ) -> None:
+        """Persist operational services."""
 
     async def insert_operational_incidents(
         self, values: list[OperationalIncident]
-    ) -> None: ...
+    ) -> None:
+        """Persist operational incidents."""
 
-    async def insert_operational_alerts(
-        self, values: list[OperationalAlert]
-    ) -> None: ...
+    async def insert_operational_alerts(self, values: list[OperationalAlert]) -> None:
+        """Persist operational alerts."""
 
     async def insert_operational_incident_timeline_events(
         self, values: list[IncidentTimelineEvent]
-    ) -> None: ...
+    ) -> None:
+        """Persist incident timeline events."""
 
     async def insert_operational_incident_notes(
         self, values: list[IncidentNote]
-    ) -> None: ...
+    ) -> None:
+        """Persist incident notes."""
 
     async def insert_operational_escalation_policies(
         self, values: list[EscalationPolicy]
-    ) -> None: ...
+    ) -> None:
+        """Persist escalation policies."""
 
     async def insert_operational_on_call_schedules(
         self, values: list[OnCallSchedule]
-    ) -> None: ...
+    ) -> None:
+        """Persist on-call schedules."""
 
     async def insert_operational_on_call_assignments(
         self, values: list[OnCallAssignment]
-    ) -> None: ...
+    ) -> None:
+        """Persist on-call assignments."""
 
-    async def insert_operational_teams(self, values: list[OperationalTeam]) -> None: ...
+    async def insert_operational_teams(self, values: list[OperationalTeam]) -> None:
+        """Persist operational teams."""
 
-    async def insert_operational_users(self, values: list[OperationalUser]) -> None: ...
+    async def insert_operational_users(self, values: list[OperationalUser]) -> None:
+        """Persist operational users."""

--- a/src/dev_health_ops/providers/pagerduty/provider.py
+++ b/src/dev_health_ops/providers/pagerduty/provider.py
@@ -1,0 +1,34 @@
+"""Provider registry integration for PagerDuty's operational REST boundary."""
+
+from __future__ import annotations
+
+from dev_health_ops.providers.base import (
+    IngestionContext,
+    Provider,
+    ProviderBatch,
+    ProviderCapabilities,
+)
+from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+
+
+class PagerDutyProvider(Provider):
+    """Expose PagerDuty capabilities while dataset sync owns operational persistence."""
+
+    name = "pagerduty"
+    capabilities = ProviderCapabilities(
+        work_items=False,
+        status_transitions=False,
+        dependencies=False,
+        interactions=False,
+        sprints=False,
+        reopen_events=False,
+        priority=False,
+    )
+
+    def __init__(self, *, client: PagerDutyClient | None = None) -> None:
+        self._client = client
+
+    def ingest(self, ctx: IngestionContext) -> ProviderBatch:
+        del ctx
+        observations = self._client.drain_usage_observations() if self._client else []
+        return ProviderBatch(observations={"provider_usage": observations})

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TypeVar
@@ -30,7 +30,6 @@ class PagerDutySyncOptions:
     window_start: datetime | None
     window_end: datetime | None
     resume_after: datetime | None = None
-    incident_cap: int = 100
     batch_size: int = 100
     enrichment_cap: int = 100
     enrichment: PagerDutyEnrichmentToggles = field(
@@ -40,8 +39,8 @@ class PagerDutySyncOptions:
     def __post_init__(self) -> None:
         if self.batch_size <= 0:
             raise ValueError("PagerDuty batch_size must be positive")
-        if self.incident_cap < 0 or self.enrichment_cap < 0:
-            raise ValueError("PagerDuty caps must not be negative")
+        if self.enrichment_cap < 0:
+            raise ValueError("PagerDuty enrichment_cap must not be negative")
 
 
 @dataclass(frozen=True, slots=True)
@@ -138,21 +137,21 @@ class PagerDutyOperationalSync:
             case "incident-alerts":
                 persisted, watermark_at = await self._sync_enrichment(
                     options,
-                    self._client.list_incident_alerts,
+                    self._client.iter_incident_alert_pages,
                     self._normalizer.alert,
                     self._store.insert_operational_alerts,
                 )
             case "incident-log-entries":
                 persisted, watermark_at = await self._sync_enrichment(
                     options,
-                    self._client.list_incident_log_entries,
+                    self._client.iter_incident_log_entry_pages,
                     self._normalizer.log_entry,
                     self._store.insert_operational_incident_timeline_events,
                 )
             case "incident-notes":
                 persisted, watermark_at = await self._sync_enrichment(
                     options,
-                    self._client.list_incident_notes,
+                    self._client.iter_incident_note_pages,
                     self._normalizer.note,
                     self._store.insert_operational_incident_notes,
                 )
@@ -209,30 +208,45 @@ class PagerDutyOperationalSync:
     async def _sync_enrichment(
         self,
         options: PagerDutySyncOptions,
-        fetch: Callable[[str], Awaitable[list[_Source]]],
+        fetch: Callable[[str], AsyncIterator[list[_Source]]],
         normalize: Callable[[_Source, str], _Destination],
         persist: Callable[[list[_Destination]], Awaitable[None]],
     ) -> tuple[int, datetime | None]:
         values: list[_Destination] = []
         persisted = 0
-        watermark_at: datetime | None = None
-        enriched_incidents = 0
+        watermark_at = options.resume_after or options.window_start
+        if options.enrichment_cap == 0:
+            async for incident in iter_resumable_incidents(self._client, options):
+                source_time = incident_source_time(incident)
+                if source_time is not None and (
+                    watermark_at is None or source_time > watermark_at
+                ):
+                    watermark_at = source_time
+            return persisted, watermark_at
+        watermark_can_advance = True
         async for incident in iter_resumable_incidents(self._client, options):
-            if enriched_incidents >= options.enrichment_cap:
-                break
+            incident_id = self._normalizer.incident(incident).id
+            child_count = 0
+            async for page in fetch(incident.id):
+                remaining = options.enrichment_cap - child_count
+                for row in page[:remaining]:
+                    values.append(normalize(row, incident_id))
+                    child_count += 1
+                    if len(values) == options.batch_size:
+                        await persist(values)
+                        persisted += len(values)
+                        values = []
+                if child_count == options.enrichment_cap:
+                    break
+            if child_count == options.enrichment_cap:
+                watermark_can_advance = False
             source_time = incident_source_time(incident)
-            if source_time is not None and (
-                watermark_at is None or source_time > watermark_at
+            if (
+                watermark_can_advance
+                and source_time is not None
+                and (watermark_at is None or source_time > watermark_at)
             ):
                 watermark_at = source_time
-            incident_id = self._normalizer.incident(incident).id
-            for row in (await fetch(incident.id))[: options.enrichment_cap]:
-                values.append(normalize(row, incident_id))
-                if len(values) == options.batch_size:
-                    await persist(values)
-                    persisted += len(values)
-                    values = []
-            enriched_incidents += 1
         if values:
             await persist(values)
             persisted += len(values)

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol, TypeVar
@@ -62,6 +62,13 @@ class PagerDutySyncOptions:
     window_end: datetime | None
     incident_cap: int = 100
     batch_size: int = 100
+    enrichment_cap: int = 100
+
+    def __post_init__(self) -> None:
+        if self.batch_size <= 0:
+            raise ValueError("PagerDuty batch_size must be positive")
+        if self.incident_cap < 0 or self.enrichment_cap < 0:
+            raise ValueError("PagerDuty caps must not be negative")
 
 
 @dataclass(frozen=True, slots=True)
@@ -187,13 +194,18 @@ class PagerDutyOperationalSync:
         return len(values)
 
     async def _sync_incidents(self, options: PagerDutySyncOptions) -> int:
-        incidents = await self._incidents(options)
-        values = [self._normalizer.incident(row) for row in incidents]
-        for start in range(0, len(values), options.batch_size):
-            await self._store.insert_operational_incidents(
-                values[start : start + options.batch_size]
-            )
-        return len(values)
+        values: list[OperationalIncident] = []
+        persisted = 0
+        async for incident in self._iter_incidents(options):
+            values.append(self._normalizer.incident(incident))
+            if len(values) == options.batch_size:
+                await self._store.insert_operational_incidents(values)
+                persisted += len(values)
+                values = []
+        if values:
+            await self._store.insert_operational_incidents(values)
+            persisted += len(values)
+        return persisted
 
     async def _sync_enrichment(
         self,
@@ -204,26 +216,31 @@ class PagerDutyOperationalSync:
     ) -> int:
         values: list[_Destination] = []
         persisted = 0
-        for incident in await self._incidents(options):
+        async for incident in self._iter_incidents(options):
             incident_id = self._normalizer.incident(incident).id
-            values.extend(
-                normalize(row, incident_id) for row in await fetch(incident.id)
-            )
-            if len(values) >= options.batch_size:
-                await persist(values)
-                persisted += len(values)
-                values = []
+            for row in (await fetch(incident.id))[: options.enrichment_cap]:
+                values.append(normalize(row, incident_id))
+                if len(values) == options.batch_size:
+                    await persist(values)
+                    persisted += len(values)
+                    values = []
         if values:
             await persist(values)
             persisted += len(values)
         return persisted
 
-    async def _incidents(self, options: PagerDutySyncOptions) -> Sequence[Incident]:
+    async def _iter_incidents(
+        self, options: PagerDutySyncOptions
+    ) -> AsyncIterator[Incident]:
         params: dict[str, str] = {}
         if options.window_start is not None:
             params["since"] = options.window_start.isoformat()
         if options.window_end is not None:
             params["until"] = options.window_end.isoformat()
-        return (await self._client.list_incidents(params=params))[
-            : options.incident_cap
-        ]
+        emitted = 0
+        async for page in self._client.iter_incident_pages(params=params):
+            for incident in page:
+                if emitted == options.incident_cap:
+                    return
+                yield incident
+                emitted += 1

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -3,61 +3,25 @@
 from __future__ import annotations
 
 from collections.abc import Awaitable, Callable
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Protocol, TypeVar
+from typing import TypeVar
 
-from dev_health_ops.models.operational import (
-    EscalationPolicy,
-    IncidentNote,
-    IncidentTimelineEvent,
-    OnCallAssignment,
-    OnCallSchedule,
-    OperationalAlert,
-    OperationalIncident,
-    OperationalService,
-    OperationalTeam,
-    OperationalUser,
-)
+from dev_health_ops.models.operational import OperationalIncident
 from dev_health_ops.providers.pagerduty.client import PagerDutyClient
 from dev_health_ops.providers.pagerduty.degradation import (
     DATASET_FETCH_ERRORS,
     PagerDutyDatasetDegradedError,
 )
+from dev_health_ops.providers.pagerduty.enrichment import PagerDutyEnrichmentToggles
 from dev_health_ops.providers.pagerduty.incident_cursor import (
     incident_source_time,
     iter_resumable_incidents,
 )
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
-
-
-class PagerDutyOperationalStore(Protocol):
-    async def insert_operational_services(
-        self, values: list[OperationalService]
-    ) -> None: ...
-    async def insert_operational_incidents(
-        self, values: list[OperationalIncident]
-    ) -> None: ...
-    async def insert_operational_alerts(
-        self, values: list[OperationalAlert]
-    ) -> None: ...
-    async def insert_operational_incident_timeline_events(
-        self, values: list[IncidentTimelineEvent]
-    ) -> None: ...
-    async def insert_operational_incident_notes(
-        self, values: list[IncidentNote]
-    ) -> None: ...
-    async def insert_operational_escalation_policies(
-        self, values: list[EscalationPolicy]
-    ) -> None: ...
-    async def insert_operational_on_call_schedules(
-        self, values: list[OnCallSchedule]
-    ) -> None: ...
-    async def insert_operational_on_call_assignments(
-        self, values: list[OnCallAssignment]
-    ) -> None: ...
-    async def insert_operational_teams(self, values: list[OperationalTeam]) -> None: ...
-    async def insert_operational_users(self, values: list[OperationalUser]) -> None: ...
+from dev_health_ops.providers.pagerduty.operational_store import (
+    PagerDutyOperationalStore,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -69,6 +33,9 @@ class PagerDutySyncOptions:
     incident_cap: int = 100
     batch_size: int = 100
     enrichment_cap: int = 100
+    enrichment: PagerDutyEnrichmentToggles = field(
+        default_factory=PagerDutyEnrichmentToggles
+    )
 
     def __post_init__(self) -> None:
         if self.batch_size <= 0:
@@ -113,6 +80,10 @@ class PagerDutyOperationalSync:
     async def _run(self, options: PagerDutySyncOptions) -> PagerDutySyncResult:
         watermark_at: datetime | None = None
         match options.dataset_key:
+            case (
+                "incident-alerts" | "incident-log-entries" | "incident-notes"
+            ) as dataset_key if not options.enrichment.enabled(dataset_key):
+                persisted = 0
             case "services":
                 persisted = await self._sync(
                     self._client.list_services,
@@ -245,7 +216,10 @@ class PagerDutyOperationalSync:
         values: list[_Destination] = []
         persisted = 0
         watermark_at: datetime | None = None
+        enriched_incidents = 0
         async for incident in iter_resumable_incidents(self._client, options):
+            if enriched_incidents >= options.enrichment_cap:
+                break
             source_time = incident_source_time(incident)
             if source_time is not None and (
                 watermark_at is None or source_time > watermark_at
@@ -258,6 +232,7 @@ class PagerDutyOperationalSync:
                     await persist(values)
                     persisted += len(values)
                     values = []
+            enriched_incidents += 1
         if values:
             await persist(values)
             persisted += len(values)

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import AsyncIterator, Awaitable, Callable
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Protocol, TypeVar
@@ -20,8 +20,9 @@ from dev_health_ops.models.operational import (
     OperationalUser,
 )
 from dev_health_ops.providers.pagerduty.client import PagerDutyClient
-from dev_health_ops.providers.pagerduty.models import (
-    Incident,
+from dev_health_ops.providers.pagerduty.incident_cursor import (
+    incident_source_time,
+    iter_resumable_incidents,
 )
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 
@@ -60,6 +61,7 @@ class PagerDutySyncOptions:
     dataset_key: str
     window_start: datetime | None
     window_end: datetime | None
+    resume_after: datetime | None = None
     incident_cap: int = 100
     batch_size: int = 100
     enrichment_cap: int = 100
@@ -75,6 +77,7 @@ class PagerDutySyncOptions:
 class PagerDutySyncResult:
     dataset_key: str
     persisted: int
+    watermark_at: datetime | None
     degraded: bool
     observations: tuple[dict[str, object], ...]
 
@@ -98,6 +101,7 @@ class PagerDutyOperationalSync:
         self._normalizer = normalizer
 
     async def run(self, options: PagerDutySyncOptions) -> PagerDutySyncResult:
+        watermark_at: datetime | None = None
         match options.dataset_key:
             case "services":
                 persisted = await self._sync(
@@ -149,23 +153,23 @@ class PagerDutyOperationalSync:
                     options.batch_size,
                 )
             case "incidents":
-                persisted = await self._sync_incidents(options)
+                persisted, watermark_at = await self._sync_incidents(options)
             case "incident-alerts":
-                persisted = await self._sync_enrichment(
+                persisted, watermark_at = await self._sync_enrichment(
                     options,
                     self._client.list_incident_alerts,
                     self._normalizer.alert,
                     self._store.insert_operational_alerts,
                 )
             case "incident-log-entries":
-                persisted = await self._sync_enrichment(
+                persisted, watermark_at = await self._sync_enrichment(
                     options,
                     self._client.list_incident_log_entries,
                     self._normalizer.log_entry,
                     self._store.insert_operational_incident_timeline_events,
                 )
             case "incident-notes":
-                persisted = await self._sync_enrichment(
+                persisted, watermark_at = await self._sync_enrichment(
                     options,
                     self._client.list_incident_notes,
                     self._normalizer.note,
@@ -176,6 +180,7 @@ class PagerDutyOperationalSync:
         return PagerDutySyncResult(
             dataset_key=options.dataset_key,
             persisted=persisted,
+            watermark_at=watermark_at,
             degraded=False,
             observations=tuple(self._client.drain_usage_observations()),
         )
@@ -193,10 +198,18 @@ class PagerDutyOperationalSync:
             await persist(values[start : start + batch_size])
         return len(values)
 
-    async def _sync_incidents(self, options: PagerDutySyncOptions) -> int:
+    async def _sync_incidents(
+        self, options: PagerDutySyncOptions
+    ) -> tuple[int, datetime | None]:
         values: list[OperationalIncident] = []
         persisted = 0
-        async for incident in self._iter_incidents(options):
+        watermark_at: datetime | None = None
+        async for incident in iter_resumable_incidents(self._client, options):
+            source_time = incident_source_time(incident)
+            if source_time is not None and (
+                watermark_at is None or source_time > watermark_at
+            ):
+                watermark_at = source_time
             values.append(self._normalizer.incident(incident))
             if len(values) == options.batch_size:
                 await self._store.insert_operational_incidents(values)
@@ -205,7 +218,7 @@ class PagerDutyOperationalSync:
         if values:
             await self._store.insert_operational_incidents(values)
             persisted += len(values)
-        return persisted
+        return persisted, watermark_at
 
     async def _sync_enrichment(
         self,
@@ -213,10 +226,16 @@ class PagerDutyOperationalSync:
         fetch: Callable[[str], Awaitable[list[_Source]]],
         normalize: Callable[[_Source, str], _Destination],
         persist: Callable[[list[_Destination]], Awaitable[None]],
-    ) -> int:
+    ) -> tuple[int, datetime | None]:
         values: list[_Destination] = []
         persisted = 0
-        async for incident in self._iter_incidents(options):
+        watermark_at: datetime | None = None
+        async for incident in iter_resumable_incidents(self._client, options):
+            source_time = incident_source_time(incident)
+            if source_time is not None and (
+                watermark_at is None or source_time > watermark_at
+            ):
+                watermark_at = source_time
             incident_id = self._normalizer.incident(incident).id
             for row in (await fetch(incident.id))[: options.enrichment_cap]:
                 values.append(normalize(row, incident_id))
@@ -227,20 +246,4 @@ class PagerDutyOperationalSync:
         if values:
             await persist(values)
             persisted += len(values)
-        return persisted
-
-    async def _iter_incidents(
-        self, options: PagerDutySyncOptions
-    ) -> AsyncIterator[Incident]:
-        params: dict[str, str] = {}
-        if options.window_start is not None:
-            params["since"] = options.window_start.isoformat()
-        if options.window_end is not None:
-            params["until"] = options.window_end.isoformat()
-        emitted = 0
-        async for page in self._client.iter_incident_pages(params=params):
-            for incident in page:
-                if emitted == options.incident_cap:
-                    return
-                yield incident
-                emitted += 1
+        return persisted, watermark_at

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -20,6 +20,10 @@ from dev_health_ops.models.operational import (
     OperationalUser,
 )
 from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+from dev_health_ops.providers.pagerduty.degradation import (
+    DATASET_FETCH_ERRORS,
+    PagerDutyDatasetDegradedError,
+)
 from dev_health_ops.providers.pagerduty.incident_cursor import (
     incident_source_time,
     iter_resumable_incidents,
@@ -101,6 +105,12 @@ class PagerDutyOperationalSync:
         self._normalizer = normalizer
 
     async def run(self, options: PagerDutySyncOptions) -> PagerDutySyncResult:
+        try:
+            return await self._run(options)
+        except DATASET_FETCH_ERRORS as exc:
+            raise PagerDutyDatasetDegradedError(options.dataset_key, exc) from exc
+
+    async def _run(self, options: PagerDutySyncOptions) -> PagerDutySyncResult:
         watermark_at: datetime | None = None
         match options.dataset_key:
             case "services":
@@ -204,17 +214,22 @@ class PagerDutyOperationalSync:
         values: list[OperationalIncident] = []
         persisted = 0
         watermark_at: datetime | None = None
-        async for incident in iter_resumable_incidents(self._client, options):
-            source_time = incident_source_time(incident)
-            if source_time is not None and (
-                watermark_at is None or source_time > watermark_at
-            ):
-                watermark_at = source_time
-            values.append(self._normalizer.incident(incident))
-            if len(values) == options.batch_size:
+        try:
+            async for incident in iter_resumable_incidents(self._client, options):
+                source_time = incident_source_time(incident)
+                if source_time is not None and (
+                    watermark_at is None or source_time > watermark_at
+                ):
+                    watermark_at = source_time
+                values.append(self._normalizer.incident(incident))
+                if len(values) == options.batch_size:
+                    await self._store.insert_operational_incidents(values)
+                    persisted += len(values)
+                    values = []
+        except DATASET_FETCH_ERRORS:
+            if values:
                 await self._store.insert_operational_incidents(values)
-                persisted += len(values)
-                values = []
+            raise
         if values:
             await self._store.insert_operational_incidents(values)
             persisted += len(values)

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -15,7 +15,7 @@ from dev_health_ops.models.operational import (
     OperationalTeam,
     OperationalUser,
 )
-from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+from dev_health_ops.providers.pagerduty.client import PagerDutyClient, PagerDutyPage
 from dev_health_ops.providers.pagerduty.degradation import (
     DATASET_FETCH_ERRORS,
     PagerDutyDatasetDegradedError,
@@ -266,7 +266,7 @@ class PagerDutyOperationalSync:
     async def _sync_enrichment(
         self,
         options: PagerDutySyncOptions,
-        fetch: Callable[[str], AsyncIterator[list[_Source]]],
+        fetch: Callable[[str], AsyncIterator[PagerDutyPage[_Source]]],
         normalize: Callable[[_Source, str], _Destination],
         persist: Callable[[list[_Destination]], Awaitable[None]],
     ) -> tuple[int, datetime | None]:
@@ -285,6 +285,7 @@ class PagerDutyOperationalSync:
         async for incident in iter_resumable_incidents(self._client, options):
             incident_id = self._normalizer.incident(incident).id
             child_count = 0
+            has_undrained_children = False
             async for page in fetch(incident.id):
                 remaining = options.enrichment_cap - child_count
                 for row in page[:remaining]:
@@ -295,8 +296,9 @@ class PagerDutyOperationalSync:
                         persisted += len(values)
                         values = []
                 if child_count == options.enrichment_cap:
+                    has_undrained_children = page.more or len(page) > remaining
                     break
-            if child_count == options.enrichment_cap:
+            if has_undrained_children:
                 source_time = incident_source_time(incident)
                 if source_time is not None and (
                     earliest_undrained_at is None or source_time < earliest_undrained_at

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -1,0 +1,229 @@
+"""Bounded PagerDuty REST reconciliation through canonical operational sinks."""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable, Sequence
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Protocol, TypeVar
+
+from dev_health_ops.models.operational import (
+    EscalationPolicy,
+    IncidentNote,
+    IncidentTimelineEvent,
+    OnCallAssignment,
+    OnCallSchedule,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+)
+from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+from dev_health_ops.providers.pagerduty.models import (
+    Incident,
+)
+from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
+
+
+class PagerDutyOperationalStore(Protocol):
+    async def insert_operational_services(
+        self, values: list[OperationalService]
+    ) -> None: ...
+    async def insert_operational_incidents(
+        self, values: list[OperationalIncident]
+    ) -> None: ...
+    async def insert_operational_alerts(
+        self, values: list[OperationalAlert]
+    ) -> None: ...
+    async def insert_operational_incident_timeline_events(
+        self, values: list[IncidentTimelineEvent]
+    ) -> None: ...
+    async def insert_operational_incident_notes(
+        self, values: list[IncidentNote]
+    ) -> None: ...
+    async def insert_operational_escalation_policies(
+        self, values: list[EscalationPolicy]
+    ) -> None: ...
+    async def insert_operational_on_call_schedules(
+        self, values: list[OnCallSchedule]
+    ) -> None: ...
+    async def insert_operational_on_call_assignments(
+        self, values: list[OnCallAssignment]
+    ) -> None: ...
+    async def insert_operational_teams(self, values: list[OperationalTeam]) -> None: ...
+    async def insert_operational_users(self, values: list[OperationalUser]) -> None: ...
+
+
+@dataclass(frozen=True, slots=True)
+class PagerDutySyncOptions:
+    dataset_key: str
+    window_start: datetime | None
+    window_end: datetime | None
+    incident_cap: int = 100
+    batch_size: int = 100
+
+
+@dataclass(frozen=True, slots=True)
+class PagerDutySyncResult:
+    dataset_key: str
+    persisted: int
+    degraded: bool
+    observations: tuple[dict[str, object], ...]
+
+
+_Source = TypeVar("_Source")
+_Destination = TypeVar("_Destination")
+
+
+class PagerDutyOperationalSync:
+    """Sync one PagerDuty dataset without crossing account or sink boundaries."""
+
+    def __init__(
+        self,
+        *,
+        client: PagerDutyClient,
+        store: PagerDutyOperationalStore,
+        normalizer: PagerDutyNormalizer,
+    ) -> None:
+        self._client = client
+        self._store = store
+        self._normalizer = normalizer
+
+    async def run(self, options: PagerDutySyncOptions) -> PagerDutySyncResult:
+        match options.dataset_key:
+            case "services":
+                persisted = await self._sync(
+                    self._client.list_services,
+                    self._normalizer.service,
+                    self._store.insert_operational_services,
+                    options.batch_size,
+                )
+            case "business-services":
+                persisted = await self._sync(
+                    self._client.list_business_services,
+                    self._normalizer.business_service,
+                    self._store.insert_operational_services,
+                    options.batch_size,
+                )
+            case "escalation-policies":
+                persisted = await self._sync(
+                    self._client.list_escalation_policies,
+                    self._normalizer.escalation_policy,
+                    self._store.insert_operational_escalation_policies,
+                    options.batch_size,
+                )
+            case "schedules":
+                persisted = await self._sync(
+                    self._client.list_schedules,
+                    self._normalizer.schedule,
+                    self._store.insert_operational_on_call_schedules,
+                    options.batch_size,
+                )
+            case "on-calls":
+                persisted = await self._sync(
+                    self._client.list_oncalls,
+                    self._normalizer.oncall,
+                    self._store.insert_operational_on_call_assignments,
+                    options.batch_size,
+                )
+            case "users":
+                persisted = await self._sync(
+                    self._client.list_users,
+                    self._normalizer.user,
+                    self._store.insert_operational_users,
+                    options.batch_size,
+                )
+            case "teams":
+                persisted = await self._sync(
+                    self._client.list_teams,
+                    self._normalizer.team,
+                    self._store.insert_operational_teams,
+                    options.batch_size,
+                )
+            case "incidents":
+                persisted = await self._sync_incidents(options)
+            case "incident-alerts":
+                persisted = await self._sync_enrichment(
+                    options,
+                    self._client.list_incident_alerts,
+                    self._normalizer.alert,
+                    self._store.insert_operational_alerts,
+                )
+            case "incident-log-entries":
+                persisted = await self._sync_enrichment(
+                    options,
+                    self._client.list_incident_log_entries,
+                    self._normalizer.log_entry,
+                    self._store.insert_operational_incident_timeline_events,
+                )
+            case "incident-notes":
+                persisted = await self._sync_enrichment(
+                    options,
+                    self._client.list_incident_notes,
+                    self._normalizer.note,
+                    self._store.insert_operational_incident_notes,
+                )
+            case unsupported:
+                raise ValueError(f"Unsupported PagerDuty dataset {unsupported!r}")
+        return PagerDutySyncResult(
+            dataset_key=options.dataset_key,
+            persisted=persisted,
+            degraded=False,
+            observations=tuple(self._client.drain_usage_observations()),
+        )
+
+    async def _sync(
+        self,
+        fetch: Callable[[], Awaitable[list[_Source]]],
+        normalize: Callable[[_Source], _Destination],
+        persist: Callable[[list[_Destination]], Awaitable[None]],
+        batch_size: int,
+    ) -> int:
+        rows = await fetch()
+        values = [normalize(row) for row in rows]
+        for start in range(0, len(values), batch_size):
+            await persist(values[start : start + batch_size])
+        return len(values)
+
+    async def _sync_incidents(self, options: PagerDutySyncOptions) -> int:
+        incidents = await self._incidents(options)
+        values = [self._normalizer.incident(row) for row in incidents]
+        for start in range(0, len(values), options.batch_size):
+            await self._store.insert_operational_incidents(
+                values[start : start + options.batch_size]
+            )
+        return len(values)
+
+    async def _sync_enrichment(
+        self,
+        options: PagerDutySyncOptions,
+        fetch: Callable[[str], Awaitable[list[_Source]]],
+        normalize: Callable[[_Source, str], _Destination],
+        persist: Callable[[list[_Destination]], Awaitable[None]],
+    ) -> int:
+        values: list[_Destination] = []
+        persisted = 0
+        for incident in await self._incidents(options):
+            incident_id = self._normalizer.incident(incident).id
+            values.extend(
+                normalize(row, incident_id) for row in await fetch(incident.id)
+            )
+            if len(values) >= options.batch_size:
+                await persist(values)
+                persisted += len(values)
+                values = []
+        if values:
+            await persist(values)
+            persisted += len(values)
+        return persisted
+
+    async def _incidents(self, options: PagerDutySyncOptions) -> Sequence[Incident]:
+        params: dict[str, str] = {}
+        if options.window_start is not None:
+            params["since"] = options.window_start.isoformat()
+        if options.window_end is not None:
+            params["until"] = options.window_end.isoformat()
+        return (await self._client.list_incidents(params=params))[
+            : options.incident_cap
+        ]

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -3,11 +3,18 @@
 from __future__ import annotations
 
 from collections.abc import AsyncIterator, Awaitable, Callable
-from dataclasses import dataclass, field
-from datetime import datetime
+from dataclasses import dataclass, field, replace
+from datetime import datetime, timedelta
 from typing import TypeVar
 
-from dev_health_ops.models.operational import OperationalIncident
+from dev_health_ops.models.operational import (
+    EscalationPolicy,
+    OnCallSchedule,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+)
 from dev_health_ops.providers.pagerduty.client import PagerDutyClient
 from dev_health_ops.providers.pagerduty.degradation import (
     DATASET_FETCH_ERRORS,
@@ -54,6 +61,14 @@ class PagerDutySyncResult:
 
 _Source = TypeVar("_Source")
 _Destination = TypeVar("_Destination")
+_ReferenceEntity = TypeVar(
+    "_ReferenceEntity",
+    OperationalService,
+    EscalationPolicy,
+    OnCallSchedule,
+    OperationalTeam,
+    OperationalUser,
+)
 
 
 class PagerDutyOperationalSync:
@@ -84,32 +99,40 @@ class PagerDutyOperationalSync:
             ) as dataset_key if not options.enrichment.enabled(dataset_key):
                 persisted = 0
             case "services":
-                persisted = await self._sync(
+                persisted = await self._sync_reference(
                     self._client.list_services,
                     self._normalizer.service,
                     self._store.insert_operational_services,
                     options.batch_size,
+                    OperationalService,
+                    "service",
                 )
             case "business-services":
-                persisted = await self._sync(
+                persisted = await self._sync_reference(
                     self._client.list_business_services,
                     self._normalizer.business_service,
                     self._store.insert_operational_services,
                     options.batch_size,
+                    OperationalService,
+                    "business_service",
                 )
             case "escalation-policies":
-                persisted = await self._sync(
+                persisted = await self._sync_reference(
                     self._client.list_escalation_policies,
                     self._normalizer.escalation_policy,
                     self._store.insert_operational_escalation_policies,
                     options.batch_size,
+                    EscalationPolicy,
+                    "escalation_policy",
                 )
             case "schedules":
-                persisted = await self._sync(
+                persisted = await self._sync_reference(
                     self._client.list_schedules,
                     self._normalizer.schedule,
                     self._store.insert_operational_on_call_schedules,
                     options.batch_size,
+                    OnCallSchedule,
+                    "schedule",
                 )
             case "on-calls":
                 persisted = await self._sync(
@@ -119,18 +142,22 @@ class PagerDutyOperationalSync:
                     options.batch_size,
                 )
             case "users":
-                persisted = await self._sync(
+                persisted = await self._sync_reference(
                     self._client.list_users,
                     self._normalizer.user,
                     self._store.insert_operational_users,
                     options.batch_size,
+                    OperationalUser,
+                    "user",
                 )
             case "teams":
-                persisted = await self._sync(
+                persisted = await self._sync_reference(
                     self._client.list_teams,
                     self._normalizer.team,
                     self._store.insert_operational_teams,
                     options.batch_size,
+                    OperationalTeam,
+                    "team",
                 )
             case "incidents":
                 persisted, watermark_at = await self._sync_incidents(options)
@@ -176,6 +203,37 @@ class PagerDutyOperationalSync:
         values = [normalize(row) for row in rows]
         for start in range(0, len(values), batch_size):
             await persist(values[start : start + batch_size])
+        return len(values)
+
+    async def _sync_reference(
+        self,
+        fetch: Callable[[], Awaitable[list[_Source]]],
+        normalize: Callable[[_Source], _ReferenceEntity],
+        persist: Callable[[list[_ReferenceEntity]], Awaitable[None]],
+        batch_size: int,
+        entity_type: type[_ReferenceEntity],
+        source_entity_type: str,
+    ) -> int:
+        rows = await fetch()
+        values = [normalize(row) for row in rows]
+        for start in range(0, len(values), batch_size):
+            await persist(values[start : start + batch_size])
+
+        active_entities = await self._store.load_active_operational_entities(
+            entity_type,
+            org_id=self._normalizer.org_id,
+            provider="pagerduty",
+            provider_instance_id=self._normalizer.provider_instance_id,
+            source_entity_type=source_entity_type,
+        )
+        seen_ids = {value.id for value in values}
+        tombstones = [
+            _reference_tombstone(entity, self._normalizer.observed_at)
+            for entity in active_entities
+            if entity.id not in seen_ids
+        ]
+        if tombstones:
+            await persist(tombstones)
         return len(values)
 
     async def _sync_incidents(
@@ -251,3 +309,19 @@ class PagerDutyOperationalSync:
             await persist(values)
             persisted += len(values)
         return persisted, watermark_at
+
+
+def _reference_tombstone(
+    entity: _ReferenceEntity, observed_at: datetime
+) -> _ReferenceEntity:
+    source_version_at = max(
+        observed_at, entity.source_version_at + timedelta(microseconds=1)
+    )
+    return replace(
+        entity,
+        source_version_at=source_version_at,
+        observed_at=source_version_at,
+        last_synced=source_version_at,
+        is_deleted=True,
+        deleted_at=source_version_at,
+    )

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -93,6 +93,7 @@ class PagerDutyOperationalSync:
 
     async def _run(self, options: PagerDutySyncOptions) -> PagerDutySyncResult:
         watermark_at: datetime | None = None
+        persisted: int = 0
         match options.dataset_key:
             case (
                 "incident-alerts" | "incident-log-entries" | "incident-notes"

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -281,7 +281,7 @@ class PagerDutyOperationalSync:
                 ):
                     watermark_at = source_time
             return persisted, watermark_at
-        watermark_can_advance = True
+        earliest_undrained_at: datetime | None = None
         async for incident in iter_resumable_incidents(self._client, options):
             incident_id = self._normalizer.incident(incident).id
             child_count = 0
@@ -297,14 +297,20 @@ class PagerDutyOperationalSync:
                 if child_count == options.enrichment_cap:
                     break
             if child_count == options.enrichment_cap:
-                watermark_can_advance = False
+                source_time = incident_source_time(incident)
+                if source_time is not None and (
+                    earliest_undrained_at is None or source_time < earliest_undrained_at
+                ):
+                    earliest_undrained_at = source_time
             source_time = incident_source_time(incident)
-            if (
-                watermark_can_advance
-                and source_time is not None
-                and (watermark_at is None or source_time > watermark_at)
+            if source_time is not None and (
+                watermark_at is None or source_time > watermark_at
             ):
                 watermark_at = source_time
+        if earliest_undrained_at is not None and (
+            watermark_at is None or earliest_undrained_at < watermark_at
+        ):
+            watermark_at = earliest_undrained_at
         if values:
             await persist(values)
             persisted += len(values)

--- a/src/dev_health_ops/providers/registry.py
+++ b/src/dev_health_ops/providers/registry.py
@@ -108,6 +108,13 @@ def _register_builtins() -> None:
 
     register_provider("linear", _linear_factory)
 
+    def _pagerduty_factory() -> Provider:
+        from dev_health_ops.providers.pagerduty.provider import PagerDutyProvider
+
+        return PagerDutyProvider()
+
+    register_provider("pagerduty", _pagerduty_factory)
+
     # Stub providers — connectors not yet implemented
     def _launchdarkly_factory() -> Provider:
         raise NotImplementedError(

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -2295,6 +2295,14 @@ class ClickHouseStore:
             rows,
         )
 
+    @staticmethod
+    def _normalize_operational_datetime(value: datetime | None) -> datetime | None:
+        if value is None:
+            return None
+        if value.tzinfo is None:
+            return value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc)
+
     async def _insert_operational_rows(
         self,
         table: str,
@@ -2314,7 +2322,7 @@ class ClickHouseStore:
             row = asdict(entity)
             rows.append(
                 {
-                    name: self._normalize_datetime(value)
+                    name: self._normalize_operational_datetime(value)
                     if isinstance(value, datetime)
                     else value
                     for name, value in row.items()

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -9,7 +9,7 @@ from collections.abc import Sequence
 from dataclasses import asdict
 from datetime import date, datetime, timezone
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, cast
+from typing import TYPE_CHECKING, Any, TypeVar, cast
 
 from dev_health_ops.metrics.schemas import (
     FileComplexitySnapshot,
@@ -33,6 +33,7 @@ from dev_health_ops.models.git import (
     Repo,
 )
 from dev_health_ops.models.operational import (
+    OPERATIONAL_ENTITY_TABLES,
     CanonicalOperationalEntity,
     OperationalContractError,
     OperationalIncident,
@@ -48,6 +49,7 @@ from dev_health_ops.models.work_items import (
 from .utils import _parse_date_value, _parse_datetime_value
 
 logger = logging.getLogger(__name__)
+T = TypeVar("T", bound=CanonicalOperationalEntity)
 
 if TYPE_CHECKING:
     from dev_health_ops.models.atlassian_ops import (
@@ -2334,6 +2336,44 @@ class ClickHouseStore:
         self, services: list[OperationalService]
     ) -> None:
         await self._insert_operational_rows("operational_services", services)
+
+    async def load_active_operational_entities(
+        self,
+        entity_type: type[T],
+        *,
+        org_id: str,
+        provider: str,
+        provider_instance_id: str,
+        source_entity_type: str,
+    ) -> list[T]:
+        assert self.client is not None
+        columns = operational_columns(entity_type)
+        table = OPERATIONAL_ENTITY_TABLES[entity_type]
+        query = f"""
+        SELECT {", ".join(columns)}
+        FROM {table} FINAL
+        WHERE org_id = {{org_id:String}}
+          AND provider = {{provider:String}}
+          AND provider_instance_id = {{provider_instance_id:String}}
+          AND source_entity_type = {{source_entity_type:String}}
+          AND is_deleted = 0
+        """
+        parameters = {
+            "org_id": org_id,
+            "provider": provider,
+            "provider_instance_id": provider_instance_id,
+            "source_entity_type": source_entity_type,
+        }
+        async with self._lock:
+            result = await asyncio.to_thread(
+                self.client.query, query, parameters=parameters
+            )
+        entities: list[T] = []
+        for row in result.result_rows or []:
+            values = dict(zip(columns, row, strict=True))
+            values.pop("id")
+            entities.append(entity_type(**values))
+        return entities
 
     async def insert_operational_incidents(
         self, incidents: list[OperationalIncident]

--- a/src/dev_health_ops/sync/budget.py
+++ b/src/dev_health_ops/sync/budget.py
@@ -38,6 +38,10 @@ def estimate_provider_budget(context: SyncTaskContext) -> tuple[BudgetEstimate, 
         from dev_health_ops.providers.linear.budget import LinearBudgetEstimator
 
         return LinearBudgetEstimator().estimate(context)
+    if context.provider.lower() == "pagerduty":
+        from dev_health_ops.providers.pagerduty.budget import PagerDutyBudgetEstimator
+
+        return PagerDutyBudgetEstimator().estimate(context)
     if context.provider.lower() == "launchdarkly":
         from dev_health_ops.providers.launchdarkly.budget import (
             LaunchDarklyBudgetEstimator,

--- a/src/dev_health_ops/sync/datasets.py
+++ b/src/dev_health_ops/sync/datasets.py
@@ -24,6 +24,16 @@ class DatasetKey(str, Enum):
     WORK_ITEM_HISTORY = "work-item-history"
     WORK_ITEM_COMMENTS = "work-item-comments"
     FEATURE_FLAGS = "feature-flags"
+    SERVICES = "services"
+    BUSINESS_SERVICES = "business-services"
+    ESCALATION_POLICIES = "escalation-policies"
+    SCHEDULES = "schedules"
+    ON_CALLS = "on-calls"
+    USERS = "users"
+    TEAMS = "teams"
+    INCIDENT_ALERTS = "incident-alerts"
+    INCIDENT_LOG_ENTRIES = "incident-log-entries"
+    INCIDENT_NOTES = "incident-notes"
 
 
 class CostClass(str, Enum):
@@ -54,6 +64,12 @@ _LIGHT_DATASETS = frozenset(
         DatasetKey.INCIDENTS.value,
         DatasetKey.WORK_ITEM_LABELS.value,
         DatasetKey.WORK_ITEM_PROJECTS.value,
+        DatasetKey.SERVICES.value,
+        DatasetKey.BUSINESS_SERVICES.value,
+        DatasetKey.ESCALATION_POLICIES.value,
+        DatasetKey.SCHEDULES.value,
+        DatasetKey.USERS.value,
+        DatasetKey.TEAMS.value,
     }
 )
 _MEDIUM_DATASETS = frozenset(
@@ -69,6 +85,10 @@ _MEDIUM_DATASETS = frozenset(
         DatasetKey.WORK_ITEM_HISTORY.value,
         DatasetKey.WORK_ITEM_COMMENTS.value,
         DatasetKey.FEATURE_FLAGS.value,
+        DatasetKey.ON_CALLS.value,
+        DatasetKey.INCIDENT_ALERTS.value,
+        DatasetKey.INCIDENT_LOG_ENTRIES.value,
+        DatasetKey.INCIDENT_NOTES.value,
     }
 )
 _HEAVY_DATASETS = frozenset(
@@ -115,11 +135,28 @@ _LEGACY_TARGETS_BY_DATASET: dict[str, frozenset[str]] = {
     DatasetKey.WORK_ITEM_HISTORY.value: frozenset({"work-items"}),
     DatasetKey.WORK_ITEM_COMMENTS.value: frozenset({"work-items"}),
     DatasetKey.FEATURE_FLAGS.value: frozenset({"feature-flags"}),
+    DatasetKey.SERVICES.value: frozenset({"operational"}),
+    DatasetKey.BUSINESS_SERVICES.value: frozenset({"operational"}),
+    DatasetKey.ESCALATION_POLICIES.value: frozenset({"operational"}),
+    DatasetKey.SCHEDULES.value: frozenset({"operational"}),
+    DatasetKey.ON_CALLS.value: frozenset({"operational"}),
+    DatasetKey.USERS.value: frozenset({"operational"}),
+    DatasetKey.TEAMS.value: frozenset({"operational"}),
+    DatasetKey.INCIDENT_ALERTS.value: frozenset({"operational"}),
+    DatasetKey.INCIDENT_LOG_ENTRIES.value: frozenset({"operational"}),
+    DatasetKey.INCIDENT_NOTES.value: frozenset({"operational"}),
 }
 
 _NO_WATERMARK_DATASETS = frozenset(
     {
         DatasetKey.REPO_METADATA.value,
+        DatasetKey.SERVICES.value,
+        DatasetKey.BUSINESS_SERVICES.value,
+        DatasetKey.ESCALATION_POLICIES.value,
+        DatasetKey.SCHEDULES.value,
+        DatasetKey.ON_CALLS.value,
+        DatasetKey.USERS.value,
+        DatasetKey.TEAMS.value,
     }
 )
 
@@ -134,6 +171,7 @@ _LEGACY_TARGET_ORDER = (
     "tests",
     "work-items",
     "feature-flags",
+    "operational",
 )
 
 _PROVIDER_SUPPORTED_DATASETS: dict[str, frozenset[str]] = {
@@ -201,6 +239,21 @@ _PROVIDER_SUPPORTED_DATASETS: dict[str, frozenset[str]] = {
         }
     ),
     "launchdarkly": frozenset({DatasetKey.FEATURE_FLAGS.value}),
+    "pagerduty": frozenset(
+        {
+            DatasetKey.SERVICES.value,
+            DatasetKey.BUSINESS_SERVICES.value,
+            DatasetKey.ESCALATION_POLICIES.value,
+            DatasetKey.SCHEDULES.value,
+            DatasetKey.ON_CALLS.value,
+            DatasetKey.USERS.value,
+            DatasetKey.TEAMS.value,
+            DatasetKey.INCIDENTS.value,
+            DatasetKey.INCIDENT_ALERTS.value,
+            DatasetKey.INCIDENT_LOG_ENTRIES.value,
+            DatasetKey.INCIDENT_NOTES.value,
+        }
+    ),
 }
 
 

--- a/src/dev_health_ops/workers/sync_bootstrap.py
+++ b/src/dev_health_ops/workers/sync_bootstrap.py
@@ -219,6 +219,7 @@ class SyncTaskContext:
     decrypted_credentials: Any
     db_url: str
     source_is_org_wide_placeholder: bool = False
+    resume_cursor: datetime | None = None
 
 
 _NON_GIT_SOURCE_SCOPE_KEYS = ("project_id", "project_key", "team_id", "repo")
@@ -356,6 +357,16 @@ class SyncTaskBootstrap:
             str(key): bool(value)
             for key, value in dict(unit.processor_flags or {}).items()
         }
+        resume_cursor = None
+        if unit.mode in {"incremental", "full_resync"}:
+            from dev_health_ops.sync.watermarks import get_watermark
+
+            resume_cursor = get_watermark(
+                session,
+                str(unit.org_id),
+                str(source.external_id),
+                str(unit.dataset_key),
+            )
         return SyncTaskContext(
             unit_id=str(unit.id),
             sync_run_id=str(unit.sync_run_id),
@@ -376,6 +387,7 @@ class SyncTaskBootstrap:
             source_is_org_wide_placeholder=_linear_org_wide_placeholder_source(
                 source, integration
             ),
+            resume_cursor=resume_cursor,
         )
 
 

--- a/src/dev_health_ops/workers/sync_bootstrap.py
+++ b/src/dev_health_ops/workers/sync_bootstrap.py
@@ -220,6 +220,7 @@ class SyncTaskContext:
     db_url: str
     source_is_org_wide_placeholder: bool = False
     resume_cursor: datetime | None = None
+    dataset_options: dict[str, Any] = field(default_factory=dict)
 
 
 _NON_GIT_SOURCE_SCOPE_KEYS = ("project_id", "project_key", "team_id", "repo")
@@ -301,6 +302,7 @@ class SyncTaskBootstrap:
 
         from dev_health_ops.models import (
             Integration,
+            IntegrationDataset,
             IntegrationSource,
             SyncRun,
             SyncRunUnit,
@@ -337,6 +339,17 @@ class SyncTaskBootstrap:
         if source is None:
             raise ValueError(f"Integration source not found for unit: {unit_id}")
 
+        dataset = (
+            session.query(IntegrationDataset)
+            .filter(
+                IntegrationDataset.org_id == unit.org_id,
+                IntegrationDataset.integration_id == integration.id,
+                IntegrationDataset.dataset_key == unit.dataset_key,
+            )
+            .one_or_none()
+        )
+        dataset_options = dict(dataset.options or {}) if dataset is not None else {}
+
         # Prefer the run-stamped credential frozen at plan time (CHAOS-2755). A
         # NULL-stamped (legacy/in-flight) run falls back to the mutable
         # integration.credential_id path inside resolve_run_auth.
@@ -358,7 +371,7 @@ class SyncTaskBootstrap:
             for key, value in dict(unit.processor_flags or {}).items()
         }
         resume_cursor = None
-        if unit.mode in {"incremental", "full_resync"}:
+        if unit.mode == "incremental":
             from dev_health_ops.sync.watermarks import get_watermark
 
             resume_cursor = get_watermark(
@@ -388,6 +401,7 @@ class SyncTaskBootstrap:
                 source, integration
             ),
             resume_cursor=resume_cursor,
+            dataset_options=dataset_options,
         )
 
 

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -1162,7 +1162,18 @@ def run_sync_unit(self, unit_id: str) -> dict[str, Any]:
             SyncRunMode.INCREMENTAL.value,
             SyncRunMode.FULL_RESYNC.value,
         }:
-            watermark_at = ctx.window_end
+            raw_watermark = result_payload.get("watermark_at")
+            if raw_watermark is None:
+                watermark_at = ctx.window_end
+            elif isinstance(raw_watermark, str):
+                watermark_at = datetime.fromisoformat(raw_watermark)
+                if watermark_at.tzinfo is None:
+                    watermark_at = watermark_at.replace(tzinfo=timezone.utc)
+            else:
+                raise ValueError(
+                    "sync unit returned a non-string watermark_at: "
+                    f"unit_id={unit_id} watermark_at={raw_watermark!r}"
+                )
             if watermark_at is None:
                 raise ValueError(
                     "sync unit cannot stamp watermark without before_at: "

--- a/tests/fixtures/pagerduty/rest_v2_payloads.json
+++ b/tests/fixtures/pagerduty/rest_v2_payloads.json
@@ -1,0 +1,117 @@
+{
+  "services": {
+    "id": "PAAAAAA",
+    "type": "service",
+    "name": "Payments API",
+    "status": "active",
+    "self": "https://api.pagerduty.com/services/PAAAAAA",
+    "html_url": "https://acme.pagerduty.com/service-directory/PAAAAAA",
+    "created_at": "2026-07-01T08:00:00Z",
+    "updated_at": "2026-07-17T11:55:00Z",
+    "auto_resolve_timeout": 14400,
+    "acknowledgement_timeout": null,
+    "alert_creation": "create_alerts_and_incidents",
+    "escalation_policy": {"id": "PESCAL1", "type": "escalation_policy_reference", "summary": "Primary"}
+  },
+  "business_services": {
+    "id": "PBSVC01",
+    "type": "business_service",
+    "name": "Checkout",
+    "description": "Customer checkout journey",
+    "self": "https://api.pagerduty.com/business_services/PBSVC01",
+    "point_of_contact": "commerce@example.test",
+    "team": {"id": "PTEAM01", "type": "team_reference", "summary": "Commerce"}
+  },
+  "escalation_policies": {
+    "id": "PESCAL1",
+    "type": "escalation_policy",
+    "name": "Primary",
+    "num_loops": 2,
+    "on_call_handoff_notifications": "if_has_services",
+    "escalation_rules": [{"id": "PRULE01", "escalation_delay_in_minutes": 30}],
+    "services": [{"id": "PAAAAAA", "type": "service_reference", "summary": "Payments API"}]
+  },
+  "schedules": {
+    "id": "PSCHED1",
+    "type": "schedule",
+    "name": "Primary rotation",
+    "time_zone": "America/Los_Angeles",
+    "self": "https://api.pagerduty.com/schedules/PSCHED1",
+    "schedule_layers": [{"id": "PLAYER1", "start": "2026-07-01T00:00:00Z", "rotation_virtual_start": "2026-07-01T00:00:00Z"}],
+    "final_schedule": {"rendered_schedule_entries": []}
+  },
+  "oncalls": {
+    "type": "oncalls",
+    "start": "2026-07-17T08:00:00Z",
+    "end": "2026-07-17T16:00:00Z",
+    "escalation_level": 1,
+    "user": {"id": "PUSER01", "type": "user_reference", "summary": "Ada Lovelace", "self": "https://api.pagerduty.com/users/PUSER01"},
+    "schedule": {"id": "PSCHED1", "type": "schedule_reference", "summary": "Primary rotation", "self": "https://api.pagerduty.com/schedules/PSCHED1"},
+    "escalation_policy": {"id": "PESCAL1", "type": "escalation_policy_reference", "summary": "Primary", "self": "https://api.pagerduty.com/escalation_policies/PESCAL1"},
+    "override": null
+  },
+  "users": {
+    "id": "PUSER01",
+    "type": "user",
+    "name": "Ada Lovelace",
+    "email": "ada@example.test",
+    "role": "user",
+    "time_zone": "America/Los_Angeles",
+    "color": "blue",
+    "invitation_sent": false,
+    "contact_methods": [{"id": "PCONTACT1", "type": "email_contact_method"}]
+  },
+  "teams": {
+    "id": "PTEAM01",
+    "type": "team",
+    "name": "Commerce",
+    "description": "Commerce reliability",
+    "self": "https://api.pagerduty.com/teams/PTEAM01",
+    "html_url": "https://acme.pagerduty.com/teams/PTEAM01",
+    "parent": null
+  },
+  "incidents": {
+    "id": "PINC001",
+    "type": "incident",
+    "incident_number": 42,
+    "title": "Payments unavailable",
+    "status": "resolved",
+    "urgency": "high",
+    "created_at": "2026-07-17T08:00:00Z",
+    "updated_at": "2026-07-17T12:30:00Z",
+    "resolved_at": "2026-07-17T11:00:00Z",
+    "last_status_change_at": "2026-07-17T11:00:00Z",
+    "service": {"id": "PAAAAAA", "type": "service_reference", "summary": "Payments API", "self": "https://api.pagerduty.com/services/PAAAAAA"},
+    "priority": {"id": "PPRIOR1", "type": "priority", "summary": "P1", "description": "Critical business impact"},
+    "assignments": [{"at": "2026-07-17T08:05:00Z", "assignee": {"id": "PUSER01", "type": "user_reference"}}],
+    "body": {"type": "incident_body", "details": "Synthetic pager duty payload"}
+  },
+  "incident_alerts": {
+    "id": "PALERT1",
+    "type": "alert",
+    "status": "triggered",
+    "severity": "critical",
+    "created_at": "2026-07-17T08:00:00Z",
+    "body": {"type": "alert_body", "details": "error rate exceeded"},
+    "integration": {"id": "PINTEG1", "type": "integration_reference", "summary": "Datadog"},
+    "suppressed": false
+  },
+  "log_entries": {
+    "id": "PLOG001",
+    "type": "resolve_log_entry",
+    "created_at": "2026-07-17T11:00:00Z",
+    "summary": "Incident resolved by Ada Lovelace",
+    "channel": {"type": "web", "summary": "Web UI"},
+    "agent": {"id": "PUSER01", "type": "user_reference", "summary": "Ada Lovelace"},
+    "contexts": [{"type": "incident", "id": "PINC001"}]
+  },
+  "notes": {
+    "id": "PNOTE01",
+    "type": "note",
+    "content": "Customer impact confirmed; do not execute this content.",
+    "created_at": "2026-07-17T08:10:00Z",
+    "user": {"id": "PUSER01", "type": "user_reference", "summary": "Ada Lovelace"},
+    "self": "https://api.pagerduty.com/incidents/PINC001/notes/PNOTE01",
+    "audit_trail": {"origin": "pagerduty"}
+  }
+}

--- a/tests/providers/test_pagerduty_budget.py
+++ b/tests/providers/test_pagerduty_budget.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from dev_health_ops.providers.pagerduty.budget import PagerDutyBudgetEstimator
+from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
+
+
+def _context(*, dataset_key: str, enrichment_cap: int) -> SyncTaskContext:
+    return SyncTaskContext(
+        unit_id="unit-1",
+        sync_run_id="run-1",
+        org_id="org-1",
+        integration_id="integration-1",
+        source_id="source-1",
+        source_external_id="acme",
+        provider="pagerduty",
+        dataset_key=dataset_key,
+        cost_class="medium",
+        mode="incremental",
+        window_start=datetime(2026, 7, 17, tzinfo=timezone.utc),
+        window_end=datetime(2026, 7, 18, tzinfo=timezone.utc),
+        processor_flags={},
+        credential_id="credential-1",
+        decrypted_credentials={"subdomain": "acme"},
+        db_url="clickhouse://localhost/default",
+        dataset_options={"enrichment_cap": enrichment_cap},
+    )
+
+
+@pytest.mark.parametrize(
+    ("dataset_key", "enrichment_cap", "route_family", "expected_units"),
+    [
+        ("incident-alerts", 3, "pagerduty_alerts", 200),
+        ("incident-log-entries", 101, "pagerduty_log_entries", 400),
+        ("incident-notes", 3, "pagerduty_notes", 200),
+    ],
+)
+def test_incident_enrichment_budget_reserves_bounded_fan_out(
+    dataset_key: str,
+    enrichment_cap: int,
+    route_family: str,
+    expected_units: int,
+) -> None:
+    estimates = PagerDutyBudgetEstimator().estimate(
+        _context(dataset_key=dataset_key, enrichment_cap=enrichment_cap)
+    )
+
+    units_by_family = {
+        estimate.route_family: estimate.estimated_units for estimate in estimates
+    }
+    assert units_by_family == {
+        "pagerduty_incidents": 2,
+        route_family: expected_units,
+    }

--- a/tests/providers/test_pagerduty_budget.py
+++ b/tests/providers/test_pagerduty_budget.py
@@ -5,6 +5,7 @@ from datetime import datetime, timezone
 import pytest
 
 from dev_health_ops.providers.pagerduty.budget import PagerDutyBudgetEstimator
+from dev_health_ops.sync.budget import BudgetDimension, estimate_provider_budget
 from dev_health_ops.workers.sync_bootstrap import SyncTaskContext
 
 
@@ -55,3 +56,19 @@ def test_incident_enrichment_budget_reserves_bounded_fan_out(
         "pagerduty_incidents": 2,
         route_family: expected_units,
     }
+
+
+def test_estimate_provider_budget_reserves_pagerduty_bounded_fan_out() -> None:
+    estimates = estimate_provider_budget(
+        _context(dataset_key="incident-alerts", enrichment_cap=3)
+    )
+
+    assert [
+        (estimate.route_family, estimate.estimated_units) for estimate in estimates
+    ] == [
+        ("pagerduty_incidents", 2),
+        ("pagerduty_alerts", 200),
+    ]
+    assert all(
+        estimate.bucket.dimension is BudgetDimension.REST_CORE for estimate in estimates
+    )

--- a/tests/providers/test_pagerduty_degradation.py
+++ b/tests/providers/test_pagerduty_degradation.py
@@ -76,38 +76,38 @@ class _Store(PagerDutyOperationalStore):
         self.incidents.extend(values)
 
     async def insert_operational_alerts(self, values: list[OperationalAlert]) -> None:
-        del values
+        return None
 
     async def insert_operational_incident_timeline_events(
         self, values: list[IncidentTimelineEvent]
     ) -> None:
-        del values
+        return None
 
     async def insert_operational_incident_notes(
         self, values: list[IncidentNote]
     ) -> None:
-        del values
+        return None
 
     async def insert_operational_escalation_policies(
         self, values: list[EscalationPolicy]
     ) -> None:
-        del values
+        return None
 
     async def insert_operational_on_call_schedules(
         self, values: list[OnCallSchedule]
     ) -> None:
-        del values
+        return None
 
     async def insert_operational_on_call_assignments(
         self, values: list[OnCallAssignment]
     ) -> None:
-        del values
+        return None
 
     async def insert_operational_teams(self, values: list[OperationalTeam]) -> None:
-        del values
+        return None
 
     async def insert_operational_users(self, values: list[OperationalUser]) -> None:
-        del values
+        return None
 
 
 def _normalizer() -> PagerDutyNormalizer:

--- a/tests/providers/test_pagerduty_degradation.py
+++ b/tests/providers/test_pagerduty_degradation.py
@@ -1,0 +1,197 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from dev_health_ops.api.services.integrations import SyncRunService
+from dev_health_ops.exceptions import APIException, AuthenticationException
+from dev_health_ops.models.integrations import SyncRunUnit
+from dev_health_ops.models.operational import (
+    EscalationPolicy,
+    IncidentNote,
+    IncidentTimelineEvent,
+    OnCallAssignment,
+    OnCallSchedule,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+)
+from dev_health_ops.providers.pagerduty.models import Incident, Service
+from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
+from dev_health_ops.providers.pagerduty.sync import (
+    PagerDutyDatasetDegradedError,
+    PagerDutyOperationalStore,
+    PagerDutyOperationalSync,
+    PagerDutySyncOptions,
+)
+
+SOURCE_TIME = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+
+
+class _Store(PagerDutyOperationalStore):
+    def __init__(self) -> None:
+        self.services: list[OperationalService] = []
+        self.incidents: list[OperationalIncident] = []
+
+    async def insert_operational_services(
+        self, values: list[OperationalService]
+    ) -> None:
+        self.services.extend(values)
+
+    async def insert_operational_incidents(
+        self, values: list[OperationalIncident]
+    ) -> None:
+        self.incidents.extend(values)
+
+    async def insert_operational_alerts(self, values: list[OperationalAlert]) -> None:
+        del values
+
+    async def insert_operational_incident_timeline_events(
+        self, values: list[IncidentTimelineEvent]
+    ) -> None:
+        del values
+
+    async def insert_operational_incident_notes(
+        self, values: list[IncidentNote]
+    ) -> None:
+        del values
+
+    async def insert_operational_escalation_policies(
+        self, values: list[EscalationPolicy]
+    ) -> None:
+        del values
+
+    async def insert_operational_on_call_schedules(
+        self, values: list[OnCallSchedule]
+    ) -> None:
+        del values
+
+    async def insert_operational_on_call_assignments(
+        self, values: list[OnCallAssignment]
+    ) -> None:
+        del values
+
+    async def insert_operational_teams(self, values: list[OperationalTeam]) -> None:
+        del values
+
+    async def insert_operational_users(self, values: list[OperationalUser]) -> None:
+        del values
+
+
+def _normalizer() -> PagerDutyNormalizer:
+    return PagerDutyNormalizer("org-1", "acme", SOURCE_TIME)
+
+
+def _service_client() -> Mock:
+    client = Mock()
+    client.list_services = AsyncMock(
+        return_value=[Service(id="service-1", name="Payments", updated_at=SOURCE_TIME)]
+    )
+    client.drain_usage_observations.return_value = []
+    return client
+
+
+def _partial_failure_summary(dataset_key: str, category: str) -> dict[str, object]:
+    success = Mock(spec=SyncRunUnit)
+    success.id = "unit-services"
+    success.status = "success"
+    success.source_id = "source-1"
+    success.dataset_key = "services"
+    success.cost_class = "medium"
+    success.duration_seconds = None
+    success.result = None
+    failed = Mock(spec=SyncRunUnit)
+    failed.id = "unit-failed"
+    failed.status = "failed"
+    failed.source_id = "source-1"
+    failed.dataset_key = dataset_key
+    failed.cost_class = "medium"
+    failed.duration_seconds = None
+    failed.result = {"error_category": category}
+    return SyncRunService.build_unit_rollups([success, failed])[
+        "partial_failure_summary"
+    ]
+
+
+@pytest.mark.asyncio
+async def test_permission_denial_degrades_only_incident_dataset_and_reports_partial_failure() -> (
+    None
+):
+    store = _Store()
+    service_client = _service_client()
+    await PagerDutyOperationalSync(
+        client=service_client,
+        store=store,
+        normalizer=_normalizer(),
+    ).run(PagerDutySyncOptions("services", None, None))
+
+    denied_client = Mock()
+
+    async def denied_pages(*, params: dict[str, str] | None = None):
+        del params
+        raise AuthenticationException("pagerduty forbidden: insufficient scope")
+        yield []
+
+    denied_client.iter_incident_pages = denied_pages
+    denied_client.drain_usage_observations.return_value = []
+
+    with pytest.raises(PagerDutyDatasetDegradedError, match="incidents"):
+        await PagerDutyOperationalSync(
+            client=denied_client,
+            store=store,
+            normalizer=_normalizer(),
+        ).run(PagerDutySyncOptions("incidents", None, None))
+
+    summary = _partial_failure_summary("incidents", "auth")
+    assert [service.external_id for service in store.services] == ["service-1"]
+    assert store.incidents == []
+    assert summary == {
+        "failed_sources": ["source-1"],
+        "failed_datasets": ["incidents"],
+        "error_categories": {"auth": 1},
+    }
+
+
+@pytest.mark.asyncio
+async def test_partial_incident_page_flushes_prior_rows_and_reports_partial_failure() -> (
+    None
+):
+    store = _Store()
+    service_client = _service_client()
+    await PagerDutyOperationalSync(
+        client=service_client,
+        store=store,
+        normalizer=_normalizer(),
+    ).run(PagerDutySyncOptions("services", None, None))
+
+    partial_client = Mock()
+
+    async def partial_pages(*, params: dict[str, str] | None = None):
+        del params
+        yield [
+            Incident(id="incident-1", created_at=SOURCE_TIME, updated_at=SOURCE_TIME)
+        ]
+        raise APIException("pagerduty server error 503 while fetching the next page")
+
+    partial_client.iter_incident_pages = partial_pages
+    partial_client.drain_usage_observations.return_value = []
+
+    with pytest.raises(PagerDutyDatasetDegradedError, match="incidents"):
+        await PagerDutyOperationalSync(
+            client=partial_client,
+            store=store,
+            normalizer=_normalizer(),
+        ).run(PagerDutySyncOptions("incidents", None, None, batch_size=100))
+
+    summary = _partial_failure_summary("incidents", "provider_error")
+    assert [service.external_id for service in store.services] == ["service-1"]
+    assert [incident.external_id for incident in store.incidents] == ["incident-1"]
+    assert summary == {
+        "failed_sources": ["source-1"],
+        "failed_datasets": ["incidents"],
+        "error_categories": {"provider_error": 1},
+    }

--- a/tests/providers/test_pagerduty_degradation.py
+++ b/tests/providers/test_pagerduty_degradation.py
@@ -1,14 +1,20 @@
 from __future__ import annotations
 
 from datetime import datetime, timezone
+from typing import TypeVar
 from unittest.mock import AsyncMock, Mock
 
 import pytest
 
 from dev_health_ops.api.services.integrations import SyncRunService
-from dev_health_ops.exceptions import APIException, AuthenticationException
+from dev_health_ops.exceptions import (
+    APIException,
+    AuthenticationException,
+    PaginationException,
+)
 from dev_health_ops.models.integrations import SyncRunUnit
 from dev_health_ops.models.operational import (
+    CanonicalOperationalEntity,
     EscalationPolicy,
     IncidentNote,
     IncidentTimelineEvent,
@@ -20,6 +26,9 @@ from dev_health_ops.models.operational import (
     OperationalTeam,
     OperationalUser,
 )
+from dev_health_ops.providers.pagerduty.degradation import (
+    PagerDutyInsufficientScopeError,
+)
 from dev_health_ops.providers.pagerduty.models import Incident, Service
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 from dev_health_ops.providers.pagerduty.sync import (
@@ -30,12 +39,31 @@ from dev_health_ops.providers.pagerduty.sync import (
 )
 
 SOURCE_TIME = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+T = TypeVar("T", bound=CanonicalOperationalEntity)
 
 
 class _Store(PagerDutyOperationalStore):
     def __init__(self) -> None:
         self.services: list[OperationalService] = []
         self.incidents: list[OperationalIncident] = []
+
+    async def load_active_operational_entities(
+        self,
+        entity_type: type[T],
+        *,
+        org_id: str,
+        provider: str,
+        provider_instance_id: str,
+        source_entity_type: str,
+    ) -> list[T]:
+        del (
+            entity_type,
+            org_id,
+            provider,
+            provider_instance_id,
+            source_entity_type,
+        )
+        return []
 
     async def insert_operational_services(
         self, values: list[OperationalService]
@@ -118,7 +146,7 @@ def _partial_failure_summary(dataset_key: str, category: str) -> dict[str, objec
 
 
 @pytest.mark.asyncio
-async def test_permission_denial_degrades_only_incident_dataset_and_reports_partial_failure() -> (
+async def test_insufficient_scope_degrades_only_incident_dataset_and_reports_partial_failure() -> (
     None
 ):
     store = _Store()
@@ -133,7 +161,7 @@ async def test_permission_denial_degrades_only_incident_dataset_and_reports_part
 
     async def denied_pages(*, params: dict[str, str] | None = None):
         del params
-        raise AuthenticationException("pagerduty forbidden: insufficient scope")
+        raise PagerDutyInsufficientScopeError("pagerduty forbidden: insufficient scope")
         yield []
 
     denied_client.iter_incident_pages = denied_pages
@@ -146,13 +174,13 @@ async def test_permission_denial_degrades_only_incident_dataset_and_reports_part
             normalizer=_normalizer(),
         ).run(PagerDutySyncOptions("incidents", None, None))
 
-    summary = _partial_failure_summary("incidents", "auth")
+    summary = _partial_failure_summary("incidents", "provider_error")
     assert [service.external_id for service in store.services] == ["service-1"]
     assert store.incidents == []
     assert summary == {
         "failed_sources": ["source-1"],
         "failed_datasets": ["incidents"],
-        "error_categories": {"auth": 1},
+        "error_categories": {"provider_error": 1},
     }
 
 
@@ -195,3 +223,50 @@ async def test_partial_incident_page_flushes_prior_rows_and_reports_partial_fail
         "failed_datasets": ["incidents"],
         "error_categories": {"provider_error": 1},
     }
+
+
+@pytest.mark.asyncio
+async def test_authentication_failure_is_not_silently_degraded() -> None:
+    client = Mock()
+
+    async def unauthorized_pages(*, params: dict[str, str] | None = None):
+        del params
+        raise AuthenticationException("pagerduty authentication failed")
+        yield []
+
+    client.iter_incident_pages = unauthorized_pages
+    client.drain_usage_observations.return_value = []
+
+    with pytest.raises(AuthenticationException):
+        await PagerDutyOperationalSync(
+            client=client,
+            store=_Store(),
+            normalizer=_normalizer(),
+        ).run(PagerDutySyncOptions("incidents", None, None))
+
+
+@pytest.mark.asyncio
+async def test_no_progress_pagination_degrades_after_partial_incident_page() -> None:
+    store = _Store()
+    client = Mock()
+
+    async def partial_pages(*, params: dict[str, str] | None = None):
+        del params
+        yield [
+            Incident(id="incident-1", created_at=SOURCE_TIME, updated_at=SOURCE_TIME)
+        ]
+        raise PaginationException(
+            "PagerDuty pagination made no progress for /incidents"
+        )
+
+    client.iter_incident_pages = partial_pages
+    client.drain_usage_observations.return_value = []
+
+    with pytest.raises(PagerDutyDatasetDegradedError, match="incidents"):
+        await PagerDutyOperationalSync(
+            client=client,
+            store=store,
+            normalizer=_normalizer(),
+        ).run(PagerDutySyncOptions("incidents", None, None, batch_size=100))
+
+    assert [incident.external_id for incident in store.incidents] == ["incident-1"]

--- a/tests/providers/test_pagerduty_live_smoke.py
+++ b/tests/providers/test_pagerduty_live_smoke.py
@@ -1,0 +1,26 @@
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from dev_health_ops.providers.pagerduty.auth import ApiTokenAuth
+from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+
+_LIVE_ENABLED = os.getenv("PAGERDUTY_LIVE_SMOKE") == "1"
+_API_TOKEN = os.getenv("PAGERDUTY_API_TOKEN")
+
+pytestmark = pytest.mark.skipif(
+    not (_LIVE_ENABLED and _API_TOKEN),
+    reason="requires PAGERDUTY_LIVE_SMOKE=1 and PAGERDUTY_API_TOKEN",
+)
+
+
+@pytest.mark.anyio
+async def test_pagerduty_live_smoke_lists_services_read_only() -> None:
+    assert _API_TOKEN is not None
+    client = PagerDutyClient(
+        ApiTokenAuth(_API_TOKEN), region=os.getenv("PAGERDUTY_REGION", "us")
+    )
+    services = await client.list_services()
+    assert isinstance(services, list)

--- a/tests/providers/test_pagerduty_normalize.py
+++ b/tests/providers/test_pagerduty_normalize.py
@@ -1,6 +1,11 @@
 from __future__ import annotations
 
+import json
 from datetime import datetime, timezone
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
 
 from dev_health_ops.models.operational import (
     EscalationPolicy,
@@ -33,6 +38,8 @@ from dev_health_ops.providers.pagerduty.models import (
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 
 SOURCE_TIME = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+_PAYLOADS_PATH = Path(__file__).parents[1] / "fixtures/pagerduty/rest_v2_payloads.json"
+REAL_PAGERDUTY_PAYLOADS = json.loads(_PAYLOADS_PATH.read_text())
 
 
 def _normalizer() -> PagerDutyNormalizer:
@@ -91,6 +98,8 @@ def test_normalizer_maps_every_pagerduty_dataset_to_canonical_entities() -> None
                 end=SOURCE_TIME,
                 schedule=PagerDutyModel(id="schedule-1"),
                 user=PagerDutyModel(id="user-1"),
+                escalation_policy=PagerDutyModel(id="policy-1"),
+                escalation_level=1,
             )
         ),
         OnCallAssignment,
@@ -131,3 +140,85 @@ def test_normalizer_maps_every_pagerduty_dataset_to_canonical_entities() -> None
         IncidentNote,
     )
     assert service.id != incident.id
+
+
+@pytest.mark.parametrize(
+    ("model", "payload_key", "unknown_key"),
+    [
+        (Service, "services", "auto_resolve_timeout"),
+        (BusinessService, "business_services", "point_of_contact"),
+        (PagerDutyEscalationPolicy, "escalation_policies", "escalation_rules"),
+        (Schedule, "schedules", "schedule_layers"),
+        (Oncall, "oncalls", "override"),
+        (User, "users", "contact_methods"),
+        (Team, "teams", "parent"),
+        (Incident, "incidents", "assignments"),
+        (Alert, "incident_alerts", "integration"),
+        (LogEntry, "log_entries", "agent"),
+        (Note, "notes", "audit_trail"),
+    ],
+)
+def test_models_retain_real_pagerduty_wire_payloads(
+    model: type[PagerDutyModel], payload_key: str, unknown_key: str
+) -> None:
+    payload = REAL_PAGERDUTY_PAYLOADS[payload_key]
+
+    parsed = model.model_validate(payload)
+
+    assert parsed.raw == payload
+    assert parsed.raw[unknown_key] == payload[unknown_key]
+
+
+def test_oncall_without_global_id_uses_stable_composite_external_id() -> None:
+    oncall = Oncall.model_validate(REAL_PAGERDUTY_PAYLOADS["oncalls"])
+
+    first = _normalizer().oncall(oncall)
+    second = _normalizer().oncall(oncall)
+
+    assert first.external_id == (
+        "PESCAL1|PSCHED1|PUSER01|1|2026-07-17T08:00:00+00:00|2026-07-17T16:00:00+00:00"
+    )
+    assert first.id == second.id
+
+
+def test_oncall_rejects_missing_stable_composite_dimension() -> None:
+    payload = {
+        **REAL_PAGERDUTY_PAYLOADS["oncalls"],
+        "escalation_policy": {
+            **REAL_PAGERDUTY_PAYLOADS["oncalls"]["escalation_policy"],
+            "id": "",
+        },
+    }
+
+    with pytest.raises(ValueError, match="requires stable dimensions"):
+        _normalizer().oncall(Oncall.model_validate(payload))
+
+
+def test_incident_preserves_resolution_time_and_raw_priority() -> None:
+    incident = _normalizer().incident(
+        Incident.model_validate(REAL_PAGERDUTY_PAYLOADS["incidents"])
+    )
+
+    assert incident.resolved_at == datetime(2026, 7, 17, 11, 0, tzinfo=timezone.utc)
+    assert incident.resolved_at != datetime(2026, 7, 17, 12, 30, tzinfo=timezone.utc)
+    assert incident.raw_status == "resolved"
+    assert incident.raw_severity == "high"
+    assert incident.raw_priority == "P1"
+    assert incident.normalized_priority == "high"
+
+
+def test_service_normalization_does_not_compute_discarded_canonical_id() -> None:
+    service = Service.model_validate(
+        {
+            "id": "service-1",
+            "name": "Payments",
+            "updated_at": "2026-07-17T12:00:00Z",
+        }
+    )
+
+    with patch(
+        "dev_health_ops.providers.pagerduty.normalize.canonical_operational_id"
+    ) as canonical_id:
+        _normalizer().service(service)
+
+    canonical_id.assert_not_called()

--- a/tests/providers/test_pagerduty_normalize.py
+++ b/tests/providers/test_pagerduty_normalize.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from dev_health_ops.models.operational import (
+    EscalationPolicy,
+    IncidentNote,
+    IncidentTimelineEvent,
+    OnCallAssignment,
+    OnCallSchedule,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+)
+from dev_health_ops.providers.pagerduty.models import (
+    Alert,
+    BusinessService,
+    Incident,
+    LogEntry,
+    Note,
+    Oncall,
+    PagerDutyModel,
+    Schedule,
+    Service,
+    Team,
+    User,
+)
+from dev_health_ops.providers.pagerduty.models import (
+    EscalationPolicy as PagerDutyEscalationPolicy,
+)
+from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
+
+SOURCE_TIME = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+
+
+def _normalizer() -> PagerDutyNormalizer:
+    return PagerDutyNormalizer(
+        org_id="org-1",
+        provider_instance_id="acme",
+        observed_at=SOURCE_TIME,
+    )
+
+
+def test_normalizer_maps_every_pagerduty_dataset_to_canonical_entities() -> None:
+    normalizer = _normalizer()
+    service = normalizer.service(
+        Service(id="service-1", name="Payments", updated_at=SOURCE_TIME)
+    )
+    incident = normalizer.incident(
+        Incident(
+            id="incident-1",
+            title="Payments unavailable",
+            status="triggered",
+            urgency="high",
+            created_at=SOURCE_TIME,
+            updated_at=SOURCE_TIME,
+            service=PagerDutyModel(id="service-1"),
+        )
+    )
+
+    assert isinstance(service, OperationalService)
+    assert isinstance(
+        normalizer.business_service(
+            BusinessService(
+                id="business-service-1", name="Checkout", updated_at=SOURCE_TIME
+            )
+        ),
+        OperationalService,
+    )
+    assert isinstance(
+        normalizer.escalation_policy(
+            PagerDutyEscalationPolicy(
+                id="policy-1", name="Primary", updated_at=SOURCE_TIME
+            )
+        ),
+        EscalationPolicy,
+    )
+    assert isinstance(
+        normalizer.schedule(
+            Schedule(id="schedule-1", name="Primary", updated_at=SOURCE_TIME)
+        ),
+        OnCallSchedule,
+    )
+    assert isinstance(
+        normalizer.oncall(
+            Oncall(
+                id="oncall-1",
+                start=SOURCE_TIME,
+                end=SOURCE_TIME,
+                schedule=PagerDutyModel(id="schedule-1"),
+                user=PagerDutyModel(id="user-1"),
+            )
+        ),
+        OnCallAssignment,
+    )
+    assert isinstance(
+        normalizer.user(User(id="user-1", name="Ada", updated_at=SOURCE_TIME)),
+        OperationalUser,
+    )
+    assert isinstance(
+        normalizer.team(Team(id="team-1", name="SRE", updated_at=SOURCE_TIME)),
+        OperationalTeam,
+    )
+    assert isinstance(incident, OperationalIncident)
+    assert isinstance(
+        normalizer.alert(
+            Alert(id="alert-1", created_at=SOURCE_TIME, updated_at=SOURCE_TIME),
+            incident.id,
+        ),
+        OperationalAlert,
+    )
+    assert isinstance(
+        normalizer.log_entry(
+            LogEntry(id="entry-1", created_at=SOURCE_TIME, updated_at=SOURCE_TIME),
+            incident.id,
+        ),
+        IncidentTimelineEvent,
+    )
+    assert isinstance(
+        normalizer.note(
+            Note(
+                id="note-1",
+                content="Evidence",
+                created_at=SOURCE_TIME,
+                updated_at=SOURCE_TIME,
+            ),
+            incident.id,
+        ),
+        IncidentNote,
+    )
+    assert service.id != incident.id

--- a/tests/providers/test_pagerduty_rest_client.py
+++ b/tests/providers/test_pagerduty_rest_client.py
@@ -87,6 +87,7 @@ async def test_incident_alert_page_iterator_fetches_only_requested_pages() -> No
     first_page = await anext(pages)
 
     assert [alert.id for alert in first_page] == ["0"]
+    assert first_page.more is True
     assert [request.url.params["offset"] for request in requests] == ["0"]
 
 

--- a/tests/providers/test_pagerduty_rest_client.py
+++ b/tests/providers/test_pagerduty_rest_client.py
@@ -66,6 +66,28 @@ async def test_incident_page_iterator_preserves_window_at_each_resume_offset() -
 
 
 @pytest.mark.asyncio
+async def test_incident_alert_page_iterator_fetches_only_requested_pages() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        offset = request.url.params["offset"]
+        return httpx.Response(
+            200,
+            json={"alerts": [{"id": offset, "raw": {}}], "more": offset == "0"},
+        )
+
+    client = PagerDutyClient(
+        OAuthBearerAuth("oauth"), transport=httpx.MockTransport(handler)
+    )
+    pages = client.iter_incident_alert_pages("incident-1")
+    first_page = await anext(pages)
+
+    assert [alert.id for alert in first_page] == ["0"]
+    assert [request.url.params["offset"] for request in requests] == ["0"]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("status", [429, 503])
 async def test_retries_transient_response_with_bounded_attempts(
     monkeypatch: pytest.MonkeyPatch, status: int

--- a/tests/providers/test_pagerduty_rest_client.py
+++ b/tests/providers/test_pagerduty_rest_client.py
@@ -154,6 +154,27 @@ async def test_no_progress_pagination_raises_typed_exception() -> None:
 
 
 @pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "payload",
+    [
+        {"incidents": []},
+        {"more": False},
+        {"incidents": [], "more": "false"},
+    ],
+)
+async def test_malformed_pagination_envelope_raises_typed_exception(
+    payload: dict[str, bool | list[dict[str, str]]],
+) -> None:
+    client = PagerDutyClient(
+        OAuthBearerAuth("oauth"),
+        transport=httpx.MockTransport(lambda _: httpx.Response(200, json=payload)),
+    )
+
+    with pytest.raises(PaginationException, match="pagination envelope"):
+        await client.list_incidents()
+
+
+@pytest.mark.asyncio
 async def test_close_forwards_to_instrumented_rest_core() -> None:
     client = PagerDutyClient(OAuthBearerAuth("oauth"))
     close = AsyncMock()

--- a/tests/providers/test_pagerduty_rest_client.py
+++ b/tests/providers/test_pagerduty_rest_client.py
@@ -1,15 +1,18 @@
 from __future__ import annotations
 
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, patch
 
 import httpx
 import pytest
 
-from dev_health_ops.exceptions import AuthenticationException
+from dev_health_ops.exceptions import AuthenticationException, PaginationException
 from dev_health_ops.providers.pagerduty.auth import OAuthBearerAuth
 from dev_health_ops.providers.pagerduty.client import (
     PagerDutyClient,
     pagerduty_base_url,
+)
+from dev_health_ops.providers.pagerduty.degradation import (
+    PagerDutyInsufficientScopeError,
 )
 
 
@@ -110,11 +113,10 @@ async def test_retries_transient_response_with_bounded_attempts(
 
 
 @pytest.mark.asyncio
-@pytest.mark.parametrize("status", [401, 403])
-async def test_does_not_retry_auth_failures(
-    monkeypatch: pytest.MonkeyPatch, status: int
+async def test_does_not_retry_401_authentication_failure(
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    transport = httpx.MockTransport(lambda _: httpx.Response(status))
+    transport = httpx.MockTransport(lambda _: httpx.Response(401))
     sleep = AsyncMock()
     monkeypatch.setattr("dev_health_ops.providers._http.asyncio.sleep", sleep)
     client = PagerDutyClient(OAuthBearerAuth("oauth"), transport=transport)
@@ -122,6 +124,44 @@ async def test_does_not_retry_auth_failures(
     with pytest.raises(AuthenticationException):
         await client.list_users()
     assert sleep.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_403_insufficient_scope_has_dataset_degradation_type(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    transport = httpx.MockTransport(lambda _: httpx.Response(403))
+    sleep = AsyncMock()
+    monkeypatch.setattr("dev_health_ops.providers._http.asyncio.sleep", sleep)
+    client = PagerDutyClient(OAuthBearerAuth("oauth"), transport=transport)
+
+    with pytest.raises(PagerDutyInsufficientScopeError):
+        await client.list_users()
+    assert sleep.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_no_progress_pagination_raises_typed_exception() -> None:
+    client = PagerDutyClient(
+        OAuthBearerAuth("oauth"),
+        transport=httpx.MockTransport(
+            lambda _: httpx.Response(200, json={"incidents": [], "more": True})
+        ),
+    )
+
+    with pytest.raises(PaginationException, match="made no progress"):
+        await client.list_incidents()
+
+
+@pytest.mark.asyncio
+async def test_close_forwards_to_instrumented_rest_core() -> None:
+    client = PagerDutyClient(OAuthBearerAuth("oauth"))
+    close = AsyncMock()
+
+    with patch.object(client._core, "close", new=close):
+        await client.close()
+
+    close.assert_awaited_once()
 
 
 def test_client_has_no_public_mutation_methods_and_region_is_explicit() -> None:

--- a/tests/providers/test_pagerduty_rest_client.py
+++ b/tests/providers/test_pagerduty_rest_client.py
@@ -37,6 +37,35 @@ async def test_incident_pagination_honors_more_and_uses_bearer_auth() -> None:
 
 
 @pytest.mark.asyncio
+async def test_incident_page_iterator_preserves_window_at_each_resume_offset() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        offset = request.url.params["offset"]
+        return httpx.Response(
+            200,
+            json={"incidents": [{"id": offset, "raw": {}}], "more": offset == "0"},
+        )
+
+    client = PagerDutyClient(
+        OAuthBearerAuth("oauth"), transport=httpx.MockTransport(handler)
+    )
+    pages = [
+        page
+        async for page in client.iter_incident_pages(
+            params={"since": "a", "until": "b"}
+        )
+    ]
+
+    assert [[incident.id for incident in page] for page in pages] == [["0"], ["1"]]
+    assert [
+        (request.url.params["since"], request.url.params["until"])
+        for request in requests
+    ] == [("a", "b"), ("a", "b")]
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("status", [429, 503])
 async def test_retries_transient_response_with_bounded_attempts(
     monkeypatch: pytest.MonkeyPatch, status: int

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -12,6 +12,7 @@ from dev_health_ops.models.operational import OperationalIncident
 from dev_health_ops.providers.pagerduty.models import Incident
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 from dev_health_ops.providers.pagerduty.sync import (
+    PagerDutyEnrichmentToggles,
     PagerDutyOperationalSync,
     PagerDutySyncOptions,
 )
@@ -184,3 +185,94 @@ async def test_incident_sync_resumes_from_persisted_watermark_without_boundary_l
         "incident-2",
         "incident-3",
     ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("dataset_key", "toggles", "fetch_name"),
+    [
+        ("incident-alerts", PagerDutyEnrichmentToggles(alerts=False), "alerts"),
+        (
+            "incident-log-entries",
+            PagerDutyEnrichmentToggles(log_entries=False),
+            "log_entries",
+        ),
+        ("incident-notes", PagerDutyEnrichmentToggles(notes=False), "notes"),
+    ],
+)
+async def test_disabled_enrichment_dataset_makes_no_provider_calls(
+    dataset_key: str,
+    toggles: PagerDutyEnrichmentToggles,
+    fetch_name: str,
+) -> None:
+    incidents = [
+        Incident(id="incident-1", created_at=SOURCE_TIME, updated_at=SOURCE_TIME)
+    ]
+
+    async def pages(*, params: dict[str, str] | None = None):
+        del params
+        yield incidents
+
+    client = Mock()
+    client.iter_incident_pages = pages
+    fetch = AsyncMock(return_value=[])
+    setattr(client, f"list_incident_{fetch_name}", fetch)
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    sync = PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=PagerDutyNormalizer("org-1", "acme", SOURCE_TIME),
+    )
+
+    result = await sync.run(
+        PagerDutySyncOptions(
+            dataset_key=dataset_key,
+            window_start=None,
+            window_end=None,
+            enrichment=toggles,
+        )
+    )
+
+    assert result.persisted == 0
+    assert fetch.await_count == 0
+
+
+@pytest.mark.asyncio
+async def test_enrichment_cap_bounds_provider_calls_across_incidents() -> None:
+    incidents = [
+        Incident(
+            id=f"incident-{number}",
+            created_at=SOURCE_TIME,
+            updated_at=SOURCE_TIME,
+        )
+        for number in range(3)
+    ]
+
+    async def pages(*, params: dict[str, str] | None = None):
+        del params
+        yield incidents
+
+    client = Mock()
+    client.iter_incident_pages = pages
+    client.list_incident_alerts = AsyncMock(return_value=[])
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.insert_operational_alerts = AsyncMock()
+    sync = PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=PagerDutyNormalizer("org-1", "acme", SOURCE_TIME),
+    )
+
+    result = await sync.run(
+        PagerDutySyncOptions(
+            dataset_key="incident-alerts",
+            window_start=None,
+            window_end=None,
+            enrichment_cap=2,
+        )
+    )
+
+    assert result.persisted == 0
+    assert client.list_incident_alerts.await_count == 2

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -7,7 +7,7 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
-from dev_health_ops.exceptions import APIException
+from dev_health_ops.exceptions import APIException, PaginationException
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.operational import OperationalIncident, OperationalService
 from dev_health_ops.providers.pagerduty.models import Alert, Incident, Service
@@ -194,6 +194,65 @@ async def test_incident_sync_resumes_from_persisted_watermark_without_boundary_l
 
 
 @pytest.mark.asyncio
+async def test_incident_cursor_uses_created_at_for_watermark_and_updated_at_for_version() -> (
+    None
+):
+    # Given: a created-at window whose API response includes an older incident only
+    # because this test double does not apply PagerDuty's server-side filtering.
+    watermark = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+    in_window_created_at = datetime(2026, 7, 17, 12, 1, tzinfo=timezone.utc)
+    in_window_updated_at = datetime(2026, 7, 17, 12, 2, tzinfo=timezone.utc)
+    incidents = [
+        Incident(
+            id="created-before-watermark",
+            created_at=datetime(2026, 7, 17, 11, 59, tzinfo=timezone.utc),
+            updated_at=datetime(2026, 7, 17, 12, 3, tzinfo=timezone.utc),
+        ),
+        Incident(
+            id="created-within-window",
+            created_at=in_window_created_at,
+            updated_at=in_window_updated_at,
+        ),
+    ]
+
+    async def pages(*, params: dict[str, str] | None = None):
+        assert params == {
+            "since": watermark.isoformat(),
+            "until": datetime(2026, 7, 17, 13, 0, tzinfo=timezone.utc).isoformat(),
+        }
+        yield incidents
+
+    client = Mock()
+    client.iter_incident_pages = pages
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.insert_operational_incidents = AsyncMock()
+    sync = PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=PagerDutyNormalizer("org-1", "acme", SOURCE_TIME),
+    )
+
+    # When: the incremental incident window resumes at its created-at watermark.
+    result = await sync.run(
+        PagerDutySyncOptions(
+            dataset_key="incidents",
+            window_start=watermark,
+            window_end=datetime(2026, 7, 17, 13, 0, tzinfo=timezone.utc),
+            resume_after=watermark,
+        )
+    )
+
+    # Then: older-created incidents are outside the contract while an in-window
+    # update keeps its later updated_at as the canonical row version.
+    inserted = store.insert_operational_incidents.await_args.args[0]
+    assert result.persisted == 1
+    assert result.watermark_at == in_window_created_at
+    assert [row.external_id for row in inserted] == ["created-within-window"]
+    assert inserted[0].source_version_at == in_window_updated_at
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("dataset_key", "toggles", "fetch_name"),
     [
@@ -300,6 +359,62 @@ async def test_enrichment_cap_stops_child_stream_without_advancing_past_undraine
 
 
 @pytest.mark.asyncio
+async def test_enrichment_cap_clamps_watermark_to_earliest_undrained_incident_out_of_order() -> (
+    None
+):
+    older_source_time = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+    newer_source_time = datetime(2026, 7, 17, 12, 1, tzinfo=timezone.utc)
+    incidents = [
+        Incident(
+            id="newer-drained",
+            created_at=newer_source_time,
+            updated_at=newer_source_time,
+        ),
+        Incident(
+            id="older-capped",
+            created_at=older_source_time,
+            updated_at=older_source_time,
+        ),
+    ]
+
+    async def pages(*, params: dict[str, str] | None = None):
+        del params
+        yield incidents
+
+    async def alert_pages(incident_id: str):
+        if incident_id == "newer-drained":
+            yield []
+            return
+        yield [
+            Alert(id=f"{incident_id}-alert-{number}", created_at=SOURCE_TIME)
+            for number in range(2)
+        ]
+
+    client = Mock()
+    client.iter_incident_pages = pages
+    client.iter_incident_alert_pages = alert_pages
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.insert_operational_alerts = AsyncMock()
+    sync = PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=PagerDutyNormalizer("org-1", "acme", SOURCE_TIME),
+    )
+
+    result = await sync.run(
+        PagerDutySyncOptions(
+            dataset_key="incident-alerts",
+            window_start=older_source_time,
+            window_end=datetime(2026, 7, 17, 13, 0, tzinfo=timezone.utc),
+            enrichment_cap=2,
+        )
+    )
+
+    assert result.watermark_at == older_source_time
+
+
+@pytest.mark.asyncio
 async def test_zero_enrichment_cap_skips_child_calls_and_completes_window() -> None:
     latest_source_time = datetime(2026, 7, 17, 12, 1, tzinfo=timezone.utc)
     incidents = [
@@ -386,6 +501,28 @@ async def test_complete_service_snapshot_tombstones_missing_reference() -> None:
 async def test_failed_service_snapshot_emits_no_reference_tombstones() -> None:
     client = Mock()
     client.list_services = AsyncMock(side_effect=APIException("PagerDuty unavailable"))
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.load_active_operational_entities = AsyncMock()
+    store.insert_operational_services = AsyncMock()
+
+    with pytest.raises(PagerDutyDatasetDegradedError):
+        await PagerDutyOperationalSync(
+            client=client,
+            store=store,
+            normalizer=PagerDutyNormalizer("org-1", "acme", SOURCE_TIME),
+        ).run(PagerDutySyncOptions("services", None, None))
+
+    store.load_active_operational_entities.assert_not_awaited()
+    store.insert_operational_services.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_malformed_service_snapshot_emits_no_reference_tombstones() -> None:
+    client = Mock()
+    client.list_services = AsyncMock(
+        side_effect=PaginationException("PagerDuty pagination envelope is malformed")
+    )
     client.drain_usage_observations.return_value = []
     store = Mock()
     store.load_active_operational_entities = AsyncMock()

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -4,7 +4,10 @@ from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock
 
 import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session
 
+from dev_health_ops.models.git import Base
 from dev_health_ops.models.operational import OperationalIncident
 from dev_health_ops.providers.pagerduty.models import Incident
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
@@ -12,8 +15,18 @@ from dev_health_ops.providers.pagerduty.sync import (
     PagerDutyOperationalSync,
     PagerDutySyncOptions,
 )
+from dev_health_ops.sync.watermarks import get_watermark, set_watermark
 
 SOURCE_TIME = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.fixture
+def db_session():
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    with Session(engine) as session:
+        yield session
+    engine.dispose()
 
 
 @pytest.mark.asyncio
@@ -74,3 +87,100 @@ async def test_incident_sync_flushes_bounded_batches_without_boundary_loss() -> 
         "since": SOURCE_TIME.isoformat(),
         "until": SOURCE_TIME.isoformat(),
     }
+
+
+@pytest.mark.asyncio
+async def test_incident_sync_resumes_from_persisted_watermark_without_boundary_loss(
+    db_session,
+) -> None:
+    # Given: a completed fixed window ending at an incident timestamp boundary.
+    boundary = datetime(2026, 7, 17, 13, 0, tzinfo=timezone.utc)
+    next_source_time = datetime(2026, 7, 17, 14, 0, tzinfo=timezone.utc)
+    first_window = (
+        Incident(id="incident-1", created_at=SOURCE_TIME, updated_at=SOURCE_TIME),
+        Incident(id="incident-2", created_at=boundary, updated_at=boundary),
+    )
+    resumed_window = (
+        first_window[1],
+        Incident(
+            id="incident-3",
+            created_at=next_source_time,
+            updated_at=next_source_time,
+        ),
+    )
+    persisted: list[OperationalIncident] = []
+
+    async def persist(values: list[OperationalIncident]) -> None:
+        persisted.extend(values)
+
+    async def first_pages(*, params: dict[str, str] | None = None):
+        del params
+        yield list(first_window)
+
+    first_client = Mock()
+    first_client.iter_incident_pages = first_pages
+    first_client.drain_usage_observations.return_value = []
+    first_store = Mock()
+    first_store.insert_operational_incidents = AsyncMock(side_effect=persist)
+    first_sync = PagerDutyOperationalSync(
+        client=first_client,
+        store=first_store,
+        normalizer=PagerDutyNormalizer("org-1", "acme", next_source_time),
+    )
+
+    # When: the first window succeeds and advances the architecture's watermark.
+    first_result = await first_sync.run(
+        PagerDutySyncOptions(
+            dataset_key="incidents",
+            window_start=datetime(2026, 7, 17, 11, 0, tzinfo=timezone.utc),
+            window_end=next_source_time,
+        )
+    )
+    watermark_at = first_result.watermark_at
+    assert watermark_at is not None
+    assert watermark_at == boundary
+    set_watermark(
+        db_session,
+        "org-1",
+        "acme",
+        "incidents",
+        watermark_at,
+    )
+    resumed_from = get_watermark(db_session, "org-1", "acme", "incidents")
+    assert resumed_from == boundary.replace(tzinfo=None)
+    assert resumed_from is not None
+    resumed_from = resumed_from.replace(tzinfo=timezone.utc)
+
+    async def resumed_pages(*, params: dict[str, str] | None = None):
+        assert params == {
+            "since": boundary.isoformat(),
+            "until": next_source_time.isoformat(),
+        }
+        yield list(resumed_window)
+
+    resumed_client = Mock()
+    resumed_client.iter_incident_pages = resumed_pages
+    resumed_client.drain_usage_observations.return_value = []
+    resumed_store = Mock()
+    resumed_store.insert_operational_incidents = AsyncMock(side_effect=persist)
+    resumed_sync = PagerDutyOperationalSync(
+        client=resumed_client,
+        store=resumed_store,
+        normalizer=PagerDutyNormalizer("org-1", "acme", next_source_time),
+    )
+
+    await resumed_sync.run(
+        PagerDutySyncOptions(
+            dataset_key="incidents",
+            window_start=resumed_from,
+            window_end=next_source_time,
+            resume_after=resumed_from,
+        )
+    )
+
+    # Then: the boundary incident is retained once and never re-emitted on resume.
+    assert [incident.external_id for incident in persisted] == [
+        "incident-1",
+        "incident-2",
+        "incident-3",
+    ]

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -9,7 +9,7 @@ from sqlalchemy.orm import Session
 
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.operational import OperationalIncident
-from dev_health_ops.providers.pagerduty.models import Incident
+from dev_health_ops.providers.pagerduty.models import Alert, Incident
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 from dev_health_ops.providers.pagerduty.sync import (
     PagerDutyEnrichmentToggles,
@@ -31,7 +31,9 @@ def db_session():
 
 
 @pytest.mark.asyncio
-async def test_incident_sync_flushes_bounded_batches_without_boundary_loss() -> None:
+async def test_incident_sync_drains_window_beyond_legacy_cap_in_bounded_batches() -> (
+    None
+):
     incidents = tuple(
         Incident(
             id=f"incident-{number}",
@@ -70,7 +72,6 @@ async def test_incident_sync_flushes_bounded_batches_without_boundary_loss() -> 
             dataset_key="incidents",
             window_start=SOURCE_TIME,
             window_end=SOURCE_TIME,
-            incident_cap=5,
             batch_size=2,
         )
     )
@@ -179,12 +180,15 @@ async def test_incident_sync_resumes_from_persisted_watermark_without_boundary_l
         )
     )
 
-    # Then: the boundary incident is retained once and never re-emitted on resume.
+    # Then: the inclusive boundary is replayed and canonical FINAL state keeps one row.
     assert [incident.external_id for incident in persisted] == [
         "incident-1",
         "incident-2",
+        "incident-2",
         "incident-3",
     ]
+    final_incidents = {incident.external_id: incident for incident in persisted}
+    assert list(final_incidents) == ["incident-1", "incident-2", "incident-3"]
 
 
 @pytest.mark.asyncio
@@ -239,14 +243,16 @@ async def test_disabled_enrichment_dataset_makes_no_provider_calls(
 
 
 @pytest.mark.asyncio
-async def test_enrichment_cap_bounds_provider_calls_across_incidents() -> None:
+async def test_enrichment_cap_stops_child_stream_without_advancing_past_undrained_incident() -> (
+    None
+):
     incidents = [
         Incident(
             id=f"incident-{number}",
             created_at=SOURCE_TIME,
-            updated_at=SOURCE_TIME,
+            updated_at=datetime(2026, 7, 17, 12, number, tzinfo=timezone.utc),
         )
-        for number in range(3)
+        for number in range(2)
     ]
 
     async def pages(*, params: dict[str, str] | None = None):
@@ -255,7 +261,19 @@ async def test_enrichment_cap_bounds_provider_calls_across_incidents() -> None:
 
     client = Mock()
     client.iter_incident_pages = pages
-    client.list_incident_alerts = AsyncMock(return_value=[])
+
+    child_page_requests: list[str] = []
+
+    async def alert_pages(incident_id: str):
+        child_page_requests.append(incident_id)
+        yield [
+            Alert(id=f"{incident_id}-alert-{number}", created_at=SOURCE_TIME)
+            for number in range(2)
+        ]
+        child_page_requests.append(incident_id)
+        yield [Alert(id=f"{incident_id}-alert-2", created_at=SOURCE_TIME)]
+
+    client.iter_incident_alert_pages = alert_pages
     client.drain_usage_observations.return_value = []
     store = Mock()
     store.insert_operational_alerts = AsyncMock()
@@ -268,11 +286,60 @@ async def test_enrichment_cap_bounds_provider_calls_across_incidents() -> None:
     result = await sync.run(
         PagerDutySyncOptions(
             dataset_key="incident-alerts",
-            window_start=None,
-            window_end=None,
+            window_start=SOURCE_TIME,
+            window_end=datetime(2026, 7, 17, 13, 0, tzinfo=timezone.utc),
             enrichment_cap=2,
         )
     )
 
+    assert result.persisted == 4
+    assert child_page_requests == ["incident-0", "incident-1"]
+    assert result.watermark_at == SOURCE_TIME
+
+
+@pytest.mark.asyncio
+async def test_zero_enrichment_cap_skips_child_calls_and_completes_window() -> None:
+    latest_source_time = datetime(2026, 7, 17, 12, 1, tzinfo=timezone.utc)
+    incidents = [
+        Incident(id="incident-0", created_at=SOURCE_TIME, updated_at=SOURCE_TIME),
+        Incident(
+            id="incident-1",
+            created_at=latest_source_time,
+            updated_at=latest_source_time,
+        ),
+    ]
+
+    async def pages(*, params: dict[str, str] | None = None):
+        del params
+        yield incidents
+
+    child_page_requests: list[str] = []
+
+    async def alert_pages(incident_id: str):
+        child_page_requests.append(incident_id)
+        yield []
+
+    client = Mock()
+    client.iter_incident_pages = pages
+    client.iter_incident_alert_pages = alert_pages
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.insert_operational_alerts = AsyncMock()
+    sync = PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=PagerDutyNormalizer("org-1", "acme", SOURCE_TIME),
+    )
+
+    result = await sync.run(
+        PagerDutySyncOptions(
+            dataset_key="incident-alerts",
+            window_start=SOURCE_TIME,
+            window_end=latest_source_time,
+            enrichment_cap=0,
+        )
+    )
+
     assert result.persisted == 0
-    assert client.list_incident_alerts.await_count == 2
+    assert child_page_requests == []
+    assert result.watermark_at == latest_source_time

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from dev_health_ops.models.operational import OperationalIncident
+from dev_health_ops.providers.pagerduty.models import Incident
+from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
+from dev_health_ops.providers.pagerduty.sync import (
+    PagerDutyOperationalSync,
+    PagerDutySyncOptions,
+)
+
+SOURCE_TIME = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+
+
+@pytest.mark.asyncio
+async def test_incident_sync_flushes_bounded_batches_without_boundary_loss() -> None:
+    incidents = tuple(
+        Incident(
+            id=f"incident-{number}",
+            title=f"Incident {number}",
+            created_at=SOURCE_TIME,
+            updated_at=SOURCE_TIME,
+        )
+        for number in range(5)
+    )
+    client = Mock()
+    observed_params: dict[str, str] | None = None
+
+    async def pages(*, params: dict[str, str] | None = None):
+        nonlocal observed_params
+        observed_params = params
+        yield list(incidents[:2])
+        yield list(incidents[2:])
+
+    batches: list[list[OperationalIncident]] = []
+
+    async def persist(values: list[OperationalIncident]) -> None:
+        batches.append(values)
+
+    client.iter_incident_pages = pages
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.insert_operational_incidents = AsyncMock(side_effect=persist)
+    sync = PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=PagerDutyNormalizer("org-1", "acme", SOURCE_TIME),
+    )
+
+    result = await sync.run(
+        PagerDutySyncOptions(
+            dataset_key="incidents",
+            window_start=SOURCE_TIME,
+            window_end=SOURCE_TIME,
+            incident_cap=5,
+            batch_size=2,
+        )
+    )
+
+    assert result.persisted == 5
+    assert [len(batch) for batch in batches] == [2, 2, 1]
+    assert [row.external_id for batch in batches for row in batch] == [
+        "incident-0",
+        "incident-1",
+        "incident-2",
+        "incident-3",
+        "incident-4",
+    ]
+    assert observed_params == {
+        "since": SOURCE_TIME.isoformat(),
+        "until": SOURCE_TIME.isoformat(),
+    }

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -7,11 +7,13 @@ import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.orm import Session
 
+from dev_health_ops.exceptions import APIException
 from dev_health_ops.models.git import Base
-from dev_health_ops.models.operational import OperationalIncident
-from dev_health_ops.providers.pagerduty.models import Alert, Incident
+from dev_health_ops.models.operational import OperationalIncident, OperationalService
+from dev_health_ops.providers.pagerduty.models import Alert, Incident, Service
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 from dev_health_ops.providers.pagerduty.sync import (
+    PagerDutyDatasetDegradedError,
     PagerDutyEnrichmentToggles,
     PagerDutyOperationalSync,
     PagerDutySyncOptions,
@@ -343,3 +345,58 @@ async def test_zero_enrichment_cap_skips_child_calls_and_completes_window() -> N
     assert result.persisted == 0
     assert child_page_requests == []
     assert result.watermark_at == latest_source_time
+
+
+@pytest.mark.asyncio
+async def test_complete_service_snapshot_tombstones_missing_reference() -> None:
+    normalizer = PagerDutyNormalizer("org-1", "acme", SOURCE_TIME)
+    missing = normalizer.service(
+        Service(id="service-missing", name="Missing", updated_at=SOURCE_TIME)
+    )
+    client = Mock()
+    client.list_services = AsyncMock(
+        return_value=[
+            Service(id="service-current", name="Current", updated_at=SOURCE_TIME)
+        ]
+    )
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.load_active_operational_entities = AsyncMock(return_value=[missing])
+    store.insert_operational_services = AsyncMock()
+
+    await PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=normalizer,
+    ).run(PagerDutySyncOptions("services", None, None))
+
+    inserted = [
+        row
+        for call in store.insert_operational_services.await_args_list
+        for row in call.args[0]
+    ]
+    tombstone = next(row for row in inserted if row.external_id == "service-missing")
+    assert isinstance(tombstone, OperationalService)
+    assert tombstone.is_deleted is True
+    assert tombstone.deleted_at == tombstone.source_version_at
+    assert tombstone.source_version_at > missing.source_version_at
+
+
+@pytest.mark.asyncio
+async def test_failed_service_snapshot_emits_no_reference_tombstones() -> None:
+    client = Mock()
+    client.list_services = AsyncMock(side_effect=APIException("PagerDuty unavailable"))
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.load_active_operational_entities = AsyncMock()
+    store.insert_operational_services = AsyncMock()
+
+    with pytest.raises(PagerDutyDatasetDegradedError):
+        await PagerDutyOperationalSync(
+            client=client,
+            store=store,
+            normalizer=PagerDutyNormalizer("org-1", "acme", SOURCE_TIME),
+        ).run(PagerDutySyncOptions("services", None, None))
+
+    store.load_active_operational_entities.assert_not_awaited()
+    store.insert_operational_services.assert_not_awaited()

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -10,6 +10,7 @@ from sqlalchemy.orm import Session
 from dev_health_ops.exceptions import APIException, PaginationException
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.operational import OperationalIncident, OperationalService
+from dev_health_ops.providers.pagerduty.client import PagerDutyPage
 from dev_health_ops.providers.pagerduty.models import Alert, Incident, Service
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 from dev_health_ops.providers.pagerduty.sync import (
@@ -327,12 +328,17 @@ async def test_enrichment_cap_stops_child_stream_without_advancing_past_undraine
 
     async def alert_pages(incident_id: str):
         child_page_requests.append(incident_id)
-        yield [
-            Alert(id=f"{incident_id}-alert-{number}", created_at=SOURCE_TIME)
-            for number in range(2)
-        ]
+        yield PagerDutyPage(
+            [
+                Alert(id=f"{incident_id}-alert-{number}", created_at=SOURCE_TIME)
+                for number in range(2)
+            ],
+            more=True,
+        )
         child_page_requests.append(incident_id)
-        yield [Alert(id=f"{incident_id}-alert-2", created_at=SOURCE_TIME)]
+        yield PagerDutyPage(
+            [Alert(id=f"{incident_id}-alert-2", created_at=SOURCE_TIME)], more=False
+        )
 
     client.iter_incident_alert_pages = alert_pages
     client.drain_usage_observations.return_value = []
@@ -383,12 +389,15 @@ async def test_enrichment_cap_clamps_watermark_to_earliest_undrained_incident_ou
 
     async def alert_pages(incident_id: str):
         if incident_id == "newer-drained":
-            yield []
+            yield PagerDutyPage([], more=False)
             return
-        yield [
-            Alert(id=f"{incident_id}-alert-{number}", created_at=SOURCE_TIME)
-            for number in range(2)
-        ]
+        yield PagerDutyPage(
+            [
+                Alert(id=f"{incident_id}-alert-{number}", created_at=SOURCE_TIME)
+                for number in range(2)
+            ],
+            more=True,
+        )
 
     client = Mock()
     client.iter_incident_pages = pages
@@ -412,6 +421,63 @@ async def test_enrichment_cap_clamps_watermark_to_earliest_undrained_incident_ou
     )
 
     assert result.watermark_at == older_source_time
+
+
+@pytest.mark.asyncio
+async def test_enrichment_cap_on_complete_page_advances_watermark() -> None:
+    older_source_time = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+    newer_source_time = datetime(2026, 7, 17, 12, 1, tzinfo=timezone.utc)
+    incidents = [
+        Incident(
+            id="older-complete-at-cap",
+            created_at=older_source_time,
+            updated_at=older_source_time,
+        ),
+        Incident(
+            id="newer-drained",
+            created_at=newer_source_time,
+            updated_at=newer_source_time,
+        ),
+    ]
+
+    async def pages(*, params: dict[str, str] | None = None):
+        del params
+        yield incidents
+
+    async def alert_pages(incident_id: str):
+        if incident_id == "older-complete-at-cap":
+            yield PagerDutyPage(
+                [
+                    Alert(id=f"{incident_id}-alert-{number}", created_at=SOURCE_TIME)
+                    for number in range(2)
+                ],
+                more=False,
+            )
+            return
+        yield PagerDutyPage([], more=False)
+
+    client = Mock()
+    client.iter_incident_pages = pages
+    client.iter_incident_alert_pages = alert_pages
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.insert_operational_alerts = AsyncMock()
+    sync = PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=PagerDutyNormalizer("org-1", "acme", SOURCE_TIME),
+    )
+
+    result = await sync.run(
+        PagerDutySyncOptions(
+            dataset_key="incident-alerts",
+            window_start=older_source_time,
+            window_end=datetime(2026, 7, 17, 13, 0, tzinfo=timezone.utc),
+            enrichment_cap=2,
+        )
+    )
+
+    assert result.watermark_at == newer_source_time
 
 
 @pytest.mark.asyncio

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -462,6 +462,46 @@ def test_pagerduty_dataset_passes_persisted_resume_cursor_and_returns_source_wat
     assert result["watermark_at"] == WINDOW_END.isoformat()
 
 
+def test_pagerduty_dataset_applies_persisted_enrichment_options() -> None:
+    from dev_health_ops.providers.pagerduty.sync import PagerDutySyncResult
+
+    ctx = replace(
+        _context(
+            provider="pagerduty",
+            dataset_key="incident-alerts",
+            source_external_id="acme",
+        ),
+        dataset_options={"enrichment_cap": 2, "enabled": False},
+    )
+    client = Mock()
+    client.drain_usage_observations.return_value = []
+    sync_result = PagerDutySyncResult(
+        dataset_key="incident-alerts",
+        persisted=0,
+        watermark_at=WINDOW_END,
+        degraded=False,
+        observations=(),
+    )
+
+    with (
+        patch(
+            "dev_health_ops.processors.dataset_adapters._pagerduty_client",
+            return_value=(client, "acme"),
+        ),
+        patch(
+            "dev_health_ops.providers.pagerduty.sync.PagerDutyOperationalSync"
+        ) as sync,
+    ):
+        sync.return_value.run = AsyncMock(return_value=sync_result)
+        run_dataset_unit(ctx, _runtime())
+
+    await_args = sync.return_value.run.await_args
+    assert await_args is not None
+    options = await_args.args[0]
+    assert options.enrichment_cap == 2
+    assert options.enrichment.alerts is False
+
+
 def test_pagerduty_dataset_rejects_source_id_without_verified_account_identity() -> (
     None
 ):

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -420,6 +420,48 @@ def test_launchdarkly_feature_flags_threads_usage_observations_to_result() -> No
     assert result["observations"] == observations
 
 
+def test_pagerduty_dataset_passes_persisted_resume_cursor_and_returns_source_watermark() -> (
+    None
+):
+    from dev_health_ops.providers.pagerduty.sync import PagerDutySyncResult
+
+    ctx = replace(
+        _context(
+            provider="pagerduty",
+            dataset_key="incidents",
+            source_external_id="acme",
+        ),
+        resume_cursor=WINDOW_START,
+    )
+    client = Mock()
+    client.drain_usage_observations.return_value = []
+    sync_result = PagerDutySyncResult(
+        dataset_key="incidents",
+        persisted=2,
+        watermark_at=WINDOW_END,
+        degraded=False,
+        observations=(),
+    )
+
+    with (
+        patch(
+            "dev_health_ops.processors.dataset_adapters._pagerduty_client",
+            return_value=(client, "acme"),
+        ),
+        patch(
+            "dev_health_ops.providers.pagerduty.sync.PagerDutyOperationalSync"
+        ) as sync,
+    ):
+        sync.return_value.run = AsyncMock(return_value=sync_result)
+        result = run_dataset_unit(ctx, _runtime())
+
+    await_args = sync.return_value.run.await_args
+    assert await_args is not None
+    options = await_args.args[0]
+    assert options.resume_after == WINDOW_START
+    assert result["watermark_at"] == WINDOW_END.isoformat()
+
+
 def test_unsupported_provider_dataset_pair_raises_value_error() -> None:
     ctx = _context(provider="jira", dataset_key="commits", source_external_id="OPS")
 

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -462,6 +462,49 @@ def test_pagerduty_dataset_passes_persisted_resume_cursor_and_returns_source_wat
     assert result["watermark_at"] == WINDOW_END.isoformat()
 
 
+def test_pagerduty_dataset_rejects_source_id_without_verified_account_identity() -> (
+    None
+):
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="incidents",
+        source_external_id="not-a-verified-account",
+        credentials={"api_token": "secret-token"},
+    )
+
+    with pytest.raises(ValueError, match="requires an account subdomain"):
+        run_dataset_unit(ctx, _runtime())
+
+
+def test_pagerduty_client_uses_verified_account_subdomain_not_source_id() -> None:
+    from dev_health_ops.processors.dataset_adapters import _pagerduty_client
+
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="incidents",
+        source_external_id="untrusted-source-id",
+        credentials={"api_token": "secret-token", "subdomain": "verified-acme"},
+    )
+
+    with patch("dev_health_ops.providers.pagerduty.client.PagerDutyClient"):
+        _, provider_instance_id = _pagerduty_client(ctx)
+
+    assert provider_instance_id == "verified-acme"
+
+
+def test_pagerduty_client_rejects_blank_account_subdomain() -> None:
+    from dev_health_ops.processors.dataset_adapters import _pagerduty_client
+
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="incidents",
+        credentials={"api_token": "secret-token", "subdomain": "  "},
+    )
+
+    with pytest.raises(ValueError, match="requires an account subdomain"):
+        _pagerduty_client(ctx)
+
+
 def test_unsupported_provider_dataset_pair_raises_value_error() -> None:
     ctx = _context(provider="jira", dataset_key="commits", source_external_id="OPS")
 

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -434,6 +434,7 @@ def test_pagerduty_dataset_passes_persisted_resume_cursor_and_returns_source_wat
         resume_cursor=WINDOW_START,
     )
     client = Mock()
+    client.close = AsyncMock()
     client.drain_usage_observations.return_value = []
     sync_result = PagerDutySyncResult(
         dataset_key="incidents",
@@ -460,6 +461,7 @@ def test_pagerduty_dataset_passes_persisted_resume_cursor_and_returns_source_wat
     options = await_args.args[0]
     assert options.resume_after == WINDOW_START
     assert result["watermark_at"] == WINDOW_END.isoformat()
+    client.close.assert_awaited_once()
 
 
 def test_pagerduty_dataset_applies_persisted_enrichment_options() -> None:
@@ -474,6 +476,7 @@ def test_pagerduty_dataset_applies_persisted_enrichment_options() -> None:
         dataset_options={"enrichment_cap": 2, "enabled": False},
     )
     client = Mock()
+    client.close = AsyncMock()
     client.drain_usage_observations.return_value = []
     sync_result = PagerDutySyncResult(
         dataset_key="incident-alerts",
@@ -500,6 +503,33 @@ def test_pagerduty_dataset_applies_persisted_enrichment_options() -> None:
     options = await_args.args[0]
     assert options.enrichment_cap == 2
     assert options.enrichment.alerts is False
+
+
+def test_pagerduty_dataset_closes_client_when_store_setup_fails() -> None:
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="services",
+        source_external_id="acme",
+    )
+    client = Mock()
+    client.close = AsyncMock()
+    client.drain_usage_observations.return_value = []
+
+    with (
+        patch(
+            "dev_health_ops.processors.dataset_adapters._pagerduty_client",
+            return_value=(client, "acme"),
+        ),
+        patch(
+            "dev_health_ops.processors.dataset_adapters._run_with_reused_or_new_store",
+            new_callable=AsyncMock,
+            side_effect=RuntimeError("store setup failed"),
+        ),
+        pytest.raises(RuntimeError, match="store setup failed"),
+    ):
+        run_dataset_unit(ctx, _runtime())
+
+    client.close.assert_awaited_once()
 
 
 def test_pagerduty_dataset_rejects_source_id_without_verified_account_identity() -> (

--- a/tests/test_operational_datetime_normalization.py
+++ b/tests/test_operational_datetime_normalization.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+
+from dev_health_ops.models.operational import OperationalIncident
+from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+
+def test_operational_insert_normalizes_aware_and_naive_datetimes(
+    monkeypatch,
+) -> None:
+    aware_pacific = datetime(2026, 7, 17, 5, tzinfo=timezone(timedelta(hours=-7)))
+    naive_utc = datetime(2026, 7, 17, 12)
+    incident = OperationalIncident(
+        org_id="test-org",
+        provider="pagerduty",
+        provider_instance_id="pagerduty-test",
+        source_entity_type="incident",
+        external_id="incident-1",
+        source_version_at=aware_pacific,
+        source_event_at=naive_utc,
+        started_at=naive_utc,
+    )
+    store = ClickHouseStore("clickhouse://unused")
+    captured_rows: list[dict[str, object]] = []
+
+    async def capture_rows(
+        _table: str, _columns: list[str], rows: list[dict[str, object]]
+    ) -> None:
+        captured_rows.extend(rows)
+
+    monkeypatch.setattr(store, "_insert_rows", capture_rows)
+
+    asyncio.run(store._insert_operational_rows("operational_incidents", [incident]))
+
+    source_version_at = captured_rows[0]["source_version_at"]
+    source_event_at = captured_rows[0]["source_event_at"]
+    started_at = captured_rows[0]["started_at"]
+    expected = datetime(2026, 7, 17, 12, tzinfo=timezone.utc)
+
+    assert source_version_at == expected
+    assert source_event_at == expected
+    assert started_at == expected

--- a/tests/test_pagerduty_clickhouse_live.py
+++ b/tests/test_pagerduty_clickhouse_live.py
@@ -255,8 +255,16 @@ def test_pagerduty_operational_rows_round_trip_and_deduplicate(
                 coordinates.entity_family,
                 coordinates.external_id,
             )
+            source_version = row.source_version_at
+            delta = source_version.astimezone(timezone.utc) - datetime(
+                1970, 1, 1, tzinfo=timezone.utc
+            )
+            expected_epoch_us = (
+                delta.days * 86_400 + delta.seconds
+            ) * 1_000_000 + delta.microseconds
             result = client.query(
-                f"SELECT id, org_id, provider_instance_id, source_version_at "
+                f"SELECT id, org_id, provider_instance_id, "
+                f"toUnixTimestamp64Micro(source_version_at) "
                 f"FROM {table} FINAL WHERE org_id = {{org_id:String}}",
                 parameters={"org_id": ORG_ID},
             )
@@ -265,7 +273,7 @@ def test_pagerduty_operational_rows_round_trip_and_deduplicate(
                     expected_id,
                     ORG_ID,
                     PROVIDER_INSTANCE_ID,
-                    row.source_version_at.replace(tzinfo=None),
+                    expected_epoch_us,
                 )
             ]
             count = client.query(

--- a/tests/test_pagerduty_clickhouse_live.py
+++ b/tests/test_pagerduty_clickhouse_live.py
@@ -1,0 +1,278 @@
+"""Live ClickHouse round-trip and idempotency proof for PagerDuty REST sync.
+
+Set ``CLICKHOUSE_URI`` to an isolated, non-default scratch database. This test
+creates and drops a second unique database below that isolated connection so it
+never modifies the caller's scratch database or the local ``default`` database.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from urllib.parse import urlsplit, urlunsplit
+from uuid import uuid4
+
+import pytest
+
+from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
+from dev_health_ops.models.operational import (
+    CanonicalOperationalEntity,
+    EscalationPolicy,
+    IncidentNote,
+    IncidentTimelineEvent,
+    OnCallAssignment,
+    OnCallSchedule,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+    canonical_operational_id,
+)
+from dev_health_ops.models.operational_identity import operational_source_coordinates
+from dev_health_ops.providers.pagerduty.models import (
+    Alert,
+    Incident,
+    LogEntry,
+    Note,
+    Oncall,
+    PagerDutyModel,
+    Schedule,
+    Service,
+    Team,
+    User,
+)
+from dev_health_ops.providers.pagerduty.models import (
+    EscalationPolicy as PagerDutyEscalationPolicy,
+)
+from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
+from dev_health_ops.storage.clickhouse import ClickHouseStore
+
+CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
+SOURCE_TIME = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+ORG_ID = "test-chaos-2957"
+PROVIDER_INSTANCE_ID = "pagerduty-chaos-2957"
+
+pytestmark = [
+    pytest.mark.clickhouse,
+    pytest.mark.skipif(
+        not CLICKHOUSE_URI,
+        reason="Requires CLICKHOUSE_URI pointed at an isolated scratch database",
+    ),
+]
+
+
+@dataclass(frozen=True, slots=True)
+class PagerDutyOperationalRows:
+    """One representative persisted row for every PagerDuty-emitted entity."""
+
+    service: OperationalService
+    incident: OperationalIncident
+    alert: OperationalAlert
+    timeline_event: IncidentTimelineEvent
+    note: IncidentNote
+    escalation_policy: EscalationPolicy
+    schedule: OnCallSchedule
+    oncall: OnCallAssignment
+    team: OperationalTeam
+    user: OperationalUser
+
+    def table_rows(self) -> tuple[tuple[str, CanonicalOperationalEntity], ...]:
+        """Return each row paired with its canonical operational table."""
+        return (
+            ("operational_services", self.service),
+            ("operational_incidents", self.incident),
+            ("operational_alerts", self.alert),
+            ("operational_incident_timeline_events", self.timeline_event),
+            ("operational_incident_notes", self.note),
+            ("operational_escalation_policies", self.escalation_policy),
+            ("operational_on_call_schedules", self.schedule),
+            ("operational_on_call_assignments", self.oncall),
+            ("operational_teams", self.team),
+            ("operational_users", self.user),
+        )
+
+
+@pytest.fixture(scope="module")
+def pagerduty_scratch_dsn() -> Iterator[str]:
+    """Provide a unique, dropped-on-teardown ClickHouse database for this module."""
+    assert CLICKHOUSE_URI is not None
+    parsed = urlsplit(CLICKHOUSE_URI)
+    parent_database = parsed.path.lstrip("/")
+    if parent_database in {"", "default"}:
+        pytest.skip(
+            "refusing to create PagerDuty live-test schema from the default database"
+        )
+
+    import clickhouse_connect
+
+    database = f"chaos_2957_pagerduty_{uuid4().hex}"
+    scratch_dsn = urlunsplit(parsed._replace(path=f"/{database}"))
+    client = clickhouse_connect.get_client(dsn=CLICKHOUSE_URI)
+    client.command(f"CREATE DATABASE {database}")
+    try:
+        schema = ClickHouseMetricsSink(scratch_dsn)
+        try:
+            schema.ensure_schema(force=True)
+        finally:
+            schema.close()
+        yield scratch_dsn
+    finally:
+        client.command(f"DROP DATABASE IF EXISTS {database}")
+        client.close()
+
+
+def _pagerduty_rows() -> PagerDutyOperationalRows:
+    normalizer = PagerDutyNormalizer(
+        org_id=ORG_ID,
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        observed_at=SOURCE_TIME,
+    )
+    service_reference = PagerDutyModel(id="service-1")
+    policy_reference = PagerDutyModel(id="policy-1")
+    schedule_reference = PagerDutyModel(id="schedule-1")
+    user_reference = PagerDutyModel(id="user-1")
+    service = normalizer.service(
+        Service(id="service-1", name="Payments API", updated_at=SOURCE_TIME)
+    )
+    incident = normalizer.incident(
+        Incident(
+            id="incident-1",
+            title="Payments latency",
+            service=service_reference,
+            created_at=SOURCE_TIME,
+            updated_at=SOURCE_TIME,
+        )
+    )
+    return PagerDutyOperationalRows(
+        service=service,
+        incident=incident,
+        alert=normalizer.alert(
+            Alert(
+                id="alert-1",
+                summary="Elevated latency",
+                severity="critical",
+                created_at=SOURCE_TIME,
+                updated_at=SOURCE_TIME,
+            ),
+            incident.id,
+        ),
+        timeline_event=normalizer.log_entry(
+            LogEntry(
+                id="timeline-1",
+                summary="Incident acknowledged",
+                created_at=SOURCE_TIME,
+                updated_at=SOURCE_TIME,
+            ),
+            incident.id,
+        ),
+        note=normalizer.note(
+            Note(
+                id="note-1",
+                content="Evidence from the PagerDuty incident record.",
+                user=user_reference,
+                created_at=SOURCE_TIME,
+                updated_at=SOURCE_TIME,
+            ),
+            incident.id,
+        ),
+        escalation_policy=normalizer.escalation_policy(
+            PagerDutyEscalationPolicy(
+                id="policy-1", name="Primary", updated_at=SOURCE_TIME
+            )
+        ),
+        schedule=normalizer.schedule(
+            Schedule(id="schedule-1", name="Primary rotation", updated_at=SOURCE_TIME)
+        ),
+        oncall=normalizer.oncall(
+            Oncall(
+                id="oncall-1",
+                user=user_reference,
+                schedule=schedule_reference,
+                escalation_policy=policy_reference,
+                start=SOURCE_TIME,
+                end=SOURCE_TIME,
+                updated_at=SOURCE_TIME,
+            )
+        ),
+        team=normalizer.team(Team(id="team-1", name="SRE", updated_at=SOURCE_TIME)),
+        user=normalizer.user(
+            User(
+                id="user-1",
+                name="Ada Lovelace",
+                email="ada@example.test",
+                updated_at=SOURCE_TIME,
+            )
+        ),
+    )
+
+
+async def _persist(dsn: str, rows: PagerDutyOperationalRows) -> None:
+    async with ClickHouseStore(dsn) as store:
+        store.org_id = ORG_ID
+        await store.insert_operational_services([rows.service])
+        await store.insert_operational_incidents([rows.incident])
+        await store.insert_operational_alerts([rows.alert])
+        await store.insert_operational_incident_timeline_events([rows.timeline_event])
+        await store.insert_operational_incident_notes([rows.note])
+        await store.insert_operational_escalation_policies([rows.escalation_policy])
+        await store.insert_operational_on_call_schedules([rows.schedule])
+        await store.insert_operational_on_call_assignments([rows.oncall])
+        await store.insert_operational_teams([rows.team])
+        await store.insert_operational_users([rows.user])
+
+
+def test_pagerduty_operational_rows_round_trip_and_deduplicate(
+    pagerduty_scratch_dsn: str,
+) -> None:
+    # Given: normalized PagerDuty source records for every emitted entity family.
+    rows = _pagerduty_rows()
+
+    # When: each real operational sink receives the same source payload twice.
+    asyncio.run(_persist(pagerduty_scratch_dsn, rows))
+    asyncio.run(_persist(pagerduty_scratch_dsn, rows))
+
+    import clickhouse_connect
+
+    client = clickhouse_connect.get_client(dsn=pagerduty_scratch_dsn)
+    try:
+        # Then: FINAL keeps one source-versioned row per canonical identity.
+        for table, row in rows.table_rows():
+            client.command(f"OPTIMIZE TABLE {table} FINAL")
+            coordinates = operational_source_coordinates(
+                type(row),
+                provider="pagerduty",
+                provider_instance_id=PROVIDER_INSTANCE_ID,
+                external_id=row.external_id,
+            )
+            expected_id = canonical_operational_id(
+                ORG_ID,
+                coordinates.provider,
+                coordinates.provider_instance_id,
+                coordinates.entity_family,
+                coordinates.external_id,
+            )
+            result = client.query(
+                f"SELECT id, org_id, provider_instance_id, source_version_at "
+                f"FROM {table} FINAL WHERE org_id = {{org_id:String}}",
+                parameters={"org_id": ORG_ID},
+            )
+            assert result.result_rows == [
+                (
+                    expected_id,
+                    ORG_ID,
+                    PROVIDER_INSTANCE_ID,
+                    row.source_version_at.replace(tzinfo=None),
+                )
+            ]
+            count = client.query(
+                f"SELECT count() FROM {table} FINAL WHERE org_id = {{org_id:String}} "
+                "AND id = {id:String}",
+                parameters={"org_id": ORG_ID, "id": expected_id},
+            )
+            assert count.result_rows == [(1,)]
+    finally:
+        client.close()

--- a/tests/test_pagerduty_datasets.py
+++ b/tests/test_pagerduty_datasets.py
@@ -1,0 +1,25 @@
+from __future__ import annotations
+
+from dev_health_ops.sync.datasets import supported_datasets
+
+
+def test_pagerduty_exposes_the_operational_rest_dataset_set() -> None:
+    # Given: the PagerDuty provider's sync dataset registry entry.
+
+    # When: its supported datasets are resolved.
+    dataset_keys = {spec.dataset_key for spec in supported_datasets("pagerduty")}
+
+    # Then: every REST collection has an independently schedulable dataset.
+    assert dataset_keys == {
+        "services",
+        "business-services",
+        "escalation-policies",
+        "schedules",
+        "on-calls",
+        "users",
+        "teams",
+        "incidents",
+        "incident-alerts",
+        "incident-log-entries",
+        "incident-notes",
+    }

--- a/tests/test_sync_run_auth_freeze.py
+++ b/tests/test_sync_run_auth_freeze.py
@@ -37,6 +37,7 @@ from dev_health_ops.models import (
 )
 from dev_health_ops.models.settings import IntegrationCredential
 from dev_health_ops.sync.planner import SyncPlanRequest, plan_sync_run
+from dev_health_ops.sync.watermarks import set_watermark
 from dev_health_ops.workers import reference_discovery
 from dev_health_ops.workers.sync_bootstrap import (
     RunAuthFingerprintMismatchError,
@@ -139,29 +140,46 @@ def _make_source(
 
 
 def _make_dataset(
-    session: Session, integration: Integration, *, dataset_key: str = "commits"
+    session: Session,
+    integration: Integration,
+    *,
+    dataset_key: str = "commits",
+    options: dict[str, object] | None = None,
 ) -> IntegrationDataset:
     dataset = IntegrationDataset(
         org_id=ORG_ID,
         integration_id=integration.id,
         dataset_key=dataset_key,
         is_enabled=True,
-        options={},
+        options=options or {},
     )
     session.add(dataset)
     session.flush()
     return dataset
 
 
-def _plan(session: Session, integration: Integration) -> tuple[SyncRun, SyncRunUnit]:
-    _make_source(session, integration)
-    _make_dataset(session, integration)
+def _plan(
+    session: Session,
+    integration: Integration,
+    *,
+    mode: str = SyncRunMode.INCREMENTAL.value,
+    dataset_key: str = "commits",
+    dataset_options: dict[str, object] | None = None,
+    source_external_id: str = "full-chaos/dev-health",
+) -> tuple[SyncRun, SyncRunUnit]:
+    _make_source(session, integration, external_id=source_external_id)
+    _make_dataset(
+        session,
+        integration,
+        dataset_key=dataset_key,
+        options=dataset_options,
+    )
     plan = plan_sync_run(
         session,
         SyncPlanRequest(
             integration_id=str(integration.id),
             org_id=ORG_ID,
-            mode=SyncRunMode.INCREMENTAL.value,
+            mode=mode,
             triggered_by="manual",
         ),
     )
@@ -173,6 +191,53 @@ def _plan(session: Session, integration: Integration) -> tuple[SyncRun, SyncRunU
         .one()
     )
     return run, unit
+
+
+def test_full_resync_bootstrap_ignores_persisted_watermark(db_session: Session) -> None:
+    credential = _make_credential(db_session, token="tok-A", provider="pagerduty")
+    integration = _make_integration(
+        db_session,
+        provider="pagerduty",
+        credential_id=credential.id,
+    )
+    _run, unit = _plan(
+        db_session,
+        integration,
+        mode=SyncRunMode.FULL_RESYNC.value,
+        dataset_key="incidents",
+        source_external_id="acme",
+    )
+    historical_watermark = datetime(2026, 7, 1, tzinfo=timezone.utc)
+    set_watermark(
+        db_session,
+        ORG_ID,
+        "acme",
+        "incidents",
+        historical_watermark,
+    )
+
+    context = SyncTaskBootstrap.load(db_session, str(unit.id))
+
+    assert context.resume_cursor is None
+
+
+def test_bootstrap_loads_persisted_dataset_options(db_session: Session) -> None:
+    credential = _make_credential(db_session, token="tok-A", provider="pagerduty")
+    integration = _make_integration(
+        db_session,
+        provider="pagerduty",
+        credential_id=credential.id,
+    )
+    _run, unit = _plan(
+        db_session,
+        integration,
+        dataset_key="incident-alerts",
+        dataset_options={"enrichment_cap": 2, "enabled": False},
+    )
+
+    context = SyncTaskBootstrap.load(db_session, str(unit.id))
+
+    assert context.dataset_options == {"enrichment_cap": 2, "enabled": False}
 
 
 def test_midrun_credential_repoint_does_not_change_stamped_run_auth(db_session):

--- a/tests/test_target_isolation.py
+++ b/tests/test_target_isolation.py
@@ -52,6 +52,16 @@ def test_dataset_key_contract_is_exact() -> None:
         "work-item-history",
         "work-item-comments",
         "feature-flags",
+        "services",
+        "business-services",
+        "escalation-policies",
+        "schedules",
+        "on-calls",
+        "users",
+        "teams",
+        "incident-alerts",
+        "incident-log-entries",
+        "incident-notes",
     ]
 
 


### PR DESCRIPTION
## CHAOS-2957 — PagerDuty REST sync: normalize + persist through canonical operational sinks

Wave 2 of the CHAOS-2954 canonical-operations program. Adds PagerDuty as the first non-Atlassian incident-response provider: REST ingestion → normalization → persistence through the canonical operational sinks built in Wave 0/1. Read-only against PagerDuty; idempotent; org- and provider-instance-scoped.

### What's included
- **Provider + dataset wiring** (additive): PagerDuty registered in the provider registry; 10 new operational `DatasetKey`s + `_PROVIDER_SUPPORTED_DATASETS` entry; `run_dataset_unit` dispatch branch. Existing github/gitlab/jira/linear/launchdarkly paths unchanged.
- **11 datasets**: services, business_services, escalation_policies, schedules, on_calls, users, teams, incidents, incident_alerts, incident_log_entries, incident_notes.
- **Normalization** → canonical operational entities via the shared `operational_source_coordinates()` → `canonical_operational_id()` identity helper (no ad-hoc ids). Real API fields (`resolved_at`, priority/urgency/status) mapped explicitly with raw values retained; notes treated as untrusted evidence. Real PagerDuty wire-shape fixtures back the normalization tests.
- **Persistence** exclusively through the existing `insert_operational_*` sinks — no PagerDuty-specific tables, no new migration (reuses `066_operational_canonical.sql`).
- **Incremental + backfill**: created_at-windowed incident sync with idempotent inclusive-overlap resume on the timestamp watermark (ties absorbed by ReplacingMergeTree dedup); full-resync replays from backfill start; bounded batch streaming; per-incident enrichment caps + per-dataset toggles to avoid N+1.
- **Resilience**: per-dataset degradation (403/insufficient-scope + partial-page degrade only that dataset and surface partial-failure via SyncRun; 401 stays fatal); typed `PaginationException`; complete-snapshot-only reference tombstones (never on partial/degraded snapshots); HTTP client lifecycle close; budget reservation dispatched with bounded enrichment fan-out.
- **Datetime fidelity**: operational rows persist as aware-UTC via a new operational-only normalizer at the `_insert_operational_rows` seam — the shared platform `_normalize_datetime` is intentionally untouched (see CHAOS-2967).

### Identity / on-calls
`/oncalls` has no PagerDuty global id, so on-call assignments use a deterministic composite external_id (escalation_policy · schedule · user · escalation_level · window) through the same identity helper — consistent with how canonical relationship entities derive identity. Missing stable dimensions reject rather than synthesize.

### Verification
- Full local gate `ci/local_validate.sh` = **GATE PASSED** (ruff format+check, mypy, full unit suite `-n 4 --dist loadscope`, ch-migrate, live argMax proof).
- New unit/integration coverage: normalization golden fixtures per entity, idempotency + pagination/resume, per-dataset degradation, enrichment cap/toggle call-count bounds, budget dispatch, and an env-gated live smoke test (hard-skips without `PAGERDUTY_LIVE_SMOKE=1`).
- Live ClickHouse round-trip + idempotency test passes under both `TZ=UTC` and `TZ=America/Los_Angeles`.
- Reviewed via Oracle across 4 rounds to a clean PASS (0 blockers).

### Follow-ups filed
- **CHAOS-2967** — platform-wide aware-UTC fix for the shared `_normalize_datetime` (naive→aware) + non-UTC data audit (this PR scopes the fix to the operational seam only).
- **CHAOS-2968** — durable `(timestamp, last_id)` incident continuation cursor (this PR uses idempotent inclusive-overlap resume on the existing timestamp watermark).

### Notes
- **SCREENSHOT-WAIVER**: backend-only (provider/sync/normalization/persistence + tests); no user-facing UI render.
- Known pre-existing flake: `tests/api/admin/test_org_deletion.py` can intermittently fail under `-n 4` loadscope depending on worker packing (unrelated to this change; passes isolated and on gate re-run). Not introduced by this PR.

Closes CHAOS-2957.
