### PR TITLE
fix(ci): support governance policy gate in the merge queue

### DIFF
--- a/.github/workflows/governance.yml
+++ b/.github/workflows/governance.yml
@@ -18,17 +18,52 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      pull-requests: read
 
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
         with:
           fetch-depth: 0
 
+      - name: Resolve governance context
+        id: governance-context
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+          MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref }}
+          PR_BODY: ${{ github.event.pull_request.body }}
+          GH_TOKEN: ${{ github.token }}
+          REPOSITORY_NAME: ${{ github.event.repository.name }}
+        run: |
+          body="$PR_BODY"
+          if [[ "$EVENT_NAME" == "merge_group" ]]; then
+            if [[ "$MERGE_GROUP_HEAD_REF" =~ /pr-([0-9]+)- ]]; then
+              pr_number="${BASH_REMATCH[1]}"
+            else
+              echo "Unable to identify the queued pull request from $MERGE_GROUP_HEAD_REF" >&2
+              exit 2
+            fi
+            # shellcheck disable=SC2016
+            body="$(
+              gh api graphql --paginate --slurp \
+                -f query='query($owner:String!,$name:String!,$number:Int!,$endCursor:String){repository(owner:$owner,name:$name){pullRequest(number:$number){mergeQueueEntry{position mergeQueue{entries(first:100,after:$endCursor){nodes{position pullRequest{body}} pageInfo{hasNextPage endCursor}}}}}}}' \
+                -f owner="$GITHUB_REPOSITORY_OWNER" \
+                -f name="$REPOSITORY_NAME" \
+                -F number="$pr_number" \
+                --jq '.[0].data.repository.pullRequest.mergeQueueEntry as $current | [.[].data.repository.pullRequest.mergeQueueEntry.mergeQueue.entries.nodes[] | select(.position <= $current.position) | (.pullRequest.body // "")] | join("\n")'
+            )"
+          fi
+          delimiter="pr_body_$(uuidgen)"
+          {
+            echo "pr_body<<$delimiter"
+            echo "$body"
+            echo "$delimiter"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Enforce governance policy
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
-          PR_BODY: ${{ github.event.pull_request.body }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.event.merge_group.head_sha }}
+          PR_BODY: ${{ steps.governance-context.outputs.pr_body }}
         run: |
           python3 ci/check_governance_gate.py \
             --base-sha "$BASE_SHA" \

--- a/tests/test_governance_workflow.py
+++ b/tests/test_governance_workflow.py
@@ -1,0 +1,92 @@
+import os
+import subprocess
+from pathlib import Path
+
+import yaml
+
+WORKFLOW_PATH = Path(__file__).parents[1] / ".github/workflows/governance.yml"
+
+
+def _governance_context_script() -> str:
+    workflow: dict[str, object] = yaml.safe_load(
+        WORKFLOW_PATH.read_text(encoding="utf-8")
+    )
+    jobs = workflow["jobs"]
+    assert isinstance(jobs, dict)
+    governance = jobs["governance"]
+    assert isinstance(governance, dict)
+    steps = governance["steps"]
+    assert isinstance(steps, list)
+    context_step = next(
+        step
+        for step in steps
+        if isinstance(step, dict) and step.get("id") == "governance-context"
+    )
+    script = context_step["run"]
+    assert isinstance(script, str)
+    return script
+
+
+def test_governance_workflow_uses_merge_group_shas() -> None:
+    # Given a governance workflow triggered for pull requests and merge groups
+    # When its event-specific SHA inputs are inspected
+    workflow = WORKFLOW_PATH.read_text(encoding="utf-8")
+
+    # Then merge-queue runs can compare the queue group's base and head commits
+    assert (
+        "BASE_SHA: ${{ github.event.pull_request.base.sha || "
+        "github.event.merge_group.base_sha }}" in workflow
+    )
+    assert (
+        "HEAD_SHA: ${{ github.event.pull_request.head.sha || "
+        "github.event.merge_group.head_sha }}" in workflow
+    )
+
+
+def test_governance_workflow_resolves_all_merge_group_pr_bodies(
+    tmp_path: Path,
+) -> None:
+    # Given merge-group payloads omit pull_request metadata
+    fake_gh = tmp_path / "gh"
+    gh_args = tmp_path / "gh-args.txt"
+    github_output = tmp_path / "github-output.txt"
+    fake_gh.write_text(
+        "#!/usr/bin/env bash\n"
+        'printf \'%s\\n\' "$@" > "$GH_ARGS_FILE"\n'
+        "printf 'first PR evidence\\nsecond PR evidence\\n'\n",
+        encoding="utf-8",
+    )
+    fake_gh.chmod(0o755)
+
+    # When the governance workflow prepares its policy inputs
+    result = subprocess.run(
+        ["bash", "-euo", "pipefail", "-c", _governance_context_script()],
+        check=False,
+        capture_output=True,
+        text=True,
+        env={
+            "EVENT_NAME": "merge_group",
+            "MERGE_GROUP_HEAD_REF": "refs/heads/gh-readonly-queue/main/pr-1262-deadbeef",
+            "PR_BODY": "",
+            "GH_TOKEN": "test-token",
+            "GITHUB_REPOSITORY": "full-chaos/dev-health-ops",
+            "GITHUB_REPOSITORY_OWNER": "full-chaos",
+            "REPOSITORY_NAME": "dev-health-ops",
+            "GITHUB_OUTPUT": str(github_output),
+            "GH_ARGS_FILE": str(gh_args),
+            "PATH": f"{tmp_path}:{os.environ['PATH']}",
+        },
+    )
+
+    # Then it resolves the queued pull request body instead of passing an empty value
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "first PR evidence\nsecond PR evidence" in github_output.read_text(
+        encoding="utf-8"
+    )
+    invocation = gh_args.read_text(encoding="utf-8")
+    assert "mergeQueue" in invocation
+    assert "--paginate" in invocation
+    assert "--slurp" in invocation
+    assert "entries(first:100,after:$endCursor)" in invocation
+    assert "pageInfo{hasNextPage endCursor}" in invocation
+    assert "position <= $current.position" in invocation


### PR DESCRIPTION
## Summary

Makes the `governance` GitHub Actions workflow work inside the **merge queue**. Today the workflow reads only `github.event.pull_request.*`; on a `merge_group` event that payload is absent, so `BASE_SHA`/`HEAD_SHA`/`PR_BODY` collapse to empty and the governance gate runs against nothing.

## Merge-queue context

When a PR is queued, GitHub dispatches a `merge_group` event with `merge_group.base_sha`, `merge_group.head_sha`, and a `merge_group.head_ref` of the form `.../pr-<N>-<sha>` — but no `pull_request` object. This PR:

- Adds a `governance-context` step that resolves `BASE_SHA`/`HEAD_SHA` with `|| github.event.merge_group.base_sha/head_sha` fallbacks.
- For `merge_group` events, parses the queued PR number from `head_ref` and aggregates the PR bodies of **every merge-queue entry at or before the current position** via a paginated `gh api graphql` query on `mergeQueueEntry`.
- Adds `pull-requests: read` permission (required for the GraphQL body lookup).
- Feeds the resolved body into the existing `ci/check_governance_gate.py` enforcement step.

## Tests

`tests/test_governance_workflow.py` (2 tests, both pass locally):

- `test_governance_workflow_uses_merge_group_shas` — asserts the `||` SHA-fallback expressions are present.
- `test_governance_workflow_resolves_all_merge_group_pr_bodies` — executes the extracted `governance-context` bash against a fake `gh`, asserting paginated queue-body aggregation (`--paginate`, `--slurp`, `entries(first:100,after:$endCursor)`, `pageInfo{hasNextPage endCursor}`, `position <= $current.position`).

Local validation: `pytest tests/test_governance_workflow.py` → 2 passed; `actionlint .github/workflows/governance.yml` → clean; ruff-format/ruff-check/mypy (pre-push) → pass.

## Provenance

Discovered while landing CHAOS-3024 (Task1, PR #1262, squash-merged). This CI fix is **unrelated** to the CHAOS-3024 product change and is intentionally split out as a standalone follow-up rather than folded into that squashed history.

Closes CHAOS-3057

SCREENSHOT-WAIVER: workflow/test-only (no UI render)
