### PR TITLE
docs: make the documentation home hero and card driven

### DIFF
--- a/docs-prototype/index.md
+++ b/docs-prototype/index.md
@@ -1,73 +1,140 @@
 ---
 hide:
+  - navigation
   - toc
 ---
 
-<section class="fc-home-hero" markdown>
+<section class="fc-home-hero" aria-labelledby="fc-home-title" markdown>
 <div class="fc-home-hero__copy" markdown>
 
-Documentation prototype
-{: .fc-kicker }
+Dev Health documentation
+{: .fc-home-kicker }
 
-# Find the answer. Do the work.
+# Find the answer. Do the work. { #fc-home-title }
 
-Use Dev Health, administer a workspace, operate the platform, integrate data, or look up an exact contract without learning the repository first.
-{: .fc-lede }
+Use Dev Health, administer a workspace, operate the platform, integrate data, or look up an exact contract—without learning the repository first.
+{: .fc-home-lede }
+
+<div class="fc-home-actions" markdown>
 
 [Use Dev Health](use/index.md){ .md-button .md-button--primary }
-[Install and operate](operate/index.md){ .md-button }
+[Browse reference](reference/index.md){ .md-button }
 
 </div>
+</div>
 
-<div class="fc-home-hero__panel" markdown>
+<aside class="fc-home-hero__routes" aria-label="Common documentation tasks" markdown>
 
 ![Full Chaos infinity mark](assets/full-chaos-mark.svg){ .fc-home-hero__mark }
 
-### Start with a common task
+**Common tasks**
+{: .fc-home-routes__label }
 
 - [Investigate where effort appears to be going](use/investment/investigate-effort.md)
 - [Diagnose no or incomplete data](use/troubleshooting/no-or-incomplete-data.md)
 - [Look up the Investment distribution calculation](reference/metrics/investment-distribution.md)
 
-</div>
+</aside>
 </section>
 
-This is a layout and style prototype. It does not make the current WIP content canonical.
-{: .fc-prototype-note }
+This is a layout and style prototype. The current WIP documentation remains non-canonical until the migration and cutover gates are approved.
+{: .fc-prototype-note .fc-prototype-note--home }
 
 ## Choose what you need to do
 
-- **Use Dev Health**  
-  Follow product workflows, interpret results, create reports, and recover from user-visible problems.  
-  [Open product guides →](use/index.md)
-- **Administer Dev Health**  
-  Configure the workspace, access, sources, synchronization, and administrative security.  
-  [Open administration guides →](admin/index.md)
-- **Install and operate**  
-  Deploy, upgrade, monitor, maintain, troubleshoot, and recover the platform.  
-  [Open operations guides →](operate/index.md)
-- **Integrate and extend**  
-  Send data, use supported APIs and webhooks, and build supported integrations.  
-  [Open integration guides →](integrate/index.md)
-- **Reference**  
-  Look up exact API, CLI, configuration, schema, metric, taxonomy, and compatibility facts.  
-  [Open reference →](reference/index.md)
-- **Contribute**  
-  Set up development, understand boundaries, test changes, release, and improve documentation.  
-  [Open contributor guides →](contribute/index.md)
-{: .fc-domain-grid .fc-domain-grid--home }
+<div class="fc-home-cards" markdown>
 
-## New here?
+<article class="fc-home-card fc-home-card--warm" markdown>
 
-<div class="fc-home-band" markdown>
+Product workflows
+{: .fc-home-card__tag }
+
+### [Use Dev Health](use/index.md)
+
+Interpret views, create reports, follow evidence, and recover from user-visible problems.
+
+[Open product guides →](use/index.md){ .fc-home-card__link }
+
+</article>
+
+<article class="fc-home-card fc-home-card--cool" markdown>
+
+Workspace setup
+{: .fc-home-card__tag }
+
+### [Administer Dev Health](admin/index.md)
+
+Configure access, teams, sources, synchronization, coverage, and administrative security.
+
+[Open administration guides →](admin/index.md){ .fc-home-card__link }
+
+</article>
+
+<article class="fc-home-card fc-home-card--warm" markdown>
+
+Platform operations
+{: .fc-home-card__tag }
+
+### [Install and operate](operate/index.md)
+
+Deploy, upgrade, monitor, maintain, troubleshoot, back up, and recover the platform.
+
+[Open operations guides →](operate/index.md){ .fc-home-card__link }
+
+</article>
+
+<article class="fc-home-card fc-home-card--cool" markdown>
+
+Data and APIs
+{: .fc-home-card__tag }
+
+### [Integrate and extend](integrate/index.md)
+
+Send data, use supported APIs and webhooks, and build supported integrations.
+
+[Open integration guides →](integrate/index.md){ .fc-home-card__link }
+
+</article>
+
+<article class="fc-home-card fc-home-card--neutral" markdown>
+
+Exact facts
+{: .fc-home-card__tag }
+
+### [Reference](reference/index.md)
+
+Look up API, CLI, configuration, schema, metric, taxonomy, limit, and compatibility details.
+
+[Open reference →](reference/index.md){ .fc-home-card__link }
+
+</article>
+
+<article class="fc-home-card fc-home-card--neutral" markdown>
+
+Change the product
+{: .fc-home-card__tag }
+
+### [Contribute](contribute/index.md)
+
+Set up development, understand boundaries, test changes, release, and improve documentation.
+
+[Open contributor guides →](contribute/index.md){ .fc-home-card__link }
+
+</article>
+
+</div>
+
+<section class="fc-home-onramp" aria-labelledby="fc-home-onramp-title" markdown>
 <div markdown>
+
+## New to Dev Health? { #fc-home-onramp-title }
 
 `/get-started/` is provisional. It contains no reused onboarding sequence and exists only to prove whether a separate entry path reduces reader effort.
 
 </div>
 
 [Check the minimum prerequisites](get-started/index.md){ .md-button }
-</div>
+</section>
 
 ## Review the prototype
 

--- a/docs-prototype/index.md
+++ b/docs-prototype/index.md
@@ -27,7 +27,7 @@ Use Dev Health, administer a workspace, operate the platform, integrate data, or
 
 ![Full Chaos infinity mark](assets/full-chaos-mark.svg){ .fc-home-hero__mark }
 
-**Common tasks**
+**Start with a common task**
 {: .fc-home-routes__label }
 
 - [Investigate where effort appears to be going](use/investment/investigate-effort.md)
@@ -53,7 +53,14 @@ Product workflows
 
 Interpret views, create reports, follow evidence, and recover from user-visible problems.
 
-[Open product guides →](use/index.md){ .fc-home-card__link }
+<ul class="fc-home-card__tasks">
+<li>Investigate investment and effort</li>
+<li>Read delivery-flow signals</li>
+<li>Explore code and relationships</li>
+<li>Create and share reports</li>
+</ul>
+
+[View all product guides →](use/index.md){ .fc-home-card__link }
 
 </article>
 
@@ -66,7 +73,14 @@ Workspace setup
 
 Configure access, teams, sources, synchronization, coverage, and administrative security.
 
-[Open administration guides →](admin/index.md){ .fc-home-card__link }
+<ul class="fc-home-card__tasks">
+<li>Manage workspace access</li>
+<li>Connect and configure providers</li>
+<li>Check synchronization coverage</li>
+<li>Review security and audit settings</li>
+</ul>
+
+[View all administration guides →](admin/index.md){ .fc-home-card__link }
 
 </article>
 
@@ -79,7 +93,14 @@ Platform operations
 
 Deploy, upgrade, monitor, maintain, troubleshoot, back up, and recover the platform.
 
-[Open operations guides →](operate/index.md){ .fc-home-card__link }
+<ul class="fc-home-card__tasks">
+<li>Plan and install a deployment</li>
+<li>Configure the runtime</li>
+<li>Monitor platform health</li>
+<li>Upgrade, back up, and recover</li>
+</ul>
+
+[View all operations guides →](operate/index.md){ .fc-home-card__link }
 
 </article>
 
@@ -92,7 +113,14 @@ Data and APIs
 
 Send data, use supported APIs and webhooks, and build supported integrations.
 
-[Open integration guides →](integrate/index.md){ .fc-home-card__link }
+<ul class="fc-home-card__tasks">
+<li>Send Customer Push data</li>
+<li>Use supported APIs</li>
+<li>Configure webhooks</li>
+<li>Build and validate an integration</li>
+</ul>
+
+[View all integration guides →](integrate/index.md){ .fc-home-card__link }
 
 </article>
 
@@ -105,7 +133,14 @@ Exact facts
 
 Look up API, CLI, configuration, schema, metric, taxonomy, limit, and compatibility details.
 
-[Open reference →](reference/index.md){ .fc-home-card__link }
+<ul class="fc-home-card__tasks">
+<li>API and GraphQL contracts</li>
+<li>CLI commands and exit behavior</li>
+<li>Configuration keys and defaults</li>
+<li>Metrics, schemas, and taxonomies</li>
+</ul>
+
+[View all reference →](reference/index.md){ .fc-home-card__link }
 
 </article>
 
@@ -118,11 +153,58 @@ Change the product
 
 Set up development, understand boundaries, test changes, release, and improve documentation.
 
-[Open contributor guides →](contribute/index.md){ .fc-home-card__link }
+<ul class="fc-home-card__tasks">
+<li>Set up a development environment</li>
+<li>Understand architecture boundaries</li>
+<li>Run tests and quality checks</li>
+<li>Review, release, and document changes</li>
+</ul>
+
+[View all contributor guides →](contribute/index.md){ .fc-home-card__link }
 
 </article>
 
 </div>
+
+<section class="fc-home-feature-grid" aria-label="Documentation shortcuts" markdown>
+
+<div class="fc-home-feature" markdown>
+
+## Popular tasks
+
+- [Investigate where effort appears to be going](use/investment/investigate-effort.md)
+- [Diagnose no or incomplete data](use/troubleshooting/no-or-incomplete-data.md)
+- [Look up Investment distribution fields](reference/metrics/investment-distribution.md)
+- [Choose the right documentation domain](get-started/index.md)
+
+</div>
+
+<div class="fc-home-feature" markdown>
+
+## Recently updated
+
+- **Investment workflow guidance** — clearer task and evidence path  
+  [Open the workflow guide →](use/investment/investigate-effort.md)
+- **Incomplete-data troubleshooting** — direct recovery path  
+  [Open troubleshooting →](use/troubleshooting/no-or-incomplete-data.md)
+- **Investment distribution reference** — exact calculation contract  
+  [Open reference →](reference/metrics/investment-distribution.md)
+
+</div>
+
+</section>
+
+<section class="fc-home-troubleshooting" aria-labelledby="fc-home-troubleshooting-title" markdown>
+<div markdown>
+
+## Something is not working? { #fc-home-troubleshooting-title }
+
+Start from the symptom. Check scope, freshness, coverage, and synchronization before changing configuration.
+
+</div>
+
+[Open troubleshooting](use/troubleshooting/no-or-incomplete-data.md){ .md-button .md-button--primary }
+</section>
 
 <section class="fc-home-onramp" aria-labelledby="fc-home-onramp-title" markdown>
 <div markdown>

--- a/docs-prototype/stylesheets/home-sections.css
+++ b/docs-prototype/stylesheets/home-sections.css
@@ -1,0 +1,131 @@
+.fc-home-card__tasks {
+  border-top: 1px solid var(--fc-doc-border);
+  color: var(--fc-doc-text-muted);
+  list-style: none;
+  margin: 1rem 0 0 !important;
+  padding: 0.85rem 0 0 !important;
+}
+
+.fc-home-card__tasks li {
+  margin: 0 !important;
+  padding: 0.3rem 0 0.3rem 1rem;
+  position: relative;
+}
+
+.fc-home-card__tasks li::before {
+  color: var(--fc-doc-active);
+  content: "•";
+  left: 0;
+  position: absolute;
+}
+
+.fc-home-card {
+  min-height: 22rem;
+}
+
+.fc-home-feature-grid {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  margin: 0 0 3rem;
+}
+
+.fc-home-feature {
+  background: var(--fc-doc-surface);
+  border: 1px solid var(--fc-doc-border);
+  border-radius: 0.65rem;
+  padding: 1.4rem 1.5rem;
+}
+
+.fc-home-feature h2 {
+  border: 0;
+  font-size: 1.3rem;
+  margin: 0 0 0.85rem;
+  padding: 0;
+}
+
+.fc-home-feature ul {
+  list-style: none;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.fc-home-feature li {
+  border-top: 1px solid var(--fc-doc-border);
+  margin: 0 !important;
+  padding: 0.75rem 0;
+}
+
+.fc-home-feature li:first-child {
+  border-top: 0;
+}
+
+.fc-home-feature a {
+  text-decoration: none;
+}
+
+.fc-home-troubleshooting {
+  align-items: center;
+  background:
+    linear-gradient(120deg, color-mix(in srgb, var(--fc-crimson), transparent 88%), transparent 50%),
+    var(--fc-ink);
+  border: 1px solid var(--fc-surface);
+  border-left: 0.32rem solid var(--fc-flame);
+  border-radius: 0.65rem;
+  color: var(--fc-silver);
+  display: flex;
+  gap: 2rem;
+  justify-content: space-between;
+  margin: 0 0 1rem;
+  padding: 1.6rem 1.75rem;
+}
+
+.fc-home-troubleshooting h2 {
+  border: 0;
+  color: var(--fc-white);
+  font-size: 1.35rem;
+  margin: 0 0 0.4rem;
+  padding: 0;
+}
+
+.fc-home-troubleshooting p {
+  color: var(--fc-mist);
+  margin: 0;
+}
+
+.fc-home-troubleshooting .md-button {
+  background: var(--fc-flame);
+  border-color: var(--fc-flame);
+  color: var(--fc-void);
+  flex: none;
+  margin: 0;
+  text-decoration: none;
+}
+
+.fc-home-troubleshooting .md-button:hover,
+.fc-home-troubleshooting .md-button:focus-visible {
+  background: var(--fc-amber);
+  border-color: var(--fc-amber);
+  color: var(--fc-void);
+}
+
+@media screen and (max-width: 54rem) {
+  .fc-home-feature-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media screen and (max-width: 38rem) {
+  .fc-home-card {
+    min-height: 0;
+  }
+
+  .fc-home-troubleshooting {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .fc-home-troubleshooting .md-button {
+    text-align: center;
+  }
+}

--- a/docs-prototype/stylesheets/home.css
+++ b/docs-prototype/stylesheets/home.css
@@ -1,0 +1,361 @@
+/* Home-only presentation. The documentation IA and page templates remain theme-independent. */
+
+.md-content__inner:has(> .fc-home-hero) {
+  max-width: 78rem;
+  padding-top: 2.25rem;
+}
+
+.fc-home-hero {
+  background: var(--fc-ink);
+  border: 1px solid var(--fc-surface);
+  border-radius: 0.9rem;
+  color: var(--fc-silver);
+  display: grid;
+  gap: 0;
+  grid-template-columns: minmax(0, 1.35fr) minmax(18rem, 0.65fr);
+  margin: 0 0 1.25rem;
+  overflow: hidden;
+  position: relative;
+}
+
+.fc-home-hero::before,
+.fc-home-hero::after {
+  content: "";
+  height: 0.28rem;
+  position: absolute;
+  top: 0;
+  width: 50%;
+}
+
+.fc-home-hero::before {
+  background: var(--fc-flame);
+  left: 0;
+}
+
+.fc-home-hero::after {
+  background: var(--fc-aqua);
+  right: 0;
+}
+
+.fc-home-hero__copy {
+  padding: clamp(2.2rem, 5vw, 4.5rem);
+}
+
+.fc-home-kicker {
+  color: var(--fc-glacier);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.13em;
+  margin: 0 0 0.8rem !important;
+  text-transform: uppercase;
+}
+
+.fc-home-hero .fc-home-hero__copy h1 {
+  color: var(--fc-white);
+  font-size: clamp(2.65rem, 6vw, 4.6rem);
+  letter-spacing: -0.045em;
+  line-height: 0.98;
+  margin: 0;
+  max-width: 11ch;
+}
+
+.fc-home-lede {
+  color: var(--fc-mist);
+  font-size: clamp(1.04rem, 2vw, 1.25rem);
+  line-height: 1.55;
+  margin: 1.5rem 0 2rem !important;
+  max-width: 56ch !important;
+}
+
+.fc-home-actions {
+  align-items: center;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.7rem;
+}
+
+.fc-home-actions .md-button {
+  border-color: var(--fc-mist);
+  color: var(--fc-white);
+  margin: 0;
+  text-decoration: none;
+}
+
+.fc-home-actions .md-button:hover,
+.fc-home-actions .md-button:focus-visible {
+  background: var(--fc-carbon);
+  border-color: var(--fc-white);
+  color: var(--fc-white);
+}
+
+.fc-home-actions .md-button--primary {
+  background: var(--fc-flame);
+  border-color: var(--fc-flame);
+  color: var(--fc-void);
+}
+
+.fc-home-actions .md-button--primary:hover,
+.fc-home-actions .md-button--primary:focus-visible {
+  background: var(--fc-amber);
+  border-color: var(--fc-amber);
+  color: var(--fc-void);
+}
+
+.fc-home-hero__routes {
+  align-self: stretch;
+  background: var(--fc-carbon);
+  border-left: 1px solid var(--fc-surface);
+  margin: 0;
+  padding: clamp(1.8rem, 4vw, 3rem);
+}
+
+.fc-home-hero__mark {
+  display: block;
+  height: 5.5rem;
+  margin: 0 0 2.2rem;
+  width: 5.5rem;
+}
+
+.fc-home-routes__label {
+  color: var(--fc-silver);
+  font-size: 0.78rem;
+  letter-spacing: 0.08em;
+  margin-bottom: 0.65rem !important;
+  text-transform: uppercase;
+}
+
+.fc-home-hero__routes ul {
+  list-style: none;
+  margin: 0 !important;
+  padding: 0 !important;
+}
+
+.fc-home-hero__routes li {
+  border-top: 1px solid var(--fc-surface);
+  margin: 0 !important;
+}
+
+.fc-home-hero__routes li:last-child {
+  border-bottom: 1px solid var(--fc-surface);
+}
+
+.fc-home-hero__routes a {
+  align-items: center;
+  color: var(--fc-glacier);
+  display: flex;
+  font-size: 0.92rem;
+  font-weight: 680;
+  gap: 0.7rem;
+  justify-content: space-between;
+  padding: 0.85rem 0;
+  text-decoration: none;
+}
+
+.fc-home-hero__routes a::after {
+  color: var(--fc-flame);
+  content: "→";
+  flex: none;
+  font-weight: 800;
+}
+
+.fc-home-hero__routes a:hover,
+.fc-home-hero__routes a:focus-visible {
+  color: var(--fc-white);
+}
+
+.fc-prototype-note--home {
+  margin-bottom: 3rem;
+}
+
+.fc-home-cards {
+  display: grid;
+  gap: 1rem;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin: 1.35rem 0 3.25rem;
+}
+
+.fc-home-card {
+  background: var(--fc-doc-surface);
+  border: 1px solid var(--fc-doc-border);
+  border-radius: 0.65rem;
+  display: flex;
+  flex-direction: column;
+  min-height: 15rem;
+  overflow: hidden;
+  padding: 1.35rem 1.4rem 1.25rem;
+  position: relative;
+}
+
+.fc-home-card::before {
+  content: "";
+  height: 0.24rem;
+  left: 0;
+  position: absolute;
+  right: 0;
+  top: 0;
+}
+
+.fc-home-card--warm::before {
+  background: var(--fc-flame);
+}
+
+.fc-home-card--cool::before {
+  background: var(--fc-aqua);
+}
+
+.fc-home-card--neutral::before {
+  background: var(--fc-slate);
+}
+
+.fc-home-card:hover {
+  border-color: var(--fc-doc-link);
+}
+
+.fc-home-card__tag {
+  color: var(--fc-doc-text-muted);
+  font-size: 0.72rem;
+  font-weight: 800;
+  letter-spacing: 0.095em;
+  margin: 0 0 0.8rem !important;
+  text-transform: uppercase;
+}
+
+.fc-home-card h3 {
+  font-size: 1.22rem;
+  margin: 0 0 0.8rem;
+}
+
+.fc-home-card h3 a {
+  color: var(--fc-doc-text);
+  text-decoration: none;
+}
+
+.fc-home-card h3 a:hover,
+.fc-home-card h3 a:focus-visible {
+  color: var(--fc-doc-link);
+}
+
+.fc-home-card p:not(.fc-home-card__tag) {
+  color: var(--fc-doc-text-muted);
+  font-size: 0.94rem;
+  line-height: 1.55;
+}
+
+.fc-home-card .fc-home-card__link {
+  color: var(--fc-doc-link);
+  display: inline-block;
+  font-size: 0.9rem;
+  font-weight: 750;
+  margin-top: auto;
+  padding-top: 1rem;
+  text-decoration: none;
+}
+
+.fc-home-card .fc-home-card__link:hover,
+.fc-home-card .fc-home-card__link:focus-visible {
+  color: var(--fc-doc-link-hover);
+  text-decoration: underline;
+  text-underline-offset: 0.18em;
+}
+
+.fc-home-onramp {
+  align-items: center;
+  background: var(--fc-doc-surface-muted);
+  border: 1px solid var(--fc-doc-border);
+  border-left: 0.3rem solid var(--fc-aqua);
+  border-radius: 0.65rem;
+  display: flex;
+  gap: 2rem;
+  justify-content: space-between;
+  margin: 0 0 3.2rem;
+  padding: 1.5rem 1.7rem;
+}
+
+.fc-home-onramp h2 {
+  border: 0;
+  font-size: 1.25rem;
+  margin: 0 0 0.4rem;
+  padding: 0;
+}
+
+.fc-home-onramp p {
+  color: var(--fc-doc-text-muted);
+  margin: 0;
+}
+
+.fc-home-onramp .md-button {
+  flex: none;
+  margin: 0;
+  text-decoration: none;
+}
+
+@media screen and (max-width: 72rem) {
+  .fc-home-cards {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+}
+
+@media screen and (max-width: 54rem) {
+  .md-content__inner:has(> .fc-home-hero) {
+    padding-top: 1rem;
+  }
+
+  .fc-home-hero {
+    grid-template-columns: 1fr;
+  }
+
+  .fc-home-hero__routes {
+    border-left: 0;
+    border-top: 1px solid var(--fc-surface);
+  }
+
+  .fc-home-hero__mark {
+    height: 4rem;
+    margin-bottom: 1.25rem;
+    width: 4rem;
+  }
+}
+
+@media screen and (max-width: 38rem) {
+  .fc-home-hero__copy,
+  .fc-home-hero__routes {
+    padding: 1.55rem;
+  }
+
+  .fc-home-hero .fc-home-hero__copy h1 {
+    font-size: 2.55rem;
+  }
+
+  .fc-home-actions {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .fc-home-actions .md-button {
+    text-align: center;
+  }
+
+  .fc-home-cards {
+    grid-template-columns: 1fr;
+  }
+
+  .fc-home-card {
+    min-height: 0;
+  }
+
+  .fc-home-onramp {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .fc-home-onramp .md-button {
+    text-align: center;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .fc-home-card,
+  .fc-home-hero__routes a {
+    transition: none;
+  }
+}

--- a/mkdocs.prototype.yml
+++ b/mkdocs.prototype.yml
@@ -65,6 +65,7 @@ plugins:
 
 extra_css:
   - stylesheets/extra.css
+  - stylesheets/home.css
 
 markdown_extensions:
   - admonition

--- a/mkdocs.prototype.yml
+++ b/mkdocs.prototype.yml
@@ -66,6 +66,7 @@ plugins:
 extra_css:
   - stylesheets/extra.css
   - stylesheets/home.css
+  - stylesheets/home-sections.css
 
 markdown_extensions:
   - admonition


### PR DESCRIPTION
## What changed

Iterates the Phase 4 prototype home after visual review:

- hides the persistent documentation sidebar on `/` so the landing page can work as a true entry surface;
- adds a full-width Full Chaos hero with direct product/reference calls to action;
- adds a compact common-task panel inside the hero;
- replaces the flat domain list with six substantial task-domain cards;
- keeps `/get-started/` deliberately secondary and provisional;
- adds responsive one-, two-, and three-column behavior without changing the approved IA;
- isolates the landing-page styling in `home.css` rather than expanding the general page system.

## Design direction

This follows the review note that `/` should be more hero- and card-led, closer to the orientation of GitLab's main entry pages while preserving the documentation-specific task hierarchy and Full Chaos Graphite / split-spectrum palette.

The hero remains restrained: solid Graphite/Ink surfaces, Flame and Aqua edge accents, no decorative animation, and no new component framework.

## Review focus

1. Hero hierarchy, headline, and primary calls to action.
2. Whether the six domain cards provide enough orientation without becoming a sitemap.
3. Whether hiding the left navigation on `/` improves entry-page focus.
4. Mobile stacking and touch targets.
5. Light/dark theme behavior and contrast.

## Validation

The existing `Documentation v2 prototype` workflow runs a strict MkDocs build for these files.

Linear: CHAOS-2989, CHAOS-2990, CHAOS-2992