### PR TITLE
feat(ops): Wave 4 — PagerDuty OAuth-first setup UX (CHAOS-2960)

### DIFF
--- a/src/dev_health_ops/alembic/versions/0041_pagerduty_oauth_setup.py
+++ b/src/dev_health_ops/alembic/versions/0041_pagerduty_oauth_setup.py
@@ -1,0 +1,90 @@
+"""Add PagerDuty OAuth setup: authorization-request state + token metadata.
+
+Revision ID: 0041
+Revises: 0040
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0041"
+down_revision: str | None = "0040"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "pagerduty_oauth_authorization_requests",
+        sa.Column("state_hash", sa.Text(), nullable=False),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("credential_name", sa.Text(), nullable=False),
+        sa.Column("code_verifier_encrypted", sa.Text(), nullable=False),
+        sa.Column("enabled_datasets", sa.JSON(), nullable=False),
+        sa.Column("region", sa.Text(), nullable=False),
+        sa.Column("subdomain", sa.Text(), nullable=True),
+        sa.Column("initiated_by", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=False),
+        sa.PrimaryKeyConstraint("state_hash"),
+    )
+    op.create_index(
+        "ix_pagerduty_oauth_authorization_requests_org_id",
+        "pagerduty_oauth_authorization_requests",
+        ["org_id"],
+    )
+    op.create_index(
+        "ix_pagerduty_oauth_authorization_requests_expires_at",
+        "pagerduty_oauth_authorization_requests",
+        ["expires_at"],
+    )
+
+    op.add_column(
+        "provider_oauth_credentials",
+        sa.Column("binding_id", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "provider_oauth_credentials",
+        sa.Column("expires_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "provider_oauth_credentials",
+        sa.Column("granted_scopes", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "provider_oauth_credentials",
+        sa.Column(
+            "has_refresh_token",
+            sa.Boolean(),
+            nullable=False,
+            server_default="0",
+        ),
+    )
+    op.add_column(
+        "provider_oauth_credentials",
+        sa.Column("account_id", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "provider_oauth_credentials",
+        sa.Column("account_display", sa.Text(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("provider_oauth_credentials", "account_display")
+    op.drop_column("provider_oauth_credentials", "account_id")
+    op.drop_column("provider_oauth_credentials", "has_refresh_token")
+    op.drop_column("provider_oauth_credentials", "granted_scopes")
+    op.drop_column("provider_oauth_credentials", "expires_at")
+    op.drop_column("provider_oauth_credentials", "binding_id")
+    op.drop_index(
+        "ix_pagerduty_oauth_authorization_requests_expires_at",
+        table_name="pagerduty_oauth_authorization_requests",
+    )
+    op.drop_index(
+        "ix_pagerduty_oauth_authorization_requests_org_id",
+        table_name="pagerduty_oauth_authorization_requests",
+    )
+    op.drop_table("pagerduty_oauth_authorization_requests")

--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -16,6 +16,7 @@ from .routers import (
     identities_router,
     integrations_router,
     orgs_router,
+    pagerduty_router,
     platform_router,
     settings_router,
     setup_router,
@@ -49,6 +50,7 @@ router.include_router(orgs_router)
 router.include_router(platform_router)
 router.include_router(features_router)
 router.include_router(github_app_router)
+router.include_router(pagerduty_router)
 router.include_router(governance_router)
 router.include_router(integrations_router)
 

--- a/src/dev_health_ops/api/admin/routers/__init__.py
+++ b/src/dev_health_ops/api/admin/routers/__init__.py
@@ -15,6 +15,7 @@ from .governance import router as governance_router
 from .identities import router as identities_router
 from .integrations import router as integrations_router
 from .orgs import router as orgs_router
+from .pagerduty import router as pagerduty_router
 from .platform import router as platform_router
 from .settings import router as settings_router
 from .setup import router as setup_router
@@ -34,6 +35,7 @@ __all__ = [
     "identities_router",
     "integrations_router",
     "orgs_router",
+    "pagerduty_router",
     "platform_router",
     "settings_router",
     "setup_router",

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -250,6 +250,11 @@ async def create_credential(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> IntegrationCredentialResponse:
+    if payload.provider == "pagerduty":
+        raise HTTPException(
+            status_code=400,
+            detail="Use the dedicated PagerDuty setup endpoints",
+        )
     svc = IntegrationCredentialsService(session, org_id)
     cred = await svc.set(
         provider=payload.provider,
@@ -270,6 +275,11 @@ async def update_credential(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> IntegrationCredentialResponse:
+    if provider == "pagerduty":
+        raise HTTPException(
+            status_code=400,
+            detail="Use the dedicated PagerDuty setup endpoints",
+        )
     svc = IntegrationCredentialsService(session, org_id)
     existing = await svc.get(provider, name)
     if not existing:
@@ -713,7 +723,10 @@ async def _test_pagerduty_connection(
     """Preflight a minimal PagerDuty read without exposing credential material."""
     from dev_health_ops.providers.pagerduty.auth import ApiTokenAuth, OAuthBearerAuth
     from dev_health_ops.providers.pagerduty.client import PagerDutyClient
-    from dev_health_ops.providers.pagerduty.oauth import missing_read_scopes
+    from dev_health_ops.providers.pagerduty.oauth import (
+        DATASET_SCOPES,
+        missing_read_scopes,
+    )
 
     access_token = creds.get("access_token")
     api_token = creds.get("api_token")
@@ -725,11 +738,44 @@ async def _test_pagerduty_connection(
         else ApiTokenAuth(str(api_token))
     )
     client = PagerDutyClient(auth, region=str(creds.get("region", "us")))
-    users = await client.list_users()
-    datasets = {str(value) for value in creds.get("enabled_datasets", [])}
+    datasets = [str(value) for value in creds.get("enabled_datasets", [])]
+    unknown = set(datasets).difference(DATASET_SCOPES)
+    if unknown:
+        await client.close()
+        return False, {
+            "error": f"Unknown PagerDuty datasets: {', '.join(sorted(unknown))}"
+        }
     granted = {str(value) for value in creds.get("granted_scopes", [])}
-    missing = sorted(missing_read_scopes(datasets, granted)) if access_token else []
-    return not missing, {"users_checked": len(users), "missing_scopes": missing}
+    missing = (
+        sorted(missing_read_scopes(set(datasets), granted)) if access_token else []
+    )
+    try:
+        if missing:
+            return False, {"records_checked": 0, "missing_scopes": missing}
+        if not datasets:
+            return False, {"error": "Select at least one PagerDuty dataset"}
+        match datasets[0]:
+            case "incidents":
+                records_count = len(await client.list_incidents())
+            case "services":
+                records_count = len(await client.list_services())
+            case "business_services":
+                records_count = len(await client.list_business_services())
+            case "escalation_policies":
+                records_count = len(await client.list_escalation_policies())
+            case "schedules":
+                records_count = len(await client.list_schedules())
+            case "oncalls":
+                records_count = len(await client.list_oncalls())
+            case "users":
+                records_count = len(await client.list_users())
+            case "teams":
+                records_count = len(await client.list_teams())
+            case unreachable:
+                raise RuntimeError(f"Unsupported PagerDuty dataset: {unreachable}")
+        return True, {"records_checked": records_count, "missing_scopes": []}
+    finally:
+        await client.close()
 
 
 async def _test_launchdarkly_connection(

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -754,6 +754,7 @@ async def _test_pagerduty_connection(
             return False, {"records_checked": 0, "missing_scopes": missing}
         if not datasets:
             return False, {"error": "Select at least one PagerDuty dataset"}
+        records_count = 0
         match datasets[0]:
             case "incidents":
                 records_count = len(await client.list_incidents())

--- a/src/dev_health_ops/api/admin/routers/pagerduty.py
+++ b/src/dev_health_ops/api/admin/routers/pagerduty.py
@@ -1,0 +1,675 @@
+"""PagerDuty OAuth setup endpoints.
+
+This router deliberately owns only the authorization start and callback flow.
+Status, disconnect, preflight, and alternate authentication modes belong in this
+module as separately scoped follow-up endpoints.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Mapping
+from datetime import datetime
+from typing import Literal
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException
+from pydantic import BaseModel, ConfigDict, Field, field_validator
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.admin.middleware import get_admin_org_id, get_admin_user
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.configuration import IntegrationCredentialsService
+from dev_health_ops.providers.pagerduty.oauth import (
+    DATASET_SCOPES,
+    OAuthCallbackValidationError,
+    OAuthTokens,
+    PagerDutyOAuthConfig,
+    build_authorization_request,
+    exchange_code,
+    missing_read_scopes,
+    revoke_token,
+    validate_callback,
+)
+from dev_health_ops.providers.pagerduty.oauth_authorization_store import (
+    PagerDutyAuthorizationRequestStore,
+)
+from dev_health_ops.providers.pagerduty.oauth_storage import (
+    PagerDutyOAuthCredentialRepository,
+)
+
+from .common import get_session
+
+router = APIRouter()
+
+
+class PagerDutyAuthorizeRequest(BaseModel):
+    """Inputs required to begin a server-bound PagerDuty PKCE flow."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    credential_name: str = "default"
+    region: Literal["us", "eu"] = "us"
+    subdomain: str = Field(min_length=1)
+    enabled_datasets: list[str]
+
+    @field_validator("credential_name", "subdomain")
+    @classmethod
+    def normalize_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("value must not be blank")
+        return normalized
+
+
+class PagerDutyAuthorizeResponse(BaseModel):
+    """Provider authorization URL without server-held PKCE data."""
+
+    model_config = ConfigDict(frozen=True)
+
+    authorize_url: str
+
+
+class PagerDutyCallbackRequest(BaseModel):
+    """Frontend-mediated PagerDuty OAuth callback inputs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    state: str = Field(min_length=1)
+    code: str | None = None
+    error: str | None = None
+
+
+class PagerDutyCallbackResponse(BaseModel):
+    """Non-secret PagerDuty OAuth connection result."""
+
+    model_config = ConfigDict(frozen=True)
+
+    connected: Literal[True]
+    credential_name: str
+    region: str
+    subdomain: str
+    granted_scopes: list[str]
+
+
+class PagerDutyStatusResponse(BaseModel):
+    """Non-secret PagerDuty credential status."""
+
+    model_config = ConfigDict(frozen=True)
+
+    connected: bool
+    credential_name: str
+    auth_mode: str | None
+    region: str | None
+    subdomain: str | None
+    account_id: str | None
+    account_display: str | None
+    granted_scopes: list[str]
+    expires_at: datetime | None
+    has_refresh_token: bool
+
+
+class PagerDutyDisconnectRequest(BaseModel):
+    """Named PagerDuty credential to deactivate."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    credential_name: str = "default"
+
+    @field_validator("credential_name")
+    @classmethod
+    def normalize_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("value must not be blank")
+        return normalized
+
+
+class PagerDutyDisconnectResponse(BaseModel):
+    """Idempotent PagerDuty disconnection result."""
+
+    model_config = ConfigDict(frozen=True)
+
+    disconnected: Literal[True]
+    credential_name: str
+
+
+class PagerDutyPreflightRequest(BaseModel):
+    """Requested PagerDuty datasets for a scope readiness check."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    credential_name: str = "default"
+    enabled_datasets: list[str]
+
+    @field_validator("credential_name")
+    @classmethod
+    def normalize_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("value must not be blank")
+        return normalized
+
+
+class PagerDutyDatasetPreflight(BaseModel):
+    """Scope readiness for one requested PagerDuty dataset."""
+
+    model_config = ConfigDict(frozen=True)
+
+    requested: str
+    required_scopes: list[str]
+    granted: bool
+    missing: list[str]
+
+
+class PagerDutyPreflightResponse(BaseModel):
+    """Non-secret scope readiness for the requested datasets."""
+
+    model_config = ConfigDict(frozen=True)
+
+    connected: bool
+    credential_name: str
+    datasets: list[PagerDutyDatasetPreflight]
+
+
+class PagerDutyClientCredentialsRequest(BaseModel):
+    """Machine-to-machine PagerDuty credential inputs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    credential_name: str = "default"
+    client_id: str = Field(min_length=1)
+    client_secret: str = Field(min_length=1)
+    subdomain: str = Field(min_length=1)
+    region: Literal["us", "eu"] = "us"
+
+    @field_validator("credential_name", "subdomain")
+    @classmethod
+    def normalize_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("value must not be blank")
+        return normalized
+
+
+class PagerDutyApiTokenRequest(BaseModel):
+    """PagerDuty API-token credential inputs."""
+
+    model_config = ConfigDict(extra="forbid")
+
+    credential_name: str = "default"
+    api_token: str = Field(min_length=1)
+    subdomain: str = Field(min_length=1)
+    region: Literal["us", "eu"] = "us"
+
+    @field_validator("credential_name", "subdomain")
+    @classmethod
+    def normalize_required_text(cls, value: str) -> str:
+        normalized = value.strip()
+        if not normalized:
+            raise ValueError("value must not be blank")
+        return normalized
+
+
+class PagerDutyConnectionResponse(BaseModel):
+    """Non-secret result after saving a non-OAuth PagerDuty credential."""
+
+    model_config = ConfigDict(frozen=True)
+
+    connected: Literal[True]
+    credential_name: str
+    auth_mode: Literal["client_credentials", "api_token"]
+    region: Literal["us", "eu"]
+    subdomain: str
+
+
+@router.post(
+    "/integrations/pagerduty/authorize",
+    response_model=PagerDutyAuthorizeResponse,
+)
+async def authorize_pagerduty(
+    body: PagerDutyAuthorizeRequest,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+    admin_user: AuthenticatedUser = Depends(get_admin_user),
+) -> PagerDutyAuthorizeResponse:
+    """Create a one-time authorization context and return PagerDuty's URL."""
+    enabled_datasets = set(body.enabled_datasets)
+    unknown_datasets = enabled_datasets.difference(DATASET_SCOPES)
+    if unknown_datasets:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unknown PagerDuty datasets: {', '.join(sorted(unknown_datasets))}"
+            ),
+        )
+
+    config = PagerDutyOAuthConfig.from_env()
+    if config is None:
+        raise HTTPException(
+            status_code=400,
+            detail="PAGER_DUTY_CLIENT_ID is not configured",
+        )
+
+    authorization_request = build_authorization_request(config, enabled_datasets)
+    await PagerDutyAuthorizationRequestStore(session).create(
+        org_id=org_id,
+        state=authorization_request.state,
+        credential_name=body.credential_name,
+        code_verifier=authorization_request.code_verifier,
+        enabled_datasets=body.enabled_datasets,
+        region=body.region,
+        subdomain=body.subdomain,
+        initiated_by=admin_user.user_id or None,
+    )
+    return PagerDutyAuthorizeResponse(authorize_url=authorization_request.url)
+
+
+@router.post(
+    "/integrations/pagerduty/callback",
+    response_model=PagerDutyCallbackResponse,
+)
+async def complete_pagerduty_authorization(
+    body: PagerDutyCallbackRequest,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> PagerDutyCallbackResponse:
+    """Consume a one-time state and persist the encrypted OAuth binding."""
+    consumed = await PagerDutyAuthorizationRequestStore(session).consume(
+        org_id=org_id,
+        state=body.state,
+    )
+    if consumed is None:
+        raise HTTPException(
+            status_code=400,
+            detail="Invalid or expired PagerDuty OAuth state",
+        )
+    await session.commit()
+
+    try:
+        code = validate_callback(code=body.code or "", error=body.error)
+    except OAuthCallbackValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+    config = PagerDutyOAuthConfig.from_env()
+    if config is None:
+        raise HTTPException(
+            status_code=500,
+            detail="PagerDuty OAuth configuration is unavailable",
+        )
+
+    subdomain = consumed.subdomain
+    if subdomain is None:
+        raise HTTPException(
+            status_code=400,
+            detail="PagerDuty OAuth state is missing account context",
+        )
+
+    try:
+        tokens = await exchange_code(
+            config,
+            code=code,
+            code_verifier=consumed.code_verifier,
+        )
+    except httpx.HTTPStatusError as exc:
+        if 400 <= exc.response.status_code < 500:
+            raise HTTPException(
+                status_code=400,
+                detail="PagerDuty OAuth authorization code was rejected",
+            ) from exc
+        raise HTTPException(
+            status_code=502,
+            detail="PagerDuty OAuth service is unavailable",
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise HTTPException(
+            status_code=503,
+            detail="PagerDuty OAuth service is unavailable",
+        ) from exc
+    missing_scopes = missing_read_scopes(
+        set(consumed.enabled_datasets),
+        set(tokens.granted_scopes),
+    )
+    if missing_scopes:
+        await _revoke_tokens(config, tokens)
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                "Missing required PagerDuty OAuth scopes: "
+                f"{', '.join(sorted(missing_scopes))}"
+            ),
+        )
+
+    binding_id = uuid.uuid4().hex
+    try:
+        await PagerDutyOAuthCredentialRepository(
+            session,
+            org_id,
+            consumed.credential_name,
+        ).create_or_replace(
+            tokens,
+            binding_id=binding_id,
+            account_id=subdomain,
+            account_display=subdomain,
+        )
+        await IntegrationCredentialsService(session, org_id).set(
+            provider="pagerduty",
+            name=consumed.credential_name,
+            credentials={
+                "auth_mode": "oauth",
+                "oauth_credential_name": consumed.credential_name,
+                "oauth_binding_id": binding_id,
+                "subdomain": subdomain,
+                "region": consumed.region,
+                "account_id": subdomain,
+            },
+            config={
+                "auth_mode": "oauth",
+                "region": consumed.region,
+                "subdomain": subdomain,
+                "account_id": subdomain,
+                "granted_scopes": sorted(tokens.granted_scopes),
+            },
+            is_active=True,
+        )
+        await session.commit()
+    except Exception:
+        await session.rollback()
+        await _revoke_tokens(config, tokens)
+        raise
+
+    return PagerDutyCallbackResponse(
+        connected=True,
+        credential_name=consumed.credential_name,
+        region=consumed.region,
+        subdomain=subdomain,
+        granted_scopes=sorted(tokens.granted_scopes),
+    )
+
+
+async def _revoke_access_token(config: PagerDutyOAuthConfig, access_token: str) -> None:
+    """Attempt revocation without obscuring the OAuth setup outcome."""
+    try:
+        await revoke_token(config, access_token)
+    except httpx.HTTPError:
+        return
+
+
+async def _revoke_tokens(config: PagerDutyOAuthConfig, tokens: OAuthTokens) -> None:
+    """Compensate a failed OAuth setup using the refresh token when available."""
+    await _revoke_access_token(config, tokens.refresh_token or tokens.access_token)
+
+
+async def _remove_oauth_binding(
+    repository: PagerDutyOAuthCredentialRepository,
+    config: PagerDutyOAuthConfig | None,
+) -> str | None:
+    """Delete the local OAuth binding unconditionally; return its revoke token.
+
+    Local deletion never depends on decrypting the stored token or on a
+    successful remote revocation, so corrupt ciphertext or a transport error
+    cannot strand the row. The returned token (when app config is available)
+    must be revoked by the caller only AFTER the local removal is committed.
+    """
+    token_to_revoke: str | None = None
+    try:
+        versioned = await repository.get()
+        if versioned is not None:
+            token_to_revoke = (
+                versioned.tokens.refresh_token or versioned.tokens.access_token
+            )
+    except ValueError:
+        # Corrupt/undecryptable stored token (decrypt_value and token JSON
+        # validation both raise ValueError): we cannot recover a token to revoke
+        # but must still delete the local row. Programming errors propagate.
+        token_to_revoke = None
+    finally:
+        await repository.delete()
+    return token_to_revoke if config is not None else None
+
+
+def _config_string(config: Mapping[str, object] | None, key: str) -> str | None:
+    """Return a non-secret string configuration value when present."""
+    if config is None:
+        return None
+    value = config.get(key)
+    return value if isinstance(value, str) else None
+
+
+def _config_scopes(config: Mapping[str, object] | None) -> frozenset[str]:
+    """Return persisted non-secret granted scopes without decrypting credentials."""
+    if config is None:
+        return frozenset()
+    raw_scopes = config.get("granted_scopes")
+    if not isinstance(raw_scopes, list):
+        return frozenset()
+    return frozenset(scope for scope in raw_scopes if isinstance(scope, str))
+
+
+@router.get(
+    "/integrations/pagerduty/status",
+    response_model=PagerDutyStatusResponse,
+)
+async def get_pagerduty_status(
+    credential_name: str = "default",
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> PagerDutyStatusResponse:
+    """Return PagerDuty setup status without decrypting OAuth tokens."""
+    credentials = IntegrationCredentialsService(session, org_id)
+    descriptor = await credentials.get("pagerduty", credential_name)
+    if descriptor is None:
+        return PagerDutyStatusResponse(
+            connected=False,
+            credential_name=credential_name,
+            auth_mode=None,
+            region=None,
+            subdomain=None,
+            account_id=None,
+            account_display=None,
+            granted_scopes=[],
+            expires_at=None,
+            has_refresh_token=False,
+        )
+
+    config = descriptor.config
+    metadata = await PagerDutyOAuthCredentialRepository(
+        session,
+        org_id,
+        credential_name,
+    ).get_status_metadata()
+    auth_mode = _config_string(config, "auth_mode")
+    granted_scopes = (
+        metadata.granted_scopes if auth_mode == "oauth" and metadata else frozenset()
+    )
+    return PagerDutyStatusResponse(
+        connected=descriptor.is_active,
+        credential_name=credential_name,
+        auth_mode=_config_string(config, "auth_mode"),
+        region=_config_string(config, "region"),
+        subdomain=_config_string(config, "subdomain"),
+        account_id=(
+            metadata.account_id
+            if metadata is not None
+            else _config_string(config, "account_id")
+        ),
+        account_display=metadata.account_display if metadata is not None else None,
+        granted_scopes=sorted(granted_scopes),
+        expires_at=metadata.expires_at if metadata is not None else None,
+        has_refresh_token=(
+            metadata.has_refresh_token if metadata is not None else False
+        ),
+    )
+
+
+@router.post(
+    "/integrations/pagerduty/disconnect",
+    response_model=PagerDutyDisconnectResponse,
+)
+async def disconnect_pagerduty(
+    body: PagerDutyDisconnectRequest,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> PagerDutyDisconnectResponse:
+    """Destroy OAuth tokens and deactivate, rather than delete, the descriptor."""
+    credentials = IntegrationCredentialsService(session, org_id)
+    descriptor = await credentials.get("pagerduty", body.credential_name)
+    repository = PagerDutyOAuthCredentialRepository(
+        session, org_id, body.credential_name
+    )
+    config = PagerDutyOAuthConfig.from_env()
+    token_to_revoke = await _remove_oauth_binding(repository, config)
+    if descriptor is not None:
+        descriptor.is_active = False
+        await session.flush()
+    # Commit the local removal BEFORE remote revocation so a commit failure
+    # cannot leave an active-looking local binding whose remote token is dead.
+    await session.commit()
+    if config is not None and token_to_revoke is not None:
+        await _revoke_access_token(config, token_to_revoke)
+    return PagerDutyDisconnectResponse(
+        disconnected=True,
+        credential_name=body.credential_name,
+    )
+
+
+@router.post(
+    "/integrations/pagerduty/preflight",
+    response_model=PagerDutyPreflightResponse,
+)
+async def preflight_pagerduty(
+    body: PagerDutyPreflightRequest,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> PagerDutyPreflightResponse:
+    """Report requested dataset scopes without imposing unrelated requirements."""
+    unknown_datasets = set(body.enabled_datasets).difference(DATASET_SCOPES)
+    if unknown_datasets:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Unknown PagerDuty datasets: {', '.join(sorted(unknown_datasets))}",
+        )
+
+    credentials = IntegrationCredentialsService(session, org_id)
+    descriptor = await credentials.get("pagerduty", body.credential_name)
+    config = descriptor.config if descriptor is not None else None
+    metadata = await PagerDutyOAuthCredentialRepository(
+        session,
+        org_id,
+        body.credential_name,
+    ).get_status_metadata()
+    auth_mode = _config_string(config, "auth_mode")
+    granted_scopes = (
+        metadata.granted_scopes if auth_mode == "oauth" and metadata else frozenset()
+    )
+    datasets = []
+    for dataset in body.enabled_datasets:
+        required_scopes = sorted(DATASET_SCOPES[dataset])
+        grantable = auth_mode in {"api_token", "client_credentials"}
+        missing_scopes = (
+            frozenset()
+            if grantable
+            else missing_read_scopes({dataset}, set(granted_scopes))
+        )
+        datasets.append(
+            PagerDutyDatasetPreflight(
+                requested=dataset,
+                required_scopes=required_scopes,
+                granted=not missing_scopes,
+                missing=sorted(missing_scopes),
+            )
+        )
+    return PagerDutyPreflightResponse(
+        connected=descriptor is not None
+        and descriptor.is_active
+        and (auth_mode != "oauth" or metadata is not None),
+        credential_name=body.credential_name,
+        datasets=datasets,
+    )
+
+
+@router.post(
+    "/integrations/pagerduty/client-credentials",
+    response_model=PagerDutyConnectionResponse,
+)
+async def set_pagerduty_client_credentials(
+    body: PagerDutyClientCredentialsRequest,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> PagerDutyConnectionResponse:
+    """Persist a non-OAuth PagerDuty client-credentials descriptor."""
+    config = PagerDutyOAuthConfig.from_env()
+    token_to_revoke = await _remove_oauth_binding(
+        PagerDutyOAuthCredentialRepository(session, org_id, body.credential_name),
+        config,
+    )
+    await IntegrationCredentialsService(session, org_id).set(
+        provider="pagerduty",
+        name=body.credential_name,
+        credentials={
+            "auth_mode": "client_credentials",
+            "client_id": body.client_id,
+            "client_secret": body.client_secret,
+            "subdomain": body.subdomain,
+            "region": body.region,
+        },
+        config={
+            "auth_mode": "client_credentials",
+            "region": body.region,
+            "subdomain": body.subdomain,
+        },
+        is_active=True,
+    )
+    await session.commit()
+    if config is not None and token_to_revoke is not None:
+        await _revoke_access_token(config, token_to_revoke)
+    return PagerDutyConnectionResponse(
+        connected=True,
+        credential_name=body.credential_name,
+        auth_mode="client_credentials",
+        region=body.region,
+        subdomain=body.subdomain,
+    )
+
+
+@router.post(
+    "/integrations/pagerduty/api-token",
+    response_model=PagerDutyConnectionResponse,
+)
+async def set_pagerduty_api_token(
+    body: PagerDutyApiTokenRequest,
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> PagerDutyConnectionResponse:
+    """Persist a non-OAuth PagerDuty API-token descriptor."""
+    config = PagerDutyOAuthConfig.from_env()
+    token_to_revoke = await _remove_oauth_binding(
+        PagerDutyOAuthCredentialRepository(session, org_id, body.credential_name),
+        config,
+    )
+    await IntegrationCredentialsService(session, org_id).set(
+        provider="pagerduty",
+        name=body.credential_name,
+        credentials={
+            "auth_mode": "api_token",
+            "api_token": body.api_token,
+            "subdomain": body.subdomain,
+            "region": body.region,
+        },
+        config={
+            "auth_mode": "api_token",
+            "region": body.region,
+            "subdomain": body.subdomain,
+        },
+        is_active=True,
+    )
+    await session.commit()
+    if config is not None and token_to_revoke is not None:
+        await _revoke_access_token(config, token_to_revoke)
+    return PagerDutyConnectionResponse(
+        connected=True,
+        credential_name=body.credential_name,
+        auth_mode="api_token",
+        region=body.region,
+        subdomain=body.subdomain,
+    )

--- a/src/dev_health_ops/api/services/configuration/integration_credentials.py
+++ b/src/dev_health_ops/api/services/configuration/integration_credentials.py
@@ -8,7 +8,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import Any, Final
 
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -21,6 +21,56 @@ from dev_health_ops.sync.error_sanitize import sanitize_error_text
 from ._helpers import _normalize_credential_keys
 
 logger = logging.getLogger(__name__)
+
+_PAGERDUTY_FORBIDDEN_TOKEN_KEYS: Final = frozenset(
+    {"access_token", "refresh_token", "expires_at"}
+)
+_PAGERDUTY_DESCRIPTOR_KEYS: Final = {
+    "oauth": frozenset(
+        {
+            "auth_mode",
+            "oauth_credential_name",
+            "oauth_binding_id",
+            "subdomain",
+            "region",
+            "account_id",
+        }
+    ),
+    "client_credentials": frozenset(
+        {"auth_mode", "client_id", "client_secret", "subdomain", "region"}
+    ),
+    "api_token": frozenset({"auth_mode", "api_token", "subdomain", "region"}),
+}
+_PAGERDUTY_CONFIG_KEYS: Final = {
+    "oauth": frozenset(
+        {"auth_mode", "region", "subdomain", "account_id", "granted_scopes"}
+    ),
+    "client_credentials": frozenset({"auth_mode", "region", "subdomain"}),
+    "api_token": frozenset({"auth_mode", "region", "subdomain"}),
+}
+_PAGERDUTY_FORBIDDEN_CONFIG_KEYS: Final = _PAGERDUTY_FORBIDDEN_TOKEN_KEYS.union(
+    {"client_secret", "client_id", "api_token"}
+)
+
+
+def _validate_pagerduty_descriptor(
+    credentials: dict[str, Any], config: dict[str, Any] | None
+) -> None:
+    config_values = config or {}
+    if _PAGERDUTY_FORBIDDEN_TOKEN_KEYS.intersection(credentials) or (
+        _PAGERDUTY_FORBIDDEN_CONFIG_KEYS.intersection(config_values)
+    ):
+        raise ValueError("PagerDuty OAuth tokens must not be stored in descriptors")
+
+    auth_mode = credentials.get("auth_mode")
+    if not isinstance(auth_mode, str) or auth_mode not in _PAGERDUTY_DESCRIPTOR_KEYS:
+        raise ValueError("PagerDuty credentials require a recognized auth_mode")
+    if frozenset(credentials) != _PAGERDUTY_DESCRIPTOR_KEYS[auth_mode]:
+        raise ValueError("PagerDuty credentials do not match the auth_mode descriptor")
+    if not frozenset(config_values).issubset(_PAGERDUTY_CONFIG_KEYS[auth_mode]):
+        raise ValueError("PagerDuty config does not match the auth_mode descriptor")
+    if config_values.get("auth_mode") != auth_mode:
+        raise ValueError("PagerDuty config auth_mode must match credentials")
 
 
 class AmbiguousCredentialError(ValueError):
@@ -173,6 +223,8 @@ class IntegrationCredentialsService:
         is_active: bool = True,
     ) -> IntegrationCredential:
         """Set integration credentials (always encrypted)."""
+        if provider == "pagerduty":
+            _validate_pagerduty_descriptor(credentials, config)
         stmt = select(IntegrationCredential).where(
             IntegrationCredential.org_id == self.org_id,
             IntegrationCredential.provider == provider,

--- a/src/dev_health_ops/credentials/fingerprint.py
+++ b/src/dev_health_ops/credentials/fingerprint.py
@@ -65,6 +65,7 @@ _IDENTIFIER_KEYS: tuple[str, ...] = (
     "organization_id",
     "workspace_id",
     "team_id",
+    "oauth_binding_id",
 )
 
 # Secret-bearing fields. Each present value is SHA-256 hashed into a
@@ -83,6 +84,8 @@ _SECRET_KEYS: tuple[str, ...] = (
     "apiKey",
     "private_key",
     "privateKey",
+    "client_secret",
+    "clientSecret",
 )
 
 

--- a/src/dev_health_ops/credentials/resolver.py
+++ b/src/dev_health_ops/credentials/resolver.py
@@ -390,16 +390,36 @@ def pagerduty_credentials_from_mapping(
 ) -> PagerDutyCredentials | None:
     """Build PagerDuty credentials without logging secret-bearing validation errors."""
     aliases = {
+        "authMode": "auth_mode",
         "accessToken": "access_token",
         "refreshToken": "refresh_token",
         "apiToken": "api_token",
         "clientId": "client_id",
         "clientSecret": "client_secret",
+        "oauthCredentialName": "oauth_credential_name",
+        "oauthBindingId": "oauth_binding_id",
+        "accountId": "account_id",
         "grantedScopes": "granted_scopes",
     }
+    allowed_keys = {
+        "auth_mode",
+        "access_token",
+        "refresh_token",
+        "expires_at",
+        "granted_scopes",
+        "client_id",
+        "client_secret",
+        "api_token",
+        "oauth_credential_name",
+        "oauth_binding_id",
+        "account_id",
+        "subdomain",
+        "region",
+    }
     values = {
-        aliases.get(key, key): value
+        normalized_key: value
         for key, value in cred_dict.items()
+        if (normalized_key := aliases.get(key, key)) in allowed_keys
         if value is not None
     }
     values.update(source=source, credential_name=credential_name)

--- a/src/dev_health_ops/credentials/types.py
+++ b/src/dev_health_ops/credentials/types.py
@@ -137,6 +137,7 @@ class PagerDutyCredentials(ProviderCredentials):
     """PagerDuty OAuth, client-credentials, or API-token fallback credentials."""
 
     provider: str = "pagerduty"
+    auth_mode: str | None = None
     access_token: str | None = None
     refresh_token: str | None = None
     expires_at: str | None = None
@@ -144,11 +145,27 @@ class PagerDutyCredentials(ProviderCredentials):
     client_id: str | None = None
     client_secret: str | None = None
     api_token: str | None = None
+    oauth_credential_name: str | None = None
+    oauth_binding_id: str | None = None
+    account_id: str | None = None
     subdomain: str | None = None
     region: str = "us"
 
     def __post_init__(self) -> None:
-        if not any(
+        if self.auth_mode is not None:
+            if self.auth_mode not in {"oauth", "client_credentials", "api_token"}:
+                raise ValueError(
+                    "PagerDuty auth_mode must be 'oauth', 'client_credentials', or 'api_token'"
+                )
+            if self.auth_mode == "api_token" and self.access_token:
+                raise ValueError(
+                    "PagerDuty api_token credentials must not carry an access token"
+                )
+            if self.auth_mode in {"oauth", "client_credentials"} and self.api_token:
+                raise ValueError(
+                    "PagerDuty OAuth and client_credentials credentials must not carry an API token"
+                )
+        elif not any(
             (self.access_token, self.api_token, self.client_id and self.client_secret)
         ):
             raise ValueError(

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -223,6 +223,45 @@ class ProviderOAuthCredential(Base):
     updated_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )
+    binding_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    expires_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    granted_scopes: Mapped[list[str] | None] = mapped_column(JSON, nullable=True)
+    has_refresh_token: Mapped[bool] = mapped_column(
+        Boolean, nullable=False, default=False, server_default="0"
+    )
+    account_id: Mapped[str | None] = mapped_column(Text, nullable=True)
+    account_display: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+
+class PagerDutyOAuthAuthorizationRequest(Base):
+    """Server-side PKCE authorization-request state for PagerDuty OAuth setup.
+
+    Persists the one-time authorization context between ``authorize`` and the
+    OAuth ``callback``. Keyed by the SHA-256 hash of the opaque ``state`` token
+    sent to PagerDuty (never the plaintext state), so a database reader cannot
+    forge a callback. Only the PKCE ``code_verifier`` is encrypted; it is used
+    server-side for the code exchange and never travels through the browser.
+    Rows are single-use (consumed on callback) and expire via ``expires_at``.
+    """
+
+    __tablename__ = "pagerduty_oauth_authorization_requests"
+
+    state_hash: Mapped[str] = mapped_column(Text, primary_key=True)
+    org_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
+    credential_name: Mapped[str] = mapped_column(Text, nullable=False)
+    code_verifier_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
+    enabled_datasets: Mapped[list[str]] = mapped_column(JSON, nullable=False)
+    region: Mapped[str] = mapped_column(Text, nullable=False)
+    subdomain: Mapped[str | None] = mapped_column(Text, nullable=True)
+    initiated_by: Mapped[str | None] = mapped_column(Text, nullable=True)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False
+    )
+    expires_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), nullable=False, index=True
+    )
 
 
 class GithubAppInstallation(Base):

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -167,12 +167,32 @@ def _pagerduty_client(context: SyncTaskContext) -> tuple[Any, str]:
     if credentials is None:
         raise ValueError("Missing PagerDuty credentials for dataset unit")
     auth: PagerDutyAuth
-    if credentials.access_token:
-        auth = OAuthBearerAuth(credentials.access_token)
-    elif credentials.api_token:
-        auth = ApiTokenAuth(credentials.api_token)
-    else:
-        raise ValueError("PagerDuty dataset unit requires an access token or API token")
+    match credentials.auth_mode:
+        case "oauth" | "client_credentials" as auth_mode:
+            access_token = credentials.access_token
+            if not access_token:
+                raise ValueError(
+                    f"PagerDuty {auth_mode} credential is missing a hydrated access token"
+                )
+            auth = OAuthBearerAuth(access_token)
+        case "api_token":
+            api_token = credentials.api_token
+            if not api_token:
+                raise ValueError(
+                    "PagerDuty api_token credential is missing an API token"
+                )
+            auth = ApiTokenAuth(api_token)
+        case None:
+            if credentials.access_token:
+                auth = OAuthBearerAuth(credentials.access_token)
+            elif credentials.api_token:
+                auth = ApiTokenAuth(credentials.api_token)
+            else:
+                raise ValueError(
+                    "PagerDuty dataset unit requires an access token or API token"
+                )
+        case auth_mode:
+            raise ValueError(f"Unsupported PagerDuty auth mode: {auth_mode}")
     provider_instance_id = (
         credentials.subdomain.strip() if credentials.subdomain else ""
     )

--- a/src/dev_health_ops/providers/pagerduty/oauth.py
+++ b/src/dev_health_ops/providers/pagerduty/oauth.py
@@ -26,8 +26,7 @@ READ_SCOPES = frozenset(
 DATASET_SCOPES = {
     "incidents": frozenset({"Incidents.read"}),
     "services": frozenset({"Services.read"}),
-    # PagerDuty's published scoped-OAuth list has no Business_services.read scope.
-    "business_services": frozenset(),
+    "business_services": frozenset({"Services.read"}),
     "escalation_policies": frozenset({"Escalation_policies.read"}),
     "schedules": frozenset({"Schedules.read"}),
     "oncalls": frozenset({"Oncalls.read"}),
@@ -35,6 +34,8 @@ DATASET_SCOPES = {
     "teams": frozenset({"Teams.read"}),
 }
 DEFAULT_RENEWAL_WINDOW: Final = timedelta(minutes=5)
+
+_HTTP_TIMEOUT: Final = httpx.Timeout(10.0)
 
 
 class OAuthTokens(BaseModel):
@@ -121,14 +122,18 @@ def build_authorization_request(
     )
 
 
-def validate_callback(
-    request: AuthorizationRequest, *, state: str, code: str, code_verifier: str
-) -> str:
-    """Validate callback state and its PKCE verifier before exchanging the code."""
-    if not secrets.compare_digest(request.state, state):
-        raise OAuthCallbackValidationError("PagerDuty OAuth callback state mismatch")
-    if not secrets.compare_digest(request.code_verifier, code_verifier):
-        raise OAuthCallbackValidationError("PagerDuty OAuth callback PKCE mismatch")
+def validate_callback(*, code: str, error: str | None = None) -> str:
+    """Reject an error/denied callback or an empty code before code exchange.
+
+    State/CSRF binding is enforced by the server-side authorization-request
+    store (one-time consume keyed by the state hash); the PKCE ``code_verifier``
+    is held server-side and never travels through the browser, so it is never
+    accepted from the caller here.
+    """
+    if error:
+        raise OAuthCallbackValidationError(
+            f"PagerDuty OAuth callback returned an error: {error}"
+        )
     if not code:
         raise OAuthCallbackValidationError("PagerDuty OAuth callback code is required")
     return code
@@ -137,17 +142,18 @@ def validate_callback(
 async def exchange_code(
     config: PagerDutyOAuthConfig, *, code: str, code_verifier: str
 ) -> OAuthTokens:
-    response = await httpx.AsyncClient().post(
-        config.token_url,
-        data={
-            "grant_type": "authorization_code",
-            "client_id": config.client_id,
-            "client_secret": config.client_secret or "",
-            "redirect_uri": config.redirect_uri,
-            "code": code,
-            "code_verifier": code_verifier,
-        },
-    )
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        response = await client.post(
+            config.token_url,
+            data={
+                "grant_type": "authorization_code",
+                "client_id": config.client_id,
+                "client_secret": config.client_secret or "",
+                "redirect_uri": config.redirect_uri,
+                "code": code,
+                "code_verifier": code_verifier,
+            },
+        )
     response.raise_for_status()
     return _tokens(response.json())
 
@@ -155,15 +161,16 @@ async def exchange_code(
 async def refresh_tokens(
     config: PagerDutyOAuthConfig, refresh_token: str
 ) -> OAuthTokens:
-    response = await httpx.AsyncClient().post(
-        config.token_url,
-        data={
-            "grant_type": "refresh_token",
-            "client_id": config.client_id,
-            "client_secret": config.client_secret or "",
-            "refresh_token": refresh_token,
-        },
-    )
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        response = await client.post(
+            config.token_url,
+            data={
+                "grant_type": "refresh_token",
+                "client_id": config.client_id,
+                "client_secret": config.client_secret or "",
+                "refresh_token": refresh_token,
+            },
+        )
     response.raise_for_status()
     return _tokens(response.json())
 
@@ -171,24 +178,25 @@ async def refresh_tokens(
 async def client_credentials(
     config: PagerDutyOAuthConfig, *, scopes: set[str], subdomain: str, region: str
 ) -> OAuthTokens:
-    response = await httpx.AsyncClient().post(
-        config.token_url,
-        data={
-            "grant_type": "client_credentials",
-            "client_id": config.client_id,
-            "client_secret": config.client_secret or "",
-            "scope": " ".join(sorted(scopes)),
-            "subdomain": subdomain,
-            "region": region,
-        },
-    )
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
+        response = await client.post(
+            config.token_url,
+            data={
+                "grant_type": "client_credentials",
+                "client_id": config.client_id,
+                "client_secret": config.client_secret or "",
+                "scope": " ".join(sorted(scopes)),
+                "subdomain": subdomain,
+                "region": region,
+            },
+        )
     response.raise_for_status()
     return _tokens(response.json())
 
 
 async def revoke_token(config: PagerDutyOAuthConfig, token: str) -> None:
     """Best-effort OAuth revocation request; callers own local credential removal."""
-    async with httpx.AsyncClient() as client:
+    async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT) as client:
         response = await client.post(
             config.revoke_url,
             data={"token": token, "client_id": config.client_id},

--- a/src/dev_health_ops/providers/pagerduty/oauth_authorization_store.py
+++ b/src/dev_health_ops/providers/pagerduty/oauth_authorization_store.py
@@ -1,0 +1,121 @@
+"""Server-side, one-time PKCE authorization-request storage for PagerDuty."""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+
+from sqlalchemy import delete
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.core.encryption import decrypt_value, encrypt_value
+from dev_health_ops.models.settings import PagerDutyOAuthAuthorizationRequest
+
+
+def _utc_time(now: datetime | None) -> datetime:
+    timestamp = now or datetime.now(UTC)
+    if timestamp.tzinfo is None:
+        return timestamp.replace(tzinfo=UTC)
+    return timestamp.astimezone(UTC)
+
+
+@dataclass(frozen=True, slots=True)
+class ConsumedAuthorizationRequest:
+    """Authorization context available only after a successful one-time consume."""
+
+    credential_name: str
+    code_verifier: str
+    enabled_datasets: list[str]
+    region: str
+    subdomain: str | None
+
+
+class PagerDutyAuthorizationRequestStore:
+    """Persist encrypted PKCE context keyed only by an opaque state's SHA-256 hash."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        self._session = session
+
+    async def create(
+        self,
+        *,
+        org_id: str,
+        state: str,
+        credential_name: str,
+        code_verifier: str,
+        enabled_datasets: list[str],
+        region: str,
+        subdomain: str | None = None,
+        initiated_by: str | None = None,
+        ttl: timedelta = timedelta(minutes=15),
+        now: datetime | None = None,
+    ) -> None:
+        """Store encrypted PKCE context for a short-lived OAuth authorization request."""
+        created_at = _utc_time(now)
+        await self._session.execute(
+            delete(PagerDutyOAuthAuthorizationRequest).where(
+                PagerDutyOAuthAuthorizationRequest.org_id == org_id,
+                PagerDutyOAuthAuthorizationRequest.expires_at <= created_at,
+            )
+        )
+        self._session.add(
+            PagerDutyOAuthAuthorizationRequest(
+                state_hash=hashlib.sha256(state.encode()).hexdigest(),
+                org_id=org_id,
+                credential_name=credential_name,
+                code_verifier_encrypted=encrypt_value(code_verifier),
+                enabled_datasets=enabled_datasets,
+                region=region,
+                subdomain=subdomain,
+                initiated_by=initiated_by,
+                created_at=created_at,
+                expires_at=created_at + ttl,
+            )
+        )
+        await self._session.flush()
+
+    async def consume(
+        self,
+        *,
+        org_id: str,
+        state: str,
+        now: datetime | None = None,
+    ) -> ConsumedAuthorizationRequest | None:
+        """Atomically consume an unexpired request scoped to its organization."""
+        consumed_at = _utc_time(now)
+        result = await self._session.execute(
+            delete(PagerDutyOAuthAuthorizationRequest)
+            .where(
+                PagerDutyOAuthAuthorizationRequest.state_hash
+                == hashlib.sha256(state.encode()).hexdigest(),
+                PagerDutyOAuthAuthorizationRequest.org_id == org_id,
+            )
+            .returning(PagerDutyOAuthAuthorizationRequest)
+        )
+        authorization_request = result.scalar_one_or_none()
+        await self._session.flush()
+
+        if authorization_request is None:
+            return None
+        if _utc_time(authorization_request.expires_at) <= consumed_at:
+            return None
+
+        return ConsumedAuthorizationRequest(
+            credential_name=authorization_request.credential_name,
+            code_verifier=decrypt_value(authorization_request.code_verifier_encrypted),
+            enabled_datasets=authorization_request.enabled_datasets,
+            region=authorization_request.region,
+            subdomain=authorization_request.subdomain,
+        )
+
+    async def purge_expired(self, *, now: datetime | None = None) -> int:
+        """Delete expired authorization requests and return the number removed."""
+        expired_at = _utc_time(now)
+        result = await self._session.execute(
+            delete(PagerDutyOAuthAuthorizationRequest)
+            .where(PagerDutyOAuthAuthorizationRequest.expires_at <= expired_at)
+            .returning(PagerDutyOAuthAuthorizationRequest.state_hash)
+        )
+        await self._session.flush()
+        return len(result.scalars().all())

--- a/src/dev_health_ops/providers/pagerduty/oauth_lifecycle.py
+++ b/src/dev_health_ops/providers/pagerduty/oauth_lifecycle.py
@@ -26,7 +26,15 @@ class OAuthCredentialStore(Protocol):
 
     async def get(self) -> VersionedOAuthTokens | None: ...
 
-    async def rotate(self, current_version: int, tokens: OAuthTokens) -> int: ...
+    async def get_for_update(self) -> VersionedOAuthTokens | None: ...
+
+    async def rotate(
+        self,
+        current_version: int,
+        tokens: OAuthTokens,
+        *,
+        expected_binding_id: str,
+    ) -> int: ...
 
     async def delete(self) -> None: ...
 
@@ -44,6 +52,29 @@ class ClientCredentialsTokenCache:
 
     tokens: OAuthTokens | None = None
     _lock: anyio.Lock = field(default_factory=anyio.Lock)
+
+
+ClientCredentialsCacheKey = tuple[str, str, frozenset[str], str, str, str]
+
+
+@dataclass
+class ClientCredentialsTokenCacheRegistry:
+    """Owns isolated client-credential token caches for account-scoped keys."""
+
+    _caches: dict[ClientCredentialsCacheKey, ClientCredentialsTokenCache] = field(
+        default_factory=dict
+    )
+    _lock: anyio.Lock = field(default_factory=anyio.Lock)
+
+    async def cache_for(
+        self, key: ClientCredentialsCacheKey
+    ) -> ClientCredentialsTokenCache:
+        async with self._lock:
+            cache = self._caches.get(key)
+            if cache is None:
+                cache = ClientCredentialsTokenCache()
+                self._caches[key] = cache
+            return cache
 
 
 def is_renewal_due(
@@ -69,20 +100,28 @@ async def get_valid_access_token(
         raise OAuthRotationConflictError("PagerDuty OAuth credential was not found")
     if not is_renewal_due(versioned.tokens, now=now, renewal_window=renewal_window):
         return versioned.tokens.access_token
-    if versioned.tokens.refresh_token is None:
+    locked = await repository.get_for_update()
+    if locked is None:
+        raise OAuthRotationConflictError("PagerDuty OAuth credential was not found")
+    if not is_renewal_due(locked.tokens, now=now, renewal_window=renewal_window):
+        return locked.tokens.access_token
+    if locked.tokens.refresh_token is None or locked.binding_id is None:
         raise OAuthRotationConflictError(
             "PagerDuty OAuth credential cannot be refreshed"
         )
-    refreshed = await refresh_tokens(config, versioned.tokens.refresh_token)
-    rotated = (
-        refreshed
-        if refreshed.refresh_token
-        else refreshed.model_copy(
-            update={"refresh_token": versioned.tokens.refresh_token}
-        )
+    refreshed = await refresh_tokens(config, locked.tokens.refresh_token)
+    rotated = refreshed.model_copy(
+        update={
+            "refresh_token": refreshed.refresh_token or locked.tokens.refresh_token,
+            "granted_scopes": refreshed.granted_scopes or locked.tokens.granted_scopes,
+        }
     )
     try:
-        await repository.rotate(versioned.version, rotated)
+        await repository.rotate(
+            locked.version,
+            rotated,
+            expected_binding_id=locked.binding_id,
+        )
         return rotated.access_token
     except OAuthRotationConflictError:
         latest = await repository.get()
@@ -110,16 +149,30 @@ async def get_client_credentials_access_token(
         return cache.tokens.access_token
 
 
+async def get_client_credentials_access_token_keyed(
+    registry: ClientCredentialsTokenCacheRegistry,
+    key: ClientCredentialsCacheKey,
+    config: PagerDutyOAuthConfig,
+    request: ClientCredentialsRequest,
+    *,
+    now: datetime | None = None,
+) -> str:
+    cache = await registry.cache_for(key)
+    return await get_client_credentials_access_token(cache, config, request, now=now)
+
+
 async def disconnect(
     repository: OAuthCredentialStore,
     config: PagerDutyOAuthConfig,
 ) -> None:
     """Best-effort remote revocation followed by guaranteed local credential deletion."""
-    versioned = await repository.get()
-    if versioned is not None:
-        token = versioned.tokens.refresh_token or versioned.tokens.access_token
-        try:
-            await revoke_token(config, token)
-        except httpx.HTTPError:
-            pass
-    await repository.delete()
+    try:
+        versioned = await repository.get()
+        if versioned is not None:
+            token = versioned.tokens.refresh_token or versioned.tokens.access_token
+            try:
+                await revoke_token(config, token)
+            except httpx.HTTPError:
+                pass
+    finally:
+        await repository.delete()

--- a/src/dev_health_ops/providers/pagerduty/oauth_lifecycle.py
+++ b/src/dev_health_ops/providers/pagerduty/oauth_lifecycle.py
@@ -24,9 +24,11 @@ from dev_health_ops.providers.pagerduty.oauth_storage import (
 class OAuthCredentialStore(Protocol):
     """Minimal persistence seam for token renewal and disconnect."""
 
-    async def get(self) -> VersionedOAuthTokens | None: ...
+    async def get(self) -> VersionedOAuthTokens | None:
+        """Return the current stored credential version, if any."""
 
-    async def get_for_update(self) -> VersionedOAuthTokens | None: ...
+    async def get_for_update(self) -> VersionedOAuthTokens | None:
+        """Return the current credential version under a row lock, if any."""
 
     async def rotate(
         self,
@@ -34,9 +36,11 @@ class OAuthCredentialStore(Protocol):
         tokens: OAuthTokens,
         *,
         expected_binding_id: str,
-    ) -> int: ...
+    ) -> int:
+        """Rotate the stored token to a new version, returning that version."""
 
-    async def delete(self) -> None: ...
+    async def delete(self) -> None:
+        """Delete the stored credential."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -173,6 +177,8 @@ async def disconnect(
             try:
                 await revoke_token(config, token)
             except httpx.HTTPError:
+                # Remote revocation is best-effort; the guaranteed local delete
+                # in the finally block is the authoritative disconnect action.
                 pass
     finally:
         await repository.delete()

--- a/src/dev_health_ops/providers/pagerduty/oauth_storage.py
+++ b/src/dev_health_ops/providers/pagerduty/oauth_storage.py
@@ -1,8 +1,9 @@
 """Encrypted, optimistic PagerDuty OAuth token persistence."""
 
 from dataclasses import dataclass
+from datetime import UTC, datetime
 
-from sqlalchemy import delete, update
+from sqlalchemy import delete, select, update
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.core.encryption import decrypt_value, encrypt_value
@@ -18,6 +19,20 @@ class OAuthRotationConflictError(RuntimeError):
 class VersionedOAuthTokens:
     tokens: OAuthTokens
     version: int
+    binding_id: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class OAuthStatusMetadata:
+    """Non-secret PagerDuty OAuth state for integration status surfaces."""
+
+    binding_id: str | None
+    expires_at: datetime | None
+    granted_scopes: frozenset[str]
+    has_refresh_token: bool
+    account_id: str | None
+    account_display: str | None
+    version: int
 
 
 class PagerDutyOAuthCredentialRepository:
@@ -30,8 +45,16 @@ class PagerDutyOAuthCredentialRepository:
         self._org_id = org_id
         self._credential_name = credential_name
 
-    async def rotate(self, current_version: int, tokens: OAuthTokens) -> int:
+    async def rotate(
+        self,
+        current_version: int,
+        tokens: OAuthTokens,
+        *,
+        expected_binding_id: str,
+    ) -> int:
+        """Atomically persist a refreshed token for its original OAuth binding."""
         payload = encrypt_value(tokens.model_dump_json())
+        now = datetime.now(UTC)
         statement = (
             update(ProviderOAuthCredential)
             .where(
@@ -39,8 +62,16 @@ class PagerDutyOAuthCredentialRepository:
                 ProviderOAuthCredential.provider == "pagerduty",
                 ProviderOAuthCredential.credential_name == self._credential_name,
                 ProviderOAuthCredential.version == current_version,
+                ProviderOAuthCredential.binding_id == expected_binding_id,
             )
-            .values(token_encrypted=payload, version=current_version + 1)
+            .values(
+                token_encrypted=payload,
+                version=current_version + 1,
+                expires_at=tokens.expires_at,
+                granted_scopes=sorted(tokens.granted_scopes),
+                has_refresh_token=bool(tokens.refresh_token),
+                updated_at=now,
+            )
             .returning(ProviderOAuthCredential.version)
         )
         result = await self._session.execute(statement)
@@ -52,13 +83,99 @@ class PagerDutyOAuthCredentialRepository:
 
     async def get(self) -> VersionedOAuthTokens | None:
         credential = await self._session.get(
-            ProviderOAuthCredential, (self._org_id, "pagerduty", self._credential_name)
+            ProviderOAuthCredential,
+            (self._org_id, "pagerduty", self._credential_name),
+            populate_existing=True,
         )
         if credential is None:
             return None
         return VersionedOAuthTokens(
             OAuthTokens.model_validate_json(decrypt_value(credential.token_encrypted)),
             credential.version,
+            credential.binding_id,
+        )
+
+    async def get_for_update(self) -> VersionedOAuthTokens | None:
+        """Load and lock this credential for a refresh transaction."""
+        credential = await self._locked_credential()
+        if credential is None:
+            return None
+        return VersionedOAuthTokens(
+            OAuthTokens.model_validate_json(decrypt_value(credential.token_encrypted)),
+            credential.version,
+            credential.binding_id,
+        )
+
+    async def create_or_replace(
+        self,
+        tokens: OAuthTokens,
+        *,
+        binding_id: str,
+        account_id: str | None = None,
+        account_display: str | None = None,
+        now: datetime | None = None,
+    ) -> int:
+        """Persist a newly connected OAuth binding, replacing any prior binding."""
+        timestamp = now or datetime.now(UTC)
+        credential = await self._locked_credential()
+        payload = encrypt_value(tokens.model_dump_json())
+        if credential is None:
+            credential = ProviderOAuthCredential(
+                org_id=self._org_id,
+                provider="pagerduty",
+                credential_name=self._credential_name,
+                token_encrypted=payload,
+                version=1,
+                created_at=timestamp,
+                updated_at=timestamp,
+                binding_id=binding_id,
+                expires_at=tokens.expires_at,
+                granted_scopes=sorted(tokens.granted_scopes),
+                has_refresh_token=bool(tokens.refresh_token),
+                account_id=account_id,
+                account_display=account_display,
+            )
+            self._session.add(credential)
+        else:
+            credential.token_encrypted = payload
+            credential.version += 1
+            credential.binding_id = binding_id
+            credential.updated_at = timestamp
+            credential.expires_at = tokens.expires_at
+            credential.granted_scopes = sorted(tokens.granted_scopes)
+            credential.has_refresh_token = bool(tokens.refresh_token)
+            credential.account_id = account_id
+            credential.account_display = account_display
+        await self._session.flush()
+        return credential.version
+
+    async def get_status_metadata(self) -> OAuthStatusMetadata | None:
+        """Read non-secret credential metadata without decrypting the token payload."""
+        statement = select(
+            ProviderOAuthCredential.binding_id,
+            ProviderOAuthCredential.expires_at,
+            ProviderOAuthCredential.granted_scopes,
+            ProviderOAuthCredential.has_refresh_token,
+            ProviderOAuthCredential.account_id,
+            ProviderOAuthCredential.account_display,
+            ProviderOAuthCredential.version,
+        ).where(
+            ProviderOAuthCredential.org_id == self._org_id,
+            ProviderOAuthCredential.provider == "pagerduty",
+            ProviderOAuthCredential.credential_name == self._credential_name,
+        )
+        result = await self._session.execute(statement)
+        row = result.one_or_none()
+        if row is None:
+            return None
+        return OAuthStatusMetadata(
+            binding_id=row.binding_id,
+            expires_at=row.expires_at,
+            granted_scopes=frozenset(row.granted_scopes or ()),
+            has_refresh_token=row.has_refresh_token,
+            account_id=row.account_id,
+            account_display=row.account_display,
+            version=row.version,
         )
 
     async def delete(self) -> None:
@@ -70,3 +187,17 @@ class PagerDutyOAuthCredentialRepository:
         )
         await self._session.execute(statement)
         await self._session.flush()
+
+    async def _locked_credential(self) -> ProviderOAuthCredential | None:
+        statement = (
+            select(ProviderOAuthCredential)
+            .where(
+                ProviderOAuthCredential.org_id == self._org_id,
+                ProviderOAuthCredential.provider == "pagerduty",
+                ProviderOAuthCredential.credential_name == self._credential_name,
+            )
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+        result = await self._session.execute(statement)
+        return result.scalar_one_or_none()

--- a/src/dev_health_ops/providers/pagerduty/sync_auth.py
+++ b/src/dev_health_ops/providers/pagerduty/sync_auth.py
@@ -1,0 +1,184 @@
+"""Synchronous-session OAuth hydration for PagerDuty worker requests."""
+
+import hashlib
+from datetime import UTC, datetime
+from typing import Any
+
+import anyio
+from sqlalchemy import delete, select, update
+from sqlalchemy.orm import Session
+
+from dev_health_ops.core.encryption import decrypt_value, encrypt_value
+from dev_health_ops.db import get_postgres_session_sync
+from dev_health_ops.models.settings import ProviderOAuthCredential
+from dev_health_ops.providers.pagerduty.oauth import (
+    READ_SCOPES,
+    OAuthTokens,
+    PagerDutyOAuthConfig,
+)
+from dev_health_ops.providers.pagerduty.oauth_lifecycle import (
+    ClientCredentialsRequest,
+    ClientCredentialsTokenCacheRegistry,
+    get_client_credentials_access_token_keyed,
+    get_valid_access_token,
+)
+from dev_health_ops.providers.pagerduty.oauth_storage import (
+    OAuthRotationConflictError,
+    VersionedOAuthTokens,
+)
+
+_REGISTRY = ClientCredentialsTokenCacheRegistry()
+
+
+class _SyncSessionOAuthStore:
+    """Adapt a sync SQLAlchemy session to the async OAuth renewal protocol."""
+
+    def __init__(
+        self,
+        session: Session,
+        org_id: str,
+        credential_name: str,
+        binding_id: str | None = None,
+    ) -> None:
+        self._session = session
+        self._org_id = org_id
+        self._credential_name = credential_name
+        self._binding_id = binding_id
+
+    async def get(self) -> VersionedOAuthTokens | None:
+        """Return the current encrypted token payload without acquiring a lock."""
+        credential = self._session.get(
+            ProviderOAuthCredential,
+            (self._org_id, "pagerduty", self._credential_name),
+            populate_existing=True,
+        )
+        if credential is None:
+            return None
+        return self._versioned_tokens(credential)
+
+    async def get_for_update(self) -> VersionedOAuthTokens | None:
+        """Return and lock the current payload while a refresh is in progress."""
+        statement = (
+            select(ProviderOAuthCredential)
+            .where(
+                ProviderOAuthCredential.org_id == self._org_id,
+                ProviderOAuthCredential.provider == "pagerduty",
+                ProviderOAuthCredential.credential_name == self._credential_name,
+            )
+            .with_for_update()
+            .execution_options(populate_existing=True)
+        )
+        credential = self._session.execute(statement).scalar_one_or_none()
+        if credential is None:
+            return None
+        return self._versioned_tokens(credential)
+
+    async def rotate(
+        self,
+        current_version: int,
+        tokens: OAuthTokens,
+        *,
+        expected_binding_id: str,
+    ) -> int:
+        """Persist a refresh only when its version and OAuth binding still match."""
+        statement = (
+            update(ProviderOAuthCredential)
+            .where(
+                ProviderOAuthCredential.org_id == self._org_id,
+                ProviderOAuthCredential.provider == "pagerduty",
+                ProviderOAuthCredential.credential_name == self._credential_name,
+                ProviderOAuthCredential.version == current_version,
+                ProviderOAuthCredential.binding_id == expected_binding_id,
+            )
+            .values(
+                token_encrypted=encrypt_value(tokens.model_dump_json()),
+                version=current_version + 1,
+                expires_at=tokens.expires_at,
+                granted_scopes=sorted(tokens.granted_scopes),
+                has_refresh_token=bool(tokens.refresh_token),
+                updated_at=datetime.now(UTC),
+            )
+            .returning(ProviderOAuthCredential.version)
+        )
+        version = self._session.execute(statement).scalar_one_or_none()
+        if version is None:
+            raise OAuthRotationConflictError("PagerDuty OAuth token rotation conflict")
+        self._session.flush()
+        return version
+
+    async def delete(self) -> None:
+        """Delete this encrypted credential without reading or logging its token."""
+        statement = delete(ProviderOAuthCredential).where(
+            ProviderOAuthCredential.org_id == self._org_id,
+            ProviderOAuthCredential.provider == "pagerduty",
+            ProviderOAuthCredential.credential_name == self._credential_name,
+        )
+        self._session.execute(statement)
+        self._session.flush()
+
+    def _versioned_tokens(
+        self, credential: ProviderOAuthCredential
+    ) -> VersionedOAuthTokens:
+        if self._binding_id is not None and credential.binding_id != self._binding_id:
+            raise OAuthRotationConflictError(
+                "PagerDuty OAuth credential binding mismatch"
+            )
+        return VersionedOAuthTokens(
+            OAuthTokens.model_validate_json(decrypt_value(credential.token_encrypted)),
+            credential.version,
+            credential.binding_id,
+        )
+
+
+def hydrate_pagerduty_credentials(
+    mapping: dict[str, Any], *, org_id: str
+) -> dict[str, Any]:
+    """Copy a PagerDuty credential descriptor and attach its ephemeral access token."""
+    result = mapping.copy()
+    auth_mode = mapping.get("auth_mode")
+    if auth_mode == "oauth":
+        config = PagerDutyOAuthConfig.from_env()
+        if config is None:
+            raise ValueError("PagerDuty OAuth app is not configured")
+        credential_name = mapping["oauth_credential_name"]
+        with get_postgres_session_sync() as session:
+            result["access_token"] = anyio.run(
+                get_valid_access_token,
+                _SyncSessionOAuthStore(
+                    session,
+                    org_id,
+                    credential_name,
+                    mapping["oauth_binding_id"],
+                ),
+                config,
+            )
+        return result
+    if auth_mode == "client_credentials":
+        config = PagerDutyOAuthConfig(
+            client_id=mapping["client_id"],
+            client_secret=mapping["client_secret"],
+            redirect_uri="",
+        )
+        request = ClientCredentialsRequest(
+            READ_SCOPES,
+            mapping["subdomain"],
+            mapping["region"],
+        )
+        key = (
+            org_id,
+            "client_credentials",
+            READ_SCOPES,
+            request.subdomain,
+            request.region,
+            hashlib.sha256(
+                f"{config.client_id}:{config.client_secret}".encode()
+            ).hexdigest(),
+        )
+        result["access_token"] = anyio.run(
+            get_client_credentials_access_token_keyed,
+            _REGISTRY,
+            key,
+            config,
+            request,
+        )
+    return result

--- a/src/dev_health_ops/workers/sync_bootstrap.py
+++ b/src/dev_health_ops/workers/sync_bootstrap.py
@@ -168,29 +168,39 @@ def resolve_run_auth(
 
     auth_source = getattr(run, "auth_source", None) if run is not None else None
     if auth_source is None:
-        return _resolve_integration_auth(session, integration, provider, error_label)
-
-    stamped_credential_id = getattr(run, "credential_id", None)
-    if stamped_credential_id is None:
-        decrypted_credentials: Any = dict(_resolve_env_credentials(provider))
-        credential_id: Any = None
-    else:
-        credential = _load_credential(
-            session, stamped_credential_id, integration.org_id
+        credential_id, decrypted_credentials = _resolve_integration_auth(
+            session, integration, provider, error_label
         )
-        if credential is None:
-            # Stamped credential deleted mid-run: the intended, honest failure
-            # surface (the run was frozen against a now-absent credential).
-            raise ValueError(f"Credential not found for {error_label}")
-        decrypted_credentials = _credential_mapping(credential)
-        credential_id = stamped_credential_id
-    _verify_stamped_fingerprint(
-        run,
-        decrypted_credentials=decrypted_credentials,
-        credential_id=credential_id,
-        integration=integration,
-        error_label=error_label,
-    )
+    else:
+        stamped_credential_id = getattr(run, "credential_id", None)
+        if stamped_credential_id is None:
+            decrypted_credentials = dict(_resolve_env_credentials(provider))
+            credential_id = None
+        else:
+            credential = _load_credential(
+                session, stamped_credential_id, integration.org_id
+            )
+            if credential is None:
+                # Stamped credential deleted mid-run: the intended, honest failure
+                # surface (the run was frozen against a now-absent credential).
+                raise ValueError(f"Credential not found for {error_label}")
+            decrypted_credentials = _credential_mapping(credential)
+            credential_id = stamped_credential_id
+        _verify_stamped_fingerprint(
+            run,
+            decrypted_credentials=decrypted_credentials,
+            credential_id=credential_id,
+            integration=integration,
+            error_label=error_label,
+        )
+    if provider == "pagerduty" and isinstance(decrypted_credentials, dict):
+        from dev_health_ops.providers.pagerduty.sync_auth import (
+            hydrate_pagerduty_credentials,
+        )
+
+        decrypted_credentials = hydrate_pagerduty_credentials(
+            decrypted_credentials, org_id=integration.org_id
+        )
     return credential_id, decrypted_credentials
 
 

--- a/tests/api/admin/test_pagerduty_oauth_setup.py
+++ b/tests/api/admin/test_pagerduty_oauth_setup.py
@@ -1,0 +1,1392 @@
+from __future__ import annotations
+
+import hashlib
+import importlib
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
+from urllib.parse import parse_qs, urlparse
+
+import httpx
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.routing import APIRoute
+from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.api.admin.router import router as admin_router
+from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.services.configuration import IntegrationCredentialsService
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import (
+    IntegrationCredential,
+    PagerDutyOAuthAuthorizationRequest,
+    ProviderOAuthCredential,
+)
+from dev_health_ops.providers.pagerduty.oauth import OAuthTokens, PagerDutyOAuthConfig
+from dev_health_ops.providers.pagerduty.oauth_storage import (
+    PagerDutyOAuthCredentialRepository,
+)
+from tests._helpers import tables_of
+
+pagerduty_router = importlib.import_module("dev_health_ops.api.admin.routers.pagerduty")
+credentials_router = importlib.import_module(
+    "dev_health_ops.api.admin.routers.credentials"
+)
+
+_ORG_ID = "pagerduty-oauth-test-org"
+_USER_ID = "pagerduty-oauth-test-user"
+_CONFIG = PagerDutyOAuthConfig(
+    client_id="test-client-id",
+    client_secret="test-client-secret",
+    redirect_uri="https://app.example.test/pagerduty/callback",
+)
+
+
+@pytest_asyncio.fixture
+async def session_maker(
+    tmp_path,
+) -> AsyncIterator[async_sessionmaker[AsyncSession]]:
+    engine = create_async_engine(
+        f"sqlite+aiosqlite:///{tmp_path / 'pagerduty-oauth.db'}"
+    )
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection,
+                tables=tables_of(
+                    IntegrationCredential,
+                    PagerDutyOAuthAuthorizationRequest,
+                    ProviderOAuthCredential,
+                ),
+            )
+        )
+
+    maker = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    try:
+        yield maker
+    finally:
+        await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def client(
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> AsyncIterator[AsyncClient]:
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "pagerduty-oauth-test-encryption-key")
+    monkeypatch.setattr(
+        pagerduty_router.PagerDutyOAuthConfig,
+        "from_env",
+        classmethod(lambda _: _CONFIG),
+    )
+
+    app = FastAPI()
+    app.include_router(pagerduty_router.router, prefix="/api/v1/admin")
+    app.include_router(credentials_router.router, prefix="/api/v1/admin")
+
+    async def session_override() -> AsyncIterator[AsyncSession]:
+        async with session_maker() as session:
+            yield session
+            await session.commit()
+
+    app.dependency_overrides[pagerduty_router.get_session] = session_override
+    app.dependency_overrides[pagerduty_router.get_admin_org_id] = lambda: _ORG_ID
+    app.dependency_overrides[pagerduty_router.get_admin_user] = lambda: (
+        AuthenticatedUser(
+            user_id=_USER_ID,
+            email="admin@example.test",
+            org_id=_ORG_ID,
+            role="owner",
+        )
+    )
+
+    transport = ASGITransport(app=app)
+    async with AsyncClient(transport=transport, base_url="http://test") as async_client:
+        yield async_client
+
+    app.dependency_overrides.clear()
+
+
+async def _authorize(client: AsyncClient, *, datasets: list[str]) -> str:
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/authorize",
+        json={
+            "credential_name": "operations",
+            "region": "eu",
+            "subdomain": "acme",
+            "enabled_datasets": datasets,
+        },
+    )
+    assert response.status_code == 200
+    return parse_qs(urlparse(response.json()["authorize_url"]).query)["state"][0]
+
+
+async def _persisted_counts(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> tuple[int, int]:
+    async with session_maker() as session:
+        oauth_credentials = list(
+            (await session.execute(select(ProviderOAuthCredential))).scalars()
+        )
+        integration_credentials = list(
+            (await session.execute(select(IntegrationCredential))).scalars()
+        )
+    return len(oauth_credentials), len(integration_credentials)
+
+
+@pytest.mark.asyncio
+async def test_authorize_returns_url_and_persists_hashed_request(
+    client: AsyncClient,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    state = await _authorize(client, datasets=["incidents", "services"])
+
+    async with session_maker() as session:
+        persisted = (
+            await session.execute(select(PagerDutyOAuthAuthorizationRequest))
+        ).scalar_one()
+
+    assert persisted.state_hash == hashlib.sha256(state.encode()).hexdigest()
+    assert persisted.state_hash != state
+    assert persisted.credential_name == "operations"
+    assert persisted.region == "eu"
+    assert persisted.subdomain == "acme"
+    assert persisted.enabled_datasets == ["incidents", "services"]
+    assert persisted.initiated_by == _USER_ID
+
+
+@pytest.mark.asyncio
+async def test_authorize_rejects_unknown_dataset(
+    client: AsyncClient,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/authorize",
+        json={"subdomain": "acme", "enabled_datasets": ["unknown"]},
+    )
+
+    assert response.status_code == 400
+    async with session_maker() as session:
+        assert (
+            await session.execute(select(PagerDutyOAuthAuthorizationRequest))
+        ).scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_authorize_rejects_missing_registered_app_config(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    monkeypatch.setattr(
+        pagerduty_router.PagerDutyOAuthConfig,
+        "from_env",
+        classmethod(lambda _: None),
+    )
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/authorize",
+        json={"subdomain": "acme", "enabled_datasets": ["incidents"]},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "PAGER_DUTY_CLIENT_ID is not configured"
+    async with session_maker() as session:
+        assert (
+            await session.execute(select(PagerDutyOAuthAuthorizationRequest))
+        ).scalar_one_or_none() is None
+
+
+@pytest.mark.asyncio
+async def test_callback_persists_oauth_token_and_safe_descriptor(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    state = await _authorize(client, datasets=["incidents", "services"])
+    tokens = OAuthTokens(
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read", "Services.read"}),
+    )
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=tokens)
+    )
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "connected": True,
+        "credential_name": "operations",
+        "region": "eu",
+        "subdomain": "acme",
+        "granted_scopes": ["Incidents.read", "Services.read"],
+    }
+    async with session_maker() as session:
+        oauth_credential = (
+            await session.execute(select(ProviderOAuthCredential))
+        ).scalar_one()
+        descriptor = await IntegrationCredentialsService(
+            session, _ORG_ID
+        ).get_decrypted_credentials("pagerduty", "operations")
+        integration_credential = (
+            await session.execute(select(IntegrationCredential))
+        ).scalar_one()
+
+    assert oauth_credential.account_id == "acme"
+    assert oauth_credential.account_display == "acme"
+    assert integration_credential.is_active is True
+    assert descriptor is not None
+    assert descriptor == {
+        "auth_mode": "oauth",
+        "oauth_credential_name": "operations",
+        "oauth_binding_id": oauth_credential.binding_id,
+        "subdomain": "acme",
+        "region": "eu",
+        "account_id": "acme",
+    }
+    assert "access_token" not in descriptor
+    assert "refresh_token" not in descriptor
+    assert integration_credential.config == {
+        "auth_mode": "oauth",
+        "region": "eu",
+        "subdomain": "acme",
+        "account_id": "acme",
+        "granted_scopes": ["Incidents.read", "Services.read"],
+    }
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_unknown_state_without_persistence(
+    client: AsyncClient,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": "unknown-state", "code": "authorization-code"},
+    )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Invalid or expired PagerDuty OAuth state"
+    assert await _persisted_counts(session_maker) == (0, 0)
+
+
+def test_pagerduty_routes_are_registered_with_admin_router() -> None:
+    registered_paths = {
+        route.path for route in admin_router.routes if isinstance(route, APIRoute)
+    }
+
+    assert "/api/v1/admin/integrations/pagerduty/authorize" in registered_paths
+    assert "/api/v1/admin/integrations/pagerduty/callback" in registered_paths
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_replayed_state_without_another_persistence(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    tokens = OAuthTokens(
+        access_token="access-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read"}),
+    )
+    exchange = AsyncMock(return_value=tokens)
+    monkeypatch.setattr(pagerduty_router, "exchange_code", exchange)
+
+    first_response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+    replay_response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    assert first_response.status_code == 200
+    assert replay_response.status_code == 400
+    assert await _persisted_counts(session_maker) == (1, 1)
+    exchange.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_denied_authorization(
+    client: AsyncClient,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "error": "access_denied"},
+    )
+
+    assert response.status_code == 400
+    assert await _persisted_counts(session_maker) == (0, 0)
+
+
+@pytest.mark.asyncio
+async def test_callback_revokes_and_rejects_missing_required_scope(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    tokens = OAuthTokens(
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Services.read"}),
+    )
+    revoke = AsyncMock()
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=tokens)
+    )
+    monkeypatch.setattr(pagerduty_router, "revoke_token", revoke)
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    assert response.status_code == 400
+    assert "Incidents.read" in response.json()["detail"]
+    revoke.assert_awaited_once_with(_CONFIG, "refresh-token")
+    assert await _persisted_counts(session_maker) == (0, 0)
+
+    replay = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+    assert replay.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_status_returns_non_secret_oauth_metadata(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    tokens = OAuthTokens(
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read"}),
+    )
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=tokens)
+    )
+    await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/status",
+        params={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 200
+    payload = response.json()
+    assert payload["connected"] is True
+    assert payload["auth_mode"] == "oauth"
+    assert payload["subdomain"] == "acme"
+    assert payload["granted_scopes"] == ["Incidents.read"]
+    assert "access_token" not in payload
+    assert "refresh_token" not in payload
+
+
+@pytest.mark.asyncio
+async def test_status_returns_not_connected_when_descriptor_is_absent(
+    client: AsyncClient,
+) -> None:
+    response = await client.get("/api/v1/admin/integrations/pagerduty/status")
+
+    assert response.status_code == 200
+    assert response.json()["connected"] is False
+
+
+@pytest.mark.asyncio
+async def test_disconnect_deactivates_descriptor_without_deleting_it(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    tokens = OAuthTokens(
+        access_token="access-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read"}),
+    )
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=tokens)
+    )
+    revoke = AsyncMock()
+    monkeypatch.setattr(pagerduty_router, "revoke_token", revoke)
+    await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/disconnect",
+        json={"credential_name": "operations"},
+    )
+    repeated_response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/disconnect",
+        json={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 200
+    assert repeated_response.status_code == 200
+    # Remote revocation is best-effort and happens after the local removal commits.
+    revoke.assert_awaited()
+    async with session_maker() as session:
+        descriptor = await IntegrationCredentialsService(session, _ORG_ID).get(
+            "pagerduty", "operations"
+        )
+        metadata = await PagerDutyOAuthCredentialRepository(
+            session, _ORG_ID, "operations"
+        ).get_status_metadata()
+    # Descriptor is deactivated (not deleted); the OAuth token row is gone.
+    assert descriptor is not None
+    assert descriptor.is_active is False
+    assert metadata is None
+
+
+@pytest.mark.asyncio
+async def test_preflight_reports_dataset_scopes_without_users_requirement(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    tokens = OAuthTokens(
+        access_token="access-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read"}),
+    )
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=tokens)
+    )
+    await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/preflight",
+        json={
+            "credential_name": "operations",
+            "enabled_datasets": ["incidents", "users"],
+        },
+    )
+
+    assert response.status_code == 200
+    datasets = {
+        dataset["requested"]: dataset for dataset in response.json()["datasets"]
+    }
+    assert datasets["incidents"] == {
+        "requested": "incidents",
+        "required_scopes": ["Incidents.read"],
+        "granted": True,
+        "missing": [],
+    }
+    assert datasets["users"]["granted"] is False
+    assert datasets["users"]["missing"] == ["Users.read"]
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_persists_exact_descriptor(
+    client: AsyncClient,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/client-credentials",
+        json={
+            "credential_name": "automation",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "subdomain": "acme",
+            "region": "eu",
+        },
+    )
+
+    assert response.status_code == 200
+    async with session_maker() as session:
+        service = IntegrationCredentialsService(session, _ORG_ID)
+        descriptor = await service.get_decrypted_credentials("pagerduty", "automation")
+        credential = await service.get("pagerduty", "automation")
+    assert descriptor == {
+        "auth_mode": "client_credentials",
+        "client_id": "client-id",
+        "client_secret": "client-secret",
+        "subdomain": "acme",
+        "region": "eu",
+    }
+    assert credential is not None
+    assert credential.config == {
+        "auth_mode": "client_credentials",
+        "region": "eu",
+        "subdomain": "acme",
+    }
+
+
+@pytest.mark.asyncio
+async def test_api_token_persists_exact_descriptor(
+    client: AsyncClient,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/api-token",
+        json={
+            "credential_name": "personal",
+            "api_token": "api-token",
+            "subdomain": "acme",
+            "region": "us",
+        },
+    )
+
+    assert response.status_code == 200
+    async with session_maker() as session:
+        service = IntegrationCredentialsService(session, _ORG_ID)
+        descriptor = await service.get_decrypted_credentials("pagerduty", "personal")
+        credential = await service.get("pagerduty", "personal")
+    assert descriptor == {
+        "auth_mode": "api_token",
+        "api_token": "api-token",
+        "subdomain": "acme",
+        "region": "us",
+    }
+    assert credential is not None
+    assert credential.config == {
+        "auth_mode": "api_token",
+        "region": "us",
+        "subdomain": "acme",
+    }
+
+
+@pytest.mark.asyncio
+async def test_credential_probe_does_not_require_users_read(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+
+    list_incidents = AsyncMock(return_value=[])
+    monkeypatch.setattr(PagerDutyClient, "list_incidents", list_incidents)
+
+    success, details = await credentials_router._test_pagerduty_connection(
+        {
+            "access_token": "oauth-access-token",
+            "region": "us",
+            "enabled_datasets": ["incidents"],
+            "granted_scopes": ["Incidents.read"],
+        }
+    )
+
+    assert success is True
+    assert details == {"records_checked": 0, "missing_scopes": []}
+    list_incidents.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_burns_state_after_denied_authorization(
+    client: AsyncClient,
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+
+    denied = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "error": "access_denied"},
+    )
+    replay = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    assert denied.status_code == 400
+    assert replay.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_callback_burns_state_and_sanitizes_invalid_code_error(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    response = httpx.Response(
+        400,
+        content=b"provider-secret-response",
+        request=httpx.Request("POST", "https://identity.pagerduty.test/oauth/token"),
+    )
+    monkeypatch.setattr(
+        pagerduty_router,
+        "exchange_code",
+        AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "invalid grant", request=response.request, response=response
+            )
+        ),
+    )
+
+    invalid_code = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+    replay = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    assert invalid_code.status_code == 400
+    assert "provider-secret-response" not in invalid_code.text
+    assert replay.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_callback_sanitizes_upstream_exchange_failure(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    response = httpx.Response(
+        503,
+        content=b"provider-secret-response",
+        request=httpx.Request("POST", "https://identity.pagerduty.test/oauth/token"),
+    )
+    monkeypatch.setattr(
+        pagerduty_router,
+        "exchange_code",
+        AsyncMock(
+            side_effect=httpx.HTTPStatusError(
+                "unavailable", request=response.request, response=response
+            )
+        ),
+    )
+
+    upstream_error = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    assert upstream_error.status_code == 502
+    assert "provider-secret-response" not in upstream_error.text
+
+
+@pytest.mark.asyncio
+async def test_callback_burns_state_and_revokes_after_descriptor_write_failure(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    tokens = OAuthTokens(
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read"}),
+    )
+    revoke = AsyncMock()
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=tokens)
+    )
+    monkeypatch.setattr(pagerduty_router, "revoke_token", revoke)
+    monkeypatch.setattr(
+        pagerduty_router.IntegrationCredentialsService,
+        "set",
+        AsyncMock(side_effect=RuntimeError("descriptor write failure")),
+    )
+
+    with pytest.raises(RuntimeError, match="descriptor write failure"):
+        await client.post(
+            "/api/v1/admin/integrations/pagerduty/callback",
+            json={"state": state, "code": "authorization-code"},
+        )
+    replay = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    revoke.assert_awaited_once_with(_CONFIG, "refresh-token")
+    assert replay.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_callback_burns_state_and_revokes_after_persistence_commit_failure(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    tokens = OAuthTokens(
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read"}),
+    )
+    revoke = AsyncMock()
+    original_commit = AsyncSession.commit
+    commits = 0
+
+    async def commit_with_failure(session: AsyncSession) -> None:
+        nonlocal commits
+        commits += 1
+        if commits == 2:
+            raise RuntimeError("persistence commit failure")
+        await original_commit(session)
+
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=tokens)
+    )
+    monkeypatch.setattr(pagerduty_router, "revoke_token", revoke)
+    monkeypatch.setattr(AsyncSession, "commit", commit_with_failure)
+
+    with pytest.raises(RuntimeError, match="persistence commit failure"):
+        await client.post(
+            "/api/v1/admin/integrations/pagerduty/callback",
+            json={"state": state, "code": "authorization-code"},
+        )
+    replay = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+
+    revoke.assert_awaited_once_with(_CONFIG, "refresh-token")
+    assert replay.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_service_rejects_pagerduty_live_tokens(
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_maker() as session:
+        service = IntegrationCredentialsService(session, _ORG_ID)
+        with pytest.raises(ValueError, match="tokens"):
+            await service.set(
+                "pagerduty",
+                {
+                    "auth_mode": "api_token",
+                    "api_token": "api-token",
+                    "subdomain": "acme",
+                    "region": "us",
+                    "access_token": "forbidden",
+                },
+            )
+        with pytest.raises(ValueError, match="tokens"):
+            await service.set(
+                "pagerduty",
+                {
+                    "auth_mode": "api_token",
+                    "api_token": "api-token",
+                    "subdomain": "acme",
+                    "region": "us",
+                },
+                config={"refresh_token": "forbidden"},
+            )
+
+
+@pytest.mark.asyncio
+async def test_generic_pagerduty_credential_routes_are_rejected(
+    client: AsyncClient,
+) -> None:
+    created = await client.post(
+        "/api/v1/admin/credentials",
+        json={"provider": "pagerduty", "credentials": {"api_token": "forbidden"}},
+    )
+    updated = await client.patch(
+        "/api/v1/admin/credentials/pagerduty/default",
+        json={"credentials": {"api_token": "forbidden"}},
+    )
+
+    assert created.status_code == 400
+    assert updated.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_disconnect_removes_oauth_row_without_descriptor_or_oauth_config(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    state = await _authorize(client, datasets=["incidents"])
+    tokens = OAuthTokens(
+        access_token="access-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read"}),
+    )
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=tokens)
+    )
+    await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+    async with session_maker() as session:
+        descriptor = await IntegrationCredentialsService(session, _ORG_ID).get(
+            "pagerduty", "operations"
+        )
+        assert descriptor is not None
+        await session.delete(descriptor)
+        await session.commit()
+    monkeypatch.setattr(
+        pagerduty_router.PagerDutyOAuthConfig,
+        "from_env",
+        classmethod(lambda _: None),
+    )
+
+    disconnected = await client.post(
+        "/api/v1/admin/integrations/pagerduty/disconnect",
+        json={"credential_name": "operations"},
+    )
+    repeated = await client.post(
+        "/api/v1/admin/integrations/pagerduty/disconnect",
+        json={"credential_name": "operations"},
+    )
+    async with session_maker() as session:
+        metadata = await PagerDutyOAuthCredentialRepository(
+            session, _ORG_ID, "operations"
+        ).get_status_metadata()
+
+    assert disconnected.status_code == 200
+    assert repeated.status_code == 200
+    assert metadata is None
+
+
+@pytest.mark.asyncio
+async def test_non_oauth_modes_remove_existing_oauth_binding(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    tokens = OAuthTokens(
+        access_token="access-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read"}),
+    )
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=tokens)
+    )
+    first_state = await _authorize(client, datasets=["incidents"])
+    await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": first_state, "code": "authorization-code"},
+    )
+    monkeypatch.setattr(
+        pagerduty_router.PagerDutyOAuthConfig,
+        "from_env",
+        classmethod(lambda _: None),
+    )
+    await client.post(
+        "/api/v1/admin/integrations/pagerduty/api-token",
+        json={
+            "credential_name": "operations",
+            "api_token": "api-token",
+            "subdomain": "acme",
+            "region": "us",
+        },
+    )
+    async with session_maker() as session:
+        after_api_token = await PagerDutyOAuthCredentialRepository(
+            session, _ORG_ID, "operations"
+        ).get_status_metadata()
+
+    monkeypatch.setattr(
+        pagerduty_router.PagerDutyOAuthConfig,
+        "from_env",
+        classmethod(lambda _: _CONFIG),
+    )
+    second_state = await _authorize(client, datasets=["incidents"])
+    await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": second_state, "code": "authorization-code"},
+    )
+    monkeypatch.setattr(
+        pagerduty_router.PagerDutyOAuthConfig,
+        "from_env",
+        classmethod(lambda _: None),
+    )
+    await client.post(
+        "/api/v1/admin/integrations/pagerduty/client-credentials",
+        json={
+            "credential_name": "operations",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "subdomain": "acme",
+            "region": "us",
+        },
+    )
+    async with session_maker() as session:
+        after_client_credentials = await PagerDutyOAuthCredentialRepository(
+            session, _ORG_ID, "operations"
+        ).get_status_metadata()
+
+    assert after_api_token is None
+    assert after_client_credentials is None
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    ("path", "payload"),
+    [
+        (
+            "/integrations/pagerduty/authorize",
+            {"credential_name": " ", "subdomain": "acme", "enabled_datasets": []},
+        ),
+        (
+            "/integrations/pagerduty/client-credentials",
+            {
+                "credential_name": "automation",
+                "client_id": "id",
+                "client_secret": "secret",
+                "subdomain": " ",
+                "region": "us",
+            },
+        ),
+        (
+            "/integrations/pagerduty/api-token",
+            {
+                "credential_name": " ",
+                "api_token": "token",
+                "subdomain": "acme",
+                "region": "us",
+            },
+        ),
+    ],
+)
+async def test_setup_rejects_blank_required_text(
+    client: AsyncClient, path: str, payload: dict[str, object]
+) -> None:
+    response = await client.post(f"/api/v1/admin{path}", json=payload)
+
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_client_credentials_strips_descriptor_text(
+    client: AsyncClient,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/client-credentials",
+        json={
+            "credential_name": " automation ",
+            "client_id": "id",
+            "client_secret": "secret",
+            "subdomain": " acme ",
+            "region": "us",
+        },
+    )
+    async with session_maker() as session:
+        descriptor = await IntegrationCredentialsService(
+            session, _ORG_ID
+        ).get_decrypted_credentials("pagerduty", "automation")
+
+    assert response.status_code == 200
+    assert descriptor is not None
+    assert descriptor["subdomain"] == "acme"
+
+
+class _RecordingPagerDutyClient:
+    """Stand-in PagerDuty client that records calls and closes for preflight tests."""
+
+    instances: list[_RecordingPagerDutyClient] = []
+    fail_methods: set[str] = set()
+
+    def __init__(self, auth: object, *, region: str = "us", transport: object = None):
+        self.auth = auth
+        self.region = region
+        self.closed = 0
+        self.calls: list[str] = []
+        type(self).instances.append(self)
+
+    async def close(self) -> None:
+        self.closed += 1
+
+    async def _probe(self, name: str) -> list[object]:
+        self.calls.append(name)
+        if name in type(self).fail_methods:
+            raise RuntimeError(f"boom:{name}")
+        return [object()]
+
+    async def list_incidents(self) -> list[object]:
+        return await self._probe("list_incidents")
+
+    async def list_services(self) -> list[object]:
+        return await self._probe("list_services")
+
+    async def list_users(self) -> list[object]:
+        return await self._probe("list_users")
+
+
+def _install_recording_client(
+    monkeypatch: pytest.MonkeyPatch,
+) -> type[_RecordingPagerDutyClient]:
+    _RecordingPagerDutyClient.instances.clear()
+    _RecordingPagerDutyClient.fail_methods = set()
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.client.PagerDutyClient",
+        _RecordingPagerDutyClient,
+    )
+    return _RecordingPagerDutyClient
+
+
+@pytest.mark.asyncio
+async def test_preflight_helper_blocks_missing_scope_without_calling_api(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.api.admin.routers.credentials import _test_pagerduty_connection
+
+    client_cls = _install_recording_client(monkeypatch)
+    ok, detail = await _test_pagerduty_connection(
+        {
+            "access_token": "tok",
+            "enabled_datasets": ["incidents"],
+            "granted_scopes": [],
+            "region": "us",
+        }
+    )
+
+    assert ok is False
+    assert "Incidents.read" in detail["missing_scopes"]
+    instance = client_cls.instances[-1]
+    assert instance.calls == []
+    assert instance.closed == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_helper_closes_client_on_success_and_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.api.admin.routers.credentials import _test_pagerduty_connection
+
+    client_cls = _install_recording_client(monkeypatch)
+    ok, detail = await _test_pagerduty_connection(
+        {
+            "access_token": "tok",
+            "enabled_datasets": ["incidents"],
+            "granted_scopes": ["Incidents.read"],
+            "region": "us",
+        }
+    )
+    assert ok is True
+    assert detail["records_checked"] == 1
+    success_instance = client_cls.instances[-1]
+    assert success_instance.calls == ["list_incidents"]
+    assert success_instance.closed == 1
+
+    client_cls.fail_methods = {"list_incidents"}
+    with pytest.raises(RuntimeError, match="boom:list_incidents"):
+        await _test_pagerduty_connection(
+            {
+                "access_token": "tok",
+                "enabled_datasets": ["incidents"],
+                "granted_scopes": ["Incidents.read"],
+                "region": "us",
+            }
+        )
+    error_instance = client_cls.instances[-1]
+    assert error_instance.closed == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_helper_rejects_unknown_dataset(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.api.admin.routers.credentials import _test_pagerduty_connection
+
+    client_cls = _install_recording_client(monkeypatch)
+    ok, detail = await _test_pagerduty_connection(
+        {
+            "access_token": "tok",
+            "enabled_datasets": ["not_a_dataset"],
+            "granted_scopes": [],
+            "region": "us",
+        }
+    )
+
+    assert ok is False
+    assert "Unknown PagerDuty datasets" in detail["error"]
+    assert client_cls.instances[-1].closed == 1
+
+
+@pytest.mark.asyncio
+async def test_preflight_helper_api_token_skips_oauth_scope_math(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.api.admin.routers.credentials import _test_pagerduty_connection
+
+    client_cls = _install_recording_client(monkeypatch)
+    ok, detail = await _test_pagerduty_connection(
+        {
+            "api_token": "tok",
+            "enabled_datasets": ["incidents"],
+            "granted_scopes": [],
+            "region": "us",
+        }
+    )
+
+    assert ok is True
+    assert detail["missing_scopes"] == []
+    instance = client_cls.instances[-1]
+    assert instance.calls == ["list_incidents"]
+    assert instance.closed == 1
+
+
+async def _connect_oauth(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    datasets: list[str] | None = None,
+    granted: set[str] | None = None,
+) -> None:
+    state = await _authorize(client, datasets=datasets or ["incidents"])
+    connected_tokens = OAuthTokens(
+        access_token="access-token",
+        refresh_token="refresh-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset(granted or {"Incidents.read"}),
+    )
+    monkeypatch.setattr(
+        pagerduty_router, "exchange_code", AsyncMock(return_value=connected_tokens)
+    )
+    connect = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": state, "code": "authorization-code"},
+    )
+    assert connect.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_callback_rejects_missing_subdomain_before_exchange(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_maker() as session:
+        await pagerduty_router.PagerDutyAuthorizationRequestStore(session).create(
+            org_id=_ORG_ID,
+            state="state-without-subdomain",
+            credential_name="operations",
+            code_verifier="verifier",
+            enabled_datasets=["incidents"],
+            region="eu",
+            subdomain=None,
+            initiated_by=_USER_ID,
+        )
+        await session.commit()
+    exchange = AsyncMock(side_effect=AssertionError("exchange must not run"))
+    monkeypatch.setattr(pagerduty_router, "exchange_code", exchange)
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/callback",
+        json={"state": "state-without-subdomain", "code": "authorization-code"},
+    )
+
+    assert response.status_code == 400
+    exchange.assert_not_awaited()
+
+
+def test_validate_pagerduty_descriptor_guards_config_secrets_and_mode() -> None:
+    from dev_health_ops.api.services.configuration.integration_credentials import (
+        _validate_pagerduty_descriptor,
+    )
+
+    api_token_creds = {
+        "auth_mode": "api_token",
+        "api_token": "token",
+        "subdomain": "acme",
+        "region": "us",
+    }
+    # A secret smuggled into the non-secret config is rejected.
+    with pytest.raises(ValueError):
+        _validate_pagerduty_descriptor(
+            api_token_creds,
+            {"auth_mode": "api_token", "region": "us", "client_secret": "leak"},
+        )
+    # An unknown config key is rejected.
+    with pytest.raises(ValueError):
+        _validate_pagerduty_descriptor(
+            api_token_creds,
+            {"auth_mode": "api_token", "region": "us", "surprise": "x"},
+        )
+    # A config auth_mode that disagrees with the credentials is rejected.
+    with pytest.raises(ValueError):
+        _validate_pagerduty_descriptor(
+            api_token_creds,
+            {"auth_mode": "oauth", "region": "us", "subdomain": "acme"},
+        )
+    # The dedicated api-token payload itself remains valid.
+    _validate_pagerduty_descriptor(
+        api_token_creds,
+        {"auth_mode": "api_token", "region": "us", "subdomain": "acme"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_disconnect_deletes_oauth_row_even_with_corrupt_ciphertext(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _connect_oauth(client, monkeypatch)
+    async with session_maker() as session:
+        row = (await session.execute(select(ProviderOAuthCredential))).scalar_one()
+        row.token_encrypted = "corrupt-not-decryptable"
+        await session.commit()
+    monkeypatch.setattr(pagerduty_router, "revoke_token", AsyncMock())
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/disconnect",
+        json={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 200
+    async with session_maker() as session:
+        metadata = await PagerDutyOAuthCredentialRepository(
+            session, _ORG_ID, "operations"
+        ).get_status_metadata()
+    assert metadata is None
+
+
+@pytest.mark.asyncio
+async def test_disconnect_deactivates_legacy_descriptor_without_revalidation(
+    client: AsyncClient,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    import json
+
+    from dev_health_ops.core.encryption import encrypt_value
+
+    async with session_maker() as session:
+        session.add(
+            IntegrationCredential(
+                provider="pagerduty",
+                name="legacy",
+                org_id=_ORG_ID,
+                credentials_encrypted=encrypt_value(
+                    json.dumps({"api_token": "legacy-token"})
+                ),
+                config={},
+                is_active=True,
+            )
+        )
+        await session.commit()
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/disconnect",
+        json={"credential_name": "legacy"},
+    )
+
+    assert response.status_code == 200
+    async with session_maker() as session:
+        descriptor = await IntegrationCredentialsService(session, _ORG_ID).get(
+            "pagerduty", "legacy"
+        )
+    assert descriptor is not None
+    assert descriptor.is_active is False
+
+
+@pytest.mark.asyncio
+async def test_disconnect_revokes_only_after_local_removal_committed(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _connect_oauth(client, monkeypatch)
+    observed: dict[str, bool] = {}
+
+    async def spy_revoke(config: object, token: str) -> None:
+        async with session_maker() as session:
+            meta = await PagerDutyOAuthCredentialRepository(
+                session, _ORG_ID, "operations"
+            ).get_status_metadata()
+        observed["row_present_at_revoke"] = meta is not None
+
+    monkeypatch.setattr(pagerduty_router, "revoke_token", spy_revoke)
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/disconnect",
+        json={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 200
+    # Revocation ran, and by the time it ran the local row was already committed-gone.
+    assert observed.get("row_present_at_revoke") is False
+
+
+@pytest.mark.asyncio
+async def test_disconnect_rejects_whitespace_credential_name(
+    client: AsyncClient,
+) -> None:
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/disconnect",
+        json={"credential_name": "   "},
+    )
+    assert response.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_preflight_rejects_whitespace_credential_name(
+    client: AsyncClient,
+) -> None:
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/preflight",
+        json={"credential_name": "   ", "enabled_datasets": ["incidents"]},
+    )
+    assert response.status_code == 422
+
+
+def test_validate_pagerduty_descriptor_requires_matching_config_auth_mode() -> None:
+    from dev_health_ops.api.services.configuration.integration_credentials import (
+        _validate_pagerduty_descriptor,
+    )
+
+    creds = {
+        "auth_mode": "api_token",
+        "api_token": "token",
+        "subdomain": "acme",
+        "region": "us",
+    }
+    # Absent, empty, or null config auth_mode no longer satisfies the invariant.
+    bad_configs: list[dict[str, object] | None] = [
+        None,
+        {},
+        {"auth_mode": None, "region": "us", "subdomain": "acme"},
+    ]
+    for bad_config in bad_configs:
+        with pytest.raises(ValueError):
+            _validate_pagerduty_descriptor(creds, bad_config)
+
+
+@pytest.mark.asyncio
+async def test_remove_oauth_binding_reraises_unexpected_error_after_delete(
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "pagerduty-oauth-test-encryption-key")
+    async with session_maker() as session:
+        repository = PagerDutyOAuthCredentialRepository(session, _ORG_ID, "operations")
+        await repository.create_or_replace(
+            OAuthTokens(
+                access_token="access-token",
+                expires_at=datetime.now(UTC) + timedelta(hours=1),
+            ),
+            binding_id="binding-id",
+        )
+        await session.commit()
+
+        async def boom() -> None:
+            raise RuntimeError("programming error")
+
+        monkeypatch.setattr(repository, "get", boom)
+        # An unexpected (non-ValueError) failure must propagate, not be swallowed...
+        with pytest.raises(RuntimeError, match="programming error"):
+            await pagerduty_router._remove_oauth_binding(repository, _CONFIG)
+        # ...while the local row is still deleted via the finally clause.
+        assert await repository.get_status_metadata() is None

--- a/tests/api/webhooks/test_pagerduty.py
+++ b/tests/api/webhooks/test_pagerduty.py
@@ -134,7 +134,17 @@ def test_rejects_an_invalid_signature(client: TestClient) -> None:
     assert response.status_code == 401
 
 
-@pytest.mark.parametrize("body", [b"{", b"x" * 1_048_577])
+@pytest.mark.parametrize(
+    "body",
+    [
+        pytest.param(b"{", id="malformed"),
+        # Short explicit id: using the 1 MiB value as the param would make
+        # pytest generate a ~1 MB node id, which pytest-xdist pipes between the
+        # controller and workers during --dist loadscope collection and can
+        # deadlock the run in CI (CHAOS-2960).
+        pytest.param(b"x" * 1_048_577, id="oversized"),
+    ],
+)
 def test_rejects_malformed_or_oversized_payloads(
     client: TestClient, body: bytes
 ) -> None:

--- a/tests/providers/test_pagerduty_oauth_authorization_store.py
+++ b/tests/providers/test_pagerduty_oauth_authorization_store.py
@@ -1,0 +1,244 @@
+from __future__ import annotations
+
+import hashlib
+from collections.abc import AsyncIterator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+import pytest_asyncio
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.models.git import Base
+from dev_health_ops.models.settings import PagerDutyOAuthAuthorizationRequest
+from dev_health_ops.providers.pagerduty.oauth_authorization_store import (
+    PagerDutyAuthorizationRequestStore,
+)
+from tests._helpers import tables_of
+
+_TABLES = tables_of(PagerDutyOAuthAuthorizationRequest)
+_NOW = datetime(2026, 7, 18, tzinfo=UTC)
+
+
+@pytest.fixture(autouse=True)
+def encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-pagerduty-oauth-key")
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(
+            lambda sync_connection: Base.metadata.create_all(
+                sync_connection, tables=_TABLES
+            )
+        )
+    session_factory = async_sessionmaker(
+        engine, class_=AsyncSession, expire_on_commit=False
+    )
+    async with session_factory() as database_session:
+        yield database_session
+    await engine.dispose()
+
+
+@pytest.mark.anyio
+async def test_consume_returns_encrypted_pkce_context(session: AsyncSession) -> None:
+    store = PagerDutyAuthorizationRequestStore(session)
+
+    await store.create(
+        org_id="org-1",
+        state="opaque-state",
+        credential_name="primary",
+        code_verifier="pkce-verifier",
+        enabled_datasets=["incidents", "services"],
+        region="us",
+        subdomain="acme",
+        now=_NOW,
+    )
+
+    consumed = await store.consume(org_id="org-1", state="opaque-state", now=_NOW)
+
+    assert consumed is not None
+    assert consumed.credential_name == "primary"
+    assert consumed.code_verifier == "pkce-verifier"
+    assert consumed.enabled_datasets == ["incidents", "services"]
+    assert consumed.region == "us"
+    assert consumed.subdomain == "acme"
+
+
+@pytest.mark.anyio
+async def test_create_persists_only_state_hash_and_ciphertext(
+    session: AsyncSession,
+) -> None:
+    store = PagerDutyAuthorizationRequestStore(session)
+    state = "opaque-state"
+    code_verifier = "pkce-verifier"
+
+    await store.create(
+        org_id="org-1",
+        state=state,
+        credential_name="primary",
+        code_verifier=code_verifier,
+        enabled_datasets=["incidents"],
+        region="us",
+        now=_NOW,
+    )
+
+    persisted_request = (
+        await session.execute(select(PagerDutyOAuthAuthorizationRequest))
+    ).scalar_one()
+
+    assert persisted_request.state_hash == hashlib.sha256(state.encode()).hexdigest()
+    assert persisted_request.code_verifier_encrypted != code_verifier
+
+
+@pytest.mark.anyio
+async def test_consume_returns_none_after_request_is_used(
+    session: AsyncSession,
+) -> None:
+    store = PagerDutyAuthorizationRequestStore(session)
+
+    await store.create(
+        org_id="org-1",
+        state="single-use-state",
+        credential_name="primary",
+        code_verifier="pkce-verifier",
+        enabled_datasets=["incidents"],
+        region="us",
+        now=_NOW,
+    )
+    first_consume = await store.consume(
+        org_id="org-1", state="single-use-state", now=_NOW
+    )
+
+    second_consume = await store.consume(
+        org_id="org-1", state="single-use-state", now=_NOW
+    )
+
+    assert first_consume is not None
+    assert second_consume is None
+
+
+@pytest.mark.anyio
+async def test_consume_removes_expired_request(session: AsyncSession) -> None:
+    store = PagerDutyAuthorizationRequestStore(session)
+
+    await store.create(
+        org_id="org-1",
+        state="expired-state",
+        credential_name="primary",
+        code_verifier="pkce-verifier",
+        enabled_datasets=["incidents"],
+        region="us",
+        ttl=timedelta(seconds=0),
+        now=_NOW,
+    )
+
+    consumed = await store.consume(org_id="org-1", state="expired-state", now=_NOW)
+
+    assert consumed is None
+    assert await store.purge_expired(now=_NOW) == 0
+
+
+@pytest.mark.anyio
+async def test_consume_preserves_request_for_other_organizations(
+    session: AsyncSession,
+) -> None:
+    store = PagerDutyAuthorizationRequestStore(session)
+
+    await store.create(
+        org_id="org-1",
+        state="organization-scoped-state",
+        credential_name="primary",
+        code_verifier="pkce-verifier",
+        enabled_datasets=["incidents"],
+        region="us",
+        now=_NOW,
+    )
+
+    wrong_organization = await store.consume(
+        org_id="org-2", state="organization-scoped-state", now=_NOW
+    )
+    matching_organization = await store.consume(
+        org_id="org-1", state="organization-scoped-state", now=_NOW
+    )
+
+    assert wrong_organization is None
+    assert matching_organization is not None
+    assert matching_organization.code_verifier == "pkce-verifier"
+
+
+@pytest.mark.anyio
+async def test_consume_returns_none_for_unknown_state(session: AsyncSession) -> None:
+    store = PagerDutyAuthorizationRequestStore(session)
+
+    consumed = await store.consume(org_id="org-1", state="unknown-state", now=_NOW)
+
+    assert consumed is None
+
+
+@pytest.mark.anyio
+async def test_purge_expired_keeps_active_requests(session: AsyncSession) -> None:
+    store = PagerDutyAuthorizationRequestStore(session)
+
+    await store.create(
+        org_id="org-1",
+        state="expired-state",
+        credential_name="primary",
+        code_verifier="expired-verifier",
+        enabled_datasets=["incidents"],
+        region="us",
+        ttl=timedelta(seconds=0),
+        now=_NOW,
+    )
+    await store.create(
+        org_id="org-1",
+        state="active-state",
+        credential_name="primary",
+        code_verifier="active-verifier",
+        enabled_datasets=["services"],
+        region="eu",
+        ttl=timedelta(minutes=1),
+        now=_NOW,
+    )
+
+    purged = await store.purge_expired(now=_NOW)
+
+    active_request = await store.consume(org_id="org-1", state="active-state", now=_NOW)
+    assert purged == 0
+    assert active_request is not None
+    assert active_request.code_verifier == "active-verifier"
+
+
+@pytest.mark.anyio
+async def test_create_purges_expired_requests_for_same_organization(
+    session: AsyncSession,
+) -> None:
+    store = PagerDutyAuthorizationRequestStore(session)
+    await store.create(
+        org_id="org-1",
+        state="expired",
+        credential_name="primary",
+        code_verifier="old",
+        enabled_datasets=[],
+        region="us",
+        ttl=timedelta(seconds=0),
+        now=_NOW,
+    )
+    await store.create(
+        org_id="org-1",
+        state="active",
+        credential_name="primary",
+        code_verifier="new",
+        enabled_datasets=[],
+        region="us",
+        now=_NOW + timedelta(seconds=1),
+    )
+
+    rows = list(
+        (await session.execute(select(PagerDutyOAuthAuthorizationRequest))).scalars()
+    )
+
+    assert len(rows) == 1
+    assert rows[0].state_hash == hashlib.sha256(b"active").hexdigest()

--- a/tests/providers/test_pagerduty_oauth_lifecycle.py
+++ b/tests/providers/test_pagerduty_oauth_lifecycle.py
@@ -9,7 +9,6 @@ import pytest
 
 from dev_health_ops.providers.pagerduty.auth import ApiTokenAuth, OAuthBearerAuth
 from dev_health_ops.providers.pagerduty.oauth import (
-    AuthorizationRequest,
     OAuthCallbackValidationError,
     OAuthTokens,
     PagerDutyOAuthConfig,
@@ -39,7 +38,16 @@ class FakeRepository:
     async def get(self) -> VersionedOAuthTokens:
         return self.current
 
-    async def rotate(self, current_version: int, tokens: OAuthTokens) -> int:
+    async def get_for_update(self) -> VersionedOAuthTokens:
+        return self.current
+
+    async def rotate(
+        self,
+        current_version: int,
+        tokens: OAuthTokens,
+        *,
+        expected_binding_id: str,
+    ) -> int:
         if self.rotate_error:
             self.current = VersionedOAuthTokens(
                 OAuthTokens(
@@ -48,10 +56,15 @@ class FakeRepository:
                     expires_at=datetime.now(UTC) + timedelta(hours=1),
                 ),
                 current_version + 1,
+                expected_binding_id,
             )
             raise OAuthRotationConflictError("conflict")
         self.rotations = [tokens]
-        self.current = VersionedOAuthTokens(tokens, current_version + 1)
+        self.current = VersionedOAuthTokens(
+            tokens,
+            current_version + 1,
+            expected_binding_id,
+        )
         return current_version + 1
 
     async def delete(self) -> None:
@@ -79,6 +92,7 @@ async def test_refreshes_expired_token_and_preserves_rotated_refresh_token(
                 expires_at=datetime.now(UTC) - timedelta(seconds=1),
             ),
             1,
+            "binding",
         )
     )
 
@@ -113,6 +127,7 @@ async def test_concurrent_rotation_uses_winner_without_corrupting_token(
                 expires_at=datetime.now(UTC) - timedelta(seconds=1),
             ),
             4,
+            "binding",
         ),
         rotate_error=True,
     )
@@ -146,6 +161,7 @@ async def test_refresh_failure_does_not_rotate_persisted_token(
                 expires_at=datetime.now(UTC) - timedelta(seconds=1),
             ),
             1,
+            "binding",
         )
     )
 
@@ -203,17 +219,16 @@ async def test_repository_rejects_stale_atomic_rotation(
     )
 
     with pytest.raises(OAuthRotationConflictError):
-        await repository.rotate(1, tokens)
+        await repository.rotate(1, tokens, expected_binding_id="binding")
     assert session.flush.await_count == 0
 
 
-def test_callback_rejects_invalid_state_and_pkce_verifier() -> None:
-    request = AuthorizationRequest("url", "state", "nonce", "verifier")
-
-    with pytest.raises(OAuthCallbackValidationError, match="state"):
-        validate_callback(request, state="other", code="code", code_verifier="verifier")
-    with pytest.raises(OAuthCallbackValidationError, match="PKCE"):
-        validate_callback(request, state="state", code="code", code_verifier="other")
+def test_callback_rejects_provider_error_and_missing_code() -> None:
+    with pytest.raises(OAuthCallbackValidationError, match="error"):
+        validate_callback(code="", error="access_denied")
+    with pytest.raises(OAuthCallbackValidationError, match="code"):
+        validate_callback(code="")
+    assert validate_callback(code="abc") == "abc"
 
 
 @pytest.mark.asyncio
@@ -260,6 +275,15 @@ async def test_client_credentials_posts_scoped_region_and_subdomain(
     captured: dict[str, str] = {}
 
     class FakeClient:
+        def __init__(self, *_: object, **__: object) -> None:
+            pass
+
+        async def __aenter__(self) -> FakeClient:
+            return self
+
+        async def __aexit__(self, *_: object) -> None:
+            return None
+
         async def post(self, _: str, *, data: dict[str, str]) -> httpx.Response:
             captured.update(data)
             return httpx.Response(

--- a/tests/providers/test_pagerduty_oauth_store_refresh.py
+++ b/tests/providers/test_pagerduty_oauth_store_refresh.py
@@ -1,0 +1,326 @@
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from dataclasses import dataclass, field
+from datetime import UTC, datetime, timedelta
+
+import anyio
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_async_engine
+
+from dev_health_ops.models.settings import ProviderOAuthCredential
+from dev_health_ops.providers.pagerduty.oauth import OAuthTokens, PagerDutyOAuthConfig
+from dev_health_ops.providers.pagerduty.oauth_lifecycle import (
+    ClientCredentialsCacheKey,
+    ClientCredentialsRequest,
+    ClientCredentialsTokenCacheRegistry,
+    get_client_credentials_access_token_keyed,
+    get_valid_access_token,
+)
+from dev_health_ops.providers.pagerduty.oauth_storage import (
+    OAuthRotationConflictError,
+    PagerDutyOAuthCredentialRepository,
+    VersionedOAuthTokens,
+)
+
+
+@pytest.fixture(autouse=True)
+def encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+
+
+@pytest_asyncio.fixture
+async def session() -> AsyncIterator[AsyncSession]:
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    async with engine.begin() as connection:
+        await connection.run_sync(ProviderOAuthCredential.metadata.create_all)
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_factory() as database_session:
+        yield database_session
+    await engine.dispose()
+
+
+def tokens(
+    access_token: str,
+    *,
+    refresh_token: str | None = "refresh",
+    expires_at: datetime | None = None,
+    granted_scopes: frozenset[str] = frozenset({"Users.read"}),
+) -> OAuthTokens:
+    return OAuthTokens(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at=expires_at or datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=granted_scopes,
+    )
+
+
+@pytest.mark.asyncio
+async def test_create_or_replace_reconnects_with_new_binding_and_version(
+    session: AsyncSession,
+) -> None:
+    repository = PagerDutyOAuthCredentialRepository(session, "org", "primary")
+
+    first_version = await repository.create_or_replace(
+        tokens("first"), binding_id="binding-first", account_id="account-first"
+    )
+    second_version = await repository.create_or_replace(
+        tokens("second"),
+        binding_id="binding-second",
+        account_id="account-second",
+        account_display="Primary account",
+    )
+
+    stored = await repository.get()
+
+    assert first_version == 1
+    assert second_version == 2
+    assert stored is not None
+    assert stored.tokens.access_token == "second"
+    assert stored.version == 2
+    assert stored.binding_id == "binding-second"
+
+
+@pytest.mark.asyncio
+async def test_rotate_rejects_a_binding_mismatch(session: AsyncSession) -> None:
+    repository = PagerDutyOAuthCredentialRepository(session, "org")
+    await repository.create_or_replace(tokens("first"), binding_id="binding-first")
+
+    with pytest.raises(OAuthRotationConflictError):
+        await repository.rotate(
+            1,
+            tokens("second"),
+            expected_binding_id="different-binding",
+        )
+
+
+@pytest.mark.asyncio
+async def test_rotate_rejects_a_version_conflict(session: AsyncSession) -> None:
+    repository = PagerDutyOAuthCredentialRepository(session, "org")
+    await repository.create_or_replace(tokens("first"), binding_id="binding-first")
+    await repository.rotate(1, tokens("second"), expected_binding_id="binding-first")
+
+    with pytest.raises(OAuthRotationConflictError):
+        await repository.rotate(1, tokens("third"), expected_binding_id="binding-first")
+
+
+@pytest.mark.asyncio
+async def test_get_status_metadata_does_not_decrypt_tokens(
+    session: AsyncSession,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    now = datetime.now(UTC)
+    session.add(
+        ProviderOAuthCredential(
+            org_id="org",
+            provider="pagerduty",
+            credential_name="default",
+            token_encrypted="undecryptable-garbage",
+            version=3,
+            created_at=now,
+            updated_at=now,
+            binding_id="binding",
+            expires_at=now + timedelta(hours=1),
+            granted_scopes=["Users.read", "Incidents.read"],
+            has_refresh_token=True,
+            account_id="account",
+            account_display="Operations",
+        )
+    )
+    await session.flush()
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.oauth_storage.decrypt_value",
+        lambda _: (_ for _ in ()).throw(AssertionError("must not decrypt")),
+    )
+
+    metadata = await PagerDutyOAuthCredentialRepository(
+        session, "org"
+    ).get_status_metadata()
+
+    assert metadata is not None
+    assert metadata.binding_id == "binding"
+    assert metadata.granted_scopes == frozenset({"Incidents.read", "Users.read"})
+    assert metadata.has_refresh_token is True
+    assert metadata.account_id == "account"
+    assert metadata.account_display == "Operations"
+    assert metadata.version == 3
+
+
+@dataclass
+class SerializingCredentialStore:
+    current: VersionedOAuthTokens
+    second_initial_read: anyio.Event = field(default_factory=anyio.Event)
+    rotations: int = 0
+    _row_lock: anyio.Lock = field(default_factory=anyio.Lock)
+    _get_calls: int = 0
+
+    async def get(self) -> VersionedOAuthTokens:
+        self._get_calls += 1
+        if self._get_calls == 2:
+            self.second_initial_read.set()
+        return self.current
+
+    async def get_for_update(self) -> VersionedOAuthTokens:
+        await self._row_lock.acquire()
+        return self.current
+
+    async def rotate(
+        self,
+        current_version: int,
+        tokens: OAuthTokens,
+        *,
+        expected_binding_id: str,
+    ) -> int:
+        if (
+            current_version != self.current.version
+            or expected_binding_id != self.current.binding_id
+        ):
+            self._row_lock.release()
+            raise OAuthRotationConflictError("conflict")
+        self.rotations += 1
+        self.current = VersionedOAuthTokens(
+            tokens,
+            current_version + 1,
+            expected_binding_id,
+        )
+        self._row_lock.release()
+        return self.current.version
+
+    async def delete(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_concurrent_refresh_is_serialized_per_credential_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    refresh_started = anyio.Event()
+    allow_refresh = anyio.Event()
+    refresh_calls = 0
+
+    async def refresh(_: PagerDutyOAuthConfig, __: str) -> OAuthTokens:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        refresh_started.set()
+        await allow_refresh.wait()
+        return tokens("fresh")
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.oauth_lifecycle.refresh_tokens", refresh
+    )
+    store = SerializingCredentialStore(
+        VersionedOAuthTokens(
+            tokens("stale", expires_at=datetime.now(UTC) - timedelta(seconds=1)),
+            1,
+            "binding",
+        )
+    )
+    config = PagerDutyOAuthConfig("id", "secret", "uri")
+    results: list[str] = []
+
+    async def load_token() -> None:
+        results.append(await get_valid_access_token(store, config))
+
+    async with anyio.create_task_group() as task_group:
+        task_group.start_soon(load_token)
+        await refresh_started.wait()
+        task_group.start_soon(load_token)
+        await store.second_initial_read.wait()
+        allow_refresh.set()
+
+    assert results == ["fresh", "fresh"]
+    assert refresh_calls == 1
+    assert store.rotations == 1
+
+
+@pytest.mark.asyncio
+async def test_keyed_client_credentials_cache_does_not_cross_account_boundaries(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    issued_subdomains: list[str] = []
+
+    async def exchange(
+        _: PagerDutyOAuthConfig, *, scopes: set[str], subdomain: str, region: str
+    ) -> OAuthTokens:
+        issued_subdomains.append(subdomain)
+        return tokens(
+            f"token-{subdomain}-{region}",
+            refresh_token=None,
+            granted_scopes=frozenset(scopes),
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.oauth_lifecycle.client_credentials",
+        exchange,
+    )
+    registry = ClientCredentialsTokenCacheRegistry()
+    config = PagerDutyOAuthConfig("id", "secret", "uri")
+    request_one = ClientCredentialsRequest(frozenset({"Users.read"}), "one", "us")
+    request_two = ClientCredentialsRequest(frozenset({"Users.read"}), "two", "us")
+    key_one: ClientCredentialsCacheKey = (
+        "org-one",
+        "primary",
+        request_one.scopes,
+        request_one.subdomain,
+        request_one.region,
+        "secret-one",
+    )
+    key_two: ClientCredentialsCacheKey = (
+        "org-two",
+        "primary",
+        request_two.scopes,
+        request_two.subdomain,
+        request_two.region,
+        "secret-two",
+    )
+
+    first = await get_client_credentials_access_token_keyed(
+        registry, key_one, config, request_one
+    )
+    second = await get_client_credentials_access_token_keyed(
+        registry, key_two, config, request_two
+    )
+    first_again = await get_client_credentials_access_token_keyed(
+        registry, key_one, config, request_one
+    )
+
+    assert first == "token-one-us"
+    assert second == "token-two-us"
+    assert first_again == "token-one-us"
+    assert issued_subdomains == ["one", "two"]
+
+
+@pytest.mark.asyncio
+async def test_reads_force_fresh_state_after_external_rotation(
+    session: AsyncSession,
+) -> None:
+    from sqlalchemy import update
+
+    repository = PagerDutyOAuthCredentialRepository(session, "org", "primary")
+    await repository.create_or_replace(tokens("first"), binding_id="binding-first")
+
+    # Populate the session identity map at version 1.
+    initial = await repository.get()
+    assert initial is not None
+    assert initial.version == 1
+
+    # Rotate the row via a Core UPDATE, which bypasses the ORM identity map.
+    await session.execute(
+        update(ProviderOAuthCredential)
+        .where(
+            ProviderOAuthCredential.org_id == "org",
+            ProviderOAuthCredential.provider == "pagerduty",
+            ProviderOAuthCredential.credential_name == "primary",
+        )
+        .values(version=42)
+    )
+    await session.flush()
+
+    # populate_existing must force a DB re-read, not return the cached v1 object.
+    refreshed = await repository.get()
+    assert refreshed is not None
+    assert refreshed.version == 42
+    locked = await repository.get_for_update()
+    assert locked is not None
+    assert locked.version == 42

--- a/tests/providers/test_pagerduty_sync_auth.py
+++ b/tests/providers/test_pagerduty_sync_auth.py
@@ -1,0 +1,393 @@
+from __future__ import annotations
+
+import json
+from collections.abc import Iterator
+from contextlib import contextmanager
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from dev_health_ops.core.encryption import decrypt_value, encrypt_value
+from dev_health_ops.credentials.fingerprint import credential_fingerprint
+from dev_health_ops.models.settings import (
+    IntegrationCredential,
+    ProviderOAuthCredential,
+)
+from dev_health_ops.providers.pagerduty.oauth import OAuthTokens, PagerDutyOAuthConfig
+from dev_health_ops.providers.pagerduty.oauth_lifecycle import (
+    ClientCredentialsTokenCacheRegistry,
+)
+from dev_health_ops.providers.pagerduty.oauth_storage import OAuthRotationConflictError
+from dev_health_ops.providers.pagerduty.sync_auth import hydrate_pagerduty_credentials
+from dev_health_ops.workers.sync_bootstrap import resolve_run_auth
+
+
+@pytest.fixture(autouse=True)
+def encryption_key(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("SETTINGS_ENCRYPTION_KEY", "test-encryption-key")
+
+
+@pytest.fixture
+def session() -> Iterator[Session]:
+    engine = create_engine("sqlite://")
+    ProviderOAuthCredential.metadata.create_all(engine)
+    session_factory = sessionmaker(bind=engine, expire_on_commit=False)
+    with session_factory() as database_session:
+        yield database_session
+    engine.dispose()
+
+
+def tokens(
+    access_token: str,
+    *,
+    refresh_token: str | None = "refresh-token",
+    expires_at: datetime | None = None,
+) -> OAuthTokens:
+    return OAuthTokens(
+        access_token=access_token,
+        refresh_token=refresh_token,
+        expires_at=expires_at or datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Users.read"}),
+    )
+
+
+def seed_credential(
+    session: Session,
+    oauth_tokens: OAuthTokens,
+    *,
+    binding_id: str = "binding-id",
+    credential_name: str = "primary",
+) -> None:
+    now = datetime.now(UTC)
+    session.add(
+        ProviderOAuthCredential(
+            org_id="oauth-org",
+            provider="pagerduty",
+            credential_name=credential_name,
+            token_encrypted=encrypt_value(oauth_tokens.model_dump_json()),
+            version=1,
+            created_at=now,
+            updated_at=now,
+            binding_id=binding_id,
+            expires_at=oauth_tokens.expires_at,
+            granted_scopes=sorted(oauth_tokens.granted_scopes),
+            has_refresh_token=oauth_tokens.refresh_token is not None,
+        )
+    )
+    session.commit()
+
+
+def patch_sync_session(monkeypatch: pytest.MonkeyPatch, session: Session) -> None:
+    @contextmanager
+    def postgres_session() -> Iterator[Session]:
+        try:
+            yield session
+            session.commit()
+        except BaseException:
+            session.rollback()
+            raise
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.sync_auth.get_postgres_session_sync",
+        postgres_session,
+    )
+
+
+def test_hydrate_oauth_uses_stored_non_expired_token_without_mutating_mapping(
+    monkeypatch: pytest.MonkeyPatch, session: Session
+) -> None:
+    seed_credential(session, tokens("stored-token"))
+    patch_sync_session(monkeypatch, session)
+    monkeypatch.setenv("PAGER_DUTY_CLIENT_ID", "client-id")
+    mapping = {
+        "auth_mode": "oauth",
+        "oauth_credential_name": "primary",
+        "oauth_binding_id": "binding-id",
+        "subdomain": "acme",
+        "region": "us",
+    }
+
+    hydrated = hydrate_pagerduty_credentials(mapping, org_id="oauth-org")
+
+    assert hydrated == {**mapping, "access_token": "stored-token"}
+    assert hydrated is not mapping
+    assert mapping == {
+        "auth_mode": "oauth",
+        "oauth_credential_name": "primary",
+        "oauth_binding_id": "binding-id",
+        "subdomain": "acme",
+        "region": "us",
+    }
+
+
+def test_hydrate_oauth_refreshes_due_token_and_rotates_bound_credential(
+    monkeypatch: pytest.MonkeyPatch, session: Session
+) -> None:
+    seed_credential(
+        session,
+        tokens("stale-token", expires_at=datetime.now(UTC) - timedelta(seconds=1)),
+    )
+    patch_sync_session(monkeypatch, session)
+    monkeypatch.setenv("PAGER_DUTY_CLIENT_ID", "client-id")
+
+    async def refresh(_: PagerDutyOAuthConfig, __: str) -> OAuthTokens:
+        return tokens("refreshed-token")
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.oauth_lifecycle.refresh_tokens", refresh
+    )
+    mapping = {
+        "auth_mode": "oauth",
+        "oauth_credential_name": "primary",
+        "oauth_binding_id": "binding-id",
+        "subdomain": "acme",
+        "region": "us",
+    }
+
+    hydrated = hydrate_pagerduty_credentials(mapping, org_id="oauth-org")
+
+    session.expire_all()
+    stored = session.get(ProviderOAuthCredential, ("oauth-org", "pagerduty", "primary"))
+    assert hydrated["access_token"] == "refreshed-token"
+    assert stored is not None
+    assert stored.version == 2
+    assert stored.binding_id == "binding-id"
+    assert OAuthTokens.model_validate_json(
+        decrypt_value(stored.token_encrypted)
+    ).access_token == ("refreshed-token")
+
+
+def test_hydrate_oauth_rejects_a_reconnected_credential_binding(
+    monkeypatch: pytest.MonkeyPatch, session: Session
+) -> None:
+    seed_credential(session, tokens("stored-token"))
+    patch_sync_session(monkeypatch, session)
+    monkeypatch.setenv("PAGER_DUTY_CLIENT_ID", "client-id")
+    mapping = {
+        "auth_mode": "oauth",
+        "oauth_credential_name": "primary",
+        "oauth_binding_id": "stale-binding-id",
+        "subdomain": "acme",
+        "region": "us",
+    }
+
+    with pytest.raises(OAuthRotationConflictError, match="binding mismatch"):
+        hydrate_pagerduty_credentials(mapping, org_id="oauth-org")
+
+
+def test_hydrate_client_credentials_mints_machine_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def client_credentials(
+        config: PagerDutyOAuthConfig,
+        *,
+        scopes: set[str],
+        subdomain: str,
+        region: str,
+    ) -> OAuthTokens:
+        assert config.client_id == "self-hosted-id"
+        assert config.client_secret == "self-hosted-secret"
+        assert subdomain == "acme"
+        assert region == "eu"
+        return tokens("machine-token", refresh_token=None).model_copy(
+            update={"granted_scopes": frozenset(scopes)}
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.oauth_lifecycle.client_credentials",
+        client_credentials,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.sync_auth._REGISTRY",
+        ClientCredentialsTokenCacheRegistry(),
+    )
+    mapping = {
+        "auth_mode": "client_credentials",
+        "client_id": "self-hosted-id",
+        "client_secret": "self-hosted-secret",
+        "subdomain": "acme",
+        "region": "eu",
+    }
+
+    hydrated = hydrate_pagerduty_credentials(mapping, org_id="client-org")
+
+    assert hydrated == {**mapping, "access_token": "machine-token"}
+    assert hydrated is not mapping
+
+
+def test_hydrate_api_token_returns_a_copied_mapping_without_database_access(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    @contextmanager
+    def fail_if_opened() -> Iterator[Session]:
+        raise AssertionError("api-token credentials must not open an OAuth session")
+        yield
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.sync_auth.get_postgres_session_sync",
+        fail_if_opened,
+    )
+    mapping = {
+        "auth_mode": "api_token",
+        "api_token": "api-token",
+        "subdomain": "acme",
+        "region": "us",
+    }
+
+    hydrated = hydrate_pagerduty_credentials(mapping, org_id="api-token-org")
+
+    assert hydrated == mapping
+    assert hydrated is not mapping
+
+
+def test_resolve_run_auth_hydrates_pagerduty_after_strict_fingerprint_verification(
+    monkeypatch: pytest.MonkeyPatch, session: Session
+) -> None:
+    descriptor = {
+        "auth_mode": "oauth",
+        "oauth_credential_name": "primary",
+        "oauth_binding_id": "binding-id",
+        "subdomain": "acme",
+        "region": "us",
+    }
+    credential = IntegrationCredential(
+        provider="pagerduty",
+        name="primary",
+        org_id="oauth-org",
+        credentials_encrypted=encrypt_value(json.dumps(descriptor)),
+        config={},
+        is_active=True,
+    )
+    session.add(credential)
+    session.flush()
+    integration = SimpleNamespace(
+        id=uuid4(), org_id="oauth-org", credential_id=credential.id
+    )
+    run = SimpleNamespace(
+        auth_source="integration_credential",
+        credential_id=credential.id,
+        credential_fingerprint=credential_fingerprint(
+            descriptor,
+            credential_id=str(credential.id),
+            integration_id=str(integration.id),
+        ),
+    )
+
+    def hydrate(mapping: dict[str, object], *, org_id: str) -> dict[str, object]:
+        assert mapping == descriptor
+        assert org_id == "oauth-org"
+        return {**mapping, "access_token": "hydrated-access-token"}
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.sync_auth.hydrate_pagerduty_credentials",
+        hydrate,
+    )
+    monkeypatch.setenv("SYNC_RUN_AUTH_STRICT", "1")
+
+    credential_id, resolved = resolve_run_auth(
+        session,
+        run=run,
+        integration=integration,
+        provider="pagerduty",
+        error_label="PagerDuty strict hydration",
+    )
+
+    assert credential_id == credential.id
+    assert resolved == {**descriptor, "access_token": "hydrated-access-token"}
+    assert run.credential_fingerprint == credential_fingerprint(
+        descriptor,
+        credential_id=str(credential.id),
+        integration_id=str(integration.id),
+    )
+
+
+def test_resolve_run_auth_keeps_non_pagerduty_credentials_unhydrated(
+    session: Session,
+) -> None:
+    descriptor = {"token": "github-token"}
+    credential = IntegrationCredential(
+        provider="github",
+        name="default",
+        org_id="github-org",
+        credentials_encrypted=encrypt_value(json.dumps(descriptor)),
+        config={},
+        is_active=True,
+    )
+    session.add(credential)
+    session.flush()
+    integration = SimpleNamespace(
+        id=uuid4(), org_id="github-org", credential_id=credential.id
+    )
+    run = SimpleNamespace(
+        auth_source="integration_credential",
+        credential_id=credential.id,
+        credential_fingerprint=credential_fingerprint(
+            descriptor,
+            credential_id=str(credential.id),
+            integration_id=str(integration.id),
+        ),
+    )
+
+    credential_id, resolved = resolve_run_auth(
+        session,
+        run=run,
+        integration=integration,
+        provider="github",
+        error_label="GitHub regression",
+    )
+
+    assert credential_id == credential.id
+    assert resolved == descriptor
+
+
+def test_hydrate_client_credentials_isolates_cache_by_secret(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    minted_secrets: list[str | None] = []
+
+    async def client_credentials(
+        config: PagerDutyOAuthConfig,
+        *,
+        scopes: set[str],
+        subdomain: str,
+        region: str,
+    ) -> OAuthTokens:
+        minted_secrets.append(config.client_secret)
+        return tokens(f"machine-{config.client_secret}", refresh_token=None).model_copy(
+            update={"granted_scopes": frozenset(scopes)}
+        )
+
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.oauth_lifecycle.client_credentials",
+        client_credentials,
+    )
+    monkeypatch.setattr(
+        "dev_health_ops.providers.pagerduty.sync_auth._REGISTRY",
+        ClientCredentialsTokenCacheRegistry(),
+    )
+    base = {
+        "auth_mode": "client_credentials",
+        "client_id": "self-hosted-id",
+        "subdomain": "acme",
+        "region": "eu",
+    }
+
+    first = hydrate_pagerduty_credentials(
+        {**base, "client_secret": "secret-a"}, org_id="client-org"
+    )
+    second = hydrate_pagerduty_credentials(
+        {**base, "client_secret": "secret-b"}, org_id="client-org"
+    )
+    first_again = hydrate_pagerduty_credentials(
+        {**base, "client_secret": "secret-a"}, org_id="client-org"
+    )
+
+    # Different secrets never share a cache entry; a repeated secret is cached.
+    assert first["access_token"] == "machine-secret-a"
+    assert second["access_token"] == "machine-secret-b"
+    assert first_again["access_token"] == "machine-secret-a"
+    assert minted_secrets == ["secret-a", "secret-b"]

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -575,6 +575,176 @@ def test_pagerduty_client_rejects_blank_account_subdomain() -> None:
         _pagerduty_client(ctx)
 
 
+def test_pagerduty_client_uses_oauth_bearer_auth_for_hydrated_oauth() -> None:
+    from dev_health_ops.processors.dataset_adapters import _pagerduty_client
+    from dev_health_ops.providers.pagerduty.auth import OAuthBearerAuth
+
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="incidents",
+        credentials={
+            "auth_mode": "oauth",
+            "access_token": "hydrated-oauth-token",
+            "subdomain": "acme",
+        },
+    )
+
+    with patch(
+        "dev_health_ops.providers.pagerduty.client.PagerDutyClient"
+    ) as pagerduty_client:
+        _pagerduty_client(ctx)
+
+    auth = pagerduty_client.call_args.args[0]
+    assert isinstance(auth, OAuthBearerAuth)
+    assert auth.access_token == "hydrated-oauth-token"
+
+
+def test_pagerduty_client_uses_oauth_bearer_auth_for_hydrated_client_credentials() -> (
+    None
+):
+    from dev_health_ops.processors.dataset_adapters import _pagerduty_client
+    from dev_health_ops.providers.pagerduty.auth import OAuthBearerAuth
+
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="incidents",
+        credentials={
+            "auth_mode": "client_credentials",
+            "client_id": "client-id",
+            "client_secret": "client-secret",
+            "access_token": "hydrated-client-token",
+            "subdomain": "acme",
+        },
+    )
+
+    with patch(
+        "dev_health_ops.providers.pagerduty.client.PagerDutyClient"
+    ) as pagerduty_client:
+        _pagerduty_client(ctx)
+
+    auth = pagerduty_client.call_args.args[0]
+    assert isinstance(auth, OAuthBearerAuth)
+    assert auth.access_token == "hydrated-client-token"
+
+
+def test_pagerduty_client_uses_api_token_auth_for_api_token_mode() -> None:
+    from dev_health_ops.processors.dataset_adapters import _pagerduty_client
+    from dev_health_ops.providers.pagerduty.auth import ApiTokenAuth
+
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="incidents",
+        credentials={
+            "auth_mode": "api_token",
+            "api_token": "api-token",
+            "subdomain": "acme",
+        },
+    )
+
+    with patch(
+        "dev_health_ops.providers.pagerduty.client.PagerDutyClient"
+    ) as pagerduty_client:
+        _pagerduty_client(ctx)
+
+    auth = pagerduty_client.call_args.args[0]
+    assert isinstance(auth, ApiTokenAuth)
+    assert auth.api_token == "api-token"
+
+
+def test_pagerduty_client_rejects_oauth_mode_without_hydrated_access_token() -> None:
+    from dev_health_ops.processors.dataset_adapters import _pagerduty_client
+
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="incidents",
+        credentials={"auth_mode": "oauth", "subdomain": "acme"},
+    )
+
+    with pytest.raises(
+        ValueError,
+        match="PagerDuty oauth credential is missing a hydrated access token",
+    ):
+        _pagerduty_client(ctx)
+
+
+def test_pagerduty_credentials_reject_api_token_mode_with_access_token() -> None:
+    from dev_health_ops.credentials.types import CredentialSource, PagerDutyCredentials
+
+    with pytest.raises(
+        ValueError,
+        match="api_token credentials must not carry an access token",
+    ):
+        PagerDutyCredentials(
+            source=CredentialSource.DATABASE,
+            auth_mode="api_token",
+            api_token="api-token",
+            access_token="hydrated-oauth-token",
+        )
+
+
+def test_pagerduty_client_keeps_legacy_access_token_fallback() -> None:
+    from dev_health_ops.processors.dataset_adapters import _pagerduty_client
+    from dev_health_ops.providers.pagerduty.auth import OAuthBearerAuth
+
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="incidents",
+        credentials={"access_token": "legacy-access-token", "subdomain": "acme"},
+    )
+
+    with patch(
+        "dev_health_ops.providers.pagerduty.client.PagerDutyClient"
+    ) as pagerduty_client:
+        _pagerduty_client(ctx)
+
+    auth = pagerduty_client.call_args.args[0]
+    assert isinstance(auth, OAuthBearerAuth)
+    assert auth.access_token == "legacy-access-token"
+
+
+def test_pagerduty_client_keeps_legacy_api_token_fallback() -> None:
+    from dev_health_ops.processors.dataset_adapters import _pagerduty_client
+    from dev_health_ops.providers.pagerduty.auth import ApiTokenAuth
+
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="incidents",
+        credentials={"api_token": "legacy-api-token", "subdomain": "acme"},
+    )
+
+    with patch(
+        "dev_health_ops.providers.pagerduty.client.PagerDutyClient"
+    ) as pagerduty_client:
+        _pagerduty_client(ctx)
+
+    auth = pagerduty_client.call_args.args[0]
+    assert isinstance(auth, ApiTokenAuth)
+    assert auth.api_token == "legacy-api-token"
+
+
+def test_pagerduty_mapping_preserves_auth_mode_metadata_and_ignores_unknown_keys() -> (
+    None
+):
+    from dev_health_ops.credentials.resolver import pagerduty_credentials_from_mapping
+
+    credentials = pagerduty_credentials_from_mapping(
+        {
+            "auth_mode": "oauth",
+            "oauth_credential_name": "pagerduty-oauth",
+            "oauth_binding_id": "binding-id",
+            "account_id": "account-id",
+            "subdomain": "acme",
+            "unknown": "ignored",
+        }
+    )
+
+    assert credentials is not None
+    assert credentials.auth_mode == "oauth"
+    assert credentials.oauth_credential_name == "pagerduty-oauth"
+    assert credentials.oauth_binding_id == "binding-id"
+    assert credentials.account_id == "account-id"
+
+
 def test_unsupported_provider_dataset_pair_raises_value_error() -> None:
     ctx = _context(provider="jira", dataset_key="commits", source_external_id="OPS")
 


### PR DESCRIPTION
## Wave 4 — PagerDuty OAuth-first setup UX (CHAOS-2960)

Backend contract for the PagerDuty integration setup surface. Part of the CHAOS-2954 canonical-operations program (Waves 0–3 merged: #1233, #1235, #1236, #1237). This is the **ops** PR; the web PR follows once this merges.

### What
- **OAuth-first setup**: `POST /admin/integrations/pagerduty/authorize` (server-bound PKCE) + `callback`, plus `client-credentials` and `api-token` setup endpoints, and `status` / `disconnect` / `preflight`.
- **Token storage contract**: `provider_oauth_credentials` is the **sole** OAuth token store (encrypted, versioned, binding-id keyed); `integration_credentials` holds only a stable, **tokenless descriptor** (`auth_mode` + binding/identifiers). A central validator rejects any live-token key in credentials **or** config and enforces per-mode key + `auth_mode` allowlists; generic credential routes reject PagerDuty.
- **Sync-time hydration**: the worker hydrates the live access token at request time **after** fingerprint verification (never plan-time/beat), via a short independent session.
- **Callback safety**: one-time hashed state consumed + **committed before exchange** (no replay on failure); missing-scope → revoke (refresh-first) + 400, no persist; both tables written atomically; sanitized exchange error mapping (4xx→400, 5xx→502, transport→503).
- **Disconnect**: deletes the local token row **unconditionally** (survives corrupt ciphertext), deactivates (never deletes) the descriptor, commits locally **before** best-effort remote revoke; legacy no-`auth_mode` descriptors deactivate safely.
- **Preflight/probe**: auth-mode-aware, scope-aware, no hard `Users.read`; `business_services` → `Services.read`.
- **Concurrency**: double-checked, binding-guarded token refresh with `populate_existing` reads; client-credentials cache keyed by a `client_id:client_secret` hash witness.
- **Migration**: Alembic `0041` adds the authorization-request table + token metadata columns (verified upgrade/downgrade/re-upgrade reversible).

### Testing
- `bash ci/local_validate.sh` GREEN: ruff format/check, mypy, **full unit suite (8247 passed)**, live-ClickHouse argMax proof.
- 72 PagerDuty-focused tests incl. regression coverage for replay-burn, refresh-first revoke, corrupt-ciphertext disconnect, legacy-descriptor disconnect, revoke-after-commit ordering, config-secret rejection, and unexpected-error propagation.
- Independent architecture + security review passed after four review rounds.

SCREENSHOT-WAIVER: backend-only change (no rendered UI); the user-facing surface lands in the follow-up web PR.

Closes CHAOS-2960.
