### PR TITLE
docs: implement the Phase 6 Use Dev Health migration

### DIFF
--- a/.github/documentation-program/phase-6/gaps.tsv
+++ b/.github/documentation-program/phase-6/gaps.tsv
@@ -1,0 +1,7 @@
+topic	current_product_state	documentation_state	next_gate
+AI Attribution	preview route at /ai/attribution	excluded from public v2 navigation	Add only after supported availability is confirmed
+Flame diagrams	legacy documentation; current canonical route not verified	excluded from public v2 navigation	Verify current equivalent or archive at Phase 9
+Report Weekly Review	preview route	not documented as current	Verify implementation before adding
+Report Executive Summary	preview route	not documented as current	Verify implementation before adding
+Report Export History	preview route	not documented as current	Verify implementation before adding
+Context Fabric	feature-gated product destination	reserved, no customer docs node yet	Add validated customer tasks in a later IA amendment

--- a/.github/documentation-program/phase-6/implementation-evidence.md
+++ b/.github/documentation-program/phase-6/implementation-evidence.md
@@ -1,0 +1,33 @@
+# Phase 6 implementation evidence
+
+## Implemented families
+
+- shared scope, time, filters, comparisons, and data states;
+- Investment Flows and Investment Expense;
+- delivery flow, PR Flow, Quadrants, and review pressure;
+- Code Hotspots and Work Graph;
+- Completion Forecast, trend comparison, and team conversations;
+- current AI Impact, Review Load, and Governance Risk destinations;
+- Report Center create, clone, run, history, output, and provenance;
+- user-visible troubleshooting and administrator/operator escalation.
+
+## Current product-route verification
+
+The v2 guidance follows `full-chaos/dev-health-web/src/lib/navigation/areas.ts`:
+
+- Diagnose: `/metrics?tab=flow`, `/investment`, `/diagnose/work-graph`, `/code`, `/complexity`;
+- Plan: `/plan/capacity`;
+- AI: `/ai/impact`, `/ai/review-load`, `/ai/risk`;
+- Reports: `/reports`, `/reports/new`, `/reports/[id]`;
+- Admin: `/org/admin/sync`, `/data-health`.
+
+## Explicit gaps
+
+- AI Attribution is a preview route and remains out of public v2 navigation.
+- Flame diagrams/current equivalent lacks a verified canonical current route and remains internal source evidence.
+- Weekly Review, Executive Summary, and Export History are preview report routes and have no public guide.
+- Context Fabric exists behind a product feature route, but customer documentation remains reserved until the project owner adds validated tasks to the documentation IA.
+
+## Scale rule
+
+The project owner authorized implementation through Phase 9. This evidence does not waive source review, accessibility, final redirect validation, or production cutover gates.

--- a/.github/documentation-program/phase-6/redirects.tsv
+++ b/.github/documentation-program/phase-6/redirects.tsv
@@ -1,0 +1,13 @@
+source_path	target_path	status
+/user-guide/views/investment-flows/	/use/investment/investment-flows/	planned
+/user-guide/views/investment-expense/	/use/investment/investment-expense/	planned
+/user-guide/views/pr-flow/	/use/delivery-flow/pr-flow/	planned
+/user-guide/views/quadrants/	/use/delivery-flow/quadrants/	planned
+/user-guide/views/code-hotspots/	/use/code-and-relationships/code-hotspots/	planned
+/user-guide/views/work-graph/	/use/code-and-relationships/work-graph/	planned
+/user-guide/work-graph/	/use/code-and-relationships/work-graph/	planned
+/user-guide/views/capacity-planning/	/use/plan-and-improve/capacity-planning/	planned
+/user-guide/views/ai-impact/	/use/ai-workflows/impact/	planned
+/user-guide/views/ai-review-load/	/use/ai-workflows/review-load/	planned
+/user-guide/views/ai-risk/	/use/ai-workflows/risk/	planned
+/user-guide/reports/	/use/reports/	planned

--- a/docs-prototype/use/ai-workflows/impact.md
+++ b/docs-prototype/use/ai-workflows/impact.md
@@ -1,0 +1,22 @@
+---
+page_id: use-ai-impact
+summary: Read AI-associated delivery, review, and quality signals without treating estimates as causal proof.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - current /ai/impact product surface
+applicability: current
+lifecycle: active
+---
+
+# Read AI Impact
+
+Use `/ai/impact` to frame a team or repository conversation about AI-associated delivery, review, and quality signals.
+
+1. Start with the selected scope, period, and attribution coverage.
+2. Separate AI-assisted, agent-created, and unknown attribution states.
+3. Read delivery lift and drag components together.
+4. Inspect review, rework, test-gap, revert, and incident context where shown.
+5. Follow evidence before proposing a workflow change.
+
+An association can appear because of source coverage, work mix, or another system change. The view is not a productivity label, forecast, or causal experiment.

--- a/docs-prototype/use/ai-workflows/index.md
+++ b/docs-prototype/use/ai-workflows/index.md
@@ -1,0 +1,18 @@
+---
+page_id: use-ai
+summary: Read current AI-associated workflow signals with explicit coverage, uncertainty, and responsible-use limits.
+content_type: landing
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Use AI-associated workflow views
+
+Current navigation exposes **Impact**, **Review Load**, and **Governance Risk** under `/ai`. AI Attribution exists as a preview route and is intentionally omitted from the public v2 navigation until it becomes a supported destination.
+
+- [Read AI Impact](impact.md)
+- [Read AI Review Load](review-load.md)
+- [Read AI Governance Risk](risk.md)
+
+These views describe AI-associated workflow signals from available evidence. They do not evaluate people, expose prompt content, or prove that AI caused a result.

--- a/docs-prototype/use/ai-workflows/review-load.md
+++ b/docs-prototype/use/ai-workflows/review-load.md
@@ -1,0 +1,22 @@
+---
+page_id: use-ai-review
+summary: Read AI-associated review pressure while preserving unknown attribution and team-level context.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - current /ai/review-load product surface
+applicability: current
+lifecycle: active
+---
+
+# Read AI Review Load
+
+Use `/ai/review-load` to inspect whether AI-associated work appears alongside changes in review volume, latency, rework, or queue pressure.
+
+1. Confirm attribution coverage and unknown share.
+2. Compare equivalent scopes and periods.
+3. Check whether a small number of large or repeatedly revised changes drive the result.
+4. Inspect representative pull requests and review evidence.
+5. Choose a workflow-level response rather than a person-level judgment.
+
+The view does not establish that AI caused review pressure or that a reviewer or author performed well or poorly.

--- a/docs-prototype/use/ai-workflows/risk.md
+++ b/docs-prototype/use/ai-workflows/risk.md
@@ -1,0 +1,22 @@
+---
+page_id: use-ai-risk
+summary: Read AI Governance Risk, including its current Test Gaps and Evidence tabs, as a set of review prompts.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - current /ai/risk product surface
+applicability: current
+lifecycle: active
+---
+
+# Read AI Governance Risk
+
+Use `/ai/risk` to inspect quality and governance signals associated with AI-linked work. The current destination owns the retired standalone Test Gaps and Evidence routes as in-page tabs.
+
+1. Confirm scope, period, and attribution coverage.
+2. Read the named risk signal and its current threshold or unit.
+3. Open **Test Gaps** and **Evidence** where relevant.
+4. Distinguish observed source facts from derived or model-assisted risk estimates.
+5. Verify representative work before taking action.
+
+A risk signal is a review queue, not proof of policy violation, security impact, or individual fault.

--- a/docs-prototype/use/code-and-relationships/code-hotspots.md
+++ b/docs-prototype/use/code-and-relationships/code-hotspots.md
@@ -1,0 +1,22 @@
+---
+page_id: use-hotspots
+summary: Identify concentrated change or complexity that deserves source inspection.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - current Code and Complexity product surfaces
+applicability: current
+lifecycle: active
+---
+
+# Read Code Hotspots
+
+Use hotspots to find files, modules, or areas with concentrated change, complexity, or ownership signals.
+
+1. Confirm repository, branch or supported scope, and period.
+2. Read the current metric and unit before comparing nodes.
+3. Separate change concentration from code quality.
+4. Open source and related work before recommending refactoring.
+5. Check generated, vendored, test, migration, and large-file effects.
+
+A hotspot is a prioritization input. It does not prove that code is defective or that its authors caused a problem.

--- a/docs-prototype/use/code-and-relationships/index.md
+++ b/docs-prototype/use/code-and-relationships/index.md
@@ -1,0 +1,15 @@
+---
+page_id: use-code
+summary: Investigate code change concentration and relationships between work and source artifacts.
+content_type: landing
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Diagnose code and work relationships
+
+- [Read Code Hotspots](code-hotspots.md)
+- [Follow relationships in Work Graph](work-graph.md)
+
+The legacy Flame diagrams page remains source evidence only until a current canonical product route and interaction are verified. It is not included in the v2 navigation.

--- a/docs-prototype/use/code-and-relationships/work-graph.md
+++ b/docs-prototype/use/code-and-relationships/work-graph.md
@@ -1,0 +1,24 @@
+---
+page_id: use-work-graph
+summary: Follow supported relationships among work units, issues, pull requests, commits, repositories, and evidence.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - current /diagnose/work-graph product surface
+  - current Work Graph GraphQL and relationship contracts
+applicability: current
+lifecycle: active
+---
+
+# Follow relationships in Work Graph
+
+Work Graph is the evidence destination for questions that require relationships rather than a summary value.
+
+1. Open `/diagnose/work-graph` directly or follow a contextual action from a supported workflow.
+2. Preserve the originating scope, time window, and category filters.
+3. Read node and edge labels from the current graph contract.
+4. Expand only the relationship needed for the question.
+5. Open the source artifact where available.
+6. Treat a missing edge as missing or unsupported evidence until coverage is checked.
+
+Do not infer ownership, intent, or causation from graph proximity alone.

--- a/docs-prototype/use/delivery-flow/index.md
+++ b/docs-prototype/use/delivery-flow/index.md
@@ -1,0 +1,18 @@
+---
+page_id: use-delivery
+summary: Diagnose movement, review pressure, and delivery patterns using the current Flow destination.
+content_type: landing
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Diagnose delivery flow
+
+The current product exposes Flow under the Diagnose area. Use these guides to interpret patterns while preserving scope and time.
+
+- [Read PR Flow](pr-flow.md)
+- [Read Quadrants](quadrants.md)
+- [Investigate review pressure](review-pressure.md)
+
+A flow signal describes the selected system and period. It does not rank people or establish the cause of a delay.

--- a/docs-prototype/use/delivery-flow/pr-flow.md
+++ b/docs-prototype/use/delivery-flow/pr-flow.md
@@ -1,0 +1,22 @@
+---
+page_id: use-pr-flow
+summary: Read pull-request movement and delay patterns in the current Flow destination.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - current /metrics?tab=flow product surface
+applicability: current
+lifecycle: active
+---
+
+# Read PR Flow
+
+Use PR Flow to ask where pull requests appear to wait, move, or accumulate in the selected scope and period.
+
+1. Confirm the repository or team and time window.
+2. Read stage labels and units from the current view rather than assuming a generic lifecycle.
+3. Look for sustained patterns across several items or periods.
+4. Open representative supporting work before naming a bottleneck.
+5. Check review availability, source coverage, and unusually large or long-lived work.
+
+Do not treat a single long pull request as a team verdict. Use [Investigate review pressure](review-pressure.md) when review load is the specific question.

--- a/docs-prototype/use/delivery-flow/quadrants.md
+++ b/docs-prototype/use/delivery-flow/quadrants.md
@@ -1,0 +1,22 @@
+---
+page_id: use-quadrants
+summary: Read the current quadrant axes, thresholds, and population without assigning generic meanings to a zone.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - current Quadrants product surface and zone calculations
+applicability: current
+lifecycle: active
+---
+
+# Read Quadrants
+
+Quadrants combine two current measures to help locate work that merits inspection.
+
+1. Read both axis labels, units, and the selected period.
+2. Check how thresholds are defined in the current view.
+3. Inspect the number and coverage of items in each zone.
+4. Open representative items before describing the zone.
+5. Compare the same axis definitions and scope over time.
+
+A quadrant is a visual grouping, not a diagnosis. Do not reuse a zone label after the underlying axis or threshold changes.

--- a/docs-prototype/use/delivery-flow/review-pressure.md
+++ b/docs-prototype/use/delivery-flow/review-pressure.md
@@ -1,0 +1,18 @@
+---
+page_id: use-review-pressure
+summary: Investigate sustained review pressure without ranking reviewers or authors.
+content_type: task-guide
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Investigate review pressure
+
+1. Keep the team or repository scope and period visible.
+2. Check review queue, latency, rework, and size signals together when available.
+3. Inspect whether the pattern is broad or driven by a small number of items.
+4. Check coverage and role availability before comparing teams.
+5. Follow evidence to the affected workflow and choose a system-level response.
+
+Use team capacity, review policy, work size, ownership, and dependency context. Do not publish person-to-person rankings or infer motivation from queue data.

--- a/docs-prototype/use/index.md
+++ b/docs-prototype/use/index.md
@@ -13,21 +13,21 @@ lifecycle: active
 
 Choose the workflow that matches the question you need to answer. Set scope and time once, preserve them as you move between views, and follow a result to evidence before choosing an action.
 
-## Set context first
+## Start with context
 
-- Select the intended workspace, repository or team, and time window.
-- Apply only filters that belong to the question.
-- Check whether the data is current and sufficiently complete.
-- Compare like-for-like scopes and periods.
+- [Set scope and time](navigate/scope-and-time.md)
+- [Use filters and comparisons](navigate/filters-and-comparisons.md)
+- [Distinguish loading, empty, stale, and partial states](navigate/data-states.md)
 
-## Investigate investment
+## Product workflows
 
-- [Investigate where effort appears to be going](investment/investigate-effort.md)
-- [Read Investment Mix](investment/investment-mix.md)
-- [Follow investment evidence](investment/follow-evidence.md)
+- [Understand investment](investment/index.md)
+- [Diagnose delivery flow](delivery-flow/index.md)
+- [Diagnose code and work relationships](code-and-relationships/index.md)
+- [Plan and improve](plan-and-improve/index.md)
+- [Use AI workflow views](ai-workflows/index.md)
+- [Create and read reports](reports/index.md)
 
 ## Recover from a problem
 
-Start from the visible symptom. Use [No or incomplete data](troubleshooting/no-or-incomplete-data.md) before changing configuration or treating an absence as zero.
-
-Other workflow families are added only after their source packets are verified against the current product and the Phase 5 pattern is approved.
+Start from the symptom in [Troubleshoot product use](troubleshooting/index.md). Do not treat unavailable, incomplete, or delayed data as a measured zero.

--- a/docs-prototype/use/investment/investment-expense.md
+++ b/docs-prototype/use/investment/investment-expense.md
@@ -1,0 +1,22 @@
+---
+page_id: use-investment-expense
+summary: Read how Investment composition changes over time without treating the view as accounting expense.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - current Investment time-series and analytics contracts
+applicability: current
+lifecycle: active
+---
+
+# Read Investment Expense
+
+This time-series view asks how the effort-weighted Investment composition changes across the selected period. “Expense” describes sustained effort pressure; it is not a financial ledger.
+
+1. Confirm the interval and aggregation grain.
+2. Read abrupt changes as prompts to inspect incidents, releases, or coverage—not as causes by themselves.
+3. Read gradual changes across several points before describing a structural shift.
+4. Keep the same scope and source coverage when comparing periods.
+5. Follow the relevant theme to supporting work.
+
+Use [Weighting and aggregation](../../reference/metrics/weighting-and-aggregation.md) for the contribution contract and [Stale or delayed results](../troubleshooting/stale-or-delayed-results.md) when the series stops advancing.

--- a/docs-prototype/use/investment/investment-flows.md
+++ b/docs-prototype/use/investment/investment-flows.md
@@ -1,0 +1,23 @@
+---
+page_id: use-investment-flows
+summary: Read how effort-weighted Investment contributions connect categories with repositories or teams.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - src/dev_health_ops/api/services/investment_flow.py
+  - src/dev_health_ops/api/queries/investment.py
+applicability: current
+lifecycle: active
+---
+
+# Read Investment Flows
+
+Use Investment Flows when the question is how effort-weighted categories connect with repositories, teams, or other supported scope nodes.
+
+1. Preserve the same scope, period, and category filters used in Investment Mix.
+2. Read link width as an aggregated contribution, not a count of work items.
+3. Check unassigned nodes before concluding that a team or repository owns the flow.
+4. Select a path and follow it to supporting work where the product offers that action.
+5. Compare equivalent periods only after checking coverage and attribution changes.
+
+Multi-repository work can be allocated across repositories by the current allocation model. A flow into `unassigned` is an attribution or mapping state, not a new Investment category.

--- a/docs-prototype/use/navigate/data-states.md
+++ b/docs-prototype/use/navigate/data-states.md
@@ -1,0 +1,24 @@
+---
+page_id: use-data-states
+summary: Distinguish measured values from unavailable, incomplete, stale, delayed, and unsupported states.
+content_type: concept
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Understand loading, empty, stale, and partial data
+
+| State | Meaning |
+| --- | --- |
+| Loading | The request or client transition has not completed. |
+| Measured value | The supported calculation returned a value for the current context. |
+| Measured zero | The calculation returned zero; it is not shorthand for missing data. |
+| Empty | No matching rows or result are available; the cause still needs diagnosis. |
+| Unavailable | The product does not have a supported value for the context. |
+| Incomplete or partial | Required source or processed input is missing. |
+| Stale | A value exists but is older than the question requires. |
+| Delayed | Ingestion, computation, or report work has not completed. |
+| Unsupported | The route, feature, source, or combination is not currently supported. |
+
+Use the visible status and timestamps where available. Start with [No or incomplete data](../troubleshooting/no-or-incomplete-data.md) rather than converting an absence into a conclusion.

--- a/docs-prototype/use/navigate/filters-and-comparisons.md
+++ b/docs-prototype/use/navigate/filters-and-comparisons.md
@@ -1,0 +1,23 @@
+---
+page_id: use-filters
+summary: Apply filters deliberately and compare like-for-like contexts.
+content_type: task-guide
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Use filters and comparisons
+
+Filters narrow the evidence included in a result. They do not repair missing source data.
+
+## Apply a filter
+
+1. State the question before changing controls.
+2. Add one filter at a time and confirm the visible scope remains correct.
+3. Clear optional filters when testing whether they excluded all matching work.
+4. Preserve the same filter set when following evidence.
+
+## Compare responsibly
+
+Compare equivalent scopes, periods, source coverage, and feature availability. Call out changes in any of those conditions. Treat a small delta as a reason to inspect evidence, not as proof of improvement or regression.

--- a/docs-prototype/use/navigate/index.md
+++ b/docs-prototype/use/navigate/index.md
@@ -1,0 +1,18 @@
+---
+page_id: use-navigate
+summary: Preserve scope, time, filters, and data state while moving between product workflows.
+content_type: landing
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Navigate and set context
+
+A Dev Health result only answers the question represented by its current workspace, scope, period, filters, availability, and source coverage.
+
+- [Set scope and time](scope-and-time.md)
+- [Use filters and comparisons](filters-and-comparisons.md)
+- [Understand data states](data-states.md)
+
+Keep the context visible when moving from a summary to evidence or from one view to another.

--- a/docs-prototype/use/navigate/scope-and-time.md
+++ b/docs-prototype/use/navigate/scope-and-time.md
@@ -1,0 +1,20 @@
+---
+page_id: use-scope
+summary: Select and preserve the repository or team scope and time window for a product question.
+content_type: task-guide
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Set scope and time window
+
+1. Select the workspace that owns the source data.
+2. Choose the repository, team, or supported aggregate scope required by the question.
+3. Choose a time window that overlaps collected data and is long enough for the signal you are reading.
+4. Record the context before opening evidence or another view.
+5. Preserve it when comparing results.
+
+A wider period can test coverage, but it changes the analytical question. A team and a repository can contain different work, attribution, and coverage even when their names appear related.
+
+Use [Unexpected scope or filters](../troubleshooting/scope-and-filters.md) when the result does not match the visible context.

--- a/docs-prototype/use/plan-and-improve/capacity-planning.md
+++ b/docs-prototype/use/plan-and-improve/capacity-planning.md
@@ -1,0 +1,23 @@
+---
+page_id: use-capacity
+summary: Use the current Completion Forecast without presenting a probabilistic window as a promise.
+content_type: workflow-guide
+owner: product-analytics
+source_of_truth:
+  - current /plan/capacity product surface
+  - current Monte Carlo throughput forecast implementation
+applicability: current
+lifecycle: active
+---
+
+# Use Completion Forecast
+
+The current Plan destination exposes **Completion Forecast** at `/plan/capacity`.
+
+1. Confirm the backlog or work set, team or repository scope, and historical period.
+2. Read the forecast range and probability labels shown in the current view.
+3. Check whether throughput history is representative of the planned work.
+4. Run scenarios only when the changed assumption is explicit.
+5. Communicate a range and confidence, not a promised date.
+
+A forecast can become unreliable when scope, work size, staffing, workflow, or source coverage changes materially.

--- a/docs-prototype/use/plan-and-improve/compare-trends.md
+++ b/docs-prototype/use/plan-and-improve/compare-trends.md
@@ -1,0 +1,18 @@
+---
+page_id: use-trends
+summary: Compare trends while preserving scope, units, coverage, and product-definition changes.
+content_type: task-guide
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Compare trends responsibly
+
+1. Use the same scope, unit, and aggregation where possible.
+2. Choose equivalent periods and note seasonality or release events.
+3. Verify that source coverage and feature availability did not change.
+4. Inspect the underlying work before naming a cause.
+5. Describe the observed direction and uncertainty separately from an explanation.
+
+Feature Flags is currently a Govern destination at `/feature-flags`; treat it as a separate workflow unless the comparison explicitly asks about flag lifecycle or debt.

--- a/docs-prototype/use/plan-and-improve/index.md
+++ b/docs-prototype/use/plan-and-improve/index.md
@@ -1,0 +1,16 @@
+---
+page_id: use-plan
+summary: Use forecasts and trends to prepare bounded planning and improvement decisions.
+content_type: landing
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Plan and improve
+
+- [Use Completion Forecast](capacity-planning.md)
+- [Compare trends responsibly](compare-trends.md)
+- [Prepare a team operating conversation](team-conversations.md)
+
+Forecasts and trends describe uncertainty in the selected system. They are not commitments or performance scores.

--- a/docs-prototype/use/plan-and-improve/team-conversations.md
+++ b/docs-prototype/use/plan-and-improve/team-conversations.md
@@ -1,0 +1,19 @@
+---
+page_id: use-conversations
+summary: Prepare a team-level conversation from several evidence-linked signals without creating a scorecard.
+content_type: task-guide
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Prepare a team operating conversation
+
+1. State the operational question and selected period.
+2. Choose the minimum views needed to answer it.
+3. Preserve scope and time across those views.
+4. Bring representative evidence and known coverage gaps.
+5. Separate observed facts, derived measures, hypotheses, and decisions.
+6. End with one bounded action and a review condition.
+
+Do not combine unrelated metrics into a person or team score. A conversation guide is not a substitute for the source evidence or local context.

--- a/docs-prototype/use/reports/create-or-clone.md
+++ b/docs-prototype/use/reports/create-or-clone.md
@@ -1,0 +1,25 @@
+---
+page_id: use-report-create
+summary: Create a saved report or clone an existing definition without confusing the definition with a run.
+content_type: task-guide
+owner: product-analytics
+source_of_truth:
+  - current Report Center create, update, and clone mutations
+applicability: current
+lifecycle: active
+---
+
+# Create or clone a report
+
+## Create
+
+1. Open `/reports/new` from Report Center.
+2. Name the report and choose the supported scope, date range, metrics, and report plan fields shown by the current form.
+3. Save the definition.
+4. Open the saved report and run it before sharing the result.
+
+## Clone
+
+Open an existing report, choose **Clone**, provide the new name, and review the copied parameters before running it.
+
+A saved report is a definition. Its latest successful output and run history are separate records.

--- a/docs-prototype/use/reports/index.md
+++ b/docs-prototype/use/reports/index.md
@@ -1,0 +1,21 @@
+---
+page_id: use-reports
+summary: Create, run, and read saved reports in the current Report Center.
+content_type: landing
+owner: product-analytics
+source_of_truth:
+  - full-chaos/dev-health-web docs/reports.md
+  - current report GraphQL schema and workers
+applicability: current
+lifecycle: active
+---
+
+# Create and read reports
+
+The current Report Center is available at `/reports` with creation at `/reports/new` and report detail at `/reports/[id]`.
+
+- [Create or clone a report](create-or-clone.md)
+- [Run and monitor a report](run-and-schedule.md)
+- [Read output and provenance](read-output-and-provenance.md)
+
+Weekly Review, Executive Summary, and Export History are preview routes and are not documented as current destinations.

--- a/docs-prototype/use/reports/read-output-and-provenance.md
+++ b/docs-prototype/use/reports/read-output-and-provenance.md
@@ -1,0 +1,22 @@
+---
+page_id: use-report-read
+summary: Read rendered report output with its definition, run status, trigger, and source context.
+content_type: task-guide
+owner: product-analytics
+source_of_truth:
+  - current SavedReport and ReportRun GraphQL contracts
+applicability: current
+lifecycle: active
+---
+
+# Read output and provenance
+
+A report detail page can show rendered Markdown from the latest successful run and a history of prior runs.
+
+1. Confirm which saved definition produced the output.
+2. Check the run status, trigger type, duration, and completion time.
+3. Review the scope, date range, metrics, and plan stored with the report.
+4. Distinguish generated narrative from measured or derived source values.
+5. Treat missing or failed output as a run state, not a measured zero.
+
+Do not share customer-sensitive output outside its approved audience. A future artifact URL field does not guarantee that downloadable output is currently supported.

--- a/docs-prototype/use/reports/run-and-schedule.md
+++ b/docs-prototype/use/reports/run-and-schedule.md
@@ -1,0 +1,22 @@
+---
+page_id: use-report-run
+summary: Trigger a report, monitor its run status, and distinguish manual from scheduler-triggered runs.
+content_type: task-guide
+owner: product-analytics
+source_of_truth:
+  - current Report Center Run Now action and ReportRun contract
+applicability: current
+lifecycle: active
+---
+
+# Run and monitor a report
+
+1. Open the report detail page.
+2. Review its scope, date range, metrics, and report plan.
+3. Choose **Run Now** for a manual run.
+4. Monitor run history for status and duration.
+5. Open the latest successful output after completion.
+
+The run contract distinguishes manual and scheduler-triggered executions. Do not claim that every workspace exposes schedule configuration in the UI; document scheduling controls only where the current deployment and permissions provide them.
+
+Use [Report generation problems](../troubleshooting/reports.md) when a run remains queued, fails, or completes without usable output.

--- a/docs-prototype/use/troubleshooting/index.md
+++ b/docs-prototype/use/troubleshooting/index.md
@@ -1,0 +1,18 @@
+---
+page_id: use-troubleshooting
+summary: Start from a visible symptom and escalate only after user-level checks are complete.
+content_type: troubleshooting-index
+owner: documentation
+applicability: current
+lifecycle: active
+---
+
+# Troubleshoot product use
+
+- [No or incomplete data](no-or-incomplete-data.md)
+- [Unexpected scope or filters](scope-and-filters.md)
+- [Missing permission or unavailable view](permissions-and-availability.md)
+- [Stale or delayed results](stale-or-delayed-results.md)
+- [Report generation problems](reports.md)
+
+Preserve the failing context. Do not send ordinary product users directly to deployment commands, database repair, or worker internals.

--- a/docs-prototype/use/troubleshooting/permissions-and-availability.md
+++ b/docs-prototype/use/troubleshooting/permissions-and-availability.md
@@ -1,0 +1,18 @@
+---
+page_id: use-permissions
+summary: Distinguish missing access, feature availability, and preview-only routes.
+content_type: troubleshooting
+owner: documentation
+applicability: current
+lifecycle: active
+---
+
+# Missing permission or unavailable view
+
+1. Confirm you are in the intended workspace and signed in with the expected role.
+2. Confirm the destination is currently supported rather than preview-only.
+3. Confirm any required workspace feature or entitlement is enabled.
+4. Ask an administrator to verify membership and access without sharing secrets.
+5. Retain the route and visible message for escalation.
+
+AI Attribution, several report subroutes, and some other product routes are currently marked preview in the product navigation source. Their absence from v2 navigation is intentional.

--- a/docs-prototype/use/troubleshooting/reports.md
+++ b/docs-prototype/use/troubleshooting/reports.md
@@ -1,0 +1,26 @@
+---
+page_id: use-report-problems
+summary: Diagnose report creation, triggering, run-history, and rendered-output problems.
+content_type: troubleshooting
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Report generation problems
+
+## Report cannot be saved
+
+Check required form fields, scope availability, and permission. Retain the validation message.
+
+## Run remains queued or running
+
+Check whether status and duration are advancing. Avoid triggering duplicate runs until the current run state is understood.
+
+## Run failed
+
+Record the report ID, run ID, trigger type, time, and sanitized error. Preserve the report definition.
+
+## Run succeeded but output is missing
+
+Confirm you opened the latest successful run and that rendered output exists. A successful status without usable content requires escalation; it is not a zero result.

--- a/docs-prototype/use/troubleshooting/scope-and-filters.md
+++ b/docs-prototype/use/troubleshooting/scope-and-filters.md
@@ -1,0 +1,18 @@
+---
+page_id: use-scope-problems
+summary: Diagnose a result that appears to use the wrong workspace, repository, team, time, or filter set.
+content_type: troubleshooting
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Unexpected scope or filters
+
+1. Record the workspace, route, repository or team, period, and filters.
+2. Confirm the visible selection matches the intended question.
+3. Clear optional filters one at a time.
+4. Reload or revisit the destination through current navigation if the URL contains stale parameters.
+5. Compare the same context in a second supported view.
+
+If the selected entity is absent or maps incorrectly, escalate to workspace administration with identifiers—not credentials—and check source coverage.

--- a/docs-prototype/use/troubleshooting/stale-or-delayed-results.md
+++ b/docs-prototype/use/troubleshooting/stale-or-delayed-results.md
@@ -1,0 +1,18 @@
+---
+page_id: use-stale
+summary: Determine whether a result is old, still processing, or no longer advancing.
+content_type: troubleshooting
+owner: product-analytics
+applicability: current
+lifecycle: active
+---
+
+# Stale or delayed results
+
+1. Record the last-computed, source, run, or synchronization time shown by the product.
+2. Compare it with the selected time window and expected source cadence.
+3. Confirm whether a report, ingestion, backfill, or computation is still active.
+4. Avoid repeated manual retries while status is advancing.
+5. Escalate to [Check synchronization status and freshness](../../admin/sync-and-coverage/status-and-freshness.md) when the user-level state cannot explain the delay.
+
+A stale value exists but is old. A delayed value is not complete yet. Neither should be represented as current or as zero.

--- a/mkdocs.prototype.yml
+++ b/mkdocs.prototype.yml
@@ -43,13 +43,49 @@ nav:
       - Check prerequisites: get-started/prerequisites.md
   - Use Dev Health:
       - use/index.md
+      - Navigate and set context:
+          - use/navigate/index.md
+          - Set scope and time: use/navigate/scope-and-time.md
+          - Use filters and comparisons: use/navigate/filters-and-comparisons.md
+          - Understand data states: use/navigate/data-states.md
       - Understand investment:
           - use/investment/index.md
           - Investigate where effort goes: use/investment/investigate-effort.md
           - Read Investment Mix: use/investment/investment-mix.md
+          - Read Investment Flows: use/investment/investment-flows.md
+          - Read Investment Expense: use/investment/investment-expense.md
           - Follow investment evidence: use/investment/follow-evidence.md
+      - Diagnose delivery flow:
+          - use/delivery-flow/index.md
+          - Read PR Flow: use/delivery-flow/pr-flow.md
+          - Read Quadrants: use/delivery-flow/quadrants.md
+          - Investigate review pressure: use/delivery-flow/review-pressure.md
+      - Diagnose code and work relationships:
+          - use/code-and-relationships/index.md
+          - Read Code Hotspots: use/code-and-relationships/code-hotspots.md
+          - Follow Work Graph relationships: use/code-and-relationships/work-graph.md
+      - Plan and improve:
+          - use/plan-and-improve/index.md
+          - Use Completion Forecast: use/plan-and-improve/capacity-planning.md
+          - Compare trends responsibly: use/plan-and-improve/compare-trends.md
+          - Prepare a team conversation: use/plan-and-improve/team-conversations.md
+      - Use AI workflow views:
+          - use/ai-workflows/index.md
+          - Read AI Impact: use/ai-workflows/impact.md
+          - Read AI Review Load: use/ai-workflows/review-load.md
+          - Read AI Governance Risk: use/ai-workflows/risk.md
+      - Create and read reports:
+          - use/reports/index.md
+          - Create or clone a report: use/reports/create-or-clone.md
+          - Run and monitor a report: use/reports/run-and-schedule.md
+          - Read output and provenance: use/reports/read-output-and-provenance.md
       - Troubleshoot product use:
+          - use/troubleshooting/index.md
           - No or incomplete data: use/troubleshooting/no-or-incomplete-data.md
+          - Unexpected scope or filters: use/troubleshooting/scope-and-filters.md
+          - Missing permission or unavailable view: use/troubleshooting/permissions-and-availability.md
+          - Stale or delayed results: use/troubleshooting/stale-or-delayed-results.md
+          - Report problems: use/troubleshooting/reports.md
   - Administer Dev Health:
       - admin/index.md
       - Synchronization and coverage:


### PR DESCRIPTION
## Objective

Implement the approved **Use Dev Health** workflow families using the Phase 5 page model while excluding routes that are still preview-only or lack a verified current product destination.

## What changed

- adds shared scope, time, filter, comparison, and data-state guidance;
- adds Investment Flows and Investment Expense;
- adds delivery-flow, PR Flow, Quadrants, and review-pressure guidance;
- adds Code Hotspots and the current Work Graph route;
- adds Completion Forecast, trend comparison, and team-conversation guidance;
- adds current AI Impact, Review Load, and Governance Risk pages with responsible-use limits;
- adds Report Center creation, clone, run, history, output, and provenance guidance;
- adds user-visible troubleshooting and explicit user/admin/operator escalation boundaries;
- records redirects and explicit gaps rather than publishing preview or unverified routes.

## Current-route evidence

The navigation and availability statements are checked against `full-chaos/dev-health-web/src/lib/navigation/areas.ts` and the current report implementation. AI Attribution and several report destinations remain preview-only. Flame diagrams/current equivalent remains an explicit verification gap. Context Fabric remains reserved for a later customer-task IA amendment.

## Review focus

1. Source and product accuracy of each current route and state.
2. Whether the new guides stay task-oriented and avoid duplicate reference prose.
3. Whether AI/analytics language separates observation, derivation, association, uncertainty, and unavailable data.
4. Whether troubleshooting keeps ordinary users out of operator internals until escalation is justified.
5. Whether excluded preview/unverified routes remain absent from public navigation.

Linear: CHAOS-2996, CHAOS-2997, CHAOS-2998