### PR TITLE
feat(workers): add dormant sync transaction kernels (CHAOS-3039)

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,9 +1,10 @@
 ARG GO_BUILD_IMAGE="mirror.gcr.io/library/golang:1.25.9-alpine@sha256:5caaf1cca9dc351e13deafbc3879fd4754801acba8653fa9540cea125d01a71f"
 
-# ── Stage 0: one-shot River migrator builder ──────────────────────────────────
+# ── Stage 0: one-shot Go tooling builder ───────────────────────────────────────
 # The Python migration command invokes this static binary only when the
 # dedicated MIGRATION_DATABASE_URI contract is configured. Long-running
-# processes never invoke it and never receive the migration role.
+# processes never invoke it and never receive the migration role. The parity
+# binary is packaged separately into a read-only local-observer target.
 FROM --platform=$BUILDPLATFORM ${GO_BUILD_IMAGE} AS go-migrator-builder
 
 ARG TARGETOS
@@ -19,6 +20,7 @@ WORKDIR /src
 COPY go.mod go.sum ./
 RUN --mount=type=cache,target=/go/pkg/mod go mod download
 
+COPY cmd/dev-health-sync-parity ./cmd/dev-health-sync-parity
 COPY cmd/dev-health-worker-migrate ./cmd/dev-health-worker-migrate
 COPY internal ./internal
 
@@ -30,7 +32,15 @@ RUN --mount=type=cache,target=/go/pkg/mod \
       -ldflags="-s -w -buildid=" \
       -o /out/dev-health-worker-migrate \
       ./cmd/dev-health-worker-migrate \
-    && touch -d "@${SOURCE_DATE_EPOCH}" /out/dev-health-worker-migrate
+    && GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" go build \
+      -buildvcs=false \
+      -trimpath \
+      -ldflags="-s -w -buildid=" \
+      -o /out/dev-health-sync-parity \
+      ./cmd/dev-health-sync-parity \
+    && touch -d "@${SOURCE_DATE_EPOCH}" \
+      /out/dev-health-worker-migrate \
+      /out/dev-health-sync-parity
 
 # ── Stage 1: builder ──────────────────────────────────────────────────────────
 # Install build dependencies and compile wheels. This stage is NOT shipped.
@@ -102,6 +112,30 @@ HEALTHCHECK --interval=15s --timeout=5s --start-period=30s --retries=3 \
 
 ENTRYPOINT ["dev-hops", "api"]
 CMD ["--host", "0.0.0.0", "--port", "8000"]
+
+# ── Read-only sync parity observer target ──────────────────────────────────────
+# This image contains exactly the checked-in contract and Python helper needed
+# by dev-health-sync-parity. The helper runtime remains pinned to
+# /app/.venv/bin/python; the local container target creates that fixed path
+# without falling back to PATH lookup.
+FROM runtime AS sync-parity
+
+USER root
+
+COPY --from=go-migrator-builder /out/dev-health-sync-parity /usr/local/bin/dev-health-sync-parity
+COPY --from=builder /build/contracts/sync-dispatch/v1 /app/contracts/sync-dispatch/v1
+COPY --from=builder /build/scripts/worker/observe_sync_dispatch_parity.py /app/scripts/worker/observe_sync_dispatch_parity.py
+COPY --from=builder /build/src /app/src
+
+RUN mkdir -p /app/.venv/bin \
+  && ln -s /usr/local/bin/python /app/.venv/bin/python
+
+ENV PYTHONPATH=/app/src
+
+USER appuser
+
+ENTRYPOINT ["dev-health-sync-parity"]
+CMD ["--limit", "100"]
 
 
 # ── Generic runner target ──────────────────────────────────────────────────────

--- a/docker/go-worker.Dockerfile
+++ b/docker/go-worker.Dockerfile
@@ -54,6 +54,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
       /runtime/scheduler/usr/local/bin \
       /runtime/reconciler/usr/local/bin \
       /runtime/reconciler/app/contracts/jobs \
+      /runtime/reconciler/app/contracts/sync-dispatch \
       /runtime/stream-runner/usr/local/bin \
       /runtime/operator/usr/local/bin \
       /runtime/operator/app/contracts/jobs \
@@ -65,6 +66,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     cp /out/dev-health-scheduler /runtime/scheduler/usr/local/bin/dev-health-scheduler; \
     cp /out/dev-health-reconciler /runtime/reconciler/usr/local/bin/dev-health-reconciler; \
     cp -R /src/contracts/jobs/v1 /runtime/reconciler/app/contracts/jobs/v1; \
+    cp -R /src/contracts/sync-dispatch/v1 /runtime/reconciler/app/contracts/sync-dispatch/v1; \
     cp /out/dev-health-stream-runner /runtime/stream-runner/usr/local/bin/dev-health-stream-runner; \
     cp /out/dev-health-workerctl /runtime/operator/usr/local/bin/dev-health-workerctl; \
     cp /out/worker-contractcheck /runtime/contractcheck/usr/local/bin/worker-contractcheck; \

--- a/docs/architecture/go-worker-runtime-trd.md
+++ b/docs/architecture/go-worker-runtime-trd.md
@@ -568,14 +568,18 @@ Until that handler and its route are present, Celery Beat plus
 evaluate or failure-test occurrences before then, but it must not advance a
 production marker or claim schedule ownership.
 
-The current Phase 2 implementation stops before this mutation boundary.
-`internal/scheduler/sync` is an unregistered, read-only shadow: it performs one
+The read-only comparison path in `internal/scheduler/sync` still performs one
 bounded schedule/configuration `SELECT` and evaluates a versioned candidate
-snapshot in memory. It has no advisory lock, row lock, occurrence claim,
-update, enqueue, or command wiring. Celery Beat and
-`dispatch_scheduled_syncs` therefore remain the sole production scheduler
-until the steps above and their duplicate-occurrence tests are implemented
-and approved.
+snapshot in memory. Beside it, an unregistered transaction kernel now locks a
+bounded due window with `FOR UPDATE ... SKIP LOCKED`, derives a stable
+config-and-occurrence identity, invokes an injected coordinator through the
+same PostgreSQL transaction, and advances `next_run_at` only after that
+coordinator reports a durable handoff. No scheduler command constructs or
+calls this kernel. It also deliberately excludes missing-marker creation,
+organization and entitlement policy, authoritative `JobRun`/`SyncRun`/unit
+and outbox materialization, catch-up policy, and the
+`sync.plan_scheduled_config` handler. Celery Beat and
+`dispatch_scheduled_syncs` therefore remain the sole production scheduler.
 
 ### 10.2 Simple periodic maintenance
 
@@ -672,7 +676,24 @@ increment. The future River relay must insert the River job and mark the sync
 outbox through one PostgreSQL transaction and therefore needs the corresponding
 semantic-table privileges on that transaction's pool.
 
-For dispatch, finalize, and discovery rows, the reconciler inserts the River job and marks the outbox row dispatched in the same PostgreSQL transaction. The River job uses a deterministic unique insertion key derived from the outbox row and kind. An insert or mark failure rolls the transaction back and leaves the row eligible for reconciliation.
+An unregistered sync-reconciler transaction kernel now implements the narrow
+transport boundary: for River-routed at-least-once rows it locks and claims a
+bounded due window, invokes an injected River publisher through the same
+transaction, and marks the outbox dispatched only after the insert succeeds.
+For the at-most-once `post_sync` kind it marks dispatched first and invokes a
+separate transaction-local seam that cannot perform the eventual external
+effect. Route generation and claim-token predicates fail closed at the
+terminal write. The checked-in contract currently contains no River route, so
+even explicit mutation mode returns without opening a write transaction, and
+the reconciler command does not construct this kernel.
+
+This kernel is not the complete reconciler loop. Activation still needs
+command wiring and operator controls, materialization of missing
+dispatch/finalize/post-sync outbox rows, expired-domain-lease repair, persisted
+failure classification and retry backoff, concrete River publishers and
+handlers, and the bounded post-sync quiescence plus external-handoff mechanism.
+The reconciler image packages `contracts/sync-dispatch/v1` so the registry is
+available at runtime; that packaging does not change route ownership.
 
 - `dispatch_sync_run`: at-least-once queue insertion; unit claims prevent duplicate provider work.
 - `finalize_sync_run`: at-least-once queue insertion; finalization ledger prevents duplicate finalization.

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -117,13 +117,22 @@ not claimable by Python. The Go reconciler checks the persisted four-row set
 against the checked-in contract and closes readiness on a pause, missing row,
 generation error, or route drift.
 
-This is a fail-closed selector foundation, not River activation. All persisted
-and checked-in routes remain Celery, deployment profiles remain
-`coexistence_disabled` with zero replicas, and no Go sync handler or River
-sync-domain claimant exists. Do not change a route to River: it would strand
-the wakeup. The mutation-capable sync-domain scheduler,
-organization/entitlement gates, lease repair, River insertion, and handlers
-remain unfinished CHAOS-3039 work.
+Two dormant transaction kernels now sit behind that foundation. The scheduler
+kernel locks a bounded due window with `FOR UPDATE ... SKIP LOCKED`, invokes an
+injected coordinator through the same PostgreSQL transaction, and advances the
+schedule marker only after that durable handoff succeeds. The sync reconciler
+kernel can claim only unpaused River-routed rows, invoke an injected
+same-transaction River publisher for at-least-once kinds, and preserve a
+separate mark-before seam for `post_sync`. Neither kernel is constructed by
+the scheduler or reconciler command.
+
+This remains a fail-closed selector foundation, not River activation. All
+persisted and checked-in routes remain Celery, deployment profiles remain
+`coexistence_disabled` with zero replicas, and no Go sync handler is compiled.
+Do not change a route to River: it would strand the wakeup. Activation still
+requires command wiring, materialization of missing sync outbox rows,
+expired-lease repair and failure backoff, real River publishers and handlers,
+and the bounded post-sync quiescence/external-handoff path.
 
 For a read-only same-snapshot comparison, set `POSTGRES_URI` or `DATABASE_URI`
 and run:
@@ -136,13 +145,21 @@ The command holds one exported read-only `REPEATABLE READ` snapshot across the
 Python and Go observations and emits only a safe match/mismatch report. It
 does not claim or publish work. See the
 [v2 parity evidence](../architecture/evidence/go-worker-migration/v2-sync-dispatch-parity/README.md).
+The `sync-parity` target in `docker/Dockerfile` packages the Go binary, Python
+observer, installed Python runtime, and checked-in sync-dispatch contract so
+the same comparison can run as an isolated container. The Go reconciler image
+also packages `contracts/sync-dispatch/v1`; packaging makes its registry
+loadable at startup but does not wire the dormant mutation kernel.
 
 The Go scheduler also remains blocked on the Phase 4
 `sync.plan_scheduled_config` coordinator. `sync.dispatch_run` starts from an
 existing `SyncRun` and cannot replace scheduled planning. Until the new
 coordinator consumes a stable occurrence identity and creates the scheduled
 domain plan transactionally, Celery Beat and `dispatch_scheduled_syncs` remain
-the sole schedule mutation owners.
+the sole schedule mutation owners. The dormant transaction kernel supplies the
+atomic handoff boundary, but the planner, organization/entitlement decisions,
+missing-marker materialization, catch-up policy, and command loop remain
+unimplemented.
 
 The rest of this page documents the active Celery runtime. See the
 [Go worker runtime TRD](../architecture/go-worker-runtime-trd.md) for the target

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -328,7 +328,10 @@ The same-snapshot comparison is now implemented by
 `REPEATABLE READ` transaction across the Python and Go observers, and the
 sanitized production-equivalent local result is recorded in
 `v2-sync-dispatch-parity`. That match closes the observer-comparison slice
-only; it is not mutation, handler, scheduler, or canary evidence.
+only; it is not mutation, handler, scheduler, or canary evidence. The
+`sync-parity` Docker target packages the Go binary, Python observer and
+installed runtime, plus the checked-in sync-dispatch contract for repeatable
+container execution.
 
 The first mutation-safety prerequisite is also implemented without activating
 River. Migration `0049` seeds a four-row database route fence with Celery
@@ -341,13 +344,12 @@ the database fence differs from the checked-in route contract. All routes
 remain Celery and there is intentionally no operator route mutation command in
 this slice.
 
-The dormant `internal/scheduler/sync` package adds the corresponding
-read-only schedule-evaluation foundation. It reads at most 101 active
-configuration/job rows to produce a 100-row, deterministically ordered
-snapshot, then evaluates occurrence, manual-only, active-job,
-`is_running`-staleness, and `next_run_at` gates without a transaction, row
-lock, advisory lock, update, enqueue, or process-loop registration. Its
-versioned digest retains candidate identities only in memory. The evaluator
+The dormant `internal/scheduler/sync` package retains its read-only
+schedule-evaluation foundation. It reads at most 101 active configuration/job
+rows to produce a 100-row, deterministically ordered snapshot, then evaluates
+occurrence, manual-only, active-job, `is_running`-staleness, and `next_run_at`
+gates without a transaction or write. Its versioned digest retains candidate
+identities only in memory. The evaluator
 implements a versioned deterministic five-field Croniter subset, including the
 ordinary list/range/step/name forms and the explicitly tested timezone and DST
 behavior. A valid Croniter form outside that grammar is reported as
@@ -356,8 +358,16 @@ unported mixed special-day forms, and optional seconds/year fields. Results
 and their digest are labeled `schedule_and_marker_only`; they are not full
 dispatch eligibility because organization existence, entitlement, occurrence
 claiming, and the dispatch transaction are still Celery-owned work below.
-Nothing imports this package from a command or deployment profile, so its
-presence is comparison infrastructure rather than activation.
+
+A separate dormant transaction kernel now locks an existing-marker due window,
+calls an injected coordinator through the same PostgreSQL transaction, and
+advances the marker only after that durable handoff succeeds. A second dormant
+kernel can claim River-routed sync outbox rows and invoke transaction-local
+at-least-once or `post_sync` mark-before seams. The Go reconciler image packages
+the sync-dispatch contract needed to construct that kernel. Nothing imports
+either kernel from a command or deployment profile, and every checked-in and
+persisted route remains Celery, so these additions are failure-tested
+boundaries rather than activation.
 
 Scheduler activation has an explicit Phase 4 dependency. The atomic
 coordinator insert named by the TRD is `sync.plan_scheduled_config`, whose
@@ -366,9 +376,13 @@ authoritative `JobRun`, `SyncRun`, units, and dispatch outbox in one domain
 transaction. `sync.dispatch_run` cannot fill that role because it requires an
 existing `SyncRun`. Until the scheduled-planning coordinator is implemented,
 Celery Beat and `dispatch_scheduled_syncs` remain the sole mutation owners; the
-Go scheduler must not advance production markers. An earlier canary would
-require a separately reviewed durable occurrence/handoff contract rather than
-an in-memory or best-effort bridge.
+Go scheduler command must not advance production markers. Scheduler activation
+still needs the planner's authoritative domain-state/outbox materialization,
+organization and entitlement policy, missing-marker and catch-up behavior, and
+command-loop wiring. Reconciler activation still needs missing-outbox
+materialization, expired-lease repair, persisted failure backoff, concrete
+River insertion and handlers, command/operator wiring, and the bounded
+`post_sync` quiescence plus external-handoff path.
 
 An opt-in live PostgreSQL test now proves the Python producer's outer rollback
 and dedupe/savepoint path. Before any generic kind is promoted from Celery,
@@ -394,6 +408,12 @@ sync-domain outbox remains part of the work below.
 - Add no-op/shadow transport mode.
 - Keep Celery transport selectable until sync cutover.
 - Expose schedule/reconciler metrics and readiness.
+
+Foundation status: the scheduler transaction handoff and reconciler transport
+kernels exist with unit/failure-injection coverage, the reconciler image
+packages its sync-dispatch contract, and a containerized parity target exists.
+They remain command-unwired and Celery-only; the materialization, backoff,
+concrete River delivery, and `post_sync` activation gaps above remain open.
 
 #### Acceptance
 

--- a/internal/scheduler/sync/repository.go
+++ b/internal/scheduler/sync/repository.go
@@ -5,12 +5,17 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-// Repository reads the legacy scheduler tables for shadow comparison only.
-// It does not expose a transaction, lock, claim, or mutation operation.
-type Repository struct{ pool *pgxpool.Pool }
+// Repository reads the legacy scheduler tables for shadow comparison and
+// exposes a separate dormant transaction kernel. Snapshot never locks or
+// writes.
+type Repository struct {
+	pool  *pgxpool.Pool
+	begin beginSchedulerTransaction
+}
 
 type candidateRows interface {
 	Next() bool
@@ -22,7 +27,16 @@ func NewRepository(pool *pgxpool.Pool) (*Repository, error) {
 	if pool == nil {
 		return nil, fmt.Errorf("scheduler shadow repository requires a pool")
 	}
-	return &Repository{pool: pool}, nil
+	return &Repository{
+		pool: pool,
+		begin: func(ctx context.Context) (schedulerTransaction, error) {
+			tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.ReadCommitted})
+			if err != nil {
+				return nil, err
+			}
+			return postgresSchedulerTransaction{Tx: tx}, nil
+		},
+	}, nil
 }
 
 // Snapshot reads one bounded active-config window then evaluates it locally.

--- a/internal/scheduler/sync/transaction.go
+++ b/internal/scheduler/sync/transaction.go
@@ -1,0 +1,315 @@
+package sync
+
+import (
+	"context"
+	"crypto/sha256"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+const (
+	// OccurrenceIdentityVersion is the stable framing used to deduplicate one
+	// config's cron occurrence across scheduler replicas and retries.
+	OccurrenceIdentityVersion = "sync_scheduler_occurrence_v1"
+)
+
+var (
+	// ErrInvalidTransactionRequest identifies a caller contract violation.
+	ErrInvalidTransactionRequest = errors.New("invalid scheduler transaction request")
+	// ErrScheduleMarkerLost identifies a locked marker that disappeared before
+	// the atomic handoff could advance it.
+	ErrScheduleMarkerLost = errors.New("scheduler schedule marker was lost")
+)
+
+// Occurrence is the deterministic handoff envelope for one due schedule. It
+// contains timing identity only. Organization existence, entitlement, target
+// routing, and business payload construction remain coordinator obligations.
+type Occurrence struct {
+	ID              string
+	IdentityVersion string
+	ConfigID        string
+	OrgID           string
+	JobID           string
+	ScheduledFor    time.Time
+	ObservedAt      time.Time
+	NextRunAt       time.Time
+}
+
+// HandoffTransaction is the same PostgreSQL transaction that protects the
+// locked schedule marker. Coordinators must persist a durable handoff through
+// this transaction; a remote or otherwise non-transactional side effect does
+// not satisfy the atomic handoff contract.
+type HandoffTransaction interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	QueryRow(context.Context, string, ...any) pgx.Row
+}
+
+// Coordinator owns every non-timing eligibility decision, including
+// organization existence and feature entitlement, then persists the durable
+// handoff. Returning nil means the authorized handoff is present in the
+// supplied transaction and permits the kernel to advance the schedule marker.
+type Coordinator interface {
+	Handoff(context.Context, HandoffTransaction, Occurrence) error
+}
+
+// CoordinatorFunc adapts a function to Coordinator.
+type CoordinatorFunc func(context.Context, HandoffTransaction, Occurrence) error
+
+func (function CoordinatorFunc) Handoff(
+	ctx context.Context,
+	tx HandoffTransaction,
+	occurrence Occurrence,
+) error {
+	if function == nil {
+		return ErrInvalidTransactionRequest
+	}
+	return function(ctx, tx, occurrence)
+}
+
+type lockedCandidate struct {
+	orgID     string
+	candidate Candidate
+}
+
+type lockedCandidateRows interface {
+	candidateRows
+	Close()
+}
+
+type schedulerTransaction interface {
+	HandoffTransaction
+	queryCandidates(context.Context, string, ...any) (lockedCandidateRows, error)
+	Commit(context.Context) error
+	Rollback(context.Context) error
+}
+
+type beginSchedulerTransaction func(context.Context) (schedulerTransaction, error)
+
+type postgresSchedulerTransaction struct{ pgx.Tx }
+
+func (transaction postgresSchedulerTransaction) queryCandidates(
+	ctx context.Context,
+	statement string,
+	args ...any,
+) (lockedCandidateRows, error) {
+	return transaction.Query(ctx, statement, args...)
+}
+
+// HandoffDue locks and re-evaluates one bounded candidate window, persists each
+// coordinator handoff, and only then advances its schedule marker. All changes
+// commit or roll back together. It is intentionally not called by the dormant
+// scheduler command.
+//
+// The kernel requires an existing sync ScheduledJob marker. Creating missing
+// markers requires configuration and entitlement policy that is deliberately
+// outside this timing-only package.
+func (repository *Repository) HandoffDue(
+	ctx context.Context,
+	observedAt time.Time,
+	limit int,
+	coordinator Coordinator,
+) ([]Occurrence, error) {
+	if ctx == nil || observedAt.IsZero() || limit < minimumSnapshotLimit ||
+		limit > maximumSnapshotLimit || coordinator == nil ||
+		repository == nil || repository.begin == nil {
+		return nil, ErrInvalidTransactionRequest
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+
+	transaction, err := repository.begin(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("begin scheduler transaction: %w", err)
+	}
+	defer func() { _ = transaction.Rollback(ctx) }()
+
+	rows, err := transaction.queryCandidates(
+		ctx,
+		schedulerHandoffCandidatesSQL,
+		observedAt.UTC(),
+		limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("lock scheduler candidates: %w", err)
+	}
+	candidates, err := readLockedCandidates(ctx, rows, limit)
+	rows.Close()
+	if err != nil {
+		return nil, err
+	}
+
+	handedOff := make([]Occurrence, 0, len(candidates))
+	for _, locked := range candidates {
+		evaluation, err := evaluateContext(ctx, locked.candidate, observedAt)
+		if err != nil {
+			return nil, err
+		}
+		if !evaluation.TimingEligible || evaluation.NextOccurrence == nil ||
+			locked.candidate.Job == nil {
+			continue
+		}
+		nextRunAt, _, err := nextOccurrenceContext(
+			ctx,
+			locked.candidate.Job.ScheduleCron,
+			observedAt.UTC(),
+			locked.candidate.Job.Timezone,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("compute next schedule marker for config %s: %w", locked.candidate.ConfigID, err)
+		}
+		occurrence := newOccurrence(
+			locked.candidate.ConfigID,
+			locked.orgID,
+			locked.candidate.Job.ID,
+			*evaluation.NextOccurrence,
+			observedAt,
+			nextRunAt,
+		)
+		if err := coordinator.Handoff(ctx, transaction, occurrence); err != nil {
+			return nil, fmt.Errorf("handoff scheduler occurrence %s: %w", occurrence.ID, err)
+		}
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		command, err := transaction.Exec(
+			ctx,
+			schedulerAdvanceMarkerSQL,
+			occurrence.NextRunAt,
+			occurrence.ObservedAt,
+			occurrence.JobID,
+		)
+		if err != nil {
+			return nil, fmt.Errorf("advance scheduler marker for config %s: %w", occurrence.ConfigID, err)
+		}
+		if command.RowsAffected() != 1 {
+			return nil, ErrScheduleMarkerLost
+		}
+		handedOff = append(handedOff, occurrence)
+	}
+
+	if err := transaction.Commit(ctx); err != nil {
+		return nil, fmt.Errorf("commit scheduler transaction: %w", err)
+	}
+	return handedOff, nil
+}
+
+func readLockedCandidates(
+	ctx context.Context,
+	rows lockedCandidateRows,
+	capacity int,
+) ([]lockedCandidate, error) {
+	candidates := make([]lockedCandidate, 0, capacity)
+	for rows.Next() {
+		if err := ctx.Err(); err != nil {
+			return nil, err
+		}
+		if len(candidates) >= capacity {
+			return nil, fmt.Errorf("scheduler locked candidate window exceeded limit")
+		}
+		var locked lockedCandidate
+		var job Job
+		var configCron, configTimezone string
+		if err := rows.Scan(
+			&locked.candidate.ConfigID,
+			&locked.orgID,
+			&locked.candidate.Active,
+			&configCron,
+			&configTimezone,
+			&locked.candidate.LastSyncAt,
+			&locked.candidate.CreatedAt,
+			&job.ID,
+			&job.ScheduleCron,
+			&job.Timezone,
+			&job.Status,
+			&job.IsRunning,
+			&job.LastRunAt,
+			&job.UpdatedAt,
+			&job.NextRunAt,
+		); err != nil {
+			return nil, err
+		}
+		locked.candidate.ScheduleCron = configCron
+		locked.candidate.ScheduleTZ = configTimezone
+		locked.candidate.Job = &job
+		candidates = append(candidates, locked)
+	}
+	if err := ctx.Err(); err != nil {
+		return nil, err
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return candidates, nil
+}
+
+func newOccurrence(
+	configID, orgID, jobID string,
+	scheduledFor, observedAt, nextRunAt time.Time,
+) Occurrence {
+	scheduledFor = scheduledFor.UTC()
+	hasher := sha256.New()
+	writeDigestField(hasher, "identity_version", OccurrenceIdentityVersion)
+	writeDigestField(hasher, "config_id", configID)
+	writeDigestField(hasher, "scheduled_for", canonicalTime(scheduledFor))
+	return Occurrence{
+		ID:              "sha256:" + fmt.Sprintf("%x", hasher.Sum(nil)),
+		IdentityVersion: OccurrenceIdentityVersion,
+		ConfigID:        configID,
+		OrgID:           orgID,
+		JobID:           jobID,
+		ScheduledFor:    scheduledFor,
+		ObservedAt:      observedAt.UTC(),
+		NextRunAt:       nextRunAt.UTC(),
+	}
+}
+
+// The inner join deliberately excludes configs without a persisted sync marker.
+// Both rows are locked so multiple scheduler replicas cannot hand off the same
+// occurrence. SQL gates reduce lock contention; evaluateContext is the final
+// source of timing truth after the locks are held.
+const schedulerHandoffCandidatesSQL = `
+SELECT
+    config.id::text,
+    config.org_id,
+    config.is_active,
+    config.sync_options->>'schedule_cron',
+    COALESCE(config.sync_options->>'timezone', ''),
+    config.last_sync_at,
+    config.created_at,
+    job.id::text,
+    job.schedule_cron,
+    job.timezone,
+    job.status,
+    job.is_running,
+    job.last_run_at,
+    job.updated_at,
+    job.next_run_at
+FROM public.sync_configurations AS config
+JOIN public.scheduled_jobs AS job
+    ON job.org_id = config.org_id
+    AND job.sync_config_id = config.id
+    AND job.job_type = 'sync'
+WHERE config.is_active = TRUE
+    AND COALESCE(config.sync_options->>'schedule_cron', '') <> ''
+    AND job.status = 0
+    AND (job.next_run_at IS NULL OR job.next_run_at <= $1)
+    AND (
+        job.is_running = FALSE
+        OR COALESCE(job.last_run_at, job.updated_at) IS NULL
+        OR COALESCE(job.last_run_at, job.updated_at) < $1 - INTERVAL '2 hours'
+    )
+ORDER BY COALESCE(job.next_run_at, config.last_sync_at, config.created_at), config.id
+FOR UPDATE OF config, job SKIP LOCKED
+LIMIT $2
+`
+
+const schedulerAdvanceMarkerSQL = `
+UPDATE public.scheduled_jobs
+SET next_run_at = $1, updated_at = $2
+WHERE id = $3
+`

--- a/internal/scheduler/sync/transaction_integration_test.go
+++ b/internal/scheduler/sync/transaction_integration_test.go
@@ -1,0 +1,232 @@
+//go:build integration
+
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+func TestHandoffDuePostgresSkipsReplicaLockedOccurrence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createSchedulerIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	firstRepository, err := NewRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRepository, err := NewRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedAt := at("2026-01-01T12:00:00Z")
+	firstEntered := make(chan struct{})
+	releaseFirst := make(chan struct{})
+	firstResult := make(chan error, 1)
+	var firstOccurrence Occurrence
+
+	go func() {
+		occurrences, handoffErr := firstRepository.HandoffDue(
+			ctx,
+			observedAt,
+			1,
+			CoordinatorFunc(func(
+				handoffCtx context.Context,
+				transaction HandoffTransaction,
+				occurrence Occurrence,
+			) error {
+				firstOccurrence = occurrence
+				if _, err := transaction.Exec(
+					handoffCtx,
+					"INSERT INTO public.scheduler_handoffs (id) VALUES ($1)",
+					occurrence.ID,
+				); err != nil {
+					return err
+				}
+				close(firstEntered)
+				select {
+				case <-releaseFirst:
+					return nil
+				case <-handoffCtx.Done():
+					return handoffCtx.Err()
+				}
+			}),
+		)
+		if handoffErr == nil && len(occurrences) != 1 {
+			handoffErr = fmt.Errorf("first replica occurrences = %d, want 1", len(occurrences))
+		}
+		firstResult <- handoffErr
+	}()
+
+	select {
+	case <-firstEntered:
+	case <-ctx.Done():
+		t.Fatal(ctx.Err())
+	}
+	secondOccurrences, err := secondRepository.HandoffDue(
+		ctx,
+		observedAt,
+		1,
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+			return fmt.Errorf("second replica reached locked occurrence")
+		}),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(secondOccurrences) != 0 {
+		t.Fatalf("second replica occurrences = %d, want 0", len(secondOccurrences))
+	}
+	close(releaseFirst)
+	if err := <-firstResult; err != nil {
+		t.Fatal(err)
+	}
+	if firstOccurrence.ConfigID != "00000000-0000-4000-8000-000000003038" ||
+		firstOccurrence.OrgID != "org-integration" ||
+		firstOccurrence.JobID != "00000000-0000-4000-8000-000000003039" ||
+		!firstOccurrence.ScheduledFor.Equal(at("2026-01-01T11:00:00Z")) ||
+		!firstOccurrence.NextRunAt.Equal(at("2026-01-01T13:00:00Z")) {
+		t.Fatalf("decoded occurrence = %#v", firstOccurrence)
+	}
+
+	var handoffs int
+	var nextRunAt time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			(SELECT count(*) FROM public.scheduler_handoffs),
+			next_run_at
+		FROM public.scheduled_jobs
+		WHERE id = '00000000-0000-4000-8000-000000003039'
+	`).Scan(&handoffs, &nextRunAt); err != nil {
+		t.Fatal(err)
+	}
+	if handoffs != 1 || !nextRunAt.Equal(at("2026-01-01T13:00:00Z")) {
+		t.Fatalf("handoffs=%d nextRunAt=%s", handoffs, nextRunAt)
+	}
+
+	if _, err := pool.Exec(ctx, `
+		UPDATE public.scheduled_jobs SET next_run_at = NULL
+		WHERE id = '00000000-0000-4000-8000-000000003039'
+	`); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, "DELETE FROM public.scheduler_handoffs"); err != nil {
+		t.Fatal(err)
+	}
+	coordinatorErr := errors.New("coordinator authorization failed")
+	if _, err := firstRepository.HandoffDue(
+		ctx,
+		observedAt,
+		1,
+		CoordinatorFunc(func(
+			handoffCtx context.Context,
+			transaction HandoffTransaction,
+			occurrence Occurrence,
+		) error {
+			if _, err := transaction.Exec(
+				handoffCtx,
+				"INSERT INTO public.scheduler_handoffs (id) VALUES ($1)",
+				occurrence.ID,
+			); err != nil {
+				return err
+			}
+			return coordinatorErr
+		}),
+	); !errors.Is(err, coordinatorErr) {
+		t.Fatalf("failed coordinator error = %v", err)
+	}
+	var rolledBackNextRunAt *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			(SELECT count(*) FROM public.scheduler_handoffs),
+			next_run_at
+		FROM public.scheduled_jobs
+		WHERE id = '00000000-0000-4000-8000-000000003039'
+	`).Scan(&handoffs, &rolledBackNextRunAt); err != nil {
+		t.Fatal(err)
+	}
+	if handoffs != 0 || rolledBackNextRunAt != nil {
+		t.Fatalf("rollback left handoffs=%d nextRunAt=%v", handoffs, rolledBackNextRunAt)
+	}
+}
+
+func createSchedulerIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) error {
+	for _, statement := range []string{
+		`CREATE TABLE public.sync_configurations (
+			id uuid PRIMARY KEY,
+			org_id text NOT NULL,
+			is_active boolean NOT NULL,
+			sync_options jsonb NOT NULL,
+			last_sync_at timestamptz,
+			created_at timestamptz NOT NULL
+		)`,
+		`CREATE TABLE public.scheduled_jobs (
+			id uuid PRIMARY KEY,
+			org_id text NOT NULL,
+			sync_config_id uuid NOT NULL,
+			job_type text NOT NULL,
+			schedule_cron text NOT NULL,
+			timezone text NOT NULL,
+			status integer NOT NULL,
+			is_running boolean NOT NULL,
+			last_run_at timestamptz,
+			updated_at timestamptz,
+			next_run_at timestamptz
+		)`,
+		`CREATE TABLE public.scheduler_handoffs (id text PRIMARY KEY)`,
+		`INSERT INTO public.sync_configurations (
+			id, org_id, is_active, sync_options, last_sync_at, created_at
+		) VALUES (
+			'00000000-0000-4000-8000-000000003038',
+			'org-integration',
+			TRUE,
+			'{"schedule_cron":"0 * * * *","timezone":"UTC"}'::jsonb,
+			'2026-01-01T02:00:00-08:00',
+			'2026-01-01T01:00:00-08:00'
+		)`,
+		`INSERT INTO public.scheduled_jobs (
+			id, org_id, sync_config_id, job_type, schedule_cron, timezone,
+			status, is_running, updated_at
+		) VALUES (
+			'00000000-0000-4000-8000-000000003039',
+			'org-integration',
+			'00000000-0000-4000-8000-000000003038',
+			'sync',
+			'0 * * * *',
+			'UTC',
+			0,
+			FALSE,
+			'2026-01-01T01:00:00-08:00'
+		)`,
+	} {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/scheduler/sync/transaction_test.go
+++ b/internal/scheduler/sync/transaction_test.go
@@ -1,0 +1,365 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"regexp"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type fakeLockedRows struct {
+	rows   [][]any
+	index  int
+	closed bool
+	err    error
+}
+
+func (rows *fakeLockedRows) Next() bool {
+	return rows.index < len(rows.rows)
+}
+
+func (rows *fakeLockedRows) Scan(dest ...any) error {
+	values := rows.rows[rows.index]
+	rows.index++
+	for index, value := range values {
+		switch target := dest[index].(type) {
+		case *string:
+			*target = value.(string)
+		case *bool:
+			*target = value.(bool)
+		case *int:
+			*target = value.(int)
+		case *time.Time:
+			*target = value.(time.Time)
+		case **time.Time:
+			if value == nil {
+				*target = nil
+			} else {
+				copied := value.(time.Time)
+				*target = &copied
+			}
+		default:
+			return errors.New("unsupported fake scan destination")
+		}
+	}
+	return nil
+}
+
+func (rows *fakeLockedRows) Err() error { return rows.err }
+
+func (rows *fakeLockedRows) Close() { rows.closed = true }
+
+type fakeSchedulerTransaction struct {
+	rows           *fakeLockedRows
+	events         []string
+	queryArgs      []any
+	execArgs       [][]any
+	execTag        pgconn.CommandTag
+	execErr        error
+	commitErr      error
+	committed      bool
+	rolledBack     bool
+	queryStatement string
+}
+
+func (transaction *fakeSchedulerTransaction) queryCandidates(
+	_ context.Context,
+	statement string,
+	args ...any,
+) (lockedCandidateRows, error) {
+	transaction.queryStatement = statement
+	transaction.queryArgs = args
+	return transaction.rows, nil
+}
+
+func (transaction *fakeSchedulerTransaction) Exec(
+	_ context.Context,
+	_ string,
+	args ...any,
+) (pgconn.CommandTag, error) {
+	transaction.events = append(transaction.events, "marker")
+	transaction.execArgs = append(transaction.execArgs, args)
+	return transaction.execTag, transaction.execErr
+}
+
+func (*fakeSchedulerTransaction) QueryRow(context.Context, string, ...any) pgx.Row {
+	panic("unexpected QueryRow")
+}
+
+func (transaction *fakeSchedulerTransaction) Commit(context.Context) error {
+	transaction.events = append(transaction.events, "commit")
+	transaction.committed = transaction.commitErr == nil
+	return transaction.commitErr
+}
+
+func (transaction *fakeSchedulerTransaction) Rollback(context.Context) error {
+	transaction.rolledBack = true
+	return nil
+}
+
+func lockedRow(
+	configID, orgID, jobID, cron string,
+	createdAt, lastSyncAt time.Time,
+) []any {
+	return []any{
+		configID,
+		orgID,
+		true,
+		cron,
+		"UTC",
+		lastSyncAt,
+		createdAt,
+		jobID,
+		cron,
+		"UTC",
+		activeJobStatus,
+		false,
+		nil,
+		createdAt,
+		nil,
+	}
+}
+
+func TestHandoffDuePersistsHandoffBeforeAdvancingMarker(t *testing.T) {
+	observedAt := at("2026-01-01T12:00:00Z")
+	transaction := &fakeSchedulerTransaction{
+		rows: &fakeLockedRows{rows: [][]any{
+			lockedRow("config-due", "org-a", "job-a", "0 * * * *", at("2026-01-01T09:00:00Z"), at("2026-01-01T10:00:00Z")),
+			lockedRow("config-future", "org-b", "job-b", "0 13 * * *", at("2026-01-01T09:00:00Z"), at("2026-01-01T10:00:00Z")),
+		}},
+		execTag: pgconn.NewCommandTag("UPDATE 1"),
+	}
+	repository := &Repository{
+		begin: func(context.Context) (schedulerTransaction, error) {
+			return transaction, nil
+		},
+	}
+	var received Occurrence
+	coordinator := CoordinatorFunc(func(
+		_ context.Context,
+		handoff HandoffTransaction,
+		occurrence Occurrence,
+	) error {
+		if handoff != transaction {
+			t.Fatal("coordinator did not receive the locking transaction")
+		}
+		transaction.events = append(transaction.events, "handoff")
+		received = occurrence
+		return nil
+	})
+
+	occurrences, err := repository.HandoffDue(context.Background(), observedAt, 2, coordinator)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(occurrences) != 1 || occurrences[0] != received {
+		t.Fatalf("occurrences = %#v, received = %#v", occurrences, received)
+	}
+	if received.ConfigID != "config-due" || received.OrgID != "org-a" ||
+		received.JobID != "job-a" ||
+		!received.ScheduledFor.Equal(at("2026-01-01T11:00:00Z")) ||
+		!received.NextRunAt.Equal(at("2026-01-01T13:00:00Z")) {
+		t.Fatalf("occurrence = %#v", received)
+	}
+	if strings.Join(transaction.events, ",") != "handoff,marker,commit" {
+		t.Fatalf("transaction events = %v", transaction.events)
+	}
+	if !transaction.committed || !transaction.rolledBack || !transaction.rows.closed {
+		t.Fatalf(
+			"transaction committed=%v rolledBack=%v rowsClosed=%v",
+			transaction.committed,
+			transaction.rolledBack,
+			transaction.rows.closed,
+		)
+	}
+	if len(transaction.execArgs) != 1 ||
+		!transaction.execArgs[0][0].(time.Time).Equal(received.NextRunAt) ||
+		!transaction.execArgs[0][1].(time.Time).Equal(observedAt) ||
+		transaction.execArgs[0][2] != "job-a" {
+		t.Fatalf("marker args = %#v", transaction.execArgs)
+	}
+}
+
+func TestHandoffDueRollsBackWithoutMarkerWhenCoordinatorFails(t *testing.T) {
+	observedAt := at("2026-01-01T12:00:00Z")
+	transaction := &fakeSchedulerTransaction{
+		rows: &fakeLockedRows{rows: [][]any{
+			lockedRow("config-a", "org-a", "job-a", "0 * * * *", at("2026-01-01T09:00:00Z"), at("2026-01-01T10:00:00Z")),
+		}},
+		execTag: pgconn.NewCommandTag("UPDATE 1"),
+	}
+	repository := &Repository{
+		begin: func(context.Context) (schedulerTransaction, error) {
+			return transaction, nil
+		},
+	}
+	handoffErr := errors.New("durable handoff unavailable")
+
+	_, err := repository.HandoffDue(
+		context.Background(),
+		observedAt,
+		1,
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+			transaction.events = append(transaction.events, "handoff")
+			return handoffErr
+		}),
+	)
+	if !errors.Is(err, handoffErr) {
+		t.Fatalf("HandoffDue() err = %v", err)
+	}
+	if transaction.committed || !transaction.rolledBack || len(transaction.execArgs) != 0 {
+		t.Fatalf(
+			"transaction committed=%v rolledBack=%v markerCalls=%d",
+			transaction.committed,
+			transaction.rolledBack,
+			len(transaction.execArgs),
+		)
+	}
+	if strings.Join(transaction.events, ",") != "handoff" {
+		t.Fatalf("transaction events = %v", transaction.events)
+	}
+}
+
+func TestHandoffDueRejectsLostMarkerAndRollsBackHandoff(t *testing.T) {
+	observedAt := at("2026-01-01T12:00:00Z")
+	transaction := &fakeSchedulerTransaction{
+		rows: &fakeLockedRows{rows: [][]any{
+			lockedRow("config-a", "org-a", "job-a", "0 * * * *", at("2026-01-01T09:00:00Z"), at("2026-01-01T10:00:00Z")),
+		}},
+		execTag: pgconn.NewCommandTag("UPDATE 0"),
+	}
+	repository := &Repository{
+		begin: func(context.Context) (schedulerTransaction, error) {
+			return transaction, nil
+		},
+	}
+
+	_, err := repository.HandoffDue(
+		context.Background(),
+		observedAt,
+		1,
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+			transaction.events = append(transaction.events, "handoff")
+			return nil
+		}),
+	)
+	if !errors.Is(err, ErrScheduleMarkerLost) {
+		t.Fatalf("HandoffDue() err = %v", err)
+	}
+	if transaction.committed || !transaction.rolledBack {
+		t.Fatalf("transaction committed=%v rolledBack=%v", transaction.committed, transaction.rolledBack)
+	}
+	if strings.Join(transaction.events, ",") != "handoff,marker" {
+		t.Fatalf("transaction events = %v", transaction.events)
+	}
+}
+
+func TestOccurrenceIdentityIsDeterministicForConfigAndCronOccurrence(t *testing.T) {
+	scheduledFor := at("2026-01-01T11:00:00Z")
+	first := newOccurrence(
+		"config-a",
+		"org-a",
+		"job-a",
+		scheduledFor,
+		at("2026-01-01T12:00:00Z"),
+		at("2026-01-01T13:00:00Z"),
+	)
+	retry := newOccurrence(
+		"config-a",
+		"org-b",
+		"replacement-job",
+		scheduledFor.In(time.FixedZone("offset", -8*60*60)),
+		at("2026-01-01T12:30:00Z"),
+		at("2026-01-01T14:00:00Z"),
+	)
+	next := newOccurrence(
+		"config-a",
+		"org-a",
+		"job-a",
+		at("2026-01-01T12:00:00Z"),
+		at("2026-01-01T13:00:00Z"),
+		at("2026-01-01T14:00:00Z"),
+	)
+	otherConfig := newOccurrence(
+		"config-b",
+		"org-a",
+		"job-a",
+		scheduledFor,
+		at("2026-01-01T12:00:00Z"),
+		at("2026-01-01T13:00:00Z"),
+	)
+
+	if first.ID != retry.ID {
+		t.Fatalf("retry identity changed: %s != %s", first.ID, retry.ID)
+	}
+	if first.ID != "sha256:27478ac7c7bbcfc33caa3922492910d97220984911632d754944fdeaf405f0f9" {
+		t.Fatalf("golden identity changed: %s", first.ID)
+	}
+	if first.ID == next.ID || first.ID == otherConfig.ID {
+		t.Fatalf("identity collision: first=%s next=%s other=%s", first.ID, next.ID, otherConfig.ID)
+	}
+	if first.IdentityVersion != OccurrenceIdentityVersion ||
+		!strings.HasPrefix(first.ID, "sha256:") || len(first.ID) != len("sha256:")+64 {
+		t.Fatalf("identity = %#v", first)
+	}
+}
+
+func TestHandoffStatementIsBoundedAndMultiReplicaSafe(t *testing.T) {
+	statement := strings.ToUpper(schedulerHandoffCandidatesSQL)
+	for _, want := range []string{
+		"JOIN PUBLIC.SCHEDULED_JOBS AS JOB",
+		"JOB.SYNC_CONFIG_ID = CONFIG.ID",
+		"JOB.JOB_TYPE = 'SYNC'",
+		"FOR UPDATE OF CONFIG, JOB SKIP LOCKED",
+		"LIMIT $2",
+	} {
+		if !strings.Contains(statement, want) {
+			t.Fatalf("handoff query missing %q: %s", want, schedulerHandoffCandidatesSQL)
+		}
+	}
+	for _, forbidden := range []string{"INSERT", "DELETE", "ADVISORY"} {
+		if regexp.MustCompile(`\b` + forbidden + `\b`).MatchString(statement) {
+			t.Fatalf("handoff query contains %q", forbidden)
+		}
+	}
+}
+
+func TestHandoffDueValidatesRequestBeforeOpeningTransaction(t *testing.T) {
+	calls := 0
+	repository := &Repository{
+		begin: func(context.Context) (schedulerTransaction, error) {
+			calls++
+			return nil, errors.New("unexpected begin")
+		},
+	}
+	coordinator := CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+		return nil
+	})
+	for _, test := range []struct {
+		name        string
+		ctx         context.Context
+		observedAt  time.Time
+		limit       int
+		coordinator Coordinator
+	}{
+		{"nil context", nil, time.Now(), 1, coordinator},
+		{"zero observation", context.Background(), time.Time{}, 1, coordinator},
+		{"zero limit", context.Background(), time.Now(), 0, coordinator},
+		{"oversized limit", context.Background(), time.Now(), maximumSnapshotLimit + 1, coordinator},
+		{"nil coordinator", context.Background(), time.Now(), 1, nil},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			if _, err := repository.HandoffDue(test.ctx, test.observedAt, test.limit, test.coordinator); !errors.Is(err, ErrInvalidTransactionRequest) {
+				t.Fatalf("HandoffDue() err = %v", err)
+			}
+		})
+	}
+	if calls != 0 {
+		t.Fatalf("transactions opened = %d", calls)
+	}
+}

--- a/internal/scheduler/sync/types.go
+++ b/internal/scheduler/sync/types.go
@@ -1,6 +1,7 @@
-// Package sync provides a dormant, read-only shadow of the legacy Python
-// sync scheduler. It evaluates candidates only; it never claims, writes, or
-// starts a scheduler loop.
+// Package sync provides a dormant shadow of the legacy Python sync scheduler.
+// Snapshot remains read-only. The separate transaction kernel can persist a
+// coordinator handoff and its schedule marker atomically, but no command starts
+// a scheduler loop.
 package sync
 
 import (

--- a/internal/syncreconciler/kernel.go
+++ b/internal/syncreconciler/kernel.go
@@ -1,0 +1,350 @@
+package syncreconciler
+
+import (
+	"context"
+	"errors"
+	"sort"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	minimumLeaseDuration = time.Second
+	maximumLeaseDuration = 15 * time.Minute
+)
+
+var (
+	// ErrLeaseLost means the persisted route or claim changed before this
+	// transaction's terminal write. The transaction is rolled back so the work
+	// remains retryable under its current owner.
+	ErrLeaseLost = errors.New("sync dispatch transport lease lost")
+	// ErrPublisherRequired means mutation reached an at-least-once claim without
+	// an injected same-transaction River publisher.
+	ErrPublisherRequired = errors.New("sync dispatch transport publisher required")
+	// ErrPostSyncMarkerRequired means mutation reached the special at-most-once
+	// post_sync kind without its explicit mark-before seam.
+	ErrPostSyncMarkerRequired = errors.New("sync dispatch post-sync mark-before seam required")
+)
+
+// KernelMode selects a strictly bounded reconciler behavior. Shadow is the
+// only mode suitable for the current runtime. Mutation is intentionally
+// unreferenced until a future cutover has an audited activation path.
+type KernelMode string
+
+const (
+	KernelModeShadow   KernelMode = "shadow"
+	KernelModeMutation KernelMode = "mutation"
+)
+
+// TransportClaim is the minimum non-sensitive state a transport publisher
+// needs. It is valid only inside the pgx transaction passed to the publisher.
+type TransportClaim struct {
+	ID              string
+	Kind            string
+	ClaimToken      string
+	RouteGeneration int64
+	AvailableAt     time.Time
+	Attempts        int64
+}
+
+// AtLeastOncePublisher inserts one River job using the supplied transaction.
+// The returned identifier is optional audit metadata. Returning an error rolls
+// back both the River insert and the claim, making the attempt retry-safe.
+type AtLeastOncePublisher func(context.Context, pgx.Tx, TransportClaim) (string, error)
+
+// PostSyncMarkBefore is deliberately separate from AtLeastOncePublisher.
+// The kernel persists the terminal dispatched mark first, then invokes this
+// transaction-local seam before commit. It must not perform an external effect;
+// post_sync's external at-most-once work belongs to a later, explicit phase.
+type PostSyncMarkBefore func(context.Context, pgx.Tx, TransportClaim) error
+
+// KernelResult is bounded to one requested claim window. Shadow includes the
+// existing read-only observation; mutation reports only aggregate counts.
+type KernelResult struct {
+	Mode         KernelMode
+	Observation  Observation
+	Claimed      int
+	Dispatched   int
+	PostSyncMark int
+}
+
+type beginFunc func(context.Context) (pgx.Tx, error)
+
+// Kernel keeps a dormant mutation implementation beside the observer without
+// coupling it to command wiring. A future activation must explicitly construct
+// it in KernelModeMutation and provide the delivery seams to Step.
+type Kernel struct {
+	mode        KernelMode
+	observer    Stepper
+	begin       beginFunc
+	descriptors map[string]syncdispatchcontract.Descriptor
+	riverKinds  []string
+}
+
+// NewKernel constructs an unactivated kernel backed by the semantic database.
+// No transaction or route mutation occurs during construction.
+func NewKernel(
+	pool *pgxpool.Pool,
+	registry Registry,
+	mode KernelMode,
+) (*Kernel, error) {
+	if pool == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	observer, err := NewObserver(pool, registry)
+	if err != nil {
+		return nil, err
+	}
+	return newKernel(registry, mode, observer, pool.Begin)
+}
+
+func newKernel(
+	registry Registry,
+	mode KernelMode,
+	observer Stepper,
+	begin beginFunc,
+) (*Kernel, error) {
+	descriptors, err := fixedDescriptors(registry)
+	if err != nil || observer == nil || (mode != KernelModeShadow && mode != KernelModeMutation) ||
+		(mode == KernelModeMutation && begin == nil) {
+		return nil, ErrInvalidConfiguration
+	}
+	kernel := &Kernel{
+		mode:        mode,
+		observer:    observer,
+		begin:       begin,
+		descriptors: make(map[string]syncdispatchcontract.Descriptor, len(descriptors)),
+	}
+	for _, descriptor := range descriptors {
+		kernel.descriptors[descriptor.Kind] = descriptor
+		if descriptor.Route == syncdispatchcontract.RouteRiver {
+			kernel.riverKinds = append(kernel.riverKinds, descriptor.Kind)
+		}
+	}
+	sort.Strings(kernel.riverKinds)
+	return kernel, nil
+}
+
+// Step runs exactly one bounded unit of work. Shadow delegates to the existing
+// read-only observer and never begins a transaction. Mutation claims only rows
+// whose persisted route is River and unpaused; both the outbox and route are
+// locked in deterministic order before any publisher is called.
+func (kernel *Kernel) Step(
+	ctx context.Context,
+	now time.Time,
+	limit int,
+	leaseDuration time.Duration,
+	publish AtLeastOncePublisher,
+	postSyncMark PostSyncMarkBefore,
+) (KernelResult, error) {
+	if kernel == nil || kernel.observer == nil || ctx == nil || now.IsZero() ||
+		limit < minimumStepLimit || limit > maximumStepLimit ||
+		leaseDuration < minimumLeaseDuration || leaseDuration > maximumLeaseDuration {
+		return KernelResult{}, ErrInvalidConfiguration
+	}
+	if err := ctx.Err(); err != nil {
+		return KernelResult{}, err
+	}
+	now = now.UTC()
+	if kernel.mode == KernelModeShadow {
+		observation, err := kernel.observer.Step(ctx, now, limit)
+		return KernelResult{Mode: KernelModeShadow, Observation: observation}, err
+	}
+	if kernel.mode != KernelModeMutation || kernel.begin == nil {
+		return KernelResult{}, ErrInvalidConfiguration
+	}
+	// The checked-in contract is currently Celery-only. Avoid even opening a
+	// write-capable transaction until a later activation changes a frozen kind
+	// to River and explicitly wires this kernel.
+	if len(kernel.riverKinds) == 0 {
+		return KernelResult{Mode: KernelModeMutation}, nil
+	}
+
+	tx, err := kernel.begin(ctx)
+	if err != nil || tx == nil {
+		return KernelResult{}, ErrUnavailable
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	claims, err := claimRiverRoutes(ctx, tx, now, limit, leaseDuration, kernel.riverKinds)
+	if err != nil {
+		return KernelResult{}, err
+	}
+	result := KernelResult{Mode: KernelModeMutation, Claimed: len(claims)}
+	for _, claim := range claims {
+		descriptor, known := kernel.descriptors[claim.Kind]
+		if !known || descriptor.Route != syncdispatchcontract.RouteRiver {
+			return KernelResult{}, ErrLeaseLost
+		}
+		if descriptor.Delivery == syncdispatchcontract.DeliveryAtMostOnceMarkBefore {
+			if err := markRiverDispatched(ctx, tx, claim, now, ""); err != nil {
+				return KernelResult{}, err
+			}
+			if postSyncMark == nil {
+				return KernelResult{}, ErrPostSyncMarkerRequired
+			}
+			if err := postSyncMark(ctx, tx, claim); err != nil {
+				return KernelResult{}, err
+			}
+			result.Dispatched++
+			result.PostSyncMark++
+			continue
+		}
+		if descriptor.Delivery != syncdispatchcontract.DeliveryAtLeastOnce {
+			return KernelResult{}, ErrInvalidConfiguration
+		}
+		if publish == nil {
+			return KernelResult{}, ErrPublisherRequired
+		}
+		transportJobID, err := publish(ctx, tx, claim)
+		if err != nil {
+			return KernelResult{}, err
+		}
+		if err := markRiverDispatched(ctx, tx, claim, now, transportJobID); err != nil {
+			return KernelResult{}, err
+		}
+		result.Dispatched++
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return KernelResult{}, ErrUnavailable
+	}
+	return result, nil
+}
+
+func claimRiverRoutes(
+	ctx context.Context,
+	tx pgx.Tx,
+	now time.Time,
+	limit int,
+	leaseDuration time.Duration,
+	riverKinds []string,
+) ([]TransportClaim, error) {
+	if tx == nil || len(riverKinds) == 0 {
+		return []TransportClaim{}, nil
+	}
+	rows, err := tx.Query(
+		ctx,
+		claimRiverRoutesSQL,
+		now,
+		limit,
+		now.Add(leaseDuration),
+		riverKinds,
+	)
+	if err != nil || rows == nil {
+		return nil, ErrUnavailable
+	}
+	defer rows.Close()
+	claims := make([]TransportClaim, 0, limit)
+	for rows.Next() {
+		var claim TransportClaim
+		if err := rows.Scan(
+			&claim.ID,
+			&claim.Kind,
+			&claim.ClaimToken,
+			&claim.RouteGeneration,
+			&claim.AvailableAt,
+			&claim.Attempts,
+		); err != nil {
+			return nil, ErrUnavailable
+		}
+		if !uuidPattern.MatchString(claim.ID) || !uuidPattern.MatchString(claim.ClaimToken) ||
+			claim.RouteGeneration < 1 || claim.AvailableAt.IsZero() || claim.Attempts < 1 {
+			return nil, ErrUnavailable
+		}
+		claims = append(claims, claim)
+	}
+	if err := rows.Err(); err != nil || len(claims) > limit {
+		return nil, ErrUnavailable
+	}
+	sort.Slice(claims, func(left, right int) bool {
+		if claims[left].AvailableAt.Equal(claims[right].AvailableAt) {
+			return claims[left].ID < claims[right].ID
+		}
+		return claims[left].AvailableAt.Before(claims[right].AvailableAt)
+	})
+	return claims, nil
+}
+
+func markRiverDispatched(
+	ctx context.Context,
+	tx pgx.Tx,
+	claim TransportClaim,
+	now time.Time,
+	transportJobID string,
+) error {
+	command, err := tx.Exec(ctx, markRiverDispatchedSQL,
+		claim.ID, claim.ClaimToken, claim.RouteGeneration, now, transportJobID)
+	if err != nil {
+		return ErrUnavailable
+	}
+	if command.RowsAffected() != 1 {
+		return ErrLeaseLost
+	}
+	return nil
+}
+
+// claimRiverRoutesSQL is intentionally not reachable from current command
+// wiring. It takes both route and outbox row locks so a route change cannot
+// race a persisted River claim. The explicit returned AvailableAt is sorted
+// again in Go because UPDATE ... RETURNING does not promise result ordering.
+const claimRiverRoutesSQL = `
+WITH candidates AS (
+	SELECT outbox.id, route.generation
+	FROM public.sync_dispatch_outbox AS outbox
+	JOIN public.sync_dispatch_transport_routes AS route
+		ON route.kind = outbox.kind
+	WHERE outbox.status = 'pending'
+		AND outbox.available_at <= $1
+		AND (outbox.claim_expires_at IS NULL OR outbox.claim_expires_at <= $1)
+		AND outbox.kind = ANY($4::text[])
+		AND route.transport = 'river'
+		AND route.paused = FALSE
+	ORDER BY outbox.available_at, outbox.id
+	FOR UPDATE OF outbox, route SKIP LOCKED
+	LIMIT $2
+)
+UPDATE public.sync_dispatch_outbox AS outbox
+SET claim_token = gen_random_uuid()::text,
+	claim_expires_at = $3,
+	claim_transport = 'river',
+	claim_route_generation = candidates.generation,
+	attempts = outbox.attempts + 1,
+	updated_at = $1
+FROM candidates
+WHERE outbox.id = candidates.id
+RETURNING outbox.id::text, outbox.kind, outbox.claim_token::text,
+	outbox.claim_route_generation, outbox.available_at, outbox.attempts
+`
+
+// markRiverDispatchedSQL rechecks the live route generation and pause state in
+// the terminal write. The transaction already holds both locks, but preserving
+// this predicate makes an accidental future call without the claim lock fail
+// closed rather than dispatching across a route ownership change.
+const markRiverDispatchedSQL = `
+UPDATE public.sync_dispatch_outbox AS outbox
+SET status = 'dispatched',
+	dispatched_at = $4,
+	dispatched_transport = outbox.claim_transport,
+	dispatched_route_generation = outbox.claim_route_generation,
+	transport_job_id = NULLIF($5, ''),
+	claim_token = NULL,
+	claim_expires_at = NULL,
+	claim_transport = NULL,
+	claim_route_generation = NULL,
+	last_error = NULL,
+	updated_at = $4
+FROM public.sync_dispatch_transport_routes AS route
+WHERE outbox.id = $1
+	AND outbox.claim_token = $2
+	AND outbox.status = 'pending'
+	AND outbox.claim_expires_at > $4
+	AND outbox.claim_transport = 'river'
+	AND outbox.claim_route_generation = $3
+	AND route.kind = outbox.kind
+	AND route.transport = 'river'
+	AND route.paused = FALSE
+	AND route.generation = outbox.claim_route_generation
+`

--- a/internal/syncreconciler/kernel_integration_test.go
+++ b/internal/syncreconciler/kernel_integration_test.go
@@ -1,0 +1,291 @@
+//go:build integration
+
+package syncreconciler
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	integrationDispatchID = "00000000-0000-4000-8000-000000003301"
+	integrationStaleID    = "00000000-0000-4000-8000-000000003302"
+)
+
+// This test intentionally creates the production column types instead of
+// importing Python metadata. It validates the dormant Go kernel's PostgreSQL
+// SQL against text claim tokens, UUID outbox identifiers, timestamptz leases,
+// and bigint route generations.
+func TestKernelMutationPostgresTransactionFence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createKernelIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun),
+		KernelModeMutation,
+		&kernelStepper{},
+		pool.Begin,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("actual CTE skips locked row and commits publisher plus terminal mark", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, pool)
+		now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+		seedKernelOutbox(t, ctx, pool, integrationDispatchID, now.Add(-time.Second))
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		firstDone := make(chan error, 1)
+		go func() {
+			_, stepErr := kernel.Step(ctx, now, 1, time.Minute,
+				func(publisherCtx context.Context, tx pgx.Tx, claim TransportClaim) (string, error) {
+					if claim.ID != integrationDispatchID || claim.Kind != syncdispatchcontract.KindDispatchSyncRun ||
+						claim.RouteGeneration != 7 || claim.Attempts != 1 {
+						return "", fmt.Errorf("unexpected claim: %#v", claim)
+					}
+					var generation int64
+					if err := tx.QueryRow(publisherCtx, `
+						SELECT claim_route_generation
+						FROM public.sync_dispatch_outbox WHERE id = $1`, claim.ID).Scan(&generation); err != nil {
+						return "", err
+					}
+					if generation != claim.RouteGeneration {
+						return "", fmt.Errorf("publisher saw claim generation %d, want %d", generation, claim.RouteGeneration)
+					}
+					close(entered)
+					select {
+					case <-release:
+					case <-publisherCtx.Done():
+						return "", publisherCtx.Err()
+					}
+					if _, err := tx.Exec(publisherCtx, `
+						INSERT INTO public.river_transport_jobs (outbox_id, claim_token)
+						VALUES ($1, $2)`, claim.ID, claim.ClaimToken); err != nil {
+						return "", err
+					}
+					return "river-job-3301", nil
+				}, nil)
+			firstDone <- stepErr
+		}()
+
+		select {
+		case <-entered:
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		}
+		second, err := kernel.Step(ctx, now, 1, time.Minute,
+			func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+				return "", errors.New("second reconciler reached a locked row")
+			}, nil)
+		if err != nil || second.Claimed != 0 || second.Dispatched != 0 {
+			t.Fatalf("SKIP LOCKED second Step() = %#v, %v", second, err)
+		}
+		close(release)
+		if err := <-firstDone; err != nil {
+			t.Fatal(err)
+		}
+
+		var (
+			status, dispatchedTransport, transportJobID string
+			attempts                                    int
+			claimToken, claimTransport                  *string
+			claimGeneration, dispatchedGeneration       *int64
+		)
+		if err := pool.QueryRow(ctx, `
+			SELECT status, attempts, claim_token, claim_transport, claim_route_generation,
+				dispatched_transport, dispatched_route_generation, transport_job_id
+			FROM public.sync_dispatch_outbox WHERE id = $1`, integrationDispatchID).Scan(
+			&status, &attempts, &claimToken, &claimTransport, &claimGeneration,
+			&dispatchedTransport, &dispatchedGeneration, &transportJobID,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if status != "dispatched" || attempts != 1 || claimToken != nil || claimTransport != nil ||
+			claimGeneration != nil || dispatchedTransport != "river" || dispatchedGeneration == nil ||
+			*dispatchedGeneration != 7 || transportJobID != "river-job-3301" {
+			t.Fatalf("terminal row = status:%s attempts:%d claim:%v/%v/%v dispatched:%s/%v/%s",
+				status, attempts, claimToken, claimTransport, claimGeneration,
+				dispatchedTransport, dispatchedGeneration, transportJobID)
+		}
+		var jobs int
+		if err := pool.QueryRow(ctx, "SELECT count(*) FROM public.river_transport_jobs").Scan(&jobs); err != nil {
+			t.Fatal(err)
+		}
+		if jobs != 1 {
+			t.Fatalf("same-transaction publisher jobs = %d, want 1", jobs)
+		}
+	})
+
+	t.Run("actual terminal write fences stale persisted route generation", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, pool)
+		now := time.Date(2026, time.July, 23, 12, 1, 0, 0, time.UTC)
+		seedKernelOutbox(t, ctx, pool, integrationStaleID, now.Add(-time.Second))
+		claim := TransportClaim{
+			ID:              integrationStaleID,
+			Kind:            syncdispatchcontract.KindDispatchSyncRun,
+			ClaimToken:      "10000000-0000-4000-8000-000000003302",
+			RouteGeneration: 7,
+			AvailableAt:     now.Add(-time.Second),
+			Attempts:        1,
+		}
+		if _, err := pool.Exec(ctx, `
+			UPDATE public.sync_dispatch_outbox
+			SET claim_token = $2, claim_expires_at = $3, claim_transport = 'river',
+				claim_route_generation = 7, attempts = 1
+			WHERE id = $1`, claim.ID, claim.ClaimToken, now.Add(time.Minute)); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := pool.Exec(ctx, `
+			UPDATE public.sync_dispatch_transport_routes
+			SET generation = 8 WHERE kind = $1`, syncdispatchcontract.KindDispatchSyncRun); err != nil {
+			t.Fatal(err)
+		}
+		tx, err := pool.Begin(ctx)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer tx.Rollback(ctx)
+		if err := markRiverDispatched(ctx, tx, claim, now, "stale-river-job"); !errors.Is(err, ErrLeaseLost) {
+			t.Fatalf("markRiverDispatched() error = %v", err)
+		}
+	})
+
+	t.Run("publisher failure rolls back both persisted claim and River insert", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, pool)
+		now := time.Date(2026, time.July, 23, 12, 2, 0, 0, time.UTC)
+		seedKernelOutbox(t, ctx, pool, integrationDispatchID, now.Add(-time.Second))
+		publisherErr := errors.New("injected publisher failure")
+		if _, err := kernel.Step(ctx, now, 1, time.Minute,
+			func(publisherCtx context.Context, tx pgx.Tx, claim TransportClaim) (string, error) {
+				if _, err := tx.Exec(publisherCtx, `
+					INSERT INTO public.river_transport_jobs (outbox_id, claim_token)
+					VALUES ($1, $2)`, claim.ID, claim.ClaimToken); err != nil {
+					return "", err
+				}
+				return "", publisherErr
+			}, nil); !errors.Is(err, publisherErr) {
+			t.Fatalf("Step() error = %v", err)
+		}
+		var status string
+		var attempts int
+		var claimToken *string
+		if err := pool.QueryRow(ctx, `
+			SELECT status, attempts, claim_token FROM public.sync_dispatch_outbox WHERE id = $1`,
+			integrationDispatchID).Scan(&status, &attempts, &claimToken); err != nil {
+			t.Fatal(err)
+		}
+		if status != "pending" || attempts != 0 || claimToken != nil {
+			t.Fatalf("rolled-back outbox = status:%s attempts:%d claim:%v", status, attempts, claimToken)
+		}
+		var jobs int
+		if err := pool.QueryRow(ctx, "SELECT count(*) FROM public.river_transport_jobs").Scan(&jobs); err != nil {
+			t.Fatal(err)
+		}
+		if jobs != 0 {
+			t.Fatalf("rolled-back River jobs = %d, want 0", jobs)
+		}
+	})
+}
+
+func createKernelIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) error {
+	for _, statement := range []string{
+		"CREATE EXTENSION IF NOT EXISTS pgcrypto",
+		`CREATE TABLE public.sync_dispatch_transport_routes (
+			kind text PRIMARY KEY,
+			transport text NOT NULL,
+			generation bigint NOT NULL,
+			paused boolean NOT NULL,
+			paused_at timestamptz,
+			rollback_transport text NOT NULL
+		)`,
+		`CREATE TABLE public.sync_dispatch_outbox (
+			id uuid PRIMARY KEY,
+			org_id text NOT NULL,
+			sync_run_id uuid NOT NULL,
+			kind text NOT NULL,
+			status text NOT NULL,
+			available_at timestamptz NOT NULL,
+			attempts integer NOT NULL,
+			last_error text,
+			dispatched_at timestamptz,
+			claim_token text,
+			claim_expires_at timestamptz,
+			claim_transport text,
+			claim_route_generation bigint,
+			dispatched_transport text,
+			dispatched_route_generation bigint,
+			transport_job_id text,
+			created_at timestamptz NOT NULL,
+			updated_at timestamptz NOT NULL
+		)`,
+		`CREATE TABLE public.river_transport_jobs (
+			outbox_id uuid PRIMARY KEY,
+			claim_token text NOT NULL
+		)`,
+	} {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resetKernelIntegrationTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	for _, statement := range []string{
+		"TRUNCATE public.river_transport_jobs",
+		"TRUNCATE public.sync_dispatch_outbox",
+		"TRUNCATE public.sync_dispatch_transport_routes",
+		`INSERT INTO public.sync_dispatch_transport_routes (
+			kind, transport, generation, paused, paused_at, rollback_transport
+		) VALUES
+			('dispatch_sync_run', 'river', 7, FALSE, NULL, 'celery'),
+			('finalize_sync_run', 'celery', 1, FALSE, NULL, 'celery'),
+			('post_sync', 'celery', 1, FALSE, NULL, 'celery'),
+			('reference_discovery', 'celery', 1, FALSE, NULL, 'celery')`,
+	} {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func seedKernelOutbox(t *testing.T, ctx context.Context, pool *pgxpool.Pool, id string, availableAt time.Time) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.sync_dispatch_outbox (
+			id, org_id, sync_run_id, kind, status, available_at, attempts, created_at, updated_at
+		) VALUES ($1, 'org-integration', '00000000-0000-4000-8000-000000003300',
+			'dispatch_sync_run', 'pending', $2, 0, $2, $2)`, id, availableAt); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/syncreconciler/kernel_test.go
+++ b/internal/syncreconciler/kernel_test.go
@@ -1,0 +1,328 @@
+package syncreconciler
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type kernelStepper struct {
+	calls int
+}
+
+func (stepper *kernelStepper) Step(_ context.Context, _ time.Time, _ int) (Observation, error) {
+	stepper.calls++
+	return Observation{Limit: 1}, nil
+}
+
+type fakeKernelRows struct {
+	pgx.Rows
+	claims []TransportClaim
+	index  int
+	err    error
+}
+
+func (rows *fakeKernelRows) Next() bool { return rows.index < len(rows.claims) }
+
+func (rows *fakeKernelRows) Scan(dest ...any) error {
+	if rows.index >= len(rows.claims) {
+		return errors.New("scan past rows")
+	}
+	claim := rows.claims[rows.index]
+	rows.index++
+	values := []any{
+		claim.ID, claim.Kind, claim.ClaimToken, claim.RouteGeneration,
+		claim.AvailableAt, claim.Attempts,
+	}
+	for index, destination := range dest {
+		switch typed := destination.(type) {
+		case *string:
+			*typed = values[index].(string)
+		case *int64:
+			*typed = values[index].(int64)
+		case *time.Time:
+			*typed = values[index].(time.Time)
+		default:
+			return errors.New("unexpected scan destination")
+		}
+	}
+	return nil
+}
+
+func (rows *fakeKernelRows) Err() error { return rows.err }
+func (*fakeKernelRows) Close()          {}
+
+type fakeKernelTx struct {
+	pgx.Tx
+	claims       []TransportClaim
+	querySQL     string
+	queryArgs    []any
+	execSQL      []string
+	commit       bool
+	rollback     bool
+	terminalRows int64
+}
+
+func (tx *fakeKernelTx) Query(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
+	tx.querySQL = sql
+	tx.queryArgs = args
+	return &fakeKernelRows{claims: append([]TransportClaim(nil), tx.claims...)}, nil
+}
+
+func (tx *fakeKernelTx) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+	tx.execSQL = append(tx.execSQL, sql)
+	return pgconn.NewCommandTag("UPDATE " + strconv.FormatInt(tx.terminalRows, 10)), nil
+}
+
+func (tx *fakeKernelTx) Commit(context.Context) error {
+	tx.commit = true
+	return nil
+}
+
+func (tx *fakeKernelTx) Rollback(context.Context) error {
+	tx.rollback = true
+	return nil
+}
+
+func riverRegistry(t *testing.T, riverKinds ...string) registryMap {
+	t.Helper()
+	registry := testRegistry(t, "")
+	for _, kind := range riverKinds {
+		descriptor := registry[kind]
+		descriptor.Route = syncdispatchcontract.RouteRiver
+		registry[kind] = descriptor
+	}
+	return registry
+}
+
+func kernelClaim(kind string, at time.Time, id string) TransportClaim {
+	return TransportClaim{
+		ID:              id,
+		Kind:            kind,
+		ClaimToken:      "10000000-0000-4000-8000-000000000001",
+		RouteGeneration: 7,
+		AvailableAt:     at,
+		Attempts:        2,
+	}
+}
+
+func TestKernelShadowIsReadOnlyAndNeverBeginsTransaction(t *testing.T) {
+	stepper := &kernelStepper{}
+	kernel, err := newKernel(testRegistry(t, ""), KernelModeShadow, stepper, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := kernel.Step(context.Background(), time.Now(), 1, time.Minute, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.Mode != KernelModeShadow || stepper.calls != 1 || result.Claimed != 0 || result.Dispatched != 0 {
+		t.Fatalf("shadow result = %#v, calls = %d", result, stepper.calls)
+	}
+}
+
+func TestKernelMutationWithCeleryOnlyContractNeverBeginsATransaction(t *testing.T) {
+	called := false
+	kernel, err := newKernel(
+		testRegistry(t, ""), KernelModeMutation, &kernelStepper{},
+		func(context.Context) (pgx.Tx, error) {
+			called = true
+			return nil, errors.New("must not begin")
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := kernel.Step(context.Background(), time.Now(), 1, time.Minute, nil, nil)
+	if err != nil || called || result.Mode != KernelModeMutation || result.Claimed != 0 {
+		t.Fatalf("celery-only mutation result = %#v err=%v begin=%t", result, err, called)
+	}
+}
+
+func TestKernelMutationClaimsOnlyBoundedPersistedRiverRoutesInDeterministicOrder(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindFinalizeSyncRun, now, candidateID2),
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now.Add(-time.Second), candidateID1),
+	}}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.KindFinalizeSyncRun),
+		KernelModeMutation,
+		&kernelStepper{},
+		func(context.Context) (pgx.Tx, error) { return tx, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var published []string
+	result, err := kernel.Step(context.Background(), now, 2, time.Minute,
+		func(_ context.Context, gotTx pgx.Tx, claim TransportClaim) (string, error) {
+			if gotTx != tx {
+				t.Fatal("publisher received a different transaction")
+			}
+			published = append(published, claim.ID)
+			return "river-" + claim.ID, nil
+		}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !reflect.DeepEqual(published, []string{candidateID1, candidateID2}) ||
+		result.Claimed != 2 || result.Dispatched != 2 || !tx.commit {
+		t.Fatalf("result = %#v published = %v tx = %#v", result, published, tx)
+	}
+	upper := strings.ToUpper(tx.querySQL)
+	for _, required := range []string{
+		"ROUTE.TRANSPORT = 'RIVER'", "ROUTE.PAUSED = FALSE",
+		"OUTBOX.KIND = ANY($4::TEXT[])", "ORDER BY OUTBOX.AVAILABLE_AT, OUTBOX.ID",
+		"FOR UPDATE OF OUTBOX, ROUTE SKIP LOCKED", "LIMIT $2",
+		"SET CLAIM_TOKEN = GEN_RANDOM_UUID()::TEXT",
+	} {
+		if !strings.Contains(upper, required) {
+			t.Fatalf("claim SQL missing %q:\n%s", required, tx.querySQL)
+		}
+	}
+	if len(tx.queryArgs) != 4 || !reflect.DeepEqual(tx.queryArgs[3], []string{
+		syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.KindFinalizeSyncRun,
+	}) {
+		t.Fatalf("claim arguments = %#v", tx.queryArgs)
+	}
+	if len(tx.execSQL) != 2 || !strings.Contains(strings.ToUpper(tx.execSQL[0]), "ROUTE.GENERATION = OUTBOX.CLAIM_ROUTE_GENERATION") {
+		t.Fatalf("terminal SQL = %v", tx.execSQL)
+	}
+	if strings.Contains(strings.ToUpper(markRiverDispatchedSQL), "CLAIM_TOKEN = $2::UUID") {
+		t.Fatalf("terminal SQL wrongly treats the text claim token as UUID:\n%s", markRiverDispatchedSQL)
+	}
+}
+
+func TestKernelMutationPublisherFailureRollsBackClaimAndRiverInsertForRetry(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
+	}}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
+		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publisherErr := errors.New("river insert failed")
+	if _, err := kernel.Step(context.Background(), now, 1, time.Minute,
+		func(context.Context, pgx.Tx, TransportClaim) (string, error) { return "", publisherErr }, nil); !errors.Is(err, publisherErr) {
+		t.Fatalf("Step() error = %v", err)
+	}
+	if tx.commit || !tx.rollback || len(tx.execSQL) != 0 {
+		t.Fatalf("failed publish committed or terminalized: %#v", tx)
+	}
+}
+
+func TestKernelMutationGenerationRecheckRejectsTerminalWriteAndRollsBack(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	tx := &fakeKernelTx{terminalRows: 0, claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
+	}}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
+		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	published := false
+	if _, err := kernel.Step(context.Background(), now, 1, time.Minute,
+		func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+			published = true
+			return "river-job", nil
+		}, nil); !errors.Is(err, ErrLeaseLost) {
+		t.Fatalf("Step() error = %v", err)
+	}
+	if !published || tx.commit || !tx.rollback {
+		t.Fatalf("generation recheck result = published:%t tx:%#v", published, tx)
+	}
+}
+
+func TestKernelPostSyncMarksBeforeItsSeparateTransactionLocalSeam(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindPostSync, now, candidateID1),
+	}}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindPostSync), KernelModeMutation,
+		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	published := false
+	marked := false
+	result, err := kernel.Step(context.Background(), now, 1, time.Minute,
+		func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+			published = true
+			return "", nil
+		}, func(_ context.Context, gotTx pgx.Tx, claim TransportClaim) error {
+			if gotTx != tx || claim.Kind != syncdispatchcontract.KindPostSync || len(tx.execSQL) != 1 {
+				t.Fatalf("post-sync seam order or transaction invalid: tx=%#v claim=%#v", tx, claim)
+			}
+			marked = true
+			return nil
+		})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if published || !marked || !tx.commit || result.PostSyncMark != 1 || result.Dispatched != 1 {
+		t.Fatalf("post-sync result = %#v published:%t marked:%t tx:%#v", result, published, marked, tx)
+	}
+}
+
+func TestKernelPostSyncMarkerFailureRollsBackItsPriorTerminalMark(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindPostSync, now, candidateID1),
+	}}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindPostSync), KernelModeMutation,
+		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	markerErr := errors.New("mark-before seam failed")
+	if _, err := kernel.Step(context.Background(), now, 1, time.Minute, nil,
+		func(context.Context, pgx.Tx, TransportClaim) error { return markerErr }); !errors.Is(err, markerErr) {
+		t.Fatalf("Step() error = %v", err)
+	}
+	if tx.commit || !tx.rollback || len(tx.execSQL) != 1 {
+		t.Fatalf("post-sync marker failure leaked terminal write: %#v", tx)
+	}
+}
+
+func TestKernelRejectsInvalidModesAndMissingMutationSeams(t *testing.T) {
+	if _, err := newKernel(testRegistry(t, ""), "active", &kernelStepper{}, nil); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("invalid mode error = %v", err)
+	}
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
+	}}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
+		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := kernel.Step(context.Background(), now, 1, time.Minute, nil, nil); !errors.Is(err, ErrPublisherRequired) {
+		t.Fatalf("missing publisher error = %v", err)
+	}
+	if tx.commit || !tx.rollback {
+		t.Fatalf("missing publisher transaction = %#v", tx)
+	}
+}

--- a/internal/syncreconciler/observer.go
+++ b/internal/syncreconciler/observer.go
@@ -1,6 +1,8 @@
 // Package syncreconciler observes the legacy sync-dispatch outbox during the
-// phased worker migration. It is deliberately read-only: execution, claims,
-// and transport delivery remain owned by the existing Celery reconciler.
+// phased worker migration. Its production observer is deliberately read-only.
+// The package also contains an unreferenced, opt-in transaction kernel for a
+// later River cutover; execution remains owned by Celery until that kernel is
+// explicitly wired by a subsequent phase.
 package syncreconciler
 
 import (

--- a/tests/test_sync_reconciler.py
+++ b/tests/test_sync_reconciler.py
@@ -1112,6 +1112,66 @@ def test_reconciler_relays_pending_post_sync_row_with_rebuilt_payload(
     assert post_sync_row.dispatched_route_generation == 1
 
 
+def test_reconciler_post_sync_publish_failure_stays_marked_and_is_not_retried(
+    db_session, monkeypatch
+):
+    from dev_health_ops.workers import post_sync_dispatch, sync_reconciler, sync_units
+
+    run, running, _planned = _seed_run(db_session, planned_units=0)
+    running.status = SyncRunUnitStatus.SUCCESS.value
+    running.lease_owner = None
+    running.lease_expires_at = None
+    run.status = SyncRunStatus.SUCCESS.value
+    run.completed_units = 1
+    run.completed_at = datetime.now(timezone.utc)
+    db_session.add(
+        SyncRunPostDispatch(
+            org_id=run.org_id,
+            sync_run_id=run.id,
+            kind=OUTBOX_KIND_POST_SYNC,
+            dispatched_at=datetime.now(timezone.utc),
+        )
+    )
+    upsert_outbox_wakeup(
+        db_session,
+        sync_run_id=run.id,
+        kind=OUTBOX_KIND_POST_SYNC,
+        available_at=datetime.now(timezone.utc),
+    )
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    publish_attempts = []
+    monkeypatch.setattr(sync_units.dispatch_sync_run, "apply_async", lambda **_: None)
+    monkeypatch.setattr(sync_units.finalize_sync_run, "apply_async", lambda **_: None)
+
+    def fail_post_sync_publish(**kwargs):
+        publish_attempts.append(kwargs)
+        raise RuntimeError("broker down")
+
+    monkeypatch.setattr(
+        post_sync_dispatch,
+        "_dispatch_post_sync_tasks",
+        fail_post_sync_publish,
+    )
+
+    first = sync_reconciler.reconcile_sync_dispatch(limit=10)
+    second = sync_reconciler.reconcile_sync_dispatch(limit=10)
+
+    post_sync_row = _outbox_row(db_session, run, OUTBOX_KIND_POST_SYNC)
+    assert first["relayed_post_sync"] == 0
+    assert first["publish_failures"] == 0
+    assert second["relayed_post_sync"] == 0
+    assert len(publish_attempts) == 1
+    assert post_sync_row.status == OUTBOX_STATUS_DISPATCHED
+    assert post_sync_row.claim_token is None
+    assert post_sync_row.claim_expires_at is None
+    assert post_sync_row.claim_transport is None
+    assert post_sync_row.claim_route_generation is None
+    assert post_sync_row.dispatched_transport == "celery"
+    assert post_sync_row.dispatched_route_generation == 1
+    assert post_sync_row.last_error is None
+
+
 def test_reconciler_materializes_missing_post_sync_outbox_for_ledger(
     db_session, monkeypatch
 ):

--- a/tests/workers/test_go_worker_deployment_contract.py
+++ b/tests/workers/test_go_worker_deployment_contract.py
@@ -11,6 +11,8 @@ import yaml
 
 _REPO_ROOT = Path(__file__).resolve().parents[2]
 _PROFILES = _REPO_ROOT / "deploy" / "go-workers" / "profiles.json"
+_APP_DOCKERFILE = _REPO_ROOT / "docker" / "Dockerfile"
+_GO_WORKER_DOCKERFILE = _REPO_ROOT / "docker" / "go-worker.Dockerfile"
 _PRODUCTION_COMPOSE = (
     _REPO_ROOT / "deploy" / "docker-compose" / "compose.production.yml"
 )
@@ -108,6 +110,37 @@ def test_go_profiles_are_disabled_future_topology() -> None:
             "WORKER_OPERATOR_TOKEN",
         ],
     }
+
+
+def test_reconciler_image_packages_both_runtime_contract_roots() -> None:
+    dockerfile = _GO_WORKER_DOCKERFILE.read_text(encoding="utf-8")
+
+    assert (
+        "cp -R /src/contracts/jobs/v1 "
+        "/runtime/reconciler/app/contracts/jobs/v1;" in dockerfile
+    )
+    assert (
+        "cp -R /src/contracts/sync-dispatch/v1 "
+        "/runtime/reconciler/app/contracts/sync-dispatch/v1;" in dockerfile
+    )
+
+
+def test_sync_parity_image_packages_fixed_runtime_paths() -> None:
+    dockerfile = _APP_DOCKERFILE.read_text(encoding="utf-8")
+
+    for required in (
+        "FROM runtime AS sync-parity",
+        "COPY --from=go-migrator-builder /out/dev-health-sync-parity "
+        "/usr/local/bin/dev-health-sync-parity",
+        "COPY --from=builder /build/contracts/sync-dispatch/v1 "
+        "/app/contracts/sync-dispatch/v1",
+        "COPY --from=builder /build/scripts/worker/observe_sync_dispatch_parity.py "
+        "/app/scripts/worker/observe_sync_dispatch_parity.py",
+        "ln -s /usr/local/bin/python /app/.venv/bin/python",
+        "ENV PYTHONPATH=/app/src",
+        'ENTRYPOINT ["dev-health-sync-parity"]',
+    ):
+        assert required in dockerfile
 
 
 def test_profile_pgbouncer_budget_matches_production_compose_defaults() -> None:


### PR DESCRIPTION
## Summary

- add a dormant scheduler transaction kernel with bounded `SKIP LOCKED` selection, stable occurrence identities, and atomic coordinator handoff plus schedule-marker advancement
- add a dormant sync-reconciler transport kernel with persisted route/generation fencing, same-transaction River publishing seams, and a separate `post_sync` mark-before boundary
- package the sync-dispatch contract in the reconciler image and add a containerized parity-observer target with fixed runtime paths
- characterize Celery's existing `post_sync` mark-before behavior and update the worker migration docs

## Safety boundary

- neither mutation kernel is constructed by a command or deployment profile
- all checked-in and persisted sync-dispatch routes remain Celery
- Go worker profiles remain `coexistence_disabled` with zero replicas
- this PR does not activate River, advance production scheduler markers, or change production ownership

## Validation

- `bash ci/local_validate.sh` — passed; 8,710 tests, 58 expected skips
- `go test -race -count=1 ./internal/scheduler/sync ./cmd/dev-health-scheduler ./internal/syncreconciler`
- `go test -tags=integration -count=1 ./internal/scheduler/sync ./internal/syncreconciler`
- `docker compose config --quiet`
- built the `sync-parity` image and observed repeated same-snapshot `status=match` results against the canonical local PostgreSQL dataset
- independent adversarial review: approve-with-nits; the packaging regression nit was addressed before publication

## Remaining activation work

- scheduled planning coordinator, organization/entitlement checks, missing-marker creation, catch-up policy, and scheduler command loop
- missing sync-outbox materialization, expired-domain-lease repair, persisted failure backoff, concrete River publishers/handlers, and operator wiring
- bounded `post_sync` quiescence and external-handoff mechanism

SCREENSHOT-WAIVER: backend, worker-runtime, test, and documentation changes only; no rendered UI changed.
