### PR TITLE
feat(workers): add dormant sync scheduler and parity foundations (CHAOS-3039)

### DIFF
--- a/ci/check_go_containers.sh
+++ b/ci/check_go_containers.sh
@@ -143,6 +143,9 @@ smoke_target() {
       grep -F "\"${dependency}\"" <<<"${readiness_body}" >/dev/null \
         || die "${target} readiness omitted ${dependency}"
     done
+    if [ "${target}" = "reconciler" ] && grep -F '"job_registry"' <<<"${readiness_body}" >/dev/null; then
+      die "reconciler image could not load its packaged job contract artifacts"
+    fi
   fi
   wait_for_status "http://${published_address}/metrics" 200 \
     || die "${target} metrics endpoint did not become available"

--- a/cmd/dev-health-reconciler/dependencies.go
+++ b/cmd/dev-health-reconciler/dependencies.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"errors"
+	"log/slog"
+	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/joboutbox"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
@@ -11,10 +13,16 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
 	"github.com/full-chaos/dev-health-ops/internal/storage/postgres"
 	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/syncreconciler"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-const defaultReconcilerContractRoot = "contracts/jobs/v1"
+const (
+	defaultReconcilerContractRoot   = "contracts/jobs/v1"
+	defaultSyncDispatchContractRoot = "contracts/sync-dispatch/v1"
+	recorderCleanupTimeout          = time.Second
+)
 
 var errReconcilerDependencyUnavailable = errors.New("reconciler readiness dependency is unavailable")
 
@@ -24,6 +32,7 @@ type reconcilerDatabase interface {
 	DomainReady(context.Context) error
 	QueueReady(context.Context) error
 	RiverSchemaReady(context.Context, string) error
+	DomainPool() *pgxpool.Pool
 	QueuePool() *pgxpool.Pool
 	Close()
 }
@@ -75,6 +84,13 @@ func (database *postgresReconcilerDatabase) QueuePool() *pgxpool.Pool {
 	return database.pools.QueueControl
 }
 
+func (database *postgresReconcilerDatabase) DomainPool() *pgxpool.Pool {
+	if database == nil || database.pools == nil {
+		return nil
+	}
+	return database.pools.Domain
+}
+
 func (database *postgresReconcilerDatabase) Close() {
 	if database != nil && database.pools != nil {
 		database.pools.Close()
@@ -87,14 +103,37 @@ type reconcilerDependencySources struct {
 	buildRelay          func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error)
 	newLoop             func(joboutbox.RelayStepper, joboutbox.ReconcilerLoopConfig) (*joboutbox.ReconcilerLoop, error)
 	contractRoot        string
+
+	loadSyncDispatchRegistry func(string) (*syncdispatchcontract.Registry, error)
+	buildSyncObserver        func(*pgxpool.Pool, *syncdispatchcontract.Registry) (syncreconciler.Stepper, error)
+	newSyncRecorder          func(*slog.Logger) (reconcilerObservationRecorder, error)
+	newSyncLoop              func(syncreconciler.Stepper, syncreconciler.LoopConfig) (*syncreconciler.Loop, error)
+	syncDispatchContractRoot string
 }
 
 var productionReconcilerDependencySources = reconcilerDependencySources{
-	openDatabase:        openReconcilerDatabase,
-	loadRuntimeRegistry: jobruntime.Load,
-	buildRelay:          buildReconcilerRelay,
-	newLoop:             joboutbox.NewReconcilerLoop,
-	contractRoot:        defaultReconcilerContractRoot,
+	openDatabase:             openReconcilerDatabase,
+	loadRuntimeRegistry:      jobruntime.Load,
+	buildRelay:               buildReconcilerRelay,
+	newLoop:                  joboutbox.NewReconcilerLoop,
+	contractRoot:             defaultReconcilerContractRoot,
+	loadSyncDispatchRegistry: syncdispatchcontract.Load,
+	buildSyncObserver: func(pool *pgxpool.Pool, registry *syncdispatchcontract.Registry) (syncreconciler.Stepper, error) {
+		return syncreconciler.NewObserver(pool, registry)
+	},
+	newSyncRecorder: func(logger *slog.Logger) (reconcilerObservationRecorder, error) {
+		return syncreconciler.NewSlogObservationRecorder(logger)
+	},
+	newSyncLoop:              syncreconciler.NewLoop,
+	syncDispatchContractRoot: defaultSyncDispatchContractRoot,
+}
+
+// reconcilerObservationRecorder is the command-owned recorder seam. The
+// sync observer loop only offers observations; this command owns lifecycle
+// shutdown so its worker cannot outlive the database pools it observes.
+type reconcilerObservationRecorder interface {
+	syncreconciler.ObservationRecorder
+	Shutdown(context.Context) error
 }
 
 func buildReconcilerRelay(
@@ -122,19 +161,28 @@ type reconcilerDependencies struct {
 	relayErr        error
 	loop            *joboutbox.ReconcilerLoop
 	loopErr         error
+
+	syncDispatchRegistry *syncdispatchcontract.Registry
+	syncRegistryErr      error
+	syncObserverErr      error
+	syncRecorder         reconcilerObservationRecorder
+	syncRecorderErr      error
+	syncLoop             *syncreconciler.Loop
+	syncLoopErr          error
 }
 
-func configureReconcilerDependenciesWithSources(
+func configureReconcilerDependenciesWithSourcesAndLogger(
 	ctx context.Context,
 	cfg config.Config,
 	registry *health.Registry,
+	logger *slog.Logger,
 	sources reconcilerDependencySources,
 ) ([]lifecycle.Component, error) {
 	if registry == nil {
 		return nil, errReconcilerDependencyUnavailable
 	}
 
-	dependencies := buildReconcilerDependencies(ctx, cfg, registry, sources)
+	dependencies := buildReconcilerDependencies(ctx, cfg, registry, logger, sources)
 	checks := []struct {
 		name  string
 		check health.CheckFunc
@@ -143,6 +191,7 @@ func configureReconcilerDependenciesWithSources(
 		{name: "job_registry", check: dependencies.registryReady},
 		{name: "queue_postgres", check: dependencies.queueReady},
 		{name: "river_schema", check: dependencies.riverSchemaReady(cfg.RiverDatabaseSchema)},
+		{name: "sync_dispatch_registry", check: dependencies.syncRegistryReady},
 	}
 	for _, check := range checks {
 		if err := registry.RegisterRequired(check.name, check.check); err != nil {
@@ -155,15 +204,22 @@ func configureReconcilerDependenciesWithSources(
 			dependencies.close()
 			return nil, err
 		}
-		return nil, nil
 	}
-	if dependencies.database == nil {
+	if dependencies.syncLoop == nil {
+		if err := registry.RegisterRequired("sync_dispatch_observer", dependencies.syncObserverReady); err != nil {
+			dependencies.close()
+			return nil, err
+		}
+	}
+	if dependencies.database == nil || dependencies.loop == nil || dependencies.syncLoop == nil || dependencies.syncRecorder == nil {
 		dependencies.close()
-		return nil, errReconcilerDependencyUnavailable
+		return nil, nil
 	}
 	return []lifecycle.Component{
 		reconcilerDatabaseLifecycle{database: dependencies.database},
 		dependencies.loop,
+		reconcilerRecorderLifecycle{recorder: dependencies.syncRecorder},
+		dependencies.syncLoop,
 	}, nil
 }
 
@@ -171,6 +227,7 @@ func buildReconcilerDependencies(
 	ctx context.Context,
 	cfg config.Config,
 	registry *health.Registry,
+	logger *slog.Logger,
 	sources reconcilerDependencySources,
 ) *reconcilerDependencies {
 	dependencies := &reconcilerDependencies{}
@@ -188,9 +245,17 @@ func buildReconcilerDependencies(
 	} else {
 		dependencies.runtimeRegistry, dependencies.registryErr = sources.loadRuntimeRegistry(sources.contractRoot)
 	}
+	if sources.loadSyncDispatchRegistry == nil || sources.syncDispatchContractRoot == "" {
+		dependencies.syncRegistryErr = errReconcilerDependencyUnavailable
+	} else {
+		dependencies.syncDispatchRegistry, dependencies.syncRegistryErr = sources.loadSyncDispatchRegistry(sources.syncDispatchContractRoot)
+	}
 	if dependencies.databaseErr != nil || dependencies.database == nil ||
 		dependencies.registryErr != nil || dependencies.runtimeRegistry == nil ||
-		sources.buildRelay == nil || sources.newLoop == nil {
+		dependencies.syncRegistryErr != nil || dependencies.syncDispatchRegistry == nil ||
+		sources.buildRelay == nil || sources.newLoop == nil ||
+		sources.buildSyncObserver == nil || sources.newSyncRecorder == nil ||
+		sources.newSyncLoop == nil {
 		dependencies.relayErr = errReconcilerDependencyUnavailable
 		dependencies.disableDatabase()
 		return dependencies
@@ -213,6 +278,33 @@ func buildReconcilerDependencies(
 		return dependencies
 	}
 	dependencies.loop = loop
+	observer, err := sources.buildSyncObserver(dependencies.database.DomainPool(), dependencies.syncDispatchRegistry)
+	if err != nil || observer == nil {
+		dependencies.syncObserverErr = errReconcilerDependencyUnavailable
+		dependencies.disableDatabase()
+		return dependencies
+	}
+	if logger == nil {
+		dependencies.syncRecorderErr = errReconcilerDependencyUnavailable
+		dependencies.disableDatabase()
+		return dependencies
+	}
+	recorder, err := sources.newSyncRecorder(logger)
+	dependencies.syncRecorder = recorder
+	if err != nil || recorder == nil {
+		dependencies.syncRecorderErr = errReconcilerDependencyUnavailable
+		dependencies.disableDatabase()
+		return dependencies
+	}
+	syncLoopConfig := syncreconciler.DefaultLoopConfig(registry)
+	syncLoopConfig.Recorder = recorder
+	syncLoop, err := sources.newSyncLoop(observer, syncLoopConfig)
+	if err != nil || syncLoop == nil {
+		dependencies.syncLoopErr = errReconcilerDependencyUnavailable
+		dependencies.disableDatabase()
+		return dependencies
+	}
+	dependencies.syncLoop = syncLoop
 	return dependencies
 }
 
@@ -262,8 +354,31 @@ func (dependencies *reconcilerDependencies) reconcilerReady(context.Context) err
 	return nil
 }
 
+func (dependencies *reconcilerDependencies) syncRegistryReady(context.Context) error {
+	if dependencies == nil || dependencies.syncRegistryErr != nil || dependencies.syncDispatchRegistry == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return nil
+}
+
+func (dependencies *reconcilerDependencies) syncObserverReady(context.Context) error {
+	if dependencies == nil || dependencies.syncObserverErr != nil || dependencies.syncRecorderErr != nil || dependencies.syncLoopErr != nil || dependencies.syncLoop == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return nil
+}
+
 func (dependencies *reconcilerDependencies) close() {
-	if dependencies != nil && dependencies.database != nil {
+	if dependencies == nil {
+		return
+	}
+	if dependencies.syncRecorder != nil {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), recorderCleanupTimeout)
+		_ = dependencies.syncRecorder.Shutdown(cleanupCtx)
+		cleanupCancel()
+		dependencies.syncRecorder = nil
+	}
+	if dependencies.database != nil {
 		dependencies.database.Close()
 	}
 }
@@ -281,6 +396,26 @@ func (dependencies *reconcilerDependencies) disableDatabase() {
 
 type reconcilerDatabaseLifecycle struct {
 	database reconcilerDatabase
+}
+
+type reconcilerRecorderLifecycle struct {
+	recorder reconcilerObservationRecorder
+}
+
+func (reconcilerRecorderLifecycle) Name() string { return "sync-dispatch-observation-recorder" }
+
+func (component reconcilerRecorderLifecycle) Start(context.Context) error {
+	if component.recorder == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return nil
+}
+
+func (component reconcilerRecorderLifecycle) Shutdown(ctx context.Context) error {
+	if component.recorder == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return component.recorder.Shutdown(ctx)
 }
 
 func (reconcilerDatabaseLifecycle) Name() string { return "postgres-runtime-pools" }

--- a/cmd/dev-health-reconciler/dependencies.go
+++ b/cmd/dev-health-reconciler/dependencies.go
@@ -1,0 +1,300 @@
+package main
+
+import (
+	"context"
+	"errors"
+
+	"github.com/full-chaos/dev-health-ops/internal/joboutbox"
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
+	"github.com/full-chaos/dev-health-ops/internal/storage/postgres"
+	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const defaultReconcilerContractRoot = "contracts/jobs/v1"
+
+var errReconcilerDependencyUnavailable = errors.New("reconciler readiness dependency is unavailable")
+
+// reconcilerDatabase keeps the command's domain and queue-control trust
+// boundaries testable without weakening the production RuntimePools contract.
+type reconcilerDatabase interface {
+	DomainReady(context.Context) error
+	QueueReady(context.Context) error
+	RiverSchemaReady(context.Context, string) error
+	QueuePool() *pgxpool.Pool
+	Close()
+}
+
+type postgresReconcilerDatabase struct {
+	pools       *postgres.RuntimePools
+	domainRole  string
+	queueRole   string
+	riverSchema string
+}
+
+func openReconcilerDatabase(ctx context.Context, cfg config.Config) (reconcilerDatabase, error) {
+	runtimeConfig := postgres.RuntimeConfigFromPlatform(cfg)
+	pools, err := postgres.NewRuntimePools(ctx, runtimeConfig)
+	if err != nil {
+		return nil, err
+	}
+	return &postgresReconcilerDatabase{
+		pools: pools, domainRole: runtimeConfig.DomainRole, queueRole: runtimeConfig.QueueRole, riverSchema: runtimeConfig.RiverSchema,
+	}, nil
+}
+
+func (database *postgresReconcilerDatabase) DomainReady(ctx context.Context) error {
+	if database == nil || database.pools == nil || database.pools.Domain == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return postgres.CheckDomainAuthorization(ctx, database.pools.Domain, database.domainRole, database.riverSchema)
+}
+
+func (database *postgresReconcilerDatabase) QueueReady(ctx context.Context) error {
+	if database == nil || database.pools == nil || database.pools.QueueControl == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return postgres.CheckQueueAuthorization(ctx, database.pools.QueueControl, database.queueRole, database.riverSchema)
+}
+
+func (database *postgresReconcilerDatabase) RiverSchemaReady(ctx context.Context, schema string) error {
+	if database == nil || database.pools == nil || database.pools.QueueControl == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	_, err := riverstore.CheckSchema(ctx, database.pools.QueueControl, schema, nil)
+	return err
+}
+
+func (database *postgresReconcilerDatabase) QueuePool() *pgxpool.Pool {
+	if database == nil || database.pools == nil {
+		return nil
+	}
+	return database.pools.QueueControl
+}
+
+func (database *postgresReconcilerDatabase) Close() {
+	if database != nil && database.pools != nil {
+		database.pools.Close()
+	}
+}
+
+type reconcilerDependencySources struct {
+	openDatabase        func(context.Context, config.Config) (reconcilerDatabase, error)
+	loadRuntimeRegistry func(string) (*jobruntime.Registry, error)
+	buildRelay          func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error)
+	newLoop             func(joboutbox.RelayStepper, joboutbox.ReconcilerLoopConfig) (*joboutbox.ReconcilerLoop, error)
+	contractRoot        string
+}
+
+var productionReconcilerDependencySources = reconcilerDependencySources{
+	openDatabase:        openReconcilerDatabase,
+	loadRuntimeRegistry: jobruntime.Load,
+	buildRelay:          buildReconcilerRelay,
+	newLoop:             joboutbox.NewReconcilerLoop,
+	contractRoot:        defaultReconcilerContractRoot,
+}
+
+func buildReconcilerRelay(
+	queuePool *pgxpool.Pool,
+	riverSchema string,
+	registry *jobruntime.Registry,
+) (joboutbox.RelayStepper, error) {
+	repository, err := joboutbox.NewRepository(queuePool)
+	if err != nil {
+		return nil, err
+	}
+	inserter, err := joboutbox.NewRiverInserter(queuePool, riverSchema, registry)
+	if err != nil {
+		return nil, err
+	}
+	return joboutbox.NewRelay(repository, inserter, joboutbox.DefaultRelayConfig())
+}
+
+type reconcilerDependencies struct {
+	database    reconcilerDatabase
+	databaseErr error
+
+	runtimeRegistry *jobruntime.Registry
+	registryErr     error
+	relayErr        error
+	loop            *joboutbox.ReconcilerLoop
+	loopErr         error
+}
+
+func configureReconcilerDependenciesWithSources(
+	ctx context.Context,
+	cfg config.Config,
+	registry *health.Registry,
+	sources reconcilerDependencySources,
+) ([]lifecycle.Component, error) {
+	if registry == nil {
+		return nil, errReconcilerDependencyUnavailable
+	}
+
+	dependencies := buildReconcilerDependencies(ctx, cfg, registry, sources)
+	checks := []struct {
+		name  string
+		check health.CheckFunc
+	}{
+		{name: "domain_postgres", check: dependencies.domainReady},
+		{name: "job_registry", check: dependencies.registryReady},
+		{name: "queue_postgres", check: dependencies.queueReady},
+		{name: "river_schema", check: dependencies.riverSchemaReady(cfg.RiverDatabaseSchema)},
+	}
+	for _, check := range checks {
+		if err := registry.RegisterRequired(check.name, check.check); err != nil {
+			dependencies.close()
+			return nil, err
+		}
+	}
+	if dependencies.loop == nil {
+		if err := registry.RegisterRequired("reconciler_loop", dependencies.reconcilerReady); err != nil {
+			dependencies.close()
+			return nil, err
+		}
+		return nil, nil
+	}
+	if dependencies.database == nil {
+		dependencies.close()
+		return nil, errReconcilerDependencyUnavailable
+	}
+	return []lifecycle.Component{
+		reconcilerDatabaseLifecycle{database: dependencies.database},
+		dependencies.loop,
+	}, nil
+}
+
+func buildReconcilerDependencies(
+	ctx context.Context,
+	cfg config.Config,
+	registry *health.Registry,
+	sources reconcilerDependencySources,
+) *reconcilerDependencies {
+	dependencies := &reconcilerDependencies{}
+	if sources.openDatabase == nil {
+		dependencies.databaseErr = errReconcilerDependencyUnavailable
+	} else {
+		dependencies.database, dependencies.databaseErr = sources.openDatabase(ctx, cfg)
+		if dependencies.databaseErr != nil {
+			dependencies.databaseErr = errReconcilerDependencyUnavailable
+			dependencies.disableDatabase()
+		}
+	}
+	if sources.loadRuntimeRegistry == nil || sources.contractRoot == "" {
+		dependencies.registryErr = errReconcilerDependencyUnavailable
+	} else {
+		dependencies.runtimeRegistry, dependencies.registryErr = sources.loadRuntimeRegistry(sources.contractRoot)
+	}
+	if dependencies.databaseErr != nil || dependencies.database == nil ||
+		dependencies.registryErr != nil || dependencies.runtimeRegistry == nil ||
+		sources.buildRelay == nil || sources.newLoop == nil {
+		dependencies.relayErr = errReconcilerDependencyUnavailable
+		dependencies.disableDatabase()
+		return dependencies
+	}
+
+	relay, err := sources.buildRelay(
+		dependencies.database.QueuePool(),
+		cfg.RiverDatabaseSchema,
+		dependencies.runtimeRegistry,
+	)
+	if err != nil || relay == nil {
+		dependencies.relayErr = errReconcilerDependencyUnavailable
+		dependencies.disableDatabase()
+		return dependencies
+	}
+	loop, err := sources.newLoop(relay, joboutbox.DefaultReconcilerLoopConfig(registry))
+	if err != nil || loop == nil {
+		dependencies.loopErr = errReconcilerDependencyUnavailable
+		dependencies.disableDatabase()
+		return dependencies
+	}
+	dependencies.loop = loop
+	return dependencies
+}
+
+func (dependencies *reconcilerDependencies) domainReady(ctx context.Context) error {
+	if dependencies == nil || dependencies.databaseErr != nil || dependencies.database == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	if err := dependencies.database.DomainReady(ctx); err != nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return nil
+}
+
+func (dependencies *reconcilerDependencies) queueReady(ctx context.Context) error {
+	if dependencies == nil || dependencies.databaseErr != nil || dependencies.database == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	if err := dependencies.database.QueueReady(ctx); err != nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return nil
+}
+
+func (dependencies *reconcilerDependencies) registryReady(context.Context) error {
+	if dependencies == nil || dependencies.registryErr != nil || dependencies.runtimeRegistry == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return nil
+}
+
+func (dependencies *reconcilerDependencies) riverSchemaReady(schema string) health.CheckFunc {
+	return func(ctx context.Context) error {
+		if dependencies == nil || dependencies.databaseErr != nil || dependencies.database == nil {
+			return errReconcilerDependencyUnavailable
+		}
+		if err := dependencies.database.RiverSchemaReady(ctx, schema); err != nil {
+			return errReconcilerDependencyUnavailable
+		}
+		return nil
+	}
+}
+
+func (dependencies *reconcilerDependencies) reconcilerReady(context.Context) error {
+	if dependencies == nil || dependencies.relayErr != nil || dependencies.loopErr != nil || dependencies.loop == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return nil
+}
+
+func (dependencies *reconcilerDependencies) close() {
+	if dependencies != nil && dependencies.database != nil {
+		dependencies.database.Close()
+	}
+}
+
+func (dependencies *reconcilerDependencies) disableDatabase() {
+	if dependencies == nil {
+		return
+	}
+	dependencies.close()
+	dependencies.database = nil
+	if dependencies.databaseErr == nil {
+		dependencies.databaseErr = errReconcilerDependencyUnavailable
+	}
+}
+
+type reconcilerDatabaseLifecycle struct {
+	database reconcilerDatabase
+}
+
+func (reconcilerDatabaseLifecycle) Name() string { return "postgres-runtime-pools" }
+
+func (component reconcilerDatabaseLifecycle) Start(context.Context) error {
+	if component.database == nil {
+		return errReconcilerDependencyUnavailable
+	}
+	return nil
+}
+
+func (component reconcilerDatabaseLifecycle) Shutdown(context.Context) error {
+	if component.database != nil {
+		component.database.Close()
+	}
+	return nil
+}

--- a/cmd/dev-health-reconciler/dependencies_test.go
+++ b/cmd/dev-health-reconciler/dependencies_test.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"log/slog"
 	"path/filepath"
 	"slices"
 	"strings"
@@ -16,6 +18,8 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
 	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/syncreconciler"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -30,14 +34,15 @@ func TestReconcilerMissingDependenciesStayLiveAndFailReadinessWithoutValues(t *t
 	}
 
 	registry := health.NewRegistry(100 * time.Millisecond)
-	components, err := configureReconcilerDependenciesWithSources(
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
 		context.Background(),
 		config.Config{RiverDatabaseSchema: "river"},
 		registry,
+		reconcilerTestLogger(),
 		sources,
 	)
 	if err != nil {
-		t.Fatalf("configureReconcilerDependenciesWithSources() error = %v", err)
+		t.Fatalf("configureReconcilerDependenciesWithSourcesAndLogger() error = %v", err)
 	}
 	if len(components) != 0 {
 		t.Fatalf("components = %d, want no lifecycle components", len(components))
@@ -46,7 +51,7 @@ func TestReconcilerMissingDependenciesStayLiveAndFailReadinessWithoutValues(t *t
 		t.Fatalf("open readiness gate: %v", err)
 	}
 
-	want := []string{"domain_postgres", "job_registry", "queue_postgres", "reconciler_loop", "river_schema"}
+	want := []string{"domain_postgres", "job_registry", "queue_postgres", "reconciler_loop", "river_schema", "sync_dispatch_observer", "sync_dispatch_registry"}
 	status := registry.Readiness(context.Background())
 	if status.Ready || !slices.Equal(status.Failed, want) {
 		t.Fatalf("readiness = %#v, want failed %v", status, want)
@@ -60,6 +65,7 @@ func TestReconcilerComposesNoopLoopInDatabaseThenLoopOrder(t *testing.T) {
 	t.Chdir(filepath.Join("..", ".."))
 	database := &fakeReconcilerDatabase{}
 	calls := 0
+	syncCalls := 0
 	sources := reconcilerSourcesForTest(t, database)
 	sources.buildRelay = func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error) {
 		return reconcilerStepFunc(func(context.Context, time.Time, int) (joboutbox.StepResult, error) {
@@ -67,18 +73,31 @@ func TestReconcilerComposesNoopLoopInDatabaseThenLoopOrder(t *testing.T) {
 			return joboutbox.StepResult{}, nil
 		}), nil
 	}
+	sources.buildSyncObserver = func(*pgxpool.Pool, *syncdispatchcontract.Registry) (syncreconciler.Stepper, error) {
+		return syncStepFunc(func(context.Context, time.Time, int) (syncreconciler.Observation, error) {
+			syncCalls++
+			return syncreconciler.Observation{}, nil
+		}), nil
+	}
+	sources.newSyncLoop = func(stepper syncreconciler.Stepper, loopConfig syncreconciler.LoopConfig) (*syncreconciler.Loop, error) {
+		if loopConfig.Recorder == nil {
+			t.Fatal("sync loop did not receive the command-owned recorder")
+		}
+		return syncreconciler.NewLoop(stepper, loopConfig)
+	}
 
 	registry := health.NewRegistry(100 * time.Millisecond)
-	components, err := configureReconcilerDependenciesWithSources(
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
 		context.Background(),
 		config.Config{RiverDatabaseSchema: "river"},
 		registry,
+		reconcilerTestLogger(),
 		sources,
 	)
 	if err != nil {
-		t.Fatalf("configureReconcilerDependenciesWithSources() error = %v", err)
+		t.Fatalf("configureReconcilerDependenciesWithSourcesAndLogger() error = %v", err)
 	}
-	if got := componentNames(components); !slices.Equal(got, []string{"postgres-runtime-pools", "outbox-reconciler-loop"}) {
+	if got := componentNames(components); !slices.Equal(got, []string{"postgres-runtime-pools", "outbox-reconciler-loop", "sync-dispatch-observation-recorder", "sync-dispatch-observer-loop"}) {
 		t.Fatalf("component order = %v", got)
 	}
 	for _, component := range components {
@@ -88,6 +107,9 @@ func TestReconcilerComposesNoopLoopInDatabaseThenLoopOrder(t *testing.T) {
 	}
 	if calls != 1 {
 		t.Fatalf("immediate no-op relay calls = %d, want 1", calls)
+	}
+	if syncCalls != 1 {
+		t.Fatalf("immediate sync observer calls = %d, want 1", syncCalls)
 	}
 	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
 		t.Fatalf("open readiness gate: %v", err)
@@ -105,6 +127,106 @@ func TestReconcilerComposesNoopLoopInDatabaseThenLoopOrder(t *testing.T) {
 	}
 }
 
+func TestReconcilerNilLoggerFailsClosedBeforeRecorderConstruction(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	sources := reconcilerSourcesForTest(t, database)
+	sources.buildRelay = func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error) {
+		return reconcilerStepFunc(func(context.Context, time.Time, int) (joboutbox.StepResult, error) {
+			return joboutbox.StepResult{}, nil
+		}), nil
+	}
+	recorderConstructed := false
+	sources.newSyncRecorder = func(*slog.Logger) (reconcilerObservationRecorder, error) {
+		recorderConstructed = true
+		return nil, errors.New("recorder must not be built without logger")
+	}
+
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		health.NewRegistry(100*time.Millisecond),
+		nil,
+		sources,
+	)
+	if err != nil || len(components) != 0 || recorderConstructed || !database.closed.Load() {
+		t.Fatalf(
+			"nil logger components=%d err=%v recorder_constructed=%v database_closed=%v",
+			len(components),
+			err,
+			recorderConstructed,
+			database.closed.Load(),
+		)
+	}
+}
+
+func TestReconcilerSyncLoopConstructionFailureClosesRecorderBeforeDatabase(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	recorder := &fakeReconcilerRecorder{}
+	sources := reconcilerSourcesForTest(t, database)
+	sources.buildRelay = func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error) {
+		return reconcilerStepFunc(func(context.Context, time.Time, int) (joboutbox.StepResult, error) {
+			return joboutbox.StepResult{}, nil
+		}), nil
+	}
+	sources.newSyncRecorder = func(*slog.Logger) (reconcilerObservationRecorder, error) {
+		return recorder, nil
+	}
+	sources.newSyncLoop = func(syncreconciler.Stepper, syncreconciler.LoopConfig) (*syncreconciler.Loop, error) {
+		return nil, errors.New("sync loop construction failed")
+	}
+
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		health.NewRegistry(100*time.Millisecond),
+		reconcilerTestLogger(),
+		sources,
+	)
+	if err != nil || len(components) != 0 || !recorder.closed.Load() || !database.closed.Load() {
+		t.Fatalf(
+			"sync loop failure components=%d err=%v recorder_closed=%v database_closed=%v",
+			len(components),
+			err,
+			recorder.closed.Load(),
+			database.closed.Load(),
+		)
+	}
+}
+
+func TestReconcilerRecorderConstructionFailureClosesReturnedRecorderAndDatabase(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	recorder := &fakeReconcilerRecorder{}
+	sources := reconcilerSourcesForTest(t, database)
+	sources.buildRelay = func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error) {
+		return reconcilerStepFunc(func(context.Context, time.Time, int) (joboutbox.StepResult, error) {
+			return joboutbox.StepResult{}, nil
+		}), nil
+	}
+	sources.newSyncRecorder = func(*slog.Logger) (reconcilerObservationRecorder, error) {
+		return recorder, errors.New("recorder construction failed")
+	}
+
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		health.NewRegistry(100*time.Millisecond),
+		reconcilerTestLogger(),
+		sources,
+	)
+	if err != nil || len(components) != 0 || !recorder.closed.Load() || !database.closed.Load() {
+		t.Fatalf(
+			"recorder construction failure components=%d err=%v recorder_closed=%v database_closed=%v",
+			len(components),
+			err,
+			recorder.closed.Load(),
+			database.closed.Load(),
+		)
+	}
+}
+
 func TestReconcilerConstructionFailureClosesDatabaseAndFailsReadiness(t *testing.T) {
 	t.Chdir(filepath.Join("..", ".."))
 	database := &fakeReconcilerDatabase{}
@@ -114,14 +236,15 @@ func TestReconcilerConstructionFailureClosesDatabaseAndFailsReadiness(t *testing
 	}
 
 	registry := health.NewRegistry(100 * time.Millisecond)
-	components, err := configureReconcilerDependenciesWithSources(
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
 		context.Background(),
 		config.Config{RiverDatabaseSchema: "river"},
 		registry,
+		reconcilerTestLogger(),
 		sources,
 	)
 	if err != nil {
-		t.Fatalf("configureReconcilerDependenciesWithSources() error = %v", err)
+		t.Fatalf("configureReconcilerDependenciesWithSourcesAndLogger() error = %v", err)
 	}
 	if len(components) != 0 {
 		t.Fatalf("components = %d, want no partial runtime", len(components))
@@ -132,7 +255,69 @@ func TestReconcilerConstructionFailureClosesDatabaseAndFailsReadiness(t *testing
 	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
 		t.Fatalf("open readiness gate: %v", err)
 	}
-	want := []string{"domain_postgres", "queue_postgres", "reconciler_loop", "river_schema"}
+	want := []string{"domain_postgres", "queue_postgres", "reconciler_loop", "river_schema", "sync_dispatch_observer"}
+	if status := registry.Readiness(context.Background()); status.Ready || !slices.Equal(status.Failed, want) {
+		t.Fatalf("readiness = %#v, want failed %v", status, want)
+	}
+}
+
+func TestReconcilerSyncRegistryLoadFailureClosesDatabaseAndFailsReadiness(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	sources := reconcilerSourcesForTest(t, database)
+	sources.loadSyncDispatchRegistry = func(string) (*syncdispatchcontract.Registry, error) {
+		return nil, errors.New("invalid sync-dispatch contract")
+	}
+
+	registry := health.NewRegistry(100 * time.Millisecond)
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		registry,
+		reconcilerTestLogger(),
+		sources,
+	)
+	if err != nil {
+		t.Fatalf("configureReconcilerDependenciesWithSourcesAndLogger() error = %v", err)
+	}
+	if len(components) != 0 || !database.closed.Load() {
+		t.Fatalf("components = %d, database closed = %v", len(components), database.closed.Load())
+	}
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"domain_postgres", "queue_postgres", "reconciler_loop", "river_schema", "sync_dispatch_observer", "sync_dispatch_registry"}
+	if status := registry.Readiness(context.Background()); status.Ready || !slices.Equal(status.Failed, want) {
+		t.Fatalf("readiness = %#v, want failed %v", status, want)
+	}
+}
+
+func TestReconcilerSyncObserverBuildFailureClosesDatabaseAndFailsReadiness(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	sources := reconcilerSourcesForTest(t, database)
+	sources.buildSyncObserver = func(*pgxpool.Pool, *syncdispatchcontract.Registry) (syncreconciler.Stepper, error) {
+		return nil, errors.New("sync observer construction failed")
+	}
+
+	registry := health.NewRegistry(100 * time.Millisecond)
+	components, err := configureReconcilerDependenciesWithSourcesAndLogger(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		registry,
+		reconcilerTestLogger(),
+		sources,
+	)
+	if err != nil {
+		t.Fatalf("configureReconcilerDependenciesWithSourcesAndLogger() error = %v", err)
+	}
+	if len(components) != 0 || !database.closed.Load() {
+		t.Fatalf("components = %d, database closed = %v", len(components), database.closed.Load())
+	}
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	want := []string{"domain_postgres", "queue_postgres", "reconciler_loop", "river_schema", "sync_dispatch_observer"}
 	if status := registry.Readiness(context.Background()); status.Ready || !slices.Equal(status.Failed, want) {
 		t.Fatalf("readiness = %#v, want failed %v", status, want)
 	}
@@ -141,26 +326,35 @@ func TestReconcilerConstructionFailureClosesDatabaseAndFailsReadiness(t *testing
 func TestReconcilerReadinessRegistrationFailureClosesConstructedDatabase(t *testing.T) {
 	t.Chdir(filepath.Join("..", ".."))
 	database := &fakeReconcilerDatabase{}
+	recorder := &fakeReconcilerRecorder{}
 	sources := reconcilerSourcesForTest(t, database)
 	sources.buildRelay = func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error) {
 		return reconcilerStepFunc(func(context.Context, time.Time, int) (joboutbox.StepResult, error) {
 			return joboutbox.StepResult{}, nil
 		}), nil
 	}
+	sources.newSyncRecorder = func(*slog.Logger) (reconcilerObservationRecorder, error) {
+		return recorder, nil
+	}
 	registry := health.NewRegistry(100 * time.Millisecond)
 	if err := registry.RegisterRequired("domain_postgres", func(context.Context) error { return nil }); err != nil {
 		t.Fatalf("register collision: %v", err)
 	}
-	if _, err := configureReconcilerDependenciesWithSources(
+	if _, err := configureReconcilerDependenciesWithSourcesAndLogger(
 		context.Background(),
 		config.Config{RiverDatabaseSchema: "river"},
 		registry,
+		reconcilerTestLogger(),
 		sources,
 	); err == nil {
 		t.Fatal("duplicate readiness registration unexpectedly succeeded")
 	}
-	if !database.closed.Load() {
-		t.Fatal("readiness registration failure leaked runtime pools")
+	if !recorder.closed.Load() || !database.closed.Load() {
+		t.Fatalf(
+			"readiness registration failure recorder_closed=%v database_closed=%v",
+			recorder.closed.Load(),
+			database.closed.Load(),
+		)
 	}
 }
 
@@ -200,7 +394,19 @@ func reconcilerSourcesForTest(t *testing.T, database reconcilerDatabase) reconci
 	}
 	sources.loadRuntimeRegistry = jobruntime.Load
 	sources.contractRoot = "contracts/jobs/v1"
+	sources.loadSyncDispatchRegistry = syncdispatchcontract.Load
+	sources.syncDispatchContractRoot = "contracts/sync-dispatch/v1"
+	sources.buildSyncObserver = func(*pgxpool.Pool, *syncdispatchcontract.Registry) (syncreconciler.Stepper, error) {
+		return syncStepFunc(func(context.Context, time.Time, int) (syncreconciler.Observation, error) {
+			return syncreconciler.Observation{}, nil
+		}), nil
+	}
+	sources.newSyncLoop = syncreconciler.NewLoop
 	return sources
+}
+
+func reconcilerTestLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(io.Discard, nil))
 }
 
 func componentNames(components []lifecycle.Component) []string {
@@ -217,12 +423,36 @@ func (step reconcilerStepFunc) Step(ctx context.Context, now time.Time, limit in
 	return step(ctx, now, limit)
 }
 
+type syncStepFunc func(context.Context, time.Time, int) (syncreconciler.Observation, error)
+
+func (step syncStepFunc) Step(ctx context.Context, now time.Time, limit int) (syncreconciler.Observation, error) {
+	return step(ctx, now, limit)
+}
+
+type fakeReconcilerRecorder struct {
+	closed atomic.Bool
+}
+
+func (recorder *fakeReconcilerRecorder) TryRecord(syncreconciler.Observation) bool {
+	return !recorder.closed.Load()
+}
+
+func (recorder *fakeReconcilerRecorder) Shutdown(context.Context) error {
+	recorder.closed.Store(true)
+	return nil
+}
+
 type fakeReconcilerDatabase struct {
-	domainErr error
-	queueErr  error
-	schemaErr error
-	queuePool *pgxpool.Pool
-	closed    atomic.Bool
+	domainErr  error
+	queueErr   error
+	schemaErr  error
+	domainPool *pgxpool.Pool
+	queuePool  *pgxpool.Pool
+	closed     atomic.Bool
+}
+
+func (database *fakeReconcilerDatabase) DomainPool() *pgxpool.Pool {
+	return database.domainPool
 }
 
 func (database *fakeReconcilerDatabase) DomainReady(context.Context) error {

--- a/cmd/dev-health-reconciler/dependencies_test.go
+++ b/cmd/dev-health-reconciler/dependencies_test.go
@@ -1,0 +1,246 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"slices"
+	"strings"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/joboutbox"
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestReconcilerMissingDependenciesStayLiveAndFailReadinessWithoutValues(t *testing.T) {
+	secret := "postgresql://queue:do-not-print@database.internal/app"
+	sources := productionReconcilerDependencySources
+	sources.openDatabase = func(context.Context, config.Config) (reconcilerDatabase, error) {
+		return nil, errors.New(secret)
+	}
+	sources.loadRuntimeRegistry = func(string) (*jobruntime.Registry, error) {
+		return nil, errors.New("load " + secret)
+	}
+
+	registry := health.NewRegistry(100 * time.Millisecond)
+	components, err := configureReconcilerDependenciesWithSources(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		registry,
+		sources,
+	)
+	if err != nil {
+		t.Fatalf("configureReconcilerDependenciesWithSources() error = %v", err)
+	}
+	if len(components) != 0 {
+		t.Fatalf("components = %d, want no lifecycle components", len(components))
+	}
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatalf("open readiness gate: %v", err)
+	}
+
+	want := []string{"domain_postgres", "job_registry", "queue_postgres", "reconciler_loop", "river_schema"}
+	status := registry.Readiness(context.Background())
+	if status.Ready || !slices.Equal(status.Failed, want) {
+		t.Fatalf("readiness = %#v, want failed %v", status, want)
+	}
+	if text := fmt.Sprint(status); strings.Contains(text, secret) || strings.Contains(text, "do-not-print") {
+		t.Fatalf("readiness exposed dependency value: %s", text)
+	}
+}
+
+func TestReconcilerComposesNoopLoopInDatabaseThenLoopOrder(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	calls := 0
+	sources := reconcilerSourcesForTest(t, database)
+	sources.buildRelay = func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error) {
+		return reconcilerStepFunc(func(context.Context, time.Time, int) (joboutbox.StepResult, error) {
+			calls++
+			return joboutbox.StepResult{}, nil
+		}), nil
+	}
+
+	registry := health.NewRegistry(100 * time.Millisecond)
+	components, err := configureReconcilerDependenciesWithSources(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		registry,
+		sources,
+	)
+	if err != nil {
+		t.Fatalf("configureReconcilerDependenciesWithSources() error = %v", err)
+	}
+	if got := componentNames(components); !slices.Equal(got, []string{"postgres-runtime-pools", "outbox-reconciler-loop"}) {
+		t.Fatalf("component order = %v", got)
+	}
+	for _, component := range components {
+		if err := component.Start(context.Background()); err != nil {
+			t.Fatalf("start %s: %v", component.Name(), err)
+		}
+	}
+	if calls != 1 {
+		t.Fatalf("immediate no-op relay calls = %d, want 1", calls)
+	}
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatalf("open readiness gate: %v", err)
+	}
+	if status := registry.Readiness(context.Background()); !status.Ready {
+		t.Fatalf("readiness = %#v, want ready", status)
+	}
+	for index := len(components) - 1; index >= 0; index-- {
+		if err := components[index].Shutdown(context.Background()); err != nil {
+			t.Fatalf("shutdown %s: %v", components[index].Name(), err)
+		}
+	}
+	if !database.closed.Load() {
+		t.Fatal("database lifecycle did not close pools")
+	}
+}
+
+func TestReconcilerConstructionFailureClosesDatabaseAndFailsReadiness(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	sources := reconcilerSourcesForTest(t, database)
+	sources.buildRelay = func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error) {
+		return nil, errors.New("dial postgresql://queue:do-not-print@database.internal/app")
+	}
+
+	registry := health.NewRegistry(100 * time.Millisecond)
+	components, err := configureReconcilerDependenciesWithSources(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		registry,
+		sources,
+	)
+	if err != nil {
+		t.Fatalf("configureReconcilerDependenciesWithSources() error = %v", err)
+	}
+	if len(components) != 0 {
+		t.Fatalf("components = %d, want no partial runtime", len(components))
+	}
+	if !database.closed.Load() {
+		t.Fatal("relay construction failure leaked runtime pools")
+	}
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatalf("open readiness gate: %v", err)
+	}
+	want := []string{"domain_postgres", "queue_postgres", "reconciler_loop", "river_schema"}
+	if status := registry.Readiness(context.Background()); status.Ready || !slices.Equal(status.Failed, want) {
+		t.Fatalf("readiness = %#v, want failed %v", status, want)
+	}
+}
+
+func TestReconcilerReadinessRegistrationFailureClosesConstructedDatabase(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+	database := &fakeReconcilerDatabase{}
+	sources := reconcilerSourcesForTest(t, database)
+	sources.buildRelay = func(*pgxpool.Pool, string, *jobruntime.Registry) (joboutbox.RelayStepper, error) {
+		return reconcilerStepFunc(func(context.Context, time.Time, int) (joboutbox.StepResult, error) {
+			return joboutbox.StepResult{}, nil
+		}), nil
+	}
+	registry := health.NewRegistry(100 * time.Millisecond)
+	if err := registry.RegisterRequired("domain_postgres", func(context.Context) error { return nil }); err != nil {
+		t.Fatalf("register collision: %v", err)
+	}
+	if _, err := configureReconcilerDependenciesWithSources(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		registry,
+		sources,
+	); err == nil {
+		t.Fatal("duplicate readiness registration unexpectedly succeeded")
+	}
+	if !database.closed.Load() {
+		t.Fatal("readiness registration failure leaked runtime pools")
+	}
+}
+
+func TestReconcilerPoolReadinessErrorsAreCollapsed(t *testing.T) {
+	database := &fakeReconcilerDatabase{
+		domainErr: errors.New("postgresql://domain:do-not-print@database.internal/app"),
+		queueErr:  errors.New("postgresql://queue:do-not-print@database.internal/app"),
+		schemaErr: errors.New("driver detail"),
+	}
+	dependencies := &reconcilerDependencies{database: database}
+	if err := dependencies.domainReady(context.Background()); !errors.Is(err, errReconcilerDependencyUnavailable) {
+		t.Fatalf("domainReady() error = %v", err)
+	}
+	if err := dependencies.queueReady(context.Background()); !errors.Is(err, errReconcilerDependencyUnavailable) {
+		t.Fatalf("queueReady() error = %v", err)
+	}
+	if err := dependencies.riverSchemaReady("river")(context.Background()); !errors.Is(err, errReconcilerDependencyUnavailable) {
+		t.Fatalf("riverSchemaReady() error = %v", err)
+	}
+}
+
+func TestReconcilerRegistryReadinessIsExplicitAndValueFree(t *testing.T) {
+	secret := "contracts/jobs/v1/postgresql://do-not-print"
+	dependencies := &reconcilerDependencies{registryErr: errors.New(secret)}
+	if err := dependencies.registryReady(context.Background()); !errors.Is(err, errReconcilerDependencyUnavailable) {
+		t.Fatalf("registryReady() error = %v", err)
+	} else if strings.Contains(err.Error(), secret) || strings.Contains(err.Error(), "do-not-print") {
+		t.Fatalf("registry readiness exposed dependency value: %v", err)
+	}
+}
+
+func reconcilerSourcesForTest(t *testing.T, database reconcilerDatabase) reconcilerDependencySources {
+	t.Helper()
+	sources := productionReconcilerDependencySources
+	sources.openDatabase = func(context.Context, config.Config) (reconcilerDatabase, error) {
+		return database, nil
+	}
+	sources.loadRuntimeRegistry = jobruntime.Load
+	sources.contractRoot = "contracts/jobs/v1"
+	return sources
+}
+
+func componentNames(components []lifecycle.Component) []string {
+	names := make([]string, 0, len(components))
+	for _, component := range components {
+		names = append(names, component.Name())
+	}
+	return names
+}
+
+type reconcilerStepFunc func(context.Context, time.Time, int) (joboutbox.StepResult, error)
+
+func (step reconcilerStepFunc) Step(ctx context.Context, now time.Time, limit int) (joboutbox.StepResult, error) {
+	return step(ctx, now, limit)
+}
+
+type fakeReconcilerDatabase struct {
+	domainErr error
+	queueErr  error
+	schemaErr error
+	queuePool *pgxpool.Pool
+	closed    atomic.Bool
+}
+
+func (database *fakeReconcilerDatabase) DomainReady(context.Context) error {
+	return database.domainErr
+}
+
+func (database *fakeReconcilerDatabase) QueueReady(context.Context) error {
+	return database.queueErr
+}
+
+func (database *fakeReconcilerDatabase) RiverSchemaReady(context.Context, string) error {
+	return database.schemaErr
+}
+
+func (database *fakeReconcilerDatabase) QueuePool() *pgxpool.Pool {
+	return database.queuePool
+}
+
+func (database *fakeReconcilerDatabase) Close() {
+	database.closed.Store(true)
+}

--- a/cmd/dev-health-reconciler/main.go
+++ b/cmd/dev-health-reconciler/main.go
@@ -7,7 +7,6 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
 	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
 	"github.com/full-chaos/dev-health-ops/internal/platform/shell"
-	"github.com/full-chaos/dev-health-ops/internal/processreadiness"
 )
 
 var reconcilerSpec = shell.Spec{
@@ -20,18 +19,14 @@ func main() {
 }
 
 func configureReconcilerDependencies(
-	_ context.Context,
-	_ config.Config,
+	ctx context.Context,
+	cfg config.Config,
 	registry *health.Registry,
 ) ([]lifecycle.Component, error) {
-	// Phase 1 has no reconciler loop or composed storage clients. Keep every
-	// dependency required by the control-process topology explicitly closed.
-	err := processreadiness.RegisterUnavailable(
+	return configureReconcilerDependenciesWithSources(
+		ctx,
+		cfg,
 		registry,
-		"domain_postgres",
-		"queue_postgres",
-		"reconciler_loop",
-		"river_schema",
+		productionReconcilerDependencySources,
 	)
-	return nil, err
 }

--- a/cmd/dev-health-reconciler/main.go
+++ b/cmd/dev-health-reconciler/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"log/slog"
 
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
@@ -10,23 +11,25 @@ import (
 )
 
 var reconcilerSpec = shell.Spec{
-	Service:               "dev-health-reconciler",
-	ConfigureDependencies: configureReconcilerDependencies,
+	Service:                         "dev-health-reconciler",
+	ConfigureDependenciesWithLogger: configureReconcilerDependenciesWithLogger,
 }
 
 func main() {
 	shell.Main(reconcilerSpec)
 }
 
-func configureReconcilerDependencies(
+func configureReconcilerDependenciesWithLogger(
 	ctx context.Context,
 	cfg config.Config,
 	registry *health.Registry,
+	logger *slog.Logger,
 ) ([]lifecycle.Component, error) {
-	return configureReconcilerDependenciesWithSources(
+	return configureReconcilerDependenciesWithSourcesAndLogger(
 		ctx,
 		cfg,
 		registry,
+		logger,
 		productionReconcilerDependencySources,
 	)
 }

--- a/cmd/dev-health-reconciler/main_test.go
+++ b/cmd/dev-health-reconciler/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"slices"
@@ -20,14 +21,19 @@ func TestReconcilerSpecConfiguresFailClosedDependencies(t *testing.T) {
 	if reconcilerSpec.Service != "dev-health-reconciler" {
 		t.Fatalf("service = %q", reconcilerSpec.Service)
 	}
-	if reconcilerSpec.ConfigureDependencies == nil {
-		t.Fatal("reconciler dependency configuration is not wired")
+	if reconcilerSpec.ConfigureDependenciesWithLogger == nil || reconcilerSpec.ConfigureDependencies != nil {
+		t.Fatal("reconciler logger-aware dependency configuration is not exclusively wired")
 	}
 
 	registry := health.NewRegistry(100 * time.Millisecond)
-	components, err := configureReconcilerDependencies(context.Background(), config.Config{}, registry)
+	components, err := configureReconcilerDependenciesWithLogger(
+		context.Background(),
+		config.Config{},
+		registry,
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+	)
 	if err != nil {
-		t.Fatalf("configureReconcilerDependencies() error = %v", err)
+		t.Fatalf("configureReconcilerDependenciesWithLogger() error = %v", err)
 	}
 	if len(components) != 0 {
 		t.Fatalf("components = %d, want no runtime pools without database configuration", len(components))
@@ -36,7 +42,7 @@ func TestReconcilerSpecConfiguresFailClosedDependencies(t *testing.T) {
 		t.Fatalf("open readiness gate: %v", err)
 	}
 
-	want := []string{"domain_postgres", "job_registry", "queue_postgres", "reconciler_loop", "river_schema"}
+	want := []string{"domain_postgres", "job_registry", "queue_postgres", "reconciler_loop", "river_schema", "sync_dispatch_observer", "sync_dispatch_registry"}
 	status := registry.Readiness(context.Background())
 	if status.Ready || !slices.Equal(status.Failed, want) {
 		t.Fatalf("readiness = %#v, want failed %v", status, want)

--- a/cmd/dev-health-reconciler/main_test.go
+++ b/cmd/dev-health-reconciler/main_test.go
@@ -1,13 +1,19 @@
 package main
 
 import (
+	"bytes"
 	"context"
+	"io"
+	"net"
+	"net/http"
 	"slices"
 	"testing"
 	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+	"github.com/full-chaos/dev-health-ops/internal/platform/shell"
 )
 
 func TestReconcilerSpecConfiguresFailClosedDependencies(t *testing.T) {
@@ -24,15 +30,82 @@ func TestReconcilerSpecConfiguresFailClosedDependencies(t *testing.T) {
 		t.Fatalf("configureReconcilerDependencies() error = %v", err)
 	}
 	if len(components) != 0 {
-		t.Fatalf("components = %d, want no reconciler runtime before its loop is implemented", len(components))
+		t.Fatalf("components = %d, want no runtime pools without database configuration", len(components))
 	}
 	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
 		t.Fatalf("open readiness gate: %v", err)
 	}
 
-	want := []string{"domain_postgres", "queue_postgres", "reconciler_loop", "river_schema"}
+	want := []string{"domain_postgres", "job_registry", "queue_postgres", "reconciler_loop", "river_schema"}
 	status := registry.Readiness(context.Background())
 	if status.Ready || !slices.Equal(status.Failed, want) {
 		t.Fatalf("readiness = %#v, want failed %v", status, want)
+	}
+}
+
+func TestReconcilerOperatorStaysLiveWhenDependenciesAreMissing(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	address := listener.Addr().String()
+	if err := listener.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	lookup := func(key string) (string, bool) {
+		values := map[string]string{
+			"DEV_HEALTH_HTTP_ADDR":        address,
+			"DEV_HEALTH_SHUTDOWN_TIMEOUT": "1s",
+		}
+		value, ok := values[key]
+		return value, ok
+	}
+	var stdout, stderr bytes.Buffer
+	done := make(chan int, 1)
+	go func() {
+		done <- shell.Execute(ctx, reconcilerSpec, nil, secrets.LookupEnv(lookup), shell.IO{
+			Stdout: &stdout,
+			Stderr: &stderr,
+		})
+	}()
+
+	client := &http.Client{Timeout: 100 * time.Millisecond}
+	deadline := time.Now().Add(3 * time.Second)
+	for {
+		response, requestErr := client.Get("http://" + address + "/healthz")
+		if requestErr == nil {
+			_, _ = io.Copy(io.Discard, response.Body)
+			_ = response.Body.Close()
+			if response.StatusCode != http.StatusOK {
+				t.Fatalf("healthz status = %d", response.StatusCode)
+			}
+			break
+		}
+		if time.Now().After(deadline) {
+			t.Fatalf("operator HTTP did not start: %v logs=%s stderr=%s", requestErr, stdout.String(), stderr.String())
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	response, err := client.Get("http://" + address + "/readyz")
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, _ = io.Copy(io.Discard, response.Body)
+	_ = response.Body.Close()
+	if response.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("readyz status = %d, want %d", response.StatusCode, http.StatusServiceUnavailable)
+	}
+
+	cancel()
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Fatalf("shell exit = %d logs=%s stderr=%s", code, stdout.String(), stderr.String())
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("operator HTTP did not stop after cancellation")
 	}
 }

--- a/contracts/sync-dispatch/v1/README.md
+++ b/contracts/sync-dispatch/v1/README.md
@@ -1,0 +1,17 @@
+# Sync dispatch transport routes v1
+
+`transport-routes.json` is the language-neutral, validation-only contract for
+the four existing sync-dispatch outbox wakeups. Its exact Draft 2020-12 shape
+is defined by `transport-routes.schema.json`. It does not activate a production
+transport, claim work, or publish a message.
+
+All checked-in routes and rollback routes remain `celery`. The current Celery
+reconciler is therefore the only mutation owner. A later, separately approved
+migration may select `river` per kind, but its rollback route remains `celery`;
+editing this artifact alone cannot activate that migration.
+
+`dispatch_sync_run`, `finalize_sync_run`, and `reference_discovery` are
+`at_least_once`. `post_sync` is intentionally
+`at_most_once_mark_before`: the outbox row is marked dispatched before
+publication and is not re-armed if that publication fails, preventing duplicate
+post-sync fanout until its downstream consumers are replay-safe.

--- a/contracts/sync-dispatch/v1/transport-routes.json
+++ b/contracts/sync-dispatch/v1/transport-routes.json
@@ -1,0 +1,29 @@
+{
+  "schema_version": 1,
+  "routes": [
+    {
+      "kind": "dispatch_sync_run",
+      "delivery": "at_least_once",
+      "route": "celery",
+      "rollback_route": "celery"
+    },
+    {
+      "kind": "finalize_sync_run",
+      "delivery": "at_least_once",
+      "route": "celery",
+      "rollback_route": "celery"
+    },
+    {
+      "kind": "post_sync",
+      "delivery": "at_most_once_mark_before",
+      "route": "celery",
+      "rollback_route": "celery"
+    },
+    {
+      "kind": "reference_discovery",
+      "delivery": "at_least_once",
+      "route": "celery",
+      "rollback_route": "celery"
+    }
+  ]
+}

--- a/contracts/sync-dispatch/v1/transport-routes.schema.json
+++ b/contracts/sync-dispatch/v1/transport-routes.schema.json
@@ -1,0 +1,94 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://contracts.fullchaos.dev/sync-dispatch/v1/transport-routes.schema.json",
+  "title": "Dev Health sync-dispatch transport routes",
+  "type": "object",
+  "additionalProperties": false,
+  "required": ["schema_version", "routes"],
+  "properties": {
+    "schema_version": {"type": "integer", "const": 1},
+    "routes": {
+      "type": "array",
+      "minItems": 4,
+      "maxItems": 4,
+      "prefixItems": [
+        {"$ref": "#/$defs/dispatch_sync_run"},
+        {"$ref": "#/$defs/finalize_sync_run"},
+        {"$ref": "#/$defs/post_sync"},
+        {"$ref": "#/$defs/reference_discovery"}
+      ],
+      "items": false
+    }
+  },
+  "$defs": {
+    "transport": {
+      "type": "string",
+      "pattern": "^[a-z][a-z0-9_]*$",
+      "enum": ["celery", "river"]
+    },
+    "transport_pair": {
+      "anyOf": [
+        {
+          "properties": {
+            "route": {"const": "celery"},
+            "rollback_route": {"const": "celery"}
+          }
+        },
+        {
+          "properties": {
+            "route": {"const": "river"},
+            "rollback_route": {"const": "celery"}
+          }
+        }
+      ]
+    },
+    "dispatch_sync_run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "delivery", "route", "rollback_route"],
+      "allOf": [{"$ref": "#/$defs/transport_pair"}],
+      "properties": {
+        "kind": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$", "const": "dispatch_sync_run"},
+        "delivery": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$", "const": "at_least_once"},
+        "route": {"$ref": "#/$defs/transport"},
+        "rollback_route": {"$ref": "#/$defs/transport"}
+      }
+    },
+    "finalize_sync_run": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "delivery", "route", "rollback_route"],
+      "allOf": [{"$ref": "#/$defs/transport_pair"}],
+      "properties": {
+        "kind": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$", "const": "finalize_sync_run"},
+        "delivery": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$", "const": "at_least_once"},
+        "route": {"$ref": "#/$defs/transport"},
+        "rollback_route": {"$ref": "#/$defs/transport"}
+      }
+    },
+    "post_sync": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "delivery", "route", "rollback_route"],
+      "allOf": [{"$ref": "#/$defs/transport_pair"}],
+      "properties": {
+        "kind": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$", "const": "post_sync"},
+        "delivery": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$", "const": "at_most_once_mark_before"},
+        "route": {"$ref": "#/$defs/transport"},
+        "rollback_route": {"$ref": "#/$defs/transport"}
+      }
+    },
+    "reference_discovery": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["kind", "delivery", "route", "rollback_route"],
+      "allOf": [{"$ref": "#/$defs/transport_pair"}],
+      "properties": {
+        "kind": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$", "const": "reference_discovery"},
+        "delivery": {"type": "string", "pattern": "^[a-z][a-z0-9_]*$", "const": "at_least_once"},
+        "route": {"$ref": "#/$defs/transport"},
+        "rollback_route": {"$ref": "#/$defs/transport"}
+      }
+    }
+  }
+}

--- a/docker/go-worker.Dockerfile
+++ b/docker/go-worker.Dockerfile
@@ -53,6 +53,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
       /runtime/worker/app/deploy/go-workers \
       /runtime/scheduler/usr/local/bin \
       /runtime/reconciler/usr/local/bin \
+      /runtime/reconciler/app/contracts/jobs \
       /runtime/stream-runner/usr/local/bin \
       /runtime/operator/usr/local/bin \
       /runtime/operator/app/contracts/jobs \
@@ -63,6 +64,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     cp /out/dev-health-worker /runtime/worker/usr/local/bin/dev-health-worker; \
     cp /out/dev-health-scheduler /runtime/scheduler/usr/local/bin/dev-health-scheduler; \
     cp /out/dev-health-reconciler /runtime/reconciler/usr/local/bin/dev-health-reconciler; \
+    cp -R /src/contracts/jobs/v1 /runtime/reconciler/app/contracts/jobs/v1; \
     cp /out/dev-health-stream-runner /runtime/stream-runner/usr/local/bin/dev-health-stream-runner; \
     cp /out/dev-health-workerctl /runtime/operator/usr/local/bin/dev-health-workerctl; \
     cp /out/worker-contractcheck /runtime/contractcheck/usr/local/bin/worker-contractcheck; \
@@ -101,6 +103,7 @@ ENTRYPOINT ["/usr/local/bin/dev-health-scheduler"]
 
 FROM runtime AS reconciler
 COPY --from=build --chown=65532:65532 /runtime/reconciler/ /
+WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/dev-health-reconciler"]
 
 FROM runtime AS stream-runner

--- a/docs/architecture/dispatch-outbox.md
+++ b/docs/architecture/dispatch-outbox.md
@@ -164,6 +164,7 @@ The outbox kinds have different delivery guarantees depending on their idempoten
 
 | Outbox Kind | Delivery Guarantee | Idempotency Mechanism |
 | :--- | :--- | :--- |
+| `reference_discovery` | At-Least-Once | The durable discovery ledger and lease allow an expired attempt to resume, while the successful transition arms dispatch once. |
 | `dispatch_sync_run` | At-Least-Once | Unit claim guards prevent duplicate execution. Capped units remain in `PLANNED` status. |
 | `finalize_sync_run` | At-Least-Once | The `SyncRunPostDispatch` ledger enforces once-only finalization. |
 | `post_sync` | At-Most-Once | The relay marks the row as dispatched before publishing. It never re-arms on publish failure. |
@@ -173,6 +174,22 @@ A permanent authorization denial consumes the transition using the existing
 rows are excluded from relay claims, and `upsert_outbox_wakeup` preserves that
 terminal denial rather than re-arming it. A pending finalizer remains recoverable
 after other terminal outcomes without reopening feature-denied work.
+
+### Transport Route Contract
+
+[`contracts/sync-dispatch/v1/transport-routes.json`](../../contracts/sync-dispatch/v1/transport-routes.json)
+is the language-neutral route and delivery contract for these four outbox
+kinds. Python and Go validate the same bounded artifact and reject missing,
+duplicate, reordered, or semantically mismatched entries. The route is
+selected per kind so a later migration can preserve the existing Celery
+rollback path without treating queue state as product state.
+
+The checked-in Phase 2 foundation remains deliberately inactive: every
+`route` and `rollback_route` is `celery`, the Go loader is not connected to
+claiming or publishing, and the existing Celery reconciler remains the only
+mutation owner. Changing the artifact alone therefore cannot activate a Go
+transport. Runtime ownership, shadow comparison, and promotion gates are
+separate later slices.
 
 ### At-Most-Once post_sync Semantics
 

--- a/docs/architecture/dispatch-outbox.md
+++ b/docs/architecture/dispatch-outbox.md
@@ -185,11 +185,25 @@ selected per kind so a later migration can preserve the existing Celery
 rollback path without treating queue state as product state.
 
 The checked-in Phase 2 foundation remains deliberately inactive: every
-`route` and `rollback_route` is `celery`, the Go loader is not connected to
-claiming or publishing, and the existing Celery reconciler remains the only
-mutation owner. Changing the artifact alone therefore cannot activate a Go
-transport. Runtime ownership, shadow comparison, and promotion gates are
-separate later slices.
+`route` and `rollback_route` is `celery`, and the existing Celery reconciler
+remains the only mutation owner. The dormant Go reconciler loads the contract
+and observes only the first bounded due-row window in the same
+`(available_at, id)` claim order. It never locks, claims, updates, or publishes
+an outbox row. Its readiness and fixed-cardinality metrics fail closed on
+contract drift, database errors, or an unknown kind inside the sampled window.
+Both runtimes emit a redacted `sync_dispatch_parity_observation`: Celery
+immediately before its claim and Go initially and at most once per minute.
+The event carries the UTC cutoff, bounded limit, predicate and digest versions,
+aggregate counts, and a SHA-256 digest over the ordered candidate identities;
+it never carries the identities themselves, tenant data, claim tokens, or
+payloads. Capture failure is telemetry-only and cannot prevent the existing
+Celery claim path. Changing the artifact alone therefore cannot activate a Go
+transport.
+
+Matching digests prove parity only when the two observations use the same
+cutoff and limit against a quiescent or otherwise correlated dataset.
+Independent live timestamps are operational evidence, not a promotion gate.
+Promotion still requires separately reviewed tandem evidence.
 
 ### At-Most-Once post_sync Semantics
 

--- a/docs/architecture/dispatch-outbox.md
+++ b/docs/architecture/dispatch-outbox.md
@@ -177,7 +177,7 @@ after other terminal outcomes without reopening feature-denied work.
 
 ### Transport Route Contract
 
-[`contracts/sync-dispatch/v1/transport-routes.json`](../../contracts/sync-dispatch/v1/transport-routes.json)
+[`contracts/sync-dispatch/v1/transport-routes.json`](https://github.com/full-chaos/dev-health-ops/blob/main/contracts/sync-dispatch/v1/transport-routes.json)
 is the language-neutral route and delivery contract for these four outbox
 kinds. Python and Go validate the same bounded artifact and reject missing,
 duplicate, reordered, or semantically mismatched entries. The route is

--- a/docs/architecture/go-worker-runtime-trd.md
+++ b/docs/architecture/go-worker-runtime-trd.md
@@ -556,6 +556,15 @@ The scheduler repeats a bounded loop:
 
 Multiple scheduler replicas are safe. A singleton deployment is no longer a correctness requirement, although only one process may hold a global advisory lock if that mode is selected.
 
+The current Phase 2 implementation stops before this mutation boundary.
+`internal/scheduler/sync` is an unregistered, read-only shadow: it performs one
+bounded schedule/configuration `SELECT` and evaluates a versioned candidate
+snapshot in memory. It has no advisory lock, row lock, occurrence claim,
+update, enqueue, or command wiring. Celery Beat and
+`dispatch_scheduled_syncs` therefore remain the sole production scheduler
+until the steps above and their duplicate-occurrence tests are implemented
+and approved.
+
 ### 10.2 Simple periodic maintenance
 
 River periodic jobs may be used for process-internal maintenance only when:

--- a/docs/architecture/repo-layout.md
+++ b/docs/architecture/repo-layout.md
@@ -70,13 +70,15 @@ internal/
 ├── jobcontract/              # Go job-envelope and compatibility types
 ├── joboutbox/                # Transactional Python-to-River relay
 ├── joboperator/              # Payload-redacted operator policy and storage
+├── syncdispatchcontract/     # Cross-language sync-outbox route policy
 └── testsupport/containers/   # Isolated pinned dependency harness
 contracts/jobs/v1/            # Schemas, registry, examples, and migration state
+contracts/sync-dispatch/v1/   # Sync-outbox delivery and transport routes
 ```
 
-These roots are Phase 1 foundations. The command shells do not imply a
-production job handler, River route, or canary approval. Detailed runtime
-topology and migration gates live in the
+These roots are migration foundations. The command shells and route-contract
+loaders do not imply a production job handler, River route, or canary
+approval. Detailed runtime topology and migration gates live in the
 [Go worker runtime TRD](go-worker-runtime-trd.md) and
 [migration PRD](../product/go-worker-migration-prd.md).
 

--- a/docs/architecture/repo-layout.md
+++ b/docs/architecture/repo-layout.md
@@ -71,6 +71,7 @@ internal/
 ├── joboutbox/                # Transactional Python-to-River relay
 ├── joboperator/              # Payload-redacted operator policy and storage
 ├── syncdispatchcontract/     # Cross-language sync-outbox route policy
+├── syncreconciler/           # Read-only bounded sync-outbox observer
 └── testsupport/containers/   # Isolated pinned dependency harness
 contracts/jobs/v1/            # Schemas, registry, examples, and migration state
 contracts/sync-dispatch/v1/   # Sync-outbox delivery and transport routes

--- a/docs/architecture/repo-layout.md
+++ b/docs/architecture/repo-layout.md
@@ -70,6 +70,7 @@ internal/
 ├── jobcontract/              # Go job-envelope and compatibility types
 ├── joboutbox/                # Transactional Python-to-River relay
 ├── joboperator/              # Payload-redacted operator policy and storage
+├── scheduler/sync/           # Dormant read-only sync-schedule evaluator
 ├── syncdispatchcontract/     # Cross-language sync-outbox route policy
 ├── syncreconciler/           # Read-only bounded sync-outbox observer
 └── testsupport/containers/   # Isolated pinned dependency harness

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -103,8 +103,13 @@ policy is loaded at process startup: before a future rollback changes the
 checked-in route, stop new production, drain or classify in-flight River work,
 restore Celery routing, and restart the reconciler. Deferred generic-outbox
 rows remain auditable; the bridge does not silently republish them to Celery.
-The separate sync-domain scheduler, lease repair, and selectable Celery/River
-transport remain unfinished CHAOS-3039 work.
+The dormant Go foundations now also include bounded read-only sync-outbox
+observation and sync-schedule evaluation. They expose comparison material only:
+the schedule repository performs one limited `SELECT`, and neither package
+locks, claims, updates, publishes, or registers a production loop. The
+mutation-capable sync-domain scheduler, organization/entitlement gates, lease
+repair, and selectable Celery/River transport remain unfinished CHAOS-3039
+work.
 
 The rest of this page documents the active Celery runtime. See the
 [Go worker runtime TRD](../architecture/go-worker-runtime-trd.md) for the target

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -109,7 +109,9 @@ the schedule repository performs one limited `SELECT`, and neither package
 locks, claims, updates, publishes, or registers a production loop. The
 schedule result is scoped to schedule/marker timing and does not represent
 organization or feature-entitlement approval. Nondeterministic Croniter `R`
-expressions are reported as unsupported rather than reproduced. The
+expressions and other valid forms outside the versioned deterministic grammar
+are reported as unsupported rather than guessed. Unsupported rows are never
+timing-eligible. The
 mutation-capable sync-domain scheduler, organization/entitlement gates, lease
 repair, and selectable Celery/River transport remain unfinished CHAOS-3039
 work.

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -82,15 +82,29 @@ not yet have authoritative semantic rows; queue pause/resume and profile drain
 are available to an authorized operator. Encoded arguments, driver errors,
 DSNs, and tokens are absent from command output and audit records.
 
-The generic `worker_job_outbox` bridge is also a foundation, not an active
-route. Python's producer helper stages a versioned row inside the caller's
-existing domain transaction; the Go relay claims leases and performs the River
-insert plus delivered mark in one queue-control transaction. Its concurrent
-claimer, lease-expiry, insert/mark rollback, commit-before-ack, duplicate,
-redaction, and retention matrix runs against real PostgreSQL and River. No
-current domain producer calls the helper and no reconciler polling loop invokes
-the relay yet, so Celery ownership is unchanged until a later migration issue
-composes those seams.
+The generic `worker_job_outbox` bridge is now route-safe foundation rather than
+a dormant placeholder. Python's producer helper refuses to enqueue unless the
+checked-in migration state and route pair is executable (`shadow`,
+`river_canary`, or `river`), and the Go relay leaves known Celery-routed rows
+untouched before independently rechecking the route at River insertion.
+Unknown kinds still get claimed so contract failures can terminalize with
+bounded evidence, and the
+`dev-health-reconciler` command now composes the bounded immediate+poll loop
+with explicit packaged-registry readiness and low-cardinality metrics. Startup
+is fail-closed: the loop only opens readiness after one successful step, and
+persistence failures close it instead of being reported as harmless lease
+races.
+
+The checked-in deployment profile still keeps the topology disabled
+(`coexistence_disabled`, all replicas `0`), both registered kinds still route
+to Celery, no current domain producer calls the bridge, and no Go handler is
+compiled. Celery therefore remains the only production writer. Migration
+policy is loaded at process startup: before a future rollback changes the
+checked-in route, stop new production, drain or classify in-flight River work,
+restore Celery routing, and restart the reconciler. Deferred generic-outbox
+rows remain auditable; the bridge does not silently republish them to Celery.
+The separate sync-domain scheduler, lease repair, and selectable Celery/River
+transport remain unfinished CHAOS-3039 work.
 
 The rest of this page documents the active Celery runtime. See the
 [Go worker runtime TRD](../architecture/go-worker-runtime-trd.md) for the target

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -107,6 +107,9 @@ The dormant Go foundations now also include bounded read-only sync-outbox
 observation and sync-schedule evaluation. They expose comparison material only:
 the schedule repository performs one limited `SELECT`, and neither package
 locks, claims, updates, publishes, or registers a production loop. The
+schedule result is scoped to schedule/marker timing and does not represent
+organization or feature-entitlement approval. Nondeterministic Croniter `R`
+expressions are reported as unsupported rather than reproduced. The
 mutation-capable sync-domain scheduler, organization/entitlement gates, lease
 repair, and selectable Celery/River transport remain unfinished CHAOS-3039
 work.

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -315,12 +315,15 @@ snapshot, then evaluates occurrence, manual-only, active-job,
 `is_running`-staleness, and `next_run_at` gates without a transaction, row
 lock, advisory lock, update, enqueue, or process-loop registration. Its
 versioned digest retains candidate identities only in memory. The evaluator
-matches the production five-field Croniter surface, including timezone and
-DST behavior; optional Croniter seconds/year fields remain explicitly outside
-this shadow version. Organization existence, entitlement, occurrence
-claiming, and the dispatch transaction are still Celery-owned work below.
-Nothing imports this package from a command or deployment profile, so its
-presence is comparison infrastructure rather than activation.
+matches the deterministic production five-field Croniter surface, including
+timezone and DST behavior. Croniter's random `R` form is reported as
+unsupported rather than imitated, and optional seconds/year fields remain
+explicitly outside this shadow version. Results and their digest are labeled
+`schedule_and_marker_only`; they are not full dispatch eligibility because
+organization existence, entitlement, occurrence claiming, and the dispatch
+transaction are still Celery-owned work below. Nothing imports this package
+from a command or deployment profile, so its presence is comparison
+infrastructure rather than activation.
 
 An opt-in live PostgreSQL test now proves the Python producer's outer rollback
 and dedupe/savepoint path. Before any generic kind is promoted from Celery,

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -315,15 +315,16 @@ snapshot, then evaluates occurrence, manual-only, active-job,
 `is_running`-staleness, and `next_run_at` gates without a transaction, row
 lock, advisory lock, update, enqueue, or process-loop registration. Its
 versioned digest retains candidate identities only in memory. The evaluator
-matches the deterministic production five-field Croniter surface, including
-timezone and DST behavior. Croniter's random `R` form is reported as
-unsupported rather than imitated, and optional seconds/year fields remain
-explicitly outside this shadow version. Results and their digest are labeled
-`schedule_and_marker_only`; they are not full dispatch eligibility because
-organization existence, entitlement, occurrence claiming, and the dispatch
-transaction are still Celery-owned work below. Nothing imports this package
-from a command or deployment profile, so its presence is comparison
-infrastructure rather than activation.
+implements a versioned deterministic five-field Croniter subset, including the
+ordinary list/range/step/name forms and the explicitly tested timezone and DST
+behavior. A valid Croniter form outside that grammar is reported as
+unsupported and can never become timing-eligible; this includes random `R`,
+unported mixed special-day forms, and optional seconds/year fields. Results
+and their digest are labeled `schedule_and_marker_only`; they are not full
+dispatch eligibility because organization existence, entitlement, occurrence
+claiming, and the dispatch transaction are still Celery-owned work below.
+Nothing imports this package from a command or deployment profile, so its
+presence is comparison infrastructure rather than activation.
 
 An opt-in live PostgreSQL test now proves the Python producer's outer rollback
 and dedupe/savepoint path. Before any generic kind is promoted from Celery,

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -290,8 +290,8 @@ readiness and metrics. Startup is fail-closed until that loop succeeds once,
 and later persistence failures close readiness. Checked-in deployment profiles
 remain `coexistence_disabled` with zero replicas; both registered kinds still
 route to Celery, no producer calls the bridge, and no Go handler is compiled.
-The broader scheduler and sync-domain transport work in CHAOS-3039 therefore
-remains unported and no tandem parity is claimed.
+The mutation-capable scheduler and sync-domain transport work in CHAOS-3039
+therefore remains unported and no tandem parity is claimed.
 
 The first sync-domain transport dependency is now frozen independently of
 runtime activation. `contracts/sync-dispatch/v1/transport-routes.json`
@@ -307,6 +307,20 @@ the Celery reconciler is still the only mutation owner. The observer supplies
 an autonomous comparison surface, but observations with different cutoffs are
 operational evidence rather than tandem proof. This slice does not authorize
 promotion.
+
+The dormant `internal/scheduler/sync` package adds the corresponding
+read-only schedule-evaluation foundation. It reads at most 101 active
+configuration/job rows to produce a 100-row, deterministically ordered
+snapshot, then evaluates occurrence, manual-only, active-job,
+`is_running`-staleness, and `next_run_at` gates without a transaction, row
+lock, advisory lock, update, enqueue, or process-loop registration. Its
+versioned digest retains candidate identities only in memory. The evaluator
+matches the production five-field Croniter surface, including timezone and
+DST behavior; optional Croniter seconds/year fields remain explicitly outside
+this shadow version. Organization existence, entitlement, occurrence
+claiming, and the dispatch transaction are still Celery-owned work below.
+Nothing imports this package from a command or deployment profile, so its
+presence is comparison infrastructure rather than activation.
 
 An opt-in live PostgreSQL test now proves the Python producer's outer rollback
 and dedupe/savepoint path. Before any generic kind is promoted from Celery,

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -293,6 +293,14 @@ route to Celery, no producer calls the bridge, and no Go handler is compiled.
 The broader scheduler and sync-domain transport work in CHAOS-3039 therefore
 remains unported and no tandem parity is claimed.
 
+The first sync-domain transport dependency is now frozen independently of
+runtime activation. `contracts/sync-dispatch/v1/transport-routes.json`
+enumerates the four existing wakeup kinds and preserves their current delivery
+semantics. Strict Python and Go loaders consume the same artifact, but neither
+loader participates in claims or publication. Every checked-in route and
+rollback route remains Celery, so the Celery reconciler is still the only
+mutation owner and this slice does not yet establish tandem parity.
+
 An opt-in live PostgreSQL test now proves the Python producer's outer rollback
 and dedupe/savepoint path. Before any generic kind is promoted from Celery,
 retain that proof in promotion validation, record evidence for the relay

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -296,10 +296,17 @@ remains unported and no tandem parity is claimed.
 The first sync-domain transport dependency is now frozen independently of
 runtime activation. `contracts/sync-dispatch/v1/transport-routes.json`
 enumerates the four existing wakeup kinds and preserves their current delivery
-semantics. Strict Python and Go loaders consume the same artifact, but neither
-loader participates in claims or publication. Every checked-in route and
-rollback route remains Celery, so the Celery reconciler is still the only
-mutation owner and this slice does not yet establish tandem parity.
+semantics. Strict Python and Go loaders consume the same artifact. The dormant
+Go reconciler also runs a bounded, read-only observer over the first due-row
+window in Python claim order and closes readiness on contract or database
+drift. Celery records the same versioned, redacted digest immediately before
+claiming; Go records its initial observation and then at most one per minute.
+It does not lock, claim, update, or publish, and capture failure does not alter
+Celery behavior. Every checked-in route and rollback route remains Celery, so
+the Celery reconciler is still the only mutation owner. The observer supplies
+an autonomous comparison surface, but observations with different cutoffs are
+operational evidence rather than tandem proof. This slice does not authorize
+promotion.
 
 An opt-in live PostgreSQL test now proves the Python producer's outer rollback
 and dedupe/savepoint path. Before any generic kind is promoted from Celery,

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -282,6 +282,26 @@ circular.
 
 ## 6. Phase 2 — first bounded jobs and orchestration infrastructure
 
+Current boundary: the route-safe generic `worker_job_outbox` slice is in
+place. Python now gates enqueue on a valid executable migration state/route
+pair, the Go relay leaves known Celery rows untouched while still terminalizing
+unknown rows, and the reconciler command composes the bounded loop with
+readiness and metrics. Startup is fail-closed until that loop succeeds once,
+and later persistence failures close readiness. Checked-in deployment profiles
+remain `coexistence_disabled` with zero replicas; both registered kinds still
+route to Celery, no producer calls the bridge, and no Go handler is compiled.
+The broader scheduler and sync-domain transport work in CHAOS-3039 therefore
+remains unported and no tandem parity is claimed.
+
+An opt-in live PostgreSQL test now proves the Python producer's outer rollback
+and dedupe/savepoint path. Before any generic kind is promoted from Celery,
+retain that proof in promotion validation, record evidence for the relay
+batch-size/claim-lease defaults, and exercise pending, claimed, delivered,
+running, and retryable work through the documented stop/drain/restore/restart
+rollback sequence. The generic bridge intentionally does not republish
+deferred rows to Celery; selectable Celery/River transport for the existing
+sync-domain outbox remains part of the work below.
+
 ### CHAOS-3039 — Implement Go scheduler and sync reconciler transport
 
 #### Work

--- a/internal/joboperator/postgres_integration_test.go
+++ b/internal/joboperator/postgres_integration_test.go
@@ -34,6 +34,26 @@ type allowIntegrationDomainGuard struct{}
 
 func (allowIntegrationDomainGuard) Check(context.Context, Action, JobSummary) error { return nil }
 
+// operatorIntegrationPolicyRegistry changes only the fixture's insertion
+// policy. The operator backend continues to use the checked-in, Celery-routed
+// registry so this test cannot weaken or misrepresent production routing.
+type operatorIntegrationPolicyRegistry struct {
+	registry *jobruntime.Registry
+}
+
+func (policy operatorIntegrationPolicyRegistry) Descriptor(kind string) (jobruntime.Descriptor, bool) {
+	descriptor, ok := policy.registry.Descriptor(kind)
+	if !ok {
+		return jobruntime.Descriptor{}, false
+	}
+	if kind == jobcontract.KindHeartbeat {
+		descriptor.MigrationState = "canary"
+		descriptor.Route = "river_canary"
+		descriptor.RollbackRoute = "celery"
+	}
+	return descriptor, true
+}
+
 func TestPostgresOperatorAuthenticationBackendAndAudit(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
@@ -77,8 +97,18 @@ func TestPostgresOperatorAuthenticationBackendAndAudit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	heartbeat, ok := registry.Descriptor(jobcontract.KindHeartbeat)
+	if !ok || heartbeat.Executable() {
+		t.Fatalf("checked-in heartbeat policy = %#v, want non-executable", heartbeat)
+	}
 	now := time.Now().UTC().Truncate(time.Microsecond)
-	jobID := insertOperatorIntegrationJob(t, ctx, adminPool, registry, now)
+	jobID := insertOperatorIntegrationJob(
+		t,
+		ctx,
+		adminPool,
+		operatorIntegrationPolicyRegistry{registry: registry},
+		now,
+	)
 	if _, err := adminPool.Exec(ctx, `
 		INSERT INTO river.river_queue (name, updated_at)
 		VALUES ('heartbeat', $1), ('retention', $1)
@@ -252,7 +282,7 @@ func insertOperatorIntegrationJob(
 	t *testing.T,
 	ctx context.Context,
 	pool *pgxpool.Pool,
-	registry *jobruntime.Registry,
+	registry joboutbox.PolicyRegistry,
 	now time.Time,
 ) int64 {
 	t.Helper()

--- a/internal/joboutbox/inserter.go
+++ b/internal/joboutbox/inserter.go
@@ -100,6 +100,9 @@ func prepareRow(registry PolicyRegistry, row Row) (jobruntime.Descriptor, relayA
 	if !ok {
 		return jobruntime.Descriptor{}, relayArgs{}, ErrContractRejected
 	}
+	if !descriptor.Executable() {
+		return jobruntime.Descriptor{}, relayArgs{}, ErrPolicyRejected
+	}
 	if row.ContractVersion < 1 || !containsVersion(descriptor.SupportedVersions, row.ContractVersion) {
 		return jobruntime.Descriptor{}, relayArgs{}, ErrContractRejected
 	}

--- a/internal/joboutbox/inserter_test.go
+++ b/internal/joboutbox/inserter_test.go
@@ -29,6 +29,7 @@ func testDescriptor() jobruntime.Descriptor {
 		Queue:             "heartbeat",
 		Priority:          2,
 		MaxAttempts:       1,
+		Route:             "river",
 	}
 }
 
@@ -120,6 +121,40 @@ func TestPrepareRowEmitsCanonicalArgsWithUniqueIdempotencyOnly(t *testing.T) {
 	}
 	if strings.Contains(string(encoded), "worker_outbox_id") {
 		t.Fatal("outbox metadata leaked into encoded_args")
+	}
+}
+
+func TestPrepareRowRejectsNonExecutableMigrationRoutes(t *testing.T) {
+	for _, route := range []string{"celery", "coexistence_disabled", ""} {
+		t.Run(route, func(t *testing.T) {
+			row := testRow(t)
+			descriptor := testDescriptor()
+			descriptor.Route = route
+			registry := staticRegistry{descriptors: map[string]jobruntime.Descriptor{row.JobKind: descriptor}}
+
+			_, _, err := prepareRow(registry, row)
+			if !errors.Is(err, ErrPolicyRejected) {
+				t.Fatalf("prepareRow() error = %v, want %v", err, ErrPolicyRejected)
+			}
+			if err.Error() != ErrPolicyRejected.Error() {
+				t.Fatalf("prepareRow() returned an unbounded policy error: %v", err)
+			}
+		})
+	}
+}
+
+func TestPrepareRowAcceptsExecutableMigrationRoutes(t *testing.T) {
+	for _, route := range []string{"shadow", "river_canary", "river"} {
+		t.Run(route, func(t *testing.T) {
+			row := testRow(t)
+			descriptor := testDescriptor()
+			descriptor.Route = route
+			registry := staticRegistry{descriptors: map[string]jobruntime.Descriptor{row.JobKind: descriptor}}
+
+			if _, _, err := prepareRow(registry, row); err != nil {
+				t.Fatalf("prepareRow() error = %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/joboutbox/loop.go
+++ b/internal/joboutbox/loop.go
@@ -1,0 +1,334 @@
+package joboutbox
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+)
+
+const (
+	minReconcilerPollInterval = 10 * time.Millisecond
+	maxReconcilerPollInterval = 15 * time.Minute
+	minReconcilerLimit        = 1
+	maxReconcilerLimit        = 100
+)
+
+var (
+	// ErrReconcilerLoopAlreadyStarted prevents a second owner from claiming the
+	// same outbox reconciler instance.
+	ErrReconcilerLoopAlreadyStarted = errors.New("worker outbox reconciler loop already started")
+	errReconcilerLoopNotReady       = errors.New("worker outbox reconciler loop has not completed a successful step")
+)
+
+// RelayStepper is the bounded, transactional unit of reconciliation. Relay
+// implements this interface; keeping the loop on this small seam makes its
+// lifecycle independently testable.
+type RelayStepper interface {
+	Step(context.Context, time.Time, int) (StepResult, error)
+}
+
+// ReconcilerLoopConfig bounds the polling work owned by ReconcilerLoop. The
+// registry is required so the loop can fail readiness closed until its first
+// successful step and export a stable operator metric fragment.
+type ReconcilerLoopConfig struct {
+	PollInterval time.Duration
+	Limit        int
+	Registry     *health.Registry
+}
+
+func DefaultReconcilerLoopConfig(registry *health.Registry) ReconcilerLoopConfig {
+	return ReconcilerLoopConfig{
+		PollInterval: time.Second,
+		Limit:        100,
+		Registry:     registry,
+	}
+}
+
+func (config ReconcilerLoopConfig) validate() error {
+	if config.Registry == nil ||
+		config.PollInterval < minReconcilerPollInterval || config.PollInterval > maxReconcilerPollInterval ||
+		config.Limit < minReconcilerLimit || config.Limit > maxReconcilerLimit {
+		return ErrInvalidConfiguration
+	}
+	return nil
+}
+
+type reconcilerClock interface {
+	Now() time.Time
+	NewTicker(time.Duration) reconcilerTicker
+}
+
+type reconcilerTicker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type systemReconcilerClock struct{}
+
+func (systemReconcilerClock) Now() time.Time { return time.Now() }
+
+func (systemReconcilerClock) NewTicker(interval time.Duration) reconcilerTicker {
+	return systemReconcilerTicker{Ticker: time.NewTicker(interval)}
+}
+
+type systemReconcilerTicker struct{ *time.Ticker }
+
+func (ticker systemReconcilerTicker) Chan() <-chan time.Time { return ticker.C }
+
+// ReconcilerLoop owns one polling goroutine around bounded Relay steps. A
+// successful empty step is a valid database/connectivity proof and opens its
+// required readiness dependency. Step errors are fatal: callers should use
+// Errors with lifecycle.Runtime so the process exits rather than silently
+// serving stale control-plane state.
+type ReconcilerLoop struct {
+	stepper RelayStepper
+	config  ReconcilerLoopConfig
+	clock   reconcilerClock
+
+	ready atomic.Bool
+
+	mu       sync.Mutex
+	started  bool
+	stopping bool
+	cancel   context.CancelFunc
+	done     chan struct{}
+	ticker   reconcilerTicker
+
+	claimed   uint64
+	delivered uint64
+	retried   uint64
+	dead      uint64
+	leaseLost uint64
+	lastOK    time.Time
+	up        bool
+
+	errors chan error
+}
+
+// NewReconcilerLoop constructs a fail-closed lifecycle component. The
+// readiness and metrics registrations happen at composition time, before the
+// shell opens its global readiness gate.
+func NewReconcilerLoop(stepper RelayStepper, config ReconcilerLoopConfig) (*ReconcilerLoop, error) {
+	return newReconcilerLoop(stepper, config, systemReconcilerClock{})
+}
+
+func newReconcilerLoop(
+	stepper RelayStepper,
+	config ReconcilerLoopConfig,
+	clock reconcilerClock,
+) (*ReconcilerLoop, error) {
+	if stepper == nil || clock == nil || config.validate() != nil {
+		return nil, ErrInvalidConfiguration
+	}
+	loop := &ReconcilerLoop{
+		stepper: stepper,
+		config:  config,
+		clock:   clock,
+		errors:  make(chan error, 1),
+	}
+	if err := config.Registry.RegisterRequired("reconciler_loop", loop.readiness); err != nil {
+		return nil, fmt.Errorf("register reconciler readiness: %w", err)
+	}
+	if err := config.Registry.RegisterMetrics("outbox_reconciler", loop); err != nil {
+		return nil, fmt.Errorf("register reconciler metrics: %w", err)
+	}
+	return loop, nil
+}
+
+func (*ReconcilerLoop) Name() string { return "outbox-reconciler-loop" }
+
+// Start performs one immediate bounded step before beginning periodic polling.
+// This means the lifecycle runtime never advertises a healthy reconciler based
+// only on goroutine creation.
+func (loop *ReconcilerLoop) Start(ctx context.Context) error {
+	if loop == nil || ctx == nil {
+		return ErrInvalidConfiguration
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+
+	loop.mu.Lock()
+	if loop.started {
+		loop.mu.Unlock()
+		return ErrReconcilerLoopAlreadyStarted
+	}
+	loop.started = true
+	loop.mu.Unlock()
+
+	if err := loop.step(ctx, loop.clock.Now()); err != nil {
+		loop.setFailed()
+		return fmt.Errorf("initial outbox reconciliation: %w", err)
+	}
+
+	loopCtx, cancel := context.WithCancel(ctx)
+	ticker := loop.clock.NewTicker(loop.config.PollInterval)
+	done := make(chan struct{})
+	loop.mu.Lock()
+	if loop.stopping {
+		loop.mu.Unlock()
+		ticker.Stop()
+		cancel()
+		loop.setFailed()
+		return context.Canceled
+	}
+	loop.cancel = cancel
+	loop.ticker = ticker
+	loop.done = done
+	loop.mu.Unlock()
+	go loop.run(loopCtx, ticker, done)
+	return nil
+}
+
+func (loop *ReconcilerLoop) run(ctx context.Context, ticker reconcilerTicker, done chan struct{}) {
+	defer close(done)
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now, open := <-ticker.Chan():
+			if !open {
+				return
+			}
+			if err := loop.step(ctx, now); err != nil {
+				loop.setFailed()
+				select {
+				case loop.errors <- fmt.Errorf("outbox reconciliation step: %w", err):
+				case <-ctx.Done():
+				}
+				return
+			}
+		}
+	}
+}
+
+func (loop *ReconcilerLoop) step(ctx context.Context, now time.Time) error {
+	result, err := loop.stepper.Step(ctx, now, loop.config.Limit)
+	if err != nil {
+		return err
+	}
+	loop.mu.Lock()
+	loop.claimed += nonNegativeUint(result.Claimed)
+	loop.delivered += nonNegativeUint(result.Delivered)
+	loop.retried += nonNegativeUint(result.Retried)
+	loop.dead += nonNegativeUint(result.Dead)
+	loop.leaseLost += nonNegativeUint(result.LeaseLost)
+	loop.lastOK = now
+	loop.up = true
+	loop.mu.Unlock()
+	loop.ready.Store(true)
+	return nil
+}
+
+func nonNegativeUint(value int) uint64 {
+	if value < 0 {
+		return 0
+	}
+	return uint64(value)
+}
+
+func (loop *ReconcilerLoop) setFailed() {
+	loop.ready.Store(false)
+	loop.mu.Lock()
+	loop.up = false
+	loop.mu.Unlock()
+}
+
+func (loop *ReconcilerLoop) readiness(context.Context) error {
+	if loop != nil && loop.ready.Load() {
+		return nil
+	}
+	return errReconcilerLoopNotReady
+}
+
+// Errors reports periodic fatal reconciliation errors to lifecycle.Runtime.
+// It is intentionally buffered so the loop can stop before the runtime's
+// error watcher is scheduled.
+func (loop *ReconcilerLoop) Errors() <-chan error {
+	if loop == nil {
+		return nil
+	}
+	return loop.errors
+}
+
+// Shutdown closes readiness before cancelling its polling goroutine, then
+// waits only as long as the lifecycle shutdown context permits.
+func (loop *ReconcilerLoop) Shutdown(ctx context.Context) error {
+	if loop == nil || ctx == nil {
+		return ErrInvalidConfiguration
+	}
+	loop.setFailed()
+
+	loop.mu.Lock()
+	loop.stopping = true
+	cancel := loop.cancel
+	ticker := loop.ticker
+	done := loop.done
+	loop.mu.Unlock()
+	if ticker != nil {
+		ticker.Stop()
+	}
+	if cancel != nil {
+		cancel()
+	}
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// WritePrometheus exports only process-wide, low-cardinality counters and
+// gauges. It deliberately contains no job kind, organization, payload, or
+// dynamic error text labels.
+func (loop *ReconcilerLoop) WritePrometheus(output io.Writer) error {
+	if loop == nil || output == nil {
+		return errors.New("Prometheus output is required")
+	}
+	loop.mu.Lock()
+	claimed := loop.claimed
+	delivered := loop.delivered
+	retried := loop.retried
+	dead := loop.dead
+	leaseLost := loop.leaseLost
+	lastOK := loop.lastOK
+	up := loop.up
+	now := loop.clock.Now()
+	loop.mu.Unlock()
+
+	lastSuccessAge := 0.0
+	if up && !lastOK.IsZero() && !now.Before(lastOK) {
+		lastSuccessAge = now.Sub(lastOK).Seconds()
+	}
+	var text strings.Builder
+	writeReconcilerCounter(&text, "worker_outbox_reconciler_claimed_total", "Outbox rows claimed by the reconciler.", claimed)
+	writeReconcilerCounter(&text, "worker_outbox_reconciler_delivered_total", "Outbox rows delivered to River by the reconciler.", delivered)
+	writeReconcilerCounter(&text, "worker_outbox_reconciler_retried_total", "Outbox rows scheduled for relay retry by the reconciler.", retried)
+	writeReconcilerCounter(&text, "worker_outbox_reconciler_dead_total", "Outbox rows terminalized by the reconciler.", dead)
+	writeReconcilerCounter(&text, "worker_outbox_reconciler_lease_lost_total", "Outbox claims lost before reconciliation completed.", leaseLost)
+	fmt.Fprint(&text, "# HELP worker_outbox_reconciler_up Whether the reconciler loop is currently healthy.\n# TYPE worker_outbox_reconciler_up gauge\nworker_outbox_reconciler_up ")
+	if up {
+		text.WriteString("1\n")
+	} else {
+		text.WriteString("0\n")
+	}
+	fmt.Fprintf(&text, "# HELP worker_outbox_reconciler_last_success_age_seconds Age of the last successful reconciler step.\n# TYPE worker_outbox_reconciler_last_success_age_seconds gauge\nworker_outbox_reconciler_last_success_age_seconds %s\n", strconv.FormatFloat(lastSuccessAge, 'g', -1, 64))
+	_, err := io.WriteString(output, text.String())
+	return err
+}
+
+func writeReconcilerCounter(output *strings.Builder, name, help string, value uint64) {
+	fmt.Fprintf(output, "# HELP %s %s\n# TYPE %s counter\n%s %d\n", name, help, name, name, value)
+}

--- a/internal/joboutbox/loop_test.go
+++ b/internal/joboutbox/loop_test.go
@@ -1,0 +1,265 @@
+package joboutbox
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+)
+
+type loopStepFunc func(context.Context, time.Time, int) (StepResult, error)
+
+func (fn loopStepFunc) Step(ctx context.Context, now time.Time, limit int) (StepResult, error) {
+	return fn(ctx, now, limit)
+}
+
+type testReconcilerClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	ticker *testReconcilerTicker
+}
+
+func (clock *testReconcilerClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *testReconcilerClock) NewTicker(time.Duration) reconcilerTicker {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	clock.ticker = &testReconcilerTicker{ticks: make(chan time.Time, 4)}
+	return clock.ticker
+}
+
+type testReconcilerTicker struct {
+	ticks   chan time.Time
+	stopped chan struct{}
+	once    sync.Once
+}
+
+func (ticker *testReconcilerTicker) Chan() <-chan time.Time { return ticker.ticks }
+
+func (ticker *testReconcilerTicker) Stop() {
+	ticker.once.Do(func() {
+		if ticker.stopped == nil {
+			ticker.stopped = make(chan struct{})
+		}
+		close(ticker.stopped)
+	})
+}
+
+func newTestReconcilerLoop(
+	t *testing.T,
+	stepper RelayStepper,
+	clock *testReconcilerClock,
+) (*ReconcilerLoop, *health.Registry) {
+	t.Helper()
+	registry := health.NewRegistry(time.Second)
+	loop, err := newReconcilerLoop(stepper, ReconcilerLoopConfig{
+		PollInterval: minReconcilerPollInterval,
+		Limit:        7,
+		Registry:     registry,
+	}, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loop, registry
+}
+
+func openReconcilerReadiness(t *testing.T, registry *health.Registry) {
+	t.Helper()
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcilerLoopImmediateNoopStepOpensReadiness(t *testing.T) {
+	clock := &testReconcilerClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	calls := make(chan struct{}, 1)
+	loop, registry := newTestReconcilerLoop(t, loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) {
+		calls <- struct{}{}
+		return StepResult{}, nil
+	}), clock)
+	openReconcilerReadiness(t, registry)
+	if status := registry.Readiness(context.Background()); status.Ready || !strings.Contains(strings.Join(status.Failed, ","), "reconciler_loop") {
+		t.Fatalf("pre-start readiness = %#v", status)
+	}
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-calls:
+	default:
+		t.Fatal("immediate reconciliation step did not run")
+	}
+	if status := registry.Readiness(context.Background()); !status.Ready {
+		t.Fatalf("post-start readiness = %#v", status)
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcilerLoopAccumulatesResultsAndExportsLowCardinalityMetrics(t *testing.T) {
+	clock := &testReconcilerClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	results := []StepResult{{Claimed: 2, Delivered: 1, Retried: 1}, {Claimed: 3, Dead: 1, LeaseLost: 2}}
+	steps := make(chan struct{}, 2)
+	loop, _ := newTestReconcilerLoop(t, loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) {
+		result := results[0]
+		results = results[1:]
+		steps <- struct{}{}
+		return result, nil
+	}), clock)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	<-steps
+	clock.mu.Lock()
+	clock.now = clock.now.Add(3 * time.Second)
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	ticker.ticks <- clock.Now()
+	<-steps
+
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"worker_outbox_reconciler_claimed_total 5",
+		"worker_outbox_reconciler_delivered_total 1",
+		"worker_outbox_reconciler_retried_total 1",
+		"worker_outbox_reconciler_dead_total 1",
+		"worker_outbox_reconciler_lease_lost_total 2",
+		"worker_outbox_reconciler_up 1",
+		"worker_outbox_reconciler_last_success_age_seconds 0",
+	} {
+		if !strings.Contains(metrics.String(), want+"\n") {
+			t.Fatalf("metrics missing %q:\n%s", want, metrics.String())
+		}
+	}
+	if strings.Contains(metrics.String(), "{") {
+		t.Fatalf("reconciler metrics must not expose labels:\n%s", metrics.String())
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcilerLoopPropagatesPeriodicFatalErrorAndClosesReadiness(t *testing.T) {
+	clock := &testReconcilerClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	fatal := errors.New("database unavailable")
+	steps := 0
+	failedStep := make(chan struct{}, 1)
+	loop, registry := newTestReconcilerLoop(t, loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) {
+		steps++
+		if steps == 1 {
+			return StepResult{}, nil
+		}
+		failedStep <- struct{}{}
+		return StepResult{}, fatal
+	}), clock)
+	openReconcilerReadiness(t, registry)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	ticker.ticks <- clock.Now().Add(time.Second)
+	<-failedStep
+	if err := <-loop.Errors(); !errors.Is(err, fatal) {
+		t.Fatalf("Errors() = %v, want %v", err, fatal)
+	}
+	if status := registry.Readiness(context.Background()); status.Ready || !strings.Contains(strings.Join(status.Failed, ","), "reconciler_loop") {
+		t.Fatalf("failed-loop readiness = %#v", status)
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcilerLoopRejectsDoubleStartAndCancelsOnShutdown(t *testing.T) {
+	clock := &testReconcilerClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	calls := 0
+	loop, _ := newTestReconcilerLoop(t, loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) {
+		calls++
+		return StepResult{}, nil
+	}), clock)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := loop.Start(context.Background()); !errors.Is(err, ErrReconcilerLoopAlreadyStarted) {
+		t.Fatalf("second Start() error = %v", err)
+	}
+	if calls != 1 {
+		t.Fatalf("immediate step calls = %d, want one", calls)
+	}
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ticker.stopped:
+	default:
+		t.Fatal("shutdown did not stop ticker")
+	}
+}
+
+func TestReconcilerLoopShutdownHonorsLifecycleDeadlineDuringStep(t *testing.T) {
+	clock := &testReconcilerClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	entered := make(chan struct{}, 1)
+	release := make(chan struct{})
+	calls := 0
+	loop, _ := newTestReconcilerLoop(t, loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) {
+		calls++
+		if calls == 1 {
+			return StepResult{}, nil
+		}
+		entered <- struct{}{}
+		<-release
+		return StepResult{}, nil
+	}), clock)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	ticker.ticks <- clock.Now().Add(time.Second)
+	<-entered
+
+	shutdownCtx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := loop.Shutdown(shutdownCtx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Shutdown() error = %v, want context cancellation", err)
+	}
+	close(release)
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestReconcilerLoopRejectsUnboundedConfiguration(t *testing.T) {
+	registry := health.NewRegistry(time.Second)
+	stepper := loopStepFunc(func(context.Context, time.Time, int) (StepResult, error) { return StepResult{}, nil })
+	for _, config := range []ReconcilerLoopConfig{
+		{PollInterval: minReconcilerPollInterval, Limit: 1},
+		{PollInterval: minReconcilerPollInterval - time.Nanosecond, Limit: 1, Registry: registry},
+		{PollInterval: maxReconcilerPollInterval + time.Nanosecond, Limit: 1, Registry: registry},
+		{PollInterval: minReconcilerPollInterval, Limit: 0, Registry: registry},
+		{PollInterval: minReconcilerPollInterval, Limit: maxReconcilerLimit + 1, Registry: registry},
+	} {
+		if _, err := NewReconcilerLoop(stepper, config); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("NewReconcilerLoop(%#v) error = %v", config, err)
+		}
+	}
+}

--- a/internal/joboutbox/relay.go
+++ b/internal/joboutbox/relay.go
@@ -3,8 +3,11 @@ package joboutbox
 import (
 	"context"
 	"errors"
+	"sort"
 	"time"
 )
+
+const maxRelayPolicyKinds = 1000
 
 type RelayConfig struct {
 	LeaseDuration    time.Duration
@@ -43,23 +46,71 @@ type StepResult struct {
 // Relay is a single bounded reconciliation step. Process lifecycle and polling
 // are intentionally left to the Phase 2 reconciler binary.
 type Relay struct {
-	repository *Repository
-	inserter   *RiverInserter
-	config     RelayConfig
+	repository    *Repository
+	inserter      *RiverInserter
+	config        RelayConfig
+	deferredKinds []string
 }
 
 func NewRelay(repository *Repository, inserter *RiverInserter, config RelayConfig) (*Relay, error) {
 	if repository == nil || inserter == nil || config.validate() != nil {
 		return nil, ErrInvalidConfiguration
 	}
-	return &Relay{repository: repository, inserter: inserter, config: config}, nil
+	registry, ok := inserter.registry.(RelayPolicyRegistry)
+	if !ok {
+		return nil, ErrInvalidConfiguration
+	}
+	deferredKinds, err := deferredRelayKinds(registry)
+	if err != nil {
+		return nil, err
+	}
+	return &Relay{
+		repository:    repository,
+		inserter:      inserter,
+		config:        config,
+		deferredKinds: deferredKinds,
+	}, nil
+}
+
+func deferredRelayKinds(registry RelayPolicyRegistry) ([]string, error) {
+	if registry == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	descriptors := registry.Descriptors()
+	if len(descriptors) < 1 || len(descriptors) > maxRelayPolicyKinds {
+		return nil, ErrInvalidConfiguration
+	}
+	seen := make(map[string]struct{}, len(descriptors))
+	deferred := make([]string, 0, len(descriptors))
+	for _, descriptor := range descriptors {
+		if descriptor.Kind == "" {
+			return nil, ErrInvalidConfiguration
+		}
+		if _, duplicate := seen[descriptor.Kind]; duplicate {
+			return nil, ErrInvalidConfiguration
+		}
+		seen[descriptor.Kind] = struct{}{}
+		resolved, ok := registry.Descriptor(descriptor.Kind)
+		if !ok || resolved.Kind != descriptor.Kind || resolved.Route != descriptor.Route {
+			return nil, ErrInvalidConfiguration
+		}
+		switch descriptor.Route {
+		case "celery":
+			deferred = append(deferred, descriptor.Kind)
+		case "shadow", "river_canary", "river":
+		default:
+			return nil, ErrInvalidConfiguration
+		}
+	}
+	sort.Strings(deferred)
+	return deferred, nil
 }
 
 func (relay *Relay) Step(ctx context.Context, now time.Time, limit int) (StepResult, error) {
 	if relay == nil || now.IsZero() {
 		return StepResult{}, ErrInvalidConfiguration
 	}
-	claims, err := relay.repository.ClaimDue(ctx, now, limit, relay.config.LeaseDuration)
+	claims, err := relay.repository.claimDueExcept(ctx, now, limit, relay.config.LeaseDuration, relay.deferredKinds)
 	if err != nil {
 		return StepResult{}, err
 	}
@@ -74,30 +125,61 @@ func (relay *Relay) Step(ctx context.Context, now time.Time, limit int) (StepRes
 		case errors.Is(dispatchErr, ErrLeaseLost):
 			result.LeaseLost++
 		case errors.Is(dispatchErr, ErrContractRejected):
-			if relay.record(ctx, claim, now, failureContract) == nil {
+			recorded, recordErr := relay.recordOutcome(ctx, claim, now, failureContract, &result)
+			if recordErr != nil {
+				return result, recordErr
+			}
+			if recorded {
 				result.Dead++
-			} else {
-				result.LeaseLost++
 			}
 		case errors.Is(dispatchErr, ErrPolicyRejected):
-			if relay.record(ctx, claim, now, failurePolicy) == nil {
+			recorded, recordErr := relay.recordOutcome(ctx, claim, now, failurePolicy, &result)
+			if recordErr != nil {
+				return result, recordErr
+			}
+			if recorded {
 				result.Dead++
-			} else {
-				result.LeaseLost++
 			}
 		default:
-			if relay.record(ctx, claim, now, failureRiver) == nil {
+			recorded, recordErr := relay.recordOutcome(ctx, claim, now, failureRiver, &result)
+			if recordErr != nil {
+				return result, recordErr
+			}
+			if recorded {
 				if claim.AttemptCount >= relay.config.MaxRelayAttempts {
 					result.Dead++
 				} else {
 					result.Retried++
 				}
-			} else {
-				result.LeaseLost++
 			}
 		}
 	}
 	return result, nil
+}
+
+// recordOutcome distinguishes an expected stale-lease race from a persistence
+// outage. Only a proven lost lease is counted and tolerated; an unavailable
+// database is fatal so the lifecycle loop closes readiness instead of
+// reporting a successful reconciliation step.
+func (relay *Relay) recordOutcome(
+	ctx context.Context,
+	claim Claim,
+	now time.Time,
+	kind failureKind,
+	result *StepResult,
+) (bool, error) {
+	return classifyRecordOutcome(relay.record(ctx, claim, now, kind), result)
+}
+
+func classifyRecordOutcome(err error, result *StepResult) (bool, error) {
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, ErrLeaseLost) {
+		result.LeaseLost++
+		return false, nil
+	}
+	return false, err
 }
 
 func (relay *Relay) record(ctx context.Context, claim Claim, now time.Time, kind failureKind) error {

--- a/internal/joboutbox/relay_integration_test.go
+++ b/internal/joboutbox/relay_integration_test.go
@@ -31,7 +31,10 @@ const (
 	outboxQueuePassword  = "outbox_queue_password"
 )
 
-type failingRiverClient struct{ err error }
+type failingRiverClient struct {
+	err          error
+	beforeReturn func()
+}
 
 func (client failingRiverClient) InsertTx(
 	context.Context,
@@ -39,6 +42,9 @@ func (client failingRiverClient) InsertTx(
 	river.JobArgs,
 	*river.InsertOpts,
 ) (*rivertype.JobInsertResult, error) {
+	if client.beforeReturn != nil {
+		client.beforeReturn()
+	}
 	return nil, client.err
 }
 
@@ -71,10 +77,19 @@ func TestGenericOutboxLiveFailureInjectionMatrix(t *testing.T) {
 	queueURI := integrationRoleURI(t, instance.URI, outboxQueueRole, outboxQueuePassword)
 	queuePool := openIntegrationPool(t, ctx, queueURI)
 	defer queuePool.Close()
-	registry, err := jobruntime.Load(filepath.Join("..", "..", "contracts", "jobs", "v1"))
+	productionRegistry, err := jobruntime.Load(filepath.Join("..", "..", "contracts", "jobs", "v1"))
 	if err != nil {
 		t.Fatal(err)
 	}
+	for _, descriptor := range productionRegistry.Descriptors() {
+		if descriptor.Route != "celery" || descriptor.Executable() {
+			t.Fatalf("checked-in production route became executable: %#v", descriptor)
+		}
+	}
+	registry := integrationRouteRegistry(productionRegistry, map[string]string{
+		jobcontract.KindHeartbeat:        "river",
+		jobcontract.KindRetentionCleanup: "river",
+	})
 	repository, err := NewRepository(queuePool)
 	if err != nil {
 		t.Fatal(err)
@@ -271,6 +286,137 @@ func TestGenericOutboxLiveFailureInjectionMatrix(t *testing.T) {
 		assertErrorEvidence(t, ctx, adminPool, "contract_rejected", "stored job contract was rejected")
 	})
 
+	t.Run("all-celery production policy defers known rows but terminalizes unknown rows", func(t *testing.T) {
+		resetOutboxTables(t, ctx, adminPool)
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		deferred := normalSeed(85, now)
+		seedOutbox(t, ctx, adminPool, deferred)
+		unknown := normalSeed(86, now)
+		unknown.Kind = "secret.unknown"
+		seedOutbox(t, ctx, adminPool, unknown)
+
+		productionInserter, err := NewRiverInserter(queuePool, "river", productionRegistry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		relay, err := NewRelay(repository, productionInserter, DefaultRelayConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := relay.Step(ctx, now, 10)
+		if err != nil || result.Claimed != 1 || result.Dead != 1 || result.Delivered != 0 {
+			t.Fatalf("Step() = %#v, %v", result, err)
+		}
+		assertOutboxStatus(t, ctx, adminPool, deferred.ID, statusPending, 0)
+		assertOutboxStatus(t, ctx, adminPool, unknown.ID, statusDead, 1)
+	})
+
+	t.Run("celery rollback never reclaims an expired River claim", func(t *testing.T) {
+		resetOutboxTables(t, ctx, adminPool)
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		deferred := normalSeed(96, now)
+		seedOutbox(t, ctx, adminPool, deferred)
+		claim := claimOne(t, ctx, repository, now, time.Second)
+
+		productionInserter, err := NewRiverInserter(queuePool, "river", productionRegistry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		relay, err := NewRelay(repository, productionInserter, DefaultRelayConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := relay.Step(ctx, now.Add(2*time.Second), 1)
+		if err != nil || result != (StepResult{}) {
+			t.Fatalf("Step() = %#v, %v", result, err)
+		}
+
+		var status, claimToken string
+		var attempts int
+		if err := adminPool.QueryRow(ctx, `
+			SELECT status, attempt_count, claim_token::text
+			FROM public.worker_job_outbox WHERE id=$1`, deferred.ID).
+			Scan(&status, &attempts, &claimToken); err != nil {
+			t.Fatal(err)
+		}
+		if status != statusClaimed || attempts != 1 || claimToken != claim.ClaimToken {
+			t.Fatalf("deferred expired claim changed: status=%s attempts=%d claim=%s", status, attempts, claimToken)
+		}
+	})
+
+	for routeIndex, route := range []string{"shadow", "river_canary", "river"} {
+		t.Run("relay claims executable "+route+" route", func(t *testing.T) {
+			resetOutboxTables(t, ctx, adminPool)
+			now := time.Now().UTC().Truncate(time.Microsecond)
+			seed := normalSeed(87+routeIndex, now)
+			seedOutbox(t, ctx, adminPool, seed)
+			routeRegistry := integrationRouteRegistry(productionRegistry, map[string]string{
+				jobcontract.KindHeartbeat: route,
+			})
+			routeInserter, err := NewRiverInserter(queuePool, "river", routeRegistry)
+			if err != nil {
+				t.Fatal(err)
+			}
+			relay, err := NewRelay(repository, routeInserter, DefaultRelayConfig())
+			if err != nil {
+				t.Fatal(err)
+			}
+			result, err := relay.Step(ctx, now, 1)
+			if err != nil || result.Claimed != 1 || result.Delivered != 1 {
+				t.Fatalf("Step() = %#v, %v", result, err)
+			}
+			assertOutboxStatus(t, ctx, adminPool, seed.ID, statusDelivered, 1)
+		})
+	}
+
+	t.Run("relay leaves known celery rows pending while executable and unknown rows converge", func(t *testing.T) {
+		resetOutboxTables(t, ctx, adminPool)
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		executable := normalSeed(82, now)
+		seedOutbox(t, ctx, adminPool, executable)
+		deferred := normalSeed(83, now)
+		deferred.Kind = jobcontract.KindRetentionCleanup
+		deferred.Queue = "retention"
+		deferred.Priority = 3
+		deferred.MaxAttempts = 3
+		seedOutbox(t, ctx, adminPool, deferred)
+		unknown := normalSeed(84, now)
+		unknown.Kind = "secret.unknown"
+		seedOutbox(t, ctx, adminPool, unknown)
+
+		mixedRegistry := integrationRouteRegistry(productionRegistry, map[string]string{
+			jobcontract.KindHeartbeat: "river",
+		})
+		mixedInserter, err := NewRiverInserter(queuePool, "river", mixedRegistry)
+		if err != nil {
+			t.Fatal(err)
+		}
+		relay, err := NewRelay(repository, mixedInserter, DefaultRelayConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := relay.Step(ctx, now, 10)
+		if err != nil || result.Claimed != 2 || result.Delivered != 1 || result.Dead != 1 {
+			t.Fatalf("Step() = %#v, %v", result, err)
+		}
+
+		var status string
+		var attempts int
+		var claimToken, errorCode *string
+		if err := adminPool.QueryRow(ctx, `
+			SELECT status, attempt_count, claim_token::text, last_error_code
+			FROM public.worker_job_outbox WHERE id=$1`, deferred.ID).
+			Scan(&status, &attempts, &claimToken, &errorCode); err != nil {
+			t.Fatal(err)
+		}
+		if status != statusPending || attempts != 0 || claimToken != nil || errorCode != nil {
+			t.Fatalf("deferred celery row was mutated: status=%s attempts=%d claim=%v error=%v",
+				status, attempts, claimToken, errorCode)
+		}
+		assertOutboxStatus(t, ctx, adminPool, executable.ID, statusDelivered, 1)
+		assertOutboxStatus(t, ctx, adminPool, unknown.ID, statusDead, 1)
+	})
+
 	t.Run("driver error is never persisted or returned", func(t *testing.T) {
 		resetOutboxTables(t, ctx, adminPool)
 		now := time.Now().UTC().Truncate(time.Microsecond)
@@ -295,6 +441,28 @@ func TestGenericOutboxLiveFailureInjectionMatrix(t *testing.T) {
 		}
 		if strings.Contains(stored, "secret") || strings.Contains(stored, "postgres://") {
 			t.Fatalf("stored error leaked driver value: %q", stored)
+		}
+	})
+
+	t.Run("failure evidence persistence outage is fatal", func(t *testing.T) {
+		resetOutboxTables(t, ctx, adminPool)
+		now := time.Now().UTC().Truncate(time.Microsecond)
+		seedOutbox(t, ctx, adminPool, normalSeed(95, now))
+		stepCtx, cancelStep := context.WithCancel(ctx)
+		failingInserter := &RiverInserter{
+			client: failingRiverClient{
+				err:          errors.New("driver unavailable"),
+				beforeReturn: cancelStep,
+			},
+			registry: registry,
+		}
+		relay, err := NewRelay(repository, failingInserter, DefaultRelayConfig())
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := relay.Step(stepCtx, now, 1)
+		if !errors.Is(err, ErrUnavailable) || result.Claimed != 1 || result.LeaseLost != 0 || result.Retried != 0 {
+			t.Fatalf("Step() = %#v, %v", result, err)
 		}
 	})
 
@@ -429,6 +597,50 @@ func assertErrorEvidence(t *testing.T, ctx context.Context, pool *pgxpool.Pool, 
 			t.Fatalf("error evidence = %q", value)
 		}
 	}
+}
+
+func assertOutboxStatus(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	id string,
+	wantStatus string,
+	wantAttempts int,
+) {
+	t.Helper()
+	var status string
+	var attempts int
+	if err := pool.QueryRow(ctx, `
+		SELECT status, attempt_count FROM public.worker_job_outbox WHERE id=$1`, id).
+		Scan(&status, &attempts); err != nil {
+		t.Fatal(err)
+	}
+	if status != wantStatus || attempts != wantAttempts {
+		t.Fatalf("outbox %s = status %s attempts %d, want %s/%d", id, status, attempts, wantStatus, wantAttempts)
+	}
+}
+
+func integrationRouteRegistry(
+	production *jobruntime.Registry,
+	routes map[string]string,
+) enumerableRegistry {
+	descriptors := production.Descriptors()
+	byKind := make(map[string]jobruntime.Descriptor, len(descriptors))
+	for index := range descriptors {
+		if route, ok := routes[descriptors[index].Kind]; ok {
+			descriptors[index].Route = route
+			switch route {
+			case "shadow":
+				descriptors[index].MigrationState = "shadow"
+			case "river_canary":
+				descriptors[index].MigrationState = "canary"
+			case "river":
+				descriptors[index].MigrationState = "go_default"
+			}
+		}
+		byKind[descriptors[index].Kind] = descriptors[index]
+	}
+	return enumerableRegistry{descriptors: descriptors, byKind: byKind}
 }
 
 func injectedFault() error { return errors.New("simulated process crash") }

--- a/internal/joboutbox/relay_test.go
+++ b/internal/joboutbox/relay_test.go
@@ -1,0 +1,110 @@
+package joboutbox
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+)
+
+type enumerableRegistry struct {
+	descriptors []jobruntime.Descriptor
+	byKind      map[string]jobruntime.Descriptor
+}
+
+type descriptorOnlyRegistry struct{}
+
+func (descriptorOnlyRegistry) Descriptor(string) (jobruntime.Descriptor, bool) {
+	return jobruntime.Descriptor{}, false
+}
+
+func (registry enumerableRegistry) Descriptor(kind string) (jobruntime.Descriptor, bool) {
+	descriptor, ok := registry.byKind[kind]
+	return descriptor, ok
+}
+
+func (registry enumerableRegistry) Descriptors() []jobruntime.Descriptor {
+	return append([]jobruntime.Descriptor(nil), registry.descriptors...)
+}
+
+func TestDeferredRelayKindsSeparatesKnownCeleryFromExecutableRoutes(t *testing.T) {
+	descriptors := []jobruntime.Descriptor{
+		{Kind: "job.river", Route: "river"},
+		{Kind: "job.celery", Route: "celery"},
+		{Kind: "job.shadow", Route: "shadow"},
+		{Kind: "job.canary", Route: "river_canary"},
+	}
+	registry := enumerableRegistry{descriptors: descriptors, byKind: map[string]jobruntime.Descriptor{}}
+	for _, descriptor := range descriptors {
+		registry.byKind[descriptor.Kind] = descriptor
+	}
+
+	deferred, err := deferredRelayKinds(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deferred) != 1 || deferred[0] != "job.celery" {
+		t.Fatalf("deferredRelayKinds() = %#v", deferred)
+	}
+}
+
+func TestDeferredRelayKindsAllowsAllKnownKindsToRemainOnCelery(t *testing.T) {
+	descriptors := []jobruntime.Descriptor{
+		{Kind: "job.alpha", Route: "celery"},
+		{Kind: "job.beta", Route: "celery"},
+	}
+	registry := enumerableRegistry{descriptors: descriptors, byKind: map[string]jobruntime.Descriptor{}}
+	for _, descriptor := range descriptors {
+		registry.byKind[descriptor.Kind] = descriptor
+	}
+
+	deferred, err := deferredRelayKinds(registry)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(deferred) != 2 || deferred[0] != "job.alpha" || deferred[1] != "job.beta" {
+		t.Fatalf("deferredRelayKinds() = %#v", deferred)
+	}
+}
+
+func TestDeferredRelayKindsFailClosedOnIncompleteEnumeration(t *testing.T) {
+	tests := []enumerableRegistry{
+		{},
+		{
+			descriptors: []jobruntime.Descriptor{{Kind: "job", Route: "river"}},
+			byKind:      map[string]jobruntime.Descriptor{},
+		},
+		{
+			descriptors: []jobruntime.Descriptor{{Kind: "job", Route: "unexpected"}},
+			byKind:      map[string]jobruntime.Descriptor{"job": {Kind: "job", Route: "unexpected"}},
+		},
+	}
+	for index, registry := range tests {
+		if _, err := deferredRelayKinds(registry); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("case %d error = %v", index, err)
+		}
+	}
+}
+
+func TestNewRelayRequiresEnumerableInserterPolicy(t *testing.T) {
+	inserter := &RiverInserter{registry: descriptorOnlyRegistry{}}
+	if _, err := NewRelay(&Repository{}, inserter, DefaultRelayConfig()); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("NewRelay() error = %v", err)
+	}
+}
+
+func TestClassifyRecordOutcomePropagatesPersistenceFailure(t *testing.T) {
+	result := StepResult{}
+	recorded, err := classifyRecordOutcome(ErrUnavailable, &result)
+	if recorded || !errors.Is(err, ErrUnavailable) || result.LeaseLost != 0 {
+		t.Fatalf("classifyRecordOutcome() = recorded %v, error %v, result %#v", recorded, err, result)
+	}
+}
+
+func TestClassifyRecordOutcomeToleratesOnlyLostLease(t *testing.T) {
+	result := StepResult{}
+	recorded, err := classifyRecordOutcome(ErrLeaseLost, &result)
+	if recorded || err != nil || result.LeaseLost != 1 {
+		t.Fatalf("classifyRecordOutcome() = recorded %v, error %v, result %#v", recorded, err, result)
+	}
+}

--- a/internal/joboutbox/repository.go
+++ b/internal/joboutbox/repository.go
@@ -40,9 +40,27 @@ func (repository *Repository) ClaimDue(
 	limit int,
 	leaseDuration time.Duration,
 ) ([]Claim, error) {
+	return repository.claimDueExcept(ctx, now, limit, leaseDuration, nil)
+}
+
+// claimDueExcept atomically claims pending work except immutable known kinds
+// whose checked-in route is not executable. Unknown kinds remain eligible so
+// they cannot accumulate without bounded contract-failure evidence.
+func (repository *Repository) claimDueExcept(
+	ctx context.Context,
+	now time.Time,
+	limit int,
+	leaseDuration time.Duration,
+	deferredKinds []string,
+) ([]Claim, error) {
 	if repository == nil || repository.pool == nil || now.IsZero() || limit < 1 || limit > 100 ||
-		leaseDuration < time.Second || leaseDuration > 15*time.Minute {
+		leaseDuration < time.Second || leaseDuration > 15*time.Minute || len(deferredKinds) > maxRelayPolicyKinds {
 		return nil, ErrInvalidConfiguration
+	}
+	if deferredKinds == nil {
+		// pgx encodes a nil slice as SQL NULL; ALL(NULL) is unknown and would
+		// suppress every candidate instead of applying an empty exclusion.
+		deferredKinds = []string{}
 	}
 	tx, err := repository.pool.Begin(ctx)
 	if err != nil {
@@ -57,6 +75,7 @@ func (repository *Repository) ClaimDue(
 				(status = 'pending' AND scheduled_at <= $1 AND next_attempt_at <= $1)
 				OR (status = 'claimed' AND claim_expires_at <= $1)
 			)
+			AND job_kind <> ALL($4::text[])
 			ORDER BY next_attempt_at, created_at, id
 			FOR UPDATE SKIP LOCKED
 			LIMIT $2
@@ -72,7 +91,7 @@ func (repository *Repository) ClaimDue(
 			updated_at = $1
 		FROM candidates
 		WHERE outbox.id = candidates.id
-		RETURNING `+rowColumns, now.UTC(), limit, now.UTC().Add(leaseDuration))
+		RETURNING `+rowColumns, now.UTC(), limit, now.UTC().Add(leaseDuration), deferredKinds)
 	if err != nil {
 		return nil, ErrUnavailable
 	}

--- a/internal/joboutbox/types.go
+++ b/internal/joboutbox/types.go
@@ -73,6 +73,14 @@ type PolicyRegistry interface {
 	Descriptor(kind string) (jobruntime.Descriptor, bool)
 }
 
+// RelayPolicyRegistry additionally supplies a complete route enumeration.
+// Unknown stored kinds intentionally do not appear in this list: the relay
+// must claim them so contract validation can terminalize them safely.
+type RelayPolicyRegistry interface {
+	PolicyRegistry
+	Descriptors() []jobruntime.Descriptor
+}
+
 type insertFunc func(context.Context, pgx.Tx, Row) (int64, error)
 
 type repositoryFaults struct {

--- a/internal/jobruntime/registry.go
+++ b/internal/jobruntime/registry.go
@@ -167,6 +167,27 @@ func (registry *Registry) Descriptor(kind string) (Descriptor, bool) {
 	return descriptor, ok
 }
 
+// Descriptors returns every registered policy in deterministic kind order.
+// The complete enumeration lets bounded infrastructure such as the outbox
+// relay distinguish known deferred routes from unknown rows that must still
+// be inspected and terminalized.
+func (registry *Registry) Descriptors() []Descriptor {
+	if registry == nil {
+		return nil
+	}
+	kinds := make([]string, 0, len(registry.byKind))
+	for kind := range registry.byKind {
+		kinds = append(kinds, kind)
+	}
+	sort.Strings(kinds)
+	descriptors := make([]Descriptor, 0, len(kinds))
+	for _, kind := range kinds {
+		descriptor, _ := registry.Descriptor(kind)
+		descriptors = append(descriptors, descriptor)
+	}
+	return descriptors
+}
+
 // Profile returns sorted defensive copies of the profile's job policies.
 func (registry *Registry) Profile(profile string) []Descriptor {
 	if registry == nil {

--- a/internal/jobruntime/registry_test.go
+++ b/internal/jobruntime/registry_test.go
@@ -102,6 +102,31 @@ func TestRegistryMigrationPairsFailClosed(t *testing.T) {
 	}
 }
 
+func TestRegistryDescriptorsAreCompleteSortedDefensiveCopies(t *testing.T) {
+	t.Parallel()
+	registry, err := Load("../../contracts/jobs/v1")
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	descriptors := registry.Descriptors()
+	if len(descriptors) != 2 || descriptors[0].Kind != jobcontract.KindHeartbeat ||
+		descriptors[1].Kind != jobcontract.KindRetentionCleanup {
+		t.Fatalf("Descriptors() = %#v", descriptors)
+	}
+	for _, descriptor := range descriptors {
+		if descriptor.Route != "celery" || descriptor.Executable() {
+			t.Fatalf("checked-in production policy became executable: %#v", descriptor)
+		}
+	}
+
+	descriptors[0].SupportedVersions[0] = 99
+	descriptors[0].SensitiveFields = append(descriptors[0].SensitiveFields, "secret")
+	again := registry.Descriptors()
+	if again[0].SupportedVersions[0] != 1 || len(again[0].SensitiveFields) != 0 {
+		t.Fatalf("Descriptors() exposed mutable registry state: %#v", again[0])
+	}
+}
+
 func testContractRegistry() jobcontract.Registry {
 	return jobcontract.Registry{
 		SchemaVersion: 1, ContractFamily: "dev-health.jobs", EnvelopeSchema: "envelope.schema.json",

--- a/internal/platform/shell/shell.go
+++ b/internal/platform/shell/shell.go
@@ -28,11 +28,22 @@ type ConfigureDependencies func(
 	*health.Registry,
 ) ([]lifecycle.Component, error)
 
+// ConfigureDependenciesWithLogger is the optional logger-aware variant of
+// ConfigureDependencies. The logger is the shell-owned JSON logger for this
+// process; commands must not replace it with a separate handler or sink.
+type ConfigureDependenciesWithLogger func(
+	context.Context,
+	config.Config,
+	*health.Registry,
+	*slog.Logger,
+) ([]lifecycle.Component, error)
+
 type Spec struct {
-	Service               string
-	Profiles              []string
-	DefaultProfile        string
-	ConfigureDependencies ConfigureDependencies
+	Service                         string
+	Profiles                        []string
+	DefaultProfile                  string
+	ConfigureDependencies           ConfigureDependencies
+	ConfigureDependenciesWithLogger ConfigureDependenciesWithLogger
 }
 
 type IO struct {
@@ -123,8 +134,25 @@ func Execute(
 	ctx, stop := lifecycle.SignalContext(parent)
 	defer stop()
 	components := []lifecycle.Component{operatorHTTP}
-	if spec.ConfigureDependencies != nil {
-		configured, configureErr := spec.ConfigureDependencies(ctx, cfg, registry)
+	if spec.ConfigureDependencies != nil && spec.ConfigureDependenciesWithLogger != nil {
+		logger.ErrorContext(
+			ctx,
+			"configure runtime dependencies",
+			"error_category",
+			"ambiguous_dependency_configuration",
+		)
+		return 1
+	}
+	if spec.ConfigureDependencies != nil || spec.ConfigureDependenciesWithLogger != nil {
+		var configured []lifecycle.Component
+		var configureErr error
+		if spec.ConfigureDependenciesWithLogger != nil {
+			configured, configureErr = spec.ConfigureDependenciesWithLogger(
+				ctx, cfg, registry, logger,
+			)
+		} else {
+			configured, configureErr = spec.ConfigureDependencies(ctx, cfg, registry)
+		}
 		if configureErr != nil {
 			// Dependency adapters return operational detail to their caller, but the
 			// shell never assumes an arbitrary error is free of DSNs or secrets.

--- a/internal/platform/shell/shell_test.go
+++ b/internal/platform/shell/shell_test.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log/slog"
 	"net"
 	"net/http"
 	"strings"
@@ -98,6 +99,71 @@ func TestDependencyConfigurationFailureIsCategorizedWithoutLoggingErrorText(t *t
 	}
 	if !strings.Contains(combined, "dependency_configuration_failed") {
 		t.Fatalf("dependency failure omitted safe category: %s", combined)
+	}
+}
+
+func TestLoggerAwareDependencyConfigurationReceivesShellJSONLogger(t *testing.T) {
+	t.Parallel()
+
+	var received *slog.Logger
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), Spec{
+		Service: "dev-health-worker",
+		ConfigureDependenciesWithLogger: func(
+			_ context.Context,
+			_ config.Config,
+			_ *health.Registry,
+			logger *slog.Logger,
+		) ([]lifecycle.Component, error) {
+			received = logger
+			logger.Info("dependency logger injected", "logger_injected", true)
+			return nil, errors.New("stop after logger injection")
+		},
+	}, nil, testLookup(nil), IO{Stdout: &stdout, Stderr: &stderr})
+	if code == 0 || received == nil {
+		t.Fatalf("logger-aware dependency configuration code=%d logger=%v", code, received)
+	}
+	if !strings.Contains(stdout.String(), `"logger_injected":true`) {
+		t.Fatalf("logger-aware callback did not use shell JSON logger: %s", stdout.String())
+	}
+}
+
+func TestShellRejectsAmbiguousDependencyCallbacks(t *testing.T) {
+	t.Parallel()
+
+	legacyCalled := false
+	loggerAwareCalled := false
+	var stdout, stderr bytes.Buffer
+	code := Execute(context.Background(), Spec{
+		Service: "dev-health-worker",
+		ConfigureDependencies: func(
+			context.Context,
+			config.Config,
+			*health.Registry,
+		) ([]lifecycle.Component, error) {
+			legacyCalled = true
+			return nil, nil
+		},
+		ConfigureDependenciesWithLogger: func(
+			context.Context,
+			config.Config,
+			*health.Registry,
+			*slog.Logger,
+		) ([]lifecycle.Component, error) {
+			loggerAwareCalled = true
+			return nil, nil
+		},
+	}, nil, testLookup(nil), IO{Stdout: &stdout, Stderr: &stderr})
+	if code == 0 || legacyCalled || loggerAwareCalled {
+		t.Fatalf(
+			"ambiguous callbacks code=%d legacy=%v logger-aware=%v",
+			code,
+			legacyCalled,
+			loggerAwareCalled,
+		)
+	}
+	if !strings.Contains(stdout.String()+stderr.String(), "ambiguous_dependency_configuration") {
+		t.Fatalf("ambiguous callback failure was not categorized: %s", stdout.String()+stderr.String())
 	}
 }
 

--- a/internal/scheduler/sync/cron.go
+++ b/internal/scheduler/sync/cron.go
@@ -1,0 +1,429 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"strconv"
+	"strings"
+	"time"
+)
+
+const maximumCronSearchMinutes = 5 * 366 * 24 * 60
+
+type cronSpec struct {
+	minute  field
+	hour    field
+	day     dayOfMonthField
+	month   field
+	weekDay dayOfWeekField
+}
+
+type field struct {
+	values   map[int]struct{}
+	wildcard bool
+}
+
+type dayOfMonthField struct {
+	field
+	last           bool
+	nearestWeekday int
+}
+
+type dayOfWeekField struct {
+	field
+	nthWeekday  int
+	nth         int
+	lastWeekday int
+}
+
+// NextOccurrence implements the five-field, local-wall-clock portion of the
+// croniter contract used by Python. It intentionally accepts only five fields:
+// the shadow's input boundary is narrower than croniter's optional sixth and
+// seventh fields, whose interpretation differs across cron libraries.
+func NextOccurrence(expression string, base time.Time, timezoneName string) (time.Time, bool, error) {
+	return nextOccurrenceContext(context.Background(), expression, base, timezoneName)
+}
+
+func nextOccurrenceContext(
+	ctx context.Context,
+	expression string,
+	base time.Time,
+	timezoneName string,
+) (time.Time, bool, error) {
+	if ctx == nil {
+		return time.Time{}, false, fmt.Errorf("cron evaluation context is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return time.Time{}, false, err
+	}
+	spec, err := parseCron(expression)
+	if err != nil {
+		return time.Time{}, false, err
+	}
+	location, fallback := scheduleLocation(timezoneName)
+	base = base.UTC()
+	localBase := base.In(location)
+	wall := time.Date(
+		localBase.Year(), localBase.Month(), localBase.Day(), localBase.Hour(), localBase.Minute(), 0, 0, time.UTC,
+	).Add(time.Minute)
+	for minute := 0; minute < maximumCronSearchMinutes; minute++ {
+		if minute%1024 == 0 {
+			if err := ctx.Err(); err != nil {
+				return time.Time{}, fallback, err
+			}
+		}
+		if spec.matches(wall) {
+			return localWallClockToUTC(wall, location), fallback, nil
+		}
+		wall = wall.Add(time.Minute)
+	}
+	return time.Time{}, fallback, fmt.Errorf("cron occurrence exceeds search horizon")
+}
+
+func scheduleLocation(name string) (*time.Location, bool) {
+	if name == "" {
+		return time.UTC, false
+	}
+	// time.LoadLocation has a process-local "Local" pseudo-zone, but Python's
+	// ZoneInfo("Local") rejects it. Preserve the Python fallback contract.
+	if name == "Local" {
+		return time.UTC, true
+	}
+	location, err := time.LoadLocation(name)
+	if err != nil {
+		return time.UTC, true
+	}
+	return location, false
+}
+
+func parseCron(expression string) (cronSpec, error) {
+	parts := strings.Fields(expression)
+	if len(parts) != 5 {
+		return cronSpec{}, fmt.Errorf("cron expression must have exactly five fields")
+	}
+	minute, err := parseField(parts[0], 0, 59, nil)
+	if err != nil {
+		return cronSpec{}, err
+	}
+	hour, err := parseField(parts[1], 0, 23, nil)
+	if err != nil {
+		return cronSpec{}, err
+	}
+	day, err := parseDayOfMonthField(parts[2])
+	if err != nil {
+		return cronSpec{}, err
+	}
+	month, err := parseField(parts[3], 1, 12, monthNames)
+	if err != nil {
+		return cronSpec{}, err
+	}
+	weekDay, err := parseDayOfWeekField(parts[4])
+	if err != nil {
+		return cronSpec{}, err
+	}
+	return cronSpec{minute: minute, hour: hour, day: day, month: month, weekDay: weekDay}, nil
+}
+
+var monthNames = map[string]int{
+	"jan": 1, "feb": 2, "mar": 3, "apr": 4, "may": 5, "jun": 6,
+	"jul": 7, "aug": 8, "sep": 9, "oct": 10, "nov": 11, "dec": 12,
+}
+
+var weekDayNames = map[string]int{
+	"sun": 0, "mon": 1, "tue": 2, "wed": 3, "thu": 4, "fri": 5, "sat": 6,
+}
+
+func parseField(raw string, minimum, maximum int, aliases map[string]int) (field, error) {
+	result := field{values: make(map[int]struct{})}
+	if raw == "*" {
+		result.wildcard = true
+		for value := minimum; value <= maximum; value++ {
+			result.values[value] = struct{}{}
+		}
+		return result, nil
+	}
+	for _, term := range strings.Split(strings.ToLower(raw), ",") {
+		if term == "" {
+			return field{}, fmt.Errorf("cron field has an empty list term")
+		}
+		base, step, hasStep, err := parseStep(term)
+		if err != nil {
+			return field{}, err
+		}
+		start, end, err := parseRange(base, minimum, maximum, aliases)
+		if err != nil {
+			return field{}, err
+		}
+		if !hasStep {
+			step = 1
+		} else if base != "*" && !strings.Contains(base, "-") {
+			// croniter interprets value/step as value-max/step, not a
+			// singleton. For example 5/15 means 5,20,35,50.
+			end = maximum
+		}
+		values := rangeValues(start, end, minimum, maximum)
+		for index := 0; index < len(values); index += step {
+			result.values[values[index]] = struct{}{}
+		}
+	}
+	return result, nil
+}
+
+func parseDayOfMonthField(raw string) (dayOfMonthField, error) {
+	normalized := strings.ToLower(raw)
+	if normalized == "?" {
+		wildcard, _ := parseField("*", 1, 31, nil)
+		return dayOfMonthField{field: wildcard}, nil
+	}
+	if normalized == "l" {
+		return dayOfMonthField{field: field{values: make(map[int]struct{})}, last: true}, nil
+	}
+	if strings.HasSuffix(normalized, "w") {
+		if strings.ContainsAny(normalized, ",-/") || normalized == "lw" {
+			return dayOfMonthField{}, fmt.Errorf("nearest weekday requires one day value")
+		}
+		value, err := parseValue(strings.TrimSuffix(normalized, "w"), 1, 31, nil)
+		if err != nil {
+			return dayOfMonthField{}, err
+		}
+		return dayOfMonthField{
+			field:          field{values: make(map[int]struct{})},
+			nearestWeekday: value,
+		}, nil
+	}
+	parsed, err := parseField(normalized, 1, 31, nil)
+	return dayOfMonthField{field: parsed}, err
+}
+
+func parseDayOfWeekField(raw string) (dayOfWeekField, error) {
+	normalized := strings.ToLower(raw)
+	if normalized == "?" {
+		wildcard, _ := parseField("*", 0, 7, weekDayNames)
+		normalizeSunday(&wildcard)
+		return dayOfWeekField{field: wildcard}, nil
+	}
+	if strings.HasPrefix(normalized, "l") && len(normalized) > 1 {
+		if strings.ContainsAny(normalized[1:], ",-/#") {
+			return dayOfWeekField{}, fmt.Errorf("last weekday requires one weekday value")
+		}
+		value, err := strconv.Atoi(normalized[1:])
+		if err != nil || value < 0 || value > 7 {
+			return dayOfWeekField{}, fmt.Errorf("invalid last weekday %q", raw)
+		}
+		if value == 7 {
+			value = 0
+		}
+		return dayOfWeekField{
+			field:       field{values: make(map[int]struct{})},
+			lastWeekday: value + 1,
+		}, nil
+	}
+	if strings.Contains(normalized, "#") {
+		parts := strings.Split(normalized, "#")
+		if len(parts) != 2 || strings.ContainsAny(parts[0], ",-/") {
+			return dayOfWeekField{}, fmt.Errorf("nth weekday requires one weekday value")
+		}
+		weekday, err := parseValue(parts[0], 0, 7, weekDayNames)
+		if err != nil {
+			return dayOfWeekField{}, err
+		}
+		nth, err := strconv.Atoi(parts[1])
+		if err != nil || nth < 1 || nth > 5 {
+			return dayOfWeekField{}, fmt.Errorf("invalid nth weekday %q", raw)
+		}
+		if weekday == 7 {
+			weekday = 0
+		}
+		return dayOfWeekField{
+			field:      field{values: make(map[int]struct{})},
+			nthWeekday: weekday + 1,
+			nth:        nth,
+		}, nil
+	}
+	parsed, err := parseField(normalized, 0, 7, weekDayNames)
+	if err != nil {
+		return dayOfWeekField{}, err
+	}
+	normalizeSunday(&parsed)
+	return dayOfWeekField{field: parsed}, nil
+}
+
+func normalizeSunday(parsed *field) {
+	if _, sunday := parsed.values[7]; sunday {
+		delete(parsed.values, 7)
+		parsed.values[0] = struct{}{}
+	}
+}
+
+func parseStep(term string) (string, int, bool, error) {
+	parts := strings.Split(term, "/")
+	if len(parts) == 1 {
+		return term, 0, false, nil
+	}
+	if len(parts) != 2 || parts[0] == "" || parts[1] == "" {
+		return "", 0, false, fmt.Errorf("invalid cron step %q", term)
+	}
+	step, err := strconv.Atoi(parts[1])
+	if err != nil || step <= 0 {
+		return "", 0, false, fmt.Errorf("invalid cron step %q", term)
+	}
+	return parts[0], step, true, nil
+}
+
+func parseRange(raw string, minimum, maximum int, aliases map[string]int) (int, int, error) {
+	if raw == "*" {
+		return minimum, maximum, nil
+	}
+	parts := strings.Split(raw, "-")
+	if len(parts) == 1 {
+		value, err := parseValue(parts[0], minimum, maximum, aliases)
+		return value, value, err
+	}
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid cron range %q", raw)
+	}
+	start, err := parseValue(parts[0], minimum, maximum, aliases)
+	if err != nil {
+		return 0, 0, err
+	}
+	end, err := parseValue(parts[1], minimum, maximum, aliases)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid cron range %q", raw)
+	}
+	return start, end, nil
+}
+
+func rangeValues(start, end, minimum, maximum int) []int {
+	if start <= end {
+		result := make([]int, 0, end-start+1)
+		for value := start; value <= end; value++ {
+			result = append(result, value)
+		}
+		return result
+	}
+	result := make([]int, 0, maximum-start+1+end-minimum+1)
+	for value := start; value <= maximum; value++ {
+		result = append(result, value)
+	}
+	for value := minimum; value <= end; value++ {
+		result = append(result, value)
+	}
+	return result
+}
+
+func parseValue(raw string, minimum, maximum int, aliases map[string]int) (int, error) {
+	if aliases != nil {
+		if value, ok := aliases[raw]; ok {
+			return value, nil
+		}
+	}
+	value, err := strconv.Atoi(raw)
+	if err != nil || value < minimum || value > maximum {
+		return 0, fmt.Errorf("invalid cron value %q", raw)
+	}
+	return value, nil
+}
+
+func (spec cronSpec) matches(wall time.Time) bool {
+	if !contains(spec.minute, wall.Minute()) || !contains(spec.hour, wall.Hour()) ||
+		!contains(spec.month, int(wall.Month())) {
+		return false
+	}
+	dayMatches := spec.day.matches(wall)
+	weekDayMatches := spec.weekDay.matches(wall)
+	// croniter follows traditional cron: when both day-of-month and day-of-week
+	// are restricted, either may match; a wildcard field is ignored.
+	switch {
+	case spec.day.wildcard && spec.weekDay.wildcard:
+		return true
+	case spec.day.wildcard:
+		return weekDayMatches
+	case spec.weekDay.wildcard:
+		return dayMatches
+	default:
+		return dayMatches || weekDayMatches
+	}
+}
+
+func (field dayOfMonthField) matches(wall time.Time) bool {
+	switch {
+	case field.last:
+		return wall.Day() == daysInMonth(wall.Year(), wall.Month())
+	case field.nearestWeekday != 0:
+		return wall.Day() == nearestWeekday(wall.Year(), wall.Month(), field.nearestWeekday)
+	default:
+		return contains(field.field, wall.Day())
+	}
+}
+
+func (field dayOfWeekField) matches(wall time.Time) bool {
+	weekday := int(wall.Weekday())
+	switch {
+	case field.nth != 0:
+		return weekday == field.nthWeekday-1 && (wall.Day()-1)/7+1 == field.nth
+	case field.lastWeekday != 0:
+		return weekday == field.lastWeekday-1 && wall.AddDate(0, 0, 7).Month() != wall.Month()
+	default:
+		return contains(field.field, weekday)
+	}
+}
+
+func daysInMonth(year int, month time.Month) int {
+	return time.Date(year, month+1, 0, 0, 0, 0, 0, time.UTC).Day()
+}
+
+func nearestWeekday(year int, month time.Month, requested int) int {
+	last := daysInMonth(year, month)
+	if requested > last {
+		requested = last
+	}
+	weekday := time.Date(year, month, requested, 0, 0, 0, 0, time.UTC).Weekday()
+	switch weekday {
+	case time.Saturday:
+		if requested == 1 {
+			return 3
+		}
+		return requested - 1
+	case time.Sunday:
+		if requested == last {
+			return requested - 2
+		}
+		return requested + 1
+	default:
+		return requested
+	}
+}
+
+func contains(field field, value int) bool {
+	_, ok := field.values[value]
+	return ok
+}
+
+// localWallClockToUTC reproduces Python's naive-local + ZoneInfo(fold=0)
+// conversion. Ambiguous fall-back times choose the earlier instant. A
+// nonexistent spring-forward wall time uses the pre-transition offset, which
+// yields the same single post-gap UTC instant as the Python helper.
+func localWallClockToUTC(wall time.Time, location *time.Location) time.Time {
+	naiveUTC := time.Date(wall.Year(), wall.Month(), wall.Day(), wall.Hour(), wall.Minute(), 0, 0, time.UTC)
+	offsets := make(map[int]struct{})
+	for hour := -48; hour <= 48; hour++ {
+		_, offset := naiveUTC.Add(time.Duration(hour) * time.Hour).In(location).Zone()
+		offsets[offset] = struct{}{}
+	}
+	var selected time.Time
+	for offset := range offsets {
+		candidate := naiveUTC.Add(-time.Duration(offset) * time.Second)
+		local := candidate.In(location)
+		if local.Year() == wall.Year() && local.Month() == wall.Month() && local.Day() == wall.Day() && local.Hour() == wall.Hour() && local.Minute() == wall.Minute() && (selected.IsZero() || candidate.Before(selected)) {
+			selected = candidate
+		}
+	}
+	if !selected.IsZero() {
+		return selected.UTC()
+	}
+	// No instant round-trips during a spring-forward gap. Python's fold=0
+	// construction uses the offset immediately before the gap.
+	prior := localWallClockToUTC(wall.Add(-time.Minute), location)
+	_, offset := prior.In(location).Zone()
+	return naiveUTC.Add(-time.Duration(offset) * time.Second).UTC()
+}

--- a/internal/scheduler/sync/cron.go
+++ b/internal/scheduler/sync/cron.go
@@ -29,11 +29,15 @@ type dayOfMonthField struct {
 	nearestWeekday int
 }
 
+type dayOfWeekClause struct {
+	weekday int
+	nth     int
+	last    bool
+}
+
 type dayOfWeekField struct {
 	field
-	nthWeekday  int
-	nth         int
-	lastWeekday int
+	clauses []dayOfWeekClause
 }
 
 // NextOccurrence implements the five-field, local-wall-clock portion of the
@@ -101,6 +105,9 @@ func parseCron(expression string) (cronSpec, error) {
 	if len(parts) != 5 {
 		return cronSpec{}, fmt.Errorf("cron expression must have exactly five fields")
 	}
+	if hasRandomCronField(parts) {
+		return cronSpec{}, ErrUnsupportedRandomCron
+	}
 	minute, err := parseField(parts[0], 0, 59, nil)
 	if err != nil {
 		return cronSpec{}, err
@@ -122,6 +129,19 @@ func parseCron(expression string) (cronSpec, error) {
 		return cronSpec{}, err
 	}
 	return cronSpec{minute: minute, hour: hour, day: day, month: month, weekDay: weekDay}, nil
+}
+
+func hasRandomCronField(parts []string) bool {
+	for _, part := range parts {
+		for _, term := range strings.Split(strings.ToLower(part), ",") {
+			base := strings.SplitN(term, "/", 2)[0]
+			if base == "r" ||
+				(strings.HasPrefix(base, "r(") && strings.HasSuffix(base, ")")) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 var monthNames = map[string]int{
@@ -175,9 +195,6 @@ func parseDayOfMonthField(raw string) (dayOfMonthField, error) {
 		wildcard, _ := parseField("*", 1, 31, nil)
 		return dayOfMonthField{field: wildcard}, nil
 	}
-	if normalized == "l" {
-		return dayOfMonthField{field: field{values: make(map[int]struct{})}, last: true}, nil
-	}
 	if strings.HasSuffix(normalized, "w") {
 		if strings.ContainsAny(normalized, ",-/") || normalized == "lw" {
 			return dayOfMonthField{}, fmt.Errorf("nearest weekday requires one day value")
@@ -191,8 +208,22 @@ func parseDayOfMonthField(raw string) (dayOfMonthField, error) {
 			nearestWeekday: value,
 		}, nil
 	}
-	parsed, err := parseField(normalized, 1, 31, nil)
-	return dayOfMonthField{field: parsed}, err
+	result := dayOfMonthField{field: field{values: make(map[int]struct{})}}
+	for _, term := range strings.Split(normalized, ",") {
+		if term == "l" {
+			result.last = true
+			continue
+		}
+		parsed, err := parseField(term, 1, 31, nil)
+		if err != nil {
+			return dayOfMonthField{}, err
+		}
+		result.wildcard = result.wildcard || parsed.wildcard
+		for value := range parsed.values {
+			result.values[value] = struct{}{}
+		}
+	}
+	return result, nil
 }
 
 func parseDayOfWeekField(raw string) (dayOfWeekField, error) {
@@ -202,50 +233,105 @@ func parseDayOfWeekField(raw string) (dayOfWeekField, error) {
 		normalizeSunday(&wildcard)
 		return dayOfWeekField{field: wildcard}, nil
 	}
-	if strings.HasPrefix(normalized, "l") && len(normalized) > 1 {
-		if strings.ContainsAny(normalized[1:], ",-/#") {
-			return dayOfWeekField{}, fmt.Errorf("last weekday requires one weekday value")
-		}
-		value, err := strconv.Atoi(normalized[1:])
-		if err != nil || value < 0 || value > 7 {
-			return dayOfWeekField{}, fmt.Errorf("invalid last weekday %q", raw)
-		}
-		if value == 7 {
-			value = 0
-		}
-		return dayOfWeekField{
-			field:       field{values: make(map[int]struct{})},
-			lastWeekday: value + 1,
-		}, nil
+	if strings.Contains(normalized, "?") {
+		return dayOfWeekField{}, fmt.Errorf("question mark cannot be combined with other weekday terms")
 	}
-	if strings.Contains(normalized, "#") {
-		parts := strings.Split(normalized, "#")
-		if len(parts) != 2 || strings.ContainsAny(parts[0], ",-/") {
-			return dayOfWeekField{}, fmt.Errorf("nth weekday requires one weekday value")
+	result := dayOfWeekField{field: field{values: make(map[int]struct{})}}
+	var ordinaryTerms []string
+	for _, term := range strings.Split(normalized, ",") {
+		switch {
+		case strings.HasPrefix(term, "l") && len(term) > 1:
+			if strings.ContainsAny(term[1:], "-/#") {
+				return dayOfWeekField{}, fmt.Errorf("last weekday requires one weekday value")
+			}
+			value, err := strconv.Atoi(term[1:])
+			if err != nil || value < 0 || value > 7 {
+				return dayOfWeekField{}, fmt.Errorf("invalid last weekday %q", term)
+			}
+			if value == 7 {
+				value = 0
+			}
+			result.clauses = append(result.clauses, dayOfWeekClause{weekday: value, last: true})
+		case strings.Contains(term, "#"):
+			parts := strings.Split(term, "#")
+			if len(parts) != 2 || strings.ContainsAny(parts[0], "-/") {
+				return dayOfWeekField{}, fmt.Errorf("nth weekday requires one weekday value")
+			}
+			weekday, err := parseValue(parts[0], 0, 7, weekDayNames)
+			if err != nil {
+				return dayOfWeekField{}, err
+			}
+			nth, err := strconv.Atoi(parts[1])
+			if err != nil || nth < 1 || nth > 5 {
+				return dayOfWeekField{}, fmt.Errorf("invalid nth weekday %q", term)
+			}
+			if weekday == 7 {
+				weekday = 0
+			}
+			result.clauses = append(result.clauses, dayOfWeekClause{weekday: weekday, nth: nth})
+		default:
+			ordinaryTerms = append(ordinaryTerms, term)
 		}
-		weekday, err := parseValue(parts[0], 0, 7, weekDayNames)
-		if err != nil {
-			return dayOfWeekField{}, err
-		}
-		nth, err := strconv.Atoi(parts[1])
-		if err != nil || nth < 1 || nth > 5 {
-			return dayOfWeekField{}, fmt.Errorf("invalid nth weekday %q", raw)
-		}
-		if weekday == 7 {
-			weekday = 0
-		}
-		return dayOfWeekField{
-			field:      field{values: make(map[int]struct{})},
-			nthWeekday: weekday + 1,
-			nth:        nth,
-		}, nil
 	}
-	parsed, err := parseField(normalized, 0, 7, weekDayNames)
+	if len(result.clauses) > 0 {
+		for _, term := range ordinaryTerms {
+			// Croniter ignores a plain wildcard alongside nth/last clauses,
+			// but rejects all ordinary literal/range/step mixtures.
+			if term != "*" {
+				return dayOfWeekField{}, fmt.Errorf("weekday literals cannot be mixed with nth or last clauses")
+			}
+		}
+		return result, nil
+	}
+	parsed, err := parseDayOfWeekOrdinaryField(normalized)
 	if err != nil {
 		return dayOfWeekField{}, err
 	}
-	normalizeSunday(&parsed)
 	return dayOfWeekField{field: parsed}, nil
+}
+
+func parseDayOfWeekOrdinaryField(raw string) (field, error) {
+	result := field{values: make(map[int]struct{}), wildcard: raw == "*"}
+	for _, term := range strings.Split(raw, ",") {
+		if term == "" {
+			return field{}, fmt.Errorf("cron field has an empty list term")
+		}
+		base, step, hasStep, err := parseStep(term)
+		if err != nil {
+			return field{}, err
+		}
+		start, end, err := parseRange(base, 0, 7, weekDayNames)
+		if err != nil {
+			return field{}, err
+		}
+		if !hasStep {
+			step = 1
+		} else if base != "*" && !strings.Contains(base, "-") {
+			end = 7
+		}
+		values := canonicalWeekdayRange(start, end)
+		for index := 0; index < len(values); index += step {
+			result.values[values[index]] = struct{}{}
+		}
+	}
+	return result, nil
+}
+
+func canonicalWeekdayRange(start, end int) []int {
+	raw := rangeValues(start, end, 0, 7)
+	result := make([]int, 0, len(raw))
+	seen := make(map[int]struct{}, 7)
+	for _, value := range raw {
+		if value == 7 {
+			value = 0
+		}
+		if _, duplicate := seen[value]; duplicate {
+			continue
+		}
+		seen[value] = struct{}{}
+		result = append(result, value)
+	}
+	return result
 }
 
 func normalizeSunday(parsed *field) {
@@ -346,26 +432,33 @@ func (spec cronSpec) matches(wall time.Time) bool {
 }
 
 func (field dayOfMonthField) matches(wall time.Time) bool {
-	switch {
-	case field.last:
-		return wall.Day() == daysInMonth(wall.Year(), wall.Month())
-	case field.nearestWeekday != 0:
-		return wall.Day() == nearestWeekday(wall.Year(), wall.Month(), field.nearestWeekday)
-	default:
-		return contains(field.field, wall.Day())
+	if contains(field.field, wall.Day()) {
+		return true
 	}
+	if field.last && wall.Day() == daysInMonth(wall.Year(), wall.Month()) {
+		return true
+	}
+	return field.nearestWeekday != 0 &&
+		wall.Day() == nearestWeekday(wall.Year(), wall.Month(), field.nearestWeekday)
 }
 
 func (field dayOfWeekField) matches(wall time.Time) bool {
 	weekday := int(wall.Weekday())
-	switch {
-	case field.nth != 0:
-		return weekday == field.nthWeekday-1 && (wall.Day()-1)/7+1 == field.nth
-	case field.lastWeekday != 0:
-		return weekday == field.lastWeekday-1 && wall.AddDate(0, 0, 7).Month() != wall.Month()
-	default:
-		return contains(field.field, weekday)
+	if contains(field.field, weekday) {
+		return true
 	}
+	for _, clause := range field.clauses {
+		if weekday != clause.weekday {
+			continue
+		}
+		if clause.last && wall.AddDate(0, 0, 7).Month() != wall.Month() {
+			return true
+		}
+		if clause.nth != 0 && (wall.Day()-1)/7+1 == clause.nth {
+			return true
+		}
+	}
+	return false
 }
 
 func daysInMonth(year int, month time.Month) int {

--- a/internal/scheduler/sync/cron.go
+++ b/internal/scheduler/sync/cron.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-const maximumCronSearchMinutes = 5 * 366 * 24 * 60
+const maximumCronSearchMinutes = 50 * 366 * 24 * 60
 
 type cronSpec struct {
 	minute  field
@@ -40,10 +40,10 @@ type dayOfWeekField struct {
 	clauses []dayOfWeekClause
 }
 
-// NextOccurrence implements the five-field, local-wall-clock portion of the
-// croniter contract used by Python. It intentionally accepts only five fields:
-// the shadow's input boundary is narrower than croniter's optional sixth and
-// seventh fields, whose interpretation differs across cron libraries.
+// NextOccurrence implements the versioned deterministic five-field,
+// local-wall-clock subset of the Croniter contract used by Python. Random R
+// expressions, mixed auxiliary W/nth/last DOM-DOW expressions, and optional
+// sixth/seventh fields are outside this shadow-comparison boundary.
 func NextOccurrence(expression string, base time.Time, timezoneName string) (time.Time, bool, error) {
 	return nextOccurrenceContext(context.Background(), expression, base, timezoneName)
 }
@@ -103,9 +103,17 @@ func scheduleLocation(name string) (*time.Location, bool) {
 func parseCron(expression string) (cronSpec, error) {
 	parts := strings.Fields(expression)
 	if len(parts) != 5 {
+		if len(parts) == 6 || len(parts) == 7 ||
+			len(parts) == 1 && strings.HasPrefix(strings.ToLower(parts[0]), "@") {
+			return cronSpec{}, ErrUnsupportedCron
+		}
 		return cronSpec{}, fmt.Errorf("cron expression must have exactly five fields")
 	}
-	if hasRandomCronField(parts) {
+	random, err := hasRandomCronField(parts)
+	if err != nil {
+		return cronSpec{}, err
+	}
+	if random {
 		return cronSpec{}, ErrUnsupportedRandomCron
 	}
 	minute, err := parseField(parts[0], 0, 59, nil)
@@ -128,20 +136,44 @@ func parseCron(expression string) (cronSpec, error) {
 	if err != nil {
 		return cronSpec{}, err
 	}
+	// Croniter retains auxiliary W/nth/last state while internally evaluating
+	// DOM/DOW union branches. Mixed restricted fields therefore have surprising
+	// conjunction and search-failure behavior. Keep them outside this
+	// deterministic subset instead of returning a false timing decision.
+	if day.nearestWeekday != 0 && !weekDay.wildcard ||
+		len(weekDay.clauses) > 0 && !day.wildcard {
+		return cronSpec{}, ErrUnsupportedCron
+	}
 	return cronSpec{minute: minute, hour: hour, day: day, month: month, weekDay: weekDay}, nil
 }
 
-func hasRandomCronField(parts []string) bool {
-	for _, part := range parts {
-		for _, term := range strings.Split(strings.ToLower(part), ",") {
-			base := strings.SplitN(term, "/", 2)[0]
-			if base == "r" ||
-				(strings.HasPrefix(base, "r(") && strings.HasSuffix(base, ")")) {
-				return true
+func hasRandomCronField(parts []string) (bool, error) {
+	ranges := [][2]int{{0, 59}, {0, 23}, {1, 31}, {1, 12}, {0, 7}}
+	for fieldIndex, part := range parts {
+		base, _, _, err := parseStep(strings.ToLower(part))
+		if err != nil {
+			continue
+		}
+		if base == "r" {
+			return true, nil
+		}
+		if !strings.HasPrefix(base, "r(") || !strings.HasSuffix(base, ")") {
+			continue
+		}
+		bounds := strings.Split(strings.TrimSuffix(strings.TrimPrefix(base, "r("), ")"), "-")
+		if len(bounds) != 2 {
+			continue
+		}
+		start, startErr := strconv.Atoi(bounds[0])
+		end, endErr := strconv.Atoi(bounds[1])
+		if startErr == nil && endErr == nil && start >= 0 && start < end {
+			if end < ranges[fieldIndex][0] || start > ranges[fieldIndex][1] {
+				return false, fmt.Errorf("random cron range is outside field bounds")
 			}
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 var monthNames = map[string]int{
@@ -181,9 +213,9 @@ func parseField(raw string, minimum, maximum int, aliases map[string]int) (field
 			// singleton. For example 5/15 means 5,20,35,50.
 			end = maximum
 		}
-		values := rangeValues(start, end, minimum, maximum)
-		for index := 0; index < len(values); index += step {
-			result.values[values[index]] = struct{}{}
+		rangeSyntax := base == "*" || strings.Contains(base, "-") || hasStep
+		for _, value := range rangeValues(start, end, minimum, maximum, step, rangeSyntax) {
+			result.values[value] = struct{}{}
 		}
 	}
 	return result, nil
@@ -195,11 +227,15 @@ func parseDayOfMonthField(raw string) (dayOfMonthField, error) {
 		wildcard, _ := parseField("*", 1, 31, nil)
 		return dayOfMonthField{field: wildcard}, nil
 	}
-	if strings.HasSuffix(normalized, "w") {
+	if strings.HasSuffix(normalized, "w") || strings.HasPrefix(normalized, "w") {
 		if strings.ContainsAny(normalized, ",-/") || normalized == "lw" {
 			return dayOfMonthField{}, fmt.Errorf("nearest weekday requires one day value")
 		}
-		value, err := parseValue(strings.TrimSuffix(normalized, "w"), 1, 31, nil)
+		dayValue := strings.TrimSuffix(normalized, "w")
+		if strings.HasPrefix(normalized, "w") {
+			dayValue = strings.TrimPrefix(normalized, "w")
+		}
+		value, err := parseValue(dayValue, 1, 31, nil)
 		if err != nil {
 			return dayOfMonthField{}, err
 		}
@@ -229,8 +265,7 @@ func parseDayOfMonthField(raw string) (dayOfMonthField, error) {
 func parseDayOfWeekField(raw string) (dayOfWeekField, error) {
 	normalized := strings.ToLower(raw)
 	if normalized == "?" {
-		wildcard, _ := parseField("*", 0, 7, weekDayNames)
-		normalizeSunday(&wildcard)
+		wildcard, _ := parseDayOfWeekOrdinaryField("*")
 		return dayOfWeekField{field: wildcard}, nil
 	}
 	if strings.Contains(normalized, "?") {
@@ -254,7 +289,10 @@ func parseDayOfWeekField(raw string) (dayOfWeekField, error) {
 			result.clauses = append(result.clauses, dayOfWeekClause{weekday: value, last: true})
 		case strings.Contains(term, "#"):
 			parts := strings.Split(term, "#")
-			if len(parts) != 2 || strings.ContainsAny(parts[0], "-/") {
+			if len(parts) == 2 && strings.ContainsAny(parts[0], "-/") {
+				return dayOfWeekField{}, ErrUnsupportedCron
+			}
+			if len(parts) != 2 {
 				return dayOfWeekField{}, fmt.Errorf("nth weekday requires one weekday value")
 			}
 			weekday, err := parseValue(parts[0], 0, 7, weekDayNames)
@@ -275,10 +313,15 @@ func parseDayOfWeekField(raw string) (dayOfWeekField, error) {
 	}
 	if len(result.clauses) > 0 {
 		for _, term := range ordinaryTerms {
-			// Croniter ignores a plain wildcard alongside nth/last clauses,
-			// but rejects all ordinary literal/range/step mixtures.
-			if term != "*" {
-				return dayOfWeekField{}, fmt.Errorf("weekday literals cannot be mixed with nth or last clauses")
+			ordinary, err := parseDayOfWeekOrdinaryField(term)
+			if err != nil {
+				return dayOfWeekField{}, err
+			}
+			// Croniter permits ordinary terms alongside nth/last clauses only
+			// when each term independently expands to the complete seven-day
+			// cycle. A redundant partial term such as "*,5,1#1" is rejected.
+			if len(ordinary.values) != 7 {
+				return dayOfWeekField{}, ErrUnsupportedCron
 			}
 		}
 		return result, nil
@@ -296,49 +339,59 @@ func parseDayOfWeekOrdinaryField(raw string) (field, error) {
 		if term == "" {
 			return field{}, fmt.Errorf("cron field has an empty list term")
 		}
+		// Croniter preserves a literal "*" as wildcard syntax even when it is
+		// accompanied by redundant list terms. A full numeric expansion such
+		// as "*/1,5" remains restricted for DOM/DOW union semantics.
+		if term == "*" {
+			result.wildcard = true
+		}
 		base, step, hasStep, err := parseStep(term)
 		if err != nil {
 			return field{}, err
 		}
-		start, end, err := parseRange(base, 0, 7, weekDayNames)
+		start, end, err := parseDayOfWeekRange(base)
 		if err != nil {
 			return field{}, err
 		}
 		if !hasStep {
 			step = 1
 		} else if base != "*" && !strings.Contains(base, "-") {
-			end = 7
+			end = 6
 		}
-		values := canonicalWeekdayRange(start, end)
-		for index := 0; index < len(values); index += step {
-			result.values[values[index]] = struct{}{}
+		rangeSyntax := base == "*" || strings.Contains(base, "-") || hasStep
+		for _, value := range rangeValues(start, end, 0, 6, step, rangeSyntax) {
+			result.values[value] = struct{}{}
 		}
 	}
 	return result, nil
 }
 
-func canonicalWeekdayRange(start, end int) []int {
-	raw := rangeValues(start, end, 0, 7)
-	result := make([]int, 0, len(raw))
-	seen := make(map[int]struct{}, 7)
-	for _, value := range raw {
-		if value == 7 {
-			value = 0
-		}
-		if _, duplicate := seen[value]; duplicate {
-			continue
-		}
-		seen[value] = struct{}{}
-		result = append(result, value)
+func parseDayOfWeekRange(raw string) (int, int, error) {
+	if raw == "*" {
+		return 0, 6, nil
 	}
-	return result
-}
-
-func normalizeSunday(parsed *field) {
-	if _, sunday := parsed.values[7]; sunday {
-		delete(parsed.values, 7)
-		parsed.values[0] = struct{}{}
+	parts := strings.Split(raw, "-")
+	if len(parts) < 1 || len(parts) > 2 {
+		return 0, 0, fmt.Errorf("invalid cron range %q", raw)
 	}
+	start, err := parseValue(parts[0], 0, 7, weekDayNames)
+	if err != nil {
+		return 0, 0, err
+	}
+	end := start
+	if len(parts) == 2 {
+		end, err = parseValue(parts[1], 0, 7, weekDayNames)
+		if err != nil {
+			return 0, 0, fmt.Errorf("invalid cron range %q", raw)
+		}
+	}
+	if start == 7 {
+		start = 0
+	}
+	if end == 7 {
+		end = 0
+	}
+	return start, end, nil
 }
 
 func parseStep(term string) (string, int, bool, error) {
@@ -379,19 +432,40 @@ func parseRange(raw string, minimum, maximum int, aliases map[string]int) (int, 
 	return start, end, nil
 }
 
-func rangeValues(start, end, minimum, maximum int) []int {
-	if start <= end {
-		result := make([]int, 0, end-start+1)
-		for value := start; value <= end; value++ {
+func rangeValues(start, end, minimum, maximum, step int, fullCycleOnEqual bool) []int {
+	if start < end {
+		result := make([]int, 0, (end-start)/step+1)
+		for value := start; value <= end; value += step {
 			result = append(result, value)
 		}
 		return result
 	}
-	result := make([]int, 0, maximum-start+1+end-minimum+1)
-	for value := start; value <= maximum; value++ {
+	if start == end {
+		if !fullCycleOnEqual {
+			return []int{start}
+		}
+		result := make([]int, 0, (maximum-minimum)/step+1)
+		for value := minimum; value <= maximum; value += step {
+			result = append(result, value)
+		}
+		return result
+	}
+
+	result := make([]int, 0, maximum-minimum+1)
+	for value := start; value <= maximum; value += step {
 		result = append(result, value)
 	}
-	for value := minimum; value <= end; value++ {
+	toSkip := 0
+	if len(result) > 0 {
+		last := result[len(result)-1]
+		alreadySkipped := maximum - last
+		currentPosition := last - minimum
+		fieldLength := maximum - minimum + 1
+		if currentPosition+step > fieldLength && alreadySkipped < step {
+			toSkip = step - alreadySkipped
+		}
+	}
+	for value := minimum + toSkip; value <= end; value += step {
 		result = append(result, value)
 	}
 	return result

--- a/internal/scheduler/sync/evaluate.go
+++ b/internal/scheduler/sync/evaluate.go
@@ -31,6 +31,7 @@ func evaluateContext(ctx context.Context, candidate Candidate, observedAt time.T
 		RunningMarker:    RunningNotSet,
 		Timezone:         "UTC",
 		EligibilityScope: ScheduleMarkerEvaluationScope,
+		CronGrammar:      CronGrammarVersion,
 	}
 	if !candidate.Active {
 		result.Decision = DecisionInactive
@@ -80,6 +81,10 @@ func evaluateContext(ctx context.Context, candidate Candidate, observedAt time.T
 	if err != nil {
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return result, err
+		}
+		if errors.Is(err, ErrUnsupportedRandomCron) {
+			result.Decision = DecisionUnsupportedCron
+			return result, nil
 		}
 		result.Decision = DecisionInvalidCron
 		return result, nil

--- a/internal/scheduler/sync/evaluate.go
+++ b/internal/scheduler/sync/evaluate.go
@@ -25,13 +25,13 @@ func evaluateContext(ctx context.Context, candidate Candidate, observedAt time.T
 	}
 	observedAt = observedAt.UTC()
 	result := Evaluation{
-		ConfigID:         candidate.ConfigID,
-		ObservedAt:       observedAt,
-		Decision:         DecisionNotDue,
-		RunningMarker:    RunningNotSet,
-		Timezone:         "UTC",
-		EligibilityScope: ScheduleMarkerEvaluationScope,
-		CronGrammar:      CronGrammarVersion,
+		ConfigID:           candidate.ConfigID,
+		ObservedAt:         observedAt,
+		Decision:           DecisionNotDue,
+		RunningMarker:      RunningNotSet,
+		Timezone:           "UTC",
+		EligibilityScope:   ScheduleMarkerEvaluationScope,
+		CronGrammarVersion: CronGrammarVersion,
 	}
 	if !candidate.Active {
 		result.Decision = DecisionInactive
@@ -82,7 +82,7 @@ func evaluateContext(ctx context.Context, candidate Candidate, observedAt time.T
 		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
 			return result, err
 		}
-		if errors.Is(err, ErrUnsupportedRandomCron) {
+		if errors.Is(err, ErrUnsupportedCron) {
 			result.Decision = DecisionUnsupportedCron
 			return result, nil
 		}

--- a/internal/scheduler/sync/evaluate.go
+++ b/internal/scheduler/sync/evaluate.go
@@ -1,0 +1,110 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Evaluate mirrors the legacy Python scheduler's pure decision gates. It
+// deliberately omits organization and feature checks because those require
+// business services and are not part of this dormant read-only foundation.
+// A true TimingEligible result therefore must never authorize dispatch.
+func Evaluate(candidate Candidate, observedAt time.Time) Evaluation {
+	result, _ := evaluateContext(context.Background(), candidate, observedAt)
+	return result
+}
+
+func evaluateContext(ctx context.Context, candidate Candidate, observedAt time.Time) (Evaluation, error) {
+	if ctx == nil {
+		return Evaluation{}, fmt.Errorf("scheduler evaluation context is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return Evaluation{}, err
+	}
+	observedAt = observedAt.UTC()
+	result := Evaluation{
+		ConfigID:         candidate.ConfigID,
+		ObservedAt:       observedAt,
+		Decision:         DecisionNotDue,
+		RunningMarker:    RunningNotSet,
+		Timezone:         "UTC",
+		EligibilityScope: ScheduleMarkerEvaluationScope,
+	}
+	if !candidate.Active {
+		result.Decision = DecisionInactive
+		return result, nil
+	}
+	if candidate.ScheduleCron == "" {
+		result.Decision = DecisionManual
+		return result, nil
+	}
+
+	cronExpr := candidate.ScheduleCron
+	timezoneName := candidate.ScheduleTZ
+	if candidate.Job != nil {
+		if candidate.Job.Status != activeJobStatus {
+			result.Decision = DecisionInactiveJob
+			return result, nil
+		}
+		cronExpr = candidate.Job.ScheduleCron
+		timezoneName = candidate.Job.Timezone
+		result.RunningMarker = runningMarkerState(candidate.Job, observedAt)
+		if result.RunningMarker == RunningFresh {
+			result.Decision = DecisionFreshRunning
+			return result, nil
+		}
+		// Python's persisted next-run gate precedes cron parsing and due-ness.
+		// This preserves that classification even for malformed cron text or
+		// a cron occurrence that would independently be not due.
+		if candidate.Job.NextRunAt != nil && candidate.Job.NextRunAt.UTC().After(observedAt) {
+			result.Decision = DecisionNextRunGate
+			return result, nil
+		}
+	}
+	if timezoneName != "" {
+		result.Timezone = timezoneName
+	}
+
+	base := candidate.CreatedAt
+	if candidate.LastSyncAt != nil {
+		base = *candidate.LastSyncAt
+	}
+	result.Base = base.UTC()
+	next, fallback, err := nextOccurrenceContext(ctx, cronExpr, result.Base, result.Timezone)
+	result.TimezoneFallback = fallback
+	if fallback {
+		result.Timezone = "UTC"
+	}
+	if err != nil {
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return result, err
+		}
+		result.Decision = DecisionInvalidCron
+		return result, nil
+	}
+	result.NextOccurrence = &next
+	result.Due = !next.After(observedAt)
+	if !result.Due {
+		result.Decision = DecisionNotDue
+		return result, nil
+	}
+	result.TimingEligible = true
+	result.Decision = DecisionScheduleDue
+	return result, nil
+}
+
+func runningMarkerState(job *Job, observedAt time.Time) RunningMarkerState {
+	if job == nil || !job.IsRunning {
+		return RunningNotSet
+	}
+	marker := job.LastRunAt
+	if marker == nil {
+		marker = job.UpdatedAt
+	}
+	if marker == nil || observedAt.Sub(marker.UTC()) > staleRunningTTL {
+		return RunningStale
+	}
+	return RunningFresh
+}

--- a/internal/scheduler/sync/repository.go
+++ b/internal/scheduler/sync/repository.go
@@ -1,0 +1,138 @@
+package sync
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// Repository reads the legacy scheduler tables for shadow comparison only.
+// It does not expose a transaction, lock, claim, or mutation operation.
+type Repository struct{ pool *pgxpool.Pool }
+
+type candidateRows interface {
+	Next() bool
+	Scan(dest ...any) error
+	Err() error
+}
+
+func NewRepository(pool *pgxpool.Pool) (*Repository, error) {
+	if pool == nil {
+		return nil, fmt.Errorf("scheduler shadow repository requires a pool")
+	}
+	return &Repository{pool: pool}, nil
+}
+
+// Snapshot reads one bounded active-config window then evaluates it locally.
+func (repository *Repository) Snapshot(ctx context.Context, observedAt time.Time, limit int) (Snapshot, error) {
+	if ctx == nil {
+		return Snapshot{}, fmt.Errorf("scheduler shadow snapshot context is required")
+	}
+	if repository == nil || repository.pool == nil {
+		return Snapshot{}, fmt.Errorf("scheduler shadow repository is not initialized")
+	}
+	if limit < minimumSnapshotLimit || limit > maximumSnapshotLimit {
+		return Snapshot{}, fmt.Errorf("snapshot limit must be between %d and %d", minimumSnapshotLimit, maximumSnapshotLimit)
+	}
+	rows, err := repository.pool.Query(ctx, schedulerSnapshotSQL, limit+1)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	defer rows.Close()
+	candidates, err := readCandidates(ctx, rows, limit+1)
+	if err != nil {
+		return Snapshot{}, err
+	}
+	return buildSnapshotContext(ctx, observedAt, limit, candidates)
+}
+
+func readCandidates(ctx context.Context, rows candidateRows, capacity int) ([]Candidate, error) {
+	if ctx == nil {
+		return nil, fmt.Errorf("scheduler shadow row-scan context is required")
+	}
+	candidates := make([]Candidate, 0, capacity)
+	for {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if !rows.Next() {
+			break
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		var candidate Candidate
+		var job Job
+		var configCron, configTimezone, jobID, jobCron, jobTimezone *string
+		var jobStatus *int
+		var jobIsRunning *bool
+		var lastSyncAt, lastRunAt, updatedAt, nextRunAt *time.Time
+		if err := rows.Scan(
+			&candidate.ConfigID, &candidate.Active, &configCron, &configTimezone,
+			&lastSyncAt, &candidate.CreatedAt,
+			&jobID, &jobCron, &jobTimezone, &jobStatus, &jobIsRunning,
+			&lastRunAt, &updatedAt, &nextRunAt,
+		); err != nil {
+			return nil, err
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		candidate.LastSyncAt = lastSyncAt
+		if configCron != nil {
+			candidate.ScheduleCron = *configCron
+		}
+		if configTimezone != nil {
+			candidate.ScheduleTZ = *configTimezone
+		}
+		if jobID != nil {
+			if jobCron == nil || jobTimezone == nil || jobStatus == nil || jobIsRunning == nil {
+				return nil, fmt.Errorf("sync job join returned incomplete row")
+			}
+			job.ID, job.ScheduleCron, job.Timezone = *jobID, *jobCron, *jobTimezone
+			job.Status, job.IsRunning = *jobStatus, *jobIsRunning
+			job.LastRunAt, job.UpdatedAt, job.NextRunAt = lastRunAt, updatedAt, nextRunAt
+			candidate.Job = &job
+		}
+		candidates = append(candidates, candidate)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return candidates, nil
+}
+
+// schedulerSnapshotSQL is tied to SyncConfiguration, ScheduledJob, and the
+// PostgreSQL-only uq_scheduled_job_org_sync_config_type uniqueness migration.
+// The join reproduces the Python lookup exactly: same org/config and job_type
+// sync. It intentionally has no transaction modifiers or write statements.
+const schedulerSnapshotSQL = `
+SELECT
+    config.id::text,
+    config.is_active,
+    config.sync_options->>'schedule_cron',
+    config.sync_options->>'timezone',
+    config.last_sync_at,
+    config.created_at,
+    job.id::text,
+    job.schedule_cron,
+    job.timezone,
+    job.status,
+    job.is_running,
+    job.last_run_at,
+    job.updated_at,
+    job.next_run_at
+FROM public.sync_configurations AS config
+LEFT JOIN public.scheduled_jobs AS job
+    ON job.org_id = config.org_id
+    AND job.sync_config_id = config.id
+    AND job.job_type = 'sync'
+WHERE config.is_active = TRUE
+ORDER BY config.id
+LIMIT $1
+`

--- a/internal/scheduler/sync/scheduler_test.go
+++ b/internal/scheduler/sync/scheduler_test.go
@@ -38,6 +38,9 @@ func TestNextOccurrencePythonGoldenVectors(t *testing.T) {
 		{"leap day", "0 0 29 2 *", "UTC", at("2026-03-01T12:00:00Z"), at("2028-02-29T00:00:00Z"), false},
 		{"value step expands through maximum", "5/15 * * * *", "UTC", at("2026-01-01T00:05:00Z"), at("2026-01-01T00:20:00Z"), false},
 		{"last day of month", "0 0 L * *", "UTC", at("2026-01-10T00:00:00Z"), at("2026-01-31T00:00:00Z"), false},
+		{"last day mixed after literal", "0 0 1,L * *", "UTC", at("2026-01-02T00:00:00Z"), at("2026-01-31T00:00:00Z"), false},
+		{"literal after last day", "0 0 1,L * *", "UTC", at("2026-01-31T00:00:00Z"), at("2026-02-01T00:00:00Z"), false},
+		{"last day mixed before literal", "0 0 L,15 * *", "UTC", at("2026-01-15T00:00:00Z"), at("2026-01-31T00:00:00Z"), false},
 		{"nearest weekday", "0 0 15W * *", "UTC", at("2026-02-01T00:00:00Z"), at("2026-02-16T00:00:00Z"), false},
 		{"nearest weekday clamped", "0 0 31W * *", "UTC", at("2026-04-01T00:00:00Z"), at("2026-04-30T00:00:00Z"), false},
 		{"nth named weekday", "0 0 * * MON#1", "UTC", at("2026-01-10T00:00:00Z"), at("2026-02-02T00:00:00Z"), false},
@@ -45,9 +48,14 @@ func TestNextOccurrencePythonGoldenVectors(t *testing.T) {
 		{"last weekday", "0 0 * * L5", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-30T00:00:00Z"), false},
 		{"last sunday zero", "0 0 * * L0", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-25T00:00:00Z"), false},
 		{"last sunday seven", "0 0 * * L7", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-25T00:00:00Z"), false},
+		{"multiple nth weekdays", "0 0 * * MON#1,FRI#2", "UTC", at("2026-01-05T00:00:00Z"), at("2026-01-09T00:00:00Z"), false},
+		{"multiple last weekdays", "0 0 * * L1,L5", "UTC", at("2026-01-26T00:00:00Z"), at("2026-01-30T00:00:00Z"), false},
+		{"mixed last and nth weekdays", "0 0 * * L1,5#2", "UTC", at("2026-01-09T00:00:00Z"), at("2026-01-26T00:00:00Z"), false},
 		{"question-mark wildcards", "0 0 ? * ?", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-02T00:00:00Z"), false},
 		{"wrapped month range", "0 0 * NOV-FEB *", "UTC", at("2026-03-01T00:00:00Z"), at("2026-11-01T00:00:00Z"), false},
 		{"wrapped weekday range", "0 0 * * FRI-MON", "UTC", at("2026-01-05T00:00:00Z"), at("2026-01-09T00:00:00Z"), false},
+		{"wrapped named weekday step dedupes sunday", "0 0 * * FRI-MON/2", "UTC", at("2026-01-04T00:00:00Z"), at("2026-01-09T00:00:00Z"), false},
+		{"wrapped numeric weekday step dedupes sunday", "0 0 * * 6-0/2", "UTC", at("2026-01-03T00:00:00Z"), at("2026-01-10T00:00:00Z"), false},
 		{"named month step", "0 0 * JAN/2 *", "UTC", at("2026-02-01T00:00:00Z"), at("2026-03-01T00:00:00Z"), false},
 		{"named weekday step", "0 0 * * MON/2", "UTC", at("2026-01-05T00:00:00Z"), at("2026-01-07T00:00:00Z"), false},
 	} {
@@ -65,11 +73,17 @@ func TestNextOccurrenceRejectsCroniterInvalidFiveFieldFormsAndExtendedFields(t *
 		"0 0 L-2 * *",
 		"0 0 LW * *",
 		"0 0 1,15W * *",
+		"0 0 L,15W * *",
+		"0 0 ?,L * *",
 		"0 0 * * 5L",
 		"0 0 * * MONL",
 		"0 0 * * MON#6",
+		"0 0 * * 1#1,2",
+		"0 0 * * L1,2",
+		"0 0 * * L1,MON-FRI",
 		"? 0 * * *",
 		"0 ? * * *",
+		"H * * * *",
 		"0 0 * * * 2026",
 		"0 0 * * * 0 2026",
 	} {
@@ -78,6 +92,45 @@ func TestNextOccurrenceRejectsCroniterInvalidFiveFieldFormsAndExtendedFields(t *
 				t.Fatalf("NextOccurrence(%q) accepted invalid expression", expression)
 			}
 		})
+	}
+}
+
+func TestRandomCronIsExplicitlyUnsupported(t *testing.T) {
+	for _, expression := range []string{
+		"R * * * *",
+		"r/5 * * * *",
+		"R(10-20) * * * *",
+		"R(10-20)/5 * * * *",
+		"0 R * * *",
+		"0 0 R * *",
+		"0 0 * R *",
+		"0 0 * * R",
+	} {
+		t.Run(expression, func(t *testing.T) {
+			if _, _, err := NextOccurrence(expression, at("2026-01-01T00:00:00Z"), "UTC"); !errors.Is(err, ErrUnsupportedRandomCron) {
+				t.Fatalf("NextOccurrence(%q) err=%v", expression, err)
+			}
+			got := Evaluate(Candidate{
+				ConfigID:     "random",
+				Active:       true,
+				ScheduleCron: expression,
+				CreatedAt:    at("2026-01-01T00:00:00Z"),
+			}, at("2026-01-02T00:00:00Z"))
+			if got.Decision != DecisionUnsupportedCron || got.TimingEligible ||
+				got.CronGrammar != CronGrammarVersion {
+				t.Fatalf("Evaluate(%q) = %#v", expression, got)
+			}
+		})
+	}
+
+	got := Evaluate(Candidate{
+		ConfigID:     "hashed",
+		Active:       true,
+		ScheduleCron: "H * * * *",
+		CreatedAt:    at("2026-01-01T00:00:00Z"),
+	}, at("2026-01-02T00:00:00Z"))
+	if got.Decision != DecisionInvalidCron {
+		t.Fatalf("hashed cron classification = %#v", got)
 	}
 }
 
@@ -109,6 +162,9 @@ func TestEvaluateDueManualAndRunningMarkers(t *testing.T) {
 			}
 			if got.EligibilityScope != ScheduleMarkerEvaluationScope {
 				t.Fatalf("eligibility scope = %q", got.EligibilityScope)
+			}
+			if got.CronGrammar != CronGrammarVersion {
+				t.Fatalf("cron grammar = %q", got.CronGrammar)
 			}
 		})
 	}
@@ -157,10 +213,11 @@ func TestSnapshotSortsBoundsAndDigestsDeterministically(t *testing.T) {
 	}
 	if snapshot.DigestVersion != TimingDigestVersion || snapshot.EvaluationVersion != EvaluationVersion ||
 		snapshot.EligibilityScope != ScheduleMarkerEvaluationScope ||
+		snapshot.CronGrammar != CronGrammarVersion ||
 		!strings.HasPrefix(snapshot.CandidateDigest, "sha256:") || len(snapshot.CandidateDigest) != len("sha256:")+64 {
 		t.Fatalf("snapshot digest = %#v", snapshot)
 	}
-	if snapshot.CandidateDigest != "sha256:b27a7855649d4b88c703be3e59aa7e16d89259cbbd59b27c535c0a3ae8e38ebe" {
+	if snapshot.CandidateDigest != "sha256:83f190e6252b829ece384aff328d489a1d09883d5c171348bdc280b39ba1c191" {
 		t.Fatalf("candidate digest = %s", snapshot.CandidateDigest)
 	}
 	again, err := BuildSnapshot(observed, 2, []Candidate{candidates[2], candidates[0], candidates[1]})

--- a/internal/scheduler/sync/scheduler_test.go
+++ b/internal/scheduler/sync/scheduler_test.go
@@ -34,14 +34,21 @@ func TestNextOccurrencePythonGoldenVectors(t *testing.T) {
 		{"fall fold zero", "30 1 * * *", "America/Los_Angeles", at("2026-11-01T06:00:00Z"), at("2026-11-01T08:30:00Z"), false},
 		{"spring gap", "30 2 * * *", "America/Los_Angeles", at("2026-03-08T09:00:00Z"), at("2026-03-08T10:30:00Z"), false},
 		{"day-of-month weekday or", "0 0 13 * 5", "UTC", at("2026-02-12T12:00:00Z"), at("2026-02-13T00:00:00Z"), false},
+		{"literal weekday wildcard list", "0 0 1 * *,5", "UTC", at("2026-01-02T00:00:00Z"), at("2026-02-01T00:00:00Z"), false},
+		{"last-day ordinary weekday remains or", "0 0 L * MON", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-05T00:00:00Z"), false},
 		{"sunday seven", "0 0 * * 7", "UTC", at("2026-01-02T12:00:00Z"), at("2026-01-04T00:00:00Z"), false},
 		{"leap day", "0 0 29 2 *", "UTC", at("2026-03-01T12:00:00Z"), at("2028-02-29T00:00:00Z"), false},
+		{"century leap gap", "0 0 29 2 *", "UTC", at("2096-03-01T00:00:00Z"), at("2104-02-29T00:00:00Z"), false},
 		{"value step expands through maximum", "5/15 * * * *", "UTC", at("2026-01-01T00:05:00Z"), at("2026-01-01T00:20:00Z"), false},
+		{"equal range is full cycle", "5-5 * * * *", "UTC", at("2026-01-01T00:05:00Z"), at("2026-01-01T00:06:00Z"), false},
+		{"equal stepped range starts at field minimum", "5-5/10 * * * *", "UTC", at("2026-01-01T00:05:00Z"), at("2026-01-01T00:10:00Z"), false},
 		{"last day of month", "0 0 L * *", "UTC", at("2026-01-10T00:00:00Z"), at("2026-01-31T00:00:00Z"), false},
 		{"last day mixed after literal", "0 0 1,L * *", "UTC", at("2026-01-02T00:00:00Z"), at("2026-01-31T00:00:00Z"), false},
 		{"literal after last day", "0 0 1,L * *", "UTC", at("2026-01-31T00:00:00Z"), at("2026-02-01T00:00:00Z"), false},
 		{"last day mixed before literal", "0 0 L,15 * *", "UTC", at("2026-01-15T00:00:00Z"), at("2026-01-31T00:00:00Z"), false},
 		{"nearest weekday", "0 0 15W * *", "UTC", at("2026-02-01T00:00:00Z"), at("2026-02-16T00:00:00Z"), false},
+		{"prefix nearest weekday", "0 0 W15 * *", "UTC", at("2026-02-01T00:00:00Z"), at("2026-02-16T00:00:00Z"), false},
+		{"prefix nearest weekday clamps", "0 0 W31 * *", "UTC", at("2026-02-01T00:00:00Z"), at("2026-02-27T00:00:00Z"), false},
 		{"nearest weekday clamped", "0 0 31W * *", "UTC", at("2026-04-01T00:00:00Z"), at("2026-04-30T00:00:00Z"), false},
 		{"nth named weekday", "0 0 * * MON#1", "UTC", at("2026-01-10T00:00:00Z"), at("2026-02-02T00:00:00Z"), false},
 		{"fifth numeric weekday", "0 0 * * 5#5", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-30T00:00:00Z"), false},
@@ -51,11 +58,16 @@ func TestNextOccurrencePythonGoldenVectors(t *testing.T) {
 		{"multiple nth weekdays", "0 0 * * MON#1,FRI#2", "UTC", at("2026-01-05T00:00:00Z"), at("2026-01-09T00:00:00Z"), false},
 		{"multiple last weekdays", "0 0 * * L1,L5", "UTC", at("2026-01-26T00:00:00Z"), at("2026-01-30T00:00:00Z"), false},
 		{"mixed last and nth weekdays", "0 0 * * L1,5#2", "UTC", at("2026-01-09T00:00:00Z"), at("2026-01-26T00:00:00Z"), false},
+		{"full-cycle literal with nth weekday", "0 0 * * 0-6,1#1", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-05T00:00:00Z"), false},
+		{"full-cycle step with nth weekday", "0 0 * * */1,1#1", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-05T00:00:00Z"), false},
 		{"question-mark wildcards", "0 0 ? * ?", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-02T00:00:00Z"), false},
 		{"wrapped month range", "0 0 * NOV-FEB *", "UTC", at("2026-03-01T00:00:00Z"), at("2026-11-01T00:00:00Z"), false},
+		{"wrapped month step carries phase", "0 0 * NOV-FEB/3 *", "UTC", at("2026-01-01T00:00:00Z"), at("2026-11-01T00:00:00Z"), false},
 		{"wrapped weekday range", "0 0 * * FRI-MON", "UTC", at("2026-01-05T00:00:00Z"), at("2026-01-09T00:00:00Z"), false},
 		{"wrapped named weekday step dedupes sunday", "0 0 * * FRI-MON/2", "UTC", at("2026-01-04T00:00:00Z"), at("2026-01-09T00:00:00Z"), false},
 		{"wrapped numeric weekday step dedupes sunday", "0 0 * * 6-0/2", "UTC", at("2026-01-03T00:00:00Z"), at("2026-01-10T00:00:00Z"), false},
+		{"wrapped numeric weekday step carries phase", "0 0 * * 6-1/2", "UTC", at("2026-01-03T00:00:00Z"), at("2026-01-10T00:00:00Z"), false},
+		{"sunday value step aliases before expansion", "0 0 * * 7/2", "UTC", at("2026-01-04T00:00:00Z"), at("2026-01-06T00:00:00Z"), false},
 		{"named month step", "0 0 * JAN/2 *", "UTC", at("2026-02-01T00:00:00Z"), at("2026-03-01T00:00:00Z"), false},
 		{"named weekday step", "0 0 * * MON/2", "UTC", at("2026-01-05T00:00:00Z"), at("2026-01-07T00:00:00Z"), false},
 	} {
@@ -117,20 +129,59 @@ func TestRandomCronIsExplicitlyUnsupported(t *testing.T) {
 				CreatedAt:    at("2026-01-01T00:00:00Z"),
 			}, at("2026-01-02T00:00:00Z"))
 			if got.Decision != DecisionUnsupportedCron || got.TimingEligible ||
-				got.CronGrammar != CronGrammarVersion {
+				got.CronGrammarVersion != CronGrammarVersion {
 				t.Fatalf("Evaluate(%q) = %#v", expression, got)
 			}
 		})
 	}
 
-	got := Evaluate(Candidate{
-		ConfigID:     "hashed",
-		Active:       true,
-		ScheduleCron: "H * * * *",
-		CreatedAt:    at("2026-01-01T00:00:00Z"),
-	}, at("2026-01-02T00:00:00Z"))
-	if got.Decision != DecisionInvalidCron {
-		t.Fatalf("hashed cron classification = %#v", got)
+	for _, expression := range []string{
+		"H * * * *",
+		"R/0 * * * *",
+		"R(20-10) * * * *",
+		"R,5 * * * *",
+		"R(60-70) * * * *",
+		"0 R(24-25) * * *",
+	} {
+		got := Evaluate(Candidate{
+			ConfigID:     "invalid",
+			Active:       true,
+			ScheduleCron: expression,
+			CreatedAt:    at("2026-01-01T00:00:00Z"),
+		}, at("2026-01-02T00:00:00Z"))
+		if got.Decision != DecisionInvalidCron {
+			t.Fatalf("invalid cron %q classification = %#v", expression, got)
+		}
+	}
+}
+
+func TestMixedSpecialCronIsExplicitlyUnsupported(t *testing.T) {
+	for _, expression := range []string{
+		"0 0 15W * MON",
+		"0 0 10 * MON#1",
+		"0 0 1 * MON#1",
+		"0 0 L * L1",
+		"0 0 15W * L1",
+		"0 0 * * MON-FRI#2",
+		"0 0 * * *,5,1#1",
+		"0 0 * * * 0",
+		"0 0 * * * 0 2026",
+		"@daily",
+	} {
+		t.Run(expression, func(t *testing.T) {
+			if _, _, err := NextOccurrence(expression, at("2026-01-01T00:00:00Z"), "UTC"); !errors.Is(err, ErrUnsupportedCron) {
+				t.Fatalf("NextOccurrence(%q) err=%v", expression, err)
+			}
+			got := Evaluate(Candidate{
+				ConfigID:     "mixed-special",
+				Active:       true,
+				ScheduleCron: expression,
+				CreatedAt:    at("2026-01-01T00:00:00Z"),
+			}, at("2026-01-02T00:00:00Z"))
+			if got.Decision != DecisionUnsupportedCron || got.TimingEligible {
+				t.Fatalf("Evaluate(%q) = %#v", expression, got)
+			}
+		})
 	}
 }
 
@@ -163,8 +214,8 @@ func TestEvaluateDueManualAndRunningMarkers(t *testing.T) {
 			if got.EligibilityScope != ScheduleMarkerEvaluationScope {
 				t.Fatalf("eligibility scope = %q", got.EligibilityScope)
 			}
-			if got.CronGrammar != CronGrammarVersion {
-				t.Fatalf("cron grammar = %q", got.CronGrammar)
+			if got.CronGrammarVersion != CronGrammarVersion {
+				t.Fatalf("cron grammar = %q", got.CronGrammarVersion)
 			}
 		})
 	}
@@ -213,11 +264,11 @@ func TestSnapshotSortsBoundsAndDigestsDeterministically(t *testing.T) {
 	}
 	if snapshot.DigestVersion != TimingDigestVersion || snapshot.EvaluationVersion != EvaluationVersion ||
 		snapshot.EligibilityScope != ScheduleMarkerEvaluationScope ||
-		snapshot.CronGrammar != CronGrammarVersion ||
+		snapshot.CronGrammarVersion != CronGrammarVersion ||
 		!strings.HasPrefix(snapshot.CandidateDigest, "sha256:") || len(snapshot.CandidateDigest) != len("sha256:")+64 {
 		t.Fatalf("snapshot digest = %#v", snapshot)
 	}
-	if snapshot.CandidateDigest != "sha256:83f190e6252b829ece384aff328d489a1d09883d5c171348bdc280b39ba1c191" {
+	if snapshot.CandidateDigest != "sha256:02fafd6dd76a45d41ef0fa24dba521ce0ff003b8f0f3a3e5a512b19ce9435360" {
 		t.Fatalf("candidate digest = %s", snapshot.CandidateDigest)
 	}
 	again, err := BuildSnapshot(observed, 2, []Candidate{candidates[2], candidates[0], candidates[1]})

--- a/internal/scheduler/sync/scheduler_test.go
+++ b/internal/scheduler/sync/scheduler_test.go
@@ -1,0 +1,253 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+)
+
+func at(value string) time.Time {
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		panic(err)
+	}
+	return parsed
+}
+
+func pointer(value time.Time) *time.Time { return &value }
+
+func TestNextOccurrencePythonGoldenVectors(t *testing.T) {
+	for _, test := range []struct {
+		name, expression, timezone string
+		base, want                 time.Time
+		fallback                   bool
+	}{
+		{"utc", "0 0 * * *", "UTC", at("2026-06-26T12:00:00Z"), at("2026-06-27T00:00:00Z"), false},
+		{"empty timezone", "0 0 * * *", "", at("2026-06-26T12:00:00Z"), at("2026-06-27T00:00:00Z"), false},
+		{"whitespace timezone fallback", "0 0 * * *", " ", at("2026-06-26T12:00:00Z"), at("2026-06-27T00:00:00Z"), true},
+		{"local pseudo-zone fallback", "0 0 * * *", "Local", at("2026-06-26T12:00:00Z"), at("2026-06-27T00:00:00Z"), true},
+		{"local wall clock", "0 0 * * *", "America/Los_Angeles", at("2026-06-26T12:00:00Z"), at("2026-06-27T07:00:00Z"), false},
+		{"unknown timezone", "0 0 * * *", "Not/AZone", at("2026-06-26T12:00:00Z"), at("2026-06-27T00:00:00Z"), true},
+		{"fall fold zero", "30 1 * * *", "America/Los_Angeles", at("2026-11-01T06:00:00Z"), at("2026-11-01T08:30:00Z"), false},
+		{"spring gap", "30 2 * * *", "America/Los_Angeles", at("2026-03-08T09:00:00Z"), at("2026-03-08T10:30:00Z"), false},
+		{"day-of-month weekday or", "0 0 13 * 5", "UTC", at("2026-02-12T12:00:00Z"), at("2026-02-13T00:00:00Z"), false},
+		{"sunday seven", "0 0 * * 7", "UTC", at("2026-01-02T12:00:00Z"), at("2026-01-04T00:00:00Z"), false},
+		{"leap day", "0 0 29 2 *", "UTC", at("2026-03-01T12:00:00Z"), at("2028-02-29T00:00:00Z"), false},
+		{"value step expands through maximum", "5/15 * * * *", "UTC", at("2026-01-01T00:05:00Z"), at("2026-01-01T00:20:00Z"), false},
+		{"last day of month", "0 0 L * *", "UTC", at("2026-01-10T00:00:00Z"), at("2026-01-31T00:00:00Z"), false},
+		{"nearest weekday", "0 0 15W * *", "UTC", at("2026-02-01T00:00:00Z"), at("2026-02-16T00:00:00Z"), false},
+		{"nearest weekday clamped", "0 0 31W * *", "UTC", at("2026-04-01T00:00:00Z"), at("2026-04-30T00:00:00Z"), false},
+		{"nth named weekday", "0 0 * * MON#1", "UTC", at("2026-01-10T00:00:00Z"), at("2026-02-02T00:00:00Z"), false},
+		{"fifth numeric weekday", "0 0 * * 5#5", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-30T00:00:00Z"), false},
+		{"last weekday", "0 0 * * L5", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-30T00:00:00Z"), false},
+		{"last sunday zero", "0 0 * * L0", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-25T00:00:00Z"), false},
+		{"last sunday seven", "0 0 * * L7", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-25T00:00:00Z"), false},
+		{"question-mark wildcards", "0 0 ? * ?", "UTC", at("2026-01-01T00:00:00Z"), at("2026-01-02T00:00:00Z"), false},
+		{"wrapped month range", "0 0 * NOV-FEB *", "UTC", at("2026-03-01T00:00:00Z"), at("2026-11-01T00:00:00Z"), false},
+		{"wrapped weekday range", "0 0 * * FRI-MON", "UTC", at("2026-01-05T00:00:00Z"), at("2026-01-09T00:00:00Z"), false},
+		{"named month step", "0 0 * JAN/2 *", "UTC", at("2026-02-01T00:00:00Z"), at("2026-03-01T00:00:00Z"), false},
+		{"named weekday step", "0 0 * * MON/2", "UTC", at("2026-01-05T00:00:00Z"), at("2026-01-07T00:00:00Z"), false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got, fallback, err := NextOccurrence(test.expression, test.base, test.timezone)
+			if err != nil || !got.Equal(test.want) || fallback != test.fallback {
+				t.Fatalf("NextOccurrence() = %s fallback=%v err=%v, want %s fallback=%v", got, fallback, err, test.want, test.fallback)
+			}
+		})
+	}
+}
+
+func TestNextOccurrenceRejectsCroniterInvalidFiveFieldFormsAndExtendedFields(t *testing.T) {
+	for _, expression := range []string{
+		"0 0 L-2 * *",
+		"0 0 LW * *",
+		"0 0 1,15W * *",
+		"0 0 * * 5L",
+		"0 0 * * MONL",
+		"0 0 * * MON#6",
+		"? 0 * * *",
+		"0 ? * * *",
+		"0 0 * * * 2026",
+		"0 0 * * * 0 2026",
+	} {
+		t.Run(expression, func(t *testing.T) {
+			if _, _, err := NextOccurrence(expression, at("2026-01-01T00:00:00Z"), "UTC"); err == nil {
+				t.Fatalf("NextOccurrence(%q) accepted invalid expression", expression)
+			}
+		})
+	}
+}
+
+func TestEvaluateDueManualAndRunningMarkers(t *testing.T) {
+	now := at("2026-01-01T12:00:00Z")
+	base := at("2026-01-01T10:00:00Z")
+	fresh := now.Add(-staleRunningTTL)
+	stale := fresh.Add(-time.Nanosecond)
+	future := now.Add(time.Hour)
+	for _, test := range []struct {
+		name                string
+		candidate           Candidate
+		decision            Decision
+		due, timingEligible bool
+		running             RunningMarkerState
+	}{
+		{"not due", Candidate{ConfigID: "a", Active: true, ScheduleCron: "0 13 * * *", CreatedAt: base}, DecisionNotDue, false, false, RunningNotSet},
+		{"due from last sync", Candidate{ConfigID: "b", Active: true, ScheduleCron: "0 * * * *", CreatedAt: now, LastSyncAt: pointer(base)}, DecisionScheduleDue, true, true, RunningNotSet},
+		{"manual", Candidate{ConfigID: "c", Active: true, CreatedAt: base}, DecisionManual, false, false, RunningNotSet},
+		{"fresh running exact threshold", Candidate{ConfigID: "d", Active: true, ScheduleCron: "0 * * * *", CreatedAt: now, LastSyncAt: pointer(base), Job: &Job{Status: activeJobStatus, IsRunning: true, LastRunAt: pointer(fresh)}}, DecisionFreshRunning, false, false, RunningFresh},
+		{"stale running", Candidate{ConfigID: "e", Active: true, ScheduleCron: "0 * * * *", CreatedAt: now, LastSyncAt: pointer(base), Job: &Job{ScheduleCron: "0 * * * *", Status: activeJobStatus, IsRunning: true, LastRunAt: pointer(stale)}}, DecisionScheduleDue, true, true, RunningStale},
+		{"future persisted run precedes malformed cron", Candidate{ConfigID: "f", Active: true, ScheduleCron: "0 * * * *", CreatedAt: base, Job: &Job{ScheduleCron: "malformed", Timezone: "UTC", Status: activeJobStatus, NextRunAt: pointer(future)}}, DecisionNextRunGate, false, false, RunningNotSet},
+		{"future persisted run precedes cron not due", Candidate{ConfigID: "g", Active: true, ScheduleCron: "0 * * * *", CreatedAt: base, Job: &Job{ScheduleCron: "0 13 * * *", Timezone: "UTC", Status: activeJobStatus, NextRunAt: pointer(future)}}, DecisionNextRunGate, false, false, RunningNotSet},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := Evaluate(test.candidate, now)
+			if got.Decision != test.decision || got.Due != test.due || got.TimingEligible != test.timingEligible || got.RunningMarker != test.running {
+				t.Fatalf("Evaluate() = %#v", got)
+			}
+			if got.EligibilityScope != ScheduleMarkerEvaluationScope {
+				t.Fatalf("eligibility scope = %q", got.EligibilityScope)
+			}
+		})
+	}
+}
+
+func TestEvaluatePreservesPythonTimezoneFallbackSemantics(t *testing.T) {
+	base := at("2026-01-01T10:00:00Z")
+	now := at("2026-01-01T12:00:00Z")
+	for _, test := range []struct {
+		name, timezone string
+		fallback       bool
+	}{
+		{"empty is UTC without fallback", "", false},
+		{"whitespace is invalid and falls back", " ", true},
+		{"local pseudo-zone is invalid and falls back", "Local", true},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			got := Evaluate(Candidate{
+				ConfigID:     "timezone",
+				Active:       true,
+				ScheduleCron: "0 * * * *",
+				ScheduleTZ:   test.timezone,
+				CreatedAt:    base,
+			}, now)
+			if got.Timezone != "UTC" || got.TimezoneFallback != test.fallback ||
+				got.Decision != DecisionScheduleDue || !got.TimingEligible {
+				t.Fatalf("Evaluate() = %#v", got)
+			}
+		})
+	}
+}
+
+func TestSnapshotSortsBoundsAndDigestsDeterministically(t *testing.T) {
+	observed := at("2026-01-01T12:00:00Z")
+	candidates := []Candidate{
+		{ConfigID: "b", Active: true, ScheduleCron: "0 * * * *", CreatedAt: at("2026-01-01T10:00:00Z")},
+		{ConfigID: "a", Active: true, ScheduleCron: "0 * * * *", CreatedAt: at("2026-01-01T11:00:00Z")},
+		{ConfigID: "c", Active: true, ScheduleCron: "0 * * * *", CreatedAt: at("2026-01-01T11:00:00Z")},
+	}
+	snapshot, err := BuildSnapshot(observed, 2, candidates)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !snapshot.Truncated || len(snapshot.Candidates) != 2 || snapshot.Candidates[0].Candidate.ConfigID != "a" || snapshot.Candidates[1].Candidate.ConfigID != "b" {
+		t.Fatalf("snapshot order = %#v", snapshot)
+	}
+	if snapshot.DigestVersion != TimingDigestVersion || snapshot.EvaluationVersion != EvaluationVersion ||
+		snapshot.EligibilityScope != ScheduleMarkerEvaluationScope ||
+		!strings.HasPrefix(snapshot.CandidateDigest, "sha256:") || len(snapshot.CandidateDigest) != len("sha256:")+64 {
+		t.Fatalf("snapshot digest = %#v", snapshot)
+	}
+	if snapshot.CandidateDigest != "sha256:b27a7855649d4b88c703be3e59aa7e16d89259cbbd59b27c535c0a3ae8e38ebe" {
+		t.Fatalf("candidate digest = %s", snapshot.CandidateDigest)
+	}
+	again, err := BuildSnapshot(observed, 2, []Candidate{candidates[2], candidates[0], candidates[1]})
+	if err != nil || snapshot.CandidateDigest != again.CandidateDigest {
+		t.Fatalf("deterministic digest first=%s second=%s err=%v", snapshot.CandidateDigest, again.CandidateDigest, err)
+	}
+	if _, err := BuildSnapshot(observed, 0, nil); err == nil {
+		t.Fatal("zero limit accepted")
+	}
+	if _, err := BuildSnapshot(observed, 101, nil); err == nil {
+		t.Fatal("oversized limit accepted")
+	}
+}
+
+type cancelAfterChecksContext struct {
+	context.Context
+	checks   int
+	cancelOn int
+}
+
+func (ctx *cancelAfterChecksContext) Err() error {
+	ctx.checks++
+	if ctx.checks >= ctx.cancelOn {
+		return context.Canceled
+	}
+	return nil
+}
+
+func TestCronEvaluationHonorsCancellationDuringBoundedSearch(t *testing.T) {
+	ctx := &cancelAfterChecksContext{Context: context.Background(), cancelOn: 3}
+	_, _, err := nextOccurrenceContext(
+		ctx,
+		"0 0 31 2 *",
+		at("2026-03-01T00:00:00Z"),
+		"UTC",
+	)
+	if !errors.Is(err, context.Canceled) || ctx.checks < ctx.cancelOn {
+		t.Fatalf("nextOccurrenceContext() err=%v checks=%d", err, ctx.checks)
+	}
+}
+
+type cancelingCandidateRows struct {
+	yielded bool
+	cancel  context.CancelFunc
+}
+
+func (rows *cancelingCandidateRows) Next() bool {
+	if rows.yielded {
+		return false
+	}
+	rows.yielded = true
+	return true
+}
+
+func (rows *cancelingCandidateRows) Scan(...any) error {
+	rows.cancel()
+	return nil
+}
+
+func (*cancelingCandidateRows) Err() error { return nil }
+
+func TestRepositorySnapshotContextBoundaries(t *testing.T) {
+	if _, err := (&Repository{}).Snapshot(nil, time.Now(), 1); err == nil || !strings.Contains(err.Error(), "context") {
+		t.Fatalf("Snapshot(nil) err=%v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	rows := &cancelingCandidateRows{cancel: cancel}
+	if _, err := readCandidates(ctx, rows, 2); !errors.Is(err, context.Canceled) {
+		t.Fatalf("readCandidates() err=%v", err)
+	}
+}
+
+func TestRepositoryStatementIsBoundedReadOnlyExactJoin(t *testing.T) {
+	statement := strings.ToUpper(schedulerSnapshotSQL)
+	for _, want := range []string{
+		"SELECT", "FROM PUBLIC.SYNC_CONFIGURATIONS AS CONFIG", "LEFT JOIN PUBLIC.SCHEDULED_JOBS AS JOB",
+		"JOB.ORG_ID = CONFIG.ORG_ID", "JOB.SYNC_CONFIG_ID = CONFIG.ID", "JOB.JOB_TYPE = 'SYNC'",
+		"WHERE CONFIG.IS_ACTIVE = TRUE", "ORDER BY CONFIG.ID", "LIMIT $1",
+	} {
+		if !strings.Contains(statement, want) {
+			t.Fatalf("query missing %q: %s", want, schedulerSnapshotSQL)
+		}
+	}
+	for _, forbidden := range []string{"INSERT", "UPDATE", "DELETE", "FOR UPDATE", "LOCK", "ADVISORY"} {
+		if regexp.MustCompile(`\b` + forbidden + `\b`).MatchString(statement) {
+			t.Fatalf("read query contains %q", forbidden)
+		}
+	}
+}

--- a/internal/scheduler/sync/snapshot.go
+++ b/internal/scheduler/sync/snapshot.go
@@ -1,0 +1,119 @@
+package sync
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"sort"
+	"strconv"
+	"time"
+)
+
+const (
+	minimumSnapshotLimit = 1
+	maximumSnapshotLimit = 100
+)
+
+// BuildSnapshot evaluates at most limit candidates plus one truncation proof.
+// Ordering is fixed by config ID so equivalent PostgreSQL snapshots compare
+// deterministically even when their source scan order changes.
+func BuildSnapshot(observedAt time.Time, limit int, candidates []Candidate) (Snapshot, error) {
+	return buildSnapshotContext(context.Background(), observedAt, limit, candidates)
+}
+
+func buildSnapshotContext(
+	ctx context.Context,
+	observedAt time.Time,
+	limit int,
+	candidates []Candidate,
+) (Snapshot, error) {
+	if ctx == nil {
+		return Snapshot{}, fmt.Errorf("snapshot context is required")
+	}
+	if err := ctx.Err(); err != nil {
+		return Snapshot{}, err
+	}
+	if limit < minimumSnapshotLimit || limit > maximumSnapshotLimit {
+		return Snapshot{}, fmt.Errorf("snapshot limit must be between %d and %d", minimumSnapshotLimit, maximumSnapshotLimit)
+	}
+	if len(candidates) > limit+1 {
+		return Snapshot{}, fmt.Errorf("snapshot exceeds bounded candidate window")
+	}
+	ordered := append([]Candidate(nil), candidates...)
+	sort.Slice(ordered, func(left, right int) bool { return ordered[left].ConfigID < ordered[right].ConfigID })
+	if err := ctx.Err(); err != nil {
+		return Snapshot{}, err
+	}
+	truncated := len(ordered) > limit
+	if truncated {
+		ordered = ordered[:limit]
+	}
+	observedAt = observedAt.UTC()
+	result := Snapshot{
+		ObservedAt:        observedAt,
+		Limit:             limit,
+		Truncated:         truncated,
+		DigestVersion:     TimingDigestVersion,
+		EvaluationVersion: EvaluationVersion,
+		EligibilityScope:  ScheduleMarkerEvaluationScope,
+		Candidates:        make([]EvaluatedCandidate, 0, len(ordered)),
+	}
+	for _, candidate := range ordered {
+		if err := ctx.Err(); err != nil {
+			return Snapshot{}, err
+		}
+		evaluation, err := evaluateContext(ctx, candidate, observedAt)
+		if err != nil {
+			return Snapshot{}, err
+		}
+		result.Candidates = append(result.Candidates, EvaluatedCandidate{
+			Candidate: candidate, Evaluation: evaluation,
+		})
+	}
+	if err := ctx.Err(); err != nil {
+		return Snapshot{}, err
+	}
+	result.CandidateDigest = candidateDigest(result)
+	return result, nil
+}
+
+func candidateDigest(snapshot Snapshot) string {
+	hasher := sha256.New()
+	writeDigestField(hasher, "digest_version", snapshot.DigestVersion)
+	writeDigestField(hasher, "evaluation_version", snapshot.EvaluationVersion)
+	writeDigestField(hasher, "eligibility_scope", snapshot.EligibilityScope)
+	writeDigestField(hasher, "observed_at", canonicalTime(snapshot.ObservedAt))
+	writeDigestField(hasher, "limit", strconv.Itoa(snapshot.Limit))
+	writeDigestField(hasher, "truncated", strconv.FormatBool(snapshot.Truncated))
+	for _, evaluated := range snapshot.Candidates {
+		writeDigestField(hasher, "config_id", evaluated.Candidate.ConfigID)
+		writeDigestField(hasher, "decision", string(evaluated.Evaluation.Decision))
+		writeDigestField(hasher, "due", strconv.FormatBool(evaluated.Evaluation.Due))
+		writeDigestField(hasher, "timing_eligible", strconv.FormatBool(evaluated.Evaluation.TimingEligible))
+		writeDigestField(hasher, "running_marker", string(evaluated.Evaluation.RunningMarker))
+		writeDigestField(hasher, "timezone", evaluated.Evaluation.Timezone)
+		writeDigestField(hasher, "timezone_fallback", strconv.FormatBool(evaluated.Evaluation.TimezoneFallback))
+		next := ""
+		if evaluated.Evaluation.NextOccurrence != nil {
+			next = canonicalTime(*evaluated.Evaluation.NextOccurrence)
+		}
+		writeDigestField(hasher, "next_occurrence", next)
+	}
+	return "sha256:" + fmt.Sprintf("%x", hasher.Sum(nil))
+}
+
+type digestWriter interface{ Write([]byte) (int, error) }
+
+func writeDigestField(output digestWriter, name, value string) {
+	_, _ = output.Write([]byte(strconv.Itoa(len([]byte(name)))))
+	_, _ = output.Write([]byte(":"))
+	_, _ = output.Write([]byte(name))
+	_, _ = output.Write([]byte(strconv.Itoa(len([]byte(value)))))
+	_, _ = output.Write([]byte(":"))
+	_, _ = output.Write([]byte(value))
+	_, _ = output.Write([]byte("\n"))
+}
+
+func canonicalTime(value time.Time) string {
+	return value.UTC().Format("2006-01-02T15:04:05.000000000Z")
+}

--- a/internal/scheduler/sync/snapshot.go
+++ b/internal/scheduler/sync/snapshot.go
@@ -50,14 +50,14 @@ func buildSnapshotContext(
 	}
 	observedAt = observedAt.UTC()
 	result := Snapshot{
-		ObservedAt:        observedAt,
-		Limit:             limit,
-		Truncated:         truncated,
-		DigestVersion:     TimingDigestVersion,
-		EvaluationVersion: EvaluationVersion,
-		EligibilityScope:  ScheduleMarkerEvaluationScope,
-		CronGrammar:       CronGrammarVersion,
-		Candidates:        make([]EvaluatedCandidate, 0, len(ordered)),
+		ObservedAt:         observedAt,
+		Limit:              limit,
+		Truncated:          truncated,
+		DigestVersion:      TimingDigestVersion,
+		EvaluationVersion:  EvaluationVersion,
+		EligibilityScope:   ScheduleMarkerEvaluationScope,
+		CronGrammarVersion: CronGrammarVersion,
+		Candidates:         make([]EvaluatedCandidate, 0, len(ordered)),
 	}
 	for _, candidate := range ordered {
 		if err := ctx.Err(); err != nil {
@@ -83,7 +83,7 @@ func candidateDigest(snapshot Snapshot) string {
 	writeDigestField(hasher, "digest_version", snapshot.DigestVersion)
 	writeDigestField(hasher, "evaluation_version", snapshot.EvaluationVersion)
 	writeDigestField(hasher, "eligibility_scope", snapshot.EligibilityScope)
-	writeDigestField(hasher, "cron_grammar", snapshot.CronGrammar)
+	writeDigestField(hasher, "cron_grammar_version", snapshot.CronGrammarVersion)
 	writeDigestField(hasher, "observed_at", canonicalTime(snapshot.ObservedAt))
 	writeDigestField(hasher, "limit", strconv.Itoa(snapshot.Limit))
 	writeDigestField(hasher, "truncated", strconv.FormatBool(snapshot.Truncated))

--- a/internal/scheduler/sync/snapshot.go
+++ b/internal/scheduler/sync/snapshot.go
@@ -56,6 +56,7 @@ func buildSnapshotContext(
 		DigestVersion:     TimingDigestVersion,
 		EvaluationVersion: EvaluationVersion,
 		EligibilityScope:  ScheduleMarkerEvaluationScope,
+		CronGrammar:       CronGrammarVersion,
 		Candidates:        make([]EvaluatedCandidate, 0, len(ordered)),
 	}
 	for _, candidate := range ordered {
@@ -82,6 +83,7 @@ func candidateDigest(snapshot Snapshot) string {
 	writeDigestField(hasher, "digest_version", snapshot.DigestVersion)
 	writeDigestField(hasher, "evaluation_version", snapshot.EvaluationVersion)
 	writeDigestField(hasher, "eligibility_scope", snapshot.EligibilityScope)
+	writeDigestField(hasher, "cron_grammar", snapshot.CronGrammar)
 	writeDigestField(hasher, "observed_at", canonicalTime(snapshot.ObservedAt))
 	writeDigestField(hasher, "limit", strconv.Itoa(snapshot.Limit))
 	writeDigestField(hasher, "truncated", strconv.FormatBool(snapshot.Truncated))

--- a/internal/scheduler/sync/types.go
+++ b/internal/scheduler/sync/types.go
@@ -37,14 +37,14 @@ const (
 type Decision string
 
 const (
-	DecisionScheduleDue  Decision = "schedule_due"
-	DecisionInactive     Decision = "inactive"
-	DecisionManual       Decision = "manual"
-	DecisionInactiveJob  Decision = "inactive_job"
-	DecisionFreshRunning Decision = "fresh_running"
-	DecisionNotDue       Decision = "not_due"
-	DecisionNextRunGate  Decision = "next_run_gate"
-	DecisionInvalidCron  Decision = "invalid_cron"
+	DecisionScheduleDue     Decision = "schedule_due"
+	DecisionInactive        Decision = "inactive"
+	DecisionManual          Decision = "manual"
+	DecisionInactiveJob     Decision = "inactive_job"
+	DecisionFreshRunning    Decision = "fresh_running"
+	DecisionNotDue          Decision = "not_due"
+	DecisionNextRunGate     Decision = "next_run_gate"
+	DecisionInvalidCron     Decision = "invalid_cron"
 	DecisionUnsupportedCron Decision = "unsupported_cron"
 )
 

--- a/internal/scheduler/sync/types.go
+++ b/internal/scheduler/sync/types.go
@@ -1,0 +1,100 @@
+// Package sync provides a dormant, read-only shadow of the legacy Python
+// sync scheduler. It evaluates candidates only; it never claims, writes, or
+// starts a scheduler loop.
+package sync
+
+import "time"
+
+const (
+	// TimingDigestVersion identifies the fixed schedule/marker-only candidate
+	// framing for later cross-runtime comparison.
+	TimingDigestVersion = "sync_scheduler_timing_digest_v1"
+	// EvaluationVersion identifies the Python-compatible timing rules.
+	EvaluationVersion = "sync_scheduler_timing_evaluation_v1"
+	// ScheduleMarkerEvaluationScope makes explicit that organization existence,
+	// feature entitlement, and all other dispatch gates are out of scope.
+	ScheduleMarkerEvaluationScope = "schedule_and_marker_only"
+
+	activeJobStatus = 0
+	staleRunningTTL = 2 * time.Hour
+)
+
+type RunningMarkerState string
+
+const (
+	RunningNotSet RunningMarkerState = "not_running"
+	RunningFresh  RunningMarkerState = "fresh"
+	RunningStale  RunningMarkerState = "stale"
+)
+
+type Decision string
+
+const (
+	DecisionScheduleDue  Decision = "schedule_due"
+	DecisionInactive     Decision = "inactive"
+	DecisionManual       Decision = "manual"
+	DecisionInactiveJob  Decision = "inactive_job"
+	DecisionFreshRunning Decision = "fresh_running"
+	DecisionNotDue       Decision = "not_due"
+	DecisionNextRunGate  Decision = "next_run_gate"
+	DecisionInvalidCron  Decision = "invalid_cron"
+)
+
+// Candidate is the minimal scheduler state read from the legacy semantic
+// tables. It contains no execution handle and is safe to evaluate repeatedly.
+type Candidate struct {
+	ConfigID     string
+	Active       bool
+	ScheduleCron string
+	ScheduleTZ   string
+	LastSyncAt   *time.Time
+	CreatedAt    time.Time
+	Job          *Job
+}
+
+type Job struct {
+	ID           string
+	ScheduleCron string
+	Timezone     string
+	Status       int
+	IsRunning    bool
+	LastRunAt    *time.Time
+	UpdatedAt    *time.Time
+	NextRunAt    *time.Time
+}
+
+// Evaluation records occurrence due-ness separately from schedule/marker
+// timing eligibility. TimingEligible never means dispatch eligible: the
+// dormant shadow intentionally omits organization and feature-service gates.
+type Evaluation struct {
+	ConfigID         string
+	Base             time.Time
+	NextOccurrence   *time.Time
+	ObservedAt       time.Time
+	Due              bool
+	TimingEligible   bool
+	Decision         Decision
+	RunningMarker    RunningMarkerState
+	Timezone         string
+	TimezoneFallback bool
+	EligibilityScope string
+}
+
+type EvaluatedCandidate struct {
+	Candidate  Candidate
+	Evaluation Evaluation
+}
+
+// Snapshot is a bounded, deterministically ordered read model. Candidate IDs
+// remain in-memory comparison material and are represented only by the digest
+// in any later telemetry surface.
+type Snapshot struct {
+	ObservedAt        time.Time
+	Limit             int
+	Truncated         bool
+	Candidates        []EvaluatedCandidate
+	DigestVersion     string
+	EvaluationVersion string
+	EligibilityScope  string
+	CandidateDigest   string
+}

--- a/internal/scheduler/sync/types.go
+++ b/internal/scheduler/sync/types.go
@@ -3,7 +3,10 @@
 // starts a scheduler loop.
 package sync
 
-import "time"
+import (
+	"errors"
+	"time"
+)
 
 const (
 	// TimingDigestVersion identifies the fixed schedule/marker-only candidate
@@ -11,6 +14,10 @@ const (
 	TimingDigestVersion = "sync_scheduler_timing_digest_v1"
 	// EvaluationVersion identifies the Python-compatible timing rules.
 	EvaluationVersion = "sync_scheduler_timing_evaluation_v1"
+	// CronGrammarVersion identifies the deterministic five-field Croniter
+	// subset. Random R expressions and optional sixth/seventh fields are
+	// explicitly outside this grammar.
+	CronGrammarVersion = "croniter_five_field_deterministic_v1"
 	// ScheduleMarkerEvaluationScope makes explicit that organization existence,
 	// feature entitlement, and all other dispatch gates are out of scope.
 	ScheduleMarkerEvaluationScope = "schedule_and_marker_only"
@@ -38,7 +45,13 @@ const (
 	DecisionNotDue       Decision = "not_due"
 	DecisionNextRunGate  Decision = "next_run_gate"
 	DecisionInvalidCron  Decision = "invalid_cron"
+	DecisionUnsupportedCron Decision = "unsupported_cron"
 )
+
+// ErrUnsupportedRandomCron identifies Croniter's random R syntax. Recreating
+// Croniter selects a new value, so cross-runtime shadow comparison cannot
+// evaluate this syntax deterministically.
+var ErrUnsupportedRandomCron = errors.New("random R cron syntax is unsupported for deterministic comparison")
 
 // Candidate is the minimal scheduler state read from the legacy semantic
 // tables. It contains no execution handle and is safe to evaluate repeatedly.
@@ -78,6 +91,7 @@ type Evaluation struct {
 	Timezone         string
 	TimezoneFallback bool
 	EligibilityScope string
+	CronGrammar      string
 }
 
 type EvaluatedCandidate struct {
@@ -96,5 +110,6 @@ type Snapshot struct {
 	DigestVersion     string
 	EvaluationVersion string
 	EligibilityScope  string
+	CronGrammar       string
 	CandidateDigest   string
 }

--- a/internal/scheduler/sync/types.go
+++ b/internal/scheduler/sync/types.go
@@ -5,6 +5,7 @@ package sync
 
 import (
 	"errors"
+	"fmt"
 	"time"
 )
 
@@ -48,10 +49,15 @@ const (
 	DecisionUnsupportedCron Decision = "unsupported_cron"
 )
 
+// ErrUnsupportedCron identifies syntax intentionally routed outside the
+// versioned deterministic subset. It does not assert that Croniter would
+// otherwise accept the expression.
+var ErrUnsupportedCron = errors.New("cron syntax is unsupported for deterministic comparison")
+
 // ErrUnsupportedRandomCron identifies Croniter's random R syntax. Recreating
 // Croniter selects a new value, so cross-runtime shadow comparison cannot
 // evaluate this syntax deterministically.
-var ErrUnsupportedRandomCron = errors.New("random R cron syntax is unsupported for deterministic comparison")
+var ErrUnsupportedRandomCron = fmt.Errorf("%w: random R expression", ErrUnsupportedCron)
 
 // Candidate is the minimal scheduler state read from the legacy semantic
 // tables. It contains no execution handle and is safe to evaluate repeatedly.
@@ -80,18 +86,18 @@ type Job struct {
 // timing eligibility. TimingEligible never means dispatch eligible: the
 // dormant shadow intentionally omits organization and feature-service gates.
 type Evaluation struct {
-	ConfigID         string
-	Base             time.Time
-	NextOccurrence   *time.Time
-	ObservedAt       time.Time
-	Due              bool
-	TimingEligible   bool
-	Decision         Decision
-	RunningMarker    RunningMarkerState
-	Timezone         string
-	TimezoneFallback bool
-	EligibilityScope string
-	CronGrammar      string
+	ConfigID           string
+	Base               time.Time
+	NextOccurrence     *time.Time
+	ObservedAt         time.Time
+	Due                bool
+	TimingEligible     bool
+	Decision           Decision
+	RunningMarker      RunningMarkerState
+	Timezone           string
+	TimezoneFallback   bool
+	EligibilityScope   string
+	CronGrammarVersion string
 }
 
 type EvaluatedCandidate struct {
@@ -103,13 +109,13 @@ type EvaluatedCandidate struct {
 // remain in-memory comparison material and are represented only by the digest
 // in any later telemetry surface.
 type Snapshot struct {
-	ObservedAt        time.Time
-	Limit             int
-	Truncated         bool
-	Candidates        []EvaluatedCandidate
-	DigestVersion     string
-	EvaluationVersion string
-	EligibilityScope  string
-	CronGrammar       string
-	CandidateDigest   string
+	ObservedAt         time.Time
+	Limit              int
+	Truncated          bool
+	Candidates         []EvaluatedCandidate
+	DigestVersion      string
+	EvaluationVersion  string
+	EligibilityScope   string
+	CronGrammarVersion string
+	CandidateDigest    string
 }

--- a/internal/syncdispatchcontract/routes.go
+++ b/internal/syncdispatchcontract/routes.go
@@ -1,0 +1,270 @@
+// Package syncdispatchcontract validates the frozen v1 sync-dispatch routes.
+//
+// It deliberately has no runtime integration. Consumers may load and look up
+// the checked-in policy, but route execution remains outside this package.
+package syncdispatchcontract
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"unicode/utf8"
+)
+
+const (
+	// Filename is the only artifact accepted by Load.
+	Filename = "transport-routes.json"
+
+	maxArtifactBytes = 16 * 1024
+	maxJSONDepth     = 8
+
+	KindDispatchSyncRun    = "dispatch_sync_run"
+	KindFinalizeSyncRun    = "finalize_sync_run"
+	KindPostSync           = "post_sync"
+	KindReferenceDiscovery = "reference_discovery"
+
+	DeliveryAtLeastOnce          = "at_least_once"
+	DeliveryAtMostOnceMarkBefore = "at_most_once_mark_before"
+
+	RouteCelery = "celery"
+	RouteRiver  = "river"
+)
+
+// Descriptor is a single immutable-by-value sync-dispatch route descriptor.
+// No reference values are exposed from Registry.
+type Descriptor struct {
+	Kind          string `json:"kind"`
+	Delivery      string `json:"delivery"`
+	Route         string `json:"route"`
+	RollbackRoute string `json:"rollback_route"`
+}
+
+type artifact struct {
+	SchemaVersion int          `json:"schema_version"`
+	Routes        []Descriptor `json:"routes"`
+}
+
+// Registry is immutable after Load and safe for concurrent lookups.
+type Registry struct {
+	byKind map[string]Descriptor
+}
+
+// Load reads the one bounded sync-dispatch route artifact rooted at root. It
+// performs best-effort regular-file and symbolic-link checks, but callers must
+// not treat those path checks as a TOCTOU guarantee for concurrently mutable
+// filesystem paths.
+func Load(root string) (*Registry, error) {
+	data, err := readArtifact(root)
+	if err != nil {
+		return nil, err
+	}
+
+	var parsed artifact
+	if err := decodeStrict(data, &parsed); err != nil {
+		return nil, fmt.Errorf("decode %s: %w", Filename, err)
+	}
+	if err := parsed.validate(); err != nil {
+		return nil, err
+	}
+
+	byKind := make(map[string]Descriptor, len(parsed.Routes))
+	for _, descriptor := range parsed.Routes {
+		byKind[descriptor.Kind] = descriptor
+	}
+	return &Registry{byKind: byKind}, nil
+}
+
+// Lookup returns a value copy of the descriptor for kind. Altering the
+// returned value cannot change the registry's loaded policy.
+func (registry *Registry) Lookup(kind string) (Descriptor, bool) {
+	if registry == nil {
+		return Descriptor{}, false
+	}
+	descriptor, ok := registry.byKind[kind]
+	return descriptor, ok
+}
+
+func (parsed artifact) validate() error {
+	if parsed.SchemaVersion != 1 {
+		return errors.New("unsupported sync-dispatch route schema_version")
+	}
+	if len(parsed.Routes) != len(frozenDeliveries) {
+		return errors.New("sync-dispatch routes must cover every frozen kind exactly once")
+	}
+
+	previous := ""
+	seen := make(map[string]struct{}, len(parsed.Routes))
+	for _, descriptor := range parsed.Routes {
+		if descriptor.Kind <= previous {
+			return errors.New("sync-dispatch routes must be lexicographically sorted by kind")
+		}
+		previous = descriptor.Kind
+		if _, duplicate := seen[descriptor.Kind]; duplicate {
+			return fmt.Errorf("duplicate sync-dispatch route kind %q", descriptor.Kind)
+		}
+		seen[descriptor.Kind] = struct{}{}
+
+		expectedDelivery, ok := frozenDeliveries[descriptor.Kind]
+		if !ok {
+			return fmt.Errorf("sync-dispatch route kind %q is not frozen", descriptor.Kind)
+		}
+		if descriptor.Delivery != expectedDelivery {
+			return fmt.Errorf("sync-dispatch route %s has invalid delivery", descriptor.Kind)
+		}
+		if !validRoutePair(descriptor.Route, descriptor.RollbackRoute) {
+			return fmt.Errorf("sync-dispatch route %s has invalid transport pair", descriptor.Kind)
+		}
+	}
+	return nil
+}
+
+var frozenDeliveries = map[string]string{
+	KindDispatchSyncRun:    DeliveryAtLeastOnce,
+	KindFinalizeSyncRun:    DeliveryAtLeastOnce,
+	KindPostSync:           DeliveryAtMostOnceMarkBefore,
+	KindReferenceDiscovery: DeliveryAtLeastOnce,
+}
+
+func validRoutePair(route, rollbackRoute string) bool {
+	return rollbackRoute == RouteCelery && (route == RouteCelery || route == RouteRiver)
+}
+
+func readArtifact(root string) ([]byte, error) {
+	if root == "" {
+		return nil, errors.New("sync-dispatch contract root is required")
+	}
+	rootPath, err := filepath.Abs(root)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sync-dispatch contract root: %w", err)
+	}
+	rootInfo, err := os.Lstat(rootPath)
+	if err != nil {
+		return nil, fmt.Errorf("inspect sync-dispatch contract root: %w", err)
+	}
+	if rootInfo.Mode()&os.ModeSymlink != 0 || !rootInfo.IsDir() {
+		return nil, errors.New("sync-dispatch contract root must be a directory, not a symbolic link")
+	}
+
+	path := filepath.Join(rootPath, Filename)
+	info, err := os.Lstat(path)
+	if err != nil {
+		return nil, fmt.Errorf("inspect %s: %w", Filename, err)
+	}
+	if info.Mode()&os.ModeSymlink != 0 || !info.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s must be a regular file", Filename)
+	}
+	if info.Size() > maxArtifactBytes {
+		return nil, fmt.Errorf("%s exceeds %d bytes", Filename, maxArtifactBytes)
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("open %s: %w", Filename, err)
+	}
+	defer file.Close()
+	openedInfo, err := file.Stat()
+	if err != nil {
+		return nil, fmt.Errorf("stat %s: %w", Filename, err)
+	}
+	if !openedInfo.Mode().IsRegular() {
+		return nil, fmt.Errorf("%s must be a regular file", Filename)
+	}
+	data, err := io.ReadAll(io.LimitReader(file, maxArtifactBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read %s: %w", Filename, err)
+	}
+	if len(data) > maxArtifactBytes {
+		return nil, fmt.Errorf("%s exceeds %d bytes", Filename, maxArtifactBytes)
+	}
+	return data, nil
+}
+
+func decodeStrict(data []byte, destination any) error {
+	if len(data) == 0 {
+		return errors.New("JSON value is empty")
+	}
+	if !utf8.Valid(data) {
+		return errors.New("JSON must be UTF-8")
+	}
+	if err := validateJSONTokens(data); err != nil {
+		return err
+	}
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(destination); err != nil {
+		return errors.New("JSON does not match sync-dispatch contract")
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return errors.New("JSON has trailing data")
+	}
+	return nil
+}
+
+func validateJSONTokens(data []byte) error {
+	decoder := json.NewDecoder(bytes.NewReader(data))
+	decoder.UseNumber()
+	if err := consumeJSONValue(decoder, 0); err != nil {
+		return errors.New("invalid JSON structure")
+	}
+	if _, err := decoder.Token(); !errors.Is(err, io.EOF) {
+		return errors.New("JSON has trailing data")
+	}
+	return nil
+}
+
+func consumeJSONValue(decoder *json.Decoder, depth int) error {
+	if depth > maxJSONDepth {
+		return errors.New("JSON nesting exceeds limit")
+	}
+	token, err := decoder.Token()
+	if err != nil {
+		return err
+	}
+	delimiter, ok := token.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delimiter {
+	case '{':
+		keys := make(map[string]struct{})
+		for decoder.More() {
+			keyToken, err := decoder.Token()
+			if err != nil {
+				return err
+			}
+			key, ok := keyToken.(string)
+			if !ok {
+				return errors.New("JSON object key is not a string")
+			}
+			if _, duplicate := keys[key]; duplicate {
+				return errors.New("duplicate JSON key")
+			}
+			keys[key] = struct{}{}
+			if err := consumeJSONValue(decoder, depth+1); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim('}') {
+			return errors.New("JSON object has invalid closing delimiter")
+		}
+	case '[':
+		for decoder.More() {
+			if err := consumeJSONValue(decoder, depth+1); err != nil {
+				return err
+			}
+		}
+		closing, err := decoder.Token()
+		if err != nil || closing != json.Delim(']') {
+			return errors.New("JSON array has invalid closing delimiter")
+		}
+	default:
+		return errors.New("JSON contains an unexpected delimiter")
+	}
+	return nil
+}

--- a/internal/syncdispatchcontract/routes_test.go
+++ b/internal/syncdispatchcontract/routes_test.go
@@ -1,0 +1,176 @@
+package syncdispatchcontract
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCheckedInArtifactIsFrozenAndLookupIsImmutable(t *testing.T) {
+	t.Parallel()
+	registry, err := Load(filepath.Join("..", "..", "contracts", "sync-dispatch", "v1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, kind := range []string{
+		KindDispatchSyncRun,
+		KindFinalizeSyncRun,
+		KindPostSync,
+		KindReferenceDiscovery,
+	} {
+		descriptor, ok := registry.Lookup(kind)
+		if !ok {
+			t.Fatalf("%s route is missing", kind)
+		}
+		if descriptor.Route != RouteCelery || descriptor.RollbackRoute != RouteCelery {
+			t.Fatalf("%s descriptor is not currently Celery-only: %#v", kind, descriptor)
+		}
+	}
+	descriptor, ok := registry.Lookup(KindPostSync)
+	if !ok || descriptor.Delivery != DeliveryAtMostOnceMarkBefore {
+		t.Fatalf("post_sync descriptor = %#v", descriptor)
+	}
+	descriptor.Route = RouteRiver
+	again, ok := registry.Lookup(KindPostSync)
+	if !ok || again.Route != RouteCelery {
+		t.Fatalf("registry was mutated through lookup: %#v", again)
+	}
+	if _, ok := registry.Lookup("not-a-frozen-kind"); ok {
+		t.Fatal("unknown route kind was found")
+	}
+}
+
+func TestLoadRejectsInvalidArtifacts(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name     string
+		contents string
+	}{
+		{name: "malformed", contents: `{"schema_version":`},
+		{name: "unknown field", contents: strings.Replace(canonicalArtifact, `"schema_version": 1,`, `"schema_version": 1, "unexpected": true,`, 1)},
+		{name: "duplicate JSON key", contents: strings.Replace(canonicalArtifact, `"schema_version": 1,`, `"schema_version": 1, "schema_version": 1,`, 1)},
+		{name: "out of order", contents: outOfOrderArtifact},
+		{name: "missing coverage", contents: strings.Replace(canonicalArtifact, `"reference_discovery"`, `"unfrozen_kind"`, 1)},
+		{name: "wrong delivery", contents: strings.Replace(canonicalArtifact, `"kind": "post_sync", "delivery": "at_most_once_mark_before"`, `"kind": "post_sync", "delivery": "at_least_once"`, 1)},
+		{name: "unknown route", contents: strings.Replace(canonicalArtifact, `"route": "celery"`, `"route": "sqs"`, 1)},
+		{name: "celery with river rollback", contents: strings.Replace(canonicalArtifact, `"rollback_route": "celery"`, `"rollback_route": "river"`, 1)},
+		{name: "river with river rollback", contents: strings.ReplaceAll(canonicalArtifact, `"celery"`, `"river"`)},
+		{name: "trailing data", contents: canonicalArtifact + "\n{}"},
+	}
+	for _, test := range cases {
+		t.Run(test.name, func(t *testing.T) {
+			root := writeArtifact(t, test.contents)
+			if _, err := Load(root); err == nil {
+				t.Fatal("Load() error = nil")
+			}
+		})
+	}
+}
+
+func TestLoadAcceptsSelectableRiverRoutes(t *testing.T) {
+	t.Parallel()
+	root := writeArtifact(t, strings.Replace(canonicalArtifact, `"route": "celery"`, `"route": "river"`, 1))
+	registry, err := Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptor, ok := registry.Lookup(KindDispatchSyncRun)
+	if !ok || descriptor.Route != RouteRiver || descriptor.RollbackRoute != RouteCelery {
+		t.Fatalf("dispatch_sync_run descriptor = %#v", descriptor)
+	}
+}
+
+func TestLoadRejectsUnsafeOrInvalidPaths(t *testing.T) {
+	t.Parallel()
+	if _, err := Load(""); err == nil {
+		t.Fatal("empty root was accepted")
+	}
+	if _, err := Load(filepath.Join(t.TempDir(), "missing")); err == nil {
+		t.Fatal("missing root was accepted")
+	}
+
+	fileRoot := filepath.Join(t.TempDir(), "not-a-directory")
+	if err := os.WriteFile(fileRoot, []byte("not a directory"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(fileRoot); err == nil {
+		t.Fatal("file root was accepted")
+	}
+
+	t.Run("artifact symbolic link", func(t *testing.T) {
+		root := t.TempDir()
+		target := filepath.Join(root, "target.json")
+		if err := os.WriteFile(target, []byte(canonicalArtifact), 0o600); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.Symlink(target, filepath.Join(root, Filename)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Load(root); err == nil {
+			t.Fatal("symbolic-link artifact was accepted")
+		}
+	})
+
+	t.Run("root symbolic link", func(t *testing.T) {
+		actual := writeArtifact(t, canonicalArtifact)
+		linked := filepath.Join(t.TempDir(), "linked-root")
+		if err := os.Symlink(actual, linked); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Load(linked); err == nil {
+			t.Fatal("symbolic-link root was accepted")
+		}
+	})
+
+	t.Run("artifact directory", func(t *testing.T) {
+		root := t.TempDir()
+		if err := os.Mkdir(filepath.Join(root, Filename), 0o700); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := Load(root); err == nil {
+			t.Fatal("directory artifact was accepted")
+		}
+	})
+}
+
+func TestLoadRejectsOversizedArtifact(t *testing.T) {
+	t.Parallel()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte(strings.Repeat(" ", maxArtifactBytes+1)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Load(root); err == nil {
+		t.Fatal("oversized artifact was accepted")
+	}
+}
+
+func writeArtifact(t *testing.T, contents string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, Filename), []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+const canonicalArtifact = `{
+  "schema_version": 1,
+  "routes": [
+    {"kind": "dispatch_sync_run", "delivery": "at_least_once", "route": "celery", "rollback_route": "celery"},
+    {"kind": "finalize_sync_run", "delivery": "at_least_once", "route": "celery", "rollback_route": "celery"},
+    {"kind": "post_sync", "delivery": "at_most_once_mark_before", "route": "celery", "rollback_route": "celery"},
+    {"kind": "reference_discovery", "delivery": "at_least_once", "route": "celery", "rollback_route": "celery"}
+  ]
+}`
+
+const outOfOrderArtifact = `{
+  "schema_version": 1,
+  "routes": [
+    {"kind": "finalize_sync_run", "delivery": "at_least_once", "route": "celery", "rollback_route": "celery"},
+    {"kind": "dispatch_sync_run", "delivery": "at_least_once", "route": "celery", "rollback_route": "celery"},
+    {"kind": "post_sync", "delivery": "at_most_once_mark_before", "route": "celery", "rollback_route": "celery"},
+    {"kind": "reference_discovery", "delivery": "at_least_once", "route": "celery", "rollback_route": "celery"}
+  ]
+}`

--- a/internal/syncreconciler/loop.go
+++ b/internal/syncreconciler/loop.go
@@ -1,0 +1,431 @@
+package syncreconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+)
+
+const (
+	minPollInterval           = 10 * time.Millisecond
+	maxPollInterval           = 15 * time.Minute
+	minObservationTimeout     = 10 * time.Millisecond
+	maxObservationTimeout     = 30 * time.Second
+	defaultObservationTimeout = 2 * time.Second
+)
+
+var (
+	ErrLoopAlreadyStarted = errors.New("sync dispatch observer loop already started")
+	ErrTickerClosed       = errors.New("sync dispatch observer ticker closed unexpectedly")
+	errLoopNotReady       = errors.New("sync dispatch observer loop has not completed a successful observation")
+)
+
+// Stepper is kept small so loop lifecycle has no database dependency in its
+// tests. Observer satisfies this interface.
+type Stepper interface {
+	Step(context.Context, time.Time, int) (Observation, error)
+}
+
+type LoopConfig struct {
+	PollInterval       time.Duration
+	ObservationTimeout time.Duration
+	Limit              int
+	Registry           *health.Registry
+	// Recorder is optional and caller-owned. Implementations must honor the
+	// non-blocking TryRecord contract; Loop additionally permits only one
+	// recorder call in flight and drops while busy. Shutdown never waits for
+	// this caller-owned dependency, so a contract-violating recorder can strand
+	// at most one goroutine without holding readiness or process shutdown.
+	Recorder ObservationRecorder
+}
+
+// DefaultLoopConfig allows two seconds for one indexed read of at most 101
+// candidates. This is deliberately conservative relative to the bounded query
+// while still failing readiness promptly on database stalls.
+func DefaultLoopConfig(registry *health.Registry) LoopConfig {
+	return LoopConfig{
+		PollInterval:       time.Second,
+		ObservationTimeout: defaultObservationTimeout,
+		Limit:              maximumStepLimit,
+		Registry:           registry,
+	}
+}
+
+func (config LoopConfig) validate() error {
+	if config.Registry == nil || config.PollInterval < minPollInterval || config.PollInterval > maxPollInterval ||
+		config.ObservationTimeout < minObservationTimeout || config.ObservationTimeout > maxObservationTimeout ||
+		config.Limit < minimumStepLimit || config.Limit > maximumStepLimit {
+		return ErrInvalidConfiguration
+	}
+	return nil
+}
+
+type loopClock interface {
+	Now() time.Time
+	NewTicker(time.Duration) loopTicker
+}
+
+type loopTicker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now() }
+func (systemClock) NewTicker(interval time.Duration) loopTicker {
+	return systemTicker{Ticker: time.NewTicker(interval)}
+}
+
+type systemTicker struct{ *time.Ticker }
+
+func (ticker systemTicker) Chan() <-chan time.Time { return ticker.C }
+
+// Loop owns periodic observation and publishes only the latest successful
+// snapshot. Later observation errors are fatal so readiness cannot advertise
+// stale database state.
+type Loop struct {
+	stepper Stepper
+	config  LoopConfig
+	clock   loopClock
+
+	ready atomic.Bool
+
+	mu       sync.Mutex
+	started  bool
+	stopping bool
+	cancel   context.CancelFunc
+	done     chan struct{}
+	ticker   loopTicker
+
+	observation  Observation
+	lastOK       time.Time
+	up           bool
+	errors       chan error
+	recorderBusy chan struct{}
+}
+
+func NewLoop(stepper Stepper, config LoopConfig) (*Loop, error) {
+	return newLoop(stepper, config, systemClock{})
+}
+
+func newLoop(stepper Stepper, config LoopConfig, clock loopClock) (*Loop, error) {
+	if stepper == nil || clock == nil || config.validate() != nil {
+		return nil, ErrInvalidConfiguration
+	}
+	loop := &Loop{stepper: stepper, config: config, clock: clock, errors: make(chan error, 1)}
+	if config.Recorder != nil {
+		loop.recorderBusy = make(chan struct{}, 1)
+	}
+	if err := config.Registry.RegisterRequired("sync_dispatch_observer", loop.readiness); err != nil {
+		return nil, fmt.Errorf("register sync dispatch observer readiness: %w", err)
+	}
+	if err := config.Registry.RegisterMetrics("sync_dispatch_observer", loop); err != nil {
+		return nil, fmt.Errorf("register sync dispatch observer metrics: %w", err)
+	}
+	return loop, nil
+}
+
+func (*Loop) Name() string { return "sync-dispatch-observer-loop" }
+
+func (loop *Loop) Start(ctx context.Context) error {
+	if loop == nil || ctx == nil {
+		return ErrInvalidConfiguration
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	loop.mu.Lock()
+	if loop.started {
+		loop.mu.Unlock()
+		cancel()
+		return ErrLoopAlreadyStarted
+	}
+	if loop.stopping {
+		loop.mu.Unlock()
+		cancel()
+		return context.Canceled
+	}
+	loop.started = true
+	loop.cancel = cancel
+	loop.done = done
+	loop.mu.Unlock()
+
+	if err := loop.step(loopCtx, loop.clock.Now()); err != nil {
+		loop.setFailed()
+		cancel()
+		close(done)
+		return fmt.Errorf("initial sync dispatch observation: %w", err)
+	}
+	ticker := loop.clock.NewTicker(loop.config.PollInterval)
+	loop.mu.Lock()
+	if loop.stopping || loopCtx.Err() != nil {
+		startErr := loopCtx.Err()
+		if startErr == nil {
+			startErr = context.Canceled
+		}
+		loop.mu.Unlock()
+		ticker.Stop()
+		cancel()
+		loop.setFailed()
+		close(done)
+		return startErr
+	}
+	loop.ticker = ticker
+	loop.mu.Unlock()
+	go loop.run(loopCtx, ticker, done)
+	if err := loopCtx.Err(); err != nil {
+		loop.setFailed()
+		return err
+	}
+	return nil
+}
+
+func (loop *Loop) run(ctx context.Context, ticker loopTicker, done chan struct{}) {
+	var fatal error
+	defer close(done)
+	defer ticker.Stop()
+	defer func() {
+		if fatal != nil {
+			loop.reportError(ctx, fatal)
+		}
+	}()
+	defer loop.setFailed()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now, open := <-ticker.Chan():
+			if !open {
+				if ctx.Err() == nil {
+					fatal = ErrTickerClosed
+				}
+				return
+			}
+			if err := loop.step(ctx, now); err != nil {
+				if isContextError(err) && (ctx.Err() != nil || loop.isStopping()) {
+					return
+				}
+				fatal = fmt.Errorf("sync dispatch observation step: %w", err)
+				return
+			}
+		}
+	}
+}
+
+func (loop *Loop) reportError(ctx context.Context, err error) {
+	select {
+	case loop.errors <- err:
+	case <-ctx.Done():
+	}
+}
+
+func (loop *Loop) step(ctx context.Context, now time.Time) error {
+	stepCtx, cancel := context.WithTimeout(ctx, loop.config.ObservationTimeout)
+	defer cancel()
+	observation, err := loop.stepper.Step(stepCtx, now, loop.config.Limit)
+	if contextErr := stepCtx.Err(); contextErr != nil {
+		return contextErr
+	}
+	if err != nil {
+		// Unknown stored kinds are a failed observation, but their bounded total
+		// is still valuable operator evidence. Keep it as a gauge while the
+		// readiness failure prevents this process from being considered healthy.
+		if errors.Is(err, ErrUnknownKind) {
+			offer := false
+			loop.mu.Lock()
+			if !loop.stopping && stepCtx.Err() == nil {
+				loop.observation = copyObservation(observation)
+				offer = true
+			}
+			loop.mu.Unlock()
+			if offer {
+				loop.offerObservation(observation)
+			}
+		}
+		return err
+	}
+	if err := stepCtx.Err(); err != nil {
+		return err
+	}
+	loop.mu.Lock()
+	if loop.stopping {
+		loop.mu.Unlock()
+		return context.Canceled
+	}
+	if err := stepCtx.Err(); err != nil {
+		loop.mu.Unlock()
+		return err
+	}
+	loop.observation = copyObservation(observation)
+	loop.lastOK = now
+	loop.up = true
+	loop.ready.Store(true)
+	loop.mu.Unlock()
+	loop.offerObservation(observation)
+	return nil
+}
+
+func (loop *Loop) offerObservation(observation Observation) {
+	if loop == nil || loop.config.Recorder == nil || loop.recorderBusy == nil {
+		return
+	}
+	select {
+	case loop.recorderBusy <- struct{}{}:
+	default:
+		return
+	}
+	observation = copyObservation(observation)
+	go func() {
+		defer func() {
+			_ = recover()
+			<-loop.recorderBusy
+		}()
+		_ = loop.config.Recorder.TryRecord(observation)
+	}()
+}
+
+func (loop *Loop) isStopping() bool {
+	loop.mu.Lock()
+	defer loop.mu.Unlock()
+	return loop.stopping
+}
+
+func isContextError(err error) bool {
+	return errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)
+}
+
+func copyObservation(observation Observation) Observation {
+	observation.Kinds = append([]KindObservation(nil), observation.Kinds...)
+	return observation
+}
+
+func (loop *Loop) setFailed() {
+	loop.mu.Lock()
+	loop.up = false
+	loop.ready.Store(false)
+	loop.mu.Unlock()
+}
+
+func (loop *Loop) readiness(context.Context) error {
+	if loop != nil && loop.ready.Load() {
+		return nil
+	}
+	return errLoopNotReady
+}
+
+func (loop *Loop) Errors() <-chan error {
+	if loop == nil {
+		return nil
+	}
+	return loop.errors
+}
+
+func (loop *Loop) Shutdown(ctx context.Context) error {
+	if loop == nil || ctx == nil {
+		return ErrInvalidConfiguration
+	}
+	loop.mu.Lock()
+	loop.stopping = true
+	loop.up = false
+	loop.ready.Store(false)
+	cancel := loop.cancel
+	ticker := loop.ticker
+	done := loop.done
+	loop.mu.Unlock()
+	if ticker != nil {
+		ticker.Stop()
+	}
+	if cancel != nil {
+		cancel()
+	}
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// WritePrometheus emits current observations as gauges. It never accumulates
+// snapshots: counters would misrepresent current queued work after rows are
+// dispatched or claims expire.
+func (loop *Loop) WritePrometheus(output io.Writer) error {
+	if loop == nil || output == nil {
+		return errors.New("Prometheus output is required")
+	}
+	loop.mu.Lock()
+	observation := copyObservation(loop.observation)
+	lastOK := loop.lastOK
+	up := loop.up
+	now := loop.clock.Now()
+	loop.mu.Unlock()
+
+	var text strings.Builder
+	text.WriteString("# HELP sync_dispatch_observer_due_pending Due pending rows in the bounded Python claim-order window by fixed kind.\n# TYPE sync_dispatch_observer_due_pending gauge\n")
+	for _, kind := range fixedMetricKinds(observation) {
+		fmt.Fprintf(&text, "sync_dispatch_observer_due_pending{kind=%q} %d\n", kind.Kind, kind.DuePending)
+	}
+	text.WriteString("# HELP sync_dispatch_observer_expired_claims Expired claims among due rows in the bounded Python claim-order window by fixed kind.\n# TYPE sync_dispatch_observer_expired_claims gauge\n")
+	for _, kind := range fixedMetricKinds(observation) {
+		fmt.Fprintf(&text, "sync_dispatch_observer_expired_claims{kind=%q} %d\n", kind.Kind, kind.ExpiredClaims)
+	}
+	fmt.Fprintf(&text, "# HELP sync_dispatch_observer_unknown_kinds Unknown-kind rows in the bounded Python claim-order window.\n# TYPE sync_dispatch_observer_unknown_kinds gauge\nsync_dispatch_observer_unknown_kinds %d\n", observation.UnknownKindCount)
+	fmt.Fprintf(&text, "# HELP sync_dispatch_observer_celery_due_pending Due pending rows routed to Celery in the bounded Python claim-order window.\n# TYPE sync_dispatch_observer_celery_due_pending gauge\nsync_dispatch_observer_celery_due_pending %d\n", observation.CeleryDuePending)
+	fmt.Fprintf(&text, "# HELP sync_dispatch_observer_river_due_pending Due pending rows routed to River in the bounded Python claim-order window.\n# TYPE sync_dispatch_observer_river_due_pending gauge\nsync_dispatch_observer_river_due_pending %d\n", observation.RiverDuePending)
+	fmt.Fprintf(&text, "# HELP sync_dispatch_observer_sampled_candidates Due rows sampled from the bounded Python claim-order window.\n# TYPE sync_dispatch_observer_sampled_candidates gauge\nsync_dispatch_observer_sampled_candidates %d\n", observation.SampledCandidates)
+	text.WriteString("# HELP sync_dispatch_observer_truncated Whether an extra due row proved the bounded Python claim-order window was truncated.\n# TYPE sync_dispatch_observer_truncated gauge\nsync_dispatch_observer_truncated ")
+	if observation.Truncated {
+		text.WriteString("1\n")
+	} else {
+		text.WriteString("0\n")
+	}
+	text.WriteString("# HELP sync_dispatch_observer_up Whether the observer loop is currently healthy.\n# TYPE sync_dispatch_observer_up gauge\nsync_dispatch_observer_up ")
+	if up {
+		text.WriteString("1\n")
+	} else {
+		text.WriteString("0\n")
+	}
+	if !lastOK.IsZero() {
+		lastSuccessAge := 0.0
+		if !now.Before(lastOK) {
+			lastSuccessAge = now.Sub(lastOK).Seconds()
+		}
+		fmt.Fprintf(&text, "# HELP sync_dispatch_observer_last_success_age_seconds Age of the last successful sync-dispatch observation.\n# TYPE sync_dispatch_observer_last_success_age_seconds gauge\nsync_dispatch_observer_last_success_age_seconds %s\n", strconv.FormatFloat(lastSuccessAge, 'g', -1, 64))
+	}
+	_, err := io.WriteString(output, text.String())
+	return err
+}
+
+// fixedMetricKinds prevents an accidental or test-only Stepper from creating
+// an unbounded Prometheus label series. Missing fixed kinds are exported as
+// zero until the next valid observer snapshot.
+func fixedMetricKinds(observation Observation) []KindObservation {
+	byKind := make(map[string]KindObservation, len(observation.Kinds))
+	for _, kind := range observation.Kinds {
+		if kind.DuePending < 0 || kind.ExpiredClaims < 0 {
+			continue
+		}
+		byKind[kind.Kind] = kind
+	}
+	result := make([]KindObservation, 0, len(frozenKinds))
+	for _, name := range frozenKinds {
+		kind := byKind[name]
+		kind.Kind = name
+		result = append(result, kind)
+	}
+	return result
+}

--- a/internal/syncreconciler/loop_test.go
+++ b/internal/syncreconciler/loop_test.go
@@ -1,0 +1,645 @@
+package syncreconciler
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+)
+
+type loopStepFunc func(context.Context, time.Time, int) (Observation, error)
+
+func (fn loopStepFunc) Step(ctx context.Context, now time.Time, limit int) (Observation, error) {
+	return fn(ctx, now, limit)
+}
+
+type recorderFunc func(Observation) bool
+
+func (fn recorderFunc) TryRecord(observation Observation) bool { return fn(observation) }
+
+type testClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	ticker *testTicker
+}
+
+func (clock *testClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *testClock) NewTicker(time.Duration) loopTicker {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	clock.ticker = &testTicker{ticks: make(chan time.Time, 2)}
+	return clock.ticker
+}
+
+type testTicker struct {
+	ticks   chan time.Time
+	stopped chan struct{}
+	once    sync.Once
+}
+
+func (ticker *testTicker) Chan() <-chan time.Time { return ticker.ticks }
+func (ticker *testTicker) Stop() {
+	ticker.once.Do(func() {
+		ticker.stopped = make(chan struct{})
+		close(ticker.stopped)
+	})
+}
+
+func newTestLoop(t *testing.T, stepper Stepper, clock *testClock) (*Loop, *health.Registry) {
+	t.Helper()
+	return newTestLoopWithTimeout(t, stepper, clock, defaultObservationTimeout)
+}
+
+func newTestLoopWithTimeout(
+	t *testing.T,
+	stepper Stepper,
+	clock *testClock,
+	timeout time.Duration,
+) (*Loop, *health.Registry) {
+	t.Helper()
+	return newTestLoopConfigured(t, stepper, clock, timeout, nil)
+}
+
+func newTestLoopConfigured(
+	t *testing.T,
+	stepper Stepper,
+	clock *testClock,
+	timeout time.Duration,
+	recorder ObservationRecorder,
+) (*Loop, *health.Registry) {
+	t.Helper()
+	registry := health.NewRegistry(time.Second)
+	loop, err := newLoop(stepper, LoopConfig{
+		PollInterval:       minPollInterval,
+		ObservationTimeout: timeout,
+		Limit:              7,
+		Registry:           registry,
+		Recorder:           recorder,
+	}, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loop, registry
+}
+
+func openReadinessGate(t *testing.T, registry *health.Registry) {
+	t.Helper()
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func testObservation() Observation {
+	return Observation{
+		Kinds: []KindObservation{
+			{Kind: frozenKinds[0], DuePending: 2, ExpiredClaims: 1},
+			{Kind: frozenKinds[1], DuePending: 1},
+			{Kind: frozenKinds[2], DuePending: 3, ExpiredClaims: 2, Route: "river"},
+			{Kind: frozenKinds[3]},
+		},
+		CeleryDuePending:  3,
+		RiverDuePending:   3,
+		SampledCandidates: 6,
+		ObservedAt:        time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC),
+		Limit:             7,
+		PredicateVersion:  PredicateVersion,
+		DigestVersion:     DigestVersion,
+		CandidateDigest:   "sha256:must-not-be-a-metric-label",
+	}
+}
+
+func TestLoopImmediateObservationGatesReadinessAndExportsGauges(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	calls := make(chan struct{}, 1)
+	loop, registry := newTestLoop(t, loopStepFunc(func(_ context.Context, _ time.Time, limit int) (Observation, error) {
+		if limit != 7 {
+			t.Fatalf("limit = %d", limit)
+		}
+		calls <- struct{}{}
+		return testObservation(), nil
+	}), clock)
+	openReadinessGate(t, registry)
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("pre-start readiness = %#v", readiness)
+	}
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	<-calls
+	if readiness := registry.Readiness(context.Background()); !readiness.Ready {
+		t.Fatalf("post-start readiness = %#v", readiness)
+	}
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"sync_dispatch_observer_due_pending{kind=\"dispatch_sync_run\"} 2",
+		"sync_dispatch_observer_expired_claims{kind=\"post_sync\"} 2",
+		"sync_dispatch_observer_celery_due_pending 3",
+		"sync_dispatch_observer_river_due_pending 3",
+		"sync_dispatch_observer_sampled_candidates 6",
+		"sync_dispatch_observer_truncated 0",
+		"sync_dispatch_observer_up 1",
+		"bounded Python claim-order window",
+	} {
+		if !strings.Contains(metrics.String(), want) {
+			t.Fatalf("metrics missing %q:\n%s", want, metrics.String())
+		}
+	}
+	if strings.Contains(metrics.String(), " counter\n") ||
+		strings.Contains(metrics.String(), PredicateVersion) ||
+		strings.Contains(metrics.String(), DigestVersion) ||
+		strings.Contains(metrics.String(), canonicalObservedAt(testObservation().ObservedAt)) ||
+		strings.Contains(metrics.String(), "must-not-be-a-metric-label") {
+		t.Fatalf("metrics must be numeric bounded gauges:\n%s", metrics.String())
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoopRecorderDropAndPanicNeverAffectSuccessfulReadiness(t *testing.T) {
+	for name, recorder := range map[string]ObservationRecorder{
+		"drop": recorderFunc(func(Observation) bool { return false }),
+		"panic": recorderFunc(func(Observation) bool {
+			panic("recorder panic")
+		}),
+	} {
+		t.Run(name, func(t *testing.T) {
+			clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+			loop, registry := newTestLoopConfigured(
+				t,
+				loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+					return testObservation(), nil
+				}),
+				clock,
+				defaultObservationTimeout,
+				recorder,
+			)
+			openReadinessGate(t, registry)
+			if err := loop.Start(context.Background()); err != nil {
+				t.Fatalf("Start() error = %v", err)
+			}
+			if readiness := registry.Readiness(context.Background()); !readiness.Ready {
+				t.Fatalf("recorder changed readiness = %#v", readiness)
+			}
+			if err := loop.Shutdown(context.Background()); err != nil {
+				t.Fatal(err)
+			}
+		})
+	}
+}
+
+func TestLoopBlockingRecorderCannotStallStepsOrSpawnUnboundedCalls(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	recorderEntered := make(chan struct{})
+	recorderRelease := make(chan struct{})
+	var recorderCalls atomic.Int64
+	recorder := recorderFunc(func(Observation) bool {
+		recorderCalls.Add(1)
+		close(recorderEntered)
+		<-recorderRelease
+		return true
+	})
+	steps := make(chan struct{}, 2)
+	loop, registry := newTestLoopConfigured(
+		t,
+		loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+			steps <- struct{}{}
+			return testObservation(), nil
+		}),
+		clock,
+		defaultObservationTimeout,
+		recorder,
+	)
+	openReadinessGate(t, registry)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	<-steps
+	<-recorderEntered
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	ticker.ticks <- clock.Now().Add(time.Second)
+	<-steps
+	if recorderCalls.Load() != 1 {
+		t.Fatalf("blocking recorder calls = %d, want one bounded in-flight call", recorderCalls.Load())
+	}
+	if readiness := registry.Readiness(context.Background()); !readiness.Ready {
+		t.Fatalf("blocking recorder changed readiness = %#v", readiness)
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatalf("blocking recorder stalled shutdown: %v", err)
+	}
+	close(recorderRelease)
+}
+
+func TestLoopOffersBoundedUnknownKindObservation(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	recorded := make(chan Observation, 1)
+	recorder := recorderFunc(func(observation Observation) bool {
+		recorded <- observation
+		return true
+	})
+	unknown := validRecorderObservation()
+	unknown.UnknownKindCount = 1
+	unknown.SampledCandidates = 3
+	loop, registry := newTestLoopConfigured(
+		t,
+		loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+			return unknown, ErrUnknownKind
+		}),
+		clock,
+		defaultObservationTimeout,
+		recorder,
+	)
+	openReadinessGate(t, registry)
+	if err := loop.Start(context.Background()); !errors.Is(err, ErrUnknownKind) {
+		t.Fatalf("Start() error = %v", err)
+	}
+	select {
+	case observation := <-recorded:
+		if observation.UnknownKindCount != 1 || observation.SampledCandidates != 3 {
+			t.Fatalf("recorded observation = %#v", observation)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("unknown-kind observation was not offered")
+	}
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("unknown-kind readiness = %#v", readiness)
+	}
+}
+
+func TestLoopPeriodicErrorClosesReadinessAndSurfacesError(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	fatal := errors.New("database unavailable")
+	calls := 0
+	loop, registry := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+		calls++
+		if calls == 1 {
+			return testObservation(), nil
+		}
+		return Observation{}, fatal
+	}), clock)
+	openReadinessGate(t, registry)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	clock.mu.Lock()
+	clock.now = clock.now.Add(5 * time.Second)
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	ticker.ticks <- clock.Now()
+	if err := <-loop.Errors(); !errors.Is(err, fatal) {
+		t.Fatalf("Errors() = %v", err)
+	}
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("failed readiness = %#v", readiness)
+	}
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"sync_dispatch_observer_up 0\n",
+		"sync_dispatch_observer_last_success_age_seconds 5\n",
+	} {
+		if !strings.Contains(metrics.String(), want) {
+			t.Fatalf("post-failure metrics missing %q:\n%s", want, metrics.String())
+		}
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoopInitialObservationDeadlineIsBoundedAndSanitized(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	exited := make(chan struct{})
+	loop, registry := newTestLoopWithTimeout(t, loopStepFunc(func(ctx context.Context, _ time.Time, _ int) (Observation, error) {
+		<-ctx.Done()
+		close(exited)
+		return Observation{}, fmt.Errorf("postgres://operator:secret@db/app: %w", ctx.Err())
+	}), clock, minObservationTimeout)
+	openReadinessGate(t, registry)
+
+	err := loop.Start(context.Background())
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start() error = %v, want deadline", err)
+	}
+	if strings.Contains(err.Error(), "postgres://") || strings.Contains(err.Error(), "secret") {
+		t.Fatalf("Start() leaked step error detail: %v", err)
+	}
+	select {
+	case <-exited:
+	default:
+		t.Fatal("initial step goroutine did not exit after deadline")
+	}
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("deadline readiness = %#v", readiness)
+	}
+	select {
+	case fatal := <-loop.Errors():
+		t.Fatalf("initial deadline unexpectedly surfaced on Errors(): %v", fatal)
+	default:
+	}
+}
+
+func TestLoopPeriodicObservationDeadlineIsFatalAndSanitized(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	pollExited := make(chan struct{})
+	calls := 0
+	loop, registry := newTestLoopWithTimeout(t, loopStepFunc(func(ctx context.Context, _ time.Time, _ int) (Observation, error) {
+		calls++
+		if calls == 1 {
+			return testObservation(), nil
+		}
+		<-ctx.Done()
+		close(pollExited)
+		return Observation{}, fmt.Errorf("postgres://operator:secret@db/app: %w", ctx.Err())
+	}), clock, minObservationTimeout)
+	openReadinessGate(t, registry)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	ticker.ticks <- clock.Now().Add(time.Second)
+	fatal := <-loop.Errors()
+	if !errors.Is(fatal, context.DeadlineExceeded) {
+		t.Fatalf("Errors() = %v, want deadline", fatal)
+	}
+	if strings.Contains(fatal.Error(), "postgres://") || strings.Contains(fatal.Error(), "secret") {
+		t.Fatalf("Errors() leaked step error detail: %v", fatal)
+	}
+	select {
+	case <-pollExited:
+	default:
+		t.Fatal("periodic step goroutine did not exit after deadline")
+	}
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("deadline readiness = %#v", readiness)
+	}
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(metrics.String(), "sync_dispatch_observer_up 0\n") {
+		t.Fatalf("deadline metrics =\n%s", metrics.String())
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoopReportsUnknownKindGaugeWhileFailingClosed(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	loop, _ := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+		return Observation{UnknownKindCount: 4, SampledCandidates: 4}, ErrUnknownKind
+	}), clock)
+	if err := loop.Start(context.Background()); !errors.Is(err, ErrUnknownKind) {
+		t.Fatalf("Start() error = %v", err)
+	}
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(metrics.String(), "sync_dispatch_observer_unknown_kinds 4\n") ||
+		!strings.Contains(metrics.String(), "sync_dispatch_observer_up 0\n") {
+		t.Fatalf("unknown-kind failure metrics =\n%s", metrics.String())
+	}
+}
+
+func TestLoopParentCancellationClosesReadiness(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	loop, registry := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+		return testObservation(), nil
+	}), clock)
+	openReadinessGate(t, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := loop.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	if readiness := registry.Readiness(context.Background()); !readiness.Ready {
+		t.Fatalf("started readiness = %#v", readiness)
+	}
+	cancel()
+	loop.mu.Lock()
+	done := loop.done
+	loop.mu.Unlock()
+	<-done
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("canceled readiness = %#v", readiness)
+	}
+	select {
+	case err := <-loop.Errors():
+		t.Fatalf("parent cancellation surfaced fatal error: %v", err)
+	default:
+	}
+}
+
+func TestLoopShutdownCancelsAndWaitsForInitialStep(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	entered := make(chan struct{})
+	canceled := make(chan struct{})
+	release := make(chan struct{})
+	loop, registry := newTestLoop(t, loopStepFunc(func(ctx context.Context, _ time.Time, _ int) (Observation, error) {
+		close(entered)
+		<-ctx.Done()
+		close(canceled)
+		<-release
+		return Observation{}, ctx.Err()
+	}), clock)
+	openReadinessGate(t, registry)
+
+	startResult := make(chan error, 1)
+	go func() { startResult <- loop.Start(context.Background()) }()
+	<-entered
+	shutdownResult := make(chan error, 1)
+	go func() { shutdownResult <- loop.Shutdown(context.Background()) }()
+	<-canceled
+	select {
+	case err := <-shutdownResult:
+		t.Fatalf("Shutdown returned before initial step exited: %v", err)
+	default:
+	}
+	close(release)
+	if err := <-shutdownResult; err != nil {
+		t.Fatalf("Shutdown() error = %v", err)
+	}
+	if err := <-startResult; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start() error = %v, want cancellation", err)
+	}
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("post-shutdown readiness = %#v", readiness)
+	}
+	select {
+	case err := <-loop.Errors():
+		t.Fatalf("shutdown surfaced fatal error: %v", err)
+	default:
+	}
+}
+
+func TestLoopParentCancellationDuringInitialStepNeverPublishesReadiness(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	loop, registry := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+		close(entered)
+		<-release
+		return testObservation(), nil
+	}), clock)
+	openReadinessGate(t, registry)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	startResult := make(chan error, 1)
+	go func() { startResult <- loop.Start(ctx) }()
+	<-entered
+	cancel()
+	close(release)
+	if err := <-startResult; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Start() error = %v, want cancellation", err)
+	}
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("canceled initial-step readiness = %#v", readiness)
+	}
+	select {
+	case err := <-loop.Errors():
+		t.Fatalf("initial cancellation surfaced fatal error: %v", err)
+	default:
+	}
+}
+
+func TestLoopCancellationDuringPollingReadIsNormalAndNonfatal(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	pollEntered := make(chan struct{})
+	calls := 0
+	loop, registry := newTestLoop(t, loopStepFunc(func(ctx context.Context, _ time.Time, _ int) (Observation, error) {
+		calls++
+		if calls == 1 {
+			return testObservation(), nil
+		}
+		close(pollEntered)
+		<-ctx.Done()
+		return Observation{}, ctx.Err()
+	}), clock)
+	openReadinessGate(t, registry)
+	ctx, cancel := context.WithCancel(context.Background())
+	if err := loop.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	clock.mu.Lock()
+	ticker := clock.ticker
+	done := loop.done
+	clock.mu.Unlock()
+	ticker.ticks <- clock.Now().Add(time.Second)
+	<-pollEntered
+	cancel()
+	<-done
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("poll-canceled readiness = %#v", readiness)
+	}
+	select {
+	case err := <-loop.Errors():
+		t.Fatalf("poll cancellation surfaced fatal error: %v", err)
+	default:
+	}
+}
+
+func TestLoopUnexpectedTickerCloseIsFatalAndClosesReadiness(t *testing.T) {
+	clock := &testClock{now: time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)}
+	loop, registry := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int) (Observation, error) {
+		return testObservation(), nil
+	}), clock)
+	openReadinessGate(t, registry)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	close(ticker.ticks)
+	if err := <-loop.Errors(); !errors.Is(err, ErrTickerClosed) {
+		t.Fatalf("Errors() = %v, want %v", err, ErrTickerClosed)
+	}
+	if readiness := registry.Readiness(context.Background()); readiness.Ready {
+		t.Fatalf("ticker-close readiness = %#v", readiness)
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoopRejectsInvalidConfigAndShutdownStopsTicker(t *testing.T) {
+	registry := health.NewRegistry(time.Second)
+	stepper := loopStepFunc(func(context.Context, time.Time, int) (Observation, error) { return Observation{}, nil })
+	for _, config := range []LoopConfig{
+		{PollInterval: minPollInterval, ObservationTimeout: minObservationTimeout, Limit: 1},
+		{PollInterval: minPollInterval - time.Nanosecond, ObservationTimeout: minObservationTimeout, Limit: 1, Registry: registry},
+		{PollInterval: minPollInterval, ObservationTimeout: minObservationTimeout - time.Nanosecond, Limit: 1, Registry: registry},
+		{PollInterval: minPollInterval, ObservationTimeout: maxObservationTimeout + time.Nanosecond, Limit: 1, Registry: registry},
+		{PollInterval: minPollInterval, ObservationTimeout: minObservationTimeout, Limit: 0, Registry: registry},
+		{PollInterval: minPollInterval, ObservationTimeout: minObservationTimeout, Limit: maximumStepLimit + 1, Registry: registry},
+	} {
+		if _, err := NewLoop(stepper, config); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("NewLoop(%#v) error = %v", config, err)
+		}
+	}
+	defaultConfig := DefaultLoopConfig(health.NewRegistry(time.Second))
+	if defaultConfig.ObservationTimeout != 2*time.Second || defaultConfig.validate() != nil {
+		t.Fatalf("DefaultLoopConfig() = %#v", defaultConfig)
+	}
+	clock := &testClock{now: time.Now()}
+	loop, _ := newTestLoop(t, stepper, clock)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ticker.stopped:
+	default:
+		t.Fatal("shutdown did not stop ticker")
+	}
+}
+
+func TestMetricsNeverExposeNonFrozenKindLabels(t *testing.T) {
+	loop := &Loop{clock: systemClock{}, observation: Observation{Kinds: []KindObservation{{Kind: "tenant-secret", DuePending: 9}}}}
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(metrics.String(), "tenant-secret") || strings.Count(metrics.String(), "sync_dispatch_observer_due_pending{kind=") != len(frozenKinds) {
+		t.Fatalf("metrics leaked unbounded labels:\n%s", metrics.String())
+	}
+}
+
+func TestMetricsOmitLastSuccessAgeBeforeFirstSuccess(t *testing.T) {
+	loop := &Loop{clock: systemClock{}}
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(metrics.String(), "sync_dispatch_observer_last_success_age_seconds") {
+		t.Fatalf("pre-success metrics exported a fabricated age:\n%s", metrics.String())
+	}
+}

--- a/internal/syncreconciler/observer.go
+++ b/internal/syncreconciler/observer.go
@@ -1,0 +1,330 @@
+// Package syncreconciler observes the legacy sync-dispatch outbox during the
+// phased worker migration. It is deliberately read-only: execution, claims,
+// and transport delivery remain owned by the existing Celery reconciler.
+package syncreconciler
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"regexp"
+	"sort"
+	"strconv"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	minimumStepLimit = 1
+	maximumStepLimit = 100
+
+	// PredicateVersion names the exact due-row predicate and ordering shared
+	// with Python claim_due_outbox_rows.
+	PredicateVersion = "sync_dispatch_due_v1"
+	// DigestVersion names the canonical metadata and candidate framing used by
+	// CandidateDigest.
+	DigestVersion = "sync_dispatch_candidate_digest_v1"
+)
+
+var (
+	// ErrInvalidConfiguration is returned before an observer can make an
+	// unbounded or ambiguous database observation.
+	ErrInvalidConfiguration = errors.New("invalid sync dispatch observer configuration")
+	// ErrUnavailable deliberately hides database details from lifecycle and
+	// metrics paths while still closing readiness.
+	ErrUnavailable = errors.New("sync dispatch observer database unavailable")
+	// ErrUnknownKind makes contract drift inside the bounded candidate window
+	// a fail-closed condition. The returned Observation retains bounded
+	// diagnostic counts and the parity digest.
+	ErrUnknownKind = errors.New("sync dispatch observer found an unknown kind")
+)
+
+var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+// Registry is the intentionally small route-policy seam used by the
+// observer. syncdispatchcontract.Registry satisfies it without coupling this
+// package to artifact loading or route execution.
+type Registry interface {
+	Lookup(string) (syncdispatchcontract.Descriptor, bool)
+}
+
+// KindObservation is a bounded claim-order snapshot for one fixed v1 kind.
+// Route is copied from the checked-in contract and is never inferred from a
+// stored outbox row.
+type KindObservation struct {
+	Kind          string
+	Route         string
+	DuePending    int64
+	ExpiredClaims int64
+}
+
+// Observation describes only the first Limit due rows in Python claim order.
+// ObservedAt is always the UTC cutoff supplied to the SQL predicate.
+// CandidateDigest is sha256:<lowercase hex> over canonical metadata followed
+// by the sampled candidates in order.
+//
+// Every field uses this cross-language byte framing:
+//
+//	decimal UTF-8 byte length of field name, ":", field-name bytes,
+//	decimal UTF-8 byte length of value, ":", value bytes, "\n"
+//
+// Fields occur in this exact order:
+//
+//	digest_version, predicate_version, observed_at, limit,
+//	then candidate_kind, candidate_id for every sampled row.
+//
+// observed_at is UTC with exactly nine fractional digits and a trailing Z;
+// limit is base-10 ASCII; UUIDs are canonical lowercase text. Length prefixes
+// make arbitrary UTF-8 kinds unambiguous. Metrics deliberately omit all string
+// parity fields.
+type Observation struct {
+	Kinds             []KindObservation
+	UnknownKindCount  int64
+	CeleryDuePending  int64
+	RiverDuePending   int64
+	SampledCandidates int64
+	Truncated         bool
+	ObservedAt        time.Time
+	Limit             int
+	PredicateVersion  string
+	DigestVersion     string
+	CandidateDigest   string
+}
+
+type candidateRow struct {
+	id             string
+	kind           string
+	claimExpiresAt *time.Time
+}
+
+type readFunc func(context.Context, time.Time, int) ([]candidateRow, error)
+
+// Observer performs a single bounded, ordered SELECT using pgxpool.
+type Observer struct {
+	descriptors []syncdispatchcontract.Descriptor
+	byKind      map[string]syncdispatchcontract.Descriptor
+	read        readFunc
+}
+
+var frozenKinds = []string{
+	syncdispatchcontract.KindDispatchSyncRun,
+	syncdispatchcontract.KindFinalizeSyncRun,
+	syncdispatchcontract.KindPostSync,
+	syncdispatchcontract.KindReferenceDiscovery,
+}
+
+// NewObserver constructs a database-backed, observe-only reconciler. No
+// transaction is opened because this component must never claim, lock, or
+// mutate a sync-dispatch row.
+func NewObserver(pool *pgxpool.Pool, registry Registry) (*Observer, error) {
+	if pool == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	return newObserver(registry, func(ctx context.Context, now time.Time, limit int) ([]candidateRow, error) {
+		return readObservation(ctx, pool, now, limit)
+	})
+}
+
+func newObserver(registry Registry, read readFunc) (*Observer, error) {
+	descriptors, err := fixedDescriptors(registry)
+	if err != nil || read == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	byKind := make(map[string]syncdispatchcontract.Descriptor, len(descriptors))
+	for _, descriptor := range descriptors {
+		byKind[descriptor.Kind] = descriptor
+	}
+	return &Observer{descriptors: descriptors, byKind: byKind, read: read}, nil
+}
+
+// Step takes exactly one bounded database snapshot. It requests one extra row
+// solely to prove truncation, then aggregates and digests only the first limit
+// rows.
+func (observer *Observer) Step(ctx context.Context, now time.Time, limit int) (Observation, error) {
+	if observer == nil || observer.read == nil || ctx == nil || now.IsZero() ||
+		limit < minimumStepLimit || limit > maximumStepLimit {
+		return Observation{}, ErrInvalidConfiguration
+	}
+	if err := ctx.Err(); err != nil {
+		return Observation{}, err
+	}
+
+	now = now.UTC()
+	rows, err := observer.read(ctx, now, limit+1)
+	if err != nil {
+		if contextErr := ctx.Err(); contextErr != nil {
+			return Observation{}, contextErr
+		}
+		if errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded) {
+			return Observation{}, err
+		}
+		return Observation{}, ErrUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return Observation{}, err
+	}
+	return observer.buildObservation(rows, now, limit)
+}
+
+func fixedDescriptors(registry Registry) ([]syncdispatchcontract.Descriptor, error) {
+	if registry == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	descriptors := make([]syncdispatchcontract.Descriptor, 0, len(frozenKinds))
+	for _, kind := range frozenKinds {
+		descriptor, ok := registry.Lookup(kind)
+		expectedDelivery := syncdispatchcontract.DeliveryAtLeastOnce
+		if kind == syncdispatchcontract.KindPostSync {
+			expectedDelivery = syncdispatchcontract.DeliveryAtMostOnceMarkBefore
+		}
+		if !ok || descriptor.Kind != kind || descriptor.Delivery != expectedDelivery ||
+			descriptor.RollbackRoute != syncdispatchcontract.RouteCelery ||
+			(descriptor.Route != syncdispatchcontract.RouteCelery && descriptor.Route != syncdispatchcontract.RouteRiver) {
+			return nil, ErrInvalidConfiguration
+		}
+		descriptors = append(descriptors, descriptor)
+	}
+	sort.Slice(descriptors, func(left, right int) bool { return descriptors[left].Kind < descriptors[right].Kind })
+	return descriptors, nil
+}
+
+func (observer *Observer) buildObservation(rows []candidateRow, now time.Time, limit int) (Observation, error) {
+	if len(rows) > limit+1 {
+		return Observation{}, ErrUnavailable
+	}
+	sampled := rows
+	truncated := len(rows) > limit
+	if truncated {
+		sampled = rows[:limit]
+	}
+
+	result := Observation{
+		Kinds:             make([]KindObservation, 0, len(observer.descriptors)),
+		SampledCandidates: int64(len(sampled)),
+		Truncated:         truncated,
+		ObservedAt:        now,
+		Limit:             limit,
+		PredicateVersion:  PredicateVersion,
+		DigestVersion:     DigestVersion,
+	}
+	kindIndexes := make(map[string]int, len(observer.descriptors))
+	for _, descriptor := range observer.descriptors {
+		kindIndexes[descriptor.Kind] = len(result.Kinds)
+		result.Kinds = append(result.Kinds, KindObservation{Kind: descriptor.Kind, Route: descriptor.Route})
+	}
+
+	hasher := sha256.New()
+	writeDigestField(hasher, "digest_version", result.DigestVersion)
+	writeDigestField(hasher, "predicate_version", result.PredicateVersion)
+	writeDigestField(hasher, "observed_at", canonicalObservedAt(result.ObservedAt))
+	writeDigestField(hasher, "limit", strconv.Itoa(result.Limit))
+	seenIDs := make(map[string]struct{}, len(rows))
+	for index, row := range rows {
+		if !uuidPattern.MatchString(row.id) {
+			return Observation{}, ErrUnavailable
+		}
+		if _, duplicate := seenIDs[row.id]; duplicate {
+			return Observation{}, ErrUnavailable
+		}
+		seenIDs[row.id] = struct{}{}
+		if row.claimExpiresAt != nil && row.claimExpiresAt.After(now) {
+			return Observation{}, ErrUnavailable
+		}
+		if index >= limit {
+			continue
+		}
+
+		writeDigestField(hasher, "candidate_kind", row.kind)
+		writeDigestField(hasher, "candidate_id", row.id)
+		kindIndex, known := kindIndexes[row.kind]
+		if !known {
+			result.UnknownKindCount++
+			continue
+		}
+		result.Kinds[kindIndex].DuePending++
+		if row.claimExpiresAt != nil {
+			result.Kinds[kindIndex].ExpiredClaims++
+		}
+		switch observer.byKind[row.kind].Route {
+		case syncdispatchcontract.RouteCelery:
+			result.CeleryDuePending++
+		case syncdispatchcontract.RouteRiver:
+			result.RiverDuePending++
+		default:
+			return Observation{}, ErrUnavailable
+		}
+	}
+	result.CandidateDigest = "sha256:" + hex.EncodeToString(hasher.Sum(nil))
+
+	knownDue := result.CeleryDuePending + result.RiverDuePending
+	if knownDue < 0 || result.UnknownKindCount < 0 ||
+		knownDue > result.SampledCandidates ||
+		knownDue+result.UnknownKindCount != result.SampledCandidates ||
+		result.SampledCandidates > int64(limit) ||
+		(result.Truncated && result.SampledCandidates != int64(limit)) {
+		return Observation{}, ErrUnavailable
+	}
+	if result.UnknownKindCount != 0 {
+		return result, ErrUnknownKind
+	}
+	return result, nil
+}
+
+type digestWriter interface {
+	Write([]byte) (int, error)
+}
+
+func writeDigestField(output digestWriter, name, value string) {
+	_, _ = output.Write([]byte(strconv.Itoa(len(name))))
+	_, _ = output.Write([]byte(":"))
+	_, _ = output.Write([]byte(name))
+	_, _ = output.Write([]byte(strconv.Itoa(len(value))))
+	_, _ = output.Write([]byte(":"))
+	_, _ = output.Write([]byte(value))
+	_, _ = output.Write([]byte("\n"))
+}
+
+func canonicalObservedAt(value time.Time) string {
+	return value.UTC().Format("2006-01-02T15:04:05.000000000Z")
+}
+
+func readObservation(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	now time.Time,
+	limit int,
+) ([]candidateRow, error) {
+	rows, err := pool.Query(ctx, observationSQL, now, limit)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	result := make([]candidateRow, 0, limit)
+	for rows.Next() {
+		var row candidateRow
+		if err := rows.Scan(&row.id, &row.kind, &row.claimExpiresAt); err != nil {
+			return nil, err
+		}
+		result = append(result, row)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return result, nil
+}
+
+// observationSQL mirrors Python claim_due_outbox_rows exactly. The caller
+// passes limit+1 so the read remains bounded while one extra row can prove the
+// sampled claim-order window was truncated.
+const observationSQL = `
+SELECT outbox.id::text, outbox.kind, outbox.claim_expires_at
+FROM public.sync_dispatch_outbox AS outbox
+WHERE outbox.status = 'pending'
+    AND outbox.available_at <= $1
+    AND (outbox.claim_expires_at IS NULL OR outbox.claim_expires_at <= $1)
+ORDER BY outbox.available_at, outbox.id
+LIMIT $2
+`

--- a/internal/syncreconciler/observer_test.go
+++ b/internal/syncreconciler/observer_test.go
@@ -1,0 +1,282 @@
+package syncreconciler
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+)
+
+const (
+	candidateID1 = "00000000-0000-4000-8000-000000000001"
+	candidateID2 = "00000000-0000-4000-8000-000000000002"
+	candidateID3 = "00000000-0000-4000-8000-000000000003"
+	candidateID4 = "00000000-0000-4000-8000-000000000004"
+)
+
+type registryMap map[string]syncdispatchcontract.Descriptor
+
+func (registry registryMap) Lookup(kind string) (syncdispatchcontract.Descriptor, bool) {
+	descriptor, ok := registry[kind]
+	return descriptor, ok
+}
+
+func testRegistry(t *testing.T, riverKind string) registryMap {
+	t.Helper()
+	registry := make(registryMap, len(frozenKinds))
+	for _, kind := range frozenKinds {
+		route := syncdispatchcontract.RouteCelery
+		if kind == riverKind {
+			route = syncdispatchcontract.RouteRiver
+		}
+		delivery := syncdispatchcontract.DeliveryAtLeastOnce
+		if kind == syncdispatchcontract.KindPostSync {
+			delivery = syncdispatchcontract.DeliveryAtMostOnceMarkBefore
+		}
+		registry[kind] = syncdispatchcontract.Descriptor{
+			Kind:          kind,
+			Delivery:      delivery,
+			Route:         route,
+			RollbackRoute: syncdispatchcontract.RouteCelery,
+		}
+	}
+	return registry
+}
+
+func TestObserverStepBuildsBoundedClaimOrderSnapshotAndRoutePartitions(t *testing.T) {
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	expired := now.Add(-time.Second)
+	observer, err := newObserver(
+		testRegistry(t, syncdispatchcontract.KindPostSync),
+		func(_ context.Context, gotNow time.Time, fetchLimit int) ([]candidateRow, error) {
+			if !gotNow.Equal(now) || fetchLimit != 3 {
+				t.Fatalf("read arguments = %s, %d", gotNow, fetchLimit)
+			}
+			return []candidateRow{
+				{id: candidateID1, kind: syncdispatchcontract.KindDispatchSyncRun, claimExpiresAt: &expired},
+				{id: candidateID2, kind: syncdispatchcontract.KindPostSync},
+				{id: candidateID3, kind: syncdispatchcontract.KindFinalizeSyncRun},
+			}, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation, err := observer.Step(context.Background(), now, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if observation.PredicateVersion != PredicateVersion ||
+		observation.DigestVersion != DigestVersion ||
+		!observation.ObservedAt.Equal(now) || observation.ObservedAt.Location() != time.UTC ||
+		observation.Limit != 2 ||
+		observation.SampledCandidates != 2 || !observation.Truncated ||
+		observation.CeleryDuePending != 1 || observation.RiverDuePending != 1 {
+		t.Fatalf("observation = %#v", observation)
+	}
+	if observation.Kinds[0].DuePending != 1 || observation.Kinds[0].ExpiredClaims != 1 ||
+		observation.Kinds[2].DuePending != 1 || observation.Kinds[2].Route != syncdispatchcontract.RouteRiver {
+		t.Fatalf("kind observations = %#v", observation.Kinds)
+	}
+	const expectedDigest = "sha256:470a95b9d29c43636664b00b6beb7f192c18b523e41802b7a785cd463eb42218"
+	if observation.CandidateDigest != expectedDigest {
+		t.Fatalf("candidate digest = %s, want %s", observation.CandidateDigest, expectedDigest)
+	}
+}
+
+func TestObserverUnknownKindScopeIsOnlySampledCandidates(t *testing.T) {
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	t.Run("unknown beyond sample only proves truncation", func(t *testing.T) {
+		observer, err := newObserver(testRegistry(t, ""), func(context.Context, time.Time, int) ([]candidateRow, error) {
+			return []candidateRow{
+				{id: candidateID1, kind: syncdispatchcontract.KindDispatchSyncRun},
+				{id: candidateID2, kind: "future_contract_kind"},
+			}, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		observation, err := observer.Step(context.Background(), now, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if observation.UnknownKindCount != 0 || observation.SampledCandidates != 1 || !observation.Truncated {
+			t.Fatalf("observation = %#v", observation)
+		}
+	})
+
+	t.Run("unknown inside sample fails closed", func(t *testing.T) {
+		observer, err := newObserver(testRegistry(t, ""), func(context.Context, time.Time, int) ([]candidateRow, error) {
+			return []candidateRow{{id: candidateID1, kind: "unknown_kind"}}, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		observation, err := observer.Step(context.Background(), now, 1)
+		if !errors.Is(err, ErrUnknownKind) || observation.UnknownKindCount != 1 ||
+			observation.SampledCandidates != 1 || observation.Truncated {
+			t.Fatalf("Step() = %#v, %v", observation, err)
+		}
+	})
+}
+
+func TestCandidateDigestIncludesNormalizedSnapshotMetadata(t *testing.T) {
+	observer, err := newObserver(testRegistry(t, ""), func(context.Context, time.Time, int) ([]candidateRow, error) {
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	localCutoff := time.Date(2026, time.July, 22, 5, 0, 0, 123, time.FixedZone("offset", -7*60*60))
+	first, err := observer.Step(context.Background(), localCutoff, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	second, err := observer.Step(context.Background(), localCutoff.Add(time.Nanosecond), 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	third, err := observer.Step(context.Background(), localCutoff, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !first.ObservedAt.Equal(localCutoff.UTC()) || first.ObservedAt.Location() != time.UTC ||
+		first.Limit != 1 || first.PredicateVersion != PredicateVersion || first.DigestVersion != DigestVersion {
+		t.Fatalf("self-describing observation = %#v", first)
+	}
+	if first.CandidateDigest == second.CandidateDigest || first.CandidateDigest == third.CandidateDigest {
+		t.Fatalf("digest did not bind cutoff and limit: first=%s second=%s third=%s",
+			first.CandidateDigest, second.CandidateDigest, third.CandidateDigest)
+	}
+}
+
+func TestObserverValidatesRegistryInputsAndCandidateBounds(t *testing.T) {
+	validRegistry := testRegistry(t, "")
+	if _, err := newObserver(validRegistry, nil); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("nil read error = %v", err)
+	}
+	if _, err := newObserver(registryMap{}, func(context.Context, time.Time, int) ([]candidateRow, error) { return nil, nil }); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("incomplete registry error = %v", err)
+	}
+	for name, mutate := range map[string]func(*syncdispatchcontract.Descriptor){
+		"wrong delivery": func(descriptor *syncdispatchcontract.Descriptor) {
+			descriptor.Delivery = syncdispatchcontract.DeliveryAtMostOnceMarkBefore
+		},
+		"wrong rollback": func(descriptor *syncdispatchcontract.Descriptor) {
+			descriptor.RollbackRoute = syncdispatchcontract.RouteRiver
+		},
+		"invalid route": func(descriptor *syncdispatchcontract.Descriptor) {
+			descriptor.Route = "shadow"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			registry := testRegistry(t, "")
+			descriptor := registry[syncdispatchcontract.KindDispatchSyncRun]
+			mutate(&descriptor)
+			registry[syncdispatchcontract.KindDispatchSyncRun] = descriptor
+			if _, err := newObserver(registry, func(context.Context, time.Time, int) ([]candidateRow, error) { return nil, nil }); !errors.Is(err, ErrInvalidConfiguration) {
+				t.Fatalf("newObserver error = %v", err)
+			}
+		})
+	}
+
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	for name, rows := range map[string][]candidateRow{
+		"more than limit plus one": {
+			{id: candidateID1, kind: frozenKinds[0]},
+			{id: candidateID2, kind: frozenKinds[0]},
+			{id: candidateID3, kind: frozenKinds[0]},
+		},
+		"duplicate id": {
+			{id: candidateID1, kind: frozenKinds[0]},
+			{id: candidateID1, kind: frozenKinds[1]},
+		},
+		"invalid id": {
+			{id: "not-a-uuid", kind: frozenKinds[0]},
+		},
+		"live claim": {
+			{id: candidateID1, kind: frozenKinds[0], claimExpiresAt: timePointer(now.Add(time.Second))},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			observer, err := newObserver(validRegistry, func(context.Context, time.Time, int) ([]candidateRow, error) {
+				return rows, nil
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := observer.Step(context.Background(), now, 1); !errors.Is(err, ErrUnavailable) {
+				t.Fatalf("Step() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestObserverRejectsInvalidStepInputs(t *testing.T) {
+	observer, err := newObserver(testRegistry(t, ""), func(context.Context, time.Time, int) ([]candidateRow, error) {
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, call := range []struct {
+		now   time.Time
+		limit int
+	}{
+		{limit: 1},
+		{now: time.Now(), limit: 0},
+		{now: time.Now(), limit: maximumStepLimit + 1},
+	} {
+		if _, err := observer.Step(context.Background(), call.now, call.limit); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("Step(%s, %d) error = %v", call.now, call.limit, err)
+		}
+	}
+}
+
+func TestObserverPreservesContextCancellationAndDeadlines(t *testing.T) {
+	for name, contextErr := range map[string]error{
+		"canceled": context.Canceled,
+		"deadline": context.DeadlineExceeded,
+	} {
+		t.Run(name, func(t *testing.T) {
+			observer, err := newObserver(testRegistry(t, ""), func(context.Context, time.Time, int) ([]candidateRow, error) {
+				return nil, contextErr
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+			if _, err := observer.Step(context.Background(), time.Now(), 1); !errors.Is(err, contextErr) {
+				t.Fatalf("Step() error = %v, want %v", err, contextErr)
+			}
+		})
+	}
+}
+
+func TestObservationSQLIsReadOnlyAndMatchesPythonClaimWindow(t *testing.T) {
+	upper := strings.ToUpper(observationSQL)
+	for _, required := range []string{
+		"SELECT OUTBOX.ID::TEXT, OUTBOX.KIND, OUTBOX.CLAIM_EXPIRES_AT",
+		"OUTBOX.STATUS = 'PENDING'",
+		"OUTBOX.AVAILABLE_AT <= $1",
+		"OUTBOX.CLAIM_EXPIRES_AT IS NULL OR OUTBOX.CLAIM_EXPIRES_AT <= $1",
+		"ORDER BY OUTBOX.AVAILABLE_AT, OUTBOX.ID",
+		"LIMIT $2",
+	} {
+		if !strings.Contains(upper, required) {
+			t.Fatalf("observation SQL missing %q:\n%s", required, observationSQL)
+		}
+	}
+	for _, forbidden := range []string{
+		"INSERT", "UPDATE", "DELETE", "MERGE", "LOCK", "FOR UPDATE",
+		"SKIP LOCKED", "CALL", "NOTIFY", "COUNT(", "GROUP BY",
+	} {
+		if strings.Contains(upper, forbidden) {
+			t.Fatalf("read-only bounded SQL contains %q:\n%s", forbidden, observationSQL)
+		}
+	}
+}
+
+func timePointer(value time.Time) *time.Time { return &value }

--- a/internal/syncreconciler/recorder.go
+++ b/internal/syncreconciler/recorder.go
@@ -1,0 +1,221 @@
+package syncreconciler
+
+import (
+	"context"
+	"log/slog"
+	"math"
+	"regexp"
+	"sync"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+)
+
+const (
+	parityObservationEvent = "sync_dispatch_parity_observation"
+	parityRuntime          = "go_observer"
+
+	defaultRecorderCadence = 60 * time.Second
+	minRecorderCadence     = time.Millisecond
+	maxRecorderCadence     = 15 * time.Minute
+	recorderQueueCapacity  = 1
+)
+
+var digestPattern = regexp.MustCompile(`^sha256:[0-9a-f]{64}$`)
+
+// ObservationRecorder is deliberately a non-blocking offer interface.
+// TryRecord must return immediately and may drop an observation when busy.
+// Loop contains panics but cannot enforce this timing contract for arbitrary
+// implementations without creating an unbounded goroutine failure mode.
+type ObservationRecorder interface {
+	TryRecord(Observation) bool
+}
+
+// SlogObservationRecorder asynchronously emits redacted parity observations.
+// Its one-slot queue bounds memory and makes TryRecord non-blocking. The owner
+// that constructs it must call Shutdown after every Loop using it has stopped.
+// Shutdown honors its context; a permanently blocked slog Handler can strand
+// at most this recorder's single worker, never a goroutine per observation.
+type SlogObservationRecorder struct {
+	logger  *slog.Logger
+	cadence time.Duration
+	now     func() time.Time
+
+	mu      sync.Mutex
+	emitted bool
+	last    time.Time
+	closed  bool
+	queue   chan Observation
+	done    chan struct{}
+}
+
+// NewSlogObservationRecorder constructs the production recorder with an
+// initial emission followed by at most one successful enqueue per 60 seconds.
+func NewSlogObservationRecorder(logger *slog.Logger) (*SlogObservationRecorder, error) {
+	return newSlogObservationRecorder(logger, defaultRecorderCadence, time.Now)
+}
+
+func newSlogObservationRecorder(
+	logger *slog.Logger,
+	cadence time.Duration,
+	now func() time.Time,
+) (*SlogObservationRecorder, error) {
+	if logger == nil || now == nil || cadence < minRecorderCadence || cadence > maxRecorderCadence {
+		return nil, ErrInvalidConfiguration
+	}
+	recorder := &SlogObservationRecorder{
+		logger:  logger,
+		cadence: cadence,
+		now:     now,
+		queue:   make(chan Observation, recorderQueueCapacity),
+		done:    make(chan struct{}),
+	}
+	go recorder.run()
+	return recorder, nil
+}
+
+// TryRecord validates and copies one observation before a non-blocking queue
+// offer. Invalid, rate-limited, busy, and post-shutdown offers are dropped.
+func (recorder *SlogObservationRecorder) TryRecord(observation Observation) bool {
+	if recorder == nil || !validRecordedObservation(observation) {
+		return false
+	}
+	observation = copyObservation(observation)
+	now := recorder.now()
+
+	recorder.mu.Lock()
+	defer recorder.mu.Unlock()
+	if recorder.closed {
+		return false
+	}
+	if recorder.emitted {
+		elapsed := now.Sub(recorder.last)
+		if elapsed < recorder.cadence {
+			return false
+		}
+	}
+	select {
+	case recorder.queue <- observation:
+		recorder.emitted = true
+		recorder.last = now
+		return true
+	default:
+		return false
+	}
+}
+
+func (recorder *SlogObservationRecorder) run() {
+	defer close(recorder.done)
+	for observation := range recorder.queue {
+		recorder.emitSafely(observation)
+	}
+}
+
+func (recorder *SlogObservationRecorder) emitSafely(observation Observation) {
+	defer func() { _ = recover() }()
+	kinds := make([]recordedKind, 0, len(observation.Kinds))
+	for _, kind := range observation.Kinds {
+		kinds = append(kinds, recordedKind{
+			Kind: kind.Kind, Route: kind.Route,
+			DuePending: kind.DuePending, ExpiredClaims: kind.ExpiredClaims,
+		})
+	}
+	recorder.logger.LogAttrs(
+		context.Background(),
+		slog.LevelInfo,
+		parityObservationEvent,
+		slog.String("event", parityObservationEvent),
+		slog.String("runtime", parityRuntime),
+		slog.String("observed_at", canonicalObservedAt(observation.ObservedAt)),
+		slog.Int("limit", observation.Limit),
+		slog.String("predicate_version", observation.PredicateVersion),
+		slog.String("digest_version", observation.DigestVersion),
+		slog.String("candidate_digest", observation.CandidateDigest),
+		slog.Int64("sampled_candidates", observation.SampledCandidates),
+		slog.Bool("truncated", observation.Truncated),
+		slog.Int64("unknown_kind_count", observation.UnknownKindCount),
+		slog.Int64("celery_due_pending", observation.CeleryDuePending),
+		slog.Int64("river_due_pending", observation.RiverDuePending),
+		slog.Any("kinds", kinds),
+	)
+}
+
+type recordedKind struct {
+	Kind          string `json:"kind"`
+	Route         string `json:"route"`
+	DuePending    int64  `json:"due_pending"`
+	ExpiredClaims int64  `json:"expired_claims"`
+}
+
+// Shutdown stops future offers and waits for already accepted records. It does
+// not own or close the underlying slog Handler.
+func (recorder *SlogObservationRecorder) Shutdown(ctx context.Context) error {
+	if recorder == nil || ctx == nil {
+		return ErrInvalidConfiguration
+	}
+	recorder.mu.Lock()
+	if !recorder.closed {
+		recorder.closed = true
+		close(recorder.queue)
+	}
+	done := recorder.done
+	recorder.mu.Unlock()
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func validRecordedObservation(observation Observation) bool {
+	if len(observation.Kinds) != len(frozenKinds) ||
+		observation.ObservedAt.IsZero() || observation.ObservedAt.Location() != time.UTC ||
+		observation.Limit < minimumStepLimit || observation.Limit > maximumStepLimit ||
+		observation.PredicateVersion != PredicateVersion ||
+		observation.DigestVersion != DigestVersion ||
+		!digestPattern.MatchString(observation.CandidateDigest) ||
+		observation.SampledCandidates < 0 ||
+		observation.SampledCandidates > int64(observation.Limit) ||
+		observation.UnknownKindCount < 0 ||
+		observation.UnknownKindCount > observation.SampledCandidates ||
+		(observation.Truncated && observation.SampledCandidates != int64(observation.Limit)) {
+		return false
+	}
+
+	var celery, river, known int64
+	for index, kind := range observation.Kinds {
+		if kind.Kind != frozenKinds[index] || kind.DuePending < 0 ||
+			kind.ExpiredClaims < 0 || kind.ExpiredClaims > kind.DuePending {
+			return false
+		}
+		switch kind.Route {
+		case syncdispatchcontract.RouteCelery:
+			if celery > math.MaxInt64-kind.DuePending {
+				return false
+			}
+			celery += kind.DuePending
+		case syncdispatchcontract.RouteRiver:
+			if river > math.MaxInt64-kind.DuePending {
+				return false
+			}
+			river += kind.DuePending
+		default:
+			return false
+		}
+		if known > math.MaxInt64-kind.DuePending {
+			return false
+		}
+		known += kind.DuePending
+	}
+	if known > math.MaxInt64-observation.UnknownKindCount {
+		return false
+	}
+	return celery == observation.CeleryDuePending &&
+		river == observation.RiverDuePending &&
+		known+observation.UnknownKindCount == observation.SampledCandidates
+}
+
+// compile-time guard that keeps the production implementation on the narrow
+// non-blocking recorder seam.
+var _ ObservationRecorder = (*SlogObservationRecorder)(nil)

--- a/internal/syncreconciler/recorder_test.go
+++ b/internal/syncreconciler/recorder_test.go
@@ -1,0 +1,384 @@
+package syncreconciler
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"reflect"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func validRecorderObservation() Observation {
+	return Observation{
+		Kinds: []KindObservation{
+			{Kind: frozenKinds[0], Route: "celery", DuePending: 1, ExpiredClaims: 1},
+			{Kind: frozenKinds[1], Route: "celery"},
+			{Kind: frozenKinds[2], Route: "river", DuePending: 1},
+			{Kind: frozenKinds[3], Route: "celery"},
+		},
+		CeleryDuePending:  1,
+		RiverDuePending:   1,
+		SampledCandidates: 2,
+		ObservedAt:        time.Date(2026, time.July, 22, 12, 0, 0, 123, time.UTC),
+		Limit:             3,
+		PredicateVersion:  PredicateVersion,
+		DigestVersion:     DigestVersion,
+		CandidateDigest:   "sha256:" + strings.Repeat("0", 64),
+	}
+}
+
+func TestSlogRecorderEmitsExactRedactedJSON(t *testing.T) {
+	var output bytes.Buffer
+	logger := slog.New(slog.NewJSONHandler(&output, &slog.HandlerOptions{
+		ReplaceAttr: func(groups []string, attribute slog.Attr) slog.Attr {
+			if len(groups) == 0 && (attribute.Key == slog.TimeKey || attribute.Key == slog.LevelKey) {
+				return slog.Attr{}
+			}
+			return attribute
+		},
+	}))
+	recorder, err := NewSlogObservationRecorder(logger)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recorder.TryRecord(validRecorderObservation()) {
+		t.Fatal("initial observation was dropped")
+	}
+	if err := recorder.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+
+	var record map[string]any
+	if err := json.Unmarshal(output.Bytes(), &record); err != nil {
+		t.Fatalf("decode JSON: %v\n%s", err, output.String())
+	}
+	expectedKeys := []string{
+		"candidate_digest", "celery_due_pending", "digest_version", "event",
+		"kinds", "limit", "msg", "observed_at", "predicate_version",
+		"river_due_pending", "runtime", "sampled_candidates", "truncated",
+		"unknown_kind_count",
+	}
+	actualKeys := make([]string, 0, len(record))
+	for key := range record {
+		actualKeys = append(actualKeys, key)
+	}
+	sortStrings(actualKeys)
+	if !reflect.DeepEqual(actualKeys, expectedKeys) {
+		t.Fatalf("JSON keys = %v, want %v\n%s", actualKeys, expectedKeys, output.String())
+	}
+	for key, want := range map[string]any{
+		"msg":                parityObservationEvent,
+		"event":              parityObservationEvent,
+		"runtime":            parityRuntime,
+		"observed_at":        "2026-07-22T12:00:00.000000123Z",
+		"limit":              float64(3),
+		"predicate_version":  PredicateVersion,
+		"digest_version":     DigestVersion,
+		"candidate_digest":   "sha256:" + strings.Repeat("0", 64),
+		"sampled_candidates": float64(2),
+		"truncated":          false,
+		"unknown_kind_count": float64(0),
+		"celery_due_pending": float64(1),
+		"river_due_pending":  float64(1),
+	} {
+		if !reflect.DeepEqual(record[key], want) {
+			t.Fatalf("%s = %#v, want %#v", key, record[key], want)
+		}
+	}
+	kinds, ok := record["kinds"].([]any)
+	if !ok || len(kinds) != len(frozenKinds) {
+		t.Fatalf("kinds = %#v", record["kinds"])
+	}
+	for index, value := range kinds {
+		kind, ok := value.(map[string]any)
+		if !ok || kind["kind"] != frozenKinds[index] ||
+			len(kind) != 4 || kind["route"] != validRecorderObservation().Kinds[index].Route {
+			t.Fatalf("kind[%d] = %#v", index, value)
+		}
+	}
+	for _, forbidden := range []string{
+		candidateID1,
+		"tenant_id",
+		"org_id",
+		"sync_run_id",
+	} {
+		if strings.Contains(output.String(), forbidden) {
+			t.Fatalf("redacted JSON contains %q:\n%s", forbidden, output.String())
+		}
+	}
+}
+
+func TestSlogRecorderCadenceIsInitialThenAtMostOncePerMinute(t *testing.T) {
+	handler := &notificationHandler{handled: make(chan struct{}, 2)}
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	recorder, err := newSlogObservationRecorder(slog.New(handler), defaultRecorderCadence, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := validRecorderObservation()
+	if !recorder.TryRecord(observation) {
+		t.Fatal("initial observation was dropped")
+	}
+	<-handler.handled
+	if recorder.TryRecord(observation) {
+		t.Fatal("same-time observation bypassed cadence")
+	}
+	now = now.Add(defaultRecorderCadence - time.Nanosecond)
+	if recorder.TryRecord(observation) {
+		t.Fatal("early observation bypassed cadence")
+	}
+	now = now.Add(time.Nanosecond)
+	if !recorder.TryRecord(observation) {
+		t.Fatal("observation at cadence boundary was dropped")
+	}
+	<-handler.handled
+	if err := recorder.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSlogRecorderDropsMalformedObservationAndSurvivesHandlerPanic(t *testing.T) {
+	var malformedOutput bytes.Buffer
+	malformedRecorder, err := NewSlogObservationRecorder(slog.New(slog.NewJSONHandler(&malformedOutput, nil)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	malformed := validRecorderObservation()
+	malformed.Kinds = malformed.Kinds[:3]
+	if malformedRecorder.TryRecord(malformed) {
+		t.Fatal("malformed observation was accepted")
+	}
+	if err := malformedRecorder.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if malformedOutput.Len() != 0 {
+		t.Fatalf("malformed observation was logged: %s", malformedOutput.String())
+	}
+
+	handler := &panicOnceHandler{
+		panicked: make(chan struct{}),
+		handled:  make(chan struct{}),
+	}
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	recorder, err := newSlogObservationRecorder(slog.New(handler), minRecorderCadence, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recorder.TryRecord(validRecorderObservation()) {
+		t.Fatal("panic record was dropped before handler")
+	}
+	<-handler.panicked
+	now = now.Add(minRecorderCadence)
+	if !recorder.TryRecord(validRecorderObservation()) {
+		t.Fatal("worker did not survive handler panic")
+	}
+	<-handler.handled
+	if err := recorder.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSlogRecorderRejectsInvalidConstructionAndFixedShapes(t *testing.T) {
+	logger := slog.New(slog.NewJSONHandler(&bytes.Buffer{}, nil))
+	for _, construct := range []func() error{
+		func() error {
+			_, err := newSlogObservationRecorder(nil, defaultRecorderCadence, time.Now)
+			return err
+		},
+		func() error {
+			_, err := newSlogObservationRecorder(logger, minRecorderCadence-time.Nanosecond, time.Now)
+			return err
+		},
+		func() error {
+			_, err := newSlogObservationRecorder(logger, maxRecorderCadence+time.Nanosecond, time.Now)
+			return err
+		},
+	} {
+		if err := construct(); err == nil {
+			t.Fatal("invalid recorder construction succeeded")
+		}
+	}
+
+	for name, mutate := range map[string]func(*Observation){
+		"unsorted kinds": func(observation *Observation) {
+			observation.Kinds[0], observation.Kinds[1] = observation.Kinds[1], observation.Kinds[0]
+		},
+		"route totals": func(observation *Observation) {
+			observation.CeleryDuePending++
+		},
+		"expired exceeds due": func(observation *Observation) {
+			observation.Kinds[0].ExpiredClaims = observation.Kinds[0].DuePending + 1
+		},
+		"wrong version": func(observation *Observation) {
+			observation.DigestVersion = "future"
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			observation := validRecorderObservation()
+			mutate(&observation)
+			if validRecordedObservation(observation) {
+				t.Fatalf("malformed observation was valid: %#v", observation)
+			}
+		})
+	}
+}
+
+func TestSlogRecorderConcurrentOffersAreRaceSafeAndBounded(t *testing.T) {
+	handler := &notificationHandler{handled: make(chan struct{}, 1)}
+	recorder, err := newSlogObservationRecorder(
+		slog.New(handler),
+		defaultRecorderCadence,
+		func() time.Time { return time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC) },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var accepted atomic.Int64
+	var wait sync.WaitGroup
+	for range 100 {
+		wait.Add(1)
+		go func() {
+			defer wait.Done()
+			if recorder.TryRecord(validRecorderObservation()) {
+				accepted.Add(1)
+			}
+		}()
+	}
+	wait.Wait()
+	if accepted.Load() != 1 {
+		t.Fatalf("accepted offers = %d, want 1", accepted.Load())
+	}
+	<-handler.handled
+	if err := recorder.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if recorder.TryRecord(validRecorderObservation()) {
+		t.Fatal("post-shutdown observation was accepted")
+	}
+}
+
+func TestSlogRecorderBusyHandlerUsesBoundedQueueAndDrops(t *testing.T) {
+	handler := &blockingOnceHandler{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		handled: make(chan struct{}, 2),
+	}
+	now := time.Date(2026, time.July, 22, 12, 0, 0, 0, time.UTC)
+	recorder, err := newSlogObservationRecorder(slog.New(handler), minRecorderCadence, func() time.Time { return now })
+	if err != nil {
+		t.Fatal(err)
+	}
+	observation := validRecorderObservation()
+	if !recorder.TryRecord(observation) {
+		t.Fatal("initial observation was dropped")
+	}
+	<-handler.entered
+	now = now.Add(minRecorderCadence)
+	if !recorder.TryRecord(observation) {
+		t.Fatal("single queued observation was dropped")
+	}
+	now = now.Add(minRecorderCadence)
+	if recorder.TryRecord(observation) {
+		t.Fatal("full bounded queue accepted another observation")
+	}
+	close(handler.release)
+	<-handler.handled
+	<-handler.handled
+	if err := recorder.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestSlogRecorderShutdownIsContextBoundedWhenHandlerBlocks(t *testing.T) {
+	handler := &blockingOnceHandler{
+		entered: make(chan struct{}),
+		release: make(chan struct{}),
+		handled: make(chan struct{}, 1),
+	}
+	recorder, err := NewSlogObservationRecorder(slog.New(handler))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !recorder.TryRecord(validRecorderObservation()) {
+		t.Fatal("initial observation was dropped")
+	}
+	<-handler.entered
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	if err := recorder.Shutdown(ctx); !errors.Is(err, context.Canceled) {
+		t.Fatalf("Shutdown() error = %v, want cancellation", err)
+	}
+	close(handler.release)
+	<-handler.handled
+	if err := recorder.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type notificationHandler struct {
+	handled chan struct{}
+}
+
+func (*notificationHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (handler *notificationHandler) Handle(context.Context, slog.Record) error {
+	handler.handled <- struct{}{}
+	return nil
+}
+func (handler *notificationHandler) WithAttrs([]slog.Attr) slog.Handler { return handler }
+func (handler *notificationHandler) WithGroup(string) slog.Handler      { return handler }
+
+type panicOnceHandler struct {
+	once     sync.Once
+	panicked chan struct{}
+	handled  chan struct{}
+}
+
+func (*panicOnceHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (handler *panicOnceHandler) Handle(context.Context, slog.Record) error {
+	didPanic := false
+	handler.once.Do(func() {
+		didPanic = true
+		close(handler.panicked)
+	})
+	if didPanic {
+		panic("handler panic")
+	}
+	close(handler.handled)
+	return nil
+}
+func (handler *panicOnceHandler) WithAttrs([]slog.Attr) slog.Handler { return handler }
+func (handler *panicOnceHandler) WithGroup(string) slog.Handler      { return handler }
+
+type blockingOnceHandler struct {
+	once    sync.Once
+	entered chan struct{}
+	release chan struct{}
+	handled chan struct{}
+}
+
+func (*blockingOnceHandler) Enabled(context.Context, slog.Level) bool { return true }
+func (handler *blockingOnceHandler) Handle(context.Context, slog.Record) error {
+	handler.once.Do(func() {
+		close(handler.entered)
+		<-handler.release
+	})
+	handler.handled <- struct{}{}
+	return nil
+}
+func (handler *blockingOnceHandler) WithAttrs([]slog.Attr) slog.Handler { return handler }
+func (handler *blockingOnceHandler) WithGroup(string) slog.Handler      { return handler }
+
+func sortStrings(values []string) {
+	for index := 1; index < len(values); index++ {
+		for current := index; current > 0 && values[current] < values[current-1]; current-- {
+			values[current], values[current-1] = values[current-1], values[current]
+		}
+	}
+}

--- a/src/dev_health_ops/sync/dispatch_outbox.py
+++ b/src/dev_health_ops/sync/dispatch_outbox.py
@@ -25,11 +25,12 @@ tolerated because consumers are idempotent by contract.
 
 from __future__ import annotations
 
+import hashlib
 import os
 import uuid
 from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
-from typing import Any
+from typing import Any, TypedDict
 
 from sqlalchemy import and_, case, or_, select, update
 from sqlalchemy.exc import IntegrityError
@@ -38,6 +39,11 @@ from sqlalchemy.orm import Session
 from dev_health_ops.models import (
     SyncDispatchOutbox,
     SyncRun,
+)
+from dev_health_ops.sync.dispatch_routes import (
+    DispatchRouteContractError,
+    TransportRoute,
+    load_transport_routes,
 )
 from dev_health_ops.sync.error_sanitize import sanitize_error_text
 
@@ -52,6 +58,18 @@ OUTBOX_STATUS_DISPATCHED = "dispatched"
 _MAX_ERROR_LENGTH = 2000
 _TERMINAL_DENIAL_ERROR = "feature_disabled"
 
+SYNC_DISPATCH_PARITY_EVENT = "sync_dispatch_parity_observation"
+SYNC_DISPATCH_PARITY_PREDICATE_VERSION = "sync_dispatch_due_v1"
+SYNC_DISPATCH_PARITY_DIGEST_VERSION = "sync_dispatch_candidate_digest_v1"
+_SYNC_DISPATCH_PARITY_MIN_LIMIT = 1
+_SYNC_DISPATCH_PARITY_MAX_LIMIT = 100
+_SYNC_DISPATCH_PARITY_DELIVERY = {
+    OUTBOX_KIND_DISPATCH: "at_least_once",
+    OUTBOX_KIND_FINALIZE: "at_least_once",
+    OUTBOX_KIND_POST_SYNC: "at_most_once_mark_before",
+    OUTBOX_KIND_DISCOVERY: "at_least_once",
+}
+
 
 @dataclass(frozen=True)
 class ClaimedOutboxRow:
@@ -62,6 +80,21 @@ class ClaimedOutboxRow:
     attempts: int
     available_at: datetime
     claim_token: str
+
+
+class SyncDispatchParityObservationUnavailable(RuntimeError):
+    """A bounded reason why the optional read-only parity capture is unavailable."""
+
+    def __init__(self, reason: str) -> None:
+        super().__init__(reason)
+        self.reason = reason
+
+
+class _ParityKindRecord(TypedDict):
+    kind: str
+    route: str
+    due_pending: int
+    expired_claims: int
 
 
 def backoff_seconds(attempts: int) -> int:
@@ -267,6 +300,164 @@ def _terminal_denial_condition(table: Any) -> Any:
         table.c.status == OUTBOX_STATUS_DISPATCHED,
         table.c.last_error == _TERMINAL_DENIAL_ERROR,
     )
+
+
+def observe_due_outbox_rows(
+    session: Session,
+    *,
+    now: datetime,
+    limit: int,
+) -> dict[str, Any]:
+    """Build one bounded, read-only parity record in Python claim order.
+
+    The record intentionally contains aggregates and a digest only. It never
+    exposes candidate identifiers, tenant data, claim tokens, or payloads.
+    """
+    if (
+        not isinstance(limit, int)
+        or isinstance(limit, bool)
+        or not (
+            _SYNC_DISPATCH_PARITY_MIN_LIMIT <= limit <= _SYNC_DISPATCH_PARITY_MAX_LIMIT
+        )
+    ):
+        raise SyncDispatchParityObservationUnavailable("invalid_limit")
+
+    observed_at = _as_aware(now)
+    routes = _validated_parity_routes()
+    try:
+        rows = list(
+            session.execute(
+                select(
+                    SyncDispatchOutbox.id,
+                    SyncDispatchOutbox.kind,
+                    SyncDispatchOutbox.claim_expires_at,
+                )
+                .where(
+                    SyncDispatchOutbox.status == OUTBOX_STATUS_PENDING,
+                    SyncDispatchOutbox.available_at <= observed_at,
+                    or_(
+                        SyncDispatchOutbox.claim_expires_at.is_(None),
+                        SyncDispatchOutbox.claim_expires_at <= observed_at,
+                    ),
+                )
+                .order_by(SyncDispatchOutbox.available_at, SyncDispatchOutbox.id)
+                .limit(limit + 1)
+            ).all()
+        )
+    except Exception as error:
+        raise SyncDispatchParityObservationUnavailable("query_unavailable") from error
+
+    if len(rows) > limit + 1:
+        raise SyncDispatchParityObservationUnavailable("query_unavailable")
+    sampled_rows = rows[:limit]
+    truncated = len(rows) > limit
+    kinds: dict[str, _ParityKindRecord] = {
+        kind: {
+            "kind": kind,
+            "route": route.route,
+            "due_pending": 0,
+            "expired_claims": 0,
+        }
+        for kind, route in routes.items()
+    }
+    hasher = hashlib.sha256()
+    _write_parity_digest_field(
+        hasher, "digest_version", SYNC_DISPATCH_PARITY_DIGEST_VERSION
+    )
+    _write_parity_digest_field(
+        hasher, "predicate_version", SYNC_DISPATCH_PARITY_PREDICATE_VERSION
+    )
+    _write_parity_digest_field(
+        hasher, "observed_at", _canonical_parity_observed_at(observed_at)
+    )
+    _write_parity_digest_field(hasher, "limit", str(limit))
+
+    unknown_kind_count = 0
+    celery_due_pending = 0
+    river_due_pending = 0
+    for row_id, kind, claim_expires_at in sampled_rows:
+        candidate_id = _canonical_parity_candidate_id(row_id)
+        if claim_expires_at is not None and _as_aware(claim_expires_at) > observed_at:
+            raise SyncDispatchParityObservationUnavailable("query_unavailable")
+        _write_parity_digest_field(hasher, "candidate_kind", kind)
+        _write_parity_digest_field(hasher, "candidate_id", candidate_id)
+        kind_record = kinds.get(kind)
+        if kind_record is None:
+            unknown_kind_count += 1
+            continue
+        kind_record["due_pending"] += 1
+        if claim_expires_at is not None:
+            kind_record["expired_claims"] += 1
+        if kind_record["route"] == "celery":
+            celery_due_pending += 1
+        elif kind_record["route"] == "river":
+            river_due_pending += 1
+        else:
+            raise SyncDispatchParityObservationUnavailable("route_unavailable")
+
+    sampled_candidates = len(sampled_rows)
+    if (
+        celery_due_pending + river_due_pending + unknown_kind_count
+        != sampled_candidates
+    ):
+        raise SyncDispatchParityObservationUnavailable("query_unavailable")
+    return {
+        "event": SYNC_DISPATCH_PARITY_EVENT,
+        "runtime": "celery",
+        "observed_at": _canonical_parity_observed_at(observed_at),
+        "limit": limit,
+        "predicate_version": SYNC_DISPATCH_PARITY_PREDICATE_VERSION,
+        "digest_version": SYNC_DISPATCH_PARITY_DIGEST_VERSION,
+        "candidate_digest": f"sha256:{hasher.hexdigest()}",
+        "sampled_candidates": sampled_candidates,
+        "truncated": truncated,
+        "unknown_kind_count": unknown_kind_count,
+        "celery_due_pending": celery_due_pending,
+        "river_due_pending": river_due_pending,
+        "kinds": [kinds[kind] for kind in sorted(kinds)],
+    }
+
+
+def _validated_parity_routes() -> dict[str, TransportRoute]:
+    try:
+        loaded = load_transport_routes()
+        routes = {kind: loaded.by_kind(kind) for kind in _SYNC_DISPATCH_PARITY_DELIVERY}
+    except DispatchRouteContractError as error:
+        raise SyncDispatchParityObservationUnavailable("route_unavailable") from error
+    for kind, expected_delivery in _SYNC_DISPATCH_PARITY_DELIVERY.items():
+        route = routes.get(kind)
+        if (
+            route is None
+            or route.delivery != expected_delivery
+            or route.rollback_route != "celery"
+            or route.route not in {"celery", "river"}
+        ):
+            raise SyncDispatchParityObservationUnavailable("route_unavailable")
+    return routes
+
+
+def _canonical_parity_candidate_id(value: object) -> str:
+    try:
+        return str(uuid.UUID(str(value)))
+    except (TypeError, ValueError, AttributeError) as error:
+        raise SyncDispatchParityObservationUnavailable("query_unavailable") from error
+
+
+def _canonical_parity_observed_at(value: datetime) -> str:
+    value = _as_aware(value)
+    return value.strftime("%Y-%m-%dT%H:%M:%S") + f".{value.microsecond:06d}000Z"
+
+
+def _write_parity_digest_field(hasher: Any, name: str, value: str) -> None:
+    name_bytes = name.encode("utf-8")
+    value_bytes = value.encode("utf-8")
+    hasher.update(str(len(name_bytes)).encode("ascii"))
+    hasher.update(b":")
+    hasher.update(name_bytes)
+    hasher.update(str(len(value_bytes)).encode("ascii"))
+    hasher.update(b":")
+    hasher.update(value_bytes)
+    hasher.update(b"\n")
 
 
 def claim_due_outbox_rows(

--- a/src/dev_health_ops/sync/dispatch_routes.py
+++ b/src/dev_health_ops/sync/dispatch_routes.py
@@ -1,0 +1,208 @@
+"""Strict, validation-only loader for the sync-dispatch transport contract.
+
+This module deliberately has no dependency on the reconciler or a queue client:
+loading a route contract cannot claim or publish sync work.
+"""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Mapping
+from dataclasses import dataclass
+from pathlib import Path
+from types import MappingProxyType
+from typing import Any
+
+MAX_TRANSPORT_ROUTES_BYTES = 16 * 1024
+_MAX_JSON_DEPTH = 8
+
+_DOCUMENT_FIELDS = frozenset({"schema_version", "routes"})
+_ROUTE_FIELDS = frozenset({"kind", "delivery", "route", "rollback_route"})
+_EXPECTED_KINDS = (
+    "dispatch_sync_run",
+    "finalize_sync_run",
+    "post_sync",
+    "reference_discovery",
+)
+_EXPECTED_DELIVERY = MappingProxyType(
+    {
+        "dispatch_sync_run": "at_least_once",
+        "finalize_sync_run": "at_least_once",
+        "post_sync": "at_most_once_mark_before",
+        "reference_discovery": "at_least_once",
+    }
+)
+_ALLOWED_TRANSPORT_PAIRS = frozenset(
+    {
+        ("celery", "celery"),
+        ("river", "celery"),
+    }
+)
+
+
+class DispatchRouteContractError(ValueError):
+    """Raised when the sync-dispatch transport artifact is malformed or drifts."""
+
+
+@dataclass(frozen=True, slots=True)
+class TransportRoute:
+    """The delivery semantics and current/fallback transport for one wakeup kind."""
+
+    kind: str
+    delivery: str
+    route: str
+    rollback_route: str
+
+
+@dataclass(frozen=True, slots=True)
+class TransportRoutes:
+    """Immutable transport routes indexed by the canonical wakeup kind."""
+
+    routes: Mapping[str, TransportRoute]
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "routes", MappingProxyType(dict(self.routes)))
+
+    def by_kind(self, kind: str) -> TransportRoute:
+        try:
+            return self.routes[kind]
+        except KeyError as error:
+            raise DispatchRouteContractError("unknown sync-dispatch kind") from error
+
+
+def default_transport_routes_path() -> Path:
+    """Return the checked-in v1 transport contract from a source checkout."""
+
+    return (
+        Path(__file__).resolve().parents[3]
+        / "contracts"
+        / "sync-dispatch"
+        / "v1"
+        / "transport-routes.json"
+    )
+
+
+def load_transport_routes(path: Path | None = None) -> TransportRoutes:
+    """Load exactly the frozen v1 route set without activating any transport."""
+
+    artifact_path = path or default_transport_routes_path()
+    document = _load_document(artifact_path)
+    if not isinstance(document, dict) or set(document) != _DOCUMENT_FIELDS:
+        raise DispatchRouteContractError("transport route document shape is invalid")
+    if (
+        not isinstance(document["schema_version"], int)
+        or isinstance(document["schema_version"], bool)
+        or document["schema_version"] != 1
+    ):
+        raise DispatchRouteContractError(
+            "transport route schema version is unsupported"
+        )
+    raw_routes = document["routes"]
+    if not isinstance(raw_routes, list):
+        raise DispatchRouteContractError("transport routes must be an array")
+
+    parsed: list[TransportRoute] = []
+    for raw in raw_routes:
+        if not isinstance(raw, dict) or set(raw) != _ROUTE_FIELDS:
+            raise DispatchRouteContractError("transport route entry shape is invalid")
+        kind = _required_string(raw, "kind")
+        delivery = _required_string(raw, "delivery")
+        route = _required_string(raw, "route")
+        rollback_route = _required_string(raw, "rollback_route")
+        if (route, rollback_route) not in _ALLOWED_TRANSPORT_PAIRS:
+            raise DispatchRouteContractError("transport route is unsupported")
+        expected_delivery = _EXPECTED_DELIVERY.get(kind)
+        if expected_delivery is None or delivery != expected_delivery:
+            raise DispatchRouteContractError("transport delivery is inconsistent")
+        parsed.append(
+            TransportRoute(
+                kind=kind,
+                delivery=delivery,
+                route=route,
+                rollback_route=rollback_route,
+            )
+        )
+
+    kinds = tuple(route.kind for route in parsed)
+    if len(set(kinds)) != len(kinds):
+        raise DispatchRouteContractError("transport routes contain duplicate kinds")
+    if kinds != tuple(sorted(kinds)):
+        raise DispatchRouteContractError("transport routes are not sorted")
+    if kinds != _EXPECTED_KINDS:
+        raise DispatchRouteContractError(
+            "transport routes are missing or unknown kinds"
+        )
+    return TransportRoutes(
+        routes=MappingProxyType({route.kind: route for route in parsed})
+    )
+
+
+def _load_document(path: Path) -> Any:
+    if path.is_symlink() or not path.is_file():
+        raise DispatchRouteContractError(
+            "transport route artifact must be a regular file"
+        )
+    try:
+        data = path.read_bytes()
+    except OSError as error:
+        raise DispatchRouteContractError(
+            "transport route artifact cannot be read"
+        ) from error
+    if not data:
+        raise DispatchRouteContractError("transport route artifact is empty")
+    if len(data) > MAX_TRANSPORT_ROUTES_BYTES:
+        raise DispatchRouteContractError("transport route artifact exceeds size limit")
+    try:
+        text = data.decode("utf-8")
+    except UnicodeDecodeError as error:
+        raise DispatchRouteContractError(
+            "transport route artifact must be UTF-8"
+        ) from error
+
+    def object_pairs(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if key in result:
+                raise DispatchRouteContractError(
+                    "transport route artifact has duplicate JSON keys"
+                )
+            result[key] = value
+        return result
+
+    def reject_constant(_value: str) -> None:
+        raise DispatchRouteContractError(
+            "transport route artifact has non-finite number"
+        )
+
+    try:
+        document = json.loads(
+            text, object_pairs_hook=object_pairs, parse_constant=reject_constant
+        )
+    except DispatchRouteContractError:
+        raise
+    except (json.JSONDecodeError, RecursionError) as error:
+        raise DispatchRouteContractError(
+            "transport route artifact is invalid JSON"
+        ) from error
+    _validate_json_depth(document, 0)
+    return document
+
+
+def _required_string(document: dict[str, Any], key: str) -> str:
+    value = document.get(key)
+    if not isinstance(value, str) or not value:
+        raise DispatchRouteContractError("transport route string field is invalid")
+    return value
+
+
+def _validate_json_depth(value: Any, depth: int) -> None:
+    if depth > _MAX_JSON_DEPTH:
+        raise DispatchRouteContractError(
+            "transport route artifact is too deeply nested"
+        )
+    if isinstance(value, dict):
+        for child in value.values():
+            _validate_json_depth(child, depth + 1)
+    elif isinstance(value, list):
+        for child in value:
+            _validate_json_depth(child, depth + 1)

--- a/src/dev_health_ops/workers/job_contracts/registry.py
+++ b/src/dev_health_ops/workers/job_contracts/registry.py
@@ -47,6 +47,18 @@ _MIGRATION_JOB_FIELDS = {
     "rollback_route",
     "evidence",
 }
+_MIGRATION_ROUTES = frozenset({"celery", "shadow", "river_canary", "river", "removed"})
+_MIGRATION_ROLLBACK_ROUTES = frozenset({"celery", "river", "none"})
+_MIGRATION_STATE_ROUTES = {
+    "inventory": ("celery", "celery"),
+    "contract_frozen": ("celery", "celery"),
+    "go_implemented": ("celery", "celery"),
+    "shadow": ("shadow", "celery"),
+    "canary": ("river_canary", "celery"),
+    "go_default": ("river", "celery"),
+    "celery_fallback_only": ("river", "celery"),
+    "celery_removed": ("river", "none"),
+}
 
 
 @dataclass(frozen=True, slots=True)
@@ -92,6 +104,7 @@ class MigrationJob:
     kind: str
     producer_version: int
     required_profiles: tuple[str, ...]
+    route: str = "celery"
 
 
 def default_contract_root() -> Path:
@@ -210,13 +223,26 @@ def load_migration_jobs(root: Path | None = None) -> tuple[MigrationJob, ...]:
             isinstance(profile, str) and profile for profile in profiles
         ):
             raise ContractDecodeError("required_profiles is invalid")
+        route = _required_string(raw, "route")
+        rollback_route = _required_string(raw, "rollback_route")
+        state = _required_string(raw, "state")
+        if (
+            route not in _MIGRATION_ROUTES
+            or rollback_route not in _MIGRATION_ROLLBACK_ROUTES
+        ):
+            raise ContractDecodeError("migration route is unsupported")
+        if _MIGRATION_STATE_ROUTES.get(state) != (route, rollback_route):
+            raise ContractDecodeError("migration state route is inconsistent")
         jobs.append(
             MigrationJob(
                 kind=_required_string(raw, "kind"),
                 producer_version=_required_int(raw, "producer_version"),
                 required_profiles=tuple(profiles),
+                route=route,
             )
         )
+    if len({job.kind for job in jobs}) != len(jobs):
+        raise ContractDecodeError("migration state contains duplicate kinds")
     return tuple(jobs)
 
 

--- a/src/dev_health_ops/workers/job_outbox.py
+++ b/src/dev_health_ops/workers/job_outbox.py
@@ -15,11 +15,15 @@ from dev_health_ops.models.worker_job_outbox import WorkerJobOutbox
 from .job_contracts import (
     ContractDecodeError,
     ContractPayload,
+    MigrationJob,
     Registry,
     build_envelope,
     encode_envelope,
+    load_migration_jobs,
     load_registry,
 )
+
+_EXECUTABLE_MIGRATION_ROUTES = frozenset({"shadow", "river_canary", "river"})
 
 
 class OutboxEnqueueError(ValueError):
@@ -53,6 +57,10 @@ def enqueue_worker_job(
     try:
         contract_registry = registry or load_registry()
         contract = contract_registry.by_kind(payload.KIND)
+        _require_executable_migration_route(
+            payload.KIND,
+            load_migration_jobs(),
+        )
         envelope = build_envelope(
             payload,
             correlation_id=correlation_id,
@@ -107,6 +115,16 @@ def enqueue_worker_job(
             existing, payload.KIND, envelope.contract_version, payload_hash
         )
     return row
+
+
+def _require_executable_migration_route(
+    kind: str, jobs: tuple[MigrationJob, ...]
+) -> None:
+    matching_jobs = tuple(job for job in jobs if job.kind == kind)
+    if len(matching_jobs) != 1:
+        raise ContractDecodeError("migration state does not define job route")
+    if matching_jobs[0].route not in _EXECUTABLE_MIGRATION_ROUTES:
+        raise ContractDecodeError("migration route is not executable")
 
 
 def _find_existing(session: Session, dedupe_key: str) -> WorkerJobOutbox | None:

--- a/src/dev_health_ops/workers/sync_reconciler.py
+++ b/src/dev_health_ops/workers/sync_reconciler.py
@@ -31,6 +31,20 @@ _WORKER_LOST_RETRY_EXHAUSTED_CATEGORY = "worker_lost_retry_exhausted"
 _DEFAULT_RATE_LIMIT_OBSERVATION_RETENTION_DAYS = 14
 
 
+def _emit_sync_dispatch_parity_observation(payload: dict[str, Any]) -> None:
+    """Keep optional parity telemetry from owning the Celery claim path."""
+    try:
+        logger.info("sync_dispatch_parity_observation", extra=payload)
+    except Exception:  # noqa: BLE001 - logging must never gate durable dispatch
+        return
+
+
+def _recover_sync_dispatch_parity_capture_transaction(session: Any) -> None:
+    """Restore a session after an optional observation statement fails."""
+    session.rollback()
+    session.expire_all()
+
+
 def _rate_limit_observation_retention_days() -> int:
     try:
         days = int(
@@ -120,10 +134,12 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
         OUTBOX_KIND_DISPATCH,
         OUTBOX_KIND_FINALIZE,
         OUTBOX_KIND_POST_SYNC,
+        SyncDispatchParityObservationUnavailable,
         claim_due_outbox_rows,
         lock_outbox_claim_for_publish,
         mark_outbox_dispatched,
         mark_outbox_publish_failed,
+        observe_due_outbox_rows,
         upsert_outbox_wakeup,
     )
     from dev_health_ops.workers.post_sync_dispatch import (
@@ -341,7 +357,35 @@ def reconcile_sync_dispatch(limit: int = 100) -> dict[str, Any]:
         session.commit()
         session.expire_all()
 
-        claimed_rows = claim_due_outbox_rows(session, now=now, limit=max(1, int(limit)))
+        claim_limit = max(1, int(limit))
+        try:
+            parity_observation = observe_due_outbox_rows(
+                session, now=now, limit=claim_limit
+            )
+        except SyncDispatchParityObservationUnavailable as error:
+            _recover_sync_dispatch_parity_capture_transaction(session)
+            _emit_sync_dispatch_parity_observation(
+                {
+                    "event": "sync_dispatch_parity_observation",
+                    "runtime": "celery",
+                    "capture_status": "unavailable",
+                    "reason": error.reason,
+                }
+            )
+        except Exception:
+            _recover_sync_dispatch_parity_capture_transaction(session)
+            _emit_sync_dispatch_parity_observation(
+                {
+                    "event": "sync_dispatch_parity_observation",
+                    "runtime": "celery",
+                    "capture_status": "unavailable",
+                    "reason": "capture_unavailable",
+                }
+            )
+        else:
+            _emit_sync_dispatch_parity_observation(parity_observation)
+
+        claimed_rows = claim_due_outbox_rows(session, now=now, limit=claim_limit)
         session.commit()
         session.expire_all()
         for row in claimed_rows:

--- a/tests/sync/test_dispatch_routes.py
+++ b/tests/sync/test_dispatch_routes.py
@@ -1,0 +1,267 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from dev_health_ops.sync import dispatch_outbox
+from dev_health_ops.sync.dispatch_routes import (
+    MAX_TRANSPORT_ROUTES_BYTES,
+    DispatchRouteContractError,
+    default_transport_routes_path,
+    load_transport_routes,
+)
+
+
+def _write_document(path: Path, document: object) -> None:
+    path.write_text(json.dumps(document), encoding="utf-8")
+
+
+def _contract_document() -> dict[str, object]:
+    return json.loads(default_transport_routes_path().read_text(encoding="utf-8"))
+
+
+def test_v1_schema_describes_the_canonical_transport_artifact() -> None:
+    artifact_path = default_transport_routes_path()
+    schema_path = artifact_path.with_name("transport-routes.schema.json")
+    schema = json.loads(schema_path.read_text(encoding="utf-8"))
+    artifact = _contract_document()
+
+    assert schema["$schema"] == "https://json-schema.org/draft/2020-12/schema"
+    assert schema["$id"] == (
+        "https://contracts.fullchaos.dev/sync-dispatch/v1/transport-routes.schema.json"
+    )
+    assert schema["type"] == "object"
+    assert schema["additionalProperties"] is False
+    assert schema["required"] == ["schema_version", "routes"]
+    assert schema["properties"]["schema_version"] == {"type": "integer", "const": 1}
+
+    routes_schema = schema["properties"]["routes"]
+    assert routes_schema["type"] == "array"
+    assert routes_schema["minItems"] == routes_schema["maxItems"] == 4
+    assert routes_schema["items"] is False
+    route_definitions = [
+        route["$ref"].removeprefix("#/$defs/") for route in routes_schema["prefixItems"]
+    ]
+    assert route_definitions == [
+        "dispatch_sync_run",
+        "finalize_sync_run",
+        "post_sync",
+        "reference_discovery",
+    ]
+
+    definitions = schema["$defs"]
+    assert definitions["transport"] == {
+        "type": "string",
+        "pattern": "^[a-z][a-z0-9_]*$",
+        "enum": ["celery", "river"],
+    }
+    assert definitions["transport_pair"] == {
+        "anyOf": [
+            {
+                "properties": {
+                    "route": {"const": "celery"},
+                    "rollback_route": {"const": "celery"},
+                }
+            },
+            {
+                "properties": {
+                    "route": {"const": "river"},
+                    "rollback_route": {"const": "celery"},
+                }
+            },
+        ]
+    }
+    artifact_routes = artifact["routes"]
+    assert isinstance(artifact_routes, list)
+    for route, definition_name in zip(artifact_routes, route_definitions, strict=True):
+        assert isinstance(route, dict)
+        descriptor = definitions[definition_name]
+        assert descriptor["type"] == "object"
+        assert descriptor["additionalProperties"] is False
+        assert descriptor["allOf"] == [{"$ref": "#/$defs/transport_pair"}]
+        assert descriptor["required"] == [
+            "kind",
+            "delivery",
+            "route",
+            "rollback_route",
+        ]
+        properties = descriptor["properties"]
+        assert route["kind"] == properties["kind"]["const"]
+        assert route["delivery"] == properties["delivery"]["const"]
+        assert route["route"] in definitions["transport"]["enum"]
+        assert route["rollback_route"] in definitions["transport"]["enum"]
+
+    assert load_transport_routes().by_kind("post_sync").delivery == (
+        "at_most_once_mark_before"
+    )
+
+
+def test_contract_covers_exactly_the_production_outbox_kinds() -> None:
+    production_kinds = sorted(
+        value
+        for name, value in vars(dispatch_outbox).items()
+        if name.startswith("OUTBOX_KIND_") and isinstance(value, str)
+    )
+
+    assert tuple(production_kinds) == tuple(sorted(load_transport_routes().routes))
+
+
+def test_checked_in_transport_routes_are_celery_only_and_immutable() -> None:
+    routes = load_transport_routes()
+
+    assert tuple(routes.routes) == (
+        "dispatch_sync_run",
+        "finalize_sync_run",
+        "post_sync",
+        "reference_discovery",
+    )
+    assert routes.by_kind("post_sync").delivery == "at_most_once_mark_before"
+    assert all(
+        route.route == route.rollback_route == "celery"
+        for route in routes.routes.values()
+    )
+    with pytest.raises(TypeError):
+        routes.routes["post_sync"] = routes.by_kind("post_sync")  # type: ignore[index]
+    with pytest.raises(DispatchRouteContractError, match="unknown"):
+        routes.by_kind("not_a_wakeup")
+
+
+@pytest.mark.parametrize(
+    ("mutate", "message"),
+    [
+        (
+            lambda document: document.update({"extra": True}),
+            "shape",
+        ),
+        (
+            lambda document: document.update({"schema_version": 2}),
+            "version",
+        ),
+        (
+            lambda document: document.update({"schema_version": True}),
+            "version",
+        ),
+        (
+            lambda document: document["routes"].append(document["routes"][0]),
+            "duplicate",
+        ),
+        (
+            lambda document: document.update(
+                {"routes": list(reversed(document["routes"]))}
+            ),
+            "sorted",
+        ),
+        (
+            lambda document: document.update({"routes": document["routes"][:-1]}),
+            "missing",
+        ),
+        (
+            lambda document: document["routes"][2].update(
+                {"delivery": "at_least_once"}
+            ),
+            "delivery",
+        ),
+        (
+            lambda document: document["routes"][0].update({"route": "shadow"}),
+            "unsupported",
+        ),
+        (
+            lambda document: document["routes"][0].update({"extra": True}),
+            "shape",
+        ),
+    ],
+)
+def test_loader_rejects_contract_drift(
+    tmp_path: Path, mutate: object, message: str
+) -> None:
+    path = tmp_path / "transport-routes.json"
+    document = _contract_document()
+    mutate(document)  # type: ignore[operator]
+    _write_document(path, document)
+
+    with pytest.raises(DispatchRouteContractError, match=message):
+        load_transport_routes(path)
+
+
+@pytest.mark.parametrize(
+    "payload",
+    [
+        b"",
+        b"\xff",
+        b'{"schema_version": 1} {"routes": []}',
+        b'{"schema_version": 1, "schema_version": 1, "routes": []}',
+    ],
+)
+def test_loader_rejects_ambiguous_or_non_utf8_artifacts(
+    tmp_path: Path, payload: bytes
+) -> None:
+    path = tmp_path / "transport-routes.json"
+    path.write_bytes(payload)
+
+    with pytest.raises(DispatchRouteContractError):
+        load_transport_routes(path)
+
+
+def test_loader_rejects_oversized_and_symlink_artifacts(tmp_path: Path) -> None:
+    oversized = tmp_path / "oversized.json"
+    oversized.write_bytes(b" " * (MAX_TRANSPORT_ROUTES_BYTES + 1))
+    with pytest.raises(DispatchRouteContractError, match="size"):
+        load_transport_routes(oversized)
+
+    target = tmp_path / "target.json"
+    _write_document(target, _contract_document())
+    symlink = tmp_path / "transport-routes.json"
+    symlink.symlink_to(target)
+    with pytest.raises(DispatchRouteContractError, match="regular"):
+        load_transport_routes(symlink)
+
+
+def test_loader_accepts_a_future_river_route_with_explicit_celery_rollback(
+    tmp_path: Path,
+) -> None:
+    path = tmp_path / "transport-routes.json"
+    document = _contract_document()
+    raw_routes = document["routes"]
+    assert isinstance(raw_routes, list)
+    first_route = raw_routes[0]
+    assert isinstance(first_route, dict)
+    first_route.update({"route": "river", "rollback_route": "celery"})
+    _write_document(path, document)
+
+    assert load_transport_routes(path).by_kind("dispatch_sync_run").route == "river"
+
+
+@pytest.mark.parametrize(
+    ("route", "rollback_route"),
+    [
+        ("celery", "river"),
+        ("river", "river"),
+    ],
+)
+def test_loader_rejects_unsafe_transport_pairs(
+    tmp_path: Path, route: str, rollback_route: str
+) -> None:
+    path = tmp_path / "transport-routes.json"
+    document = _contract_document()
+    raw_routes = document["routes"]
+    assert isinstance(raw_routes, list)
+    first_route = raw_routes[0]
+    assert isinstance(first_route, dict)
+    first_route.update({"route": route, "rollback_route": rollback_route})
+    _write_document(path, document)
+
+    with pytest.raises(DispatchRouteContractError, match="unsupported"):
+        load_transport_routes(path)
+
+
+def test_loader_rejects_excessively_nested_json(tmp_path: Path) -> None:
+    path = tmp_path / "transport-routes.json"
+    nested: dict[str, object] = {}
+    for _ in range(9):
+        nested = {"nested": nested}
+    _write_document(path, {"schema_version": 1, "routes": [], "nested": nested})
+
+    with pytest.raises(DispatchRouteContractError, match="deeply"):
+        load_transport_routes(path)

--- a/tests/test_dispatch_outbox.py
+++ b/tests/test_dispatch_outbox.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from datetime import datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, event
 from sqlalchemy.orm import Session
 
 from dev_health_ops.models import (
@@ -22,12 +22,17 @@ from dev_health_ops.sync.dispatch_outbox import (
     OUTBOX_KIND_FINALIZE,
     OUTBOX_STATUS_DISPATCHED,
     OUTBOX_STATUS_PENDING,
+    SYNC_DISPATCH_PARITY_DIGEST_VERSION,
+    SYNC_DISPATCH_PARITY_EVENT,
+    SYNC_DISPATCH_PARITY_PREDICATE_VERSION,
     ClaimedOutboxRow,
+    SyncDispatchParityObservationUnavailable,
     backoff_seconds,
     claim_due_outbox_rows,
     lock_outbox_claim_for_publish,
     mark_outbox_dispatched,
     mark_outbox_publish_failed,
+    observe_due_outbox_rows,
     upsert_outbox_wakeup,
 )
 
@@ -93,6 +98,142 @@ def _aware(value):
     if value.tzinfo is None:
         return value.replace(tzinfo=timezone.utc)
     return value.astimezone(timezone.utc)
+
+
+def test_observe_due_outbox_rows_matches_claim_window_and_go_digest(db_session):
+    now = datetime(2026, 7, 22, 12, 0, 0, tzinfo=timezone.utc)
+    dispatch = _seed_outbox(
+        db_session,
+        available_at=now - timedelta(seconds=3),
+        kind=OUTBOX_KIND_DISPATCH,
+    )
+    post_sync = _seed_outbox(
+        db_session,
+        available_at=now - timedelta(seconds=2),
+        kind="post_sync",
+    )
+    finalize = _seed_outbox(
+        db_session,
+        available_at=now - timedelta(seconds=1),
+        kind=OUTBOX_KIND_FINALIZE,
+    )
+    live_claim = _seed_outbox(
+        db_session,
+        available_at=now - timedelta(seconds=4),
+        kind="reference_discovery",
+    )
+    dispatch.id = uuid.UUID("00000000-0000-4000-8000-000000000001")
+    post_sync.id = uuid.UUID("00000000-0000-4000-8000-000000000002")
+    finalize.id = uuid.UUID("00000000-0000-4000-8000-000000000003")
+    live_claim.id = uuid.UUID("00000000-0000-4000-8000-000000000004")
+    dispatch.claim_expires_at = now - timedelta(seconds=1)
+    live_claim.claim_expires_at = now + timedelta(seconds=1)
+    db_session.flush()
+
+    statements: list[str] = []
+
+    def record_statement(_conn, _cursor, statement, _parameters, _context, _many):
+        statements.append(statement)
+
+    engine = db_session.get_bind()
+    event.listen(engine, "before_cursor_execute", record_statement)
+    try:
+        record = observe_due_outbox_rows(db_session, now=now, limit=2)
+    finally:
+        event.remove(engine, "before_cursor_execute", record_statement)
+
+    assert record == {
+        "event": SYNC_DISPATCH_PARITY_EVENT,
+        "runtime": "celery",
+        "observed_at": "2026-07-22T12:00:00.000000000Z",
+        "limit": 2,
+        "predicate_version": SYNC_DISPATCH_PARITY_PREDICATE_VERSION,
+        "digest_version": SYNC_DISPATCH_PARITY_DIGEST_VERSION,
+        "candidate_digest": (
+            "sha256:470a95b9d29c43636664b00b6beb7f192c18b523e41802b7a785cd463eb42218"
+        ),
+        "sampled_candidates": 2,
+        "truncated": True,
+        "unknown_kind_count": 0,
+        "celery_due_pending": 2,
+        "river_due_pending": 0,
+        "kinds": [
+            {
+                "kind": "dispatch_sync_run",
+                "route": "celery",
+                "due_pending": 1,
+                "expired_claims": 1,
+            },
+            {
+                "kind": "finalize_sync_run",
+                "route": "celery",
+                "due_pending": 0,
+                "expired_claims": 0,
+            },
+            {
+                "kind": "post_sync",
+                "route": "celery",
+                "due_pending": 1,
+                "expired_claims": 0,
+            },
+            {
+                "kind": "reference_discovery",
+                "route": "celery",
+                "due_pending": 0,
+                "expired_claims": 0,
+            },
+        ],
+    }
+    observed_sql = "\n".join(statements).upper()
+    for fragment in (
+        "SELECT",
+        "STATUS =",
+        "AVAILABLE_AT <=",
+        "CLAIM_EXPIRES_AT IS NULL",
+        "ORDER BY",
+        "AVAILABLE_AT, SYNC_DISPATCH_OUTBOX.ID",
+        "LIMIT",
+    ):
+        assert fragment in observed_sql
+    assert not any(
+        statement.lstrip().upper().startswith("UPDATE") for statement in statements
+    )
+    assert dispatch.claim_token is None
+    assert post_sync.claim_token is None
+    assert finalize.claim_token is None
+    assert live_claim.claim_token is None
+
+
+def test_observe_due_outbox_rows_bounds_redacts_and_counts_unknown_kind(db_session):
+    now = datetime(2026, 7, 22, 12, 0, 0, 123456, tzinfo=timezone.utc)
+    unknown = _seed_outbox(
+        db_session,
+        available_at=now - timedelta(seconds=2),
+        kind="future_contract_kind",
+    )
+    known = _seed_outbox(
+        db_session,
+        available_at=now - timedelta(seconds=1),
+        kind=OUTBOX_KIND_DISPATCH,
+    )
+    record = observe_due_outbox_rows(db_session, now=now, limit=1)
+
+    assert record["observed_at"] == "2026-07-22T12:00:00.123456000Z"
+    assert record["unknown_kind_count"] == 1
+    assert record["celery_due_pending"] == 0
+    rendered = repr(record)
+    for forbidden in (
+        str(unknown.id),
+        str(known.id),
+        unknown.org_id,
+        str(unknown.sync_run_id),
+    ):
+        assert forbidden not in rendered
+    for limit in (0, 101, True):
+        with pytest.raises(
+            SyncDispatchParityObservationUnavailable, match="invalid_limit"
+        ):
+            observe_due_outbox_rows(db_session, now=now, limit=limit)
 
 
 def test_upsert_insert_creates_pending_row(db_session):

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
+import logging
+import os
 import uuid
 from contextlib import contextmanager
 from datetime import date, datetime, timedelta, timezone
 
 import pytest
-from sqlalchemy import create_engine
+from sqlalchemy import create_engine, text
+from sqlalchemy.exc import DBAPIError
 from sqlalchemy.orm import Session
 
 from dev_health_ops.models import (
@@ -59,6 +62,175 @@ def _patch_db_session(monkeypatch, session):
     monkeypatch.setattr(
         db, "get_postgres_session_sync", lambda: _fake_session_ctx(session)
     )
+
+
+def test_reconciler_emits_parity_observation_before_claim(
+    db_session, monkeypatch, caplog
+):
+    from dev_health_ops.sync import dispatch_outbox
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, _planned = _seed_run(db_session, planned_units=1)
+    db_session.delete(running)
+    run.total_units = 1
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatches.append((args, queue)),
+    )
+    order = []
+    original_observe = dispatch_outbox.observe_due_outbox_rows
+    original_claim = dispatch_outbox.claim_due_outbox_rows
+
+    def observe(*args, **kwargs):
+        order.append("observe")
+        return original_observe(*args, **kwargs)
+
+    def claim(*args, **kwargs):
+        order.append("claim")
+        return original_claim(*args, **kwargs)
+
+    monkeypatch.setattr(dispatch_outbox, "observe_due_outbox_rows", observe)
+    monkeypatch.setattr(dispatch_outbox, "claim_due_outbox_rows", claim)
+    caplog.set_level(logging.INFO, logger="dev_health_ops.workers.sync_reconciler")
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    assert result["relayed_dispatch"] == 1
+    assert dispatches == [((str(run.id),), "sync")]
+    assert order.index("observe") < order.index("claim")
+    records = [
+        record
+        for record in caplog.records
+        if record.message == "sync_dispatch_parity_observation"
+    ]
+    assert len(records) == 1
+    record = records[0]
+    assert record.event == "sync_dispatch_parity_observation"
+    assert record.runtime == "celery"
+    assert record.limit == 10
+    assert record.candidate_digest.startswith("sha256:")
+    assert record.observed_at.endswith("000Z")
+    captured = f"{record.message} {record.__dict__}"
+    for forbidden in (str(run.id), run.org_id, "claim_token", "payload"):
+        assert forbidden not in captured
+
+
+def test_reconciler_parity_capture_failure_logs_and_does_not_change_claims(
+    db_session, monkeypatch, caplog
+):
+    from dev_health_ops.sync import dispatch_outbox
+    from dev_health_ops.sync.dispatch_outbox import (
+        SyncDispatchParityObservationUnavailable,
+    )
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, _planned = _seed_run(db_session, planned_units=1)
+    db_session.delete(running)
+    run.total_units = 1
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatches.append((args, queue)),
+    )
+    monkeypatch.setattr(
+        dispatch_outbox,
+        "observe_due_outbox_rows",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            SyncDispatchParityObservationUnavailable("query_unavailable")
+        ),
+    )
+    caplog.set_level(logging.INFO, logger="dev_health_ops.workers.sync_reconciler")
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    assert result["relayed_dispatch"] == 1
+    assert dispatches == [((str(run.id),), "sync")]
+    record = next(
+        record
+        for record in caplog.records
+        if record.message == "sync_dispatch_parity_observation"
+    )
+    assert record.capture_status == "unavailable"
+    assert record.reason == "query_unavailable"
+
+
+def test_reconciler_logs_unavailable_parity_capture_for_limit_above_bound(
+    db_session, monkeypatch, caplog
+):
+    from dev_health_ops.workers import sync_reconciler
+
+    _patch_db_session(monkeypatch, db_session)
+    caplog.set_level(logging.INFO, logger="dev_health_ops.workers.sync_reconciler")
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=101)
+
+    assert result["relayed_dispatch"] == 0
+    record = next(
+        record
+        for record in caplog.records
+        if record.message == "sync_dispatch_parity_observation"
+    )
+    assert record.capture_status == "unavailable"
+    assert record.reason == "invalid_limit"
+
+
+def test_reconciler_parity_logging_failure_does_not_change_claims(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import sync_reconciler, sync_units
+
+    run, running, _planned = _seed_run(db_session, planned_units=1)
+    db_session.delete(running)
+    run.total_units = 1
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    dispatches = []
+    monkeypatch.setattr(
+        sync_units.dispatch_sync_run,
+        "apply_async",
+        lambda args=None, queue=None: dispatches.append((args, queue)),
+    )
+    monkeypatch.setattr(
+        sync_reconciler.logger,
+        "info",
+        lambda *_args, **_kwargs: (_ for _ in ()).throw(
+            RuntimeError("blocked telemetry sink")
+        ),
+    )
+
+    result = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    assert result["relayed_dispatch"] == 1
+    assert dispatches == [((str(run.id),), "sync")]
+
+
+@pytest.mark.skipif(
+    not os.getenv("DEV_HEALTH_POSTGRES_TEST_URI"),
+    reason="requires DEV_HEALTH_POSTGRES_TEST_URI",
+)
+def test_parity_capture_recovery_clears_real_postgres_statement_failure():
+    from dev_health_ops.workers.sync_reconciler import (
+        _recover_sync_dispatch_parity_capture_transaction,
+    )
+
+    engine = create_engine(os.environ["DEV_HEALTH_POSTGRES_TEST_URI"])
+    try:
+        with Session(engine) as session:
+            with pytest.raises(DBAPIError):
+                session.execute(text("SELECT 1 / 0"))
+
+            _recover_sync_dispatch_parity_capture_transaction(session)
+
+            assert session.execute(text("SELECT 1")).scalar_one() == 1
+    finally:
+        engine.dispose()
 
 
 def _seed_run(

--- a/tests/workers/job_contracts/test_registry.py
+++ b/tests/workers/job_contracts/test_registry.py
@@ -39,6 +39,45 @@ def test_python_registry_rejects_envelope_schema_drift(tmp_path: Path) -> None:
         load_registry(candidate)
 
 
+def test_migration_registry_rejects_unknown_route(tmp_path: Path) -> None:
+    candidate = tmp_path / "v1"
+    shutil.copytree(default_contract_root(), candidate)
+    state_path = candidate / "migration-state.json"
+    document = json.loads(state_path.read_text())
+    document["jobs"][0]["route"] = "environment_override"
+    state_path.write_text(json.dumps(document))
+
+    with pytest.raises(ContractDecodeError, match="route is unsupported"):
+        load_migration_jobs(candidate)
+
+
+def test_migration_registry_accepts_terminal_rollback_route(tmp_path: Path) -> None:
+    candidate = tmp_path / "v1"
+    shutil.copytree(default_contract_root(), candidate)
+    state_path = candidate / "migration-state.json"
+    document = json.loads(state_path.read_text())
+    document["jobs"][0].update(
+        {"state": "celery_removed", "route": "river", "rollback_route": "none"}
+    )
+    state_path.write_text(json.dumps(document))
+
+    jobs = load_migration_jobs(candidate)
+
+    assert jobs[0].route == "river"
+
+
+def test_migration_registry_rejects_state_route_mismatch(tmp_path: Path) -> None:
+    candidate = tmp_path / "v1"
+    shutil.copytree(default_contract_root(), candidate)
+    state_path = candidate / "migration-state.json"
+    document = json.loads(state_path.read_text())
+    document["jobs"][0]["route"] = "shadow"
+    state_path.write_text(json.dumps(document))
+
+    with pytest.raises(ContractDecodeError, match="state route is inconsistent"):
+        load_migration_jobs(candidate)
+
+
 def test_rollout_requires_every_live_profile_report() -> None:
     registry = load_registry()
     migration_jobs = load_migration_jobs()

--- a/tests/workers/test_worker_job_outbox.py
+++ b/tests/workers/test_worker_job_outbox.py
@@ -1,16 +1,19 @@
 from __future__ import annotations
 
+import os
 import uuid
 from datetime import UTC, datetime, timedelta
 from typing import cast
+from unittest.mock import patch
 
 import pytest
 from sqlalchemy import Table, create_engine, select
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
+from sqlalchemy.schema import CreateSchema, DropSchema
 
 from dev_health_ops.models import Base, WorkerJobOutbox
-from dev_health_ops.workers.job_contracts import HeartbeatPayload
+from dev_health_ops.workers.job_contracts import HeartbeatPayload, MigrationJob
 from dev_health_ops.workers.job_outbox import OutboxEnqueueError, enqueue_worker_job
 
 
@@ -21,7 +24,30 @@ def engine():
     return value
 
 
+@pytest.fixture
+def postgres_engine():
+    uri = os.getenv("WORKER_OUTBOX_POSTGRES_TEST_URI")
+    if not uri:
+        pytest.skip("WORKER_OUTBOX_POSTGRES_TEST_URI is not configured")
+    schema = f"worker_outbox_test_{uuid.uuid4().hex}"
+    admin = create_engine(uri)
+    with admin.begin() as connection:
+        connection.execute(CreateSchema(schema))
+    value = create_engine(uri, connect_args={"options": f"-csearch_path={schema}"})
+    worker_outbox_table = cast(Table, WorkerJobOutbox.__table__)
+    worker_outbox_table.create(value)
+    try:
+        yield value
+    finally:
+        value.dispose()
+        with admin.begin() as connection:
+            connection.execute(DropSchema(schema, cascade=True))
+        admin.dispose()
+
+
 def _enqueue(session: Session, **overrides):
+    migration_route = overrides.pop("migration_route", None)
+    migration_jobs = overrides.pop("migration_jobs", None)
     now = overrides.pop("now", datetime(2026, 7, 21, 12, 0, tzinfo=UTC))
     values = {
         "correlation_id": "heartbeat-producer-1",
@@ -31,10 +57,33 @@ def _enqueue(session: Session, **overrides):
         "now": now,
     }
     values.update(overrides)
-    return enqueue_worker_job(
-        session,
-        HeartbeatPayload(scheduled_for="2026-07-21T12:00:00Z"),
-        **values,
+    if migration_route is not None:
+        migration_jobs = _migration_job(migration_route)
+    if migration_jobs is None:
+        return enqueue_worker_job(
+            session,
+            HeartbeatPayload(scheduled_for="2026-07-21T12:00:00Z"),
+            **values,
+        )
+    with patch(
+        "dev_health_ops.workers.job_outbox.load_migration_jobs",
+        return_value=migration_jobs,
+    ):
+        return enqueue_worker_job(
+            session,
+            HeartbeatPayload(scheduled_for="2026-07-21T12:00:00Z"),
+            **values,
+        )
+
+
+def _migration_job(route: str) -> tuple[MigrationJob, ...]:
+    return (
+        MigrationJob(
+            kind="system.heartbeat",
+            producer_version=1,
+            required_profiles=("ops",),
+            route=route,
+        ),
     )
 
 
@@ -51,10 +100,25 @@ def test_rejects_implicit_autobegin_after_prior_read(engine):
             _enqueue(session)
 
 
-def test_stages_canonical_registry_derived_dispatch_without_committing(engine):
+def test_rejects_celery_route_without_writing_or_weakening_transaction(engine):
+    with Session(engine) as session, session.begin():
+        with pytest.raises(OutboxEnqueueError, match="worker job contract is invalid"):
+            _enqueue(session)
+        assert session.scalar(select(WorkerJobOutbox)) is None
+
+
+def test_rejects_missing_migration_route_without_writing(engine):
+    with Session(engine) as session, session.begin():
+        with pytest.raises(OutboxEnqueueError, match="worker job contract is invalid"):
+            _enqueue(session, migration_jobs=())
+        assert session.scalar(select(WorkerJobOutbox)) is None
+
+
+@pytest.mark.parametrize("route", ("shadow", "river_canary", "river"))
+def test_stages_executable_migration_route_without_committing(engine, route: str):
     with Session(engine) as session:
         with session.begin():
-            row = _enqueue(session)
+            row = _enqueue(session, migration_route=route)
             assert row.id is not None
             assert row.job_kind == "system.heartbeat"
             assert row.contract_version == 1
@@ -73,8 +137,12 @@ def test_stages_canonical_registry_derived_dispatch_without_committing(engine):
 
 def test_commit_and_same_content_reuse_return_one_logical_dispatch(engine):
     with Session(engine) as session, session.begin():
-        first = _enqueue(session)
-        second = _enqueue(session, scheduled_at=datetime(2026, 7, 22, tzinfo=UTC))
+        first = _enqueue(session, migration_route="shadow")
+        second = _enqueue(
+            session,
+            scheduled_at=datetime(2026, 7, 22, tzinfo=UTC),
+            migration_route="shadow",
+        )
         assert second.id == first.id
 
     with Session(engine) as verifier:
@@ -83,24 +151,32 @@ def test_commit_and_same_content_reuse_return_one_logical_dispatch(engine):
 
 def test_dedupe_key_reuse_with_different_content_fails_closed(engine):
     with Session(engine) as session, session.begin():
-        _enqueue(session)
+        _enqueue(session, migration_route="shadow")
 
     with Session(engine) as session, session.begin():
         with pytest.raises(OutboxEnqueueError, match="dedupe key conflicts"):
-            enqueue_worker_job(
-                session,
-                HeartbeatPayload(scheduled_for="2026-07-21T13:00:00Z"),
-                correlation_id="heartbeat-producer-2",
-                idempotency_key="heartbeat:2026-07-21T12:00:00Z",
-                domain_id="00000000-0000-4000-8000-000000000001",
-            )
+            with patch(
+                "dev_health_ops.workers.job_outbox.load_migration_jobs",
+                return_value=_migration_job("shadow"),
+            ):
+                enqueue_worker_job(
+                    session,
+                    HeartbeatPayload(scheduled_for="2026-07-21T13:00:00Z"),
+                    correlation_id="heartbeat-producer-2",
+                    idempotency_key="heartbeat:2026-07-21T12:00:00Z",
+                    domain_id="00000000-0000-4000-8000-000000000001",
+                )
 
 
 def test_invalid_envelope_is_value_free_and_writes_nothing(engine):
     secret = "postgres://worker:secret@example.invalid/app"
     with Session(engine) as session, session.begin():
         with pytest.raises(OutboxEnqueueError) as raised:
-            _enqueue(session, correlation_id=secret)
+            _enqueue(
+                session,
+                correlation_id=secret,
+                migration_route="shadow",
+            )
         assert secret not in str(raised.value)
         assert session.scalar(select(WorkerJobOutbox)) is None
 
@@ -108,12 +184,16 @@ def test_invalid_envelope_is_value_free_and_writes_nothing(engine):
 def test_rejects_naive_schedule_timestamp(engine):
     with Session(engine) as session, session.begin():
         with pytest.raises(OutboxEnqueueError, match="timezone-aware"):
-            _enqueue(session, scheduled_at=datetime(2026, 7, 21, 12, 5))
+            _enqueue(
+                session,
+                scheduled_at=datetime(2026, 7, 21, 12, 5),
+                migration_route="shadow",
+            )
 
 
 def test_model_uses_uuid_primary_key(engine):
     with Session(engine) as session, session.begin():
-        row = _enqueue(session)
+        row = _enqueue(session, migration_route="shadow")
         assert isinstance(row.id, uuid.UUID)
 
 
@@ -121,6 +201,28 @@ def test_database_rejects_oversized_stored_args(engine):
     with Session(engine) as session:
         with pytest.raises(IntegrityError):
             with session.begin():
-                row = _enqueue(session)
+                row = _enqueue(session, migration_route="shadow")
                 row.args = {"oversized": "x" * (16 * 1024)}
                 session.flush()
+
+
+def test_postgres_savepoint_preserves_outer_rollback_and_dedupe(postgres_engine):
+    with Session(postgres_engine) as session:
+        with session.begin():
+            _enqueue(session, migration_route="shadow")
+            session.rollback()
+
+    with Session(postgres_engine) as verifier:
+        assert verifier.scalar(select(WorkerJobOutbox)) is None
+
+    with Session(postgres_engine) as session, session.begin():
+        first = _enqueue(session, migration_route="shadow")
+        second = _enqueue(
+            session,
+            scheduled_at=datetime(2026, 7, 22, tzinfo=UTC),
+            migration_route="shadow",
+        )
+        assert second.id == first.id
+
+    with Session(postgres_engine) as verifier:
+        assert len(verifier.scalars(select(WorkerJobOutbox)).all()) == 1


### PR DESCRIPTION
## Summary

- fail closed in the Python generic-outbox producer unless the checked-in migration state selects an executable Go route
- exclude known Celery-routed kinds before relay claiming and independently enforce route policy at River insertion
- compose the generic outbox relay into the reconciler lifecycle with bounded polling, readiness, and low-cardinality metrics
- freeze the four sync-dispatch kinds in one strict Python/Go transport contract, with both active and rollback routes still set to Celery
- add matching bounded Python and Go sync-outbox observations with versioned, redacted candidate digests
- add a dormant, read-only Go sync-scheduler timing shadow with bounded snapshots, cancellation, explicit grammar/scope versions, and Python-derived Croniter vectors
- document the no-handoff rollback boundary and remaining promotion evidence

## Safety boundary

- deployment remains `coexistence_disabled` with all Go minimum replicas at zero
- every generic and sync-dispatch route checked in by this PR remains Celery-owned
- the Go outbox observer and scheduler shadow perform bounded reads only; they do not lock, claim, update, enqueue, publish, or register a production scheduler loop
- scheduler results are explicitly scoped to `schedule_and_marker_only`, not organization or feature-entitlement approval
- valid Croniter forms outside the versioned deterministic subset are `unsupported_cron` and never timing-eligible
- Celery remains the sole production mutation owner; mutation-capable scheduling, occurrence claiming, lease repair, and selectable Celery/River sync transport remain unfinished CHAOS-3039 work

## Validation

- `bash ci/local_validate.sh`: passed; 8,699 tests passed, 53 expected skips
- Ruff format/check and mypy: passed
- all Go format, vet, test, build, contract, and River static-compatibility checks: passed
- focused scheduler normal/race/vet gates: passed
- independent Croniter differential, including generated ordinary range/step/wrap matrices: zero supported-form mismatches
- independent adversarial reviews: no remaining P0-P2 findings
- existing isolated PostgreSQL/River relay failure matrix and generic-outbox transaction/savepoint proof: passed
- the new aborted-transaction parity-capture regression is opt-in and remains skipped when `DEV_HEALTH_POSTGRES_TEST_URI` is not configured

## Remaining promotion gates

- capture correlated same-cutoff/limit evidence before treating live observer digests as parity proof
- run the opt-in PostgreSQL capture-recovery regression in the promotion environment
- implement and validate organization/entitlement gates, occurrence claiming, scheduler writes/enqueue, and duplicate-occurrence protection before any scheduler activation
- baseline relay batch/lease/poll defaults and exercise pending, claimed, delivered, running, and retryable states through stop, drain/classify, restore, and restart before promoting any route

SCREENSHOT-WAIVER: backend/runtime-only change; no rendered UI changes.
