### PR TITLE
fix(security): revoke PagerDuty and redact Sentry secrets

### DIFF
--- a/docs/ops/observability-tooling.md
+++ b/docs/ops/observability-tooling.md
@@ -41,6 +41,15 @@ Key files:
 - `src/dev_health_ops/logging_config.py` — JSON log configuration
 - `src/dev_health_ops/api/middleware/correlation_id.py` — Request ID propagation
 
+### Telemetry privacy boundary
+
+Sentry sets `send_default_pii=False` and passes every event through a non-mutating
+recursive `before_send` scrubber. The scrubber redacts nested credential-bearing
+keys (PagerDuty, OAuth, API token, client secret, authorization, cookies, and
+CSRF) and credential-shaped URL or query values while retaining ordinary
+diagnostic fields. This is an event-emission boundary: it does not claim that
+FastAPI automatically captures request bodies or local variables.
+
 ### Frontend (Next.js) — dev-health-web
 
 | Layer | Tool | Config |

--- a/docs/security/credential-encryption-rotation.md
+++ b/docs/security/credential-encryption-rotation.md
@@ -41,3 +41,19 @@ This runbook rotates data protected by `SETTINGS_ENCRYPTION_KEY` without breakin
 - If decryption errors appear immediately after rotation, restore the previous `SETTINGS_ENCRYPTION_KEY` and restart API/workers.
 - If the re-encryption utility reports failures, stop and inspect the affected rows before retrying. Failures usually mean the row is plaintext, corrupted, or encrypted with an unexpected key.
 - If a deployment accidentally omits `SETTINGS_ENCRYPTION_SALT`, restore the explicit production salt and restart before writing new credentials.
+
+## Connection removal
+
+Disconnecting a PagerDuty connection atomically clears its
+`IntegrationCredential.credentials_encrypted` value and removes its
+`ProviderOAuthCredential` row. The inactive integration descriptor remains as a
+non-secret tombstone, retaining only its configuration and lifecycle metadata.
+
+This applies to OAuth, client-credentials, and API-token authentication. After
+commit, a fresh database session cannot retrieve decryptable secret material for
+the disconnected credential; other provider credentials are unchanged. Remote
+OAuth token revocation remains best-effort and happens only after local removal
+has committed.
+
+This contract does not backfill or migrate already-inactive descriptors. Review
+those rows separately if historical credential cleanup is required.

--- a/src/dev_health_ops/api/admin/routers/pagerduty.py
+++ b/src/dev_health_ops/api/admin/routers/pagerduty.py
@@ -511,7 +511,7 @@ async def disconnect_pagerduty(
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
 ) -> PagerDutyDisconnectResponse:
-    """Destroy OAuth tokens and deactivate, rather than delete, the descriptor."""
+    """Revoke PagerDuty secrets and retain only an inactive descriptor tombstone."""
     credentials = IntegrationCredentialsService(session, org_id)
     descriptor = await credentials.get("pagerduty", body.credential_name)
     repository = PagerDutyOAuthCredentialRepository(
@@ -521,6 +521,7 @@ async def disconnect_pagerduty(
     token_to_revoke = await _remove_oauth_binding(repository, config)
     if descriptor is not None:
         descriptor.is_active = False
+        descriptor.credentials_encrypted = None
         await session.flush()
     # Commit the local removal BEFORE remote revocation so a commit failure
     # cannot leave an active-looking local binding whose remote token is dead.

--- a/src/dev_health_ops/sentry.py
+++ b/src/dev_health_ops/sentry.py
@@ -20,6 +20,7 @@ import os
 import re
 from collections.abc import Mapping
 from typing import TYPE_CHECKING, Final, TypeVar
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from dev_health_ops.sync.error_sanitize import REDACTION_MARKER, sanitize_error_text
 
@@ -30,15 +31,20 @@ logger = logging.getLogger(__name__)
 
 _initialized = False
 _MappingKey = TypeVar("_MappingKey")
+_SENSITIVE_EXACT_KEYS: Final = frozenset(
+    {
+        "auth",
+        "authorization",
+        "code",
+        "error_description",
+        "state",
+    }
+)
 _SENSITIVE_KEY_PARTS: Final = frozenset(
     {
         "apikey",
-        "auth",
-        "authorization",
         "cookie",
         "csrf",
-        "oauth",
-        "pagerduty",
         "password",
         "secret",
         "token",
@@ -49,12 +55,45 @@ _SENSITIVE_KEY_PARTS: Final = frozenset(
 def _is_sensitive_key(key: str) -> bool:
     normalized = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key).lower()
     parts = frozenset(re.split(r"[^a-z0-9]+", normalized))
-    return not _SENSITIVE_KEY_PARTS.isdisjoint(parts)
+    return normalized in _SENSITIVE_EXACT_KEYS or not _SENSITIVE_KEY_PARTS.isdisjoint(
+        parts
+    )
+
+
+def _scrub_sentry_string(value: str) -> str:
+    parsed = urlsplit(value)
+    if parsed.scheme and parsed.netloc and parsed.query:
+        query = urlencode(
+            [
+                (
+                    key,
+                    REDACTION_MARKER
+                    if _is_sensitive_key(key)
+                    else sanitize_error_text(nested, max_length=None) or "",
+                )
+                for key, nested in parse_qsl(parsed.query, keep_blank_values=True)
+            ]
+        )
+        netloc = (
+            f"{REDACTION_MARKER}@{parsed.netloc.rsplit('@', maxsplit=1)[1]}"
+            if "@" in parsed.netloc
+            else parsed.netloc
+        )
+        return urlunsplit(
+            (
+                parsed.scheme,
+                netloc,
+                parsed.path,
+                query,
+                sanitize_error_text(parsed.fragment, max_length=None) or "",
+            )
+        )
+    return sanitize_error_text(value, max_length=None) or ""
 
 
 def _scrub_sentry_value(value: object) -> object:
     if isinstance(value, str):
-        return sanitize_error_text(value, max_length=None)
+        return _scrub_sentry_string(value)
     if isinstance(value, Mapping):
         return _scrub_sentry_mapping(value)
     if isinstance(value, list):

--- a/src/dev_health_ops/sentry.py
+++ b/src/dev_health_ops/sentry.py
@@ -4,25 +4,128 @@ Initializes Sentry for FastAPI and Celery when SENTRY_DSN is set.
 Safe to call multiple times (no-op if already initialised or DSN absent).
 
 Compatible with Sentry SaaS, self-hosted Sentry, and BugSink.
-When using BugSink, set SENTRY_TRACES_RATE=0 (BugSink ignores traces)
-and SENTRY_SEND_PII=true (data stays on your infrastructure).
+When using BugSink, set SENTRY_TRACES_RATE=0 (BugSink ignores traces).
 
 Environment variables:
     SENTRY_DSN            — Sentry DSN (required to activate)
     SENTRY_ENVIRONMENT    — Environment tag (default: production)
     SENTRY_TRACES_RATE    — Traces sample rate 0.0–1.0 (default: 0.0)
     SENTRY_PROFILES_RATE  — Profiles sample rate 0.0–1.0 (default: 0.0)
-    SENTRY_SEND_PII       — Send PII with events (default: true for self-hosted)
 """
 
 from __future__ import annotations
 
 import logging
 import os
+import re
+from collections.abc import Mapping
+from typing import TYPE_CHECKING, Final, TypeVar
+
+from dev_health_ops.sync.error_sanitize import REDACTION_MARKER, sanitize_error_text
+
+if TYPE_CHECKING:
+    from sentry_sdk.types import Event, Hint
 
 logger = logging.getLogger(__name__)
 
 _initialized = False
+_MappingKey = TypeVar("_MappingKey")
+_SENSITIVE_KEY_PARTS: Final = frozenset(
+    {
+        "apikey",
+        "auth",
+        "authorization",
+        "cookie",
+        "csrf",
+        "oauth",
+        "pagerduty",
+        "password",
+        "secret",
+        "token",
+    }
+)
+
+
+def _is_sensitive_key(key: str) -> bool:
+    normalized = re.sub(r"(?<=[a-z0-9])(?=[A-Z])", "_", key).lower()
+    parts = frozenset(re.split(r"[^a-z0-9]+", normalized))
+    return not _SENSITIVE_KEY_PARTS.isdisjoint(parts)
+
+
+def _scrub_sentry_value(value: object) -> object:
+    if isinstance(value, str):
+        return sanitize_error_text(value, max_length=None)
+    if isinstance(value, Mapping):
+        return _scrub_sentry_mapping(value)
+    if isinstance(value, list):
+        return [_scrub_sentry_value(item) for item in value]
+    if isinstance(value, tuple):
+        return tuple(_scrub_sentry_value(item) for item in value)
+    return value
+
+
+def _scrub_sentry_mapping(
+    value: Mapping[_MappingKey, object],
+) -> dict[_MappingKey, object]:
+    return {
+        key: REDACTION_MARKER
+        if isinstance(key, str) and _is_sensitive_key(key)
+        else _scrub_sentry_value(nested)
+        for key, nested in value.items()
+    }
+
+
+def _scrub_sentry_context(value: object) -> dict[str, object]:
+    if isinstance(value, Mapping):
+        return _scrub_sentry_mapping(value)
+    return {"value": _scrub_sentry_value(value)}
+
+
+def before_send(
+    event: Event,
+    _hint: Hint,
+) -> Event:
+    """Return a copy of an event with nested credential-bearing data redacted."""
+    scrubbed = event.copy()
+    if "extra" in event:
+        scrubbed["extra"] = _scrub_sentry_mapping(event["extra"])
+    if "request" in event:
+        scrubbed["request"] = _scrub_sentry_mapping(event["request"])
+    if "user" in event:
+        scrubbed["user"] = _scrub_sentry_mapping(event["user"])
+    if "logentry" in event:
+        scrubbed["logentry"] = _scrub_sentry_mapping(event["logentry"])
+    if "contexts" in event:
+        scrubbed["contexts"] = {
+            key: _scrub_sentry_context(value)
+            for key, value in event["contexts"].items()
+        }
+    if "exception" in event:
+        exception = event["exception"].copy()
+        exception["values"] = [
+            _scrub_sentry_mapping(value) for value in event["exception"]["values"]
+        ]
+        scrubbed["exception"] = exception
+    if "breadcrumbs" in event:
+        breadcrumbs = event["breadcrumbs"]
+        if isinstance(breadcrumbs, dict):
+            scrubbed["breadcrumbs"] = {
+                "values": [
+                    _scrub_sentry_mapping(value) for value in breadcrumbs["values"]
+                ]
+            }
+    if "message" in event:
+        scrubbed["message"] = (
+            sanitize_error_text(event["message"], max_length=None) or ""
+        )
+    if "tags" in event:
+        scrubbed["tags"] = {
+            key: REDACTION_MARKER
+            if _is_sensitive_key(key)
+            else sanitize_error_text(value, max_length=None) or ""
+            for key, value in event["tags"].items()
+        }
+    return scrubbed
 
 
 def init_sentry() -> bool:
@@ -50,8 +153,6 @@ def init_sentry() -> bool:
         environment = os.getenv("SENTRY_ENVIRONMENT", "production")
         traces_rate = float(os.getenv("SENTRY_TRACES_RATE", "0.0"))
         profiles_rate = float(os.getenv("SENTRY_PROFILES_RATE", "0.0"))
-        send_pii = os.getenv("SENTRY_SEND_PII", "true").lower() == "true"
-
         sentry_sdk.init(
             dsn=dsn,
             environment=environment,
@@ -67,7 +168,8 @@ def init_sentry() -> bool:
                     event_level=logging.ERROR,
                 ),
             ],
-            send_default_pii=send_pii,
+            send_default_pii=False,
+            before_send=before_send,
         )
         _initialized = True
         logger.info(

--- a/tests/api/admin/test_pagerduty_oauth_setup.py
+++ b/tests/api/admin/test_pagerduty_oauth_setup.py
@@ -472,9 +472,10 @@ async def test_disconnect_deactivates_descriptor_without_deleting_it(
         metadata = await PagerDutyOAuthCredentialRepository(
             session, _ORG_ID, "operations"
         ).get_status_metadata()
-    # Descriptor is deactivated (not deleted); the OAuth token row is gone.
+    # Descriptor is deactivated (not deleted); all decryptable secret storage is gone.
     assert descriptor is not None
     assert descriptor.is_active is False
+    assert descriptor.credentials_encrypted is None
     assert metadata is None
 
 
@@ -1270,9 +1271,42 @@ async def test_disconnect_deletes_oauth_row_even_with_corrupt_ciphertext(
 
 
 @pytest.mark.asyncio
-async def test_disconnect_deactivates_legacy_descriptor_without_revalidation(
+@pytest.mark.parametrize(
+    ("credential_name", "credentials", "config"),
+    [
+        (
+            "api-token",
+            {
+                "auth_mode": "api_token",
+                "api_token": "legacy-token",
+                "subdomain": "acme",
+                "region": "us",
+            },
+            {"auth_mode": "api_token", "subdomain": "acme", "region": "us"},
+        ),
+        (
+            "client-credentials",
+            {
+                "auth_mode": "client_credentials",
+                "client_id": "legacy-client-id",
+                "client_secret": "legacy-client-secret",
+                "subdomain": "acme",
+                "region": "us",
+            },
+            {
+                "auth_mode": "client_credentials",
+                "subdomain": "acme",
+                "region": "us",
+            },
+        ),
+    ],
+)
+async def test_disconnect_deactivates_and_clears_legacy_descriptor_secrets(
     client: AsyncClient,
     session_maker: async_sessionmaker[AsyncSession],
+    credential_name: str,
+    credentials: dict[str, str],
+    config: dict[str, str],
 ) -> None:
     import json
 
@@ -1282,12 +1316,10 @@ async def test_disconnect_deactivates_legacy_descriptor_without_revalidation(
         session.add(
             IntegrationCredential(
                 provider="pagerduty",
-                name="legacy",
+                name=credential_name,
                 org_id=_ORG_ID,
-                credentials_encrypted=encrypt_value(
-                    json.dumps({"api_token": "legacy-token"})
-                ),
-                config={},
+                credentials_encrypted=encrypt_value(json.dumps(credentials)),
+                config=config,
                 is_active=True,
             )
         )
@@ -1295,16 +1327,17 @@ async def test_disconnect_deactivates_legacy_descriptor_without_revalidation(
 
     response = await client.post(
         "/api/v1/admin/integrations/pagerduty/disconnect",
-        json={"credential_name": "legacy"},
+        json={"credential_name": credential_name},
     )
 
     assert response.status_code == 200
     async with session_maker() as session:
         descriptor = await IntegrationCredentialsService(session, _ORG_ID).get(
-            "pagerduty", "legacy"
+            "pagerduty", credential_name
         )
     assert descriptor is not None
     assert descriptor.is_active is False
+    assert descriptor.credentials_encrypted is None
 
 
 @pytest.mark.asyncio

--- a/tests/api/admin/test_pagerduty_oauth_setup.py
+++ b/tests/api/admin/test_pagerduty_oauth_setup.py
@@ -1271,6 +1271,143 @@ async def test_disconnect_deletes_oauth_row_even_with_corrupt_ciphertext(
 
 
 @pytest.mark.asyncio
+async def test_disconnect_commit_failure_rolls_back_all_local_secret_cleanup(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _connect_oauth(client, monkeypatch)
+    async with session_maker() as session:
+        descriptor_before = (
+            await session.execute(
+                select(IntegrationCredential).where(
+                    IntegrationCredential.org_id == _ORG_ID,
+                    IntegrationCredential.provider == "pagerduty",
+                    IntegrationCredential.name == "operations",
+                )
+            )
+        ).scalar_one()
+        oauth_before = (
+            await session.execute(
+                select(ProviderOAuthCredential).where(
+                    ProviderOAuthCredential.org_id == _ORG_ID,
+                    ProviderOAuthCredential.provider == "pagerduty",
+                    ProviderOAuthCredential.credential_name == "operations",
+                )
+            )
+        ).scalar_one()
+        descriptor_ciphertext = descriptor_before.credentials_encrypted
+        oauth_ciphertext = oauth_before.token_encrypted
+
+    async def fail_commit(_session: AsyncSession) -> None:
+        raise RuntimeError("disconnect commit failure")
+
+    revoke = AsyncMock()
+    monkeypatch.setattr(AsyncSession, "commit", fail_commit)
+    monkeypatch.setattr(pagerduty_router, "revoke_token", revoke)
+
+    with pytest.raises(RuntimeError, match="disconnect commit failure"):
+        await client.post(
+            "/api/v1/admin/integrations/pagerduty/disconnect",
+            json={"credential_name": "operations"},
+        )
+
+    revoke.assert_not_awaited()
+    async with session_maker() as session:
+        descriptor_after = (
+            await session.execute(
+                select(IntegrationCredential).where(
+                    IntegrationCredential.org_id == _ORG_ID,
+                    IntegrationCredential.provider == "pagerduty",
+                    IntegrationCredential.name == "operations",
+                )
+            )
+        ).scalar_one()
+        oauth_after = (
+            await session.execute(
+                select(ProviderOAuthCredential).where(
+                    ProviderOAuthCredential.org_id == _ORG_ID,
+                    ProviderOAuthCredential.provider == "pagerduty",
+                    ProviderOAuthCredential.credential_name == "operations",
+                )
+            )
+        ).scalar_one()
+    assert descriptor_after.is_active is True
+    assert descriptor_after.credentials_encrypted == descriptor_ciphertext
+    assert oauth_after.token_encrypted == oauth_ciphertext
+
+
+@pytest.mark.asyncio
+async def test_disconnect_preserves_unrelated_connector_credentials(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    await _connect_oauth(client, monkeypatch)
+    standby_tokens = OAuthTokens(
+        access_token="standby-access-token",
+        refresh_token="standby-refresh-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=frozenset({"Incidents.read"}),
+    )
+    async with session_maker() as session:
+        service = IntegrationCredentialsService(session, _ORG_ID)
+        standby_descriptor = await service.set(
+            "pagerduty",
+            {
+                "auth_mode": "oauth",
+                "oauth_credential_name": "standby",
+                "oauth_binding_id": "standby-binding",
+                "subdomain": "acme",
+                "region": "us",
+                "account_id": "acme",
+            },
+            name="standby",
+            config={
+                "auth_mode": "oauth",
+                "subdomain": "acme",
+                "region": "us",
+                "account_id": "acme",
+                "granted_scopes": ["Incidents.read"],
+            },
+        )
+        github_descriptor = await service.set(
+            "github",
+            {"token": "unrelated-github-token"},
+            name="source-control",
+        )
+        await PagerDutyOAuthCredentialRepository(
+            session, _ORG_ID, "standby"
+        ).create_or_replace(standby_tokens, binding_id="standby-binding")
+        await session.commit()
+        standby_ciphertext = standby_descriptor.credentials_encrypted
+        github_ciphertext = github_descriptor.credentials_encrypted
+    monkeypatch.setattr(pagerduty_router, "revoke_token", AsyncMock())
+
+    response = await client.post(
+        "/api/v1/admin/integrations/pagerduty/disconnect",
+        json={"credential_name": "operations"},
+    )
+
+    assert response.status_code == 200
+    async with session_maker() as session:
+        service = IntegrationCredentialsService(session, _ORG_ID)
+        standby_after = await service.get("pagerduty", "standby")
+        github_after = await service.get("github", "source-control")
+        standby_oauth = await PagerDutyOAuthCredentialRepository(
+            session, _ORG_ID, "standby"
+        ).get()
+    assert standby_after is not None
+    assert standby_after.is_active is True
+    assert standby_after.credentials_encrypted == standby_ciphertext
+    assert standby_oauth is not None
+    assert standby_oauth.tokens == standby_tokens
+    assert github_after is not None
+    assert github_after.is_active is True
+    assert github_after.credentials_encrypted == github_ciphertext
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize(
     ("credential_name", "credentials", "config"),
     [

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -4,6 +4,7 @@ import sys
 from copy import deepcopy
 from types import ModuleType
 from typing import Any
+from urllib.parse import parse_qs, urlparse
 
 from sentry_sdk.types import Event, Hint
 
@@ -126,11 +127,76 @@ def test_before_send_scrubs_nested_secrets_without_mutating_input() -> None:
     }
     request = scrubbed.get("request")
     assert isinstance(request, dict)
-    assert request["url"] == "https://app.example.test/callback?[REDACTED]"
-    assert request["data"] == {"oauth": REDACTION_MARKER, "csrf": REDACTION_MARKER}
+    scrubbed_url = request["url"]
+    assert isinstance(scrubbed_url, str)
+    parsed_url = urlparse(scrubbed_url)
+    assert parsed_url.scheme == "https"
+    assert parsed_url.netloc == "app.example.test"
+    assert parsed_url.path == "/callback"
+    assert parse_qs(parsed_url.query) == {"access_token": [REDACTION_MARKER]}
+    assert request["data"] == {
+        "oauth": {"client_secret": REDACTION_MARKER},
+        "csrf": REDACTION_MARKER,
+    }
     assert request["headers"] == {
         "Cookie": REDACTION_MARKER,
         "X-Request-ID": "request-123",
+    }
+
+
+def test_before_send_scrubs_nested_oauth_callback_fields_without_mutation() -> None:
+    event: Event = {
+        "extra": {
+            "callback": {
+                "state": "opaque-state",
+                "code": "authorization-code",
+                "error_description": "provider-secret-detail",
+                "oauth_provider": "pagerduty",
+                "pagerduty_region": "eu",
+            }
+        }
+    }
+    original = deepcopy(event)
+
+    scrubbed = sentry.before_send(event, {})
+
+    assert event == original
+    assert scrubbed.get("extra") == {
+        "callback": {
+            "state": REDACTION_MARKER,
+            "code": REDACTION_MARKER,
+            "error_description": REDACTION_MARKER,
+            "oauth_provider": "pagerduty",
+            "pagerduty_region": "eu",
+        }
+    }
+
+
+def test_before_send_scrubs_oauth_callback_query_values_and_preserves_url() -> None:
+    callback_url = (
+        "https://app.example.test/oauth/pagerduty/callback"
+        "?state=opaque-state&code=authorization-code"
+        "&error_description=provider-secret-detail&region=eu"
+    )
+    event: Event = {"request": {"url": callback_url}}
+    original = deepcopy(event)
+
+    scrubbed = sentry.before_send(event, {})
+
+    assert event == original
+    request = scrubbed.get("request")
+    assert isinstance(request, dict)
+    scrubbed_url = request["url"]
+    assert isinstance(scrubbed_url, str)
+    parsed = urlparse(scrubbed_url)
+    assert parsed.scheme == "https"
+    assert parsed.netloc == "app.example.test"
+    assert parsed.path == "/oauth/pagerduty/callback"
+    assert parse_qs(parsed.query) == {
+        "state": [REDACTION_MARKER],
+        "code": [REDACTION_MARKER],
+        "error_description": [REDACTION_MARKER],
+        "region": ["eu"],
     }
 
 

--- a/tests/test_sentry.py
+++ b/tests/test_sentry.py
@@ -1,10 +1,14 @@
 from __future__ import annotations
 
 import sys
+from copy import deepcopy
 from types import ModuleType
 from typing import Any
 
+from sentry_sdk.types import Event, Hint
+
 from dev_health_ops import sentry
+from dev_health_ops.sync.error_sanitize import REDACTION_MARKER
 
 
 class _Integration:
@@ -73,3 +77,114 @@ def test_init_sentry_configures_strawberry_async_execution(monkeypatch: Any) -> 
     ]
     assert len(strawberry_instances) == 1
     assert strawberry_instances[0].kwargs == {"async_execution": True}
+
+
+def test_before_send_scrubs_nested_secrets_without_mutating_input() -> None:
+    event: Event = {
+        "message": "request rejected with Bearer value-to-redact",
+        "extra": {
+            "deployment": "production",
+            "providers": [
+                {"PagerDuty_API_Token": "pd-token-value"},
+                {"clientSecret": "client-value", "region": "eu"},
+            ],
+        },
+        "exception": {
+            "values": [{"type": "ProviderError", "value": "client_secret=client-value"}]
+        },
+        "breadcrumbs": {
+            "values": [{"message": "upstream rejected Bearer breadcrumb-value"}]
+        },
+        "request": {
+            "url": "https://app.example.test/callback?access_token=value-to-redact",
+            "data": {
+                "oauth": {"client_secret": "client-value"},
+                "csrf": "anti-forgery-value",
+            },
+            "headers": {"Cookie": "session-value", "X-Request-ID": "request-123"},
+        },
+    }
+    original = deepcopy(event)
+
+    hint: Hint = {}
+    scrubbed = sentry.before_send(event, hint)
+
+    assert event == original
+    assert scrubbed.get("message") == "request rejected with [REDACTED]"
+    assert scrubbed.get("extra") == {
+        "deployment": "production",
+        "providers": [
+            {"PagerDuty_API_Token": REDACTION_MARKER},
+            {"clientSecret": REDACTION_MARKER, "region": "eu"},
+        ],
+    }
+    assert scrubbed.get("exception") == {
+        "values": [{"type": "ProviderError", "value": REDACTION_MARKER}]
+    }
+    assert scrubbed.get("breadcrumbs") == {
+        "values": [{"message": "upstream rejected [REDACTED]"}]
+    }
+    request = scrubbed.get("request")
+    assert isinstance(request, dict)
+    assert request["url"] == "https://app.example.test/callback?[REDACTED]"
+    assert request["data"] == {"oauth": REDACTION_MARKER, "csrf": REDACTION_MARKER}
+    assert request["headers"] == {
+        "Cookie": REDACTION_MARKER,
+        "X-Request-ID": "request-123",
+    }
+
+
+def test_before_send_preserves_non_mapping_context_values() -> None:
+    event: Any = {"contexts": {"runtime": "Python 3.13"}}
+
+    scrubbed = sentry.before_send(event, {})
+
+    assert scrubbed.get("contexts") == {"runtime": {"value": "Python 3.13"}}
+
+
+def test_init_sentry_disables_default_pii_and_registers_scrubber(
+    monkeypatch: Any,
+) -> None:
+    captured: dict[str, Any] = {}
+    sentry_sdk = ModuleType("sentry_sdk")
+
+    def init(**kwargs: Any) -> None:
+        captured.update(kwargs)
+
+    sentry_sdk.init = init  # type: ignore[attr-defined]
+    monkeypatch.setitem(sys.modules, "sentry_sdk", sentry_sdk)
+    monkeypatch.setitem(
+        sys.modules, "sentry_sdk.integrations", ModuleType("integrations")
+    )
+    _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.celery",
+        "CeleryIntegration",
+    )
+    _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.fastapi",
+        "FastApiIntegration",
+    )
+    _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.logging",
+        "LoggingIntegration",
+    )
+    _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.starlette",
+        "StarletteIntegration",
+    )
+    _install_integration_module(
+        monkeypatch,
+        "sentry_sdk.integrations.strawberry",
+        "StrawberryIntegration",
+    )
+    monkeypatch.setattr(sentry, "_initialized", False)
+    monkeypatch.setenv("SENTRY_DSN", "https://public@example.com/1")
+
+    assert sentry.init_sentry() is True
+
+    assert captured["send_default_pii"] is False
+    assert captured["before_send"] is sentry.before_send


### PR DESCRIPTION
## Summary
- clear decryptable PagerDuty descriptor credentials during disconnect while preserving its inactive tombstone
- disable Sentry default PII and recursively redact nested secret-bearing event data
- redact OAuth callback `state`, `code`, and `error_description` fields and URL query values while preserving safe diagnostics
- prove PagerDuty disconnect rollback and unrelated-credential isolation with real database sessions
- document both security boundaries and add regression coverage

## Validation
- `bash ci/local_validate.sh`
  - ruff format/check, mypy, full unit suite (8,282 passed, 46 skipped), isolated ClickHouse migration and argMax execution proof
- focused Sentry suite: 6 passed
- focused PagerDuty suite: 54 passed
- exact runtime leak/rollback drivers: 2 passed
- changed-file LSP diagnostics: clean

## Exact head
- `f4f66635f0a66e9d3d005b705d297c6a0bc37936`

Closes CHAOS-3020
Closes CHAOS-3021