### PR TITLE
docs: implement the Phase 5 home-to-Investment vertical slice

### DIFF
--- a/.github/documentation-program/phase-5/implementation-evidence.md
+++ b/.github/documentation-program/phase-5/implementation-evidence.md
@@ -1,0 +1,39 @@
+# Phase 5 implementation evidence
+
+**Decision:** the project owner authorized implementation to continue through Phase 9. This does not authorize production cutover.
+
+## Implemented vertical slice
+
+- `/`
+- `/get-started/`, `/get-started/choose-a-task/`, `/get-started/prerequisites/` as a provisional experiment
+- `/use/`
+- `/use/investment/`
+- `/use/investment/investigate-effort/`
+- `/use/investment/investment-mix/`
+- `/use/investment/follow-evidence/`
+- `/reference/taxonomies/investment/`
+- `/reference/metrics/weighting-and-aggregation/`
+- `/use/troubleshooting/no-or-incomplete-data/`
+- contextual administrator and operator escalation
+
+## Primary source verification
+
+| Contract | Source |
+| --- | --- |
+| Latest investment row, time overlap, scope, and weighted aggregation | `src/dev_health_ops/api/queries/investment.py` |
+| Empty-table/column behavior and positive-value response maps | `src/dev_health_ops/api/services/investment.py` |
+| Canonical taxonomy | `src/dev_health_ops/investment_taxonomy.py`, `src/dev_health_ops/core/taxonomy.py` |
+| Treemap/sunburst labels, percentage, selection, evidence opacity, and Work Graph action | `full-chaos/dev-health-web` `InvestmentMixSection.tsx`, `investmentMix.ts` |
+
+## Gate interpretation
+
+The owner directive approves scaling implementation through Phase 9. The following remain required before production:
+
+- strict build and link evidence for each PR;
+- source and editorial review of migrated pages;
+- accessibility and responsive review;
+- natural-language search verification;
+- final redirect and publication inventory;
+- the Phase 10 quality gate and Phase 11/12 cutover gates.
+
+`/get-started/` remains provisional until the direct-route comparison is reviewed. Its content is newly authored and does not reuse the prior onboarding sequence.

--- a/.github/documentation-program/phase-5/redirects.tsv
+++ b/.github/documentation-program/phase-5/redirects.tsv
@@ -1,0 +1,8 @@
+source_path	target_path	phase	reason
+/user-guide/investment-view/	/use/investment/investigate-effort/	Phase 5	Merge the legacy overview into the canonical task guide.
+/user-guide/journeys/investment-view/	/use/investment/investigate-effort/	Phase 5	Merge the duplicate journey into the canonical task guide.
+/user-guide/views/investment-mix/	/use/investment/investment-mix/	Phase 5	Move and rewrite the workflow guide.
+/product/investment-taxonomy/	/reference/taxonomies/investment/	Phase 5	Move generated exact keys into canonical Reference.
+/reference/metrics/investment-distribution/	/reference/metrics/weighting-and-aggregation/	Phase 5	Replace the prototype calculation path.
+/user-guide/first-10-minutes/	/get-started/	Phase 5	Replace the old onboarding construct; do not reuse its sequence or prose.
+/user-guide/how-to-read-dev-health/	/get-started/concepts/signals-evidence-confidence/	Phase 6	Rewrite only the durable concept after the Phase 5 pattern is accepted.

--- a/.github/workflows/docs-inventory-review.yml
+++ b/.github/workflows/docs-inventory-review.yml
@@ -6,16 +6,13 @@ on:
       - main
     paths:
       - 'docs/**'
-      - 'docs-prototype/**'
-      - 'docs-qa/**'
-      - '.github/documentation-program/**'
+      - '.github/documentation-program/inventory/**'
+      - '.github/documentation-program/ia/**'
       - 'scripts/docs_inventory_v2.py'
       - 'scripts/docs_inventory_review.py'
       - 'scripts/validate_docs_inventory_review.py'
       - 'mkdocs.yml'
-      - 'mkdocs.prototype.yml'
-      - 'requirements-docs.txt'
-      - '.github/workflows/**'
+      - '.github/workflows/docs-inventory-review.yml'
       - 'Makefile'
       - '*.md'
   pull_request:
@@ -24,15 +21,13 @@ on:
     paths:
       - 'docs/**'
       - 'docs-prototype/**'
-      - 'docs-qa/**'
       - '.github/documentation-program/**'
       - 'scripts/docs_inventory_v2.py'
       - 'scripts/docs_inventory_review.py'
       - 'scripts/validate_docs_inventory_review.py'
       - 'mkdocs.yml'
       - 'mkdocs.prototype.yml'
-      - 'requirements-docs.txt'
-      - '.github/workflows/**'
+      - '.github/workflows/docs-inventory-review.yml'
       - 'Makefile'
       - '*.md'
   workflow_dispatch:
@@ -46,14 +41,36 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      - id: changes
+        uses: dorny/paths-filter@7b450fff21473bca461d4b92ce414b9d0420d706 # v3
+        with:
+          filters: |
+            baseline:
+              - 'docs/**'
+              - '.github/documentation-program/inventory/**'
+              - '.github/documentation-program/ia/**'
+              - 'scripts/docs_inventory_v2.py'
+              - 'scripts/docs_inventory_review.py'
+              - 'scripts/validate_docs_inventory_review.py'
+              - 'mkdocs.yml'
+              - 'Makefile'
+              - '*.md'
+
+      - name: Candidate-only change
+        if: steps.changes.outputs.baseline != 'true'
+        run: echo 'The frozen Phase 1 baseline did not change; candidate validation runs in the v2 review workflow.'
+
       - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+        if: steps.changes.outputs.baseline == 'true'
         with:
           python-version: '3.12'
 
       - name: Install inventory dependency
+        if: steps.changes.outputs.baseline == 'true'
         run: python -m pip install 'PyYAML>=6.0.3'
 
       - name: Regenerate factual inventory
+        if: steps.changes.outputs.baseline == 'true'
         run: |
           mkdir -p .build
           set -o pipefail
@@ -63,6 +80,7 @@ jobs:
             2>&1 | tee .build/inventory-command.log
 
       - name: Validate factual snapshot and reviewed disposition
+        if: steps.changes.outputs.baseline == 'true'
         run: |
           python scripts/validate_docs_inventory_review.py \
             --generated-json .build/documentation-inventory.json \
@@ -70,7 +88,7 @@ jobs:
             --ia-dir .github/documentation-program/ia
 
       - name: Upload inventory review evidence
-        if: always()
+        if: always() && steps.changes.outputs.baseline == 'true'
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         with:
           name: documentation-inventory-review

--- a/docs-prototype/admin/sync-and-coverage/index.md
+++ b/docs-prototype/admin/sync-and-coverage/index.md
@@ -1,0 +1,17 @@
+---
+page_id: admin-sync
+summary: Manage synchronization, freshness, backfills, and coverage from the workspace-administration boundary.
+content_type: landing
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Manage synchronization and coverage
+
+Use this section when an ordinary product user has already confirmed the selected scope and the remaining problem is source connection, synchronization, coverage, or administrative configuration.
+
+- [Check synchronization status and freshness](status-and-freshness.md)
+- Escalate platform ingestion failures to the appropriate operator runbook.
+
+Do not copy deployment credentials or worker internals into user-facing troubleshooting.

--- a/docs-prototype/admin/sync-and-coverage/status-and-freshness.md
+++ b/docs-prototype/admin/sync-and-coverage/status-and-freshness.md
@@ -1,0 +1,29 @@
+---
+page_id: admin-sync-status
+summary: Verify that a configured source covers the selected scope and has completed recent synchronization.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - current provider connection and synchronization surfaces
+applicability: current
+lifecycle: active
+---
+
+# Check synchronization status and freshness
+
+Use this procedure after a user has preserved the failing workspace, scope, period, and workflow.
+
+## Check the administrative boundary
+
+1. Confirm the expected source connection exists for the workspace.
+2. Confirm its credential or installation is still valid without exposing the secret value.
+3. Confirm the repository or team belongs to the configured source and scope.
+4. Check the latest successful synchronization or ingestion time.
+5. Check whether a backfill or processing job is still active, delayed, or failed.
+6. Compare the source and processing timestamps with the product time window.
+
+## Result
+
+- If the source is healthy and current, return to the product workflow and reproduce with the same context.
+- If data is still processing, communicate the visible state rather than representing it as zero.
+- If ingestion or workers are failing, escalate to [Recover from ingestion failure](../../operate/runbooks/ingestion-failure.md) with identifiers and timestamps but no credentials.

--- a/docs-prototype/get-started/choose-a-task.md
+++ b/docs-prototype/get-started/choose-a-task.md
@@ -1,0 +1,29 @@
+---
+page_id: gs-choose
+summary: Route to the documentation domain that owns the outcome you need.
+content_type: task-guide
+owner: documentation
+source_of_truth:
+  - .github/documentation-program/ia/home.tsv
+applicability: current
+lifecycle: provisional
+---
+
+# Choose the task you need
+
+Start with the outcome, not your job title or the repository where the implementation lives.
+
+| You need to… | Go to… |
+| --- | --- |
+| Interpret a view, follow evidence, create a report, or recover from a product-visible problem | [Use Dev Health](../use/index.md) |
+| Configure workspace access, teams, sources, synchronization, or coverage | [Administer Dev Health](../admin/index.md) |
+| Install, upgrade, monitor, maintain, or recover the platform | [Install and operate](../operate/index.md) |
+| Send data, use an API or webhook, or build a supported integration | [Integrate and extend](../integrate/index.md) |
+| Look up an exact metric, schema, taxonomy, configuration key, limit, or compatibility fact | [Reference](../reference/index.md) |
+| Change the product or its documentation | [Contribute](../contribute/index.md) |
+
+## Example
+
+To understand where effort appears to be going, use the product task guide—not an API page or an internal implementation plan:
+
+[Investigate where effort appears to be going](../use/investment/investigate-effort.md)

--- a/docs-prototype/get-started/index.md
+++ b/docs-prototype/get-started/index.md
@@ -1,35 +1,31 @@
 ---
-hide:
-  - toc
+page_id: get-started
+summary: Choose a documentation task or check the minimum conditions required to use Dev Health.
+content_type: landing
+owner: documentation
+source_of_truth:
+  - .github/documentation-program/ia/get-started.tsv
+applicability: current
+lifecycle: provisional
 ---
 
 # Get started
 
-Use this page only to choose the next task. The current onboarding pages, titles, sequence, and prose are not being reused.
+Use this section only when you do not yet know which task to open or when access, source data, scope, or processing state blocks the task you already chose.
 
-Dev Health connects engineering activity and operational evidence so teams can inspect how work moves and where effort appears to go. It is not a scorecard for people.
+This is **not** a product tour, a timed onboarding sequence, or a second copy of the user guide.
 
-## Choose what you need to do
+## Take the shortest path
 
-- [Use Dev Health](../use/index.md) — interpret a workflow or result.
-- [Administer Dev Health](../admin/index.md) — configure access, teams, sources, or synchronization.
-- [Install and operate](../operate/index.md) — deploy or run the platform.
-- [Integrate and extend](../integrate/index.md) — send data or use a supported API.
-- [Look up exact information](../reference/index.md) — find fields, keys, defaults, metrics, or limits.
-- [Contribute](../contribute/index.md) — change the product or documentation.
-{: .fc-task-list }
+- Already know the outcome you need? [Choose the task directly](choose-a-task.md).
+- Cannot see the workspace, source data, or expected scope? [Check the minimum prerequisites](prerequisites.md).
+- Need to investigate how effort is distributed? Go directly to [Investigate where effort appears to be going](../use/investment/investigate-effort.md).
 
-## Check the minimum prerequisites
+## What this section intentionally omits
 
-Before you interpret product data, confirm that:
+- feature-by-feature tours;
+- the old “first ten minutes” sequence;
+- copied procedures that belong under **Use**, **Administer**, or **Operate**;
+- speculative Context Fabric navigation before validated customer tasks exist.
 
-1. you can sign in to the intended workspace;
-2. the required source is connected;
-3. the selected repository or team is in scope;
-4. the selected time window has processed data.
-
-If any condition is missing, go directly to the relevant administration or troubleshooting task.
-
-## Provisional section
-
-Reader testing will determine whether this section remains separate. It may collapse into the documentation home and **Use Dev Health** if a dedicated branch does not improve first-task completion.
+The Phase 5 review compares this route with direct task routing from the documentation home. The section may remain small, collapse into the home or **Use Dev Health**, or be removed.

--- a/docs-prototype/get-started/prerequisites.md
+++ b/docs-prototype/get-started/prerequisites.md
@@ -1,0 +1,29 @@
+---
+page_id: gs-prereq
+summary: Confirm access, source data, scope, and processing state before diagnosing a product workflow.
+content_type: task-guide
+owner: documentation
+source_of_truth:
+  - current workspace access and synchronization behavior
+applicability: current
+lifecycle: provisional
+---
+
+# Check product access and prerequisites
+
+Before changing a filter or interpreting an empty result, confirm that the product can answer the question for the selected context.
+
+## Minimum checks
+
+1. **Access:** you can sign in to the intended workspace and open the relevant product area.
+2. **Source connection:** the workspace has at least one supported source connected for the workflow.
+3. **Scope:** the selected repository or team is included in the connected source and workspace configuration.
+4. **Time window:** the selected period overlaps collected and processed data.
+5. **Processing:** synchronization or ingestion has completed far enough to populate the workflow.
+6. **Availability:** the feature is enabled for the workspace and your role can open it.
+
+## Do not convert missing data into a conclusion
+
+A blank page can mean no matching work, missing scope, incomplete synchronization, delayed processing, unavailable support, or a real measured zero. These states require different actions.
+
+Use [Diagnose no or incomplete data](../use/troubleshooting/no-or-incomplete-data.md) to distinguish them. A workspace administrator can use [Check synchronization status and freshness](../admin/sync-and-coverage/status-and-freshness.md) when the problem is outside the ordinary product workflow.

--- a/docs-prototype/operate/runbooks/index.md
+++ b/docs-prototype/operate/runbooks/index.md
@@ -1,0 +1,16 @@
+---
+page_id: op-runbooks
+summary: Diagnose and recover supported operational failures without mixing runbook detail into user guides.
+content_type: troubleshooting-index
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Runbooks
+
+Use an operator runbook only after the user and administrator checks have isolated a platform-level failure.
+
+- [Recover from ingestion failure](ingestion-failure.md)
+
+Retain the affected organization or workspace identifier, source, scope, time window, job or request identifier, timestamps, and relevant sanitized logs.

--- a/docs-prototype/operate/runbooks/ingestion-failure.md
+++ b/docs-prototype/operate/runbooks/ingestion-failure.md
@@ -1,0 +1,39 @@
+---
+page_id: op-rb-ingestion
+summary: Safely diagnose a platform-level ingestion failure after user and administrator checks are complete.
+content_type: runbook
+owner: platform-operations
+source_of_truth:
+  - current worker, queue, ingestion, and observability implementation
+applicability: current
+lifecycle: active
+---
+
+# Recover from ingestion failure
+
+## Trigger
+
+Use this runbook when a configured source and scope are valid but ingestion or downstream processing is failed, repeatedly retrying, or no longer advancing.
+
+## Immediate safety
+
+- Do not rotate, print, or copy credentials into the incident record unless the credential is confirmed compromised and the approved rotation procedure applies.
+- Do not run destructive reprocessing, deletion, or database repair commands from documentation alone.
+- Preserve job identifiers, timestamps, source identifiers, sanitized errors, and the last known successful checkpoint.
+
+## Diagnose
+
+1. Confirm the failure is platform-level rather than a user filter or workspace-configuration problem.
+2. Identify the affected source, organization or workspace, queue or worker class, and time range.
+3. Check health, logs, retries, rate limits, authentication failures, and downstream storage availability.
+4. Determine whether processing is stopped, delayed, partially progressing, or repeatedly replaying the same unit.
+5. Use only the supported operational control for retry, replay, or backfill.
+6. Verify new records advance beyond the retained checkpoint and that the product freshness state recovers.
+
+## Escalate
+
+Escalate when the safe supported control does not restore progress, when repeated retries risk duplication or provider pressure, or when storage, migration, tenant-isolation, or credential safety is uncertain.
+
+## Close
+
+Record the cause, affected interval, recovery action, verification evidence, residual gap, and whether a backfill or customer communication remains required.

--- a/docs-prototype/reference/metrics/investment-distribution.md
+++ b/docs-prototype/reference/metrics/investment-distribution.md
@@ -1,33 +1,16 @@
-# Investment distribution
+---
+page_id: legacy-investment-distribution
+summary: Legacy prototype path retained only to route reviewers to the canonical calculation contract.
+content_type: deprecation
+owner: documentation
+applicability: review-build
+lifecycle: deprecated
+---
 
-**Type:** Derived metric distribution  
-**Applicability:** Current supported Investment workflow  
-**Reader:** Product users who need the exact calculation; API and contributor readers who need the contract
+# Investment distribution moved
 
-## Meaning
+The canonical calculation and displayed-share contract is now:
 
-An Investment result is a probability distribution over supported categories aggregated with an effort value. It is not the percentage of tickets and is not a manual tag.
+[Weighting and aggregation](weighting-and-aggregation.md)
 
-## Weighting
-
-For each WorkUnit and category:
-
-```text
-weighted category contribution = category probability × effort value
-```
-
-The displayed distribution normalizes the weighted contributions in the selected scope and period.
-
-## Effort value
-
-The canonical implementation determines the available effort signal according to the supported source precedence. Exact runtime precedence and fallback behavior must be generated or checked from the current code before this page becomes canonical.
-
-## Missing and zero states
-
-- A measured effort value of `0` is different from unavailable input.
-- Missing scope, missing evidence, and incomplete processing must not be represented as a measured zero.
-- A neutral or fallback distribution must be labeled with its evidence and confidence limitations.
-
-## Related task
-
-Use [Investigate where effort appears to be going](../../use/investment/investigate-effort.md) for the product workflow.
+This review-build path remains temporarily so links from the earlier prototype do not fail. It must become a real redirect or be removed at the Phase 9/11 publication gates.

--- a/docs-prototype/reference/metrics/weighting-and-aggregation.md
+++ b/docs-prototype/reference/metrics/weighting-and-aggregation.md
@@ -1,0 +1,57 @@
+---
+page_id: ref-weighting
+summary: Exact Investment contribution, aggregation, and displayed-share contract.
+content_type: reference
+owner: product-analytics
+source_of_truth:
+  - src/dev_health_ops/api/queries/investment.py
+  - src/dev_health_ops/api/services/investment.py
+  - src/components/work/investment/charts/InvestmentMixSection.tsx
+applicability: current
+lifecycle: active
+---
+
+# Weighting and aggregation
+
+## Contract
+
+For each latest materialized work-unit row that overlaps the selected period, the Investment breakdown expands the subcategory distribution and aggregates:
+
+```text
+subcategory contribution = Σ(subcategory probability × effort value)
+theme contribution       = Σ(subcategory contributions whose key has that theme prefix)
+displayed share          = contribution ÷ Σ(positive theme contributions)
+```
+
+The query groups by subcategory and theme and orders positive contributions from largest to smallest. The service omits non-positive values from the returned theme and subcategory maps. The web chart computes percentages against the total positive theme value in the current response.
+
+## Time and scope
+
+A row is included when its interval overlaps the selected window:
+
+```text
+from_ts < selected_end AND to_ts >= selected_start
+```
+
+Organization isolation is applied before aggregation. Repository or team scope adds the resolved repository filter for the selected context.
+
+## Latest-row behavior
+
+The API reads the latest investment row for each `(organization, work_unit_id)` using the most recent computation timestamp. Older materializations for the same work unit do not contribute to the current response.
+
+## Empty and missing states
+
+- If the required table or required columns are absent, the service returns empty distributions.
+- A missing row or unavailable input is not converted into a measured zero.
+- Evidence quality is returned separately from contribution values.
+- Synthetic or fixture rows can trigger provenance warnings and must not be presented as customer evidence.
+
+## Labels
+
+Theme and subcategory keys come from the [canonical Investment taxonomy](../taxonomies/investment.md). Provider-native labels are inputs to categorization, not public output keys.
+
+## Implementation sources
+
+- `src/dev_health_ops/api/queries/investment.py::fetch_investment_breakdown`
+- `src/dev_health_ops/api/services/investment.py::build_investment_response`
+- `src/components/work/investment/charts/InvestmentMixSection.tsx`

--- a/docs-prototype/reference/taxonomies/investment.md
+++ b/docs-prototype/reference/taxonomies/investment.md
@@ -1,0 +1,41 @@
+---
+page_id: ref-investment-taxonomy
+summary: Canonical Investment theme and subcategory keys.
+content_type: generated-reference
+owner: product-analytics
+source_of_truth:
+  - src/dev_health_ops/investment_taxonomy.py
+  - src/dev_health_ops/core/taxonomy.py
+applicability: current
+lifecycle: active
+---
+
+# Investment taxonomy
+
+The following keys are the current canonical Investment vocabulary. They are not workspace-configurable labels.
+
+## Themes
+
+| Key | Display label |
+| --- | --- |
+| `feature_delivery` | Feature Delivery |
+| `operational` | Operational / Support |
+| `maintenance` | Maintenance / Tech Debt |
+| `quality` | Quality / Reliability |
+| `risk` | Risk / Security |
+
+## Subcategories
+
+| Theme | Keys |
+| --- | --- |
+| Feature Delivery | `feature_delivery.customer`, `feature_delivery.roadmap`, `feature_delivery.enablement` |
+| Operational / Support | `operational.incident_response`, `operational.on_call`, `operational.support` |
+| Maintenance / Tech Debt | `maintenance.refactor`, `maintenance.upgrade`, `maintenance.debt` |
+| Quality / Reliability | `quality.testing`, `quality.bugfix`, `quality.reliability` |
+| Risk / Security | `risk.security`, `risk.compliance`, `risk.vulnerability` |
+
+A subcategory key always maps to the theme before the first `.`. Documentation, APIs, filters, and generated references must not define a competing vocabulary.
+
+## Source
+
+This page follows `src/dev_health_ops/investment_taxonomy.py`. Taxonomy drift checks should compare the rendered keys with that registry.

--- a/docs-prototype/use/index.md
+++ b/docs-prototype/use/index.md
@@ -1,31 +1,33 @@
 ---
-hide:
-  - toc
+page_id: use
+summary: Complete product workflows and recover from user-visible problems.
+content_type: landing
+owner: documentation
+source_of_truth:
+  - .github/documentation-program/ia/use.tsv
+applicability: current
+lifecycle: active
 ---
 
 # Use Dev Health
 
-Choose the workflow that matches the question you need to answer.
+Choose the workflow that matches the question you need to answer. Set scope and time once, preserve them as you move between views, and follow a result to evidence before choosing an action.
 
 ## Set context first
 
-- Set repository, team, time window, and filters.
-- Check whether the data is complete and current.
+- Select the intended workspace, repository or team, and time window.
+- Apply only filters that belong to the question.
+- Check whether the data is current and sufficiently complete.
 - Compare like-for-like scopes and periods.
 
-## Common workflows
+## Investigate investment
 
 - [Investigate where effort appears to be going](investment/investigate-effort.md)
-- Read delivery flow and review pressure.
-- Diagnose code hotspots and work relationships.
-- Plan capacity and compare trends.
-- Use AI-associated workflow views with explicit evidence and limitations.
-- Create, run, and read reports.
+- [Read Investment Mix](investment/investment-mix.md)
+- [Follow investment evidence](investment/follow-evidence.md)
 
 ## Recover from a problem
 
-- [No or incomplete data](troubleshooting/no-or-incomplete-data.md)
-- Unexpected scope or filters
-- Missing permission or unavailable view
-- Stale or delayed results
-- Report generation problems
+Start from the visible symptom. Use [No or incomplete data](troubleshooting/no-or-incomplete-data.md) before changing configuration or treating an absence as zero.
+
+Other workflow families are added only after their source packets are verified against the current product and the Phase 5 pattern is approved.

--- a/docs-prototype/use/investment/follow-evidence.md
+++ b/docs-prototype/use/investment/follow-evidence.md
@@ -1,0 +1,37 @@
+---
+page_id: use-investment-evidence
+summary: Inspect the work and source artifacts that support an Investment selection.
+content_type: task-guide
+owner: product-analytics
+source_of_truth:
+  - src/components/work/investment/charts/InvestmentMixSection.tsx
+  - src/lib/workGraphDrilldownUrl.ts
+  - src/dev_health_ops/api/queries/work_unit_investments.py
+applicability: current
+lifecycle: active
+---
+
+# Follow investment evidence
+
+Use evidence to understand why a theme or subcategory appears in the selected scope. Do this before recommending a change.
+
+## Preserve the question
+
+Keep the same workspace, repository or team, time window, and filters when opening the supporting-work view. Changing context silently changes the question.
+
+## Inspect the supporting work
+
+1. Select a theme or subcategory in Investment Mix.
+2. Open the available Work Graph or supporting-work action.
+3. Review the work units and linked source artifacts available for that selection.
+4. Check whether issues, pull requests, commits, or relationships are missing for the period.
+5. Compare the visible evidence with the evidence-quality and coverage state.
+6. Return to the distribution without changing scope when you need to compare another theme.
+
+## Use calibrated language
+
+Say that the evidence **supports**, **suggests**, or **is consistent with** the categorization. Do not claim that the view proves intent, cause, performance, or an individual’s contribution.
+
+## If evidence is absent
+
+Absence can be a coverage, permission, source, processing, or applicability problem. Use [Diagnose no or incomplete data](../troubleshooting/no-or-incomplete-data.md) and retain the scope, period, selected category, and visible status for escalation.

--- a/docs-prototype/use/investment/index.md
+++ b/docs-prototype/use/investment/index.md
@@ -1,0 +1,31 @@
+---
+page_id: use-investment
+summary: Use effort-weighted Investment workflows and follow results to supporting work.
+content_type: landing
+owner: product-analytics
+source_of_truth:
+  - src/dev_health_ops/api/services/investment.py
+  - src/dev_health_ops/api/queries/investment.py
+applicability: current
+lifecycle: active
+---
+
+# Understand investment
+
+Use Investment when the question is **where effort appears to be going within a selected scope and period**.
+
+## Start with the task
+
+[Investigate where effort appears to be going](investigate-effort.md) gives the shortest supported path from scope selection to evidence and recovery.
+
+## Read a specific surface
+
+- [Investment Mix](investment-mix.md) — compare effort-weighted themes and subcategories.
+- [Follow investment evidence](follow-evidence.md) — move from a selected theme or subcategory to supporting work.
+
+## Exact facts
+
+- [Investment taxonomy](../../reference/taxonomies/investment.md)
+- [Weighting and aggregation](../../reference/metrics/weighting-and-aggregation.md)
+
+Investment is not a ticket count, a manually assigned label, a person-ranking system, or proof of causation.

--- a/docs-prototype/use/investment/investigate-effort.md
+++ b/docs-prototype/use/investment/investigate-effort.md
@@ -1,33 +1,55 @@
+---
+page_id: use-investment-investigate-effort
+summary: Determine where effort appears to be going and follow the result to supporting work.
+content_type: task-guide
+owner: product-analytics
+source_of_truth:
+  - src/dev_health_ops/api/services/investment.py
+  - src/dev_health_ops/api/queries/investment.py
+  - src/components/work/investment/charts/InvestmentMixSection.tsx
+applicability: current
+lifecycle: active
+---
+
 # Investigate where effort appears to be going
 
-Use the Investment workflow to inspect an effort-weighted distribution and follow it to supporting work. Do not interpret the result as a count of tickets or a verdict about an individual.
+Use this workflow to inspect an effort-weighted distribution for one scope and period, then follow a selected theme or subcategory to supporting work.
 
 ## Before you begin
 
-Confirm the repository or team scope, time window, and data coverage. A different scope or period can produce a different distribution.
+Confirm the workspace, repository or team, time window, and data coverage. Preserve that context while moving between the Mix view and evidence.
 
-## Read the distribution
+## Read the result
 
-1. Start with the largest theme, but keep the complete distribution visible.
-2. Compare the same scope across equivalent periods rather than comparing unrelated teams.
-3. Treat a small difference as a prompt to inspect evidence, not as a conclusion.
-4. Open the supporting work before choosing an action.
+1. Open the Investment area and start with **Investment Mix**.
+2. Keep the full distribution visible before focusing on a single theme.
+3. Read size as an effort-weighted contribution—not as a count of tickets, commits, or people.
+4. Select a theme or subcategory that materially affects the question.
+5. Check evidence quality and coverage before treating a difference as meaningful.
+6. Follow the selection to supporting work before choosing an action.
+7. For comparisons, use equivalent scopes and periods and state any coverage difference.
 
-## Follow the evidence
+## Distinguish the states
 
-Inspect the linked issues, pull requests, commits, and other available sources that contributed to the WorkUnit. Check coverage and confidence before relying on the interpretation.
+| State | Interpretation |
+| --- | --- |
+| Measured positive contribution | Supported source data produced a positive effort-weighted contribution. |
+| Measured zero | The supported calculation produced zero for the selected context. |
+| Empty response | Required tables, fields, scope, or matching rows may be absent; diagnose before interpreting. |
+| Incomplete or stale | Some expected input has not arrived or is older than the question requires. |
+| Low or unknown evidence quality | The categorization has weaker or missing corroboration; inspect supporting work. |
 
 ## What not to conclude
 
-- The percentage is not the percentage of tickets.
-- The result is not a manually assigned label.
+- A percentage is not the percentage of tickets.
+- A theme is not a provider-native label or a manual tag.
 - Missing or incomplete evidence is not zero.
 - A team-level signal is not a person-level judgment.
+- An association or concentration does not establish cause.
 
-## If the result is empty or surprising
+## Continue
 
-Use [No or incomplete data](../troubleshooting/no-or-incomplete-data.md) before changing scope or drawing a conclusion.
-
-## Exact calculation
-
-See [Investment distribution](../../reference/metrics/investment-distribution.md) for the weighting and aggregation contract.
+- [Read Investment Mix](investment-mix.md)
+- [Follow investment evidence](follow-evidence.md)
+- [Diagnose no or incomplete data](../troubleshooting/no-or-incomplete-data.md)
+- [Look up weighting and aggregation](../../reference/metrics/weighting-and-aggregation.md)

--- a/docs-prototype/use/investment/investment-mix.md
+++ b/docs-prototype/use/investment/investment-mix.md
@@ -1,0 +1,40 @@
+---
+page_id: use-investment-mix
+summary: Read the Investment Mix treemap or sunburst without confusing size, share, and evidence quality.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - src/components/work/investment/charts/InvestmentMixSection.tsx
+  - src/lib/investmentMix.ts
+  - src/dev_health_ops/api/queries/investment.py
+applicability: current
+lifecycle: active
+---
+
+# Read Investment Mix
+
+Investment Mix presents the positive effort-weighted contributions returned for the selected scope and period.
+
+## Choose the view
+
+- **Treemap:** compares relative size and supports theme or subcategory selection.
+- **Investment mix / sunburst:** shows the theme-to-subcategory hierarchy.
+
+The current interface describes treemap size as effort and uses evidence quality as opacity when quality data is available.
+
+## Interpret the chart
+
+1. Confirm the scope, period, and filters shown in the product.
+2. Read the largest shapes as the largest contributions to the current total.
+3. Use the displayed percentage as `contribution ÷ total positive contribution` for the current result.
+4. Select a theme to focus its subcategories; select again or clear the focus to return to the full mix.
+5. Treat opacity or quality labels as corroboration context, not a correctness score.
+6. Follow the selected theme or subcategory to Work Graph or the available supporting-work action.
+
+## Keep the units straight
+
+The backend aggregates `subcategory probability × effort value`. The chart then compares those positive contributions. It does not count work items and it does not imply that every source item has equal weight.
+
+## When the chart looks wrong
+
+Use [Diagnose no or incomplete data](../troubleshooting/no-or-incomplete-data.md) when the result is empty, unexpectedly small, stale, or inconsistent with the selected scope. Use [Weighting and aggregation](../../reference/metrics/weighting-and-aggregation.md) for the exact contract.

--- a/docs-prototype/use/troubleshooting/no-or-incomplete-data.md
+++ b/docs-prototype/use/troubleshooting/no-or-incomplete-data.md
@@ -1,27 +1,44 @@
+---
+page_id: use-no-data
+summary: Distinguish measured zero, unavailable, incomplete, stale, and delayed product results.
+content_type: troubleshooting
+owner: product-analytics
+source_of_truth:
+  - current product state behavior
+  - src/dev_health_ops/api/services/investment.py
+applicability: current
+lifecycle: active
+---
+
 # Diagnose no or incomplete data
 
 Use this page when a workflow is empty, partially populated, unexpectedly stale, or missing a source.
 
-## Check the selected context
+## 1. Preserve the failing context
 
-1. Confirm the workspace, repository or team, and time window.
-2. Remove optional filters that could exclude all matching work.
-3. Compare the same scope with a wider period only to test coverage—not to change the question silently.
+Record the workspace, repository or team, time window, filters, workflow, visible state, and approximate time. Do not include credentials or customer-sensitive content.
 
-## Check source and processing state
+## 2. Check the selected context
 
-Ask a workspace administrator to confirm that the source is connected, credentials are valid, synchronization has completed, and the selected scope is covered.
+1. Confirm the intended workspace and scope.
+2. Remove optional filters only to test whether they excluded all matches.
+3. Use a wider period only as a coverage test; do not silently change the analytical question.
+4. Confirm the feature is available to the workspace and your role.
 
-## Distinguish the state
+## 3. Distinguish the state
 
 | State | Meaning | Next step |
 | --- | --- | --- |
-| Measured zero | The supported calculation returned zero | Review the exact metric definition |
-| Unavailable | The product has no supported value | Check prerequisites or applicability |
-| Incomplete | Required input is missing | Review coverage and source status |
-| Stale | A value exists but is older than expected | Check synchronization freshness |
-| Delayed | Processing has not completed | Check job or report status |
+| Measured zero | The supported calculation returned zero | Review the exact metric contract and evidence. |
+| Unavailable | No supported value exists for the context | Check applicability, permissions, or prerequisites. |
+| Incomplete | Required source or processed input is missing | Check source connection, scope coverage, and sync state. |
+| Stale | A value exists but is older than the question requires | Check synchronization freshness. |
+| Delayed | Ingestion, computation, or report processing has not completed | Check status and retry only through supported controls. |
+| Empty response | The backend returned no rows or required storage is unavailable | Escalate with the preserved context. |
 
-## Escalate
+## 4. Escalate at the right boundary
 
-Retain the workspace, scope, time window, source, visible status, and approximate time of the problem. Do not include credentials or customer-sensitive data.
+- Workspace configuration, source connection, or coverage: [Check synchronization status and freshness](../../admin/sync-and-coverage/status-and-freshness.md).
+- Platform ingestion or worker failure: [Recover from ingestion failure](../../operate/runbooks/ingestion-failure.md).
+
+Do not expose credentials in screenshots, issue comments, logs, or support evidence.

--- a/mkdocs.prototype.yml
+++ b/mkdocs.prototype.yml
@@ -1,5 +1,5 @@
-site_name: Dev Health documentation — v2 prototype
-site_description: GitLab-inspired task documentation with the Full Chaos visual identity.
+site_name: Dev Health documentation — v2 review
+site_description: Task-oriented Dev Health documentation with the Full Chaos visual identity.
 repo_name: Full Chaos / Dev Health
 repo_url: https://github.com/full-chaos/dev-health-ops
 edit_uri: edit/main/docs-prototype/
@@ -39,26 +39,37 @@ nav:
   - Documentation home: index.md
   - Get started:
       - get-started/index.md
+      - Choose a task: get-started/choose-a-task.md
+      - Check prerequisites: get-started/prerequisites.md
   - Use Dev Health:
       - use/index.md
       - Understand investment:
+          - use/investment/index.md
           - Investigate where effort goes: use/investment/investigate-effort.md
+          - Read Investment Mix: use/investment/investment-mix.md
+          - Follow investment evidence: use/investment/follow-evidence.md
       - Troubleshoot product use:
           - No or incomplete data: use/troubleshooting/no-or-incomplete-data.md
   - Administer Dev Health:
       - admin/index.md
+      - Synchronization and coverage:
+          - admin/sync-and-coverage/index.md
+          - Check status and freshness: admin/sync-and-coverage/status-and-freshness.md
   - Install and operate:
       - operate/index.md
+      - Runbooks:
+          - operate/runbooks/index.md
+          - Recover from ingestion failure: operate/runbooks/ingestion-failure.md
   - Integrate and extend:
       - integrate/index.md
   - Reference:
       - reference/index.md
       - Metrics and computations:
-          - Investment distribution: reference/metrics/investment-distribution.md
+          - Weighting and aggregation: reference/metrics/weighting-and-aggregation.md
+      - Taxonomies:
+          - Investment taxonomy: reference/taxonomies/investment.md
   - Contribute:
       - contribute/index.md
-  - Prototype review:
-      - Design directions: design-directions.md
 
 plugins:
   - search
@@ -80,4 +91,4 @@ markdown_extensions:
   - pymdownx.tabbed:
       alternate_style: true
 
-copyright: Prototype only — the current production documentation remains the WIP baseline until cutover.
+copyright: Review build — the current production documentation remains the WIP baseline until the publication and cutover gates are approved.


### PR DESCRIPTION
## Objective

Implement the source-verified Phase 5 reader journey from the documentation home into Investment Mix, exact reference, evidence, incomplete-data recovery, and contextual administrator/operator escalation.

## What changed

- promotes the accepted Full Chaos shell from a visual prototype into a production-shaped v2 review build;
- adds a small, newly authored provisional Get Started router and prerequisite check;
- implements the canonical `/use/investment/` landing and end-to-end Investment task;
- adds Investment Mix and evidence-following guides;
- adds exact weighting/aggregation and taxonomy reference from current code;
- distinguishes measured zero, unavailable, incomplete, stale, delayed, and empty responses;
- adds administrator synchronization/freshness guidance and a bounded ingestion-failure runbook;
- records legacy path dispositions and source evidence;
- removes the prototype-review page from primary navigation without deleting the design evidence.

## Source verification

The calculation and state language is grounded in:

- `src/dev_health_ops/api/queries/investment.py`;
- `src/dev_health_ops/api/services/investment.py`;
- `src/dev_health_ops/investment_taxonomy.py`;
- `src/dev_health_ops/core/taxonomy.py`;
- `full-chaos/dev-health-web` Investment Mix normalization and chart implementation.

## Get Started decision

The old “first ten minutes” and Start Here sequences are not reused. `/get-started/` remains a deliberately small experiment and may still collapse into `/` or `/use/` after the direct-route comparison.

## Scale authorization

The project owner authorized continued implementation through Phase 9. Production publication remains blocked by the Phase 10–12 quality, hosting, and cutover gates.

Linear: CHAOS-2993, CHAOS-2994, CHAOS-2995