### PR TITLE
[CHAOS-3022] Expose resolved PagerDuty services

### DIFF
--- a/src/dev_health_ops/api/admin/router.py
+++ b/src/dev_health_ops/api/admin/router.py
@@ -17,6 +17,7 @@ from .routers import (
     integrations_router,
     orgs_router,
     pagerduty_router,
+    pagerduty_services_router,
     platform_router,
     settings_router,
     setup_router,
@@ -51,6 +52,7 @@ router.include_router(platform_router)
 router.include_router(features_router)
 router.include_router(github_app_router)
 router.include_router(pagerduty_router)
+router.include_router(pagerduty_services_router)
 router.include_router(governance_router)
 router.include_router(integrations_router)
 

--- a/src/dev_health_ops/api/admin/routers/__init__.py
+++ b/src/dev_health_ops/api/admin/routers/__init__.py
@@ -16,6 +16,7 @@ from .identities import router as identities_router
 from .integrations import router as integrations_router
 from .orgs import router as orgs_router
 from .pagerduty import router as pagerduty_router
+from .pagerduty_services import router as pagerduty_services_router
 from .platform import router as platform_router
 from .settings import router as settings_router
 from .setup import router as setup_router
@@ -36,6 +37,7 @@ __all__ = [
     "integrations_router",
     "orgs_router",
     "pagerduty_router",
+    "pagerduty_services_router",
     "platform_router",
     "settings_router",
     "setup_router",

--- a/src/dev_health_ops/api/admin/routers/pagerduty_services.py
+++ b/src/dev_health_ops/api/admin/routers/pagerduty_services.py
@@ -1,0 +1,217 @@
+from __future__ import annotations
+
+from collections.abc import Mapping
+from math import ceil
+from typing import Any
+
+import httpx
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from dev_health_ops.api.admin.middleware import get_admin_org_id
+from dev_health_ops.api.services.configuration import IntegrationCredentialsService
+from dev_health_ops.exceptions import (
+    AuthenticationException,
+    ConnectorException,
+    RateLimitException,
+)
+from dev_health_ops.providers.pagerduty.auth import (
+    ApiTokenAuth,
+    OAuthBearerAuth,
+    PagerDutyAuth,
+)
+from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+from dev_health_ops.providers.pagerduty.degradation import (
+    PagerDutyInsufficientScopeError,
+)
+from dev_health_ops.providers.pagerduty.oauth import (
+    READ_SCOPES,
+    PagerDutyOAuthConfig,
+    client_credentials,
+)
+from dev_health_ops.providers.pagerduty.oauth_lifecycle import get_valid_access_token
+from dev_health_ops.providers.pagerduty.oauth_storage import (
+    OAuthRotationConflictError,
+    PagerDutyOAuthCredentialRepository,
+)
+
+from .common import get_session
+
+router = APIRouter()
+
+
+class PagerDutyServiceResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    external_id: str
+    display_name: str
+    name_resolved: bool
+    status: str | None
+
+
+class PagerDutyServicesResponse(BaseModel):
+    model_config = ConfigDict(frozen=True)
+
+    credential_name: str
+    services: list[PagerDutyServiceResponse]
+
+
+def _required_string(values: Mapping[str, Any], key: str) -> str:
+    value = values.get(key)
+    if not isinstance(value, str) or not value.strip():
+        raise HTTPException(
+            status_code=409,
+            detail=f"PagerDuty credential is missing required {key}",
+        )
+    return value.strip()
+
+
+async def _build_auth(
+    values: Mapping[str, Any],
+    *,
+    session: AsyncSession,
+    org_id: str,
+) -> PagerDutyAuth:
+    auth_mode = _required_string(values, "auth_mode")
+    match auth_mode:
+        case "api_token":
+            return ApiTokenAuth(_required_string(values, "api_token"))
+        case "oauth":
+            config = PagerDutyOAuthConfig.from_env()
+            if config is None:
+                raise HTTPException(
+                    status_code=409,
+                    detail="PagerDuty OAuth app is not configured",
+                )
+            try:
+                access_token = await get_valid_access_token(
+                    PagerDutyOAuthCredentialRepository(
+                        session,
+                        org_id,
+                        _required_string(values, "oauth_credential_name"),
+                        expected_binding_id=_required_string(
+                            values, "oauth_binding_id"
+                        ),
+                    ),
+                    config,
+                )
+            except (OAuthRotationConflictError, ValueError) as exc:
+                raise HTTPException(
+                    status_code=409,
+                    detail="PagerDuty OAuth credential must be reconnected",
+                ) from exc
+            except httpx.HTTPError as exc:
+                raise HTTPException(
+                    status_code=502,
+                    detail="PagerDuty OAuth renewal is temporarily unavailable",
+                ) from exc
+            await session.commit()
+            return OAuthBearerAuth(access_token)
+        case "client_credentials":
+            config = PagerDutyOAuthConfig(
+                client_id=_required_string(values, "client_id"),
+                client_secret=_required_string(values, "client_secret"),
+                redirect_uri="",
+            )
+            try:
+                tokens = await client_credentials(
+                    config,
+                    scopes=set(READ_SCOPES),
+                    subdomain=_required_string(values, "subdomain"),
+                    region=_required_string(values, "region"),
+                )
+            except httpx.HTTPError as exc:
+                raise HTTPException(
+                    status_code=502,
+                    detail="PagerDuty authentication is temporarily unavailable",
+                ) from exc
+            return OAuthBearerAuth(tokens.access_token)
+        case _:
+            raise HTTPException(
+                status_code=409,
+                detail="PagerDuty credential uses an unsupported authentication mode",
+            )
+
+
+@router.get(
+    "/integrations/pagerduty/services",
+    response_model=PagerDutyServicesResponse,
+)
+async def list_pagerduty_services(
+    credential_name: str = Query(default="default", min_length=1),
+    session: AsyncSession = Depends(get_session),
+    org_id: str = Depends(get_admin_org_id),
+) -> PagerDutyServicesResponse:
+    normalized_name = credential_name.strip()
+    if not normalized_name:
+        raise HTTPException(status_code=422, detail="credential_name must not be blank")
+
+    credentials_service = IntegrationCredentialsService(session, org_id)
+    descriptor = await credentials_service.get("pagerduty", normalized_name)
+    values = await credentials_service.get_decrypted_credentials(
+        "pagerduty", normalized_name
+    )
+    if descriptor is None or not descriptor.is_active or values is None:
+        raise HTTPException(
+            status_code=404, detail="PagerDuty credential was not found"
+        )
+
+    auth = await _build_auth(
+        values,
+        session=session,
+        org_id=org_id,
+    )
+    region = _required_string(values, "region")
+    client = PagerDutyClient(auth, region=region)
+    try:
+        services = await client.list_services()
+    except PagerDutyInsufficientScopeError as exc:
+        raise HTTPException(
+            status_code=403,
+            detail="PagerDuty credential is missing Services.read permission",
+        ) from exc
+    except AuthenticationException as exc:
+        raise HTTPException(
+            status_code=401,
+            detail="PagerDuty credential is no longer authorized",
+        ) from exc
+    except RateLimitException as exc:
+        headers = (
+            {"Retry-After": str(max(0, ceil(exc.retry_after_seconds)))}
+            if exc.retry_after_seconds is not None
+            else None
+        )
+        raise HTTPException(
+            status_code=429,
+            detail="PagerDuty rate limit exceeded",
+            headers=headers,
+        ) from exc
+    except ConnectorException as exc:
+        raise HTTPException(
+            status_code=502,
+            detail="PagerDuty services are temporarily unavailable",
+        ) from exc
+    finally:
+        await client.close()
+
+    resolved = [
+        PagerDutyServiceResponse(
+            external_id=service.id,
+            display_name=(
+                service.name.strip()
+                if service.name and service.name.strip()
+                else f"PagerDuty service {service.id}"
+            ),
+            name_resolved=bool(service.name and service.name.strip()),
+            status=service.status,
+        )
+        for service in services
+    ]
+    resolved.sort(
+        key=lambda service: (service.display_name.casefold(), service.external_id)
+    )
+    return PagerDutyServicesResponse(
+        credential_name=normalized_name,
+        services=resolved,
+    )

--- a/src/dev_health_ops/providers/pagerduty/oauth_storage.py
+++ b/src/dev_health_ops/providers/pagerduty/oauth_storage.py
@@ -39,11 +39,17 @@ class PagerDutyOAuthCredentialRepository:
     """Persists one encrypted PagerDuty OAuth payload per named organization credential."""
 
     def __init__(
-        self, session: AsyncSession, org_id: str, credential_name: str = "default"
+        self,
+        session: AsyncSession,
+        org_id: str,
+        credential_name: str = "default",
+        *,
+        expected_binding_id: str | None = None,
     ) -> None:
         self._session = session
         self._org_id = org_id
         self._credential_name = credential_name
+        self._expected_binding_id = expected_binding_id
 
     async def rotate(
         self,
@@ -89,17 +95,25 @@ class PagerDutyOAuthCredentialRepository:
         )
         if credential is None:
             return None
-        return VersionedOAuthTokens(
-            OAuthTokens.model_validate_json(decrypt_value(credential.token_encrypted)),
-            credential.version,
-            credential.binding_id,
-        )
+        return self._versioned_tokens(credential)
 
     async def get_for_update(self) -> VersionedOAuthTokens | None:
         """Load and lock this credential for a refresh transaction."""
         credential = await self._locked_credential()
         if credential is None:
             return None
+        return self._versioned_tokens(credential)
+
+    def _versioned_tokens(
+        self, credential: ProviderOAuthCredential
+    ) -> VersionedOAuthTokens:
+        if (
+            self._expected_binding_id is not None
+            and credential.binding_id != self._expected_binding_id
+        ):
+            raise OAuthRotationConflictError(
+                "PagerDuty OAuth credential binding mismatch"
+            )
         return VersionedOAuthTokens(
             OAuthTokens.model_validate_json(decrypt_value(credential.token_encrypted)),
             credential.version,

--- a/tests/api/admin/test_pagerduty_oauth_setup.py
+++ b/tests/api/admin/test_pagerduty_oauth_setup.py
@@ -19,12 +19,19 @@ from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker, create_asyn
 from dev_health_ops.api.admin.router import router as admin_router
 from dev_health_ops.api.services.auth import AuthenticatedUser
 from dev_health_ops.api.services.configuration import IntegrationCredentialsService
+from dev_health_ops.exceptions import (
+    APIException,
+    AuthenticationException,
+    RateLimitException,
+)
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.settings import (
     IntegrationCredential,
     PagerDutyOAuthAuthorizationRequest,
     ProviderOAuthCredential,
 )
+from dev_health_ops.providers.pagerduty.auth import PagerDutyAuth
+from dev_health_ops.providers.pagerduty.models import Service
 from dev_health_ops.providers.pagerduty.oauth import OAuthTokens, PagerDutyOAuthConfig
 from dev_health_ops.providers.pagerduty.oauth_storage import (
     PagerDutyOAuthCredentialRepository,
@@ -32,6 +39,9 @@ from dev_health_ops.providers.pagerduty.oauth_storage import (
 from tests._helpers import tables_of
 
 pagerduty_router = importlib.import_module("dev_health_ops.api.admin.routers.pagerduty")
+pagerduty_services_router = importlib.import_module(
+    "dev_health_ops.api.admin.routers.pagerduty_services"
+)
 credentials_router = importlib.import_module(
     "dev_health_ops.api.admin.routers.credentials"
 )
@@ -85,6 +95,7 @@ async def client(
 
     app = FastAPI()
     app.include_router(pagerduty_router.router, prefix="/api/v1/admin")
+    app.include_router(pagerduty_services_router.router, prefix="/api/v1/admin")
     app.include_router(credentials_router.router, prefix="/api/v1/admin")
 
     async def session_override() -> AsyncIterator[AsyncSession]:
@@ -94,6 +105,10 @@ async def client(
 
     app.dependency_overrides[pagerduty_router.get_session] = session_override
     app.dependency_overrides[pagerduty_router.get_admin_org_id] = lambda: _ORG_ID
+    app.dependency_overrides[pagerduty_services_router.get_session] = session_override
+    app.dependency_overrides[pagerduty_services_router.get_admin_org_id] = lambda: (
+        _ORG_ID
+    )
     app.dependency_overrides[pagerduty_router.get_admin_user] = lambda: (
         AuthenticatedUser(
             user_id=_USER_ID,
@@ -1390,3 +1405,398 @@ async def test_remove_oauth_binding_reraises_unexpected_error_after_delete(
             await pagerduty_router._remove_oauth_binding(repository, _CONFIG)
         # ...while the local row is still deleted via the finally clause.
         assert await repository.get_status_metadata() is None
+
+
+class _ServiceDiscoveryClient:
+    instances: list[_ServiceDiscoveryClient] = []
+    services: list[Service] = []
+    error: Exception | None = None
+    events: list[str] | None = None
+
+    def __init__(self, auth: PagerDutyAuth, *, region: str = "us") -> None:
+        self.auth = auth
+        self.region = region
+        self.closed = 0
+        type(self).instances.append(self)
+
+    async def list_services(self) -> list[Service]:
+        events = type(self).events
+        if events is not None:
+            events.append("list")
+        error = type(self).error
+        if error is not None:
+            raise error
+        return type(self).services
+
+    async def close(self) -> None:
+        self.closed += 1
+
+
+async def _save_api_token_credential(
+    session_maker: async_sessionmaker[AsyncSession],
+    *,
+    org_id: str = _ORG_ID,
+    name: str = "operations",
+) -> None:
+    async with session_maker() as session:
+        await IntegrationCredentialsService(session, org_id).set(
+            provider="pagerduty",
+            name=name,
+            credentials={
+                "auth_mode": "api_token",
+                "api_token": "secret-token",
+                "subdomain": "acme",
+                "region": "us",
+            },
+            config={
+                "auth_mode": "api_token",
+                "subdomain": "acme",
+                "region": "us",
+            },
+        )
+        await session.commit()
+
+
+async def _save_oauth_descriptor(
+    session_maker: async_sessionmaker[AsyncSession],
+    *,
+    name: str,
+    oauth_credential_name: str,
+    binding_id: str,
+) -> None:
+    async with session_maker() as session:
+        await IntegrationCredentialsService(session, _ORG_ID).set(
+            provider="pagerduty",
+            name=name,
+            credentials={
+                "auth_mode": "oauth",
+                "oauth_credential_name": oauth_credential_name,
+                "oauth_binding_id": binding_id,
+                "subdomain": "acme",
+                "region": "eu",
+                "account_id": "acme",
+            },
+            config={
+                "auth_mode": "oauth",
+                "subdomain": "acme",
+                "region": "eu",
+                "account_id": "acme",
+                "granted_scopes": ["Services.read"],
+            },
+        )
+        await session.commit()
+
+
+@pytest.mark.asyncio
+async def test_services_returns_resolved_names_sorted_and_closes_client(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _save_api_token_credential(session_maker)
+    _ServiceDiscoveryClient.instances.clear()
+    _ServiceDiscoveryClient.error = None
+    _ServiceDiscoveryClient.services = [
+        Service(id="P2", name=None, status="disabled"),
+        Service(id="P1", name="Checkout", status="active"),
+        Service(id="P3", name="Alerts", status="active"),
+    ]
+    monkeypatch.setattr(
+        pagerduty_services_router, "PagerDutyClient", _ServiceDiscoveryClient
+    )
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/services",
+        params={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "credential_name": "operations",
+        "services": [
+            {
+                "external_id": "P3",
+                "display_name": "Alerts",
+                "name_resolved": True,
+                "status": "active",
+            },
+            {
+                "external_id": "P1",
+                "display_name": "Checkout",
+                "name_resolved": True,
+                "status": "active",
+            },
+            {
+                "external_id": "P2",
+                "display_name": "PagerDuty service P2",
+                "name_resolved": False,
+                "status": "disabled",
+            },
+        ],
+    }
+    instance = _ServiceDiscoveryClient.instances[-1]
+    assert instance.region == "us"
+    assert instance.closed == 1
+
+
+@pytest.mark.asyncio
+async def test_services_are_scoped_to_current_org(
+    client: AsyncClient,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _save_api_token_credential(session_maker, org_id="another-org")
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/services",
+        params={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_services_close_client_when_provider_fails(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _save_api_token_credential(session_maker)
+    _ServiceDiscoveryClient.instances.clear()
+    _ServiceDiscoveryClient.error = APIException("provider unavailable")
+    monkeypatch.setattr(
+        pagerduty_services_router, "PagerDutyClient", _ServiceDiscoveryClient
+    )
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/services",
+        params={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 502
+    assert response.json() == {
+        "detail": "PagerDuty services are temporarily unavailable"
+    }
+    assert _ServiceDiscoveryClient.instances[-1].closed == 1
+
+
+@pytest.mark.asyncio
+async def test_services_maps_authentication_failure_to_reconnect_response(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _save_api_token_credential(session_maker)
+    monkeypatch.setattr(
+        _ServiceDiscoveryClient,
+        "error",
+        AuthenticationException("provider rejected secret-token"),
+    )
+    monkeypatch.setattr(
+        pagerduty_services_router, "PagerDutyClient", _ServiceDiscoveryClient
+    )
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/services",
+        params={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 401
+    assert response.json() == {"detail": "PagerDuty credential is no longer authorized"}
+    assert "secret-token" not in response.text
+
+
+@pytest.mark.asyncio
+async def test_services_maps_rate_limit_with_retry_after(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _save_api_token_credential(session_maker)
+    monkeypatch.setattr(
+        _ServiceDiscoveryClient,
+        "error",
+        RateLimitException(retry_after_seconds=17.5),
+    )
+    monkeypatch.setattr(
+        pagerduty_services_router, "PagerDutyClient", _ServiceDiscoveryClient
+    )
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/services",
+        params={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 429
+    assert response.headers["retry-after"] == "18"
+    assert response.json() == {"detail": "PagerDuty rate limit exceeded"}
+
+
+@pytest.mark.asyncio
+async def test_services_oauth_uses_descriptor_referenced_credential(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _connect_oauth(
+        client,
+        monkeypatch,
+        datasets=["services"],
+        granted={"Services.read"},
+    )
+    async with session_maker() as session:
+        metadata = await PagerDutyOAuthCredentialRepository(
+            session, _ORG_ID, "operations"
+        ).get_status_metadata()
+    assert metadata is not None
+    assert metadata.binding_id is not None
+    await _save_oauth_descriptor(
+        session_maker,
+        name="service-catalog",
+        oauth_credential_name="operations",
+        binding_id=metadata.binding_id,
+    )
+    monkeypatch.setattr(
+        pagerduty_services_router, "PagerDutyClient", _ServiceDiscoveryClient
+    )
+    monkeypatch.setattr(_ServiceDiscoveryClient, "error", None)
+    monkeypatch.setattr(_ServiceDiscoveryClient, "services", [])
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/services",
+        params={"credential_name": "service-catalog"},
+    )
+
+    assert response.status_code == 200
+    assert _ServiceDiscoveryClient.instances[-1].auth.headers() == {
+        "Authorization": "Bearer access-token"
+    }
+
+
+@pytest.mark.asyncio
+async def test_services_oauth_rejects_descriptor_binding_mismatch(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _connect_oauth(
+        client,
+        monkeypatch,
+        datasets=["services"],
+        granted={"Services.read"},
+    )
+    await _save_oauth_descriptor(
+        session_maker,
+        name="operations",
+        oauth_credential_name="operations",
+        binding_id="stale-binding",
+    )
+    monkeypatch.setattr(
+        pagerduty_services_router, "PagerDutyClient", _ServiceDiscoveryClient
+    )
+    monkeypatch.setattr(_ServiceDiscoveryClient, "error", None)
+    monkeypatch.setattr(_ServiceDiscoveryClient, "services", [])
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/services",
+        params={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 409
+    assert response.json() == {
+        "detail": "PagerDuty OAuth credential must be reconnected"
+    }
+
+
+@pytest.mark.asyncio
+async def test_services_commit_oauth_rotation_before_provider_io(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    await _connect_oauth(
+        client,
+        monkeypatch,
+        datasets=["services"],
+        granted={"Services.read"},
+    )
+    events: list[str] = []
+    original_commit = AsyncSession.commit
+
+    async def record_commit(session: AsyncSession) -> None:
+        events.append("commit")
+        await original_commit(session)
+
+    async def access_token(*_args: object, **_kwargs: object) -> str:
+        events.append("token")
+        return "rotated-access-token"
+
+    monkeypatch.setattr(AsyncSession, "commit", record_commit)
+    monkeypatch.setattr(
+        pagerduty_services_router, "get_valid_access_token", access_token
+    )
+    monkeypatch.setattr(
+        pagerduty_services_router, "PagerDutyClient", _ServiceDiscoveryClient
+    )
+    _ServiceDiscoveryClient.instances.clear()
+    _ServiceDiscoveryClient.error = None
+    _ServiceDiscoveryClient.services = []
+    _ServiceDiscoveryClient.events = events
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/services",
+        params={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 200
+    assert events[:3] == ["token", "commit", "list"]
+    assert _ServiceDiscoveryClient.instances[-1].closed == 1
+    _ServiceDiscoveryClient.events = None
+
+
+@pytest.mark.asyncio
+async def test_services_materializes_client_credentials_without_exposing_secret(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    async with session_maker() as session:
+        await IntegrationCredentialsService(session, _ORG_ID).set(
+            provider="pagerduty",
+            name="automation",
+            credentials={
+                "auth_mode": "client_credentials",
+                "client_id": "client-id",
+                "client_secret": "client-secret",
+                "subdomain": "acme",
+                "region": "eu",
+            },
+            config={
+                "auth_mode": "client_credentials",
+                "subdomain": "acme",
+                "region": "eu",
+            },
+        )
+        await session.commit()
+    token_exchange = AsyncMock(
+        return_value=OAuthTokens(
+            access_token="machine-access-token",
+            expires_at=datetime.now(UTC) + timedelta(hours=1),
+        )
+    )
+    monkeypatch.setattr(pagerduty_services_router, "client_credentials", token_exchange)
+    monkeypatch.setattr(
+        pagerduty_services_router, "PagerDutyClient", _ServiceDiscoveryClient
+    )
+    _ServiceDiscoveryClient.instances.clear()
+    _ServiceDiscoveryClient.error = None
+    _ServiceDiscoveryClient.services = []
+
+    response = await client.get(
+        "/api/v1/admin/integrations/pagerduty/services",
+        params={"credential_name": "automation"},
+    )
+
+    assert response.status_code == 200
+    instance = _ServiceDiscoveryClient.instances[-1]
+    assert instance.region == "eu"
+    assert instance.auth.headers() == {"Authorization": "Bearer machine-access-token"}
+    assert "client-secret" not in response.text


### PR DESCRIPTION
## Summary
- add an admin-only, organization-scoped PagerDuty service discovery endpoint
- materialize API token, OAuth, and client-credentials auth without exposing secrets
- enforce descriptor-to-OAuth-row binding integrity and deterministic resolved-name ordering
- preserve provider semantics with sanitized 401, 403, 429 plus Retry-After, and 502 responses

## Linear
- CHAOS-3022

## Validation
- `bash ci/local_validate.sh`: PASS
  - Ruff format/check
  - full mypy
  - 8,274 passed, 46 skipped
  - isolated scratch ClickHouse migrations and live argMax proof
- `pytest tests/api/admin/test_pagerduty_oauth_setup.py tests/providers/test_pagerduty_oauth_store_refresh.py -q`: 58 passed
- `make docs:check-built-site`: strict MkDocs build and link check passed
- final Oracle review: PASS, zero findings

## Notes
- No production database schema changes.
- This PR is intentionally left unmerged for review.

SCREENSHOT-WAIVER: Backend-only service-discovery API; rendered evidence is attached to full-chaos/dev-health-web#795.