### PR TITLE
fix: enable canonical incident ingestion by default

### DIFF
--- a/docs/architecture/licensing.md
+++ b/docs/architecture/licensing.md
@@ -68,17 +68,16 @@ it is never an ACR API bearer credential.
 
 ### Canonical Incident Ingestion
 
-`canonical_incident_ingestion` is registered as an explicit-purchase feature and
-is `false` for Community, Team, and Enterprise defaults. Alembic revision `0042`
-seeds only its globally enabled `FeatureFlag`; it does not seed an organization
-grant. The global row is an availability and kill switch, not customer
-enablement.
+`canonical_incident_ingestion` is a Community-tier feature and is therefore enabled
+by default for Community, Team, and Enterprise organizations. Alembic revision `0048`
+upserts the feature row and globally enables it, repairing installations that missed
+the original revision `0042` seed. The global row remains an availability and kill
+switch.
 
-An active, unexpired `OrgFeatureOverride` is the only positive organization path
-for this feature. `OrgLicense.features_override`, tier, deployment environment,
-and CI cannot positively enable it. A missing row, false or expired override,
-storage failure, or globally disabled flag denies access. Removing the
-organization override is the rollback action.
+An active false `OrgFeatureOverride` disables the feature for one organization. An
+expired override falls back to the tier default, and removing an override restores
+the default-on behavior. A missing row, storage failure, or globally disabled flag
+still denies access.
 
 Backend call sites use the shared typed evaluator exported by
 `dev_health_ops.licensing`: `evaluate_org_feature_sync` or

--- a/docs/architecture/pagerduty-contract.md
+++ b/docs/architecture/pagerduty-contract.md
@@ -209,11 +209,11 @@ subscription identity.
 
 ## Rollout and release posture
 
-`canonical_incident_ingestion` remains default-off. CI, deployment, and
-credential setup do not create a positive organization override or enable a
-customer. Feature-off blocks new canonical webhook enqueue, processing, and
-writes while status, inspection, disconnect, deletion, and secret cleanup
-remain available.
+`canonical_incident_ingestion` is enabled by default for every license tier after
+the canonical cutover. The global feature row remains a kill switch, and an
+organization may carry an explicit false override. Feature-off blocks new canonical
+webhook enqueue, processing, and writes while status, inspection, disconnect,
+deletion, and secret cleanup remain available.
 
 The PostgreSQL binding migration and any shared ordering migration must be
 safe for mixed versions. Rollout uses a dual-schema bridge, inventory of every
@@ -227,5 +227,5 @@ Binding persistence uses one lock order through the persistence boundary:
 binding, source, integration, credential; revoke candidates use deterministic
 UUID order. The worker hydrates credentials through the async-native path,
 revalidates that graph immediately before the ClickHouse write, and retains a
-completed receipt for 604800 seconds (seven days). Migration head is 0044.
+completed receipt for 604800 seconds (seven days). Migration head is 0048.
 There is no production downgrade path to the legacy writer or reader.

--- a/src/dev_health_ops/alembic/versions/0048_enable_canonical_incident_ingestion.py
+++ b/src/dev_health_ops/alembic/versions/0048_enable_canonical_incident_ingestion.py
@@ -1,0 +1,60 @@
+"""Enable canonical incident ingestion by default.
+
+Revision ID: 0048
+Revises: 0047
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Sequence
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "0048"
+down_revision: str | None = "0047"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+_FEATURE_KEY = "canonical_incident_ingestion"
+
+
+def upgrade() -> None:
+    """Repair a missed seed and make the registered feature globally available."""
+    now = datetime.now(UTC)
+    op.get_bind().execute(
+        sa.text(
+            """
+            INSERT INTO feature_flags
+                (id, key, name, description, category, min_tier, is_enabled,
+                 is_beta, is_deprecated, created_at, updated_at)
+            VALUES
+                (:id, :key, :name, :description, :category, :min_tier, TRUE,
+                 FALSE, FALSE, :created_at, :updated_at)
+            ON CONFLICT (key) DO UPDATE SET
+                name = excluded.name,
+                description = excluded.description,
+                category = excluded.category,
+                min_tier = excluded.min_tier,
+                is_enabled = TRUE,
+                is_deprecated = FALSE,
+                updated_at = excluded.updated_at
+            """
+        ),
+        {
+            "id": str(uuid.uuid4()),
+            "key": _FEATURE_KEY,
+            "name": "Canonical Incident Ingestion",
+            "description": "Canonical operational incident ingestion and consumption",
+            "category": "integrations",
+            "min_tier": "community",
+            "created_at": now,
+            "updated_at": now,
+        },
+    )
+
+
+def downgrade() -> None:
+    """Keep the availability row intact; rollout policy is versioned in code."""

--- a/src/dev_health_ops/licensing/gating.py
+++ b/src/dev_health_ops/licensing/gating.py
@@ -13,6 +13,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from dev_health_ops.licensing.feature_decisions import evaluate_org_features_async
 from dev_health_ops.licensing.registry import (
+    CANONICAL_INCIDENT_INGESTION_FEATURE,
     EXPLICIT_PURCHASE_FEATURES,
     get_features_for_tier,
 )
@@ -384,7 +385,13 @@ async def get_org_entitlements_from_db(
     features = get_features_for_tier(tier)
     limits = DEFAULT_LIMITS[tier]
 
-    decision_keys = sorted(EXPLICIT_PURCHASE_FEATURES | {"customer_push_ingest"})
+    decision_keys = sorted(
+        EXPLICIT_PURCHASE_FEATURES
+        | {
+            CANONICAL_INCIDENT_INGESTION_FEATURE,
+            "customer_push_ingest",
+        }
+    )
     decisions = await evaluate_org_features_async(session, org_id, decision_keys)
     for feature_key, decision in decisions.items():
         features[feature_key] = decision.allowed

--- a/src/dev_health_ops/licensing/registry.py
+++ b/src/dev_health_ops/licensing/registry.py
@@ -14,12 +14,8 @@ from dev_health_ops.licensing.types import TIER_ORDER, FeatureCategory, LicenseT
 STANDARD_FEATURE_ROW = tuple[str, str, FeatureCategory, LicenseTier, str]
 
 CANONICAL_INCIDENT_INGESTION_FEATURE: Final = "canonical_incident_ingestion"
-EXPLICIT_PURCHASE_FEATURES: frozenset[str] = frozenset(
-    {"agent_context_runtime", CANONICAL_INCIDENT_INGESTION_FEATURE}
-)
-ORG_OVERRIDE_ONLY_FEATURES: frozenset[str] = frozenset(
-    {CANONICAL_INCIDENT_INGESTION_FEATURE}
-)
+EXPLICIT_PURCHASE_FEATURES: frozenset[str] = frozenset({"agent_context_runtime"})
+ORG_OVERRIDE_ONLY_FEATURES: frozenset[str] = frozenset()
 
 
 def is_explicit_purchase_feature(feature_key: str) -> bool:

--- a/tests/api/admin/canonical_incident_sync_support.py
+++ b/tests/api/admin/canonical_incident_sync_support.py
@@ -130,9 +130,9 @@ async def canonical_api_state_context(tmp_path: Path) -> AsyncIterator[ApiState]
         await session.flush()
         session.add(
             OrgFeatureOverride(
-                org_id=enabled.org_id,
+                org_id=disabled.org_id,
                 feature_id=feature.id,
-                is_enabled=True,
+                is_enabled=False,
             )
         )
         await session.commit()

--- a/tests/api/admin/test_canonical_incident_sync_gate.py
+++ b/tests/api/admin/test_canonical_incident_sync_gate.py
@@ -68,7 +68,7 @@ async def test_sync_target_discovery_is_org_scoped(
 
 
 @pytest.mark.asyncio
-async def test_sync_config_create_succeeds_when_feature_enabled(
+async def test_sync_config_create_succeeds_by_default_without_override(
     canonical_api_state: ApiState,
 ) -> None:
     # Given
@@ -86,21 +86,29 @@ async def test_sync_config_create_succeeds_when_feature_enabled(
 
 
 @pytest.mark.asyncio
-async def test_sync_config_create_fails_for_missing_override(
+async def test_sync_config_create_succeeds_without_override(
     canonical_api_state: ApiState,
 ) -> None:
     # Given
     state = canonical_api_state
+    async with state.session_maker() as session:
+        await session.execute(
+            delete(OrgFeatureOverride).where(
+                OrgFeatureOverride.org_id == state.disabled.org_id,
+                OrgFeatureOverride.feature_id == state.feature_id,
+            )
+        )
+        await session.commit()
 
     # When
     async with api_client(state, state.disabled) as client:
         response = await client.post(
             "/api/v1/admin/sync-configs",
-            json=_operational_payload("missing-override"),
+            json=_operational_payload("default-without-override"),
         )
 
     # Then
-    assert response.status_code == 403
+    assert response.status_code == 201, response.text
 
 
 @pytest.mark.asyncio
@@ -109,16 +117,6 @@ async def test_sync_config_create_fails_for_false_override(
 ) -> None:
     # Given
     state = canonical_api_state
-    async with state.session_maker() as session:
-        session.add(
-            OrgFeatureOverride(
-                org_id=state.disabled.org_id,
-                feature_id=state.feature_id,
-                is_enabled=False,
-            )
-        )
-        await session.commit()
-
     # When
     async with api_client(state, state.disabled) as client:
         response = await client.post(

--- a/tests/api/licensing/test_canonical_incident_entitlements.py
+++ b/tests/api/licensing/test_canonical_incident_entitlements.py
@@ -99,15 +99,15 @@ def _session_patcher(
 
 
 @pytest.mark.asyncio
-async def test_async_entitlements_deny_canonical_license_override(
+async def test_async_entitlements_enable_canonical_by_default(
     entitlement_store,
 ) -> None:
-    maker, org_id, _ = entitlement_store
+    maker, _, org_id = entitlement_store
 
     async with maker() as session:
         entitlements = await get_org_entitlements_from_db(org_id, session)
 
-    assert entitlements["features"][_FEATURE_KEY] is False
+    assert entitlements["features"][_FEATURE_KEY] is True
 
 
 @pytest.mark.asyncio
@@ -115,7 +115,7 @@ async def test_rest_entitlements_add_canonical_feature_without_changing_shape(
     entitlement_store,
     monkeypatch,
 ) -> None:
-    maker, org_id, _ = entitlement_store
+    maker, _, org_id = entitlement_store
     app = FastAPI()
     app.include_router(_router_module.router)
     app.dependency_overrides[get_current_user] = lambda: AuthenticatedUser(
@@ -140,11 +140,11 @@ async def test_rest_entitlements_add_canonical_feature_without_changing_shape(
     assert response.status_code == 200
     body = response.json()
     assert {"org_id", "tier", "features", "limits"} <= body.keys()
-    assert body["features"][_FEATURE_KEY] is False
+    assert body["features"][_FEATURE_KEY] is True
 
 
 @pytest.mark.asyncio
-async def test_async_entitlements_enable_only_org_with_active_override(
+async def test_async_entitlements_disable_only_org_with_false_override(
     entitlement_store,
 ) -> None:
     maker, enabled_org_id, disabled_org_id = entitlement_store
@@ -158,7 +158,7 @@ async def test_async_entitlements_enable_only_org_with_active_override(
             OrgFeatureOverride(
                 org_id=enabled_org_id,
                 feature_id=feature.id,
-                is_enabled=True,
+                is_enabled=False,
             )
         )
         await session.commit()
@@ -167,5 +167,5 @@ async def test_async_entitlements_enable_only_org_with_active_override(
         enabled = await get_org_entitlements_from_db(enabled_org_id, session)
         disabled = await get_org_entitlements_from_db(disabled_org_id, session)
 
-    assert enabled["features"][_FEATURE_KEY] is True
-    assert disabled["features"][_FEATURE_KEY] is False
+    assert enabled["features"][_FEATURE_KEY] is False
+    assert disabled["features"][_FEATURE_KEY] is True

--- a/tests/canonical_incident_orchestration_support.py
+++ b/tests/canonical_incident_orchestration_support.py
@@ -73,9 +73,9 @@ def canonical_state_context() -> Iterator[CanonicalState]:
     session.flush()
     session.add(
         OrgFeatureOverride(
-            org_id=enabled_org_id,
+            org_id=disabled_org_id,
             feature_id=feature.id,
-            is_enabled=True,
+            is_enabled=False,
         )
     )
     session.commit()
@@ -159,16 +159,31 @@ def create_canonical_graph(
     )
 
 
-def remove_feature_override(
+def disable_feature_for_org(
     state: CanonicalState,
     org_id: uuid.UUID,
     *,
     commit: bool = True,
 ) -> None:
-    state.session.query(OrgFeatureOverride).filter_by(
-        org_id=org_id,
-        feature_id=state.feature_id,
-    ).delete(synchronize_session=False)
+    override = (
+        state.session.query(OrgFeatureOverride)
+        .filter_by(
+            org_id=org_id,
+            feature_id=state.feature_id,
+        )
+        .one_or_none()
+    )
+    if override is None:
+        state.session.add(
+            OrgFeatureOverride(
+                org_id=org_id,
+                feature_id=state.feature_id,
+                is_enabled=False,
+            )
+        )
+    else:
+        override.is_enabled = False
+        override.expires_at = None
     if commit:
         state.session.commit()
     else:

--- a/tests/test_canonical_incident_default_on_migration.py
+++ b/tests/test_canonical_incident_default_on_migration.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+import importlib
+from pathlib import Path
+from types import ModuleType
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+from sqlalchemy import create_engine
+
+_FEATURE_KEY = "canonical_incident_ingestion"
+
+
+def _migration() -> ModuleType:
+    return importlib.import_module(
+        "dev_health_ops.alembic.versions.0048_enable_canonical_incident_ingestion"
+    )
+
+
+def _create_feature_flags_table(connection: sa.Connection) -> None:
+    connection.execute(
+        sa.text(
+            """
+            CREATE TABLE feature_flags (
+                id TEXT PRIMARY KEY,
+                key TEXT NOT NULL UNIQUE,
+                name TEXT NOT NULL,
+                description TEXT,
+                category TEXT NOT NULL,
+                min_tier TEXT NOT NULL,
+                is_enabled BOOLEAN NOT NULL,
+                is_beta BOOLEAN NOT NULL,
+                is_deprecated BOOLEAN NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL
+            )
+            """
+        )
+    )
+
+
+def test_default_on_migration_repairs_disabled_row_idempotently() -> None:
+    migration = _migration()
+    engine = create_engine("sqlite:///:memory:")
+
+    try:
+        with engine.connect() as connection:
+            _create_feature_flags_table(connection)
+            connection.execute(
+                sa.text(
+                    """
+                    INSERT INTO feature_flags
+                        (id, key, name, category, min_tier, is_enabled, is_beta,
+                         is_deprecated, created_at, updated_at)
+                    VALUES
+                        ('existing', :key, 'Canonical Incident Ingestion',
+                         'integrations', 'community', FALSE, FALSE, FALSE,
+                         CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                    """
+                ),
+                {"key": _FEATURE_KEY},
+            )
+            context = MigrationContext.configure(connection)
+            with Operations.context(context):
+                migration.upgrade()
+                migration.upgrade()
+
+            row = connection.execute(
+                sa.text(
+                    "SELECT key, min_tier, is_enabled FROM feature_flags WHERE key = :key"
+                ),
+                {"key": _FEATURE_KEY},
+            ).one()
+
+        assert row == (_FEATURE_KEY, "community", True)
+    finally:
+        engine.dispose()
+
+
+def test_default_on_migration_inserts_missing_feature() -> None:
+    migration = _migration()
+    engine = create_engine("sqlite:///:memory:")
+
+    try:
+        with engine.connect() as connection:
+            _create_feature_flags_table(connection)
+            context = MigrationContext.configure(connection)
+            with Operations.context(context):
+                migration.upgrade()
+
+            row = connection.execute(
+                sa.text(
+                    "SELECT key, min_tier, is_enabled FROM feature_flags WHERE key = :key"
+                ),
+                {"key": _FEATURE_KEY},
+            ).one()
+
+        assert row == (_FEATURE_KEY, "community", True)
+    finally:
+        engine.dispose()
+
+
+def test_default_on_migration_extends_current_head() -> None:
+    migration = _migration()
+
+    assert migration.revision == "0048"
+    assert migration.down_revision == "0047"
+    assert migration.__file__ is not None
+    assert Path(migration.__file__).name == (
+        "0048_enable_canonical_incident_ingestion.py"
+    )

--- a/tests/test_canonical_incident_dispatch_scope.py
+++ b/tests/test_canonical_incident_dispatch_scope.py
@@ -9,7 +9,7 @@ from tests.canonical_incident_dispatch_support import patch_dispatch, plan_run
 from tests.canonical_incident_orchestration_support import (
     CanonicalState,
     canonical_state_context,
-    remove_feature_override,
+    disable_feature_for_org,
 )
 
 
@@ -48,7 +48,7 @@ def test_dispatch_gate_uses_persisted_run_scope_not_all_integration_datasets(
     unit.provider = "github"
     unit.dataset_key = "commits"
     state.session.commit()
-    remove_feature_override(state, state.enabled_org_id)
+    disable_feature_for_org(state, state.enabled_org_id)
     patch_dispatch(monkeypatch, state.session)
 
     result = sync_units.dispatch_sync_run(str(run.id))

--- a/tests/test_canonical_incident_dispatch_worker_gate.py
+++ b/tests/test_canonical_incident_dispatch_worker_gate.py
@@ -22,7 +22,7 @@ from tests.canonical_incident_dispatch_support import (
 from tests.canonical_incident_orchestration_support import (
     CanonicalState,
     canonical_state_context,
-    remove_feature_override,
+    disable_feature_for_org,
 )
 
 
@@ -41,7 +41,7 @@ def test_dispatch_terminalizes_run_when_feature_flips_off(
     # Given
     state = canonical_state
     run, unit = plan_run(state)
-    remove_feature_override(state, state.enabled_org_id)
+    disable_feature_for_org(state, state.enabled_org_id)
     patch_dispatch(monkeypatch, state.session)
     finalize_calls: list[str] = []
     monkeypatch.setattr(
@@ -82,7 +82,7 @@ def test_repeated_dispatch_denial_is_idempotent_and_never_retries(
     # Given
     state = canonical_state
     run, unit = plan_run(state)
-    remove_feature_override(state, state.enabled_org_id)
+    disable_feature_for_org(state, state.enabled_org_id)
     patch_dispatch(monkeypatch, state.session)
     finalize_calls: list[str] = []
     monkeypatch.setattr(
@@ -121,7 +121,7 @@ def test_zero_unit_denial_schedules_finalizer_once(
     # Given
     state = canonical_state
     run = plan_zero_unit_run(state)
-    remove_feature_override(state, state.enabled_org_id)
+    disable_feature_for_org(state, state.enabled_org_id)
     patch_dispatch(monkeypatch, state.session)
     finalize_calls: list[str] = []
     monkeypatch.setattr(
@@ -155,7 +155,7 @@ def test_denial_never_publishes_terminal_finalizer(
     # Given
     state = canonical_state
     run, unit = plan_run(state)
-    remove_feature_override(state, state.enabled_org_id)
+    disable_feature_for_org(state, state.enabled_org_id)
     patch_dispatch(monkeypatch, state.session)
 
     def reject_enqueue(_run_id: str) -> None:
@@ -203,7 +203,7 @@ def test_dispatch_terminalizes_running_claim_when_feature_flips_off(
     unit.lease_expires_at = now + timedelta(minutes=5)
     unit.available_at = now
     state.session.commit()
-    remove_feature_override(state, state.enabled_org_id)
+    disable_feature_for_org(state, state.enabled_org_id)
     patch_dispatch(monkeypatch, state.session)
     finalize_calls: list[str] = []
     monkeypatch.setattr(

--- a/tests/test_canonical_incident_feature_denial.py
+++ b/tests/test_canonical_incident_feature_denial.py
@@ -68,7 +68,7 @@ def test_running_denial_does_not_cancel_replacement_lease_owner(
             state.session,
             run,
             CanonicalIncidentFeatureDisabledError(
-                FeatureDecisionReason.EXPLICIT_PURCHASE_REQUIRED
+                FeatureDecisionReason.ORG_OVERRIDE_DISABLED
             ),
         )
     finally:
@@ -101,7 +101,7 @@ def test_running_denial_terminalizes_legacy_null_owner(
         state.session,
         run,
         CanonicalIncidentFeatureDisabledError(
-            FeatureDecisionReason.EXPLICIT_PURCHASE_REQUIRED
+            FeatureDecisionReason.ORG_OVERRIDE_DISABLED
         ),
     )
 

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -20,7 +20,7 @@ _VERSIONS_DIR = (
 def _canonical_incident_migration_module() -> ModuleType:
     matching_paths = [
         path
-        for path in _VERSIONS_DIR.glob("*.py")
+        for path in _VERSIONS_DIR.glob("0042_*.py")
         if _FEATURE_KEY in path.read_text(encoding="utf-8")
     ]
     assert len(matching_paths) == 1
@@ -112,9 +112,10 @@ def test_canonical_incident_feature_seed_is_in_single_head_graph() -> None:
 
     assert migration.down_revision == "0041"
     assert migration.revision in revisions
-    assert scripts.get_heads() == ["0047"]
+    assert scripts.get_heads() == ["0048"]
     assert scripts.get_revision("0043").down_revision == "0042"
     assert scripts.get_revision("0044").down_revision == "0043"
     assert scripts.get_revision("0045").down_revision == "0044"
     assert scripts.get_revision("0046").down_revision == "0045"
     assert scripts.get_revision("0047").down_revision == "0046"
+    assert scripts.get_revision("0048").down_revision == "0047"

--- a/tests/test_canonical_incident_planner_scheduler_gate.py
+++ b/tests/test_canonical_incident_planner_scheduler_gate.py
@@ -26,7 +26,7 @@ from tests.canonical_incident_orchestration_support import (
     CanonicalState,
     canonical_state_context,
     create_canonical_graph,
-    remove_feature_override,
+    disable_feature_for_org,
 )
 
 
@@ -55,7 +55,7 @@ def test_jira_incidents_use_the_existing_canonical_feature_gate() -> None:
     )
 
 
-def test_planner_creates_canonical_work_when_feature_enabled(
+def test_planner_creates_canonical_work_when_feature_enabled_by_default(
     canonical_state: CanonicalState,
 ) -> None:
     # Given
@@ -235,7 +235,7 @@ def test_scheduler_rechecks_feature_immediately_before_enqueue(
 
     def create_then_disable(*args, **kwargs):
         trigger = real_trigger(*args, **kwargs)
-        remove_feature_override(state, state.enabled_org_id)
+        disable_feature_for_org(state, state.enabled_org_id)
         return trigger
 
     monkeypatch.setattr(sync_scheduler, "organization_exists_sync", lambda *_args: True)

--- a/tests/test_canonical_incident_scheduler_denial.py
+++ b/tests/test_canonical_incident_scheduler_denial.py
@@ -30,7 +30,7 @@ from tests.canonical_incident_orchestration_support import (
     CanonicalState,
     canonical_state_context,
     create_canonical_graph,
-    remove_feature_override,
+    disable_feature_for_org,
 )
 
 NOW = datetime(2026, 7, 20, 12, 0, tzinfo=timezone.utc)
@@ -74,7 +74,7 @@ def _install_plan_then_disable(
 
     def create_then_disable(*args, **kwargs):
         trigger = real_trigger(*args, **kwargs)
-        remove_feature_override(state, state.enabled_org_id, commit=False)
+        disable_feature_for_org(state, state.enabled_org_id, commit=False)
         return trigger
 
     monkeypatch.setattr(sync_scheduler, "organization_exists_sync", lambda *_args: True)

--- a/tests/test_canonical_incident_worker_gate.py
+++ b/tests/test_canonical_incident_worker_gate.py
@@ -9,7 +9,7 @@ from tests.canonical_incident_dispatch_support import patch_dispatch, plan_run
 from tests.canonical_incident_orchestration_support import (
     CanonicalState,
     canonical_state_context,
-    remove_feature_override,
+    disable_feature_for_org,
 )
 
 
@@ -31,7 +31,7 @@ def test_worker_terminalizes_claim_when_feature_flips_after_dispatch(
     run, unit = plan_run(state)
     patch_dispatch(monkeypatch, state.session)
     assert sync_units.dispatch_sync_run(str(run.id))["status"] == "dispatched"
-    remove_feature_override(state, state.enabled_org_id)
+    disable_feature_for_org(state, state.enabled_org_id)
     provider_calls: list[str] = []
     finalize_calls: list[str] = []
     monkeypatch.setattr(
@@ -91,7 +91,7 @@ def test_repeated_worker_denial_is_terminal_and_does_not_finalize_twice(
     run, unit = plan_run(state)
     patch_dispatch(monkeypatch, state.session)
     sync_units.dispatch_sync_run(str(run.id))
-    remove_feature_override(state, state.enabled_org_id)
+    disable_feature_for_org(state, state.enabled_org_id)
     finalize_calls: list[str] = []
     monkeypatch.setattr(
         sync_units, "_start_unit_heartbeat", lambda *_args: (None, None)
@@ -144,7 +144,7 @@ def test_worker_rechecks_feature_after_lease_check_before_provider(
     )
 
     def disable_after_lease_check(_unit_id: str, _lease_owner: str | None) -> bool:
-        remove_feature_override(state, state.enabled_org_id)
+        disable_feature_for_org(state, state.enabled_org_id)
         return True
 
     monkeypatch.setattr(

--- a/tests/test_feature_decision_parity.py
+++ b/tests/test_feature_decision_parity.py
@@ -50,8 +50,8 @@ _SCENARIOS = (
     ),
     DecisionScenario(
         name="missing-override",
-        expected_allowed=False,
-        expected_reason=FeatureDecisionReason.EXPLICIT_PURCHASE_REQUIRED,
+        expected_allowed=True,
+        expected_reason=FeatureDecisionReason.ENABLED_BY_TIER,
     ),
     DecisionScenario(
         name="active-override",
@@ -69,8 +69,8 @@ _SCENARIOS = (
         name="expired-override",
         org_override=True,
         override_expires_at=datetime(2000, 1, 1, tzinfo=UTC),
-        expected_allowed=False,
-        expected_reason=FeatureDecisionReason.ORG_OVERRIDE_EXPIRED,
+        expected_allowed=True,
+        expected_reason=FeatureDecisionReason.ENABLED_BY_TIER,
     ),
     DecisionScenario(
         name="global-kill-switch",
@@ -80,15 +80,15 @@ _SCENARIOS = (
         expected_reason=FeatureDecisionReason.GLOBAL_DISABLED,
     ),
     DecisionScenario(
-        name="license-override-denied",
+        name="license-override-enabled",
         license_override=True,
-        expected_allowed=False,
-        expected_reason=FeatureDecisionReason.ORG_OVERRIDE_REQUIRED,
+        expected_allowed=True,
+        expected_reason=FeatureDecisionReason.ENABLED_BY_LICENSE_OVERRIDE,
     ),
 )
 
 
-def test_override_expiring_at_evaluation_time_is_expired() -> None:
+def test_expired_override_falls_back_to_default_tier_access() -> None:
     boundary = datetime(2030, 1, 1, tzinfo=UTC)
     context = FeatureDecisionContext(
         feature_key=_FEATURE_KEY,
@@ -107,8 +107,8 @@ def test_override_expiring_at_evaluation_time_is_expired() -> None:
 
     decision = decide_feature(context)
 
-    assert decision.allowed is False
-    assert decision.reason is FeatureDecisionReason.ORG_OVERRIDE_EXPIRED
+    assert decision.allowed is True
+    assert decision.reason is FeatureDecisionReason.ENABLED_BY_TIER
 
 
 def test_expired_override_preserves_existing_explicit_purchase_fallback() -> None:

--- a/tests/test_feature_decisions.py
+++ b/tests/test_feature_decisions.py
@@ -106,35 +106,35 @@ def test_existing_explicit_purchase_license_override_enables_acr() -> None:
         engine.dispose()
 
 
-def test_canonical_incident_ingestion_is_false_for_every_tier() -> None:
+def test_canonical_incident_ingestion_is_enabled_for_every_tier() -> None:
     for tier in TIER_ORDER:
         features = get_features_for_tier(tier)
 
-        assert features[_FEATURE_KEY] is False
+        assert features[_FEATURE_KEY] is True
 
-    assert is_explicit_purchase_feature(_FEATURE_KEY) is True
+    assert is_explicit_purchase_feature(_FEATURE_KEY) is False
 
 
-def test_canonical_incident_ingestion_requires_org_override(
+def test_canonical_incident_ingestion_defaults_on_without_org_override(
     feature_session: tuple[Session, uuid.UUID, uuid.UUID],
 ) -> None:
     session, org_id, _ = feature_session
 
     decision = FeatureService(session).check_feature_access(org_id, _FEATURE_KEY)
 
-    assert decision.allowed is False
+    assert decision.allowed is True
 
 
-def test_canonical_incident_ingestion_org_override_is_org_scoped(
+def test_canonical_incident_ingestion_disable_override_is_org_scoped(
     feature_session: tuple[Session, uuid.UUID, uuid.UUID],
 ) -> None:
-    session, enabled_org_id, disabled_org_id = feature_session
+    session, disabled_org_id, enabled_org_id = feature_session
     feature = session.query(FeatureFlag).filter_by(key=_FEATURE_KEY).one()
     session.add(
         OrgFeatureOverride(
-            org_id=enabled_org_id,
+            org_id=disabled_org_id,
             feature_id=feature.id,
-            is_enabled=True,
+            is_enabled=False,
         )
     )
     session.commit()
@@ -171,7 +171,7 @@ def test_canonical_incident_ingestion_false_override_fails_closed(
     assert decision.allowed is False
 
 
-def test_canonical_incident_ingestion_expired_override_fails_closed(
+def test_canonical_incident_ingestion_expired_override_falls_back_to_default(
     feature_session: tuple[Session, uuid.UUID, uuid.UUID],
 ) -> None:
     session, org_id, _ = feature_session
@@ -188,7 +188,7 @@ def test_canonical_incident_ingestion_expired_override_fails_closed(
 
     decision = FeatureService(session).check_feature_access(org_id, _FEATURE_KEY)
 
-    assert decision.allowed is False
+    assert decision.allowed is True
 
 
 def test_canonical_incident_ingestion_global_kill_switch_wins(
@@ -211,7 +211,7 @@ def test_canonical_incident_ingestion_global_kill_switch_wins(
     assert decision.allowed is False
 
 
-def test_canonical_incident_ingestion_license_override_cannot_enable(
+def test_canonical_incident_ingestion_license_override_can_enable(
     feature_session: tuple[Session, uuid.UUID, uuid.UUID],
 ) -> None:
     session, org_id, _ = feature_session
@@ -226,10 +226,10 @@ def test_canonical_incident_ingestion_license_override_cannot_enable(
 
     decision = FeatureService(session).check_feature_access(org_id, _FEATURE_KEY)
 
-    assert decision.allowed is False
+    assert decision.allowed is True
 
 
-def test_canonical_incident_ingestion_override_removal_rolls_back(
+def test_canonical_incident_ingestion_override_removal_restores_default(
     feature_session: tuple[Session, uuid.UUID, uuid.UUID],
 ) -> None:
     session, org_id, _ = feature_session
@@ -246,7 +246,7 @@ def test_canonical_incident_ingestion_override_removal_rolls_back(
 
     decision = FeatureService(session).check_feature_access(org_id, _FEATURE_KEY)
 
-    assert decision.allowed is False
+    assert decision.allowed is True
 
 
 def test_canonical_incident_ingestion_storage_failure_fails_closed(


### PR DESCRIPTION
## Summary
- enable canonical incident ingestion by default for Community, Team, and Enterprise organizations
- preserve the global kill switch, explicit per-org false overrides, and fail-closed behavior for missing or invalid feature state
- add idempotent Alembic revision 0046 to repair a missing or disabled feature row and update gate tests to use real false overrides

## Rollout
- apply PostgreSQL migrations after deploy; restarting existing Compose services does not rerun the one-shot migrate service

## Testing
- `SCRATCH_DB=ci_canonical_default_on bash ci/local_validate.sh`
- 8,577 passed, 50 expected skips
- ClickHouse scratch migration/status and argMax live proof passed

Linear: CHAOS-3063

SCREENSHOT-WAIVER: backend-only; no rendered UI changes.