### PR TITLE
feat(workers): advance dormant sync runtime (CHAOS-3039)

### DIFF
--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -217,7 +217,7 @@ check_integration() {
 		GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=10m \
 			./internal/testsupport/containers ./internal/storage/postgres ./internal/storage/river \
 			./internal/joboutbox ./internal/joboperator ./internal/syncreconciler ./internal/syncroute \
-			./internal/scheduler/sync
+			./internal/scheduler/sync ./internal/syncdispatchruntime
 	)
 }
 

--- a/cmd/dev-health-scheduler/main.go
+++ b/cmd/dev-health-scheduler/main.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"errors"
 
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
@@ -21,26 +22,73 @@ var schedulerSpec = shell.Spec{
 // Python scheduler retains all production marker-mutation ownership.
 var schedulerOwnership = schedulersync.DefaultOwnershipPolicy()
 
+var errSchedulerActivationUnavailable = errors.New("scheduler activation is unavailable")
+
+// schedulerActivation is a source-reviewed, package-private composition seam.
+// It deliberately cannot be influenced by process environment or deployment
+// profile. A future owner-transfer change must prove coordinator policy parity
+// before it supplies a loop factory and sets both gates true.
+type schedulerActivation struct {
+	goOwnsMarkers           bool
+	coordinatorPolicyParity bool
+}
+
+var checkedInSchedulerActivation = schedulerActivation{}
+
+type schedulerDependencySources struct {
+	buildLoop func(context.Context, config.Config, *health.Registry) (lifecycle.Component, error)
+}
+
+var productionSchedulerDependencySources = schedulerDependencySources{}
+
 func main() {
 	shell.Main(schedulerSpec)
 }
 
 func configureSchedulerDependencies(
-	_ context.Context,
-	_ config.Config,
+	ctx context.Context,
+	cfg config.Config,
 	registry *health.Registry,
+) ([]lifecycle.Component, error) {
+	return configureSchedulerDependenciesWithSources(
+		ctx,
+		cfg,
+		registry,
+		checkedInSchedulerActivation,
+		productionSchedulerDependencySources,
+	)
+}
+
+func configureSchedulerDependenciesWithSources(
+	ctx context.Context,
+	cfg config.Config,
+	registry *health.Registry,
+	activation schedulerActivation,
+	sources schedulerDependencySources,
 ) ([]lifecycle.Component, error) {
 	if err := schedulerOwnership.Validate(); err != nil {
 		return nil, err
 	}
-	// Phase 1 has no scheduler loop or composed storage clients. Keep every
-	// dependency required by the control-process topology explicitly closed.
-	err := processreadiness.RegisterUnavailable(
-		registry,
-		"domain_postgres",
-		"queue_postgres",
-		"river_schema",
-		"scheduler_loop",
-	)
-	return nil, err
+	if registry == nil {
+		return nil, errSchedulerActivationUnavailable
+	}
+	if !activation.goOwnsMarkers || !activation.coordinatorPolicyParity {
+		// The checked-in Celery/coexistence_disabled policy must not even open a
+		// PostgreSQL client. Keep all externally visible readiness names closed.
+		return nil, processreadiness.RegisterUnavailable(
+			registry,
+			"domain_postgres",
+			"queue_postgres",
+			"river_schema",
+			"scheduler_loop",
+		)
+	}
+	if sources.buildLoop == nil {
+		return nil, errSchedulerActivationUnavailable
+	}
+	loop, err := sources.buildLoop(ctx, cfg, registry)
+	if err != nil || loop == nil {
+		return nil, errSchedulerActivationUnavailable
+	}
+	return []lifecycle.Component{loop}, nil
 }

--- a/cmd/dev-health-scheduler/main_test.go
+++ b/cmd/dev-health-scheduler/main_test.go
@@ -2,14 +2,22 @@ package main
 
 import (
 	"context"
+	"errors"
 	"slices"
 	"testing"
 	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	"github.com/full-chaos/dev-health-ops/internal/platform/lifecycle"
 	schedulersync "github.com/full-chaos/dev-health-ops/internal/scheduler/sync"
 )
+
+type schedulerTestComponent struct{}
+
+func (schedulerTestComponent) Name() string                   { return "scheduler-test-loop" }
+func (schedulerTestComponent) Start(context.Context) error    { return nil }
+func (schedulerTestComponent) Shutdown(context.Context) error { return nil }
 
 func TestSchedulerSpecConfiguresFailClosedDependencies(t *testing.T) {
 	if schedulerOwnership != schedulersync.DefaultOwnershipPolicy() {
@@ -38,5 +46,53 @@ func TestSchedulerSpecConfiguresFailClosedDependencies(t *testing.T) {
 	status := registry.Readiness(context.Background())
 	if status.Ready || !slices.Equal(status.Failed, want) {
 		t.Fatalf("readiness = %#v, want failed %v", status, want)
+	}
+}
+
+func TestSchedulerActivationIsPrivateSourceReviewedComposition(t *testing.T) {
+	registry := health.NewRegistry(100 * time.Millisecond)
+	called := false
+	components, err := configureSchedulerDependenciesWithSources(
+		context.Background(),
+		config.Config{},
+		registry,
+		schedulerActivation{goOwnsMarkers: true, coordinatorPolicyParity: true},
+		schedulerDependencySources{buildLoop: func(context.Context, config.Config, *health.Registry) (lifecycle.Component, error) {
+			called = true
+			return schedulerTestComponent{}, nil
+		}},
+	)
+	if err != nil || !called || len(components) != 1 || components[0].Name() != "scheduler-test-loop" {
+		t.Fatalf("reviewed activation components=%v called=%v err=%v", components, called, err)
+	}
+
+	registry = health.NewRegistry(100 * time.Millisecond)
+	_, err = configureSchedulerDependenciesWithSources(
+		context.Background(), config.Config{}, registry,
+		schedulerActivation{goOwnsMarkers: true},
+		schedulerDependencySources{buildLoop: func(context.Context, config.Config, *health.Registry) (lifecycle.Component, error) {
+			t.Fatal("activation without coordinator parity invoked the loop factory")
+			return nil, nil
+		}},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if status := registry.Readiness(context.Background()); status.Ready || !slices.Contains(status.Failed, "scheduler_loop") {
+		t.Fatalf("non-parity readiness = %#v", status)
+	}
+
+	_, err = configureSchedulerDependenciesWithSources(
+		context.Background(), config.Config{}, health.NewRegistry(time.Second),
+		schedulerActivation{goOwnsMarkers: true, coordinatorPolicyParity: true},
+		schedulerDependencySources{buildLoop: func(context.Context, config.Config, *health.Registry) (lifecycle.Component, error) {
+			return nil, errors.New("private factory failure")
+		}},
+	)
+	if !errors.Is(err, errSchedulerActivationUnavailable) {
+		t.Fatalf("failed private factory error = %v", err)
 	}
 }

--- a/docs/architecture/go-worker-runtime-trd.md
+++ b/docs/architecture/go-worker-runtime-trd.md
@@ -583,9 +583,11 @@ embeds an opaque Celery/`coexistence_disabled` ownership policy, and its
 transaction kernel rejects mutation before opening a transaction. Constructing
 Go mutation authority requires a reviewed package-private source change. Until
 an activation review enables the consumer and supplies the remaining scheduler
-loop, unsupported-cron fallback, and coordinator policy parity, Celery Beat
-plus `dispatch_scheduled_syncs` remains the only mutation owner; a Go scheduler
-must not advance a production marker or claim schedule ownership.
+lifecycle composition, unsupported-cron policy parity, and coordinator policy
+parity, Celery Beat plus `dispatch_scheduled_syncs` remains the only mutation
+owner; a Go scheduler must not advance a production marker or claim schedule
+ownership. The dormant loop rolls back the entire locked window and keeps
+readiness closed when any candidate needs unsupported/invalid-cron fallback.
 
 The read-only comparison path in `internal/scheduler/sync` still performs one
 bounded schedule/configuration `SELECT` and evaluates a versioned candidate
@@ -697,14 +699,13 @@ kernel's outbox-only terminal transaction without the lock-upgrade deadlock.
 A reviewed cutover must pause with a generation increment, wait for live claims
 to drain or expire, deploy the matching checked-in handler/contract and
 capability, then resume the new transport with another generation increment.
-The command currently composes an empty capability registry, so River resume is
-rejected. A transport-changing `post_sync` resume also requires an external
-quiescer registered to the old transport capability and invoked for its old
-generation; a same-transport Celery resume remains available for recovery.
-Because the quiescer timeout is cooperative, a concrete implementation must
-prove it honors context cancellation before activation. All checked-in routes
-remain Celery, so the available control is same-transport pause/drain/resume
-until that separately reviewed deployment exists.
+The current runtime only ships a publisher-owned, in-process
+`GenerationTracker` local generation-drain API for the `post_sync`
+pre-publish window; `EnterLocalHandoff` and `WaitForLocalHandoffs` can close a
+generation and honor cancellation, but they are intentionally not a route or
+worker controller. River resume is still rejected. All checked-in routes remain
+Celery, so the available control is same-transport pause/drain/resume until
+that separately reviewed deployment exists.
 
 The future River relay must insert the River job and mark the sync outbox
 through one PostgreSQL transaction and therefore needs the corresponding
@@ -717,14 +718,13 @@ operator's outbox-table barrier now also waits through the post-terminal,
 pre-commit window before it changes the route generation.
 
 An unregistered sync-reconciler transaction kernel now implements the narrow
-transport boundary: for River-routed at-least-once rows it locks and claims a
-bounded due outbox window, invokes an injected River publisher through the same
-transaction, and marks the outbox dispatched only after the insert succeeds.
-For the at-most-once `post_sync` kind it marks dispatched first and invokes a
-separate transaction-local seam that cannot perform the eventual external
-effect. Route generation and claim-token predicates fail closed at the
-terminal write. The checked-in contract currently contains no River route, so
-even explicit mutation mode returns without opening a write transaction.
+transport boundary: it first commits a bounded set of River claims, then each
+at-least-once claim is delivered and terminally marked in its own fresh
+transaction. For the at-most-once `post_sync` kind the terminal mark is
+committed before the external handoff is invoked. Route generation and
+claim-token predicates fail closed at the terminal write. The checked-in
+contract currently contains no River route, so even explicit mutation mode
+returns without opening a write transaction.
 
 The reconciler command now reaches this package only through a shadow adapter
 whose kernel retains no transaction-begin function. The existing observer
@@ -742,23 +742,23 @@ execution owner.
 This kernel is not the complete reconciler loop. A command-unwired
 expired-domain-lease repair step now preserves the eligible Linear-backfill
 retry matrix and serializes provider/org/cost-class mutations. A separate
-persisted failure recorder can release an already committed River claim with
-bounded Python-parity backoff. The current kernel still claims, invokes the
-publisher, and marks in one transaction, however, so a publish failure rolls
-that transaction back; activation must split and commit the claim before it
-can use the recorder. The queue-control trust boundary is proven with the real
-River `InsertTx` API and exact outbox/route privileges. The operator route
-controller supplies the post-terminal, pre-commit serialization barrier and an
-exact capability registry, but the shipped registry is intentionally empty.
-Activation still needs an explicit materializer/transport loop, concrete River
-publishers and handlers registered as capabilities, and the bounded post-sync
-external quiescer and handoff mechanism.
+persisted failure recorder can rearm an already committed River claim with
+bounded Python-parity backoff. The queue-control trust boundary is proven with
+the real River `InsertTx` API and exact outbox/route privileges. The typed
+runtime package is intentionally all-or-nothing: its claim envelope validates
+the contract version, UUID shape, and generation, its publisher only inserts
+through the caller's transaction, and its generation tracker is a publisher-
+owned local generation-drain API for `post_sync`. Activation still needs an
+explicit materializer/transport loop and concrete River publishers and
+handlers registered as capabilities, authoritative domain-reference lookup,
+and a separately proven cross-process `post_sync` quiescer/controller plus
+external-handoff binding.
 The reconciler image packages `contracts/sync-dispatch/v1` so the registry is
 available at runtime; that packaging does not change route ownership.
 
-- `dispatch_sync_run`: at-least-once queue insertion; unit claims prevent duplicate provider work.
-- `finalize_sync_run`: at-least-once queue insertion; finalization ledger prevents duplicate finalization.
-- `post_sync`: mark-before-insert/at-most-once until CHAOS-2596 closes.
+- `dispatch_sync_run`: at-least-once queue insertion via a committed claim set and fresh per-claim River `InsertTx`; unit claims prevent duplicate provider work.
+- `finalize_sync_run`: at-least-once queue insertion via a committed claim set and fresh per-claim River `InsertTx`; finalization ledger prevents duplicate finalization.
+- `post_sync`: mark-before-external-handoff/at-most-once, with the terminal mark committed before the external handoff begins, until CHAOS-2596 closes.
 - eligible Linear backfill expired leases: continue `RUNNING -> RETRYING` with current eligibility matrix.
 
 No second generic sync workflow is introduced in River.

--- a/docs/ops/workers.md
+++ b/docs/ops/workers.md
@@ -96,6 +96,23 @@ is fail-closed: the loop only opens readiness after one successful step, and
 persistence failures close it instead of being reported as harmless lease
 races.
 
+The typed `syncdispatchruntime` package is dormant and all-or-nothing. Its
+claim projection drops the claim token, its River args validate the exact
+contract/version/UUID/generation tuple, its publisher only calls `InsertTx`
+through the caller's transaction, and its `GenerationTracker` exposes a
+publisher-owned local generation-drain API for `post_sync`. It does not
+register routes or workers, and it is not a controller capability.
+
+The scheduler track is complete in code, but the checked-in ownership policy
+still keeps Celery as the production owner. The scheduler loop is
+package-private and fail-closed: `HandoffDueResult` treats unsupported or
+invalid cron as a whole-window activation boundary, rolls the locked window
+back with `ErrSchedulerFallbackRequired`, and performs no coordinator or
+marker writes for that window; readiness only flips after one successful
+handoff window. Celery remains the sole owner until policy parity is complete,
+so the checked-in scheduler state stays non-authoritative and avoids silent
+candidate starvation.
+
 The checked-in deployment profile still keeps the topology disabled
 (`coexistence_disabled`, all replicas `0`), both registered kinds still route
 to Celery, no current domain producer calls the bridge, and no Go handler is
@@ -121,32 +138,39 @@ surface. Pause and resume lock the route row first, then hold an outbox-table
 barrier and re-read state and live claims, covering both Celery's
 route-plus-outbox transaction and Go's outbox-only terminal commit. Resume
 requires the target to equal the checked-in route. River requires an exact
-compiled capability, and a transport-changing `post_sync` resume additionally
-requires an external quiescer registered under the old transport capability and
-invoked for its old generation. The shipped command registers no capabilities,
-so today it can pause, inspect/drain, and resume the same Celery route,
-including `post_sync`, but cannot activate River. A future cutover quiescer must
-prove it honors context cancellation; its configured timeout is cooperative.
+typed capability, and a transport-changing `post_sync` resume requires a
+separately proven cross-process quiescer/controller under the old transport
+boundary. The publisher-owned local generation-drain API honors cancellation
+inside one Go process, but it neither implements the route quiescer contract
+nor proves other Go or Celery publishers have drained. The shipped command
+registers no capabilities, so today it can
+pause, inspect/drain, and resume the same Celery route, including `post_sync`,
+but cannot activate River.
 
 Two dormant transaction kernels now sit behind that foundation. The scheduler
 kernel locks a bounded due window with `FOR UPDATE ... SKIP LOCKED`, invokes an
 injected coordinator through the same PostgreSQL transaction, and advances the
-schedule marker only after that durable handoff succeeds. Its public repository
-constructor embeds an opaque Celery/`coexistence_disabled` ownership policy, so
-`HandoffDue` rejects mutation before beginning a transaction; Go mutation
-authority requires a reviewed package-private source change. The sync reconciler
-kernel can claim only unpaused River-routed rows, invoke an injected
-same-transaction River publisher for at-least-once kinds, and preserve a
-separate mark-before seam for `post_sync`. Neither kernel is constructed by
-the scheduler or reconciler command.
+schedule marker only after that durable handoff succeeds. Its public
+repository constructor embeds an opaque Celery/`coexistence_disabled`
+ownership policy, so `HandoffDue` rejects mutation before beginning a
+transaction; Go mutation authority requires a reviewed package-private source
+change. The dormant lifecycle loop exists, but its checked-in composition has
+no mutation repository or coordinator factory. An unsupported or invalid cron
+candidate rolls back the entire locked window with readiness closed, so Celery
+remains sole owner instead of allowing a healthy-but-starved Go window. The
+sync reconciler kernel first commits a bounded claim set, then
+delivers and terminally marks each at-least-once claim in its own fresh
+transaction, while `post_sync` is terminally marked and committed before the
+external handoff begins. Neither kernel is constructed by the scheduler or
+reconciler command.
 
 This remains a fail-closed selector foundation, not River activation. All
 persisted and checked-in routes remain Celery, deployment profiles remain
 `coexistence_disabled` with zero replicas, and no Go sync handler is compiled.
 Do not change a route to River: it would strand the wakeup. Activation still
-requires a scheduler command loop and remaining policy parity; reconciler loop
-wiring; split claim-commit/publish flow; concrete River publishers, handlers,
-and capabilities; and the bounded post-sync quiescence/external-handoff path.
+requires scheduler coordinator/policy composition, reconciler loop wiring,
+concrete River publishers, handlers, and capabilities, and a cross-process
+`post_sync` quiescer/controller plus external-handoff binding.
 
 For a read-only same-snapshot comparison, set `POSTGRES_URI` or `DATABASE_URI`
 and run:
@@ -175,10 +199,10 @@ the sole schedule mutation owners by default. An operator may separately set
 consumer materialize pre-existing Go-authored identities; it does not own
 timing or activate the Go command loop. The default-off consumer now provides
 the authoritative Python planner path for a valid pending identity, while the
-dormant transaction kernel still needs organization/entitlement and
-missing-marker parity, catch-up and unsupported-cron policy, and a command
-loop. Its ownership fence prevents the current command from mutating production
-markers.
+dormant transaction kernel still needs organization existence, entitlement, and
+occurrence-claim parity, catch-up, and unsupported-cron policy parity. Its
+checked-in lifecycle composition has no mutation factory, and its ownership
+fence prevents the current command from mutating production markers.
 
 The rest of this page documents the active Celery runtime. See the
 [Go worker runtime TRD](../architecture/go-worker-runtime-trd.md) for the target

--- a/docs/plans/go-worker-migration-implementation-plan.md
+++ b/docs/plans/go-worker-migration-implementation-plan.md
@@ -283,14 +283,16 @@ circular.
 ## 6. Phase 2 — first bounded jobs and orchestration infrastructure
 
 Current boundary: the route-safe generic `worker_job_outbox` slice is in
-place. Python now gates enqueue on a valid executable migration state/route
-pair, the Go relay leaves known Celery rows untouched while still terminalizing
-unknown rows, and the reconciler command composes the bounded loop with
-readiness and metrics. Startup is fail-closed until that loop succeeds once,
-and later persistence failures close readiness. Checked-in deployment profiles
-remain `coexistence_disabled` with zero replicas; both registered kinds still
-route to Celery, no producer calls the bridge, and no Go handler is compiled.
-The mutation-capable scheduler and sync-domain transport work in CHAOS-3039
+place, the scheduler track is complete in code, and the remaining active work
+is the typed `syncdispatchruntime` wiring. Python now
+gates enqueue on a valid executable migration state/route pair, the Go relay
+leaves known Celery rows untouched while still terminalizing unknown rows, and
+the reconciler command composes the bounded loop with readiness and metrics.
+Startup is fail-closed until that loop succeeds once, and later persistence
+failures close readiness. Checked-in deployment profiles remain
+`coexistence_disabled` with zero replicas; both registered kinds still route to
+Celery, no producer calls the bridge, and no Go handler is compiled. The
+mutation-capable scheduler and sync-domain transport work in CHAOS-3039
 therefore remains unported and no tandem parity is claimed.
 
 The first sync-domain transport dependency is now frozen independently of
@@ -335,19 +337,19 @@ container execution.
 
 The first mutation-safety prerequisite is also implemented without activating
 River. Migration `0049` seeds a four-row database route fence with Celery
-ownership and generation 1. Python claims bind the active route generation.
-Dispatch, finalize, and discovery publish transactions lock both outbox and
-route, and mark/failure writes fail closed after any route change. The
+ownership and generation 1. Python claims bind the active route generation and
+retain their route-plus-outbox locking through publish and mark. Separately,
+the dormant Go kernel commits a bounded River claim set first, then performs
+fresh per-claim River inserts and terminal marks in atomic transactions.
+Go mark/failure writes fail closed after any route change. The
 authenticated `dev-health-workerctl routes` surface can inspect, pause, drain,
 and resume one fixed route at a time with durable audit intent and monotonic
 generation changes. Route mutation follows Python's route-row-first lock order,
 then holds a table barrier across the post-terminal/pre-commit window and
-rechecks route state and live claims. A transport-changing `post_sync` resume
-additionally requires an external quiescer registered for the old transport
-generation. The shipped command registers no River or `post_sync` cutover
-capability, every checked-in route remains Celery, and the Go reconciler closes
-readiness while a route is paused or divergent, so these controls do not
-activate River.
+rechecks route state and live claims. The shipped command
+registers no River cutover capability, every checked-in route remains Celery,
+and the Go reconciler closes readiness while a route is paused or divergent,
+so these controls do not activate River.
 
 The dormant `internal/scheduler/sync` package retains its read-only
 schedule-evaluation foundation. It reads at most 101 active configuration/job
@@ -360,9 +362,12 @@ ordinary list/range/step/name forms and the explicitly tested timezone and DST
 behavior. A valid Croniter form outside that grammar is reported as
 unsupported and can never become timing-eligible; this includes random `R`,
 unported mixed special-day forms, and optional seconds/year fields. Results
-and their digest are labeled `schedule_and_marker_only`; they are not full
-dispatch eligibility because organization existence, entitlement, occurrence
-claiming, and the dispatch transaction are still Celery-owned work below.
+and their digest are labeled `schedule_and_marker_only`; unsupported or
+invalid cron is a fail-closed activation boundary that rolls the locked window
+back with `ErrSchedulerFallbackRequired`, performs no coordinator or marker
+writes, and never opens readiness. Celery remains the sole owner until policy
+parity is complete, so the scheduler can keep older candidates from starving
+while the checked-in Go path stays non-authoritative.
 
 A separate dormant transaction kernel now locks an existing-marker due window,
 calls an injected coordinator through the same PostgreSQL transaction, and
@@ -401,8 +406,10 @@ constructor embeds an opaque Celery/`coexistence_disabled` ownership policy,
 and `HandoffDue` rejects mutation before opening a transaction. Only
 package-private test and future activation composition can construct Go
 mutation authority. Scheduler activation needs a reviewed source change,
-command loop, unsupported-cron fallback, remaining coordinator policy parity,
-and an explicit review that enables the consumer before Go may own a marker.
+lifecycle factory composition, unsupported-cron policy parity, remaining
+coordinator policy parity, and an explicit review that enables the consumer
+before Go may own a marker. The dormant loop currently rolls back a whole
+locked window and keeps readiness closed if any cron requires Celery fallback.
 
 The Go reconciler command now constructs only an explicit no-begin shadow
 adapter around the transport kernel. A separate command-unwired materializer
@@ -412,20 +419,21 @@ publishes work; existing pending rows and at-most-once post-sync rows retain
 their current semantics. A second command-unwired repair step preserves the
 current eligible Linear-backfill expired-lease transition, including bounded
 retry exhaustion and provider/org/cost-class serialization. A persisted
-publish-failure recorder can release an already committed River claim with the
-same bounded backoff as Python, but the dormant kernel still claims, publishes,
-and marks in one transaction, so a publisher failure currently rolls the claim
-back instead of invoking that recorder. The least-privilege queue-control role
-has also been exercised through the real River `InsertTx` API in the same
+publish-failure recorder can rearm an already committed River claim with the
+same bounded backoff as Python. The least-privilege queue-control role has
+also been exercised through the real River `InsertTx` API in the same
 transaction as the outbox terminal mark. Reconciler activation still needs the
-claim-commit/publish workflow that uses the failure recorder and concrete River
-publishers and handlers. The capability-aware route/operator control plane now
-serializes the documented post-terminal, pre-commit window, but the shipped
-capability registry is empty: River resume is rejected and `post_sync` cannot
-change transports without a concrete external quiescer registered for the old
-transport. A same-transport Celery resume remains available for recovery. The
-cutover quiescer must prove it honors context cancellation before activation
-because the current timeout is cooperative.
+command composition that resolves authoritative domain references and binds
+the committed-claim kernel to concrete River publishers and handlers. The
+typed `syncdispatchruntime` package is
+intentionally all-or-nothing: its claim projection drops the claim token, its
+River args validate the exact contract/version/UUID/generation tuple, its
+publisher only calls `InsertTx` through the caller's transaction, and its
+`GenerationTracker` exposes a publisher-owned local generation-drain API for
+`post_sync`. The shipped command registers no River cutover capability, every
+checked-in route remains Celery, and a transport-changing `post_sync` resume
+still requires a separately proven cross-process quiescer/controller and
+external-handoff binding.
 
 An opt-in live PostgreSQL test now proves the Python producer's outer rollback
 and dedupe/savepoint path. Before any generic kind is promoted from Celery,
@@ -461,13 +469,18 @@ occurrences without retrying poison rows forever. The reconciler command is
 wired only to the shadow adapter, while the Go outbox materializer and
 expired-lease repair remain command-unwired. Persisted transport-failure
 backoff and the least-privilege River transaction boundary are implemented as
-dormant primitives, but the kernel has not yet split claim commit from publish
-or registered concrete publishers and handlers. The scheduler has an opaque
-default-Celery ownership fence, and audited route pause/drain/resume controls
-are implemented with an empty activation-capability registry. Every route
-remains Celery-only; the scheduler command loop and coordinator parity,
-concrete River delivery capabilities, and the `post_sync` external quiescer
-and handoff gaps above remain open.
+dormant primitives, but the kernel now claims first and then performs fresh
+per-claim insert/mark transactions, with `post_sync` committed before its
+external handoff. The scheduler has an opaque default-Celery
+ownership fence, the remaining Python policy-parity blockers are organization
+existence, entitlement, occurrence claiming, catch-up, and unsupported-cron
+policy; an unsupported or invalid cron currently rolls back the whole Go
+window and keeps readiness closed. The typed `syncdispatchruntime` generation
+tracker is only a publisher-owned local drain API today. Audited route pause/drain/resume
+controls are implemented with an empty activation-capability registry. Every
+route remains Celery-only; scheduler lifecycle factory/coordinator parity,
+concrete River delivery capabilities, and the cross-process `post_sync`
+quiescer/controller plus external-handoff binding remain open.
 
 #### Acceptance
 

--- a/internal/scheduler/sync/loop.go
+++ b/internal/scheduler/sync/loop.go
@@ -1,0 +1,343 @@
+package sync
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+)
+
+const (
+	minLoopPollInterval = 10 * time.Millisecond
+	maxLoopPollInterval = 15 * time.Minute
+	minLoopStepTimeout  = 10 * time.Millisecond
+	maxLoopStepTimeout  = 30 * time.Second
+	defaultLoopTimeout  = 2 * time.Second
+)
+
+var (
+	ErrLoopAlreadyStarted = errors.New("sync scheduler loop already started")
+	errLoopNotReady       = errors.New("sync scheduler loop has not completed a successful handoff window")
+)
+
+// HandoffStepper keeps the scheduler lifecycle independent of PostgreSQL
+// construction. Repository implements it through HandoffDueResult.
+type HandoffStepper interface {
+	HandoffDueResult(context.Context, time.Time, int, Coordinator) (HandoffResult, error)
+}
+
+// LoopConfig bounds each scheduler transaction and its retry cadence. A
+// timeout is an error, never a successful empty handoff window.
+type LoopConfig struct {
+	PollInterval time.Duration
+	StepTimeout  time.Duration
+	MaxBackoff   time.Duration
+	Limit        int
+	Registry     *health.Registry
+}
+
+func DefaultLoopConfig(registry *health.Registry) LoopConfig {
+	return LoopConfig{
+		PollInterval: time.Second,
+		StepTimeout:  defaultLoopTimeout,
+		MaxBackoff:   time.Minute,
+		Limit:        maximumSnapshotLimit,
+		Registry:     registry,
+	}
+}
+
+func (config LoopConfig) validate() error {
+	if config.Registry == nil ||
+		config.PollInterval < minLoopPollInterval || config.PollInterval > maxLoopPollInterval ||
+		config.StepTimeout < minLoopStepTimeout || config.StepTimeout > maxLoopStepTimeout ||
+		config.MaxBackoff < config.PollInterval || config.MaxBackoff > maxLoopPollInterval ||
+		config.Limit < minimumSnapshotLimit || config.Limit > maximumSnapshotLimit {
+		return ErrInvalidTransactionRequest
+	}
+	return nil
+}
+
+type loopClock interface {
+	Now() time.Time
+	NewTicker(time.Duration) loopTicker
+}
+
+type loopTicker interface {
+	Chan() <-chan time.Time
+	Stop()
+}
+
+type systemLoopClock struct{}
+
+func (systemLoopClock) Now() time.Time { return time.Now() }
+func (systemLoopClock) NewTicker(interval time.Duration) loopTicker {
+	return systemLoopTicker{Ticker: time.NewTicker(interval)}
+}
+
+type systemLoopTicker struct{ *time.Ticker }
+
+func (ticker systemLoopTicker) Chan() <-chan time.Time { return ticker.C }
+
+// Loop performs one bounded transactional handoff window at a time. Failures
+// close readiness and use a capped exponential retry delay; a later successful
+// window reopens readiness. Unsupported and invalid cron forms are counted as
+// explicit no-write fallback, leaving Celery able to evaluate them.
+type Loop struct {
+	stepper     HandoffStepper
+	coordinator Coordinator
+	config      LoopConfig
+	clock       loopClock
+
+	ready atomic.Bool
+
+	mu       sync.Mutex
+	started  bool
+	stopping bool
+	cancel   context.CancelFunc
+	done     chan struct{}
+	ticker   loopTicker
+
+	cycles          uint64
+	handoffs        uint64
+	unsupportedCron uint64
+	invalidCron     uint64
+	failures        uint64
+	consecutive     uint64
+	lastOK          time.Time
+	up              bool
+}
+
+func NewLoop(stepper HandoffStepper, coordinator Coordinator, config LoopConfig) (*Loop, error) {
+	return newLoop(stepper, coordinator, config, systemLoopClock{})
+}
+
+func newLoop(stepper HandoffStepper, coordinator Coordinator, config LoopConfig, clock loopClock) (*Loop, error) {
+	if stepper == nil || coordinator == nil || clock == nil || config.validate() != nil {
+		return nil, ErrInvalidTransactionRequest
+	}
+	loop := &Loop{stepper: stepper, coordinator: coordinator, config: config, clock: clock}
+	if err := config.Registry.RegisterRequired("scheduler_loop", loop.readiness); err != nil {
+		return nil, fmt.Errorf("register scheduler loop readiness: %w", err)
+	}
+	if err := config.Registry.RegisterMetrics("sync_scheduler", loop); err != nil {
+		return nil, fmt.Errorf("register scheduler loop metrics: %w", err)
+	}
+	return loop, nil
+}
+
+func (*Loop) Name() string { return "sync-scheduler-loop" }
+
+func (loop *Loop) Start(ctx context.Context) error {
+	if loop == nil || ctx == nil {
+		return ErrInvalidTransactionRequest
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	loopCtx, cancel := context.WithCancel(ctx)
+	done := make(chan struct{})
+	loop.mu.Lock()
+	if loop.started {
+		loop.mu.Unlock()
+		cancel()
+		return ErrLoopAlreadyStarted
+	}
+	if loop.stopping {
+		loop.mu.Unlock()
+		cancel()
+		return context.Canceled
+	}
+	loop.started, loop.cancel, loop.done = true, cancel, done
+	loop.mu.Unlock()
+
+	if err := loop.step(loopCtx, loop.clock.Now()); err != nil {
+		loop.setFailed()
+		cancel()
+		close(done)
+		return fmt.Errorf("initial scheduler handoff: %w", err)
+	}
+	ticker := loop.clock.NewTicker(loop.config.PollInterval)
+	loop.mu.Lock()
+	if loop.stopping || loopCtx.Err() != nil {
+		loop.mu.Unlock()
+		ticker.Stop()
+		cancel()
+		loop.setFailed()
+		close(done)
+		if err := loopCtx.Err(); err != nil {
+			return err
+		}
+		return context.Canceled
+	}
+	loop.ticker = ticker
+	loop.mu.Unlock()
+	go loop.run(loopCtx, ticker, done)
+	return nil
+}
+
+func (loop *Loop) run(ctx context.Context, ticker loopTicker, done chan struct{}) {
+	defer close(done)
+	defer ticker.Stop()
+	var nextEligible time.Time
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case now, open := <-ticker.Chan():
+			if !open {
+				loop.setFailed()
+				return
+			}
+			if !nextEligible.IsZero() && now.Before(nextEligible) {
+				continue
+			}
+			if err := loop.step(ctx, now); err != nil {
+				loop.setFailed()
+				// Measure retry delay from failure completion. A slow or timed
+				// out step may leave old ticker values buffered; those must not
+				// collapse the intended backoff.
+				nextEligible = loop.clock.Now().Add(loop.backoff())
+				continue
+			}
+			nextEligible = time.Time{}
+		}
+	}
+}
+
+func (loop *Loop) step(parent context.Context, now time.Time) error {
+	stepCtx, cancel := context.WithTimeout(parent, loop.config.StepTimeout)
+	defer cancel()
+	result, err := loop.stepper.HandoffDueResult(stepCtx, now.UTC(), loop.config.Limit, loop.coordinator)
+	if stepCtx.Err() != nil {
+		return stepCtx.Err()
+	}
+	if result.UnsupportedCron > 0 || result.InvalidCron > 0 {
+		loop.mu.Lock()
+		loop.unsupportedCron += uint64(result.UnsupportedCron)
+		loop.invalidCron += uint64(result.InvalidCron)
+		loop.mu.Unlock()
+		if err == nil {
+			return ErrSchedulerFallbackRequired
+		}
+	}
+	if err != nil {
+		return err
+	}
+	loop.mu.Lock()
+	if loop.stopping {
+		loop.mu.Unlock()
+		return context.Canceled
+	}
+	loop.cycles++
+	loop.handoffs += uint64(len(result.HandedOff))
+	loop.unsupportedCron += uint64(result.UnsupportedCron)
+	loop.invalidCron += uint64(result.InvalidCron)
+	loop.consecutive = 0
+	loop.lastOK, loop.up = now.UTC(), true
+	loop.ready.Store(true)
+	loop.mu.Unlock()
+	return nil
+}
+
+func (loop *Loop) backoff() time.Duration {
+	loop.mu.Lock()
+	defer loop.mu.Unlock()
+	loop.failures++
+	loop.consecutive++
+	delay := loop.config.PollInterval
+	for failures := uint64(1); failures < loop.consecutive && delay < loop.config.MaxBackoff; failures++ {
+		if delay > loop.config.MaxBackoff/2 {
+			delay = loop.config.MaxBackoff
+			break
+		}
+		delay *= 2
+	}
+	if delay > loop.config.MaxBackoff {
+		return loop.config.MaxBackoff
+	}
+	return delay
+}
+
+func (loop *Loop) setFailed() {
+	loop.ready.Store(false)
+	loop.mu.Lock()
+	loop.up = false
+	loop.mu.Unlock()
+}
+
+func (loop *Loop) readiness(context.Context) error {
+	if loop != nil && loop.ready.Load() {
+		return nil
+	}
+	return errLoopNotReady
+}
+
+func (loop *Loop) Shutdown(ctx context.Context) error {
+	if loop == nil || ctx == nil {
+		return ErrInvalidTransactionRequest
+	}
+	loop.setFailed()
+	loop.mu.Lock()
+	loop.stopping = true
+	cancel, ticker, done := loop.cancel, loop.ticker, loop.done
+	loop.mu.Unlock()
+	if ticker != nil {
+		ticker.Stop()
+	}
+	if cancel != nil {
+		cancel()
+	}
+	if done == nil {
+		return nil
+	}
+	select {
+	case <-done:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+func (loop *Loop) WritePrometheus(output io.Writer) error {
+	if loop == nil || output == nil {
+		return errors.New("Prometheus output is required")
+	}
+	loop.mu.Lock()
+	cycles, handoffs := loop.cycles, loop.handoffs
+	unsupported, invalid := loop.unsupportedCron, loop.invalidCron
+	failures, consecutive := loop.failures, loop.consecutive
+	lastOK, up, now := loop.lastOK, loop.up, loop.clock.Now()
+	loop.mu.Unlock()
+
+	age := 0.0
+	if !lastOK.IsZero() && !now.Before(lastOK) {
+		age = now.Sub(lastOK).Seconds()
+	}
+	var text strings.Builder
+	writeLoopCounter(&text, "sync_scheduler_windows_total", "Successful bounded scheduler handoff windows.", cycles)
+	writeLoopCounter(&text, "sync_scheduler_handoffs_total", "Scheduled occurrences durably handed off before marker advancement.", handoffs)
+	writeLoopCounter(&text, "sync_scheduler_unsupported_cron_fallback_total", "Unsupported cron candidates left for the existing scheduler owner.", unsupported)
+	writeLoopCounter(&text, "sync_scheduler_invalid_cron_total", "Invalid cron candidates left without marker mutation.", invalid)
+	writeLoopCounter(&text, "sync_scheduler_failures_total", "Failed bounded scheduler handoff windows.", failures)
+	fmt.Fprintf(&text, "# HELP sync_scheduler_consecutive_failures Consecutive failed handoff windows.\n# TYPE sync_scheduler_consecutive_failures gauge\nsync_scheduler_consecutive_failures %d\n", consecutive)
+	fmt.Fprint(&text, "# HELP sync_scheduler_up Whether the scheduler has completed a current successful handoff window.\n# TYPE sync_scheduler_up gauge\nsync_scheduler_up ")
+	if up {
+		text.WriteString("1\n")
+	} else {
+		text.WriteString("0\n")
+	}
+	fmt.Fprintf(&text, "# HELP sync_scheduler_last_success_age_seconds Age of the last successful handoff window.\n# TYPE sync_scheduler_last_success_age_seconds gauge\nsync_scheduler_last_success_age_seconds %s\n", strconv.FormatFloat(age, 'g', -1, 64))
+	_, err := io.WriteString(output, text.String())
+	return err
+}
+
+func writeLoopCounter(output *strings.Builder, name, help string, value uint64) {
+	fmt.Fprintf(output, "# HELP %s %s\n# TYPE %s counter\n%s %d\n", name, help, name, name, value)
+}

--- a/internal/scheduler/sync/loop_test.go
+++ b/internal/scheduler/sync/loop_test.go
@@ -1,0 +1,271 @@
+package sync
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+)
+
+type loopStepFunc func(context.Context, time.Time, int, Coordinator) (HandoffResult, error)
+
+func (function loopStepFunc) HandoffDueResult(
+	ctx context.Context,
+	now time.Time,
+	limit int,
+	coordinator Coordinator,
+) (HandoffResult, error) {
+	return function(ctx, now, limit, coordinator)
+}
+
+type testLoopClock struct {
+	mu     sync.Mutex
+	now    time.Time
+	ticker *testLoopTicker
+}
+
+func (clock *testLoopClock) Now() time.Time {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	return clock.now
+}
+
+func (clock *testLoopClock) NewTicker(time.Duration) loopTicker {
+	clock.mu.Lock()
+	defer clock.mu.Unlock()
+	clock.ticker = &testLoopTicker{ticks: make(chan time.Time, 8)}
+	return clock.ticker
+}
+
+type testLoopTicker struct {
+	ticks   chan time.Time
+	stopped chan struct{}
+	once    sync.Once
+}
+
+func (ticker *testLoopTicker) Chan() <-chan time.Time { return ticker.ticks }
+func (ticker *testLoopTicker) Stop() {
+	ticker.once.Do(func() {
+		ticker.stopped = make(chan struct{})
+		close(ticker.stopped)
+	})
+}
+
+func newTestLoop(t *testing.T, stepper HandoffStepper, clock *testLoopClock) (*Loop, *health.Registry) {
+	t.Helper()
+	registry := health.NewRegistry(time.Second)
+	loop, err := newLoop(stepper, CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+		return nil
+	}), LoopConfig{
+		PollInterval: minLoopPollInterval,
+		StepTimeout:  time.Second,
+		MaxBackoff:   80 * time.Millisecond,
+		Limit:        3,
+		Registry:     registry,
+	}, clock)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return loop, registry
+}
+
+func openLoopReadiness(t *testing.T, registry *health.Registry) {
+	t.Helper()
+	if err := (health.Gate{Registry: registry}).Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoopImmediateWindowOpensReadinessAndExportsMetrics(t *testing.T) {
+	clock := &testLoopClock{now: at("2026-07-23T12:00:00Z")}
+	calls := make(chan struct{}, 1)
+	loop, registry := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int, Coordinator) (HandoffResult, error) {
+		calls <- struct{}{}
+		return HandoffResult{
+			HandedOff: []Occurrence{{ID: "first"}},
+		}, nil
+	}), clock)
+	openLoopReadiness(t, registry)
+	if status := registry.Readiness(context.Background()); status.Ready || !strings.Contains(strings.Join(status.Failed, ","), "scheduler_loop") {
+		t.Fatalf("pre-start readiness = %#v", status)
+	}
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-calls:
+	default:
+		t.Fatal("immediate scheduler window did not run")
+	}
+	if status := registry.Readiness(context.Background()); !status.Ready {
+		t.Fatalf("post-start readiness = %#v", status)
+	}
+
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"sync_scheduler_windows_total 1",
+		"sync_scheduler_handoffs_total 1",
+		"sync_scheduler_unsupported_cron_fallback_total 0",
+		"sync_scheduler_invalid_cron_total 0",
+		"sync_scheduler_up 1",
+	} {
+		if !strings.Contains(metrics.String(), want+"\n") {
+			t.Fatalf("metrics missing %q:\n%s", want, metrics.String())
+		}
+	}
+	if strings.Contains(metrics.String(), "{") {
+		t.Fatalf("metrics must not expose dynamic labels:\n%s", metrics.String())
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoopFallbackWindowFailsClosedAndExportsCounts(t *testing.T) {
+	clock := &testLoopClock{now: at("2026-07-23T12:00:00Z")}
+	loop, registry := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int, Coordinator) (HandoffResult, error) {
+		return HandoffResult{Candidates: 3, UnsupportedCron: 2, InvalidCron: 1}, ErrSchedulerFallbackRequired
+	}), clock)
+	openLoopReadiness(t, registry)
+	if err := loop.Start(context.Background()); !errors.Is(err, ErrSchedulerFallbackRequired) {
+		t.Fatalf("Start() error = %v", err)
+	}
+	if status := registry.Readiness(context.Background()); status.Ready {
+		t.Fatalf("fallback readiness = %#v", status)
+	}
+	var metrics bytes.Buffer
+	if err := loop.WritePrometheus(&metrics); err != nil {
+		t.Fatal(err)
+	}
+	for _, want := range []string{
+		"sync_scheduler_unsupported_cron_fallback_total 2",
+		"sync_scheduler_invalid_cron_total 1",
+		"sync_scheduler_up 0",
+	} {
+		if !strings.Contains(metrics.String(), want+"\n") {
+			t.Fatalf("metrics missing %q:\n%s", want, metrics.String())
+		}
+	}
+}
+
+func TestLoopFailureBacksOffClosesReadinessAndRecovers(t *testing.T) {
+	clock := &testLoopClock{now: at("2026-07-23T12:00:00Z")}
+	failure := errors.New("database unavailable")
+	calls := 0
+	var failureCompleted time.Time
+	failed := make(chan struct{}, 1)
+	recovered := make(chan struct{}, 1)
+	loop, registry := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int, Coordinator) (HandoffResult, error) {
+		calls++
+		switch calls {
+		case 1:
+			return HandoffResult{}, nil
+		case 2:
+			clock.mu.Lock()
+			clock.now = clock.now.Add(3 * minLoopPollInterval)
+			failureCompleted = clock.now
+			clock.mu.Unlock()
+			failed <- struct{}{}
+			return HandoffResult{}, failure
+		default:
+			recovered <- struct{}{}
+			return HandoffResult{}, nil
+		}
+	}), clock)
+	openLoopReadiness(t, registry)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.now = clock.now.Add(minLoopPollInterval)
+	firstTick := clock.now
+	clock.mu.Unlock()
+	ticker.ticks <- firstTick
+	<-failed
+	if status := registry.Readiness(context.Background()); status.Ready || !strings.Contains(strings.Join(status.Failed, ","), "scheduler_loop") {
+		t.Fatalf("failed readiness = %#v", status)
+	}
+	var failedMetrics bytes.Buffer
+	if err := loop.WritePrometheus(&failedMetrics); err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(failedMetrics.String(), "sync_scheduler_last_success_age_seconds 0\n") {
+		t.Fatalf("failed metrics hid prior success age:\n%s", failedMetrics.String())
+	}
+	// The first retry delay is exactly PollInterval from failure completion,
+	// not from the stale tick that began the slow operation.
+	ticker.ticks <- failureCompleted.Add(minLoopPollInterval - time.Nanosecond)
+	time.Sleep(5 * time.Millisecond)
+	if calls != 2 {
+		t.Fatalf("backoff ignored; calls = %d", calls)
+	}
+	clock.mu.Lock()
+	clock.now = failureCompleted.Add(minLoopPollInterval)
+	retryTick := clock.now
+	clock.mu.Unlock()
+	ticker.ticks <- retryTick
+	<-recovered
+	if status := registry.Readiness(context.Background()); !status.Ready {
+		t.Fatalf("recovered readiness = %#v", status)
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoopTimeoutIsFailureNotEmptySuccessAndShutdownCancelsStep(t *testing.T) {
+	clock := &testLoopClock{now: at("2026-07-23T12:00:00Z")}
+	entered := make(chan struct{}, 1)
+	released := make(chan struct{})
+	loop, registry := newTestLoop(t, loopStepFunc(func(ctx context.Context, _ time.Time, _ int, _ Coordinator) (HandoffResult, error) {
+		entered <- struct{}{}
+		<-ctx.Done()
+		close(released)
+		return HandoffResult{}, ctx.Err()
+	}), clock)
+	openLoopReadiness(t, registry)
+	if err := loop.Start(context.Background()); !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("Start() error = %v", err)
+	}
+	<-entered
+	<-released
+	if status := registry.Readiness(context.Background()); status.Ready || !strings.Contains(strings.Join(status.Failed, ","), "scheduler_loop") {
+		t.Fatalf("timeout readiness = %#v", status)
+	}
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoopRejectsDoubleStartAndStopsTicker(t *testing.T) {
+	clock := &testLoopClock{now: at("2026-07-23T12:00:00Z")}
+	loop, _ := newTestLoop(t, loopStepFunc(func(context.Context, time.Time, int, Coordinator) (HandoffResult, error) {
+		return HandoffResult{}, nil
+	}), clock)
+	if err := loop.Start(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	if err := loop.Start(context.Background()); !errors.Is(err, ErrLoopAlreadyStarted) {
+		t.Fatalf("second Start() error = %v", err)
+	}
+	clock.mu.Lock()
+	ticker := clock.ticker
+	clock.mu.Unlock()
+	if err := loop.Shutdown(context.Background()); err != nil {
+		t.Fatal(err)
+	}
+	select {
+	case <-ticker.stopped:
+	default:
+		t.Fatal("shutdown did not stop ticker")
+	}
+}

--- a/internal/scheduler/sync/ownership.go
+++ b/internal/scheduler/sync/ownership.go
@@ -51,6 +51,14 @@ func DefaultOwnershipPolicy() OwnershipPolicy {
 	}
 }
 
+// reviewedGoMutationOwnershipPolicy is intentionally package-private. Tests
+// and a future audited command composition can exercise the Go-owned kernel,
+// but neither environment nor an external package can manufacture marker
+// mutation authority.
+func reviewedGoMutationOwnershipPolicy() OwnershipPolicy {
+	return OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation}
+}
+
 // Validate rejects every owner/mode pair except the bounded current and future
 // states. In particular, a Go shadow process never acquires mutation authority.
 func (policy OwnershipPolicy) Validate() error {

--- a/internal/scheduler/sync/transaction.go
+++ b/internal/scheduler/sync/transaction.go
@@ -23,6 +23,10 @@ var (
 	// ErrScheduleMarkerLost identifies a locked marker that disappeared before
 	// the atomic handoff could advance it.
 	ErrScheduleMarkerLost = errors.New("scheduler schedule marker was lost")
+	// ErrSchedulerFallbackRequired prevents Go scheduler activation while a
+	// locked window contains cron behavior that remains owned by Celery. The
+	// transaction rolls back without handoffs or marker advancement.
+	ErrSchedulerFallbackRequired = errors.New("scheduler window requires Celery cron fallback")
 )
 
 // Occurrence is the deterministic handoff envelope for one due schedule. It
@@ -37,6 +41,18 @@ type Occurrence struct {
 	ScheduledFor    time.Time
 	ObservedAt      time.Time
 	NextRunAt       time.Time
+}
+
+// HandoffResult is the bounded outcome of one locked scheduler window. The
+// fallback counts are intentionally process-level only: unsupported or invalid
+// cron text leaves the marker untouched so the current Celery owner can retain
+// its established croniter behavior.
+type HandoffResult struct {
+	Candidates      int
+	TimingEligible  int
+	UnsupportedCron int
+	InvalidCron     int
+	HandedOff       []Occurrence
 }
 
 // HandoffTransaction is the same PostgreSQL transaction that protects the
@@ -113,24 +129,37 @@ func (repository *Repository) HandoffDue(
 	limit int,
 	coordinator Coordinator,
 ) ([]Occurrence, error) {
+	result, err := repository.HandoffDueResult(ctx, observedAt, limit, coordinator)
+	return result.HandedOff, err
+}
+
+// HandoffDueResult locks and re-evaluates one bounded candidate window. It is
+// the lifecycle-facing form of HandoffDue and exposes only aggregate fallback
+// counts, never organization or configuration identifiers.
+func (repository *Repository) HandoffDueResult(
+	ctx context.Context,
+	observedAt time.Time,
+	limit int,
+	coordinator Coordinator,
+) (HandoffResult, error) {
 	if ctx == nil || observedAt.IsZero() || limit < minimumSnapshotLimit ||
 		limit > maximumSnapshotLimit || coordinator == nil ||
 		repository == nil || repository.begin == nil {
-		return nil, ErrInvalidTransactionRequest
+		return HandoffResult{}, ErrInvalidTransactionRequest
 	}
 	if err := repository.ownership.Validate(); err != nil {
-		return nil, err
+		return HandoffResult{}, err
 	}
 	if !repository.ownership.allowsMutation() {
-		return nil, ErrSchedulerMutationDisabled
+		return HandoffResult{}, ErrSchedulerMutationDisabled
 	}
 	if err := ctx.Err(); err != nil {
-		return nil, err
+		return HandoffResult{}, err
 	}
 
 	transaction, err := repository.begin(ctx)
 	if err != nil {
-		return nil, fmt.Errorf("begin scheduler transaction: %w", err)
+		return HandoffResult{}, fmt.Errorf("begin scheduler transaction: %w", err)
 	}
 	defer func() { _ = transaction.Rollback(ctx) }()
 
@@ -141,20 +170,44 @@ func (repository *Repository) HandoffDue(
 		limit,
 	)
 	if err != nil {
-		return nil, fmt.Errorf("lock scheduler candidates: %w", err)
+		return HandoffResult{}, fmt.Errorf("lock scheduler candidates: %w", err)
 	}
 	candidates, err := readLockedCandidates(ctx, rows, limit)
 	rows.Close()
 	if err != nil {
-		return nil, err
+		return HandoffResult{}, err
 	}
 
-	handedOff := make([]Occurrence, 0, len(candidates))
-	for _, locked := range candidates {
+	result := HandoffResult{Candidates: len(candidates), HandedOff: make([]Occurrence, 0, len(candidates))}
+	evaluations := make([]Evaluation, len(candidates))
+	for index, locked := range candidates {
 		evaluation, err := evaluateContext(ctx, locked.candidate, observedAt)
 		if err != nil {
-			return nil, err
+			return HandoffResult{}, err
 		}
+		evaluations[index] = evaluation
+		switch evaluation.Decision {
+		case DecisionUnsupportedCron:
+			result.UnsupportedCron++
+		case DecisionInvalidCron:
+			result.InvalidCron++
+		}
+		if !evaluation.TimingEligible || evaluation.NextOccurrence == nil ||
+			locked.candidate.Job == nil {
+			continue
+		}
+		result.TimingEligible++
+	}
+	// Cron fallback is an ownership boundary, not a successful empty window.
+	// Refuse the entire locked window before any coordinator or marker write so
+	// an incompatible oldest row cannot silently starve later schedules while
+	// this process advertises healthy Go ownership.
+	if result.UnsupportedCron > 0 || result.InvalidCron > 0 {
+		return result, ErrSchedulerFallbackRequired
+	}
+
+	for index, locked := range candidates {
+		evaluation := evaluations[index]
 		if !evaluation.TimingEligible || evaluation.NextOccurrence == nil ||
 			locked.candidate.Job == nil {
 			continue
@@ -166,7 +219,7 @@ func (repository *Repository) HandoffDue(
 			locked.candidate.Job.Timezone,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("compute next schedule marker for config %s: %w", locked.candidate.ConfigID, err)
+			return HandoffResult{}, fmt.Errorf("compute next schedule marker for config %s: %w", locked.candidate.ConfigID, err)
 		}
 		occurrence := newOccurrence(
 			locked.candidate.ConfigID,
@@ -177,10 +230,10 @@ func (repository *Repository) HandoffDue(
 			nextRunAt,
 		)
 		if err := coordinator.Handoff(ctx, transaction, occurrence); err != nil {
-			return nil, fmt.Errorf("handoff scheduler occurrence %s: %w", occurrence.ID, err)
+			return HandoffResult{}, fmt.Errorf("handoff scheduler occurrence %s: %w", occurrence.ID, err)
 		}
 		if err := ctx.Err(); err != nil {
-			return nil, err
+			return HandoffResult{}, err
 		}
 		command, err := transaction.Exec(
 			ctx,
@@ -190,18 +243,18 @@ func (repository *Repository) HandoffDue(
 			occurrence.JobID,
 		)
 		if err != nil {
-			return nil, fmt.Errorf("advance scheduler marker for config %s: %w", occurrence.ConfigID, err)
+			return HandoffResult{}, fmt.Errorf("advance scheduler marker for config %s: %w", occurrence.ConfigID, err)
 		}
 		if command.RowsAffected() != 1 {
-			return nil, ErrScheduleMarkerLost
+			return HandoffResult{}, ErrScheduleMarkerLost
 		}
-		handedOff = append(handedOff, occurrence)
+		result.HandedOff = append(result.HandedOff, occurrence)
 	}
 
 	if err := transaction.Commit(ctx); err != nil {
-		return nil, fmt.Errorf("commit scheduler transaction: %w", err)
+		return HandoffResult{}, fmt.Errorf("commit scheduler transaction: %w", err)
 	}
-	return handedOff, nil
+	return result, nil
 }
 
 func readLockedCandidates(

--- a/internal/scheduler/sync/transaction_integration_test.go
+++ b/internal/scheduler/sync/transaction_integration_test.go
@@ -58,7 +58,7 @@ func TestHandoffDuePostgresSkipsReplicaLockedOccurrence(t *testing.T) {
 	if defaultOccurrences != 0 || defaultNextRunAt != nil {
 		t.Fatalf("default ownership mutated occurrences=%d nextRunAt=%v", defaultOccurrences, defaultNextRunAt)
 	}
-	ownership := OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation}
+	ownership := reviewedGoMutationOwnershipPolicy()
 	firstRepository, err := newRepositoryWithOwnership(pool, ownership)
 	if err != nil {
 		t.Fatal(err)
@@ -226,6 +226,60 @@ func TestHandoffDuePostgresSkipsReplicaLockedOccurrence(t *testing.T) {
 	}
 	if occurrenceRows != 1 {
 		t.Fatalf("scheduled occurrence rows = %d, want 1", occurrenceRows)
+	}
+}
+
+func TestHandoffDuePostgresUnsupportedCronFallsBackWithoutMarkerWrite(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createSchedulerIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := pool.Exec(ctx, `
+		UPDATE public.sync_configurations SET sync_options =
+		'{"schedule_cron":"R * * * *","timezone":"UTC"}'::jsonb;
+		UPDATE public.scheduled_jobs SET schedule_cron = 'R * * * *'
+	`); err != nil {
+		t.Fatal(err)
+	}
+	repository, err := newRepositoryWithOwnership(pool, reviewedGoMutationOwnershipPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	result, err := repository.HandoffDueResult(ctx, at("2026-01-01T12:00:00Z"), 1, NewOccurrenceCoordinator())
+	if !errors.Is(err, ErrSchedulerFallbackRequired) {
+		t.Fatalf("HandoffDueResult() error = %v", err)
+	}
+	if result.UnsupportedCron != 1 || len(result.HandedOff) != 0 {
+		t.Fatalf("unsupported result = %#v", result)
+	}
+	var occurrences int
+	var nextRunAt *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT (SELECT count(*) FROM public.scheduled_sync_occurrences), next_run_at
+		FROM public.scheduled_jobs
+		WHERE id = '00000000-0000-4000-8000-000000003039'
+	`).Scan(&occurrences, &nextRunAt); err != nil {
+		t.Fatal(err)
+	}
+	if occurrences != 0 || nextRunAt != nil {
+		t.Fatalf("unsupported fallback mutated occurrences=%d nextRunAt=%v", occurrences, nextRunAt)
 	}
 }
 

--- a/internal/scheduler/sync/transaction_test.go
+++ b/internal/scheduler/sync/transaction_test.go
@@ -69,7 +69,7 @@ type fakeSchedulerTransaction struct {
 
 func mutationRepository(transaction schedulerTransaction) *Repository {
 	return &Repository{
-		ownership: OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation},
+		ownership: reviewedGoMutationOwnershipPolicy(),
 		begin: func(context.Context) (schedulerTransaction, error) {
 			return transaction, nil
 		},
@@ -226,6 +226,71 @@ func TestHandoffDueRollsBackWithoutMarkerWhenCoordinatorFails(t *testing.T) {
 	}
 }
 
+func TestHandoffDueResultLeavesUnsupportedCronForCeleryWithoutMarkerMutation(t *testing.T) {
+	observedAt := at("2026-01-01T12:00:00Z")
+	transaction := &fakeSchedulerTransaction{
+		rows: &fakeLockedRows{rows: [][]any{
+			lockedRow("config-random", "org-a", "job-a", "R * * * *", at("2026-01-01T09:00:00Z"), at("2026-01-01T10:00:00Z")),
+		}},
+		execTag: pgconn.NewCommandTag("UPDATE 1"),
+	}
+	result, err := mutationRepository(transaction).HandoffDueResult(
+		context.Background(), observedAt, 1,
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+			t.Fatal("unsupported cron reached coordinator")
+			return nil
+		}),
+	)
+	if !errors.Is(err, ErrSchedulerFallbackRequired) {
+		t.Fatalf("HandoffDueResult() error = %v", err)
+	}
+	if result.Candidates != 1 || result.UnsupportedCron != 1 || result.InvalidCron != 0 || len(result.HandedOff) != 0 {
+		t.Fatalf("handoff result = %#v", result)
+	}
+	if len(transaction.execArgs) != 0 || transaction.committed || !transaction.rolledBack {
+		t.Fatalf(
+			"unsupported fallback marker calls=%d committed=%v rolledBack=%v",
+			len(transaction.execArgs),
+			transaction.committed,
+			transaction.rolledBack,
+		)
+	}
+}
+
+func TestHandoffDueResultFailsClosedBeforeMixedFallbackWindowWrites(t *testing.T) {
+	observedAt := at("2026-01-01T12:00:00Z")
+	transaction := &fakeSchedulerTransaction{
+		rows: &fakeLockedRows{rows: [][]any{
+			lockedRow("config-unsupported", "org-a", "job-a", "R * * * *", at("2026-01-01T09:00:00Z"), at("2026-01-01T10:00:00Z")),
+			lockedRow("config-valid", "org-b", "job-b", "0 * * * *", at("2026-01-01T09:00:00Z"), at("2026-01-01T10:00:00Z")),
+		}},
+		execTag: pgconn.NewCommandTag("UPDATE 1"),
+	}
+	coordinatorCalls := 0
+	result, err := mutationRepository(transaction).HandoffDueResult(
+		context.Background(), observedAt, 2,
+		CoordinatorFunc(func(context.Context, HandoffTransaction, Occurrence) error {
+			coordinatorCalls++
+			return nil
+		}),
+	)
+	if !errors.Is(err, ErrSchedulerFallbackRequired) {
+		t.Fatalf("HandoffDueResult() error = %v", err)
+	}
+	if result.Candidates != 2 || result.UnsupportedCron != 1 || result.TimingEligible != 1 {
+		t.Fatalf("handoff result = %#v", result)
+	}
+	if coordinatorCalls != 0 || len(transaction.execArgs) != 0 || transaction.committed || !transaction.rolledBack {
+		t.Fatalf(
+			"mixed fallback wrote: coordinator=%d marker=%d committed=%v rolledBack=%v",
+			coordinatorCalls,
+			len(transaction.execArgs),
+			transaction.committed,
+			transaction.rolledBack,
+		)
+	}
+}
+
 func TestHandoffDueRejectsLostMarkerAndRollsBackHandoff(t *testing.T) {
 	observedAt := at("2026-01-01T12:00:00Z")
 	transaction := &fakeSchedulerTransaction{
@@ -329,7 +394,7 @@ func TestHandoffStatementIsBoundedAndMultiReplicaSafe(t *testing.T) {
 func TestHandoffDueValidatesRequestBeforeOpeningTransaction(t *testing.T) {
 	calls := 0
 	repository := &Repository{
-		ownership: OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation},
+		ownership: reviewedGoMutationOwnershipPolicy(),
 		begin: func(context.Context) (schedulerTransaction, error) {
 			calls++
 			return nil, errors.New("unexpected begin")

--- a/internal/syncdispatchruntime/capability.go
+++ b/internal/syncdispatchruntime/capability.go
@@ -1,0 +1,184 @@
+package syncdispatchruntime
+
+import (
+	"context"
+	"errors"
+	"reflect"
+	"sort"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+)
+
+var ErrCapabilityUnavailable = errors.New("sync dispatch runtime capability is unavailable")
+
+// The four typed handler interfaces intentionally contain no generic fallback.
+// A future composition must provide a concrete implementation for each kind
+// before it can advertise executable River readiness.
+type DispatchSyncRunHandler interface {
+	Work(context.Context, DispatchSyncRunArgs) error
+}
+
+type FinalizeSyncRunHandler interface {
+	Work(context.Context, FinalizeSyncRunArgs) error
+}
+
+type PostSyncHandler interface {
+	Work(context.Context, PostSyncArgs) error
+}
+
+type ReferenceDiscoveryHandler interface {
+	Work(context.Context, ReferenceDiscoveryArgs) error
+}
+
+type DispatchSyncRunHandlerFunc func(context.Context, DispatchSyncRunArgs) error
+
+func (function DispatchSyncRunHandlerFunc) Work(ctx context.Context, args DispatchSyncRunArgs) error {
+	return function(ctx, args)
+}
+
+type FinalizeSyncRunHandlerFunc func(context.Context, FinalizeSyncRunArgs) error
+
+func (function FinalizeSyncRunHandlerFunc) Work(ctx context.Context, args FinalizeSyncRunArgs) error {
+	return function(ctx, args)
+}
+
+type PostSyncHandlerFunc func(context.Context, PostSyncArgs) error
+
+func (function PostSyncHandlerFunc) Work(ctx context.Context, args PostSyncArgs) error {
+	return function(ctx, args)
+}
+
+type ReferenceDiscoveryHandlerFunc func(context.Context, ReferenceDiscoveryArgs) error
+
+func (function ReferenceDiscoveryHandlerFunc) Work(ctx context.Context, args ReferenceDiscoveryArgs) error {
+	return function(ctx, args)
+}
+
+// PostSyncHandoff remains separate because post_sync is mark-before and its
+// external effect must happen after the terminal transaction commits. It is
+// deliberately not implemented by this package.
+type PostSyncHandoff interface {
+	Handoff(context.Context, PostSyncArgs) error
+}
+
+type Handlers struct {
+	DispatchSyncRun    DispatchSyncRunHandler
+	FinalizeSyncRun    FinalizeSyncRunHandler
+	PostSync           PostSyncHandler
+	ReferenceDiscovery ReferenceDiscoveryHandler
+	PostSyncHandoff    PostSyncHandoff
+}
+
+// CapabilityDescriptor is payload-free composition evidence. It records only
+// retained, typed registrations; it is not a route-activation or cross-process
+// executable-readiness claim.
+type CapabilityDescriptor struct {
+	Kind              string
+	Transport         string
+	ContractVersion   int
+	HandlerRegistered bool
+	PublisherBound    bool
+	HandoffBound      bool
+}
+
+// Capabilities is an immutable in-process composition artifact. It does not
+// alter a route and intentionally exposes no syncroute projection: a
+// cross-process cutover needs separately proven control-plane composition.
+type Capabilities struct {
+	descriptors []CapabilityDescriptor
+	quiescer    *GenerationTracker
+	handlers    Handlers
+	postSync    PostSyncHandoff
+}
+
+func NewCapabilities(publisher *Publisher, handlers Handlers, quiescer *GenerationTracker) (*Capabilities, error) {
+	if !publisher.valid() || !quiescer.valid() || !present(handlers.DispatchSyncRun) ||
+		!present(handlers.FinalizeSyncRun) || !present(handlers.PostSync) ||
+		!present(handlers.ReferenceDiscovery) || !present(handlers.PostSyncHandoff) {
+		return nil, ErrCapabilityUnavailable
+	}
+	descriptors := []CapabilityDescriptor{
+		{Kind: syncdispatchcontract.KindDispatchSyncRun, Transport: syncdispatchcontract.RouteRiver, ContractVersion: ContractVersionV1, HandlerRegistered: true, PublisherBound: true},
+		{Kind: syncdispatchcontract.KindFinalizeSyncRun, Transport: syncdispatchcontract.RouteRiver, ContractVersion: ContractVersionV1, HandlerRegistered: true, PublisherBound: true},
+		{Kind: syncdispatchcontract.KindPostSync, Transport: syncdispatchcontract.RouteRiver, ContractVersion: ContractVersionV1, HandlerRegistered: true, HandoffBound: true},
+		{Kind: syncdispatchcontract.KindReferenceDiscovery, Transport: syncdispatchcontract.RouteRiver, ContractVersion: ContractVersionV1, HandlerRegistered: true, PublisherBound: true},
+	}
+	sort.Slice(descriptors, func(left, right int) bool { return descriptors[left].Kind < descriptors[right].Kind })
+	return &Capabilities{
+		descriptors: descriptors,
+		quiescer:    quiescer,
+		handlers:    handlers,
+		postSync:    handlers.PostSyncHandoff,
+	}, nil
+}
+
+func present(value any) bool {
+	if value == nil {
+		return false
+	}
+	reflected := reflect.ValueOf(value)
+	switch reflected.Kind() {
+	case reflect.Chan, reflect.Func, reflect.Interface, reflect.Map, reflect.Pointer, reflect.Slice:
+		return !reflected.IsNil()
+	default:
+		return true
+	}
+}
+
+func (capabilities *Capabilities) Descriptors() []CapabilityDescriptor {
+	if capabilities == nil {
+		return nil
+	}
+	return append([]CapabilityDescriptor(nil), capabilities.descriptors...)
+}
+
+// DispatchSyncRun invokes the concrete, retained registration for its exact
+// argument type. Composition must bind this typed seam into a River worker
+// before it may use the descriptor as executable readiness evidence.
+func (capabilities *Capabilities) DispatchSyncRun(ctx context.Context, args DispatchSyncRunArgs) error {
+	if capabilities == nil || !present(capabilities.handlers.DispatchSyncRun) || ctx == nil || args.valid() != nil {
+		return ErrCapabilityUnavailable
+	}
+	return capabilities.handlers.DispatchSyncRun.Work(ctx, args)
+}
+
+func (capabilities *Capabilities) FinalizeSyncRun(ctx context.Context, args FinalizeSyncRunArgs) error {
+	if capabilities == nil || !present(capabilities.handlers.FinalizeSyncRun) || ctx == nil || args.valid() != nil {
+		return ErrCapabilityUnavailable
+	}
+	return capabilities.handlers.FinalizeSyncRun.Work(ctx, args)
+}
+
+func (capabilities *Capabilities) PostSync(ctx context.Context, args PostSyncArgs) error {
+	if capabilities == nil || !present(capabilities.handlers.PostSync) || ctx == nil || args.valid() != nil {
+		return ErrCapabilityUnavailable
+	}
+	return capabilities.handlers.PostSync.Work(ctx, args)
+}
+
+func (capabilities *Capabilities) ReferenceDiscovery(ctx context.Context, args ReferenceDiscoveryArgs) error {
+	if capabilities == nil || !present(capabilities.handlers.ReferenceDiscovery) || ctx == nil || args.valid() != nil {
+		return ErrCapabilityUnavailable
+	}
+	return capabilities.handlers.ReferenceDiscovery.Work(ctx, args)
+}
+
+// HandoffPostSync runs the supplied concrete external handoff inside the
+// tracker-managed pre-publish window. It is intentionally separate from
+// Publisher.Publish: callers may invoke it only after the mark-before terminal
+// transaction committed. The tracker covers only handoffs issued through this
+// process; it is not a syncroute capability or a cross-process cutover barrier.
+func (capabilities *Capabilities) HandoffPostSync(ctx context.Context, args PostSyncArgs) error {
+	if capabilities == nil || capabilities.quiescer == nil || !present(capabilities.postSync) || ctx == nil || args.valid() != nil {
+		return ErrCapabilityUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	leave, err := capabilities.quiescer.EnterLocalHandoff(args.RouteGeneration())
+	if err != nil {
+		return err
+	}
+	defer leave()
+	return capabilities.postSync.Handoff(ctx, args)
+}

--- a/internal/syncdispatchruntime/publisher.go
+++ b/internal/syncdispatchruntime/publisher.go
@@ -1,0 +1,129 @@
+package syncdispatchruntime
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"regexp"
+	"strconv"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+var (
+	ErrInvalidPublisher = errors.New("invalid sync dispatch River publisher")
+	ErrRiverInsert      = errors.New("sync dispatch River insert failed")
+	ErrInsertRejected   = errors.New("sync dispatch River insert was rejected")
+)
+
+var queuePattern = regexp.MustCompile(`^[a-z][a-z0-9_-]{0,63}$`)
+
+// InsertClient is the smallest River API surface required for atomic
+// publishing. The publisher cannot begin, commit, roll back, or use a more
+// privileged database handle than the transaction its caller supplies.
+type InsertClient interface {
+	InsertTx(context.Context, pgx.Tx, river.JobArgs, *river.InsertOpts) (*rivertype.JobInsertResult, error)
+}
+
+// PublisherOptions are explicit because this package does not own dispatch
+// queue policy. Callers must choose a bounded queue and retry limit during a
+// separately approved composition step.
+type PublisherOptions struct {
+	Queue       string
+	MaxAttempts int
+}
+
+func (options PublisherOptions) valid() bool {
+	return queuePattern.MatchString(options.Queue) && options.MaxAttempts >= 1 && options.MaxAttempts <= 100
+}
+
+// Publisher performs exactly one supported River InsertTx call. It has no
+// route selection, claim mutation, logging, or handler activation behavior.
+type Publisher struct {
+	client  InsertClient
+	options PublisherOptions
+}
+
+func NewPublisher(client InsertClient, options PublisherOptions) (*Publisher, error) {
+	if !present(client) || !options.valid() {
+		return nil, ErrInvalidPublisher
+	}
+	return &Publisher{client: client, options: options}, nil
+}
+
+func (publisher *Publisher) valid() bool {
+	return publisher != nil && present(publisher.client) && publisher.options.valid()
+}
+
+// Publish inserts a concrete v1 River job in the caller's already-open
+// least-privilege transaction. A failure is intentionally opaque so callers
+// do not persist or log encoded arguments or driver details.
+func (publisher *Publisher) Publish(
+	ctx context.Context,
+	tx pgx.Tx,
+	claim Claim,
+	reference DomainReference,
+) (string, error) {
+	if !publisher.valid() || ctx == nil || !present(tx) {
+		return "", ErrInvalidPublisher
+	}
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	args, err := Convert(claim, reference)
+	if err != nil {
+		return "", err
+	}
+	result, err := publisher.client.InsertTx(ctx, tx, args, &river.InsertOpts{
+		Queue:       publisher.options.Queue,
+		MaxAttempts: publisher.options.MaxAttempts,
+		UniqueOpts: river.UniqueOpts{
+			ByArgs:  true,
+			ByState: rivertype.JobStates(),
+		},
+	})
+	if err != nil {
+		return "", ErrRiverInsert
+	}
+	if err := verifyInsert(result, args, publisher.options); err != nil {
+		return "", err
+	}
+	return strconv.FormatInt(result.Job.ID, 10), nil
+}
+
+func verifyInsert(result *rivertype.JobInsertResult, args Args, options PublisherOptions) error {
+	if result == nil || result.Job == nil || result.Job.ID <= 0 {
+		return fmt.Errorf("%w: missing job identity", ErrInsertRejected)
+	}
+	if result.Job.Kind != args.Kind() || result.Job.Queue != options.Queue || result.Job.MaxAttempts != options.MaxAttempts {
+		return fmt.Errorf("%w: returned job policy mismatch", ErrInsertRejected)
+	}
+	// river_job.encoded_args is jsonb, so PostgreSQL may normalize whitespace
+	// in a returned projection. Decode it strictly instead of byte-comparing
+	// formatting, while still rejecting unknown fields or any value drift.
+	if len(result.Job.EncodedArgs) == 0 || !matchesReturnedArgs(result.Job.EncodedArgs, args) {
+		return fmt.Errorf("%w: returned argument shape mismatch", ErrInsertRejected)
+	}
+	return nil
+}
+
+func matchesReturnedArgs(encoded []byte, expected Args) bool {
+	var returned TransportArgs
+	decoder := json.NewDecoder(bytes.NewReader(encoded))
+	decoder.DisallowUnknownFields()
+	if err := decoder.Decode(&returned); err != nil || returned.valid() != nil {
+		return false
+	}
+	var extra any
+	if err := decoder.Decode(&extra); !errors.Is(err, io.EOF) {
+		return false
+	}
+	return returned.Version == expected.ContractVersion() && returned.OrgID == expected.OrganizationID() &&
+		returned.RunID == expected.SyncRunID() && returned.DispatchOutbox == expected.OutboxID() &&
+		returned.RouteGeneration == expected.RouteGeneration()
+}

--- a/internal/syncdispatchruntime/publisher_integration_test.go
+++ b/internal/syncdispatchruntime/publisher_integration_test.go
@@ -1,0 +1,120 @@
+//go:build integration
+
+package syncdispatchruntime
+
+import (
+	"context"
+	"net/url"
+	"testing"
+	"time"
+
+	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5/pgxpool"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/riverdriver/riverpgxv5"
+)
+
+const (
+	integrationDomainRole     = "sync_dispatch_runtime_domain"
+	integrationDomainPassword = "sync_dispatch_runtime_domain_password"
+	integrationQueueRole      = "sync_dispatch_runtime_queue"
+	integrationQueuePassword  = "sync_dispatch_runtime_queue_password"
+)
+
+// TestPublisherInsertTxPostgres verifies the bounded publisher against River's
+// real pgx InsertTx API under the queue-control role. The domain tables exist
+// only because the checked-in River migration validates their names; this test
+// neither grants nor uses domain-table access from the publisher transaction.
+func TestPublisherInsertTxPostgres(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+
+	adminPool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer adminPool.Close()
+	for _, statement := range []string{
+		"REVOKE CREATE ON SCHEMA public FROM PUBLIC",
+		"CREATE ROLE " + integrationDomainRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + integrationDomainPassword + "'",
+		"CREATE ROLE " + integrationQueueRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + integrationQueuePassword + "'",
+		"GRANT CONNECT ON DATABASE worker_test TO " + integrationDomainRole + ", " + integrationQueueRole,
+		"CREATE TABLE public.worker_job_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
+		"CREATE TABLE public.sync_dispatch_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
+		"CREATE TABLE public.sync_dispatch_transport_routes (kind text PRIMARY KEY, generation bigint NOT NULL)",
+	} {
+		if _, err := adminPool.Exec(ctx, statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if _, err := riverstore.ApplyPinnedMigrations(ctx, adminPool, riverstore.MigrationOptions{
+		Schema: "river", DomainRole: integrationDomainRole, QueueRole: integrationQueueRole,
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	queuePool, err := pgxpool.New(ctx, integrationRoleURI(t, instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer queuePool.Close()
+	client, err := river.NewClient(riverpgxv5.New(queuePool), &river.Config{Schema: "river"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	publisher, err := NewPublisher(client, PublisherOptions{Queue: "sync", MaxAttempts: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	tx, err := queuePool.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	jobID, err := publisher.Publish(ctx, tx, Claim{
+		OutboxID: testOutbox, Kind: "dispatch_sync_run", RouteGeneration: 11,
+	}, testReference())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if jobID == "" {
+		t.Fatal("publisher returned an empty River job id")
+	}
+	if err := tx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	var encoded []byte
+	if err := adminPool.QueryRow(ctx, "SELECT args FROM river.river_job WHERE id = $1", jobID).Scan(&encoded); err != nil {
+		t.Fatal(err)
+	}
+	args, err := Convert(Claim{OutboxID: testOutbox, Kind: "dispatch_sync_run", RouteGeneration: 11}, testReference())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !matchesReturnedArgs(encoded, args) {
+		t.Fatal("stored River arguments do not match the exact v1 argument shape")
+	}
+}
+
+func integrationRoleURI(t *testing.T, rawURI string) string {
+	t.Helper()
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed.User = url.UserPassword(integrationQueueRole, integrationQueuePassword)
+	return parsed.String()
+}

--- a/internal/syncdispatchruntime/quiescer.go
+++ b/internal/syncdispatchruntime/quiescer.go
@@ -1,0 +1,104 @@
+package syncdispatchruntime
+
+import (
+	"context"
+	"errors"
+	"sync"
+)
+
+var ErrGenerationClosed = errors.New("sync dispatch generation is quiesced")
+
+// GenerationTracker bounds post_sync pre-publish windows in one publisher
+// process. It is not a distributed quiescence primitive and must not be used
+// as a syncroute.Quiescer: a cross-process cutover needs a separately proven
+// external barrier.
+type GenerationTracker struct {
+	mu            sync.Mutex
+	active        map[int64]int
+	closedThrough int64
+	changed       chan struct{}
+}
+
+func NewGenerationTracker() *GenerationTracker {
+	return &GenerationTracker{active: make(map[int64]int), changed: make(chan struct{})}
+}
+
+func (tracker *GenerationTracker) valid() bool {
+	// active is initialized once and never replaced. changed is deliberately
+	// excluded because signalLocked replaces it while holding mu.
+	return tracker != nil && tracker.active != nil
+}
+
+// EnterLocalHandoff records a post_sync handoff in this process immediately
+// before its external effect. The returned leave function is idempotent and
+// must be deferred by the concrete handoff adapter.
+func (tracker *GenerationTracker) EnterLocalHandoff(generation int64) (func(), error) {
+	if !tracker.valid() || generation < 1 {
+		return nil, ErrCapabilityUnavailable
+	}
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if generation <= tracker.closedThrough {
+		return nil, ErrGenerationClosed
+	}
+	tracker.active[generation]++
+	var once sync.Once
+	return func() {
+		once.Do(func() { tracker.leave(generation) })
+	}, nil
+}
+
+// WaitForLocalHandoffs closes this process to the requested and older
+// generations, then waits for its existing handoffs to leave. It deliberately
+// makes no claim about handoffs in another process or a Celery worker.
+func (tracker *GenerationTracker) WaitForLocalHandoffs(ctx context.Context, throughGeneration int64) error {
+	if !tracker.valid() || ctx == nil || throughGeneration < 1 {
+		return ErrCapabilityUnavailable
+	}
+	if err := ctx.Err(); err != nil {
+		return err
+	}
+	for {
+		tracker.mu.Lock()
+		if throughGeneration > tracker.closedThrough {
+			tracker.closedThrough = throughGeneration
+			tracker.signalLocked()
+		}
+		if !tracker.activeThroughLocked(throughGeneration) {
+			tracker.mu.Unlock()
+			return nil
+		}
+		changed := tracker.changed
+		tracker.mu.Unlock()
+		select {
+		case <-changed:
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+}
+
+func (tracker *GenerationTracker) leave(generation int64) {
+	tracker.mu.Lock()
+	defer tracker.mu.Unlock()
+	if tracker.active[generation] <= 1 {
+		delete(tracker.active, generation)
+	} else {
+		tracker.active[generation]--
+	}
+	tracker.signalLocked()
+}
+
+func (tracker *GenerationTracker) activeThroughLocked(generation int64) bool {
+	for activeGeneration, count := range tracker.active {
+		if activeGeneration <= generation && count > 0 {
+			return true
+		}
+	}
+	return false
+}
+
+func (tracker *GenerationTracker) signalLocked() {
+	close(tracker.changed)
+	tracker.changed = make(chan struct{})
+}

--- a/internal/syncdispatchruntime/runtime_test.go
+++ b/internal/syncdispatchruntime/runtime_test.go
@@ -1,0 +1,356 @@
+package syncdispatchruntime
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/syncroute"
+	"github.com/jackc/pgx/v5"
+	"github.com/riverqueue/river"
+	"github.com/riverqueue/river/rivertype"
+)
+
+var (
+	_ Args = DispatchSyncRunArgs{}
+	_ Args = FinalizeSyncRunArgs{}
+	_ Args = PostSyncArgs{}
+	_ Args = ReferenceDiscoveryArgs{}
+)
+
+const (
+	testOutbox = "10000000-0000-4000-8000-000000000001"
+	testOrg    = "20000000-0000-4000-8000-000000000002"
+	testRun    = "30000000-0000-4000-8000-000000000003"
+)
+
+func TestConvertProducesExactVersionedTypedArgsWithoutClaimToken(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		kind string
+		want any
+	}{
+		{syncdispatchcontract.KindDispatchSyncRun, DispatchSyncRunArgs{}},
+		{syncdispatchcontract.KindFinalizeSyncRun, FinalizeSyncRunArgs{}},
+		{syncdispatchcontract.KindPostSync, PostSyncArgs{}},
+		{syncdispatchcontract.KindReferenceDiscovery, ReferenceDiscoveryArgs{}},
+	}
+	for _, test := range tests {
+		t.Run(test.kind, func(t *testing.T) {
+			args, err := Convert(Claim{OutboxID: testOutbox, Kind: test.kind, RouteGeneration: 9}, testReference())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if reflect.TypeOf(args) != reflect.TypeOf(test.want) || args.Kind() != test.kind ||
+				args.ContractVersion() != ContractVersionV1 || args.OutboxID() != testOutbox ||
+				args.OrganizationID() != testOrg || args.SyncRunID() != testRun || args.RouteGeneration() != 9 {
+				t.Fatalf("converted args = %#v", args)
+			}
+			encoded, err := json.Marshal(args)
+			if err != nil {
+				t.Fatal(err)
+			}
+			var fields map[string]any
+			if err := json.Unmarshal(encoded, &fields); err != nil {
+				t.Fatal(err)
+			}
+			if len(fields) != 5 || fields["contract_version"] != float64(1) || fields["organization_id"] != testOrg ||
+				fields["sync_run_id"] != testRun || fields["outbox_id"] != testOutbox ||
+				fields["route_generation"] != float64(9) {
+				t.Fatalf("encoded fields = %#v", fields)
+			}
+			if _, leaked := fields["claim_token"]; leaked {
+				t.Fatal("claim token leaked into River arguments")
+			}
+		})
+	}
+}
+
+func TestConvertFailsClosedForInvalidClaimAndDomainReference(t *testing.T) {
+	t.Parallel()
+	for _, test := range []struct {
+		name      string
+		claim     Claim
+		reference DomainReference
+		want      error
+	}{
+		{"unknown kind", Claim{OutboxID: testOutbox, Kind: "not_a_kind", RouteGeneration: 1}, testReference(), ErrInvalidClaim},
+		{"non uuid outbox", Claim{OutboxID: "unsafe", Kind: syncdispatchcontract.KindPostSync, RouteGeneration: 1}, testReference(), ErrInvalidClaim},
+		{"zero generation", Claim{OutboxID: testOutbox, Kind: syncdispatchcontract.KindPostSync}, testReference(), ErrInvalidClaim},
+		{"non uuid org", Claim{OutboxID: testOutbox, Kind: syncdispatchcontract.KindPostSync, RouteGeneration: 1}, DomainReference{OrganizationID: "unsafe", SyncRunID: testRun}, ErrInvalidReference},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			_, err := Convert(test.claim, test.reference)
+			if !errors.Is(err, test.want) {
+				t.Fatalf("Convert() error = %v, want %v", err, test.want)
+			}
+		})
+	}
+}
+
+func TestPublisherUsesCallerTransactionAndVerifiesExactArgs(t *testing.T) {
+	t.Parallel()
+	client := &recordingInsertClient{}
+	publisher, err := NewPublisher(client, PublisherOptions{Queue: "sync", MaxAttempts: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	jobID, err := publisher.Publish(context.Background(), &inertTx{}, Claim{
+		OutboxID: testOutbox, Kind: syncdispatchcontract.KindDispatchSyncRun, RouteGeneration: 3,
+	}, testReference())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if jobID != "42" || client.tx == nil || client.args == nil || client.args.Kind() != syncdispatchcontract.KindDispatchSyncRun ||
+		client.options.Queue != "sync" || client.options.MaxAttempts != 5 || !client.options.UniqueOpts.ByArgs {
+		t.Fatalf("publisher call = job:%s tx:%T args:%#v opts:%#v", jobID, client.tx, client.args, client.options)
+	}
+}
+
+func TestPublisherRejectsMismatchedRiverResultWithoutLeakingArguments(t *testing.T) {
+	t.Parallel()
+	client := &recordingInsertClient{mutate: func(job *rivertype.JobRow) { job.Queue = "other" }}
+	publisher, err := NewPublisher(client, PublisherOptions{Queue: "sync", MaxAttempts: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = publisher.Publish(context.Background(), &inertTx{}, Claim{
+		OutboxID: testOutbox, Kind: syncdispatchcontract.KindFinalizeSyncRun, RouteGeneration: 3,
+	}, testReference())
+	if !errors.Is(err, ErrInsertRejected) {
+		t.Fatalf("Publish() error = %v, want %v", err, ErrInsertRejected)
+	}
+}
+
+func TestPublisherRejectsTypedNilClientAndMissingReturnedArgs(t *testing.T) {
+	t.Parallel()
+	var typedNil *recordingInsertClient
+	if _, err := NewPublisher(typedNil, PublisherOptions{Queue: "sync", MaxAttempts: 5}); !errors.Is(err, ErrInvalidPublisher) {
+		t.Fatalf("NewPublisher(typed nil) error = %v, want %v", err, ErrInvalidPublisher)
+	}
+	validPublisher := mustPublisher(t)
+	var typedNilTx *inertTx
+	if _, err := validPublisher.Publish(context.Background(), typedNilTx, Claim{
+		OutboxID: testOutbox, Kind: syncdispatchcontract.KindFinalizeSyncRun, RouteGeneration: 3,
+	}, testReference()); !errors.Is(err, ErrInvalidPublisher) {
+		t.Fatalf("Publish(typed nil transaction) error = %v, want %v", err, ErrInvalidPublisher)
+	}
+	publisher, err := NewPublisher(&recordingInsertClient{mutate: func(job *rivertype.JobRow) { job.EncodedArgs = nil }}, PublisherOptions{Queue: "sync", MaxAttempts: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, err = publisher.Publish(context.Background(), &inertTx{}, Claim{
+		OutboxID: testOutbox, Kind: syncdispatchcontract.KindFinalizeSyncRun, RouteGeneration: 3,
+	}, testReference())
+	if !errors.Is(err, ErrInsertRejected) {
+		t.Fatalf("Publish() error = %v, want %v", err, ErrInsertRejected)
+	}
+}
+
+func TestCapabilitiesCannotAdvertiseWithoutEveryConcreteHandlerAndHandoff(t *testing.T) {
+	t.Parallel()
+	publisher := mustPublisher(t)
+	if _, err := NewCapabilities(&Publisher{}, completeHandlers(), NewGenerationTracker()); !errors.Is(err, ErrCapabilityUnavailable) {
+		t.Fatalf("NewCapabilities(zero publisher) error = %v, want %v", err, ErrCapabilityUnavailable)
+	}
+	if _, err := NewCapabilities(publisher, completeHandlers(), &GenerationTracker{}); !errors.Is(err, ErrCapabilityUnavailable) {
+		t.Fatalf("NewCapabilities(zero tracker) error = %v, want %v", err, ErrCapabilityUnavailable)
+	}
+	if _, err := NewCapabilities(publisher, Handlers{}, NewGenerationTracker()); !errors.Is(err, ErrCapabilityUnavailable) {
+		t.Fatalf("NewCapabilities() error = %v, want %v", err, ErrCapabilityUnavailable)
+	}
+	var nilHandler DispatchSyncRunHandlerFunc
+	if _, err := NewCapabilities(publisher, Handlers{DispatchSyncRun: nilHandler}, NewGenerationTracker()); !errors.Is(err, ErrCapabilityUnavailable) {
+		t.Fatalf("NewCapabilities(nil typed handler) error = %v, want %v", err, ErrCapabilityUnavailable)
+	}
+
+	capabilities, err := NewCapabilities(publisher, completeHandlers(), NewGenerationTracker())
+	if err != nil {
+		t.Fatal(err)
+	}
+	descriptors := capabilities.Descriptors()
+	if len(descriptors) != 4 || descriptors[0].Kind != syncdispatchcontract.KindDispatchSyncRun ||
+		!descriptors[0].HandlerRegistered || !descriptors[0].PublisherBound {
+		t.Fatalf("descriptors = %#v", descriptors)
+	}
+}
+
+func TestCapabilitiesRetainAndDispatchEveryTypedHandler(t *testing.T) {
+	t.Parallel()
+	called := make(map[string]bool)
+	handlers := completeHandlers()
+	handlers.DispatchSyncRun = DispatchSyncRunHandlerFunc(func(context.Context, DispatchSyncRunArgs) error { called["dispatch"] = true; return nil })
+	handlers.FinalizeSyncRun = FinalizeSyncRunHandlerFunc(func(context.Context, FinalizeSyncRunArgs) error { called["finalize"] = true; return nil })
+	handlers.PostSync = PostSyncHandlerFunc(func(context.Context, PostSyncArgs) error { called["post"] = true; return nil })
+	handlers.ReferenceDiscovery = ReferenceDiscoveryHandlerFunc(func(context.Context, ReferenceDiscoveryArgs) error { called["reference"] = true; return nil })
+	capabilities, err := NewCapabilities(mustPublisher(t), handlers, NewGenerationTracker())
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, test := range []struct {
+		kind string
+		run  func(Args) error
+	}{
+		{syncdispatchcontract.KindDispatchSyncRun, func(args Args) error {
+			return capabilities.DispatchSyncRun(context.Background(), args.(DispatchSyncRunArgs))
+		}},
+		{syncdispatchcontract.KindFinalizeSyncRun, func(args Args) error {
+			return capabilities.FinalizeSyncRun(context.Background(), args.(FinalizeSyncRunArgs))
+		}},
+		{syncdispatchcontract.KindPostSync, func(args Args) error { return capabilities.PostSync(context.Background(), args.(PostSyncArgs)) }},
+		{syncdispatchcontract.KindReferenceDiscovery, func(args Args) error {
+			return capabilities.ReferenceDiscovery(context.Background(), args.(ReferenceDiscoveryArgs))
+		}},
+	} {
+		args, err := Convert(Claim{OutboxID: testOutbox, Kind: test.kind, RouteGeneration: 1}, testReference())
+		if err != nil || test.run(args) != nil {
+			t.Fatalf("dispatch %s failed: conversion=%v", test.kind, err)
+		}
+	}
+	if !called["dispatch"] || !called["finalize"] || !called["post"] || !called["reference"] {
+		t.Fatalf("typed handler calls = %#v", called)
+	}
+}
+
+func TestGenerationTrackerIsLocalOnlyAndWaitsForLocalHandoffs(t *testing.T) {
+	t.Parallel()
+	tracker := NewGenerationTracker()
+	if _, isCrossProcessBarrier := any(tracker).(syncroute.Quiescer); isCrossProcessBarrier {
+		t.Fatal("GenerationTracker must not implement syncroute.Quiescer")
+	}
+	leave, err := tracker.EnterLocalHandoff(7)
+	if err != nil {
+		t.Fatal(err)
+	}
+	cancelled, cancel := context.WithCancel(context.Background())
+	cancel()
+	err = tracker.WaitForLocalHandoffs(cancelled, 7)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("cancelled WaitForLocalHandoffs() error = %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- tracker.WaitForLocalHandoffs(context.Background(), 7)
+	}()
+	select {
+	case err := <-done:
+		t.Fatalf("WaitForLocalHandoffs returned before leave: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	if _, err := tracker.EnterLocalHandoff(7); !errors.Is(err, ErrGenerationClosed) {
+		t.Fatalf("EnterLocalHandoff old generation error = %v, want %v", err, ErrGenerationClosed)
+	}
+	leave()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("WaitForLocalHandoffs() error = %v", err)
+		}
+	case <-time.After(time.Second):
+		t.Fatal("WaitForLocalHandoffs did not release after old handoff left")
+	}
+	if leaveNew, err := tracker.EnterLocalHandoff(8); err != nil {
+		t.Fatalf("EnterLocalHandoff new generation error = %v", err)
+	} else {
+		leaveNew()
+	}
+}
+
+func TestPostSyncHandoffIsPairedWithGenerationTracker(t *testing.T) {
+	t.Parallel()
+	entered := make(chan struct{})
+	release := make(chan struct{})
+	handlers := completeHandlers()
+	handlers.PostSyncHandoff = postSyncHandoffFunc(func(context.Context, PostSyncArgs) error {
+		close(entered)
+		<-release
+		return nil
+	})
+	capabilities, err := NewCapabilities(mustPublisher(t), handlers, NewGenerationTracker())
+	if err != nil {
+		t.Fatal(err)
+	}
+	args, err := Convert(Claim{OutboxID: testOutbox, Kind: syncdispatchcontract.KindPostSync, RouteGeneration: 4}, testReference())
+	if err != nil {
+		t.Fatal(err)
+	}
+	postSyncArgs := args.(PostSyncArgs)
+	done := make(chan error, 1)
+	go func() { done <- capabilities.HandoffPostSync(context.Background(), postSyncArgs) }()
+	<-entered
+	quiesced := make(chan error, 1)
+	go func() {
+		quiesced <- capabilities.quiescer.WaitForLocalHandoffs(context.Background(), 4)
+	}()
+	select {
+	case err := <-quiesced:
+		t.Fatalf("WaitForLocalHandoffs returned before handoff left: %v", err)
+	case <-time.After(20 * time.Millisecond):
+	}
+	close(release)
+	if err := <-done; err != nil {
+		t.Fatalf("HandoffPostSync() error = %v", err)
+	}
+	if err := <-quiesced; err != nil {
+		t.Fatalf("WaitForLocalHandoffs() error = %v", err)
+	}
+}
+
+func testReference() DomainReference {
+	return DomainReference{OrganizationID: testOrg, SyncRunID: testRun}
+}
+
+type inertTx struct{ pgx.Tx }
+
+type recordingInsertClient struct {
+	tx      pgx.Tx
+	args    river.JobArgs
+	options *river.InsertOpts
+	mutate  func(*rivertype.JobRow)
+}
+
+func (client *recordingInsertClient) InsertTx(_ context.Context, tx pgx.Tx, args river.JobArgs, options *river.InsertOpts) (*rivertype.JobInsertResult, error) {
+	client.tx = tx
+	client.args = args
+	copyOptions := *options
+	client.options = &copyOptions
+	encoded, err := json.Marshal(args)
+	if err != nil {
+		return nil, err
+	}
+	job := &rivertype.JobRow{ID: 42, Kind: args.Kind(), Queue: options.Queue, MaxAttempts: options.MaxAttempts, EncodedArgs: encoded}
+	if client.mutate != nil {
+		client.mutate(job)
+	}
+	return &rivertype.JobInsertResult{Job: job}, nil
+}
+
+func mustPublisher(t *testing.T) *Publisher {
+	t.Helper()
+	publisher, err := NewPublisher(&recordingInsertClient{}, PublisherOptions{Queue: "sync", MaxAttempts: 5})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return publisher
+}
+
+func completeHandlers() Handlers {
+	return Handlers{
+		DispatchSyncRun:    DispatchSyncRunHandlerFunc(func(context.Context, DispatchSyncRunArgs) error { return nil }),
+		FinalizeSyncRun:    FinalizeSyncRunHandlerFunc(func(context.Context, FinalizeSyncRunArgs) error { return nil }),
+		PostSync:           PostSyncHandlerFunc(func(context.Context, PostSyncArgs) error { return nil }),
+		ReferenceDiscovery: ReferenceDiscoveryHandlerFunc(func(context.Context, ReferenceDiscoveryArgs) error { return nil }),
+		PostSyncHandoff:    postSyncHandoffFunc(func(context.Context, PostSyncArgs) error { return nil }),
+	}
+}
+
+type postSyncHandoffFunc func(context.Context, PostSyncArgs) error
+
+func (function postSyncHandoffFunc) Handoff(ctx context.Context, args PostSyncArgs) error {
+	return function(ctx, args)
+}

--- a/internal/syncdispatchruntime/types.go
+++ b/internal/syncdispatchruntime/types.go
@@ -1,0 +1,140 @@
+// Package syncdispatchruntime contains dormant, typed River transport
+// primitives for the frozen sync-dispatch v1 contract. It has no command,
+// route, or worker registration side effects.
+package syncdispatchruntime
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/riverqueue/river"
+)
+
+const ContractVersionV1 = 1
+
+var uuidPattern = regexp.MustCompile(`^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$`)
+
+var (
+	ErrInvalidClaim     = errors.New("invalid sync dispatch transport claim")
+	ErrInvalidReference = errors.New("invalid sync dispatch domain reference")
+)
+
+// Claim is the non-sensitive projection of a live transport claim. In
+// particular, it deliberately excludes the claim token: that lease secret is
+// only for the reconciler's same-transaction terminal write and must never be
+// serialized into River arguments.
+type Claim struct {
+	OutboxID        string
+	Kind            string
+	RouteGeneration int64
+}
+
+// DomainReference is the authoritative, tenant-scoped domain identity looked
+// up by a caller that owns the semantic database boundary. Queue arguments do
+// not replace the sync run as the source of truth.
+type DomainReference struct {
+	OrganizationID string
+	SyncRunID      string
+}
+
+// Args is the exact versioned River argument shape shared by all four frozen
+// dispatch kinds. Concrete kind types prevent an accidental kind/argument
+// mismatch at the publisher boundary.
+type Args interface {
+	river.JobArgs
+	ContractVersion() int
+	OutboxID() string
+	OrganizationID() string
+	SyncRunID() string
+	RouteGeneration() int64
+	valid() error
+}
+
+// TransportArgs is the common v1 encoded argument envelope. It has no
+// arbitrary payload field and no claim token, provider credential, or raw
+// domain record.
+type TransportArgs struct {
+	Version         int    `json:"contract_version"`
+	OrgID           string `json:"organization_id"`
+	RunID           string `json:"sync_run_id"`
+	DispatchOutbox  string `json:"outbox_id" river:"unique"`
+	RouteGeneration int64  `json:"route_generation"`
+}
+
+func (args TransportArgs) ContractVersion() int   { return args.Version }
+func (args TransportArgs) OutboxID() string       { return args.DispatchOutbox }
+func (args TransportArgs) OrganizationID() string { return args.OrgID }
+func (args TransportArgs) SyncRunID() string      { return args.RunID }
+func (args TransportArgs) Generation() int64      { return args.RouteGeneration }
+
+func (args TransportArgs) valid() error {
+	if args.Version != ContractVersionV1 || !uuidPattern.MatchString(args.OrgID) ||
+		!uuidPattern.MatchString(args.RunID) || !uuidPattern.MatchString(args.DispatchOutbox) ||
+		args.RouteGeneration < 1 {
+		return ErrInvalidReference
+	}
+	return nil
+}
+
+// DispatchSyncRunArgs is the exact v1 River argument type for dispatch_sync_run.
+type DispatchSyncRunArgs struct{ TransportArgs }
+
+func (DispatchSyncRunArgs) Kind() string                { return syncdispatchcontract.KindDispatchSyncRun }
+func (args DispatchSyncRunArgs) RouteGeneration() int64 { return args.Generation() }
+func (args DispatchSyncRunArgs) valid() error           { return args.TransportArgs.valid() }
+
+// FinalizeSyncRunArgs is the exact v1 River argument type for finalize_sync_run.
+type FinalizeSyncRunArgs struct{ TransportArgs }
+
+func (FinalizeSyncRunArgs) Kind() string                { return syncdispatchcontract.KindFinalizeSyncRun }
+func (args FinalizeSyncRunArgs) RouteGeneration() int64 { return args.Generation() }
+func (args FinalizeSyncRunArgs) valid() error           { return args.TransportArgs.valid() }
+
+// PostSyncArgs is the exact v1 argument type for post_sync. It is also used
+// by the separately controlled mark-before external-handoff seam; creating it
+// does not publish a message or execute an external effect.
+type PostSyncArgs struct{ TransportArgs }
+
+func (PostSyncArgs) Kind() string                { return syncdispatchcontract.KindPostSync }
+func (args PostSyncArgs) RouteGeneration() int64 { return args.Generation() }
+func (args PostSyncArgs) valid() error           { return args.TransportArgs.valid() }
+
+// ReferenceDiscoveryArgs is the exact v1 River argument type for
+// reference_discovery.
+type ReferenceDiscoveryArgs struct{ TransportArgs }
+
+func (ReferenceDiscoveryArgs) Kind() string                { return syncdispatchcontract.KindReferenceDiscovery }
+func (args ReferenceDiscoveryArgs) RouteGeneration() int64 { return args.Generation() }
+func (args ReferenceDiscoveryArgs) valid() error           { return args.TransportArgs.valid() }
+
+// Convert strictly projects a live claim plus authoritative domain reference
+// into one concrete v1 argument type. It never reads or logs payload data.
+func Convert(claim Claim, reference DomainReference) (Args, error) {
+	if !uuidPattern.MatchString(claim.OutboxID) || claim.RouteGeneration < 1 {
+		return nil, ErrInvalidClaim
+	}
+	base := TransportArgs{
+		Version:         ContractVersionV1,
+		OrgID:           reference.OrganizationID,
+		RunID:           reference.SyncRunID,
+		DispatchOutbox:  claim.OutboxID,
+		RouteGeneration: claim.RouteGeneration,
+	}
+	if err := base.valid(); err != nil {
+		return nil, err
+	}
+	switch claim.Kind {
+	case syncdispatchcontract.KindDispatchSyncRun:
+		return DispatchSyncRunArgs{TransportArgs: base}, nil
+	case syncdispatchcontract.KindFinalizeSyncRun:
+		return FinalizeSyncRunArgs{TransportArgs: base}, nil
+	case syncdispatchcontract.KindPostSync:
+		return PostSyncArgs{TransportArgs: base}, nil
+	case syncdispatchcontract.KindReferenceDiscovery:
+		return ReferenceDiscoveryArgs{TransportArgs: base}, nil
+	default:
+		return nil, fmt.Errorf("%w: unknown kind", ErrInvalidClaim)
+	}
+}

--- a/internal/syncreconciler/failure_backoff.go
+++ b/internal/syncreconciler/failure_backoff.go
@@ -21,8 +21,9 @@ type failureTransaction interface {
 type failureBegin func(context.Context) (failureTransaction, error)
 
 // PublishFailureRecorder persists a retry after a publisher fails outside the
-// transaction that committed its claim. It is deliberately command-unwired:
-// activation must first split claim commit from per-claim dispatch.
+// transaction that committed its claim. The dormant Kernel invokes it after
+// rolling back the failed per-claim delivery transaction; command activation
+// remains a separate reviewed boundary.
 type PublishFailureRecorder struct {
 	begin failureBegin
 }

--- a/internal/syncreconciler/kernel.go
+++ b/internal/syncreconciler/kernel.go
@@ -24,9 +24,13 @@ var (
 	// ErrPublisherRequired means mutation reached an at-least-once claim without
 	// an injected same-transaction River publisher.
 	ErrPublisherRequired = errors.New("sync dispatch transport publisher required")
-	// ErrPostSyncMarkerRequired means mutation reached the special at-most-once
-	// post_sync kind without its explicit mark-before seam.
-	ErrPostSyncMarkerRequired = errors.New("sync dispatch post-sync mark-before seam required")
+	// ErrPostSyncHandoffRequired means mutation can claim the special at-most-once
+	// post_sync kind without an explicit post-commit external handoff.
+	ErrPostSyncHandoffRequired = errors.New("sync dispatch post-sync handoff required")
+	// ErrPostSyncHandoffFailed reports one or more post-commit handoff failures
+	// without exposing an adapter's potentially sensitive error text. The
+	// associated terminal marks are already durable and must never be rearmed.
+	ErrPostSyncHandoffFailed = errors.New("sync dispatch post-sync handoff failed")
 )
 
 // KernelMode selects a strictly bounded reconciler behavior. Shadow is the
@@ -40,7 +44,7 @@ const (
 )
 
 // TransportClaim is the minimum non-sensitive state a transport publisher
-// needs. It is valid only inside the pgx transaction passed to the publisher.
+// needs. The claim token and route generation are persisted before delivery.
 type TransportClaim struct {
 	ID              string
 	Kind            string
@@ -50,25 +54,29 @@ type TransportClaim struct {
 	Attempts        int64
 }
 
-// AtLeastOncePublisher inserts one River job using the supplied transaction.
-// The returned identifier is optional audit metadata. Returning an error rolls
-// back both the River insert and the claim, making the attempt retry-safe.
+// AtLeastOncePublisher inserts one River job using the supplied fresh
+// transaction. The returned identifier is optional audit metadata. Returning
+// an error rolls back the River insert; the already committed claim is then
+// released through the bounded persisted failure recorder.
 type AtLeastOncePublisher func(context.Context, pgx.Tx, TransportClaim) (string, error)
 
-// PostSyncMarkBefore is deliberately separate from AtLeastOncePublisher.
-// The kernel persists the terminal dispatched mark first, then invokes this
-// transaction-local seam before commit. It must not perform an external effect;
-// post_sync's external at-most-once work belongs to a later, explicit phase.
-type PostSyncMarkBefore func(context.Context, pgx.Tx, TransportClaim) error
+// PostSyncHandoff is deliberately separate from AtLeastOncePublisher. The
+// kernel commits the terminal dispatched mark before invoking this callback,
+// so it cannot accidentally perform an external effect in the mark
+// transaction. A callback failure is surfaced but never re-arms post_sync.
+type PostSyncHandoff func(context.Context, TransportClaim) error
 
 // KernelResult is bounded to one requested claim window. Shadow includes the
 // existing read-only observation; mutation reports only aggregate counts.
 type KernelResult struct {
-	Mode         KernelMode
-	Observation  Observation
-	Claimed      int
-	Dispatched   int
-	PostSyncMark int
+	Mode                  KernelMode
+	Observation           Observation
+	Claimed               int
+	Dispatched            int
+	PostSyncMark          int
+	PostSyncHandoffFailed int
+	Retried               int
+	LeaseLost             int
 }
 
 type beginFunc func(context.Context) (pgx.Tx, error)
@@ -80,6 +88,7 @@ type Kernel struct {
 	mode        KernelMode
 	observer    Stepper
 	begin       beginFunc
+	failures    *PublishFailureRecorder
 	descriptors map[string]syncdispatchcontract.Descriptor
 	riverKinds  []string
 }
@@ -125,6 +134,15 @@ func newKernel(
 		begin:       begin,
 		descriptors: make(map[string]syncdispatchcontract.Descriptor, len(descriptors)),
 	}
+	if mode == KernelModeMutation {
+		failures, failureErr := newPublishFailureRecorder(func(ctx context.Context) (failureTransaction, error) {
+			return begin(ctx)
+		})
+		if failureErr != nil {
+			return nil, ErrInvalidConfiguration
+		}
+		kernel.failures = failures
+	}
 	for _, descriptor := range descriptors {
 		kernel.descriptors[descriptor.Kind] = descriptor
 		if descriptor.Route == syncdispatchcontract.RouteRiver {
@@ -136,16 +154,17 @@ func newKernel(
 }
 
 // Step runs exactly one bounded unit of work. Shadow delegates to the existing
-// read-only observer and never begins a transaction. Mutation claims only rows
-// whose persisted route is River and unpaused. The outbox is locked before any
-// publisher is called; route generation is rechecked by the terminal write.
+// read-only observer and never begins a transaction. Mutation first commits one
+// bounded set of River claims. Each at-least-once claim is then delivered and
+// terminally marked in its own fresh transaction. post_sync is terminally
+// marked and committed before its external handoff is invoked.
 func (kernel *Kernel) Step(
 	ctx context.Context,
 	now time.Time,
 	limit int,
 	leaseDuration time.Duration,
 	publish AtLeastOncePublisher,
-	postSyncMark PostSyncMarkBefore,
+	postSyncHandoff PostSyncHandoff,
 ) (KernelResult, error) {
 	if kernel == nil || kernel.observer == nil || ctx == nil || now.IsZero() ||
 		limit < minimumStepLimit || limit > maximumStepLimit ||
@@ -160,7 +179,7 @@ func (kernel *Kernel) Step(
 		observation, err := kernel.observer.Step(ctx, now, limit)
 		return KernelResult{Mode: KernelModeShadow, Observation: observation}, err
 	}
-	if kernel.mode != KernelModeMutation || kernel.begin == nil {
+	if kernel.mode != KernelModeMutation || kernel.begin == nil || kernel.failures == nil {
 		return KernelResult{}, ErrInvalidConfiguration
 	}
 	// The checked-in contract is currently Celery-only. Avoid even opening a
@@ -169,56 +188,202 @@ func (kernel *Kernel) Step(
 	if len(kernel.riverKinds) == 0 {
 		return KernelResult{Mode: KernelModeMutation}, nil
 	}
-
-	tx, err := kernel.begin(ctx)
-	if err != nil || tx == nil {
-		return KernelResult{}, ErrUnavailable
+	for _, kind := range kernel.riverKinds {
+		descriptor := kernel.descriptors[kind]
+		switch descriptor.Delivery {
+		case syncdispatchcontract.DeliveryAtLeastOnce:
+			if publish == nil {
+				return KernelResult{}, ErrPublisherRequired
+			}
+		case syncdispatchcontract.DeliveryAtMostOnceMarkBefore:
+			if postSyncHandoff == nil {
+				return KernelResult{}, ErrPostSyncHandoffRequired
+			}
+		default:
+			return KernelResult{}, ErrInvalidConfiguration
+		}
 	}
-	defer func() { _ = tx.Rollback(ctx) }()
 
-	claims, err := claimRiverRoutes(ctx, tx, now, limit, leaseDuration, kernel.riverKinds)
+	claims, err := kernel.commitClaims(ctx, now, limit, leaseDuration)
 	if err != nil {
 		return KernelResult{}, err
 	}
 	result := KernelResult{Mode: KernelModeMutation, Claimed: len(claims)}
+	handoffFailed := false
 	for _, claim := range claims {
 		descriptor, known := kernel.descriptors[claim.Kind]
 		if !known || descriptor.Route != syncdispatchcontract.RouteRiver {
-			return KernelResult{}, ErrLeaseLost
+			return result, kernelStepError(handoffFailed, ErrLeaseLost)
 		}
 		if descriptor.Delivery == syncdispatchcontract.DeliveryAtMostOnceMarkBefore {
-			if err := markRiverDispatched(ctx, tx, claim, now, ""); err != nil {
-				return KernelResult{}, err
-			}
-			if postSyncMark == nil {
-				return KernelResult{}, ErrPostSyncMarkerRequired
-			}
-			if err := postSyncMark(ctx, tx, claim); err != nil {
-				return KernelResult{}, err
+			if err := kernel.commitPostSyncMark(ctx, claim, now); err != nil {
+				// Only the unadorned exact-CAS miss is safely skippable. A joined
+				// persistence error (for example, an ambiguous commit plus a CAS
+				// probe miss) remains fatal.
+				if err == ErrLeaseLost {
+					result.LeaseLost++
+					continue
+				}
+				return result, kernelStepError(handoffFailed, err)
 			}
 			result.Dispatched++
 			result.PostSyncMark++
+			if err := postSyncHandoff(ctx, claim); err != nil {
+				handoffFailed = true
+				result.PostSyncHandoffFailed++
+			}
 			continue
 		}
 		if descriptor.Delivery != syncdispatchcontract.DeliveryAtLeastOnce {
-			return KernelResult{}, ErrInvalidConfiguration
+			return result, kernelStepError(handoffFailed, ErrInvalidConfiguration)
 		}
-		if publish == nil {
-			return KernelResult{}, ErrPublisherRequired
+		outcome, err := kernel.deliverAtLeastOnce(ctx, claim, now, publish)
+		switch outcome {
+		case deliverySucceeded:
+			result.Dispatched++
+		case deliveryRetried:
+			result.Retried++
+		case deliveryLeaseLost:
+			result.LeaseLost++
 		}
-		transportJobID, err := publish(ctx, tx, claim)
+		// See the post_sync branch above: do not mask a compound error that
+		// merely contains ErrLeaseLost alongside an unavailable dependency.
+		if err == ErrLeaseLost {
+			continue
+		}
 		if err != nil {
-			return KernelResult{}, err
+			return result, kernelStepError(handoffFailed, err)
 		}
-		if err := markRiverDispatched(ctx, tx, claim, now, transportJobID); err != nil {
-			return KernelResult{}, err
-		}
-		result.Dispatched++
+	}
+	return result, kernelStepError(handoffFailed, nil)
+}
+
+func kernelStepError(handoffFailed bool, laterErr error) error {
+	if !handoffFailed {
+		return laterErr
+	}
+	if laterErr == nil {
+		return ErrPostSyncHandoffFailed
+	}
+	return errors.Join(ErrPostSyncHandoffFailed, laterErr)
+}
+
+type deliveryOutcome uint8
+
+const (
+	deliveryNoResult deliveryOutcome = iota
+	deliverySucceeded
+	deliveryRetried
+	deliveryLeaseLost
+)
+
+func (kernel *Kernel) commitClaims(
+	ctx context.Context,
+	now time.Time,
+	limit int,
+	leaseDuration time.Duration,
+) ([]TransportClaim, error) {
+	tx, err := kernel.begin(ctx)
+	if err != nil || tx == nil {
+		return nil, ErrUnavailable
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	claims, err := claimRiverRoutes(ctx, tx, now, limit, leaseDuration, kernel.riverKinds)
+	if err != nil {
+		return nil, err
 	}
 	if err := tx.Commit(ctx); err != nil {
-		return KernelResult{}, ErrUnavailable
+		return nil, ErrUnavailable
 	}
-	return result, nil
+	return claims, nil
+}
+
+func (kernel *Kernel) deliverAtLeastOnce(
+	ctx context.Context,
+	claim TransportClaim,
+	now time.Time,
+	publish AtLeastOncePublisher,
+) (deliveryOutcome, error) {
+	tx, err := kernel.begin(ctx)
+	if err != nil || tx == nil {
+		return deliveryNoResult, ErrUnavailable
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+
+	if err := lockRiverClaim(ctx, tx, claim, now); err != nil {
+		if err == ErrLeaseLost {
+			return deliveryLeaseLost, err
+		}
+		return deliveryNoResult, err
+	}
+	transportJobID, publishErr := publish(ctx, tx, claim)
+	if publishErr != nil {
+		_ = tx.Rollback(ctx)
+		recordErr := kernel.failures.Record(ctx, claim, now, publishErr)
+		switch {
+		case recordErr == nil:
+			return deliveryRetried, nil
+		case recordErr == ErrLeaseLost:
+			return deliveryLeaseLost, nil
+		default:
+			return deliveryNoResult, recordErr
+		}
+	}
+	if err := markRiverDispatched(ctx, tx, claim, now, transportJobID); err != nil {
+		if err == ErrLeaseLost {
+			return deliveryLeaseLost, err
+		}
+		return deliveryNoResult, err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		// Commit failure is outcome-unknown. The exact-CAS recorder may prove
+		// that the terminal transaction did not commit by successfully rearming
+		// the claim, but Step still fails closed because it cannot prove whether
+		// a River job became durable.
+		_ = tx.Rollback(ctx)
+		recordErr := kernel.failures.Record(ctx, claim, now, ErrUnavailable)
+		if recordErr != nil {
+			return deliveryNoResult, errors.Join(ErrUnavailable, recordErr)
+		}
+		return deliveryNoResult, ErrUnavailable
+	}
+	return deliverySucceeded, nil
+}
+
+func lockRiverClaim(
+	ctx context.Context,
+	tx pgx.Tx,
+	claim TransportClaim,
+	now time.Time,
+) error {
+	command, err := tx.Exec(ctx, lockRiverClaimSQL,
+		claim.ID, claim.ClaimToken, claim.RouteGeneration, now)
+	if err != nil {
+		return ErrUnavailable
+	}
+	if command.RowsAffected() != 1 {
+		return ErrLeaseLost
+	}
+	return nil
+}
+
+func (kernel *Kernel) commitPostSyncMark(
+	ctx context.Context,
+	claim TransportClaim,
+	now time.Time,
+) error {
+	tx, err := kernel.begin(ctx)
+	if err != nil || tx == nil {
+		return ErrUnavailable
+	}
+	defer func() { _ = tx.Rollback(ctx) }()
+	if err := markRiverDispatched(ctx, tx, claim, now, ""); err != nil {
+		return err
+	}
+	if err := tx.Commit(ctx); err != nil {
+		return ErrUnavailable
+	}
+	return nil
 }
 
 func claimRiverRoutes(
@@ -330,6 +495,28 @@ FROM candidates
 WHERE outbox.id = candidates.id
 RETURNING outbox.id::text, outbox.kind, outbox.claim_token::text,
 	outbox.claim_route_generation, outbox.available_at, outbox.attempts
+`
+
+// lockRiverClaimSQL reacquires the committed claim before River InsertTx. The
+// queue role cannot lock the route relation, so it locks only the outbox row
+// and verifies the live route snapshot. The terminal update repeats this CAS;
+// the operator's outbox-table barrier serializes route mutation across the
+// remaining insert-and-mark transaction window.
+const lockRiverClaimSQL = `
+SELECT outbox.id
+FROM public.sync_dispatch_outbox AS outbox
+JOIN public.sync_dispatch_transport_routes AS route
+	ON route.kind = outbox.kind
+WHERE outbox.id = $1
+	AND outbox.claim_token = $2
+	AND outbox.status = 'pending'
+	AND outbox.claim_expires_at > $4
+	AND outbox.claim_transport = 'river'
+	AND outbox.claim_route_generation = $3
+	AND route.transport = 'river'
+	AND route.paused = FALSE
+	AND route.generation = outbox.claim_route_generation
+FOR UPDATE OF outbox
 `
 
 // markRiverDispatchedSQL rechecks the live route generation and pause state in

--- a/internal/syncreconciler/kernel_integration_test.go
+++ b/internal/syncreconciler/kernel_integration_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"net/url"
 	"strconv"
+	"strings"
 	"testing"
 	"time"
 
@@ -265,9 +266,68 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 		if jobs != 1 {
 			t.Fatalf("same-transaction River jobs = %d, want 1", jobs)
 		}
+		again, err := kernel.Step(ctx, now, 1, time.Minute, publish, nil)
+		if err != nil || again.Claimed != 0 || again.Dispatched != 0 {
+			t.Fatalf("terminal row was reclaimed: %#v, %v", again, err)
+		}
+		if err := adminPool.QueryRow(ctx, "SELECT count(*) FROM river.river_job").Scan(&jobs); err != nil {
+			t.Fatal(err)
+		}
+		if jobs != 1 {
+			t.Fatalf("repeat Step() inserted %d River jobs, want 1", jobs)
+		}
 	})
 
-	t.Run("concurrent route change rolls back River insert and outbox claim", func(t *testing.T) {
+	t.Run("crash after claim commit leaves a durable bounded lease for later retry", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		now := time.Date(2026, time.July, 23, 12, 0, 15, 0, time.UTC)
+		seedKernelOutbox(t, ctx, adminPool, integrationDispatchID, now.Add(-time.Second))
+
+		claims, err := kernel.commitClaims(ctx, now, 1, time.Minute)
+		if err != nil || len(claims) != 1 {
+			t.Fatalf("commitClaims() = %#v, %v", claims, err)
+		}
+		var token string
+		var attempts int
+		var expiresAt time.Time
+		if err := adminPool.QueryRow(ctx, `
+			SELECT claim_token, claim_expires_at, attempts
+			FROM public.sync_dispatch_outbox WHERE id = $1`, integrationDispatchID).Scan(
+			&token, &expiresAt, &attempts,
+		); err != nil {
+			t.Fatal(err)
+		}
+		if token != claims[0].ClaimToken || !expiresAt.Equal(now.Add(time.Minute)) || attempts != 1 {
+			t.Fatalf("durable claim token:%s expires:%s attempts:%d", token, expiresAt, attempts)
+		}
+		var jobs int
+		if err := adminPool.QueryRow(ctx, "SELECT count(*) FROM river.river_job").Scan(&jobs); err != nil {
+			t.Fatal(err)
+		}
+		if jobs != 0 {
+			t.Fatalf("claim-only crash window inserted %d River jobs", jobs)
+		}
+		blocked, err := kernel.Step(ctx, now, 1, time.Minute, publish, nil)
+		if err != nil || blocked.Claimed != 0 {
+			t.Fatalf("live durable lease was reclaimed: %#v, %v", blocked, err)
+		}
+		retryNow := now.Add(time.Minute + time.Nanosecond)
+		retried, err := kernel.Step(ctx, retryNow, 1, time.Minute, publish, nil)
+		if err != nil || retried.Claimed != 1 || retried.Dispatched != 1 {
+			t.Fatalf("expired durable claim retry = %#v, %v", retried, err)
+		}
+		if err := adminPool.QueryRow(ctx, `
+			SELECT attempts FROM public.sync_dispatch_outbox WHERE id = $1`,
+			integrationDispatchID,
+		).Scan(&attempts); err != nil {
+			t.Fatal(err)
+		}
+		if attempts != 2 {
+			t.Fatalf("retry attempts = %d, want 2", attempts)
+		}
+	})
+
+	t.Run("concurrent route change rolls back River insert but preserves durable claim", func(t *testing.T) {
 		resetKernelIntegrationTables(t, ctx, adminPool)
 		now := time.Date(2026, time.July, 23, 12, 0, 30, 0, time.UTC)
 		seedKernelOutbox(t, ctx, adminPool, integrationDispatchID, now.Add(-time.Second))
@@ -314,7 +374,7 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 			t.Fatalf("concurrent route update: %v", err)
 		}
 		close(release)
-		if err := <-firstDone; !errors.Is(err, ErrLeaseLost) {
+		if err := <-firstDone; err != nil {
 			t.Fatalf("Step() after route change error = %v", err)
 		}
 		var status string
@@ -328,7 +388,7 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 		).Scan(&status, &attempts, &claimToken); err != nil {
 			t.Fatal(err)
 		}
-		if status != "pending" || attempts != 0 || claimToken != nil {
+		if status != "pending" || attempts != 1 || claimToken == nil {
 			t.Fatalf(
 				"route-fenced outbox = status:%s attempts:%d claim:%v",
 				status,
@@ -393,12 +453,47 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 		}
 	})
 
-	t.Run("failure after River InsertTx rolls back claim, job, and terminal mark", func(t *testing.T) {
+	t.Run("stale committed lease is rejected before River insertion", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		now := time.Date(2026, time.July, 23, 12, 1, 30, 0, time.UTC)
+		seedKernelOutbox(t, ctx, adminPool, integrationStaleID, now.Add(-time.Second))
+		claims, err := kernel.commitClaims(ctx, now, 1, time.Minute)
+		if err != nil || len(claims) != 1 {
+			t.Fatalf("commitClaims() = %#v, %v", claims, err)
+		}
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE public.sync_dispatch_outbox SET claim_expires_at = $2
+			WHERE id = $1`, claims[0].ID, now); err != nil {
+			t.Fatal(err)
+		}
+		published := false
+		outcome, err := kernel.deliverAtLeastOnce(
+			ctx,
+			claims[0],
+			now,
+			func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+				published = true
+				return "", nil
+			},
+		)
+		if !errors.Is(err, ErrLeaseLost) || outcome != deliveryLeaseLost || published {
+			t.Fatalf("stale delivery outcome=%d published=%t error=%v", outcome, published, err)
+		}
+		var jobs int
+		if err := adminPool.QueryRow(ctx, "SELECT count(*) FROM river.river_job").Scan(&jobs); err != nil {
+			t.Fatal(err)
+		}
+		if jobs != 0 {
+			t.Fatalf("stale lease inserted %d River jobs", jobs)
+		}
+	})
+
+	t.Run("failure after River InsertTx rolls back job and records durable retry", func(t *testing.T) {
 		resetKernelIntegrationTables(t, ctx, adminPool)
 		now := time.Date(2026, time.July, 23, 12, 2, 0, 0, time.UTC)
 		seedKernelOutbox(t, ctx, adminPool, integrationDispatchID, now.Add(-time.Second))
 		publisherErr := errors.New("injected publisher failure")
-		if _, err := kernel.Step(
+		result, err := kernel.Step(
 			ctx,
 			now,
 			1,
@@ -410,26 +505,33 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 				return "", publisherErr
 			},
 			nil,
-		); !errors.Is(err, publisherErr) {
-			t.Fatalf("Step() error = %v", err)
+		)
+		if err != nil || result.Retried != 1 || result.Dispatched != 0 {
+			t.Fatalf("Step() = %#v, %v", result, err)
 		}
 		var status string
 		var attempts int
 		var claimToken *string
+		var availableAt time.Time
+		var lastError string
 		if err := adminPool.QueryRow(
 			ctx,
-			`SELECT status, attempts, claim_token
+			`SELECT status, attempts, claim_token, available_at, COALESCE(last_error, '')
 			FROM public.sync_dispatch_outbox WHERE id = $1`,
 			integrationDispatchID,
-		).Scan(&status, &attempts, &claimToken); err != nil {
+		).Scan(&status, &attempts, &claimToken, &availableAt, &lastError); err != nil {
 			t.Fatal(err)
 		}
-		if status != "pending" || attempts != 0 || claimToken != nil {
+		if status != "pending" || attempts != 1 || claimToken != nil ||
+			!availableAt.Equal(now.Add(time.Minute)) ||
+			lastError != transportPublishFailureEvidence {
 			t.Fatalf(
-				"rolled-back outbox = status:%s attempts:%d claim:%v",
+				"retried outbox = status:%s attempts:%d claim:%v available:%s error:%s",
 				status,
 				attempts,
 				claimToken,
+				availableAt,
+				lastError,
 			)
 		}
 		var jobs int
@@ -438,6 +540,132 @@ func TestKernelMutationPostgresTransactionFence(t *testing.T) {
 		}
 		if jobs != 0 {
 			t.Fatalf("rolled-back River jobs = %d, want 0", jobs)
+		}
+	})
+
+	t.Run("partial batch commits successful claims and records failed claim retry", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		now := time.Date(2026, time.July, 23, 12, 3, 0, 0, time.UTC)
+		seedKernelOutbox(t, ctx, adminPool, integrationDispatchID, now.Add(-2*time.Second))
+		seedKernelOutbox(t, ctx, adminPool, integrationStaleID, now.Add(-time.Second))
+		result, err := kernel.Step(
+			ctx,
+			now,
+			2,
+			time.Minute,
+			func(publisherCtx context.Context, tx pgx.Tx, claim TransportClaim) (string, error) {
+				jobID, insertErr := publish(publisherCtx, tx, claim)
+				if insertErr != nil {
+					return "", insertErr
+				}
+				if claim.ID == integrationStaleID {
+					return "", errors.New("injected second publish failure")
+				}
+				return jobID, nil
+			},
+			nil,
+		)
+		if err != nil || result.Claimed != 2 || result.Dispatched != 1 || result.Retried != 1 {
+			t.Fatalf("partial Step() = %#v, %v", result, err)
+		}
+		var (
+			firstStatus, secondStatus string
+			secondToken               *string
+			secondAvailable           time.Time
+			jobs                      int
+		)
+		if err := adminPool.QueryRow(ctx, `
+			SELECT status FROM public.sync_dispatch_outbox WHERE id = $1`,
+			integrationDispatchID,
+		).Scan(&firstStatus); err != nil {
+			t.Fatal(err)
+		}
+		if err := adminPool.QueryRow(ctx, `
+			SELECT status, claim_token, available_at
+			FROM public.sync_dispatch_outbox WHERE id = $1`,
+			integrationStaleID,
+		).Scan(&secondStatus, &secondToken, &secondAvailable); err != nil {
+			t.Fatal(err)
+		}
+		if err := adminPool.QueryRow(ctx, "SELECT count(*) FROM river.river_job").Scan(&jobs); err != nil {
+			t.Fatal(err)
+		}
+		if firstStatus != "dispatched" || secondStatus != "pending" || secondToken != nil ||
+			!secondAvailable.Equal(now.Add(time.Minute)) || jobs != 1 {
+			t.Fatalf(
+				"partial batch first:%s second:%s/%v/%s jobs:%d",
+				firstStatus,
+				secondStatus,
+				secondToken,
+				secondAvailable,
+				jobs,
+			)
+		}
+	})
+
+	t.Run("post_sync handoff observes committed mark and failure never rearms", func(t *testing.T) {
+		resetKernelIntegrationTables(t, ctx, adminPool)
+		now := time.Date(2026, time.July, 23, 12, 4, 0, 0, time.UTC)
+		if _, err := adminPool.Exec(ctx, `
+			UPDATE public.sync_dispatch_transport_routes
+			SET transport = 'river', generation = 7
+			WHERE kind = $1`, syncdispatchcontract.KindPostSync); err != nil {
+			t.Fatal(err)
+		}
+		seedKernelOutboxKind(
+			t,
+			ctx,
+			adminPool,
+			integrationStaleID,
+			syncdispatchcontract.KindPostSync,
+			now.Add(-time.Second),
+		)
+		postKernel, err := NewKernel(
+			domainPool,
+			queuePool,
+			riverRegistry(t, syncdispatchcontract.KindPostSync),
+			KernelModeMutation,
+		)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handoffErr := errors.New("injected post-sync handoff failure")
+		result, err := postKernel.Step(
+			ctx,
+			now,
+			1,
+			time.Minute,
+			nil,
+			func(_ context.Context, claim TransportClaim) error {
+				var status string
+				var claimToken *string
+				if err := adminPool.QueryRow(ctx, `
+					SELECT status, claim_token
+					FROM public.sync_dispatch_outbox WHERE id = $1`,
+					claim.ID,
+				).Scan(&status, &claimToken); err != nil {
+					return err
+				}
+				if status != "dispatched" || claimToken != nil {
+					return fmt.Errorf("handoff observed row %s/%v", status, claimToken)
+				}
+				return handoffErr
+			},
+		)
+		if !errors.Is(err, ErrPostSyncHandoffFailed) || errors.Is(err, handoffErr) ||
+			strings.Contains(err.Error(), handoffErr.Error()) ||
+			result.Dispatched != 1 || result.PostSyncMark != 1 || result.PostSyncHandoffFailed != 1 {
+			t.Fatalf("post_sync Step() = %#v, %v", result, err)
+		}
+		var status string
+		if err := adminPool.QueryRow(ctx, `
+			SELECT status FROM public.sync_dispatch_outbox WHERE id = $1`,
+			integrationStaleID,
+		).Scan(&status); err != nil {
+			t.Fatal(err)
+		}
+		if status != "dispatched" {
+			t.Fatalf("post_sync handoff failure rearmed status %q", status)
 		}
 	})
 }
@@ -516,15 +744,34 @@ func seedKernelOutbox(
 	id string,
 	availableAt time.Time,
 ) {
+	seedKernelOutboxKind(
+		t,
+		ctx,
+		pool,
+		id,
+		syncdispatchcontract.KindDispatchSyncRun,
+		availableAt,
+	)
+}
+
+func seedKernelOutboxKind(
+	t *testing.T,
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	id string,
+	kind string,
+	availableAt time.Time,
+) {
 	t.Helper()
 	if _, err := pool.Exec(
 		ctx,
 		`INSERT INTO public.sync_dispatch_outbox (
 			id, org_id, sync_run_id, kind, status, available_at, attempts, created_at, updated_at
 		) VALUES ($1, 'org-integration', '00000000-0000-4000-8000-000000003300',
-			'dispatch_sync_run', 'pending', $2, 0, $2, $2)`,
+			$3, 'pending', $2, 0, $2, $2)`,
 		id,
 		availableAt,
+		kind,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/syncreconciler/kernel_test.go
+++ b/internal/syncreconciler/kernel_test.go
@@ -63,34 +63,80 @@ func (*fakeKernelRows) Close()          {}
 
 type fakeKernelTx struct {
 	pgx.Tx
+	name         string
+	events       *[]string
 	claims       []TransportClaim
 	querySQL     string
 	queryArgs    []any
 	execSQL      []string
+	execArgs     [][]any
+	execRows     []int64
+	execErr      error
+	execErrs     []error
+	commitErr    error
 	commit       bool
-	rollback     bool
+	rollback     int
 	terminalRows int64
 }
 
 func (tx *fakeKernelTx) Query(_ context.Context, sql string, args ...any) (pgx.Rows, error) {
+	tx.record("query")
 	tx.querySQL = sql
 	tx.queryArgs = args
 	return &fakeKernelRows{claims: append([]TransportClaim(nil), tx.claims...)}, nil
 }
 
-func (tx *fakeKernelTx) Exec(_ context.Context, sql string, _ ...any) (pgconn.CommandTag, error) {
+func (tx *fakeKernelTx) Exec(_ context.Context, sql string, args ...any) (pgconn.CommandTag, error) {
+	tx.record("exec")
 	tx.execSQL = append(tx.execSQL, sql)
-	return pgconn.NewCommandTag("UPDATE " + strconv.FormatInt(tx.terminalRows, 10)), nil
+	tx.execArgs = append(tx.execArgs, append([]any(nil), args...))
+	rows := tx.terminalRows
+	if index := len(tx.execSQL) - 1; index < len(tx.execRows) {
+		rows = tx.execRows[index]
+	}
+	err := tx.execErr
+	if index := len(tx.execSQL) - 1; index < len(tx.execErrs) {
+		err = tx.execErrs[index]
+	}
+	return pgconn.NewCommandTag("UPDATE " + strconv.FormatInt(rows, 10)), err
 }
 
 func (tx *fakeKernelTx) Commit(context.Context) error {
-	tx.commit = true
-	return nil
+	tx.record("commit")
+	tx.commit = tx.commitErr == nil
+	return tx.commitErr
 }
 
 func (tx *fakeKernelTx) Rollback(context.Context) error {
-	tx.rollback = true
+	tx.record("rollback")
+	tx.rollback++
 	return nil
+}
+
+func (tx *fakeKernelTx) record(event string) {
+	if tx.events != nil {
+		*tx.events = append(*tx.events, tx.name+":"+event)
+	}
+}
+
+func kernelBeginSequence(t *testing.T, events *[]string, transactions ...*fakeKernelTx) beginFunc {
+	t.Helper()
+	index := 0
+	return func(context.Context) (pgx.Tx, error) {
+		if index >= len(transactions) {
+			t.Fatalf("unexpected transaction begin %d", index+1)
+		}
+		tx := transactions[index]
+		index++
+		tx.events = events
+		if tx.name == "" {
+			tx.name = "tx" + strconv.Itoa(index)
+		}
+		if events != nil {
+			*events = append(*events, tx.name+":begin")
+		}
+		return tx, nil
+	}
 }
 
 func riverRegistry(t *testing.T, riverKinds ...string) registryMap {
@@ -168,15 +214,18 @@ func TestKernelMutationWithCeleryOnlyContractNeverBeginsATransaction(t *testing.
 
 func TestKernelMutationClaimsOnlyBoundedPersistedRiverRoutesInDeterministicOrder(t *testing.T) {
 	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
-	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
+	events := []string{}
+	claimTx := &fakeKernelTx{name: "claim", claims: []TransportClaim{
 		kernelClaim(syncdispatchcontract.KindFinalizeSyncRun, now, candidateID2),
 		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now.Add(-time.Second), candidateID1),
 	}}
+	firstDelivery := &fakeKernelTx{name: "delivery-1", terminalRows: 1}
+	secondDelivery := &fakeKernelTx{name: "delivery-2", terminalRows: 1}
 	kernel, err := newKernel(
 		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.KindFinalizeSyncRun),
 		KernelModeMutation,
 		&kernelStepper{},
-		func(context.Context) (pgx.Tx, error) { return tx, nil },
+		kernelBeginSequence(t, &events, claimTx, firstDelivery, secondDelivery),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -184,8 +233,15 @@ func TestKernelMutationClaimsOnlyBoundedPersistedRiverRoutesInDeterministicOrder
 	var published []string
 	result, err := kernel.Step(context.Background(), now, 2, time.Minute,
 		func(_ context.Context, gotTx pgx.Tx, claim TransportClaim) (string, error) {
-			if gotTx != tx {
-				t.Fatal("publisher received a different transaction")
+			if !claimTx.commit {
+				t.Fatal("publisher ran before the bounded claims committed")
+			}
+			wantTx := pgx.Tx(firstDelivery)
+			if len(published) == 1 {
+				wantTx = secondDelivery
+			}
+			if gotTx != wantTx {
+				t.Fatalf("publisher transaction = %T/%p, want %p", gotTx, gotTx, wantTx)
 			}
 			published = append(published, claim.ID)
 			return "river-" + claim.ID, nil
@@ -194,10 +250,14 @@ func TestKernelMutationClaimsOnlyBoundedPersistedRiverRoutesInDeterministicOrder
 		t.Fatal(err)
 	}
 	if !reflect.DeepEqual(published, []string{candidateID1, candidateID2}) ||
-		result.Claimed != 2 || result.Dispatched != 2 || !tx.commit {
-		t.Fatalf("result = %#v published = %v tx = %#v", result, published, tx)
+		result.Claimed != 2 || result.Dispatched != 2 ||
+		!claimTx.commit || !firstDelivery.commit || !secondDelivery.commit {
+		t.Fatalf("result = %#v published = %v events = %v", result, published, events)
 	}
-	upper := strings.ToUpper(tx.querySQL)
+	if got, want := events[:4], []string{"claim:begin", "claim:query", "claim:commit", "claim:rollback"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("claim ordering = %v, want prefix %v", events, want)
+	}
+	upper := strings.ToUpper(claimTx.querySQL)
 	for _, required := range []string{
 		"ROUTE.TRANSPORT = 'RIVER'", "ROUTE.PAUSED = FALSE",
 		"OUTBOX.KIND = ANY($4::TEXT[])", "ORDER BY OUTBOX.AVAILABLE_AT, OUTBOX.ID",
@@ -205,57 +265,215 @@ func TestKernelMutationClaimsOnlyBoundedPersistedRiverRoutesInDeterministicOrder
 		"SET CLAIM_TOKEN = GEN_RANDOM_UUID()::TEXT",
 	} {
 		if !strings.Contains(upper, required) {
-			t.Fatalf("claim SQL missing %q:\n%s", required, tx.querySQL)
+			t.Fatalf("claim SQL missing %q:\n%s", required, claimTx.querySQL)
 		}
 	}
 	if strings.Contains(upper, "FOR UPDATE OF ROUTE") ||
 		strings.Contains(upper, "FOR SHARE OF ROUTE") ||
 		strings.Contains(upper, "FOR KEY SHARE OF ROUTE") {
-		t.Fatalf("claim SQL requires forbidden route mutation privilege:\n%s", tx.querySQL)
+		t.Fatalf("claim SQL requires forbidden route mutation privilege:\n%s", claimTx.querySQL)
 	}
-	if len(tx.queryArgs) != 4 || !reflect.DeepEqual(tx.queryArgs[3], []string{
+	if len(claimTx.queryArgs) != 4 || !reflect.DeepEqual(claimTx.queryArgs[3], []string{
 		syncdispatchcontract.KindDispatchSyncRun, syncdispatchcontract.KindFinalizeSyncRun,
 	}) {
-		t.Fatalf("claim arguments = %#v", tx.queryArgs)
+		t.Fatalf("claim arguments = %#v", claimTx.queryArgs)
 	}
-	if len(tx.execSQL) != 2 || !strings.Contains(strings.ToUpper(tx.execSQL[0]), "ROUTE.GENERATION = OUTBOX.CLAIM_ROUTE_GENERATION") {
-		t.Fatalf("terminal SQL = %v", tx.execSQL)
+	if len(firstDelivery.execSQL) != 2 || len(secondDelivery.execSQL) != 2 ||
+		!strings.Contains(strings.ToUpper(firstDelivery.execSQL[0]), "FOR UPDATE OF OUTBOX") ||
+		!strings.Contains(strings.ToUpper(firstDelivery.execSQL[1]), "ROUTE.GENERATION = OUTBOX.CLAIM_ROUTE_GENERATION") {
+		t.Fatalf("terminal SQL = %v / %v", firstDelivery.execSQL, secondDelivery.execSQL)
 	}
 	if strings.Contains(strings.ToUpper(markRiverDispatchedSQL), "CLAIM_TOKEN = $2::UUID") {
 		t.Fatalf("terminal SQL wrongly treats the text claim token as UUID:\n%s", markRiverDispatchedSQL)
 	}
 }
 
-func TestKernelMutationPublisherFailureRollsBackClaimAndRiverInsertForRetry(t *testing.T) {
+func TestKernelMutationPublisherFailureRecordsCommittedClaimBackoffAndContinues(t *testing.T) {
 	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
-	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
+	events := []string{}
+	claimTx := &fakeKernelTx{name: "claim", claims: []TransportClaim{
 		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now.Add(time.Second), candidateID2),
 	}}
+	failedDelivery := &fakeKernelTx{name: "delivery-1", terminalRows: 1}
+	backoffTx := &fakeKernelTx{name: "backoff", terminalRows: 1}
+	successfulDelivery := &fakeKernelTx{name: "delivery-2", terminalRows: 1}
 	kernel, err := newKernel(
 		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
-		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+		&kernelStepper{},
+		kernelBeginSequence(t, &events, claimTx, failedDelivery, backoffTx, successfulDelivery),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
 	publisherErr := errors.New("river insert failed")
-	if _, err := kernel.Step(context.Background(), now, 1, time.Minute,
-		func(context.Context, pgx.Tx, TransportClaim) (string, error) { return "", publisherErr }, nil); !errors.Is(err, publisherErr) {
+	result, err := kernel.Step(context.Background(), now, 2, time.Minute,
+		func(_ context.Context, _ pgx.Tx, claim TransportClaim) (string, error) {
+			if claim.ID == candidateID1 {
+				return "", publisherErr
+			}
+			return "river-" + claim.ID, nil
+		}, nil)
+	if err != nil {
 		t.Fatalf("Step() error = %v", err)
 	}
-	if tx.commit || !tx.rollback || len(tx.execSQL) != 0 {
-		t.Fatalf("failed publish committed or terminalized: %#v", tx)
+	if result.Claimed != 2 || result.Retried != 1 || result.Dispatched != 1 ||
+		!claimTx.commit || failedDelivery.commit || failedDelivery.rollback == 0 ||
+		!backoffTx.commit || !successfulDelivery.commit {
+		t.Fatalf("result = %#v events = %v", result, events)
+	}
+	if len(backoffTx.execArgs) != 1 ||
+		backoffTx.execArgs[0][0] != candidateID1 ||
+		backoffTx.execArgs[0][1] != kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1).ClaimToken {
+		t.Fatalf("backoff CAS args = %#v", backoffTx.execArgs)
+	}
+}
+
+func TestKernelMutationFailureRecorderOutageStopsRemainingDelivery(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	claimTx := &fakeKernelTx{claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID2),
+	}}
+	failedDelivery := &fakeKernelTx{terminalRows: 1}
+	backoffTx := &fakeKernelTx{
+		terminalRows: 1,
+		execErr:      errors.New("failure recorder database outage"),
+	}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
+		&kernelStepper{},
+		kernelBeginSequence(t, nil, claimTx, failedDelivery, backoffTx),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	published := 0
+	result, err := kernel.Step(context.Background(), now, 2, time.Minute,
+		func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+			published++
+			return "", errors.New("river insert failed")
+		}, nil)
+	if !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("Step() error = %v, want ErrUnavailable", err)
+	}
+	if published != 1 || result.Dispatched != 0 || result.Retried != 0 {
+		t.Fatalf("recorder outage continued delivery: result=%#v published=%d", result, published)
 	}
 }
 
 func TestKernelMutationGenerationRecheckRejectsTerminalWriteAndRollsBack(t *testing.T) {
 	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
-	tx := &fakeKernelTx{terminalRows: 0, claims: []TransportClaim{
+	claimTx := &fakeKernelTx{claims: []TransportClaim{
 		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
 	}}
+	deliveryTx := &fakeKernelTx{terminalRows: 0}
 	kernel, err := newKernel(
 		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
-		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+		&kernelStepper{}, kernelBeginSequence(t, nil, claimTx, deliveryTx),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	published := false
+	result, err := kernel.Step(context.Background(), now, 1, time.Minute,
+		func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+			published = true
+			return "river-job", nil
+		}, nil)
+	if err != nil || result.LeaseLost != 1 {
+		t.Fatalf("Step() = %#v, %v", result, err)
+	}
+	if published || !claimTx.commit || deliveryTx.commit || deliveryTx.rollback == 0 {
+		t.Fatalf("generation recheck result = published:%t claim:%#v delivery:%#v", published, claimTx, deliveryTx)
+	}
+}
+
+func TestKernelMutationLeaseLossContinuesAlreadyClaimedAtLeastOnceBatch(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	claimTx := &fakeKernelTx{claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now.Add(time.Second), candidateID2),
+	}}
+	staleDelivery := &fakeKernelTx{execRows: []int64{1, 0}}
+	successfulDelivery := &fakeKernelTx{terminalRows: 1}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
+		&kernelStepper{}, kernelBeginSequence(t, nil, claimTx, staleDelivery, successfulDelivery),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var published []string
+	result, err := kernel.Step(context.Background(), now, 2, time.Minute,
+		func(_ context.Context, _ pgx.Tx, claim TransportClaim) (string, error) {
+			published = append(published, claim.ID)
+			return "river-" + claim.ID, nil
+		}, nil)
+	if err != nil {
+		t.Fatalf("Step() error = %v", err)
+	}
+	if result.Claimed != 2 || result.LeaseLost != 1 || result.Dispatched != 1 ||
+		!reflect.DeepEqual(published, []string{candidateID1, candidateID2}) ||
+		staleDelivery.commit || staleDelivery.rollback == 0 || !successfulDelivery.commit {
+		t.Fatalf("stale lease did not continue batch: result=%#v published=%v stale=%#v successful=%#v", result, published, staleDelivery, successfulDelivery)
+	}
+}
+
+func TestKernelMutationUnavailableDeliveryDoesNotCountLeaseLoss(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	for _, test := range []struct {
+		name          string
+		delivery      *fakeKernelTx
+		wantPublished int
+	}{
+		{
+			name:          "lock query unavailable",
+			delivery:      &fakeKernelTx{terminalRows: 1, execErrs: []error{errors.New("lock database unavailable")}},
+			wantPublished: 0,
+		},
+		{
+			name:          "terminal update unavailable",
+			delivery:      &fakeKernelTx{terminalRows: 1, execErrs: []error{nil, errors.New("terminal database unavailable")}},
+			wantPublished: 1,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			claimTx := &fakeKernelTx{claims: []TransportClaim{
+				kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
+			}}
+			kernel, err := newKernel(
+				riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
+				&kernelStepper{}, kernelBeginSequence(t, nil, claimTx, test.delivery),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			published := 0
+			result, err := kernel.Step(context.Background(), now, 1, time.Minute,
+				func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+					published++
+					return "river-job", nil
+				}, nil)
+			if !errors.Is(err, ErrUnavailable) || result.LeaseLost != 0 ||
+				result.Dispatched != 0 || published != test.wantPublished {
+				t.Fatalf("Step() = %#v, %v; published=%d", result, err, published)
+			}
+		})
+	}
+}
+
+func TestKernelMutationClaimCommitFailurePublishesNothing(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	claimTx := &fakeKernelTx{
+		claims: []TransportClaim{
+			kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
+		},
+		commitErr: errors.New("claim commit outcome unknown"),
+	}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
+		&kernelStepper{}, kernelBeginSequence(t, nil, claimTx),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -264,23 +482,107 @@ func TestKernelMutationGenerationRecheckRejectsTerminalWriteAndRollsBack(t *test
 	if _, err := kernel.Step(context.Background(), now, 1, time.Minute,
 		func(context.Context, pgx.Tx, TransportClaim) (string, error) {
 			published = true
-			return "river-job", nil
-		}, nil); !errors.Is(err, ErrLeaseLost) {
-		t.Fatalf("Step() error = %v", err)
+			return "", nil
+		}, nil); !errors.Is(err, ErrUnavailable) {
+		t.Fatalf("Step() error = %v, want ErrUnavailable", err)
 	}
-	if !published || tx.commit || !tx.rollback {
-		t.Fatalf("generation recheck result = published:%t tx:%#v", published, tx)
+	if published {
+		t.Fatal("publisher ran after the bounded claim commit failed")
 	}
 }
 
-func TestKernelPostSyncMarksBeforeItsSeparateTransactionLocalSeam(t *testing.T) {
+func TestKernelMutationDeliveryCommitAmbiguityFailsClosedAfterCASProbe(t *testing.T) {
 	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
-	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
+	for _, test := range []struct {
+		name            string
+		backoffRows     int64
+		wantLeaseLost   bool
+		wantBackoffDone bool
+	}{
+		{
+			name:            "CAS proves terminal transaction did not commit",
+			backoffRows:     1,
+			wantBackoffDone: true,
+		},
+		{
+			name:          "CAS miss leaves terminal outcome ambiguous",
+			backoffRows:   0,
+			wantLeaseLost: true,
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			claimTx := &fakeKernelTx{claims: []TransportClaim{
+				kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
+				kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID2),
+			}}
+			deliveryTx := &fakeKernelTx{
+				terminalRows: 1,
+				commitErr:    errors.New("delivery commit outcome unknown"),
+			}
+			backoffTx := &fakeKernelTx{terminalRows: test.backoffRows}
+			kernel, err := newKernel(
+				riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
+				&kernelStepper{}, kernelBeginSequence(t, nil, claimTx, deliveryTx, backoffTx),
+			)
+			if err != nil {
+				t.Fatal(err)
+			}
+			published := 0
+			result, err := kernel.Step(context.Background(), now, 2, time.Minute,
+				func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+					published++
+					return "river-job", nil
+				}, nil)
+			if !errors.Is(err, ErrUnavailable) {
+				t.Fatalf("Step() error = %v, want ErrUnavailable", err)
+			}
+			if errors.Is(err, ErrLeaseLost) != test.wantLeaseLost {
+				t.Fatalf("Step() lease-lost classification = %v, want %t", err, test.wantLeaseLost)
+			}
+			if published != 1 || result.Dispatched != 0 || result.Retried != 0 {
+				t.Fatalf("ambiguous commit continued delivery: result=%#v published=%d", result, published)
+			}
+			if backoffTx.commit != test.wantBackoffDone {
+				t.Fatalf("backoff commit = %t, want %t", backoffTx.commit, test.wantBackoffDone)
+			}
+		})
+	}
+}
+
+func TestKernelMutationUnknownClaimDescriptorFailsClosedAfterClaimCommit(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	claim := kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1)
+	claim.Kind = "unknown_kind"
+	claimTx := &fakeKernelTx{claims: []TransportClaim{claim}}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
+		&kernelStepper{}, kernelBeginSequence(t, nil, claimTx),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result, err := kernel.Step(context.Background(), now, 1, time.Minute,
+		func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+			t.Fatal("unknown descriptor reached publisher")
+			return "", nil
+		}, nil); !errors.Is(err, ErrLeaseLost) || result.Claimed != 1 {
+		t.Fatalf("Step() = %#v, %v", result, err)
+	}
+	if !claimTx.commit {
+		t.Fatal("unknown descriptor test did not exercise a durable claim")
+	}
+}
+
+func TestKernelPostSyncCommitsMarkBeforePostCommitHandoff(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	events := []string{}
+	claimTx := &fakeKernelTx{name: "claim", claims: []TransportClaim{
 		kernelClaim(syncdispatchcontract.KindPostSync, now, candidateID1),
 	}}
+	markTx := &fakeKernelTx{name: "mark", terminalRows: 1}
 	kernel, err := newKernel(
 		riverRegistry(t, syncdispatchcontract.KindPostSync), KernelModeMutation,
-		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+		&kernelStepper{}, kernelBeginSequence(t, &events, claimTx, markTx),
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -291,40 +593,119 @@ func TestKernelPostSyncMarksBeforeItsSeparateTransactionLocalSeam(t *testing.T) 
 		func(context.Context, pgx.Tx, TransportClaim) (string, error) {
 			published = true
 			return "", nil
-		}, func(_ context.Context, gotTx pgx.Tx, claim TransportClaim) error {
-			if gotTx != tx || claim.Kind != syncdispatchcontract.KindPostSync || len(tx.execSQL) != 1 {
-				t.Fatalf("post-sync seam order or transaction invalid: tx=%#v claim=%#v", tx, claim)
+		}, func(_ context.Context, claim TransportClaim) error {
+			if claim.Kind != syncdispatchcontract.KindPostSync || !markTx.commit || len(markTx.execSQL) != 1 {
+				t.Fatalf("post-sync handoff ran before mark commit: mark=%#v claim=%#v", markTx, claim)
 			}
+			events = append(events, "handoff")
 			marked = true
 			return nil
 		})
 	if err != nil {
 		t.Fatal(err)
 	}
-	if published || !marked || !tx.commit || result.PostSyncMark != 1 || result.Dispatched != 1 {
-		t.Fatalf("post-sync result = %#v published:%t marked:%t tx:%#v", result, published, marked, tx)
+	if published || !marked || !claimTx.commit || !markTx.commit ||
+		result.PostSyncMark != 1 || result.Dispatched != 1 ||
+		events[len(events)-1] != "handoff" {
+		t.Fatalf("post-sync result = %#v published:%t marked:%t events:%v", result, published, marked, events)
 	}
 }
 
-func TestKernelPostSyncMarkerFailureRollsBackItsPriorTerminalMark(t *testing.T) {
+func TestKernelPostSyncHandoffFailureNeverRearmsCommittedMark(t *testing.T) {
 	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
-	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
+	claimTx := &fakeKernelTx{claims: []TransportClaim{
 		kernelClaim(syncdispatchcontract.KindPostSync, now, candidateID1),
 	}}
+	markTx := &fakeKernelTx{terminalRows: 1}
 	kernel, err := newKernel(
 		riverRegistry(t, syncdispatchcontract.KindPostSync), KernelModeMutation,
-		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+		&kernelStepper{}, kernelBeginSequence(t, nil, claimTx, markTx),
 	)
 	if err != nil {
 		t.Fatal(err)
 	}
-	markerErr := errors.New("mark-before seam failed")
-	if _, err := kernel.Step(context.Background(), now, 1, time.Minute, nil,
-		func(context.Context, pgx.Tx, TransportClaim) error { return markerErr }); !errors.Is(err, markerErr) {
-		t.Fatalf("Step() error = %v", err)
+	adapterErr := errors.New("adapter secret: post-commit handoff failed")
+	result, err := kernel.Step(context.Background(), now, 1, time.Minute, nil,
+		func(context.Context, TransportClaim) error { return adapterErr })
+	if !errors.Is(err, ErrPostSyncHandoffFailed) || errors.Is(err, adapterErr) ||
+		strings.Contains(err.Error(), adapterErr.Error()) || result.PostSyncHandoffFailed != 1 {
+		t.Fatalf("Step() error/result = %v / %#v", err, result)
 	}
-	if tx.commit || !tx.rollback || len(tx.execSQL) != 1 {
-		t.Fatalf("post-sync marker failure leaked terminal write: %#v", tx)
+	if !claimTx.commit || !markTx.commit || len(markTx.execSQL) != 1 {
+		t.Fatalf("post-sync handoff failure rearmed terminal mark: claim=%#v mark=%#v", claimTx, markTx)
+	}
+}
+
+func TestKernelPostSyncLeaseLossAndHandoffFailureContinueAlreadyClaimedBatch(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	claimTx := &fakeKernelTx{claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindPostSync, now, candidateID1),
+		kernelClaim(syncdispatchcontract.KindPostSync, now.Add(time.Second), candidateID2),
+		kernelClaim(syncdispatchcontract.KindPostSync, now.Add(2*time.Second), candidateID3),
+	}}
+	staleMark := &fakeKernelTx{terminalRows: 0}
+	firstMark := &fakeKernelTx{terminalRows: 1}
+	secondMark := &fakeKernelTx{terminalRows: 1}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindPostSync), KernelModeMutation,
+		&kernelStepper{}, kernelBeginSequence(t, nil, claimTx, staleMark, firstMark, secondMark),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapterErr := errors.New("adapter secret: callback failed")
+	var handedOff []string
+	result, err := kernel.Step(context.Background(), now, 3, time.Minute, nil,
+		func(_ context.Context, claim TransportClaim) error {
+			handedOff = append(handedOff, claim.ID)
+			if claim.ID == candidateID2 {
+				return adapterErr
+			}
+			return nil
+		})
+	if !errors.Is(err, ErrPostSyncHandoffFailed) || errors.Is(err, adapterErr) ||
+		strings.Contains(err.Error(), adapterErr.Error()) || result.Claimed != 3 ||
+		result.LeaseLost != 1 || result.PostSyncMark != 2 || result.Dispatched != 2 ||
+		result.PostSyncHandoffFailed != 1 ||
+		!reflect.DeepEqual(handedOff, []string{candidateID2, candidateID3}) ||
+		staleMark.commit || staleMark.rollback == 0 || !firstMark.commit || !secondMark.commit {
+		t.Fatalf("post-sync batch result=%#v error=%v handoffs=%v stale=%#v first=%#v second=%#v", result, err, handedOff, staleMark, firstMark, secondMark)
+	}
+}
+
+func TestKernelPostSyncFailureIsPreservedWithLaterFatalError(t *testing.T) {
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	claimTx := &fakeKernelTx{claims: []TransportClaim{
+		kernelClaim(syncdispatchcontract.KindPostSync, now, candidateID1),
+		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now.Add(time.Second), candidateID2),
+	}}
+	markTx := &fakeKernelTx{terminalRows: 1}
+	failedDelivery := &fakeKernelTx{
+		terminalRows: 1,
+		execErrs:     []error{errors.New("delivery database unavailable")},
+	}
+	kernel, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindPostSync, syncdispatchcontract.KindDispatchSyncRun),
+		KernelModeMutation,
+		&kernelStepper{},
+		kernelBeginSequence(t, nil, claimTx, markTx, failedDelivery),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	adapterErr := errors.New("adapter secret: callback failed")
+	result, err := kernel.Step(context.Background(), now, 2, time.Minute,
+		func(context.Context, pgx.Tx, TransportClaim) (string, error) {
+			t.Fatal("publisher ran after the delivery lock failed")
+			return "", nil
+		},
+		func(context.Context, TransportClaim) error { return adapterErr },
+	)
+	if !errors.Is(err, ErrPostSyncHandoffFailed) || !errors.Is(err, ErrUnavailable) ||
+		errors.Is(err, adapterErr) || strings.Contains(err.Error(), adapterErr.Error()) ||
+		result.PostSyncHandoffFailed != 1 || result.PostSyncMark != 1 ||
+		result.Dispatched != 1 || result.LeaseLost != 0 {
+		t.Fatalf("Step() = %#v, %v", result, err)
 	}
 }
 
@@ -336,9 +717,13 @@ func TestKernelRejectsInvalidModesAndMissingMutationSeams(t *testing.T) {
 	tx := &fakeKernelTx{terminalRows: 1, claims: []TransportClaim{
 		kernelClaim(syncdispatchcontract.KindDispatchSyncRun, now, candidateID1),
 	}}
+	began := false
 	kernel, err := newKernel(
 		riverRegistry(t, syncdispatchcontract.KindDispatchSyncRun), KernelModeMutation,
-		&kernelStepper{}, func(context.Context) (pgx.Tx, error) { return tx, nil },
+		&kernelStepper{}, func(context.Context) (pgx.Tx, error) {
+			began = true
+			return tx, nil
+		},
 	)
 	if err != nil {
 		t.Fatal(err)
@@ -346,7 +731,23 @@ func TestKernelRejectsInvalidModesAndMissingMutationSeams(t *testing.T) {
 	if _, err := kernel.Step(context.Background(), now, 1, time.Minute, nil, nil); !errors.Is(err, ErrPublisherRequired) {
 		t.Fatalf("missing publisher error = %v", err)
 	}
-	if tx.commit || !tx.rollback {
+	if began || tx.commit || tx.rollback != 0 {
 		t.Fatalf("missing publisher transaction = %#v", tx)
+	}
+	postSync, err := newKernel(
+		riverRegistry(t, syncdispatchcontract.KindPostSync), KernelModeMutation,
+		&kernelStepper{}, func(context.Context) (pgx.Tx, error) {
+			began = true
+			return tx, nil
+		},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := postSync.Step(context.Background(), now, 1, time.Minute, nil, nil); !errors.Is(err, ErrPostSyncHandoffRequired) {
+		t.Fatalf("missing post-sync handoff error = %v", err)
+	}
+	if began {
+		t.Fatal("missing post-sync handoff began a claim transaction")
 	}
 }


### PR DESCRIPTION
## Summary

- Commit bounded River claims before delivery, then atomically insert and terminally mark each at-least-once claim in a fresh transaction.
- Persist Python-parity publish backoff, continue expected stale-lease races, and keep post-sync mark-before handoffs redacted and non-rearming.
- Add exact typed sync-dispatch River args, an `InsertTx`-only publisher, retained typed handlers, and a publisher-local generation tracker that cannot implement the route quiescer contract.
- Add a bounded scheduler lifecycle with source-reviewed activation gates, readiness/metrics/backoff, and zero-write fail-closed behavior for unsupported or invalid cron.
- Align the worker TRD, runbook, migration plan, and tagged integration gate with the implemented boundary.

## Dormant safety boundary

- Every checked-in and persisted sync-dispatch route remains Celery.
- Scheduler activation gates are false, the production loop factory is nil, and the default command opens no database dependencies.
- No Compose, deployment profile, workerctl, reconciler command, route, or replica configuration changed.
- The local generation tracker is deliberately not a `syncroute.Quiescer`; cross-process post-sync cutover remains blocked.

## Validation

- `bash ci/local_validate.sh` — passed; 8,732 Python tests plus Go format, vet, test, build, River compatibility, ClickHouse migrations, and live engine proof.
- Focused Go unit and race tests for scheduler, reconciler, and syncdispatchruntime — passed.
- Tagged PostgreSQL integration tests for scheduler, reconciler, and syncdispatchruntime — passed.
- `python -m mkdocs build -q` and focused docs inventory/freshness tests — passed.
- Independent final audit — approved with no remaining defects.

## Remaining activation blockers

- Scheduler coordinator/organization/entitlement/catch-up policy composition and production lifecycle factory.
- Reconciler command wiring, authoritative domain-reference lookup, fixed queue/retry policy, and concrete River worker registrations.
- Cross-process post-sync quiescer/controller and external-handoff binding.

SCREENSHOT-WAIVER: Backend runtime, tests, and documentation only; no rendered UI changes.