### PR TITLE
[CHAOS-3061] PagerDuty setup and sync fail after OAuth connection

### DIFF
--- a/docs/architecture/pagerduty-contract.md
+++ b/docs/architecture/pagerduty-contract.md
@@ -51,14 +51,14 @@ scope strings:
 
 | Family | Dataset keys | Scope |
 | --- | --- | --- |
-| incidents | `incidents`, `incident-alerts`, `incident-log-entries`, `incident-notes` | `Incidents.read` |
-| services | `services` | `Services.read` |
-| business services | `business-services` | `Services.read` |
-| escalation policies | `escalation-policies` | `Escalation_policies.read` |
-| schedules | `schedules` | `Schedules.read` |
-| on calls | `on-calls` | `Oncalls.read` |
-| users | `users` | `Users.read` |
-| teams | `teams` | `Teams.read` |
+| incidents | `incidents`, `incident-alerts`, `incident-log-entries`, `incident-notes` | `incidents.read` |
+| services | `services` | `services.read` |
+| business services | `business-services` | `services.read` |
+| escalation policies | `escalation-policies` | `escalation_policies.read` |
+| schedules | `schedules` | `schedules.read` |
+| on calls | `on-calls` | `oncalls.read` |
+| users | `users` | `users.read` |
+| teams | `teams` | `teams.read` |
 
 The hyphenated registry key `business-services` maps explicitly to the
 `business_services` family. No caller may guess a dataset key or scope.

--- a/docs/user-guide/pagerduty-oauth-app-setup.md
+++ b/docs/user-guide/pagerduty-oauth-app-setup.md
@@ -21,6 +21,12 @@ and incident that Dev Health should ingest.
 | Private automation without interactive consent | Client credentials | Register a private scoped PagerDuty app and enter its client ID, client secret, account subdomain, and region in Dev Health. |
 | Compatibility only | REST API token | Use the explicit API-token fallback only when OAuth is unavailable. |
 
+PagerDuty app visibility does not determine whether browser authorization is
+available. A private Scoped OAuth app may use PKCE user authorization within the
+PagerDuty account that created it, or use client credentials without interactive
+consent. Publishing is only relevant when distributing an eligible app to other
+PagerDuty accounts.
+
 The rest of this guide covers the recommended authorization-code flow.
 
 ## 1. Register the app in PagerDuty
@@ -51,13 +57,13 @@ app.
 
 | PagerDuty resource | OAuth scope | Dev Health datasets |
 | --- | --- | --- |
-| Incidents | `Incidents.read` | Incidents, alerts, timeline entries, and notes |
-| Services | `Services.read` | Services and business services |
-| Escalation policies | `Escalation_policies.read` | Escalation policies |
-| Schedules | `Schedules.read` | Schedules |
-| On-calls | `Oncalls.read` | On-call assignments |
-| Users | `Users.read` | Users and responder identity |
-| Teams | `Teams.read` | Teams |
+| Incidents | `incidents.read` | Incidents, alerts, timeline entries, and notes |
+| Services | `services.read` | Services and business services |
+| Escalation policies | `escalation_policies.read` | Escalation policies |
+| Schedules | `schedules.read` | Schedules |
+| On-calls | `oncalls.read` | On-call assignments |
+| Users | `users.read` | Users and responder identity |
+| Teams | `teams.read` | Teams |
 
 8. Register the app.
 9. Copy or download the **Client ID** and **Client Secret** immediately and store
@@ -105,17 +111,11 @@ Do not expose `PAGER_DUTY_SECRET` through browser-visible environment variables.
 
 1. Sign in to Dev Health as an organization admin.
 2. Open **Admin → Integrations → PagerDuty**.
-3. Leave the credential name as `default` unless the organization intentionally
-   connects multiple PagerDuty accounts.
-4. Enter the PagerDuty account subdomain. For
-   `https://acme.pagerduty.com`, enter `acme`.
-5. Select the account region, `us` or `eu`.
-6. Select the datasets to sync.
-7. Keep **OAuth** selected and choose **Connect PagerDuty**.
-8. In PagerDuty, review the read-only permissions and authorize the app.
-9. After Dev Health reports that the connection is complete, return to the
+3. Select **OAuth authorization**.
+4. In PagerDuty, review the read-only permissions and authorize the app.
+5. After Dev Health reports that the connection is complete, return to the
    PagerDuty integration page and load its status.
-10. Run permission preflight for every selected dataset.
+6. Run permission preflight for every selected dataset.
 
 The callback stores an encrypted access token, refresh token when provided,
 expiration, granted scopes, account identity, region, and subdomain. The normal
@@ -133,8 +133,8 @@ A healthy OAuth connection reports:
   "region": "us",
   "subdomain": "acme",
   "granted_scopes": [
-    "Incidents.read",
-    "Services.read"
+    "incidents.read",
+    "services.read"
   ],
   "has_refresh_token": true
 }

--- a/src/dev_health_ops/api/admin/routers/credentials.py
+++ b/src/dev_health_ops/api/admin/routers/credentials.py
@@ -29,6 +29,9 @@ from dev_health_ops.exceptions import (
 )
 from dev_health_ops.providers.github.client import GitHubAuth
 from dev_health_ops.providers.github.code_client import GitHubCodeClient
+from dev_health_ops.providers.pagerduty.sync_auth import (
+    hydrate_pagerduty_credentials_async,
+)
 from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
 from .common import get_session
@@ -364,6 +367,11 @@ async def test_connection(
         elif payload.provider == "launchdarkly":
             success, details = await _test_launchdarkly_connection(creds)
         elif payload.provider == "pagerduty":
+            # OAuth access tokens live in the separately encrypted provider
+            # OAuth store, while client-credential descriptors require a token
+            # exchange.  The generic credential row intentionally contains
+            # neither ephemeral token, so hydrate it before the live probe.
+            creds = await hydrate_pagerduty_credentials_async(creds, org_id=org_id)
             success, details = await _test_pagerduty_connection(creds)
         else:
             error = f"Unknown provider: {payload.provider}"
@@ -745,6 +753,38 @@ async def _test_pagerduty_connection(
     )
     client = PagerDutyClient(auth, region=str(creds.get("region", "us")))
     datasets = [str(value) for value in creds.get("enabled_datasets", [])]
+    if not datasets:
+        # Stored PagerDuty credentials are created before an integration's
+        # dataset selection exists, so they intentionally do not carry
+        # ``enabled_datasets``.  A credential-level connection test must still
+        # prove a live read instead of recording a false failure that later
+        # blocks sync preflight.  Prefer the smallest stable account resource,
+        # then fall back to any resource covered by the OAuth grant.  API
+        # tokens do not expose scopes, so services is their live probe too.
+        probe_candidates = (
+            "services",
+            "incidents",
+            "escalation-policies",
+            "schedules",
+            "on-calls",
+            "users",
+            "teams",
+            "business-services",
+        )
+        if api_token:
+            datasets = ["services"]
+        else:
+            granted = {str(value) for value in creds.get("granted_scopes", [])}
+            selected = next(
+                (
+                    dataset
+                    for dataset in probe_candidates
+                    if not missing_read_scopes({dataset}, granted)
+                ),
+                None,
+            )
+            if selected is not None:
+                datasets = [selected]
     unknown = set(datasets).difference(DATASET_OAUTH_FAMILIES)
     if unknown:
         await client.close()
@@ -759,7 +799,7 @@ async def _test_pagerduty_connection(
         if missing:
             return False, {"records_checked": 0, "missing_scopes": missing}
         if not datasets:
-            return False, {"error": "Select at least one PagerDuty dataset"}
+            return False, {"error": "PagerDuty credential has no supported read scope"}
         records_count = 0
         match pagerduty_oauth_family(datasets[0]):
             case "incidents":

--- a/src/dev_health_ops/api/admin/routers/pagerduty_services.py
+++ b/src/dev_health_ops/api/admin/routers/pagerduty_services.py
@@ -169,7 +169,7 @@ async def list_pagerduty_services(
     except PagerDutyInsufficientScopeError as exc:
         raise HTTPException(
             status_code=403,
-            detail="PagerDuty credential is missing Services.read permission",
+            detail="PagerDuty credential is missing services.read permission",
         ) from exc
     except AuthenticationException as exc:
         raise HTTPException(

--- a/src/dev_health_ops/processors/dataset_adapters.py
+++ b/src/dev_health_ops/processors/dataset_adapters.py
@@ -491,22 +491,29 @@ def _run_pagerduty_dataset(
             else None,
         }
 
-    sync_error: Exception | None = None
+    async def _run_and_close() -> dict[str, Any]:
+        sync_error: Exception | None = None
+        try:
+            return await _run_with_reused_or_new_store(context, runtime, _handler)
+        except Exception as exc:
+            sync_error = exc
+            raise
+        finally:
+            try:
+                # httpx binds its connection pool to the loop that performs the
+                # requests. Close on that same loop; a second run_async() call
+                # creates a fresh loop after the first one has been closed.
+                await client.close()
+            except Exception:
+                if sync_error is None:
+                    raise
+
     try:
-        sync_result = run_async(
-            _run_with_reused_or_new_store(context, runtime, _handler)
-        )
+        sync_result = run_async(_run_and_close())
     except Exception as exc:
-        sync_error = exc
         usage_sink.extend(client.drain_usage_observations())
         _attach_usage_sink_to_exception(exc, usage_sink)
         raise
-    finally:
-        try:
-            run_async(client.close())
-        except Exception:
-            if sync_error is None:
-                raise
     result: dict[str, Any] = {
         "provider": context.provider,
         "dataset": context.dataset_key,

--- a/src/dev_health_ops/providers/pagerduty/client.py
+++ b/src/dev_health_ops/providers/pagerduty/client.py
@@ -130,13 +130,23 @@ class PagerDutyClient:
             yield page
 
     async def list_incident_notes(self, incident_id: str) -> list[Note]:
-        return await self._many(f"/incidents/{incident_id}/notes", "notes", Note, None)
+        return await self._many(
+            f"/incidents/{incident_id}/notes",
+            "notes",
+            Note,
+            None,
+            paginated=False,
+        )
 
     async def iter_incident_note_pages(
         self, incident_id: str
     ) -> AsyncIterator[PagerDutyPage[Note]]:
         async for page in self._iter_many(
-            f"/incidents/{incident_id}/notes", "notes", Note, None
+            f"/incidents/{incident_id}/notes",
+            "notes",
+            Note,
+            None,
+            paginated=False,
         ):
             yield page
 
@@ -175,19 +185,37 @@ class PagerDutyClient:
         return model.model_validate(response.json()[key])
 
     async def _many(
-        self, path: str, key: str, model: type[T], params: dict[str, str] | None
+        self,
+        path: str,
+        key: str,
+        model: type[T],
+        params: dict[str, str] | None,
+        *,
+        paginated: bool = True,
     ) -> list[T]:
         values: list[T] = []
-        async for page in self._iter_many(path, key, model, params):
+        async for page in self._iter_many(
+            path, key, model, params, paginated=paginated
+        ):
             values.extend(page)
         return values
 
     async def _iter_many(
-        self, path: str, key: str, model: type[T], params: dict[str, str] | None
+        self,
+        path: str,
+        key: str,
+        model: type[T],
+        params: dict[str, str] | None,
+        *,
+        paginated: bool = True,
     ) -> AsyncIterator[PagerDutyPage[T]]:
         offset = 0
         while True:
-            query = {**(params or {}), "limit": "100", "offset": str(offset)}
+            query = (
+                {**(params or {}), "limit": "100", "offset": str(offset)}
+                if paginated
+                else params
+            )
             response = await self._core.request(
                 "GET",
                 path,
@@ -201,8 +229,17 @@ class PagerDutyClient:
                     f"PagerDuty pagination envelope for {path} must be an object"
                 )
             raw_page = payload.get(key)
+            if not isinstance(raw_page, list):
+                raise PaginationException(
+                    f"PagerDuty pagination envelope for {path} is malformed"
+                )
+            if not paginated:
+                yield PagerDutyPage(
+                    [model.model_validate(value) for value in raw_page], more=False
+                )
+                return
             more = payload.get("more")
-            if not isinstance(raw_page, list) or not isinstance(more, bool):
+            if not isinstance(more, bool):
                 raise PaginationException(
                     f"PagerDuty pagination envelope for {path} is malformed"
                 )

--- a/src/dev_health_ops/providers/pagerduty/normalize.py
+++ b/src/dev_health_ops/providers/pagerduty/normalize.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from dataclasses import dataclass
 from datetime import datetime
-from typing import TypedDict
+from typing import TypedDict, overload
 
 from dev_health_ops.models.operational import (
     CanonicalOperationalEntity,
@@ -23,6 +23,7 @@ from dev_health_ops.models.operational import (
     EscalationPolicy as CanonicalEscalationPolicy,
 )
 from dev_health_ops.models.operational_identity import operational_source_coordinates
+from dev_health_ops.providers.normalize_common import to_utc
 from dev_health_ops.providers.pagerduty.models import (
     Alert,
     BusinessService,
@@ -104,8 +105,8 @@ class PagerDutyNormalizer:
                 CanonicalEscalationPolicy, row.escalation_policy
             ),
             escalation_level=row.escalation_level,
-            starts_at=row.start,
-            ends_at=row.end,
+            starts_at=_utc(row.start),
+            ends_at=_utc(row.end),
         )
 
     def user(self, row: User) -> OperationalUser:
@@ -125,7 +126,7 @@ class PagerDutyNormalizer:
     def incident(self, row: Incident) -> OperationalIncident:
         return OperationalIncident(
             **self._common(OperationalIncident, row, "incident"),
-            source_event_at=row.created_at,
+            source_event_at=_utc(row.created_at),
             source_event_id=str(row.incident_number) if row.incident_number else None,
             raw_status=row.status,
             raw_severity=row.urgency,
@@ -136,7 +137,7 @@ class PagerDutyNormalizer:
             service_id=self._reference_id(OperationalService, row.service),
             service_external_id=row.service.id if row.service else None,
             title=row.title or row.summary or row.id,
-            started_at=row.created_at,
+            started_at=_utc(row.created_at),
             resolved_at=self._incident_resolution_time(row)
             if row.status == "resolved"
             else None,
@@ -151,7 +152,7 @@ class PagerDutyNormalizer:
             normalized_severity=_severity(row.severity),
             incident_id=incident_id,
             title=row.summary or row.id,
-            triggered_at=row.created_at,
+            triggered_at=_utc(row.created_at),
             resolved_at=self._source_time(row) if row.status == "resolved" else None,
         )
 
@@ -162,7 +163,7 @@ class PagerDutyNormalizer:
             event_type=row.type or "pagerduty_log_entry",
             body=row.summary or row.message,
             actor_type="pagerduty",
-            occurred_at=row.created_at,
+            occurred_at=_utc(row.created_at),
         )
 
     def note(self, row: Note, incident_id: str) -> IncidentNote:
@@ -171,7 +172,7 @@ class PagerDutyNormalizer:
             incident_id=incident_id,
             body=row.content or "",
             author_user_id=self._reference_id(OperationalUser, row.user),
-            created_at=row.created_at,
+            created_at=_utc(row.created_at),
         )
 
     def _common(
@@ -196,8 +197,8 @@ class PagerDutyNormalizer:
             "external_id": coordinates.external_id,
             "source_version_at": self._source_time(row),
             "source_url": row.html_url or row.self_url,
-            "observed_at": self.observed_at,
-            "last_synced": self.observed_at,
+            "observed_at": _utc(self.observed_at),
+            "last_synced": _utc(self.observed_at),
         }
 
     def _reference_id(
@@ -227,34 +228,54 @@ class PagerDutyNormalizer:
         )
 
     def _oncall_external_id(self, row: Oncall) -> str:
+        if row.id:
+            return row.id
         if (
             row.escalation_policy is None
-            or row.schedule is None
             or row.user is None
             or not row.escalation_policy.id
-            or not row.schedule.id
             or not row.user.id
             or row.escalation_level is None
-            or row.start is None
-            or row.end is None
         ):
             raise ValueError("PagerDuty on-call assignment requires stable dimensions")
+        schedule_id = (
+            row.schedule.id if row.schedule and row.schedule.id else "<permanent>"
+        )
+        start_at = (
+            _utc(row.start).isoformat() if row.start is not None else "<permanent>"
+        )
+        end_at = _utc(row.end).isoformat() if row.end is not None else "<permanent>"
         return "|".join(
             (
                 row.escalation_policy.id,
-                row.schedule.id,
+                schedule_id,
                 row.user.id,
                 str(row.escalation_level),
-                row.start.isoformat(),
-                row.end.isoformat(),
+                start_at,
+                end_at,
             )
         )
 
     def _incident_resolution_time(self, row: Incident) -> datetime | None:
-        return row.resolved_at or row.last_status_change_at
+        return _utc(row.resolved_at or row.last_status_change_at)
 
     def _source_time(self, row: PagerDutyModel) -> datetime:
-        return row.updated_at or row.created_at or self.observed_at
+        source_time = _utc(row.updated_at or row.created_at or self.observed_at)
+        assert source_time is not None
+        return source_time
+
+
+@overload
+def _utc(value: None) -> None: ...
+
+
+@overload
+def _utc(value: datetime) -> datetime: ...
+
+
+def _utc(value: datetime | None) -> datetime | None:
+    normalized = to_utc(value)
+    return normalized.replace(fold=0) if normalized is not None else None
 
 
 def _incident_status(raw_status: str | None) -> str | None:

--- a/src/dev_health_ops/providers/pagerduty/oauth.py
+++ b/src/dev_health_ops/providers/pagerduty/oauth.py
@@ -14,24 +14,24 @@ from pydantic import BaseModel, ConfigDict
 
 READ_SCOPES = frozenset(
     {
-        "Incidents.read",
-        "Services.read",
-        "Escalation_policies.read",
-        "Schedules.read",
-        "Oncalls.read",
-        "Users.read",
-        "Teams.read",
+        "incidents.read",
+        "services.read",
+        "escalation_policies.read",
+        "schedules.read",
+        "oncalls.read",
+        "users.read",
+        "teams.read",
     }
 )
 DATASET_SCOPES = {
-    "incidents": frozenset({"Incidents.read"}),
-    "services": frozenset({"Services.read"}),
-    "business_services": frozenset({"Services.read"}),
-    "escalation_policies": frozenset({"Escalation_policies.read"}),
-    "schedules": frozenset({"Schedules.read"}),
-    "oncalls": frozenset({"Oncalls.read"}),
-    "users": frozenset({"Users.read"}),
-    "teams": frozenset({"Teams.read"}),
+    "incidents": frozenset({"incidents.read"}),
+    "services": frozenset({"services.read"}),
+    "business_services": frozenset({"services.read"}),
+    "escalation_policies": frozenset({"escalation_policies.read"}),
+    "schedules": frozenset({"schedules.read"}),
+    "oncalls": frozenset({"oncalls.read"}),
+    "users": frozenset({"users.read"}),
+    "teams": frozenset({"teams.read"}),
 }
 DATASET_OAUTH_FAMILIES = {
     "incidents": "incidents",

--- a/src/dev_health_ops/providers/pagerduty/sync_auth.py
+++ b/src/dev_health_ops/providers/pagerduty/sync_auth.py
@@ -165,6 +165,13 @@ async def hydrate_pagerduty_credentials_async(
                 result["access_token"] = await get_valid_access_token(
                     repository, config
                 )
+                current = await repository.get()
+                granted_scopes = (
+                    current.tokens.granted_scopes
+                    if current is not None
+                    else versioned.tokens.granted_scopes
+                )
+                result["granted_scopes"] = sorted(granted_scopes)
         case "client_credentials":
             config = PagerDutyOAuthConfig(
                 client_id=mapping["client_id"],
@@ -192,6 +199,7 @@ async def hydrate_pagerduty_credentials_async(
                 config,
                 request,
             )
+            result["granted_scopes"] = sorted(READ_SCOPES)
         case _:
             pass
     return result
@@ -226,6 +234,13 @@ def hydrate_pagerduty_credentials(
                 store,
                 config,
             )
+            current = anyio.run(store.get)
+            granted_scopes = (
+                current.tokens.granted_scopes
+                if current is not None
+                else versioned.tokens.granted_scopes
+            )
+            result["granted_scopes"] = sorted(granted_scopes)
         return result
     if auth_mode == "client_credentials":
         config = PagerDutyOAuthConfig(
@@ -255,4 +270,5 @@ def hydrate_pagerduty_credentials(
             config,
             request,
         )
+        result["granted_scopes"] = sorted(READ_SCOPES)
     return result

--- a/src/dev_health_ops/storage/clickhouse.py
+++ b/src/dev_health_ops/storage/clickhouse.py
@@ -65,6 +65,18 @@ from .utils import _parse_date_value, _parse_datetime_value
 logger = logging.getLogger(__name__)
 T = TypeVar("T", bound=CanonicalOperationalEntity)
 
+
+def _canonical_operational_datetime(value: Any) -> Any:
+    """Restore ClickHouse DateTime64 values to the canonical UTC shape."""
+    if not isinstance(value, datetime):
+        return value
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=timezone.utc)
+    else:
+        value = value.astimezone(timezone.utc)
+    return value.replace(fold=0)
+
+
 if TYPE_CHECKING:
     from dev_health_ops.models.atlassian_ops import (
         AtlassianOpsAlert,
@@ -2412,7 +2424,9 @@ class ClickHouseStore:
     ) -> T:
         values = dict(zip(columns, row, strict=True))
         constructor = {
-            item.name: values[item.name] for item in fields(entity_type) if item.init
+            item.name: _canonical_operational_datetime(values[item.name])
+            for item in fields(entity_type)
+            if item.init
         }
         stored_ordering_fields = ORDERING_FIELD_NAMES.intersection(values)
         if stored_ordering_fields and stored_ordering_fields != ORDERING_FIELD_NAMES:

--- a/src/dev_health_ops/sync/trigger_routing.py
+++ b/src/dev_health_ops/sync/trigger_routing.py
@@ -190,6 +190,13 @@ def planner_request_for_config_if_routed(
         request is not None
         and bool(getattr(config, "planner_managed", False))
         and getattr(config, "source_id", None) is None
+        # PagerDuty is account-scoped. Its one canonical IntegrationSource is
+        # repaired transactionally inside plan_sync_run and therefore cannot
+        # carry this config's planner tag when the request is built. Leaving
+        # source_ids unset lets the planner consume that verified account
+        # source; applying repository-style tag scoping here produces a
+        # permanent zero-unit run.
+        and str(getattr(config, "provider", "")).lower() != "pagerduty"
     ):
         request = dataclasses.replace(
             request, source_ids=_planner_scoped_source_ids(session, config)

--- a/tests/api/admin/test_pagerduty_oauth_setup.py
+++ b/tests/api/admin/test_pagerduty_oauth_setup.py
@@ -393,7 +393,7 @@ async def test_callback_revokes_and_rejects_missing_required_scope(
         access_token="access-token",
         refresh_token="refresh-token",
         expires_at=datetime.now(UTC) + timedelta(hours=1),
-        granted_scopes=frozenset({"Services.read"}),
+        granted_scopes=frozenset({"services.read"}),
     )
     revoke = AsyncMock()
     monkeypatch.setattr(
@@ -407,7 +407,7 @@ async def test_callback_revokes_and_rejects_missing_required_scope(
     )
 
     assert response.status_code == 400
-    assert "Incidents.read" in response.json()["detail"]
+    assert "incidents.read" in response.json()["detail"]
     revoke.assert_awaited_once_with(_CONFIG, "refresh-token")
     assert await _persisted_counts(session_maker) == (0, 0)
 
@@ -595,7 +595,7 @@ async def test_preflight_reports_dataset_scopes_without_users_requirement(
     }
     assert datasets["incidents"] == {
         "requested": "incidents",
-        "required_scopes": ["Incidents.read"],
+        "required_scopes": ["incidents.read"],
         "granted": True,
         "missing": [],
     }
@@ -795,13 +795,82 @@ async def test_credential_probe_does_not_require_users_read(
             "access_token": "oauth-access-token",
             "region": "us",
             "enabled_datasets": ["incidents"],
-            "granted_scopes": ["Incidents.read"],
+            "granted_scopes": ["incidents.read"],
         }
     )
 
     assert success is True
     assert details == {"records_checked": 0, "missing_scopes": []}
     list_incidents.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_credential_probe_selects_authorized_dataset_when_not_stored(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+
+    list_services = AsyncMock(return_value=[])
+    monkeypatch.setattr(PagerDutyClient, "list_services", list_services)
+
+    success, details = await credentials_router._test_pagerduty_connection(
+        {
+            "access_token": "oauth-access-token",
+            "region": "us",
+            "granted_scopes": ["services.read"],
+        }
+    )
+
+    assert success is True
+    assert details == {"records_checked": 0, "missing_scopes": []}
+    list_services.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_generic_connection_test_hydrates_stored_oauth_credential(
+    client: AsyncClient,
+    monkeypatch: pytest.MonkeyPatch,
+    session_maker: async_sessionmaker[AsyncSession],
+) -> None:
+    from dev_health_ops.providers.pagerduty.client import PagerDutyClient
+
+    await _connect_oauth(client, monkeypatch)
+
+    async def hydrate(mapping: dict[str, object], *, org_id: str) -> dict[str, object]:
+        assert org_id == _ORG_ID
+        assert mapping["auth_mode"] == "oauth"
+        assert mapping["oauth_credential_name"] == "operations"
+        return {
+            **mapping,
+            "access_token": "oauth-access-token",
+            "granted_scopes": sorted(READ_SCOPES),
+        }
+
+    list_services = AsyncMock(return_value=[])
+    monkeypatch.setattr(
+        credentials_router, "hydrate_pagerduty_credentials_async", hydrate
+    )
+    monkeypatch.setattr(PagerDutyClient, "list_services", list_services)
+
+    response = await client.post(
+        "/api/v1/admin/credentials/test",
+        json={"provider": "pagerduty", "name": "operations"},
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "success": True,
+        "error": None,
+        "details": {"records_checked": 0, "missing_scopes": []},
+    }
+    list_services.assert_awaited_once()
+    async with session_maker() as session:
+        stored = await IntegrationCredentialsService(session, _ORG_ID).get(
+            "pagerduty", "operations"
+        )
+    assert stored is not None
+    assert stored.last_test_success is True
+    assert stored.last_test_error is None
 
 
 @pytest.mark.asyncio
@@ -1260,7 +1329,7 @@ async def test_preflight_helper_blocks_missing_scope_without_calling_api(
     )
 
     assert ok is False
-    assert "Incidents.read" in detail["missing_scopes"]
+    assert "incidents.read" in detail["missing_scopes"]
     instance = client_cls.instances[-1]
     assert instance.calls == []
     assert instance.closed == 1
@@ -1277,7 +1346,7 @@ async def test_preflight_helper_closes_client_on_success_and_error(
         {
             "access_token": "tok",
             "enabled_datasets": ["incidents"],
-            "granted_scopes": ["Incidents.read"],
+            "granted_scopes": ["incidents.read"],
             "region": "us",
         }
     )
@@ -1293,7 +1362,7 @@ async def test_preflight_helper_closes_client_on_success_and_error(
             {
                 "access_token": "tok",
                 "enabled_datasets": ["incidents"],
-                "granted_scopes": ["Incidents.read"],
+                "granted_scopes": ["incidents.read"],
                 "region": "us",
             }
         )
@@ -1627,7 +1696,7 @@ async def test_disconnect_preserves_unrelated_connector_credentials(
         access_token="standby-access-token",
         refresh_token="standby-refresh-token",
         expires_at=datetime.now(UTC) + timedelta(hours=1),
-        granted_scopes=frozenset({"Incidents.read"}),
+        granted_scopes=frozenset({"incidents.read"}),
     )
     async with session_maker() as session:
         service = IntegrationCredentialsService(session, _ORG_ID)
@@ -1647,7 +1716,7 @@ async def test_disconnect_preserves_unrelated_connector_credentials(
                 "subdomain": "acme",
                 "region": "us",
                 "account_id": "acme",
-                "granted_scopes": ["Incidents.read"],
+                "granted_scopes": ["incidents.read"],
             },
         )
         github_descriptor = await service.set(
@@ -1930,7 +1999,7 @@ async def _save_oauth_descriptor(
                 "subdomain": "acme",
                 "region": "eu",
                 "account_id": "acme",
-                "granted_scopes": ["Services.read"],
+                "granted_scopes": ["services.read"],
             },
         )
         await session.commit()
@@ -2090,7 +2159,7 @@ async def test_services_oauth_uses_descriptor_referenced_credential(
         client,
         monkeypatch,
         datasets=["services"],
-        granted={"Services.read"},
+        granted={"services.read"},
     )
     async with session_maker() as session:
         metadata = await PagerDutyOAuthCredentialRepository(
@@ -2131,7 +2200,7 @@ async def test_services_oauth_rejects_descriptor_binding_mismatch(
         client,
         monkeypatch,
         datasets=["services"],
-        granted={"Services.read"},
+        granted={"services.read"},
     )
     await _save_oauth_descriptor(
         session_maker,
@@ -2165,7 +2234,7 @@ async def test_services_commit_oauth_rotation_before_provider_io(
         client,
         monkeypatch,
         datasets=["services"],
-        granted={"Services.read"},
+        granted={"services.read"},
     )
     events: list[str] = []
     original_commit = AsyncSession.commit

--- a/tests/providers/test_pagerduty_async_hydration.py
+++ b/tests/providers/test_pagerduty_async_hydration.py
@@ -68,6 +68,7 @@ async def test_async_oauth_hydration_uses_the_running_event_loop(
     )
 
     assert hydrated["access_token"] == "oauth-token"
+    assert hydrated["granted_scopes"] == sorted(READ_SCOPES)
 
 
 @pytest.mark.anyio
@@ -109,3 +110,4 @@ async def test_async_client_credentials_hydration_mints_scoped_token(
     )
 
     assert hydrated["access_token"] == "machine-token"
+    assert hydrated["granted_scopes"] == sorted(READ_SCOPES)

--- a/tests/providers/test_pagerduty_client.py
+++ b/tests/providers/test_pagerduty_client.py
@@ -22,6 +22,6 @@ def test_authorization_request_uses_pkce_and_read_scopes() -> None:
     assert "code_challenge_method=S256" in request.url
     assert request.state in request.url
     assert len(request.code_verifier) > 40
-    assert missing_read_scopes({"incidents", "users"}, {"Incidents.read"}) == {
-        "Users.read"
+    assert missing_read_scopes({"incidents", "users"}, {"incidents.read"}) == {
+        "users.read"
     }

--- a/tests/providers/test_pagerduty_credential_validation.py
+++ b/tests/providers/test_pagerduty_credential_validation.py
@@ -46,7 +46,7 @@ def test_validate_api_token_uses_one_least_privileged_service_read() -> None:
         partial(
             validate_pagerduty_credential,
             credential,
-            required_scopes=frozenset({"Services.read"}),
+            required_scopes=frozenset({"services.read"}),
             transport=httpx.MockTransport(handler),
         )
     )
@@ -67,7 +67,7 @@ def test_validate_oauth_derives_canonical_account_identity_from_service_response
         source=CredentialSource.DATABASE,
         auth_mode="oauth",
         access_token="oauth-token",
-        granted_scopes=("Services.read",),
+        granted_scopes=("services.read",),
         subdomain="caller-controlled-label",
     )
 
@@ -76,7 +76,7 @@ def test_validate_oauth_derives_canonical_account_identity_from_service_response
         partial(
             validate_pagerduty_credential,
             credential,
-            required_scopes=frozenset({"Services.read"}),
+            required_scopes=frozenset({"services.read"}),
             transport=httpx.MockTransport(
                 lambda _: httpx.Response(
                     200,
@@ -109,7 +109,7 @@ def test_validate_rejects_empty_service_response_without_account_identity() -> N
         source=CredentialSource.DATABASE,
         auth_mode="oauth",
         access_token="oauth-token",
-        granted_scopes=("Services.read",),
+        granted_scopes=("services.read",),
     )
 
     # When: the live capability check contains no service to prove its account.
@@ -118,7 +118,7 @@ def test_validate_rejects_empty_service_response_without_account_identity() -> N
             partial(
                 validate_pagerduty_credential,
                 credential,
-                required_scopes=frozenset({"Services.read"}),
+                required_scopes=frozenset({"services.read"}),
                 transport=httpx.MockTransport(
                     lambda _: httpx.Response(200, json={"services": []})
                 ),
@@ -135,7 +135,7 @@ def test_validate_oauth_rejects_missing_required_scopes_without_request() -> Non
         source=CredentialSource.DATABASE,
         auth_mode="oauth",
         access_token="oauth-token",
-        granted_scopes=("Users.read",),
+        granted_scopes=("users.read",),
     )
 
     # When: validation is requested for the operational scope set.
@@ -144,7 +144,7 @@ def test_validate_oauth_rejects_missing_required_scopes_without_request() -> Non
             partial(
                 validate_pagerduty_credential,
                 credential,
-                required_scopes=frozenset({"Services.read"}),
+                required_scopes=frozenset({"services.read"}),
                 transport=httpx.MockTransport(
                     lambda _: (_ for _ in ()).throw(AssertionError("must not request"))
                 ),
@@ -175,7 +175,7 @@ def test_validate_client_credentials_exchanges_then_reads_without_mutation() -> 
                 json={
                     "access_token": "machine-token",
                     "expires_in": 3600,
-                    "scope": "Services.read Users.read",
+                    "scope": "services.read users.read",
                 },
             )
         return httpx.Response(
@@ -198,7 +198,7 @@ def test_validate_client_credentials_exchanges_then_reads_without_mutation() -> 
         partial(
             validate_pagerduty_credential,
             credential,
-            required_scopes=frozenset({"Services.read", "Users.read"}),
+            required_scopes=frozenset({"services.read", "users.read"}),
             transport=httpx.MockTransport(handler),
         )
     )

--- a/tests/providers/test_pagerduty_normalize.py
+++ b/tests/providers/test_pagerduty_normalize.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import json
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from unittest.mock import patch
 
@@ -181,6 +181,23 @@ def test_oncall_without_global_id_uses_stable_composite_external_id() -> None:
     assert first.id == second.id
 
 
+def test_oncall_without_schedule_or_window_uses_permanent_fallback() -> None:
+    payload = {
+        **REAL_PAGERDUTY_PAYLOADS["oncalls"],
+        "schedule": None,
+        "start": None,
+        "end": None,
+    }
+
+    oncall = Oncall.model_validate(payload)
+
+    first = _normalizer().oncall(oncall)
+    second = _normalizer().oncall(oncall)
+
+    assert first.external_id == "PESCAL1|<permanent>|PUSER01|1|<permanent>|<permanent>"
+    assert first.id == second.id
+
+
 def test_oncall_rejects_missing_stable_composite_dimension() -> None:
     payload = {
         **REAL_PAGERDUTY_PAYLOADS["oncalls"],
@@ -205,6 +222,48 @@ def test_incident_preserves_resolution_time_and_raw_priority() -> None:
     assert incident.raw_severity == "high"
     assert incident.raw_priority == "P1"
     assert incident.normalized_priority == "high"
+
+
+def test_normalizer_canonicalizes_provider_timestamps_to_utc_fold_zero() -> None:
+    provider_time = datetime(
+        2026,
+        7,
+        17,
+        5,
+        tzinfo=timezone(timedelta(hours=-7)),
+        fold=1,
+    )
+    normalizer = PagerDutyNormalizer(
+        org_id="org-1",
+        provider_instance_id="acme",
+        observed_at=provider_time,
+    )
+
+    service = normalizer.service(
+        Service(id="service-1", name="Payments", updated_at=provider_time)
+    )
+    incident = normalizer.incident(
+        Incident(
+            id="incident-1",
+            title="Payments unavailable",
+            status="resolved",
+            created_at=provider_time,
+            updated_at=provider_time,
+            resolved_at=provider_time,
+        )
+    )
+
+    for timestamp in (
+        service.source_version_at,
+        service.observed_at,
+        service.last_synced,
+        incident.source_event_at,
+        incident.started_at,
+        incident.resolved_at,
+    ):
+        assert timestamp is not None
+        assert timestamp.utcoffset() == timedelta(0)
+        assert timestamp.fold == 0
 
 
 def test_service_normalization_does_not_compute_discarded_canonical_id() -> None:

--- a/tests/providers/test_pagerduty_oauth_lifecycle.py
+++ b/tests/providers/test_pagerduty_oauth_lifecycle.py
@@ -264,7 +264,7 @@ async def test_client_credentials_cache_renews_once_and_qualifies_account_scope(
         return OAuthTokens(
             access_token="machine",
             expires_at=datetime.now(UTC) + timedelta(hours=1),
-            granted_scopes=frozenset({"Users.read"}),
+            granted_scopes=frozenset({"users.read"}),
         )
 
     monkeypatch.setattr(
@@ -272,7 +272,7 @@ async def test_client_credentials_cache_renews_once_and_qualifies_account_scope(
         exchange,
     )
     cache = ClientCredentialsTokenCache()
-    request = ClientCredentialsRequest(frozenset({"Users.read"}), "acme", "eu")
+    request = ClientCredentialsRequest(frozenset({"users.read"}), "acme", "eu")
     config = PagerDutyOAuthConfig("id", "secret", "uri")
 
     assert (
@@ -281,7 +281,7 @@ async def test_client_credentials_cache_renews_once_and_qualifies_account_scope(
     assert (
         await get_client_credentials_access_token(cache, config, request) == "machine"
     )
-    assert calls == [({"Users.read"}, "acme", "eu")]
+    assert calls == [({"users.read"}, "acme", "eu")]
 
 
 def test_auth_strategies_use_only_supported_header_forms() -> None:
@@ -318,7 +318,7 @@ async def test_client_credentials_posts_scoped_region_and_subdomain(
     )
     await client_credentials(
         PagerDutyOAuthConfig("id", "secret", "uri"),
-        scopes={"Users.read"},
+        scopes={"users.read"},
         subdomain="acme",
         region="eu",
     )

--- a/tests/providers/test_pagerduty_oauth_store_refresh.py
+++ b/tests/providers/test_pagerduty_oauth_store_refresh.py
@@ -46,7 +46,7 @@ def tokens(
     *,
     refresh_token: str | None = "refresh",
     expires_at: datetime | None = None,
-    granted_scopes: frozenset[str] = frozenset({"Users.read"}),
+    granted_scopes: frozenset[str] = frozenset({"users.read"}),
 ) -> OAuthTokens:
     return OAuthTokens(
         access_token=access_token,
@@ -122,7 +122,7 @@ async def test_get_status_metadata_does_not_decrypt_tokens(
             updated_at=now,
             binding_id="binding",
             expires_at=now + timedelta(hours=1),
-            granted_scopes=["Users.read", "Incidents.read"],
+            granted_scopes=["users.read", "incidents.read"],
             has_refresh_token=True,
             account_id="account",
             account_display="Operations",
@@ -140,7 +140,7 @@ async def test_get_status_metadata_does_not_decrypt_tokens(
 
     assert metadata is not None
     assert metadata.binding_id == "binding"
-    assert metadata.granted_scopes == frozenset({"Incidents.read", "Users.read"})
+    assert metadata.granted_scopes == frozenset({"incidents.read", "users.read"})
     assert metadata.has_refresh_token is True
     assert metadata.account_id == "account"
     assert metadata.account_display == "Operations"
@@ -256,8 +256,8 @@ async def test_keyed_client_credentials_cache_does_not_cross_account_boundaries(
     )
     registry = ClientCredentialsTokenCacheRegistry()
     config = PagerDutyOAuthConfig("id", "secret", "uri")
-    request_one = ClientCredentialsRequest(frozenset({"Users.read"}), "one", "us")
-    request_two = ClientCredentialsRequest(frozenset({"Users.read"}), "two", "us")
+    request_one = ClientCredentialsRequest(frozenset({"users.read"}), "one", "us")
+    request_two = ClientCredentialsRequest(frozenset({"users.read"}), "two", "us")
     key_one: ClientCredentialsCacheKey = (
         "org-one",
         "primary",

--- a/tests/providers/test_pagerduty_rest_client.py
+++ b/tests/providers/test_pagerduty_rest_client.py
@@ -92,6 +92,28 @@ async def test_incident_alert_page_iterator_fetches_only_requested_pages() -> No
 
 
 @pytest.mark.asyncio
+async def test_incident_notes_accept_non_paginated_envelope() -> None:
+    requests: list[httpx.Request] = []
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        requests.append(request)
+        return httpx.Response(
+            200,
+            json={"notes": [{"id": "note-1", "content": "Recovered"}]},
+        )
+
+    client = PagerDutyClient(
+        OAuthBearerAuth("oauth"), transport=httpx.MockTransport(handler)
+    )
+
+    notes = await client.list_incident_notes("incident-1")
+
+    assert [note.id for note in notes] == ["note-1"]
+    assert len(requests) == 1
+    assert requests[0].url.params == httpx.QueryParams()
+
+
+@pytest.mark.asyncio
 @pytest.mark.parametrize("status", [429, 503])
 async def test_retries_transient_response_with_bounded_attempts(
     monkeypatch: pytest.MonkeyPatch, status: int

--- a/tests/providers/test_pagerduty_sync_auth.py
+++ b/tests/providers/test_pagerduty_sync_auth.py
@@ -119,7 +119,11 @@ def test_hydrate_oauth_uses_stored_non_expired_token_without_mutating_mapping(
 
     hydrated = hydrate_pagerduty_credentials(mapping, org_id="oauth-org")
 
-    assert hydrated == {**mapping, "access_token": "stored-token"}
+    assert hydrated == {
+        **mapping,
+        "access_token": "stored-token",
+        "granted_scopes": sorted(READ_SCOPES),
+    }
     assert hydrated is not mapping
     assert mapping == {
         "auth_mode": "oauth",
@@ -190,7 +194,7 @@ def test_hydrate_oauth_rejects_a_token_missing_operational_scopes(
 ) -> None:
     # Given: a persisted OAuth token that lacks one required operational scope.
     seed_credential(
-        session, tokens("stored-token", granted_scopes=frozenset({"Users.read"}))
+        session, tokens("stored-token", granted_scopes=frozenset({"users.read"}))
     )
     patch_sync_session(monkeypatch, session)
     monkeypatch.setenv("PAGER_DUTY_CLIENT_ID", "client-id")
@@ -247,7 +251,11 @@ def test_hydrate_client_credentials_mints_machine_token(
 
     hydrated = hydrate_pagerduty_credentials(mapping, org_id="client-org")
 
-    assert hydrated == {**mapping, "access_token": "machine-token"}
+    assert hydrated == {
+        **mapping,
+        "access_token": "machine-token",
+        "granted_scopes": sorted(READ_SCOPES),
+    }
     assert hydrated is not mapping
 
 
@@ -268,7 +276,7 @@ def test_hydrate_client_credentials_rejects_a_partial_scope_grant(
         return tokens(
             "partial-machine-token",
             refresh_token=None,
-            granted_scopes=frozenset({"Users.read"}),
+            granted_scopes=frozenset({"users.read"}),
         )
 
     monkeypatch.setattr(

--- a/tests/test_dataset_adapters.py
+++ b/tests/test_dataset_adapters.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Mapping
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -772,6 +773,49 @@ def test_pagerduty_dataset_closes_client_when_store_setup_fails() -> None:
         run_dataset_unit(ctx, _runtime())
 
     client.close.assert_awaited_once()
+
+
+def test_pagerduty_dataset_closes_client_on_request_event_loop() -> None:
+    from dev_health_ops.providers.pagerduty.sync import PagerDutySyncResult
+
+    ctx = _context(
+        provider="pagerduty",
+        dataset_key="services",
+        source_external_id="acme",
+    )
+    loop_ids: list[int] = []
+    client = Mock()
+    client.drain_usage_observations.return_value = []
+
+    async def run_sync(*_: object, **__: object) -> PagerDutySyncResult:
+        loop_ids.append(id(asyncio.get_running_loop()))
+        return PagerDutySyncResult(
+            dataset_key="services",
+            persisted=1,
+            watermark_at=WINDOW_END,
+            degraded=False,
+            observations=(),
+        )
+
+    async def close_client() -> None:
+        loop_ids.append(id(asyncio.get_running_loop()))
+
+    client.close = AsyncMock(side_effect=close_client)
+
+    with (
+        patch(
+            "dev_health_ops.processors.dataset_adapters._pagerduty_client",
+            return_value=(client, "acme"),
+        ),
+        patch(
+            "dev_health_ops.providers.pagerduty.sync.PagerDutyOperationalSync"
+        ) as sync,
+    ):
+        sync.return_value.run = AsyncMock(side_effect=run_sync)
+        run_dataset_unit(ctx, _runtime())
+
+    assert len(loop_ids) == 2
+    assert loop_ids[0] == loop_ids[1]
 
 
 def test_pagerduty_dataset_rejects_source_id_without_verified_account_identity() -> (

--- a/tests/test_operational_contract.py
+++ b/tests/test_operational_contract.py
@@ -230,6 +230,33 @@ def test_store_inserts_a_canonical_service_with_org_id_parity() -> None:
     assert row[columns.index("org_id")] == "org-example"
 
 
+def test_store_hydrates_clickhouse_datetimes_as_canonical_utc() -> None:
+    canonical = OperationalService(
+        org_id="org-example",
+        provider="pagerduty",
+        provider_instance_id="pd-example",
+        source_entity_type="service",
+        external_id="payments-api",
+        source_version_at=datetime(2026, 7, 17, tzinfo=timezone.utc),
+        observed_at=datetime(2026, 7, 17, 1, tzinfo=timezone.utc),
+        last_synced=datetime(2026, 7, 17, 2, tzinfo=timezone.utc),
+        name="Payments API",
+    )
+    columns = tuple(field.name for field in fields(OperationalService))
+    row = tuple(
+        value.replace(tzinfo=None) if isinstance(value, datetime) else value
+        for value in (getattr(canonical, column) for column in columns)
+    )
+
+    hydrated = _current_store()._hydrate_operational_entity(
+        OperationalService, columns, row
+    )
+
+    assert hydrated == canonical
+    assert hydrated.source_version_at.tzinfo is timezone.utc
+    assert hydrated.source_version_at.fold == 0
+
+
 def test_store_rejects_mixed_canonical_entity_batches() -> None:
     # Given: two distinct entity types from the same canonical lifecycle.
     lifecycle = equivalent_operational_lifecycles()[0]

--- a/tests/test_pagerduty_clickhouse_live.py
+++ b/tests/test_pagerduty_clickhouse_live.py
@@ -11,12 +11,20 @@ import asyncio
 import os
 from collections.abc import Iterator
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
+from typing import cast
 from urllib.parse import urlsplit, urlunsplit
-from uuid import uuid4
+from uuid import UUID, uuid4
 
 import pytest
 
+from dev_health_ops.metrics.active_incidents import (
+    IncidentWindow,
+    active_incidents_query,
+)
+from dev_health_ops.metrics.compute_dora import compute_dora_metrics_daily
+from dev_health_ops.metrics.compute_incidents import compute_incident_metrics_daily
+from dev_health_ops.metrics.schemas import IncidentRow
 from dev_health_ops.metrics.sinks.clickhouse import ClickHouseMetricsSink
 from dev_health_ops.models.operational import (
     CanonicalOperationalEntity,
@@ -30,6 +38,7 @@ from dev_health_ops.models.operational import (
     OperationalService,
     OperationalTeam,
     OperationalUser,
+    ServiceRepositoryMapping,
     canonical_operational_id,
 )
 from dev_health_ops.models.operational_identity import operational_source_coordinates
@@ -55,6 +64,7 @@ CLICKHOUSE_URI = os.environ.get("CLICKHOUSE_URI")
 SOURCE_TIME = datetime(2026, 7, 17, 12, 0, tzinfo=timezone.utc)
 ORG_ID = "test-chaos-2957"
 PROVIDER_INSTANCE_ID = "pagerduty-chaos-2957"
+METRIC_REPO_ID = UUID("11111111-1111-1111-1111-111111111111")
 
 pytestmark = [
     pytest.mark.clickhouse,
@@ -285,3 +295,135 @@ def test_pagerduty_operational_rows_round_trip_and_deduplicate(
             assert count.result_rows == [(1,)]
     finally:
         client.close()
+
+
+def test_mapped_canonical_pagerduty_incident_drives_incident_metrics(
+    pagerduty_scratch_dsn: str,
+) -> None:
+    # Given: a resolved PagerDuty incident and an explicit mapping from its
+    # canonical service to an organization-owned repository.
+    rows = _pagerduty_rows()
+    resolved_at = SOURCE_TIME + timedelta(hours=4)
+    normalizer = PagerDutyNormalizer(
+        org_id=ORG_ID,
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        observed_at=resolved_at,
+    )
+    resolved_incident = normalizer.incident(
+        Incident(
+            id="incident-1",
+            title="Payments latency",
+            status="resolved",
+            service=PagerDutyModel(id="service-1"),
+            created_at=SOURCE_TIME,
+            resolved_at=resolved_at,
+            last_status_change_at=resolved_at,
+            updated_at=resolved_at,
+        )
+    )
+    mapping = ServiceRepositoryMapping(
+        org_id=ORG_ID,
+        provider="pagerduty",
+        provider_instance_id=PROVIDER_INSTANCE_ID,
+        source_entity_type="service_repository_mapping",
+        external_id="service-1:github:full-chaos/payments-api",
+        source_version_at=resolved_at,
+        observed_at=resolved_at,
+        last_synced=resolved_at,
+        service_id=rows.service.id,
+        repo_id=METRIC_REPO_ID,
+        repo_provider="github",
+        repo_full_name="full-chaos/payments-api",
+        mapping_kind="admin",
+        rule_id="service_repository_mapping.admin.v1",
+        valid_from=SOURCE_TIME,
+        is_active=True,
+    )
+
+    async def persist_projection_inputs() -> None:
+        async with ClickHouseStore(pagerduty_scratch_dsn) as store:
+            store.org_id = ORG_ID
+            await store.insert_operational_services([rows.service])
+            await store.insert_operational_incidents([resolved_incident])
+            await store.insert_operational_service_repository_mappings([mapping])
+
+    asyncio.run(persist_projection_inputs())
+
+    sink = ClickHouseMetricsSink(pagerduty_scratch_dsn)
+    try:
+        sink.client.insert(
+            "repos",
+            [
+                [
+                    METRIC_REPO_ID,
+                    "full-chaos/payments-api",
+                    None,
+                    SOURCE_TIME,
+                    None,
+                    None,
+                    resolved_at,
+                    ORG_ID,
+                    "github",
+                    None,
+                ]
+            ],
+            column_names=[
+                "id",
+                "repo",
+                "ref",
+                "created_at",
+                "settings",
+                "tags",
+                "last_synced",
+                "org_id",
+                "provider",
+                "source_id",
+            ],
+        )
+
+        # When: the real canonical projection and both incident metric
+        # computations consume the persisted ClickHouse rows.
+        projected = sink.query_dicts(
+            active_incidents_query(
+                window=IncidentWindow.RESOLVED,
+                org_id=ORG_ID,
+                repo_filter="",
+            ),
+            {
+                "org_id": ORG_ID,
+                "start": SOURCE_TIME,
+                "end": SOURCE_TIME + timedelta(days=1),
+                "as_of": resolved_at + timedelta(seconds=1),
+            },
+        )
+        incident_rows = cast(list[IncidentRow], projected)
+        incident_metrics = compute_incident_metrics_daily(
+            day=SOURCE_TIME.date(),
+            incidents=incident_rows,
+            computed_at=resolved_at,
+        )
+        dora_metrics = compute_dora_metrics_daily(
+            day=SOURCE_TIME.date(),
+            deployments=[],
+            incidents=incident_rows,
+            computed_at=resolved_at,
+        )
+
+        # Then: one mapped canonical incident contributes to repository-scoped
+        # counts, MTTR, and DORA restoration time without a legacy-table write.
+        assert len(projected) == 1
+        assert projected[0]["repo_id"] == METRIC_REPO_ID
+        assert projected[0]["incident_id"] == resolved_incident.id
+        assert len(incident_metrics) == 1
+        assert incident_metrics[0].incidents_count == 1
+        assert incident_metrics[0].mttr_p50_hours == pytest.approx(4.0)
+        assert [(metric.metric_name, metric.value) for metric in dora_metrics] == [
+            ("time_to_restore_service", pytest.approx(4 * 60 * 60))
+        ]
+        legacy_count = sink.query(
+            "SELECT count() FROM incidents WHERE org_id = {org_id:String}",
+            {"org_id": ORG_ID},
+        )
+        assert legacy_count.result_rows == [(0,)]
+    finally:
+        sink.close()

--- a/tests/test_pagerduty_datasets.py
+++ b/tests/test_pagerduty_datasets.py
@@ -37,13 +37,13 @@ def test_pagerduty_registry_dataset_keys_normalize_to_oauth_families() -> None:
 
     # Then: eight endpoint families collapse to PagerDuty's seven read scopes.
     assert scopes == {
-        "Incidents.read",
-        "Services.read",
-        "Escalation_policies.read",
-        "Schedules.read",
-        "Oncalls.read",
-        "Users.read",
-        "Teams.read",
+        "incidents.read",
+        "services.read",
+        "escalation_policies.read",
+        "schedules.read",
+        "oncalls.read",
+        "users.read",
+        "teams.read",
     }
 
 

--- a/tests/test_trigger_routing.py
+++ b/tests/test_trigger_routing.py
@@ -296,6 +296,25 @@ def test_planner_managed_parent_with_zero_tagged_enabled_sources_syncs_nothing(
     assert req.source_ids == ()
 
 
+def test_planner_managed_pagerduty_parent_keeps_account_scope_unset(db_session):
+    integration_id = uuid.uuid4()
+    _integration(db_session, integration_id, provider="pagerduty")
+    config = _config(
+        db_session,
+        provider="pagerduty",
+        sync_targets=["operational"],
+        integration_id=integration_id,
+        planner_managed=True,
+    )
+
+    req = planner_request_for_config_if_routed(
+        db_session, config, triggered_by="manual"
+    )
+
+    assert req is not None
+    assert req.source_ids is None
+
+
 def test_non_planner_managed_parent_keeps_all_enabled_semantics(
     db_session,
 ):


### PR DESCRIPTION
## Summary

- repair PagerDuty OAuth scope/callback handling and hydrate rotating OAuth credentials into test and sync paths
- preserve account-wide PagerDuty planner units and service mapping options
- repair runtime ingestion across client lifecycle, incident notes, permanent on-calls, UTC normalization, and canonical ClickHouse datetime hydration
- add a real ClickHouse regression proving that a resolved canonical PagerDuty incident with an explicit service-to-repository mapping produces incident and DORA restoration metrics without writing the legacy `incidents` table

## Live validation

- a real private scoped OAuth app passed credential testing
- a real sync completed all 11 PagerDuty datasets successfully
- the incident dataset persisted one canonical incident and four log entries
- the current local service has no repository mapping and its incident is open, so repository-scoped incident metrics are correctly absent
- the isolated ClickHouse regression projects a mapped canonical incident into one incident count, a 4-hour MTTR, and a 14,400-second DORA `time_to_restore_service` value

## Tests

- `bash ci/local_validate.sh` before the test-only regression commit: 8,577 passed, 50 skipped; Ruff, mypy, migrations, and live ClickHouse proof passed
- focused canonical incident projection/metrics suite after the regression: 28 passed, including 2 live ClickHouse tests
- pre-push Ruff and mypy gates passed

## Configuration and migration impact

- no schema migration
- private PagerDuty app credentials remain supported
- `canonical_incident_ingestion` must be enabled for the organization
- PagerDuty incidents persist without repository mappings; repository-scoped metrics and correlations require an explicit service-to-repository mapping
- open incidents do not contribute to resolved-incident or time-to-restore metrics until PagerDuty reports a resolution timestamp

## Risk and rollback

- main runtime risk is canonical ClickHouse datetime hydration across operational entity types; covered by focused and full validation
- rollback by reverting `552b66084` and `1c46e72bb`

SCREENSHOT-WAIVER: Backend/runtime and test-only changes; no rendered UI changes.

Linear: https://linear.app/fullchaos/issue/CHAOS-3061/pagerduty-setup-and-sync-fail-after-oauth-connection

Web: https://github.com/full-chaos/dev-health-web/pull/805
