### PR TITLE
Wave 3: PagerDuty V3 webhooks + operational correlation (CHAOS-2958, CHAOS-2959)

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -1219,6 +1219,29 @@ def _non_git_source_rows(
     ]
 
 
+def _planner_dataset_options(
+    provider: str,
+    dataset_key: str,
+    sync_targets: list[str],
+    parent_options: dict[str, Any],
+) -> dict[str, Any]:
+    """Seed a planner dataset's options, propagating supported sync config.
+
+    ``service_repository_mappings`` from the integration's sync configuration is
+    forwarded onto the PagerDuty ``services`` dataset so the adapter can build
+    admin/Compass mapping inputs; the read side validates it defensively.
+    """
+    options: dict[str, Any] = {"legacy_targets": list(sync_targets)}
+    mappings = parent_options.get("service_repository_mappings")
+    if (
+        provider == "pagerduty"
+        and dataset_key == "services"
+        and isinstance(mappings, dict)
+    ):
+        options["service_repository_mappings"] = mappings
+    return options
+
+
 async def _create_planner_managed_config(
     session: AsyncSession,
     org_id: str,
@@ -1280,7 +1303,9 @@ async def _create_planner_managed_config(
             integration_id=integration.id,
             dataset_key=dataset_key,
             is_enabled=True,
-            options={"legacy_targets": list(sync_targets)},
+            options=_planner_dataset_options(
+                provider, dataset_key, sync_targets, parent_options
+            ),
         )
         for dataset_key in _planner_dataset_keys(provider, sync_targets)
     ]

--- a/src/dev_health_ops/api/graphql/models/outputs.py
+++ b/src/dev_health_ops/api/graphql/models/outputs.py
@@ -466,6 +466,14 @@ class WorkGraphNodeType(Enum):
     REVIEW_OUTCOME = "review_outcome"
     DEPLOYMENT = "deployment"
     INCIDENT = "incident"
+    OPERATIONAL_SERVICE = "operational_service"
+    OPERATIONAL_ALERT = "operational_alert"
+    INCIDENT_TIMELINE_EVENT = "incident_timeline_event"
+    INCIDENT_RESPONDER = "incident_responder"
+    ESCALATION_POLICY = "escalation_policy"
+    REPOSITORY = "repository"
+    USER = "user"
+    TEAM = "team"
 
 
 @strawberry.enum
@@ -507,6 +515,14 @@ class WorkGraphEdgeType(Enum):
     HAS_REVIEW_OUTCOME = "has_review_outcome"
     DEPLOYS = "deploys"
     LINKED_INCIDENT = "linked_incident"
+    MAPS_TO_REPOSITORY = "maps_to_repository"
+    HAS_INCIDENT = "has_incident"
+    HAS_ALERT = "has_alert"
+    HAS_TIMELINE_EVENT = "has_timeline_event"
+    HAS_RESPONDER = "has_responder"
+    ASSIGNED_TO = "assigned_to"
+    ESCALATES_WITH = "escalates_with"
+    REMEDIATED_BY = "remediated_by"
 
 
 @strawberry.enum

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -155,24 +155,15 @@ def _incident_label(status: str) -> str:
 
 
 def _map_node_type(value: str) -> WorkGraphNodeType:
-    try:
-        return WorkGraphNodeType(value.lower())
-    except ValueError:
-        return WorkGraphNodeType.ISSUE
+    return WorkGraphNodeType(value.lower())
 
 
 def _map_edge_type(value: str) -> WorkGraphEdgeType:
-    try:
-        return WorkGraphEdgeType(value.lower())
-    except ValueError:
-        return WorkGraphEdgeType.RELATES
+    return WorkGraphEdgeType(value.lower())
 
 
 def _map_provenance(value: str) -> WorkGraphProvenance:
-    try:
-        return WorkGraphProvenance(value.lower())
-    except ValueError:
-        return WorkGraphProvenance.HEURISTIC
+    return WorkGraphProvenance(value.lower())
 
 
 def _dependency_edge_type_sql() -> str:

--- a/src/dev_health_ops/api/graphql/resolvers/work_graph.py
+++ b/src/dev_health_ops/api/graphql/resolvers/work_graph.py
@@ -304,6 +304,9 @@ async def _batch_resolve_display_names(
             is_bare_uuid = looks_like_uuid(entity_id)
             is_opaque_hex = bool(_OPAQUE_HEX_ID_RE.match(entity_id))
 
+            if entity_type == "incident" and (is_opaque_hex or is_bare_uuid):
+                incident_ids.add(entity_id)
+                continue
             # Opaque hex ids (feature_flag hashes, etc.) are not resolvable.
             if is_opaque_hex:
                 continue
@@ -315,8 +318,6 @@ async def _batch_resolve_display_names(
                 pr_ids.add(entity_id)
             elif entity_type == "deployment" and is_bare_uuid:
                 deployment_ids.add(entity_id)
-            elif entity_type == "incident" and is_bare_uuid:
-                incident_ids.add(entity_id)
 
     # --- PRs: one query against git_pull_requests -------------------------
     if pr_ids:
@@ -399,7 +400,13 @@ async def _batch_resolve_display_names(
             inc_rows = await query_dicts(
                 client,
                 """
-                SELECT incident_id, status
+                SELECT id AS incident_id, normalized_status AS status, title
+                FROM operational_incidents FINAL
+                WHERE org_id = %(org_id)s
+                  AND is_deleted = 0
+                  AND id IN %(inc_ids)s
+                UNION ALL
+                SELECT incident_id, status, '' AS title
                 FROM incidents FINAL
                 WHERE org_id = %(org_id)s
                   AND incident_id IN %(inc_ids)s
@@ -409,11 +416,16 @@ async def _batch_resolve_display_names(
             for r in inc_rows:
                 inc_id = str(r.get("incident_id") or "")
                 status = str(r.get("status") or "").strip()
+                title = str(r.get("title") or "").strip()
                 # Empty status → omit from resolved (→ Unresolved badge, not raw UUID).
                 # Known statuses are normalised to customer-facing labels; unknown
                 # statuses map to the neutral "Incident" label via _incident_label().
                 if inc_id and status:
-                    resolved[inc_id] = f"incident ({_incident_label(status)})"
+                    resolved[inc_id] = (
+                        f"{title} ({_incident_label(status)})"
+                        if title
+                        else f"incident ({_incident_label(status)})"
+                    )
         except Exception:
             logger.warning("Incident display-name lookup failed", exc_info=True)
 

--- a/src/dev_health_ops/api/webhooks/pagerduty.py
+++ b/src/dev_health_ops/api/webhooks/pagerduty.py
@@ -31,7 +31,6 @@ logger = logging.getLogger(__name__)
 
 MAX_WEBHOOK_BODY_BYTES = 1_048_576
 MAX_SIGNATURE_CANDIDATES = 8
-STREAM_MAXLEN = 100_000
 router = APIRouter(prefix="/pagerduty")
 
 
@@ -111,13 +110,15 @@ def _enqueue_event(
         "provider_instance_id": provider_instance_id,
         "payload": webhook.model_dump_json(),
     }
+    # Never cap this stream with MAXLEN: entries stay until a worker persists
+    # them and xdel's the entry (or dead-letters it). A MAXLEN trim would drop
+    # the OLDEST *unpersisted* events under backlog — silent data loss.
+
     try:
         return str(
             client.xadd(
                 _stream_name(org_id, provider_instance_id),
                 fields,
-                maxlen=STREAM_MAXLEN,
-                approximate=True,
             )
         )
     except Exception as exc:

--- a/src/dev_health_ops/api/webhooks/pagerduty.py
+++ b/src/dev_health_ops/api/webhooks/pagerduty.py
@@ -211,10 +211,8 @@ async def pagerduty_webhook(
             received_at=received_at,
         )
         getattr(process_pagerduty_webhook_event, "delay")(
-            webhook=webhook.model_dump(mode="json"),
             org_id=org_id,
             provider_instance_id=provider_instance_id,
-            received_at=received_at.isoformat(),
             stream_entry_id=stream_entry_id,
         )
     except HTTPException:

--- a/src/dev_health_ops/api/webhooks/pagerduty.py
+++ b/src/dev_health_ops/api/webhooks/pagerduty.py
@@ -1,0 +1,244 @@
+"""PagerDuty V3 webhook receiver and durable hand-off.
+
+Subscriptions may be scoped to a PagerDuty account, a team, or selected
+services. Subscription management remains manual in PagerDuty V1; this
+receiver maps one configured subscription to one canonical provider instance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import logging
+import os
+from datetime import UTC, datetime
+
+from fastapi import APIRouter, Header, HTTPException, Request, status
+from pydantic import ValidationError
+
+from dev_health_ops.api.ingest.streams import get_redis_client
+from dev_health_ops.api.middleware.rate_limit import limiter
+from dev_health_ops.workers.system_webhooks import process_pagerduty_webhook_event
+
+from .pagerduty_models import (
+    PagerDutyV3Webhook,
+    PagerDutyWebhookConfiguration,
+    PagerDutyWebhookResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+MAX_WEBHOOK_BODY_BYTES = 1_048_576
+REPLAY_TTL_SECONDS = 86_400
+STREAM_MAXLEN = 100_000
+router = APIRouter(prefix="/pagerduty")
+
+
+def _configuration() -> tuple[str | None, str | None, str | None]:
+    return (
+        os.getenv("PAGERDUTY_WEBHOOK_SECRET"),
+        os.getenv("PAGERDUTY_WEBHOOK_ORG_ID"),
+        os.getenv("PAGERDUTY_WEBHOOK_PROVIDER_INSTANCE_ID"),
+    )
+
+
+def _verify_signature(body: bytes, header: str | None, secret: str) -> bool:
+    if header is None or not header.startswith("v1="):
+        return False
+    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    return hmac.compare_digest(f"v1={digest}", header)
+
+
+def _parse_webhook(body: bytes) -> PagerDutyV3Webhook:
+    try:
+        decoded = json.loads(body)
+    except json.JSONDecodeError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Malformed JSON"
+        ) from exc
+    try:
+        return PagerDutyV3Webhook.model_validate(decoded)
+    except ValidationError as exc:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid PagerDuty V3 event"
+        ) from exc
+
+
+def _stream_name(org_id: str, provider_instance_id: str) -> str:
+    return f"pagerduty-webhooks:{org_id}:{provider_instance_id}"
+
+
+def _replay_key(org_id: str, provider_instance_id: str, event_id: str) -> str:
+    return f"pagerduty-webhook:{org_id}:{provider_instance_id}:{event_id}"
+
+
+def _claim_event(org_id: str, provider_instance_id: str, event_id: str) -> bool:
+    client = get_redis_client()
+    if client is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook queue unavailable",
+        )
+    try:
+        return bool(
+            client.set(
+                _replay_key(org_id, provider_instance_id, event_id),
+                "received",
+                nx=True,
+                ex=REPLAY_TTL_SECONDS,
+            )
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook queue unavailable",
+        ) from exc
+
+
+def _enqueue_event(
+    *,
+    webhook: PagerDutyV3Webhook,
+    org_id: str,
+    provider_instance_id: str,
+    received_at: datetime,
+) -> str:
+    client = get_redis_client()
+    if client is None:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook queue unavailable",
+        )
+    fields = {
+        "event_id": webhook.event.id,
+        "event_type": webhook.event.event_type.value,
+        "occurred_at": webhook.event.occurred_at.astimezone(UTC).isoformat(),
+        "received_at": received_at.isoformat(),
+        "org_id": org_id,
+        "provider_instance_id": provider_instance_id,
+        "payload": webhook.model_dump_json(),
+    }
+    try:
+        return str(
+            client.xadd(
+                _stream_name(org_id, provider_instance_id),
+                fields,
+                maxlen=STREAM_MAXLEN,
+                approximate=True,
+            )
+        )
+    except Exception as exc:
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook queue unavailable",
+        ) from exc
+
+
+def _release_claim(org_id: str, provider_instance_id: str, event_id: str) -> None:
+    client = get_redis_client()
+    if client is None:
+        return
+    try:
+        client.delete(_replay_key(org_id, provider_instance_id, event_id))
+    except Exception:
+        logger.warning(
+            "pagerduty_webhook.audit claim_release_failed event_id=%s", event_id
+        )
+
+
+@router.get("/configuration", response_model=PagerDutyWebhookConfiguration)
+def pagerduty_configuration() -> PagerDutyWebhookConfiguration:
+    secret, org_id, provider_instance_id = _configuration()
+    return PagerDutyWebhookConfiguration(
+        configured=bool(secret and org_id and provider_instance_id),
+        org_id=org_id,
+        provider_instance_id=provider_instance_id,
+    )
+
+
+async def _validated_webhook(
+    request: Request, signature: str | None
+) -> tuple[PagerDutyV3Webhook, str, str]:
+    secret, org_id, provider_instance_id = _configuration()
+    if not secret or not org_id or not provider_instance_id:
+        logger.warning("pagerduty_webhook.audit rejected reason=unconfigured")
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook unconfigured",
+        )
+    body = await request.body()
+    if len(body) > MAX_WEBHOOK_BODY_BYTES:
+        logger.warning("pagerduty_webhook.audit rejected reason=oversized")
+        raise HTTPException(
+            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+            detail="Payload too large",
+        )
+    if not _verify_signature(body, signature, secret):
+        logger.warning("pagerduty_webhook.audit rejected reason=invalid_signature")
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED, detail="Invalid signature"
+        )
+    webhook = _parse_webhook(body)
+    return webhook, org_id, provider_instance_id
+
+
+@router.post(
+    "", response_model=PagerDutyWebhookResponse, status_code=status.HTTP_202_ACCEPTED
+)
+@limiter.limit("60/minute")
+async def pagerduty_webhook(
+    request: Request,
+    x_pagerduty_signature: str | None = Header(default=None),
+) -> PagerDutyWebhookResponse:
+    webhook, org_id, provider_instance_id = await _validated_webhook(
+        request, x_pagerduty_signature
+    )
+    if not _claim_event(org_id, provider_instance_id, webhook.event.id):
+        logger.info(
+            "pagerduty_webhook.audit accepted duplicate event_id=%s", webhook.event.id
+        )
+        return PagerDutyWebhookResponse(
+            status="accepted",
+            event_id=webhook.event.id,
+            message="Duplicate event accepted",
+        )
+    received_at = datetime.now(UTC)
+    try:
+        stream_entry_id = _enqueue_event(
+            webhook=webhook,
+            org_id=org_id,
+            provider_instance_id=provider_instance_id,
+            received_at=received_at,
+        )
+        getattr(process_pagerduty_webhook_event, "delay")(
+            webhook=webhook.model_dump(mode="json"),
+            org_id=org_id,
+            provider_instance_id=provider_instance_id,
+            received_at=received_at.isoformat(),
+            stream_entry_id=stream_entry_id,
+        )
+    except HTTPException:
+        _release_claim(org_id, provider_instance_id, webhook.event.id)
+        raise
+    except Exception as exc:
+        _release_claim(org_id, provider_instance_id, webhook.event.id)
+        raise HTTPException(
+            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
+            detail="Webhook queue unavailable",
+        ) from exc
+    logger.info("pagerduty_webhook.audit accepted event_id=%s", webhook.event.id)
+    return PagerDutyWebhookResponse(
+        status="accepted", event_id=webhook.event.id, message="Event accepted"
+    )
+
+
+@router.post("/test-event", response_model=PagerDutyWebhookResponse)
+@limiter.limit("60/minute")
+async def validate_pagerduty_test_event(
+    request: Request,
+    x_pagerduty_signature: str | None = Header(default=None),
+) -> PagerDutyWebhookResponse:
+    webhook, _, _ = await _validated_webhook(request, x_pagerduty_signature)
+    return PagerDutyWebhookResponse(
+        status="validated", event_id=webhook.event.id, message="Event validated"
+    )

--- a/src/dev_health_ops/api/webhooks/pagerduty.py
+++ b/src/dev_health_ops/api/webhooks/pagerduty.py
@@ -30,7 +30,7 @@ from .pagerduty_models import (
 logger = logging.getLogger(__name__)
 
 MAX_WEBHOOK_BODY_BYTES = 1_048_576
-REPLAY_TTL_SECONDS = 86_400
+MAX_SIGNATURE_CANDIDATES = 8
 STREAM_MAXLEN = 100_000
 router = APIRouter(prefix="/pagerduty")
 
@@ -44,10 +44,30 @@ def _configuration() -> tuple[str | None, str | None, str | None]:
 
 
 def _verify_signature(body: bytes, header: str | None, secret: str) -> bool:
-    if header is None or not header.startswith("v1="):
+    if header is None:
         return False
-    digest = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
-    return hmac.compare_digest(f"v1={digest}", header)
+    header_candidates = header.split(",")
+    if len(header_candidates) > MAX_SIGNATURE_CANDIDATES:
+        return False
+
+    candidates: list[str] = []
+    for header_candidate in header_candidates:
+        candidate = header_candidate.strip().removeprefix("v1=")
+        if (
+            header_candidate.strip().startswith("v1=")
+            and len(candidate) == 64
+            and all(character in "0123456789abcdefABCDEF" for character in candidate)
+        ):
+            candidates.append(candidate.lower())
+    if not candidates:
+        return False
+
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+    valid = False
+    for candidate in candidates:
+        matches = hmac.compare_digest(expected, candidate)
+        valid = matches or valid
+    return valid
 
 
 def _parse_webhook(body: bytes) -> PagerDutyV3Webhook:
@@ -67,33 +87,6 @@ def _parse_webhook(body: bytes) -> PagerDutyV3Webhook:
 
 def _stream_name(org_id: str, provider_instance_id: str) -> str:
     return f"pagerduty-webhooks:{org_id}:{provider_instance_id}"
-
-
-def _replay_key(org_id: str, provider_instance_id: str, event_id: str) -> str:
-    return f"pagerduty-webhook:{org_id}:{provider_instance_id}:{event_id}"
-
-
-def _claim_event(org_id: str, provider_instance_id: str, event_id: str) -> bool:
-    client = get_redis_client()
-    if client is None:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Webhook queue unavailable",
-        )
-    try:
-        return bool(
-            client.set(
-                _replay_key(org_id, provider_instance_id, event_id),
-                "received",
-                nx=True,
-                ex=REPLAY_TTL_SECONDS,
-            )
-        )
-    except Exception as exc:
-        raise HTTPException(
-            status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
-            detail="Webhook queue unavailable",
-        ) from exc
 
 
 def _enqueue_event(
@@ -134,18 +127,6 @@ def _enqueue_event(
         ) from exc
 
 
-def _release_claim(org_id: str, provider_instance_id: str, event_id: str) -> None:
-    client = get_redis_client()
-    if client is None:
-        return
-    try:
-        client.delete(_replay_key(org_id, provider_instance_id, event_id))
-    except Exception:
-        logger.warning(
-            "pagerduty_webhook.audit claim_release_failed event_id=%s", event_id
-        )
-
-
 @router.get("/configuration", response_model=PagerDutyWebhookConfiguration)
 def pagerduty_configuration() -> PagerDutyWebhookConfiguration:
     secret, org_id, provider_instance_id = _configuration()
@@ -166,13 +147,7 @@ async def _validated_webhook(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Webhook unconfigured",
         )
-    body = await request.body()
-    if len(body) > MAX_WEBHOOK_BODY_BYTES:
-        logger.warning("pagerduty_webhook.audit rejected reason=oversized")
-        raise HTTPException(
-            status_code=status.HTTP_413_CONTENT_TOO_LARGE,
-            detail="Payload too large",
-        )
+    body = await _read_body_limited(request)
     if not _verify_signature(body, signature, secret):
         logger.warning("pagerduty_webhook.audit rejected reason=invalid_signature")
         raise HTTPException(
@@ -180,6 +155,35 @@ async def _validated_webhook(
         )
     webhook = _parse_webhook(body)
     return webhook, org_id, provider_instance_id
+
+
+async def _read_body_limited(request: Request) -> bytes:
+    content_length = request.headers.get("content-length")
+    if content_length is not None:
+        try:
+            declared_size = int(content_length)
+        except ValueError as exc:
+            raise HTTPException(
+                status_code=status.HTTP_400_BAD_REQUEST,
+                detail="Invalid Content-Length",
+            ) from exc
+        if declared_size < 0 or declared_size > MAX_WEBHOOK_BODY_BYTES:
+            logger.warning("pagerduty_webhook.audit rejected reason=oversized")
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail="Payload too large",
+            )
+
+    body = bytearray()
+    async for chunk in request.stream():
+        if len(body) + len(chunk) > MAX_WEBHOOK_BODY_BYTES:
+            logger.warning("pagerduty_webhook.audit rejected reason=oversized")
+            raise HTTPException(
+                status_code=status.HTTP_413_CONTENT_TOO_LARGE,
+                detail="Payload too large",
+            )
+        body.extend(chunk)
+    return bytes(body)
 
 
 @router.post(
@@ -193,15 +197,6 @@ async def pagerduty_webhook(
     webhook, org_id, provider_instance_id = await _validated_webhook(
         request, x_pagerduty_signature
     )
-    if not _claim_event(org_id, provider_instance_id, webhook.event.id):
-        logger.info(
-            "pagerduty_webhook.audit accepted duplicate event_id=%s", webhook.event.id
-        )
-        return PagerDutyWebhookResponse(
-            status="accepted",
-            event_id=webhook.event.id,
-            message="Duplicate event accepted",
-        )
     received_at = datetime.now(UTC)
     try:
         stream_entry_id = _enqueue_event(
@@ -216,10 +211,8 @@ async def pagerduty_webhook(
             stream_entry_id=stream_entry_id,
         )
     except HTTPException:
-        _release_claim(org_id, provider_instance_id, webhook.event.id)
         raise
     except Exception as exc:
-        _release_claim(org_id, provider_instance_id, webhook.event.id)
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail="Webhook queue unavailable",

--- a/src/dev_health_ops/api/webhooks/pagerduty_models.py
+++ b/src/dev_health_ops/api/webhooks/pagerduty_models.py
@@ -1,9 +1,9 @@
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import UTC, datetime
 from enum import StrEnum
 
-from pydantic import BaseModel, ConfigDict, JsonValue
+from pydantic import BaseModel, ConfigDict, JsonValue, field_validator
 
 
 class PagerDutyEventType(StrEnum):
@@ -17,10 +17,10 @@ class PagerDutyEventType(StrEnum):
     INCIDENT_RESOLVED = "incident.resolved"
     INCIDENT_REOPENED = "incident.reopened"
     INCIDENT_ANNOTATED = "incident.annotated"
-    RESPONDER_ADDED = "responder.added"
-    RESPONDER_REPLIED = "responder.replied"
-    SERVICE_UPDATED = "service_updated"
-    STATUS_UPDATE_PUBLISHED = "status_update_published"
+    RESPONDER_ADDED = "incident.responder.added"
+    RESPONDER_REPLIED = "incident.responder.replied"
+    SERVICE_UPDATED = "incident.service_updated"
+    STATUS_UPDATE_PUBLISHED = "incident.status_update_published"
     SERVICE_CREATED = "service.created"
     SERVICE_DELETED = "service.deleted"
     SERVICE_UPDATED_V3 = "service.updated"
@@ -33,6 +33,13 @@ class PagerDutyEvent(BaseModel):
     event_type: PagerDutyEventType
     occurred_at: datetime
     data: dict[str, JsonValue]
+
+    @field_validator("occurred_at")
+    @classmethod
+    def occurred_at_must_be_timezone_aware(cls, value: datetime) -> datetime:
+        if value.tzinfo is None or value.utcoffset() is None:
+            raise ValueError("occurred_at must include a timezone offset")
+        return value.astimezone(UTC)
 
 
 class PagerDutyV3Webhook(BaseModel):

--- a/src/dev_health_ops/api/webhooks/pagerduty_models.py
+++ b/src/dev_health_ops/api/webhooks/pagerduty_models.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+from datetime import datetime
+from enum import StrEnum
+
+from pydantic import BaseModel, ConfigDict, JsonValue
+
+
+class PagerDutyEventType(StrEnum):
+    INCIDENT_TRIGGERED = "incident.triggered"
+    INCIDENT_ACKNOWLEDGED = "incident.acknowledged"
+    INCIDENT_UNACKNOWLEDGED = "incident.unacknowledged"
+    INCIDENT_ESCALATED = "incident.escalated"
+    INCIDENT_REASSIGNED = "incident.reassigned"
+    INCIDENT_DELEGATED = "incident.delegated"
+    INCIDENT_PRIORITY_UPDATED = "incident.priority_updated"
+    INCIDENT_RESOLVED = "incident.resolved"
+    INCIDENT_REOPENED = "incident.reopened"
+    INCIDENT_ANNOTATED = "incident.annotated"
+    RESPONDER_ADDED = "responder.added"
+    RESPONDER_REPLIED = "responder.replied"
+    SERVICE_UPDATED = "service_updated"
+    STATUS_UPDATE_PUBLISHED = "status_update_published"
+    SERVICE_CREATED = "service.created"
+    SERVICE_DELETED = "service.deleted"
+    SERVICE_UPDATED_V3 = "service.updated"
+
+
+class PagerDutyEvent(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    id: str
+    event_type: PagerDutyEventType
+    occurred_at: datetime
+    data: dict[str, JsonValue]
+
+
+class PagerDutyV3Webhook(BaseModel):
+    model_config = ConfigDict(extra="ignore", frozen=True)
+
+    event: PagerDutyEvent
+
+
+class PagerDutyWebhookResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    status: str
+    event_id: str | None = None
+    message: str
+
+
+class PagerDutyWebhookConfiguration(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    configured: bool
+    org_id: str | None
+    provider_instance_id: str | None

--- a/src/dev_health_ops/api/webhooks/router.py
+++ b/src/dev_health_ops/api/webhooks/router.py
@@ -30,10 +30,12 @@ from .models import (
     map_gitlab_event,
     map_jira_event,
 )
+from .pagerduty import router as pagerduty_router
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v1/webhooks", tags=["webhooks"])
+router.include_router(pagerduty_router)
 
 
 def _dispatch_webhook_task(event: WebhookEvent) -> None:
@@ -44,7 +46,7 @@ def _dispatch_webhook_task(event: WebhookEvent) -> None:
     doesn't fail catastrophically).
     """
     try:
-        process_webhook_event.delay(
+        getattr(process_webhook_event, "delay")(
             provider=event.provider,
             event_type=event.event_type,
             delivery_id=event.delivery_id,

--- a/src/dev_health_ops/metrics/active_incidents.py
+++ b/src/dev_health_ops/metrics/active_incidents.py
@@ -68,7 +68,7 @@ def active_incidents_query(
     canonical_projection = f"""
         SELECT
             mapping.repo_id,
-            incident.external_id AS incident_id,
+            incident.id AS incident_id,
             incident.normalized_status AS status,
             incident.started_at,
             incident.resolved_at,
@@ -78,6 +78,9 @@ def active_incidents_query(
         INNER JOIN operational_service_repository_mappings AS mapping FINAL
             ON incident.org_id = mapping.org_id
            AND incident.service_id = mapping.service_id
+        INNER JOIN repos AS repo FINAL
+            ON mapping.org_id = repo.org_id
+           AND mapping.repo_id = repo.id
         WHERE incident.org_id = {{org_id:String}}
           AND mapping.org_id = {{org_id:String}}
           AND incident.is_deleted = 0

--- a/src/dev_health_ops/metrics/active_incidents.py
+++ b/src/dev_health_ops/metrics/active_incidents.py
@@ -29,6 +29,11 @@ def active_incidents_query(
     Legacy rows appear first and win a same-repository identity collision until the
     legacy backfill is retired, preserving existing GitHub/GitLab behavior.
     """
+    # Initialize before the match so control-flow analysis sees a definite
+    # assignment; an unhandled window then yields an empty filter and a loud SQL
+    # error rather than a silent wrong result.
+    legacy_time_filter = ""
+    canonical_time_filter = ""
     match window:
         case IncidentWindow.RESOLVED:
             legacy_time_filter = (

--- a/src/dev_health_ops/metrics/active_incidents.py
+++ b/src/dev_health_ops/metrics/active_incidents.py
@@ -53,14 +53,14 @@ def active_incidents_query(
 
     legacy_org_filter = "org_id = {org_id:String} AND" if org_id else ""
     legacy_projection = f"""
-        SELECT repo_id, incident_id, status, started_at, resolved_at, last_synced, 1 AS source_priority
+        SELECT repo_id, incident_id, status, started_at, resolved_at, last_synced AS synced_at, 1 AS source_priority
         FROM incidents FINAL
         WHERE {legacy_org_filter}
               {legacy_time_filter}
     """
     if not org_id:
         return f"""
-            SELECT repo_id, incident_id, status, started_at, resolved_at, last_synced
+            SELECT repo_id, incident_id, status, started_at, resolved_at, synced_at AS last_synced
             FROM ({legacy_projection})
             WHERE 1 = 1{repo_filter}
         """
@@ -72,7 +72,7 @@ def active_incidents_query(
             incident.normalized_status AS status,
             incident.started_at,
             incident.resolved_at,
-            incident.last_synced,
+            incident.last_synced AS synced_at,
             0 AS source_priority
         FROM operational_incidents AS incident FINAL
         INNER JOIN operational_service_repository_mappings AS mapping FINAL
@@ -99,10 +99,10 @@ def active_incidents_query(
         SELECT
             repo_id,
             incident_id,
-            argMax(status, (source_priority, last_synced)) AS status,
-            argMax(started_at, (source_priority, last_synced)) AS started_at,
-            argMax(resolved_at, (source_priority, last_synced)) AS resolved_at,
-            argMax(last_synced, (source_priority, last_synced)) AS last_synced
+            argMax(status, (source_priority, synced_at)) AS status,
+            argMax(started_at, (source_priority, synced_at)) AS started_at,
+            argMax(resolved_at, (source_priority, synced_at)) AS resolved_at,
+            argMax(synced_at, (source_priority, synced_at)) AS last_synced
         FROM projected_incidents
         WHERE 1 = 1{repo_filter}
         GROUP BY repo_id, incident_id

--- a/src/dev_health_ops/metrics/active_incidents.py
+++ b/src/dev_health_ops/metrics/active_incidents.py
@@ -1,0 +1,123 @@
+"""Repository-scoped incident projection for analytics consumers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from enum import StrEnum
+from typing import Any, TypeVar
+
+ProjectedIncidentRow = TypeVar("ProjectedIncidentRow", bound=Mapping[str, Any])
+
+
+class IncidentWindow(StrEnum):
+    """Canonical incident lifecycle timestamp used to bound a projection."""
+
+    RESOLVED = "resolved"
+    STARTED = "started"
+
+
+def active_incidents_query(
+    *,
+    window: IncidentWindow,
+    org_id: str,
+    repo_filter: str,
+) -> str:
+    """Build the legacy-plus-canonical repository incident projection query.
+
+    PagerDuty incidents have no repository directly. They become repository-scoped
+    only through a currently active service mapping in the same organization.
+    Legacy rows appear first and win a same-repository identity collision until the
+    legacy backfill is retired, preserving existing GitHub/GitLab behavior.
+    """
+    match window:
+        case IncidentWindow.RESOLVED:
+            legacy_time_filter = (
+                "resolved_at IS NOT NULL "
+                "AND resolved_at >= {start:DateTime64(3, 'UTC')} "
+                "AND resolved_at < {end:DateTime64(3, 'UTC')}"
+            )
+            canonical_time_filter = (
+                "incident.resolved_at IS NOT NULL "
+                "AND incident.resolved_at >= {start:DateTime64(3, 'UTC')} "
+                "AND incident.resolved_at < {end:DateTime64(3, 'UTC')}"
+            )
+        case IncidentWindow.STARTED:
+            legacy_time_filter = (
+                "started_at >= {start:DateTime64(3, 'UTC')} "
+                "AND started_at < {end:DateTime64(3, 'UTC')}"
+            )
+            canonical_time_filter = (
+                "incident.started_at >= {start:DateTime64(3, 'UTC')} "
+                "AND incident.started_at < {end:DateTime64(3, 'UTC')}"
+            )
+
+    legacy_org_filter = "org_id = {org_id:String} AND" if org_id else ""
+    legacy_projection = f"""
+        SELECT repo_id, incident_id, status, started_at, resolved_at, last_synced, 1 AS source_priority
+        FROM incidents FINAL
+        WHERE {legacy_org_filter}
+              {legacy_time_filter}
+    """
+    if not org_id:
+        return f"""
+            SELECT repo_id, incident_id, status, started_at, resolved_at, last_synced
+            FROM ({legacy_projection})
+            WHERE 1 = 1{repo_filter}
+        """
+
+    canonical_projection = f"""
+        SELECT
+            mapping.repo_id,
+            incident.external_id AS incident_id,
+            incident.normalized_status AS status,
+            incident.started_at,
+            incident.resolved_at,
+            incident.last_synced,
+            0 AS source_priority
+        FROM operational_incidents AS incident FINAL
+        INNER JOIN operational_service_repository_mappings AS mapping FINAL
+            ON incident.org_id = mapping.org_id
+           AND incident.service_id = mapping.service_id
+        WHERE incident.org_id = {{org_id:String}}
+          AND mapping.org_id = {{org_id:String}}
+          AND incident.is_deleted = 0
+          AND mapping.repo_id IS NOT NULL
+          AND mapping.is_active = 1
+          AND mapping.valid_from <= {{as_of:DateTime64(6, 'UTC')}}
+          AND (mapping.valid_to IS NULL OR mapping.valid_to > {{as_of:DateTime64(6, 'UTC')}})
+          AND {canonical_time_filter}
+    """
+    return f"""
+        WITH projected_incidents AS (
+            {legacy_projection}
+            UNION ALL
+            {canonical_projection}
+        )
+        SELECT
+            repo_id,
+            incident_id,
+            argMax(status, (source_priority, last_synced)) AS status,
+            argMax(started_at, (source_priority, last_synced)) AS started_at,
+            argMax(resolved_at, (source_priority, last_synced)) AS resolved_at,
+            argMax(last_synced, (source_priority, last_synced)) AS last_synced
+        FROM projected_incidents
+        WHERE 1 = 1{repo_filter}
+        GROUP BY repo_id, incident_id
+        HAVING repo_id IS NOT NULL
+        ORDER BY repo_id, incident_id
+    """
+
+
+def deduplicate_active_incidents(
+    rows: Sequence[ProjectedIncidentRow],
+) -> list[ProjectedIncidentRow]:
+    """Keep the first row for each repository-local stable incident identity."""
+    seen: set[tuple[str, str]] = set()
+    deduplicated: list[ProjectedIncidentRow] = []
+    for row in rows:
+        key = (str(row["repo_id"]), str(row["incident_id"]))
+        if key in seen:
+            continue
+        seen.add(key)
+        deduplicated.append(row)
+    return deduplicated

--- a/src/dev_health_ops/metrics/job_daily.py
+++ b/src/dev_health_ops/metrics/job_daily.py
@@ -14,6 +14,11 @@ from typing import Any
 
 from dev_health_ops.audit.ai_governance.loaders import build_governance_rows_for_day
 from dev_health_ops.db import resolve_sink_uri
+from dev_health_ops.metrics.active_incidents import (
+    IncidentWindow,
+    active_incidents_query,
+    deduplicate_active_incidents,
+)
 from dev_health_ops.metrics.ai_impact import compute_ai_impact_metrics_daily
 from dev_health_ops.metrics.benchmarking.runner import run_benchmarking_for_day
 from dev_health_ops.metrics.compounding_risk import build_compounding_risk_rows_for_day
@@ -266,7 +271,12 @@ def _extract_ai_workflow_for_day(
         logger.debug("AI workflow extraction skipped: org_id %r is not a UUID", org_id)
         return [], [], [], [], [], []
 
-    wf_params: dict[str, Any] = {"org_id": org_id, "start": start, "end": end}
+    wf_params: dict[str, Any] = {
+        "org_id": org_id,
+        "start": start,
+        "end": end,
+        "as_of": datetime.now(timezone.utc),
+    }
     wf_repo_filter = ""
     if repo_id is not None:
         wf_params["repo_id"] = str(repo_id)
@@ -400,14 +410,14 @@ def _extract_ai_workflow_for_day(
     )
 
     wf_incident_rows = primary_sink.query_dicts(
-        "SELECT repo_id, incident_id, started_at, last_synced"
-        " FROM incidents FINAL"
-        " WHERE org_id = {org_id:String}"
-        "   AND started_at >= {start:DateTime64(3, 'UTC')}"
-        "   AND started_at < {end:DateTime64(3, 'UTC')}"
-        f"{wf_repo_filter}",
+        active_incidents_query(
+            window=IncidentWindow.STARTED,
+            org_id=org_id,
+            repo_filter=wf_repo_filter,
+        ),
         wf_params,
     )
+    wf_incident_rows = deduplicate_active_incidents(wf_incident_rows)
     wf_incident_rows = _valid_id_rows(wf_incident_rows, "incident_id", "incidents")
 
     def _by_provider(

--- a/src/dev_health_ops/metrics/job_dora.py
+++ b/src/dev_health_ops/metrics/job_dora.py
@@ -8,6 +8,11 @@ from datetime import date, datetime, time, timedelta, timezone
 from typing import Any
 
 from dev_health_ops.db import resolve_sink_uri
+from dev_health_ops.metrics.active_incidents import (
+    IncidentWindow,
+    active_incidents_query,
+    deduplicate_active_incidents,
+)
 from dev_health_ops.metrics.compute_dora import compute_dora_metrics_daily
 from dev_health_ops.metrics.schemas import (
     DeploymentRow,
@@ -126,22 +131,25 @@ def _load_incidents(
     repo_name: str | None = None,
 ) -> list[IncidentRow]:
     """Read incidents resolved in the day window from ClickHouse."""
-    params: dict[str, Any] = {"org_id": org_id, "start": start, "end": end}
+    params: dict[str, Any] = {
+        "org_id": org_id,
+        "start": start,
+        "end": end,
+        "as_of": datetime.now(timezone.utc),
+    }
     repo_filter = _repo_filter(
         params, org_id=org_id, repo_id=repo_id, repo_name=repo_name
     )
 
     rows = primary_sink.query_dicts(
-        "SELECT repo_id, incident_id, status, started_at, resolved_at"
-        " FROM incidents FINAL"
-        " WHERE org_id = {org_id:String}"
-        "   AND resolved_at IS NOT NULL"
-        "   AND resolved_at >= {start:DateTime64(3, 'UTC')}"
-        "   AND resolved_at < {end:DateTime64(3, 'UTC')}"
-        f"{repo_filter}",
+        active_incidents_query(
+            window=IncidentWindow.RESOLVED,
+            org_id=org_id,
+            repo_filter=repo_filter,
+        ),
         params,
     )
-    return [r for r in rows if _has_valid_repo(r)]
+    return deduplicate_active_incidents([r for r in rows if _has_valid_repo(r)])
 
 
 def _has_valid_repo(row: dict[str, Any]) -> bool:

--- a/src/dev_health_ops/metrics/loaders/clickhouse.py
+++ b/src/dev_health_ops/metrics/loaders/clickhouse.py
@@ -7,6 +7,11 @@ import uuid
 from datetime import date, datetime, timedelta, timezone
 from typing import Any, cast
 
+from dev_health_ops.metrics.active_incidents import (
+    IncidentWindow,
+    active_incidents_query,
+    deduplicate_active_incidents,
+)
 from dev_health_ops.metrics.compute_work_items import (
     ManualFallbackRule,
     TeamAttributionCandidate,
@@ -631,17 +636,25 @@ class ClickHouseDataLoader(AIImpactClickHouseLoader, DataLoader):
             params["repo_id"] = str(repo_id)
             repo_filter = " AND repo_id = {repo_id:UUID}"
 
-        org_filter = self._org_filter()
         params = self._inject_org_id(params)
-
-        query = f"""
-        SELECT * FROM incidents
-        WHERE started_at >= {{start:DateTime}} AND started_at < {{end:DateTime}}
-        {repo_filter}
-        {org_filter}
-        """
+        params["as_of"] = naive_utc(datetime.now(timezone.utc))
+        query = active_incidents_query(
+            window=IncidentWindow.STARTED,
+            org_id=self.org_id,
+            repo_filter=repo_filter,
+        )
         dicts = await _clickhouse_query_dicts(self.client, query, params)
-        return [dict(d) for d in dicts]  # type: ignore
+        incidents: list[IncidentRow] = [
+            {
+                "repo_id": row["repo_id"],
+                "incident_id": row["incident_id"],
+                "status": row.get("status"),
+                "started_at": row["started_at"],
+                "resolved_at": row.get("resolved_at"),
+            }
+            for row in dicts
+        ]
+        return deduplicate_active_incidents(incidents)
 
     async def load_testops_pipeline_data(
         self,

--- a/src/dev_health_ops/migrations/clickhouse/067_deployments_org_id.sql
+++ b/src/dev_health_ops/migrations/clickhouse/067_deployments_org_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE deployments ADD COLUMN IF NOT EXISTS org_id String DEFAULT 'default';

--- a/src/dev_health_ops/migrations/clickhouse/067_deployments_org_id.sql
+++ b/src/dev_health_ops/migrations/clickhouse/067_deployments_org_id.sql
@@ -1,1 +1,0 @@
-ALTER TABLE deployments ADD COLUMN IF NOT EXISTS org_id String DEFAULT 'default';

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -380,6 +380,9 @@ def _run_pagerduty_dataset(
 ) -> dict[str, Any]:
     from dev_health_ops.providers.pagerduty.enrichment import PagerDutyEnrichmentToggles
     from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
+    from dev_health_ops.providers.pagerduty.service_repository_mapping import (
+        PagerDutyServiceRepositoryMappingInputs,
+    )
     from dev_health_ops.providers.pagerduty.sync import (
         PagerDutyOperationalSync,
         PagerDutySyncOptions,
@@ -393,6 +396,9 @@ def _run_pagerduty_dataset(
     enrichment = PagerDutyEnrichmentToggles.from_dataset_options(
         context.dataset_key, context.dataset_options
     )
+    mapping_inputs = PagerDutyServiceRepositoryMappingInputs.from_dataset_options(
+        context.dataset_options
+    )
 
     async def _handler(store: Any) -> dict[str, Any]:
         result = await PagerDutyOperationalSync(
@@ -405,6 +411,7 @@ def _run_pagerduty_dataset(
                 or context.window_start
                 or datetime.now(timezone.utc),
             ),
+            mapping_inputs=mapping_inputs,
         ).run(
             PagerDutySyncOptions(
                 dataset_key=context.dataset_key,

--- a/src/dev_health_ops/providers/pagerduty/models.py
+++ b/src/dev_health_ops/providers/pagerduty/models.py
@@ -62,6 +62,7 @@ class LogEntry(PagerDutyModel):
     created_at: datetime | None = None
     channel: dict[str, JsonValue] | None = None
     summary: str | None = None
+    message: str | None = None
 
 
 class Note(PagerDutyModel):

--- a/src/dev_health_ops/providers/pagerduty/normalize.py
+++ b/src/dev_health_ops/providers/pagerduty/normalize.py
@@ -160,7 +160,7 @@ class PagerDutyNormalizer:
             **self._common(IncidentTimelineEvent, row, "log_entry"),
             incident_id=incident_id,
             event_type=row.type or "pagerduty_log_entry",
-            body=row.summary,
+            body=row.summary or row.message,
             actor_type="pagerduty",
             occurred_at=row.created_at,
         )

--- a/src/dev_health_ops/providers/pagerduty/operational_store.py
+++ b/src/dev_health_ops/providers/pagerduty/operational_store.py
@@ -14,6 +14,7 @@ from dev_health_ops.models.operational import (
     OperationalService,
     OperationalTeam,
     OperationalUser,
+    ServiceRepositoryMapping,
 )
 
 T = TypeVar("T", bound=CanonicalOperationalEntity)
@@ -36,6 +37,11 @@ class PagerDutyOperationalStore(Protocol):
         self, values: list[OperationalService]
     ) -> None:
         """Persist operational services."""
+
+    async def insert_operational_service_repository_mappings(
+        self, values: list[ServiceRepositoryMapping]
+    ) -> None:
+        """Persist service-to-repository mapping evidence."""
 
     async def insert_operational_incidents(
         self, values: list[OperationalIncident]

--- a/src/dev_health_ops/providers/pagerduty/service_repository_mapping.py
+++ b/src/dev_health_ops/providers/pagerduty/service_repository_mapping.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import re
-from collections.abc import Iterator
+from collections.abc import Iterator, Mapping
 from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import Enum
@@ -86,6 +86,60 @@ class PagerDutyServiceRepositoryMappingInputs:
     def empty(cls) -> PagerDutyServiceRepositoryMappingInputs:
         """Return an input collection with no configured mappings."""
         return cls(admin={}, compass={}, heuristic={})
+
+    @classmethod
+    def from_dataset_options(
+        cls, options: Mapping[str, object]
+    ) -> PagerDutyServiceRepositoryMappingInputs:
+        """Build explicit admin/Compass mapping inputs from sync configuration.
+
+        Untrusted config is parsed defensively: malformed entries are skipped
+        rather than raising, so one bad row cannot break a dataset sync.
+        """
+        config = options.get("service_repository_mappings")
+        if not isinstance(config, Mapping):
+            return cls.empty()
+        return cls(
+            admin=_parse_reference_config(config.get("admin")),
+            compass=_parse_reference_config(config.get("compass")),
+            heuristic={},
+        )
+
+
+def _reference_from_entry(entry: object) -> RepositoryReference | None:
+    if not isinstance(entry, Mapping):
+        return None
+    provider = entry.get("provider")
+    full_name = entry.get("full_name")
+    if (
+        isinstance(provider, str)
+        and isinstance(full_name, str)
+        and provider
+        and full_name
+    ):
+        return RepositoryReference(provider=provider, full_name=full_name)
+    return None
+
+
+def _parse_reference_config(
+    value: object,
+) -> dict[str, tuple[RepositoryReference, ...]]:
+    if not isinstance(value, Mapping):
+        return {}
+    parsed: dict[str, tuple[RepositoryReference, ...]] = {}
+    for service_external_id, references in value.items():
+        if not isinstance(service_external_id, str) or not isinstance(
+            references, (list, tuple)
+        ):
+            continue
+        resolved = tuple(
+            reference
+            for entry in references
+            if (reference := _reference_from_entry(entry)) is not None
+        )
+        if resolved:
+            parsed[service_external_id] = resolved
+    return parsed
 
 
 def mapping_from_repository_reference(

--- a/src/dev_health_ops/providers/pagerduty/service_repository_mapping.py
+++ b/src/dev_health_ops/providers/pagerduty/service_repository_mapping.py
@@ -1,0 +1,154 @@
+"""Evidence-preserving PagerDuty service-to-repository mapping population."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Iterator
+from dataclasses import dataclass
+from datetime import datetime
+from enum import Enum
+
+from pydantic import JsonValue
+
+from dev_health_ops.models.operational import (
+    OperationalService,
+    ServiceRepositoryMapping,
+)
+
+_GITHUB_URL = re.compile(r"https?://(?:www\.)?github\.com/([^/\s]+)/([^/#?\s]+)")
+_GITLAB_URL = re.compile(r"https?://(?:www\.)?gitlab\.com/([^\s]+)/?$")
+_REPOSITORY_KEYS = frozenset({"repo", "repository", "repository_slug", "repo_slug"})
+
+
+class PagerDutyServiceRepositoryMappingSource(str, Enum):
+    """Ordered mapping sources, from explicit configuration to bounded inference."""
+
+    ADMIN_CONFIGURATION = "admin_configuration"
+    METADATA = "pagerduty_service_metadata"
+    COMPASS = "compass_service_catalog"
+    HEURISTIC = "bounded_service_repository_heuristic"
+
+    @property
+    def confidence(self) -> float:
+        match self:
+            case PagerDutyServiceRepositoryMappingSource.ADMIN_CONFIGURATION:
+                return 1.0
+            case PagerDutyServiceRepositoryMappingSource.METADATA:
+                return 0.95
+            case PagerDutyServiceRepositoryMappingSource.COMPASS:
+                return 0.9
+            case PagerDutyServiceRepositoryMappingSource.HEURISTIC:
+                return 0.4
+
+    @property
+    def mapping_kind(self) -> str:
+        return f"{self.value}_exact" if self is not self.HEURISTIC else self.value
+
+    @property
+    def rule_id(self) -> str:
+        match self:
+            case PagerDutyServiceRepositoryMappingSource.ADMIN_CONFIGURATION:
+                return "service_repository_mapping.admin.v1"
+            case PagerDutyServiceRepositoryMappingSource.METADATA:
+                return "pagerduty.service_metadata.repository_url_or_key.v1"
+            case PagerDutyServiceRepositoryMappingSource.COMPASS:
+                return "compass.service_repository_relationship.v1"
+            case PagerDutyServiceRepositoryMappingSource.HEURISTIC:
+                return "pagerduty.service_repository.bounded_name_match.v1"
+
+
+@dataclass(frozen=True, slots=True)
+class RepositoryReference:
+    """A repository reference supplied by a mapping source."""
+
+    provider: str
+    full_name: str
+
+
+def mapping_from_repository_reference(
+    service: OperationalService,
+    reference: RepositoryReference,
+    source: PagerDutyServiceRepositoryMappingSource,
+    observed_at: datetime,
+    *,
+    rule_id: str | None = None,
+) -> ServiceRepositoryMapping:
+    """Create one auditable mapping without inventing a repository identity."""
+    resolved_rule_id = rule_id or source.rule_id
+    if source is PagerDutyServiceRepositoryMappingSource.HEURISTIC and not rule_id:
+        raise ValueError("bounded heuristic mappings require a stable rule_id")
+    return ServiceRepositoryMapping(
+        org_id=service.org_id,
+        provider=service.provider,
+        provider_instance_id=service.provider_instance_id,
+        source_entity_type=source.value,
+        external_id=f"{service.external_id}:{reference.provider}:{reference.full_name}:{resolved_rule_id}",
+        source_version_at=observed_at,
+        source_url=service.source_url,
+        source_event_id="pagerduty_sync",
+        service_id=service.id,
+        repo_full_name=reference.full_name,
+        repo_provider=reference.provider,
+        mapping_kind=source.mapping_kind,
+        rule_id=resolved_rule_id,
+        valid_from=observed_at,
+        is_active=True,
+        relationship_provenance=source.value,
+        relationship_confidence=source.confidence,
+    )
+
+
+def mappings_from_service_metadata(
+    service: OperationalService,
+    metadata: dict[str, JsonValue],
+    observed_at: datetime,
+) -> tuple[ServiceRepositoryMapping, ...]:
+    """Extract only exact repository URLs or explicitly labeled repository slugs."""
+    references = {
+        reference
+        for key, value in _walk_metadata(metadata)
+        for reference in _repository_references(key, value)
+    }
+    return tuple(
+        mapping_from_repository_reference(
+            service,
+            reference,
+            PagerDutyServiceRepositoryMappingSource.METADATA,
+            observed_at,
+        )
+        for reference in sorted(
+            references, key=lambda item: (item.provider, item.full_name)
+        )
+    )
+
+
+def _walk_metadata(
+    value: JsonValue, key: str | None = None
+) -> Iterator[tuple[str | None, str]]:
+    match value:
+        case str() as text:
+            yield key, text
+        case dict() as values:
+            for nested_key, nested_value in values.items():
+                yield from _walk_metadata(nested_value, nested_key.casefold())
+        case list() as values:
+            for nested_value in values:
+                yield from _walk_metadata(nested_value, key)
+        case _:
+            return
+
+
+def _repository_references(
+    key: str | None, value: str
+) -> tuple[RepositoryReference, ...]:
+    references: list[RepositoryReference] = []
+    for pattern, provider in ((_GITHUB_URL, "github"), (_GITLAB_URL, "gitlab")):
+        match = pattern.search(value)
+        if match is not None:
+            full_name = "/".join(
+                segment.removesuffix(".git") for segment in match.groups()
+            )
+            references.append(RepositoryReference(provider, full_name))
+    if key in _REPOSITORY_KEYS and value.count("/") == 1:
+        references.append(RepositoryReference("github", value.removesuffix(".git")))
+    return tuple(references)

--- a/src/dev_health_ops/providers/pagerduty/service_repository_mapping.py
+++ b/src/dev_health_ops/providers/pagerduty/service_repository_mapping.py
@@ -4,9 +4,10 @@ from __future__ import annotations
 
 import re
 from collections.abc import Iterator
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from datetime import datetime
 from enum import Enum
+from uuid import UUID
 
 from pydantic import JsonValue
 
@@ -65,6 +66,28 @@ class RepositoryReference:
     full_name: str
 
 
+@dataclass(frozen=True, slots=True)
+class HeuristicRepositoryReference:
+    """A bounded repository inference with a stable, auditable rule identifier."""
+
+    repository: RepositoryReference
+    rule_id: str
+
+
+@dataclass(frozen=True, slots=True)
+class PagerDutyServiceRepositoryMappingInputs:
+    """Explicit mapping inputs keyed by PagerDuty service external ID."""
+
+    admin: dict[str, tuple[RepositoryReference, ...]]
+    compass: dict[str, tuple[RepositoryReference, ...]]
+    heuristic: dict[str, tuple[HeuristicRepositoryReference, ...]]
+
+    @classmethod
+    def empty(cls) -> PagerDutyServiceRepositoryMappingInputs:
+        """Return an input collection with no configured mappings."""
+        return cls(admin={}, compass={}, heuristic={})
+
+
 def mapping_from_repository_reference(
     service: OperationalService,
     reference: RepositoryReference,
@@ -119,6 +142,87 @@ def mappings_from_service_metadata(
         for reference in sorted(
             references, key=lambda item: (item.provider, item.full_name)
         )
+    )
+
+
+def mappings_from_service_sources(
+    service: OperationalService,
+    metadata: dict[str, JsonValue],
+    observed_at: datetime,
+    inputs: PagerDutyServiceRepositoryMappingInputs,
+) -> tuple[ServiceRepositoryMapping, ...]:
+    """Collect configured and metadata evidence, retaining only preferred mappings."""
+    mappings = [*mappings_from_service_metadata(service, metadata, observed_at)]
+    mappings.extend(
+        mapping_from_repository_reference(
+            service,
+            reference,
+            PagerDutyServiceRepositoryMappingSource.ADMIN_CONFIGURATION,
+            observed_at,
+        )
+        for reference in inputs.admin.get(service.external_id, ())
+    )
+    mappings.extend(
+        mapping_from_repository_reference(
+            service,
+            reference,
+            PagerDutyServiceRepositoryMappingSource.COMPASS,
+            observed_at,
+        )
+        for reference in inputs.compass.get(service.external_id, ())
+    )
+    mappings.extend(
+        mapping_from_repository_reference(
+            service,
+            heuristic.repository,
+            PagerDutyServiceRepositoryMappingSource.HEURISTIC,
+            observed_at,
+            rule_id=heuristic.rule_id,
+        )
+        for heuristic in inputs.heuristic.get(service.external_id, ())
+    )
+    return select_preferred_mappings(tuple(mappings))
+
+
+def select_preferred_mappings(
+    mappings: tuple[ServiceRepositoryMapping, ...],
+) -> tuple[ServiceRepositoryMapping, ...]:
+    """Keep the highest-precedence evidence for each service-to-repository pair."""
+    preferred: dict[tuple[str, str | None, str | None], ServiceRepositoryMapping] = {}
+    for mapping in mappings:
+        key = (mapping.service_id, mapping.repo_provider, mapping.repo_full_name)
+        current = preferred.get(key)
+        if current is None or (mapping.relationship_confidence or 0.0) > (
+            current.relationship_confidence or 0.0
+        ):
+            preferred[key] = mapping
+    return tuple(
+        preferred[key]
+        for key in sorted(
+            preferred, key=lambda item: (item[0], item[1] or "", item[2] or "")
+        )
+    )
+
+
+def resolve_repository_mappings(
+    mappings: tuple[ServiceRepositoryMapping, ...],
+    repositories: tuple[tuple[UUID, str, str], ...],
+) -> tuple[ServiceRepositoryMapping, ...]:
+    """Resolve mapping evidence against repositories already owned by the organization."""
+    repository_ids = {
+        (provider, full_name): repository_id
+        for repository_id, provider, full_name in repositories
+    }
+    return tuple(
+        replace(
+            mapping,
+            repo_id=(
+                repository_ids.get((mapping.repo_provider, mapping.repo_full_name))
+                if mapping.repo_provider and mapping.repo_full_name
+                else mapping.repo_id
+            ),
+        )
+        for mapping in mappings
     )
 
 

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -238,7 +238,6 @@ class PagerDutyOperationalSync:
                 self._mapping_inputs,
             )
         ]
-        mappings = tuple(mapping_evidence)
         if _has_repository_catalog(self._store):
             repository_rows = self._store.query_dicts(
                 "SELECT id, provider, repo FROM repos FINAL WHERE org_id = {org_id:String}",
@@ -254,16 +253,18 @@ class PagerDutyOperationalSync:
                 and isinstance(provider, str)
                 and isinstance(repo, str)
             )
-            mappings = resolve_repository_mappings(mappings, repositories)
+            mappings = resolve_repository_mappings(
+                tuple(mapping_evidence), repositories
+            )
+            for start in range(0, len(mappings), batch_size):
+                await self._store.insert_operational_service_repository_mappings(
+                    list(mappings[start : start + batch_size])
+                )
+            await self._reconcile_service_repository_mappings(mappings)
         else:
             logger.info(
-                "PagerDuty repository catalog unavailable; retaining unresolved mapping evidence"
+                "PagerDuty repository catalog unavailable; skipping service repository mapping population"
             )
-        for start in range(0, len(mappings), batch_size):
-            await self._store.insert_operational_service_repository_mappings(
-                list(mappings[start : start + batch_size])
-            )
-        await self._reconcile_service_repository_mappings(mappings)
 
         active_entities = await self._store.load_active_operational_entities(
             OperationalService,

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -29,6 +29,9 @@ from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 from dev_health_ops.providers.pagerduty.operational_store import (
     PagerDutyOperationalStore,
 )
+from dev_health_ops.providers.pagerduty.service_repository_mapping import (
+    mappings_from_service_metadata,
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -100,14 +103,7 @@ class PagerDutyOperationalSync:
             ) as dataset_key if not options.enrichment.enabled(dataset_key):
                 persisted = 0
             case "services":
-                persisted = await self._sync_reference(
-                    self._client.list_services,
-                    self._normalizer.service,
-                    self._store.insert_operational_services,
-                    options.batch_size,
-                    OperationalService,
-                    "service",
-                )
+                persisted = await self._sync_services(options.batch_size)
             case "business-services":
                 persisted = await self._sync_reference(
                     self._client.list_business_services,
@@ -192,6 +188,44 @@ class PagerDutyOperationalSync:
             degraded=False,
             observations=tuple(self._client.drain_usage_observations()),
         )
+
+    async def _sync_services(self, batch_size: int) -> int:
+        """Sync services and retain exact repository metadata as mapping evidence."""
+        rows = await self._client.list_services()
+        values = [self._normalizer.service(row) for row in rows]
+        for start in range(0, len(values), batch_size):
+            await self._store.insert_operational_services(
+                values[start : start + batch_size]
+            )
+
+        mappings = [
+            mapping
+            for row, service in zip(rows, values, strict=True)
+            for mapping in mappings_from_service_metadata(
+                service, row.raw, self._normalizer.observed_at
+            )
+        ]
+        for start in range(0, len(mappings), batch_size):
+            await self._store.insert_operational_service_repository_mappings(
+                mappings[start : start + batch_size]
+            )
+
+        active_entities = await self._store.load_active_operational_entities(
+            OperationalService,
+            org_id=self._normalizer.org_id,
+            provider="pagerduty",
+            provider_instance_id=self._normalizer.provider_instance_id,
+            source_entity_type="service",
+        )
+        seen_ids = {value.id for value in values}
+        tombstones = [
+            _reference_tombstone(entity, self._normalizer.observed_at)
+            for entity in active_entities
+            if entity.id not in seen_ids
+        ]
+        if tombstones:
+            await self._store.insert_operational_services(tombstones)
+        return len(values)
 
     async def _sync(
         self,

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -5,7 +5,8 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
-from typing import TypeVar
+from typing import Protocol, TypeVar, runtime_checkable
+from uuid import UUID
 
 from dev_health_ops.models.operational import (
     EscalationPolicy,
@@ -14,6 +15,7 @@ from dev_health_ops.models.operational import (
     OperationalService,
     OperationalTeam,
     OperationalUser,
+    ServiceRepositoryMapping,
 )
 from dev_health_ops.providers.pagerduty.client import PagerDutyClient, PagerDutyPage
 from dev_health_ops.providers.pagerduty.degradation import (
@@ -30,7 +32,10 @@ from dev_health_ops.providers.pagerduty.operational_store import (
     PagerDutyOperationalStore,
 )
 from dev_health_ops.providers.pagerduty.service_repository_mapping import (
-    mappings_from_service_metadata,
+    PagerDutyServiceRepositoryMappingInputs,
+    PagerDutyServiceRepositoryMappingSource,
+    mappings_from_service_sources,
+    resolve_repository_mappings,
 )
 
 
@@ -74,6 +79,17 @@ _ReferenceEntity = TypeVar(
 )
 
 
+@runtime_checkable
+class PagerDutyOperationalSyncStore(PagerDutyOperationalStore, Protocol):
+    """Operational store capabilities required for PagerDuty catalog correlation."""
+
+    def query_dicts(
+        self, query: str, params: dict[str, str]
+    ) -> list[dict[str, object]]:
+        """Load organization-scoped repository catalog rows."""
+        ...
+
+
 class PagerDutyOperationalSync:
     """Sync one PagerDuty dataset without crossing account or sink boundaries."""
 
@@ -83,10 +99,16 @@ class PagerDutyOperationalSync:
         client: PagerDutyClient,
         store: PagerDutyOperationalStore,
         normalizer: PagerDutyNormalizer,
+        mapping_inputs: PagerDutyServiceRepositoryMappingInputs | None = None,
     ) -> None:
         self._client = client
         self._store = store
         self._normalizer = normalizer
+        self._mapping_inputs = (
+            mapping_inputs
+            if mapping_inputs is not None
+            else PagerDutyServiceRepositoryMappingInputs.empty()
+        )
 
     async def run(self, options: PagerDutySyncOptions) -> PagerDutySyncResult:
         try:
@@ -198,17 +220,40 @@ class PagerDutyOperationalSync:
                 values[start : start + batch_size]
             )
 
-        mappings = [
+        mapping_evidence = [
             mapping
             for row, service in zip(rows, values, strict=True)
-            for mapping in mappings_from_service_metadata(
-                service, row.raw, self._normalizer.observed_at
+            for mapping in mappings_from_service_sources(
+                service,
+                row.raw,
+                self._normalizer.observed_at,
+                self._mapping_inputs,
             )
         ]
+        if not isinstance(self._store, PagerDutyOperationalSyncStore):
+            raise TypeError(
+                "PagerDuty service correlation requires repository catalog access"
+            )
+        repository_rows = self._store.query_dicts(
+            "SELECT id, provider, repo FROM repos FINAL WHERE org_id = {org_id:String}",
+            {"org_id": self._normalizer.org_id},
+        )
+        repositories = tuple(
+            (repository_id, provider, repo)
+            for row in repository_rows
+            for repository_id, provider, repo in [
+                (row.get("id"), row.get("provider"), row.get("repo"))
+            ]
+            if isinstance(repository_id, UUID)
+            and isinstance(provider, str)
+            and isinstance(repo, str)
+        )
+        mappings = resolve_repository_mappings(tuple(mapping_evidence), repositories)
         for start in range(0, len(mappings), batch_size):
             await self._store.insert_operational_service_repository_mappings(
-                mappings[start : start + batch_size]
+                list(mappings[start : start + batch_size])
             )
+        await self._reconcile_service_repository_mappings(mappings)
 
         active_entities = await self._store.load_active_operational_entities(
             OperationalService,
@@ -226,6 +271,38 @@ class PagerDutyOperationalSync:
         if tombstones:
             await self._store.insert_operational_services(tombstones)
         return len(values)
+
+    async def _reconcile_service_repository_mappings(
+        self, mappings: tuple[ServiceRepositoryMapping, ...]
+    ) -> None:
+        """Deactivate mapping evidence absent from a complete successful source snapshot."""
+        for source in PagerDutyServiceRepositoryMappingSource:
+            active_mappings = await self._store.load_active_operational_entities(
+                ServiceRepositoryMapping,
+                org_id=self._normalizer.org_id,
+                provider="pagerduty",
+                provider_instance_id=self._normalizer.provider_instance_id,
+                source_entity_type=source.value,
+            )
+            seen_ids = {
+                mapping.id
+                for mapping in mappings
+                if mapping.source_entity_type == source.value
+            }
+            tombstones = [
+                replace(
+                    mapping,
+                    is_active=False,
+                    valid_to=self._normalizer.observed_at,
+                    source_version_at=self._normalizer.observed_at,
+                )
+                for mapping in active_mappings
+                if mapping.id not in seen_ids
+            ]
+            if tombstones:
+                await self._store.insert_operational_service_repository_mappings(
+                    tombstones
+                )
 
     async def _sync(
         self,

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -85,17 +85,15 @@ _ReferenceEntity = TypeVar(
 class PagerDutyOperationalSyncStore(PagerDutyOperationalStore, Protocol):
     """Operational store capabilities required for PagerDuty catalog correlation."""
 
-    def query_dicts(
-        self, query: str, params: dict[str, str]
-    ) -> list[dict[str, object]]:
-        """Load organization-scoped repository catalog rows."""
+    async def load_repository_catalog(self, org_id: str) -> list[tuple[UUID, str, str]]:
+        """Load organization-scoped (repo_id, provider, full_name) catalog rows."""
         ...
 
 
 def _has_repository_catalog(
     store: PagerDutyOperationalStore,
 ) -> TypeGuard[PagerDutyOperationalSyncStore]:
-    return hasattr(store, "query_dicts")
+    return hasattr(store, "load_repository_catalog")
 
 
 class PagerDutyOperationalSync:
@@ -239,19 +237,8 @@ class PagerDutyOperationalSync:
             )
         ]
         if _has_repository_catalog(self._store):
-            repository_rows = self._store.query_dicts(
-                "SELECT id, provider, repo FROM repos FINAL WHERE org_id = {org_id:String}",
-                {"org_id": self._normalizer.org_id},
-            )
             repositories = tuple(
-                (repository_id, provider, repo)
-                for row in repository_rows
-                for repository_id, provider, repo in [
-                    (row.get("id"), row.get("provider"), row.get("repo"))
-                ]
-                if isinstance(repository_id, UUID)
-                and isinstance(provider, str)
-                and isinstance(repo, str)
+                await self._store.load_repository_catalog(self._normalizer.org_id)
             )
             mappings = resolve_repository_mappings(
                 tuple(mapping_evidence), repositories

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
-from typing import Protocol, TypeVar, runtime_checkable
+from typing import Protocol, TypeGuard, TypeVar
 from uuid import UUID
 
 from dev_health_ops.models.operational import (
@@ -79,7 +79,6 @@ _ReferenceEntity = TypeVar(
 )
 
 
-@runtime_checkable
 class PagerDutyOperationalSyncStore(PagerDutyOperationalStore, Protocol):
     """Operational store capabilities required for PagerDuty catalog correlation."""
 
@@ -88,6 +87,12 @@ class PagerDutyOperationalSyncStore(PagerDutyOperationalStore, Protocol):
     ) -> list[dict[str, object]]:
         """Load organization-scoped repository catalog rows."""
         ...
+
+
+def _has_repository_catalog(
+    store: PagerDutyOperationalStore,
+) -> TypeGuard[PagerDutyOperationalSyncStore]:
+    return hasattr(store, "query_dicts")
 
 
 class PagerDutyOperationalSync:
@@ -230,7 +235,7 @@ class PagerDutyOperationalSync:
                 self._mapping_inputs,
             )
         ]
-        if not isinstance(self._store, PagerDutyOperationalSyncStore):
+        if not _has_repository_catalog(self._store):
             raise TypeError(
                 "PagerDuty service correlation requires repository catalog access"
             )

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import AsyncIterator, Awaitable, Callable
 from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta
@@ -37,6 +38,8 @@ from dev_health_ops.providers.pagerduty.service_repository_mapping import (
     mappings_from_service_sources,
     resolve_repository_mappings,
 )
+
+logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True, slots=True)
@@ -235,25 +238,27 @@ class PagerDutyOperationalSync:
                 self._mapping_inputs,
             )
         ]
-        if not _has_repository_catalog(self._store):
-            raise TypeError(
-                "PagerDuty service correlation requires repository catalog access"
+        mappings = tuple(mapping_evidence)
+        if _has_repository_catalog(self._store):
+            repository_rows = self._store.query_dicts(
+                "SELECT id, provider, repo FROM repos FINAL WHERE org_id = {org_id:String}",
+                {"org_id": self._normalizer.org_id},
             )
-        repository_rows = self._store.query_dicts(
-            "SELECT id, provider, repo FROM repos FINAL WHERE org_id = {org_id:String}",
-            {"org_id": self._normalizer.org_id},
-        )
-        repositories = tuple(
-            (repository_id, provider, repo)
-            for row in repository_rows
-            for repository_id, provider, repo in [
-                (row.get("id"), row.get("provider"), row.get("repo"))
-            ]
-            if isinstance(repository_id, UUID)
-            and isinstance(provider, str)
-            and isinstance(repo, str)
-        )
-        mappings = resolve_repository_mappings(tuple(mapping_evidence), repositories)
+            repositories = tuple(
+                (repository_id, provider, repo)
+                for row in repository_rows
+                for repository_id, provider, repo in [
+                    (row.get("id"), row.get("provider"), row.get("repo"))
+                ]
+                if isinstance(repository_id, UUID)
+                and isinstance(provider, str)
+                and isinstance(repo, str)
+            )
+            mappings = resolve_repository_mappings(mappings, repositories)
+        else:
+            logger.info(
+                "PagerDuty repository catalog unavailable; retaining unresolved mapping evidence"
+            )
         for start in range(0, len(mappings), batch_size):
             await self._store.insert_operational_service_repository_mappings(
                 list(mappings[start : start + batch_size])

--- a/src/dev_health_ops/providers/pagerduty/sync.py
+++ b/src/dev_health_ops/providers/pagerduty/sync.py
@@ -288,12 +288,7 @@ class PagerDutyOperationalSync:
                 if mapping.source_entity_type == source.value
             }
             tombstones = [
-                replace(
-                    mapping,
-                    is_active=False,
-                    valid_to=self._normalizer.observed_at,
-                    source_version_at=self._normalizer.observed_at,
-                )
+                _mapping_tombstone(mapping, self._normalizer.observed_at)
                 for mapping in active_mappings
                 if mapping.id not in seen_ids
             ]
@@ -442,4 +437,23 @@ def _reference_tombstone(
         last_synced=source_version_at,
         is_deleted=True,
         deleted_at=source_version_at,
+    )
+
+
+def _mapping_tombstone(
+    mapping: ServiceRepositoryMapping, observed_at: datetime
+) -> ServiceRepositoryMapping:
+    # source_version_at is the ReplacingMergeTree version. Reusing observed_at
+    # ties an active row created in the same window (RMT keeps an arbitrary row,
+    # so the deactivation may not win); bump strictly above the prior version.
+    source_version_at = max(
+        observed_at, mapping.source_version_at + timedelta(microseconds=1)
+    )
+    return replace(
+        mapping,
+        is_active=False,
+        valid_to=observed_at,
+        source_version_at=source_version_at,
+        observed_at=observed_at,
+        last_synced=observed_at,
     )

--- a/src/dev_health_ops/providers/pagerduty/webhooks.py
+++ b/src/dev_health_ops/providers/pagerduty/webhooks.py
@@ -1,0 +1,223 @@
+"""Canonical PagerDuty webhook reconciliation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from datetime import datetime
+from typing import Protocol, TypeVar
+
+from pydantic import JsonValue
+
+from dev_health_ops.api.webhooks.pagerduty_models import (
+    PagerDutyEventType,
+    PagerDutyV3Webhook,
+)
+from dev_health_ops.models.operational import (
+    CanonicalOperationalEntity,
+    IncidentNote,
+    IncidentTimelineEvent,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+)
+from dev_health_ops.providers.pagerduty.models import Incident, Service
+from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
+
+
+class PagerDutyWebhookStore(Protocol):
+    async def load_active_operational_entities(
+        self,
+        entity_type: type[CanonicalOperationalEntity],
+        *,
+        org_id: str,
+        provider: str,
+        provider_instance_id: str,
+        source_entity_type: str,
+    ) -> list[CanonicalOperationalEntity]: ...
+
+    async def insert_operational_services(
+        self, values: list[OperationalService]
+    ) -> None: ...
+
+    async def insert_operational_incidents(
+        self, values: list[OperationalIncident]
+    ) -> None: ...
+
+    async def insert_operational_alerts(
+        self, values: list[OperationalAlert]
+    ) -> None: ...
+
+    async def insert_operational_incident_timeline_events(
+        self, values: list[IncidentTimelineEvent]
+    ) -> None: ...
+
+    async def insert_operational_incident_notes(
+        self, values: list[IncidentNote]
+    ) -> None: ...
+
+
+class PagerDutyIncidentClient(Protocol):
+    async def get_incident(self, incident_id: str) -> Incident: ...
+
+
+TEntity = TypeVar("TEntity", bound=CanonicalOperationalEntity)
+
+
+def _payload_mapping(value: JsonValue | None) -> dict[str, JsonValue]:
+    return value if isinstance(value, dict) else {}
+
+
+def _incident_payload(webhook: PagerDutyV3Webhook) -> dict[str, JsonValue]:
+    nested = _payload_mapping(webhook.event.data.get("incident"))
+    return nested or webhook.event.data
+
+
+def _needs_incident_hydration(incident: Incident) -> bool:
+    return not incident.title or not incident.status or incident.created_at is None
+
+
+def _versioned(
+    entity: TEntity, *, occurred_at: datetime, received_at: datetime
+) -> TEntity:
+    return replace(
+        entity,
+        source_version_at=occurred_at,
+        observed_at=received_at,
+        last_synced=received_at,
+    )
+
+
+async def _is_newer(
+    store: PagerDutyWebhookStore, entity: CanonicalOperationalEntity
+) -> bool:
+    active = await store.load_active_operational_entities(
+        type(entity),
+        org_id=entity.org_id,
+        provider=entity.provider,
+        provider_instance_id=entity.provider_instance_id,
+        source_entity_type=entity.source_entity_type,
+    )
+    for current in active:
+        if current.external_id == entity.external_id:
+            return entity.source_version_at > current.source_version_at
+    return True
+
+
+async def _insert_if_newer(
+    store: PagerDutyWebhookStore, entity: CanonicalOperationalEntity
+) -> bool:
+    if not await _is_newer(store, entity):
+        return False
+    match entity:
+        case OperationalService():
+            await store.insert_operational_services([entity])
+        case OperationalIncident():
+            await store.insert_operational_incidents([entity])
+        case OperationalAlert():
+            await store.insert_operational_alerts([entity])
+        case IncidentTimelineEvent():
+            await store.insert_operational_incident_timeline_events([entity])
+        case IncidentNote():
+            await store.insert_operational_incident_notes([entity])
+        case unreachable:
+            raise TypeError(
+                f"Unsupported PagerDuty webhook entity: {type(unreachable)!r}"
+            )
+    return True
+
+
+async def _tombstone_service(
+    *,
+    store: PagerDutyWebhookStore,
+    service: OperationalService,
+) -> bool:
+    active = await store.load_active_operational_entities(
+        OperationalService,
+        org_id=service.org_id,
+        provider=service.provider,
+        provider_instance_id=service.provider_instance_id,
+        source_entity_type="service",
+    )
+    matching = next(
+        (row for row in active if row.external_id == service.external_id), None
+    )
+    match matching:
+        case OperationalService() if (
+            service.source_version_at <= matching.source_version_at
+        ):
+            return False
+        case OperationalService():
+            tombstone = replace(
+                matching,
+                source_version_at=service.source_version_at,
+                observed_at=service.observed_at,
+                last_synced=service.last_synced,
+                is_deleted=True,
+                deleted_at=service.source_version_at,
+            )
+        case None:
+            tombstone = replace(
+                service, is_deleted=True, deleted_at=service.source_version_at
+            )
+        case unexpected:
+            raise TypeError(f"Operational service lookup returned {type(unexpected)!r}")
+    await store.insert_operational_services([tombstone])
+    return True
+
+
+async def reconcile_pagerduty_webhook(
+    *,
+    webhook: PagerDutyV3Webhook,
+    org_id: str,
+    provider_instance_id: str,
+    received_at: datetime,
+    store: PagerDutyWebhookStore,
+    client: PagerDutyIncidentClient,
+) -> bool:
+    normalizer = PagerDutyNormalizer(org_id, provider_instance_id, received_at)
+    occurred_at = webhook.event.occurred_at
+    match webhook.event.event_type:
+        case (
+            PagerDutyEventType.SERVICE_CREATED
+            | PagerDutyEventType.SERVICE_UPDATED
+            | PagerDutyEventType.SERVICE_UPDATED_V3
+        ):
+            service_entity = _versioned(
+                normalizer.service(Service.model_validate(webhook.event.data)),
+                occurred_at=occurred_at,
+                received_at=received_at,
+            )
+            return await _insert_if_newer(store, service_entity)
+        case PagerDutyEventType.SERVICE_DELETED:
+            service_entity = _versioned(
+                normalizer.service(Service.model_validate(webhook.event.data)),
+                occurred_at=occurred_at,
+                received_at=received_at,
+            )
+            return await _tombstone_service(store=store, service=service_entity)
+        case (
+            PagerDutyEventType.INCIDENT_TRIGGERED
+            | PagerDutyEventType.INCIDENT_ACKNOWLEDGED
+            | PagerDutyEventType.INCIDENT_UNACKNOWLEDGED
+            | PagerDutyEventType.INCIDENT_ESCALATED
+            | PagerDutyEventType.INCIDENT_REASSIGNED
+            | PagerDutyEventType.INCIDENT_DELEGATED
+            | PagerDutyEventType.INCIDENT_PRIORITY_UPDATED
+            | PagerDutyEventType.INCIDENT_RESOLVED
+            | PagerDutyEventType.INCIDENT_REOPENED
+            | PagerDutyEventType.INCIDENT_ANNOTATED
+            | PagerDutyEventType.RESPONDER_ADDED
+            | PagerDutyEventType.RESPONDER_REPLIED
+            | PagerDutyEventType.STATUS_UPDATE_PUBLISHED
+        ):
+            incident = Incident.model_validate(_incident_payload(webhook))
+            if _needs_incident_hydration(incident):
+                incident = await client.get_incident(incident.id)
+            incident_entity = _versioned(
+                normalizer.incident(incident),
+                occurred_at=occurred_at,
+                received_at=received_at,
+            )
+            return await _insert_if_newer(store, incident_entity)
+        case unreachable:
+            raise AssertionError(f"Unhandled PagerDuty event type: {unreachable!r}")

--- a/src/dev_health_ops/providers/pagerduty/webhooks.py
+++ b/src/dev_health_ops/providers/pagerduty/webhooks.py
@@ -33,6 +33,7 @@ class PagerDutyWebhookStore(Protocol):
         provider: str,
         provider_instance_id: str,
         source_entity_type: str,
+        include_deleted: bool = False,
     ) -> list[CanonicalOperationalEntity]: ...
 
     async def insert_operational_services(
@@ -96,6 +97,7 @@ async def _is_newer(
         provider=entity.provider,
         provider_instance_id=entity.provider_instance_id,
         source_entity_type=entity.source_entity_type,
+        include_deleted=True,
     )
     for current in active:
         if current.external_id == entity.external_id:
@@ -137,6 +139,7 @@ async def _tombstone_service(
         provider=service.provider,
         provider_instance_id=service.provider_instance_id,
         source_entity_type="service",
+        include_deleted=True,
     )
     matching = next(
         (row for row in active if row.external_id == service.external_id), None

--- a/src/dev_health_ops/providers/pagerduty/webhooks.py
+++ b/src/dev_health_ops/providers/pagerduty/webhooks.py
@@ -15,12 +15,23 @@ from dev_health_ops.api.webhooks.pagerduty_models import (
 from dev_health_ops.models.operational import (
     CanonicalOperationalEntity,
     IncidentNote,
+    IncidentResponder,
     IncidentTimelineEvent,
     OperationalAlert,
     OperationalIncident,
     OperationalService,
+    OperationalTeam,
+    OperationalUser,
 )
-from dev_health_ops.providers.pagerduty.models import Incident, Service
+from dev_health_ops.models.operational_identity import operational_source_coordinates
+from dev_health_ops.providers.pagerduty.models import (
+    Incident,
+    LogEntry,
+    Note,
+    Service,
+    Team,
+    User,
+)
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
 
 
@@ -56,6 +67,14 @@ class PagerDutyWebhookStore(Protocol):
         self, values: list[IncidentNote]
     ) -> None: ...
 
+    async def insert_operational_incident_responders(
+        self, values: list[IncidentResponder]
+    ) -> None: ...
+
+    async def insert_operational_users(self, values: list[OperationalUser]) -> None: ...
+
+    async def insert_operational_teams(self, values: list[OperationalTeam]) -> None: ...
+
 
 class PagerDutyIncidentClient(Protocol):
     async def get_incident(self, incident_id: str) -> Incident: ...
@@ -78,11 +97,17 @@ def _needs_incident_hydration(incident: Incident) -> bool:
 
 
 def _versioned(
-    entity: TEntity, *, occurred_at: datetime, received_at: datetime
+    entity: TEntity,
+    *,
+    event_id: str,
+    occurred_at: datetime,
+    received_at: datetime,
 ) -> TEntity:
     return replace(
         entity,
         source_version_at=occurred_at,
+        source_event_at=occurred_at,
+        source_event_id=event_id,
         observed_at=received_at,
         last_synced=received_at,
     )
@@ -121,6 +146,12 @@ async def _insert_if_newer(
             await store.insert_operational_incident_timeline_events([entity])
         case IncidentNote():
             await store.insert_operational_incident_notes([entity])
+        case IncidentResponder():
+            await store.insert_operational_incident_responders([entity])
+        case OperationalUser():
+            await store.insert_operational_users([entity])
+        case OperationalTeam():
+            await store.insert_operational_teams([entity])
         case unreachable:
             raise TypeError(
                 f"Unsupported PagerDuty webhook entity: {type(unreachable)!r}"
@@ -187,6 +218,7 @@ async def reconcile_pagerduty_webhook(
         ):
             service_entity = _versioned(
                 normalizer.service(Service.model_validate(webhook.event.data)),
+                event_id=webhook.event.id,
                 occurred_at=occurred_at,
                 received_at=received_at,
             )
@@ -194,6 +226,7 @@ async def reconcile_pagerduty_webhook(
         case PagerDutyEventType.SERVICE_DELETED:
             service_entity = _versioned(
                 normalizer.service(Service.model_validate(webhook.event.data)),
+                event_id=webhook.event.id,
                 occurred_at=occurred_at,
                 received_at=received_at,
             )
@@ -218,9 +251,120 @@ async def reconcile_pagerduty_webhook(
                 incident = await client.get_incident(incident.id)
             incident_entity = _versioned(
                 normalizer.incident(incident),
+                event_id=webhook.event.id,
                 occurred_at=occurred_at,
                 received_at=received_at,
             )
-            return await _insert_if_newer(store, incident_entity)
+            entities: list[CanonicalOperationalEntity] = [incident_entity]
+            match webhook.event.event_type:
+                case PagerDutyEventType.INCIDENT_ANNOTATED:
+                    note_payload = _payload_mapping(webhook.event.data.get("note"))
+                    if note_payload:
+                        entities.append(
+                            _versioned(
+                                normalizer.note(
+                                    Note.model_validate(note_payload),
+                                    incident_entity.id,
+                                ),
+                                event_id=webhook.event.id,
+                                occurred_at=occurred_at,
+                                received_at=received_at,
+                            )
+                        )
+                case (
+                    PagerDutyEventType.RESPONDER_ADDED
+                    | PagerDutyEventType.RESPONDER_REPLIED
+                ):
+                    responder_payload = _payload_mapping(
+                        webhook.event.data.get("responder")
+                    )
+                    user_payload = _payload_mapping(responder_payload.get("user"))
+                    team_payload = _payload_mapping(responder_payload.get("team"))
+                    user_entity = (
+                        _versioned(
+                            normalizer.user(User.model_validate(user_payload)),
+                            event_id=webhook.event.id,
+                            occurred_at=occurred_at,
+                            received_at=received_at,
+                        )
+                        if user_payload
+                        else None
+                    )
+                    team_entity = (
+                        _versioned(
+                            normalizer.team(Team.model_validate(team_payload)),
+                            event_id=webhook.event.id,
+                            occurred_at=occurred_at,
+                            received_at=received_at,
+                        )
+                        if team_payload
+                        else None
+                    )
+                    if user_entity is not None:
+                        entities.append(user_entity)
+                    if team_entity is not None:
+                        entities.append(team_entity)
+                    if responder_payload:
+                        coordinates = operational_source_coordinates(
+                            IncidentResponder,
+                            provider="pagerduty",
+                            provider_instance_id=provider_instance_id,
+                            external_id=webhook.event.id,
+                        )
+                        entities.append(
+                            IncidentResponder(
+                                org_id=org_id,
+                                provider=coordinates.provider,
+                                provider_instance_id=coordinates.provider_instance_id,
+                                source_entity_type="responder",
+                                external_id=coordinates.external_id,
+                                source_version_at=occurred_at,
+                                source_event_at=occurred_at,
+                                source_event_id=webhook.event.id,
+                                observed_at=received_at,
+                                last_synced=received_at,
+                                incident_id=incident_entity.id,
+                                user_id=user_entity.id
+                                if user_entity is not None
+                                else None,
+                                responder_name=_string_value(responder_payload, "name"),
+                                role=_string_value(responder_payload, "role"),
+                                responder_assignment_id=_string_value(
+                                    responder_payload, "id"
+                                ),
+                                requested_at=occurred_at,
+                            )
+                        )
+                case PagerDutyEventType.STATUS_UPDATE_PUBLISHED:
+                    update_payload = _payload_mapping(
+                        webhook.event.data.get("status_update")
+                    )
+                    if update_payload:
+                        entities.append(
+                            replace(
+                                _versioned(
+                                    normalizer.log_entry(
+                                        LogEntry.model_validate(update_payload),
+                                        incident_entity.id,
+                                    ),
+                                    event_id=webhook.event.id,
+                                    occurred_at=occurred_at,
+                                    received_at=received_at,
+                                ),
+                                event_type=webhook.event.event_type.value,
+                                occurred_at=occurred_at,
+                            )
+                        )
+                case _:
+                    pass
+            inserted = False
+            for entity in entities:
+                inserted = await _insert_if_newer(store, entity) or inserted
+            return inserted
         case unreachable:
             raise AssertionError(f"Unhandled PagerDuty event type: {unreachable!r}")
+
+
+def _string_value(payload: dict[str, JsonValue], key: str) -> str | None:
+    value = payload.get(key)
+    return value if isinstance(value, str) else None

--- a/src/dev_health_ops/providers/pagerduty/webhooks.py
+++ b/src/dev_health_ops/providers/pagerduty/webhooks.py
@@ -29,7 +29,6 @@ from dev_health_ops.providers.pagerduty.models import (
     LogEntry,
     Note,
     Service,
-    Team,
     User,
 )
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
@@ -211,11 +210,7 @@ async def reconcile_pagerduty_webhook(
     normalizer = PagerDutyNormalizer(org_id, provider_instance_id, received_at)
     occurred_at = webhook.event.occurred_at
     match webhook.event.event_type:
-        case (
-            PagerDutyEventType.SERVICE_CREATED
-            | PagerDutyEventType.SERVICE_UPDATED
-            | PagerDutyEventType.SERVICE_UPDATED_V3
-        ):
+        case PagerDutyEventType.SERVICE_CREATED | PagerDutyEventType.SERVICE_UPDATED_V3:
             service_entity = _versioned(
                 normalizer.service(Service.model_validate(webhook.event.data)),
                 event_id=webhook.event.id,
@@ -245,6 +240,7 @@ async def reconcile_pagerduty_webhook(
             | PagerDutyEventType.RESPONDER_ADDED
             | PagerDutyEventType.RESPONDER_REPLIED
             | PagerDutyEventType.STATUS_UPDATE_PUBLISHED
+            | PagerDutyEventType.SERVICE_UPDATED
         ):
             incident = Incident.model_validate(_incident_payload(webhook))
             if _needs_incident_hydration(incident):
@@ -258,7 +254,7 @@ async def reconcile_pagerduty_webhook(
             entities: list[CanonicalOperationalEntity] = [incident_entity]
             match webhook.event.event_type:
                 case PagerDutyEventType.INCIDENT_ANNOTATED:
-                    note_payload = _payload_mapping(webhook.event.data.get("note"))
+                    note_payload = webhook.event.data
                     if note_payload:
                         entities.append(
                             _versioned(
@@ -275,11 +271,8 @@ async def reconcile_pagerduty_webhook(
                     PagerDutyEventType.RESPONDER_ADDED
                     | PagerDutyEventType.RESPONDER_REPLIED
                 ):
-                    responder_payload = _payload_mapping(
-                        webhook.event.data.get("responder")
-                    )
+                    responder_payload = webhook.event.data
                     user_payload = _payload_mapping(responder_payload.get("user"))
-                    team_payload = _payload_mapping(responder_payload.get("team"))
                     user_entity = (
                         _versioned(
                             normalizer.user(User.model_validate(user_payload)),
@@ -290,20 +283,8 @@ async def reconcile_pagerduty_webhook(
                         if user_payload
                         else None
                     )
-                    team_entity = (
-                        _versioned(
-                            normalizer.team(Team.model_validate(team_payload)),
-                            event_id=webhook.event.id,
-                            occurred_at=occurred_at,
-                            received_at=received_at,
-                        )
-                        if team_payload
-                        else None
-                    )
                     if user_entity is not None:
                         entities.append(user_entity)
-                    if team_entity is not None:
-                        entities.append(team_entity)
                     if responder_payload:
                         coordinates = operational_source_coordinates(
                             IncidentResponder,
@@ -336,9 +317,7 @@ async def reconcile_pagerduty_webhook(
                             )
                         )
                 case PagerDutyEventType.STATUS_UPDATE_PUBLISHED:
-                    update_payload = _payload_mapping(
-                        webhook.event.data.get("status_update")
-                    )
+                    update_payload = webhook.event.data
                     if update_payload:
                         entities.append(
                             replace(

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -356,6 +356,30 @@ class ClickHouseStore:
                 )
         return repos
 
+    async def load_repository_catalog(
+        self, org_id: str
+    ) -> list[tuple[uuid.UUID, str, str]]:
+        """Load org-scoped (repo_id, provider, full_name) rows for correlation."""
+        assert self.client is not None
+        query = (
+            "SELECT id, provider, repo FROM repos FINAL WHERE org_id = {org_id:String}"
+        )
+        async with self._lock:
+            result = await asyncio.to_thread(
+                self.client.query, query, parameters={"org_id": org_id}
+            )
+        catalog: list[tuple[uuid.UUID, str, str]] = []
+        for row in getattr(result, "result_rows", None) or []:
+            repository_id, provider, repo = row[0], row[1], row[2]
+            if not isinstance(provider, str) or not isinstance(repo, str):
+                continue
+            try:
+                normalized_id = self._normalize_uuid(repository_id)
+            except ValueError:
+                continue
+            catalog.append((normalized_id, provider, repo))
+        return catalog
+
     async def get_complexity_snapshots(
         self,
         *,

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -1179,6 +1179,7 @@ class ClickHouseStore:
                         "release_ref_confidence": float(
                             item.get("release_ref_confidence") or 0.0
                         ),
+                        "org_id": str(item.get("org_id") or self.org_id or ""),
                         "last_synced": self._normalize_datetime(
                             item.get("last_synced") or synced_at_default
                         ),
@@ -1210,6 +1211,9 @@ class ClickHouseStore:
                         "release_ref_confidence": float(
                             getattr(item, "release_ref_confidence", 0.0) or 0.0
                         ),
+                        "org_id": str(
+                            getattr(item, "org_id", None) or self.org_id or ""
+                        ),
                         "last_synced": self._normalize_datetime(
                             getattr(item, "last_synced", None) or synced_at_default
                         ),
@@ -1230,6 +1234,7 @@ class ClickHouseStore:
                 "pull_request_number",
                 "release_ref",
                 "release_ref_confidence",
+                "org_id",
                 "last_synced",
             ],
             rows,

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -37,6 +37,7 @@ from dev_health_ops.models.operational import (
     CanonicalOperationalEntity,
     OperationalContractError,
     OperationalIncident,
+    ServiceRepositoryMapping,
     operational_columns,
 )
 from dev_health_ops.models.work_items import (
@@ -2431,6 +2432,42 @@ class ClickHouseStore:
         await self._insert_operational_rows(
             "operational_service_repository_mappings", mappings
         )
+
+    async def load_operational_service_repository_mappings(
+        self,
+        org_id: str,
+        *,
+        service_id: str | None = None,
+        repo_id: uuid.UUID | None = None,
+    ) -> list[ServiceRepositoryMapping]:
+        """Load active mapping evidence scoped to an organization and optional endpoint."""
+        assert self.client is not None
+        columns = operational_columns(ServiceRepositoryMapping)
+        predicates = ["org_id = {org_id:String}", "is_active = 1"]
+        parameters: dict[str, str] = {"org_id": org_id}
+        if service_id is not None:
+            predicates.append("service_id = {service_id:String}")
+            parameters["service_id"] = service_id
+        if repo_id is not None:
+            predicates.append("repo_id = {repo_id:UUID}")
+            parameters["repo_id"] = str(repo_id)
+        query = f"""
+        SELECT {", ".join(columns)}
+        FROM operational_service_repository_mappings FINAL
+        WHERE {" AND ".join(predicates)}
+        """
+        async with self._lock:
+            result = await asyncio.to_thread(
+                self.client.query,
+                query,
+                parameters=parameters,
+            )
+        mappings: list[ServiceRepositoryMapping] = []
+        for row in result.result_rows or []:
+            values = dict(zip(columns, row, strict=True))
+            values.pop("id")
+            mappings.append(ServiceRepositoryMapping(**values))
+        return mappings
 
     async def load_operational_incidents(
         self,

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -2345,6 +2345,7 @@ class ClickHouseStore:
         provider: str,
         provider_instance_id: str,
         source_entity_type: str,
+        include_deleted: bool = False,
     ) -> list[T]:
         assert self.client is not None
         columns = operational_columns(entity_type)
@@ -2356,7 +2357,7 @@ class ClickHouseStore:
           AND provider = {{provider:String}}
           AND provider_instance_id = {{provider_instance_id:String}}
           AND source_entity_type = {{source_entity_type:String}}
-          AND is_deleted = 0
+          {"" if include_deleted else "AND is_deleted = 0"}
         """
         parameters = {
             "org_id": org_id,

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -2380,6 +2380,17 @@ class ClickHouseStore:
         assert self.client is not None
         columns = operational_columns(entity_type)
         table = OPERATIONAL_ENTITY_TABLES[entity_type]
+        # Entities carry either is_deleted (services/incidents/...) or is_active
+        # (service->repo mappings); pick the column the table actually has so the
+        # generated SQL never references a non-existent column.
+        if include_deleted:
+            active_filter = ""
+        elif "is_deleted" in columns:
+            active_filter = "AND is_deleted = 0"
+        elif "is_active" in columns:
+            active_filter = "AND is_active = 1"
+        else:
+            active_filter = ""
         query = f"""
         SELECT {", ".join(columns)}
         FROM {table} FINAL
@@ -2387,7 +2398,7 @@ class ClickHouseStore:
           AND provider = {{provider:String}}
           AND provider_instance_id = {{provider_instance_id:String}}
           AND source_entity_type = {{source_entity_type:String}}
-          {"" if include_deleted else "AND is_deleted = 0"}
+          {active_filter}
         """
         parameters = {
             "org_id": org_id,

--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -459,16 +459,7 @@ class WorkGraphBuilder:
         #    source of flag associations; registry-validated + confidence-gated.
         stats["flag_guards_edges"] = self._build_flag_guards_edges()
 
-        if self.config.org_id:
-            stats["operational_incident_edges"] = self._write_edges(
-                build_operational_incident_edges(
-                    self.sink,
-                    self.config.org_id,
-                    self._now,
-                    self.config.heuristic_days_window,
-                    self.config.heuristic_confidence,
-                )
-            )
+        stats["operational_incident_edges"] = self._build_operational_incident_edges()
 
         logger.info(
             "Work graph build complete: %s",
@@ -476,6 +467,22 @@ class WorkGraphBuilder:
         )
 
         return stats
+
+    def _build_operational_incident_edges(self) -> int:
+        if not self.config.org_id:
+            return 0
+        return self._write_edges(
+            build_operational_incident_edges(
+                self.sink,
+                self.config.org_id,
+                self._now,
+                self.config.heuristic_days_window,
+                self.config.heuristic_confidence,
+                self.config.from_date,
+                self.config.to_date,
+                self.config.repo_id,
+            )
+        )
 
     def _build_flag_guards_edges(self) -> int:
         """Build GUARDS edges (feature_flag -> issue) from real flag-key text refs.

--- a/src/dev_health_ops/work_graph/builder.py
+++ b/src/dev_health_ops/work_graph/builder.py
@@ -48,6 +48,7 @@ from dev_health_ops.work_graph.models import (
     WorkGraphIssuePR,
     WorkGraphPRCommit,
 )
+from dev_health_ops.work_graph.operational_edges import build_operational_incident_edges
 
 logger = logging.getLogger(__name__)
 
@@ -412,6 +413,7 @@ class WorkGraphBuilder:
             "commit_file_edges": 0,
             "heuristic_edges": 0,
             "flag_guards_edges": 0,
+            "operational_incident_edges": 0,
         }
 
         logger.info("Starting work graph build...")
@@ -456,6 +458,17 @@ class WorkGraphBuilder:
         #    references in issue text. CHAOS-2630 Phase C1: the only non-fixture
         #    source of flag associations; registry-validated + confidence-gated.
         stats["flag_guards_edges"] = self._build_flag_guards_edges()
+
+        if self.config.org_id:
+            stats["operational_incident_edges"] = self._write_edges(
+                build_operational_incident_edges(
+                    self.sink,
+                    self.config.org_id,
+                    self._now,
+                    self.config.heuristic_days_window,
+                    self.config.heuristic_confidence,
+                )
+            )
 
         logger.info(
             "Work graph build complete: %s",

--- a/src/dev_health_ops/work_graph/models.py
+++ b/src/dev_health_ops/work_graph/models.py
@@ -24,6 +24,14 @@ class NodeType(str, Enum):
     REVIEW_OUTCOME = "review_outcome"
     DEPLOYMENT = "deployment"
     INCIDENT = "incident"
+    OPERATIONAL_SERVICE = "operational_service"
+    OPERATIONAL_ALERT = "operational_alert"
+    INCIDENT_TIMELINE_EVENT = "incident_timeline_event"
+    INCIDENT_RESPONDER = "incident_responder"
+    ESCALATION_POLICY = "escalation_policy"
+    REPOSITORY = "repository"
+    USER = "user"
+    TEAM = "team"
 
 
 class EdgeType(str, Enum):
@@ -66,6 +74,14 @@ class EdgeType(str, Enum):
     HAS_REVIEW_OUTCOME = "has_review_outcome"  # PR → review outcome
     DEPLOYS = "deploys"  # PR → deployment
     LINKED_INCIDENT = "linked_incident"  # deployment → incident
+    MAPS_TO_REPOSITORY = "maps_to_repository"
+    HAS_INCIDENT = "has_incident"
+    HAS_ALERT = "has_alert"
+    HAS_TIMELINE_EVENT = "has_timeline_event"
+    HAS_RESPONDER = "has_responder"
+    ASSIGNED_TO = "assigned_to"
+    ESCALATES_WITH = "escalates_with"
+    REMEDIATED_BY = "remediated_by"
 
 
 class Provenance(str, Enum):

--- a/src/dev_health_ops/work_graph/operational_edges.py
+++ b/src/dev_health_ops/work_graph/operational_edges.py
@@ -308,19 +308,21 @@ def build_operational_incident_edges(
                     )
                 )
         for owner, repo, number in _GITHUB_PR_URL.findall(body):
-            repo_id = repo_ids.get(f"{owner}/{repo}")
-            if repo_id is not None:
+            pr_repo_id = repo_ids.get(f"{owner}/{repo}")
+            # A repo-scoped build must not emit PR edges for another of the
+            # org's repos that a note/timeline body happens to reference.
+            if pr_repo_id is not None and (repo_id is None or pr_repo_id == repo_id):
                 edges.append(
                     _edge(
                         NodeType.INCIDENT,
                         incident_id,
                         EdgeType.REFERENCES,
                         NodeType.PR,
-                        generate_pr_id(repo_id, int(number)),
+                        generate_pr_id(pr_repo_id, int(number)),
                         Provenance.EXPLICIT_TEXT,
                         0.9,
                         f"incident_evidence:https://github.com/{owner}/{repo}/pull/{number}",
-                        repo_id,
+                        pr_repo_id,
                         event_at,
                     )
                 )

--- a/src/dev_health_ops/work_graph/operational_edges.py
+++ b/src/dev_health_ops/work_graph/operational_edges.py
@@ -1,0 +1,366 @@
+"""Canonical operational incident evidence edges."""
+
+from __future__ import annotations
+
+import re
+import uuid
+from datetime import datetime, timedelta
+
+from dev_health_ops.work_graph.ids import generate_edge_id, generate_pr_id
+from dev_health_ops.work_graph.models import (
+    EdgeType,
+    NodeType,
+    Provenance,
+    WorkGraphEdge,
+)
+
+_JIRA_KEY = re.compile(r"\b([A-Z][A-Z0-9]+-\d+)\b")
+_GITHUB_PR_URL = re.compile(r"github\.com/([^/]+)/([^/]+)/pull/(\d+)")
+
+
+def build_operational_incident_edges(
+    sink: object,
+    org_id: str,
+    now: datetime,
+    heuristic_days_window: int,
+    heuristic_confidence: float,
+) -> list[WorkGraphEdge]:
+    """Build canonical operational edges with source evidence on every link."""
+    query_dicts = getattr(sink, "query_dicts")
+    params = {"org_id": org_id}
+    mappings = query_dicts(
+        "SELECT service_id, repo_id, relationship_provenance, relationship_confidence, "
+        "mapping_kind, rule_id, source_url FROM operational_service_repository_mappings FINAL "
+        "WHERE org_id = {org_id:String} AND is_active = 1",
+        params,
+    )
+    incidents = query_dicts(
+        "SELECT id, service_id, escalation_policy_id, started_at, source_url FROM operational_incidents FINAL "
+        "WHERE org_id = {org_id:String} AND is_deleted = 0",
+        params,
+    )
+    services = query_dicts(
+        "SELECT id, owning_team_id, escalation_policy_id FROM operational_services FINAL "
+        "WHERE org_id = {org_id:String} AND is_deleted = 0",
+        params,
+    )
+    alerts = query_dicts(
+        "SELECT id, incident_id, source_url, triggered_at FROM operational_alerts FINAL "
+        "WHERE org_id = {org_id:String} AND is_deleted = 0",
+        params,
+    )
+    timeline = query_dicts(
+        "SELECT id, incident_id, actor_id, body, source_url, occurred_at FROM operational_incident_timeline_events FINAL "
+        "WHERE org_id = {org_id:String}",
+        params,
+    )
+    notes = query_dicts(
+        "SELECT id, incident_id, body, author_user_id, source_url, created_at FROM operational_incident_notes FINAL "
+        "WHERE org_id = {org_id:String}",
+        params,
+    )
+    responders = query_dicts(
+        "SELECT id, incident_id, user_id, source_url, assigned_at FROM operational_incident_responders FINAL "
+        "WHERE org_id = {org_id:String}",
+        params,
+    )
+    work_items = query_dicts(
+        "SELECT work_item_id FROM work_items FINAL WHERE org_id = {org_id:String}",
+        params,
+    )
+    repos = query_dicts(
+        "SELECT id, repo FROM repos FINAL WHERE org_id = {org_id:String}", params
+    )
+    deployments = query_dicts(
+        "SELECT repo_id, deployment_id, environment, deployed_at FROM deployments FINAL "
+        "WHERE org_id = {org_id:String}",
+        params,
+    )
+
+    edges: list[WorkGraphEdge] = []
+    service_repos: dict[str, list[uuid.UUID]] = {}
+    for row in mappings:
+        repo_id = row.get("repo_id")
+        service_id = str(row.get("service_id") or "")
+        if not repo_id or not service_id:
+            continue
+        repo_uuid = uuid.UUID(str(repo_id))
+        service_repos.setdefault(service_id, []).append(repo_uuid)
+        confidence = float(row.get("relationship_confidence") or 0.0)
+        evidence = ":".join(
+            str(row.get(key) or "")
+            for key in (
+                "relationship_provenance",
+                "mapping_kind",
+                "rule_id",
+                "source_url",
+            )
+        )
+        edges.append(
+            _edge(
+                NodeType.OPERATIONAL_SERVICE,
+                service_id,
+                EdgeType.MAPS_TO_REPOSITORY,
+                NodeType.REPOSITORY,
+                str(repo_uuid),
+                Provenance.NATIVE,
+                confidence,
+                evidence,
+                repo_uuid,
+                now,
+            )
+        )
+
+    service_teams = {
+        str(row.get("id")): str(row.get("owning_team_id"))
+        for row in services
+        if row.get("owning_team_id")
+    }
+    service_policies = {
+        str(row.get("id")): str(row.get("escalation_policy_id"))
+        for row in services
+        if row.get("escalation_policy_id")
+    }
+    incident_by_id = {str(row.get("id")): row for row in incidents}
+    for incident_id, row in incident_by_id.items():
+        service_id = str(row.get("service_id") or "")
+        event_at = row.get("started_at") or now
+        if service_id:
+            edges.append(
+                _edge(
+                    NodeType.OPERATIONAL_SERVICE,
+                    service_id,
+                    EdgeType.HAS_INCIDENT,
+                    NodeType.INCIDENT,
+                    incident_id,
+                    Provenance.NATIVE,
+                    1.0,
+                    str(row.get("source_url") or "operational_incident.service_id"),
+                    None,
+                    event_at,
+                )
+            )
+        policy_id = str(
+            row.get("escalation_policy_id") or service_policies.get(service_id) or ""
+        )
+        if policy_id:
+            edges.append(
+                _edge(
+                    NodeType.INCIDENT,
+                    incident_id,
+                    EdgeType.ESCALATES_WITH,
+                    NodeType.ESCALATION_POLICY,
+                    policy_id,
+                    Provenance.NATIVE,
+                    1.0,
+                    "operational_incident.escalation_policy_id",
+                    None,
+                    event_at,
+                )
+            )
+        team_id = service_teams.get(service_id)
+        if team_id:
+            edges.append(
+                _edge(
+                    NodeType.INCIDENT,
+                    incident_id,
+                    EdgeType.ASSIGNED_TO,
+                    NodeType.TEAM,
+                    team_id,
+                    Provenance.NATIVE,
+                    1.0,
+                    "operational_service.owning_team_id",
+                    None,
+                    event_at,
+                )
+            )
+        for repo_id in service_repos.get(service_id, []):
+            for deployment in deployments:
+                if str(deployment.get("repo_id")) != str(repo_id):
+                    continue
+                deployed_at = deployment.get("deployed_at")
+                if not isinstance(deployed_at, datetime) or not isinstance(
+                    event_at, datetime
+                ):
+                    continue
+                if abs(deployed_at - event_at) > timedelta(days=heuristic_days_window):
+                    continue
+                evidence = f"rule:operational_service_mapped_deployment_window.v1;environment:{deployment.get('environment') or 'unspecified'}"
+                edges.append(
+                    _edge(
+                        NodeType.DEPLOYMENT,
+                        str(deployment.get("deployment_id")),
+                        EdgeType.LINKED_INCIDENT,
+                        NodeType.INCIDENT,
+                        incident_id,
+                        Provenance.HEURISTIC,
+                        heuristic_confidence,
+                        evidence,
+                        repo_id,
+                        deployed_at,
+                    )
+                )
+
+    for row in alerts:
+        _append_direct(
+            edges,
+            row,
+            "incident_id",
+            NodeType.OPERATIONAL_ALERT,
+            EdgeType.HAS_ALERT,
+            now,
+        )
+    for row in timeline:
+        _append_direct(
+            edges,
+            row,
+            "incident_id",
+            NodeType.INCIDENT_TIMELINE_EVENT,
+            EdgeType.HAS_TIMELINE_EVENT,
+            now,
+        )
+        _append_user(edges, row, "actor_id", now)
+    for row in responders:
+        _append_direct(
+            edges,
+            row,
+            "incident_id",
+            NodeType.INCIDENT_RESPONDER,
+            EdgeType.HAS_RESPONDER,
+            now,
+        )
+        _append_user(edges, row, "user_id", now)
+    known_work_items = {str(row.get("work_item_id")) for row in work_items}
+    repo_ids = {
+        str(row.get("repo")): uuid.UUID(str(row.get("id")))
+        for row in repos
+        if row.get("id")
+    }
+    for row in [*timeline, *notes]:
+        incident_id = str(row.get("incident_id") or "")
+        body = str(row.get("body") or "")
+        event_at = row.get("occurred_at") or row.get("created_at") or now
+        for key in _JIRA_KEY.findall(body):
+            work_item_id = f"jira:{key}"
+            if work_item_id in known_work_items:
+                edge_type = (
+                    EdgeType.REMEDIATED_BY
+                    if "remediat" in body.casefold()
+                    else EdgeType.REFERENCES
+                )
+                edges.append(
+                    _edge(
+                        NodeType.INCIDENT,
+                        incident_id,
+                        edge_type,
+                        NodeType.ISSUE,
+                        work_item_id,
+                        Provenance.EXPLICIT_TEXT,
+                        0.9,
+                        f"incident_evidence:{key}",
+                        None,
+                        event_at,
+                    )
+                )
+        for owner, repo, number in _GITHUB_PR_URL.findall(body):
+            repo_id = repo_ids.get(f"{owner}/{repo}")
+            if repo_id is not None:
+                edges.append(
+                    _edge(
+                        NodeType.INCIDENT,
+                        incident_id,
+                        EdgeType.REFERENCES,
+                        NodeType.PR,
+                        generate_pr_id(repo_id, int(number)),
+                        Provenance.EXPLICIT_TEXT,
+                        0.9,
+                        f"incident_evidence:https://github.com/{owner}/{repo}/pull/{number}",
+                        repo_id,
+                        event_at,
+                    )
+                )
+    return edges
+
+
+def _append_direct(
+    edges: list[WorkGraphEdge],
+    row: dict[str, object],
+    incident_key: str,
+    target_type: NodeType,
+    edge_type: EdgeType,
+    now: datetime,
+) -> None:
+    incident_id, target_id = str(row.get(incident_key) or ""), str(row.get("id") or "")
+    if incident_id and target_id:
+        candidate = (
+            row.get("occurred_at") or row.get("triggered_at") or row.get("assigned_at")
+        )
+        event_ts = candidate if isinstance(candidate, datetime) else now
+        edges.append(
+            _edge(
+                NodeType.INCIDENT,
+                incident_id,
+                edge_type,
+                target_type,
+                target_id,
+                Provenance.NATIVE,
+                1.0,
+                str(row.get("source_url") or edge_type.value),
+                None,
+                event_ts,
+            )
+        )
+
+
+def _append_user(
+    edges: list[WorkGraphEdge], row: dict[str, object], user_key: str, now: datetime
+) -> None:
+    incident_id, user_id = (
+        str(row.get("incident_id") or ""),
+        str(row.get(user_key) or ""),
+    )
+    if incident_id and user_id:
+        candidate = row.get("occurred_at") or row.get("assigned_at")
+        event_ts = candidate if isinstance(candidate, datetime) else now
+        edges.append(
+            _edge(
+                NodeType.INCIDENT,
+                incident_id,
+                EdgeType.ASSIGNED_TO,
+                NodeType.USER,
+                user_id,
+                Provenance.NATIVE,
+                1.0,
+                str(row.get("source_url") or user_key),
+                None,
+                event_ts,
+            )
+        )
+
+
+def _edge(
+    source_type: NodeType,
+    source_id: str,
+    edge_type: EdgeType,
+    target_type: NodeType,
+    target_id: str,
+    provenance: Provenance,
+    confidence: float,
+    evidence: str,
+    repo_id: uuid.UUID | None,
+    event_ts: datetime,
+) -> WorkGraphEdge:
+    return WorkGraphEdge(
+        generate_edge_id(source_type, source_id, edge_type, target_type, target_id),
+        source_type,
+        source_id,
+        target_type,
+        target_id,
+        edge_type,
+        provenance,
+        confidence,
+        evidence,
+        repo_id=repo_id,
+        provider="pagerduty",
+        event_ts=event_ts,
+    )

--- a/src/dev_health_ops/work_graph/operational_edges.py
+++ b/src/dev_health_ops/work_graph/operational_edges.py
@@ -24,19 +24,35 @@ def build_operational_incident_edges(
     now: datetime,
     heuristic_days_window: int,
     heuristic_confidence: float,
+    from_date: datetime | None = None,
+    to_date: datetime | None = None,
+    repo_id: uuid.UUID | None = None,
 ) -> list[WorkGraphEdge]:
     """Build canonical operational edges with source evidence on every link."""
     query_dicts = getattr(sink, "query_dicts")
-    params = {"org_id": org_id}
+    params = {
+        "org_id": org_id,
+        "now": now,
+        "from_date": from_date,
+        "to_date": to_date,
+        "repo_id": repo_id,
+    }
+    repository_scope = " AND repo_id = {repo_id:UUID}" if repo_id else ""
+    incident_window = _timestamp_window("started_at", from_date, to_date)
+    deployment_window = _timestamp_window("deployed_at", from_date, to_date)
     mappings = query_dicts(
-        "SELECT service_id, repo_id, relationship_provenance, relationship_confidence, "
+        "SELECT service_id, repo_id, provider, relationship_provenance, relationship_confidence, "
         "mapping_kind, rule_id, source_url FROM operational_service_repository_mappings FINAL "
-        "WHERE org_id = {org_id:String} AND is_active = 1",
+        "WHERE org_id = {org_id:String} AND is_active = 1 "
+        "AND valid_from <= {now:DateTime} "
+        "AND (valid_to IS NULL OR valid_to > {now:DateTime})"
+        f"{repository_scope}",
         params,
     )
     incidents = query_dicts(
         "SELECT id, service_id, escalation_policy_id, started_at, source_url FROM operational_incidents FINAL "
-        "WHERE org_id = {org_id:String} AND is_deleted = 0",
+        "WHERE org_id = {org_id:String} AND is_deleted = 0"
+        f"{incident_window}",
         params,
     )
     services = query_dicts(
@@ -73,20 +89,28 @@ def build_operational_incident_edges(
     )
     deployments = query_dicts(
         "SELECT repo_id, deployment_id, environment, deployed_at FROM deployments FINAL "
-        "WHERE org_id = {org_id:String}",
+        "WHERE org_id = {org_id:String}"
+        f"{repository_scope}{deployment_window}",
         params,
     )
 
     edges: list[WorkGraphEdge] = []
-    service_repos: dict[str, list[uuid.UUID]] = {}
+    preferred_mappings: dict[tuple[str, uuid.UUID], dict[str, object]] = {}
     for row in mappings:
-        repo_id = row.get("repo_id")
+        mapping_repo_id = row.get("repo_id")
         service_id = str(row.get("service_id") or "")
-        if not repo_id or not service_id:
+        if not mapping_repo_id or not service_id:
             continue
-        repo_uuid = uuid.UUID(str(repo_id))
+        repo_uuid = uuid.UUID(str(mapping_repo_id))
+        key = (service_id, repo_uuid)
+        current = preferred_mappings.get(key)
+        if current is None or _mapping_confidence(row) > _mapping_confidence(current):
+            preferred_mappings[key] = row
+
+    service_repos: dict[str, list[uuid.UUID]] = {}
+    for (service_id, repo_uuid), row in preferred_mappings.items():
         service_repos.setdefault(service_id, []).append(repo_uuid)
-        confidence = float(row.get("relationship_confidence") or 0.0)
+        confidence = _mapping_confidence(row)
         evidence = ":".join(
             str(row.get(key) or "")
             for key in (
@@ -103,11 +127,12 @@ def build_operational_incident_edges(
                 EdgeType.MAPS_TO_REPOSITORY,
                 NodeType.REPOSITORY,
                 str(repo_uuid),
-                Provenance.NATIVE,
+                _mapping_provenance(str(row.get("relationship_provenance") or "")),
                 confidence,
                 evidence,
                 repo_uuid,
                 now,
+                provider=str(row.get("provider") or "pagerduty"),
             )
         )
 
@@ -121,7 +146,11 @@ def build_operational_incident_edges(
         for row in services
         if row.get("escalation_policy_id")
     }
-    incident_by_id = {str(row.get("id")): row for row in incidents}
+    incident_by_id = {
+        str(row.get("id")): row
+        for row in incidents
+        if repo_id is None or str(row.get("service_id") or "") in service_repos
+    }
     for incident_id, row in incident_by_id.items():
         service_id = str(row.get("service_id") or "")
         event_at = row.get("started_at") or now
@@ -174,18 +203,26 @@ def build_operational_incident_edges(
                     event_at,
                 )
             )
-        for repo_id in service_repos.get(service_id, []):
+        for mapped_repo_id in service_repos.get(service_id, []):
             for deployment in deployments:
-                if str(deployment.get("repo_id")) != str(repo_id):
+                if str(deployment.get("repo_id")) != str(mapped_repo_id):
                     continue
                 deployed_at = deployment.get("deployed_at")
-                if not isinstance(deployed_at, datetime) or not isinstance(
-                    event_at, datetime
+                incident_started_at = row.get("started_at")
+                environment = str(deployment.get("environment") or "").casefold()
+                if (
+                    not isinstance(deployed_at, datetime)
+                    or not isinstance(incident_started_at, datetime)
+                    or environment in {"", "unknown", "unspecified"}
                 ):
                     continue
-                if abs(deployed_at - event_at) > timedelta(days=heuristic_days_window):
+                if (
+                    deployed_at > incident_started_at
+                    or incident_started_at - deployed_at
+                    > timedelta(days=heuristic_days_window)
+                ):
                     continue
-                evidence = f"rule:operational_service_mapped_deployment_window.v1;environment:{deployment.get('environment') or 'unspecified'}"
+                evidence = f"rule:operational_service_mapped_deployment_window.v1;environment:{environment}"
                 edges.append(
                     _edge(
                         NodeType.DEPLOYMENT,
@@ -196,12 +233,14 @@ def build_operational_incident_edges(
                         Provenance.HEURISTIC,
                         heuristic_confidence,
                         evidence,
-                        repo_id,
+                        mapped_repo_id,
                         deployed_at,
                     )
                 )
 
     for row in alerts:
+        if str(row.get("incident_id") or "") not in incident_by_id:
+            continue
         _append_direct(
             edges,
             row,
@@ -211,6 +250,8 @@ def build_operational_incident_edges(
             now,
         )
     for row in timeline:
+        if str(row.get("incident_id") or "") not in incident_by_id:
+            continue
         _append_direct(
             edges,
             row,
@@ -221,6 +262,8 @@ def build_operational_incident_edges(
         )
         _append_user(edges, row, "actor_id", now)
     for row in responders:
+        if str(row.get("incident_id") or "") not in incident_by_id:
+            continue
         _append_direct(
             edges,
             row,
@@ -238,6 +281,8 @@ def build_operational_incident_edges(
     }
     for row in [*timeline, *notes]:
         incident_id = str(row.get("incident_id") or "")
+        if incident_id not in incident_by_id:
+            continue
         body = str(row.get("body") or "")
         event_at = row.get("occurred_at") or row.get("created_at") or now
         for key in _JIRA_KEY.findall(body):
@@ -349,6 +394,7 @@ def _edge(
     evidence: str,
     repo_id: uuid.UUID | None,
     event_ts: datetime,
+    provider: str = "pagerduty",
 ) -> WorkGraphEdge:
     return WorkGraphEdge(
         generate_edge_id(source_type, source_id, edge_type, target_type, target_id),
@@ -361,6 +407,30 @@ def _edge(
         confidence,
         evidence,
         repo_id=repo_id,
-        provider="pagerduty",
+        provider=provider,
         event_ts=event_ts,
+    )
+
+
+def _timestamp_window(
+    column: str, from_date: datetime | None, to_date: datetime | None
+) -> str:
+    clauses: list[str] = []
+    if from_date is not None:
+        clauses.append(f" AND {column} >= {{from_date:DateTime}}")
+    if to_date is not None:
+        clauses.append(f" AND {column} <= {{to_date:DateTime}}")
+    return "".join(clauses)
+
+
+def _mapping_confidence(row: dict[str, object]) -> float:
+    value = row.get("relationship_confidence")
+    return float(value) if isinstance(value, int | float | str) else 0.0
+
+
+def _mapping_provenance(source: str) -> Provenance:
+    return (
+        Provenance.HEURISTIC
+        if source == "bounded_service_repository_heuristic"
+        else Provenance.NATIVE
     )

--- a/src/dev_health_ops/workers/system_webhooks.py
+++ b/src/dev_health_ops/workers/system_webhooks.py
@@ -4,6 +4,7 @@ import logging
 import math
 import os
 from datetime import datetime, timezone
+from typing import NoReturn
 
 from dev_health_ops.exceptions import RateLimitException
 from dev_health_ops.utils.datetime import utc_today
@@ -18,6 +19,7 @@ logger = logging.getLogger(__name__)
 # can't park a webhook retry for an unreasonable span; real rate limits clear
 # well within an hour.
 _MAX_RETRY_COUNTDOWN_SECONDS = 3600
+_PAGERDUTY_WEBHOOK_DLQ_MAXLEN = 100_000
 
 
 @celery_app.task(
@@ -191,10 +193,6 @@ def process_pagerduty_webhook_event(
     from dev_health_ops.providers.pagerduty.webhooks import reconcile_pagerduty_webhook
     from dev_health_ops.storage import run_with_store
 
-    token = os.getenv("PAGERDUTY_API_TOKEN")
-    clickhouse_url = os.getenv("CLICKHOUSE_URI")
-    if not token or not clickhouse_url:
-        return {"processed": False, "reason": "pagerduty_webhook_unconfigured"}
     redis_client = get_redis_client()
     stream_name = f"pagerduty-webhooks:{org_id}:{provider_instance_id}"
     if redis_client is None:
@@ -209,6 +207,17 @@ def process_pagerduty_webhook_event(
             exc=RuntimeError("pagerduty webhook stream entry missing"), countdown=30
         )
     _, fields = entries[0]
+    token = os.getenv("PAGERDUTY_API_TOKEN")
+    clickhouse_url = os.getenv("CLICKHOUSE_URI")
+    if not token or not clickhouse_url:
+        _retry_or_dead_letter_pagerduty_webhook(
+            task=self,
+            redis_client=redis_client,
+            stream_name=stream_name,
+            stream_entry_id=stream_entry_id,
+            fields=fields,
+            error=RuntimeError("pagerduty webhook persistence is unconfigured"),
+        )
     parsed = PagerDutyV3Webhook.model_validate(json.loads(fields["payload"]))
     processed_at = datetime.fromisoformat(fields["received_at"])
 
@@ -237,7 +246,55 @@ def process_pagerduty_webhook_event(
             "stream_entry_id": stream_entry_id,
         }
     except Exception as exc:
-        raise self.retry(exc=exc, countdown=30 * (2**self.request.retries))
+        _retry_or_dead_letter_pagerduty_webhook(
+            task=self,
+            redis_client=redis_client,
+            stream_name=stream_name,
+            stream_entry_id=stream_entry_id,
+            fields=fields,
+            error=exc,
+        )
+
+
+def _retry_or_dead_letter_pagerduty_webhook(
+    *,
+    task,
+    redis_client,
+    stream_name: str,
+    stream_entry_id: str,
+    fields: dict[str, str],
+    error: Exception,
+) -> NoReturn:
+    if task.request.retries < task.max_retries:
+        raise task.retry(
+            exc=error,
+            countdown=30 * (2**task.request.retries),
+        )
+
+    event_id = fields.get("event_id", "unknown")
+    dlq_name = f"{stream_name}:dlq"
+    redis_client.xadd(
+        dlq_name,
+        {
+            "event_id": event_id,
+            "stream_entry_id": stream_entry_id,
+            "task_id": str(task.request.id or ""),
+            "retry_count": str(task.request.retries),
+            "failure_type": type(error).__name__,
+            "failed_at": datetime.now(timezone.utc).isoformat(),
+            "payload": fields["payload"],
+        },
+        maxlen=_PAGERDUTY_WEBHOOK_DLQ_MAXLEN,
+        approximate=True,
+    )
+    redis_client.xdel(stream_name, stream_entry_id)
+    logger.error(
+        "pagerduty_webhook.persistence_failed event_id=%s stream_entry_id=%s retries=%s",
+        event_id,
+        stream_entry_id,
+        task.request.retries,
+    )
+    raise RuntimeError("pagerduty webhook persistence exhausted") from error
 
 
 def _process_github_event(

--- a/src/dev_health_ops/workers/system_webhooks.py
+++ b/src/dev_health_ops/workers/system_webhooks.py
@@ -169,20 +169,22 @@ def _record_delivery(provider: str, delivery_id: str) -> None:
 @celery_app.task(
     bind=True,
     max_retries=3,
+    acks_late=True,
+    reject_on_worker_lost=True,
     queue="webhooks",
     name="dev_health_ops.workers.tasks.process_pagerduty_webhook_event",
 )
 def process_pagerduty_webhook_event(
     self,
     *,
-    webhook: dict,
     org_id: str,
     provider_instance_id: str,
-    received_at: str,
     stream_entry_id: str,
 ) -> dict:
+    import json
     from datetime import datetime
 
+    from dev_health_ops.api.ingest.streams import get_redis_client
     from dev_health_ops.api.webhooks.pagerduty_models import PagerDutyV3Webhook
     from dev_health_ops.providers.pagerduty.auth import ApiTokenAuth
     from dev_health_ops.providers.pagerduty.client import PagerDutyClient
@@ -193,8 +195,22 @@ def process_pagerduty_webhook_event(
     clickhouse_url = os.getenv("CLICKHOUSE_URI")
     if not token or not clickhouse_url:
         return {"processed": False, "reason": "pagerduty_webhook_unconfigured"}
-    parsed = PagerDutyV3Webhook.model_validate(webhook)
-    processed_at = datetime.fromisoformat(received_at)
+    redis_client = get_redis_client()
+    stream_name = f"pagerduty-webhooks:{org_id}:{provider_instance_id}"
+    if redis_client is None:
+        raise self.retry(
+            exc=RuntimeError("pagerduty webhook stream unavailable"), countdown=30
+        )
+    entries = getattr(redis_client, "xrange")(
+        stream_name, min=stream_entry_id, max=stream_entry_id
+    )
+    if not entries:
+        raise self.retry(
+            exc=RuntimeError("pagerduty webhook stream entry missing"), countdown=30
+        )
+    _, fields = entries[0]
+    parsed = PagerDutyV3Webhook.model_validate(json.loads(fields["payload"]))
+    processed_at = datetime.fromisoformat(fields["received_at"])
 
     async def _process(store):
         client = PagerDutyClient(ApiTokenAuth(token))
@@ -214,6 +230,7 @@ def process_pagerduty_webhook_event(
         processed = run_async(
             run_with_store(clickhouse_url, "clickhouse", _process, org_id=org_id)
         )
+        redis_client.xdel(stream_name, stream_entry_id)
         return {
             "processed": processed,
             "event_id": parsed.event.id,

--- a/src/dev_health_ops/workers/system_webhooks.py
+++ b/src/dev_health_ops/workers/system_webhooks.py
@@ -199,16 +199,32 @@ def process_pagerduty_webhook_event(
         raise self.retry(
             exc=RuntimeError("pagerduty webhook stream unavailable"), countdown=30
         )
-    entries = getattr(redis_client, "xrange")(
-        stream_name, min=stream_entry_id, max=stream_entry_id
-    )
-    if not entries:
-        raise self.retry(
-            exc=RuntimeError("pagerduty webhook stream entry missing"), countdown=30
-        )
-    _, fields = entries[0]
     token = os.getenv("PAGERDUTY_API_TOKEN")
     clickhouse_url = os.getenv("CLICKHOUSE_URI")
+    # Reading and parsing the pending entry is a pre-persistence failure
+    # surface: a Redis error, a trimmed/missing entry, or a malformed payload.
+    # Route ALL of them through the shared retry-then-dead-letter path so none
+    # escape as a silent task failure that drops the webhook.
+    fields: dict[str, str] | None = None
+    try:
+        entries = getattr(redis_client, "xrange")(
+            stream_name, min=stream_entry_id, max=stream_entry_id
+        )
+        if not entries:
+            raise RuntimeError("pagerduty webhook stream entry missing")
+        _, fields = entries[0]
+        parsed = PagerDutyV3Webhook.model_validate(json.loads(fields["payload"]))
+        processed_at = datetime.fromisoformat(fields["received_at"])
+    except Exception as exc:
+        _retry_or_dead_letter_pagerduty_webhook(
+            task=self,
+            redis_client=redis_client,
+            stream_name=stream_name,
+            stream_entry_id=stream_entry_id,
+            fields=fields,
+            error=exc,
+        )
+
     if not token or not clickhouse_url:
         _retry_or_dead_letter_pagerduty_webhook(
             task=self,
@@ -218,8 +234,6 @@ def process_pagerduty_webhook_event(
             fields=fields,
             error=RuntimeError("pagerduty webhook persistence is unconfigured"),
         )
-    parsed = PagerDutyV3Webhook.model_validate(json.loads(fields["payload"]))
-    processed_at = datetime.fromisoformat(fields["received_at"])
 
     async def _process(store):
         client = PagerDutyClient(ApiTokenAuth(token))
@@ -262,7 +276,7 @@ def _retry_or_dead_letter_pagerduty_webhook(
     redis_client,
     stream_name: str,
     stream_entry_id: str,
-    fields: dict[str, str],
+    fields: dict[str, str] | None,
     error: Exception,
 ) -> NoReturn:
     if task.request.retries < task.max_retries:
@@ -271,7 +285,7 @@ def _retry_or_dead_letter_pagerduty_webhook(
             countdown=30 * (2**task.request.retries),
         )
 
-    event_id = fields.get("event_id", "unknown")
+    event_id = (fields or {}).get("event_id", "unknown")
     dlq_name = f"{stream_name}:dlq"
     redis_client.xadd(
         dlq_name,
@@ -282,7 +296,7 @@ def _retry_or_dead_letter_pagerduty_webhook(
             "retry_count": str(task.request.retries),
             "failure_type": type(error).__name__,
             "failed_at": datetime.now(timezone.utc).isoformat(),
-            "payload": fields["payload"],
+            "payload": (fields or {}).get("payload", ""),
         },
         maxlen=_PAGERDUTY_WEBHOOK_DLQ_MAXLEN,
         approximate=True,

--- a/src/dev_health_ops/workers/system_webhooks.py
+++ b/src/dev_health_ops/workers/system_webhooks.py
@@ -166,6 +166,63 @@ def _record_delivery(provider: str, delivery_id: str) -> None:
         logger.warning("Failed to record webhook delivery: %s", e)
 
 
+@celery_app.task(
+    bind=True,
+    max_retries=3,
+    queue="webhooks",
+    name="dev_health_ops.workers.tasks.process_pagerduty_webhook_event",
+)
+def process_pagerduty_webhook_event(
+    self,
+    *,
+    webhook: dict,
+    org_id: str,
+    provider_instance_id: str,
+    received_at: str,
+    stream_entry_id: str,
+) -> dict:
+    from datetime import datetime
+
+    from dev_health_ops.api.webhooks.pagerduty_models import PagerDutyV3Webhook
+    from dev_health_ops.providers.pagerduty.auth import ApiTokenAuth
+    from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+    from dev_health_ops.providers.pagerduty.webhooks import reconcile_pagerduty_webhook
+    from dev_health_ops.storage import run_with_store
+
+    token = os.getenv("PAGERDUTY_API_TOKEN")
+    clickhouse_url = os.getenv("CLICKHOUSE_URI")
+    if not token or not clickhouse_url:
+        return {"processed": False, "reason": "pagerduty_webhook_unconfigured"}
+    parsed = PagerDutyV3Webhook.model_validate(webhook)
+    processed_at = datetime.fromisoformat(received_at)
+
+    async def _process(store):
+        client = PagerDutyClient(ApiTokenAuth(token))
+        try:
+            return await reconcile_pagerduty_webhook(
+                webhook=parsed,
+                org_id=org_id,
+                provider_instance_id=provider_instance_id,
+                received_at=processed_at,
+                store=store,
+                client=client,
+            )
+        finally:
+            await client.close()
+
+    try:
+        processed = run_async(
+            run_with_store(clickhouse_url, "clickhouse", _process, org_id=org_id)
+        )
+        return {
+            "processed": processed,
+            "event_id": parsed.event.id,
+            "stream_entry_id": stream_entry_id,
+        }
+    except Exception as exc:
+        raise self.retry(exc=exc, countdown=30 * (2**self.request.retries))
+
+
 def _process_github_event(
     event_type: str,
     payload: dict | None,

--- a/tests/api/webhooks/test_pagerduty.py
+++ b/tests/api/webhooks/test_pagerduty.py
@@ -180,3 +180,32 @@ def test_configuration_and_test_event_paths(client: TestClient) -> None:
     }
     assert validation.status_code == 200
     assert validation.json()["event_id"] == "test-event"
+
+
+def test_enqueue_does_not_cap_pending_stream_with_maxlen(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from dev_health_ops.api.webhooks import pagerduty
+
+    kwargs_seen: list[dict[str, object]] = []
+
+    class Redis:
+        def xadd(self, stream: str, fields: dict[str, str], **kwargs: object) -> str:
+            kwargs_seen.append(kwargs)
+            return "1-0"
+
+    class Task:
+        @staticmethod
+        def delay(**_: str) -> None:
+            return None
+
+    monkeypatch.setattr(pagerduty, "get_redis_client", lambda: Redis())
+    monkeypatch.setattr(pagerduty, "process_pagerduty_webhook_event", Task())
+    body = _payload()
+    headers = {"x-pagerduty-signature": _signature(body)}
+
+    response = client.post("/api/v1/webhooks/pagerduty", content=body, headers=headers)
+
+    # Pending entries must never be trimmed: no maxlen/approximate on ingest xadd.
+    assert response.status_code == 202
+    assert kwargs_seen == [{}]

--- a/tests/api/webhooks/test_pagerduty.py
+++ b/tests/api/webhooks/test_pagerduty.py
@@ -50,25 +50,15 @@ def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
         yield test_client
 
 
-def test_accepts_a_valid_signed_event_once_and_enqueues_durably(
+def test_accepts_replayed_event_and_enqueues_for_idempotent_persistence(
     client: TestClient, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     from dev_health_ops.api.webhooks import pagerduty
 
     writes: list[tuple[str, dict[str, str]]] = []
     dispatched: list[dict[str, str]] = []
-    claims: set[str] = set()
 
     class Redis:
-        def set(self, key: str, value: str, *, nx: bool, ex: int) -> bool:
-            if key in claims:
-                return False
-            claims.add(key)
-            return True
-
-        def delete(self, key: str) -> None:
-            claims.discard(key)
-
         def xadd(self, stream: str, fields: dict[str, str], **_: object) -> str:
             writes.append((stream, fields))
             return "1-0"
@@ -91,13 +81,47 @@ def test_accepts_a_valid_signed_event_once_and_enqueues_durably(
     assert duplicate.status_code == 202
     assert response.json()["status"] == "accepted"
     assert duplicate.json()["status"] == "accepted"
-    assert duplicate.json()["message"] == "Duplicate event accepted"
-    assert len(writes) == 1
+    assert duplicate.json()["message"] == "Event accepted"
+    assert len(writes) == 2
     assert writes[0][0] == "pagerduty-webhooks:org-1:acme"
     assert datetime.fromisoformat(
         writes[0][1]["occurred_at"]
     ) == datetime.fromisoformat(OCCURRED_AT.replace("Z", "+00:00"))
-    assert len(dispatched) == 1
+    assert len(dispatched) == 2
+
+
+def test_dispatch_failure_does_not_suppress_a_replayed_event(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from dev_health_ops.api.webhooks import pagerduty
+
+    writes: list[tuple[str, dict[str, str]]] = []
+
+    class Redis:
+        def xadd(self, stream: str, fields: dict[str, str], **_: object) -> str:
+            writes.append((stream, fields))
+            return f"{len(writes)}-0"
+
+    class Task:
+        attempts = 0
+
+        @classmethod
+        def delay(cls, **_: str) -> None:
+            cls.attempts += 1
+            if cls.attempts == 1:
+                raise RuntimeError("broker unavailable")
+
+    monkeypatch.setattr(pagerduty, "get_redis_client", lambda: Redis())
+    monkeypatch.setattr(pagerduty, "process_pagerduty_webhook_event", Task())
+    body = _payload()
+    headers = {"x-pagerduty-signature": _signature(body)}
+
+    failed = client.post("/api/v1/webhooks/pagerduty", content=body, headers=headers)
+    replayed = client.post("/api/v1/webhooks/pagerduty", content=body, headers=headers)
+
+    assert failed.status_code == 503
+    assert replayed.status_code == 202
+    assert len(writes) == 2
 
 
 def test_rejects_an_invalid_signature(client: TestClient) -> None:

--- a/tests/api/webhooks/test_pagerduty.py
+++ b/tests/api/webhooks/test_pagerduty.py
@@ -1,0 +1,158 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+from collections.abc import Generator
+from datetime import datetime
+
+import pytest
+from fastapi.testclient import TestClient
+
+from dev_health_ops.api.main import app
+
+SECRET = "pagerduty-webhook-secret"
+OCCURRED_AT = "2026-07-17T12:00:00Z"
+
+
+def _payload(
+    *, event_id: str = "event-1", event_type: str = "incident.triggered"
+) -> bytes:
+    return json.dumps(
+        {
+            "event": {
+                "id": event_id,
+                "event_type": event_type,
+                "occurred_at": OCCURRED_AT,
+                "data": {
+                    "id": "incident-1",
+                    "title": "Payments unavailable",
+                    "status": "triggered",
+                    "created_at": OCCURRED_AT,
+                    "updated_at": OCCURRED_AT,
+                },
+            },
+        }
+    ).encode()
+
+
+def _signature(body: bytes) -> str:
+    digest = hmac.new(SECRET.encode(), body, hashlib.sha256).hexdigest()
+    return f"v1={digest}"
+
+
+@pytest.fixture
+def client(monkeypatch: pytest.MonkeyPatch) -> Generator[TestClient]:
+    monkeypatch.setenv("PAGERDUTY_WEBHOOK_SECRET", SECRET)
+    monkeypatch.setenv("PAGERDUTY_WEBHOOK_ORG_ID", "org-1")
+    monkeypatch.setenv("PAGERDUTY_WEBHOOK_PROVIDER_INSTANCE_ID", "acme")
+    with TestClient(app) as test_client:
+        yield test_client
+
+
+def test_accepts_a_valid_signed_event_once_and_enqueues_durably(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from dev_health_ops.api.webhooks import pagerduty
+
+    writes: list[tuple[str, dict[str, str]]] = []
+    dispatched: list[dict[str, str]] = []
+    claims: set[str] = set()
+
+    class Redis:
+        def set(self, key: str, value: str, *, nx: bool, ex: int) -> bool:
+            if key in claims:
+                return False
+            claims.add(key)
+            return True
+
+        def delete(self, key: str) -> None:
+            claims.discard(key)
+
+        def xadd(self, stream: str, fields: dict[str, str], **_: object) -> str:
+            writes.append((stream, fields))
+            return "1-0"
+
+    class Task:
+        @staticmethod
+        def delay(**kwargs: str) -> None:
+            dispatched.append(kwargs)
+
+    monkeypatch.setattr(pagerduty, "get_redis_client", lambda: Redis())
+    monkeypatch.setattr(pagerduty, "process_pagerduty_webhook_event", Task())
+
+    body = _payload()
+    headers = {"x-pagerduty-signature": _signature(body)}
+
+    response = client.post("/api/v1/webhooks/pagerduty", content=body, headers=headers)
+    duplicate = client.post("/api/v1/webhooks/pagerduty", content=body, headers=headers)
+
+    assert response.status_code == 202
+    assert duplicate.status_code == 202
+    assert response.json()["status"] == "accepted"
+    assert duplicate.json()["status"] == "accepted"
+    assert duplicate.json()["message"] == "Duplicate event accepted"
+    assert len(writes) == 1
+    assert writes[0][0] == "pagerduty-webhooks:org-1:acme"
+    assert datetime.fromisoformat(
+        writes[0][1]["occurred_at"]
+    ) == datetime.fromisoformat(OCCURRED_AT.replace("Z", "+00:00"))
+    assert len(dispatched) == 1
+
+
+def test_rejects_an_invalid_signature(client: TestClient) -> None:
+    response = client.post(
+        "/api/v1/webhooks/pagerduty",
+        content=_payload(),
+        headers={"x-pagerduty-signature": "v1=not-a-signature"},
+    )
+
+    assert response.status_code == 401
+
+
+@pytest.mark.parametrize("body", [b"{", b"x" * 1_048_577])
+def test_rejects_malformed_or_oversized_payloads(
+    client: TestClient, body: bytes
+) -> None:
+    response = client.post(
+        "/api/v1/webhooks/pagerduty",
+        content=body,
+        headers={"x-pagerduty-signature": _signature(body)},
+    )
+
+    assert response.status_code in {400, 413}
+
+
+def test_rejects_unknown_event_type(
+    client: TestClient, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    from dev_health_ops.api.webhooks import pagerduty
+
+    monkeypatch.setattr(pagerduty, "get_redis_client", lambda: None)
+    body = _payload(event_type="incident.not-a-real-event")
+    response = client.post(
+        "/api/v1/webhooks/pagerduty",
+        content=body,
+        headers={"x-pagerduty-signature": _signature(body)},
+    )
+
+    assert response.status_code == 400
+
+
+def test_configuration_and_test_event_paths(client: TestClient) -> None:
+    body = _payload(event_id="test-event")
+    headers = {"x-pagerduty-signature": _signature(body)}
+
+    config = client.get("/api/v1/webhooks/pagerduty/configuration")
+    validation = client.post(
+        "/api/v1/webhooks/pagerduty/test-event", content=body, headers=headers
+    )
+
+    assert config.status_code == 200
+    assert config.json() == {
+        "configured": True,
+        "org_id": "org-1",
+        "provider_instance_id": "acme",
+    }
+    assert validation.status_code == 200
+    assert validation.json()["event_id"] == "test-event"

--- a/tests/api/webhooks/test_pagerduty_models.py
+++ b/tests/api/webhooks/test_pagerduty_models.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from dev_health_ops.api.webhooks.pagerduty_models import PagerDutyV3Webhook
+
+
+@pytest.mark.parametrize(
+    "event_type",
+    [
+        "incident.responder.added",
+        "incident.responder.replied",
+        "incident.service_updated",
+        "incident.status_update_published",
+    ],
+)
+def test_webhook_accepts_pagerduty_v3_incident_event_names(event_type: str) -> None:
+    webhook = PagerDutyV3Webhook.model_validate(
+        {
+            "event": {
+                "id": "event-1",
+                "event_type": event_type,
+                "occurred_at": "2026-07-17T12:00:00Z",
+                "data": {"id": "incident-1"},
+            }
+        }
+    )
+
+    assert webhook.event.event_type == event_type
+
+
+def test_webhook_rejects_naive_occurred_at() -> None:
+    with pytest.raises(ValidationError, match="timezone"):
+        PagerDutyV3Webhook.model_validate(
+            {
+                "event": {
+                    "id": "event-1",
+                    "event_type": "incident.triggered",
+                    "occurred_at": "2026-07-17T12:00:00",
+                    "data": {"id": "incident-1"},
+                }
+            }
+        )

--- a/tests/api/webhooks/test_pagerduty_security.py
+++ b/tests/api/webhooks/test_pagerduty_security.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+
+import pytest
+from fastapi import HTTPException
+from starlette.requests import Request
+
+from dev_health_ops.api.webhooks.pagerduty import (
+    MAX_WEBHOOK_BODY_BYTES,
+    _read_body_limited,
+    _verify_signature,
+)
+
+
+def test_verify_signature_accepts_a_rotated_v1_secret() -> None:
+    body = b'{"event": "incident.triggered"}'
+    secret = "webhook-secret"
+    expected = hmac.new(secret.encode(), body, hashlib.sha256).hexdigest()
+
+    accepted = _verify_signature(
+        body,
+        f"v1={'0' * len(expected)}, v1={expected}",
+        secret,
+    )
+
+    assert accepted is True
+
+
+@pytest.mark.anyio
+async def test_read_body_limited_rejects_content_length_before_buffering() -> None:
+    receive_called = False
+
+    async def receive() -> dict[str, object]:
+        nonlocal receive_called
+        receive_called = True
+        return {
+            "type": "http.request",
+            "body": b"x" * (MAX_WEBHOOK_BODY_BYTES + 1),
+            "more_body": False,
+        }
+
+    request = Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "headers": [
+                (
+                    b"content-length",
+                    str(MAX_WEBHOOK_BODY_BYTES + 1).encode(),
+                )
+            ],
+        },
+        receive,
+    )
+
+    with pytest.raises(HTTPException) as exc_info:
+        await _read_body_limited(request)
+
+    assert exc_info.value.status_code == 413
+    assert receive_called is False

--- a/tests/graphql/test_work_graph.py
+++ b/tests/graphql/test_work_graph.py
@@ -275,7 +275,7 @@ class TestResolveWorkGraphEdges:
             assert result.page_info.end_cursor == "e99"
 
     @pytest.mark.asyncio
-    async def test_handles_unknown_enum_values_gracefully(self, mock_context):
+    async def test_raises_for_unknown_persisted_enum_values(self, mock_context):
         rows = [
             make_edge_row(
                 source_type="unknown_type",
@@ -291,14 +291,8 @@ class TestResolveWorkGraphEdges:
         ) as mock_query:
             mock_query.return_value = rows
 
-            result = await resolve_work_graph_edges(mock_context)
-
-            assert len(result.edges) == 1
-            edge = result.edges[0]
-            assert edge.source_type == WorkGraphNodeType.ISSUE
-            assert edge.target_type == WorkGraphNodeType.ISSUE
-            assert edge.edge_type == WorkGraphEdgeType.RELATES
-            assert edge.provenance == WorkGraphProvenance.HEURISTIC
+            with pytest.raises(ValueError, match="unknown_type"):
+                await resolve_work_graph_edges(mock_context)
 
     @pytest.mark.asyncio
     async def test_raises_when_client_missing(self):

--- a/tests/graphql/test_work_graph_operational_enums.py
+++ b/tests/graphql/test_work_graph_operational_enums.py
@@ -1,0 +1,56 @@
+import pytest
+
+from dev_health_ops.api.graphql.models.outputs import (
+    WorkGraphEdgeType,
+    WorkGraphNodeType,
+)
+from dev_health_ops.api.graphql.resolvers.work_graph import (
+    _map_edge_type,
+    _map_node_type,
+)
+
+
+@pytest.mark.parametrize(
+    ("persisted_kind", "graphql_kind"),
+    [
+        ("operational_service", WorkGraphNodeType.OPERATIONAL_SERVICE),
+        ("operational_alert", WorkGraphNodeType.OPERATIONAL_ALERT),
+        ("incident_timeline_event", WorkGraphNodeType.INCIDENT_TIMELINE_EVENT),
+        ("incident_responder", WorkGraphNodeType.INCIDENT_RESPONDER),
+        ("escalation_policy", WorkGraphNodeType.ESCALATION_POLICY),
+        ("repository", WorkGraphNodeType.REPOSITORY),
+        ("user", WorkGraphNodeType.USER),
+        ("team", WorkGraphNodeType.TEAM),
+    ],
+)
+def test_maps_operational_node_kinds_to_their_graphql_enum(
+    persisted_kind: str, graphql_kind: WorkGraphNodeType
+) -> None:
+    assert _map_node_type(persisted_kind) is graphql_kind
+
+
+@pytest.mark.parametrize(
+    ("persisted_kind", "graphql_kind"),
+    [
+        ("maps_to_repository", WorkGraphEdgeType.MAPS_TO_REPOSITORY),
+        ("has_incident", WorkGraphEdgeType.HAS_INCIDENT),
+        ("has_alert", WorkGraphEdgeType.HAS_ALERT),
+        ("has_timeline_event", WorkGraphEdgeType.HAS_TIMELINE_EVENT),
+        ("has_responder", WorkGraphEdgeType.HAS_RESPONDER),
+        ("assigned_to", WorkGraphEdgeType.ASSIGNED_TO),
+        ("escalates_with", WorkGraphEdgeType.ESCALATES_WITH),
+        ("remediated_by", WorkGraphEdgeType.REMEDIATED_BY),
+    ],
+)
+def test_maps_operational_edge_kinds_to_their_graphql_enum(
+    persisted_kind: str, graphql_kind: WorkGraphEdgeType
+) -> None:
+    assert _map_edge_type(persisted_kind) is graphql_kind
+
+
+@pytest.mark.parametrize("persisted_kind", ["unknown_node", "unknown_edge"])
+def test_raises_for_an_unknown_persisted_work_graph_kind(persisted_kind: str) -> None:
+    mapper = _map_node_type if persisted_kind == "unknown_node" else _map_edge_type
+
+    with pytest.raises(ValueError, match=persisted_kind):
+        mapper(persisted_kind)

--- a/tests/metrics/test_active_incidents.py
+++ b/tests/metrics/test_active_incidents.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import uuid
+from datetime import datetime, timezone
+
+from dev_health_ops.metrics.active_incidents import (
+    IncidentWindow,
+    active_incidents_query,
+    deduplicate_active_incidents,
+)
+
+ORG_ID = "22222222-2222-2222-2222-222222222222"
+REPO_ID = uuid.UUID("11111111-1111-1111-1111-111111111111")
+START = datetime(2026, 6, 8, tzinfo=timezone.utc)
+
+
+def test_active_incidents_query_projects_mapped_canonical_rows_with_org_scope() -> None:
+    query = active_incidents_query(
+        window=IncidentWindow.RESOLVED,
+        org_id=ORG_ID,
+        repo_filter="",
+    )
+
+    assert "FROM incidents FINAL" in query
+    assert "FROM operational_incidents AS incident FINAL" in query
+    assert "operational_service_repository_mappings AS mapping FINAL" in query
+    assert "incident.org_id = {org_id:String}" in query
+    assert "mapping.org_id = {org_id:String}" in query
+    assert "incident.service_id = mapping.service_id" in query
+    assert "mapping.repo_id IS NOT NULL" in query
+    assert "mapping.is_active = 1" in query
+    assert "mapping.valid_from <= {as_of:DateTime64(6, 'UTC')}" in query
+    assert "resolved_at IS NOT NULL" in query
+
+
+def test_active_incidents_query_does_not_project_canonical_rows_without_org_scope() -> (
+    None
+):
+    query = active_incidents_query(
+        window=IncidentWindow.STARTED,
+        org_id="",
+        repo_filter="",
+    )
+
+    assert "FROM incidents FINAL" in query
+    assert "operational_incidents" not in query
+    assert "operational_service_repository_mappings" not in query
+
+
+def test_deduplicate_active_incidents_preserves_legacy_row_for_shared_identity() -> (
+    None
+):
+    legacy = {
+        "repo_id": REPO_ID,
+        "incident_id": "shared-incident",
+        "status": "resolved",
+        "started_at": START,
+        "resolved_at": START,
+        "last_synced": START,
+    }
+    canonical = {
+        "repo_id": REPO_ID,
+        "incident_id": "shared-incident",
+        "status": "resolved",
+        "started_at": START,
+        "resolved_at": START,
+        "last_synced": START,
+    }
+
+    rows = deduplicate_active_incidents([legacy, canonical])
+
+    assert rows == [legacy]
+
+
+def test_deduplicate_active_incidents_keeps_mapped_repositories_separate() -> None:
+    second_repo_id = uuid.uuid4()
+    row = {
+        "repo_id": REPO_ID,
+        "incident_id": "pd-incident",
+        "status": "resolved",
+        "started_at": START,
+        "resolved_at": START,
+        "last_synced": START,
+    }
+
+    rows = deduplicate_active_incidents([row, {**row, "repo_id": second_repo_id}])
+
+    assert {item["repo_id"] for item in rows} == {REPO_ID, second_repo_id}

--- a/tests/metrics/test_active_incidents.py
+++ b/tests/metrics/test_active_incidents.py
@@ -24,6 +24,9 @@ def test_active_incidents_query_projects_mapped_canonical_rows_with_org_scope() 
     assert "FROM incidents FINAL" in query
     assert "FROM operational_incidents AS incident FINAL" in query
     assert "operational_service_repository_mappings AS mapping FINAL" in query
+    assert "INNER JOIN repos AS repo FINAL" in query
+    assert "mapping.repo_id = repo.id" in query
+    assert "mapping.org_id = repo.org_id" in query
     assert "incident.org_id = {org_id:String}" in query
     assert "mapping.org_id = {org_id:String}" in query
     assert "incident.service_id = mapping.service_id" in query
@@ -31,6 +34,7 @@ def test_active_incidents_query_projects_mapped_canonical_rows_with_org_scope() 
     assert "mapping.is_active = 1" in query
     assert "mapping.valid_from <= {as_of:DateTime64(6, 'UTC')}" in query
     assert "resolved_at IS NOT NULL" in query
+    assert "incident.id AS incident_id" in query
 
 
 def test_active_incidents_query_does_not_project_canonical_rows_without_org_scope() -> (
@@ -86,3 +90,19 @@ def test_deduplicate_active_incidents_keeps_mapped_repositories_separate() -> No
     rows = deduplicate_active_incidents([row, {**row, "repo_id": second_repo_id}])
 
     assert {item["repo_id"] for item in rows} == {REPO_ID, second_repo_id}
+
+
+def test_deduplicate_active_incidents_keeps_distinct_canonical_identities() -> None:
+    first = {
+        "repo_id": REPO_ID,
+        "incident_id": "canonical-provider-instance-one",
+        "status": "resolved",
+        "started_at": START,
+        "resolved_at": START,
+        "last_synced": START,
+    }
+    second = {**first, "incident_id": "canonical-provider-instance-two"}
+
+    rows = deduplicate_active_incidents([first, second])
+
+    assert rows == [first, second]

--- a/tests/metrics/test_job_daily_ai_workflow.py
+++ b/tests/metrics/test_job_daily_ai_workflow.py
@@ -149,6 +149,39 @@ def test_extracts_runs_and_all_edge_kinds() -> None:
     assert deploy_incident_edges[0].source == "heuristic"
 
 
+def test_mapped_canonical_incident_is_deduplicated_before_ai_linkage() -> None:
+    class _CanonicalIncidentSink(_Sink):
+        def query_dicts(
+            self, query: str, parameters: dict[str, Any]
+        ) -> list[dict[str, Any]]:
+            if "operational_incidents" in query:
+                assert parameters["org_id"] == ORG_ID
+                assert "mapping.repo_id IS NOT NULL" in query
+                assert "mapping.org_id = {org_id:String}" in query
+                canonical_row = {
+                    "repo_id": REPO_ID,
+                    "incident_id": "pd-1",
+                    "status": "resolved",
+                    "started_at": START,
+                    "resolved_at": END,
+                    "last_synced": END,
+                }
+                return [canonical_row, canonical_row]
+            return super().query_dicts(query, parameters)
+
+    result = _extract_ai_workflow_for_day(
+        primary_sink=_CanonicalIncidentSink(),
+        org_id=ORG_ID,
+        start=START,
+        end=END,
+        repo_id=None,
+        repo_provider_by_id={str(REPO_ID): "github"},
+    )
+
+    assert len(result[-1]) == 1
+    assert result[-1][0].incident_id == "pd-1"
+
+
 def test_non_uuid_org_skips_extraction_without_queries() -> None:
     sink = _Sink()
     result = _extract_ai_workflow_for_day(

--- a/tests/providers/test_pagerduty_degradation.py
+++ b/tests/providers/test_pagerduty_degradation.py
@@ -74,7 +74,7 @@ class _Store(PagerDutyOperationalStore):
     async def insert_operational_service_repository_mappings(
         self, values: list[ServiceRepositoryMapping]
     ) -> None:
-        del values
+        """Accept mapping writes without recording them."""
 
     async def insert_operational_incidents(
         self, values: list[OperationalIncident]

--- a/tests/providers/test_pagerduty_degradation.py
+++ b/tests/providers/test_pagerduty_degradation.py
@@ -25,6 +25,7 @@ from dev_health_ops.models.operational import (
     OperationalService,
     OperationalTeam,
     OperationalUser,
+    ServiceRepositoryMapping,
 )
 from dev_health_ops.providers.pagerduty.degradation import (
     PagerDutyInsufficientScopeError,
@@ -69,6 +70,11 @@ class _Store(PagerDutyOperationalStore):
         self, values: list[OperationalService]
     ) -> None:
         self.services.extend(values)
+
+    async def insert_operational_service_repository_mappings(
+        self, values: list[ServiceRepositoryMapping]
+    ) -> None:
+        del values
 
     async def insert_operational_incidents(
         self, values: list[OperationalIncident]

--- a/tests/providers/test_pagerduty_service_repository_mapping.py
+++ b/tests/providers/test_pagerduty_service_repository_mapping.py
@@ -1,9 +1,14 @@
 from datetime import datetime, timezone
+from uuid import uuid4
 
 from dev_health_ops.models.operational import OperationalService
 from dev_health_ops.providers.pagerduty.service_repository_mapping import (
     PagerDutyServiceRepositoryMappingSource,
+    RepositoryReference,
+    mapping_from_repository_reference,
     mappings_from_service_metadata,
+    resolve_repository_mappings,
+    select_preferred_mappings,
 )
 
 
@@ -63,3 +68,70 @@ def test_service_metadata_ignores_unlabeled_slug_heuristics() -> None:
     )
 
     assert mappings == ()
+
+
+def test_repository_catalog_resolution_keeps_unmatched_metadata_as_evidence() -> None:
+    observed_at = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    service = OperationalService(
+        org_id="org-a",
+        provider="pagerduty",
+        provider_instance_id="pd-a",
+        source_entity_type="service",
+        external_id="svc-1",
+        source_version_at=observed_at,
+        name="checkout",
+    )
+    matched_repo_id = uuid4()
+    mappings = (
+        mapping_from_repository_reference(
+            service,
+            RepositoryReference("github", "full-chaos/checkout"),
+            PagerDutyServiceRepositoryMappingSource.METADATA,
+            observed_at,
+        ),
+        mapping_from_repository_reference(
+            service,
+            RepositoryReference("github", "full-chaos/missing"),
+            PagerDutyServiceRepositoryMappingSource.METADATA,
+            observed_at,
+        ),
+    )
+
+    resolved = resolve_repository_mappings(
+        mappings,
+        ((matched_repo_id, "github", "full-chaos/checkout"),),
+    )
+
+    assert resolved[0].repo_id == matched_repo_id
+    assert resolved[1].repo_id is None
+    assert resolved[1].repo_full_name == "full-chaos/missing"
+
+
+def test_mapping_precedence_selects_admin_over_exact_metadata() -> None:
+    observed_at = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    service = OperationalService(
+        org_id="org-a",
+        provider="pagerduty",
+        provider_instance_id="pd-a",
+        source_entity_type="service",
+        external_id="svc-1",
+        source_version_at=observed_at,
+        name="checkout",
+    )
+    reference = RepositoryReference("github", "full-chaos/checkout")
+    metadata = mapping_from_repository_reference(
+        service,
+        reference,
+        PagerDutyServiceRepositoryMappingSource.METADATA,
+        observed_at,
+    )
+    admin = mapping_from_repository_reference(
+        service,
+        reference,
+        PagerDutyServiceRepositoryMappingSource.ADMIN_CONFIGURATION,
+        observed_at,
+    )
+
+    preferred = select_preferred_mappings((metadata, admin))
+
+    assert preferred == (admin,)

--- a/tests/providers/test_pagerduty_service_repository_mapping.py
+++ b/tests/providers/test_pagerduty_service_repository_mapping.py
@@ -1,0 +1,65 @@
+from datetime import datetime, timezone
+
+from dev_health_ops.models.operational import OperationalService
+from dev_health_ops.providers.pagerduty.service_repository_mapping import (
+    PagerDutyServiceRepositoryMappingSource,
+    mappings_from_service_metadata,
+)
+
+
+def test_service_metadata_maps_exact_repository_urls_with_provenance() -> None:
+    observed_at = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    service = OperationalService(
+        org_id="org-a",
+        provider="pagerduty",
+        provider_instance_id="pd-a",
+        source_entity_type="service",
+        external_id="svc-1",
+        source_version_at=observed_at,
+        name="checkout",
+    )
+
+    mappings = mappings_from_service_metadata(
+        service,
+        {
+            "integrations": [
+                {"repository": "https://github.com/full-chaos/checkout"},
+                {"repo": "full-chaos/checkout"},
+            ]
+        },
+        observed_at,
+    )
+
+    assert len(mappings) == 1
+    mapping = mappings[0]
+    assert mapping.service_id == service.id
+    assert mapping.repo_provider == "github"
+    assert mapping.repo_full_name == "full-chaos/checkout"
+    assert mapping.mapping_kind == "pagerduty_service_metadata_exact"
+    assert mapping.relationship_provenance == "pagerduty_service_metadata"
+    assert mapping.relationship_confidence == 0.95
+    assert mapping.rule_id == PagerDutyServiceRepositoryMappingSource.METADATA.rule_id
+    assert mapping.valid_from == observed_at
+    assert mapping.valid_to is None
+    assert mapping.is_active is True
+
+
+def test_service_metadata_ignores_unlabeled_slug_heuristics() -> None:
+    observed_at = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    service = OperationalService(
+        org_id="org-a",
+        provider="pagerduty",
+        provider_instance_id="pd-a",
+        source_entity_type="service",
+        external_id="svc-1",
+        source_version_at=observed_at,
+        name="checkout",
+    )
+
+    mappings = mappings_from_service_metadata(
+        service,
+        {"description": "Coordinate with full-chaos/checkout before release."},
+        observed_at,
+    )
+
+    assert mappings == ()

--- a/tests/providers/test_pagerduty_service_repository_mapping.py
+++ b/tests/providers/test_pagerduty_service_repository_mapping.py
@@ -3,6 +3,7 @@ from uuid import uuid4
 
 from dev_health_ops.models.operational import OperationalService
 from dev_health_ops.providers.pagerduty.service_repository_mapping import (
+    PagerDutyServiceRepositoryMappingInputs,
     PagerDutyServiceRepositoryMappingSource,
     RepositoryReference,
     mapping_from_repository_reference,
@@ -135,3 +136,59 @@ def test_mapping_precedence_selects_admin_over_exact_metadata() -> None:
     preferred = select_preferred_mappings((metadata, admin))
 
     assert preferred == (admin,)
+
+
+def test_mapping_inputs_from_dataset_options_parses_admin_and_compass() -> None:
+    inputs = PagerDutyServiceRepositoryMappingInputs.from_dataset_options(
+        {
+            "service_repository_mappings": {
+                "admin": {
+                    "svc-1": [{"provider": "github", "full_name": "full-chaos/api"}],
+                },
+                "compass": {
+                    "svc-2": [
+                        {"provider": "gitlab", "full_name": "full-chaos/worker"},
+                    ],
+                },
+            }
+        }
+    )
+
+    assert inputs.admin == {"svc-1": (RepositoryReference("github", "full-chaos/api"),)}
+    assert inputs.compass == {
+        "svc-2": (RepositoryReference("gitlab", "full-chaos/worker"),)
+    }
+    assert inputs.heuristic == {}
+
+
+def test_mapping_inputs_from_dataset_options_defaults_to_empty() -> None:
+    empty = PagerDutyServiceRepositoryMappingInputs.empty()
+    assert PagerDutyServiceRepositoryMappingInputs.from_dataset_options({}) == empty
+    assert (
+        PagerDutyServiceRepositoryMappingInputs.from_dataset_options(
+            {"service_repository_mappings": "not-a-mapping"}
+        )
+        == empty
+    )
+
+
+def test_mapping_inputs_from_dataset_options_skips_malformed_entries() -> None:
+    inputs = PagerDutyServiceRepositoryMappingInputs.from_dataset_options(
+        {
+            "service_repository_mappings": {
+                "admin": {
+                    "svc-1": [
+                        {"provider": "github", "full_name": "full-chaos/api"},
+                        {"provider": "github"},
+                        {"full_name": "full-chaos/no-provider"},
+                        {"provider": "", "full_name": "full-chaos/blank"},
+                        "not-a-dict",
+                    ],
+                    "svc-empty": [{"provider": 1, "full_name": 2}],
+                },
+            }
+        }
+    )
+
+    assert inputs.admin == {"svc-1": (RepositoryReference("github", "full-chaos/api"),)}
+    assert inputs.compass == {}

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -626,6 +626,9 @@ async def test_complete_service_snapshot_deactivates_removed_metadata_mapping() 
     assert isinstance(tombstone, ServiceRepositoryMapping)
     assert tombstone.is_active is False
     assert tombstone.valid_to == SOURCE_TIME
+    # source_version_at (the RMT version) must be bumped strictly above the
+    # active row so the deactivation wins on a same-window retry (no tie).
+    assert tombstone.source_version_at > stale_mapping.source_version_at
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -9,10 +9,19 @@ from sqlalchemy.orm import Session
 
 from dev_health_ops.exceptions import APIException, PaginationException
 from dev_health_ops.models.git import Base
-from dev_health_ops.models.operational import OperationalIncident, OperationalService
+from dev_health_ops.models.operational import (
+    OperationalIncident,
+    OperationalService,
+    ServiceRepositoryMapping,
+)
 from dev_health_ops.providers.pagerduty.client import PagerDutyPage
 from dev_health_ops.providers.pagerduty.models import Alert, Incident, Service
 from dev_health_ops.providers.pagerduty.normalize import PagerDutyNormalizer
+from dev_health_ops.providers.pagerduty.service_repository_mapping import (
+    PagerDutyServiceRepositoryMappingSource,
+    RepositoryReference,
+    mapping_from_repository_reference,
+)
 from dev_health_ops.providers.pagerduty.sync import (
     PagerDutyDatasetDegradedError,
     PagerDutyEnrichmentToggles,
@@ -542,7 +551,12 @@ async def test_complete_service_snapshot_tombstones_missing_reference() -> None:
     )
     client.drain_usage_observations.return_value = []
     store = Mock()
-    store.load_active_operational_entities = AsyncMock(return_value=[missing])
+    store.load_active_operational_entities = AsyncMock(
+        side_effect=lambda entity_type, **_kwargs: (
+            [missing] if entity_type is OperationalService else []
+        )
+    )
+    store.query_dicts.return_value = []
     store.insert_operational_services = AsyncMock()
 
     await PagerDutyOperationalSync(
@@ -564,12 +578,63 @@ async def test_complete_service_snapshot_tombstones_missing_reference() -> None:
 
 
 @pytest.mark.asyncio
+async def test_complete_service_snapshot_deactivates_removed_metadata_mapping() -> None:
+    normalizer = PagerDutyNormalizer("org-1", "acme", SOURCE_TIME)
+    service = normalizer.service(
+        Service(id="service-current", name="Current", updated_at=SOURCE_TIME)
+    )
+    stale_mapping = mapping_from_repository_reference(
+        service,
+        RepositoryReference("github", "full-chaos/removed"),
+        PagerDutyServiceRepositoryMappingSource.METADATA,
+        SOURCE_TIME,
+    )
+    client = Mock()
+    client.list_services = AsyncMock(
+        return_value=[
+            Service(id="service-current", name="Current", updated_at=SOURCE_TIME)
+        ]
+    )
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.load_active_operational_entities = AsyncMock(return_value=[])
+    store.load_active_operational_entities = AsyncMock(
+        side_effect=lambda entity_type, **kwargs: (
+            [stale_mapping]
+            if kwargs["source_entity_type"]
+            == PagerDutyServiceRepositoryMappingSource.METADATA.value
+            else []
+        )
+    )
+    store.query_dicts.return_value = []
+    store.insert_operational_services = AsyncMock()
+    store.insert_operational_service_repository_mappings = AsyncMock()
+
+    await PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=normalizer,
+    ).run(PagerDutySyncOptions("services", None, None))
+
+    inserted = [
+        row
+        for call in store.insert_operational_service_repository_mappings.await_args_list
+        for row in call.args[0]
+    ]
+    tombstone = next(row for row in inserted if row.id == stale_mapping.id)
+    assert isinstance(tombstone, ServiceRepositoryMapping)
+    assert tombstone.is_active is False
+    assert tombstone.valid_to == SOURCE_TIME
+
+
+@pytest.mark.asyncio
 async def test_failed_service_snapshot_emits_no_reference_tombstones() -> None:
     client = Mock()
     client.list_services = AsyncMock(side_effect=APIException("PagerDuty unavailable"))
     client.drain_usage_observations.return_value = []
     store = Mock()
     store.load_active_operational_entities = AsyncMock()
+    store.query_dicts.return_value = []
     store.insert_operational_services = AsyncMock()
 
     with pytest.raises(PagerDutyDatasetDegradedError):
@@ -592,6 +657,7 @@ async def test_malformed_service_snapshot_emits_no_reference_tombstones() -> Non
     client.drain_usage_observations.return_value = []
     store = Mock()
     store.load_active_operational_entities = AsyncMock()
+    store.query_dicts.return_value = []
     store.insert_operational_services = AsyncMock()
 
     with pytest.raises(PagerDutyDatasetDegradedError):

--- a/tests/providers/test_pagerduty_sync.py
+++ b/tests/providers/test_pagerduty_sync.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 from unittest.mock import AsyncMock, Mock
+from uuid import uuid4
 
 import pytest
 from sqlalchemy import create_engine
@@ -556,7 +557,7 @@ async def test_complete_service_snapshot_tombstones_missing_reference() -> None:
             [missing] if entity_type is OperationalService else []
         )
     )
-    store.query_dicts.return_value = []
+    store.load_repository_catalog = AsyncMock(return_value=[])
     store.insert_operational_services = AsyncMock()
 
     await PagerDutyOperationalSync(
@@ -606,7 +607,7 @@ async def test_complete_service_snapshot_deactivates_removed_metadata_mapping() 
             else []
         )
     )
-    store.query_dicts.return_value = []
+    store.load_repository_catalog = AsyncMock(return_value=[])
     store.insert_operational_services = AsyncMock()
     store.insert_operational_service_repository_mappings = AsyncMock()
 
@@ -634,7 +635,7 @@ async def test_failed_service_snapshot_emits_no_reference_tombstones() -> None:
     client.drain_usage_observations.return_value = []
     store = Mock()
     store.load_active_operational_entities = AsyncMock()
-    store.query_dicts.return_value = []
+    store.load_repository_catalog = AsyncMock(return_value=[])
     store.insert_operational_services = AsyncMock()
 
     with pytest.raises(PagerDutyDatasetDegradedError):
@@ -657,7 +658,7 @@ async def test_malformed_service_snapshot_emits_no_reference_tombstones() -> Non
     client.drain_usage_observations.return_value = []
     store = Mock()
     store.load_active_operational_entities = AsyncMock()
-    store.query_dicts.return_value = []
+    store.load_repository_catalog = AsyncMock(return_value=[])
     store.insert_operational_services = AsyncMock()
 
     with pytest.raises(PagerDutyDatasetDegradedError):
@@ -669,3 +670,44 @@ async def test_malformed_service_snapshot_emits_no_reference_tombstones() -> Non
 
     store.load_active_operational_entities.assert_not_awaited()
     store.insert_operational_services.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_service_repository_mapping_resolves_repo_id_from_catalog() -> None:
+    normalizer = PagerDutyNormalizer("org-1", "acme", SOURCE_TIME)
+    repo_id = uuid4()
+    client = Mock()
+    client.list_services = AsyncMock(
+        return_value=[
+            Service(
+                id="service-current",
+                name="Current",
+                html_url="https://github.com/full-chaos/app",
+                updated_at=SOURCE_TIME,
+            )
+        ]
+    )
+    client.drain_usage_observations.return_value = []
+    store = Mock()
+    store.load_active_operational_entities = AsyncMock(return_value=[])
+    store.load_repository_catalog = AsyncMock(
+        return_value=[(repo_id, "github", "full-chaos/app")]
+    )
+    store.insert_operational_services = AsyncMock()
+    store.insert_operational_service_repository_mappings = AsyncMock()
+
+    await PagerDutyOperationalSync(
+        client=client,
+        store=store,
+        normalizer=normalizer,
+    ).run(PagerDutySyncOptions("services", None, None))
+
+    store.load_repository_catalog.assert_awaited_once_with("org-1")
+    inserted = [
+        row
+        for call in store.insert_operational_service_repository_mappings.await_args_list
+        for row in call.args[0]
+    ]
+    mapping = next(row for row in inserted if row.repo_full_name == "full-chaos/app")
+    assert mapping.repo_id == repo_id
+    assert mapping.repo_provider == "github"

--- a/tests/providers/test_pagerduty_webhook_children.py
+++ b/tests/providers/test_pagerduty_webhook_children.py
@@ -1,0 +1,200 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.webhooks.pagerduty_models import PagerDutyV3Webhook
+from dev_health_ops.models.operational import (
+    CanonicalOperationalEntity,
+    IncidentNote,
+    IncidentResponder,
+    IncidentTimelineEvent,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+    OperationalTeam,
+    OperationalUser,
+)
+from dev_health_ops.providers.pagerduty.models import Incident
+from dev_health_ops.providers.pagerduty.webhooks import reconcile_pagerduty_webhook
+
+
+class _Store:
+    def __init__(self) -> None:
+        self.incidents: list[OperationalIncident] = []
+        self.notes: list[IncidentNote] = []
+        self.responders: list[IncidentResponder] = []
+        self.timeline_events: list[IncidentTimelineEvent] = []
+        self.users: list[OperationalUser] = []
+        self.teams: list[OperationalTeam] = []
+
+    async def load_active_operational_entities(
+        self,
+        entity_type: type[CanonicalOperationalEntity],
+        *,
+        org_id: str,
+        provider: str,
+        provider_instance_id: str,
+        source_entity_type: str,
+        include_deleted: bool = False,
+    ) -> list[CanonicalOperationalEntity]:
+        return []
+
+    async def insert_operational_services(
+        self, values: list[OperationalService]
+    ) -> None:
+        return None
+
+    async def insert_operational_incidents(
+        self, values: list[OperationalIncident]
+    ) -> None:
+        self.incidents.extend(values)
+
+    async def insert_operational_alerts(self, values: list[OperationalAlert]) -> None:
+        return None
+
+    async def insert_operational_incident_timeline_events(
+        self, values: list[IncidentTimelineEvent]
+    ) -> None:
+        self.timeline_events.extend(values)
+
+    async def insert_operational_incident_notes(
+        self, values: list[IncidentNote]
+    ) -> None:
+        self.notes.extend(values)
+
+    async def insert_operational_incident_responders(
+        self, values: list[IncidentResponder]
+    ) -> None:
+        self.responders.extend(values)
+
+    async def insert_operational_users(self, values: list[OperationalUser]) -> None:
+        self.users.extend(values)
+
+    async def insert_operational_teams(self, values: list[OperationalTeam]) -> None:
+        self.teams.extend(values)
+
+
+class _Client:
+    async def get_incident(self, incident_id: str) -> Incident:
+        raise AssertionError(incident_id)
+
+
+_OCCURRED_AT = datetime(2026, 7, 17, 12, 0, tzinfo=UTC)
+
+
+def _webhook(event_type: str, data: dict[str, object]) -> PagerDutyV3Webhook:
+    return PagerDutyV3Webhook.model_validate(
+        {
+            "event": {
+                "id": f"event-{event_type}",
+                "event_type": event_type,
+                "occurred_at": _OCCURRED_AT.isoformat(),
+                "data": data,
+            }
+        }
+    )
+
+
+def _incident() -> dict[str, str]:
+    return {
+        "id": "incident-1",
+        "title": "Payments unavailable",
+        "status": "triggered",
+        "created_at": _OCCURRED_AT.isoformat(),
+    }
+
+
+@pytest.mark.anyio
+async def test_responder_webhook_materializes_responder_user_and_team() -> None:
+    store = _Store()
+    webhook = _webhook(
+        "incident.responder.added",
+        {
+            "incident": _incident(),
+            "responder": {
+                "id": "responder-1",
+                "name": "Ava",
+                "role": "responder",
+                "user": {"id": "user-1", "name": "Ava"},
+                "team": {"id": "team-1", "name": "Operations"},
+            },
+        },
+    )
+
+    processed = await reconcile_pagerduty_webhook(
+        webhook=webhook,
+        org_id="org-1",
+        provider_instance_id="acme",
+        received_at=_OCCURRED_AT,
+        store=store,
+        client=_Client(),
+    )
+
+    assert processed is True
+    assert store.responders[0].source_event_id == webhook.event.id
+    assert store.responders[0].source_version_at == _OCCURRED_AT
+    assert store.users[0].source_event_id == webhook.event.id
+    assert store.teams[0].source_event_id == webhook.event.id
+
+
+@pytest.mark.anyio
+async def test_annotation_webhook_materializes_incident_note() -> None:
+    store = _Store()
+    webhook = _webhook(
+        "incident.annotated",
+        {
+            "incident": _incident(),
+            "note": {
+                "id": "note-1",
+                "content": "Investigating the outage",
+                "created_at": _OCCURRED_AT.isoformat(),
+                "user": {"id": "user-1", "name": "Ava"},
+            },
+        },
+    )
+
+    processed = await reconcile_pagerduty_webhook(
+        webhook=webhook,
+        org_id="org-1",
+        provider_instance_id="acme",
+        received_at=_OCCURRED_AT,
+        store=store,
+        client=_Client(),
+    )
+
+    assert processed is True
+    assert store.notes[0].source_event_id == webhook.event.id
+    assert store.notes[0].source_version_at == _OCCURRED_AT
+    assert store.notes[0].body == "Investigating the outage"
+
+
+@pytest.mark.anyio
+async def test_status_update_webhook_materializes_timeline_event() -> None:
+    store = _Store()
+    webhook = _webhook(
+        "incident.status_update_published",
+        {
+            "incident": _incident(),
+            "status_update": {
+                "id": "status-update-1",
+                "summary": "Mitigation is in progress",
+                "created_at": _OCCURRED_AT.isoformat(),
+            },
+        },
+    )
+
+    processed = await reconcile_pagerduty_webhook(
+        webhook=webhook,
+        org_id="org-1",
+        provider_instance_id="acme",
+        received_at=_OCCURRED_AT,
+        store=store,
+        client=_Client(),
+    )
+
+    assert processed is True
+    assert store.timeline_events[0].source_event_id == webhook.event.id
+    assert store.timeline_events[0].source_version_at == _OCCURRED_AT
+    assert store.timeline_events[0].body == "Mitigation is in progress"

--- a/tests/providers/test_pagerduty_webhook_children.py
+++ b/tests/providers/test_pagerduty_webhook_children.py
@@ -97,7 +97,7 @@ def _webhook(event_type: str, data: dict[str, object]) -> PagerDutyV3Webhook:
     )
 
 
-def _incident() -> dict[str, str]:
+def _incident() -> dict[str, object]:
     return {
         "id": "incident-1",
         "title": "Payments unavailable",
@@ -112,14 +112,10 @@ async def test_responder_webhook_materializes_responder_user_and_team() -> None:
     webhook = _webhook(
         "incident.responder.added",
         {
+            "type": "incident_responder",
+            "state": "pending",
+            "user": {"id": "user-1", "name": "Ava"},
             "incident": _incident(),
-            "responder": {
-                "id": "responder-1",
-                "name": "Ava",
-                "role": "responder",
-                "user": {"id": "user-1", "name": "Ava"},
-                "team": {"id": "team-1", "name": "Operations"},
-            },
         },
     )
 
@@ -136,7 +132,6 @@ async def test_responder_webhook_materializes_responder_user_and_team() -> None:
     assert store.responders[0].source_event_id == webhook.event.id
     assert store.responders[0].source_version_at == _OCCURRED_AT
     assert store.users[0].source_event_id == webhook.event.id
-    assert store.teams[0].source_event_id == webhook.event.id
 
 
 @pytest.mark.anyio
@@ -145,13 +140,11 @@ async def test_annotation_webhook_materializes_incident_note() -> None:
     webhook = _webhook(
         "incident.annotated",
         {
+            "id": "note-1",
+            "type": "incident_note",
+            "content": "Investigating the outage",
+            "created_at": _OCCURRED_AT.isoformat(),
             "incident": _incident(),
-            "note": {
-                "id": "note-1",
-                "content": "Investigating the outage",
-                "created_at": _OCCURRED_AT.isoformat(),
-                "user": {"id": "user-1", "name": "Ava"},
-            },
         },
     )
 
@@ -176,12 +169,11 @@ async def test_status_update_webhook_materializes_timeline_event() -> None:
     webhook = _webhook(
         "incident.status_update_published",
         {
+            "id": "status-update-1",
+            "type": "incident_status_update",
+            "message": "Mitigation is in progress",
+            "created_at": _OCCURRED_AT.isoformat(),
             "incident": _incident(),
-            "status_update": {
-                "id": "status-update-1",
-                "summary": "Mitigation is in progress",
-                "created_at": _OCCURRED_AT.isoformat(),
-            },
         },
     )
 
@@ -198,3 +190,21 @@ async def test_status_update_webhook_materializes_timeline_event() -> None:
     assert store.timeline_events[0].source_event_id == webhook.event.id
     assert store.timeline_events[0].source_version_at == _OCCURRED_AT
     assert store.timeline_events[0].body == "Mitigation is in progress"
+
+
+@pytest.mark.anyio
+async def test_service_updated_webhook_reconciles_incident() -> None:
+    store = _Store()
+    webhook = _webhook("incident.service_updated", _incident())
+
+    processed = await reconcile_pagerduty_webhook(
+        webhook=webhook,
+        org_id="org-1",
+        provider_instance_id="acme",
+        received_at=_OCCURRED_AT,
+        store=store,
+        client=_Client(),
+    )
+
+    assert processed is True
+    assert store.incidents[0].source_event_id == webhook.event.id

--- a/tests/providers/test_pagerduty_webhooks.py
+++ b/tests/providers/test_pagerduty_webhooks.py
@@ -1,0 +1,148 @@
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from dev_health_ops.api.webhooks.pagerduty_models import PagerDutyV3Webhook
+from dev_health_ops.models.operational import (
+    CanonicalOperationalEntity,
+    IncidentNote,
+    IncidentTimelineEvent,
+    OperationalAlert,
+    OperationalIncident,
+    OperationalService,
+)
+from dev_health_ops.providers.pagerduty.models import Incident
+from dev_health_ops.providers.pagerduty.webhooks import reconcile_pagerduty_webhook
+
+
+class Store:
+    def __init__(self, current: CanonicalOperationalEntity) -> None:
+        self.current = current
+        self.services: list[OperationalService] = []
+        self.incidents: list[OperationalIncident] = []
+
+    async def load_active_operational_entities(
+        self,
+        entity_type: type[CanonicalOperationalEntity],
+        *,
+        org_id: str,
+        provider: str,
+        provider_instance_id: str,
+        source_entity_type: str,
+    ) -> list[CanonicalOperationalEntity]:
+        return [self.current] if type(self.current) is entity_type else []
+
+    async def insert_operational_services(
+        self, values: list[OperationalService]
+    ) -> None:
+        self.services.extend(values)
+
+    async def insert_operational_incidents(
+        self, values: list[OperationalIncident]
+    ) -> None:
+        self.incidents.extend(values)
+
+    async def insert_operational_alerts(self, values: list[OperationalAlert]) -> None:
+        return None
+
+    async def insert_operational_incident_timeline_events(
+        self, values: list[IncidentTimelineEvent]
+    ) -> None:
+        return None
+
+    async def insert_operational_incident_notes(
+        self, values: list[IncidentNote]
+    ) -> None:
+        return None
+
+
+class Client:
+    async def get_incident(self, incident_id: str) -> Incident:
+        raise AssertionError(incident_id)
+
+
+def _incident_event(occurred_at: datetime) -> PagerDutyV3Webhook:
+    return PagerDutyV3Webhook.model_validate(
+        {
+            "event": {
+                "id": "event-1",
+                "event_type": "incident.triggered",
+                "occurred_at": occurred_at.isoformat(),
+                "data": {
+                    "id": "incident-1",
+                    "title": "Payments unavailable",
+                    "status": "triggered",
+                    "created_at": occurred_at.isoformat(),
+                },
+            }
+        }
+    )
+
+
+@pytest.mark.anyio
+async def test_out_of_order_incident_does_not_regress_current_entity() -> None:
+    occurred_at = datetime(2026, 7, 17, tzinfo=UTC)
+    store = Store(
+        OperationalIncident(
+            org_id="org-1",
+            provider="pagerduty",
+            provider_instance_id="acme",
+            source_entity_type="incident",
+            external_id="incident-1",
+            source_version_at=datetime(2026, 7, 18, tzinfo=UTC),
+            title="Newer incident",
+        )
+    )
+
+    processed = await reconcile_pagerduty_webhook(
+        webhook=_incident_event(occurred_at),
+        org_id="org-1",
+        provider_instance_id="acme",
+        received_at=datetime(2026, 7, 19, tzinfo=UTC),
+        store=store,
+        client=Client(),
+    )
+
+    assert processed is False
+    assert store.incidents == []
+
+
+@pytest.mark.anyio
+async def test_service_delete_writes_versioned_tombstone() -> None:
+    occurred_at = datetime(2026, 7, 18, tzinfo=UTC)
+    store = Store(
+        OperationalService(
+            org_id="org-1",
+            provider="pagerduty",
+            provider_instance_id="acme",
+            source_entity_type="service",
+            external_id="service-1",
+            source_version_at=datetime(2026, 7, 17, tzinfo=UTC),
+            name="Payments",
+        )
+    )
+    webhook = PagerDutyV3Webhook.model_validate(
+        {
+            "event": {
+                "id": "event-2",
+                "event_type": "service.deleted",
+                "occurred_at": occurred_at.isoformat(),
+                "data": {"id": "service-1", "name": "Payments"},
+            }
+        }
+    )
+
+    processed = await reconcile_pagerduty_webhook(
+        webhook=webhook,
+        org_id="org-1",
+        provider_instance_id="acme",
+        received_at=occurred_at,
+        store=store,
+        client=Client(),
+    )
+
+    assert processed is True
+    assert store.services[0].is_deleted is True
+    assert store.services[0].source_version_at == occurred_at

--- a/tests/providers/test_pagerduty_webhooks.py
+++ b/tests/providers/test_pagerduty_webhooks.py
@@ -31,6 +31,7 @@ class Store:
         provider: str,
         provider_instance_id: str,
         source_entity_type: str,
+        include_deleted: bool = False,
     ) -> list[CanonicalOperationalEntity]:
         return [self.current] if type(self.current) is entity_type else []
 
@@ -146,3 +147,42 @@ async def test_service_delete_writes_versioned_tombstone() -> None:
     assert processed is True
     assert store.services[0].is_deleted is True
     assert store.services[0].source_version_at == occurred_at
+
+
+@pytest.mark.anyio
+async def test_stale_service_update_cannot_resurrect_a_tombstone() -> None:
+    store = Store(
+        OperationalService(
+            org_id="org-1",
+            provider="pagerduty",
+            provider_instance_id="acme",
+            source_entity_type="service",
+            external_id="service-1",
+            source_version_at=datetime(2026, 7, 18, tzinfo=UTC),
+            name="Payments",
+            is_deleted=True,
+            deleted_at=datetime(2026, 7, 18, tzinfo=UTC),
+        )
+    )
+    webhook = PagerDutyV3Webhook.model_validate(
+        {
+            "event": {
+                "id": "event-3",
+                "event_type": "service.updated",
+                "occurred_at": "2026-07-17T00:00:00Z",
+                "data": {"id": "service-1", "name": "Payments"},
+            }
+        }
+    )
+
+    processed = await reconcile_pagerduty_webhook(
+        webhook=webhook,
+        org_id="org-1",
+        provider_instance_id="acme",
+        received_at=datetime(2026, 7, 19, tzinfo=UTC),
+        store=store,
+        client=Client(),
+    )
+
+    assert processed is False
+    assert store.services == []

--- a/tests/providers/test_pagerduty_webhooks.py
+++ b/tests/providers/test_pagerduty_webhooks.py
@@ -8,10 +8,13 @@ from dev_health_ops.api.webhooks.pagerduty_models import PagerDutyV3Webhook
 from dev_health_ops.models.operational import (
     CanonicalOperationalEntity,
     IncidentNote,
+    IncidentResponder,
     IncidentTimelineEvent,
     OperationalAlert,
     OperationalIncident,
     OperationalService,
+    OperationalTeam,
+    OperationalUser,
 )
 from dev_health_ops.providers.pagerduty.models import Incident
 from dev_health_ops.providers.pagerduty.webhooks import reconcile_pagerduty_webhook
@@ -56,6 +59,17 @@ class Store:
     async def insert_operational_incident_notes(
         self, values: list[IncidentNote]
     ) -> None:
+        return None
+
+    async def insert_operational_incident_responders(
+        self, values: list[IncidentResponder]
+    ) -> None:
+        return None
+
+    async def insert_operational_users(self, values: list[OperationalUser]) -> None:
+        return None
+
+    async def insert_operational_teams(self, values: list[OperationalTeam]) -> None:
         return None
 
 

--- a/tests/test_admin_sync_targets.py
+++ b/tests/test_admin_sync_targets.py
@@ -1,6 +1,43 @@
-from dev_health_ops.api.admin.routers.sync import PROVIDER_SYNC_TARGETS
+from typing import Any
+
+from dev_health_ops.api.admin.routers.sync import (
+    PROVIDER_SYNC_TARGETS,
+    _planner_dataset_options,
+)
 
 
 def test_provider_sync_targets_include_feature_flag_sources():
     assert "feature-flags" in PROVIDER_SYNC_TARGETS["gitlab"]
     assert PROVIDER_SYNC_TARGETS["launchdarkly"] == ["feature-flags"]
+
+
+def test_planner_dataset_options_forwards_pagerduty_service_mappings() -> None:
+    mappings = {
+        "admin": {"svc-1": [{"provider": "github", "full_name": "full-chaos/api"}]},
+        "compass": {"svc-2": [{"provider": "gitlab", "full_name": "full-chaos/w"}]},
+    }
+    parent_options = {"service_repository_mappings": mappings}
+
+    options = _planner_dataset_options(
+        "pagerduty", "services", ["services"], parent_options
+    )
+
+    assert options["legacy_targets"] == ["services"]
+    assert options["service_repository_mappings"] == mappings
+
+
+def test_planner_dataset_options_scopes_mappings_to_pagerduty_services() -> None:
+    parent_options: dict[str, Any] = {
+        "service_repository_mappings": {"admin": {"svc-1": []}},
+    }
+
+    # Wrong dataset, wrong provider, and missing config all omit the mappings.
+    assert "service_repository_mappings" not in _planner_dataset_options(
+        "pagerduty", "incidents", ["incidents"], parent_options
+    )
+    assert "service_repository_mappings" not in _planner_dataset_options(
+        "github", "services", ["services"], parent_options
+    )
+    assert "service_repository_mappings" not in _planner_dataset_options(
+        "pagerduty", "services", ["services"], {}
+    )

--- a/tests/test_job_dora.py
+++ b/tests/test_job_dora.py
@@ -114,6 +114,50 @@ def test_run_dora_metrics_job_github_org_no_gitlab_token(monkeypatch):
     assert by_metric["time_to_restore_service"] == pytest.approx(3600.0)
 
 
+def test_run_dora_metrics_job_uses_mapped_pagerduty_projection_once(monkeypatch):
+    """A canonical PagerDuty incident joins its mapped repo without double counting."""
+    repo_id = uuid.uuid4()
+    deployment = {
+        "repo_id": repo_id,
+        "deployment_id": "d1",
+        "status": "success",
+        "environment": "production",
+        "started_at": datetime(2025, 1, 1, 9, 0, tzinfo=timezone.utc),
+        "finished_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+        "deployed_at": datetime(2025, 1, 1, 10, 0, tzinfo=timezone.utc),
+        "merged_at": None,
+        "pull_request_number": None,
+    }
+    canonical_projection = {
+        "repo_id": repo_id,
+        "incident_id": "pd-incident",
+        "status": "resolved",
+        "started_at": datetime(2025, 1, 1, 13, 0, tzinfo=timezone.utc),
+        "resolved_at": datetime(2025, 1, 1, 14, 0, tzinfo=timezone.utc),
+        "last_synced": datetime(2025, 1, 1, 14, 0, tzinfo=timezone.utc),
+    }
+    sink = _CapturingClickHouseSink(
+        deployments=[deployment],
+        incidents=[canonical_projection, canonical_projection],
+    )
+    monkeypatch.setattr(job_dora, "ClickHouseMetricsSink", lambda _db_url: sink)
+
+    job_dora.run_dora_metrics_job(
+        db_url="clickhouse://localhost:8123/default",
+        day=date(2025, 1, 1),
+        backfill_days=1,
+        org_id="a78c1a6a-0000-0000-0000-000000000000",
+    )
+
+    by_metric = {row.metric_name: row.value for row in sink.written}
+    assert by_metric["time_to_restore_service"] == pytest.approx(3600.0)
+    incident_query = next(
+        query for query, _params in sink.queries if "FROM incidents" in query
+    )
+    assert "operational_incidents" in incident_query
+    assert "operational_service_repository_mappings" in incident_query
+
+
 def test_run_dora_metrics_job_no_deployments_writes_nothing(monkeypatch):
     monkeypatch.delenv("GITLAB_TOKEN", raising=False)
     sink = _FakeClickHouseSink(deployments=[], incidents=[])

--- a/tests/test_job_dora.py
+++ b/tests/test_job_dora.py
@@ -284,8 +284,8 @@ def test_run_dora_metrics_job_no_repo_scope_omits_filter(monkeypatch):
     )
 
     for query, params in sink.queries:
-        assert "repo_id =" not in query
-        assert "FROM repos" not in query
+        assert "AND repo_id = {repo_id:UUID}" not in query
+        assert "repo = {repo_name:String}" not in query
         assert "repo_id" not in params
         assert "repo_name" not in params
 

--- a/tests/test_operational_contract.py
+++ b/tests/test_operational_contract.py
@@ -14,6 +14,7 @@ from dev_health_ops.models.operational import (
     OPERATIONAL_ENTITY_TABLES,
     OperationalIncident,
     OperationalService,
+    ServiceRepositoryMapping,
     canonical_operational_id,
 )
 from dev_health_ops.storage.clickhouse import ClickHouseStore
@@ -283,3 +284,53 @@ def test_store_hides_the_latest_incident_tombstone() -> None:
 
     # Then: the current tombstone is absent from the canonical read result.
     assert actual == []
+
+
+def test_store_loads_active_mapping_by_org_service_and_repository() -> None:
+    service = equivalent_operational_lifecycles()[0].service
+    mapping = ServiceRepositoryMapping(
+        org_id=service.org_id,
+        provider=service.provider,
+        provider_instance_id=service.provider_instance_id,
+        source_entity_type="admin_configuration",
+        external_id="svc:github:full-chaos/payments:admin.v1",
+        source_version_at=service.observed_at,
+        service_id=service.id,
+        repo_full_name="full-chaos/payments",
+        repo_provider="github",
+        mapping_kind="admin_configuration_exact",
+        rule_id="service_repository_mapping.admin.v1",
+        relationship_provenance="admin_configuration",
+        relationship_confidence=1.0,
+    )
+    row = tuple(
+        getattr(mapping, field.name) for field in fields(ServiceRepositoryMapping)
+    )
+
+    class QueryResult:
+        result_rows = [row]
+
+    class RecordingClient:
+        def __init__(self) -> None:
+            self.parameters: dict[str, str] | None = None
+
+        def query(self, query: str, parameters: dict[str, str]) -> QueryResult:
+            assert "operational_service_repository_mappings FINAL" in query
+            self.parameters = parameters
+            return QueryResult()
+
+    store = ClickHouseStore("clickhouse://unused")
+    store.client = RecordingClient()
+
+    actual = asyncio.run(
+        store.load_operational_service_repository_mappings(
+            service.org_id,
+            service_id=service.id,
+        )
+    )
+
+    assert actual == [mapping]
+    assert store.client.parameters == {
+        "org_id": service.org_id,
+        "service_id": service.id,
+    }

--- a/tests/test_operational_contract.py
+++ b/tests/test_operational_contract.py
@@ -334,3 +334,54 @@ def test_store_loads_active_mapping_by_org_service_and_repository() -> None:
         "org_id": service.org_id,
         "service_id": service.id,
     }
+
+
+def test_store_load_active_mappings_filters_by_is_active_not_is_deleted() -> None:
+    # Given: an active mapping row; the mapping table has is_active, not is_deleted.
+    mapping = ServiceRepositoryMapping(
+        org_id="org-a",
+        provider="pagerduty",
+        provider_instance_id="pd-a",
+        source_entity_type="pagerduty_service_metadata",
+        external_id="svc:github:full-chaos/api:metadata.v1",
+        source_version_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
+        service_id="svc-1",
+        repo_full_name="full-chaos/api",
+        repo_provider="github",
+        relationship_provenance="pagerduty_service_metadata",
+        relationship_confidence=0.95,
+    )
+    row = tuple(
+        getattr(mapping, field.name) for field in fields(ServiceRepositoryMapping)
+    )
+
+    class QueryResult:
+        result_rows = [row]
+
+    class RecordingClient:
+        def __init__(self) -> None:
+            self.query_text: str | None = None
+
+        def query(self, query: str, parameters: dict[str, str]) -> QueryResult:
+            self.query_text = query
+            return QueryResult()
+
+    store = ClickHouseStore("clickhouse://unused")
+    store.client = RecordingClient()
+
+    # When: reconciliation loads active mapping evidence via the generic reader.
+    actual = asyncio.run(
+        store.load_active_operational_entities(
+            ServiceRepositoryMapping,
+            org_id="org-a",
+            provider="pagerduty",
+            provider_instance_id="pd-a",
+            source_entity_type="pagerduty_service_metadata",
+        )
+    )
+
+    # Then: the SQL filters on the real is_active column, never is_deleted.
+    assert actual == [mapping]
+    assert store.client.query_text is not None
+    assert "is_active = 1" in store.client.query_text
+    assert "is_deleted" not in store.client.query_text

--- a/tests/work_graph/test_builder.py
+++ b/tests/work_graph/test_builder.py
@@ -86,6 +86,45 @@ class TestWorkGraphBuilder:
             builder.close()
             fake_sink.close.assert_called_once()
 
+    def test_passes_operational_scope_to_edge_builder(self) -> None:
+        from_date = datetime(2026, 7, 15, tzinfo=timezone.utc)
+        to_date = datetime(2026, 7, 17, tzinfo=timezone.utc)
+        repo_id = uuid.uuid4()
+        config = BuildConfig(
+            dsn="clickhouse://localhost:9000/default",
+            org_id="org-a",
+            from_date=from_date,
+            to_date=to_date,
+            repo_id=repo_id,
+        )
+        fake_sink = MagicMock()
+        fake_sink.backend_type = "clickhouse"
+
+        with (
+            patch(
+                "dev_health_ops.work_graph.builder.create_sink", return_value=fake_sink
+            ),
+            patch(
+                "dev_health_ops.work_graph.builder.build_operational_incident_edges",
+                return_value=[],
+            ) as build_operational_edges,
+        ):
+            builder = WorkGraphBuilder(config)
+            with patch.object(builder, "_write_edges", return_value=0):
+                builder._build_operational_incident_edges()
+            builder.close()
+
+        build_operational_edges.assert_called_once_with(
+            fake_sink,
+            "org-a",
+            builder._now,
+            config.heuristic_days_window,
+            config.heuristic_confidence,
+            from_date,
+            to_date,
+            repo_id,
+        )
+
 
 class TestDependencyIssuePrLinks:
     def test_linear_attachment_derives_issue_pr_fast_path_link(self):

--- a/tests/work_graph/test_operational_edges.py
+++ b/tests/work_graph/test_operational_edges.py
@@ -233,3 +233,88 @@ def test_operational_edges_apply_repository_and_time_scope() -> None:
     assert mapping_params["repo_id"] == repo_id
     assert incident_params["from_date"] == from_date
     assert incident_params["to_date"] == to_date
+
+
+def test_deployment_correlation_excludes_same_repo_id_from_another_org() -> None:
+    now = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+    shared_repo_id = uuid4()
+    sink = MagicMock()
+    queries: list[str] = []
+
+    datasets: dict[str, list[dict[str, object]]] = {
+        "operational_service_repository_mappings": [
+            {
+                "org_id": "org-a",
+                "service_id": "svc-a",
+                "repo_id": shared_repo_id,
+                "relationship_provenance": "admin_configuration",
+                "relationship_confidence": 1.0,
+                "mapping_kind": "admin_configuration_exact",
+                "rule_id": "admin.v1",
+                "source_url": None,
+            },
+            {
+                "org_id": "org-b",
+                "service_id": "svc-b",
+                "repo_id": shared_repo_id,
+                "relationship_provenance": "admin_configuration",
+                "relationship_confidence": 1.0,
+                "mapping_kind": "admin_configuration_exact",
+                "rule_id": "admin.v1",
+                "source_url": None,
+            },
+        ],
+        "operational_incidents": [
+            {
+                "org_id": "org-a",
+                "id": "inc-a",
+                "service_id": "svc-a",
+                "escalation_policy_id": None,
+                "started_at": now,
+                "source_url": None,
+            },
+            {
+                "org_id": "org-b",
+                "id": "inc-b",
+                "service_id": "svc-b",
+                "escalation_policy_id": None,
+                "started_at": now,
+                "source_url": None,
+            },
+        ],
+        "deployments": [
+            {
+                "org_id": "org-a",
+                "repo_id": shared_repo_id,
+                "deployment_id": "deploy-a",
+                "environment": "production",
+                "deployed_at": now - timedelta(hours=1),
+            },
+            {
+                "org_id": "org-b",
+                "repo_id": shared_repo_id,
+                "deployment_id": "deploy-b",
+                "environment": "production",
+                "deployed_at": now - timedelta(hours=1),
+            },
+        ],
+    }
+
+    def query(query: str, params: dict[str, object]) -> list[dict[str, object]]:
+        queries.append(query)
+        dataset = next((rows for table, rows in datasets.items() if table in query), [])
+        if "WHERE org_id = {org_id:String}" not in query:
+            return dataset
+        return [row for row in dataset if row["org_id"] == params["org_id"]]
+
+    sink.query_dicts.side_effect = query
+
+    edges = build_operational_incident_edges(sink, "org-a", now, 7, 0.3)
+
+    deployment_edges = [
+        edge for edge in edges if edge.edge_type.value == "linked_incident"
+    ]
+    assert [(edge.source_id, edge.target_id) for edge in deployment_edges] == [
+        ("deploy-a", "inc-a")
+    ]
+    assert all("WHERE org_id = {org_id:String}" in query for query in queries)

--- a/tests/work_graph/test_operational_edges.py
+++ b/tests/work_graph/test_operational_edges.py
@@ -1,0 +1,80 @@
+from datetime import datetime, timezone
+from unittest.mock import MagicMock
+from uuid import uuid4
+
+from dev_health_ops.work_graph.operational_edges import build_operational_incident_edges
+
+
+def test_mapped_service_incident_emits_provenance_backed_deployment_edge() -> None:
+    now = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    repo_id = uuid4()
+    sink = MagicMock()
+
+    def query(query: str, _params: dict[str, str]) -> list[dict[str, object]]:
+        if "operational_service_repository_mappings" in query:
+            return [
+                {
+                    "service_id": "svc-1",
+                    "repo_id": repo_id,
+                    "relationship_provenance": "admin_configuration",
+                    "relationship_confidence": 1.0,
+                    "mapping_kind": "admin_configuration_exact",
+                    "rule_id": "admin.v1",
+                    "source_url": None,
+                }
+            ]
+        if "operational_incidents" in query:
+            return [
+                {
+                    "id": "inc-1",
+                    "service_id": "svc-1",
+                    "escalation_policy_id": None,
+                    "started_at": now,
+                    "source_url": "https://pagerduty.example/inc-1",
+                }
+            ]
+        if "operational_services" in query:
+            return []
+        if (
+            "operational_alerts" in query
+            or "operational_incident_timeline_events" in query
+            or "operational_incident_notes" in query
+            or "operational_incident_responders" in query
+            or "work_items" in query
+            or "repos" in query
+        ):
+            return []
+        if "deployments" in query:
+            return [
+                {
+                    "repo_id": repo_id,
+                    "deployment_id": "deploy-1",
+                    "environment": "production",
+                    "deployed_at": now,
+                }
+            ]
+        return []
+
+    sink.query_dicts.side_effect = query
+
+    edges = build_operational_incident_edges(sink, "org-a", now, 7, 0.3)
+
+    deployment_edge = next(
+        edge for edge in edges if edge.edge_type.value == "linked_incident"
+    )
+    assert deployment_edge.source_id == "deploy-1"
+    assert deployment_edge.target_id == "inc-1"
+    assert deployment_edge.provenance.value == "heuristic"
+    assert deployment_edge.confidence == 0.3
+    assert "operational_service_mapped_deployment_window.v1" in deployment_edge.evidence
+    assert "environment:production" in deployment_edge.evidence
+
+
+def test_unmapped_service_never_emits_deployment_edge() -> None:
+    now = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    sink = MagicMock()
+    sink.query_dicts.return_value = []
+
+    edges = build_operational_incident_edges(sink, "org-a", now, 7, 0.3)
+
+    assert not [edge for edge in edges if edge.edge_type.value == "linked_incident"]

--- a/tests/work_graph/test_operational_edges.py
+++ b/tests/work_graph/test_operational_edges.py
@@ -318,3 +318,65 @@ def test_deployment_correlation_excludes_same_repo_id_from_another_org() -> None
         ("deploy-a", "inc-a")
     ]
     assert all("WHERE org_id = {org_id:String}" in query for query in queries)
+
+
+def test_repo_scoped_build_rejects_cross_repo_pr_edges_from_note_body() -> None:
+    now = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    requested_repo_id = uuid4()
+    other_repo_id = uuid4()
+    sink = MagicMock()
+
+    def query(q: str, _params: dict[str, object]) -> list[dict[str, object]]:
+        if "operational_service_repository_mappings" in q:
+            return [
+                {
+                    "service_id": "svc-1",
+                    "repo_id": requested_repo_id,
+                    "relationship_provenance": "admin_configuration",
+                    "relationship_confidence": 1.0,
+                    "mapping_kind": "admin_configuration_exact",
+                    "rule_id": "admin.v1",
+                    "source_url": None,
+                }
+            ]
+        if "operational_incidents" in q:
+            return [
+                {
+                    "id": "inc-1",
+                    "service_id": "svc-1",
+                    "escalation_policy_id": None,
+                    "started_at": now,
+                    "source_url": None,
+                }
+            ]
+        if "operational_incident_notes" in q:
+            return [
+                {
+                    "id": "note-1",
+                    "incident_id": "inc-1",
+                    "body": (
+                        "Fixed via https://github.com/req-org/req-repo/pull/7 "
+                        "and https://github.com/other-org/other-repo/pull/42"
+                    ),
+                    "author_user_id": None,
+                    "source_url": None,
+                    "created_at": now,
+                }
+            ]
+        if "FROM repos FINAL" in q:
+            return [
+                {"id": requested_repo_id, "repo": "req-org/req-repo"},
+                {"id": other_repo_id, "repo": "other-org/other-repo"},
+            ]
+        return []
+
+    sink.query_dicts.side_effect = query
+
+    edges = build_operational_incident_edges(
+        sink, "org-a", now, 7, 0.3, repo_id=requested_repo_id
+    )
+
+    pr_edges = [edge for edge in edges if "pull/" in edge.evidence]
+    assert len(pr_edges) == 1
+    assert "pull/7" in pr_edges[0].evidence
+    assert pr_edges[0].repo_id == requested_repo_id

--- a/tests/work_graph/test_operational_edges.py
+++ b/tests/work_graph/test_operational_edges.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from unittest.mock import MagicMock
 from uuid import uuid4
 
@@ -78,3 +78,158 @@ def test_unmapped_service_never_emits_deployment_edge() -> None:
     edges = build_operational_incident_edges(sink, "org-a", now, 7, 0.3)
 
     assert not [edge for edge in edges if edge.edge_type.value == "linked_incident"]
+
+
+def test_mapping_edge_preserves_heuristic_provenance_and_rule_id() -> None:
+    now = datetime(2026, 7, 17, tzinfo=timezone.utc)
+    repo_id = uuid4()
+    sink = MagicMock()
+
+    def query(query: str, _params: dict[str, object]) -> list[dict[str, object]]:
+        if "operational_service_repository_mappings" in query:
+            return [
+                {
+                    "service_id": "svc-1",
+                    "repo_id": repo_id,
+                    "provider": "catalog",
+                    "relationship_provenance": "bounded_service_repository_heuristic",
+                    "relationship_confidence": 0.4,
+                    "mapping_kind": "bounded_service_repository_heuristic",
+                    "rule_id": "pagerduty.service_repository.bounded_name_match.v1",
+                    "source_url": "https://pagerduty.example/services/svc-1",
+                }
+            ]
+        return []
+
+    sink.query_dicts.side_effect = query
+
+    edges = build_operational_incident_edges(sink, "org-a", now, 7, 0.3)
+
+    mapping_edge = next(
+        edge for edge in edges if edge.edge_type.value == "maps_to_repository"
+    )
+    assert mapping_edge.provenance.value == "heuristic"
+    assert mapping_edge.confidence == 0.4
+    assert mapping_edge.provider == "catalog"
+    assert "pagerduty.service_repository.bounded_name_match.v1" in mapping_edge.evidence
+
+
+def test_deployment_correlation_requires_explicit_environment_and_prior_deployment() -> (
+    None
+):
+    now = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+    repo_id = uuid4()
+    sink = MagicMock()
+
+    def query(query: str, _params: dict[str, object]) -> list[dict[str, object]]:
+        if "operational_service_repository_mappings" in query:
+            return [
+                {
+                    "service_id": "svc-1",
+                    "repo_id": repo_id,
+                    "provider": "pagerduty",
+                    "relationship_provenance": "pagerduty_service_metadata",
+                    "relationship_confidence": 0.95,
+                    "mapping_kind": "pagerduty_service_metadata_exact",
+                    "rule_id": "metadata.v1",
+                    "source_url": None,
+                }
+            ]
+        if "operational_incidents" in query:
+            return [
+                {
+                    "id": "inc-1",
+                    "service_id": "svc-1",
+                    "escalation_policy_id": None,
+                    "started_at": now,
+                    "source_url": None,
+                }
+            ]
+        if "deployments" in query:
+            return [
+                {
+                    "repo_id": repo_id,
+                    "deployment_id": "unspecified",
+                    "environment": "unspecified",
+                    "deployed_at": now - timedelta(hours=1),
+                },
+                {
+                    "repo_id": repo_id,
+                    "deployment_id": "after-incident",
+                    "environment": "production",
+                    "deployed_at": now + timedelta(minutes=1),
+                },
+                {
+                    "repo_id": repo_id,
+                    "deployment_id": "before-incident",
+                    "environment": "production",
+                    "deployed_at": now - timedelta(hours=1),
+                },
+            ]
+        return []
+
+    sink.query_dicts.side_effect = query
+
+    edges = build_operational_incident_edges(sink, "org-a", now, 7, 0.3)
+
+    deployment_edges = [
+        edge for edge in edges if edge.edge_type.value == "linked_incident"
+    ]
+    assert [edge.source_id for edge in deployment_edges] == ["before-incident"]
+
+
+def test_operational_edges_apply_repository_and_time_scope() -> None:
+    now = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
+    from_date = now - timedelta(days=2)
+    to_date = now + timedelta(days=1)
+    repo_id = uuid4()
+    sink = MagicMock()
+    queries: list[tuple[str, dict[str, object]]] = []
+
+    def query(query: str, params: dict[str, object]) -> list[dict[str, object]]:
+        queries.append((query, params))
+        if "operational_service_repository_mappings" in query:
+            return [
+                {
+                    "service_id": "svc-1",
+                    "repo_id": repo_id,
+                    "provider": "pagerduty",
+                    "relationship_provenance": "pagerduty_service_metadata",
+                    "relationship_confidence": 0.95,
+                    "mapping_kind": "pagerduty_service_metadata_exact",
+                    "rule_id": "metadata.v1",
+                    "source_url": "https://github.com/full-chaos/checkout",
+                }
+            ]
+        return []
+
+    sink.query_dicts.side_effect = query
+
+    edges = build_operational_incident_edges(
+        sink,
+        "org-a",
+        now,
+        7,
+        0.3,
+        from_date,
+        to_date,
+        repo_id,
+    )
+
+    assert any(edge.edge_type.value == "maps_to_repository" for edge in edges)
+    mapping_query, mapping_params = next(
+        (query, params)
+        for query, params in queries
+        if "operational_service_repository_mappings" in query
+    )
+    incident_query, incident_params = next(
+        (query, params) for query, params in queries if "operational_incidents" in query
+    )
+    assert "repo_id = {repo_id:UUID}" in mapping_query
+    assert "valid_from <= {now:DateTime}" in mapping_query
+    assert "valid_to IS NULL OR valid_to > {now:DateTime}" in mapping_query
+    assert "started_at >= {from_date:DateTime}" in incident_query
+    assert "started_at <= {to_date:DateTime}" in incident_query
+    assert mapping_params["repo_id"] == repo_id
+    assert incident_params["from_date"] == from_date
+    assert incident_params["to_date"] == to_date

--- a/tests/workers/test_system_pagerduty_webhooks.py
+++ b/tests/workers/test_system_pagerduty_webhooks.py
@@ -1,0 +1,150 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from dev_health_ops.workers import system_webhooks
+
+
+class _RetrySentinel(Exception):
+    pass
+
+
+def _retry_sentinel(*, exc: BaseException, countdown: int) -> None:
+    raise _RetrySentinel from exc
+
+
+def test_pagerduty_worker_retries_when_configuration_is_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("PAGERDUTY_API_TOKEN", raising=False)
+    monkeypatch.delenv("CLICKHOUSE_URI", raising=False)
+
+    with patch.object(
+        system_webhooks.process_pagerduty_webhook_event, "retry", _retry_sentinel
+    ):
+        task = cast(Any, system_webhooks.process_pagerduty_webhook_event)
+        with pytest.raises(_RetrySentinel):
+            task.run(
+                org_id="org-1",
+                provider_instance_id="acme",
+                stream_entry_id="1-0",
+            )
+
+
+def test_pagerduty_worker_deletes_stream_entry_only_after_persistence(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PAGERDUTY_API_TOKEN", "token")
+    monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://example")
+
+    class Redis:
+        deleted: list[tuple[str, str]] = []
+
+        def xrange(self, *_: object, **__: object) -> list[tuple[str, dict[str, str]]]:
+            return [
+                (
+                    "1-0",
+                    {
+                        "payload": json.dumps(
+                            {
+                                "event": {
+                                    "id": "event-1",
+                                    "event_type": "incident.triggered",
+                                    "occurred_at": "2026-07-17T12:00:00Z",
+                                    "data": {
+                                        "id": "incident-1",
+                                        "title": "Payments unavailable",
+                                        "status": "triggered",
+                                        "created_at": "2026-07-17T12:00:00Z",
+                                    },
+                                }
+                            }
+                        ),
+                        "received_at": "2026-07-17T12:00:00+00:00",
+                    },
+                )
+            ]
+
+        def xdel(self, stream: str, entry_id: str) -> None:
+            self.deleted.append((stream, entry_id))
+
+    redis = Redis()
+    with (
+        patch("dev_health_ops.api.ingest.streams.get_redis_client", return_value=redis),
+        patch("dev_health_ops.storage.run_with_store", return_value=MagicMock()),
+        patch("dev_health_ops.workers.system_webhooks.run_async", return_value=True),
+    ):
+        task = cast(Any, system_webhooks.process_pagerduty_webhook_event)
+        result = task.run(
+            org_id="org-1",
+            provider_instance_id="acme",
+            stream_entry_id="1-0",
+        )
+
+    assert result["processed"] is True
+    assert redis.deleted == [("pagerduty-webhooks:org-1:acme", "1-0")]
+
+
+def test_pagerduty_worker_moves_exhausted_entry_to_dlq_before_deleting_source() -> None:
+    writes: list[tuple[str, dict[str, str]]] = []
+    deleted: list[tuple[str, str]] = []
+
+    class Redis:
+        def xadd(self, stream: str, fields: dict[str, str], **_: object) -> str:
+            writes.append((stream, fields))
+            return "2-0"
+
+        def xdel(self, stream: str, entry_id: str) -> None:
+            deleted.append((stream, entry_id))
+
+    task = SimpleNamespace(
+        max_retries=3,
+        request=SimpleNamespace(id="task-1", retries=3),
+    )
+
+    with pytest.raises(RuntimeError, match="persistence exhausted"):
+        system_webhooks._retry_or_dead_letter_pagerduty_webhook(
+            task=task,
+            redis_client=Redis(),
+            stream_name="pagerduty-webhooks:org-1:acme",
+            stream_entry_id="1-0",
+            fields={"event_id": "event-1", "payload": "{}"},
+            error=RuntimeError("ClickHouse unavailable"),
+        )
+
+    assert writes[0][0] == "pagerduty-webhooks:org-1:acme:dlq"
+    assert writes[0][1]["event_id"] == "event-1"
+    assert deleted == [("pagerduty-webhooks:org-1:acme", "1-0")]
+
+
+def test_pagerduty_worker_retains_source_when_dlq_write_fails() -> None:
+    deleted: list[tuple[str, str]] = []
+
+    class Redis:
+        def xadd(self, *_: object, **__: object) -> str:
+            raise RuntimeError("Redis unavailable")
+
+        def xdel(self, stream: str, entry_id: str) -> None:
+            deleted.append((stream, entry_id))
+
+    task = SimpleNamespace(
+        max_retries=3,
+        request=SimpleNamespace(id="task-1", retries=3),
+    )
+
+    with pytest.raises(RuntimeError, match="Redis unavailable"):
+        system_webhooks._retry_or_dead_letter_pagerduty_webhook(
+            task=task,
+            redis_client=Redis(),
+            stream_name="pagerduty-webhooks:org-1:acme",
+            stream_entry_id="1-0",
+            fields={"event_id": "event-1", "payload": "{}"},
+            error=RuntimeError("ClickHouse unavailable"),
+        )
+
+    assert deleted == []

--- a/tests/workers/test_system_pagerduty_webhooks.py
+++ b/tests/workers/test_system_pagerduty_webhooks.py
@@ -148,3 +148,45 @@ def test_pagerduty_worker_retains_source_when_dlq_write_fails() -> None:
         )
 
     assert deleted == []
+
+
+def test_pagerduty_worker_reroutes_unparseable_entry_to_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("PAGERDUTY_API_TOKEN", "token")
+    monkeypatch.setenv("CLICKHOUSE_URI", "clickhouse://example")
+
+    class Redis:
+        def xrange(self, *_: object, **__: object) -> list[tuple[str, dict[str, str]]]:
+            return [
+                (
+                    "1-0",
+                    {
+                        "payload": "not-json",
+                        "received_at": "2026-07-17T12:00:00+00:00",
+                    },
+                )
+            ]
+
+        def xadd(self, *_: object, **__: object) -> str:
+            return "2-0"
+
+        def xdel(self, *_: object, **__: object) -> None:
+            return None
+
+    with (
+        patch(
+            "dev_health_ops.api.ingest.streams.get_redis_client",
+            return_value=Redis(),
+        ),
+        patch.object(
+            system_webhooks.process_pagerduty_webhook_event, "retry", _retry_sentinel
+        ),
+    ):
+        task = cast(Any, system_webhooks.process_pagerduty_webhook_event)
+        with pytest.raises(_RetrySentinel):
+            task.run(
+                org_id="org-1",
+                provider_instance_id="acme",
+                stream_entry_id="1-0",
+            )


### PR DESCRIPTION
## Wave 3 — PagerDuty V3 webhooks + operational correlation

Third wave of the canonical operations / PagerDuty program (CHAOS-2954), delivered on one branch to `main`. Builds on Wave 0-2 (canonical foundation, producer migration, PD REST sync).

Closes **CHAOS-2958** (PagerDuty V3 webhook ingestion) and **CHAOS-2959** (operational incident correlation).

### CHAOS-2958 — PagerDuty V3 webhook ingestion
- Signed V3 webhook receiver (`/webhooks/pagerduty`) with HMAC verification, body-size limits, and a durable Redis-stream hand-off to a Celery worker that reconciles into the canonical operational sinks.
- Webhook reconciliation parses PD V3 event payloads (incident lifecycle, `service_updated`, annotations, responders, status updates) into canonical operational entities.

### CHAOS-2959 — operational correlation
- Service-to-repository mapping evidence (metadata / admin / Compass / bounded heuristic) resolved against the org repo catalog, persisted as canonical mapping rows with provenance + confidence.
- Canonical operational work-graph edges (incident ↔ service / team / escalation policy / deployment / alert / timeline / responder / issue / PR) with evidence on every link.
- Incident metrics cutover (DORA / MTTR / daily / AI incident workflow) to the canonical operational store via `metrics/active_incidents.py`, deduping legacy ∪ canonical.

### Review gate
Reviewed via the Oracle read-only review gate across multiple rounds; final verdict PASS with 0 blockers. Notable defects caught and fixed during review:
- PD V3 child payloads (`incident.annotated` / responder / status-update) live at the `event.data` root, not under invented nested keys; `incident.service_updated` routes through incident (not service) reconciliation.
- Webhook ingest stream is no longer capped with `MAXLEN` (that trimmed unpersisted events under backlog); all pre-persistence worker failures now route through the retry/DLQ path instead of silently dropping.
- Service→repo mapping is now actually active in production: async org-scoped catalog loader on `ClickHouseStore`, entity-aware active-state filter (`is_active` vs `is_deleted`), admin/Compass config given a supported ingress through the integration's sync configuration.
- Mapping tombstones break `ReplacingMergeTree(source_version_at)` version ties.
- Note-derived PR edges stay within the requested repo scope.

### Testing
- `bash ci/local_validate.sh` GREEN: `ruff format --check` + `ruff check` + `mypy` + FULL unit suite (`-n 4 --dist loadscope`, 8183 passed) + ClickHouse migrate + live-engine `argMax` proof.
- New/updated coverage for webhook parsing + durability, mapping activation + config ingress, tombstone versioning, and repo-scope edge isolation.

**Known flaky (pre-existing, unrelated):** `tests/api/admin/test_org_deletion.py` can flake under `-n 4` xdist and passes on re-run.

SCREENSHOT-WAIVER: backend-only change (ingest / metrics / API resolvers / workers); no UI render.

### Follow-ups filed
- CHAOS-2965 — live push idempotency test
- CHAOS-2966 — native snapshot tombstones
- CHAOS-2967 — platform-wide aware-UTC `_normalize_datetime` + data audit
- CHAOS-2968 — durable `(timestamp, last_id)` PD incident cursor
