### PR TITLE
docs: add PagerDuty OAuth app setup guide

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -150,10 +150,13 @@ ATLASSIAN_CLOUD_ID="your-cloud-id"
 # ----------------------------------------------------------------------------
 # Registered PagerDuty OAuth app credentials. OAuth is the preferred connection;
 # API-token entry remains a compatibility fallback. Only read scopes are used.
+# Set the same app credentials on the API and every PagerDuty sync worker.
+# See docs/user-guide/pagerduty-oauth-app-setup.md for registration and scopes.
 # PAGER_DUTY_CLIENT_ID="your-pagerduty-app-client-id"
 # PAGER_DUTY_SECRET="your-pagerduty-app-client-secret"
-# Optional: authorization-code redirect URI (unused by client-credentials flow)
-# PAGER_DUTY_REDIRECT_URI="https://your-host/api/v1/admin/integrations/pagerduty/callback"
+# Browser-facing authorization-code callback. Required for the interactive OAuth
+# flow, unused by client credentials, and must exactly match PagerDuty App Registration.
+# PAGER_DUTY_REDIRECT_URI="https://your-host/org/admin/integrations/pagerduty/callback"
 # Optional API-token fallback + account qualifiers (region: us or eu)
 # PAGERDUTY_API_TOKEN=""
 # PAGERDUTY_SUBDOMAIN="your-account"

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -21,7 +21,7 @@ See [Email Setup](./email-setup.md) for provider configuration, email types, and
 
 ## Credential Management
 
-Provider credentials (GitHub, GitLab, Jira, Linear, Atlassian) are resolved through a unified credential system that supports two sources:
+Provider credentials (GitHub, GitLab, Jira, Linear, Atlassian, PagerDuty) are resolved through a unified credential system that supports two sources:
 
 | Source | When Used | How |
 |--------|-----------|-----|
@@ -42,6 +42,11 @@ Provider credentials (GitHub, GitLab, Jira, Linear, Atlassian) are resolved thro
 | Jira | `JIRA_API_TOKEN`, `JIRA_EMAIL`, `JIRA_BASE_URL` |
 | Linear | `LINEAR_API_KEY` |
 | Atlassian | `ATLASSIAN_API_TOKEN`, `ATLASSIAN_EMAIL` (optional: `ATLASSIAN_CLOUD_ID`) |
+| PagerDuty | OAuth app: `PAGER_DUTY_CLIENT_ID`, `PAGER_DUTY_SECRET`, `PAGER_DUTY_REDIRECT_URI`; API-token fallback: `PAGERDUTY_API_TOKEN` |
+
+For the organization-wide, read-only PagerDuty connection, including app
+registration, scopes, callback URLs, worker configuration, and troubleshooting,
+see [PagerDuty OAuth app setup](./user-guide/pagerduty-oauth-app-setup.md).
 
 ### Usage
 

--- a/docs/user-guide/pagerduty-oauth-app-setup.md
+++ b/docs/user-guide/pagerduty-oauth-app-setup.md
@@ -1,0 +1,222 @@
+# PagerDuty OAuth app setup
+
+This guide registers the PagerDuty OAuth 2.0 app used by Dev Health's
+organization-scoped, read-only PagerDuty integration.
+
+A Dev Health organization admin connects PagerDuty once for the organization.
+Other Dev Health users do not complete separate PagerDuty consent flows; they use
+the operational data synced into their Dev Health organization. The PagerDuty
+identity that grants consent must be able to see every service, team, schedule,
+and incident that Dev Health should ingest.
+
+> Replace `YOUR_HOST` with the public host that serves Dev Health Web. The OAuth
+> callback is a browser route on the web application, not the ops API callback
+> endpoint.
+
+## Choose a connection mode
+
+| Deployment | Recommended mode | Behavior |
+| --- | --- | --- |
+| Hosted or interactive self-hosted Dev Health | Authorization code with PKCE | A Dev Health admin authorizes the registered app once for each Dev Health organization. Dev Health stores and refreshes the organization-scoped OAuth credential. |
+| Private automation without interactive consent | Client credentials | Register a private scoped PagerDuty app and enter its client ID, client secret, account subdomain, and region in Dev Health. |
+| Compatibility only | REST API token | Use the explicit API-token fallback only when OAuth is unavailable. |
+
+The rest of this guide covers the recommended authorization-code flow.
+
+## 1. Register the app in PagerDuty
+
+You need PagerDuty Account Owner or Global Admin access to register a scoped OAuth
+app.
+
+1. In PagerDuty, open **Integrations → Developer Tools → App Registration**.
+2. Select **New App**.
+3. Enter a name such as `Dev Health` and a description such as
+   `Read-only operational data sync for Dev Health`.
+4. Enable **OAuth 2.0**, then continue to the OAuth configuration step.
+5. Select **Scoped OAuth**.
+6. Add the redirect URL for the environment:
+
+   ```text
+   https://YOUR_HOST/org/admin/integrations/pagerduty/callback
+   ```
+
+   The value must exactly match `PAGER_DUTY_REDIRECT_URI` in the ops runtime.
+   Do not register `/api/v1/admin/integrations/pagerduty/callback` as the browser
+   redirect. Dev Health Web receives the browser redirect, removes the OAuth
+   parameters from browser history, and sends the authenticated callback request
+   to the ops API.
+
+7. Grant **Read Access** for the resources below. Dev Health does not request
+   write scopes in the current PagerDuty integration.
+
+| PagerDuty resource | OAuth scope | Dev Health datasets |
+| --- | --- | --- |
+| Incidents | `Incidents.read` | Incidents, alerts, timeline entries, and notes |
+| Services | `Services.read` | Services and business services |
+| Escalation policies | `Escalation_policies.read` | Escalation policies |
+| Schedules | `Schedules.read` | Schedules |
+| On-calls | `Oncalls.read` | On-call assignments |
+| Users | `Users.read` | Users and responder identity |
+| Teams | `Teams.read` | Teams |
+
+8. Register the app.
+9. Copy or download the **Client ID** and **Client Secret** immediately and store
+   them in your secret manager. PagerDuty may not display the client secret again.
+
+For a lower blast radius and separate rate-limit accounting, register a distinct
+private app for each environment, such as production and staging.
+
+## 2. Configure the Dev Health ops runtime
+
+Set the OAuth app credentials on the ops API and every sync worker that can run
+PagerDuty jobs:
+
+```dotenv
+PAGER_DUTY_CLIENT_ID="<pagerduty-client-id>"
+PAGER_DUTY_SECRET="<pagerduty-client-secret>"
+PAGER_DUTY_REDIRECT_URI="https://YOUR_HOST/org/admin/integrations/pagerduty/callback"
+```
+
+The same values must be available to the API and workers. The API uses them to
+start and complete authorization; workers use them to refresh short-lived access
+tokens during sync.
+
+Also configure a stable PostgreSQL connection and encryption key:
+
+```dotenv
+POSTGRES_URI="postgresql+asyncpg://..."
+SETTINGS_ENCRYPTION_KEY="<stable-production-encryption-key>"
+```
+
+OAuth state, encrypted tokens, expiration metadata, granted scopes, and account
+metadata are stored in PostgreSQL. Keep `SETTINGS_ENCRYPTION_KEY` stable across
+restarts and identical anywhere encrypted credentials are read.
+
+Apply the PostgreSQL migrations before connecting PagerDuty:
+
+```bash
+dev-hops migrate postgres upgrade
+```
+
+Then restart or roll out the ops API and workers so they receive the new secrets.
+Do not expose `PAGER_DUTY_SECRET` through browser-visible environment variables.
+
+## 3. Connect PagerDuty once for the organization
+
+1. Sign in to Dev Health as an organization admin.
+2. Open **Admin → Integrations → PagerDuty**.
+3. Leave the credential name as `default` unless the organization intentionally
+   connects multiple PagerDuty accounts.
+4. Enter the PagerDuty account subdomain. For
+   `https://acme.pagerduty.com`, enter `acme`.
+5. Select the account region, `us` or `eu`.
+6. Select the datasets to sync.
+7. Keep **OAuth** selected and choose **Connect PagerDuty**.
+8. In PagerDuty, review the read-only permissions and authorize the app.
+9. After Dev Health reports that the connection is complete, return to the
+   PagerDuty integration page and load its status.
+10. Run permission preflight for every selected dataset.
+
+The callback stores an encrypted access token, refresh token when provided,
+expiration, granted scopes, account identity, region, and subdomain. The normal
+integration descriptor remains tokenless.
+
+## 4. Validate the shared connection
+
+A healthy OAuth connection reports:
+
+```json
+{
+  "connected": true,
+  "credential_name": "default",
+  "auth_mode": "oauth",
+  "region": "us",
+  "subdomain": "acme",
+  "granted_scopes": [
+    "Incidents.read",
+    "Services.read"
+  ],
+  "has_refresh_token": true
+}
+```
+
+The exact `granted_scopes` list depends on the selected datasets. Preflight should
+mark every selected dataset as granted. If a dataset is missing permission, update
+the PagerDuty app's read access and reconnect so PagerDuty issues a token with the
+new scope set.
+
+After preflight succeeds, discover PagerDuty services, map them to one or more Dev
+Health repositories, configure the sync, and start the initial backfill.
+
+## Local testing
+
+Authorization-code redirects can use localhost because PagerDuty redirects the
+browser running on your machine:
+
+```text
+http://localhost:3000/org/admin/integrations/pagerduty/callback
+```
+
+Register that exact redirect URL in the PagerDuty app and set:
+
+```dotenv
+PAGER_DUTY_REDIRECT_URI="http://localhost:3000/org/admin/integrations/pagerduty/callback"
+```
+
+PagerDuty webhooks are separate from the OAuth callback and require a publicly
+reachable HTTPS endpoint when webhook mode is enabled.
+
+## Troubleshooting
+
+### `PAGER_DUTY_CLIENT_ID is not configured`
+
+The ops API did not receive the registered app configuration. Set
+`PAGER_DUTY_CLIENT_ID`, `PAGER_DUTY_SECRET`, and `PAGER_DUTY_REDIRECT_URI`, then
+restart the API.
+
+### Redirect URI mismatch
+
+Confirm that PagerDuty App Registration and `PAGER_DUTY_REDIRECT_URI` use the
+same scheme, host, port, path, and trailing-slash behavior. The expected path is:
+
+```text
+/org/admin/integrations/pagerduty/callback
+```
+
+### Invalid or expired OAuth state
+
+Start the connection again from Dev Health. Authorization state is short-lived,
+one-time, and bound to the Dev Health organization. Reusing a callback or opening
+an old callback URL is rejected.
+
+### Missing required scopes
+
+Dev Health rejects a completed authorization that lacks a scope required by the
+selected datasets and attempts to revoke the issued token. Add the missing read
+access in PagerDuty, then reconnect.
+
+### Partial data or no accessible services
+
+Check the account subdomain and region first. Then confirm that the PagerDuty user
+who granted consent can access the required teams, services, schedules, and
+incidents. Reconnect with an appropriately authorized PagerDuty identity when
+necessary.
+
+### Sync works initially but refresh later fails
+
+Confirm that every worker has the same `PAGER_DUTY_CLIENT_ID` and
+`PAGER_DUTY_SECRET` as the API, and that `SETTINGS_ENCRYPTION_KEY` has not changed.
+If the PagerDuty client secret or grant was revoked, disconnect and reconnect the
+integration.
+
+## Disconnect and rotate
+
+Disconnecting the PagerDuty integration removes the local OAuth binding, clears
+the active credential descriptor, and attempts to revoke the remote token. To
+rotate the PagerDuty app's client secret, update the API and workers together,
+roll them out, then reconnect any authorization-code bindings that PagerDuty has
+invalidated.
+
+See PagerDuty's official [Apps documentation](https://support.pagerduty.com/main/docs/apps)
+and [Scoped OAuth overview](https://www.pagerduty.com/blog/insights/build-sophisticated-apps-for-your-pagerduty-environment-using-oauth-2-0-and-api-scopes/)
+for the provider-side concepts behind app registration and consent.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -40,6 +40,7 @@ nav:
       - Configure a workspace: configuration.md
       - Manage teams: team-configuration.md
       - Connect GitHub: user-guide/github-app-setup.md
+      - Connect PagerDuty: user-guide/pagerduty-oauth-app-setup.md
       - Ingest your data: customer-push-ingestion/overview.md
       - Set up webhooks: webhooks.md
   - Deploy & operate:


### PR DESCRIPTION
## Summary

- add a public PagerDuty OAuth app registration and connection guide
- explain the organization-wide authorization model: one admin connection per Dev Health organization, shared by its users
- document the exact browser callback URL, read-only scopes, runtime secrets, migrations, preflight, local testing, rotation, and troubleshooting
- correct the callback example in `.env.example`
- add PagerDuty to the documentation navigation and configuration index

## Why

The PagerDuty OAuth implementation is available, but operators did not have a durable setup guide. The existing environment example also pointed at the ops API callback endpoint even though PagerDuty must redirect the browser to the Dev Health Web callback route.

## User and operator impact

Operators can register the PagerDuty app and configure OAuth without requiring every Dev Health user to authorize separately. The guide makes the shared organization scope and the authorizing PagerDuty user's visibility requirements explicit.

This is documentation-only and does not change runtime behavior.

## Validation

Passing checks:

- Tests
- Lint
- Typecheck
- Governance Gate
- Build Docker images
- Live Backend E2E

Manual review:

- compared the branch with `main`; the diff is limited to four documentation/configuration files
- cross-checked environment names, scopes, callback behavior, token storage, preflight, and worker refresh requirements against the current PagerDuty implementation

Known unrelated check failure:

- **Documentation inventory review**: the frozen validator expects 313 generated ops rows, while the current inventory generator emits 501 on this branch. This PR adds one new inventory row, so the pre-existing baseline would still emit 500 without this guide. Updating the documentation inventory program is intentionally outside this focused setup-doc PR.

## Tracking

- Linear: [CHAOS-3023](https://linear.app/fullchaos/issue/CHAOS-3023/document-pagerduty-oauth-app-setup-and-organization-wide-connection)
- Parent program: CHAOS-2954
- Related setup work: CHAOS-2960