### PR TITLE
fix(pagerduty): start published OAuth without credential fields

### DIFF
--- a/src/dev_health_ops/alembic/versions/0045_pagerduty_published_oauth_state.py
+++ b/src/dev_health_ops/alembic/versions/0045_pagerduty_published_oauth_state.py
@@ -1,0 +1,48 @@
+"""Retain only server-generated PagerDuty OAuth authorization state.
+
+Revision ID: 0045
+Revises: 0044
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0045"
+down_revision: str | None = "0044"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.drop_column("pagerduty_oauth_authorization_requests", "initiated_by")
+    op.drop_column("pagerduty_oauth_authorization_requests", "subdomain")
+    op.drop_column("pagerduty_oauth_authorization_requests", "region")
+    op.drop_column("pagerduty_oauth_authorization_requests", "enabled_datasets")
+    op.drop_column("pagerduty_oauth_authorization_requests", "credential_name")
+
+
+def downgrade() -> None:
+    op.add_column(
+        "pagerduty_oauth_authorization_requests",
+        sa.Column("credential_name", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "pagerduty_oauth_authorization_requests",
+        sa.Column("enabled_datasets", sa.JSON(), nullable=True),
+    )
+    op.add_column(
+        "pagerduty_oauth_authorization_requests",
+        sa.Column("region", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "pagerduty_oauth_authorization_requests",
+        sa.Column("subdomain", sa.Text(), nullable=True),
+    )
+    op.add_column(
+        "pagerduty_oauth_authorization_requests",
+        sa.Column("initiated_by", sa.Text(), nullable=True),
+    )

--- a/src/dev_health_ops/api/admin/routers/pagerduty.py
+++ b/src/dev_health_ops/api/admin/routers/pagerduty.py
@@ -9,8 +9,9 @@ from __future__ import annotations
 
 import uuid
 from collections.abc import Mapping
+from dataclasses import dataclass
 from datetime import datetime
-from typing import Literal
+from typing import Final, Literal
 
 import httpx
 from fastapi import APIRouter, Depends, HTTPException
@@ -18,8 +19,10 @@ from pydantic import BaseModel, ConfigDict, Field, field_validator
 from sqlalchemy.exc import SQLAlchemyError
 from sqlalchemy.ext.asyncio import AsyncSession
 
-from dev_health_ops.api.admin.middleware import get_admin_org_id, get_admin_user
-from dev_health_ops.api.services.auth import AuthenticatedUser
+from dev_health_ops.api.admin.middleware import (  # noqa: F401
+    get_admin_org_id,
+    get_admin_user,
+)
 from dev_health_ops.api.services.configuration import IntegrationCredentialsService
 from dev_health_ops.credentials.types import CredentialSource, PagerDutyCredentials
 from dev_health_ops.licensing import is_org_feature_enabled_async
@@ -59,6 +62,16 @@ router = APIRouter()
 _FEATURE_DISABLED_DETAIL = (
     "Canonical incident ingestion is not enabled for this organization"
 )
+_OAUTH_CREDENTIAL_NAME: Final = "default"
+_PAGERDUTY_REGIONS: Final = ("us", "eu")
+
+
+@dataclass(frozen=True, slots=True)
+class ValidatedOAuthIdentity:
+    """PagerDuty identity proof paired with the server-selected API region."""
+
+    validated: ValidatedPagerDutyCredential
+    region: str
 
 
 async def _require_canonical_incident_ingestion(
@@ -82,22 +95,9 @@ async def _require_canonical_incident_ingestion(
 
 
 class PagerDutyAuthorizeRequest(BaseModel):
-    """Inputs required to begin a server-bound PagerDuty PKCE flow."""
+    """Empty published-app OAuth request; setup details are provider-derived."""
 
-    model_config = ConfigDict(extra="forbid")
-
-    credential_name: str = "default"
-    region: Literal["us", "eu"] = "us"
-    subdomain: str = Field(min_length=1)
-    enabled_datasets: list[str]
-
-    @field_validator("credential_name", "subdomain")
-    @classmethod
-    def normalize_required_text(cls, value: str) -> str:
-        normalized = value.strip()
-        if not normalized:
-            raise ValueError("value must not be blank")
-        return normalized
+    model_config = ConfigDict(extra="forbid", frozen=True)
 
 
 class PagerDutyAuthorizeResponse(BaseModel):
@@ -269,20 +269,9 @@ async def authorize_pagerduty(
     body: PagerDutyAuthorizeRequest,
     session: AsyncSession = Depends(get_session),
     org_id: str = Depends(get_admin_org_id),
-    admin_user: AuthenticatedUser = Depends(get_admin_user),
 ) -> PagerDutyAuthorizeResponse:
     """Create a one-time authorization context and return PagerDuty's URL."""
     await _require_canonical_incident_ingestion(session, org_id)
-    enabled_datasets = set(body.enabled_datasets)
-    unknown_datasets = enabled_datasets.difference(DATASET_OAUTH_FAMILIES)
-    if unknown_datasets:
-        raise HTTPException(
-            status_code=400,
-            detail=(
-                f"Unknown PagerDuty datasets: {', '.join(sorted(unknown_datasets))}"
-            ),
-        )
-
     config = PagerDutyOAuthConfig.from_env()
     if config is None:
         raise HTTPException(
@@ -290,16 +279,11 @@ async def authorize_pagerduty(
             detail="PAGER_DUTY_CLIENT_ID is not configured",
         )
 
-    authorization_request = build_authorization_request(config, enabled_datasets)
+    authorization_request = build_authorization_request(config)
     await PagerDutyAuthorizationRequestStore(session).create(
         org_id=org_id,
         state=authorization_request.state,
-        credential_name=body.credential_name,
         code_verifier=authorization_request.code_verifier,
-        enabled_datasets=body.enabled_datasets,
-        region=body.region,
-        subdomain=body.subdomain,
-        initiated_by=admin_user.user_id or None,
     )
     return PagerDutyAuthorizeResponse(authorize_url=authorization_request.url)
 
@@ -344,13 +328,6 @@ async def complete_pagerduty_authorization(
             detail="PagerDuty OAuth configuration is unavailable",
         )
 
-    subdomain = consumed.subdomain
-    if subdomain is None:
-        raise HTTPException(
-            status_code=400,
-            detail="PagerDuty OAuth state is missing account context",
-        )
-
     try:
         tokens = await exchange_code(
             config,
@@ -383,44 +360,27 @@ async def complete_pagerduty_authorization(
             ),
         )
     try:
-        validated = await validate_pagerduty_credential(
-            PagerDutyCredentials(
-                source=CredentialSource.DATABASE,
-                auth_mode="oauth",
-                access_token=tokens.access_token,
-                granted_scopes=tuple(tokens.granted_scopes),
-                subdomain=subdomain,
-                region=consumed.region,
-            ),
-            required_scopes=READ_SCOPES,
-        )
+        identity = await _validate_oauth_identity(tokens)
     except PagerDutyCredentialValidationError as exc:
         await _revoke_tokens(config, tokens)
         raise HTTPException(
             status_code=400,
             detail="PagerDuty OAuth account validation failed",
         ) from exc
-    try:
-        _require_verified_subdomain(validated, subdomain)
-    except HTTPException:
-        await _revoke_tokens(config, tokens)
-        raise
-
+    credential_name = _oauth_credential_name(identity.validated)
     repository = PagerDutyOAuthCredentialRepository(
         session,
         org_id,
-        consumed.credential_name,
+        credential_name,
     )
-    revocations = PagerDutyOAuthRevocationRepository(
-        session, org_id, consumed.credential_name
-    )
+    revocations = PagerDutyOAuthRevocationRepository(session, org_id, credential_name)
     binding_id = uuid.uuid4().hex
     try:
         replacement = await repository.replace_and_capture(
             tokens,
             binding_id=binding_id,
-            account_id=validated.account_id,
-            account_display=validated.account_display,
+            account_id=identity.validated.account_id,
+            account_display=identity.validated.account_display,
         )
         if replacement.replaced_tokens is not None:
             await revocations.enqueue(
@@ -430,21 +390,21 @@ async def complete_pagerduty_authorization(
             )
         await IntegrationCredentialsService(session, org_id).set(
             provider="pagerduty",
-            name=consumed.credential_name,
+            name=credential_name,
             credentials={
                 "auth_mode": "oauth",
-                "oauth_credential_name": consumed.credential_name,
+                "oauth_credential_name": credential_name,
                 "oauth_binding_id": binding_id,
-                "subdomain": validated.subdomain,
-                "region": consumed.region,
-                "account_id": validated.account_id,
+                "subdomain": identity.validated.subdomain,
+                "region": identity.region,
+                "account_id": identity.validated.account_id,
             },
             config={
                 "auth_mode": "oauth",
-                "region": consumed.region,
-                "subdomain": validated.subdomain,
-                "account_id": validated.account_id,
-                "account_display": validated.account_display,
+                "region": identity.region,
+                "subdomain": identity.validated.subdomain,
+                "account_id": identity.validated.account_id,
+                "account_display": identity.validated.account_display,
                 "granted_scopes": sorted(tokens.granted_scopes),
             },
             is_active=True,
@@ -459,11 +419,40 @@ async def complete_pagerduty_authorization(
 
     return PagerDutyCallbackResponse(
         connected=True,
-        credential_name=consumed.credential_name,
-        region=consumed.region,
-        subdomain=validated.subdomain,
+        credential_name=credential_name,
+        region=identity.region,
+        subdomain=identity.validated.subdomain,
         granted_scopes=sorted(tokens.granted_scopes),
     )
+
+
+async def _validate_oauth_identity(tokens: OAuthTokens) -> ValidatedOAuthIdentity:
+    """Resolve the authenticated PagerDuty account through server-controlled regions."""
+    validation_error: PagerDutyCredentialValidationError | None = None
+    for region in _PAGERDUTY_REGIONS:
+        try:
+            validated = await validate_pagerduty_credential(
+                PagerDutyCredentials(
+                    source=CredentialSource.DATABASE,
+                    auth_mode="oauth",
+                    access_token=tokens.access_token,
+                    granted_scopes=tuple(tokens.granted_scopes),
+                    region=region,
+                ),
+                required_scopes=READ_SCOPES,
+            )
+        except PagerDutyCredentialValidationError as exc:
+            validation_error = exc
+        else:
+            return ValidatedOAuthIdentity(validated=validated, region=region)
+    if validation_error is not None:
+        raise validation_error
+    raise PagerDutyCredentialValidationError("missing_account_identity")
+
+
+def _oauth_credential_name(validated: ValidatedPagerDutyCredential) -> str:
+    """Use PagerDuty's account display unless it is absent."""
+    return validated.account_display or _OAUTH_CREDENTIAL_NAME
 
 
 async def _revoke_access_token(config: PagerDutyOAuthConfig, access_token: str) -> None:

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -273,12 +273,7 @@ class PagerDutyOAuthAuthorizationRequest(Base):
 
     state_hash: Mapped[str] = mapped_column(Text, primary_key=True)
     org_id: Mapped[str] = mapped_column(Text, nullable=False, index=True)
-    credential_name: Mapped[str] = mapped_column(Text, nullable=False)
     code_verifier_encrypted: Mapped[str] = mapped_column(Text, nullable=False)
-    enabled_datasets: Mapped[list[str]] = mapped_column(JSON, nullable=False)
-    region: Mapped[str] = mapped_column(Text, nullable=False)
-    subdomain: Mapped[str | None] = mapped_column(Text, nullable=True)
-    initiated_by: Mapped[str | None] = mapped_column(Text, nullable=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True), nullable=False
     )

--- a/src/dev_health_ops/providers/pagerduty/oauth.py
+++ b/src/dev_health_ops/providers/pagerduty/oauth.py
@@ -118,9 +118,7 @@ def missing_read_scopes(
     return required_read_scopes(enabled_datasets).difference(granted_scopes)
 
 
-def build_authorization_request(
-    config: PagerDutyOAuthConfig, _enabled_datasets: set[str]
-) -> AuthorizationRequest:
+def build_authorization_request(config: PagerDutyOAuthConfig) -> AuthorizationRequest:
     verifier = secrets.token_urlsafe(64)
     challenge = (
         base64.urlsafe_b64encode(hashlib.sha256(verifier.encode()).digest())

--- a/src/dev_health_ops/providers/pagerduty/oauth_authorization_store.py
+++ b/src/dev_health_ops/providers/pagerduty/oauth_authorization_store.py
@@ -24,11 +24,7 @@ def _utc_time(now: datetime | None) -> datetime:
 class ConsumedAuthorizationRequest:
     """Authorization context available only after a successful one-time consume."""
 
-    credential_name: str
     code_verifier: str
-    enabled_datasets: list[str]
-    region: str
-    subdomain: str | None
 
 
 class PagerDutyAuthorizationRequestStore:
@@ -42,12 +38,7 @@ class PagerDutyAuthorizationRequestStore:
         *,
         org_id: str,
         state: str,
-        credential_name: str,
         code_verifier: str,
-        enabled_datasets: list[str],
-        region: str,
-        subdomain: str | None = None,
-        initiated_by: str | None = None,
         ttl: timedelta = timedelta(minutes=15),
         now: datetime | None = None,
     ) -> None:
@@ -63,12 +54,7 @@ class PagerDutyAuthorizationRequestStore:
             PagerDutyOAuthAuthorizationRequest(
                 state_hash=hashlib.sha256(state.encode()).hexdigest(),
                 org_id=org_id,
-                credential_name=credential_name,
                 code_verifier_encrypted=encrypt_value(code_verifier),
-                enabled_datasets=enabled_datasets,
-                region=region,
-                subdomain=subdomain,
-                initiated_by=initiated_by,
                 created_at=created_at,
                 expires_at=created_at + ttl,
             )
@@ -102,11 +88,7 @@ class PagerDutyAuthorizationRequestStore:
             return None
 
         return ConsumedAuthorizationRequest(
-            credential_name=authorization_request.credential_name,
             code_verifier=decrypt_value(authorization_request.code_verifier_encrypted),
-            enabled_datasets=authorization_request.enabled_datasets,
-            region=authorization_request.region,
-            subdomain=authorization_request.subdomain,
         )
 
     async def purge_expired(self, *, now: datetime | None = None) -> int:

--- a/tests/api/admin/test_org_deletion.py
+++ b/tests/api/admin/test_org_deletion.py
@@ -633,10 +633,7 @@ async def test_org_deletion_removes_pagerduty_binding_and_oauth_records(
                 PagerDutyOAuthAuthorizationRequest(
                     state_hash="state-hash",
                     org_id=org1_id,
-                    credential_name="operations",
                     code_verifier_encrypted="ciphertext",
-                    enabled_datasets=["incidents"],
-                    region="us",
                     created_at=datetime.now(timezone.utc),
                     expires_at=datetime.now(timezone.utc),
                 ),

--- a/tests/api/admin/test_pagerduty_feature_gate.py
+++ b/tests/api/admin/test_pagerduty_feature_gate.py
@@ -52,12 +52,7 @@ async def test_authorize_rejects_when_canonical_incident_feature_is_off(
     # When
     response = await client.post(
         "/api/v1/admin/integrations/pagerduty/authorize",
-        json={
-            "credential_name": "operations",
-            "region": "eu",
-            "subdomain": "acme",
-            "enabled_datasets": ["incidents"],
-        },
+        json={},
     )
 
     # Then

--- a/tests/api/admin/test_pagerduty_feature_gate_mutations.py
+++ b/tests/api/admin/test_pagerduty_feature_gate_mutations.py
@@ -38,12 +38,7 @@ def _canonical_incident_feature_enabled(monkeypatch: pytest.MonkeyPatch) -> None
     (
         (
             "/api/v1/admin/integrations/pagerduty/authorize",
-            {
-                "credential_name": "operations",
-                "region": "us",
-                "subdomain": "acme",
-                "enabled_datasets": ["incidents"],
-            },
+            {},
         ),
         (
             "/api/v1/admin/integrations/pagerduty/client-credentials",
@@ -116,7 +111,7 @@ async def test_pagerduty_gate_fails_closed_when_evaluator_storage_fails(
     # When
     response = await client.post(
         "/api/v1/admin/integrations/pagerduty/authorize",
-        json={"subdomain": "acme", "enabled_datasets": ["incidents"]},
+        json={},
     )
 
     # Then

--- a/tests/api/admin/test_pagerduty_oauth_setup.py
+++ b/tests/api/admin/test_pagerduty_oauth_setup.py
@@ -121,7 +121,7 @@ async def client(
             access_token=None,
             granted_scopes=required_scopes,
             account_id="acme",
-            account_display="Acme Operations",
+            account_display="operations",
             subdomain="acme",
         )
 
@@ -162,15 +162,10 @@ async def client(
     app.dependency_overrides.clear()
 
 
-async def _authorize(client: AsyncClient, *, datasets: list[str]) -> str:
+async def _authorize(client: AsyncClient, *, datasets: list[str] | None = None) -> str:
     response = await client.post(
         "/api/v1/admin/integrations/pagerduty/authorize",
-        json={
-            "credential_name": "operations",
-            "region": "eu",
-            "subdomain": "acme",
-            "enabled_datasets": datasets,
-        },
+        json={},
     )
     assert response.status_code == 200
     return parse_qs(urlparse(response.json()["authorize_url"]).query)["state"][0]
@@ -194,7 +189,7 @@ async def test_authorize_returns_url_and_persists_hashed_request(
     client: AsyncClient,
     session_maker: async_sessionmaker[AsyncSession],
 ) -> None:
-    state = await _authorize(client, datasets=["incidents", "services"])
+    state = await _authorize(client)
 
     async with session_maker() as session:
         persisted = (
@@ -203,11 +198,11 @@ async def test_authorize_returns_url_and_persists_hashed_request(
 
     assert persisted.state_hash == hashlib.sha256(state.encode()).hexdigest()
     assert persisted.state_hash != state
-    assert persisted.credential_name == "operations"
-    assert persisted.region == "eu"
-    assert persisted.subdomain == "acme"
-    assert persisted.enabled_datasets == ["incidents", "services"]
-    assert persisted.initiated_by == _USER_ID
+    assert not hasattr(persisted, "credential_name")
+    assert not hasattr(persisted, "region")
+    assert not hasattr(persisted, "subdomain")
+    assert not hasattr(persisted, "enabled_datasets")
+    assert not hasattr(persisted, "initiated_by")
 
 
 @pytest.mark.asyncio
@@ -217,10 +212,10 @@ async def test_authorize_rejects_unknown_dataset(
 ) -> None:
     response = await client.post(
         "/api/v1/admin/integrations/pagerduty/authorize",
-        json={"subdomain": "acme", "enabled_datasets": ["unknown"]},
+        json={"enabled_datasets": ["unknown"]},
     )
 
-    assert response.status_code == 400
+    assert response.status_code == 422
     async with session_maker() as session:
         assert (
             await session.execute(select(PagerDutyOAuthAuthorizationRequest))
@@ -241,7 +236,7 @@ async def test_authorize_rejects_missing_registered_app_config(
 
     response = await client.post(
         "/api/v1/admin/integrations/pagerduty/authorize",
-        json={"subdomain": "acme", "enabled_datasets": ["incidents"]},
+        json={},
     )
 
     assert response.status_code == 400
@@ -278,7 +273,7 @@ async def test_callback_persists_oauth_token_and_safe_descriptor(
     assert response.json() == {
         "connected": True,
         "credential_name": "operations",
-        "region": "eu",
+        "region": "us",
         "subdomain": "acme",
         "granted_scopes": sorted(READ_SCOPES),
     }
@@ -294,7 +289,7 @@ async def test_callback_persists_oauth_token_and_safe_descriptor(
         ).scalar_one()
 
     assert oauth_credential.account_id == "acme"
-    assert oauth_credential.account_display == "Acme Operations"
+    assert oauth_credential.account_display == "operations"
     assert integration_credential.is_active is True
     assert descriptor is not None
     assert descriptor == {
@@ -302,17 +297,17 @@ async def test_callback_persists_oauth_token_and_safe_descriptor(
         "oauth_credential_name": "operations",
         "oauth_binding_id": oauth_credential.binding_id,
         "subdomain": "acme",
-        "region": "eu",
+        "region": "us",
         "account_id": "acme",
     }
     assert "access_token" not in descriptor
     assert "refresh_token" not in descriptor
     assert integration_credential.config == {
         "auth_mode": "oauth",
-        "region": "eu",
+        "region": "us",
         "subdomain": "acme",
         "account_id": "acme",
-        "account_display": "Acme Operations",
+        "account_display": "operations",
         "granted_scopes": sorted(READ_SCOPES),
     }
 
@@ -642,7 +637,7 @@ async def test_client_credentials_persists_exact_descriptor(
         "region": "eu",
         "subdomain": "acme",
         "account_id": "acme",
-        "account_display": "Acme Operations",
+        "account_display": "operations",
     }
 
 
@@ -678,7 +673,7 @@ async def test_api_token_persists_exact_descriptor(
         "region": "us",
         "subdomain": "acme",
         "account_id": "acme",
-        "account_display": "Acme Operations",
+        "account_display": "operations",
     }
 
 
@@ -1375,7 +1370,7 @@ async def _connect_oauth(
 
 
 @pytest.mark.asyncio
-async def test_callback_rejects_missing_subdomain_before_exchange(
+async def test_callback_derives_account_context_after_exchange(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
     session_maker: async_sessionmaker[AsyncSession],
@@ -1384,15 +1379,15 @@ async def test_callback_rejects_missing_subdomain_before_exchange(
         await pagerduty_router.PagerDutyAuthorizationRequestStore(session).create(
             org_id=_ORG_ID,
             state="state-without-subdomain",
-            credential_name="operations",
             code_verifier="verifier",
-            enabled_datasets=["incidents"],
-            region="eu",
-            subdomain=None,
-            initiated_by=_USER_ID,
         )
         await session.commit()
-    exchange = AsyncMock(side_effect=AssertionError("exchange must not run"))
+    tokens = OAuthTokens(
+        access_token="access-token",
+        expires_at=datetime.now(UTC) + timedelta(hours=1),
+        granted_scopes=READ_SCOPES,
+    )
+    exchange = AsyncMock(return_value=tokens)
     monkeypatch.setattr(pagerduty_router, "exchange_code", exchange)
 
     response = await client.post(
@@ -1400,12 +1395,12 @@ async def test_callback_rejects_missing_subdomain_before_exchange(
         json={"state": "state-without-subdomain", "code": "authorization-code"},
     )
 
-    assert response.status_code == 400
-    exchange.assert_not_awaited()
+    assert response.status_code == 200
+    exchange.assert_awaited_once()
 
 
 @pytest.mark.asyncio
-async def test_callback_rejects_mismatched_verified_account_without_persistence(
+async def test_callback_uses_authenticated_account_without_browser_comparison(
     client: AsyncClient,
     monkeypatch: pytest.MonkeyPatch,
     session_maker: async_sessionmaker[AsyncSession],
@@ -1442,9 +1437,9 @@ async def test_callback_rejects_mismatched_verified_account_without_persistence(
         json={"state": state, "code": "authorization-code"},
     )
 
-    assert response.status_code == 400
-    assert await _persisted_counts(session_maker) == (0, 0)
-    revoke.assert_awaited_once_with(_CONFIG, "refresh-token")
+    assert response.status_code == 200
+    assert await _persisted_counts(session_maker) == (1, 1)
+    revoke.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/tests/providers/test_pagerduty_client.py
+++ b/tests/providers/test_pagerduty_client.py
@@ -17,7 +17,7 @@ def test_oauth_bearer_and_api_token_headers() -> None:
 
 def test_authorization_request_uses_pkce_and_read_scopes() -> None:
     config = PagerDutyOAuthConfig("client", "secret", "https://example.test/callback")
-    request = build_authorization_request(config, {"incidents", "users"})
+    request = build_authorization_request(config)
 
     assert "code_challenge_method=S256" in request.url
     assert request.state in request.url

--- a/tests/providers/test_pagerduty_oauth_authorization_store.py
+++ b/tests/providers/test_pagerduty_oauth_authorization_store.py
@@ -49,22 +49,14 @@ async def test_consume_returns_encrypted_pkce_context(session: AsyncSession) -> 
     await store.create(
         org_id="org-1",
         state="opaque-state",
-        credential_name="primary",
         code_verifier="pkce-verifier",
-        enabled_datasets=["incidents", "services"],
-        region="us",
-        subdomain="acme",
         now=_NOW,
     )
 
     consumed = await store.consume(org_id="org-1", state="opaque-state", now=_NOW)
 
     assert consumed is not None
-    assert consumed.credential_name == "primary"
     assert consumed.code_verifier == "pkce-verifier"
-    assert consumed.enabled_datasets == ["incidents", "services"]
-    assert consumed.region == "us"
-    assert consumed.subdomain == "acme"
 
 
 @pytest.mark.anyio
@@ -78,10 +70,7 @@ async def test_create_persists_only_state_hash_and_ciphertext(
     await store.create(
         org_id="org-1",
         state=state,
-        credential_name="primary",
         code_verifier=code_verifier,
-        enabled_datasets=["incidents"],
-        region="us",
         now=_NOW,
     )
 
@@ -102,10 +91,7 @@ async def test_consume_returns_none_after_request_is_used(
     await store.create(
         org_id="org-1",
         state="single-use-state",
-        credential_name="primary",
         code_verifier="pkce-verifier",
-        enabled_datasets=["incidents"],
-        region="us",
         now=_NOW,
     )
     first_consume = await store.consume(
@@ -127,10 +113,7 @@ async def test_consume_removes_expired_request(session: AsyncSession) -> None:
     await store.create(
         org_id="org-1",
         state="expired-state",
-        credential_name="primary",
         code_verifier="pkce-verifier",
-        enabled_datasets=["incidents"],
-        region="us",
         ttl=timedelta(seconds=0),
         now=_NOW,
     )
@@ -150,10 +133,7 @@ async def test_consume_preserves_request_for_other_organizations(
     await store.create(
         org_id="org-1",
         state="organization-scoped-state",
-        credential_name="primary",
         code_verifier="pkce-verifier",
-        enabled_datasets=["incidents"],
-        region="us",
         now=_NOW,
     )
 
@@ -185,20 +165,14 @@ async def test_purge_expired_keeps_active_requests(session: AsyncSession) -> Non
     await store.create(
         org_id="org-1",
         state="expired-state",
-        credential_name="primary",
         code_verifier="expired-verifier",
-        enabled_datasets=["incidents"],
-        region="us",
         ttl=timedelta(seconds=0),
         now=_NOW,
     )
     await store.create(
         org_id="org-1",
         state="active-state",
-        credential_name="primary",
         code_verifier="active-verifier",
-        enabled_datasets=["services"],
-        region="eu",
         ttl=timedelta(minutes=1),
         now=_NOW,
     )
@@ -219,20 +193,14 @@ async def test_create_purges_expired_requests_for_same_organization(
     await store.create(
         org_id="org-1",
         state="expired",
-        credential_name="primary",
         code_verifier="old",
-        enabled_datasets=[],
-        region="us",
         ttl=timedelta(seconds=0),
         now=_NOW,
     )
     await store.create(
         org_id="org-1",
         state="active",
-        credential_name="primary",
         code_verifier="new",
-        enabled_datasets=[],
-        region="us",
         now=_NOW + timedelta(seconds=1),
     )
 

--- a/tests/providers/test_pagerduty_oauth_lifecycle.py
+++ b/tests/providers/test_pagerduty_oauth_lifecycle.py
@@ -236,11 +236,11 @@ def test_callback_rejects_provider_error_and_missing_code() -> None:
 def test_authorization_request_always_requests_full_operational_read_scope_bundle() -> (
     None
 ):
-    # Given: a setup flow that initially selected only one dataset.
+    # Given: a published OAuth setup flow with no browser-selected datasets.
     config = PagerDutyOAuthConfig("id", "secret", "uri")
 
     # When: the OAuth authorization URL is created.
-    request = build_authorization_request(config, {"incidents"})
+    request = build_authorization_request(config)
 
     # Then: every canonical read scope is required before a connection can exist.
     from urllib.parse import parse_qs, urlparse

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -110,5 +110,6 @@ def test_canonical_incident_feature_seed_extends_single_alembic_head() -> None:
     scripts = ScriptDirectory.from_config(config)
 
     assert migration.down_revision == "0041"
-    assert scripts.get_heads() == ["0044"]
+    assert scripts.get_heads() == ["0045"]
     assert scripts.get_revision("0044").down_revision == "0043"
+    assert scripts.get_revision("0045").down_revision == "0044"


### PR DESCRIPTION
## Summary
- `POST /integrations/pagerduty/authorize` accepts `{}` and requests the fixed read-scope bundle internally.
- The callback derives account, subdomain, region, and display name from the authenticated PagerDuty identity; authorization state remains server-only.
- Client-credentials and API-token manual fallbacks are unchanged.
- Adds Alembic migration `0045_pagerduty_published_oauth_state`.

## Safety
- Default-off: this does not enable canonical incident ingestion or any PagerDuty integration.
- Backend-only change. SCREENSHOT-WAIVER: no rendered UI.

## Validation
- `pytest` focused PagerDuty/API/migration coverage: 106 passed.
- `ruff format --check`, `ruff check`, and `mypy`: passed (including pre-push gate).
- Local full gate reached 8,515 passing tests; its only remaining failures are two existing docs tests because `mkdocs` is absent from this worktree environment.

Related to CHAOS-3027.

## Dependency
Web PR #802 depends on this PR being merged and deployed.