### PR TITLE
fix(ops): persist PagerDuty service-repository mappings to services dataset

### DIFF
--- a/src/dev_health_ops/api/admin/routers/sync.py
+++ b/src/dev_health_ops/api/admin/routers/sync.py
@@ -2010,6 +2010,27 @@ async def update_sync_config(
         for key in cleared_keys:
             merged_options.pop(key, None)
         mutable_config.sync_options = merged_options
+    if (
+        str(getattr(config, "provider", "")).lower() == "pagerduty"
+        and "service_repository_mappings" in sync_options
+        and isinstance(sync_options["service_repository_mappings"], dict)
+        and (integration_id := getattr(config, "integration_id", None)) is not None
+    ):
+        dataset_result = await session.execute(
+            select(IntegrationDataset).where(
+                IntegrationDataset.org_id == org_id,
+                IntegrationDataset.integration_id == integration_id,
+                IntegrationDataset.dataset_key == "services",
+            )
+        )
+        services_dataset = dataset_result.scalar_one_or_none()
+        if services_dataset is not None:
+            services_dataset.options = {
+                **dict(services_dataset.options or {}),
+                "service_repository_mappings": sync_options[
+                    "service_repository_mappings"
+                ],
+            }
     if payload.is_active is not None:
         mutable_config.is_active = payload.is_active
     await session.flush()

--- a/tests/api/admin/test_sync_configs.py
+++ b/tests/api/admin/test_sync_configs.py
@@ -937,6 +937,464 @@ async def test_update_sync_config_changes_is_active(client):
 
 
 @pytest.mark.asyncio
+async def test_update_pagerduty_service_mappings_propagates_to_services_dataset(
+    client, session_maker
+):
+    ac, _ = client
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "pagerduty-service-mappings",
+            "provider": "pagerduty",
+            "sync_targets": ["operational"],
+            "sync_options": {
+                "service_repository_mappings": {
+                    "admin": {
+                        "svc-before": [
+                            {"provider": "github", "full_name": "acme/before"}
+                        ]
+                    },
+                    "compass": {
+                        "svc-before": [
+                            {
+                                "provider": "github",
+                                "full_name": "acme/component-before",
+                            }
+                        ]
+                    },
+                },
+            },
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = uuid.UUID(create_resp.json()["id"])
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+        dataset.options = {
+            **dataset.options,
+            "unrelated_dataset_option": "preserve-me",
+        }
+        await session.commit()
+
+    update_resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={
+            "sync_options": {
+                "service_repository_mappings": {
+                    "admin": {
+                        "svc-after": [{"provider": "github", "full_name": "acme/after"}]
+                    },
+                    "compass": {
+                        "svc-after": [
+                            {
+                                "provider": "github",
+                                "full_name": "acme/component-after",
+                            }
+                        ]
+                    },
+                },
+            },
+        },
+    )
+
+    assert update_resp.status_code == 200, update_resp.text
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+        users_dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "users",
+                )
+            )
+        ).scalar_one()
+
+    assert config.sync_options["service_repository_mappings"] == {
+        "admin": {"svc-after": [{"provider": "github", "full_name": "acme/after"}]},
+        "compass": {
+            "svc-after": [{"provider": "github", "full_name": "acme/component-after"}]
+        },
+    }
+    assert dataset.options["service_repository_mappings"] == {
+        "admin": {"svc-after": [{"provider": "github", "full_name": "acme/after"}]},
+        "compass": {
+            "svc-after": [{"provider": "github", "full_name": "acme/component-after"}]
+        },
+    }
+    assert dataset.options["legacy_targets"] == ["operational"]
+    assert dataset.options["unrelated_dataset_option"] == "preserve-me"
+    assert users_dataset.options == {"legacy_targets": ["operational"]}
+
+
+@pytest.mark.asyncio
+async def test_update_pagerduty_without_service_mappings_leaves_dataset_options_unchanged(
+    client, session_maker
+):
+    ac, _ = client
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "pagerduty-service-mappings-omit",
+            "provider": "pagerduty",
+            "sync_targets": ["operational"],
+            "sync_options": {
+                "service_repository_mappings": {
+                    "admin": {
+                        "svc-before": [
+                            {"provider": "github", "full_name": "acme/before"}
+                        ]
+                    },
+                    "compass": {
+                        "svc-before": [
+                            {
+                                "provider": "github",
+                                "full_name": "acme/component-before",
+                            }
+                        ]
+                    },
+                },
+            },
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = uuid.UUID(create_resp.json()["id"])
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+        options_before_update = dict(dataset.options)
+
+    update_resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"is_active": False},
+    )
+
+    assert update_resp.status_code == 200, update_resp.text
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+
+    assert config.is_active is False
+    assert dataset.options == options_before_update
+
+
+@pytest.mark.asyncio
+async def test_update_pagerduty_mappings_updates_disabled_services_dataset_before_reenable(
+    client, session_maker
+):
+    ac, _ = client
+    before_mappings = {
+        "admin": {"svc-before": [{"provider": "github", "full_name": "acme/before"}]},
+        "compass": {
+            "svc-before": [{"provider": "github", "full_name": "acme/component-before"}]
+        },
+    }
+    after_mappings = {
+        "admin": {"svc-after": [{"provider": "github", "full_name": "acme/after"}]},
+        "compass": {
+            "svc-after": [{"provider": "github", "full_name": "acme/component-after"}]
+        },
+    }
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "pagerduty-disabled-services",
+            "provider": "pagerduty",
+            "sync_targets": ["operational"],
+            "sync_options": {"service_repository_mappings": before_mappings},
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = uuid.UUID(create_resp.json()["id"])
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+        dataset.is_enabled = False
+        dataset.options = {**dataset.options, "unrelated_dataset_option": "keep"}
+        await session.commit()
+
+    update_resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_options": {"service_repository_mappings": after_mappings}},
+    )
+
+    assert update_resp.status_code == 200, update_resp.text
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+
+    assert config.sync_options["service_repository_mappings"] == after_mappings
+    assert dataset.is_enabled is False
+    assert dataset.options["service_repository_mappings"] == after_mappings
+    assert dataset.options["unrelated_dataset_option"] == "keep"
+
+    reenable_resp = await ac.patch(
+        f"/api/v1/admin/integrations/{config.integration_id}/datasets",
+        json={"datasets": [{"dataset_key": "services", "is_enabled": True}]},
+    )
+
+    assert reenable_resp.status_code == 200, reenable_resp.text
+    async with session_maker() as session:
+        reenabled_dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+
+    assert reenabled_dataset.is_enabled is True
+    assert reenabled_dataset.options["service_repository_mappings"] == after_mappings
+    assert reenabled_dataset.options["unrelated_dataset_option"] == "keep"
+
+
+@pytest.mark.asyncio
+async def test_update_pagerduty_empty_mappings_preserves_services_options(
+    client, session_maker
+):
+    ac, _ = client
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "pagerduty-clear-service-mappings",
+            "provider": "pagerduty",
+            "sync_targets": ["operational"],
+            "sync_options": {
+                "service_repository_mappings": {
+                    "admin": {
+                        "svc-before": [
+                            {"provider": "github", "full_name": "acme/before"}
+                        ]
+                    },
+                    "compass": {
+                        "svc-before": [
+                            {
+                                "provider": "github",
+                                "full_name": "acme/component-before",
+                            }
+                        ]
+                    },
+                },
+            },
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = uuid.UUID(create_resp.json()["id"])
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+        dataset.options = {**dataset.options, "unrelated_dataset_option": "keep"}
+        await session.commit()
+
+    update_resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_options": {"service_repository_mappings": {}}},
+    )
+
+    assert update_resp.status_code == 200, update_resp.text
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+
+    assert config.sync_options["service_repository_mappings"] == {}
+    assert dataset.options["service_repository_mappings"] == {}
+    assert dataset.options["legacy_targets"] == ["operational"]
+    assert dataset.options["unrelated_dataset_option"] == "keep"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("mapping_value", [None, ["not-a-mapping"]])
+async def test_update_pagerduty_non_dict_mappings_leave_services_options_unchanged(
+    client, session_maker, mapping_value
+):
+    ac, _ = client
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": f"pagerduty-invalid-mappings-{uuid.uuid4()}",
+            "provider": "pagerduty",
+            "sync_targets": ["operational"],
+            "sync_options": {
+                "service_repository_mappings": {
+                    "admin": {
+                        "svc-before": [
+                            {"provider": "github", "full_name": "acme/before"}
+                        ]
+                    }
+                }
+            },
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = uuid.UUID(create_resp.json()["id"])
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+        options_before_update = dict(dataset.options)
+
+    update_resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={"sync_options": {"service_repository_mappings": mapping_value}},
+    )
+
+    assert update_resp.status_code == 200, update_resp.text
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+
+    assert config.sync_options["service_repository_mappings"] == mapping_value
+    assert dataset.options == options_before_update
+
+
+@pytest.mark.asyncio
+async def test_update_non_pagerduty_mappings_leaves_services_dataset_unchanged(
+    client, session_maker
+):
+    ac, seeded_state = client
+    create_resp = await ac.post(
+        "/api/v1/admin/sync-configs",
+        json={
+            "name": "github-mapping-noop",
+            "provider": "github",
+            "sync_targets": ["git"],
+            "sync_options": {"all_repos": True},
+        },
+    )
+    assert create_resp.status_code == 201, create_resp.text
+    config_id = uuid.UUID(create_resp.json()["id"])
+    before_options = {"unrelated_dataset_option": "keep"}
+
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        session.add(
+            IntegrationDataset(
+                org_id=seeded_state["org_id"],
+                integration_id=config.integration_id,
+                dataset_key="services",
+                is_enabled=True,
+                options=before_options,
+            )
+        )
+        await session.commit()
+
+    update_resp = await ac.patch(
+        f"/api/v1/admin/sync-configs/{config_id}",
+        json={
+            "sync_options": {
+                "service_repository_mappings": {
+                    "admin": {
+                        "svc-after": [{"provider": "github", "full_name": "acme/after"}]
+                    }
+                }
+            }
+        },
+    )
+
+    assert update_resp.status_code == 200, update_resp.text
+    async with session_maker() as session:
+        config = await session.get(SyncConfiguration, config_id)
+        assert config is not None and config.integration_id is not None
+        dataset = (
+            await session.execute(
+                select(IntegrationDataset).where(
+                    IntegrationDataset.integration_id == config.integration_id,
+                    IntegrationDataset.dataset_key == "services",
+                )
+            )
+        ).scalar_one()
+
+    assert dataset.options == before_options
+
+
+@pytest.mark.asyncio
 async def test_update_sync_config_merges_top_level_schedule_fields(
     client, session_maker
 ):


### PR DESCRIPTION
## Summary

`update_sync_config` accepted PagerDuty `service_repository_mappings` in the request `sync_options` and merged them onto the sync config, but never propagated them to the `services` IntegrationDataset that downstream operational correlation reads from. The mappings were persisted only on the config row, so the services dataset stayed stale.

## Bug / Runtime Consequence

Editing PagerDuty service→repository mappings through the admin sync-config API silently failed to reach the `services` dataset. Correlation logic reading `IntegrationDataset.options["service_repository_mappings"]` continued to use old (or empty) mappings, so newly mapped services never linked to their repositories at runtime.

## Semantics

- **Dict-only**: the propagation runs only when `service_repository_mappings` is present in `sync_options` and is a `dict`; any other type is ignored (no overwrite).
- **All linked services**: the full mapping payload is written to the services dataset for every enabled/disabled linked service — enablement state does not gate persistence.
- **Re-enable safe**: writing merges into existing `services_dataset.options`, so re-enabling a previously configured integration preserves and refreshes mappings without loss.
- **Clear / omission**: omitting the key leaves the dataset untouched; an explicit empty dict clears the mappings deterministically.
- **Provider isolation**: gated on `provider == "pagerduty"`, so no other provider's datasets are affected.

## Test Plan

- Focused: `73 passed` (`tests/api/admin/test_sync_configs.py`) + `10 passed` targeted propagation cases.
- Full gate: `bash ci/local_validate.sh` → exit 0, `8266 passed / 46 skipped`; lint, mypy, ClickHouse migration, and argMax checks pass.
- LSP diagnostics clean on both changed files.

Fixes CHAOS-3019
Blocks CHAOS-2960

SCREENSHOT-WAIVER: backend-only persistence propagation; no rendered UI changes.
