### PR TITLE
feat(workers): add dormant sync control plane (CHAOS-3039)

### DIFF
--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -216,7 +216,7 @@ check_integration() {
 		cd "${ROOT}"
 		GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=10m \
 			./internal/testsupport/containers ./internal/storage/postgres ./internal/storage/river \
-			./internal/joboutbox ./internal/joboperator ./internal/syncreconciler
+			./internal/joboutbox ./internal/joboperator ./internal/syncreconciler ./internal/syncroute
 	)
 }
 

--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -216,7 +216,8 @@ check_integration() {
 		cd "${ROOT}"
 		GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=10m \
 			./internal/testsupport/containers ./internal/storage/postgres ./internal/storage/river \
-			./internal/joboutbox ./internal/joboperator ./internal/syncreconciler ./internal/syncroute
+			./internal/joboutbox ./internal/joboperator ./internal/syncreconciler ./internal/syncroute \
+			./internal/scheduler/sync
 	)
 }
 

--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -216,7 +216,7 @@ check_integration() {
 		cd "${ROOT}"
 		GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=10m \
 			./internal/testsupport/containers ./internal/storage/postgres ./internal/storage/river \
-			./internal/joboutbox ./internal/joboperator
+			./internal/joboutbox ./internal/joboperator ./internal/syncreconciler
 	)
 }
 

--- a/cmd/dev-health-scheduler/main.go
+++ b/cmd/dev-health-scheduler/main.go
@@ -8,12 +8,18 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
 	"github.com/full-chaos/dev-health-ops/internal/platform/shell"
 	"github.com/full-chaos/dev-health-ops/internal/processreadiness"
+	schedulersync "github.com/full-chaos/dev-health-ops/internal/scheduler/sync"
 )
 
 var schedulerSpec = shell.Spec{
 	Service:               "dev-health-scheduler",
 	ConfigureDependencies: configureSchedulerDependencies,
 }
+
+// schedulerOwnership is intentionally fixed in the binary. Do not make it an
+// environment setting: deployment_state remains coexistence_disabled and the
+// Python scheduler retains all production marker-mutation ownership.
+var schedulerOwnership = schedulersync.DefaultOwnershipPolicy()
 
 func main() {
 	shell.Main(schedulerSpec)
@@ -24,6 +30,9 @@ func configureSchedulerDependencies(
 	_ config.Config,
 	registry *health.Registry,
 ) ([]lifecycle.Component, error) {
+	if err := schedulerOwnership.Validate(); err != nil {
+		return nil, err
+	}
 	// Phase 1 has no scheduler loop or composed storage clients. Keep every
 	// dependency required by the control-process topology explicitly closed.
 	err := processreadiness.RegisterUnavailable(

--- a/cmd/dev-health-scheduler/main_test.go
+++ b/cmd/dev-health-scheduler/main_test.go
@@ -8,9 +8,13 @@ import (
 
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	schedulersync "github.com/full-chaos/dev-health-ops/internal/scheduler/sync"
 )
 
 func TestSchedulerSpecConfiguresFailClosedDependencies(t *testing.T) {
+	if schedulerOwnership != schedulersync.DefaultOwnershipPolicy() {
+		t.Fatalf("scheduler ownership = %#v", schedulerOwnership)
+	}
 	if schedulerSpec.Service != "dev-health-scheduler" {
 		t.Fatalf("service = %q", schedulerSpec.Service)
 	}

--- a/cmd/dev-health-workerctl/main.go
+++ b/cmd/dev-health-workerctl/main.go
@@ -25,6 +25,8 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/platform/version"
 	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
 	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/syncroute"
 	"github.com/jackc/pgx/v5"
 )
 
@@ -190,6 +192,18 @@ func configureRuntime(ctx context.Context, lookup platformsecrets.LookupEnv, std
 	if err != nil {
 		return nil, writeError(stderr, "deployment_contract_invalid")
 	}
+	routeRegistry, err := syncdispatchcontract.Load("contracts/sync-dispatch/v1")
+	if err != nil {
+		return nil, writeError(stderr, "contract_registry_invalid")
+	}
+	routeCapabilities, err := syncroute.NewCapabilities(nil)
+	if err != nil {
+		return nil, writeError(stderr, "contract_registry_invalid")
+	}
+	routeController, err := syncroute.NewController(pools.Domain, routeRegistry, routeCapabilities)
+	if err != nil {
+		return nil, writeError(stderr, "operator_backend_unavailable")
+	}
 	streams := make([]streamProfileStatus, 0, 2)
 	for _, process := range manifest.Processes {
 		if process.Runtime != "stream" {
@@ -218,6 +232,7 @@ func configureRuntime(ctx context.Context, lookup platformsecrets.LookupEnv, std
 	service, err := joboperator.New(joboperator.Dependencies{
 		Registry: registry, Backend: backend, Authorizer: authentication.Authorizer(),
 		DomainGuard: guard, Auditor: auditor,
+		RouteController: routeController,
 	})
 	if err != nil {
 		return nil, writeError(stderr, "operator_backend_unavailable")
@@ -261,6 +276,8 @@ func dispatch(ctx context.Context, runtime *operatorRuntime, args []string, stdo
 		return dispatchDrain(ctx, runtime, args[1:], stdout, stderr)
 	case "contracts":
 		return dispatchContracts(ctx, runtime, args[1:], stdout, stderr)
+	case "routes":
+		return dispatchRoutes(ctx, runtime, args[1:], stdout, stderr)
 	case "streams":
 		if len(args) != 2 || args[1] != "status" {
 			return writeError(stderr, "invalid_request")
@@ -275,6 +292,60 @@ func dispatch(ctx context.Context, runtime *operatorRuntime, args []string, stdo
 	default:
 		return writeError(stderr, "invalid_request")
 	}
+}
+
+func dispatchRoutes(ctx context.Context, runtime *operatorRuntime, args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		return writeError(stderr, "invalid_request")
+	}
+	if args[0] == "status" {
+		if len(args) != 2 {
+			return writeError(stderr, "invalid_request")
+		}
+		state, err := runtime.service.InspectRoute(ctx, runtime.principal, args[1])
+		if err != nil {
+			return writeServiceError(stderr, err)
+		}
+		return writeResult(stdout, stderr, state)
+	}
+	flags := quietFlags("routes " + args[0])
+	reason := flags.String("reason", "", "bounded reason code")
+	correlation := flags.String("correlation-id", "", "bounded correlation ID")
+	transport := flags.String("transport", "", "checked-in target transport")
+	quiescenceTimeout := flags.Duration("quiescence-timeout", 10*time.Second, "bounded external quiescence timeout")
+	if flags.Parse(args[1:]) != nil || flags.NArg() != 1 || *reason == "" || *correlation == "" {
+		return writeError(stderr, "invalid_request")
+	}
+	kind := flags.Arg(0)
+	var (
+		state syncroute.RouteState
+		err   error
+	)
+	switch args[0] {
+	case "pause":
+		if *transport != "" {
+			return writeError(stderr, "invalid_request")
+		}
+		state, err = runtime.service.PauseRoute(ctx, runtime.principal, kind, *reason, *correlation)
+	case "drain":
+		if *transport != "" {
+			return writeError(stderr, "invalid_request")
+		}
+		state, err = runtime.service.DrainRoute(ctx, runtime.principal, kind, *reason, *correlation)
+	case "resume":
+		if *transport == "" {
+			return writeError(stderr, "invalid_request")
+		}
+		state, err = runtime.service.ResumeRoute(
+			ctx, runtime.principal, kind, *transport, *reason, *correlation, *quiescenceTimeout,
+		)
+	default:
+		return writeError(stderr, "invalid_request")
+	}
+	if err != nil {
+		return writeServiceError(stderr, err)
+	}
+	return writeResult(stdout, stderr, state)
 }
 
 func dispatchJobs(ctx context.Context, runtime *operatorRuntime, args []string, stdout, stderr io.Writer) int {

--- a/cmd/dev-health-workerctl/main_test.go
+++ b/cmd/dev-health-workerctl/main_test.go
@@ -7,9 +7,11 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/joboperator"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/syncroute"
 )
 
 type commandAuthorizer struct{ err error }
@@ -56,6 +58,24 @@ type commandAuditor struct{}
 
 func (commandAuditor) Begin(context.Context, joboperator.AuditEvent) (joboperator.AuditHandle, error) {
 	return nil, errors.New("unused")
+}
+
+type commandRouteController struct {
+	state syncroute.RouteState
+	err   error
+}
+
+func (controller commandRouteController) Inspect(context.Context, string) (syncroute.RouteState, error) {
+	return controller.state, controller.err
+}
+func (controller commandRouteController) Pause(context.Context, string) (syncroute.RouteState, error) {
+	return controller.state, controller.err
+}
+func (controller commandRouteController) Drain(context.Context, string) (syncroute.RouteState, error) {
+	return controller.state, controller.err
+}
+func (controller commandRouteController) Resume(context.Context, string, string, time.Duration) (syncroute.RouteState, error) {
+	return controller.state, controller.err
 }
 
 func TestDispatchStatusRequiresReadAuthorizationAndEmitsBoundedJSON(t *testing.T) {
@@ -115,6 +135,7 @@ func commandRuntime(t *testing.T, authorizer joboperator.Authorizer) *operatorRu
 	service, err := joboperator.New(joboperator.Dependencies{
 		Registry: registry, Backend: commandBackend{}, Authorizer: authorizer,
 		DomainGuard: commandDomainGuard{}, Auditor: commandAuditor{},
+		RouteController: commandRouteController{},
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/dev-health-workerctl/main_test.go
+++ b/cmd/dev-health-workerctl/main_test.go
@@ -56,8 +56,12 @@ func (commandDomainGuard) Check(context.Context, joboperator.Action, joboperator
 
 type commandAuditor struct{}
 
+type commandAuditHandle struct{}
+
+func (commandAuditHandle) Complete(context.Context, joboperator.AuditStatus) error { return nil }
+
 func (commandAuditor) Begin(context.Context, joboperator.AuditEvent) (joboperator.AuditHandle, error) {
-	return nil, errors.New("unused")
+	return commandAuditHandle{}, nil
 }
 
 type commandRouteController struct {
@@ -69,12 +73,24 @@ func (controller commandRouteController) Inspect(context.Context, string) (syncr
 	return controller.state, controller.err
 }
 func (controller commandRouteController) Pause(context.Context, string) (syncroute.RouteState, error) {
+	if controller.state.Kind == "" && controller.err == nil {
+		return syncroute.RouteState{
+			Kind: "post_sync", Transport: "celery", Generation: 2, Paused: true,
+			RollbackTransport: "celery",
+		}, nil
+	}
 	return controller.state, controller.err
 }
 func (controller commandRouteController) Drain(context.Context, string) (syncroute.RouteState, error) {
 	return controller.state, controller.err
 }
 func (controller commandRouteController) Resume(context.Context, string, string, time.Duration) (syncroute.RouteState, error) {
+	if controller.state.Kind == "" && controller.err == nil {
+		return syncroute.RouteState{
+			Kind: "post_sync", Transport: "celery", Generation: 3,
+			RollbackTransport: "celery",
+		}, nil
+	}
 	return controller.state, controller.err
 }
 
@@ -106,6 +122,30 @@ func TestDispatchMutationRequiresReasonAndCorrelationBeforeService(t *testing.T)
 	code := dispatch(context.Background(), runtime, []string{"jobs", "cancel", "42"}, &stdout, &stderr)
 	if code != 1 || stderr.String() != "{\"error\":{\"code\":\"invalid_request\"}}\n" {
 		t.Fatalf("cancel validation code=%d stdout=%q stderr=%q", code, stdout.String(), stderr.String())
+	}
+}
+
+func TestDispatchRoutesCanPauseAndResumePostSyncOnCelery(t *testing.T) {
+	runtime := commandRuntime(t, commandAuthorizer{})
+	var stdout, stderr bytes.Buffer
+	if code := dispatch(context.Background(), runtime, []string{
+		"routes", "pause", "--reason", "maintenance", "--correlation-id", "route-cli-1", "post_sync",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("routes pause code=%d stderr=%s", code, stderr.String())
+	}
+	if stdout.String() != "{\"kind\":\"post_sync\",\"transport\":\"celery\",\"generation\":2,\"paused\":true,\"rollback_transport\":\"celery\",\"live_claims\":0}\n" {
+		t.Fatalf("routes pause output=%q", stdout.String())
+	}
+	stdout.Reset()
+	stderr.Reset()
+	if code := dispatch(context.Background(), runtime, []string{
+		"routes", "resume", "--reason", "maintenance", "--correlation-id", "route-cli-2",
+		"--transport", "celery", "post_sync",
+	}, &stdout, &stderr); code != 0 {
+		t.Fatalf("routes resume code=%d stderr=%s", code, stderr.String())
+	}
+	if stdout.String() != "{\"kind\":\"post_sync\",\"transport\":\"celery\",\"generation\":3,\"paused\":false,\"rollback_transport\":\"celery\",\"live_claims\":0}\n" {
+		t.Fatalf("routes resume output=%q", stdout.String())
 	}
 }
 

--- a/docs/architecture/go-worker-runtime-trd.md
+++ b/docs/architecture/go-worker-runtime-trd.md
@@ -685,11 +685,19 @@ post-sync quiescence barrier when applicable, deploy the matching
 handler/contract, and unpause the new transport with another generation
 increment. The future River relay must insert the River job and mark the sync
 outbox through one PostgreSQL transaction and therefore needs the corresponding
-semantic-table privileges on that transaction's pool.
+least-privilege queue-control pool: `SELECT` and `UPDATE` on the outbox and
+`SELECT` only on the route table. PostgreSQL row-locking clauses require
+mutation authority on every locked relation, so the River path locks only the
+outbox row. A route change committed before the terminal write fails its
+generation predicate and rolls the claim and River insert back atomically.
+Because the SELECT-only queue role cannot lock the route, a route update after
+that terminal statement but before commit is not serialized by this kernel.
+Route mutation remains absent; any future operator activation must add a
+quiescence or serialization barrier covering that final commit window.
 
 An unregistered sync-reconciler transaction kernel now implements the narrow
 transport boundary: for River-routed at-least-once rows it locks and claims a
-bounded due window, invokes an injected River publisher through the same
+bounded due outbox window, invokes an injected River publisher through the same
 transaction, and marks the outbox dispatched only after the insert succeeds.
 For the at-most-once `post_sync` kind it marks dispatched first and invokes a
 separate transaction-local seam that cannot perform the eventual external

--- a/docs/architecture/go-worker-runtime-trd.md
+++ b/docs/architecture/go-worker-runtime-trd.md
@@ -698,12 +698,13 @@ A reviewed cutover must pause with a generation increment, wait for live claims
 to drain or expire, deploy the matching checked-in handler/contract and
 capability, then resume the new transport with another generation increment.
 The command currently composes an empty capability registry, so River resume is
-rejected. A transport-changing `post_sync` resume also requires a registered
-external quiescer for the old generation; a same-transport Celery resume remains
-available for recovery. Because the quiescer timeout is cooperative, a concrete
-implementation must prove it honors context cancellation before activation.
-All checked-in routes remain Celery, so the available control is same-transport
-pause/drain/resume until that separately reviewed deployment exists.
+rejected. A transport-changing `post_sync` resume also requires an external
+quiescer registered to the old transport capability and invoked for its old
+generation; a same-transport Celery resume remains available for recovery.
+Because the quiescer timeout is cooperative, a concrete implementation must
+prove it honors context cancellation before activation. All checked-in routes
+remain Celery, so the available control is same-transport pause/drain/resume
+until that separately reviewed deployment exists.
 
 The future River relay must insert the River job and mark the sync outbox
 through one PostgreSQL transaction and therefore needs the corresponding

--- a/docs/architecture/go-worker-runtime-trd.md
+++ b/docs/architecture/go-worker-runtime-trd.md
@@ -572,13 +572,20 @@ The dormant Go coordinator only inserts or verifies the pending occurrence
 identity through the scheduler transaction. The active Python planner accepts
 and completes an existing pending row when its own Celery dispatch reaches the
 same occurrence, which makes concurrent/retried cross-language handoff
-idempotent. No independent worker scans pending occurrences, however, and no
-command constructs the Go coordinator. A Go scheduler that advanced the marker
-by itself would therefore strand the pending row. Until a durable
-pending-occurrence consumer (or equivalent Go planner) and its audited route
-exist, Celery Beat plus `dispatch_scheduled_syncs` remains the only mutation
-owner; a Go scheduler must not advance a production marker or claim schedule
-ownership.
+idempotent. Migration `0051` adds a durable reconciliation lifecycle for rows
+that are not completed by that active path. A bounded Python consumer claims
+configuration, marker, and occurrence state in the canonical lock order,
+validates the versioned identity, persists retry backoff, and quarantines
+malformed or exhausted rows before continuing to later work. The task and its
+Beat entry both default off, no checked-in profile enables them, and no command
+constructs the Go coordinator. The public scheduler repository constructor
+embeds an opaque Celery/`coexistence_disabled` ownership policy, and its
+transaction kernel rejects mutation before opening a transaction. Constructing
+Go mutation authority requires a reviewed package-private source change. Until
+an activation review enables the consumer and supplies the remaining scheduler
+loop, unsupported-cron fallback, and coordinator policy parity, Celery Beat
+plus `dispatch_scheduled_syncs` remains the only mutation owner; a Go scheduler
+must not advance a production marker or claim schedule ownership.
 
 The read-only comparison path in `internal/scheduler/sync` still performs one
 bounded schedule/configuration `SELECT` and evaluates a versioned candidate
@@ -678,22 +685,35 @@ from the old generation can still issue its broker call.
 
 The Go reconciler treats the checked-in transport registry and persisted route
 set as one readiness contract. Missing, extra, paused, malformed, or divergent
-routes close readiness. In this phase all routes remain Celery and no operator
-mutation surface is exposed. A future reviewed cutover must pause with a
-generation increment, wait for live claims to drain or expire, satisfy the
-post-sync quiescence barrier when applicable, deploy the matching
-handler/contract, and unpause the new transport with another generation
-increment. The future River relay must insert the River job and mark the sync
-outbox through one PostgreSQL transaction and therefore needs the corresponding
+routes close readiness. The authenticated operator surface exposes
+`routes status`, `pause`, `drain`, and `resume` for one fixed kind at a time.
+Mutations require operate scope, bounded reason and correlation identifiers,
+durable audit intent, and generation compare-and-set. Pause and resume acquire
+the route row first, matching Python's producer order, then hold a
+`SHARE ROW EXCLUSIVE` outbox-table barrier and re-read both route state and live
+claims. This waits out Celery's route-plus-outbox transaction and the Go
+kernel's outbox-only terminal transaction without the lock-upgrade deadlock.
+
+A reviewed cutover must pause with a generation increment, wait for live claims
+to drain or expire, deploy the matching checked-in handler/contract and
+capability, then resume the new transport with another generation increment.
+The command currently composes an empty capability registry, so River resume is
+rejected. A transport-changing `post_sync` resume also requires a registered
+external quiescer for the old generation; a same-transport Celery resume remains
+available for recovery. Because the quiescer timeout is cooperative, a concrete
+implementation must prove it honors context cancellation before activation.
+All checked-in routes remain Celery, so the available control is same-transport
+pause/drain/resume until that separately reviewed deployment exists.
+
+The future River relay must insert the River job and mark the sync outbox
+through one PostgreSQL transaction and therefore needs the corresponding
 least-privilege queue-control pool: `SELECT` and `UPDATE` on the outbox and
 `SELECT` only on the route table. PostgreSQL row-locking clauses require
 mutation authority on every locked relation, so the River path locks only the
 outbox row. A route change committed before the terminal write fails its
-generation predicate and rolls the claim and River insert back atomically.
-Because the SELECT-only queue role cannot lock the route, a route update after
-that terminal statement but before commit is not serialized by this kernel.
-Route mutation remains absent; any future operator activation must add a
-quiescence or serialization barrier covering that final commit window.
+generation predicate and rolls the claim and River insert back atomically. The
+operator's outbox-table barrier now also waits through the post-terminal,
+pre-commit window before it changes the route generation.
 
 An unregistered sync-reconciler transaction kernel now implements the narrow
 transport boundary: for River-routed at-least-once rows it locks and claims a
@@ -718,14 +738,22 @@ materializer does not inspect route ownership, claim an outbox row, or publish a
 transport job, so running its tests beside Celery does not create a second
 execution owner.
 
-This kernel is not the complete reconciler loop. Activation still needs
-an explicit materializer/transport loop, capability-aware route and operator
-controls, expired-domain-lease repair, persisted failure classification and
-retry backoff, a proven domain/queue-role River insertion boundary, concrete
-River publishers and handlers, and the bounded post-sync quiescence plus
-external-handoff mechanism. The reconciler image packages
-`contracts/sync-dispatch/v1` so the registry is available at runtime; that
-packaging does not change route ownership.
+This kernel is not the complete reconciler loop. A command-unwired
+expired-domain-lease repair step now preserves the eligible Linear-backfill
+retry matrix and serializes provider/org/cost-class mutations. A separate
+persisted failure recorder can release an already committed River claim with
+bounded Python-parity backoff. The current kernel still claims, invokes the
+publisher, and marks in one transaction, however, so a publish failure rolls
+that transaction back; activation must split and commit the claim before it
+can use the recorder. The queue-control trust boundary is proven with the real
+River `InsertTx` API and exact outbox/route privileges. The operator route
+controller supplies the post-terminal, pre-commit serialization barrier and an
+exact capability registry, but the shipped registry is intentionally empty.
+Activation still needs an explicit materializer/transport loop, concrete River
+publishers and handlers registered as capabilities, and the bounded post-sync
+external quiescer and handoff mechanism.
+The reconciler image packages `contracts/sync-dispatch/v1` so the registry is
+available at runtime; that packaging does not change route ownership.
 
 - `dispatch_sync_run`: at-least-once queue insertion; unit claims prevent duplicate provider work.
 - `finalize_sync_run`: at-least-once queue insertion; finalization ledger prevents duplicate finalization.

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -969,6 +969,44 @@ dev-hops workers start-scheduler
 For queue cleanup, stale reserved jobs, and failed-result cleanup, see
 [Workers & Celery](workers.md#queue-cleanup-and-stale-jobs).
 
+### `dev-health-workerctl routes`
+
+Inspect or control one fixed sync-dispatch transport route through the
+authenticated, payload-redacted Go operator binary:
+
+```bash
+dev-health-workerctl routes status dispatch_sync_run
+
+dev-health-workerctl routes pause \
+  --reason maintenance \
+  --correlation-id change-123 \
+  dispatch_sync_run
+
+dev-health-workerctl routes drain \
+  --reason maintenance \
+  --correlation-id change-123 \
+  dispatch_sync_run
+
+dev-health-workerctl routes resume \
+  --transport celery \
+  --reason maintenance \
+  --correlation-id change-123 \
+  dispatch_sync_run
+```
+
+The fixed kinds are `dispatch_sync_run`, `finalize_sync_run`, `post_sync`, and
+`reference_discovery`. Supply the one-time service credential through
+`WORKER_OPERATOR_TOKEN` or `WORKER_OPERATOR_TOKEN_FILE`; status requires
+`workers:read`, while pause/drain/resume require `workers:operate`. Mutations
+are serialized per semantic database, persist audit intent before changing
+state, and may return `outcome_unknown`; inspect the route before retrying.
+
+The shipped capability registry is empty and every checked-in route remains
+Celery. These commands can therefore pause, drain, and resume the same Celery
+route for operational proof, including `post_sync`, but cannot activate River.
+A transport-changing `post_sync` resume remains blocked until a concrete
+external quiescer is registered.
+
 ---
 
 ## Maintenance

--- a/docs/ops/cli-reference.md
+++ b/docs/ops/cli-reference.md
@@ -1005,7 +1005,7 @@ The shipped capability registry is empty and every checked-in route remains
 Celery. These commands can therefore pause, drain, and resume the same Celery
 route for operational proof, including `post_sync`, but cannot activate River.
 A transport-changing `post_sync` resume remains blocked until a concrete
-external quiescer is registered.
+external quiescer is registered for the old transport.
 
 ---
 

--- a/docs/ops/database-connection-pooling.md
+++ b/docs/ops/database-connection-pooling.md
@@ -49,21 +49,29 @@ The River schema defaults to `river`; migration grants its
 queue role only the schema/table/sequence access needed by the runtime and does
 not grant the domain role or `PUBLIC` access. Separately, the domain role gets
 `USAGE` on `public`, DML on every semantic table, and sequence access. The
-producer-owned `worker_job_outbox` is the exception: the domain role receives
+producer-owned `worker_job_outbox` is the domain-role exception: the domain
+role receives
 only `SELECT` and `INSERT`, so it can deduplicate and enqueue but cannot forge
 relay state or delete committed dispatches. It gets no schema `CREATE`, no
 River access, and no access to `alembic_version`; the queue role gets no general
-semantic-table or sequence access. Its sole `public` exception is `SELECT`,
-`UPDATE`, and `DELETE` on `worker_job_outbox`, allowing the relay to claim and
-retire producer-created UUID rows in the same direct transaction that inserts
-River jobs. The queue role never receives outbox `INSERT`. Readiness checks
+semantic-table or sequence access. Its `public` allowlist is `SELECT`, `UPDATE`,
+and `DELETE` on `worker_job_outbox`; `SELECT` and `UPDATE` on
+`sync_dispatch_outbox`; and `SELECT` only on
+`sync_dispatch_transport_routes`. PostgreSQL row-locking clauses require
+mutation authority on the locked relation, so the reconciler locks only the
+outbox row and rechecks the SELECT-only route generation in its terminal write.
+A concurrent generation change therefore rolls back the claim, River
+`InsertTx`, and terminal mark atomically when it commits before the terminal
+write. A future route-mutation surface must separately serialize or quiesce the
+post-terminal, pre-commit window. The queue role never receives outbox
+`INSERT`, sync outbox `DELETE`, or route `INSERT`/`UPDATE`/`DELETE`. Readiness checks
 effective privileges and all role memberships, including
 `NOINHERIT` memberships that could be activated with `SET ROLE`. Runtime roles
 must have no role memberships at all. Neither role can gain database or schema
 `CREATE` or table-maintenance capabilities; the domain role cannot access
 River, Alembic metadata, or public functions or mutate relay-owned outbox
 state, and the queue role cannot access other semantic tables or public
-functions or insert outbox rows. These checks return stable health categories
+functions or exceed that allowlist. These checks return stable health categories
 only and never emit a DSN, grant detail, or database error.
 
 ### Provision the runtime roles first

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -66,9 +66,9 @@ dev-hops service-credentials create \
 
 The plaintext token is printed once and is then supplied as
 `WORKER_OPERATOR_TOKEN` or its `_FILE` form. Read commands include `status`,
-`jobs list`, `jobs inspect`,
-`queues`, `streams status`, and `contracts`. During Phase 1, `streams status`
-reports the validated disabled deployment profiles and their Celery ownership;
+`jobs list`, `jobs inspect`, `queues`, `routes status`, `streams status`, and
+`contracts`. During Phase 1, `streams status` reports the validated disabled
+deployment profiles and their Celery ownership;
 live backlog and pending-entry state remains on the stream-runner metrics
 surface once a stream profile is composed. Mutations require both `--reason` and
 `--correlation-id`, verify an exact state transition, and persist a bounded
@@ -78,9 +78,10 @@ the resource before any retry. A confirmed mutation whose audit finalization
 is delayed returns `audit_pending` while retaining its durable `started`
 intent. Cancel/retry remain intentionally
 fail-closed for the two foundation kinds because their frozen domain links do
-not yet have authoritative semantic rows; queue pause/resume and profile drain
-are available to an authorized operator. Encoded arguments, driver errors,
-DSNs, and tokens are absent from command output and audit records.
+not yet have authoritative semantic rows; queue pause/resume, profile drain,
+and sync-route pause/drain/resume are available to an authorized operator.
+Encoded arguments, driver errors, DSNs, and tokens are absent from command
+output and audit records.
 
 The generic `worker_job_outbox` bridge is now route-safe foundation rather than
 a dormant placeholder. Python's producer helper refuses to enqueue unless the
@@ -110,17 +111,30 @@ at generation 1. Each Python claim binds the route and generation. For
 dispatch, finalize, and discovery, the publish transaction locks both the
 outbox row and route row through publish and mark; success/failure writes must
 still match that active generation. `post_sync` preserves its existing
-mark-before-publish commit, so its route lock ends at that commit. A future
-route switch therefore needs a separate bounded post-sync quiescence proof in
-addition to draining live claims. Unknown, paused, and River-routed kinds are
-not claimable by Python. The Go reconciler checks the persisted four-row set
-against the checked-in contract and closes readiness on a pause, missing row,
-generation error, or route drift.
+mark-before-publish commit, so its route lock ends at that commit. Unknown,
+paused, and River-routed kinds are not claimable by Python. The Go reconciler
+checks the persisted four-row set against the checked-in contract and closes
+readiness on a pause, missing row, generation error, or route drift.
+
+`dev-health-workerctl routes pause|drain|resume` provides the audited transition
+surface. Pause and resume lock the route row first, then hold an outbox-table
+barrier and re-read state and live claims, covering both Celery's
+route-plus-outbox transaction and Go's outbox-only terminal commit. Resume
+requires the target to equal the checked-in route. River requires an exact
+compiled capability, and a transport-changing `post_sync` resume additionally
+requires an external quiescer for its old generation. The shipped command
+registers no capabilities, so today it can pause, inspect/drain, and resume the
+same Celery route, including `post_sync`, but cannot activate River. A future
+cutover quiescer must prove it honors context cancellation; its configured
+timeout is cooperative.
 
 Two dormant transaction kernels now sit behind that foundation. The scheduler
 kernel locks a bounded due window with `FOR UPDATE ... SKIP LOCKED`, invokes an
 injected coordinator through the same PostgreSQL transaction, and advances the
-schedule marker only after that durable handoff succeeds. The sync reconciler
+schedule marker only after that durable handoff succeeds. Its public repository
+constructor embeds an opaque Celery/`coexistence_disabled` ownership policy, so
+`HandoffDue` rejects mutation before beginning a transaction; Go mutation
+authority requires a reviewed package-private source change. The sync reconciler
 kernel can claim only unpaused River-routed rows, invoke an injected
 same-transaction River publisher for at-least-once kinds, and preserve a
 separate mark-before seam for `post_sync`. Neither kernel is constructed by
@@ -130,9 +144,9 @@ This remains a fail-closed selector foundation, not River activation. All
 persisted and checked-in routes remain Celery, deployment profiles remain
 `coexistence_disabled` with zero replicas, and no Go sync handler is compiled.
 Do not change a route to River: it would strand the wakeup. Activation still
-requires command wiring, materialization of missing sync outbox rows,
-expired-lease repair and failure backoff, real River publishers and handlers,
-and the bounded post-sync quiescence/external-handoff path.
+requires a scheduler command loop and remaining policy parity; reconciler loop
+wiring; split claim-commit/publish flow; concrete River publishers, handlers,
+and capabilities; and the bounded post-sync quiescence/external-handoff path.
 
 For a read-only same-snapshot comparison, set `POSTGRES_URI` or `DATABASE_URI`
 and run:
@@ -159,9 +173,12 @@ domain plan transactionally, Celery Beat and `dispatch_scheduled_syncs` remain
 the sole schedule mutation owners by default. An operator may separately set
 `SYNC_SCHEDULED_OCCURRENCE_CONSUMER_ENABLED=true` to let the bounded Celery
 consumer materialize pre-existing Go-authored identities; it does not own
-timing or activate the Go command loop. The dormant transaction kernel still
-needs the planner, organization/entitlement decisions, missing-marker
-materialization, catch-up policy, and command loop.
+timing or activate the Go command loop. The default-off consumer now provides
+the authoritative Python planner path for a valid pending identity, while the
+dormant transaction kernel still needs organization/entitlement and
+missing-marker parity, catch-up and unsupported-cron policy, and a command
+loop. Its ownership fence prevents the current command from mutating production
+markers.
 
 The rest of this page documents the active Celery runtime. See the
 [Go worker runtime TRD](../architecture/go-worker-runtime-trd.md) for the target

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -122,11 +122,11 @@ barrier and re-read state and live claims, covering both Celery's
 route-plus-outbox transaction and Go's outbox-only terminal commit. Resume
 requires the target to equal the checked-in route. River requires an exact
 compiled capability, and a transport-changing `post_sync` resume additionally
-requires an external quiescer for its old generation. The shipped command
-registers no capabilities, so today it can pause, inspect/drain, and resume the
-same Celery route, including `post_sync`, but cannot activate River. A future
-cutover quiescer must prove it honors context cancellation; its configured
-timeout is cooperative.
+requires an external quiescer registered under the old transport capability and
+invoked for its old generation. The shipped command registers no capabilities,
+so today it can pause, inspect/drain, and resume the same Celery route,
+including `post_sync`, but cannot activate River. A future cutover quiescer must
+prove it honors context cancellation; its configured timeout is cooperative.
 
 Two dormant transaction kernels now sit behind that foundation. The scheduler
 kernel locks a bounded due window with `FOR UPDATE ... SKIP LOCKED`, invokes an

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -156,10 +156,12 @@ The Go scheduler also remains blocked on the Phase 4
 existing `SyncRun` and cannot replace scheduled planning. Until the new
 coordinator consumes a stable occurrence identity and creates the scheduled
 domain plan transactionally, Celery Beat and `dispatch_scheduled_syncs` remain
-the sole schedule mutation owners. The dormant transaction kernel supplies the
-atomic handoff boundary, but the planner, organization/entitlement decisions,
-missing-marker materialization, catch-up policy, and command loop remain
-unimplemented.
+the sole schedule mutation owners by default. An operator may separately set
+`SYNC_SCHEDULED_OCCURRENCE_CONSUMER_ENABLED=true` to let the bounded Celery
+consumer materialize pre-existing Go-authored identities; it does not own
+timing or activate the Go command loop. The dormant transaction kernel still
+needs the planner, organization/entitlement decisions, missing-marker
+materialization, catch-up policy, and command loop.
 
 The rest of this page documents the active Celery runtime. See the
 [Go worker runtime TRD](../architecture/go-worker-runtime-trd.md) for the target
@@ -294,6 +296,7 @@ The bundled Docker Compose, Kubernetes, and Helm deployments already declare the
 | `SYNC_UNIT_EXPIRED_LEASE_RETRY_BACKOFF_SECONDS` | `60` | Backoff added to `available_at` when an eligible expired-lease unit is flipped to `RETRYING` before redispatch. |
 | `SYNC_DISPATCH_REDISPATCH_COUNTDOWN` | `60` | Delay used when redispatching sync-run work. |
 | `SYNC_OUTBOX_CLAIM_TIMEOUT_SECONDS` | `300` | Dispatch outbox claim lease duration. |
+| `SYNC_SCHEDULED_OCCURRENCE_CONSUMER_ENABLED` | `false` | Enables the bounded scheduled-occurrence consumer task and its Beat entry. Keep disabled until the Go occurrence producer and operational hand-off are ready. |
 | `SYNC_WATERMARK_OVERLAP` | `0` | Subtracts this many seconds from incremental watermark reads to intentionally re-read a lookback margin. |
 
 Provider budget limits are abstract reservation units derived from the estimated shape of a sync unit. They are not the provider's raw request or GraphQL cost counters. Jira emits separate route-family buckets for REST/JQL listing (`jira:search:jira_jql`), REST issue enrichment (`jira:rest_core:jira_issue_enrichment`), optional worklog fetching (`jira:rest_core:jira_worklogs` when `JIRA_FETCH_WORKLOGS=true`), and Atlassian GraphQL enrichment (`jira:graphql_cost:jira_gql_enrichment` when `ATLASSIAN_GQL_ENABLED=true`). LaunchDarkly feature-flag sync emits `launchdarkly:*` buckets for the `flags`, `audit_log`, and `code_refs` route families (see [LaunchDarkly sync budgeting](../architecture/launchdarkly-sync-budgeting.md)). Leaving `SYNC_BUDGET_BUCKET_LIMITS` unset disables enforcement; setting it enables deferrals when the reservation would exceed a configured bucket.
@@ -352,7 +355,8 @@ The system registers Celery tasks under the `workers/` directory. The primary re
 | `execute_saved_report` | None | `reports` | Executes a SavedReport plan and persists markdown. Source: `report_task.py`. |
 | `dispatch_scheduled_reports` | None | `default` | Fans out scheduled report executions. Source: `report_scheduler.py`. |
 | ~~`run_backfill`~~ | `backfill run` | — | **Removed in CHAOS-2647.** The API backfill path now plans a backfill-mode `SyncRun` and fans out through `dispatch_sync_run` → `run_sync_unit` → `finalize_sync_run`; the standalone `backfill`-queue task and `sync_backfill.py` are deleted. |
-| `dispatch_scheduled_syncs` | None | `default` | Fans out organization sync configurations. Source: `sync_scheduler.py`. |
+| `dispatch_scheduled_syncs` | None | `scheduler` | Fans out organization sync configurations. Source: `sync_scheduler.py`. |
+| `consume_pending_scheduled_sync_occurrences` | None | `scheduler` | Default-off bounded materialization of Go-authored scheduled occurrences. Enabled only with `SYNC_SCHEDULED_OCCURRENCE_CONSUMER_ENABLED=true`. Source: `sync_scheduler.py`. |
 | `dispatch_scheduled_metrics` | None | `default` | Fans out scheduled metrics. Source: `metrics_daily.py`. |
 | `monitor_queue_depths` | None | `monitoring` | Monitors queue depths. Source: `queue_monitor.py`. |
 ---
@@ -361,7 +365,8 @@ The system registers Celery tasks under the `workers/` directory. The primary re
 
 | Schedule | Task | Interval | Queue |
 |----------|------|----------|-------|
-| `dispatch-scheduled-syncs` | `dispatch_scheduled_syncs` | Every 300 seconds (5 minutes) | `default` |
+| `dispatch-scheduled-syncs` | `dispatch_scheduled_syncs` | Every 300 seconds (5 minutes) | `scheduler` |
+| `consume-pending-scheduled-sync-occurrences` | `consume_pending_scheduled_sync_occurrences` | Every 300 seconds (5 minutes), only when enabled | `scheduler` |
 | `dispatch-scheduled-metrics` | `dispatch_scheduled_metrics` | Every 300 seconds (5 minutes) | `default` |
 | `run-complexity-daily` | `dispatch_complexity_job` | Daily at 00:45 UTC | `default` |
 | `run-daily-metrics` | `dispatch_daily_metrics_for_all_orgs` | Daily at 01:00 UTC | `default` |

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -337,12 +337,16 @@ The first mutation-safety prerequisite is also implemented without activating
 River. Migration `0049` seeds a four-row database route fence with Celery
 ownership and generation 1. Python claims bind the active route generation.
 Dispatch, finalize, and discovery publish transactions lock both outbox and
-route, and mark/failure writes fail closed after any route change. `post_sync`
-retains its mark-before-publish commit, so promotion of that kind still needs a
-separate bounded quiescence barrier. The Go reconciler closes readiness when
-the database fence differs from the checked-in route contract. All routes
-remain Celery and there is intentionally no operator route mutation command in
-this slice.
+route, and mark/failure writes fail closed after any route change. The
+authenticated `dev-health-workerctl routes` surface can inspect, pause, drain,
+and resume one fixed route at a time with durable audit intent and monotonic
+generation changes. Route mutation follows Python's route-row-first lock order,
+then holds a table barrier across the post-terminal/pre-commit window and
+rechecks route state and live claims. A transport-changing `post_sync` resume
+additionally requires a registered external quiescer. The shipped command
+registers no River or `post_sync` cutover capability, every checked-in route
+remains Celery, and the Go reconciler closes readiness while a route is paused
+or divergent, so these controls do not activate River.
 
 The dormant `internal/scheduler/sync` package retains its read-only
 schedule-evaluation foundation. It reads at most 101 active configuration/job
@@ -382,23 +386,45 @@ Celery-owned and are covered by PostgreSQL replica tests.
 The dormant Go occurrence coordinator can insert or verify the same identity
 through the scheduler transaction. The active Python planner completes an
 existing pending row when its own Celery dispatch reaches the same occurrence,
-so concurrent/retried cross-language handoff is idempotent. No independent
-consumer scans pending occurrences, however, and no command constructs the Go
-coordinator; if Go advanced the marker alone, that row would be stranded. This
-is therefore a cross-language persistence contract, not authorization to
-advance production markers. Scheduler activation still needs a durable
-pending-occurrence consumer (or equivalent Go planner), command wiring,
-unsupported-cron fallback, and operator rollout controls.
+so concurrent/retried cross-language handoff is idempotent. Migration `0051`
+adds a durable pending/retry/completed/quarantined reconciliation lifecycle,
+and a bounded Python consumer can lock configuration, marker, and occurrence
+state in the canonical order before materializing the authoritative plan. It
+validates the versioned identity, applies persisted retry backoff to transient
+planner failures, and quarantines malformed or exhausted occurrences so a
+poisoned prefix cannot strand later work. Both its Beat entry and call-time
+execution gate default off. No command constructs the Go coordinator and the
+consumer is not enabled by any checked-in profile, so this is still not
+authorization to advance production markers. The public scheduler repository
+constructor embeds an opaque Celery/`coexistence_disabled` ownership policy,
+and `HandoffDue` rejects mutation before opening a transaction. Only
+package-private test and future activation composition can construct Go
+mutation authority. Scheduler activation needs a reviewed source change,
+command loop, unsupported-cron fallback, remaining coordinator policy parity,
+and an explicit review that enables the consumer before Go may own a marker.
 
 The Go reconciler command now constructs only an explicit no-begin shadow
 adapter around the transport kernel. A separate command-unwired materializer
 can reconstruct bounded dispatch, finalize, discovery, and missing post-sync
 wakeups in one domain transaction. It never reads routes, claims rows, or
 publishes work; existing pending rows and at-most-once post-sync rows retain
-their current semantics. Reconciler activation still needs expired-lease
-repair, persisted failure backoff, concrete River insertion and handlers, a
-capability-aware route/operator control plane, and the bounded `post_sync`
-quiescence plus external-handoff path.
+their current semantics. A second command-unwired repair step preserves the
+current eligible Linear-backfill expired-lease transition, including bounded
+retry exhaustion and provider/org/cost-class serialization. A persisted
+publish-failure recorder can release an already committed River claim with the
+same bounded backoff as Python, but the dormant kernel still claims, publishes,
+and marks in one transaction, so a publisher failure currently rolls the claim
+back instead of invoking that recorder. The least-privilege queue-control role
+has also been exercised through the real River `InsertTx` API in the same
+transaction as the outbox terminal mark. Reconciler activation still needs the
+claim-commit/publish workflow that uses the failure recorder and concrete River
+publishers and handlers. The capability-aware route/operator control plane now
+serializes the documented post-terminal, pre-commit window, but the shipped
+capability registry is empty: River resume is rejected and `post_sync` cannot
+change transports without a concrete external quiescer. A same-transport Celery
+resume remains available for recovery. The cutover quiescer must prove it
+honors context cancellation before activation because the current timeout is
+cooperative.
 
 An opt-in live PostgreSQL test now proves the Python producer's outer rollback
 and dedupe/savepoint path. Before any generic kind is promoted from Celery,
@@ -429,11 +455,18 @@ Foundation status: the scheduler transaction handoff and reconciler transport
 kernels exist with unit/failure-injection coverage, the reconciler image
 packages its sync-dispatch contract, and a containerized parity target exists.
 The Python scheduler now persists idempotent occurrences and its complete plan
-atomically. The reconciler command is wired only to the shadow adapter, while
-the Go outbox materializer remains command-unwired. Every route remains
-Celery-only; expired-lease repair, persisted backoff, concrete River delivery,
-capability/operator controls, the independent pending-occurrence consumer (or
-equivalent Go planner), and `post_sync` activation gaps above remain open.
+atomically. A durable, default-off Python consumer can finish Go-authored
+occurrences without retrying poison rows forever. The reconciler command is
+wired only to the shadow adapter, while the Go outbox materializer and
+expired-lease repair remain command-unwired. Persisted transport-failure
+backoff and the least-privilege River transaction boundary are implemented as
+dormant primitives, but the kernel has not yet split claim commit from publish
+or registered concrete publishers and handlers. The scheduler has an opaque
+default-Celery ownership fence, and audited route pause/drain/resume controls
+are implemented with an empty activation-capability registry. Every route
+remains Celery-only; the scheduler command loop and coordinator parity,
+concrete River delivery capabilities, and the `post_sync` external quiescer
+and handoff gaps above remain open.
 
 #### Acceptance
 

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -343,10 +343,11 @@ and resume one fixed route at a time with durable audit intent and monotonic
 generation changes. Route mutation follows Python's route-row-first lock order,
 then holds a table barrier across the post-terminal/pre-commit window and
 rechecks route state and live claims. A transport-changing `post_sync` resume
-additionally requires a registered external quiescer. The shipped command
-registers no River or `post_sync` cutover capability, every checked-in route
-remains Celery, and the Go reconciler closes readiness while a route is paused
-or divergent, so these controls do not activate River.
+additionally requires an external quiescer registered for the old transport
+generation. The shipped command registers no River or `post_sync` cutover
+capability, every checked-in route remains Celery, and the Go reconciler closes
+readiness while a route is paused or divergent, so these controls do not
+activate River.
 
 The dormant `internal/scheduler/sync` package retains its read-only
 schedule-evaluation foundation. It reads at most 101 active configuration/job
@@ -421,10 +422,10 @@ claim-commit/publish workflow that uses the failure recorder and concrete River
 publishers and handlers. The capability-aware route/operator control plane now
 serializes the documented post-terminal, pre-commit window, but the shipped
 capability registry is empty: River resume is rejected and `post_sync` cannot
-change transports without a concrete external quiescer. A same-transport Celery
-resume remains available for recovery. The cutover quiescer must prove it
-honors context cancellation before activation because the current timeout is
-cooperative.
+change transports without a concrete external quiescer registered for the old
+transport. A same-transport Celery resume remains available for recovery. The
+cutover quiescer must prove it honors context cancellation before activation
+because the current timeout is cooperative.
 
 An opt-in live PostgreSQL test now proves the Python producer's outer rollback
 and dedupe/savepoint path. Before any generic kind is promoted from Celery,

--- a/internal/joboperator/auth.go
+++ b/internal/joboperator/auth.go
@@ -135,7 +135,7 @@ func (authorizer *credentialAuthorizer) Authorize(_ context.Context, request Aut
 		return ErrAuthorization
 	}
 	required := ScopeWorkerOperate
-	if request.Action == ActionInspect {
+	if request.Action == ActionInspect || request.Action == ActionInspectRoute {
 		required = ScopeWorkerRead
 	}
 	if _, allowed := authorizer.scopes[required]; !allowed {

--- a/internal/joboperator/postgres_integration_test.go
+++ b/internal/joboperator/postgres_integration_test.go
@@ -17,6 +17,8 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
 	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
 	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/syncroute"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
@@ -143,9 +145,22 @@ func TestPostgresOperatorAuthenticationBackendAndAudit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	routeRegistry, err := syncdispatchcontract.Load(filepath.Join("..", "..", "contracts", "sync-dispatch", "v1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	routeCapabilities, err := syncroute.NewCapabilities(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	routeController, err := syncroute.NewController(domainPool, routeRegistry, routeCapabilities)
+	if err != nil {
+		t.Fatal(err)
+	}
 	service, err := New(Dependencies{
 		Registry: registry, Backend: backend, Authorizer: authentication.Authorizer(),
 		DomainGuard: allowIntegrationDomainGuard{}, Auditor: auditor, Clock: func() time.Time { return now },
+		RouteController: routeController,
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/internal/joboperator/postgres_integration_test.go
+++ b/internal/joboperator/postgres_integration_test.go
@@ -258,6 +258,14 @@ func createOperatorIntegrationSchema(t *testing.T, ctx context.Context, pool *pg
 			id uuid PRIMARY KEY,
 			state text NOT NULL
 		)`,
+		`CREATE TABLE public.sync_dispatch_outbox (
+			id uuid PRIMARY KEY,
+			state text NOT NULL
+		)`,
+		`CREATE TABLE public.sync_dispatch_transport_routes (
+			kind text PRIMARY KEY,
+			generation bigint NOT NULL
+		)`,
 	}
 	for _, statement := range statements {
 		if _, err := tx.Exec(ctx, statement); err != nil {

--- a/internal/joboperator/service.go
+++ b/internal/joboperator/service.go
@@ -605,6 +605,7 @@ func (service *Service) mutate(ctx context.Context, mutation Mutation, operation
 			errors.Is(err, syncroute.ErrLiveClaims) ||
 			errors.Is(err, syncroute.ErrCapabilityMissing) ||
 			errors.Is(err, syncroute.ErrQuiescenceMissing) ||
+			errors.Is(err, syncroute.ErrDrift) ||
 			errors.Is(err, syncroute.ErrInvalidConfiguration) {
 			return mapRouteError(err)
 		}
@@ -753,6 +754,8 @@ func mapRouteError(err error) error {
 	case errors.Is(err, syncroute.ErrRouteStateConflict), errors.Is(err, syncroute.ErrLiveClaims):
 		return serviceError(CodeConflict, err)
 	case errors.Is(err, syncroute.ErrCapabilityMissing), errors.Is(err, syncroute.ErrQuiescenceMissing):
+		return serviceError(CodePrecondition, err)
+	case errors.Is(err, syncroute.ErrDrift):
 		return serviceError(CodePrecondition, err)
 	case errors.Is(err, syncroute.ErrInvalidConfiguration):
 		return serviceError(CodeInvalid, err)

--- a/internal/joboperator/service.go
+++ b/internal/joboperator/service.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/full-chaos/dev-health-ops/internal/jobcontract"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/syncroute"
 )
 
 type JobState string
@@ -32,12 +33,16 @@ const (
 type Action string
 
 const (
-	ActionInspect     Action = "jobs.inspect"
-	ActionCancel      Action = "jobs.cancel"
-	ActionRetry       Action = "jobs.retry"
-	ActionPauseQueue  Action = "queues.pause"
-	ActionResumeQueue Action = "queues.resume"
-	ActionDrain       Action = "workers.drain"
+	ActionInspect      Action = "jobs.inspect"
+	ActionCancel       Action = "jobs.cancel"
+	ActionRetry        Action = "jobs.retry"
+	ActionPauseQueue   Action = "queues.pause"
+	ActionResumeQueue  Action = "queues.resume"
+	ActionDrain        Action = "workers.drain"
+	ActionInspectRoute Action = "routes.inspect"
+	ActionPauseRoute   Action = "routes.pause"
+	ActionDrainRoute   Action = "routes.drain"
+	ActionResumeRoute  Action = "routes.resume"
 )
 
 // JobSummary is intentionally incapable of carrying encoded_args, exception
@@ -143,6 +148,13 @@ type Backend interface {
 	SupportsRunningCancellation() bool
 }
 
+type RouteController interface {
+	Inspect(context.Context, string) (syncroute.RouteState, error)
+	Pause(context.Context, string) (syncroute.RouteState, error)
+	Drain(context.Context, string) (syncroute.RouteState, error)
+	Resume(context.Context, string, string, time.Duration) (syncroute.RouteState, error)
+}
+
 type AuditEvent struct {
 	Principal     Principal
 	Action        Action
@@ -176,12 +188,13 @@ type Clock func() time.Time
 const auditCompletionTimeout = 5 * time.Second
 
 type Dependencies struct {
-	Registry    RuntimeRegistry
-	Backend     Backend
-	Authorizer  Authorizer
-	DomainGuard DomainGuard
-	Auditor     Auditor
-	Clock       Clock
+	Registry        RuntimeRegistry
+	Backend         Backend
+	Authorizer      Authorizer
+	DomainGuard     DomainGuard
+	Auditor         Auditor
+	Clock           Clock
+	RouteController RouteController
 }
 
 type Service struct {
@@ -191,6 +204,7 @@ type Service struct {
 	domainGuard DomainGuard
 	auditor     Auditor
 	clock       Clock
+	routes      RouteController
 }
 
 // RuntimeRegistry is the read-only subset of jobruntime.Registry needed by
@@ -205,7 +219,7 @@ type RuntimeRegistry interface {
 
 func New(dependencies Dependencies) (*Service, error) {
 	if dependencies.Registry == nil || dependencies.Backend == nil || dependencies.Authorizer == nil ||
-		dependencies.DomainGuard == nil || dependencies.Auditor == nil {
+		dependencies.DomainGuard == nil || dependencies.Auditor == nil || dependencies.RouteController == nil {
 		return nil, errors.New("complete operator dependencies are required")
 	}
 	clock := dependencies.Clock
@@ -219,7 +233,78 @@ func New(dependencies Dependencies) (*Service, error) {
 		domainGuard: dependencies.DomainGuard,
 		auditor:     dependencies.Auditor,
 		clock:       clock,
+		routes:      dependencies.RouteController,
 	}, nil
+}
+
+func (service *Service) InspectRoute(ctx context.Context, principal Principal, kind string) (syncroute.RouteState, error) {
+	if err := validatePrincipal(principal); err != nil || kind == "" {
+		return syncroute.RouteState{}, serviceError(CodeInvalid, err)
+	}
+	if err := service.authorize(ctx, principal, ActionInspectRoute, "sync_route", kind); err != nil {
+		return syncroute.RouteState{}, err
+	}
+	state, err := service.routes.Inspect(ctx, kind)
+	if err != nil {
+		return syncroute.RouteState{}, mapRouteError(err)
+	}
+	return state, nil
+}
+
+func (service *Service) PauseRoute(
+	ctx context.Context,
+	principal Principal,
+	kind, reasonCode, correlationID string,
+) (syncroute.RouteState, error) {
+	return service.routeMutation(ctx, principal, ActionPauseRoute, kind, reasonCode, correlationID,
+		func() (syncroute.RouteState, error) { return service.routes.Pause(ctx, kind) })
+}
+
+func (service *Service) DrainRoute(
+	ctx context.Context,
+	principal Principal,
+	kind, reasonCode, correlationID string,
+) (syncroute.RouteState, error) {
+	return service.routeMutation(ctx, principal, ActionDrainRoute, kind, reasonCode, correlationID,
+		func() (syncroute.RouteState, error) { return service.routes.Drain(ctx, kind) })
+}
+
+func (service *Service) ResumeRoute(
+	ctx context.Context,
+	principal Principal,
+	kind, transport, reasonCode, correlationID string,
+	quiescenceTimeout time.Duration,
+) (syncroute.RouteState, error) {
+	return service.routeMutation(ctx, principal, ActionResumeRoute, kind, reasonCode, correlationID,
+		func() (syncroute.RouteState, error) {
+			return service.routes.Resume(ctx, kind, transport, quiescenceTimeout)
+		})
+}
+
+func (service *Service) routeMutation(
+	ctx context.Context,
+	principal Principal,
+	action Action,
+	kind, reasonCode, correlationID string,
+	operation func() (syncroute.RouteState, error),
+) (syncroute.RouteState, error) {
+	if err := validateMutationInput(principal, reasonCode, correlationID); err != nil || kind == "" {
+		return syncroute.RouteState{}, serviceError(CodeInvalid, err)
+	}
+	if err := service.authorize(ctx, principal, action, "sync_route", kind); err != nil {
+		return syncroute.RouteState{}, err
+	}
+	mutation := Mutation{
+		Principal: principal, Action: action, ResourceType: "sync_route", ResourceID: kind,
+		ReasonCode: reasonCode, CorrelationID: correlationID,
+	}
+	var state syncroute.RouteState
+	err := service.mutate(ctx, mutation, func() error {
+		var operationErr error
+		state, operationErr = operation()
+		return operationErr
+	})
+	return state, err
 }
 
 type ErrorCode string
@@ -505,7 +590,7 @@ func (service *Service) mutate(ctx context.Context, mutation Mutation, operation
 	}
 	if err := operation(); err != nil {
 		status := AuditFailed
-		if errors.Is(err, ErrMutationOutcomeUnknown) {
+		if errors.Is(err, ErrMutationOutcomeUnknown) || errors.Is(err, syncroute.ErrMutationOutcomeUnknown) {
 			status = AuditOutcomeUnknown
 		}
 		completeErr := completeAudit(ctx, handle, status)
@@ -514,6 +599,14 @@ func (service *Service) mutate(ctx context.Context, mutation Mutation, operation
 		}
 		if completeErr != nil {
 			return serviceError(CodeAuditPending, errors.Join(err, completeErr))
+		}
+		if errors.Is(err, syncroute.ErrUnknownRoute) ||
+			errors.Is(err, syncroute.ErrRouteStateConflict) ||
+			errors.Is(err, syncroute.ErrLiveClaims) ||
+			errors.Is(err, syncroute.ErrCapabilityMissing) ||
+			errors.Is(err, syncroute.ErrQuiescenceMissing) ||
+			errors.Is(err, syncroute.ErrInvalidConfiguration) {
+			return mapRouteError(err)
 		}
 		return mapBackendError(err)
 	}
@@ -651,6 +744,21 @@ func mapBackendError(err error) error {
 		return serviceError(CodeConflict, err)
 	}
 	return serviceError(CodeBackend, err)
+}
+
+func mapRouteError(err error) error {
+	switch {
+	case errors.Is(err, syncroute.ErrUnknownRoute):
+		return serviceError(CodeNotFound, err)
+	case errors.Is(err, syncroute.ErrRouteStateConflict), errors.Is(err, syncroute.ErrLiveClaims):
+		return serviceError(CodeConflict, err)
+	case errors.Is(err, syncroute.ErrCapabilityMissing), errors.Is(err, syncroute.ErrQuiescenceMissing):
+		return serviceError(CodePrecondition, err)
+	case errors.Is(err, syncroute.ErrInvalidConfiguration):
+		return serviceError(CodeInvalid, err)
+	default:
+		return serviceError(CodeBackend, err)
+	}
 }
 
 func serviceError(code ErrorCode, cause error) error {

--- a/internal/joboperator/service_test.go
+++ b/internal/joboperator/service_test.go
@@ -244,6 +244,20 @@ func TestRouteResumeFailsClosedWithoutCapabilityAndAuditsFailure(t *testing.T) {
 	}
 }
 
+func TestRouteDriftIsAnOperatorPreconditionFailure(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	fixture.routes.err = syncroute.ErrDrift
+	_, err := fixture.service.PauseRoute(
+		context.Background(), testPrincipal(), "dispatch_sync_run", "cutover", "corr-route-drift",
+	)
+	assertCode(t, err, CodePrecondition)
+	if fixture.auditor.status != AuditFailed ||
+		strings.Join(fixture.order, ",") != "authorize,audit_begin,route_pause,audit_failed" {
+		t.Fatalf("route drift status=%s order=%v", fixture.auditor.status, fixture.order)
+	}
+}
+
 func TestAmbiguousRouteCommitIsAuditedAsOutcomeUnknown(t *testing.T) {
 	t.Parallel()
 	fixture := newServiceFixture(t)

--- a/internal/joboperator/service_test.go
+++ b/internal/joboperator/service_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/full-chaos/dev-health-ops/internal/jobcontract"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/syncroute"
 )
 
 func TestCancelRequiresAuthorizationDomainGuardAndDurableAudit(t *testing.T) {
@@ -206,6 +207,56 @@ func TestStatusRequiresAuthorizedReadScope(t *testing.T) {
 	assertCode(t, err, CodeUnauthorized)
 }
 
+func TestRouteControlsPreserveAuthorizationAndDurableAudit(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	fixture.routes.state = syncroute.RouteState{
+		Kind: "dispatch_sync_run", Transport: "celery", Generation: 2, Paused: true,
+	}
+	state, err := fixture.service.PauseRoute(
+		context.Background(), testPrincipal(), "dispatch_sync_run", "cutover", "corr-route-1",
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if state.Generation != 2 ||
+		strings.Join(fixture.order, ",") != "authorize,audit_begin,route_pause,audit_succeeded" {
+		t.Fatalf("route pause state=%+v order=%v", state, fixture.order)
+	}
+	if fixture.auditor.event.Action != ActionPauseRoute ||
+		fixture.auditor.event.ResourceType != "sync_route" {
+		t.Fatalf("route audit=%+v", fixture.auditor.event)
+	}
+}
+
+func TestRouteResumeFailsClosedWithoutCapabilityAndAuditsFailure(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	fixture.routes.err = syncroute.ErrCapabilityMissing
+	_, err := fixture.service.ResumeRoute(
+		context.Background(), testPrincipal(), "dispatch_sync_run", "river",
+		"cutover", "corr-route-2", time.Second,
+	)
+	assertCode(t, err, CodePrecondition)
+	if fixture.auditor.status != AuditFailed ||
+		strings.Join(fixture.order, ",") != "authorize,audit_begin,route_resume,audit_failed" {
+		t.Fatalf("route failure status=%s order=%v", fixture.auditor.status, fixture.order)
+	}
+}
+
+func TestAmbiguousRouteCommitIsAuditedAsOutcomeUnknown(t *testing.T) {
+	t.Parallel()
+	fixture := newServiceFixture(t)
+	fixture.routes.err = syncroute.ErrMutationOutcomeUnknown
+	_, err := fixture.service.PauseRoute(
+		context.Background(), testPrincipal(), "dispatch_sync_run", "cutover", "corr-route-3",
+	)
+	assertCode(t, err, CodeOutcomeUnknown)
+	if fixture.auditor.status != AuditOutcomeUnknown {
+		t.Fatalf("route audit status=%s", fixture.auditor.status)
+	}
+}
+
 func TestQueueInspectionRequiresExactSanitizedProfileCoverage(t *testing.T) {
 	t.Parallel()
 	fixture := newServiceFixture(t)
@@ -286,6 +337,7 @@ type serviceFixture struct {
 	authorizer *fakeAuthorizer
 	guard      *fakeDomainGuard
 	auditor    *fakeAuditor
+	routes     *fakeRouteController
 	order      []string
 }
 
@@ -305,16 +357,41 @@ func newServiceFixtureWithRegistry(t *testing.T, registry RuntimeRegistry) *serv
 	fixture.authorizer = &fakeAuthorizer{order: &fixture.order}
 	fixture.guard = &fakeDomainGuard{order: &fixture.order}
 	fixture.auditor = &fakeAuditor{order: &fixture.order}
+	fixture.routes = &fakeRouteController{order: &fixture.order}
 	service, err := New(Dependencies{
 		Registry: registry, Backend: fixture.backend, Authorizer: fixture.authorizer,
 		DomainGuard: fixture.guard, Auditor: fixture.auditor,
-		Clock: func() time.Time { return time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC) },
+		RouteController: fixture.routes,
+		Clock:           func() time.Time { return time.Date(2026, 7, 21, 12, 0, 0, 0, time.UTC) },
 	})
 	if err != nil {
 		t.Fatalf("New: %v", err)
 	}
 	fixture.service = service
 	return fixture
+}
+
+type fakeRouteController struct {
+	order *[]string
+	state syncroute.RouteState
+	err   error
+}
+
+func (controller *fakeRouteController) Inspect(context.Context, string) (syncroute.RouteState, error) {
+	*controller.order = append(*controller.order, "route_inspect")
+	return controller.state, controller.err
+}
+func (controller *fakeRouteController) Pause(context.Context, string) (syncroute.RouteState, error) {
+	*controller.order = append(*controller.order, "route_pause")
+	return controller.state, controller.err
+}
+func (controller *fakeRouteController) Drain(context.Context, string) (syncroute.RouteState, error) {
+	*controller.order = append(*controller.order, "route_drain")
+	return controller.state, controller.err
+}
+func (controller *fakeRouteController) Resume(context.Context, string, string, time.Duration) (syncroute.RouteState, error) {
+	*controller.order = append(*controller.order, "route_resume")
+	return controller.state, controller.err
 }
 
 type executableRegistry struct{ RuntimeRegistry }

--- a/internal/scheduler/sync/ownership.go
+++ b/internal/scheduler/sync/ownership.go
@@ -1,0 +1,69 @@
+package sync
+
+import "errors"
+
+var (
+	// ErrSchedulerMutationDisabled means the active scheduler owner has not
+	// explicitly transferred schedule-marker mutation to Go. Callers must not
+	// treat this as a retryable handoff failure.
+	ErrSchedulerMutationDisabled = errors.New("scheduler marker mutation is disabled by ownership policy")
+	// ErrInvalidOwnershipPolicy identifies an unsupported owner/mode pair.
+	// Policies are deliberately constructed in code rather than read from the
+	// environment so an accidental deployment setting cannot activate mutation.
+	ErrInvalidOwnershipPolicy = errors.New("invalid scheduler ownership policy")
+)
+
+// schedulerOwner identifies the runtime that owns production schedule-marker
+// mutation. It is package-private so ownership transfer requires a source
+// change inside this package.
+type schedulerOwner string
+
+const (
+	schedulerOwnerCelery schedulerOwner = "celery"
+	schedulerOwnerGo     schedulerOwner = "go"
+)
+
+// schedulerMode identifies the bounded behavior permitted for the owner.
+// CoexistenceDisabled is the checked-in default. Shadow is read-only; Mutation
+// is reserved for a future audited owner transfer and is never command-wired.
+type schedulerMode string
+
+const (
+	schedulerModeCoexistenceDisabled schedulerMode = "coexistence_disabled"
+	schedulerModeShadow              schedulerMode = "shadow"
+	schedulerModeMutation            schedulerMode = "mutation"
+)
+
+// OwnershipPolicy makes the marker-mutation owner and runtime mode explicit.
+// Its fields are opaque outside this package: external callers can validate the
+// checked-in default but cannot construct mutation authority.
+type OwnershipPolicy struct {
+	owner schedulerOwner
+	mode  schedulerMode
+}
+
+// DefaultOwnershipPolicy preserves the checked-in coexistence contract: Celery
+// is the only production schedule owner and Go cannot mutate a marker.
+func DefaultOwnershipPolicy() OwnershipPolicy {
+	return OwnershipPolicy{
+		owner: schedulerOwnerCelery,
+		mode:  schedulerModeCoexistenceDisabled,
+	}
+}
+
+// Validate rejects every owner/mode pair except the bounded current and future
+// states. In particular, a Go shadow process never acquires mutation authority.
+func (policy OwnershipPolicy) Validate() error {
+	switch policy {
+	case OwnershipPolicy{owner: schedulerOwnerCelery, mode: schedulerModeCoexistenceDisabled},
+		OwnershipPolicy{owner: schedulerOwnerCelery, mode: schedulerModeShadow},
+		OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation}:
+		return nil
+	default:
+		return ErrInvalidOwnershipPolicy
+	}
+}
+
+func (policy OwnershipPolicy) allowsMutation() bool {
+	return policy.owner == schedulerOwnerGo && policy.mode == schedulerModeMutation
+}

--- a/internal/scheduler/sync/ownership_test.go
+++ b/internal/scheduler/sync/ownership_test.go
@@ -1,0 +1,42 @@
+package sync
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func TestOwnershipPolicyHasNoExportedConstructionFields(t *testing.T) {
+	policyType := reflect.TypeOf(DefaultOwnershipPolicy())
+	for index := 0; index < policyType.NumField(); index++ {
+		field := policyType.Field(index)
+		if field.IsExported() {
+			t.Fatalf("ownership policy field %s is exported", field.Name)
+		}
+	}
+}
+
+func TestOwnershipPolicyOnlyPermitsExplicitOwnerModePairs(t *testing.T) {
+	for _, test := range []struct {
+		name   string
+		policy OwnershipPolicy
+		valid  bool
+	}{
+		{"default", DefaultOwnershipPolicy(), true},
+		{"celery shadow", OwnershipPolicy{owner: schedulerOwnerCelery, mode: schedulerModeShadow}, true},
+		{"go mutation", OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation}, true},
+		{"go shadow", OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeShadow}, false},
+		{"celery mutation", OwnershipPolicy{owner: schedulerOwnerCelery, mode: schedulerModeMutation}, false},
+		{"unknown", OwnershipPolicy{owner: "other", mode: "other"}, false},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			err := test.policy.Validate()
+			if test.valid && err != nil {
+				t.Fatalf("Validate() error = %v", err)
+			}
+			if !test.valid && !errors.Is(err, ErrInvalidOwnershipPolicy) {
+				t.Fatalf("Validate() error = %v", err)
+			}
+		})
+	}
+}

--- a/internal/scheduler/sync/repository.go
+++ b/internal/scheduler/sync/repository.go
@@ -13,8 +13,9 @@ import (
 // exposes a separate dormant transaction kernel. Snapshot never locks or
 // writes.
 type Repository struct {
-	pool  *pgxpool.Pool
-	begin beginSchedulerTransaction
+	pool      *pgxpool.Pool
+	begin     beginSchedulerTransaction
+	ownership OwnershipPolicy
 }
 
 type candidateRows interface {
@@ -24,11 +25,22 @@ type candidateRows interface {
 }
 
 func NewRepository(pool *pgxpool.Pool) (*Repository, error) {
+	return newRepositoryWithOwnership(pool, DefaultOwnershipPolicy())
+}
+
+// newRepositoryWithOwnership constructs the scheduler repository with an
+// explicit, validated owner/mode policy. Keeping this package-private makes a
+// future mutation activation require an audited source change in this package.
+func newRepositoryWithOwnership(pool *pgxpool.Pool, ownership OwnershipPolicy) (*Repository, error) {
 	if pool == nil {
 		return nil, fmt.Errorf("scheduler shadow repository requires a pool")
 	}
+	if err := ownership.Validate(); err != nil {
+		return nil, err
+	}
 	return &Repository{
-		pool: pool,
+		pool:      pool,
+		ownership: ownership,
 		begin: func(ctx context.Context) (schedulerTransaction, error) {
 			tx, err := pool.BeginTx(ctx, pgx.TxOptions{IsoLevel: pgx.ReadCommitted})
 			if err != nil {

--- a/internal/scheduler/sync/transaction.go
+++ b/internal/scheduler/sync/transaction.go
@@ -118,6 +118,12 @@ func (repository *Repository) HandoffDue(
 		repository == nil || repository.begin == nil {
 		return nil, ErrInvalidTransactionRequest
 	}
+	if err := repository.ownership.Validate(); err != nil {
+		return nil, err
+	}
+	if !repository.ownership.allowsMutation() {
+		return nil, ErrSchedulerMutationDisabled
+	}
 	if err := ctx.Err(); err != nil {
 		return nil, err
 	}

--- a/internal/scheduler/sync/transaction_integration_test.go
+++ b/internal/scheduler/sync/transaction_integration_test.go
@@ -36,15 +36,37 @@ func TestHandoffDuePostgresSkipsReplicaLockedOccurrence(t *testing.T) {
 	if err := createSchedulerIntegrationFixture(ctx, pool); err != nil {
 		t.Fatal(err)
 	}
-	firstRepository, err := NewRepository(pool)
-	if err != nil {
-		t.Fatal(err)
-	}
-	secondRepository, err := NewRepository(pool)
+	defaultRepository, err := NewRepository(pool)
 	if err != nil {
 		t.Fatal(err)
 	}
 	observedAt := at("2026-01-01T12:00:00Z")
+	if _, err := defaultRepository.HandoffDue(ctx, observedAt, 1, NewOccurrenceCoordinator()); !errors.Is(err, ErrSchedulerMutationDisabled) {
+		t.Fatalf("default ownership HandoffDue() error = %v", err)
+	}
+	var defaultOccurrences int
+	var defaultNextRunAt *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			(SELECT count(*) FROM public.scheduled_sync_occurrences),
+			next_run_at
+		FROM public.scheduled_jobs
+		WHERE id = '00000000-0000-4000-8000-000000003039'
+	`).Scan(&defaultOccurrences, &defaultNextRunAt); err != nil {
+		t.Fatal(err)
+	}
+	if defaultOccurrences != 0 || defaultNextRunAt != nil {
+		t.Fatalf("default ownership mutated occurrences=%d nextRunAt=%v", defaultOccurrences, defaultNextRunAt)
+	}
+	ownership := OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation}
+	firstRepository, err := newRepositoryWithOwnership(pool, ownership)
+	if err != nil {
+		t.Fatal(err)
+	}
+	secondRepository, err := newRepositoryWithOwnership(pool, ownership)
+	if err != nil {
+		t.Fatal(err)
+	}
 	firstEntered := make(chan struct{})
 	releaseFirst := make(chan struct{})
 	firstResult := make(chan error, 1)

--- a/internal/scheduler/sync/transaction_test.go
+++ b/internal/scheduler/sync/transaction_test.go
@@ -67,6 +67,15 @@ type fakeSchedulerTransaction struct {
 	queryStatement string
 }
 
+func mutationRepository(transaction schedulerTransaction) *Repository {
+	return &Repository{
+		ownership: OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation},
+		begin: func(context.Context) (schedulerTransaction, error) {
+			return transaction, nil
+		},
+	}
+}
+
 func (transaction *fakeSchedulerTransaction) queryCandidates(
 	_ context.Context,
 	statement string,
@@ -134,11 +143,7 @@ func TestHandoffDuePersistsHandoffBeforeAdvancingMarker(t *testing.T) {
 		}},
 		execTag: pgconn.NewCommandTag("UPDATE 1"),
 	}
-	repository := &Repository{
-		begin: func(context.Context) (schedulerTransaction, error) {
-			return transaction, nil
-		},
-	}
+	repository := mutationRepository(transaction)
 	var received Occurrence
 	coordinator := CoordinatorFunc(func(
 		_ context.Context,
@@ -193,11 +198,7 @@ func TestHandoffDueRollsBackWithoutMarkerWhenCoordinatorFails(t *testing.T) {
 		}},
 		execTag: pgconn.NewCommandTag("UPDATE 1"),
 	}
-	repository := &Repository{
-		begin: func(context.Context) (schedulerTransaction, error) {
-			return transaction, nil
-		},
-	}
+	repository := mutationRepository(transaction)
 	handoffErr := errors.New("durable handoff unavailable")
 
 	_, err := repository.HandoffDue(
@@ -233,11 +234,7 @@ func TestHandoffDueRejectsLostMarkerAndRollsBackHandoff(t *testing.T) {
 		}},
 		execTag: pgconn.NewCommandTag("UPDATE 0"),
 	}
-	repository := &Repository{
-		begin: func(context.Context) (schedulerTransaction, error) {
-			return transaction, nil
-		},
-	}
+	repository := mutationRepository(transaction)
 
 	_, err := repository.HandoffDue(
 		context.Background(),
@@ -332,6 +329,7 @@ func TestHandoffStatementIsBoundedAndMultiReplicaSafe(t *testing.T) {
 func TestHandoffDueValidatesRequestBeforeOpeningTransaction(t *testing.T) {
 	calls := 0
 	repository := &Repository{
+		ownership: OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation},
 		begin: func(context.Context) (schedulerTransaction, error) {
 			calls++
 			return nil, errors.New("unexpected begin")
@@ -358,6 +356,29 @@ func TestHandoffDueValidatesRequestBeforeOpeningTransaction(t *testing.T) {
 				t.Fatalf("HandoffDue() err = %v", err)
 			}
 		})
+	}
+	if calls != 0 {
+		t.Fatalf("transactions opened = %d", calls)
+	}
+}
+
+func TestDefaultOwnershipPreventsHandoffBeforeOpeningTransaction(t *testing.T) {
+	calls := 0
+	repository := &Repository{
+		ownership: DefaultOwnershipPolicy(),
+		begin: func(context.Context) (schedulerTransaction, error) {
+			calls++
+			return nil, errors.New("unexpected begin")
+		},
+	}
+	_, err := repository.HandoffDue(
+		context.Background(),
+		time.Now(),
+		1,
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error { return nil }),
+	)
+	if !errors.Is(err, ErrSchedulerMutationDisabled) {
+		t.Fatalf("HandoffDue() err = %v", err)
 	}
 	if calls != 0 {
 		t.Fatalf("transactions opened = %d", calls)

--- a/internal/storage/postgres/queue_authorization.go
+++ b/internal/storage/postgres/queue_authorization.go
@@ -86,6 +86,9 @@ SELECT
 			AND has_table_privilege(current_user, class.oid, 'UPDATE')
 			AND has_table_privilege(current_user, class.oid, 'DELETE')
 			AND NOT has_table_privilege(current_user, class.oid, 'INSERT')
+			AND NOT has_any_column_privilege(
+				current_user, class.oid, 'INSERT, REFERENCES'
+			)
 			AND NOT has_table_privilege(current_user, class.oid, 'TRUNCATE')
 			AND NOT has_table_privilege(current_user, class.oid, 'REFERENCES')
 			AND NOT has_table_privilege(current_user, class.oid, 'TRIGGER')
@@ -105,6 +108,9 @@ SELECT
 			AND has_table_privilege(current_user, class.oid, 'SELECT')
 			AND has_table_privilege(current_user, class.oid, 'UPDATE')
 			AND NOT has_table_privilege(current_user, class.oid, 'INSERT')
+			AND NOT has_any_column_privilege(
+				current_user, class.oid, 'INSERT, REFERENCES'
+			)
 			AND NOT has_table_privilege(current_user, class.oid, 'DELETE')
 			AND NOT has_table_privilege(current_user, class.oid, 'TRUNCATE')
 			AND NOT has_table_privilege(current_user, class.oid, 'REFERENCES')
@@ -125,6 +131,9 @@ SELECT
 			AND has_table_privilege(current_user, class.oid, 'SELECT')
 			AND NOT has_table_privilege(current_user, class.oid, 'INSERT')
 			AND NOT has_table_privilege(current_user, class.oid, 'UPDATE')
+			AND NOT has_any_column_privilege(
+				current_user, class.oid, 'INSERT, UPDATE, REFERENCES'
+			)
 			AND NOT has_table_privilege(current_user, class.oid, 'DELETE')
 			AND NOT has_table_privilege(current_user, class.oid, 'TRUNCATE')
 			AND NOT has_table_privilege(current_user, class.oid, 'REFERENCES')
@@ -142,6 +151,9 @@ SELECT
 			OR has_table_privilege(current_user, oid, 'INSERT')
 			OR has_table_privilege(current_user, oid, 'UPDATE')
 			OR has_table_privilege(current_user, oid, 'DELETE')
+			OR has_any_column_privilege(
+				current_user, oid, 'SELECT, INSERT, UPDATE, REFERENCES'
+			)
 			OR has_table_privilege(current_user, oid, 'TRUNCATE')
 			OR has_table_privilege(current_user, oid, 'REFERENCES')
 			OR has_table_privilege(current_user, oid, 'TRIGGER')
@@ -175,6 +187,7 @@ SELECT
 			OR NOT has_table_privilege(current_user, oid, 'DELETE')
 			OR has_table_privilege(current_user, oid, 'TRUNCATE')
 			OR has_table_privilege(current_user, oid, 'REFERENCES')
+			OR has_any_column_privilege(current_user, oid, 'REFERENCES')
 			OR has_table_privilege(current_user, oid, 'TRIGGER')
 			OR CASE
 				WHEN current_setting('server_version_num')::integer >= 170000

--- a/internal/storage/postgres/queue_authorization.go
+++ b/internal/storage/postgres/queue_authorization.go
@@ -34,7 +34,11 @@ WITH river_tables AS (
 	JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = class.relnamespace
 	WHERE namespace.nspname = 'public'
 		AND class.relkind IN ('r', 'p', 'v', 'm', 'f')
-		AND class.relname <> 'worker_job_outbox'
+		AND class.relname NOT IN (
+			'worker_job_outbox',
+			'sync_dispatch_outbox',
+			'sync_dispatch_transport_routes'
+		)
 ), public_sequences AS (
 	SELECT class.oid
 	FROM pg_catalog.pg_class AS class
@@ -82,6 +86,46 @@ SELECT
 			AND has_table_privilege(current_user, class.oid, 'UPDATE')
 			AND has_table_privilege(current_user, class.oid, 'DELETE')
 			AND NOT has_table_privilege(current_user, class.oid, 'INSERT')
+			AND NOT has_table_privilege(current_user, class.oid, 'TRUNCATE')
+			AND NOT has_table_privilege(current_user, class.oid, 'REFERENCES')
+			AND NOT has_table_privilege(current_user, class.oid, 'TRIGGER')
+			AND NOT CASE
+				WHEN current_setting('server_version_num')::integer >= 170000
+				THEN has_table_privilege(current_user, class.oid, 'MAINTAIN')
+				ELSE false
+			END
+	)
+	AND EXISTS (
+		SELECT 1
+		FROM pg_catalog.pg_class AS class
+		JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = class.relnamespace
+		WHERE namespace.nspname = 'public'
+			AND class.relname = 'sync_dispatch_outbox'
+			AND class.relkind IN ('r', 'p')
+			AND has_table_privilege(current_user, class.oid, 'SELECT')
+			AND has_table_privilege(current_user, class.oid, 'UPDATE')
+			AND NOT has_table_privilege(current_user, class.oid, 'INSERT')
+			AND NOT has_table_privilege(current_user, class.oid, 'DELETE')
+			AND NOT has_table_privilege(current_user, class.oid, 'TRUNCATE')
+			AND NOT has_table_privilege(current_user, class.oid, 'REFERENCES')
+			AND NOT has_table_privilege(current_user, class.oid, 'TRIGGER')
+			AND NOT CASE
+				WHEN current_setting('server_version_num')::integer >= 170000
+				THEN has_table_privilege(current_user, class.oid, 'MAINTAIN')
+				ELSE false
+			END
+	)
+	AND EXISTS (
+		SELECT 1
+		FROM pg_catalog.pg_class AS class
+		JOIN pg_catalog.pg_namespace AS namespace ON namespace.oid = class.relnamespace
+		WHERE namespace.nspname = 'public'
+			AND class.relname = 'sync_dispatch_transport_routes'
+			AND class.relkind IN ('r', 'p')
+			AND has_table_privilege(current_user, class.oid, 'SELECT')
+			AND NOT has_table_privilege(current_user, class.oid, 'INSERT')
+			AND NOT has_table_privilege(current_user, class.oid, 'UPDATE')
+			AND NOT has_table_privilege(current_user, class.oid, 'DELETE')
 			AND NOT has_table_privilege(current_user, class.oid, 'TRUNCATE')
 			AND NOT has_table_privilege(current_user, class.oid, 'REFERENCES')
 			AND NOT has_table_privilege(current_user, class.oid, 'TRIGGER')

--- a/internal/storage/postgres/queue_authorization_test.go
+++ b/internal/storage/postgres/queue_authorization_test.go
@@ -58,6 +58,8 @@ func TestQueueAuthorizationQueryIsReadOnlyAndChecksExactPrivilegeBoundary(t *tes
 		"'MEMBER'",
 		"HAS_DATABASE_PRIVILEGE",
 		"WORKER_JOB_OUTBOX",
+		"SYNC_DISPATCH_OUTBOX",
+		"SYNC_DISPATCH_TRANSPORT_ROUTES",
 		"PUBLIC_FUNCTIONS",
 		"PUBLIC_SEQUENCES",
 		"RIVER_TABLES",

--- a/internal/storage/postgres/queue_authorization_test.go
+++ b/internal/storage/postgres/queue_authorization_test.go
@@ -57,6 +57,7 @@ func TestQueueAuthorizationQueryIsReadOnlyAndChecksExactPrivilegeBoundary(t *tes
 		"PG_HAS_ROLE",
 		"'MEMBER'",
 		"HAS_DATABASE_PRIVILEGE",
+		"HAS_ANY_COLUMN_PRIVILEGE",
 		"WORKER_JOB_OUTBOX",
 		"SYNC_DISPATCH_OUTBOX",
 		"SYNC_DISPATCH_TRANSPORT_ROUTES",

--- a/internal/storage/postgres/runtime_authorization_integration_test.go
+++ b/internal/storage/postgres/runtime_authorization_integration_test.go
@@ -35,6 +35,8 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 		"REVOKE CREATE ON SCHEMA public FROM PUBLIC",
 		"CREATE TABLE public.runtime_semantic_probe (id bigserial PRIMARY KEY, value text NOT NULL)",
 		"CREATE TABLE public.worker_job_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
+		"CREATE TABLE public.sync_dispatch_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
+		"CREATE TABLE public.sync_dispatch_transport_routes (kind text PRIMARY KEY, generation bigint NOT NULL)",
 		"CREATE TABLE public.alembic_version (version_num varchar(32) PRIMARY KEY)",
 		"CREATE SCHEMA river",
 		"CREATE TABLE river.river_job (id bigserial PRIMARY KEY, state text NOT NULL)",
@@ -48,8 +50,11 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 		"GRANT USAGE ON SCHEMA public TO " + runtimeAuthorizationDomainRole + ", " + runtimeAuthorizationQueueRole,
 		"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.runtime_semantic_probe TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, INSERT ON TABLE public.worker_job_outbox TO " + runtimeAuthorizationDomainRole,
+		"GRANT SELECT, INSERT, UPDATE, DELETE ON TABLE public.sync_dispatch_outbox, public.sync_dispatch_transport_routes TO " + runtimeAuthorizationDomainRole,
 		"GRANT USAGE, SELECT, UPDATE ON SEQUENCE public.runtime_semantic_probe_id_seq TO " + runtimeAuthorizationDomainRole,
 		"GRANT SELECT, UPDATE, DELETE ON TABLE public.worker_job_outbox TO " + runtimeAuthorizationQueueRole,
+		"GRANT SELECT, UPDATE ON TABLE public.sync_dispatch_outbox TO " + runtimeAuthorizationQueueRole,
+		"GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO " + runtimeAuthorizationQueueRole,
 		"GRANT USAGE ON SCHEMA river TO " + runtimeAuthorizationQueueRole,
 		"GRANT SELECT, INSERT, UPDATE, DELETE ON ALL TABLES IN SCHEMA river TO " + runtimeAuthorizationQueueRole,
 		"GRANT USAGE, SELECT, UPDATE ON ALL SEQUENCES IN SCHEMA river TO " + runtimeAuthorizationQueueRole,
@@ -70,6 +75,36 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 	}
 	if err := postgresstore.CheckQueueAuthorization(ctx, queue, runtimeAuthorizationQueueRole, "river"); err != nil {
 		t.Fatalf("queue authorization failed: %v", err)
+	}
+	if _, err := queue.Exec(ctx, "INSERT INTO public.sync_dispatch_outbox (id, state) VALUES ('00000000-0000-4000-8000-000000000001', 'forbidden')"); err == nil {
+		t.Fatal("queue unexpectedly inserts sync-dispatch outbox state")
+	}
+	if _, err := queue.Exec(ctx, "DELETE FROM public.sync_dispatch_outbox"); err == nil {
+		t.Fatal("queue unexpectedly deletes sync-dispatch outbox state")
+	}
+	if _, err := queue.Exec(ctx, "UPDATE public.sync_dispatch_transport_routes SET generation = generation + 1"); err == nil {
+		t.Fatal("queue unexpectedly mutates sync-dispatch routes")
+	}
+	if _, err := admin.Exec(ctx, "GRANT DELETE ON TABLE public.sync_dispatch_outbox TO "+runtimeAuthorizationQueueRole); err != nil {
+		t.Fatal(err)
+	}
+	if err := postgresstore.CheckQueueAuthorization(ctx, queue, runtimeAuthorizationQueueRole, "river"); !errors.Is(err, postgresstore.ErrUnavailable) {
+		t.Fatalf("queue sync-outbox DELETE authorization error = %v, want ErrUnavailable", err)
+	}
+	if _, err := admin.Exec(ctx, "REVOKE DELETE ON TABLE public.sync_dispatch_outbox FROM "+runtimeAuthorizationQueueRole); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := admin.Exec(ctx, "GRANT UPDATE ON TABLE public.sync_dispatch_transport_routes TO "+runtimeAuthorizationQueueRole); err != nil {
+		t.Fatal(err)
+	}
+	if err := postgresstore.CheckQueueAuthorization(ctx, queue, runtimeAuthorizationQueueRole, "river"); !errors.Is(err, postgresstore.ErrUnavailable) {
+		t.Fatalf("queue route UPDATE authorization error = %v, want ErrUnavailable", err)
+	}
+	if _, err := admin.Exec(ctx, "REVOKE UPDATE ON TABLE public.sync_dispatch_transport_routes FROM "+runtimeAuthorizationQueueRole); err != nil {
+		t.Fatal(err)
+	}
+	if err := postgresstore.CheckQueueAuthorization(ctx, queue, runtimeAuthorizationQueueRole, "river"); err != nil {
+		t.Fatalf("queue authorization did not recover after revoking sync-dispatch excess grants: %v", err)
 	}
 	if _, err := admin.Exec(ctx, "GRANT UPDATE ON TABLE public.worker_job_outbox TO "+runtimeAuthorizationDomainRole); err != nil {
 		t.Fatal(err)

--- a/internal/storage/postgres/runtime_authorization_integration_test.go
+++ b/internal/storage/postgres/runtime_authorization_integration_test.go
@@ -103,6 +103,27 @@ func TestRuntimeAuthorizationBindsSeparateLeastPrivilegeRolePools(t *testing.T) 
 	if _, err := admin.Exec(ctx, "REVOKE UPDATE ON TABLE public.sync_dispatch_transport_routes FROM "+runtimeAuthorizationQueueRole); err != nil {
 		t.Fatal(err)
 	}
+	if _, err := admin.Exec(
+		ctx,
+		"GRANT UPDATE (generation) ON TABLE public.sync_dispatch_transport_routes TO "+runtimeAuthorizationQueueRole,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := queue.Exec(
+		ctx,
+		"UPDATE public.sync_dispatch_transport_routes SET generation = generation + 1",
+	); err != nil {
+		t.Fatalf("column-level route UPDATE grant was not effective: %v", err)
+	}
+	if err := postgresstore.CheckQueueAuthorization(ctx, queue, runtimeAuthorizationQueueRole, "river"); !errors.Is(err, postgresstore.ErrUnavailable) {
+		t.Fatalf("queue column-level route UPDATE authorization error = %v, want ErrUnavailable", err)
+	}
+	if _, err := admin.Exec(
+		ctx,
+		"REVOKE UPDATE (generation) ON TABLE public.sync_dispatch_transport_routes FROM "+runtimeAuthorizationQueueRole,
+	); err != nil {
+		t.Fatal(err)
+	}
 	if err := postgresstore.CheckQueueAuthorization(ctx, queue, runtimeAuthorizationQueueRole, "river"); err != nil {
 		t.Fatalf("queue authorization did not recover after revoking sync-dispatch excess grants: %v", err)
 	}

--- a/internal/storage/river/migrate.go
+++ b/internal/storage/river/migrate.go
@@ -230,6 +230,8 @@ func applyRuntimeGrants(ctx context.Context, tx pgx.Tx, options MigrationOptions
 		"REVOKE ALL PRIVILEGES ON ALL SEQUENCES IN SCHEMA public FROM " + queueRole,
 		"REVOKE EXECUTE ON ALL FUNCTIONS IN SCHEMA public FROM PUBLIC, " + domainRole + ", " + queueRole,
 		"DO $$ BEGIN IF to_regclass('public.worker_job_outbox') IS NOT NULL THEN GRANT SELECT, UPDATE, DELETE ON TABLE public.worker_job_outbox TO " + queueRole + "; END IF; END $$",
+		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_outbox') IS NOT NULL THEN GRANT SELECT, UPDATE ON TABLE public.sync_dispatch_outbox TO " + queueRole + "; END IF; END $$",
+		"DO $$ BEGIN IF to_regclass('public.sync_dispatch_transport_routes') IS NOT NULL THEN GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO " + queueRole + "; END IF; END $$",
 		"REVOKE ALL PRIVILEGES ON SCHEMA " + schema + " FROM PUBLIC",
 		"REVOKE ALL PRIVILEGES ON SCHEMA " + schema + " FROM " + domainRole,
 		"REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA " + schema + " FROM PUBLIC, " + domainRole,

--- a/internal/storage/river/migrate_integration_test.go
+++ b/internal/storage/river/migrate_integration_test.go
@@ -61,6 +61,8 @@ func TestRiverMigrationRolesRetentionGrowthAndRestore(t *testing.T) {
 		"CREATE TABLE public.domain_runtime_probe (id bigserial PRIMARY KEY, value text NOT NULL)",
 		"CREATE TABLE public.alembic_version (version_num varchar(32) PRIMARY KEY)",
 		"CREATE TABLE public.worker_job_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
+		"CREATE TABLE public.sync_dispatch_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
+		"CREATE TABLE public.sync_dispatch_transport_routes (kind text PRIMARY KEY, generation bigint NOT NULL)",
 		"CREATE FUNCTION public.domain_runtime_forbidden() RETURNS integer LANGUAGE sql AS 'SELECT 1'",
 	} {
 		if _, err := adminPool.Exec(ctx, statement); err != nil {
@@ -410,6 +412,27 @@ func assertRuntimePrivileges(t *testing.T, ctx context.Context, domainURI, queue
 		"INSERT INTO public.worker_job_outbox (id, state) VALUES ('00000000-0000-0000-0000-000000000002', 'forbidden')",
 	); err == nil {
 		t.Fatal("queue role unexpectedly inserts producer-owned outbox state")
+	}
+	if _, err := queuePool.Exec(
+		ctx,
+		"UPDATE public.sync_dispatch_outbox SET state='claimed' WHERE id='00000000-0000-0000-0000-000000000003'",
+	); err != nil {
+		t.Fatalf("queue role cannot transition sync-dispatch outbox state: %v", err)
+	}
+	if _, err := queuePool.Exec(
+		ctx,
+		"INSERT INTO public.sync_dispatch_outbox (id, state) VALUES ('00000000-0000-0000-0000-000000000004', 'forbidden')",
+	); err == nil {
+		t.Fatal("queue role unexpectedly inserts sync-dispatch outbox state")
+	}
+	if _, err := queuePool.Exec(ctx, "DELETE FROM public.sync_dispatch_outbox"); err == nil {
+		t.Fatal("queue role unexpectedly deletes sync-dispatch outbox state")
+	}
+	if _, err := queuePool.Exec(ctx, "SELECT generation FROM public.sync_dispatch_transport_routes"); err != nil {
+		t.Fatalf("queue role cannot read sync-dispatch route state: %v", err)
+	}
+	if _, err := queuePool.Exec(ctx, "UPDATE public.sync_dispatch_transport_routes SET generation = generation + 1"); err == nil {
+		t.Fatal("queue role unexpectedly updates sync-dispatch route state")
 	}
 	if _, err := queuePool.Exec(ctx, "CREATE TABLE river.forbidden(id bigint)"); err == nil {
 		t.Fatal("queue role unexpectedly has CREATE on the River schema")

--- a/internal/syncreconciler/failure_backoff.go
+++ b/internal/syncreconciler/failure_backoff.go
@@ -1,0 +1,143 @@
+package syncreconciler
+
+import (
+	"context"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const transportPublishFailureEvidence = "transport_publish_failed"
+
+type failureTransaction interface {
+	Exec(context.Context, string, ...any) (pgconn.CommandTag, error)
+	Commit(context.Context) error
+	Rollback(context.Context) error
+}
+
+type failureBegin func(context.Context) (failureTransaction, error)
+
+// PublishFailureRecorder persists a retry after a publisher fails outside the
+// transaction that committed its claim. It is deliberately command-unwired:
+// activation must first split claim commit from per-claim dispatch.
+type PublishFailureRecorder struct {
+	begin failureBegin
+}
+
+// NewPublishFailureRecorder constructs the dormant persistence seam.
+func NewPublishFailureRecorder(pool *pgxpool.Pool) (*PublishFailureRecorder, error) {
+	if pool == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	return newPublishFailureRecorder(func(ctx context.Context) (failureTransaction, error) {
+		return pool.Begin(ctx)
+	})
+}
+
+func newPublishFailureRecorder(begin failureBegin) (*PublishFailureRecorder, error) {
+	if begin == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	return &PublishFailureRecorder{begin: begin}, nil
+}
+
+// Record publishes no external effect. It atomically releases one still-live
+// River claim back to pending with Python-parity retry timing. failure is
+// required to make accidental success-path use fail closed, but raw exception
+// text is never persisted; the bounded stable evidence code is sufficient for
+// operators without retaining credentials or payload fragments.
+func (recorder *PublishFailureRecorder) Record(
+	ctx context.Context,
+	claim TransportClaim,
+	now time.Time,
+	failure error,
+) error {
+	if recorder == nil || recorder.begin == nil || ctx == nil || now.IsZero() || failure == nil ||
+		!uuidPattern.MatchString(claim.ID) || !uuidPattern.MatchString(claim.ClaimToken) ||
+		claim.Kind == "" || claim.Kind == syncdispatchcontract.KindPostSync ||
+		claim.RouteGeneration < 1 || claim.Attempts < 1 {
+		return ErrInvalidConfiguration
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	now = now.UTC()
+	tx, err := recorder.begin(ctx)
+	if err != nil || tx == nil {
+		return ErrUnavailable
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	command, err := tx.Exec(
+		ctx,
+		recordTransportPublishFailureSQL,
+		claim.ID,
+		claim.ClaimToken,
+		claim.RouteGeneration,
+		claim.Kind,
+		now,
+		now.Add(transportPublishBackoff(claim.Attempts)),
+		transportPublishFailureEvidence,
+	)
+	if err != nil {
+		return ErrUnavailable
+	}
+	if command.RowsAffected() != 1 {
+		return ErrLeaseLost
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ErrUnavailable
+	}
+	return nil
+}
+
+// transportPublishBackoff matches dispatch_outbox.backoff_seconds:
+// min(60 * 2^(attempt-1 capped at exponent 4), 900) seconds.
+func transportPublishBackoff(attempt int64) time.Duration {
+	if attempt < 1 {
+		attempt = 1
+	}
+	exponent := attempt - 1
+	if exponent > 4 {
+		exponent = 4
+	}
+	seconds := int64(60) * (int64(1) << exponent)
+	if seconds > 900 {
+		seconds = 900
+	}
+	return time.Duration(seconds) * time.Second
+}
+
+// recordTransportPublishFailureSQL is an exact CAS over the committed claim
+// and its live route. A stale lease, competing replica, pause, or route change
+// updates no rows and is reported as ErrLeaseLost. post_sync is never passed to
+// this at-least-once-only seam.
+const recordTransportPublishFailureSQL = `
+UPDATE public.sync_dispatch_outbox AS outbox
+SET status = 'pending',
+	available_at = $6,
+	claim_token = NULL,
+	claim_expires_at = NULL,
+	claim_transport = NULL,
+	claim_route_generation = NULL,
+	last_error = $7,
+	updated_at = $5
+FROM public.sync_dispatch_transport_routes AS route
+WHERE outbox.id = $1
+	AND outbox.claim_token = $2
+	AND outbox.kind = $4
+	AND outbox.status = 'pending'
+	AND outbox.claim_expires_at > $5
+	AND outbox.claim_transport = 'river'
+	AND outbox.claim_route_generation = $3
+	AND route.kind = outbox.kind
+	AND route.transport = outbox.claim_transport
+	AND route.transport = 'river'
+	AND route.paused = FALSE
+	AND route.generation = outbox.claim_route_generation
+`
+
+var _ failureTransaction = (pgx.Tx)(nil)

--- a/internal/syncreconciler/failure_backoff_integration_test.go
+++ b/internal/syncreconciler/failure_backoff_integration_test.go
@@ -1,0 +1,232 @@
+//go:build integration
+
+package syncreconciler
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const failureIntegrationID = "00000000-0000-4000-8000-000000003901"
+
+func TestPublishFailureRecorderPostgresCASAndPersistence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createFailureIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	recorder, err := NewPublishFailureRecorder(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("two replicas exact CAS and redacted persistence", func(t *testing.T) {
+		now := time.Date(2026, time.July, 23, 16, 0, 0, 0, time.UTC)
+		claim := seedFailureIntegrationClaim(t, ctx, pool, now, 5)
+		rawSecret := "broker rejected amqp://worker:super-secret@example.test/vhost?token=unsafe"
+		start := make(chan struct{})
+		results := make(chan error, 2)
+		var ready sync.WaitGroup
+		ready.Add(2)
+		for range 2 {
+			go func() {
+				ready.Done()
+				<-start
+				results <- recorder.Record(ctx, claim, now, errors.New(rawSecret))
+			}()
+		}
+		ready.Wait()
+		close(start)
+		first, second := <-results, <-results
+		successes := 0
+		leaseLosses := 0
+		for _, result := range []error{first, second} {
+			switch {
+			case result == nil:
+				successes++
+			case errors.Is(result, ErrLeaseLost):
+				leaseLosses++
+			default:
+				t.Fatalf("concurrent Record() error = %v", result)
+			}
+		}
+		if successes != 1 || leaseLosses != 1 {
+			t.Fatalf("concurrent results success:%d lease-lost:%d", successes, leaseLosses)
+		}
+
+		var (
+			status, evidence           string
+			availableAt, updatedAt     time.Time
+			claimToken, claimTransport *string
+			claimExpiresAt             *time.Time
+			claimGeneration            *int64
+		)
+		if err := pool.QueryRow(ctx, `
+			SELECT status, available_at, last_error, updated_at, claim_token,
+				claim_expires_at, claim_transport, claim_route_generation
+			FROM public.sync_dispatch_outbox WHERE id = $1`, failureIntegrationID).Scan(
+			&status, &availableAt, &evidence, &updatedAt, &claimToken,
+			&claimExpiresAt, &claimTransport, &claimGeneration,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if status != "pending" || !availableAt.Equal(now.Add(15*time.Minute)) ||
+			!updatedAt.Equal(now) || claimToken != nil || claimExpiresAt != nil ||
+			claimTransport != nil || claimGeneration != nil {
+			t.Fatalf("retry row status:%s available:%s updated:%s claim:%v/%v/%v/%v",
+				status, availableAt, updatedAt, claimToken, claimExpiresAt, claimTransport, claimGeneration)
+		}
+		if evidence != transportPublishFailureEvidence || strings.Contains(evidence, "secret") ||
+			strings.Contains(evidence, "token=") || len(evidence) > 64 {
+			t.Fatalf("stored failure evidence = %q", evidence)
+		}
+	})
+
+	t.Run("stale lease and route generation preserve committed claim", func(t *testing.T) {
+		now := time.Date(2026, time.July, 23, 16, 10, 0, 0, time.UTC)
+		tests := []struct {
+			name   string
+			mutate string
+		}{
+			{name: "expired lease", mutate: `
+				UPDATE public.sync_dispatch_outbox SET claim_expires_at = $2
+				WHERE id = $1`},
+			{name: "changed route generation", mutate: `
+				UPDATE public.sync_dispatch_transport_routes SET generation = 8
+				WHERE kind = 'dispatch_sync_run'`},
+			{name: "changed route transport", mutate: `
+				UPDATE public.sync_dispatch_transport_routes SET transport = 'celery'
+				WHERE kind = 'dispatch_sync_run'`},
+		}
+		for _, test := range tests {
+			t.Run(test.name, func(t *testing.T) {
+				resetFailureIntegrationFixture(t, ctx, pool)
+				claim := seedFailureIntegrationClaim(t, ctx, pool, now, 2)
+				var mutationErr error
+				if test.name == "expired lease" {
+					_, mutationErr = pool.Exec(ctx, test.mutate, claim.ID, now)
+				} else {
+					_, mutationErr = pool.Exec(ctx, test.mutate)
+				}
+				if mutationErr != nil {
+					t.Fatal(mutationErr)
+				}
+				if err := recorder.Record(ctx, claim, now, errors.New("publish failed")); !errors.Is(err, ErrLeaseLost) {
+					t.Fatalf("Record() error = %v, want ErrLeaseLost", err)
+				}
+				var token, evidence string
+				var availableAt time.Time
+				if err := pool.QueryRow(ctx, `
+					SELECT claim_token, available_at, COALESCE(last_error, '')
+					FROM public.sync_dispatch_outbox WHERE id = $1`, claim.ID).Scan(
+					&token, &availableAt, &evidence,
+				); err != nil {
+					t.Fatal(err)
+				}
+				if token != claim.ClaimToken || !availableAt.Equal(claim.AvailableAt) || evidence != "" {
+					t.Fatalf("stale row mutated token:%s available:%s evidence:%q", token, availableAt, evidence)
+				}
+			})
+		}
+	})
+}
+
+func createFailureIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) error {
+	for _, statement := range []string{
+		`CREATE TABLE public.sync_dispatch_transport_routes (
+			kind text PRIMARY KEY,
+			transport text NOT NULL,
+			generation bigint NOT NULL,
+			paused boolean NOT NULL
+		)`,
+		`CREATE TABLE public.sync_dispatch_outbox (
+			id uuid PRIMARY KEY,
+			kind text NOT NULL,
+			status text NOT NULL,
+			available_at timestamptz NOT NULL,
+			attempts integer NOT NULL,
+			last_error text,
+			claim_token text,
+			claim_expires_at timestamptz,
+			claim_transport text,
+			claim_route_generation bigint,
+			updated_at timestamptz NOT NULL
+		)`,
+	} {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resetFailureIntegrationFixture(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	for _, statement := range []string{
+		"TRUNCATE public.sync_dispatch_outbox",
+		"TRUNCATE public.sync_dispatch_transport_routes",
+	} {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func seedFailureIntegrationClaim(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	now time.Time,
+	attempts int64,
+) TransportClaim {
+	t.Helper()
+	resetFailureIntegrationFixture(t, ctx, pool)
+	claim := TransportClaim{
+		ID:              failureIntegrationID,
+		Kind:            "dispatch_sync_run",
+		ClaimToken:      "10000000-0000-4000-8000-000000003901",
+		RouteGeneration: 7,
+		AvailableAt:     now.Add(-time.Minute),
+		Attempts:        attempts,
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.sync_dispatch_transport_routes (kind, transport, generation, paused)
+		VALUES ($1, 'river', $2, FALSE)`,
+		claim.Kind, claim.RouteGeneration); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.sync_dispatch_outbox (
+			id, kind, status, available_at, attempts, claim_token,
+			claim_expires_at, claim_transport, claim_route_generation, updated_at
+		) VALUES ($3, $1, 'pending', $4, $5, $6, $7, 'river', $2, $4)`,
+		claim.Kind, claim.RouteGeneration, claim.ID, claim.AvailableAt, claim.Attempts,
+		claim.ClaimToken, now.Add(time.Minute)); err != nil {
+		t.Fatal(err)
+	}
+	return claim
+}

--- a/internal/syncreconciler/failure_backoff_test.go
+++ b/internal/syncreconciler/failure_backoff_test.go
@@ -1,0 +1,189 @@
+package syncreconciler
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+func TestTransportPublishBackoffPythonParityAndBounds(t *testing.T) {
+	tests := []struct {
+		attempt int64
+		want    time.Duration
+	}{
+		{attempt: -1, want: time.Minute},
+		{attempt: 0, want: time.Minute},
+		{attempt: 1, want: time.Minute},
+		{attempt: 2, want: 2 * time.Minute},
+		{attempt: 3, want: 4 * time.Minute},
+		{attempt: 4, want: 8 * time.Minute},
+		{attempt: 5, want: 15 * time.Minute},
+		{attempt: 6, want: 15 * time.Minute},
+		{attempt: 1 << 62, want: 15 * time.Minute},
+	}
+	for _, test := range tests {
+		t.Run(test.want.String(), func(t *testing.T) {
+			if got := transportPublishBackoff(test.attempt); got != test.want {
+				t.Fatalf("transportPublishBackoff(%d) = %s, want %s", test.attempt, got, test.want)
+			}
+		})
+	}
+}
+
+func TestPublishFailureRecorderPersistsOnlyBoundedEvidence(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 15, 0, 0, 0, time.FixedZone("offset", -7*60*60))
+	tx := &fakeFailureTransaction{rowsAffected: 1}
+	recorder := mustFailureRecorder(t, func(context.Context) (failureTransaction, error) {
+		return tx, nil
+	})
+	secret := "postgres://operator:raw-secret@example.test/db?token=do-not-store"
+	if err := recorder.Record(context.Background(), failureClaim(), now, errors.New(secret)); err != nil {
+		t.Fatal(err)
+	}
+	if !tx.committed || tx.rollbackCalls != 1 {
+		t.Fatalf("transaction committed:%v rollback calls:%d", tx.committed, tx.rollbackCalls)
+	}
+	if len(tx.args) != 7 {
+		t.Fatalf("Exec args = %d, want 7", len(tx.args))
+	}
+	if got := tx.args[4]; got != now.UTC() {
+		t.Fatalf("recorded now = %v, want %v", got, now.UTC())
+	}
+	if got := tx.args[5]; got != now.UTC().Add(4*time.Minute) {
+		t.Fatalf("available_at = %v, want %v", got, now.UTC().Add(4*time.Minute))
+	}
+	evidence, ok := tx.args[6].(string)
+	if !ok || evidence != transportPublishFailureEvidence || len(evidence) > 64 || evidence == secret {
+		t.Fatalf("persisted evidence = %#v", tx.args[6])
+	}
+}
+
+func TestPublishFailureRecorderClassifiesCASAndPersistenceFailures(t *testing.T) {
+	persistenceErr := errors.New("database unavailable")
+	tests := []struct {
+		name      string
+		begin     failureBegin
+		want      error
+		wantRolls int
+	}{
+		{
+			name: "begin outage",
+			begin: func(context.Context) (failureTransaction, error) {
+				return nil, persistenceErr
+			},
+			want: ErrUnavailable,
+		},
+		{
+			name: "exec outage rolls back",
+			begin: func(context.Context) (failureTransaction, error) {
+				return &fakeFailureTransaction{execErr: persistenceErr}, nil
+			},
+			want:      ErrUnavailable,
+			wantRolls: 1,
+		},
+		{
+			name: "stale claim rolls back",
+			begin: func(context.Context) (failureTransaction, error) {
+				return &fakeFailureTransaction{}, nil
+			},
+			want:      ErrLeaseLost,
+			wantRolls: 1,
+		},
+		{
+			name: "commit outage rolls back",
+			begin: func(context.Context) (failureTransaction, error) {
+				return &fakeFailureTransaction{rowsAffected: 1, commitErr: persistenceErr}, nil
+			},
+			want:      ErrUnavailable,
+			wantRolls: 1,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			var tx *fakeFailureTransaction
+			recorder := mustFailureRecorder(t, func(ctx context.Context) (failureTransaction, error) {
+				started, err := test.begin(ctx)
+				if value, ok := started.(*fakeFailureTransaction); ok {
+					tx = value
+				}
+				return started, err
+			})
+			err := recorder.Record(context.Background(), failureClaim(), time.Now(), errors.New("publish failed"))
+			if !errors.Is(err, test.want) {
+				t.Fatalf("Record() error = %v, want %v", err, test.want)
+			}
+			if tx != nil && tx.rollbackCalls != test.wantRolls {
+				t.Fatalf("Rollback() calls = %d, want %d", tx.rollbackCalls, test.wantRolls)
+			}
+		})
+	}
+}
+
+func TestPublishFailureRecorderRejectsPostSyncBeforePersistence(t *testing.T) {
+	began := false
+	recorder := mustFailureRecorder(t, func(context.Context) (failureTransaction, error) {
+		began = true
+		return &fakeFailureTransaction{rowsAffected: 1}, nil
+	})
+	claim := failureClaim()
+	claim.Kind = syncdispatchcontract.KindPostSync
+	err := recorder.Record(context.Background(), claim, time.Now(), errors.New("publish failed"))
+	if !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("Record(post_sync) error = %v, want ErrInvalidConfiguration", err)
+	}
+	if began {
+		t.Fatal("post_sync failure recorder began a persistence transaction")
+	}
+}
+
+func failureClaim() TransportClaim {
+	return TransportClaim{
+		ID:              "00000000-0000-4000-8000-000000003901",
+		Kind:            "dispatch_sync_run",
+		ClaimToken:      "10000000-0000-4000-8000-000000003901",
+		RouteGeneration: 7,
+		AvailableAt:     time.Date(2026, time.July, 23, 14, 0, 0, 0, time.UTC),
+		Attempts:        3,
+	}
+}
+
+func mustFailureRecorder(t *testing.T, begin failureBegin) *PublishFailureRecorder {
+	t.Helper()
+	recorder, err := newPublishFailureRecorder(begin)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return recorder
+}
+
+type fakeFailureTransaction struct {
+	args          []any
+	rowsAffected  int64
+	execErr       error
+	commitErr     error
+	committed     bool
+	rollbackCalls int
+}
+
+func (tx *fakeFailureTransaction) Exec(
+	_ context.Context,
+	_ string,
+	args ...any,
+) (pgconn.CommandTag, error) {
+	tx.args = args
+	return pgconn.NewCommandTag("UPDATE " + string(rune('0'+tx.rowsAffected))), tx.execErr
+}
+
+func (tx *fakeFailureTransaction) Commit(context.Context) error {
+	tx.committed = tx.commitErr == nil
+	return tx.commitErr
+}
+
+func (tx *fakeFailureTransaction) Rollback(context.Context) error {
+	tx.rollbackCalls++
+	return nil
+}

--- a/internal/syncreconciler/kernel.go
+++ b/internal/syncreconciler/kernel.go
@@ -84,21 +84,28 @@ type Kernel struct {
 	riverKinds  []string
 }
 
-// NewKernel constructs an unactivated kernel backed by the semantic database.
-// No transaction or route mutation occurs during construction.
+// NewKernel constructs an unactivated kernel across the two runtime database
+// trust boundaries. Observation stays on the domain pool; mutation begins only
+// on the least-privilege queue-control pool. No transaction or route mutation
+// occurs during construction.
 func NewKernel(
-	pool *pgxpool.Pool,
+	domainPool *pgxpool.Pool,
+	queueControlPool *pgxpool.Pool,
 	registry Registry,
 	mode KernelMode,
 ) (*Kernel, error) {
-	if pool == nil {
+	if domainPool == nil || (mode == KernelModeMutation && queueControlPool == nil) {
 		return nil, ErrInvalidConfiguration
 	}
-	observer, err := NewObserver(pool, registry)
+	observer, err := NewObserver(domainPool, registry)
 	if err != nil {
 		return nil, err
 	}
-	return newKernel(registry, mode, observer, pool.Begin)
+	var begin beginFunc
+	if queueControlPool != nil {
+		begin = queueControlPool.Begin
+	}
+	return newKernel(registry, mode, observer, begin)
 }
 
 func newKernel(
@@ -130,8 +137,8 @@ func newKernel(
 
 // Step runs exactly one bounded unit of work. Shadow delegates to the existing
 // read-only observer and never begins a transaction. Mutation claims only rows
-// whose persisted route is River and unpaused; both the outbox and route are
-// locked in deterministic order before any publisher is called.
+// whose persisted route is River and unpaused. The outbox is locked before any
+// publisher is called; route generation is rechecked by the terminal write.
 func (kernel *Kernel) Step(
 	ctx context.Context,
 	now time.Time,
@@ -287,9 +294,15 @@ func markRiverDispatched(
 }
 
 // claimRiverRoutesSQL is intentionally not reachable from current command
-// wiring. It takes both route and outbox row locks so a route change cannot
-// race a persisted River claim. The explicit returned AvailableAt is sorted
-// again in Go because UPDATE ... RETURNING does not promise result ordering.
+// wiring. The queue role has UPDATE on the outbox but only SELECT on routes.
+// PostgreSQL row-locking clauses require mutation authority on every locked
+// relation, so only each claimed outbox row is locked here. A route change
+// committed before markRiverDispatched is safe: the live generation recheck
+// after River InsertTx rolls the entire transaction back on mismatch. Route
+// mutation activation still requires an external serialization/quiescence
+// barrier for the post-terminal, pre-commit window. The explicit returned
+// AvailableAt is sorted again in Go because UPDATE ... RETURNING does not
+// promise result ordering.
 const claimRiverRoutesSQL = `
 WITH candidates AS (
 	SELECT outbox.id, route.generation
@@ -303,7 +316,7 @@ WITH candidates AS (
 		AND route.transport = 'river'
 		AND route.paused = FALSE
 	ORDER BY outbox.available_at, outbox.id
-	FOR UPDATE OF outbox, route SKIP LOCKED
+	FOR UPDATE OF outbox SKIP LOCKED
 	LIMIT $2
 )
 UPDATE public.sync_dispatch_outbox AS outbox
@@ -320,9 +333,9 @@ RETURNING outbox.id::text, outbox.kind, outbox.claim_token::text,
 `
 
 // markRiverDispatchedSQL rechecks the live route generation and pause state in
-// the terminal write. The transaction already holds both locks, but preserving
-// this predicate makes an accidental future call without the claim lock fail
-// closed rather than dispatching across a route ownership change.
+// the terminal write while the transaction holds the outbox lock. It catches a
+// route change committed before this statement; route mutation activation must
+// separately serialize the remaining post-terminal, pre-commit window.
 const markRiverDispatchedSQL = `
 UPDATE public.sync_dispatch_outbox AS outbox
 SET status = 'dispatched',

--- a/internal/syncreconciler/kernel_integration_test.go
+++ b/internal/syncreconciler/kernel_integration_test.go
@@ -6,24 +6,41 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net/url"
+	"strconv"
 	"testing"
 	"time"
 
+	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
+	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
 	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 )
 
 const (
 	integrationDispatchID = "00000000-0000-4000-8000-000000003301"
 	integrationStaleID    = "00000000-0000-4000-8000-000000003302"
+	kernelDomainRole      = "kernel_domain_runtime"
+	kernelQueueRole       = "kernel_queue_runtime"
+	kernelDomainPassword  = "kernel_domain_password"
+	kernelQueuePassword   = "kernel_queue_password"
 )
+
+type kernelRiverArgs struct {
+	OutboxID string `json:"outbox_id"`
+}
+
+func (kernelRiverArgs) Kind() string { return "test.sync_dispatch" }
 
 // This test intentionally creates the production column types instead of
 // importing Python metadata. It validates the dormant Go kernel's PostgreSQL
 // SQL against text claim tokens, UUID outbox identifiers, timestamptz leases,
-// and bigint route generations.
+// and bigint route generations through the actual least-privilege runtime
+// roles and River InsertTx API.
 func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
 	defer cancel()
@@ -39,47 +56,120 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 		}
 	}()
 
-	pool, err := pgxpool.New(ctx, instance.URI)
+	adminPool, err := pgxpool.New(ctx, instance.URI)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer pool.Close()
-	if err := createKernelIntegrationFixture(ctx, pool); err != nil {
+	defer adminPool.Close()
+	if err := createKernelIntegrationFixture(ctx, adminPool); err != nil {
 		t.Fatal(err)
 	}
-	kernel, err := newKernel(
-		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun),
-		KernelModeMutation,
-		&kernelStepper{},
-		pool.Begin,
+	if _, err := riverstore.ApplyPinnedMigrations(ctx, adminPool, riverstore.MigrationOptions{
+		Schema:     "river",
+		DomainRole: kernelDomainRole,
+		QueueRole:  kernelQueueRole,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	domainPool, err := pgxpool.New(
+		ctx,
+		kernelRoleURI(t, instance.URI, kernelDomainRole, kernelDomainPassword),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer domainPool.Close()
+	queuePool, err := pgxpool.New(
+		ctx,
+		kernelRoleURI(t, instance.URI, kernelQueueRole, kernelQueuePassword),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer queuePool.Close()
+	if err := postgresstore.CheckDomainAuthorization(ctx, domainPool, kernelDomainRole, "river"); err != nil {
+		t.Fatalf("domain authorization: %v", err)
+	}
+	if err := postgresstore.CheckQueueAuthorization(ctx, queuePool, kernelQueueRole, "river"); err != nil {
+		t.Fatalf("queue authorization: %v", err)
+	}
+	if _, err := queuePool.Exec(
+		ctx,
+		"UPDATE public.sync_dispatch_transport_routes SET generation = generation + 1",
+	); err == nil {
+		t.Fatal("queue role unexpectedly has route UPDATE")
+	}
 
-	t.Run("actual CTE skips locked row and commits publisher plus terminal mark", func(t *testing.T) {
-		resetKernelIntegrationTables(t, ctx, pool)
+	kernel, err := NewKernel(
+		domainPool,
+		queuePool,
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun),
+		KernelModeMutation,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	riverClient, err := river.NewClient(
+		riverpgxv5.New(queuePool),
+		&river.Config{Schema: "river"},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	publish := func(
+		publisherCtx context.Context,
+		tx pgx.Tx,
+		claim TransportClaim,
+	) (string, error) {
+		inserted, insertErr := riverClient.InsertTx(
+			publisherCtx,
+			tx,
+			kernelRiverArgs{OutboxID: claim.ID},
+			&river.InsertOpts{Queue: "sync"},
+		)
+		if insertErr != nil {
+			return "", insertErr
+		}
+		return strconv.FormatInt(inserted.Job.ID, 10), nil
+	}
+
+	t.Run("queue role atomically commits River insert plus terminal mark", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
 		now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
-		seedKernelOutbox(t, ctx, pool, integrationDispatchID, now.Add(-time.Second))
+		seedKernelOutbox(t, ctx, adminPool, integrationDispatchID, now.Add(-time.Second))
 
 		entered := make(chan struct{})
 		release := make(chan struct{})
 		firstDone := make(chan error, 1)
 		go func() {
-			_, stepErr := kernel.Step(ctx, now, 1, time.Minute,
+			_, stepErr := kernel.Step(
+				ctx,
+				now,
+				1,
+				time.Minute,
 				func(publisherCtx context.Context, tx pgx.Tx, claim TransportClaim) (string, error) {
-					if claim.ID != integrationDispatchID || claim.Kind != syncdispatchcontract.KindDispatchSyncRun ||
-						claim.RouteGeneration != 7 || claim.Attempts != 1 {
+					if claim.ID != integrationDispatchID ||
+						claim.Kind != syncdispatchcontract.KindDispatchSyncRun ||
+						claim.RouteGeneration != 7 ||
+						claim.Attempts != 1 {
 						return "", fmt.Errorf("unexpected claim: %#v", claim)
 					}
 					var generation int64
-					if err := tx.QueryRow(publisherCtx, `
-						SELECT claim_route_generation
-						FROM public.sync_dispatch_outbox WHERE id = $1`, claim.ID).Scan(&generation); err != nil {
+					if err := tx.QueryRow(
+						publisherCtx,
+						`SELECT claim_route_generation
+						FROM public.sync_dispatch_outbox WHERE id = $1`,
+						claim.ID,
+					).Scan(&generation); err != nil {
 						return "", err
 					}
 					if generation != claim.RouteGeneration {
-						return "", fmt.Errorf("publisher saw claim generation %d, want %d", generation, claim.RouteGeneration)
+						return "", fmt.Errorf(
+							"publisher saw claim generation %d, want %d",
+							generation,
+							claim.RouteGeneration,
+						)
 					}
 					close(entered)
 					select {
@@ -87,25 +177,31 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 					case <-publisherCtx.Done():
 						return "", publisherCtx.Err()
 					}
-					if _, err := tx.Exec(publisherCtx, `
-						INSERT INTO public.river_transport_jobs (outbox_id, claim_token)
-						VALUES ($1, $2)`, claim.ID, claim.ClaimToken); err != nil {
-						return "", err
-					}
-					return "river-job-3301", nil
-				}, nil)
+					return publish(publisherCtx, tx, claim)
+				},
+				nil,
+			)
 			firstDone <- stepErr
 		}()
 
 		select {
 		case <-entered:
+		case stepErr := <-firstDone:
+			t.Fatalf("first reconciler failed before publisher: %v", stepErr)
 		case <-ctx.Done():
 			t.Fatal(ctx.Err())
 		}
-		second, err := kernel.Step(ctx, now, 1, time.Minute,
+
+		second, err := kernel.Step(
+			ctx,
+			now,
+			1,
+			time.Minute,
 			func(context.Context, pgx.Tx, TransportClaim) (string, error) {
 				return "", errors.New("second reconciler reached a locked row")
-			}, nil)
+			},
+			nil,
+		)
 		if err != nil || second.Claimed != 0 || second.Dispatched != 0 {
 			t.Fatalf("SKIP LOCKED second Step() = %#v, %v", second, err)
 		}
@@ -120,35 +216,139 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 			claimToken, claimTransport                  *string
 			claimGeneration, dispatchedGeneration       *int64
 		)
-		if err := pool.QueryRow(ctx, `
-			SELECT status, attempts, claim_token, claim_transport, claim_route_generation,
+		if err := adminPool.QueryRow(
+			ctx,
+			`SELECT status, attempts, claim_token, claim_transport, claim_route_generation,
 				dispatched_transport, dispatched_route_generation, transport_job_id
-			FROM public.sync_dispatch_outbox WHERE id = $1`, integrationDispatchID).Scan(
-			&status, &attempts, &claimToken, &claimTransport, &claimGeneration,
-			&dispatchedTransport, &dispatchedGeneration, &transportJobID,
+			FROM public.sync_dispatch_outbox WHERE id = $1`,
+			integrationDispatchID,
+		).Scan(
+			&status,
+			&attempts,
+			&claimToken,
+			&claimTransport,
+			&claimGeneration,
+			&dispatchedTransport,
+			&dispatchedGeneration,
+			&transportJobID,
 		); err != nil {
 			t.Fatal(err)
 		}
-		if status != "dispatched" || attempts != 1 || claimToken != nil || claimTransport != nil ||
-			claimGeneration != nil || dispatchedTransport != "river" || dispatchedGeneration == nil ||
-			*dispatchedGeneration != 7 || transportJobID != "river-job-3301" {
-			t.Fatalf("terminal row = status:%s attempts:%d claim:%v/%v/%v dispatched:%s/%v/%s",
-				status, attempts, claimToken, claimTransport, claimGeneration,
-				dispatchedTransport, dispatchedGeneration, transportJobID)
+		if status != "dispatched" ||
+			attempts != 1 ||
+			claimToken != nil ||
+			claimTransport != nil ||
+			claimGeneration != nil ||
+			dispatchedTransport != "river" ||
+			dispatchedGeneration == nil ||
+			*dispatchedGeneration != 7 {
+			t.Fatalf(
+				"terminal row = status:%s attempts:%d claim:%v/%v/%v dispatched:%s/%v/%s",
+				status,
+				attempts,
+				claimToken,
+				claimTransport,
+				claimGeneration,
+				dispatchedTransport,
+				dispatchedGeneration,
+				transportJobID,
+			)
 		}
 		var jobs int
-		if err := pool.QueryRow(ctx, "SELECT count(*) FROM public.river_transport_jobs").Scan(&jobs); err != nil {
+		if err := adminPool.QueryRow(
+			ctx,
+			"SELECT count(*) FROM river.river_job WHERE id::text = $1",
+			transportJobID,
+		).Scan(&jobs); err != nil {
 			t.Fatal(err)
 		}
 		if jobs != 1 {
-			t.Fatalf("same-transaction publisher jobs = %d, want 1", jobs)
+			t.Fatalf("same-transaction River jobs = %d, want 1", jobs)
+		}
+	})
+
+	t.Run("concurrent route change rolls back River insert and outbox claim", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		now := time.Date(2026, time.July, 23, 12, 0, 30, 0, time.UTC)
+		seedKernelOutbox(t, ctx, adminPool, integrationDispatchID, now.Add(-time.Second))
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		firstDone := make(chan error, 1)
+		go func() {
+			_, stepErr := kernel.Step(
+				ctx,
+				now,
+				1,
+				time.Minute,
+				func(publisherCtx context.Context, tx pgx.Tx, claim TransportClaim) (string, error) {
+					jobID, insertErr := publish(publisherCtx, tx, claim)
+					if insertErr != nil {
+						return "", insertErr
+					}
+					close(entered)
+					select {
+					case <-release:
+					case <-publisherCtx.Done():
+						return "", publisherCtx.Err()
+					}
+					return jobID, nil
+				},
+				nil,
+			)
+			firstDone <- stepErr
+		}()
+		select {
+		case <-entered:
+		case stepErr := <-firstDone:
+			t.Fatalf("first reconciler failed before route change: %v", stepErr)
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		}
+		if _, err := adminPool.Exec(
+			ctx,
+			`UPDATE public.sync_dispatch_transport_routes
+			SET generation = generation + 1
+			WHERE kind = $1`,
+			syncdispatchcontract.KindDispatchSyncRun,
+		); err != nil {
+			t.Fatalf("concurrent route update: %v", err)
+		}
+		close(release)
+		if err := <-firstDone; !errors.Is(err, ErrLeaseLost) {
+			t.Fatalf("Step() after route change error = %v", err)
+		}
+		var status string
+		var attempts int
+		var claimToken *string
+		if err := adminPool.QueryRow(
+			ctx,
+			`SELECT status, attempts, claim_token
+			FROM public.sync_dispatch_outbox WHERE id = $1`,
+			integrationDispatchID,
+		).Scan(&status, &attempts, &claimToken); err != nil {
+			t.Fatal(err)
+		}
+		if status != "pending" || attempts != 0 || claimToken != nil {
+			t.Fatalf(
+				"route-fenced outbox = status:%s attempts:%d claim:%v",
+				status,
+				attempts,
+				claimToken,
+			)
+		}
+		var jobs int
+		if err := adminPool.QueryRow(ctx, "SELECT count(*) FROM river.river_job").Scan(&jobs); err != nil {
+			t.Fatal(err)
+		}
+		if jobs != 0 {
+			t.Fatalf("route-fenced River jobs = %d, want 0", jobs)
 		}
 	})
 
 	t.Run("actual terminal write fences stale persisted route generation", func(t *testing.T) {
-		resetKernelIntegrationTables(t, ctx, pool)
+		resetKernelIntegrationTables(t, ctx, adminPool)
 		now := time.Date(2026, time.July, 23, 12, 1, 0, 0, time.UTC)
-		seedKernelOutbox(t, ctx, pool, integrationStaleID, now.Add(-time.Second))
+		seedKernelOutbox(t, ctx, adminPool, integrationStaleID, now.Add(-time.Second))
 		claim := TransportClaim{
 			ID:              integrationStaleID,
 			Kind:            syncdispatchcontract.KindDispatchSyncRun,
@@ -157,57 +357,83 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 			AvailableAt:     now.Add(-time.Second),
 			Attempts:        1,
 		}
-		if _, err := pool.Exec(ctx, `
-			UPDATE public.sync_dispatch_outbox
+		if _, err := adminPool.Exec(
+			ctx,
+			`UPDATE public.sync_dispatch_outbox
 			SET claim_token = $2, claim_expires_at = $3, claim_transport = 'river',
 				claim_route_generation = 7, attempts = 1
-			WHERE id = $1`, claim.ID, claim.ClaimToken, now.Add(time.Minute)); err != nil {
+			WHERE id = $1`,
+			claim.ID,
+			claim.ClaimToken,
+			now.Add(time.Minute),
+		); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := pool.Exec(ctx, `
-			UPDATE public.sync_dispatch_transport_routes
-			SET generation = 8 WHERE kind = $1`, syncdispatchcontract.KindDispatchSyncRun); err != nil {
+		if _, err := adminPool.Exec(
+			ctx,
+			`UPDATE public.sync_dispatch_transport_routes
+			SET generation = 8 WHERE kind = $1`,
+			syncdispatchcontract.KindDispatchSyncRun,
+		); err != nil {
 			t.Fatal(err)
 		}
-		tx, err := pool.Begin(ctx)
+		tx, err := queuePool.Begin(ctx)
 		if err != nil {
 			t.Fatal(err)
 		}
 		defer tx.Rollback(ctx)
-		if err := markRiverDispatched(ctx, tx, claim, now, "stale-river-job"); !errors.Is(err, ErrLeaseLost) {
+		if err := markRiverDispatched(
+			ctx,
+			tx,
+			claim,
+			now,
+			"stale-river-job",
+		); !errors.Is(err, ErrLeaseLost) {
 			t.Fatalf("markRiverDispatched() error = %v", err)
 		}
 	})
 
-	t.Run("publisher failure rolls back both persisted claim and River insert", func(t *testing.T) {
-		resetKernelIntegrationTables(t, ctx, pool)
+	t.Run("failure after River InsertTx rolls back claim, job, and terminal mark", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
 		now := time.Date(2026, time.July, 23, 12, 2, 0, 0, time.UTC)
-		seedKernelOutbox(t, ctx, pool, integrationDispatchID, now.Add(-time.Second))
+		seedKernelOutbox(t, ctx, adminPool, integrationDispatchID, now.Add(-time.Second))
 		publisherErr := errors.New("injected publisher failure")
-		if _, err := kernel.Step(ctx, now, 1, time.Minute,
+		if _, err := kernel.Step(
+			ctx,
+			now,
+			1,
+			time.Minute,
 			func(publisherCtx context.Context, tx pgx.Tx, claim TransportClaim) (string, error) {
-				if _, err := tx.Exec(publisherCtx, `
-					INSERT INTO public.river_transport_jobs (outbox_id, claim_token)
-					VALUES ($1, $2)`, claim.ID, claim.ClaimToken); err != nil {
+				if _, err := publish(publisherCtx, tx, claim); err != nil {
 					return "", err
 				}
 				return "", publisherErr
-			}, nil); !errors.Is(err, publisherErr) {
+			},
+			nil,
+		); !errors.Is(err, publisherErr) {
 			t.Fatalf("Step() error = %v", err)
 		}
 		var status string
 		var attempts int
 		var claimToken *string
-		if err := pool.QueryRow(ctx, `
-			SELECT status, attempts, claim_token FROM public.sync_dispatch_outbox WHERE id = $1`,
-			integrationDispatchID).Scan(&status, &attempts, &claimToken); err != nil {
+		if err := adminPool.QueryRow(
+			ctx,
+			`SELECT status, attempts, claim_token
+			FROM public.sync_dispatch_outbox WHERE id = $1`,
+			integrationDispatchID,
+		).Scan(&status, &attempts, &claimToken); err != nil {
 			t.Fatal(err)
 		}
 		if status != "pending" || attempts != 0 || claimToken != nil {
-			t.Fatalf("rolled-back outbox = status:%s attempts:%d claim:%v", status, attempts, claimToken)
+			t.Fatalf(
+				"rolled-back outbox = status:%s attempts:%d claim:%v",
+				status,
+				attempts,
+				claimToken,
+			)
 		}
 		var jobs int
-		if err := pool.QueryRow(ctx, "SELECT count(*) FROM public.river_transport_jobs").Scan(&jobs); err != nil {
+		if err := adminPool.QueryRow(ctx, "SELECT count(*) FROM river.river_job").Scan(&jobs); err != nil {
 			t.Fatal(err)
 		}
 		if jobs != 0 {
@@ -218,7 +444,11 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 
 func createKernelIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) error {
 	for _, statement := range []string{
-		"CREATE EXTENSION IF NOT EXISTS pgcrypto",
+		"REVOKE CREATE ON SCHEMA public FROM PUBLIC",
+		"CREATE ROLE " + kernelDomainRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + kernelDomainPassword + "'",
+		"CREATE ROLE " + kernelQueueRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + kernelQueuePassword + "'",
+		"GRANT CONNECT ON DATABASE worker_test TO " + kernelDomainRole + ", " + kernelQueueRole,
+		"CREATE TABLE public.worker_job_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
 		`CREATE TABLE public.sync_dispatch_transport_routes (
 			kind text PRIMARY KEY,
 			transport text NOT NULL,
@@ -247,10 +477,6 @@ func createKernelIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) err
 			created_at timestamptz NOT NULL,
 			updated_at timestamptz NOT NULL
 		)`,
-		`CREATE TABLE public.river_transport_jobs (
-			outbox_id uuid PRIMARY KEY,
-			claim_token text NOT NULL
-		)`,
 	} {
 		if _, err := pool.Exec(ctx, statement); err != nil {
 			return err
@@ -259,10 +485,14 @@ func createKernelIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) err
 	return nil
 }
 
-func resetKernelIntegrationTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+func resetKernelIntegrationTables(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+) {
 	t.Helper()
 	for _, statement := range []string{
-		"TRUNCATE public.river_transport_jobs",
+		"TRUNCATE river.river_job",
 		"TRUNCATE public.sync_dispatch_outbox",
 		"TRUNCATE public.sync_dispatch_transport_routes",
 		`INSERT INTO public.sync_dispatch_transport_routes (
@@ -279,13 +509,33 @@ func resetKernelIntegrationTables(t *testing.T, ctx context.Context, pool *pgxpo
 	}
 }
 
-func seedKernelOutbox(t *testing.T, ctx context.Context, pool *pgxpool.Pool, id string, availableAt time.Time) {
+func seedKernelOutbox(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	id string,
+	availableAt time.Time,
+) {
 	t.Helper()
-	if _, err := pool.Exec(ctx, `
-		INSERT INTO public.sync_dispatch_outbox (
+	if _, err := pool.Exec(
+		ctx,
+		`INSERT INTO public.sync_dispatch_outbox (
 			id, org_id, sync_run_id, kind, status, available_at, attempts, created_at, updated_at
 		) VALUES ($1, 'org-integration', '00000000-0000-4000-8000-000000003300',
-			'dispatch_sync_run', 'pending', $2, 0, $2, $2)`, id, availableAt); err != nil {
+			'dispatch_sync_run', 'pending', $2, 0, $2, $2)`,
+		id,
+		availableAt,
+	); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func kernelRoleURI(t *testing.T, rawURI, role, password string) string {
+	t.Helper()
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed.User = url.UserPassword(role, password)
+	return parsed.String()
 }

--- a/internal/syncreconciler/kernel_test.go
+++ b/internal/syncreconciler/kernel_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
 	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 type kernelStepper struct {
@@ -114,6 +115,24 @@ func kernelClaim(kind string, at time.Time, id string) TransportClaim {
 	}
 }
 
+func TestNewKernelSeparatesDomainObservationFromQueueMutationPool(t *testing.T) {
+	domainPool := &pgxpool.Pool{}
+	queuePool := &pgxpool.Pool{}
+	registry := riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun)
+
+	shadow, err := NewKernel(domainPool, nil, registry, KernelModeShadow)
+	if err != nil || shadow.begin != nil {
+		t.Fatalf("NewKernel(shadow) = %#v, %v", shadow, err)
+	}
+	if _, err := NewKernel(domainPool, nil, registry, KernelModeMutation); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("NewKernel(mutation without queue pool) error = %v", err)
+	}
+	mutation, err := NewKernel(domainPool, queuePool, registry, KernelModeMutation)
+	if err != nil || mutation.begin == nil {
+		t.Fatalf("NewKernel(mutation) = %#v, %v", mutation, err)
+	}
+}
+
 func TestKernelShadowIsReadOnlyAndNeverBeginsTransaction(t *testing.T) {
 	stepper := &kernelStepper{}
 	kernel, err := newKernel(testRegistry(t, ""), KernelModeShadow, stepper, nil)
@@ -182,12 +201,17 @@ func TestKernelMutationClaimsOnlyBoundedPersistedRiverRoutesInDeterministicOrder
 	for _, required := range []string{
 		"ROUTE.TRANSPORT = 'RIVER'", "ROUTE.PAUSED = FALSE",
 		"OUTBOX.KIND = ANY($4::TEXT[])", "ORDER BY OUTBOX.AVAILABLE_AT, OUTBOX.ID",
-		"FOR UPDATE OF OUTBOX, ROUTE SKIP LOCKED", "LIMIT $2",
+		"FOR UPDATE OF OUTBOX SKIP LOCKED", "LIMIT $2",
 		"SET CLAIM_TOKEN = GEN_RANDOM_UUID()::TEXT",
 	} {
 		if !strings.Contains(upper, required) {
 			t.Fatalf("claim SQL missing %q:\n%s", required, tx.querySQL)
 		}
+	}
+	if strings.Contains(upper, "FOR UPDATE OF ROUTE") ||
+		strings.Contains(upper, "FOR SHARE OF ROUTE") ||
+		strings.Contains(upper, "FOR KEY SHARE OF ROUTE") {
+		t.Fatalf("claim SQL requires forbidden route mutation privilege:\n%s", tx.querySQL)
 	}
 	if len(tx.queryArgs) != 4 || !reflect.DeepEqual(tx.queryArgs[3], []string{
 		syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.KindFinalizeSyncRun,

--- a/internal/syncreconciler/lease_repair.go
+++ b/internal/syncreconciler/lease_repair.go
@@ -1,0 +1,408 @@
+package syncreconciler
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/binary"
+	"sort"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	expiredLeaseDefaultMaximumRetries int64 = 1
+	expiredLeaseDefaultRetryBackoff         = time.Minute
+	leaseRepairMinimumLimit                 = 1
+	leaseRepairMaximumLimit                 = 100
+	leaseRepairRetryReason                  = "expired_lease"
+	leaseRepairExpiredError                 = "sync unit lease expired"
+	leaseRepairWorkerLostCategory           = "worker_lost"
+	leaseRepairRetryExhaustedCategory       = "worker_lost_retry_exhausted"
+)
+
+var linearBackfillWorkItemDatasets = map[string]struct{}{
+	"work_items":         {},
+	"work_item_labels":   {},
+	"work_item_projects": {},
+	"work_item_history":  {},
+	"work_item_comments": {},
+}
+
+var linearBackfillRetrySurfaces = []string{
+	"ai_attribution",
+	"estimate_coverage_metrics_daily",
+	"investment_classifications_daily",
+	"investment_metrics_daily",
+	"issue_type_metrics_daily",
+	"sprints",
+	"work_item_cycle_times",
+	"work_item_dependencies",
+	"work_item_interactions",
+	"work_item_metrics_daily",
+	"work_item_reopen_events",
+	"work_item_state_durations_daily",
+	"work_item_team_attributions",
+	"work_item_transitions",
+	"work_item_user_metrics_daily",
+	"work_items",
+}
+
+type leaseRepairBeginFunc func(context.Context) (pgx.Tx, error)
+
+// LeaseRepairResult contains only committed state transitions. It does not
+// materialize a dispatch wakeup: that remains the responsibility of the
+// existing materializer, so future wiring can choose an explicit transaction
+// boundary for wakeup delivery.
+type LeaseRepairResult struct {
+	Selected int
+	Retried  int
+	Failed   int
+}
+
+// LeaseRepairConfig holds the policy that Python currently supplies through
+// SYNC_UNIT_EXPIRED_LEASE_MAX_RETRIES and
+// SYNC_UNIT_EXPIRED_LEASE_RETRY_BACKOFF_SECONDS. Defaults intentionally match
+// that compatibility contract, while validation rejects negative policy values.
+type LeaseRepairConfig struct {
+	MaximumRetries int64
+	RetryBackoff   time.Duration
+}
+
+func DefaultLeaseRepairConfig() LeaseRepairConfig {
+	return LeaseRepairConfig{
+		MaximumRetries: expiredLeaseDefaultMaximumRetries,
+		RetryBackoff:   expiredLeaseDefaultRetryBackoff,
+	}
+}
+
+func (config LeaseRepairConfig) valid() bool {
+	return config.MaximumRetries >= 0 && config.RetryBackoff >= 0
+}
+
+// LeaseRepair is a dormant PostgreSQL-only repair primitive. Construction has
+// no side effects, and no command constructs it today. Its SQL locks a bounded
+// ordered candidate window and then uses the observed owner in every terminal
+// write so concurrent replicas cannot repair a live or replaced lease.
+type LeaseRepair struct {
+	begin  leaseRepairBeginFunc
+	config LeaseRepairConfig
+}
+
+func NewLeaseRepair(pool *pgxpool.Pool) (*LeaseRepair, error) {
+	return NewLeaseRepairWithConfig(pool, DefaultLeaseRepairConfig())
+}
+
+func NewLeaseRepairWithConfig(pool *pgxpool.Pool, config LeaseRepairConfig) (*LeaseRepair, error) {
+	if pool == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	return newLeaseRepairWithConfig(pool.Begin, config)
+}
+
+func newLeaseRepair(begin leaseRepairBeginFunc) (*LeaseRepair, error) {
+	return newLeaseRepairWithConfig(begin, DefaultLeaseRepairConfig())
+}
+
+func newLeaseRepairWithConfig(begin leaseRepairBeginFunc, config LeaseRepairConfig) (*LeaseRepair, error) {
+	if begin == nil || !config.valid() {
+		return nil, ErrInvalidConfiguration
+	}
+	return &LeaseRepair{begin: begin, config: config}, nil
+}
+
+// Step repairs one deterministic window of expired RUNNING sync units. It
+// never creates transport/outbox rows. A future command owner must arrange
+// any wakeup materialization separately after this committed state change.
+func (repair *LeaseRepair) Step(ctx context.Context, now time.Time, limit int) (LeaseRepairResult, error) {
+	if repair == nil || repair.begin == nil || ctx == nil || now.IsZero() ||
+		limit < leaseRepairMinimumLimit || limit > leaseRepairMaximumLimit {
+		return LeaseRepairResult{}, ErrInvalidConfiguration
+	}
+	if err := ctx.Err(); err != nil {
+		return LeaseRepairResult{}, err
+	}
+	now = now.UTC()
+
+	tx, err := repair.begin(ctx)
+	if err != nil || tx == nil {
+		return LeaseRepairResult{}, ErrUnavailable
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	candidates, err := selectExpiredLeaseCandidates(ctx, tx, now, limit)
+	if err != nil {
+		return LeaseRepairResult{}, err
+	}
+	if err := acquireLeaseRepairBucketLocks(ctx, tx, candidates); err != nil {
+		return LeaseRepairResult{}, err
+	}
+	result := LeaseRepairResult{Selected: len(candidates)}
+	for _, candidate := range candidates {
+		decision := decideExpiredLeaseRepair(candidate, repair.config)
+		var affected int64
+		if decision.retry {
+			affected, err = markExpiredLeaseRetrying(ctx, tx, candidate, now, repair.config)
+			if err == nil && affected == 1 {
+				result.Retried++
+			}
+		} else {
+			affected, err = markExpiredLeaseFailed(ctx, tx, candidate, decision.exhausted, now)
+			if err == nil && affected == 1 {
+				result.Failed++
+			}
+		}
+		if err != nil {
+			return LeaseRepairResult{}, err
+		}
+		if affected < 0 || affected > 1 {
+			return LeaseRepairResult{}, ErrUnavailable
+		}
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return LeaseRepairResult{}, ErrUnavailable
+	}
+	return result, nil
+}
+
+type expiredLeaseCandidate struct {
+	id         string
+	syncRunID  string
+	leaseOwner string
+	provider   string
+	mode       string
+	datasetKey string
+	orgID      string
+	costClass  string
+	retryCount int64
+}
+
+type expiredLeaseDecision struct {
+	retry     bool
+	exhausted bool
+}
+
+func decideExpiredLeaseRepair(candidate expiredLeaseCandidate, config LeaseRepairConfig) expiredLeaseDecision {
+	_, eligibleDataset := linearBackfillWorkItemDatasets[candidate.datasetKey]
+	eligible := candidate.provider == "linear" && candidate.mode == "backfill" && eligibleDataset
+	return expiredLeaseDecision{
+		retry:     eligible && candidate.retryCount < config.MaximumRetries,
+		exhausted: eligible && candidate.retryCount >= config.MaximumRetries,
+	}
+}
+
+func selectExpiredLeaseCandidates(
+	ctx context.Context,
+	tx pgx.Tx,
+	now time.Time,
+	limit int,
+) ([]expiredLeaseCandidate, error) {
+	rows, err := tx.Query(ctx, selectExpiredLeaseCandidatesSQL, now, limit)
+	if err != nil || rows == nil {
+		return nil, ErrUnavailable
+	}
+	defer rows.Close()
+	candidates := make([]expiredLeaseCandidate, 0, limit)
+	seen := make(map[string]struct{}, limit)
+	for rows.Next() {
+		var candidate expiredLeaseCandidate
+		if err := rows.Scan(
+			&candidate.id,
+			&candidate.syncRunID,
+			&candidate.leaseOwner,
+			&candidate.provider,
+			&candidate.mode,
+			&candidate.datasetKey,
+			&candidate.orgID,
+			&candidate.costClass,
+			&candidate.retryCount,
+		); err != nil {
+			return nil, ErrUnavailable
+		}
+		if !uuidPattern.MatchString(candidate.id) || !uuidPattern.MatchString(candidate.syncRunID) ||
+			candidate.leaseOwner == "" || candidate.orgID == "" || candidate.costClass == "" || candidate.retryCount < 0 {
+			return nil, ErrUnavailable
+		}
+		if _, duplicate := seen[candidate.id]; duplicate {
+			return nil, ErrUnavailable
+		}
+		seen[candidate.id] = struct{}{}
+		candidates = append(candidates, candidate)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, ErrUnavailable
+	}
+	if len(candidates) > limit {
+		return nil, ErrUnavailable
+	}
+	return candidates, nil
+}
+
+func markExpiredLeaseRetrying(
+	ctx context.Context,
+	tx pgx.Tx,
+	candidate expiredLeaseCandidate,
+	now time.Time,
+	config LeaseRepairConfig,
+) (int64, error) {
+	retryAt := now.Add(config.RetryBackoff)
+	command, err := tx.Exec(ctx, markExpiredLeaseRetryingSQL,
+		candidate.id, candidate.leaseOwner, now, retryAt, linearBackfillRetrySurfaces)
+	if err != nil {
+		return 0, ErrUnavailable
+	}
+	return command.RowsAffected(), nil
+}
+
+func markExpiredLeaseFailed(
+	ctx context.Context,
+	tx pgx.Tx,
+	candidate expiredLeaseCandidate,
+	exhausted bool,
+	now time.Time,
+) (int64, error) {
+	category := leaseRepairWorkerLostCategory
+	surfaces := []string{}
+	if exhausted {
+		category = leaseRepairRetryExhaustedCategory
+		surfaces = linearBackfillRetrySurfaces
+	}
+	command, err := tx.Exec(ctx, markExpiredLeaseFailedSQL,
+		candidate.id, candidate.leaseOwner, now, category, exhausted, surfaces)
+	if err != nil {
+		return 0, ErrUnavailable
+	}
+	return command.RowsAffected(), nil
+}
+
+// selectExpiredLeaseCandidatesSQL is intentionally independent from the
+// dispatch materializer. It is a bounded metadata scan only: Python acquires
+// sorted advisory bucket locks before mutating capacity state, so this Go
+// component follows the same lock order rather than taking row locks first.
+// org_id equality is a defensive tenancy fence for malformed rows.
+const selectExpiredLeaseCandidatesSQL = `
+SELECT unit.id::text, unit.sync_run_id::text, unit.lease_owner,
+	unit.provider, unit.mode, unit.dataset_key, unit.org_id, unit.cost_class,
+	unit.expired_lease_retry_count
+FROM public.sync_run_units AS unit
+JOIN public.sync_runs AS run ON run.id = unit.sync_run_id
+WHERE unit.status = 'running'
+	AND unit.lease_owner IS NOT NULL
+	AND unit.lease_expires_at IS NOT NULL
+	AND unit.lease_expires_at <= $1
+	AND run.status NOT IN ('success', 'partial_failed', 'failed')
+	AND run.org_id = unit.org_id
+ORDER BY unit.lease_expires_at, unit.id
+LIMIT $2
+`
+
+type leaseRepairBucket struct {
+	orgID      string
+	provider   string
+	costClass  string
+	advisoryID int64
+}
+
+func acquireLeaseRepairBucketLocks(ctx context.Context, tx pgx.Tx, candidates []expiredLeaseCandidate) error {
+	buckets := make(map[string]leaseRepairBucket, len(candidates))
+	for _, candidate := range candidates {
+		key := candidate.orgID + "\x00" + candidate.provider + "\x00" + candidate.costClass
+		buckets[key] = leaseRepairBucket{
+			orgID: candidate.orgID, provider: candidate.provider, costClass: candidate.costClass,
+			advisoryID: leaseRepairBucketAdvisoryID(candidate.orgID, candidate.provider, candidate.costClass),
+		}
+	}
+	ordered := make([]leaseRepairBucket, 0, len(buckets))
+	for _, bucket := range buckets {
+		ordered = append(ordered, bucket)
+	}
+	sort.Slice(ordered, func(left, right int) bool {
+		if ordered[left].orgID != ordered[right].orgID {
+			return ordered[left].orgID < ordered[right].orgID
+		}
+		if ordered[left].provider != ordered[right].provider {
+			return ordered[left].provider < ordered[right].provider
+		}
+		return ordered[left].costClass < ordered[right].costClass
+	})
+	for _, bucket := range ordered {
+		if _, err := tx.Exec(ctx, "SELECT pg_advisory_xact_lock($1)", bucket.advisoryID); err != nil {
+			return ErrUnavailable
+		}
+	}
+	return nil
+}
+
+func leaseRepairBucketAdvisoryID(orgID, provider, costClass string) int64 {
+	digest := sha256.Sum256([]byte(orgID + ":" + provider + ":" + costClass))
+	return int64(binary.BigEndian.Uint64(digest[:8]) & ((uint64(1) << 63) - 1))
+}
+
+// Both mutations repeat the status, owner, expiry, nonterminal-run, and
+// tenancy predicates. This CAS complements the advisory locks: it remains
+// correct if a future caller reuses the write helper without the selector and
+// fails closed if ownership changes before the write.
+const markExpiredLeaseRetryingSQL = `
+UPDATE public.sync_run_units AS unit
+SET status = 'retrying',
+	available_at = $4,
+	error = 'sync unit lease expired',
+	result = jsonb_build_object(
+		'error_category', 'worker_lost',
+		'retry_count', unit.expired_lease_retry_count + 1,
+		'retry_reason', 'expired_lease',
+		'next_retry_at', to_jsonb($4::timestamptz),
+		'retry_exhausted', FALSE,
+		'retry_surfaces', to_jsonb($5::text[]),
+		'last_lease_expired_at', to_jsonb($3::timestamptz)
+	),
+	expired_lease_retry_count = unit.expired_lease_retry_count + 1,
+	last_retry_reason = 'expired_lease',
+	retry_exhausted_at = NULL,
+	rate_limit_deferrals = 0,
+	rate_limit_first_seen_at = NULL,
+	updated_at = $3,
+	lease_owner = NULL,
+	lease_expires_at = NULL
+FROM public.sync_runs AS run
+WHERE unit.id = $1::uuid
+	AND unit.lease_owner = $2
+	AND unit.status = 'running'
+	AND unit.lease_owner IS NOT NULL
+	AND unit.lease_expires_at IS NOT NULL
+	AND unit.lease_expires_at <= $3
+	AND run.id = unit.sync_run_id
+	AND run.status NOT IN ('success', 'partial_failed', 'failed')
+	AND run.org_id = unit.org_id
+`
+
+const markExpiredLeaseFailedSQL = `
+UPDATE public.sync_run_units AS unit
+SET status = 'failed',
+	error = 'sync unit lease expired',
+	result = jsonb_build_object(
+		'error_category', $4::text,
+		'retry_count', unit.expired_lease_retry_count,
+		'retry_reason', 'expired_lease',
+		'next_retry_at', NULL,
+		'retry_exhausted', $5::boolean,
+		'retry_surfaces', to_jsonb($6::text[]),
+		'last_lease_expired_at', to_jsonb($3::timestamptz)
+	),
+	last_retry_reason = 'expired_lease',
+	retry_exhausted_at = CASE WHEN $5::boolean THEN $3 ELSE NULL END,
+	updated_at = $3,
+	lease_owner = NULL,
+	lease_expires_at = NULL
+FROM public.sync_runs AS run
+WHERE unit.id = $1::uuid
+	AND unit.lease_owner = $2
+	AND unit.status = 'running'
+	AND unit.lease_owner IS NOT NULL
+	AND unit.lease_expires_at IS NOT NULL
+	AND unit.lease_expires_at <= $3
+	AND run.id = unit.sync_run_id
+	AND run.status NOT IN ('success', 'partial_failed', 'failed')
+	AND run.org_id = unit.org_id
+`

--- a/internal/syncreconciler/lease_repair_integration_test.go
+++ b/internal/syncreconciler/lease_repair_integration_test.go
@@ -1,0 +1,375 @@
+//go:build integration
+
+package syncreconciler
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	leaseRepairRunA  = "00000000-0000-4000-8000-000000003901"
+	leaseRepairRunB  = "00000000-0000-4000-8000-000000003902"
+	leaseRepairRunC  = "00000000-0000-4000-8000-000000003903"
+	leaseRepairUnitA = "00000000-0000-4000-8000-000000003911"
+	leaseRepairUnitB = "00000000-0000-4000-8000-000000003912"
+	leaseRepairUnitC = "00000000-0000-4000-8000-000000003913"
+)
+
+type gatedLeaseRepairTx struct {
+	pgx.Tx
+	entered chan struct{}
+	release chan struct{}
+	once    sync.Once
+}
+
+func (tx *gatedLeaseRepairTx) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	command, err := tx.Tx.Exec(ctx, sql, args...)
+	if err != nil || sql != "SELECT pg_advisory_xact_lock($1)" {
+		return command, err
+	}
+	tx.once.Do(func() { close(tx.entered) })
+	select {
+	case <-tx.release:
+		return command, nil
+	case <-ctx.Done():
+		return pgconn.CommandTag{}, ctx.Err()
+	}
+}
+
+type failingLeaseRepairTx struct {
+	pgx.Tx
+}
+
+func (tx *failingLeaseRepairTx) Exec(ctx context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	if strings.HasPrefix(strings.TrimSpace(sql), "UPDATE") {
+		return pgconn.CommandTag{}, errors.New("injected lease-repair write failure")
+	}
+	return tx.Tx.Exec(ctx, sql, args...)
+}
+
+func TestLeaseRepairPostgresContract(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createLeaseRepairIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+
+	t.Run("two replicas skip a locked candidate and one owns the retry", func(t *testing.T) {
+		resetLeaseRepairTables(t, ctx, pool)
+		seedLeaseRepairRun(t, ctx, pool, leaseRepairRunA, "org-a", "running")
+		seedLeaseRepairUnit(t, ctx, pool, leaseRepairUnitA, leaseRepairRunA, "org-a", "linear", "backfill", "work_items", 0, now.Add(-time.Minute))
+
+		entered := make(chan struct{})
+		release := make(chan struct{})
+		first, err := newLeaseRepair(func(beginCtx context.Context) (pgx.Tx, error) {
+			tx, beginErr := pool.Begin(beginCtx)
+			if beginErr != nil {
+				return nil, beginErr
+			}
+			return &gatedLeaseRepairTx{Tx: tx, entered: entered, release: release}, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		second, err := NewLeaseRepair(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		firstDone := make(chan struct {
+			result LeaseRepairResult
+			err    error
+		}, 1)
+		go func() {
+			result, stepErr := first.Step(ctx, now, 1)
+			firstDone <- struct {
+				result LeaseRepairResult
+				err    error
+			}{result, stepErr}
+		}()
+		select {
+		case <-entered:
+		case <-ctx.Done():
+			t.Fatal(ctx.Err())
+		}
+		secondDone := make(chan struct {
+			result LeaseRepairResult
+			err    error
+		}, 1)
+		go func() {
+			result, stepErr := second.Step(ctx, now, 1)
+			secondDone <- struct {
+				result LeaseRepairResult
+				err    error
+			}{result, stepErr}
+		}()
+		select {
+		case secondResult := <-secondDone:
+			t.Fatalf("second replica bypassed bucket lock: %#v, %v", secondResult.result, secondResult.err)
+		case <-time.After(100 * time.Millisecond):
+		}
+		close(release)
+		firstResult := <-firstDone
+		secondResult := <-secondDone
+		if firstResult.err != nil || firstResult.result != (LeaseRepairResult{Selected: 1, Retried: 1}) {
+			t.Fatalf("first replica Step() = %#v, %v", firstResult.result, firstResult.err)
+		}
+		if secondResult.err != nil || secondResult.result != (LeaseRepairResult{Selected: 1}) {
+			t.Fatalf("second replica Step() = %#v, %v", secondResult.result, secondResult.err)
+		}
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitA, "retrying", nil, leaseTimePointer(now.Add(expiredLeaseDefaultRetryBackoff)), "worker_lost", false, 1)
+	})
+
+	t.Run("a live owner and terminal run are excluded", func(t *testing.T) {
+		resetLeaseRepairTables(t, ctx, pool)
+		seedLeaseRepairRun(t, ctx, pool, leaseRepairRunA, "org-a", "running")
+		seedLeaseRepairRun(t, ctx, pool, leaseRepairRunB, "org-b", "success")
+		seedLeaseRepairUnit(t, ctx, pool, leaseRepairUnitA, leaseRepairRunA, "org-a", "linear", "backfill", "work_items", 0, now.Add(time.Minute))
+		seedLeaseRepairUnit(t, ctx, pool, leaseRepairUnitB, leaseRepairRunB, "org-b", "linear", "backfill", "work_items", 0, now.Add(-time.Minute))
+		repair, err := NewLeaseRepair(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := repair.Step(ctx, now, 2)
+		if err != nil || result != (LeaseRepairResult{}) {
+			t.Fatalf("live/terminal Step() = %#v, %v", result, err)
+		}
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitA, "running", leaseStringPointer("worker-a"), nil, "", false, 0)
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitB, "running", leaseStringPointer("worker-a"), nil, "", false, 0)
+	})
+
+	t.Run("retry, exhaustion, and noneligible surfaces have exact terminal metadata", func(t *testing.T) {
+		resetLeaseRepairTables(t, ctx, pool)
+		seedLeaseRepairRun(t, ctx, pool, leaseRepairRunA, "org-a", "running")
+		seedLeaseRepairRun(t, ctx, pool, leaseRepairRunB, "org-b", "running")
+		seedLeaseRepairRun(t, ctx, pool, leaseRepairRunC, "org-c", "running")
+		seedLeaseRepairUnit(t, ctx, pool, leaseRepairUnitA, leaseRepairRunA, "org-a", "linear", "backfill", "work_items", 0, now.Add(-3*time.Minute))
+		seedLeaseRepairUnit(t, ctx, pool, leaseRepairUnitB, leaseRepairRunB, "org-b", "linear", "backfill", "work_items", expiredLeaseDefaultMaximumRetries, now.Add(-2*time.Minute))
+		seedLeaseRepairUnit(t, ctx, pool, leaseRepairUnitC, leaseRepairRunC, "org-c", "github", "backfill", "work_items", 0, now.Add(-time.Minute))
+		repair, err := NewLeaseRepair(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := repair.Step(ctx, now, 3)
+		if err != nil || result != (LeaseRepairResult{Selected: 3, Retried: 1, Failed: 2}) {
+			t.Fatalf("Step() = %#v, %v", result, err)
+		}
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitA, "retrying", nil, leaseTimePointer(now.Add(expiredLeaseDefaultRetryBackoff)), "worker_lost", false, 1)
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitB, "failed", nil, nil, leaseRepairRetryExhaustedCategory, true, expiredLeaseDefaultMaximumRetries)
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitC, "failed", nil, nil, leaseRepairWorkerLostCategory, false, 0)
+	})
+
+	t.Run("transaction fault rolls back and tenant fence plus limit leave other rows untouched", func(t *testing.T) {
+		resetLeaseRepairTables(t, ctx, pool)
+		seedLeaseRepairRun(t, ctx, pool, leaseRepairRunA, "org-a", "running")
+		seedLeaseRepairRun(t, ctx, pool, leaseRepairRunB, "org-b", "running")
+		seedLeaseRepairRun(t, ctx, pool, leaseRepairRunC, "org-c", "running")
+		seedLeaseRepairUnit(t, ctx, pool, leaseRepairUnitA, leaseRepairRunA, "org-a", "linear", "backfill", "work_items", 0, now.Add(-3*time.Minute))
+		seedLeaseRepairUnit(t, ctx, pool, leaseRepairUnitB, leaseRepairRunB, "org-b", "linear", "backfill", "work_items", 0, now.Add(-2*time.Minute))
+		// A malformed cross-tenant unit must not be selected even though its run
+		// is nonterminal and its lease is expired.
+		seedLeaseRepairUnit(t, ctx, pool, leaseRepairUnitC, leaseRepairRunC, "org-other", "linear", "backfill", "work_items", 0, now.Add(-4*time.Minute))
+
+		faulting, err := newLeaseRepair(func(beginCtx context.Context) (pgx.Tx, error) {
+			tx, beginErr := pool.Begin(beginCtx)
+			if beginErr != nil {
+				return nil, beginErr
+			}
+			return &failingLeaseRepairTx{Tx: tx}, nil
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := faulting.Step(ctx, now, 1); !errors.Is(err, ErrUnavailable) {
+			t.Fatalf("faulting Step() error = %v", err)
+		}
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitA, "running", leaseStringPointer("worker-a"), nil, "", false, 0)
+
+		repair, err := NewLeaseRepair(pool)
+		if err != nil {
+			t.Fatal(err)
+		}
+		result, err := repair.Step(ctx, now, 1)
+		if err != nil || result != (LeaseRepairResult{Selected: 1, Retried: 1}) {
+			t.Fatalf("bounded Step() = %#v, %v", result, err)
+		}
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitA, "retrying", nil, leaseTimePointer(now.Add(expiredLeaseDefaultRetryBackoff)), "worker_lost", false, 1)
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitB, "running", leaseStringPointer("worker-a"), nil, "", false, 0)
+		assertLeaseRepairState(t, ctx, pool, leaseRepairUnitC, "running", leaseStringPointer("worker-a"), nil, "", false, 0)
+	})
+}
+
+func createLeaseRepairIntegrationFixture(ctx context.Context, pool *pgxpool.Pool) error {
+	for _, statement := range []string{
+		`CREATE TABLE public.sync_runs (
+			id uuid PRIMARY KEY,
+			org_id text NOT NULL,
+			status text NOT NULL
+		)`,
+		`CREATE TABLE public.sync_run_units (
+			id uuid PRIMARY KEY,
+			org_id text NOT NULL,
+			sync_run_id uuid NOT NULL REFERENCES public.sync_runs(id),
+			provider text NOT NULL,
+			dataset_key text NOT NULL,
+			cost_class text NOT NULL,
+			mode text NOT NULL,
+			status text NOT NULL,
+			attempts integer NOT NULL DEFAULT 0,
+			available_at timestamptz,
+			rate_limit_deferrals integer NOT NULL DEFAULT 0,
+			rate_limit_first_seen_at timestamptz,
+			expired_lease_retry_count integer NOT NULL DEFAULT 0,
+			last_retry_reason text,
+			retry_exhausted_at timestamptz,
+			error text,
+			result jsonb,
+			lease_owner text,
+			lease_expires_at timestamptz,
+			updated_at timestamptz NOT NULL
+		)`,
+	} {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func resetLeaseRepairTables(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, "TRUNCATE public.sync_run_units, public.sync_runs"); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedLeaseRepairRun(t *testing.T, ctx context.Context, pool *pgxpool.Pool, id, orgID, status string) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `INSERT INTO public.sync_runs (id, org_id, status) VALUES ($1, $2, $3)`, id, orgID, status); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func seedLeaseRepairUnit(t *testing.T, ctx context.Context, pool *pgxpool.Pool, id, runID, orgID, provider, mode, dataset string, retries int64, expiresAt time.Time) {
+	t.Helper()
+	if _, err := pool.Exec(ctx, `
+		INSERT INTO public.sync_run_units (
+			id, org_id, sync_run_id, provider, dataset_key, cost_class, mode, status,
+			rate_limit_deferrals, rate_limit_first_seen_at, expired_lease_retry_count,
+			lease_owner, lease_expires_at, updated_at
+		) VALUES ($1, $2, $3, $4, $5, 'standard', $6, 'running', 7, $7, $8, 'worker-a', $9, $7)`,
+		id, orgID, runID, provider, dataset, mode, expiresAt.Add(-time.Hour), retries, expiresAt); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func assertLeaseRepairState(t *testing.T, ctx context.Context, pool *pgxpool.Pool, id, wantStatus string, wantOwner *string, wantAvailable *time.Time, wantCategory string, wantExhausted bool, wantRetries int64) {
+	t.Helper()
+	var (
+		status      string
+		owner       *string
+		availableAt *time.Time
+		retries     int64
+		deferrals   int
+		firstSeen   *time.Time
+		exhaustedAt *time.Time
+		resultRaw   []byte
+	)
+	if err := pool.QueryRow(ctx, `
+		SELECT status, lease_owner, available_at, expired_lease_retry_count,
+			rate_limit_deferrals, rate_limit_first_seen_at, retry_exhausted_at, result
+		FROM public.sync_run_units WHERE id = $1`, id).Scan(
+		&status, &owner, &availableAt, &retries, &deferrals, &firstSeen, &exhaustedAt, &resultRaw,
+	); err != nil {
+		t.Fatal(err)
+	}
+	if status != wantStatus || !equalStringPointers(owner, wantOwner) || !equalTimePointers(availableAt, wantAvailable) || retries != wantRetries {
+		t.Fatalf("unit %s state status=%s owner=%v available=%v retries=%d", id, status, owner, availableAt, retries)
+	}
+	if wantStatus == "retrying" && (deferrals != 0 || firstSeen != nil) {
+		t.Fatalf("retry unit %s retained rate-limit episode: deferrals=%d first_seen=%v", id, deferrals, firstSeen)
+	}
+	if wantExhausted && exhaustedAt == nil {
+		t.Fatalf("exhausted unit %s lacks retry_exhausted_at", id)
+	}
+	if !wantExhausted && exhaustedAt != nil {
+		t.Fatalf("nonexhausted unit %s has retry_exhausted_at=%v", id, exhaustedAt)
+	}
+	if wantCategory == "" {
+		if resultRaw != nil {
+			t.Fatalf("untouched unit %s result=%s", id, resultRaw)
+		}
+		return
+	}
+	var result map[string]any
+	if err := json.Unmarshal(resultRaw, &result); err != nil {
+		t.Fatal(err)
+	}
+	if result["error_category"] != wantCategory || result["retry_reason"] != leaseRepairRetryReason ||
+		result["retry_exhausted"] != wantExhausted || result["last_lease_expired_at"] == nil ||
+		result["retry_count"] != float64(wantRetries) {
+		t.Fatalf("unit %s result=%v", id, result)
+	}
+	wantSurfaces := []string{}
+	if wantStatus == "retrying" || wantCategory == leaseRepairRetryExhaustedCategory {
+		wantSurfaces = linearBackfillRetrySurfaces
+	}
+	gotSurfaces, ok := result["retry_surfaces"].([]any)
+	if !ok || len(gotSurfaces) != len(wantSurfaces) {
+		t.Fatalf("unit %s retry surfaces=%v want=%v", id, result["retry_surfaces"], wantSurfaces)
+	}
+	for index, surface := range wantSurfaces {
+		if gotSurfaces[index] != surface {
+			t.Fatalf("unit %s retry surfaces=%v want=%v", id, gotSurfaces, wantSurfaces)
+		}
+	}
+	if got, want := result["last_lease_expired_at"], "2026-07-23T12:00:00+00:00"; got != want {
+		t.Fatalf("unit %s last lease expiry=%v, want %s", id, got, want)
+	}
+}
+
+func leaseStringPointer(value string) *string { return &value }
+
+func leaseTimePointer(value time.Time) *time.Time { return &value }
+
+func equalStringPointers(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func equalTimePointers(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.UTC().Equal(right.UTC())
+}

--- a/internal/syncreconciler/lease_repair_test.go
+++ b/internal/syncreconciler/lease_repair_test.go
@@ -1,0 +1,222 @@
+package syncreconciler
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+)
+
+type fakeLeaseRepairRows struct {
+	pgx.Rows
+	candidates []expiredLeaseCandidate
+	index      int
+	err        error
+}
+
+func (rows *fakeLeaseRepairRows) Next() bool { return rows.index < len(rows.candidates) }
+
+func (rows *fakeLeaseRepairRows) Scan(dest ...any) error {
+	if rows.index >= len(rows.candidates) {
+		return errors.New("scan past rows")
+	}
+	candidate := rows.candidates[rows.index]
+	rows.index++
+	values := []any{
+		candidate.id,
+		candidate.syncRunID,
+		candidate.leaseOwner,
+		candidate.provider,
+		candidate.mode,
+		candidate.datasetKey,
+		candidate.orgID,
+		candidate.costClass,
+		candidate.retryCount,
+	}
+	for index, destination := range dest {
+		switch typed := destination.(type) {
+		case *string:
+			*typed = values[index].(string)
+		case *int64:
+			*typed = values[index].(int64)
+		default:
+			return errors.New("unexpected scan destination")
+		}
+	}
+	return nil
+}
+
+func (rows *fakeLeaseRepairRows) Err() error { return rows.err }
+func (*fakeLeaseRepairRows) Close()          {}
+
+type fakeLeaseRepairTx struct {
+	pgx.Tx
+	candidates []expiredLeaseCandidate
+	querySQL   string
+	queryArgs  []any
+	execSQL    []string
+	execArgs   [][]any
+	affected   []int64
+	execErr    error
+	commitErr  error
+	commit     bool
+	rollback   bool
+}
+
+func (tx *fakeLeaseRepairTx) Query(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
+	tx.querySQL = sql
+	tx.queryArgs = args
+	return &fakeLeaseRepairRows{candidates: append([]expiredLeaseCandidate(nil), tx.candidates...)}, nil
+}
+
+func (tx *fakeLeaseRepairTx) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	tx.execSQL = append(tx.execSQL, sql)
+	tx.execArgs = append(tx.execArgs, args)
+	if tx.execErr != nil {
+		return pgconn.CommandTag{}, tx.execErr
+	}
+	index := len(tx.execSQL) - 1
+	affected := int64(1)
+	if index < len(tx.affected) {
+		affected = tx.affected[index]
+	}
+	return pgconn.NewCommandTag("UPDATE " + strconv.FormatInt(affected, 10)), nil
+}
+
+func (tx *fakeLeaseRepairTx) Commit(context.Context) error {
+	tx.commit = true
+	return tx.commitErr
+}
+
+func (tx *fakeLeaseRepairTx) Rollback(context.Context) error {
+	tx.rollback = true
+	return nil
+}
+
+func repairCandidate(provider, mode, dataset string, retries int64) expiredLeaseCandidate {
+	return expiredLeaseCandidate{
+		id:         candidateID1,
+		syncRunID:  "00000000-0000-4000-8000-000000003301",
+		leaseOwner: "worker-a",
+		provider:   provider,
+		mode:       mode,
+		datasetKey: dataset,
+		orgID:      "org-a",
+		costClass:  "standard",
+		retryCount: retries,
+	}
+}
+
+func TestExpiredLeaseDecisionIsFailClosedOutsideExactLinearBackfillSurface(t *testing.T) {
+	tests := []struct {
+		name      string
+		candidate expiredLeaseCandidate
+		want      expiredLeaseDecision
+	}{
+		{"eligible below ceiling", repairCandidate("linear", "backfill", "work_items", 0), expiredLeaseDecision{retry: true}},
+		{"eligible at ceiling", repairCandidate("linear", "backfill", "work_items", 1), expiredLeaseDecision{exhausted: true}},
+		{"wrong provider", repairCandidate("github", "backfill", "work_items", 0), expiredLeaseDecision{}},
+		{"wrong mode", repairCandidate("linear", "incremental", "work_items", 0), expiredLeaseDecision{}},
+		{"wrong dataset", repairCandidate("linear", "backfill", "repositories", 0), expiredLeaseDecision{}},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			if got := decideExpiredLeaseRepair(test.candidate, DefaultLeaseRepairConfig()); got != test.want {
+				t.Fatalf("decideExpiredLeaseRepair() = %#v, want %#v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestLeaseRepairConfigDefaultsAndBucketHashMatchPythonContract(t *testing.T) {
+	defaults := DefaultLeaseRepairConfig()
+	if defaults.MaximumRetries != 1 || defaults.RetryBackoff != time.Minute || !defaults.valid() {
+		t.Fatalf("default config = %#v", defaults)
+	}
+	if leaseRepairBucketAdvisoryID("org-a", "linear", "standard") != 3882165252103971925 {
+		t.Fatalf("bucket advisory id diverged from Python SHA-256 contract")
+	}
+	if _, err := newLeaseRepairWithConfig(func(context.Context) (pgx.Tx, error) { return nil, nil }, LeaseRepairConfig{MaximumRetries: -1}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("negative retry config error = %v", err)
+	}
+	if got := decideExpiredLeaseRepair(repairCandidate("linear", "backfill", "work_items", 2), LeaseRepairConfig{MaximumRetries: 3}); !got.retry || got.exhausted {
+		t.Fatalf("operator config decision = %#v", got)
+	}
+}
+
+func TestLeaseRepairStepUsesCASAndRollsBackOnFault(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	tx := &fakeLeaseRepairTx{
+		candidates: []expiredLeaseCandidate{
+			repairCandidate("linear", "backfill", "work_items", 0),
+			func() expiredLeaseCandidate {
+				candidate := repairCandidate("github", "backfill", "work_items", 0)
+				candidate.id = candidateID2
+				return candidate
+			}(),
+		},
+	}
+	repair, err := newLeaseRepair(func(context.Context) (pgx.Tx, error) { return tx, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := repair.Step(context.Background(), now, 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != (LeaseRepairResult{Selected: 2, Retried: 1, Failed: 1}) || !tx.commit {
+		t.Fatalf("Step() = %#v, commit=%t", result, tx.commit)
+	}
+	upperSelect := strings.ToUpper(tx.querySQL)
+	for _, required := range []string{
+		"RUN.STATUS NOT IN ('SUCCESS', 'PARTIAL_FAILED', 'FAILED')",
+		"RUN.ORG_ID = UNIT.ORG_ID",
+		"ORDER BY UNIT.LEASE_EXPIRES_AT, UNIT.ID",
+		"LIMIT $2",
+	} {
+		if !strings.Contains(upperSelect, required) {
+			t.Fatalf("selection SQL missing %q:\n%s", required, tx.querySQL)
+		}
+	}
+	if len(tx.execSQL) != 4 || tx.execSQL[0] != "SELECT pg_advisory_xact_lock($1)" ||
+		tx.execSQL[1] != "SELECT pg_advisory_xact_lock($1)" ||
+		!strings.Contains(tx.execSQL[2], "rate_limit_deferrals = 0") ||
+		!strings.Contains(tx.execSQL[2], "unit.lease_owner = $2") ||
+		!strings.Contains(tx.execSQL[3], "'error_category', $4::text") {
+		t.Fatalf("write SQL = %v", tx.execSQL)
+	}
+	if got, want := tx.execArgs[2][4], linearBackfillRetrySurfaces; !reflect.DeepEqual(got, want) {
+		t.Fatalf("retry surfaces = %#v, want %#v", got, want)
+	}
+
+	faultTx := &fakeLeaseRepairTx{candidates: []expiredLeaseCandidate{repairCandidate("linear", "backfill", "work_items", 0)}, execErr: errors.New("injected write fault")}
+	faultRepair, err := newLeaseRepair(func(context.Context) (pgx.Tx, error) { return faultTx, nil })
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := faultRepair.Step(context.Background(), now, 1); !errors.Is(err, ErrUnavailable) || faultTx.commit || !faultTx.rollback {
+		t.Fatalf("fault Step() err=%v commit=%t rollback=%t", err, faultTx.commit, faultTx.rollback)
+	}
+}
+
+func TestLeaseRepairRejectsInvalidBoundsWithoutBeginning(t *testing.T) {
+	called := false
+	repair, err := newLeaseRepair(func(context.Context) (pgx.Tx, error) {
+		called = true
+		return nil, nil
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, limit := range []int{0, leaseRepairMaximumLimit + 1} {
+		if _, err := repair.Step(context.Background(), time.Now(), limit); !errors.Is(err, ErrInvalidConfiguration) || called {
+			t.Fatalf("limit %d error = %v begin=%t", limit, err, called)
+		}
+	}
+}

--- a/internal/syncroute/control.go
+++ b/internal/syncroute/control.go
@@ -51,8 +51,9 @@ type Quiescer interface {
 }
 
 // Capability is registered only by composition code that has a concrete
-// publisher/handler. Post-sync additionally requires a Quiescer because its
-// mark-before-publish window outlives the database claim.
+// publisher/handler. A post-sync capability's Quiescer stops publishers owned
+// by Capability.Transport because its mark-before-publish window outlives the
+// database claim.
 type Capability struct {
 	Kind      string
 	Transport string
@@ -291,23 +292,18 @@ func resumeCapability(
 	currentTransport string,
 	targetTransport string,
 ) (Capability, bool, error) {
-	var capability Capability
 	if targetTransport == syncdispatchcontract.RouteRiver {
-		var ok bool
-		capability, ok = capabilities.Lookup(kind, targetTransport)
+		capability, ok := capabilities.Lookup(kind, targetTransport)
 		if !ok || capability.Kind != kind || capability.Transport != targetTransport {
 			return Capability{}, false, ErrCapabilityMissing
 		}
 	}
 	if kind != syncdispatchcontract.KindPostSync || currentTransport == targetTransport {
-		return capability, false, nil
+		return Capability{}, false, nil
 	}
-	if targetTransport != syncdispatchcontract.RouteRiver {
-		var ok bool
-		capability, ok = capabilities.Lookup(kind, targetTransport)
-		if !ok || capability.Kind != kind || capability.Transport != targetTransport {
-			return Capability{}, false, ErrQuiescenceMissing
-		}
+	capability, ok := capabilities.Lookup(kind, currentTransport)
+	if !ok || capability.Kind != kind || capability.Transport != currentTransport {
+		return Capability{}, false, ErrQuiescenceMissing
 	}
 	if capability.Quiescer == nil {
 		return Capability{}, false, ErrQuiescenceMissing

--- a/internal/syncroute/control.go
+++ b/internal/syncroute/control.go
@@ -206,8 +206,9 @@ func (controller *Controller) Drain(ctx context.Context, kind string) (RouteStat
 
 // Resume holds the outbox table lock while rechecking claims and changing the
 // generation. This prevents an old-generation terminal update from committing
-// after the route becomes active. River requires an exact capability; post_sync
-// additionally requires and executes a deadline-bounded external barrier.
+// after the route becomes active. River requires an exact capability; a
+// transport-changing post_sync resume additionally requires and executes a
+// deadline-bounded external barrier.
 func (controller *Controller) Resume(
 	ctx context.Context,
 	kind string,

--- a/internal/syncroute/control.go
+++ b/internal/syncroute/control.go
@@ -1,0 +1,373 @@
+package syncroute
+
+import (
+	"context"
+	"errors"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+const (
+	maximumQuiescenceTimeout = 30 * time.Second
+	routeMutationLockSQL     = `LOCK TABLE public.sync_dispatch_outbox IN SHARE ROW EXCLUSIVE MODE`
+)
+
+var (
+	ErrUnknownRoute       = errors.New("sync dispatch route is not registered")
+	ErrRouteStateConflict = errors.New("sync dispatch route state conflict")
+	ErrLiveClaims         = errors.New("sync dispatch route has live claims")
+	ErrCapabilityMissing  = errors.New("sync dispatch transport capability is missing")
+	ErrQuiescenceMissing  = errors.New("sync dispatch external quiescence capability is missing")
+	// ErrMutationOutcomeUnknown means PostgreSQL returned a commit error after
+	// a route mutation. The generation change may be durable, so callers must
+	// inspect rather than retrying the operation.
+	ErrMutationOutcomeUnknown = errors.New("sync dispatch route mutation outcome is unknown")
+)
+
+// RouteState is the bounded, payload-free route control projection.
+type RouteState struct {
+	Kind              string     `json:"kind"`
+	Transport         string     `json:"transport"`
+	Generation        int64      `json:"generation"`
+	Paused            bool       `json:"paused"`
+	PausedAt          *time.Time `json:"paused_at,omitempty"`
+	RollbackTransport string     `json:"rollback_transport"`
+	LiveClaims        int64      `json:"live_claims"`
+}
+
+// QuiescenceRequest identifies the old generation whose external handoffs
+// must be unable to issue another publish before a paused route can resume.
+type QuiescenceRequest struct {
+	Kind       string
+	Transport  string
+	Generation int64
+}
+
+type Quiescer interface {
+	Quiesce(context.Context, QuiescenceRequest) error
+}
+
+// Capability is registered only by composition code that has a concrete
+// publisher/handler. Post-sync additionally requires a Quiescer because its
+// mark-before-publish window outlives the database claim.
+type Capability struct {
+	Kind      string
+	Transport string
+	Quiescer  Quiescer
+}
+
+type Capabilities interface {
+	Lookup(kind, transport string) (Capability, bool)
+}
+
+type capabilitySet map[string]Capability
+
+// NewCapabilities returns an immutable exact-match capability registry.
+func NewCapabilities(values []Capability) (Capabilities, error) {
+	result := make(capabilitySet, len(values))
+	for _, value := range values {
+		if value.Kind == "" ||
+			(value.Transport != syncdispatchcontract.RouteRiver && value.Transport != syncdispatchcontract.RouteCelery) {
+			return nil, ErrInvalidConfiguration
+		}
+		key := value.Kind + "\x00" + value.Transport
+		if _, duplicate := result[key]; duplicate {
+			return nil, ErrInvalidConfiguration
+		}
+		result[key] = value
+	}
+	return result, nil
+}
+
+func (values capabilitySet) Lookup(kind, transport string) (Capability, bool) {
+	value, ok := values[kind+"\x00"+transport]
+	return value, ok
+}
+
+type routeRegistry interface {
+	Lookup(string) (syncdispatchcontract.Descriptor, bool)
+}
+
+type beginControlTransaction func(context.Context) (pgx.Tx, error)
+
+// Controller owns explicit, audited-by-caller route mutations. It never
+// changes a route automatically and has no dispatch or handler activation path.
+type Controller struct {
+	begin        beginControlTransaction
+	registry     routeRegistry
+	capabilities Capabilities
+	now          func() time.Time
+}
+
+func NewController(pool *pgxpool.Pool, registry routeRegistry, capabilities Capabilities) (*Controller, error) {
+	if pool == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	return newController(pool.Begin, registry, capabilities, time.Now)
+}
+
+func newController(
+	begin beginControlTransaction,
+	registry routeRegistry,
+	capabilities Capabilities,
+	now func() time.Time,
+) (*Controller, error) {
+	if begin == nil || registry == nil || capabilities == nil || now == nil {
+		return nil, ErrInvalidConfiguration
+	}
+	return &Controller{begin: begin, registry: registry, capabilities: capabilities, now: now}, nil
+}
+
+func (controller *Controller) Inspect(ctx context.Context, kind string) (RouteState, error) {
+	if !controller.validKind(kind) {
+		return RouteState{}, ErrUnknownRoute
+	}
+	tx, err := controller.begin(ctx)
+	if err != nil || tx == nil {
+		return RouteState{}, ErrUnavailable
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	state, err := readRouteState(ctx, tx, kind, controller.now().UTC(), false)
+	if err != nil {
+		return RouteState{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return RouteState{}, ErrUnavailable
+	}
+	return state, nil
+}
+
+// Pause serializes behind every outbox terminal transaction, increments the
+// generation, and prevents new claims before releasing the lock.
+func (controller *Controller) Pause(ctx context.Context, kind string) (RouteState, error) {
+	if !controller.validKind(kind) {
+		return RouteState{}, ErrUnknownRoute
+	}
+	now := controller.now().UTC()
+	tx, state, err := controller.beginRouteMutation(ctx, kind, now)
+	if err != nil {
+		return RouteState{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if state.Paused {
+		return RouteState{}, ErrRouteStateConflict
+	}
+	descriptor, _ := controller.registry.Lookup(kind)
+	if state.Transport != descriptor.Route {
+		return RouteState{}, ErrDrift
+	}
+	row := tx.QueryRow(ctx, `
+UPDATE public.sync_dispatch_transport_routes
+SET paused = TRUE, paused_at = $2, generation = generation + 1, updated_at = $2
+WHERE kind = $1 AND generation = $3 AND paused = FALSE
+RETURNING generation, paused_at`, kind, now, state.Generation)
+	if err := row.Scan(&state.Generation, &state.PausedAt); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return RouteState{}, ErrRouteStateConflict
+		}
+		return RouteState{}, ErrUnavailable
+	}
+	state.Paused = true
+	state.LiveClaims, err = countLiveClaims(ctx, tx, kind, now)
+	if err != nil {
+		return RouteState{}, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return RouteState{}, ErrMutationOutcomeUnknown
+	}
+	return state, nil
+}
+
+// Drain proves whether a paused route has any unexpired database claims.
+func (controller *Controller) Drain(ctx context.Context, kind string) (RouteState, error) {
+	if !controller.validKind(kind) {
+		return RouteState{}, ErrUnknownRoute
+	}
+	tx, err := controller.begin(ctx)
+	if err != nil || tx == nil {
+		return RouteState{}, ErrUnavailable
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	state, err := readRouteState(ctx, tx, kind, controller.now().UTC(), true)
+	if err != nil {
+		return RouteState{}, err
+	}
+	if !state.Paused {
+		return RouteState{}, ErrRouteStateConflict
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return RouteState{}, ErrUnavailable
+	}
+	return state, nil
+}
+
+// Resume holds the outbox table lock while rechecking claims and changing the
+// generation. This prevents an old-generation terminal update from committing
+// after the route becomes active. River requires an exact capability; post_sync
+// additionally requires and executes a deadline-bounded external barrier.
+func (controller *Controller) Resume(
+	ctx context.Context,
+	kind string,
+	transport string,
+	quiescenceTimeout time.Duration,
+) (RouteState, error) {
+	descriptor, known := controller.registry.Lookup(kind)
+	if !known {
+		return RouteState{}, ErrUnknownRoute
+	}
+	if transport != descriptor.Route {
+		return RouteState{}, ErrCapabilityMissing
+	}
+	var capability Capability
+	if transport == syncdispatchcontract.RouteRiver || kind == syncdispatchcontract.KindPostSync {
+		var ok bool
+		capability, ok = controller.capabilities.Lookup(kind, transport)
+		if !ok || capability.Kind != kind || capability.Transport != transport {
+			if kind == syncdispatchcontract.KindPostSync {
+				return RouteState{}, ErrQuiescenceMissing
+			}
+			return RouteState{}, ErrCapabilityMissing
+		}
+	}
+	if kind == syncdispatchcontract.KindPostSync {
+		if capability.Quiescer == nil {
+			return RouteState{}, ErrQuiescenceMissing
+		}
+		if quiescenceTimeout <= 0 || quiescenceTimeout > maximumQuiescenceTimeout {
+			return RouteState{}, ErrInvalidConfiguration
+		}
+	}
+
+	now := controller.now().UTC()
+	tx, state, err := controller.beginRouteMutation(ctx, kind, now)
+	if err != nil {
+		return RouteState{}, err
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if !state.Paused {
+		return RouteState{}, ErrRouteStateConflict
+	}
+	if state.LiveClaims != 0 {
+		return RouteState{}, ErrLiveClaims
+	}
+	if kind == syncdispatchcontract.KindPostSync {
+		barrierCtx, cancel := context.WithTimeout(ctx, quiescenceTimeout)
+		err := capability.Quiescer.Quiesce(barrierCtx, QuiescenceRequest{
+			Kind: kind, Transport: state.Transport, Generation: state.Generation - 1,
+		})
+		cancel()
+		if err != nil {
+			return RouteState{}, ErrLiveClaims
+		}
+	}
+	row := tx.QueryRow(ctx, `
+UPDATE public.sync_dispatch_transport_routes
+SET transport = $2, paused = FALSE, paused_at = NULL,
+    generation = generation + 1, updated_at = $3
+WHERE kind = $1 AND generation = $4 AND paused = TRUE
+RETURNING generation`, kind, transport, now, state.Generation)
+	if err := row.Scan(&state.Generation); err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return RouteState{}, ErrRouteStateConflict
+		}
+		return RouteState{}, ErrUnavailable
+	}
+	state.Transport = transport
+	state.Paused = false
+	state.PausedAt = nil
+	if err := tx.Commit(ctx); err != nil {
+		return RouteState{}, ErrMutationOutcomeUnknown
+	}
+	return state, nil
+}
+
+// beginRouteMutation follows the producer lock order: route row first, then
+// the outbox table barrier. An in-flight Celery publisher can therefore finish
+// its terminal UPDATE and commit before this transaction acquires the route
+// row. An outbox-only Go terminal transaction is then waited out by the table
+// lock. State and claims are re-read only after both barriers are held.
+func (controller *Controller) beginRouteMutation(
+	ctx context.Context,
+	kind string,
+	now time.Time,
+) (pgx.Tx, RouteState, error) {
+	tx, err := controller.begin(ctx)
+	if err != nil || tx == nil {
+		return nil, RouteState{}, ErrUnavailable
+	}
+	if _, err := readRouteRecord(ctx, tx, kind, true); err != nil {
+		_ = tx.Rollback(ctx)
+		return nil, RouteState{}, err
+	}
+	if _, err := tx.Exec(ctx, routeMutationLockSQL); err != nil {
+		_ = tx.Rollback(ctx)
+		return nil, RouteState{}, ErrUnavailable
+	}
+	state, err := readRouteState(ctx, tx, kind, now, true)
+	if err != nil {
+		_ = tx.Rollback(ctx)
+		return nil, RouteState{}, err
+	}
+	return tx, state, nil
+}
+
+func (controller *Controller) validKind(kind string) bool {
+	if controller == nil || controller.registry == nil {
+		return false
+	}
+	_, ok := controller.registry.Lookup(kind)
+	return ok
+}
+
+func readRouteState(ctx context.Context, tx pgx.Tx, kind string, now time.Time, lock bool) (RouteState, error) {
+	state, err := readRouteRecord(ctx, tx, kind, lock)
+	if err != nil {
+		return RouteState{}, err
+	}
+	state.LiveClaims, err = countLiveClaims(ctx, tx, kind, now)
+	return state, err
+}
+
+func readRouteRecord(ctx context.Context, tx pgx.Tx, kind string, lock bool) (RouteState, error) {
+	suffix := ""
+	if lock {
+		suffix = " FOR UPDATE"
+	}
+	var state RouteState
+	err := tx.QueryRow(ctx, `
+SELECT kind, transport, generation, paused, paused_at, rollback_transport
+FROM public.sync_dispatch_transport_routes
+WHERE kind = $1`+suffix, kind).Scan(
+		&state.Kind, &state.Transport, &state.Generation, &state.Paused,
+		&state.PausedAt, &state.RollbackTransport,
+	)
+	if errors.Is(err, pgx.ErrNoRows) {
+		return RouteState{}, ErrUnknownRoute
+	}
+	if err != nil {
+		return RouteState{}, ErrUnavailable
+	}
+	if state.Generation < 1 || state.Paused != (state.PausedAt != nil) ||
+		(state.Transport != syncdispatchcontract.RouteCelery && state.Transport != syncdispatchcontract.RouteRiver) ||
+		state.RollbackTransport != syncdispatchcontract.RouteCelery {
+		return RouteState{}, ErrDrift
+	}
+	return state, nil
+}
+
+func countLiveClaims(ctx context.Context, tx pgx.Tx, kind string, now time.Time) (int64, error) {
+	var count int64
+	err := tx.QueryRow(ctx, `
+SELECT count(*)
+FROM public.sync_dispatch_outbox
+WHERE kind = $1
+  AND claim_token IS NOT NULL
+  AND claim_expires_at > $2`, kind, now).Scan(&count)
+	if err != nil || count < 0 {
+		return 0, ErrUnavailable
+	}
+	return count, nil
+}

--- a/internal/syncroute/control.go
+++ b/internal/syncroute/control.go
@@ -221,23 +221,10 @@ func (controller *Controller) Resume(
 	if transport != descriptor.Route {
 		return RouteState{}, ErrCapabilityMissing
 	}
-	var capability Capability
-	if transport == syncdispatchcontract.RouteRiver || kind == syncdispatchcontract.KindPostSync {
-		var ok bool
-		capability, ok = controller.capabilities.Lookup(kind, transport)
+	if transport == syncdispatchcontract.RouteRiver {
+		capability, ok := controller.capabilities.Lookup(kind, transport)
 		if !ok || capability.Kind != kind || capability.Transport != transport {
-			if kind == syncdispatchcontract.KindPostSync {
-				return RouteState{}, ErrQuiescenceMissing
-			}
 			return RouteState{}, ErrCapabilityMissing
-		}
-	}
-	if kind == syncdispatchcontract.KindPostSync {
-		if capability.Quiescer == nil {
-			return RouteState{}, ErrQuiescenceMissing
-		}
-		if quiescenceTimeout <= 0 || quiescenceTimeout > maximumQuiescenceTimeout {
-			return RouteState{}, ErrInvalidConfiguration
 		}
 	}
 
@@ -253,9 +240,18 @@ func (controller *Controller) Resume(
 	if state.LiveClaims != 0 {
 		return RouteState{}, ErrLiveClaims
 	}
-	if kind == syncdispatchcontract.KindPostSync {
+	capability, requiresQuiescence, err := resumeCapability(
+		controller.capabilities, kind, state.Transport, transport,
+	)
+	if err != nil {
+		return RouteState{}, err
+	}
+	if requiresQuiescence {
+		if !validQuiescenceTimeout(quiescenceTimeout) {
+			return RouteState{}, ErrInvalidConfiguration
+		}
 		barrierCtx, cancel := context.WithTimeout(ctx, quiescenceTimeout)
-		err := capability.Quiescer.Quiesce(barrierCtx, QuiescenceRequest{
+		err = capability.Quiescer.Quiesce(barrierCtx, QuiescenceRequest{
 			Kind: kind, Transport: state.Transport, Generation: state.Generation - 1,
 		})
 		cancel()
@@ -282,6 +278,40 @@ RETURNING generation`, kind, transport, now, state.Generation)
 		return RouteState{}, ErrMutationOutcomeUnknown
 	}
 	return state, nil
+}
+
+func validQuiescenceTimeout(timeout time.Duration) bool {
+	return timeout > 0 && timeout <= maximumQuiescenceTimeout
+}
+
+func resumeCapability(
+	capabilities Capabilities,
+	kind string,
+	currentTransport string,
+	targetTransport string,
+) (Capability, bool, error) {
+	var capability Capability
+	if targetTransport == syncdispatchcontract.RouteRiver {
+		var ok bool
+		capability, ok = capabilities.Lookup(kind, targetTransport)
+		if !ok || capability.Kind != kind || capability.Transport != targetTransport {
+			return Capability{}, false, ErrCapabilityMissing
+		}
+	}
+	if kind != syncdispatchcontract.KindPostSync || currentTransport == targetTransport {
+		return capability, false, nil
+	}
+	if targetTransport != syncdispatchcontract.RouteRiver {
+		var ok bool
+		capability, ok = capabilities.Lookup(kind, targetTransport)
+		if !ok || capability.Kind != kind || capability.Transport != targetTransport {
+			return Capability{}, false, ErrQuiescenceMissing
+		}
+	}
+	if capability.Quiescer == nil {
+		return Capability{}, false, ErrQuiescenceMissing
+	}
+	return capability, true, nil
 }
 
 // beginRouteMutation follows the producer lock order: route row first, then

--- a/internal/syncroute/control_integration_test.go
+++ b/internal/syncroute/control_integration_test.go
@@ -77,6 +77,25 @@ func TestRouteControlPostgresConcurrencyDrainAndRollback(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defaultCapabilities, err := NewCapabilities(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defaultController, err := NewController(pool, registry, defaultCapabilities)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := defaultController.Pause(ctx, syncdispatchcontract.KindPostSync)
+	if err != nil || !state.Paused || state.Generation != 2 {
+		t.Fatalf("default post_sync pause state=%+v err=%v", state, err)
+	}
+	state, err = defaultController.Resume(
+		ctx, syncdispatchcontract.KindPostSync, syncdispatchcontract.RouteCelery, 0,
+	)
+	if err != nil || state.Paused || state.Generation != 3 ||
+		state.Transport != syncdispatchcontract.RouteCelery {
+		t.Fatalf("default same-transport post_sync resume state=%+v err=%v", state, err)
+	}
 
 	celeryTx, err := pool.Begin(ctx)
 	if err != nil {
@@ -152,7 +171,7 @@ SET status = 'pending', claim_token = 'claim-1', claim_expires_at = NOW() + inte
 WHERE id = '00000000-0000-4000-8000-000000000401'`); err != nil {
 		t.Fatal(err)
 	}
-	state, err := controller.Drain(ctx, syncdispatchcontract.KindDispatchSyncRun)
+	state, err = controller.Drain(ctx, syncdispatchcontract.KindDispatchSyncRun)
 	if err != nil || state.LiveClaims != 1 {
 		t.Fatalf("live drain state=%+v err=%v", state, err)
 	}
@@ -175,12 +194,27 @@ WHERE id = '00000000-0000-4000-8000-000000000401'`); err != nil {
 	postSyncDescriptor := registry[syncdispatchcontract.KindPostSync]
 	postSyncDescriptor.Route = syncdispatchcontract.RouteRiver
 	registry[syncdispatchcontract.KindPostSync] = postSyncDescriptor
+	riverWithoutQuiescer, err := NewCapabilities([]Capability{{
+		Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	noQuiescerController, err := NewController(pool, registry, riverWithoutQuiescer)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := noQuiescerController.Resume(
+		ctx, syncdispatchcontract.KindPostSync, syncdispatchcontract.RouteRiver, time.Second,
+	); !errors.Is(err, ErrQuiescenceMissing) {
+		t.Fatalf("post_sync transport change without quiescer error=%v", err)
+	}
 	quiescer.err = errors.New("old publisher still active")
 	if _, err := controller.Resume(ctx, syncdispatchcontract.KindPostSync, syncdispatchcontract.RouteRiver, time.Second); !errors.Is(err, ErrLiveClaims) {
 		t.Fatalf("post_sync quiescence error=%v", err)
 	}
 	state, err = controller.Inspect(ctx, syncdispatchcontract.KindPostSync)
-	if err != nil || !state.Paused || state.Generation != 2 || quiescer.calls != 1 {
+	if err != nil || !state.Paused || state.Generation != 4 || quiescer.calls != 1 {
 		t.Fatalf("post_sync rollback state=%+v calls=%d err=%v", state, quiescer.calls, err)
 	}
 }

--- a/internal/syncroute/control_integration_test.go
+++ b/internal/syncroute/control_integration_test.go
@@ -21,12 +21,14 @@ func (registry integrationRegistry) Lookup(kind string) (syncdispatchcontract.De
 }
 
 type integrationQuiescer struct {
-	err   error
-	calls int
+	err     error
+	calls   int
+	request QuiescenceRequest
 }
 
-func (quiescer *integrationQuiescer) Quiesce(context.Context, QuiescenceRequest) error {
+func (quiescer *integrationQuiescer) Quiesce(_ context.Context, request QuiescenceRequest) error {
 	quiescer.calls++
+	quiescer.request = request
 	return quiescer.err
 }
 
@@ -68,7 +70,8 @@ func TestRouteControlPostgresConcurrencyDrainAndRollback(t *testing.T) {
 	}
 	capabilities, err := NewCapabilities([]Capability{
 		{Kind: syncdispatchcontract.KindDispatchSyncRun, Transport: syncdispatchcontract.RouteRiver},
-		{Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver, Quiescer: quiescer},
+		{Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver},
+		{Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteCelery, Quiescer: quiescer},
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -214,8 +217,13 @@ WHERE id = '00000000-0000-4000-8000-000000000401'`); err != nil {
 		t.Fatalf("post_sync quiescence error=%v", err)
 	}
 	state, err = controller.Inspect(ctx, syncdispatchcontract.KindPostSync)
-	if err != nil || !state.Paused || state.Generation != 4 || quiescer.calls != 1 {
-		t.Fatalf("post_sync rollback state=%+v calls=%d err=%v", state, quiescer.calls, err)
+	if err != nil || !state.Paused || state.Generation != 4 || quiescer.calls != 1 ||
+		quiescer.request.Transport != syncdispatchcontract.RouteCelery ||
+		quiescer.request.Generation != 3 {
+		t.Fatalf(
+			"post_sync rollback state=%+v calls=%d request=%+v err=%v",
+			state, quiescer.calls, quiescer.request, err,
+		)
 	}
 }
 

--- a/internal/syncroute/control_integration_test.go
+++ b/internal/syncroute/control_integration_test.go
@@ -1,0 +1,262 @@
+//go:build integration
+
+package syncroute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+type integrationRegistry map[string]syncdispatchcontract.Descriptor
+
+func (registry integrationRegistry) Lookup(kind string) (syncdispatchcontract.Descriptor, bool) {
+	value, ok := registry[kind]
+	return value, ok
+}
+
+type integrationQuiescer struct {
+	err   error
+	calls int
+}
+
+func (quiescer *integrationQuiescer) Quiesce(context.Context, QuiescenceRequest) error {
+	quiescer.calls++
+	return quiescer.err
+}
+
+func TestRouteControlPostgresConcurrencyDrainAndRollback(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("close PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createRouteControlSchema(t, ctx, pool)
+
+	quiescer := &integrationQuiescer{}
+	registry := integrationRegistry{
+		syncdispatchcontract.KindDispatchSyncRun: {
+			Kind: syncdispatchcontract.KindDispatchSyncRun, Delivery: syncdispatchcontract.DeliveryAtLeastOnce,
+			Route: syncdispatchcontract.RouteCelery, RollbackRoute: syncdispatchcontract.RouteCelery,
+		},
+		syncdispatchcontract.KindPostSync: {
+			Kind: syncdispatchcontract.KindPostSync, Delivery: syncdispatchcontract.DeliveryAtMostOnceMarkBefore,
+			Route: syncdispatchcontract.RouteCelery, RollbackRoute: syncdispatchcontract.RouteCelery,
+		},
+		syncdispatchcontract.KindReferenceDiscovery: {
+			Kind: syncdispatchcontract.KindReferenceDiscovery, Delivery: syncdispatchcontract.DeliveryAtLeastOnce,
+			Route: syncdispatchcontract.RouteCelery, RollbackRoute: syncdispatchcontract.RouteCelery,
+		},
+	}
+	capabilities, err := NewCapabilities([]Capability{
+		{Kind: syncdispatchcontract.KindDispatchSyncRun, Transport: syncdispatchcontract.RouteRiver},
+		{Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver, Quiescer: quiescer},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller, err := NewController(pool, registry, capabilities)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	celeryTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var celeryOutboxID string
+	if err := celeryTx.QueryRow(ctx, `
+SELECT outbox.id::text
+FROM public.sync_dispatch_transport_routes AS route
+JOIN public.sync_dispatch_outbox AS outbox ON outbox.kind = route.kind
+WHERE route.kind = 'reference_discovery'
+FOR UPDATE OF route, outbox`).Scan(&celeryOutboxID); err != nil {
+		t.Fatal(err)
+	}
+	celeryPauseResult := make(chan error, 1)
+	go func() {
+		_, pauseErr := controller.Pause(ctx, syncdispatchcontract.KindReferenceDiscovery)
+		celeryPauseResult <- pauseErr
+	}()
+	waitForRouteRowLockWait(t, ctx, pool)
+	if _, err := celeryTx.Exec(ctx, `
+UPDATE public.sync_dispatch_outbox
+SET status = 'dispatched'
+WHERE id = $1`, celeryOutboxID); err != nil {
+		t.Fatalf("Celery terminal update deadlocked with route controller: %v", err)
+	}
+	if err := celeryTx.Commit(ctx); err != nil {
+		t.Fatalf("Celery terminal commit deadlocked with route controller: %v", err)
+	}
+	select {
+	case err := <-celeryPauseResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("route pause did not continue after Celery terminal commit")
+	}
+
+	blockingTx, err := pool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := blockingTx.Exec(ctx, `
+UPDATE public.sync_dispatch_outbox SET status = 'dispatched'
+WHERE id = '00000000-0000-4000-8000-000000000401'`); err != nil {
+		t.Fatal(err)
+	}
+	pauseResult := make(chan error, 1)
+	go func() {
+		_, pauseErr := controller.Pause(ctx, syncdispatchcontract.KindDispatchSyncRun)
+		pauseResult <- pauseErr
+	}()
+	waitForRouteLockWait(t, ctx, pool)
+	if err := blockingTx.Rollback(ctx); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case err := <-pauseResult:
+		if err != nil {
+			t.Fatal(err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("pause did not continue after terminal rollback")
+	}
+	dispatchDescriptor := registry[syncdispatchcontract.KindDispatchSyncRun]
+	dispatchDescriptor.Route = syncdispatchcontract.RouteRiver
+	registry[syncdispatchcontract.KindDispatchSyncRun] = dispatchDescriptor
+
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_dispatch_outbox
+SET status = 'pending', claim_token = 'claim-1', claim_expires_at = NOW() + interval '1 minute',
+    claim_transport = 'celery', claim_route_generation = 1
+WHERE id = '00000000-0000-4000-8000-000000000401'`); err != nil {
+		t.Fatal(err)
+	}
+	state, err := controller.Drain(ctx, syncdispatchcontract.KindDispatchSyncRun)
+	if err != nil || state.LiveClaims != 1 {
+		t.Fatalf("live drain state=%+v err=%v", state, err)
+	}
+	if _, err := controller.Resume(ctx, syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.RouteRiver, time.Second); !errors.Is(err, ErrLiveClaims) {
+		t.Fatalf("resume with live claim error=%v", err)
+	}
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_dispatch_outbox SET claim_expires_at = NOW() - interval '1 second'
+WHERE id = '00000000-0000-4000-8000-000000000401'`); err != nil {
+		t.Fatal(err)
+	}
+	state, err = controller.Resume(ctx, syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.RouteRiver, time.Second)
+	if err != nil || state.Transport != syncdispatchcontract.RouteRiver || state.Generation != 3 || state.Paused {
+		t.Fatalf("resumed state=%+v err=%v", state, err)
+	}
+
+	if _, err := controller.Pause(ctx, syncdispatchcontract.KindPostSync); err != nil {
+		t.Fatal(err)
+	}
+	postSyncDescriptor := registry[syncdispatchcontract.KindPostSync]
+	postSyncDescriptor.Route = syncdispatchcontract.RouteRiver
+	registry[syncdispatchcontract.KindPostSync] = postSyncDescriptor
+	quiescer.err = errors.New("old publisher still active")
+	if _, err := controller.Resume(ctx, syncdispatchcontract.KindPostSync, syncdispatchcontract.RouteRiver, time.Second); !errors.Is(err, ErrLiveClaims) {
+		t.Fatalf("post_sync quiescence error=%v", err)
+	}
+	state, err = controller.Inspect(ctx, syncdispatchcontract.KindPostSync)
+	if err != nil || !state.Paused || state.Generation != 2 || quiescer.calls != 1 {
+		t.Fatalf("post_sync rollback state=%+v calls=%d err=%v", state, quiescer.calls, err)
+	}
+}
+
+func waitForRouteRowLockWait(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var waiting bool
+		if err := pool.QueryRow(ctx, `
+SELECT EXISTS (
+	SELECT 1
+	FROM pg_stat_activity
+	WHERE wait_event_type = 'Lock'
+	  AND query LIKE '%FROM public.sync_dispatch_transport_routes%'
+	  AND query LIKE '%FOR UPDATE%'
+)`).Scan(&waiting); err != nil {
+			t.Fatal(err)
+		}
+		if waiting {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("route controller never waited on the in-flight Celery route-row lock")
+}
+
+func waitForRouteLockWait(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		var waiting bool
+		if err := pool.QueryRow(ctx, `
+SELECT EXISTS (
+	SELECT 1
+	FROM pg_stat_activity
+	WHERE wait_event_type = 'Lock'
+	  AND query = 'LOCK TABLE public.sync_dispatch_outbox IN SHARE ROW EXCLUSIVE MODE'
+)`).Scan(&waiting); err != nil {
+			t.Fatal(err)
+		}
+		if waiting {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatal("route pause never waited on the uncommitted outbox terminal transaction")
+}
+
+func createRouteControlSchema(t *testing.T, ctx context.Context, pool *pgxpool.Pool) {
+	t.Helper()
+	for _, statement := range []string{
+		`CREATE TABLE public.sync_dispatch_transport_routes (
+			kind text PRIMARY KEY, transport text NOT NULL, generation bigint NOT NULL,
+			paused boolean NOT NULL, paused_at timestamptz, rollback_transport text NOT NULL,
+			updated_at timestamptz NOT NULL
+		)`,
+		`CREATE TABLE public.sync_dispatch_outbox (
+			id uuid PRIMARY KEY, kind text NOT NULL, status text NOT NULL,
+			claim_token text, claim_expires_at timestamptz, claim_transport text,
+			claim_route_generation bigint
+		)`,
+		`INSERT INTO public.sync_dispatch_transport_routes
+			(kind, transport, generation, paused, paused_at, rollback_transport, updated_at)
+		VALUES
+			('dispatch_sync_run', 'celery', 1, FALSE, NULL, 'celery', NOW()),
+			('post_sync', 'celery', 1, FALSE, NULL, 'celery', NOW()),
+			('reference_discovery', 'celery', 1, FALSE, NULL, 'celery', NOW())`,
+		`INSERT INTO public.sync_dispatch_outbox
+			(id, kind, status)
+		VALUES
+			('00000000-0000-4000-8000-000000000401', 'dispatch_sync_run', 'pending'),
+			('00000000-0000-4000-8000-000000000402', 'reference_discovery', 'pending')`,
+	} {
+		if _, err := pool.Exec(ctx, statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+}

--- a/internal/syncroute/control_test.go
+++ b/internal/syncroute/control_test.go
@@ -36,7 +36,7 @@ func TestCapabilitiesRequireExactConcreteRiverRegistration(t *testing.T) {
 	}
 }
 
-func TestResumeFailsBeforeTransactionWithoutMatchingCapabilityOrPostSyncBarrier(t *testing.T) {
+func TestResumeFailsBeforeTransactionWithoutMatchingRiverCapability(t *testing.T) {
 	t.Parallel()
 	registry := controlRegistry{
 		syncdispatchcontract.KindDispatchSyncRun: {
@@ -64,50 +64,59 @@ func TestResumeFailsBeforeTransactionWithoutMatchingCapabilityOrPostSyncBarrier(
 	if _, err := controller.Resume(context.Background(), syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.RouteRiver, time.Second); !errors.Is(err, ErrCapabilityMissing) {
 		t.Fatalf("missing capability error=%v", err)
 	}
-	postCapabilities, err := NewCapabilities([]Capability{{
-		Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver,
-	}})
-	if err != nil {
-		t.Fatal(err)
-	}
-	controller, err = newController(begin, registry, postCapabilities, time.Now)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := controller.Resume(context.Background(), syncdispatchcontract.KindPostSync, syncdispatchcontract.RouteRiver, time.Second); !errors.Is(err, ErrQuiescenceMissing) {
-		t.Fatalf("missing post_sync quiescer error=%v", err)
-	}
 	if begins != 0 {
 		t.Fatalf("unsafe resume opened %d transactions", begins)
 	}
 }
 
-func TestPostSyncQuiescenceTimeoutIsStrictlyBounded(t *testing.T) {
+func TestResumeCapabilityAllowsSameTransportPostSyncAndGuardsCutover(t *testing.T) {
 	t.Parallel()
-	registry := controlRegistry{
-		syncdispatchcontract.KindPostSync: {
-			Kind: syncdispatchcontract.KindPostSync, Delivery: syncdispatchcontract.DeliveryAtMostOnceMarkBefore,
-			Route: syncdispatchcontract.RouteRiver, RollbackRoute: syncdispatchcontract.RouteCelery,
-		},
+	empty, err := NewCapabilities(nil)
+	if err != nil {
+		t.Fatal(err)
 	}
-	capabilities, err := NewCapabilities([]Capability{{
+	if _, required, err := resumeCapability(
+		empty, syncdispatchcontract.KindPostSync,
+		syncdispatchcontract.RouteCelery, syncdispatchcontract.RouteCelery,
+	); err != nil || required {
+		t.Fatalf("same-transport post_sync capability = required:%t err:%v", required, err)
+	}
+	riverWithoutBarrier, err := NewCapabilities([]Capability{{
+		Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, _, err := resumeCapability(
+		riverWithoutBarrier, syncdispatchcontract.KindPostSync,
+		syncdispatchcontract.RouteCelery, syncdispatchcontract.RouteRiver,
+	); !errors.Is(err, ErrQuiescenceMissing) {
+		t.Fatalf("Celery-to-River post_sync error=%v", err)
+	}
+	riverWithBarrier, err := NewCapabilities([]Capability{{
 		Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver,
 		Quiescer: quiescerFunc(func(context.Context, QuiescenceRequest) error { return nil }),
 	}})
 	if err != nil {
 		t.Fatal(err)
 	}
-	controller, err := newController(
-		func(context.Context) (pgx.Tx, error) { return nil, errors.New("must not begin") },
-		registry, capabilities, time.Now,
-	)
-	if err != nil {
-		t.Fatal(err)
+	if _, required, err := resumeCapability(
+		riverWithBarrier, syncdispatchcontract.KindPostSync,
+		syncdispatchcontract.RouteCelery, syncdispatchcontract.RouteRiver,
+	); err != nil || !required {
+		t.Fatalf("registered cutover capability = required:%t err:%v", required, err)
 	}
+}
+
+func TestPostSyncQuiescenceTimeoutIsStrictlyBounded(t *testing.T) {
+	t.Parallel()
 	for _, timeout := range []time.Duration{0, maximumQuiescenceTimeout + time.Nanosecond} {
-		if _, err := controller.Resume(context.Background(), syncdispatchcontract.KindPostSync, syncdispatchcontract.RouteRiver, timeout); !errors.Is(err, ErrInvalidConfiguration) {
-			t.Fatalf("timeout %s error=%v", timeout, err)
+		if validQuiescenceTimeout(timeout) {
+			t.Fatalf("timeout %s was accepted", timeout)
 		}
+	}
+	if !validQuiescenceTimeout(maximumQuiescenceTimeout) {
+		t.Fatal("maximum timeout was rejected")
 	}
 }
 

--- a/internal/syncroute/control_test.go
+++ b/internal/syncroute/control_test.go
@@ -1,0 +1,118 @@
+package syncroute
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/jackc/pgx/v5"
+)
+
+type controlRegistry map[string]syncdispatchcontract.Descriptor
+
+func (registry controlRegistry) Lookup(kind string) (syncdispatchcontract.Descriptor, bool) {
+	value, ok := registry[kind]
+	return value, ok
+}
+
+func TestCapabilitiesRequireExactConcreteRiverRegistration(t *testing.T) {
+	t.Parallel()
+	if _, err := NewCapabilities([]Capability{{Kind: "dispatch_sync_run", Transport: "sqs"}}); !errors.Is(err, ErrInvalidConfiguration) {
+		t.Fatalf("unknown transport capability error=%v", err)
+	}
+	capabilities, err := NewCapabilities([]Capability{{
+		Kind: syncdispatchcontract.KindDispatchSyncRun, Transport: syncdispatchcontract.RouteRiver,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := capabilities.Lookup(syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.RouteRiver); !ok {
+		t.Fatal("exact River capability is missing")
+	}
+	if _, ok := capabilities.Lookup(syncdispatchcontract.KindFinalizeSyncRun, syncdispatchcontract.RouteRiver); ok {
+		t.Fatal("capability leaked across kinds")
+	}
+}
+
+func TestResumeFailsBeforeTransactionWithoutMatchingCapabilityOrPostSyncBarrier(t *testing.T) {
+	t.Parallel()
+	registry := controlRegistry{
+		syncdispatchcontract.KindDispatchSyncRun: {
+			Kind: syncdispatchcontract.KindDispatchSyncRun, Delivery: syncdispatchcontract.DeliveryAtLeastOnce,
+			Route: syncdispatchcontract.RouteRiver, RollbackRoute: syncdispatchcontract.RouteCelery,
+		},
+		syncdispatchcontract.KindPostSync: {
+			Kind: syncdispatchcontract.KindPostSync, Delivery: syncdispatchcontract.DeliveryAtMostOnceMarkBefore,
+			Route: syncdispatchcontract.RouteRiver, RollbackRoute: syncdispatchcontract.RouteCelery,
+		},
+	}
+	empty, err := NewCapabilities(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	begins := 0
+	begin := func(context.Context) (pgx.Tx, error) {
+		begins++
+		return nil, errors.New("must not begin")
+	}
+	controller, err := newController(begin, registry, empty, time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Resume(context.Background(), syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.RouteRiver, time.Second); !errors.Is(err, ErrCapabilityMissing) {
+		t.Fatalf("missing capability error=%v", err)
+	}
+	postCapabilities, err := NewCapabilities([]Capability{{
+		Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver,
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller, err = newController(begin, registry, postCapabilities, time.Now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := controller.Resume(context.Background(), syncdispatchcontract.KindPostSync, syncdispatchcontract.RouteRiver, time.Second); !errors.Is(err, ErrQuiescenceMissing) {
+		t.Fatalf("missing post_sync quiescer error=%v", err)
+	}
+	if begins != 0 {
+		t.Fatalf("unsafe resume opened %d transactions", begins)
+	}
+}
+
+func TestPostSyncQuiescenceTimeoutIsStrictlyBounded(t *testing.T) {
+	t.Parallel()
+	registry := controlRegistry{
+		syncdispatchcontract.KindPostSync: {
+			Kind: syncdispatchcontract.KindPostSync, Delivery: syncdispatchcontract.DeliveryAtMostOnceMarkBefore,
+			Route: syncdispatchcontract.RouteRiver, RollbackRoute: syncdispatchcontract.RouteCelery,
+		},
+	}
+	capabilities, err := NewCapabilities([]Capability{{
+		Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver,
+		Quiescer: quiescerFunc(func(context.Context, QuiescenceRequest) error { return nil }),
+	}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	controller, err := newController(
+		func(context.Context) (pgx.Tx, error) { return nil, errors.New("must not begin") },
+		registry, capabilities, time.Now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, timeout := range []time.Duration{0, maximumQuiescenceTimeout + time.Nanosecond} {
+		if _, err := controller.Resume(context.Background(), syncdispatchcontract.KindPostSync, syncdispatchcontract.RouteRiver, timeout); !errors.Is(err, ErrInvalidConfiguration) {
+			t.Fatalf("timeout %s error=%v", timeout, err)
+		}
+	}
+}
+
+type quiescerFunc func(context.Context, QuiescenceRequest) error
+
+func (function quiescerFunc) Quiesce(ctx context.Context, request QuiescenceRequest) error {
+	return function(ctx, request)
+}

--- a/internal/syncroute/control_test.go
+++ b/internal/syncroute/control_test.go
@@ -93,18 +93,25 @@ func TestResumeCapabilityAllowsSameTransportPostSyncAndGuardsCutover(t *testing.
 	); !errors.Is(err, ErrQuiescenceMissing) {
 		t.Fatalf("Celery-to-River post_sync error=%v", err)
 	}
-	riverWithBarrier, err := NewCapabilities([]Capability{{
-		Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver,
-		Quiescer: quiescerFunc(func(context.Context, QuiescenceRequest) error { return nil }),
-	}})
+	riverWithOldBarrier, err := NewCapabilities([]Capability{
+		{Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver},
+		{
+			Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteCelery,
+			Quiescer: quiescerFunc(func(context.Context, QuiescenceRequest) error { return nil }),
+		},
+	})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if _, required, err := resumeCapability(
-		riverWithBarrier, syncdispatchcontract.KindPostSync,
+	capability, required, err := resumeCapability(
+		riverWithOldBarrier, syncdispatchcontract.KindPostSync,
 		syncdispatchcontract.RouteCelery, syncdispatchcontract.RouteRiver,
-	); err != nil || !required {
-		t.Fatalf("registered cutover capability = required:%t err:%v", required, err)
+	)
+	if err != nil || !required || capability.Transport != syncdispatchcontract.RouteCelery {
+		t.Fatalf(
+			"registered cutover capability = transport:%s required:%t err:%v",
+			capability.Transport, required, err,
+		)
 	}
 }
 

--- a/internal/syncroute/fence.go
+++ b/internal/syncroute/fence.go
@@ -82,8 +82,8 @@ func newFence(registry *syncdispatchcontract.Registry, query queryFunc) (*Fence,
 }
 
 // Check compares each active persisted route to the checked-in contract. A
-// pause is coherent only with its timestamp, but is still drift for readiness:
-// this phase has no audited partial-route pause control surface.
+// pause is coherent only with its timestamp, but is still drift for reconciler
+// readiness while an audited operator transition is in progress.
 func (fence *Fence) Check(ctx context.Context) error {
 	if fence == nil || fence.query == nil || !validRegistry(fence.registry) {
 		return ErrInvalidConfiguration

--- a/scripts/worker/provision_river_roles.sql
+++ b/scripts/worker/provision_river_roles.sql
@@ -76,8 +76,9 @@ SELECT format(
  WHERE to_regclass('public.worker_job_outbox') IS NOT NULL
 \gexec
 
--- The queue role may atomically claim/delete only the durable relay outbox.
--- It never receives INSERT or general semantic-table/sequence privileges.
+-- The queue role may atomically relay the generic outbox and transition the
+-- sync-dispatch outbox while checking its read-only route fence. It
+-- never receives INSERT or general semantic-table/sequence privileges.
 GRANT USAGE ON SCHEMA public TO :"queue_role";
 REVOKE CREATE ON SCHEMA public FROM :"queue_role";
 REVOKE ALL PRIVILEGES ON ALL TABLES IN SCHEMA public FROM :"queue_role";
@@ -87,4 +88,16 @@ SELECT format(
          :'queue_role'
        )
  WHERE to_regclass('public.worker_job_outbox') IS NOT NULL
+\gexec
+SELECT format(
+         'GRANT SELECT, UPDATE ON TABLE public.sync_dispatch_outbox TO %I',
+         :'queue_role'
+       )
+ WHERE to_regclass('public.sync_dispatch_outbox') IS NOT NULL
+\gexec
+SELECT format(
+         'GRANT SELECT ON TABLE public.sync_dispatch_transport_routes TO %I',
+         :'queue_role'
+       )
+ WHERE to_regclass('public.sync_dispatch_transport_routes') IS NOT NULL
 \gexec

--- a/src/dev_health_ops/alembic/versions/0051_add_scheduled_sync_occurrence_reconcile_state.py
+++ b/src/dev_health_ops/alembic/versions/0051_add_scheduled_sync_occurrence_reconcile_state.py
@@ -88,10 +88,10 @@ def upgrade() -> None:
             [
                 "reconcile_status",
                 "reconcile_next_attempt_at",
-                "org_id",
                 "sync_config_id",
                 "scheduled_job_id",
                 "scheduled_for",
+                "org_id",
             ],
             postgresql_where=sa.text("reconcile_status IN ('pending', 'retry')"),
         )

--- a/src/dev_health_ops/alembic/versions/0051_add_scheduled_sync_occurrence_reconcile_state.py
+++ b/src/dev_health_ops/alembic/versions/0051_add_scheduled_sync_occurrence_reconcile_state.py
@@ -1,0 +1,125 @@
+"""Add durable retry and quarantine state to scheduled sync occurrences.
+
+Revision ID: 0051
+Revises: 0050
+"""
+
+from __future__ import annotations
+
+import sqlalchemy as sa
+from alembic import op
+
+revision = "0051"
+down_revision = "0050"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "scheduled_sync_occurrences",
+        sa.Column(
+            "reconcile_attempt_count", sa.Integer(), nullable=False, server_default="0"
+        ),
+    )
+    op.add_column(
+        "scheduled_sync_occurrences",
+        sa.Column(
+            "reconcile_next_attempt_at", sa.DateTime(timezone=True), nullable=True
+        ),
+    )
+    op.add_column(
+        "scheduled_sync_occurrences",
+        sa.Column("reconcile_error_code", sa.String(length=64), nullable=True),
+    )
+    op.add_column(
+        "scheduled_sync_occurrences",
+        sa.Column("reconcile_error_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.add_column(
+        "scheduled_sync_occurrences",
+        sa.Column(
+            "reconcile_status",
+            sa.String(length=16),
+            nullable=False,
+            server_default="pending",
+        ),
+    )
+    # Existing Python-planned occurrences predate this lifecycle. Their paired
+    # links are authoritative, so preserve them before installing the
+    # bidirectional completed/link invariant below.
+    op.execute(
+        "UPDATE scheduled_sync_occurrences SET reconcile_status = 'completed' "
+        "WHERE job_run_id IS NOT NULL AND sync_run_id IS NOT NULL"
+    )
+    with op.batch_alter_table("scheduled_sync_occurrences") as batch:
+        batch.create_check_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_attempt_count",
+            "reconcile_attempt_count >= 0",
+        )
+        batch.create_check_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_status",
+            "reconcile_status IN ('pending', 'retry', 'completed', 'quarantined')",
+        )
+        batch.create_check_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_error_code",
+            "reconcile_error_code IN ('identity_conflict', 'ineligible', "
+            "'planner_error', 'retry_exhausted') OR reconcile_error_code IS NULL",
+        )
+        batch.create_check_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_error_state",
+            "(reconcile_error_code IS NULL AND reconcile_error_at IS NULL) OR "
+            "(reconcile_error_code IS NOT NULL AND reconcile_error_at IS NOT NULL)",
+        )
+        batch.create_check_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_completed_state",
+            "(reconcile_status = 'completed' AND job_run_id IS NOT NULL AND "
+            "sync_run_id IS NOT NULL) OR (reconcile_status <> 'completed' AND "
+            "job_run_id IS NULL AND sync_run_id IS NULL)",
+        )
+        batch.create_check_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_quarantined_state",
+            "reconcile_status <> 'quarantined' OR "
+            "(job_run_id IS NULL AND sync_run_id IS NULL AND "
+            "reconcile_error_code IS NOT NULL)",
+        )
+        batch.create_index(
+            "ix_scheduled_sync_occurrence_reconcile_due",
+            [
+                "reconcile_status",
+                "reconcile_next_attempt_at",
+                "org_id",
+                "sync_config_id",
+                "scheduled_job_id",
+                "scheduled_for",
+            ],
+            postgresql_where=sa.text("reconcile_status IN ('pending', 'retry')"),
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("scheduled_sync_occurrences") as batch:
+        batch.drop_index("ix_scheduled_sync_occurrence_reconcile_due")
+        batch.drop_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_quarantined_state", type_="check"
+        )
+        batch.drop_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_completed_state", type_="check"
+        )
+        batch.drop_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_error_state", type_="check"
+        )
+        batch.drop_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_error_code", type_="check"
+        )
+        batch.drop_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_status", type_="check"
+        )
+        batch.drop_constraint(
+            "ck_scheduled_sync_occurrence_reconcile_attempt_count", type_="check"
+        )
+        batch.drop_column("reconcile_status")
+        batch.drop_column("reconcile_error_at")
+        batch.drop_column("reconcile_error_code")
+        batch.drop_column("reconcile_next_attempt_at")
+        batch.drop_column("reconcile_attempt_count")

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -23,8 +23,10 @@ from sqlalchemy import (
     ForeignKey,
     Index,
     Integer,
+    String,
     Text,
     UniqueConstraint,
+    text,
 )
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -68,6 +70,12 @@ class JobRunStatus(int, Enum):
     SUCCESS = 2
     FAILED = 3
     CANCELLED = 4
+
+
+SCHEDULED_OCCURRENCE_RECONCILE_PENDING = "pending"
+SCHEDULED_OCCURRENCE_RECONCILE_RETRY = "retry"
+SCHEDULED_OCCURRENCE_RECONCILE_COMPLETED = "completed"
+SCHEDULED_OCCURRENCE_RECONCILE_QUARANTINED = "quarantined"
 
 
 class Setting(Base):
@@ -671,6 +679,22 @@ class ScheduledSyncOccurrence(Base):
         ForeignKey("sync_runs.id", ondelete="CASCADE"),
         nullable=True,
     )
+    reconcile_attempt_count: Mapped[int] = mapped_column(
+        Integer, nullable=False, default=0, server_default="0"
+    )
+    reconcile_next_attempt_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    reconcile_error_code: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    reconcile_error_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True), nullable=True
+    )
+    reconcile_status: Mapped[str] = mapped_column(
+        String(16),
+        nullable=False,
+        default=SCHEDULED_OCCURRENCE_RECONCILE_PENDING,
+        server_default=SCHEDULED_OCCURRENCE_RECONCILE_PENDING,
+    )
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         nullable=False,
@@ -688,11 +712,51 @@ class ScheduledSyncOccurrence(Base):
             "(job_run_id IS NOT NULL AND sync_run_id IS NOT NULL)",
             name="ck_scheduled_sync_occurrence_plan_links",
         ),
+        CheckConstraint(
+            "reconcile_attempt_count >= 0",
+            name="ck_scheduled_sync_occurrence_reconcile_attempt_count",
+        ),
+        CheckConstraint(
+            "reconcile_status IN ('pending', 'retry', 'completed', 'quarantined')",
+            name="ck_scheduled_sync_occurrence_reconcile_status",
+        ),
+        CheckConstraint(
+            "reconcile_error_code IN ('identity_conflict', 'ineligible', "
+            "'planner_error', 'retry_exhausted') OR reconcile_error_code IS NULL",
+            name="ck_scheduled_sync_occurrence_reconcile_error_code",
+        ),
+        CheckConstraint(
+            "(reconcile_error_code IS NULL AND reconcile_error_at IS NULL) OR "
+            "(reconcile_error_code IS NOT NULL AND reconcile_error_at IS NOT NULL)",
+            name="ck_scheduled_sync_occurrence_reconcile_error_state",
+        ),
+        CheckConstraint(
+            "(reconcile_status = 'completed' AND job_run_id IS NOT NULL AND "
+            "sync_run_id IS NOT NULL) OR (reconcile_status <> 'completed' AND "
+            "job_run_id IS NULL AND sync_run_id IS NULL)",
+            name="ck_scheduled_sync_occurrence_reconcile_completed_state",
+        ),
+        CheckConstraint(
+            "reconcile_status <> 'quarantined' OR "
+            "(job_run_id IS NULL AND sync_run_id IS NULL AND "
+            "reconcile_error_code IS NOT NULL)",
+            name="ck_scheduled_sync_occurrence_reconcile_quarantined_state",
+        ),
         Index(
             "ix_scheduled_sync_occurrence_org_config_time",
             "org_id",
             "sync_config_id",
             "scheduled_for",
+        ),
+        Index(
+            "ix_scheduled_sync_occurrence_reconcile_due",
+            "reconcile_status",
+            "reconcile_next_attempt_at",
+            "org_id",
+            "sync_config_id",
+            "scheduled_job_id",
+            "scheduled_for",
+            postgresql_where=text("reconcile_status IN ('pending', 'retry')"),
         ),
     )
 

--- a/src/dev_health_ops/models/settings.py
+++ b/src/dev_health_ops/models/settings.py
@@ -752,10 +752,10 @@ class ScheduledSyncOccurrence(Base):
             "ix_scheduled_sync_occurrence_reconcile_due",
             "reconcile_status",
             "reconcile_next_attempt_at",
-            "org_id",
             "sync_config_id",
             "scheduled_job_id",
             "scheduled_for",
+            "org_id",
             postgresql_where=text("reconcile_status IN ('pending', 'retry')"),
         ),
     )

--- a/src/dev_health_ops/sync/execution_trigger.py
+++ b/src/dev_health_ops/sync/execution_trigger.py
@@ -9,6 +9,7 @@ from typing import Any
 from sqlalchemy.orm import Session
 
 from dev_health_ops.models.settings import (
+    SCHEDULED_OCCURRENCE_RECONCILE_COMPLETED,
     JobRun,
     JobRunStatus,
     JobStatus,
@@ -122,6 +123,12 @@ def create_scheduled_sync_execution_trigger(
             occurrence, locked_config, job, org_id, scheduled_for
         )
         if occurrence.job_run_id is not None and occurrence.sync_run_id is not None:
+            occurrence.reconcile_attempt_count = 0
+            occurrence.reconcile_next_attempt_at = None
+            occurrence.reconcile_error_code = None
+            occurrence.reconcile_error_at = None
+            occurrence.reconcile_status = SCHEDULED_OCCURRENCE_RECONCILE_COMPLETED
+            session.flush()
             return _existing_scheduled_trigger_result(session, occurrence)
 
     trigger = create_sync_execution_trigger(
@@ -137,6 +144,11 @@ def create_scheduled_sync_execution_trigger(
         )
     occurrence.job_run_id = uuid.UUID(trigger.job_run_id)
     occurrence.sync_run_id = uuid.UUID(trigger.sync_run_id)
+    occurrence.reconcile_attempt_count = 0
+    occurrence.reconcile_next_attempt_at = None
+    occurrence.reconcile_error_code = None
+    occurrence.reconcile_error_at = None
+    occurrence.reconcile_status = SCHEDULED_OCCURRENCE_RECONCILE_COMPLETED
     session.flush()
     return trigger
 

--- a/src/dev_health_ops/workers/config.py
+++ b/src/dev_health_ops/workers/config.py
@@ -5,6 +5,8 @@ from typing import Any
 
 from celery.schedules import crontab
 
+from dev_health_ops.providers.utils import env_flag
+
 
 def _int_env(name: str, default: int) -> int:
     try:
@@ -284,6 +286,16 @@ beat_schedule = {
         "options": {"queue": "sync"},
     },
 }
+
+# The occurrence consumer is a default-off rollout seam for materializing
+# Go-authored schedule identities. It shares the existing scheduler queue;
+# activating it does not require a queue, compose, or worker-topology change.
+if env_flag("SYNC_SCHEDULED_OCCURRENCE_CONSUMER_ENABLED", default=False):
+    beat_schedule["consume-pending-scheduled-sync-occurrences"] = {
+        "task": "dev_health_ops.workers.tasks.consume_pending_scheduled_sync_occurrences",
+        "schedule": 300.0,
+        "options": {"queue": "scheduler"},
+    }
 
 # Result settings
 result_expires = 86400  # Results expire after 24 hours

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -37,6 +37,12 @@ STALE_RUNNING_TTL_SECONDS = 2 * 60 * 60  # 2 hours
 
 DEFAULT_SYNC_CRON = "0 * * * *"
 
+# This is intentionally only a bounded, callable reconciliation slice.  The
+# active scheduler paths do not invoke it while the Go scheduler remains
+# shadow-only; an operator-owned consumer can opt in after that hand-off is
+# reviewed.
+DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT = 100
+
 
 def _ensure_utc(value: datetime | None) -> datetime | None:
     """Coerce a DB timestamp to an aware UTC datetime (SQLite returns naive)."""
@@ -145,6 +151,159 @@ def _ensure_due_job_marker(
         session.add(job)
         session.flush()
     return job
+
+
+def _complete_pending_scheduled_sync_occurrence(
+    session: Session,
+    *,
+    occurrence_id: str,
+    org_id: str,
+    sync_config_id: uuid.UUID,
+    scheduled_job_id: uuid.UUID,
+) -> bool:
+    """Plan one Go-authored occurrence after config, job, occurrence locks.
+
+    The initial scan is deliberately unlocked so reconciliation stays bounded
+    and deterministic.  Before doing any work, this function reacquires the
+    authoritative rows in the same order as the scheduler hand-off contract:
+    configuration, scheduled job, then occurrence.  PostgreSQL consumers skip
+    a row another consumer owns instead of waiting behind a potentially slow
+    planner transaction.
+    """
+    from dev_health_ops.models.settings import (
+        ScheduledJob,
+        ScheduledSyncOccurrence,
+        SyncConfiguration,
+    )
+    from dev_health_ops.sync.execution_trigger import (
+        create_scheduled_sync_execution_trigger,
+    )
+
+    config_query = (
+        session.query(SyncConfiguration)
+        .filter(
+            SyncConfiguration.id == sync_config_id,
+            SyncConfiguration.org_id == org_id,
+        )
+        .populate_existing()
+    )
+    job_query = session.query(ScheduledJob).filter(
+        ScheduledJob.id == scheduled_job_id,
+        ScheduledJob.sync_config_id == sync_config_id,
+        ScheduledJob.org_id == org_id,
+        ScheduledJob.job_type == "sync",
+    )
+    occurrence_query = session.query(ScheduledSyncOccurrence).filter(
+        ScheduledSyncOccurrence.occurrence_id == occurrence_id,
+        ScheduledSyncOccurrence.org_id == org_id,
+        ScheduledSyncOccurrence.sync_config_id == sync_config_id,
+        ScheduledSyncOccurrence.scheduled_job_id == scheduled_job_id,
+    )
+
+    if _session_dialect_name(session) == "postgresql":
+        config = config_query.with_for_update(skip_locked=True).one_or_none()
+        if config is None:
+            return False
+        job = job_query.with_for_update(skip_locked=True).one_or_none()
+        if job is None:
+            return False
+        occurrence = occurrence_query.with_for_update(skip_locked=True).one_or_none()
+    else:
+        config = config_query.one_or_none()
+        if config is None:
+            return False
+        job = job_query.one_or_none()
+        if job is None:
+            return False
+        occurrence = occurrence_query.one_or_none()
+
+    if occurrence is None:
+        return False
+    if occurrence.job_run_id is not None or occurrence.sync_run_id is not None:
+        return False
+
+    create_scheduled_sync_execution_trigger(
+        session,
+        config,
+        job,
+        org_id,
+        scheduled_for=occurrence.scheduled_for,
+        triggered_by="schedule",
+        mode="incremental",
+    )
+    return True
+
+
+def reconcile_pending_scheduled_sync_occurrences(
+    session: Session,
+    *,
+    limit: int = DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT,
+) -> dict[str, int]:
+    """Complete a deterministic, bounded batch of unplanned Go occurrences.
+
+    This helper is deliberately dormant: it is not registered with Celery Beat,
+    called by :func:`dispatch_scheduled_syncs`, or exposed to the Go scheduler.
+    It lets a separately authorized Python consumer materialize the existing
+    stable occurrence identities without reconsidering ``next_run_at``.
+    """
+    from dev_health_ops.models.settings import ScheduledSyncOccurrence
+
+    if limit <= 0:
+        return {"scanned": 0, "completed": 0, "skipped": 0, "errors": 0}
+
+    candidates = (
+        session.query(
+            ScheduledSyncOccurrence.occurrence_id,
+            ScheduledSyncOccurrence.org_id,
+            ScheduledSyncOccurrence.sync_config_id,
+            ScheduledSyncOccurrence.scheduled_job_id,
+        )
+        .filter(
+            ScheduledSyncOccurrence.job_run_id.is_(None),
+            ScheduledSyncOccurrence.sync_run_id.is_(None),
+        )
+        .order_by(
+            ScheduledSyncOccurrence.org_id,
+            ScheduledSyncOccurrence.sync_config_id,
+            ScheduledSyncOccurrence.scheduled_for,
+            ScheduledSyncOccurrence.occurrence_id,
+        )
+        .limit(limit)
+        .all()
+    )
+    completed = 0
+    skipped = 0
+    errors = 0
+
+    for occurrence_id, org_id, sync_config_id, scheduled_job_id in candidates:
+        try:
+            # A malformed/ineligible occurrence must not roll back a prior
+            # completion or prevent the rest of this bounded batch from being
+            # reconciled.
+            with session.begin_nested():
+                if _complete_pending_scheduled_sync_occurrence(
+                    session,
+                    occurrence_id=str(occurrence_id),
+                    org_id=str(org_id),
+                    sync_config_id=_as_uuid(sync_config_id),
+                    scheduled_job_id=_as_uuid(scheduled_job_id),
+                ):
+                    completed += 1
+                else:
+                    skipped += 1
+        except Exception:
+            logger.exception(
+                "pending_scheduled_sync_occurrence_reconciliation_failed",
+                extra={"occurrence_id": str(occurrence_id), "org_id": str(org_id)},
+            )
+            errors += 1
+
+    return {
+        "scanned": len(candidates),
+        "completed": completed,
+        "skipped": skipped,
+        "errors": errors,
+    }
 
 
 def _maybe_dispatch_config(

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -250,6 +250,7 @@ def reconcile_pending_scheduled_sync_occurrences(
 
     if limit <= 0:
         return {"scanned": 0, "completed": 0, "skipped": 0, "errors": 0}
+    claim_limit = min(limit, DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT)
 
     candidates = (
         session.query(
@@ -268,7 +269,7 @@ def reconcile_pending_scheduled_sync_occurrences(
             ScheduledSyncOccurrence.scheduled_for,
             ScheduledSyncOccurrence.occurrence_id,
         )
-        .limit(limit)
+        .limit(claim_limit)
         .all()
     )
     completed = 0

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -2,9 +2,12 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import TYPE_CHECKING
 
+from sqlalchemy import func, or_, true, update
+
+from dev_health_ops.providers.utils import env_flag
 from dev_health_ops.sync.canonical_incident_gate import (
     CANONICAL_INCIDENT_FEATURE_KEY,
     CanonicalIncidentFeatureDisabledError,
@@ -26,7 +29,11 @@ from dev_health_ops.workers.task_utils import (
 if TYPE_CHECKING:
     from sqlalchemy.orm import Session
 
-    from dev_health_ops.models.settings import ScheduledJob, SyncConfiguration
+    from dev_health_ops.models.settings import (
+        ScheduledJob,
+        ScheduledSyncOccurrence,
+        SyncConfiguration,
+    )
 
 logger = logging.getLogger(__name__)
 
@@ -42,6 +49,9 @@ DEFAULT_SYNC_CRON = "0 * * * *"
 # shadow-only; an operator-owned consumer can opt in after that hand-off is
 # reviewed.
 DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT = 100
+_PENDING_OCCURRENCE_RECONCILE_SCAN_MULTIPLIER = 2
+_PENDING_OCCURRENCE_RECONCILE_MAX_ATTEMPTS = 5
+_PENDING_OCCURRENCE_RECONCILE_BACKOFF_CAP_SECONDS = 15 * 60
 
 
 def _ensure_utc(value: datetime | None) -> datetime | None:
@@ -156,82 +166,170 @@ def _ensure_due_job_marker(
 def _complete_pending_scheduled_sync_occurrence(
     session: Session,
     *,
-    occurrence_id: str,
-    org_id: str,
-    sync_config_id: uuid.UUID,
-    scheduled_job_id: uuid.UUID,
-) -> bool:
-    """Plan one Go-authored occurrence after config, job, occurrence locks.
+    config: SyncConfiguration,
+    job: ScheduledJob,
+    occurrence: ScheduledSyncOccurrence,
+) -> str:
+    """Plan one pre-locked Go-authored occurrence.
 
-    The initial scan is deliberately unlocked so reconciliation stays bounded
-    and deterministic.  Before doing any work, this function reacquires the
-    authoritative rows in the same order as the scheduler hand-off contract:
-    configuration, scheduled job, then occurrence.  PostgreSQL consumers skip
-    a row another consumer owns instead of waiting behind a potentially slow
-    planner transaction.
+    The caller locks configuration, scheduled job, then occurrence. That lets
+    a replica skip a contended occurrence prefix before applying its limit.
     """
     from dev_health_ops.models.settings import (
-        ScheduledJob,
-        ScheduledSyncOccurrence,
-        SyncConfiguration,
+        SCHEDULED_OCCURRENCE_RECONCILE_COMPLETED,
     )
     from dev_health_ops.sync.execution_trigger import (
         create_scheduled_sync_execution_trigger,
     )
 
-    config_query = (
-        session.query(SyncConfiguration)
-        .filter(
-            SyncConfiguration.id == sync_config_id,
-            SyncConfiguration.org_id == org_id,
-        )
-        .populate_existing()
-    )
-    job_query = session.query(ScheduledJob).filter(
-        ScheduledJob.id == scheduled_job_id,
-        ScheduledJob.sync_config_id == sync_config_id,
-        ScheduledJob.org_id == org_id,
-        ScheduledJob.job_type == "sync",
-    )
-    occurrence_query = session.query(ScheduledSyncOccurrence).filter(
-        ScheduledSyncOccurrence.occurrence_id == occurrence_id,
-        ScheduledSyncOccurrence.org_id == org_id,
-        ScheduledSyncOccurrence.sync_config_id == sync_config_id,
-        ScheduledSyncOccurrence.scheduled_job_id == scheduled_job_id,
-    )
-
-    if _session_dialect_name(session) == "postgresql":
-        config = config_query.with_for_update(skip_locked=True).one_or_none()
-        if config is None:
-            return False
-        job = job_query.with_for_update(skip_locked=True).one_or_none()
-        if job is None:
-            return False
-        occurrence = occurrence_query.with_for_update(skip_locked=True).one_or_none()
-    else:
-        config = config_query.one_or_none()
-        if config is None:
-            return False
-        job = job_query.one_or_none()
-        if job is None:
-            return False
-        occurrence = occurrence_query.one_or_none()
-
-    if occurrence is None:
-        return False
+    if not _scheduled_occurrence_identity_is_valid(occurrence, config, job):
+        return "identity_conflict"
     if occurrence.job_run_id is not None or occurrence.sync_run_id is not None:
-        return False
+        return "already_completed"
 
     create_scheduled_sync_execution_trigger(
         session,
         config,
         job,
-        org_id,
+        str(config.org_id),
         scheduled_for=occurrence.scheduled_for,
         triggered_by="schedule",
         mode="incremental",
     )
-    return True
+    occurrence.reconcile_attempt_count = 0
+    occurrence.reconcile_next_attempt_at = None
+    occurrence.reconcile_error_code = None
+    occurrence.reconcile_error_at = None
+    occurrence.reconcile_status = SCHEDULED_OCCURRENCE_RECONCILE_COMPLETED
+    session.flush()
+    return "completed"
+
+
+def _scheduled_occurrence_identity_is_valid(
+    occurrence: ScheduledSyncOccurrence,
+    config: SyncConfiguration,
+    job: ScheduledJob,
+) -> bool:
+    """Verify the immutable Go/Python occurrence identity before planning."""
+    from dev_health_ops.sync.execution_trigger import (
+        SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+        scheduled_sync_occurrence_identity,
+    )
+
+    try:
+        scheduled_for = _ensure_utc(occurrence.scheduled_for)
+        if scheduled_for is None:
+            return False
+        expected_id = scheduled_sync_occurrence_identity(config.id, scheduled_for)
+    except (AttributeError, TypeError, ValueError):
+        return False
+    return (
+        occurrence.identity_version == SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION
+        and occurrence.occurrence_id == expected_id
+        and occurrence.org_id == config.org_id == job.org_id
+        and occurrence.sync_config_id == config.id == job.sync_config_id
+        and occurrence.scheduled_job_id == job.id
+        and str(job.job_type) == "sync"
+    )
+
+
+def _pending_occurrence_backoff_seconds(attempt_count: int) -> int:
+    """Return a bounded exponential retry delay for a failed occurrence."""
+    return min(
+        _PENDING_OCCURRENCE_RECONCILE_BACKOFF_CAP_SECONDS,
+        60 * (2 ** min(max(attempt_count - 1, 0), 4)),
+    )
+
+
+def _defer_pending_scheduled_sync_occurrence(
+    session: Session,
+    *,
+    occurrence_id: str,
+    expected_attempt_count: int,
+    error_code: str,
+    now: datetime,
+) -> bool:
+    """CAS a pending occurrence into retry (or terminal quarantine) state."""
+    from dev_health_ops.models.settings import (
+        SCHEDULED_OCCURRENCE_RECONCILE_PENDING,
+        SCHEDULED_OCCURRENCE_RECONCILE_QUARANTINED,
+        SCHEDULED_OCCURRENCE_RECONCILE_RETRY,
+        ScheduledSyncOccurrence,
+    )
+
+    attempt_count = expected_attempt_count + 1
+    exhausted = attempt_count >= _PENDING_OCCURRENCE_RECONCILE_MAX_ATTEMPTS
+    result = session.execute(
+        update(ScheduledSyncOccurrence)
+        .where(
+            ScheduledSyncOccurrence.occurrence_id == occurrence_id,
+            ScheduledSyncOccurrence.reconcile_status.in_(
+                (
+                    SCHEDULED_OCCURRENCE_RECONCILE_PENDING,
+                    SCHEDULED_OCCURRENCE_RECONCILE_RETRY,
+                )
+            ),
+            ScheduledSyncOccurrence.reconcile_attempt_count == expected_attempt_count,
+            ScheduledSyncOccurrence.job_run_id.is_(None),
+            ScheduledSyncOccurrence.sync_run_id.is_(None),
+        )
+        .values(
+            reconcile_attempt_count=attempt_count,
+            reconcile_next_attempt_at=(
+                None
+                if exhausted
+                else now
+                + timedelta(seconds=_pending_occurrence_backoff_seconds(attempt_count))
+            ),
+            reconcile_error_code="retry_exhausted" if exhausted else error_code,
+            reconcile_error_at=now,
+            reconcile_status=(
+                SCHEDULED_OCCURRENCE_RECONCILE_QUARANTINED
+                if exhausted
+                else SCHEDULED_OCCURRENCE_RECONCILE_RETRY
+            ),
+        )
+    )
+    return bool(getattr(result, "rowcount", 0))
+
+
+def _quarantine_pending_scheduled_sync_occurrence(
+    session: Session,
+    *,
+    occurrence_id: str,
+    expected_attempt_count: int,
+    now: datetime,
+) -> bool:
+    """CAS an identity-conflicting occurrence into permanent quarantine."""
+    from dev_health_ops.models.settings import (
+        SCHEDULED_OCCURRENCE_RECONCILE_PENDING,
+        SCHEDULED_OCCURRENCE_RECONCILE_QUARANTINED,
+        SCHEDULED_OCCURRENCE_RECONCILE_RETRY,
+        ScheduledSyncOccurrence,
+    )
+
+    result = session.execute(
+        update(ScheduledSyncOccurrence)
+        .where(
+            ScheduledSyncOccurrence.occurrence_id == occurrence_id,
+            ScheduledSyncOccurrence.reconcile_status.in_(
+                (
+                    SCHEDULED_OCCURRENCE_RECONCILE_PENDING,
+                    SCHEDULED_OCCURRENCE_RECONCILE_RETRY,
+                )
+            ),
+            ScheduledSyncOccurrence.reconcile_attempt_count == expected_attempt_count,
+            ScheduledSyncOccurrence.job_run_id.is_(None),
+            ScheduledSyncOccurrence.sync_run_id.is_(None),
+        )
+        .values(
+            reconcile_next_attempt_at=None,
+            reconcile_error_code="identity_conflict",
+            reconcile_error_at=now,
+            reconcile_status=SCHEDULED_OCCURRENCE_RECONCILE_QUARANTINED,
+        )
+    )
+    return bool(getattr(result, "rowcount", 0))
 
 
 def reconcile_pending_scheduled_sync_occurrences(
@@ -241,70 +339,272 @@ def reconcile_pending_scheduled_sync_occurrences(
 ) -> dict[str, int]:
     """Complete a deterministic, bounded batch of unplanned Go occurrences.
 
-    This helper is deliberately dormant: it is not registered with Celery Beat,
-    called by :func:`dispatch_scheduled_syncs`, or exposed to the Go scheduler.
-    It lets a separately authorized Python consumer materialize the existing
-    stable occurrence identities without reconsidering ``next_run_at``.
+    The helper is only invoked by the separately gated Celery consumer; it is
+    not called by :func:`dispatch_scheduled_syncs` or exposed to the Go
+    scheduler. It materializes existing stable occurrence identities without
+    reconsidering ``next_run_at``.
     """
-    from dev_health_ops.models.settings import ScheduledSyncOccurrence
+    from dev_health_ops.models.settings import (
+        SCHEDULED_OCCURRENCE_RECONCILE_PENDING,
+        SCHEDULED_OCCURRENCE_RECONCILE_RETRY,
+        ScheduledJob,
+        ScheduledSyncOccurrence,
+        SyncConfiguration,
+    )
+    from dev_health_ops.sync.execution_trigger import (
+        ScheduledSyncOccurrenceIneligibleError,
+    )
 
     if limit <= 0:
-        return {"scanned": 0, "completed": 0, "skipped": 0, "errors": 0}
+        return _empty_pending_occurrence_reconcile_counts()
     claim_limit = min(limit, DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT)
-
-    candidates = (
-        session.query(
-            ScheduledSyncOccurrence.occurrence_id,
-            ScheduledSyncOccurrence.org_id,
-            ScheduledSyncOccurrence.sync_config_id,
-            ScheduledSyncOccurrence.scheduled_job_id,
+    now = datetime.now(timezone.utc)
+    due_occurrences = session.query(ScheduledSyncOccurrence.occurrence_id).filter(
+        ScheduledSyncOccurrence.org_id == SyncConfiguration.org_id,
+        ScheduledSyncOccurrence.sync_config_id == SyncConfiguration.id,
+        ScheduledSyncOccurrence.scheduled_job_id == ScheduledJob.id,
+        ScheduledSyncOccurrence.job_run_id.is_(None),
+        ScheduledSyncOccurrence.sync_run_id.is_(None),
+        ScheduledSyncOccurrence.reconcile_status.in_(
+            (
+                SCHEDULED_OCCURRENCE_RECONCILE_PENDING,
+                SCHEDULED_OCCURRENCE_RECONCILE_RETRY,
+            )
+        ),
+        or_(
+            ScheduledSyncOccurrence.reconcile_next_attempt_at.is_(None),
+            ScheduledSyncOccurrence.reconcile_next_attempt_at <= now,
+        ),
+    )
+    due_occurrence_exists = due_occurrences.exists()
+    earliest_due_occurrence = due_occurrences.with_entities(
+        func.min(ScheduledSyncOccurrence.scheduled_for)
+    ).scalar_subquery()
+    pairs = (
+        session.query(SyncConfiguration, ScheduledJob)
+        # The correlated due predicate pairs these rows through the occurrence
+        # IDs. Do not assume config/job coherence here: a mismatched persisted
+        # pair must be locked and quarantined, not silently left pending.
+        .join(
+            ScheduledJob,
+            true(),
         )
-        .filter(
-            ScheduledSyncOccurrence.job_run_id.is_(None),
-            ScheduledSyncOccurrence.sync_run_id.is_(None),
-        )
+        .filter(due_occurrence_exists)
         .order_by(
-            ScheduledSyncOccurrence.org_id,
-            ScheduledSyncOccurrence.sync_config_id,
-            ScheduledSyncOccurrence.scheduled_for,
-            ScheduledSyncOccurrence.occurrence_id,
+            earliest_due_occurrence,
+            SyncConfiguration.org_id,
+            SyncConfiguration.id,
+            ScheduledJob.id,
         )
+        # Claim config/job pairs before limiting. The occurrence query below
+        # keeps the global lock order config -> job -> occurrence.
+        .with_for_update(of=(SyncConfiguration, ScheduledJob), skip_locked=True)
         .limit(claim_limit)
         .all()
     )
     completed = 0
-    skipped = 0
+    retried = 0
+    quarantined = 0
+    already_completed = 0
     errors = 0
+    scanned = 0
+    scan_limit = claim_limit * _PENDING_OCCURRENCE_RECONCILE_SCAN_MULTIPLIER
 
-    for occurrence_id, org_id, sync_config_id, scheduled_job_id in candidates:
-        try:
-            # A malformed/ineligible occurrence must not roll back a prior
-            # completion or prevent the rest of this bounded batch from being
-            # reconciled.
-            with session.begin_nested():
-                if _complete_pending_scheduled_sync_occurrence(
-                    session,
-                    occurrence_id=str(occurrence_id),
-                    org_id=str(org_id),
-                    sync_config_id=_as_uuid(sync_config_id),
-                    scheduled_job_id=_as_uuid(scheduled_job_id),
-                ):
-                    completed += 1
-                else:
-                    skipped += 1
-        except Exception:
-            logger.exception(
-                "pending_scheduled_sync_occurrence_reconciliation_failed",
-                extra={"occurrence_id": str(occurrence_id), "org_id": str(org_id)},
+    for config, job in pairs:
+        while completed < claim_limit and scanned < scan_limit:
+            remaining = min(claim_limit - completed, scan_limit - scanned)
+            candidates = (
+                session.query(ScheduledSyncOccurrence)
+                .filter(
+                    ScheduledSyncOccurrence.org_id == config.org_id,
+                    ScheduledSyncOccurrence.sync_config_id == config.id,
+                    ScheduledSyncOccurrence.scheduled_job_id == job.id,
+                    ScheduledSyncOccurrence.job_run_id.is_(None),
+                    ScheduledSyncOccurrence.sync_run_id.is_(None),
+                    ScheduledSyncOccurrence.reconcile_status.in_(
+                        (
+                            SCHEDULED_OCCURRENCE_RECONCILE_PENDING,
+                            SCHEDULED_OCCURRENCE_RECONCILE_RETRY,
+                        )
+                    ),
+                    or_(
+                        ScheduledSyncOccurrence.reconcile_next_attempt_at.is_(None),
+                        ScheduledSyncOccurrence.reconcile_next_attempt_at <= now,
+                    ),
+                )
+                .order_by(
+                    ScheduledSyncOccurrence.scheduled_for,
+                    ScheduledSyncOccurrence.occurrence_id,
+                )
+                # Apply SKIP LOCKED before LIMIT so a locked prefix cannot
+                # starve a later occurrence in this claimed pair.
+                .with_for_update(of=ScheduledSyncOccurrence, skip_locked=True)
+                .limit(remaining)
+                .all()
             )
-            errors += 1
+            if not candidates:
+                break
+
+            for occurrence in candidates:
+                occurrence_id = str(occurrence.occurrence_id)
+                attempt_count = int(occurrence.reconcile_attempt_count)
+                scanned += 1
+                try:
+                    # One bad occurrence must not roll back a prior completion
+                    # or prevent later rows in the bounded scan from advancing.
+                    with session.begin_nested():
+                        outcome = _complete_pending_scheduled_sync_occurrence(
+                            session,
+                            config=config,
+                            job=job,
+                            occurrence=occurrence,
+                        )
+                        if outcome == "identity_conflict":
+                            if _quarantine_pending_scheduled_sync_occurrence(
+                                session,
+                                occurrence_id=occurrence_id,
+                                expected_attempt_count=attempt_count,
+                                now=now,
+                            ):
+                                logger.error(
+                                    "pending_scheduled_sync_occurrence_quarantined",
+                                    extra={
+                                        "occurrence_id": occurrence_id,
+                                        "org_id": str(config.org_id),
+                                        "error_code": "identity_conflict",
+                                    },
+                                )
+                                quarantined += 1
+                            else:
+                                already_completed += 1
+                        elif outcome == "completed":
+                            completed += 1
+                        else:
+                            if _defer_pending_scheduled_sync_occurrence(
+                                session,
+                                occurrence_id=occurrence_id,
+                                expected_attempt_count=attempt_count,
+                                error_code="ineligible",
+                                now=now,
+                            ):
+                                if (
+                                    attempt_count + 1
+                                    >= _PENDING_OCCURRENCE_RECONCILE_MAX_ATTEMPTS
+                                ):
+                                    quarantined += 1
+                                else:
+                                    retried += 1
+                            else:
+                                already_completed += 1
+                except ScheduledSyncOccurrenceIneligibleError:
+                    with session.begin_nested():
+                        deferred = _defer_pending_scheduled_sync_occurrence(
+                            session,
+                            occurrence_id=occurrence_id,
+                            expected_attempt_count=attempt_count,
+                            error_code="ineligible",
+                            now=now,
+                        )
+                    if deferred:
+                        if (
+                            attempt_count + 1
+                            >= _PENDING_OCCURRENCE_RECONCILE_MAX_ATTEMPTS
+                        ):
+                            quarantined += 1
+                        else:
+                            retried += 1
+                    else:
+                        already_completed += 1
+                except Exception:
+                    logger.exception(
+                        "pending_scheduled_sync_occurrence_reconciliation_failed",
+                        extra={
+                            "occurrence_id": occurrence_id,
+                            "org_id": str(config.org_id),
+                        },
+                    )
+                    with session.begin_nested():
+                        deferred = _defer_pending_scheduled_sync_occurrence(
+                            session,
+                            occurrence_id=occurrence_id,
+                            expected_attempt_count=attempt_count,
+                            error_code="planner_error",
+                            now=now,
+                        )
+                    if deferred:
+                        if (
+                            attempt_count + 1
+                            >= _PENDING_OCCURRENCE_RECONCILE_MAX_ATTEMPTS
+                        ):
+                            quarantined += 1
+                        else:
+                            retried += 1
+                    else:
+                        already_completed += 1
+                    errors += 1
+
+                if completed >= claim_limit or scanned >= scan_limit:
+                    break
 
     return {
-        "scanned": len(candidates),
+        "scanned": scanned,
         "completed": completed,
-        "skipped": skipped,
+        "retried": retried,
+        "quarantined": quarantined,
+        "already_completed": already_completed,
         "errors": errors,
     }
+
+
+def _empty_pending_occurrence_reconcile_counts() -> dict[str, int]:
+    return {
+        "scanned": 0,
+        "completed": 0,
+        "retried": 0,
+        "quarantined": 0,
+        "already_completed": 0,
+        "errors": 0,
+    }
+
+
+def _scheduled_occurrence_consumer_enabled() -> bool:
+    """Read the rollout flag at task-call time, defaulting to disabled."""
+    return env_flag("SYNC_SCHEDULED_OCCURRENCE_CONSUMER_ENABLED", default=False)
+
+
+@celery_app.task(
+    queue="scheduler",
+    name="dev_health_ops.workers.tasks.consume_pending_scheduled_sync_occurrences",
+)
+def consume_pending_scheduled_sync_occurrences() -> dict[str, int]:
+    """Materialize one bounded batch of Go-authored scheduled occurrences.
+
+    This remains a default-off rollout seam. The same flag also controls the
+    Beat registration, but the task checks it again so a queued message cannot
+    open PostgreSQL after the consumer has been switched off.
+    """
+    if not _scheduled_occurrence_consumer_enabled():
+        logger.info("sync_scheduler.pending_occurrence_consumer_disabled")
+        return _empty_pending_occurrence_reconcile_counts()
+
+    from dev_health_ops.db import get_postgres_session_sync
+
+    try:
+        with get_postgres_session_sync() as session:
+            counts = reconcile_pending_scheduled_sync_occurrences(session)
+            # The helper uses nested transactions to isolate a malformed
+            # occurrence. Commit its successful slice as one outer task
+            # transaction before acknowledging the bounded result.
+            session.commit()
+    except Exception:
+        # get_postgres_session_sync rolls back the outer transaction before
+        # control reaches here. Do not swallow this: Celery must record the
+        # failure so the next Beat tick can retry the idempotent occurrences.
+        logger.exception("sync_scheduler.pending_occurrence_consumer_failed")
+        raise
+
+    logger.info("sync_scheduler.pending_occurrence_consumer_completed", extra=counts)
+    return counts
 
 
 def _maybe_dispatch_config(

--- a/src/dev_health_ops/workers/sync_scheduler.py
+++ b/src/dev_health_ops/workers/sync_scheduler.py
@@ -360,7 +360,6 @@ def reconcile_pending_scheduled_sync_occurrences(
     claim_limit = min(limit, DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT)
     now = datetime.now(timezone.utc)
     due_occurrences = session.query(ScheduledSyncOccurrence.occurrence_id).filter(
-        ScheduledSyncOccurrence.org_id == SyncConfiguration.org_id,
         ScheduledSyncOccurrence.sync_config_id == SyncConfiguration.id,
         ScheduledSyncOccurrence.scheduled_job_id == ScheduledJob.id,
         ScheduledSyncOccurrence.job_run_id.is_(None),
@@ -416,7 +415,6 @@ def reconcile_pending_scheduled_sync_occurrences(
             candidates = (
                 session.query(ScheduledSyncOccurrence)
                 .filter(
-                    ScheduledSyncOccurrence.org_id == config.org_id,
                     ScheduledSyncOccurrence.sync_config_id == config.id,
                     ScheduledSyncOccurrence.scheduled_job_id == job.id,
                     ScheduledSyncOccurrence.job_run_id.is_(None),

--- a/src/dev_health_ops/workers/tasks.py
+++ b/src/dev_health_ops/workers/tasks.py
@@ -28,7 +28,10 @@ from dev_health_ops.workers.sync_reconciler import (
     prune_rate_limit_observations,
     reconcile_sync_dispatch,
 )
-from dev_health_ops.workers.sync_scheduler import dispatch_scheduled_syncs
+from dev_health_ops.workers.sync_scheduler import (
+    consume_pending_scheduled_sync_occurrences,
+    dispatch_scheduled_syncs,
+)
 from dev_health_ops.workers.sync_units import (
     dispatch_sync_run,
     finalize_sync_run,
@@ -76,6 +79,7 @@ __all__ = [
     "dispatch_scheduled_metrics",
     "dispatch_scheduled_reports",
     "dispatch_scheduled_syncs",
+    "consume_pending_scheduled_sync_occurrences",
     "dispatch_sync_run",
     "execute_saved_report",
     "external_ingest_stream_health",

--- a/tests/test_canonical_incident_feature_flag_migration.py
+++ b/tests/test_canonical_incident_feature_flag_migration.py
@@ -112,7 +112,7 @@ def test_canonical_incident_feature_seed_is_in_single_head_graph() -> None:
 
     assert migration.down_revision == "0041"
     assert migration.revision in revisions
-    assert scripts.get_heads() == ["0050"]
+    assert scripts.get_heads() == ["0051"]
     assert scripts.get_revision("0043").down_revision == "0042"
     assert scripts.get_revision("0044").down_revision == "0043"
     assert scripts.get_revision("0045").down_revision == "0044"
@@ -121,3 +121,4 @@ def test_canonical_incident_feature_seed_is_in_single_head_graph() -> None:
     assert scripts.get_revision("0048").down_revision == "0047"
     assert scripts.get_revision("0049").down_revision == "0048"
     assert scripts.get_revision("0050").down_revision == "0049"
+    assert scripts.get_revision("0051").down_revision == "0050"

--- a/tests/test_scheduled_sync_occurrence_consumer.py
+++ b/tests/test_scheduled_sync_occurrence_consumer.py
@@ -1,0 +1,138 @@
+"""Rollout wiring for the default-off scheduled-occurrence consumer."""
+
+from __future__ import annotations
+
+import importlib
+import os
+from contextlib import contextmanager
+from unittest.mock import MagicMock
+
+import pytest
+
+_FLAG = "SYNC_SCHEDULED_OCCURRENCE_CONSUMER_ENABLED"
+_TASK_NAME = "dev_health_ops.workers.tasks.consume_pending_scheduled_sync_occurrences"
+_SCHEDULE_NAME = "consume-pending-scheduled-sync-occurrences"
+_EMPTY_COUNTS = {
+    "scanned": 0,
+    "completed": 0,
+    "retried": 0,
+    "quarantined": 0,
+    "already_completed": 0,
+    "errors": 0,
+}
+
+
+def _run_task() -> dict[str, int]:
+    from dev_health_ops.workers.sync_scheduler import (
+        consume_pending_scheduled_sync_occurrences,
+    )
+
+    return consume_pending_scheduled_sync_occurrences.run()
+
+
+def test_disabled_consumer_does_not_open_postgres(monkeypatch) -> None:
+    from dev_health_ops import db
+
+    monkeypatch.delenv(_FLAG, raising=False)
+    get_session = MagicMock()
+    monkeypatch.setattr(db, "get_postgres_session_sync", get_session)
+
+    assert _run_task() == _EMPTY_COUNTS
+    get_session.assert_not_called()
+
+
+def test_enabled_consumer_reconciles_and_commits_outer_transaction(monkeypatch) -> None:
+    from dev_health_ops import db
+    from dev_health_ops.workers import sync_scheduler
+
+    monkeypatch.setenv(_FLAG, "true")
+    session = MagicMock()
+    counts = {
+        "scanned": 3,
+        "completed": 2,
+        "retried": 1,
+        "quarantined": 0,
+        "already_completed": 0,
+        "errors": 0,
+    }
+
+    @contextmanager
+    def session_context():
+        yield session
+
+    get_session = MagicMock(side_effect=session_context)
+    reconcile = MagicMock(return_value=counts)
+    monkeypatch.setattr(db, "get_postgres_session_sync", get_session)
+    monkeypatch.setattr(
+        sync_scheduler, "reconcile_pending_scheduled_sync_occurrences", reconcile
+    )
+
+    assert _run_task() == counts
+    get_session.assert_called_once_with()
+    reconcile.assert_called_once_with(session)
+    session.commit.assert_called_once_with()
+    session.rollback.assert_not_called()
+
+
+def test_enabled_consumer_rolls_back_logs_and_propagates(monkeypatch, caplog) -> None:
+    from dev_health_ops import db
+    from dev_health_ops.workers import sync_scheduler
+
+    monkeypatch.setenv(_FLAG, "true")
+    session = MagicMock()
+
+    @contextmanager
+    def session_context():
+        try:
+            yield session
+        except Exception:
+            session.rollback()
+            raise
+
+    monkeypatch.setattr(db, "get_postgres_session_sync", session_context)
+    monkeypatch.setattr(
+        sync_scheduler,
+        "reconcile_pending_scheduled_sync_occurrences",
+        MagicMock(side_effect=RuntimeError("reconcile failed")),
+    )
+
+    with pytest.raises(RuntimeError, match="reconcile failed"):
+        _run_task()
+
+    session.commit.assert_not_called()
+    session.rollback.assert_called_once_with()
+    assert "sync_scheduler.pending_occurrence_consumer_failed" in caplog.text
+
+
+def test_beat_entry_is_default_off_and_uses_scheduler_queue_when_enabled(
+    monkeypatch,
+) -> None:
+    from dev_health_ops.workers import config as worker_config
+
+    original = os.environ.get(_FLAG)
+    try:
+        monkeypatch.delenv(_FLAG, raising=False)
+        disabled_config = importlib.reload(worker_config)
+        assert _SCHEDULE_NAME not in disabled_config.beat_schedule
+
+        monkeypatch.setenv(_FLAG, "yes")
+        enabled_config = importlib.reload(worker_config)
+        assert enabled_config.beat_schedule[_SCHEDULE_NAME] == {
+            "task": _TASK_NAME,
+            "schedule": 300.0,
+            "options": {"queue": "scheduler"},
+        }
+    finally:
+        if original is None:
+            monkeypatch.delenv(_FLAG, raising=False)
+        else:
+            monkeypatch.setenv(_FLAG, original)
+        importlib.reload(worker_config)
+
+
+def test_consumer_task_is_exported_and_registered() -> None:
+    from dev_health_ops.workers import tasks
+    from dev_health_ops.workers.celery_app import celery_app
+
+    assert "consume_pending_scheduled_sync_occurrences" in tasks.__all__
+    assert _TASK_NAME in celery_app.tasks

--- a/tests/test_scheduled_sync_occurrence_reconcile_migration.py
+++ b/tests/test_scheduled_sync_occurrence_reconcile_migration.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import importlib
+from datetime import datetime, timezone
+
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+
+def test_migration_0051_backfills_completed_links_and_is_reversible() -> None:
+    migration = importlib.import_module(
+        "dev_health_ops.alembic.versions.0051_add_scheduled_sync_occurrence_reconcile_state"
+    )
+    assert migration.revision == "0051"
+    assert migration.down_revision == "0050"
+
+    engine = sa.create_engine("sqlite:///:memory:")
+    metadata = sa.MetaData()
+    occurrences = sa.Table(
+        "scheduled_sync_occurrences",
+        metadata,
+        sa.Column("occurrence_id", sa.Text(), primary_key=True),
+        sa.Column("org_id", sa.Text(), nullable=False),
+        sa.Column("sync_config_id", sa.Text(), nullable=False),
+        sa.Column("scheduled_job_id", sa.Text(), nullable=False),
+        sa.Column("scheduled_for", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("job_run_id", sa.Text(), nullable=True),
+        sa.Column("sync_run_id", sa.Text(), nullable=True),
+    )
+    try:
+        with engine.connect() as connection:
+            metadata.create_all(connection)
+            connection.execute(
+                occurrences.insert().values(
+                    occurrence_id="linked",
+                    org_id="org",
+                    sync_config_id="config",
+                    scheduled_job_id="job",
+                    scheduled_for=datetime(2026, 7, 23, tzinfo=timezone.utc),
+                    job_run_id="job-run",
+                    sync_run_id="sync-run",
+                )
+            )
+            context = MigrationContext.configure(connection)
+            with Operations.context(context):
+                migration.upgrade()
+
+                columns = {
+                    column["name"]
+                    for column in sa.inspect(connection).get_columns(
+                        "scheduled_sync_occurrences"
+                    )
+                }
+                assert {
+                    "reconcile_attempt_count",
+                    "reconcile_next_attempt_at",
+                    "reconcile_error_code",
+                    "reconcile_error_at",
+                    "reconcile_status",
+                } <= columns
+                assert (
+                    connection.execute(
+                        sa.text(
+                            "SELECT reconcile_status FROM scheduled_sync_occurrences "
+                            "WHERE occurrence_id = 'linked'"
+                        )
+                    ).scalar_one()
+                    == "completed"
+                )
+                index_columns = sa.inspect(connection).get_indexes(
+                    "scheduled_sync_occurrences"
+                )
+                assert any(
+                    index["name"] == "ix_scheduled_sync_occurrence_reconcile_due"
+                    and index["column_names"]
+                    == [
+                        "reconcile_status",
+                        "reconcile_next_attempt_at",
+                        "org_id",
+                        "sync_config_id",
+                        "scheduled_job_id",
+                        "scheduled_for",
+                    ]
+                    for index in index_columns
+                )
+
+                migration.downgrade()
+
+            assert "reconcile_status" not in {
+                column["name"]
+                for column in sa.inspect(connection).get_columns(
+                    "scheduled_sync_occurrences"
+                )
+            }
+    finally:
+        engine.dispose()

--- a/tests/test_scheduled_sync_occurrence_reconcile_migration.py
+++ b/tests/test_scheduled_sync_occurrence_reconcile_migration.py
@@ -77,10 +77,10 @@ def test_migration_0051_backfills_completed_links_and_is_reversible() -> None:
                     == [
                         "reconcile_status",
                         "reconcile_next_attempt_at",
-                        "org_id",
                         "sync_config_id",
                         "scheduled_job_id",
                         "scheduled_for",
+                        "org_id",
                     ]
                     for index in index_columns
                 )

--- a/tests/test_sync_scheduler_concurrency.py
+++ b/tests/test_sync_scheduler_concurrency.py
@@ -447,7 +447,7 @@ def test_postgres_occurrence_consumer_skips_locked_pair_and_poison_prefix(monkey
         poisoned_occurrence = ScheduledSyncOccurrence(
             occurrence_id="sha256:poisoned-postgres-prefix",
             identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
-            org_id=org_id,
+            org_id=f"{org_id}-mismatch",
             sync_config_id=later_config.id,
             scheduled_job_id=later_job.id,
             scheduled_for=now - 2 * HOUR,
@@ -467,6 +467,7 @@ def test_postgres_occurrence_consumer_skips_locked_pair_and_poison_prefix(monkey
         locked_config_id = locked_config.id
         later_config_id = later_config.id
         locked_job_id = locked_job.id
+        locked_occurrence_id = locked_occurrence.occurrence_id
         poisoned_occurrence_id = poisoned_occurrence.occurrence_id
         eligible_occurrence_id = eligible_occurrence.occurrence_id
 
@@ -494,9 +495,7 @@ def test_postgres_occurrence_consumer_skips_locked_pair_and_poison_prefix(monkey
         with _session_scope(session_factory) as verify:
             poisoned = verify.get(ScheduledSyncOccurrence, poisoned_occurrence_id)
             eligible = verify.get(ScheduledSyncOccurrence, eligible_occurrence_id)
-            locked = verify.get(
-                ScheduledSyncOccurrence, locked_occurrence.occurrence_id
-            )
+            locked = verify.get(ScheduledSyncOccurrence, locked_occurrence_id)
             assert poisoned is not None and poisoned.reconcile_status == "quarantined"
             assert eligible is not None and eligible.sync_run_id is not None
             assert locked is not None and locked.sync_run_id is None

--- a/tests/test_sync_scheduler_concurrency.py
+++ b/tests/test_sync_scheduler_concurrency.py
@@ -367,11 +367,20 @@ def test_postgres_pending_occurrence_consumer_skips_locked_replica(monkeypatch):
             assert first.result(timeout=30) == {
                 "scanned": 1,
                 "completed": 1,
-                "skipped": 0,
+                "retried": 0,
+                "quarantined": 0,
+                "already_completed": 0,
                 "errors": 0,
             }
 
-        assert second == {"scanned": 1, "completed": 0, "skipped": 1, "errors": 0}
+        assert second == {
+            "scanned": 0,
+            "completed": 0,
+            "retried": 0,
+            "quarantined": 0,
+            "already_completed": 0,
+            "errors": 0,
+        }
         with _session_scope(session_factory) as verify:
             occurrence = verify.get(ScheduledSyncOccurrence, occurrence_id)
             assert occurrence is not None
@@ -390,6 +399,115 @@ def test_postgres_pending_occurrence_consumer_skips_locked_replica(monkeypatch):
                 cleanup.delete(job)
             if config is not None:
                 cleanup.delete(config)
+            cleanup.commit()
+        engine.dispose()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("POSTGRES_SYNC_SCHEDULER_TEST_URL"),
+    reason="POSTGRES_SYNC_SCHEDULER_TEST_URL is not set",
+)
+def test_postgres_occurrence_consumer_skips_locked_pair_and_poison_prefix(monkeypatch):
+    """A locked earliest pair and poison prefix cannot starve later work."""
+    pytest.importorskip("psycopg2")
+    from sqlalchemy.orm import sessionmaker
+
+    url = os.environ["POSTGRES_SYNC_SCHEDULER_TEST_URL"]
+    engine = create_engine(url)
+    Base.metadata.create_all(engine)
+    _ensure_postgres_sync_marker_constraint(engine)
+    session_factory = sessionmaker(bind=engine)
+    now = datetime.now(timezone.utc)
+    org_id = f"scheduler-forward-progress-{uuid.uuid4()}"
+    monkeypatch.setattr(
+        "dev_health_ops.workers.org_guard.organization_exists_sync", lambda *_: True
+    )
+
+    with _session_scope(session_factory) as setup:
+        locked_config = _make_config(
+            setup, name="locked", last_sync_at=now - 4 * HOUR, org_id=org_id
+        )
+        later_config = _make_config(
+            setup, name="later", last_sync_at=now - 4 * HOUR, org_id=org_id
+        )
+        locked_job = _make_job(locked_config, next_run_at=now + HOUR)
+        later_job = _make_job(later_config, next_run_at=now + HOUR)
+        setup.add_all([locked_job, later_job])
+        setup.flush()
+        locked_occurrence = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(
+                locked_config.id, now - 3 * HOUR
+            ),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=org_id,
+            sync_config_id=locked_config.id,
+            scheduled_job_id=locked_job.id,
+            scheduled_for=now - 3 * HOUR,
+        )
+        poisoned_occurrence = ScheduledSyncOccurrence(
+            occurrence_id="sha256:poisoned-postgres-prefix",
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=org_id,
+            sync_config_id=later_config.id,
+            scheduled_job_id=later_job.id,
+            scheduled_for=now - 2 * HOUR,
+        )
+        eligible_occurrence = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(
+                later_config.id, now - HOUR
+            ),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=org_id,
+            sync_config_id=later_config.id,
+            scheduled_job_id=later_job.id,
+            scheduled_for=now - HOUR,
+        )
+        setup.add_all([locked_occurrence, poisoned_occurrence, eligible_occurrence])
+        setup.commit()
+        locked_config_id = locked_config.id
+        later_config_id = later_config.id
+        locked_job_id = locked_job.id
+        poisoned_occurrence_id = poisoned_occurrence.occurrence_id
+        eligible_occurrence_id = eligible_occurrence.occurrence_id
+
+    holder = session_factory()
+    try:
+        holder.query(SyncConfiguration).filter_by(
+            id=locked_config_id
+        ).with_for_update().one()
+        holder.query(ScheduledJob).filter_by(id=locked_job_id).with_for_update().one()
+
+        with _session_scope(session_factory) as worker_session:
+            result = sync_scheduler.reconcile_pending_scheduled_sync_occurrences(
+                worker_session, limit=1
+            )
+            worker_session.commit()
+
+        assert result == {
+            "scanned": 2,
+            "completed": 1,
+            "retried": 0,
+            "quarantined": 1,
+            "already_completed": 0,
+            "errors": 0,
+        }
+        with _session_scope(session_factory) as verify:
+            poisoned = verify.get(ScheduledSyncOccurrence, poisoned_occurrence_id)
+            eligible = verify.get(ScheduledSyncOccurrence, eligible_occurrence_id)
+            locked = verify.get(
+                ScheduledSyncOccurrence, locked_occurrence.occurrence_id
+            )
+            assert poisoned is not None and poisoned.reconcile_status == "quarantined"
+            assert eligible is not None and eligible.sync_run_id is not None
+            assert locked is not None and locked.sync_run_id is None
+    finally:
+        holder.rollback()
+        holder.close()
+        with _session_scope(session_factory) as cleanup:
+            for config_id in (locked_config_id, later_config_id):
+                config = cleanup.get(SyncConfiguration, config_id)
+                if config is not None:
+                    cleanup.delete(config)
             cleanup.commit()
         engine.dispose()
 

--- a/tests/test_sync_scheduler_concurrency.py
+++ b/tests/test_sync_scheduler_concurrency.py
@@ -5,7 +5,7 @@ import sys
 import uuid
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from threading import Barrier, Event
 from time import monotonic_ns
 from unittest.mock import MagicMock
@@ -22,6 +22,10 @@ from dev_health_ops.models import (
 )
 from dev_health_ops.models.git import Base
 from dev_health_ops.models.settings import ScheduledJob, SyncConfiguration
+from dev_health_ops.sync.execution_trigger import (
+    SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+    scheduled_sync_occurrence_identity,
+)
 from dev_health_ops.workers import sync_scheduler, sync_units
 from tests.test_sync_scheduler_idempotency import (
     HOUR,
@@ -282,6 +286,108 @@ def test_postgres_missing_job_row_race_dispatches_once(monkeypatch):
             ):
                 cleanup.delete(job)
             config = cleanup.get(SyncConfiguration, config_id)
+            if config is not None:
+                cleanup.delete(config)
+            cleanup.commit()
+        engine.dispose()
+
+
+@pytest.mark.skipif(
+    not os.environ.get("POSTGRES_SYNC_SCHEDULER_TEST_URL"),
+    reason="POSTGRES_SYNC_SCHEDULER_TEST_URL is not set",
+)
+def test_postgres_pending_occurrence_consumer_skips_locked_replica(monkeypatch):
+    pytest.importorskip("psycopg2")
+    from sqlalchemy.orm import sessionmaker
+
+    from dev_health_ops.sync import execution_trigger
+
+    url = os.environ["POSTGRES_SYNC_SCHEDULER_TEST_URL"]
+    engine = create_engine(url)
+    Base.metadata.create_all(engine)
+    _ensure_postgres_sync_marker_constraint(engine)
+    session_factory = sessionmaker(bind=engine)
+    org_id = f"scheduler-pending-occurrence-{uuid.uuid4()}"
+    now = datetime.now(timezone.utc)
+    planner_entered = Event()
+    release_planner = Event()
+    monkeypatch.setattr(
+        "dev_health_ops.workers.org_guard.organization_exists_sync", lambda *_: True
+    )
+    real_create_trigger = execution_trigger.create_sync_execution_trigger
+
+    def pause_planner(*args, **kwargs):
+        planner_entered.set()
+        assert release_planner.wait(timeout=10)
+        return real_create_trigger(*args, **kwargs)
+
+    monkeypatch.setattr(
+        execution_trigger, "create_sync_execution_trigger", pause_planner
+    )
+
+    with _session_scope(session_factory) as setup:
+        config = _make_config(setup, last_sync_at=now - 2 * HOUR, org_id=org_id)
+        job = _make_job(config, next_run_at=now + timedelta(hours=1))
+        setup.add(job)
+        setup.flush()
+        occurrence = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(config.id, now - HOUR),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=org_id,
+            sync_config_id=config.id,
+            scheduled_job_id=job.id,
+            scheduled_for=now - HOUR,
+        )
+        setup.add(occurrence)
+        setup.commit()
+        config_id = config.id
+        job_id = job.id
+        occurrence_id = occurrence.occurrence_id
+
+    def first_consumer() -> dict[str, int]:
+        with _session_scope(session_factory) as session:
+            result = sync_scheduler.reconcile_pending_scheduled_sync_occurrences(
+                session, limit=1
+            )
+            session.commit()
+            return result
+
+    try:
+        with ThreadPoolExecutor(max_workers=1) as executor:
+            first = executor.submit(first_consumer)
+            assert planner_entered.wait(timeout=10)
+
+            with _session_scope(session_factory) as second_session:
+                second = sync_scheduler.reconcile_pending_scheduled_sync_occurrences(
+                    second_session, limit=1
+                )
+                second_session.commit()
+
+            release_planner.set()
+            assert first.result(timeout=30) == {
+                "scanned": 1,
+                "completed": 1,
+                "skipped": 0,
+                "errors": 0,
+            }
+
+        assert second == {"scanned": 1, "completed": 0, "skipped": 1, "errors": 0}
+        with _session_scope(session_factory) as verify:
+            occurrence = verify.get(ScheduledSyncOccurrence, occurrence_id)
+            assert occurrence is not None
+            assert occurrence.job_run_id is not None
+            assert occurrence.sync_run_id is not None
+            assert verify.query(JobRun).filter_by(job_id=job_id).count() == 1
+            assert verify.query(SyncRun).filter_by(org_id=org_id).count() == 1
+            assert (
+                verify.query(SyncDispatchOutbox).filter_by(org_id=org_id).count() == 1
+            )
+    finally:
+        with _session_scope(session_factory) as cleanup:
+            job = cleanup.get(ScheduledJob, job_id)
+            config = cleanup.get(SyncConfiguration, config_id)
+            if job is not None:
+                cleanup.delete(job)
             if config is not None:
                 cleanup.delete(config)
             cleanup.commit()

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -373,9 +373,16 @@ class TestDispatchIdempotency:
     def test_pending_go_occurrence_is_completed_once_by_python(
         self, monkeypatch, db_session
     ):
+        from dev_health_ops.workers.sync_scheduler import (
+            reconcile_pending_scheduled_sync_occurrences,
+        )
+
         now = datetime.now(timezone.utc)
         config = _make_config(db_session, last_sync_at=now - 2 * HOUR)
-        job = _make_job(config)
+        # The Go scheduler already advanced this marker.  The dormant Python
+        # consumer must complete the durable occurrence without reconsidering
+        # the next-run gate.
+        job = _make_job(config, next_run_at=now + HOUR)
         db_session.add(job)
         db_session.flush()
         scheduled_for = now - HOUR
@@ -392,19 +399,22 @@ class TestDispatchIdempotency:
         )
         db_session.add(occurrence)
         db_session.commit()
-        task, dispatch_mock = _run_dispatch(monkeypatch, db_session)
+        monkeypatch.setattr(
+            "dev_health_ops.workers.org_guard.organization_exists_sync",
+            lambda *_: True,
+        )
 
-        first = _call(task)
+        first = reconcile_pending_scheduled_sync_occurrences(db_session)
         db_session.refresh(occurrence)
         first_job_run_id = occurrence.job_run_id
         first_sync_run_id = occurrence.sync_run_id
 
-        job.next_run_at = now - timedelta(seconds=1)
-        db_session.commit()
-        second = _call(task)
+        second = reconcile_pending_scheduled_sync_occurrences(db_session)
 
-        assert str(config.id) in first["dispatched"]
-        assert str(config.id) in second["dispatched"]
+        assert first == {"scanned": 1, "completed": 1, "skipped": 0, "errors": 0}
+        assert second == {"scanned": 0, "completed": 0, "skipped": 0, "errors": 0}
+        assert job.next_run_at is not None
+        assert _aware(job.next_run_at) > now
         assert first_job_run_id is not None
         assert first_sync_run_id is not None
         assert occurrence.job_run_id == first_job_run_id
@@ -413,7 +423,117 @@ class TestDispatchIdempotency:
         assert db_session.query(JobRun).count() == 1
         assert db_session.query(SyncRun).count() == 1
         assert db_session.query(SyncDispatchOutbox).count() == 1
-        dispatch_mock.apply_async.assert_not_called()
+
+    def test_pending_occurrence_reconciliation_is_deterministic_and_bounded(
+        self, monkeypatch, db_session
+    ):
+        from dev_health_ops.workers.sync_scheduler import (
+            reconcile_pending_scheduled_sync_occurrences,
+        )
+
+        now = datetime.now(timezone.utc)
+        config = _make_config(db_session, last_sync_at=now - 3 * HOUR)
+        job = _make_job(config, next_run_at=now + HOUR)
+        db_session.add(job)
+        db_session.flush()
+        later = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(config.id, now - HOUR),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=config.org_id,
+            sync_config_id=config.id,
+            scheduled_job_id=job.id,
+            scheduled_for=now - HOUR,
+        )
+        earlier = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(config.id, now - 2 * HOUR),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=config.org_id,
+            sync_config_id=config.id,
+            scheduled_job_id=job.id,
+            scheduled_for=now - 2 * HOUR,
+        )
+        db_session.add_all([later, earlier])
+        db_session.commit()
+        monkeypatch.setattr(
+            "dev_health_ops.workers.org_guard.organization_exists_sync",
+            lambda *_: True,
+        )
+
+        result = reconcile_pending_scheduled_sync_occurrences(db_session, limit=1)
+
+        db_session.refresh(earlier)
+        db_session.refresh(later)
+        assert result == {"scanned": 1, "completed": 1, "skipped": 0, "errors": 0}
+        assert earlier.job_run_id is not None
+        assert earlier.sync_run_id is not None
+        assert later.job_run_id is None
+        assert later.sync_run_id is None
+
+    def test_pending_occurrence_reconciliation_isolates_failed_rows(
+        self, monkeypatch, db_session
+    ):
+        from dev_health_ops.sync import execution_trigger
+        from dev_health_ops.workers.sync_scheduler import (
+            reconcile_pending_scheduled_sync_occurrences,
+        )
+
+        now = datetime.now(timezone.utc)
+        failing_config = _make_config(
+            db_session, name="failing", last_sync_at=now - 2 * HOUR
+        )
+        succeeding_config = _make_config(
+            db_session, name="succeeding", last_sync_at=now - 2 * HOUR
+        )
+        failing_job = _make_job(failing_config, next_run_at=now + HOUR)
+        succeeding_job = _make_job(succeeding_config, next_run_at=now + HOUR)
+        db_session.add_all([failing_job, succeeding_job])
+        db_session.flush()
+        failing_occurrence = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(
+                failing_config.id, now - HOUR
+            ),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=failing_config.org_id,
+            sync_config_id=failing_config.id,
+            scheduled_job_id=failing_job.id,
+            scheduled_for=now - HOUR,
+        )
+        succeeding_occurrence = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(
+                succeeding_config.id, now - HOUR
+            ),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=succeeding_config.org_id,
+            sync_config_id=succeeding_config.id,
+            scheduled_job_id=succeeding_job.id,
+            scheduled_for=now - HOUR,
+        )
+        db_session.add_all([failing_occurrence, succeeding_occurrence])
+        db_session.commit()
+        monkeypatch.setattr(
+            "dev_health_ops.workers.org_guard.organization_exists_sync",
+            lambda *_: True,
+        )
+        real_create_trigger = execution_trigger.create_sync_execution_trigger
+
+        def fail_one_occurrence(session, config, org_id, **kwargs):
+            if config.id == failing_config.id:
+                raise RuntimeError("injected planner failure")
+            return real_create_trigger(session, config, org_id, **kwargs)
+
+        monkeypatch.setattr(
+            execution_trigger, "create_sync_execution_trigger", fail_one_occurrence
+        )
+
+        result = reconcile_pending_scheduled_sync_occurrences(db_session)
+
+        db_session.refresh(failing_occurrence)
+        db_session.refresh(succeeding_occurrence)
+        assert result == {"scanned": 2, "completed": 1, "skipped": 0, "errors": 1}
+        assert failing_occurrence.job_run_id is None
+        assert failing_occurrence.sync_run_id is None
+        assert succeeding_occurrence.job_run_id is not None
+        assert succeeding_occurrence.sync_run_id is not None
 
     def test_planner_failure_rolls_back_occurrence_plan_and_marker(
         self, monkeypatch, db_session

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -653,6 +653,63 @@ class TestDispatchIdempotency:
         assert succeeding_occurrence.job_run_id is not None
         assert succeeding_occurrence.sync_run_id is not None
 
+    def test_pending_occurrence_retry_exhaustion_is_terminal(
+        self, monkeypatch, db_session
+    ):
+        from dev_health_ops.sync import execution_trigger
+        from dev_health_ops.workers.sync_scheduler import (
+            reconcile_pending_scheduled_sync_occurrences,
+        )
+
+        now = datetime.now(timezone.utc)
+        config = _make_config(db_session, last_sync_at=now - 2 * HOUR)
+        job = _make_job(config, next_run_at=now + HOUR)
+        db_session.add(job)
+        db_session.flush()
+        occurrence = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(config.id, now - HOUR),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=config.org_id,
+            sync_config_id=config.id,
+            scheduled_job_id=job.id,
+            scheduled_for=now - HOUR,
+            reconcile_attempt_count=4,
+            reconcile_error_code="planner_error",
+            reconcile_error_at=now - HOUR,
+            reconcile_status="retry",
+        )
+        db_session.add(occurrence)
+        db_session.commit()
+        monkeypatch.setattr(
+            "dev_health_ops.workers.org_guard.organization_exists_sync",
+            lambda *_: True,
+        )
+
+        def fail_plan(*_args, **_kwargs):
+            raise RuntimeError("injected planner failure")
+
+        monkeypatch.setattr(
+            execution_trigger, "create_sync_execution_trigger", fail_plan
+        )
+
+        result = reconcile_pending_scheduled_sync_occurrences(db_session, limit=1)
+
+        db_session.refresh(occurrence)
+        assert result == {
+            "scanned": 1,
+            "completed": 0,
+            "retried": 0,
+            "quarantined": 1,
+            "already_completed": 0,
+            "errors": 1,
+        }
+        assert occurrence.reconcile_attempt_count == 5
+        assert occurrence.reconcile_status == "quarantined"
+        assert occurrence.reconcile_error_code == "retry_exhausted"
+        assert occurrence.reconcile_next_attempt_at is None
+        assert occurrence.job_run_id is None
+        assert occurrence.sync_run_id is None
+
     def test_pending_occurrence_identity_conflict_is_quarantined_without_planning(
         self, monkeypatch, db_session
     ):
@@ -701,6 +758,49 @@ class TestDispatchIdempotency:
         assert db_session.query(JobRun).count() == 0
         assert db_session.query(SyncRun).count() == 0
         assert db_session.query(SyncDispatchOutbox).count() == 0
+
+    def test_pending_occurrence_org_mismatch_is_quarantined(
+        self, monkeypatch, db_session
+    ):
+        from dev_health_ops.workers.sync_scheduler import (
+            reconcile_pending_scheduled_sync_occurrences,
+        )
+
+        now = datetime.now(timezone.utc)
+        config = _make_config(db_session, last_sync_at=now - 2 * HOUR)
+        job = _make_job(config, next_run_at=now + HOUR)
+        db_session.add(job)
+        db_session.flush()
+        occurrence = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(config.id, now - HOUR),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=f"{config.org_id}-mismatch",
+            sync_config_id=config.id,
+            scheduled_job_id=job.id,
+            scheduled_for=now - HOUR,
+        )
+        db_session.add(occurrence)
+        db_session.commit()
+        monkeypatch.setattr(
+            "dev_health_ops.workers.org_guard.organization_exists_sync",
+            lambda *_: True,
+        )
+
+        result = reconcile_pending_scheduled_sync_occurrences(db_session, limit=1)
+
+        db_session.refresh(occurrence)
+        assert result == {
+            "scanned": 1,
+            "completed": 0,
+            "retried": 0,
+            "quarantined": 1,
+            "already_completed": 0,
+            "errors": 0,
+        }
+        assert occurrence.reconcile_status == "quarantined"
+        assert occurrence.reconcile_error_code == "identity_conflict"
+        assert occurrence.job_run_id is None
+        assert occurrence.sync_run_id is None
 
     def test_quarantined_prefix_does_not_block_later_due_occurrence(
         self, monkeypatch, db_session

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -456,8 +456,22 @@ class TestDispatchIdempotency:
 
         second = reconcile_pending_scheduled_sync_occurrences(db_session)
 
-        assert first == {"scanned": 1, "completed": 1, "skipped": 0, "errors": 0}
-        assert second == {"scanned": 0, "completed": 0, "skipped": 0, "errors": 0}
+        assert first == {
+            "scanned": 1,
+            "completed": 1,
+            "retried": 0,
+            "quarantined": 0,
+            "already_completed": 0,
+            "errors": 0,
+        }
+        assert second == {
+            "scanned": 0,
+            "completed": 0,
+            "retried": 0,
+            "quarantined": 0,
+            "already_completed": 0,
+            "errors": 0,
+        }
         assert job.next_run_at is not None
         assert _aware(job.next_run_at) > now
         assert first_job_run_id is not None
@@ -508,7 +522,14 @@ class TestDispatchIdempotency:
 
         db_session.refresh(earlier)
         db_session.refresh(later)
-        assert result == {"scanned": 1, "completed": 1, "skipped": 0, "errors": 0}
+        assert result == {
+            "scanned": 1,
+            "completed": 1,
+            "retried": 0,
+            "quarantined": 0,
+            "already_completed": 0,
+            "errors": 0,
+        }
         assert earlier.job_run_id is not None
         assert earlier.sync_run_id is not None
         assert later.job_run_id is None
@@ -551,9 +572,11 @@ class TestDispatchIdempotency:
         )
 
         assert result == {
-            "scanned": sync_scheduler.DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT,
+            "scanned": sync_scheduler.DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT + 1,
             "completed": 0,
-            "skipped": sync_scheduler.DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT,
+            "retried": sync_scheduler.DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT + 1,
+            "quarantined": 0,
+            "already_completed": 0,
             "errors": 0,
         }
 
@@ -617,11 +640,162 @@ class TestDispatchIdempotency:
 
         db_session.refresh(failing_occurrence)
         db_session.refresh(succeeding_occurrence)
-        assert result == {"scanned": 2, "completed": 1, "skipped": 0, "errors": 1}
+        assert result == {
+            "scanned": 2,
+            "completed": 1,
+            "retried": 1,
+            "quarantined": 0,
+            "already_completed": 0,
+            "errors": 1,
+        }
         assert failing_occurrence.job_run_id is None
         assert failing_occurrence.sync_run_id is None
         assert succeeding_occurrence.job_run_id is not None
         assert succeeding_occurrence.sync_run_id is not None
+
+    def test_pending_occurrence_identity_conflict_is_quarantined_without_planning(
+        self, monkeypatch, db_session
+    ):
+        from dev_health_ops.models.settings import (
+            SCHEDULED_OCCURRENCE_RECONCILE_QUARANTINED,
+        )
+        from dev_health_ops.workers.sync_scheduler import (
+            reconcile_pending_scheduled_sync_occurrences,
+        )
+
+        now = datetime.now(timezone.utc)
+        config = _make_config(db_session, last_sync_at=now - 2 * HOUR)
+        job = _make_job(config, next_run_at=now + HOUR)
+        db_session.add(job)
+        db_session.flush()
+        occurrence = ScheduledSyncOccurrence(
+            occurrence_id="sha256:identity-conflict",
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=config.org_id,
+            sync_config_id=config.id,
+            scheduled_job_id=job.id,
+            scheduled_for=now - HOUR,
+        )
+        db_session.add(occurrence)
+        db_session.commit()
+        monkeypatch.setattr(
+            "dev_health_ops.workers.org_guard.organization_exists_sync",
+            lambda *_: True,
+        )
+
+        result = reconcile_pending_scheduled_sync_occurrences(db_session, limit=1)
+
+        db_session.refresh(occurrence)
+        assert result == {
+            "scanned": 1,
+            "completed": 0,
+            "retried": 0,
+            "quarantined": 1,
+            "already_completed": 0,
+            "errors": 0,
+        }
+        assert occurrence.reconcile_status == SCHEDULED_OCCURRENCE_RECONCILE_QUARANTINED
+        assert occurrence.reconcile_error_code == "identity_conflict"
+        assert occurrence.job_run_id is None
+        assert occurrence.sync_run_id is None
+        assert db_session.query(JobRun).count() == 0
+        assert db_session.query(SyncRun).count() == 0
+        assert db_session.query(SyncDispatchOutbox).count() == 0
+
+    def test_quarantined_prefix_does_not_block_later_due_occurrence(
+        self, monkeypatch, db_session
+    ):
+        from dev_health_ops.workers.sync_scheduler import (
+            reconcile_pending_scheduled_sync_occurrences,
+        )
+
+        now = datetime.now(timezone.utc)
+        config = _make_config(db_session, last_sync_at=now - 3 * HOUR)
+        job = _make_job(config, next_run_at=now + HOUR)
+        db_session.add(job)
+        db_session.flush()
+        poisoned = ScheduledSyncOccurrence(
+            occurrence_id="sha256:poisoned-prefix",
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=config.org_id,
+            sync_config_id=config.id,
+            scheduled_job_id=job.id,
+            scheduled_for=now - 2 * HOUR,
+        )
+        eligible = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(config.id, now - HOUR),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=config.org_id,
+            sync_config_id=config.id,
+            scheduled_job_id=job.id,
+            scheduled_for=now - HOUR,
+        )
+        db_session.add_all([poisoned, eligible])
+        db_session.commit()
+        monkeypatch.setattr(
+            "dev_health_ops.workers.org_guard.organization_exists_sync",
+            lambda *_: True,
+        )
+
+        result = reconcile_pending_scheduled_sync_occurrences(db_session, limit=1)
+
+        db_session.refresh(poisoned)
+        db_session.refresh(eligible)
+        assert result == {
+            "scanned": 2,
+            "completed": 1,
+            "retried": 0,
+            "quarantined": 1,
+            "already_completed": 0,
+            "errors": 0,
+        }
+        assert poisoned.reconcile_status == "quarantined"
+        assert eligible.job_run_id is not None
+        assert eligible.sync_run_id is not None
+
+    def test_mismatched_config_job_pair_is_quarantined(self, monkeypatch, db_session):
+        from dev_health_ops.workers.sync_scheduler import (
+            reconcile_pending_scheduled_sync_occurrences,
+        )
+
+        now = datetime.now(timezone.utc)
+        config = _make_config(db_session, name="config-a", last_sync_at=now - 2 * HOUR)
+        other_config = _make_config(
+            db_session, name="config-b", last_sync_at=now - 2 * HOUR
+        )
+        job = _make_job(config, next_run_at=now + HOUR)
+        other_job = _make_job(other_config, next_run_at=now + HOUR)
+        db_session.add_all([job, other_job])
+        db_session.flush()
+        occurrence = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(config.id, now - HOUR),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=config.org_id,
+            sync_config_id=config.id,
+            scheduled_job_id=other_job.id,
+            scheduled_for=now - HOUR,
+        )
+        db_session.add(occurrence)
+        db_session.commit()
+        monkeypatch.setattr(
+            "dev_health_ops.workers.org_guard.organization_exists_sync",
+            lambda *_: True,
+        )
+
+        result = reconcile_pending_scheduled_sync_occurrences(db_session, limit=1)
+
+        db_session.refresh(occurrence)
+        assert result == {
+            "scanned": 1,
+            "completed": 0,
+            "retried": 0,
+            "quarantined": 1,
+            "already_completed": 0,
+            "errors": 0,
+        }
+        assert occurrence.reconcile_status == "quarantined"
+        assert occurrence.job_run_id is None
+        assert occurrence.sync_run_id is None
 
     def test_planner_failure_rolls_back_occurrence_plan_and_marker(
         self, monkeypatch, db_session

--- a/tests/test_sync_scheduler_idempotency.py
+++ b/tests/test_sync_scheduler_idempotency.py
@@ -370,7 +370,52 @@ class TestDispatchIdempotency:
         assert persisted.job_run_id == first_job_run_id
         assert persisted.sync_run_id == first_sync_run_id
 
-    def test_pending_go_occurrence_is_completed_once_by_python(
+    def test_active_scheduler_completes_pending_go_occurrence_once(
+        self, monkeypatch, db_session
+    ):
+        now = datetime.now(timezone.utc)
+        config = _make_config(db_session, last_sync_at=now - 2 * HOUR)
+        job = _make_job(config)
+        db_session.add(job)
+        db_session.flush()
+        scheduled_for = now - HOUR
+        occurrence = ScheduledSyncOccurrence(
+            occurrence_id=scheduled_sync_occurrence_identity(
+                config.id,
+                scheduled_for,
+            ),
+            identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+            org_id=config.org_id,
+            sync_config_id=config.id,
+            scheduled_job_id=job.id,
+            scheduled_for=scheduled_for,
+        )
+        db_session.add(occurrence)
+        db_session.commit()
+        task, dispatch_mock = _run_dispatch(monkeypatch, db_session)
+
+        first = _call(task)
+        db_session.refresh(occurrence)
+        first_job_run_id = occurrence.job_run_id
+        first_sync_run_id = occurrence.sync_run_id
+
+        job.next_run_at = now - timedelta(seconds=1)
+        db_session.commit()
+        second = _call(task)
+
+        assert str(config.id) in first["dispatched"]
+        assert str(config.id) in second["dispatched"]
+        assert first_job_run_id is not None
+        assert first_sync_run_id is not None
+        assert occurrence.job_run_id == first_job_run_id
+        assert occurrence.sync_run_id == first_sync_run_id
+        assert db_session.query(ScheduledSyncOccurrence).count() == 1
+        assert db_session.query(JobRun).count() == 1
+        assert db_session.query(SyncRun).count() == 1
+        assert db_session.query(SyncDispatchOutbox).count() == 1
+        dispatch_mock.apply_async.assert_not_called()
+
+    def test_pending_occurrence_consumer_ignores_future_marker_and_replays_once(
         self, monkeypatch, db_session
     ):
         from dev_health_ops.workers.sync_scheduler import (
@@ -468,6 +513,49 @@ class TestDispatchIdempotency:
         assert earlier.sync_run_id is not None
         assert later.job_run_id is None
         assert later.sync_run_id is None
+
+    def test_pending_occurrence_reconciliation_caps_oversized_limit(
+        self, monkeypatch, db_session
+    ):
+        from dev_health_ops.workers import sync_scheduler
+
+        now = datetime.now(timezone.utc)
+        config = _make_config(db_session, last_sync_at=now - 3 * HOUR)
+        job = _make_job(config, next_run_at=now + HOUR)
+        db_session.add(job)
+        db_session.flush()
+        for offset in range(101):
+            scheduled_for = now - timedelta(hours=offset + 1)
+            db_session.add(
+                ScheduledSyncOccurrence(
+                    occurrence_id=scheduled_sync_occurrence_identity(
+                        config.id, scheduled_for
+                    ),
+                    identity_version=SCHEDULED_SYNC_OCCURRENCE_IDENTITY_VERSION,
+                    org_id=config.org_id,
+                    sync_config_id=config.id,
+                    scheduled_job_id=job.id,
+                    scheduled_for=scheduled_for,
+                )
+            )
+        db_session.commit()
+        monkeypatch.setattr(
+            sync_scheduler,
+            "_complete_pending_scheduled_sync_occurrence",
+            lambda *_args, **_kwargs: False,
+        )
+
+        result = sync_scheduler.reconcile_pending_scheduled_sync_occurrences(
+            db_session,
+            limit=10_000,
+        )
+
+        assert result == {
+            "scanned": sync_scheduler.DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT,
+            "completed": 0,
+            "skipped": sync_scheduler.DEFAULT_PENDING_OCCURRENCE_RECONCILE_LIMIT,
+            "errors": 0,
+        }
 
     def test_pending_occurrence_reconciliation_isolates_failed_rows(
         self, monkeypatch, db_session


### PR DESCRIPTION
## Summary

- add migration `0051` and a bounded, default-off Celery consumer for pending scheduled-sync occurrences, including persisted retry backoff and poison-row quarantine
- add dormant Go expired-lease repair and publish-failure backoff primitives, with the River `InsertTx` trust boundary enforced by exact domain/queue role tests
- fence scheduler mutation behind an opaque default-Celery ownership policy
- add authenticated, audited sync-route status/pause/drain/resume controls with route-first lock ordering, an outbox commit barrier, live-claim rechecks, and safe same-Celery `post_sync` recovery
- update the migration plan, runtime TRD, worker runbook, CLI reference, and official PostgreSQL integration package list

## Activation boundary

- every checked-in and persisted route remains `celery`
- Go deployment profiles remain `coexistence_disabled` with zero replicas
- the scheduled-occurrence consumer and its Beat entry remain default-off
- no scheduler mutation loop, reconciler mutation loop, River publisher, or River handler is activated
- the shipped route capability registry is empty; River resume is rejected
- a future transport-changing `post_sync` resume requires both the target capability and an old-transport quiescer for the old generation

## Validation

- `bash ci/local_validate.sh` — 8,732 passed, 59 expected skips; full Ruff, mypy, Go format/vet/test/build/contracts, River compatibility, ClickHouse migrations, and live argMax proof passed
- `bash ci/check_go.sh integration` — real PostgreSQL role, River, outbox, operator, reconciler, route-control, and scheduler tests passed
- `go test -race ./internal/syncroute ./internal/joboperator ./cmd/dev-health-workerctl`
- scheduled-occurrence focused suite — 31 passed, 5 PostgreSQL-gated skips; the isolated real-PostgreSQL concurrency and full `0051` migration/downgrade proofs also passed
- strict MkDocs build, documentation inventory validation, and final independent safety audit passed

SCREENSHOT-WAIVER: backend, database migration, worker control, and documentation changes only; no rendered UI changes.
