### PR TITLE
fix(test): CHAOS-3071 Fix shell readiness race on main

### DIFF
--- a/internal/platform/shell/shell_test.go
+++ b/internal/platform/shell/shell_test.go
@@ -247,12 +247,17 @@ func TestShellStartsEndpointsAndTerminatesCleanly(t *testing.T) {
 		if requestErr == nil {
 			_, _ = io.Copy(io.Discard, response.Body)
 			_ = response.Body.Close()
-			if response.StatusCode != http.StatusOK {
+			if response.StatusCode == http.StatusOK {
+				break
+			}
+			if response.StatusCode != http.StatusServiceUnavailable {
 				t.Fatalf("expected ready endpoint, got %d", response.StatusCode)
 			}
-			break
 		}
 		if time.Now().After(deadline) {
+			if requestErr == nil {
+				t.Fatalf("shell did not become ready: status=%d logs=%s stderr=%s", response.StatusCode, stdout.String(), stderr.String())
+			}
 			t.Fatalf("shell did not start: %v logs=%s stderr=%s", requestErr, stdout.String(), stderr.String())
 		}
 		time.Sleep(10 * time.Millisecond)


### PR DESCRIPTION
## Summary
- tolerate the expected transient 503 from `/readyz` while shell dependencies are starting
- keep unexpected readiness statuses fatal
- preserve the existing three-second deadline and include response/log context on timeout

Fixes the failure in main run 30083505324, job 89450231450.

## Validation
- `go test -mod=readonly -race -run '^TestShellStartsEndpointsAndTerminatesCleanly$' -count=50 ./internal/platform/shell`
- `go test -mod=readonly ./internal/platform/shell`
- `bash ci/local_validate.sh` (Go, lint, and mypy gates passed; documentation/gRPC portions were blocked locally by missing MkDocs and sandbox loopback bind restrictions)

SCREENSHOT-WAIVER: backend test-only change; no rendered UI.

close CHAOS-3071