### PR TITLE
docs: implement the Phase 7 administration and operations sections

### DIFF
--- a/.github/documentation-program/phase-7/admin-evidence.md
+++ b/.github/documentation-program/phase-7/admin-evidence.md
@@ -1,0 +1,12 @@
+# Phase 7 administrator evidence
+
+The administrator section consolidates current source material into the locked `/admin/` IA:
+
+- team configuration → `/admin/teams-and-identities/teams-and-repositories/`;
+- SSO setup → `/admin/teams-and-identities/roles-and-access/`;
+- GitHub App setup and authorization → `/admin/data-sources/github/`;
+- GitLab permission guidance → `/admin/data-sources/gitlab/`;
+- model/provider credential responsibilities → `/admin/security-and-audit/credentials/`;
+- product telemetry → `/admin/security-and-audit/privacy/`.
+
+The section intentionally excludes environment variables, database configuration, worker controls, secret-manager mechanics, and incident runbooks. Those are operator responsibilities.

--- a/.github/documentation-program/phase-7/operations-evidence.md
+++ b/.github/documentation-program/phase-7/operations-evidence.md
@@ -1,0 +1,17 @@
+# Phase 7 operations evidence
+
+The operator section consolidates supported deployment and runbook source material into the locked `/operate/` IA.
+
+## Source families
+
+- deployment artifacts: `compose.yml`, `deploy/docker-compose/`, `deploy/docker-swarm/`, `deploy/kubernetes/`;
+- deployment and self-hosted guidance: `docs/ops/deployment-guide.md`, `docs/self-hosted-quickstart.md`;
+- workers and materialization: `docs/ops/workers.md`, `docs/ops/investment-materialization.md`;
+- observability and objectives: `docs/ops/observability-tooling.md`, `docs/alerting.md`, `docs/slos.md`;
+- sync and budget observability: current architecture and runtime controls;
+- security: credential encryption and rotation implementation;
+- runbooks: ingestion and report failure source material.
+
+## Safety rule
+
+The public v2 pages describe supported decisions, checks, boundaries, and evidence. They intentionally omit unverified one-line destructive commands. Exact commands, versions, and configuration keys must be generated or checked from the current reviewed release before production execution.

--- a/.github/documentation-program/phase-7/redirects.tsv
+++ b/.github/documentation-program/phase-7/redirects.tsv
@@ -1,0 +1,16 @@
+source_path	target_path	status
+/team-configuration/	/admin/teams-and-identities/teams-and-repositories/	planned
+/sso-setup/	/admin/teams-and-identities/roles-and-access/	planned
+/user-guide/github-app-setup/	/admin/data-sources/github/	planned
+/user-guide/github-app-auth/	/admin/data-sources/github/	planned
+/connectors/gitlab-permissions/	/admin/data-sources/gitlab/	planned
+/user-guide/product-telemetry/	/admin/security-and-audit/privacy/	planned
+/self-hosted-quickstart/	/operate/install/local-evaluation/	planned
+/ops/deployment-guide/	/operate/install/production/	planned
+/ops/workers/	/operate/run/workers-and-jobs/	planned
+/ops/observability-tooling/	/operate/observe/	planned
+/alerting/	/operate/observe/dashboards-and-alerts/	planned
+/slos/	/operate/observe/dashboards-and-alerts/	planned
+/ops/runbook-ingestion-failures/	/operate/runbooks/ingestion-failure/	planned
+/ops/runbook-report-failures/	/operate/runbooks/worker-or-queue-failure/	planned
+/security/credential-encryption-rotation/	/operate/security/hardening/	planned

--- a/docs-prototype/admin/data-sources/credential-lifecycle.md
+++ b/docs-prototype/admin/data-sources/credential-lifecycle.md
@@ -1,0 +1,19 @@
+---
+page_id: admin-credentials
+summary: Rotate or revoke a provider credential without losing the evidence needed to verify recovery.
+content_type: task-guide
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Rotate or revoke provider credentials
+
+1. Identify the workspace, provider, connection, owner, and dependent synchronization jobs.
+2. Create the replacement credential with the minimum required access.
+3. Update the supported secret or connection field without exposing the value in logs or screenshots.
+4. Verify authentication and one bounded synchronization.
+5. Revoke the old credential only after recovery is confirmed.
+6. Record the rotation time, verifier, and any coverage gap.
+
+For a suspected compromise, follow the security incident process rather than a routine rotation sequence.

--- a/docs-prototype/admin/data-sources/github.md
+++ b/docs-prototype/admin/data-sources/github.md
@@ -1,0 +1,25 @@
+---
+page_id: admin-github
+summary: Connect GitHub with the supported app or credential path and verify repository coverage.
+content_type: task-guide
+owner: platform-product
+source_of_truth:
+  - docs/user-guide/github-app-auth.md
+  - docs/user-guide/github-app-setup.md
+  - current GitHub App implementation
+applicability: current
+lifecycle: active
+---
+
+# Connect GitHub
+
+Prefer the supported GitHub App flow when the deployment exposes it.
+
+1. Open the workspace **Connections** or GitHub integration surface.
+2. Start the installation or authorization flow from the product.
+3. Install the app for the intended organization and select the minimum repositories required.
+4. Return through the configured callback and confirm the installation is associated with the correct workspace.
+5. Start or wait for synchronization.
+6. Verify repository coverage and freshness before using product results.
+
+Keep app IDs, client secrets, private keys, and installation credentials in the approved secret store. Do not paste them into the UI unless the supported flow explicitly requires that field.

--- a/docs-prototype/admin/data-sources/gitlab.md
+++ b/docs-prototype/admin/data-sources/gitlab.md
@@ -1,0 +1,22 @@
+---
+page_id: admin-gitlab
+summary: Connect GitLab with the minimum scopes and verify accessible groups and projects.
+content_type: task-guide
+owner: platform-product
+source_of_truth:
+  - docs/connectors/gitlab-permissions.md
+  - current GitLab provider implementation
+applicability: current
+lifecycle: active
+---
+
+# Connect GitLab
+
+1. Confirm the GitLab host and whether the deployment supports GitLab.com or the intended self-managed instance.
+2. Create or select a credential with only the scopes required by the current connector.
+3. Add the connection through the workspace administration surface.
+4. Verify the intended groups and projects are visible to the credential.
+5. Start or wait for synchronization and check coverage.
+6. Remove unused broad scopes after verification.
+
+A successful authentication response does not prove that every required project is visible. Check namespace membership and token scope separately.

--- a/docs-prototype/admin/data-sources/index.md
+++ b/docs-prototype/admin/data-sources/index.md
@@ -1,0 +1,16 @@
+---
+page_id: admin-sources
+summary: Connect supported providers and manage their credential lifecycle from the workspace boundary.
+content_type: landing
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Connect data sources
+
+- [Connect GitHub](github.md)
+- [Connect GitLab](gitlab.md)
+- [Rotate or revoke provider credentials](credential-lifecycle.md)
+
+A connection is not complete until the intended organizations, repositories, projects, or groups are visible and synchronization advances.

--- a/docs-prototype/admin/index.md
+++ b/docs-prototype/admin/index.md
@@ -1,12 +1,21 @@
+---
+page_id: admin
+summary: Configure workspace access, teams, sources, synchronization, coverage, and administrative security.
+content_type: landing
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
 # Administer Dev Health
 
-Configure the workspace, teams, identities, access, providers, synchronization, coverage, and administrative security.
+Use this section for workspace-level configuration. Deployment, worker, database, and recovery procedures belong under **Install and operate**.
 
-## Common tasks
+- [Configure the workspace](workspace/index.md)
+- [Manage teams, repositories, and access](teams-and-identities/index.md)
+- [Connect data sources](data-sources/index.md)
+- [Manage synchronization and coverage](sync-and-coverage/index.md)
+- [Review administrative security and privacy](security-and-audit/index.md)
+- [Troubleshoot administration](troubleshooting/index.md)
 
-- Configure workspace settings.
-- Manage teams, repository scope, users, memberships, and roles.
-- Connect a supported data source with least-privilege credentials.
-- Check synchronization and coverage.
-- Rotate or revoke provider credentials.
-- Diagnose authentication, connection, identity, or coverage problems.
+Never paste provider tokens, private keys, session cookies, or customer-sensitive payloads into documentation evidence or issue comments.

--- a/docs-prototype/admin/security-and-audit/credentials.md
+++ b/docs-prototype/admin/security-and-audit/credentials.md
@@ -1,0 +1,23 @@
+---
+page_id: admin-credential-resp
+summary: Separate workspace credential responsibilities from operator secret storage and encryption.
+content_type: concept
+owner: platform-product
+source_of_truth:
+  - docs/llm/byo-llm-credentials.md
+  - current provider and model credential flows
+applicability: current
+lifecycle: active
+---
+
+# Credential responsibilities
+
+Workspace administrators choose supported connections and initiate approved authorization flows. Operators provide secure storage, injection, encryption, backup exclusion, and rotation mechanisms.
+
+- Use least privilege and named ownership.
+- Prefer installation or delegated authorization flows over shared long-lived tokens.
+- Keep secret values out of screenshots, logs, report output, and issue comments.
+- Record expiry and rotation triggers.
+- Revoke abandoned credentials promptly.
+
+A credential being accepted does not prove that it has the right namespace, repository, model, or record-family access.

--- a/docs-prototype/admin/security-and-audit/index.md
+++ b/docs-prototype/admin/security-and-audit/index.md
@@ -1,0 +1,15 @@
+---
+page_id: admin-security
+summary: Manage administrative credential responsibilities, privacy choices, and review evidence.
+content_type: landing
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Administration security and audit
+
+- [Credential responsibilities](credentials.md)
+- [Privacy and product telemetry](privacy.md)
+
+Use the product audit surfaces available to the workspace. Infrastructure logging, encryption, hardening, and incident response belong under **Install and operate**.

--- a/docs-prototype/admin/security-and-audit/privacy.md
+++ b/docs-prototype/admin/security-and-audit/privacy.md
@@ -1,0 +1,25 @@
+---
+page_id: admin-privacy
+summary: Review product telemetry and data-handling choices at the workspace boundary.
+content_type: concept
+owner: platform-product
+source_of_truth:
+  - docs/user-guide/product-telemetry.md
+  - current telemetry and privacy controls
+applicability: current
+lifecycle: active
+---
+
+# Privacy and data-handling responsibilities
+
+Before enabling telemetry, model-assisted features, or a new data source, identify:
+
+- data categories collected or transmitted;
+- workspace and provider boundaries;
+- retention and deletion behavior;
+- access roles and intended audience;
+- external processors or model providers;
+- whether prompt, source, or customer-sensitive content is included;
+- the supported control for disabling or changing the behavior.
+
+Document the current product behavior, not an aspirational policy. Escalate deployment-level encryption, logging, backup, and incident questions to platform operations and security.

--- a/docs-prototype/admin/sync-and-coverage/coverage.md
+++ b/docs-prototype/admin/sync-and-coverage/coverage.md
@@ -1,0 +1,24 @@
+---
+page_id: admin-coverage
+summary: Explain which sources, repositories, teams, periods, and record families are represented in product results.
+content_type: concept
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Understand coverage
+
+Coverage is the supported input represented in a result. It can differ by provider, repository, team, record family, feature, and period.
+
+Check:
+
+- connected source and accessible namespace;
+- included repository or project scope;
+- historical window and backfill state;
+- identity and team attribution;
+- record-family support;
+- latest successful synchronization and processing time;
+- feature-specific prerequisites.
+
+High source volume does not guarantee complete coverage. A missing source, inaccessible repository, unsupported record family, or unfinished backfill can all produce a partial result.

--- a/docs-prototype/admin/teams-and-identities/index.md
+++ b/docs-prototype/admin/teams-and-identities/index.md
@@ -1,0 +1,15 @@
+---
+page_id: admin-identities
+summary: Manage team and repository scope, membership, identity mapping, and roles.
+content_type: landing
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Manage teams, repositories, and identities
+
+- [Configure teams and repository scope](teams-and-repositories.md)
+- [Manage roles and access](roles-and-access.md)
+
+Keep product membership, provider identity, team attribution, and repository scope as separate concepts. A person can have several provider identities, and a repository can contribute to more than one operational question.

--- a/docs-prototype/admin/teams-and-identities/roles-and-access.md
+++ b/docs-prototype/admin/teams-and-identities/roles-and-access.md
@@ -1,0 +1,22 @@
+---
+page_id: admin-roles
+summary: Grant the minimum product access required and verify SSO or role changes safely.
+content_type: task-guide
+owner: platform-product
+source_of_truth:
+  - docs/sso-setup.md
+  - current authentication and authorization implementation
+applicability: current
+lifecycle: active
+---
+
+# Manage roles and access
+
+1. Confirm the intended workspace and supported role model.
+2. Grant the least privilege required for the documented task.
+3. When SSO is enabled, verify issuer, audience, callback, and group or role mapping against the current deployment configuration.
+4. Test sign-in and one representative authorized action with a non-owner account.
+5. Test that an unauthorized account remains blocked.
+6. Retain sanitized audit evidence and a rollback path.
+
+Do not troubleshoot access by sharing session tokens or elevating every user to an owner role.

--- a/docs-prototype/admin/teams-and-identities/teams-and-repositories.md
+++ b/docs-prototype/admin/teams-and-identities/teams-and-repositories.md
@@ -1,0 +1,22 @@
+---
+page_id: admin-teams-repos
+summary: Configure the team and repository scope used by product filters and attribution.
+content_type: task-guide
+owner: platform-product
+source_of_truth:
+  - docs/team-configuration.md
+  - current team and repository administration UI
+applicability: current
+lifecycle: active
+---
+
+# Configure teams and repository scope
+
+1. Identify the workspace and team outcome the scope must support.
+2. Add or select repositories from a connected source.
+3. Confirm the provider identifiers and repository visibility.
+4. Review team membership or attribution rules separately from repository inclusion.
+5. Save and verify the team or repository appears in the expected product scope.
+6. Check coverage before interpreting historical gaps.
+
+Changing scope can change every downstream metric and view. Record the effective time and avoid comparing periods across a major scope change without disclosure.

--- a/docs-prototype/admin/troubleshooting/authentication-and-roles.md
+++ b/docs-prototype/admin/troubleshooting/authentication-and-roles.md
@@ -1,0 +1,19 @@
+---
+page_id: admin-auth
+summary: Diagnose sign-in, SSO, membership, role, and authorization failures.
+content_type: troubleshooting
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Authentication and role problems
+
+1. Confirm the user is signing into the intended workspace and identity provider.
+2. Check workspace membership and the current role.
+3. For SSO, verify issuer, audience, callback, and group or role mapping.
+4. Reproduce with a second account that has the expected role.
+5. Distinguish authentication failure from authorization failure.
+6. Retain the route, time, correlation or request identifier, and sanitized message.
+
+Do not solve an authorization defect by granting owner access permanently.

--- a/docs-prototype/admin/troubleshooting/index.md
+++ b/docs-prototype/admin/troubleshooting/index.md
@@ -1,0 +1,16 @@
+---
+page_id: admin-troubleshooting
+summary: Diagnose workspace access, provider connections, identity mapping, synchronization, and coverage.
+content_type: troubleshooting-index
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Troubleshoot administration
+
+- [Authentication and role problems](authentication-and-roles.md)
+- [Provider connection failures](provider-connections.md)
+- [Synchronization and coverage problems](sync-and-coverage.md)
+
+Preserve workspace, provider, user or installation identifiers, route, time, and sanitized messages. Never attach credentials.

--- a/docs-prototype/admin/troubleshooting/provider-connections.md
+++ b/docs-prototype/admin/troubleshooting/provider-connections.md
@@ -1,0 +1,17 @@
+---
+page_id: admin-provider-fail
+summary: Diagnose provider authentication, namespace visibility, callback, and repository-coverage failures.
+content_type: troubleshooting
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Provider connection failures
+
+1. Confirm the provider host and connection type.
+2. Check credential expiry, revocation, installation state, and required scope without exposing the value.
+3. Verify callback and redirect configuration for delegated flows.
+4. Verify the intended organization, group, project, or repository is visible to the connection.
+5. Retry one bounded authorization or synchronization action.
+6. Escalate repeated rate-limit, worker, queue, or storage failures to operations.

--- a/docs-prototype/admin/troubleshooting/sync-and-coverage.md
+++ b/docs-prototype/admin/troubleshooting/sync-and-coverage.md
@@ -1,0 +1,19 @@
+---
+page_id: admin-sync-fail
+summary: Diagnose a valid connection that is not advancing or does not cover the expected source data.
+content_type: troubleshooting
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Synchronization and coverage problems
+
+1. Preserve the workspace, provider, source scope, selected product context, and timestamps.
+2. Check the last successful synchronization and active backfills.
+3. Confirm repository, project, or team inclusion.
+4. Check record-family support and provider permissions.
+5. Distinguish delayed processing from a terminal failure.
+6. Escalate platform-level failures to [Recover from ingestion failure](../../operate/runbooks/ingestion-failure.md).
+
+Do not represent a coverage gap as a measured zero.

--- a/docs-prototype/admin/workspace/index.md
+++ b/docs-prototype/admin/workspace/index.md
@@ -1,0 +1,16 @@
+---
+page_id: admin-workspace
+summary: Configure workspace settings and feature availability without mixing in deployment configuration.
+content_type: landing
+owner: platform-product
+applicability: current
+lifecycle: active
+---
+
+# Configure the workspace
+
+- [Configure workspace settings](settings.md)
+- Review feature availability and entitlement in the current Admin and Settings surfaces.
+- Configure product-level model or external-service choices only when the workspace UI supports them.
+
+Environment variables, secrets, databases, and worker settings remain operator responsibilities.

--- a/docs-prototype/admin/workspace/settings.md
+++ b/docs-prototype/admin/workspace/settings.md
@@ -1,0 +1,20 @@
+---
+page_id: admin-workspace-settings
+summary: Change supported workspace settings and verify their effect without exposing deployment secrets.
+content_type: task-guide
+owner: platform-product
+source_of_truth:
+  - current /settings and /org/admin product surfaces
+applicability: current
+lifecycle: active
+---
+
+# Configure workspace settings
+
+1. Open **Admin** or **Settings** in the intended workspace.
+2. Review the current value and its workspace-wide effect.
+3. Change one supported setting at a time.
+4. Save and verify the affected product workflow with a non-sensitive example.
+5. Record the old and new value, reviewer, and rollback condition for high-impact changes.
+
+Do not store provider secrets, private keys, or infrastructure credentials in general workspace fields. A setting that requires an environment variable or secret manager belongs under [Configure the platform](../../operate/configure/index.md).

--- a/docs-prototype/operate/configure/databases-and-storage.md
+++ b/docs-prototype/operate/configure/databases-and-storage.md
@@ -1,0 +1,23 @@
+---
+page_id: op-db
+summary: Configure supported data stores, connection pools, migrations, retention, and recovery boundaries.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - docs/ops/database-connection-pooling.md
+  - current migration and storage implementation
+applicability: current
+lifecycle: active
+---
+
+# Databases and storage
+
+1. Use the supported data-store engines and connection URIs for the reviewed revision.
+2. Configure least-privilege application and migration identities.
+3. Size connection pools against service concurrency and store limits.
+4. Apply migrations through one controlled release path.
+5. Monitor storage growth, compaction, query latency, and failed writes.
+6. Back up data and migration state before high-risk changes.
+7. Test restore in an isolated environment.
+
+Do not repair schema or delete data from a generic documentation command. Use the current migration or incident procedure and retain evidence.

--- a/docs-prototype/operate/configure/environment-and-secrets.md
+++ b/docs-prototype/operate/configure/environment-and-secrets.md
@@ -1,0 +1,19 @@
+---
+page_id: op-env
+summary: Supply runtime configuration and secrets with explicit ownership, rotation, and restart behavior.
+content_type: task-guide
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Environment and secrets
+
+1. Generate the current configuration reference from runtime settings or source.
+2. Separate ordinary configuration from secret values.
+3. Store secrets in the approved secret manager and inject them at runtime.
+4. Record required, optional, default, reload, and restart behavior.
+5. Restrict read access and redact values from logs and diagnostics.
+6. Test rotation for provider, database, queue, signing, and model credentials.
+
+Never commit production secrets to the repository, images, Compose files, manifests, screenshots, or documentation examples.

--- a/docs-prototype/operate/configure/external-services.md
+++ b/docs-prototype/operate/configure/external-services.md
@@ -1,0 +1,25 @@
+---
+page_id: op-external
+summary: Configure email, model, provider, and other external services with explicit failure and spend limits.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - docs/email-setup.md
+  - current model and provider runtime configuration
+applicability: current
+lifecycle: active
+---
+
+# Model and external-service configuration
+
+For each external service, document:
+
+- endpoint and supported region or host;
+- credential owner and secret location;
+- timeout, retry, rate, circuit-breaker, and spend limits;
+- data categories transmitted;
+- health, error, and usage signals;
+- safe degradation behavior;
+- rotation and disable procedure.
+
+Verify with a bounded non-sensitive request before enabling broad workload. Do not present a configured model or email provider as healthy until the application path succeeds.

--- a/docs-prototype/operate/configure/index.md
+++ b/docs-prototype/operate/configure/index.md
@@ -1,0 +1,18 @@
+---
+page_id: op-configure
+summary: Configure runtime settings, secrets, stores, networking, workers, schedules, and external services.
+content_type: landing
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Configure the platform
+
+- [Environment and secrets](environment-and-secrets.md)
+- [Databases and storage](databases-and-storage.md)
+- [Network and TLS](network-and-tls.md)
+- [Workers and schedules](workers-and-schedules.md)
+- [External services](external-services.md)
+
+Prefer configuration generated or checked from the current runtime settings rather than copying a static variable table into several guides.

--- a/docs-prototype/operate/configure/network-and-tls.md
+++ b/docs-prototype/operate/configure/network-and-tls.md
@@ -1,0 +1,19 @@
+---
+page_id: op-network
+summary: Configure ingress, DNS, TLS, proxies, callbacks, and trusted client-address handling.
+content_type: task-guide
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Network, TLS, proxy, and domains
+
+1. Define internal service boundaries and the external ingress path.
+2. Terminate TLS at the approved boundary and encrypt required internal links.
+3. Configure DNS and provider callback URLs exactly.
+4. Configure trusted proxies narrowly; ignore forwarded client headers from untrusted peers.
+5. Restrict administrative, data-store, queue, and metrics endpoints.
+6. Verify health, application routes, callbacks, and real client-address handling.
+
+A broad trusted-proxy setting can allow header spoofing; an empty setting behind a load balancer can collapse rate-limit identity onto the proxy.

--- a/docs-prototype/operate/configure/workers-and-schedules.md
+++ b/docs-prototype/operate/configure/workers-and-schedules.md
@@ -1,0 +1,22 @@
+---
+page_id: op-workers-config
+summary: Configure worker queues, concurrency, leases, retries, schedules, and provider budgets as one system.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - docs/ops/workers.md
+  - current worker and synchronization settings
+applicability: current
+lifecycle: active
+---
+
+# Workers, schedules, and queues
+
+1. Identify every worker class and queue consumed by the deployment.
+2. Match routing settings to workers that actually consume the named queues.
+3. Configure concurrency from provider, queue, and store capacity.
+4. Configure leases, stale detection, retry limits, and backoff deliberately.
+5. Configure schedules so recurring work cannot overlap beyond safe capacity.
+6. Verify one bounded job, retry, and failure path.
+
+Do not enable a queue-routing option before the corresponding workers are deployed.

--- a/docs-prototype/operate/index.md
+++ b/docs-prototype/operate/index.md
@@ -1,12 +1,23 @@
+---
+page_id: operate
+summary: Plan, install, configure, run, observe, maintain, secure, and recover Dev Health.
+content_type: landing
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
 # Install and operate
 
-Deploy, configure, upgrade, observe, maintain, and recover Dev Health.
+Use this section for deployment and runtime responsibilities. Workspace settings and provider authorization that do not require infrastructure access belong under **Administer Dev Health**.
 
-## Common tasks
+- [Plan a deployment](plan/index.md)
+- [Install Dev Health](install/index.md)
+- [Configure the platform](configure/index.md)
+- [Upgrade, back up, and maintain](maintain/index.md)
+- [Run the platform](run/index.md)
+- [Observe the platform](observe/index.md)
+- [Harden production](security/index.md)
+- [Use a runbook](runbooks/index.md)
 
-- Plan a supported deployment.
-- Install a production environment and verify health.
-- Configure secrets, databases, networking, workers, and external services.
-- Upgrade with backups and a rollback decision.
-- Observe health, logs, metrics, traces, dashboards, and alerts.
-- Use a runbook for ingestion, worker, database, authentication, performance, backup, or disaster-recovery failure.
+High-risk procedures require current source verification, change review, a backup or recovery point, and a rollback decision before execution.

--- a/docs-prototype/operate/install/index.md
+++ b/docs-prototype/operate/install/index.md
@@ -1,0 +1,16 @@
+---
+page_id: op-install
+summary: Evaluate locally or install a reviewed production artifact, then verify first health.
+content_type: landing
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Install Dev Health
+
+- [Evaluate locally](local-evaluation.md)
+- [Install a production environment](production.md)
+- [Verify first health](verify-health.md)
+
+Use an immutable reviewed revision for production and retain the previous deployable artifact for rollback.

--- a/docs-prototype/operate/install/local-evaluation.md
+++ b/docs-prototype/operate/install/local-evaluation.md
@@ -1,0 +1,22 @@
+---
+page_id: op-local
+summary: Evaluate the platform locally with repository Compose artifacts and non-production data.
+content_type: tutorial
+owner: platform-operations
+source_of_truth:
+  - compose.yml
+  - deploy/docker-compose/
+applicability: current
+lifecycle: active
+---
+
+# Evaluate locally
+
+1. Check out a reviewed repository revision.
+2. Use the repository Compose artifact and example configuration as a starting point.
+3. Supply non-production credentials and isolated data stores.
+4. Start the API, workers, queue, and required stores.
+5. Verify `/health`, logs, worker readiness, and one bounded source synchronization.
+6. Remove local credentials and data when evaluation ends.
+
+A local evaluation is not a production hardening, backup, availability, or scale test.

--- a/docs-prototype/operate/install/production.md
+++ b/docs-prototype/operate/install/production.md
@@ -1,0 +1,26 @@
+---
+page_id: op-production
+summary: Deploy an immutable reviewed revision using a supported repository deployment artifact.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - docs/ops/deployment-guide.md
+  - deploy/kubernetes/
+  - deploy/docker-compose/
+  - deploy/docker-swarm/
+applicability: current
+lifecycle: active
+---
+
+# Install a production environment
+
+1. Select the supported deployment artifact for the environment.
+2. Pin the reviewed application image or revision.
+3. Configure external secrets rather than embedding credentials in manifests.
+4. Configure data stores, queues, ingress, TLS, trusted proxies, workers, and schedules.
+5. Apply migrations through the supported release procedure.
+6. Deploy API and worker services.
+7. Verify health before enabling provider synchronization or user traffic.
+8. Retain the prior artifact and rollback procedure.
+
+Examples in legacy deployment material are source evidence; review their versions, defaults, and security assumptions before use.

--- a/docs-prototype/operate/install/verify-health.md
+++ b/docs-prototype/operate/install/verify-health.md
@@ -1,0 +1,20 @@
+---
+page_id: op-health
+summary: Verify API, worker, queue, storage, migration, and first-ingestion health after installation.
+content_type: task-guide
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Verify first health
+
+1. Confirm the API health endpoint responds through the intended internal and external path.
+2. Confirm required migrations completed exactly once.
+3. Confirm workers are connected to the expected queues and schedules.
+4. Confirm Redis or the supported queue/rate-limit store and primary data stores are healthy.
+5. Confirm logs contain no repeated authentication, migration, or connection failures.
+6. Run one bounded provider synchronization with a known repository or project.
+7. Verify records advance into a product freshness or coverage surface.
+
+Do not enable broad backfills until this bounded path succeeds.

--- a/docs-prototype/operate/maintain/backup-and-restore.md
+++ b/docs-prototype/operate/maintain/backup-and-restore.md
@@ -1,0 +1,22 @@
+---
+page_id: op-backup
+summary: Back up and restore data, configuration references, and required cryptographic material without copying live secrets into documentation.
+content_type: task-guide
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Back up and restore
+
+Define the recovery point and time objectives, then cover:
+
+- primary and analytical data stores;
+- migration and schema state;
+- configuration and deployment manifests;
+- encrypted secret-manager records and key dependencies;
+- queue or job state when required for safe recovery;
+- external provider installation identifiers;
+- retention, encryption, access, and deletion.
+
+Test restore in isolation. Verify schema, API health, worker progress, source coverage, and a representative product query before declaring recovery complete.

--- a/docs-prototype/operate/maintain/decommission.md
+++ b/docs-prototype/operate/maintain/decommission.md
@@ -1,0 +1,22 @@
+---
+page_id: op-decommission
+summary: Remove or replace an environment while preserving required evidence and revoking access.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - docs/ops/customer-offboarding.md
+applicability: current
+lifecycle: active
+---
+
+# Decommission or replace an environment
+
+1. Confirm the approved retention, export, deletion, and communication requirements.
+2. Stop new synchronization and scheduled work.
+3. Capture required final backups and audit evidence.
+4. Revoke provider installations, tokens, model credentials, signing keys, and service accounts.
+5. Remove DNS, callbacks, access policies, and deployment resources in the approved order.
+6. Verify data and backups are retained or deleted as required.
+7. Record completion, residual dependencies, and owner.
+
+Do not remove the only recovery copy before the retention decision is verified.

--- a/docs-prototype/operate/maintain/index.md
+++ b/docs-prototype/operate/maintain/index.md
@@ -1,0 +1,16 @@
+---
+page_id: op-maintain
+summary: Upgrade, back up, restore, and decommission the platform with explicit rollback and evidence.
+content_type: landing
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Upgrade, back up, and maintain
+
+- [Upgrade Dev Health](upgrade.md)
+- [Back up and restore](backup-and-restore.md)
+- [Decommission or replace an environment](decommission.md)
+
+Maintenance is complete only after product freshness, worker progress, storage health, and rollback readiness are verified.

--- a/docs-prototype/operate/maintain/upgrade.md
+++ b/docs-prototype/operate/maintain/upgrade.md
@@ -1,0 +1,21 @@
+---
+page_id: op-upgrade
+summary: Upgrade an immutable reviewed revision with backups, migration control, health checks, and rollback criteria.
+content_type: task-guide
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Upgrade Dev Health
+
+1. Review release, configuration, schema, queue, and compatibility changes.
+2. Back up required stores and capture current configuration references.
+3. Define health, data-progress, and rollback criteria.
+4. Pause or bound high-volume backfills if the release requires it.
+5. Apply migrations through the supported release path.
+6. Deploy the immutable revision.
+7. Verify API, workers, queues, stores, product freshness, and one source path.
+8. Roll back only according to schema compatibility and retained evidence.
+
+Do not assume application rollback also reverses an irreversible data migration.

--- a/docs-prototype/operate/observe/dashboards-and-alerts.md
+++ b/docs-prototype/operate/observe/dashboards-and-alerts.md
@@ -1,0 +1,27 @@
+---
+page_id: op-alerts
+summary: Build actionable dashboards and alerts from service objectives and recovery ownership.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - docs/alerting.md
+  - docs/slos.md
+applicability: current
+lifecycle: active
+---
+
+# Dashboards and alerts
+
+A dashboard should connect user impact with service, queue, provider, store, and data-progress signals.
+
+An alert should include:
+
+- affected service and environment;
+- impact or violated objective;
+- current value and threshold window;
+- organization or provider scope when safe;
+- runbook and owner;
+- suppression or grouping behavior;
+- evidence required to close.
+
+Alert on sustained impact or recovery risk, not every transient retry. Test routing and runbook links regularly.

--- a/docs-prototype/operate/observe/health-checks.md
+++ b/docs-prototype/operate/observe/health-checks.md
@@ -1,0 +1,24 @@
+---
+page_id: op-healthchecks
+summary: Use liveness, readiness, dependency, worker, and data-progress checks for distinct decisions.
+content_type: reference
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Health checks
+
+The deployment material exposes `/health` for API health. Do not use one endpoint as proof that the whole platform is ready.
+
+Check separately:
+
+- API liveness and readiness;
+- data-store and queue connectivity;
+- migration compatibility;
+- worker and scheduler readiness;
+- provider authentication;
+- oldest queue age and job progress;
+- latest successful synchronization and product freshness.
+
+Route health endpoints so they are available to the orchestrator and operators without exposing unnecessary internal detail publicly.

--- a/docs-prototype/operate/observe/index.md
+++ b/docs-prototype/operate/observe/index.md
@@ -1,0 +1,17 @@
+---
+page_id: op-observe
+summary: Observe API, worker, queue, provider, storage, synchronization, and model behavior.
+content_type: landing
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Observe the platform
+
+- [Health checks](health-checks.md)
+- [Logs](logs.md)
+- [Metrics and traces](metrics-and-traces.md)
+- [Dashboards and alerts](dashboards-and-alerts.md)
+
+A useful signal identifies the affected organization or workspace, provider, queue or service, operation, status, and time without exposing customer payloads or credentials.

--- a/docs-prototype/operate/observe/logs.md
+++ b/docs-prototype/operate/observe/logs.md
@@ -1,0 +1,21 @@
+---
+page_id: op-logs
+summary: Collect structured, correlated, redacted logs with enough context to diagnose a request or job.
+content_type: reference
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Logs
+
+Logs should identify service, environment, organization or workspace identifier, provider, operation, request or job identifier, status, duration, retry, and sanitized error.
+
+Do not log:
+
+- tokens, passwords, private keys, session cookies, authorization headers, or signed URLs;
+- unredacted customer payloads or prompt content;
+- full database connection strings;
+- unnecessary personal data.
+
+Use correlation identifiers to connect API, worker, queue, provider, and storage events.

--- a/docs-prototype/operate/observe/metrics-and-traces.md
+++ b/docs-prototype/operate/observe/metrics-and-traces.md
@@ -1,0 +1,27 @@
+---
+page_id: op-metrics
+summary: Monitor throughput, latency, errors, saturation, queue age, provider budgets, storage, synchronization, and model usage.
+content_type: reference
+owner: platform-operations
+source_of_truth:
+  - docs/architecture/platform-sync-observability.md
+  - docs/architecture/sync-usage-actuals.md
+  - docs/llm/investment-llm-telemetry.md
+  - docs/llm/spend-observability.md
+applicability: current
+lifecycle: active
+---
+
+# Metrics and traces
+
+Monitor at minimum:
+
+- API request rate, latency, errors, and query timeouts;
+- worker throughput, duration, retry, terminal failure, and saturation;
+- queue depth and oldest age;
+- provider request, cost, deferral, rate-limit, and authentication signals;
+- data-store connection, write, query, compaction, and storage health;
+- synchronization planned, dispatched, running, stale, completed, and failed units;
+- model latency, error, circuit-breaker, token or usage, and spend where applicable.
+
+Use tenant-safe labels. Avoid high-cardinality payload values and secrets.

--- a/docs-prototype/operate/plan/capacity-and-sizing.md
+++ b/docs-prototype/operate/plan/capacity-and-sizing.md
@@ -1,0 +1,25 @@
+---
+page_id: op-sizing
+summary: Size API, worker, queue, and data-store capacity from measured workload and retry behavior.
+content_type: reference
+owner: platform-operations
+source_of_truth:
+  - docs/architecture/worker-scaling-readiness.md
+  - current worker and synchronization implementation
+applicability: current
+lifecycle: active
+---
+
+# Capacity and sizing
+
+Base initial capacity on:
+
+- connected organizations and repositories;
+- historical backfill size and incremental cadence;
+- provider request and cost budgets;
+- worker concurrency, queue depth, job duration, retry, and lease behavior;
+- API request rate and query cost;
+- data-store ingest, retention, compaction, and query load;
+- model or external-service rate and spend limits.
+
+Scale from observed queue age, saturation, latency, error rate, and data-store health. Increasing concurrency without provider, queue, or storage capacity can make recovery slower.

--- a/docs-prototype/operate/plan/index.md
+++ b/docs-prototype/operate/plan/index.md
@@ -1,0 +1,15 @@
+---
+page_id: op-plan
+summary: Choose supported deployment artifacts and document capacity, dependency, security, and recovery assumptions.
+content_type: landing
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Plan a deployment
+
+- [Installation prerequisites](prerequisites.md)
+- [Capacity and sizing](capacity-and-sizing.md)
+
+Current repository artifacts cover local Compose and deployment directories for Docker Compose, Docker Swarm, and Kubernetes. Verify the exact supported artifact and revision before committing to a production model.

--- a/docs-prototype/operate/plan/prerequisites.md
+++ b/docs-prototype/operate/plan/prerequisites.md
@@ -1,0 +1,24 @@
+---
+page_id: op-prereq
+summary: Confirm compute, container, data-store, queue, network, provider, and recovery prerequisites.
+content_type: task-guide
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Installation prerequisites
+
+Before installation, document and verify:
+
+- the supported deployment artifact and image source;
+- container runtime or orchestration access;
+- primary data store and migration permissions;
+- Redis or the supported queue/rate-limit store for non-development environments;
+- outbound access to required provider APIs and external services;
+- ingress, DNS, TLS, proxy, and trusted-proxy design;
+- secret-manager and credential ownership;
+- backup, restore, rollback, and log-retention locations;
+- expected organizations, repositories, volume, and synchronization cadence.
+
+Do not copy example credentials or sample hostnames into production unchanged.

--- a/docs-prototype/operate/run/index.md
+++ b/docs-prototype/operate/run/index.md
@@ -1,0 +1,16 @@
+---
+page_id: op-run
+summary: Run workers, jobs, ingestion, backfills, and operational controls safely.
+content_type: landing
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Run the platform
+
+- [Workers and jobs](workers-and-jobs.md)
+- [Ingestion and backfill operations](ingestion-and-backfills.md)
+- [Safe operational controls](operational-controls.md)
+
+Prefer bounded, observable controls over direct database or queue mutation.

--- a/docs-prototype/operate/run/ingestion-and-backfills.md
+++ b/docs-prototype/operate/run/ingestion-and-backfills.md
@@ -1,0 +1,20 @@
+---
+page_id: op-ingestion
+summary: Run bounded ingestion and backfills while protecting provider budgets, idempotency, and product freshness.
+content_type: task-guide
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Ingestion and backfill operations
+
+1. Define provider, organization, repositories or projects, record families, and time range.
+2. Estimate units, provider budget, queue capacity, and completion window.
+3. Start a bounded slice first.
+4. Monitor dispatch, running, retrying, failed, and completed units.
+5. Verify idempotent writes and watermarks.
+6. Expand only after the bounded slice advances product coverage correctly.
+7. Record any residual gap or replay requirement.
+
+Avoid repeatedly starting overlapping backfills for the same scope and period.

--- a/docs-prototype/operate/run/operational-controls.md
+++ b/docs-prototype/operate/run/operational-controls.md
@@ -1,0 +1,23 @@
+---
+page_id: op-controls
+summary: Use rate, queue, budget, feature, and retry controls without creating hidden data gaps.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - docs/architecture/launchdarkly-sync-budgeting.md
+  - current synchronization budget and queue controls
+applicability: current
+lifecycle: active
+---
+
+# Safe operational controls
+
+For each control, record the purpose, unit, default, safe range, owner, observability signal, and rollback.
+
+- Provider budget controls should defer work visibly rather than silently drop it.
+- Queue routing must match deployed consumers.
+- Concurrency changes must respect provider and store limits.
+- Retry changes must preserve idempotency and terminal-failure behavior.
+- Feature flags must have an owner, expiry or review trigger, and observable effect.
+
+Change one control at a time during recovery unless an approved incident plan says otherwise.

--- a/docs-prototype/operate/run/workers-and-jobs.md
+++ b/docs-prototype/operate/run/workers-and-jobs.md
@@ -1,0 +1,22 @@
+---
+page_id: op-workers
+summary: Monitor worker readiness, queue age, leases, retries, failures, and completion evidence.
+content_type: task-guide
+owner: platform-operations
+source_of_truth:
+  - docs/ops/workers.md
+  - docs/ops/investment-materialization.md
+applicability: current
+lifecycle: active
+---
+
+# Workers, jobs, retries, and schedules
+
+1. Confirm each configured queue has the intended consumers.
+2. Monitor queue depth and oldest age, not only worker process count.
+3. Monitor job duration, lease expiry, retry reason, terminal failure, and completion rate.
+4. Confirm scheduled jobs are not overlapping beyond safe capacity.
+5. Verify downstream writes and product freshness after completion.
+6. Use the supported retry or replay control only after identifying idempotency and provider-budget effects.
+
+A busy worker is not proof of progress; a quiet queue is not proof that scheduled work was created.

--- a/docs-prototype/operate/runbooks/backup-or-restore-failure.md
+++ b/docs-prototype/operate/runbooks/backup-or-restore-failure.md
@@ -1,0 +1,19 @@
+---
+page_id: op-rb-backup
+summary: Recover when a backup is incomplete, unreadable, unverified, or a restore does not produce a healthy platform.
+content_type: runbook
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Backup or restore failure
+
+1. Preserve the failed artifact, logs, manifest, encryption context, and recovery target.
+2. Determine whether the failure is capture, transfer, retention, key access, integrity, compatibility, or restore verification.
+3. Do not overwrite the last known good recovery copy.
+4. Retry into an isolated target using the approved procedure.
+5. Verify schema, data integrity, API, workers, source coverage, and representative queries.
+6. Record the remaining recovery-point gap.
+
+Escalate immediately when no verified recovery copy remains or encryption keys are unavailable.

--- a/docs-prototype/operate/runbooks/database-or-migration-failure.md
+++ b/docs-prototype/operate/runbooks/database-or-migration-failure.md
@@ -1,0 +1,19 @@
+---
+page_id: op-rb-db
+summary: Contain and recover database connectivity, storage, schema, or migration failure.
+content_type: runbook
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Database, storage, or migration failure
+
+1. Stop new high-volume work if continued writes can increase damage.
+2. Identify store, schema revision, migration, affected services, and last successful operation.
+3. Check connectivity, credentials, capacity, locks, replication, and storage health.
+4. Do not rerun or reverse a migration until its idempotency and compatibility are verified.
+5. Restore service or data from the approved recovery point when required.
+6. Verify schema, API, workers, writes, reads, and product freshness.
+
+Retain migration output and recovery evidence. Escalate suspected data loss or tenant-isolation impact immediately.

--- a/docs-prototype/operate/runbooks/disaster-recovery.md
+++ b/docs-prototype/operate/runbooks/disaster-recovery.md
@@ -1,0 +1,19 @@
+---
+page_id: op-rb-dr
+summary: Restore a replacement environment from approved recovery points and verify end-to-end service and data progress.
+content_type: runbook
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Disaster recovery
+
+1. Declare the incident, owner, recovery objectives, and communication path.
+2. Freeze destructive changes and preserve evidence.
+3. Select the recovery point and compatible application revision.
+4. Restore stores, configuration references, secret access, network, API, workers, and schedules in the approved order.
+5. Verify tenant isolation, schema, health, queue state, provider connectivity, data progress, and representative product results.
+6. Reconcile the outage interval and run required bounded backfills.
+7. Cut traffic only after the acceptance checklist passes.
+8. Retain the failed environment until investigation and data-retention decisions permit removal.

--- a/docs-prototype/operate/runbooks/index.md
+++ b/docs-prototype/operate/runbooks/index.md
@@ -1,6 +1,6 @@
 ---
 page_id: op-runbooks
-summary: Diagnose and recover supported operational failures without mixing runbook detail into user guides.
+summary: Diagnose and recover supported operational failures after user and administrator checks isolate the platform layer.
 content_type: troubleshooting-index
 owner: platform-operations
 applicability: current
@@ -9,8 +9,12 @@ lifecycle: active
 
 # Runbooks
 
-Use an operator runbook only after the user and administrator checks have isolated a platform-level failure.
+- [Ingestion failure](ingestion-failure.md)
+- [Worker or queue failure](worker-or-queue-failure.md)
+- [Database or migration failure](database-or-migration-failure.md)
+- [Provider authentication failure](provider-authentication-failure.md)
+- [Performance or rate-limit failure](performance-or-rate-limit.md)
+- [Backup or restore failure](backup-or-restore-failure.md)
+- [Disaster recovery](disaster-recovery.md)
 
-- [Recover from ingestion failure](ingestion-failure.md)
-
-Retain the affected organization or workspace identifier, source, scope, time window, job or request identifier, timestamps, and relevant sanitized logs.
+Retain the affected organization or workspace identifier, source, scope, time, job or request identifiers, sanitized logs, last known good checkpoint, and changes made during recovery.

--- a/docs-prototype/operate/runbooks/performance-or-rate-limit.md
+++ b/docs-prototype/operate/runbooks/performance-or-rate-limit.md
@@ -1,0 +1,19 @@
+---
+page_id: op-rb-perf
+summary: Recover saturation, provider throttling, or performance degradation without creating retry amplification.
+content_type: runbook
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Performance, rate limit, or saturation
+
+1. Identify the constrained service, queue, provider bucket, store, or external service.
+2. Check latency, error, saturation, queue age, deferrals, retry rate, and provider response headers.
+3. Reduce or defer optional workload before increasing concurrency.
+4. Confirm cache, query, batch, and connection behavior.
+5. Recover a bounded workload and watch the limiting signal.
+6. Restore normal budgets gradually.
+
+Do not bypass provider budgets or rate limits in a way that hides delayed coverage or creates an outage loop.

--- a/docs-prototype/operate/runbooks/provider-authentication-failure.md
+++ b/docs-prototype/operate/runbooks/provider-authentication-failure.md
@@ -1,0 +1,19 @@
+---
+page_id: op-rb-auth
+summary: Recover repeated provider authentication failures without exposing or repeatedly testing a compromised credential.
+content_type: runbook
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Provider authentication failure
+
+1. Identify provider, host, connection or installation, affected workspace, and failure time.
+2. Distinguish expiry, revocation, missing scope, callback mismatch, host mismatch, and provider outage.
+3. Stop repeated retries when they create lockout or rate-limit risk.
+4. Rotate or reauthorize through the supported path.
+5. Verify one bounded request and synchronization.
+6. Revoke the old credential and record any coverage gap.
+
+Treat unexpected use or exposure as a credential incident, not routine troubleshooting.

--- a/docs-prototype/operate/runbooks/worker-or-queue-failure.md
+++ b/docs-prototype/operate/runbooks/worker-or-queue-failure.md
@@ -1,0 +1,19 @@
+---
+page_id: op-rb-worker
+summary: Recover when workers are unavailable, queues stop advancing, or retries repeat without progress.
+content_type: runbook
+owner: platform-operations
+applicability: current
+lifecycle: active
+---
+
+# Worker or queue failure
+
+1. Identify queue, worker class, oldest age, affected operations, and last progress.
+2. Confirm consumers are deployed with matching routing configuration.
+3. Check store connectivity, leases, timeouts, retries, circuit breakers, and terminal failures.
+4. Stop unsafe retry amplification before adding concurrency.
+5. Recover one bounded job and verify downstream writes.
+6. Restore normal concurrency only after queue age declines.
+
+Escalate when job idempotency, tenant isolation, data corruption, or repeated worker loss is uncertain.

--- a/docs-prototype/operate/security/hardening.md
+++ b/docs-prototype/operate/security/hardening.md
@@ -1,0 +1,24 @@
+---
+page_id: op-hardening
+summary: Harden secrets, identities, network paths, stores, images, dependencies, logs, and backups.
+content_type: task-guide
+owner: security
+source_of_truth:
+  - docs/security/credential-encryption-rotation.md
+  - current deployment and credential implementation
+applicability: current
+lifecycle: active
+---
+
+# Production hardening
+
+- Use immutable reviewed images and supported dependency versions.
+- Store and encrypt secrets with least-privilege service identities.
+- Restrict data stores, queues, metrics, and administrative routes.
+- Enforce TLS and narrow trusted-proxy configuration.
+- Separate application, migration, backup, and operator permissions.
+- Redact logs and protect backups with tested access and retention.
+- Monitor credential use, authentication failures, and unexpected egress.
+- Patch and rotate on an owned schedule.
+
+Test recovery and rotation; a control that cannot be operated safely during an incident is incomplete.

--- a/docs-prototype/operate/security/index.md
+++ b/docs-prototype/operate/security/index.md
@@ -1,0 +1,15 @@
+---
+page_id: op-security
+summary: Apply production hardening, credential safety, network boundaries, and incident ownership.
+content_type: landing
+owner: security
+applicability: current
+lifecycle: active
+---
+
+# Security operations
+
+- [Production hardening](hardening.md)
+- Use the approved credential-incident and security-incident processes for suspected compromise.
+
+Administrative privacy choices do not replace infrastructure encryption, secret management, access control, patching, logging, backup protection, and incident response.

--- a/mkdocs.prototype.yml
+++ b/mkdocs.prototype.yml
@@ -88,14 +88,77 @@ nav:
           - Report problems: use/troubleshooting/reports.md
   - Administer Dev Health:
       - admin/index.md
+      - Configure the workspace:
+          - admin/workspace/index.md
+          - Workspace settings: admin/workspace/settings.md
+      - Manage teams and access:
+          - admin/teams-and-identities/index.md
+          - Teams and repositories: admin/teams-and-identities/teams-and-repositories.md
+          - Roles and access: admin/teams-and-identities/roles-and-access.md
+      - Connect data sources:
+          - admin/data-sources/index.md
+          - GitHub: admin/data-sources/github.md
+          - GitLab: admin/data-sources/gitlab.md
+          - Credential lifecycle: admin/data-sources/credential-lifecycle.md
       - Synchronization and coverage:
           - admin/sync-and-coverage/index.md
           - Check status and freshness: admin/sync-and-coverage/status-and-freshness.md
+          - Understand coverage: admin/sync-and-coverage/coverage.md
+      - Security and privacy:
+          - admin/security-and-audit/index.md
+          - Credential responsibilities: admin/security-and-audit/credentials.md
+          - Privacy and telemetry: admin/security-and-audit/privacy.md
+      - Troubleshoot administration:
+          - admin/troubleshooting/index.md
+          - Authentication and roles: admin/troubleshooting/authentication-and-roles.md
+          - Provider connections: admin/troubleshooting/provider-connections.md
+          - Synchronization and coverage: admin/troubleshooting/sync-and-coverage.md
   - Install and operate:
       - operate/index.md
+      - Plan a deployment:
+          - operate/plan/index.md
+          - Prerequisites: operate/plan/prerequisites.md
+          - Capacity and sizing: operate/plan/capacity-and-sizing.md
+      - Install Dev Health:
+          - operate/install/index.md
+          - Evaluate locally: operate/install/local-evaluation.md
+          - Install production: operate/install/production.md
+          - Verify first health: operate/install/verify-health.md
+      - Configure the platform:
+          - operate/configure/index.md
+          - Environment and secrets: operate/configure/environment-and-secrets.md
+          - Databases and storage: operate/configure/databases-and-storage.md
+          - Network and TLS: operate/configure/network-and-tls.md
+          - Workers and schedules: operate/configure/workers-and-schedules.md
+          - External services: operate/configure/external-services.md
+      - Upgrade, back up, and maintain:
+          - operate/maintain/index.md
+          - Upgrade: operate/maintain/upgrade.md
+          - Backup and restore: operate/maintain/backup-and-restore.md
+          - Decommission: operate/maintain/decommission.md
+      - Run the platform:
+          - operate/run/index.md
+          - Workers and jobs: operate/run/workers-and-jobs.md
+          - Ingestion and backfills: operate/run/ingestion-and-backfills.md
+          - Operational controls: operate/run/operational-controls.md
+      - Observe the platform:
+          - operate/observe/index.md
+          - Health checks: operate/observe/health-checks.md
+          - Logs: operate/observe/logs.md
+          - Metrics and traces: operate/observe/metrics-and-traces.md
+          - Dashboards and alerts: operate/observe/dashboards-and-alerts.md
+      - Security operations:
+          - operate/security/index.md
+          - Production hardening: operate/security/hardening.md
       - Runbooks:
           - operate/runbooks/index.md
-          - Recover from ingestion failure: operate/runbooks/ingestion-failure.md
+          - Ingestion failure: operate/runbooks/ingestion-failure.md
+          - Worker or queue failure: operate/runbooks/worker-or-queue-failure.md
+          - Database or migration failure: operate/runbooks/database-or-migration-failure.md
+          - Provider authentication failure: operate/runbooks/provider-authentication-failure.md
+          - Performance or rate limit: operate/runbooks/performance-or-rate-limit.md
+          - Backup or restore failure: operate/runbooks/backup-or-restore-failure.md
+          - Disaster recovery: operate/runbooks/disaster-recovery.md
   - Integrate and extend:
       - integrate/index.md
   - Reference:


### PR DESCRIPTION
## Objective

Implement the approved **Administer Dev Health** and **Install and operate** sections with a clear boundary between workspace administration and platform operations.

## Administration

- workspace settings and feature-availability boundaries;
- teams, repository scope, roles, SSO, and access;
- GitHub and GitLab connections plus credential lifecycle;
- synchronization, freshness, coverage, security, privacy, and administrative troubleshooting;
- least-privilege and secret-handling guidance.

## Operations

- deployment planning, prerequisites, capacity, local evaluation, and production installation;
- environment, secrets, stores, networking, workers, schedules, and external services;
- upgrade, backup, restore, and decommission procedures;
- worker, ingestion, backfill, operational-control, observability, and hardening guidance;
- bounded runbooks for ingestion, worker/queue, database/migration, provider authentication, performance/rate limits, backup/restore, and disaster recovery.

## Safety and source discipline

The pages consolidate reviewed repository deployment artifacts and current operational source material. They intentionally avoid unverified destructive one-line commands. Exact versions, configuration keys, and commands must be generated or checked from the reviewed release before production execution.

Workspace configuration remains under `/admin/`; environment variables, data stores, workers, secret management, deployment, and incident recovery remain under `/operate/`.

Linear: CHAOS-2999, CHAOS-3000, CHAOS-3001