### PR TITLE
CHAOS-3033: route every job kind to River (wholesale Celery cutover)

### DIFF
--- a/.github/docs-legacy/plans/go-worker-migration-implementation-plan.md
+++ b/.github/docs-legacy/plans/go-worker-migration-implementation-plan.md
@@ -125,6 +125,40 @@ inventory -> contract_frozen -> go_implemented -> shadow
 
 Promotion state is tracked in the registry or a generated migration manifest. CI rejects a state that lacks its required evidence.
 
+#### 3.3.1 Approved deviation — shadow and canary waived (CHAOS-3033, 2026-07-25)
+
+23 of the 24 checked-in kinds moved directly from `go_implemented` to
+`go_default`, skipping `shadow` and `canary`. This was an explicit decision by
+the program owner, recorded here rather than left implicit in a diff.
+
+Rationale: the platform has no production users, and the Celery baseline is
+already captured, so the staged ladder protects nobody. Its purpose is to
+migrate a system with live traffic that cannot be disrupted; that risk does not
+exist here. Parity against the existing Python implementation remains the
+acceptance bar for each family, and rollback remains available — every kind
+keeps `rollback_route: celery`, and `workerctl job-routes rollback` still proves
+quiescence before moving a route.
+
+Consequences accepted with the waiver:
+
+- No shadow or canary evidence exists for those 23 kinds. The per-family
+  evidence list in §3.2 is therefore only partly satisfied; parity evidence,
+  tests, and rollback remain required, while shadow/canary evidence does not.
+- The two-stable-release gate in Phase 7 is likewise waived.
+
+Two limits on the waiver, both deliberate:
+
+- `sync.provider_unit` is **not** covered by it and stays at `canary`. Its Go
+  route surface serves one of the 59 provider/dataset pairs in
+  `contracts/provider-matrix/v1/matrix.json`, so the canary route is what
+  confines River to that pair while the rest still dispatch through Celery.
+  Promoting it would stop the other 58 from syncing. Tracked by CHAOS-3122.
+- The CI control described above — rejecting a promotion state that lacks its
+  required evidence — **does not exist**. The wholesale promotion passed
+  `worker-contractcheck` without objection. The waiver excuses missing
+  shadow/canary evidence; it does not excuse a missing gate, which should be
+  built before any future promotion relies on it.
+
 ## 4. Phase 0 — architecture and compatibility lock
 
 ### CHAOS-3034 — Validate River, PgBouncer, Python enqueue, and licensing

--- a/cmd/dev-health-worker/dependencies_test.go
+++ b/cmd/dev-health-worker/dependencies_test.go
@@ -136,13 +136,26 @@ func TestLaunchDarklyReadinessRequiresConcreteProviderHandlerRegistration(
 	if err != nil {
 		t.Fatal(err)
 	}
+	// sync.team_autoimport ships at go_default in the checked-in contract
+	// too, so the sync profile is only complete once something reports it.
+	// A fake sync-coordinator builder supplies that coverage so this test
+	// stays isolated to what it actually exercises: the LaunchDarkly
+	// provider-route-switch gate on the provider_sync builder.
+	autoimportSpec, ok := runtimeRegistry.Descriptor(jobcontract.KindTeamAutoimport)
+	if !ok {
+		t.Fatal("sync.team_autoimport descriptor missing")
+	}
 	database := &fakeWorkerDatabase{}
 	sources := productionWorkerDependencySources
 	sources.openDatabase = func(context.Context, config.Config) (workerDatabase, error) {
 		return database, nil
 	}
 	sources.buildOperational = nil
-	sources.buildSyncCoordinator = nil
+	sources.buildSyncCoordinator = fakeHandlerBuilder(
+		"sync-coordinator",
+		[]jobruntime.HandlerSpec{autoimportSpec},
+		jobruntime.QueueBudget{Queue: syncCoordinatorQueue, MaxWorkers: syncCoordinatorQueueWorkers},
+	)
 	sources.buildProviderSync = func(
 		_ context.Context,
 		_ config.Config,
@@ -185,6 +198,13 @@ func TestLaunchDarklyReadinessRequiresConcreteProviderHandlerRegistration(
 	}
 
 	sources.buildProviderSync = nil
+	// Drop the sync-coordinator fake too: this half isolates the
+	// LaunchDarkly provider-route-switch gate itself, and partial handler
+	// coverage (team_autoimport alone) would instead fail closed at
+	// construction time -- the invariant TestNestedRiverClientCapabilityIsValidated
+	// already proves -- before the readiness gate this assertion inspects
+	// ever opens.
+	sources.buildSyncCoordinator = nil
 	missingRegistry := health.NewRegistry(100 * time.Millisecond)
 	_, err = configureWorkerDependenciesWithSources(
 		context.Background(),
@@ -266,7 +286,14 @@ func TestOpsProfileMetricsUseRegistryBoundedJobDimensions(t *testing.T) {
 			ExecutionSaturation: 0.5,
 		},
 	}}
+	// The ops kinds now ship at go_default, so the production operational
+	// builder would demand a real postgres pool this test's fake database
+	// cannot satisfy. This test only exercises the metrics path (registry-
+	// bounded dimensions over queue telemetry), so the ops profile is
+	// demoted back to Celery here to keep it dormant and out of the way.
+	_, contractRoot := demotedContractRoot(t, celeryRoutedOpsKinds...)
 	sources := productionWorkerDependencySources
+	sources.contractRoot = contractRoot
 	sources.openDatabase = func(context.Context, config.Config) (workerDatabase, error) {
 		return database, nil
 	}
@@ -298,10 +325,22 @@ func TestOpsProfileMetricsUseRegistryBoundedJobDimensions(t *testing.T) {
 	}
 }
 
+// celeryRoutedOpsKinds is every ops-profile kind. The checked-in contract now
+// ships all four at go_default, so a genuinely dormant ops profile has to be
+// built explicitly by demoting them back to Celery in a scoped fixture.
+var celeryRoutedOpsKinds = []string{
+	jobcontract.KindBillingNotification,
+	jobcontract.KindWebhookDelivery,
+	jobcontract.KindHeartbeat,
+	jobcontract.KindRetentionCleanup,
+}
+
 func TestCeleryRoutedHandlersCannotPassProfileCompleteness(t *testing.T) {
 	t.Chdir(filepath.Join("..", ".."))
 	database := &fakeWorkerDatabase{domainSaturation: 0.25, queueSaturation: 0.5}
+	_, contractRoot := demotedContractRoot(t, celeryRoutedOpsKinds...)
 	sources := productionWorkerDependencySources
+	sources.contractRoot = contractRoot
 	sources.openDatabase = func(context.Context, config.Config) (workerDatabase, error) {
 		return database, nil
 	}
@@ -389,10 +428,23 @@ func TestHeavyProfileComposesMultipleBuilderFamilies(t *testing.T) {
 		jobcontract.KindReportExecuteOnDemand:  true,
 		jobcontract.KindReportExecuteScheduled: true,
 	}
+	// dailyKinds also covers the remaining-metrics families: their route is
+	// cross-validated against families.json's unconditional "river" value,
+	// so they stay executable regardless of this fixture and the fake
+	// "daily" builder below must report them or profile completeness sees
+	// uncovered registry kinds.
 	dailyKinds := map[string]bool{
-		jobcontract.KindDailyMetricsDispatch:  true,
-		jobcontract.KindDailyMetricsPartition: true,
-		jobcontract.KindDailyMetricsFinalize:  true,
+		jobcontract.KindDailyMetricsDispatch:     true,
+		jobcontract.KindDailyMetricsPartition:    true,
+		jobcontract.KindDailyMetricsFinalize:     true,
+		jobcontract.KindRemainingCapacity:        true,
+		jobcontract.KindRemainingComplexity:      true,
+		jobcontract.KindRemainingDORA:            true,
+		jobcontract.KindRemainingExtraMetrics:    true,
+		jobcontract.KindRemainingMembership:      true,
+		jobcontract.KindRemainingRecommendations: true,
+		jobcontract.KindRemainingReleaseImpact:   true,
+		jobcontract.KindRemainingTeamMetrics:     true,
 	}
 	// The real report builder is replaced by a fake here so the composition
 	// rules are tested without a ClickHouse dependency; the production builder
@@ -556,7 +608,12 @@ func TestUnsupportedAvailableContractVersionFailsClosed(t *testing.T) {
 		},
 		checkErr: riverstore.ErrUnsupportedAvailableContractVersion,
 	}}
+	// Demote the ops kinds so the production operational builder (which now
+	// requires a real postgres pool once they are executable) stays a
+	// no-op; this test only exercises the queued-contract-versions gate.
+	_, contractRoot := demotedContractRoot(t, celeryRoutedOpsKinds...)
 	sources := productionWorkerDependencySources
+	sources.contractRoot = contractRoot
 	sources.openDatabase = func(context.Context, config.Config) (workerDatabase, error) { return database, nil }
 	sources.newRiverClientID = func() string { return "test-client" }
 
@@ -584,7 +641,12 @@ func TestQueueTelemetryFailureMakesMetricsUnavailable(t *testing.T) {
 	database := &fakeWorkerDatabase{telemetry: &fakeQueueTelemetry{
 		snapshotErr: errors.New("postgresql://queue:secret@db/app"),
 	}}
+	// Demote the ops kinds so the production operational builder (which now
+	// requires a real postgres pool once they are executable) stays a
+	// no-op; this test only exercises the queue-telemetry metrics path.
+	_, contractRoot := demotedContractRoot(t, celeryRoutedOpsKinds...)
 	sources := productionWorkerDependencySources
+	sources.contractRoot = contractRoot
 	sources.openDatabase = func(context.Context, config.Config) (workerDatabase, error) { return database, nil }
 	sources.newRiverClientID = func() string { return "test-client" }
 
@@ -734,12 +796,39 @@ func executableHeavyRegistry(
 	if err := json.Unmarshal(data, &document); err != nil {
 		t.Fatal(err)
 	}
+	// The checked-in contract now ships every heavy-profile kind at
+	// go_default, but this fixture only exercises the daily-metrics and
+	// (optionally) report builders. work-graph and investment have no
+	// builder in this binary at all, so they are demoted back to Celery here
+	// -- otherwise the heavy profile would demand handlers nothing ever
+	// constructs. The remaining-metrics families are left alone: their route
+	// is cross-validated against families.json's own (unconditional) "river"
+	// value, so demoting them independently would make the fixture
+	// internally inconsistent rather than scoped.
+	demoted := map[string]bool{
+		jobcontract.KindWorkGraphBuild:        true,
+		jobcontract.KindInvestmentMaterialize: true,
+		jobcontract.KindInvestmentDispatch:    true,
+		jobcontract.KindInvestmentChunk:       true,
+		jobcontract.KindInvestmentFinalize:    true,
+	}
 	for _, job := range document.Jobs {
 		kind, _ := job["kind"].(string)
-		if strings.HasPrefix(kind, "metrics.daily_") ||
-			(promoteReports && strings.HasPrefix(kind, "report.execute_")) {
+		switch {
+		case strings.HasPrefix(kind, "metrics.daily_"):
 			job["state"] = "go_default"
 			job["route"] = "river"
+		case strings.HasPrefix(kind, "report.execute_"):
+			if promoteReports {
+				job["state"] = "go_default"
+				job["route"] = "river"
+			} else {
+				job["state"] = "go_implemented"
+				job["route"] = "celery"
+			}
+		case demoted[kind]:
+			job["state"] = "go_implemented"
+			job["route"] = "celery"
 		}
 	}
 	encoded, err := json.Marshal(document)
@@ -965,10 +1054,24 @@ func TestFakeBuilderCannotSatisfyProfileCoverage(t *testing.T) {
 func TestConstructedQueueBudgetMustMatchDeploymentManifest(t *testing.T) {
 	t.Chdir(filepath.Join("..", ".."))
 	runtimeRegistry, contractRoot := executableHeavyRegistry(t, false)
+	// The remaining-metrics families stay executable regardless of this
+	// fixture (their route is cross-validated against families.json's
+	// unconditional "river" value), so the fake "daily" builder below must
+	// report them too or profile completeness sees uncovered registry kinds
+	// before the queue-budget assertions this test actually exercises ever
+	// run.
 	daily := selectSpecs(runtimeRegistry.Profile("heavy"), map[string]bool{
-		jobcontract.KindDailyMetricsDispatch:  true,
-		jobcontract.KindDailyMetricsPartition: true,
-		jobcontract.KindDailyMetricsFinalize:  true,
+		jobcontract.KindDailyMetricsDispatch:     true,
+		jobcontract.KindDailyMetricsPartition:    true,
+		jobcontract.KindDailyMetricsFinalize:     true,
+		jobcontract.KindRemainingCapacity:        true,
+		jobcontract.KindRemainingComplexity:      true,
+		jobcontract.KindRemainingDORA:            true,
+		jobcontract.KindRemainingExtraMetrics:    true,
+		jobcontract.KindRemainingMembership:      true,
+		jobcontract.KindRemainingRecommendations: true,
+		jobcontract.KindRemainingReleaseImpact:   true,
+		jobcontract.KindRemainingTeamMetrics:     true,
 	})
 	for _, test := range []struct {
 		name    string

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -83,8 +83,11 @@ func buildProviderSyncWorker(
 		return workerFamily{}, errWorkerDependencyUnavailable
 	}
 	spec, ok := registry.Descriptor(jobcontract.KindSyncProviderUnit)
-	if !ok || !spec.Executable() || spec.Route != "river_canary" ||
-		spec.RollbackRoute != "celery" {
+	// Executable() already restricts this to shadow, river_canary, and river.
+	// Pinning the literal canary route here would make the handler refuse to
+	// register the moment the kind was promoted past canary, which is the one
+	// transition the pin was meant to protect.
+	if !ok || !spec.Executable() || spec.RollbackRoute != "celery" {
 		return workerFamily{}, errWorkerDependencyUnavailable
 	}
 	postgresDatabase, ok := database.(*postgresWorkerDatabase)

--- a/cmd/dev-health-worker/reports_test.go
+++ b/cmd/dev-health-worker/reports_test.go
@@ -61,6 +61,50 @@ func promotedContractRoot(t *testing.T, kinds ...string) (*jobruntime.Registry, 
 	return registry, root
 }
 
+// demotedContractRoot copies the checked-in contract tree and routes exactly
+// the named kinds back to Celery. It is the inverse of promotedContractRoot:
+// the checked-in tree now ships every kind at go_default (CHAOS-3033), so a
+// genuinely celery-routed/dormant scenario has to be constructed explicitly
+// rather than found by loading the production tree unmodified.
+func demotedContractRoot(t *testing.T, kinds ...string) (*jobruntime.Registry, string) {
+	t.Helper()
+	root := filepath.Join(t.TempDir(), "v1")
+	if err := os.CopyFS(root, os.DirFS(defaultContractRoot)); err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(root, "migration-state.json")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var document struct {
+		SchemaVersion int              `json:"schema_version"`
+		Jobs          []map[string]any `json:"jobs"`
+	}
+	if err := json.Unmarshal(data, &document); err != nil {
+		t.Fatal(err)
+	}
+	for _, job := range document.Jobs {
+		kind, _ := job["kind"].(string)
+		if slices.Contains(kinds, kind) {
+			job["state"] = "go_implemented"
+			job["route"] = "celery"
+		}
+	}
+	encoded, err := json.Marshal(document)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, encoded, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	registry, err := jobruntime.Load(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return registry, root
+}
+
 func reportBuilderDatabase(t *testing.T) *postgresWorkerDatabase {
 	t.Helper()
 	ctx := context.Background()
@@ -81,10 +125,15 @@ func reportBuilderDatabase(t *testing.T) *postgresWorkerDatabase {
 
 func TestReportBuilderStaysDormantWhileRoutesAreCelery(t *testing.T) {
 	t.Chdir(filepath.Join("..", ".."))
-	registry, err := jobruntime.Load(defaultContractRoot)
-	if err != nil {
-		t.Fatal(err)
-	}
+	// report.execute_on_demand and report.execute_scheduled now ship at
+	// go_default in the checked-in contract, so dormancy is no longer the
+	// production default for this pair; it has to be constructed explicitly
+	// to prove the builder still refuses to touch ClickHouse while the route
+	// is not River.
+	registry, _ := demotedContractRoot(t,
+		jobcontract.KindReportExecuteOnDemand,
+		jobcontract.KindReportExecuteScheduled,
+	)
 	family, err := buildReportWorker(
 		context.Background(),
 		config.Config{Profile: "heavy", RiverDatabaseSchema: "river"},

--- a/cmd/dev-health-worker/sync_dispatch_test.go
+++ b/cmd/dev-health-worker/sync_dispatch_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/full-chaos/dev-health-ops/internal/deploymentcontract"
 	"github.com/full-chaos/dev-health-ops/internal/jobcontract"
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
 	"github.com/full-chaos/dev-health-ops/internal/jobs/workgraph"
 	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/secrets"
@@ -99,7 +100,16 @@ func TestSyncCoordinatorReportsItsRegisteredKind(t *testing.T) {
 		},
 	} {
 		t.Run(test.name, func(t *testing.T) {
-			registry, _ := promotedContractRoot(t, test.promote...)
+			// sync.team_autoimport now ships at go_default in the checked-in
+			// contract, so the "not consumed at all" case has to demote it
+			// back to Celery explicitly; promotedContractRoot alone would be
+			// a no-op against an already-promoted production tree.
+			var registry *jobruntime.Registry
+			if len(test.promote) == 0 {
+				registry, _ = demotedContractRoot(t, jobcontract.KindTeamAutoimport)
+			} else {
+				registry, _ = promotedContractRoot(t, test.promote...)
+			}
 			family, err := buildSyncCoordinatorWorker(
 				config.Config{
 					Profile:                        "sync",

--- a/contracts/jobs/v1/migration-state.json
+++ b/contracts/jobs/v1/migration-state.json
@@ -1,168 +1,168 @@
 {
   "schema_version": 1,
   "jobs": [
-    {"kind":"investment.chunk","state":"go_implemented","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"celery","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]},
-    {"kind":"investment.dispatch","state":"go_implemented","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"celery","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]},
-    {"kind":"investment.finalize","state":"go_implemented","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"celery","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]},
-    {"kind":"investment.materialize","state":"go_implemented","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"celery","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]},
+    {"kind":"investment.chunk","state":"go_default","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"river","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]},
+    {"kind":"investment.dispatch","state":"go_default","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"river","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]},
+    {"kind":"investment.finalize","state":"go_default","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"river","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]},
+    {"kind":"investment.materialize","state":"go_default","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"river","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]},
     {
       "kind": "metrics.daily_dispatch",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["heavy"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "handler_wiring"]
     },
     {
       "kind": "metrics.daily_finalize",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["heavy"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "finalizer_outbox_kill_window", "handler_wiring"]
     },
     {
       "kind": "metrics.daily_partition",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["heavy"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "finalizer_outbox_kill_window", "handler_wiring"]
     },
     {
-      "kind": "metrics.remaining.capacity", "state": "go_implemented",
+      "kind": "metrics.remaining.capacity", "state": "go_default",
       "producer_version": 1, "consumer_versions": [1], "required_profiles": ["heavy"],
-      "route": "celery", "rollback_route": "celery",
+      "route": "river", "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "handler_wiring", "resource_budget_contract"]
     },
     {
-      "kind": "metrics.remaining.complexity", "state": "go_implemented",
+      "kind": "metrics.remaining.complexity", "state": "go_default",
       "producer_version": 1, "consumer_versions": [1], "required_profiles": ["heavy"],
-      "route": "celery", "rollback_route": "celery",
+      "route": "river", "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "handler_wiring", "resource_budget_contract"]
     },
     {
-      "kind": "metrics.remaining.dora", "state": "go_implemented",
+      "kind": "metrics.remaining.dora", "state": "go_default",
       "producer_version": 1, "consumer_versions": [1], "required_profiles": ["heavy"],
-      "route": "celery", "rollback_route": "celery",
+      "route": "river", "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "handler_wiring", "resource_budget_contract"]
     },
     {
-      "kind": "metrics.remaining.extra_metrics", "state": "go_implemented",
+      "kind": "metrics.remaining.extra_metrics", "state": "go_default",
       "producer_version": 1, "consumer_versions": [1], "required_profiles": ["heavy"],
-      "route": "celery", "rollback_route": "celery",
+      "route": "river", "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "handler_wiring", "resource_budget_contract"]
     },
     {
-      "kind": "metrics.remaining.membership_backfill", "state": "go_implemented",
+      "kind": "metrics.remaining.membership_backfill", "state": "go_default",
       "producer_version": 1, "consumer_versions": [1], "required_profiles": ["heavy"],
-      "route": "celery", "rollback_route": "celery",
+      "route": "river", "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "handler_wiring", "resource_budget_contract"]
     },
     {
-      "kind": "metrics.remaining.recommendations", "state": "go_implemented",
+      "kind": "metrics.remaining.recommendations", "state": "go_default",
       "producer_version": 1, "consumer_versions": [1], "required_profiles": ["heavy"],
-      "route": "celery", "rollback_route": "celery",
+      "route": "river", "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "handler_wiring", "resource_budget_contract"]
     },
     {
-      "kind": "metrics.remaining.release_impact", "state": "go_implemented",
+      "kind": "metrics.remaining.release_impact", "state": "go_default",
       "producer_version": 1, "consumer_versions": [1], "required_profiles": ["heavy"],
-      "route": "celery", "rollback_route": "celery",
+      "route": "river", "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "handler_wiring", "resource_budget_contract"]
     },
     {
-      "kind": "metrics.remaining.team_metrics", "state": "go_implemented",
+      "kind": "metrics.remaining.team_metrics", "state": "go_default",
       "producer_version": 1, "consumer_versions": [1], "required_profiles": ["heavy"],
-      "route": "celery", "rollback_route": "celery",
+      "route": "river", "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "family_inventory", "handler_wiring", "resource_budget_contract"]
     },
     {
       "kind": "operational.billing_notification",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["ops"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "duplicate_delivery"]
     },
     {
       "kind": "operational.webhook_delivery",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["ops"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "duplicate_delivery"]
     },
     {
       "kind": "report.execute_on_demand",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["heavy"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["artifact_golden", "contract_schema", "cross_language_golden", "metadata_parity"]
     },
     {
       "kind": "report.execute_scheduled",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["heavy"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["artifact_golden", "contract_schema", "cross_language_golden", "metadata_parity"]
     },
     {
       "kind": "sync.provider_unit",
-      "state": "canary",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["sync"],
-      "route": "river_canary",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "duplicate_delivery", "kill_window", "provider_parity"]
     },
     {
       "kind": "sync.team_autoimport",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["sync"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "duplicate_delivery", "handler_wiring"]
     },
     {
       "kind": "system.heartbeat",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["ops"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "duplicate_delivery"]
     },
     {
       "kind": "system.retention_cleanup",
-      "state": "go_implemented",
+      "state": "go_default",
       "producer_version": 2,
       "consumer_versions": [1, 2],
       "required_profiles": ["ops"],
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "duplicate_delivery"]
     },
-    {"kind":"workgraph.build","state":"go_implemented","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"celery","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]}
+    {"kind":"workgraph.build","state":"go_default","producer_version":1,"consumer_versions":[1],"required_profiles":["heavy"],"route":"river","rollback_route":"celery","evidence":["contract_schema","cross_language_golden","family_inventory","fenced_request_ledger","handler_wiring","replay_recovery"]}
   ]
 }

--- a/contracts/jobs/v1/migration-state.json
+++ b/contracts/jobs/v1/migration-state.json
@@ -125,11 +125,11 @@
     },
     {
       "kind": "sync.provider_unit",
-      "state": "go_default",
+      "state": "canary",
       "producer_version": 1,
       "consumer_versions": [1],
       "required_profiles": ["sync"],
-      "route": "river",
+      "route": "river_canary",
       "rollback_route": "celery",
       "evidence": ["contract_schema", "cross_language_golden", "duplicate_delivery", "kill_window", "provider_parity"]
     },

--- a/internal/joboperator/service_test.go
+++ b/internal/joboperator/service_test.go
@@ -49,15 +49,28 @@ func TestCancelRunningFailsClosedWithoutPromptCancellationSupport(t *testing.T) 
 	}
 }
 
-func TestRetryFailsClosedWhileMigrationRouteIsCelery(t *testing.T) {
+// TestRetryFailsClosedWhenRouteIsRolledBackToCelery guards the same
+// fail-closed rule the name previously described for a different reason.
+// Every checked-in kind now defaults to go_default/river, so the raw checked-in
+// registry can no longer stand in for a Celery-routed kind. The guard is still
+// load-bearing: an operator can durably roll a kind's active route back to
+// celery (RollbackJobRoute) while the checked-in default stays river, and a
+// manual retry must still refuse to hand that job back to River in that state.
+// rolledBackRegistry simulates the registry a route-aware composition root
+// would report for a kind whose live route was rolled back.
+func TestRetryFailsClosedWhenRouteIsRolledBackToCelery(t *testing.T) {
 	t.Parallel()
-	fixture := newServiceFixture(t)
+	base, err := jobruntime.Load("../../contracts/jobs/v1")
+	if err != nil {
+		t.Fatalf("Load runtime registry: %v", err)
+	}
+	fixture := newServiceFixtureWithRegistry(t, rolledBackRegistry{RuntimeRegistry: base})
 	fixture.backend.job = jobSummary(StateDiscarded, jobcontract.KindRetentionCleanup, "retention", 3)
 
-	_, err := fixture.service.Retry(context.Background(), testPrincipal(), 42, "operator_request", "corr-op-1")
+	_, err = fixture.service.Retry(context.Background(), testPrincipal(), 42, "operator_request", "corr-op-1")
 	assertCode(t, err, CodeConflict)
 	if fixture.backend.retryCalls != 0 || fixture.auditor.beginCalls != 0 {
-		t.Fatal("Celery-routed job reached retry mutation")
+		t.Fatal("rolled-back-to-Celery job reached retry mutation")
 	}
 }
 
@@ -487,6 +500,21 @@ func (registry executableRegistry) Descriptor(kind string) (jobruntime.Descripto
 	if ok && kind == jobcontract.KindRetentionCleanup {
 		descriptor.MigrationState = "canary"
 		descriptor.Route = "river_canary"
+	}
+	return descriptor, ok
+}
+
+// rolledBackRegistry represents a kind whose durable, live route has been
+// rolled back to Celery (RollbackJobRoute) even though the checked-in
+// contract still defaults it to go_default/river. rollback_route stays
+// "celery" for every checked-in kind precisely so this state remains
+// representable and reachable at any time, not only during the migration.
+type rolledBackRegistry struct{ RuntimeRegistry }
+
+func (registry rolledBackRegistry) Descriptor(kind string) (jobruntime.Descriptor, bool) {
+	descriptor, ok := registry.RuntimeRegistry.Descriptor(kind)
+	if ok && kind == jobcontract.KindRetentionCleanup {
+		descriptor.Route = "celery"
 	}
 	return descriptor, ok
 }

--- a/internal/jobruntime/registry_test.go
+++ b/internal/jobruntime/registry_test.go
@@ -9,9 +9,11 @@ import (
 )
 
 // riverRoutedRegistry promotes every checked-in kind to a River route so
-// startup validation can be exercised against the real contract. Production
-// routes stay Celery until an operator promotes them; without this fixture the
-// executable set would be empty and every case would pass vacuously.
+// startup validation can be exercised against the real contract. Every kind is
+// already checked in at go_default/river, so this fixture is a no-op over the
+// real registry today, but it still guards profile-coverage assertions against
+// a future rollback that moves some kinds back to Celery, which would make the
+// executable set partial and some of these cases pass vacuously.
 func riverRoutedRegistry(t *testing.T) *Registry {
 	t.Helper()
 	contracts, err := jobcontract.LoadRegistry("../../contracts/jobs/v1")
@@ -146,7 +148,7 @@ func TestRegistryInvestmentDispatchStartupBudgetMatchesMaterialization(t *testin
 	if dispatch.Timeout != 2*time.Hour {
 		t.Fatalf("investment.dispatch timeout = %s, want 2h", dispatch.Timeout)
 	}
-	if dispatch.CurrentVersion != 1 || dispatch.Route != "celery" {
+	if dispatch.CurrentVersion != 1 || dispatch.Route != "river" {
 		t.Fatalf(
 			"investment.dispatch rollout contract drifted: version=%d route=%q",
 			dispatch.CurrentVersion,
@@ -253,13 +255,23 @@ func TestRegistryDescriptorsAreCompleteSortedDefensiveCopies(t *testing.T) {
 		descriptors[23].Kind != jobcontract.KindWorkGraphBuild {
 		t.Fatalf("Descriptors() = %#v", descriptors)
 	}
+	// Every checked-in kind is executable, and no kind is Celery-routed any
+	// more. sync.provider_unit is the single deliberate exception to
+	// go_default/river: Go's provider route surface covers one of the 59
+	// provider/dataset pairs in contracts/provider-matrix/v1/matrix.json, so it
+	// stays on river_canary where ProviderUnitRouteSwitches can confine River to
+	// that one ready pair. Asserting its route by name rather than skipping it
+	// keeps an accidental promotion visible here.
 	for _, descriptor := range descriptors {
+		wantRoute := "river"
 		if descriptor.Kind == jobcontract.KindSyncProviderUnit {
-			if descriptor.Route != "river_canary" || !descriptor.Executable() {
-				t.Fatalf("provider-unit canary policy is not executable: %#v", descriptor)
-			}
-		} else if descriptor.Route != "celery" || descriptor.Executable() {
-			t.Fatalf("checked-in compatibility policy became executable: %#v", descriptor)
+			wantRoute = "river_canary"
+		}
+		if descriptor.Route != wantRoute || !descriptor.Executable() {
+			t.Fatalf(
+				"checked-in policy drifted: kind=%s route=%q want=%q executable=%v",
+				descriptor.Kind, descriptor.Route, wantRoute, descriptor.Executable(),
+			)
 		}
 	}
 

--- a/internal/jobs/metrics/daily/daily_test.go
+++ b/internal/jobs/metrics/daily/daily_test.go
@@ -145,14 +145,21 @@ func TestFinalizerLeaseLossCancelsCompatibilityAndCannotComplete(t *testing.T) {
 	}
 }
 
-func TestDailyContractsPreserveHeavyMetricsTopologyWhileDormant(t *testing.T) {
+// TestDailyContractsPreserveHeavyMetricsTopologyAsRiverDefault guards the
+// heavy/metrics placement of the daily family regardless of migration route:
+// every kind must stay on the "heavy" profile and "metrics" queue so budget
+// and startup wiring never silently splits it across profiles. All three
+// kinds are checked in at go_default/river now, so the route/executable
+// assertions confirm the flip actually reached this family rather than
+// asserting continued dormancy.
+func TestDailyContractsPreserveHeavyMetricsTopologyAsRiverDefault(t *testing.T) {
 	registry, err := jobruntime.Load("../../../../contracts/jobs/v1")
 	if err != nil {
 		t.Fatal(err)
 	}
 	for _, kind := range []string{jobcontract.KindDailyMetricsDispatch, jobcontract.KindDailyMetricsPartition, jobcontract.KindDailyMetricsFinalize} {
 		descriptor, ok := registry.Descriptor(kind)
-		if !ok || descriptor.Profile != "heavy" || descriptor.Queue != "metrics" || descriptor.Route != "celery" || descriptor.Executable() {
+		if !ok || descriptor.Profile != "heavy" || descriptor.Queue != "metrics" || descriptor.Route != "river" || !descriptor.Executable() {
 			t.Fatalf("daily topology for %s = %#v", kind, descriptor)
 		}
 	}

--- a/internal/jobs/metrics/remaining/families.json
+++ b/internal/jobs/metrics/remaining/families.json
@@ -12,7 +12,7 @@
       "clickhouse_write_budget": 2,
       "replay": "generation_replace",
       "route_key": "metrics.remaining.complexity",
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "historical_limitation": "Only persisted git_files and git_blame contents can be scanned; missing historical contents are skipped and max_files remains a hard bound.",
       "parity_state": "numerical_oracle"
@@ -27,7 +27,7 @@
       "clickhouse_write_budget": 1,
       "replay": "append_latest_generation",
       "route_key": "metrics.remaining.dora",
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "historical_limitation": "Only already-synced canonical deployments and incidents are eligible; no provider API reconstruction is performed.",
       "parity_state": "numerical_oracle"
@@ -42,7 +42,7 @@
       "clickhouse_write_budget": 1,
       "replay": "append_latest_generation",
       "route_key": "metrics.remaining.release_impact",
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "historical_limitation": "The existing seven-day late-data recomputation window and retained telemetry buckets define the recoverable history.",
       "parity_state": "partial_numerical_oracle"
@@ -57,7 +57,7 @@
       "clickhouse_write_budget": 1,
       "replay": "generation_replace",
       "route_key": "metrics.remaining.capacity",
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "historical_limitation": "The configured throughput history window remains authoritative; deterministic replay additionally requires a persisted generation seed.",
       "parity_state": "partial_numerical_oracle"
@@ -72,7 +72,7 @@
       "clickhouse_write_budget": 1,
       "replay": "append_latest_generation",
       "route_key": "metrics.remaining.recommendations",
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "historical_limitation": "Evaluation only reads finalized persisted daily metric partitions and preserves explicit non-fired tombstones.",
       "parity_state": "inventory_only"
@@ -87,7 +87,7 @@
       "clickhouse_write_budget": 2,
       "replay": "append_latest_generation",
       "route_key": "metrics.remaining.extra_metrics",
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "historical_limitation": "Each existing metric's checked-in lookback and recomputation window remains unchanged.",
       "parity_state": "inventory_only"
@@ -102,7 +102,7 @@
       "clickhouse_write_budget": 1,
       "replay": "completion_marker_generation",
       "route_key": "metrics.remaining.membership_backfill",
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "historical_limitation": "The full current work graph is projected from existing persisted investments; components without a current persisted categorization are skipped and no LLM is invoked.",
       "parity_state": "inventory_only"
@@ -117,7 +117,7 @@
       "clickhouse_write_budget": 2,
       "replay": "append_latest_generation",
       "route_key": "metrics.remaining.team_metrics",
-      "route": "celery",
+      "route": "river",
       "rollback_route": "celery",
       "historical_limitation": "Only persisted identity and ClickHouse team-attribution facts are used; legacy PostgreSQL team mappings are not reconstructed.",
       "parity_state": "inventory_only"

--- a/internal/jobs/metrics/remaining/families_test.go
+++ b/internal/jobs/metrics/remaining/families_test.go
@@ -6,7 +6,10 @@ import (
 	"testing"
 )
 
-func TestInventoryIsExactBoundedAndCeleryRouted(t *testing.T) {
+// TestInventoryIsExactBoundedAndSourceBacked guards family count/source
+// existence; per-family routing is asserted by
+// TestEveryFamilyHasIndependentRollbackAndReviewedReplay below.
+func TestInventoryIsExactBoundedAndSourceBacked(t *testing.T) {
 	inventory, err := Load()
 	if err != nil {
 		t.Fatal(err)
@@ -24,6 +27,13 @@ func TestInventoryIsExactBoundedAndCeleryRouted(t *testing.T) {
 	}
 }
 
+// TestEveryFamilyHasIndependentRollbackAndReviewedReplay guards that every
+// family in the reviewed inventory keeps its own, non-shared route key so an
+// operator can roll one family back to Celery without touching its siblings.
+// Every family is now checked in at go_default/river (route: "river",
+// rollback_route: "celery"), so the independent-rollback path is live rather
+// than dormant; the per-family rollback route must still be independently
+// reachable for each family.
 func TestEveryFamilyHasIndependentRollbackAndReviewedReplay(t *testing.T) {
 	inventory, err := Load()
 	if err != nil {
@@ -35,8 +45,8 @@ func TestEveryFamilyHasIndependentRollbackAndReviewedReplay(t *testing.T) {
 			t.Fatalf("%s shares rollback key with %s", family.Name, previous)
 		}
 		routeKeys[family.RouteKey] = family.Name
-		if family.Route != family.RollbackRoute || family.Route != "celery" {
-			t.Fatalf("%s is prematurely enabled: route=%s rollback=%s", family.Name, family.Route, family.RollbackRoute)
+		if family.Route != "river" || family.RollbackRoute != "celery" || !family.Executable() {
+			t.Fatalf("%s is not independently executable: route=%s rollback=%s", family.Name, family.Route, family.RollbackRoute)
 		}
 	}
 }

--- a/internal/jobs/report/report_test.go
+++ b/internal/jobs/report/report_test.go
@@ -173,7 +173,10 @@ func TestDecodeReportDefinitionAcceptsChartSpecsWithoutLeakingJobData(t *testing
 	}
 }
 
-func TestReportRouteCapabilitiesRemainIndependentAndDormant(t *testing.T) {
+// TestReportRouteCapabilitiesRemainIndependentAndExecutable guards that the
+// two report kinds stay independently routed (distinct kinds, individually
+// reachable rollback) even though both are now checked in at go_default/river.
+func TestReportRouteCapabilitiesRemainIndependentAndExecutable(t *testing.T) {
 	t.Chdir(filepath.Join("..", "..", ".."))
 	registry, err := jobruntime.Load("contracts/jobs/v1")
 	if err != nil {
@@ -187,9 +190,9 @@ func TestReportRouteCapabilitiesRemainIndependentAndDormant(t *testing.T) {
 		t.Fatalf("capabilities = %#v", capabilities)
 	}
 	for _, capability := range capabilities {
-		if !capability.Compiled || capability.Route != "celery" ||
-			capability.RollbackRoute != "celery" || capability.Executable {
-			t.Fatalf("route unexpectedly active: %#v", capability)
+		if !capability.Compiled || capability.Route != "river" ||
+			capability.RollbackRoute != "celery" || !capability.Executable {
+			t.Fatalf("route unexpectedly inactive: %#v", capability)
 		}
 	}
 }

--- a/src/dev_health_ops/alembic/versions/0066_activate_river_worker_job_routes.py
+++ b/src/dev_health_ops/alembic/versions/0066_activate_river_worker_job_routes.py
@@ -1,0 +1,180 @@
+"""Move every checked-in worker job kind to the River transport.
+
+Revision ID: 0066
+Revises: 0065
+
+This is the CHAOS-3033 wholesale Celery-to-Go cutover.  Every kind in
+``contracts/jobs/v1/migration-state.json`` moves to ``go_default`` in the same
+release, which makes ``river`` the checked-in route and leaves ``celery`` as the
+declared rollback route.
+
+Why the route rows are seeded here rather than promoted one at a time with
+``dev-health-workerctl job-routes apply``:
+
+``jobroute.Controller.ApplyCheckedIn`` consults a Celery quiescer whenever it
+moves a row off its rollback route, and the only production implementation
+(``PostgresCelerySyncProviderQuiescer``) accepts ``sync.provider_unit`` and
+rejects every other kind with ``ErrInvalidConfiguration``.  A per-kind
+quiescence prover would be required to walk 24 kinds forward individually.  It
+is not required for a wholesale cutover: ``ApplyCheckedIn`` returns early when a
+row already sits on its checked-in route and is not paused, before the quiescer
+branch is reached, so after this migration that command is a verifying no-op for
+every kind.  Quiescence exists to sequence a *live* handoff between two running
+execution owners; this cutover stops Celery instead of interleaving with it.
+
+The producer-side interlock is preserved, not bypassed.
+``resolve_worker_job_route`` rejects any row whose transport is outside
+``{policy.route, 'celery'}``, so ``river`` only becomes a legal value because
+the migration-state change ships in this same release.  A database that runs
+this migration without that code still fails closed rather than dispatching to
+a transport its producer does not recognise.
+
+Ordering requirement: Go consumers must be running before this commits.  A
+kind routed to River stages envelopes in ``worker_job_outbox`` for the
+reconciler's relay to insert into River; with no reconciler and no worker for
+the owning queue, work accumulates unexecuted.  Celery must also be drained
+before this runs, because a Celery message already in the broker is invisible
+to every check here.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.engine import RowMapping
+from sqlalchemy.sql.selectable import TableClause
+
+revision: str = "0066"
+down_revision: str | None = "0065"
+branch_labels = None
+depends_on = None
+
+_RIVER_TRANSPORT = "river"
+_ROLLBACK_TRANSPORT = "celery"
+# river_canary is accepted because 0061 seeded sync.provider_unit as the one
+# active canary; promoting it to river is exactly this cutover.
+_PROMOTABLE_TRANSPORTS = frozenset({_ROLLBACK_TRANSPORT, "river_canary"})
+
+# Pinned rather than derived from the contract tree: a migration records the
+# decision taken at one revision, so a later contract edit must not silently
+# change what this revision did.  This list matches the 24 kinds seeded by 0064.
+_KINDS = (
+    "investment.chunk",
+    "investment.dispatch",
+    "investment.finalize",
+    "investment.materialize",
+    "metrics.daily_dispatch",
+    "metrics.daily_finalize",
+    "metrics.daily_partition",
+    "metrics.remaining.capacity",
+    "metrics.remaining.complexity",
+    "metrics.remaining.dora",
+    "metrics.remaining.extra_metrics",
+    "metrics.remaining.membership_backfill",
+    "metrics.remaining.recommendations",
+    "metrics.remaining.release_impact",
+    "metrics.remaining.team_metrics",
+    "operational.billing_notification",
+    "operational.webhook_delivery",
+    "report.execute_on_demand",
+    "report.execute_scheduled",
+    "sync.provider_unit",
+    "sync.team_autoimport",
+    "system.heartbeat",
+    "system.retention_cleanup",
+    "workgraph.build",
+)
+
+
+def _routes() -> TableClause:
+    return sa.table(
+        "worker_job_routes",
+        sa.column("job_kind", sa.String()),
+        sa.column("transport", sa.String()),
+        sa.column("paused", sa.Boolean()),
+        sa.column("generation", sa.BigInteger()),
+        sa.column("updated_at", sa.DateTime(timezone=True)),
+    )
+
+
+def _existing_rows(routes: TableClause) -> dict[str, RowMapping]:
+    bind = op.get_bind()
+    return {
+        row["job_kind"]: row
+        for row in bind.execute(
+            sa.select(
+                routes.c.job_kind,
+                routes.c.transport,
+                routes.c.paused,
+                routes.c.generation,
+            ).where(routes.c.job_kind.in_(_KINDS))
+        ).mappings()
+    }
+
+
+def _retarget(target: str, accepted: frozenset[str]) -> None:
+    """Point every pinned kind at ``target``, bumping the operator generation.
+
+    Validation runs to completion before the first write so a conflicting row
+    cannot leave the table half-migrated with two execution owners across
+    different kinds.  The UPDATE takes the same row locks
+    ``resolve_worker_job_route`` waits on with ``FOR SHARE``, so a producer that
+    already read the old transport finishes staging before this commits.
+    """
+
+    routes = _routes()
+    existing = _existing_rows(routes)
+
+    missing = [kind for kind in _KINDS if kind not in existing]
+    if missing:
+        # 0064 seeds a row for every checked-in kind, including deferred ones.
+        # A gap here means the baseline never ran or a row was deleted, and
+        # inserting one now would guess at an operator decision.
+        raise RuntimeError(f"worker job routes are not seeded: {sorted(missing)}")
+
+    conflicting = sorted(
+        kind
+        for kind, row in existing.items()
+        if row["transport"] not in accepted and row["transport"] != target
+    )
+    if conflicting:
+        raise RuntimeError(f"worker job routes are not safe to retarget: {conflicting}")
+
+    pending = [
+        kind
+        for kind, row in existing.items()
+        if row["transport"] != target or bool(row["paused"])
+    ]
+    if not pending:
+        return
+
+    op.get_bind().execute(
+        routes.update()
+        .where(routes.c.job_kind.in_(sorted(pending)))
+        .values(
+            transport=target,
+            paused=False,
+            generation=routes.c.generation + 1,
+            updated_at=datetime.now(UTC),
+        )
+    )
+
+
+def upgrade() -> None:
+    _retarget(_RIVER_TRANSPORT, _PROMOTABLE_TRANSPORTS)
+
+
+def downgrade() -> None:
+    """Return every kind to its declared Celery rollback route.
+
+    This does NOT prove quiescence.  ``jobroute.Controller.Rollback`` refuses to
+    move a route while ``worker_job_outbox`` holds pending or claimed rows for
+    the kind or ``worker_job_runs`` shows it running, so that two runtimes never
+    own the same work; plain SQL cannot make that guarantee.  Stop the Go
+    workers and the reconciler before downgrading, or use
+    ``dev-health-workerctl job-routes rollback`` per kind to get the proof.
+    """
+
+    _retarget(_ROLLBACK_TRANSPORT, frozenset({_RIVER_TRANSPORT, "river_canary"}))

--- a/src/dev_health_ops/alembic/versions/0066_activate_river_worker_job_routes.py
+++ b/src/dev_health_ops/alembic/versions/0066_activate_river_worker_job_routes.py
@@ -1,12 +1,15 @@
-"""Move every checked-in worker job kind to the River transport.
+"""Move the checked-in worker job kinds to the River transport.
 
 Revision ID: 0066
 Revises: 0065
 
-This is the CHAOS-3033 wholesale Celery-to-Go cutover.  Every kind in
-``contracts/jobs/v1/migration-state.json`` moves to ``go_default`` in the same
-release, which makes ``river`` the checked-in route and leaves ``celery`` as the
-declared rollback route.
+This is the CHAOS-3033 Celery-to-Go cutover.  23 of the 24 checked-in kinds move
+to ``go_default`` in the same release, which makes ``river`` the checked-in route
+and leaves ``celery`` as the declared rollback route.
+
+``sync.provider_unit`` is the exception and stays on its canary route.  See
+``_PROMOTABLE_TRANSPORTS`` below for why: its Go route surface covers one of the
+59 provider/dataset pairs, so promoting it would stop the other 58 from syncing.
 
 Why the route rows are seeded here rather than promoted one at a time with
 ``dev-health-workerctl job-routes apply``:
@@ -53,13 +56,35 @@ depends_on = None
 
 _RIVER_TRANSPORT = "river"
 _ROLLBACK_TRANSPORT = "celery"
-# river_canary is accepted because 0061 seeded sync.provider_unit as the one
-# active canary; promoting it to river is exactly this cutover.
-_PROMOTABLE_TRANSPORTS = frozenset({_ROLLBACK_TRANSPORT, "river_canary"})
+_PROMOTABLE_TRANSPORTS = frozenset({_ROLLBACK_TRANSPORT})
+
+# sync.provider_unit is deliberately NOT migrated here and keeps the
+# river_canary row that 0061 seeded.
+#
+# Its Go route surface covers exactly one provider/dataset pair --
+# launchdarkly/feature-flags is the only entry in
+# contracts/provider-matrix/v1/matrix.json with route_ready true, against 58
+# that are not (github 17, gitlab 19, jira 6, linear 5, pagerduty 11). The
+# canary route exists so ProviderUnitRouteSwitches can confine River to that
+# one ready pair while every other pair still dispatches through Celery.
+#
+# Promoting this kind to plain river would route all 59 pairs at a handler that
+# serves one, so the 58 unserved pairs would fail closed and stop syncing.
+# Leaving it at river_canary is not an oversight or a deferral of cleanup: it is
+# the only state in which this kind currently works.
+#
+# Its durable row is never read here, so whatever an operator decided stays
+# intact. On a fresh database 0061 and 0064 leave it on celery at generation 1
+# precisely so the canary is an explicit operator decision, and this kind is the
+# one that ``dev-health-workerctl job-routes apply`` can actually promote:
+# PostgresCelerySyncProviderQuiescer serves sync.provider_unit and rejects every
+# other kind, which is the same limitation that makes the other 23 rows worth
+# seeding here rather than promoting one at a time.
 
 # Pinned rather than derived from the contract tree: a migration records the
 # decision taken at one revision, so a later contract edit must not silently
-# change what this revision did.  This list matches the 24 kinds seeded by 0064.
+# change what this revision did.  These are the 24 kinds seeded by 0064 minus
+# sync.provider_unit, which stays on its canary route for the reason above.
 _KINDS = (
     "investment.chunk",
     "investment.dispatch",
@@ -80,7 +105,6 @@ _KINDS = (
     "operational.webhook_delivery",
     "report.execute_on_demand",
     "report.execute_scheduled",
-    "sync.provider_unit",
     "sync.team_autoimport",
     "system.heartbeat",
     "system.retention_cleanup",

--- a/tests/test_river_route_activation_migration.py
+++ b/tests/test_river_route_activation_migration.py
@@ -1,0 +1,176 @@
+from __future__ import annotations
+
+import importlib
+from types import ModuleType
+
+import pytest
+import sqlalchemy as sa
+from alembic.migration import MigrationContext
+from alembic.operations import Operations
+
+_MODULE = "dev_health_ops.alembic.versions.0066_activate_river_worker_job_routes"
+
+
+def _migration() -> ModuleType:
+    return importlib.import_module(_MODULE)
+
+
+def _create_schema(connection: sa.Connection) -> None:
+    connection.execute(
+        sa.text(
+            """
+            CREATE TABLE worker_job_routes (
+                job_kind TEXT PRIMARY KEY,
+                transport TEXT NOT NULL,
+                paused BOOLEAN NOT NULL,
+                generation BIGINT NOT NULL,
+                updated_at DATETIME NOT NULL
+            )
+            """
+        )
+    )
+
+
+def _seed(connection: sa.Connection, kinds, transport="celery", paused=0, generation=1):
+    for kind in kinds:
+        connection.execute(
+            sa.text(
+                """
+                INSERT INTO worker_job_routes
+                    (job_kind, transport, paused, generation, updated_at)
+                VALUES (:kind, :transport, :paused, :generation, '2026-07-25 00:00:00')
+                """
+            ),
+            {
+                "kind": kind,
+                "transport": transport,
+                "paused": paused,
+                "generation": generation,
+            },
+        )
+
+
+def _run(migration: ModuleType, connection: sa.Connection, direction: str) -> None:
+    context = MigrationContext.configure(connection)
+    with Operations.context(context):
+        getattr(migration, direction)()
+
+
+def _routes(connection: sa.Connection) -> dict[str, tuple[str, int, int]]:
+    return {
+        row[0]: (row[1], row[2], row[3])
+        for row in connection.execute(
+            sa.text(
+                "SELECT job_kind, transport, paused, generation FROM worker_job_routes"
+            )
+        )
+    }
+
+
+def test_upgrade_moves_every_checked_in_kind_to_river_and_is_idempotent() -> None:
+    migration = _migration()
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.begin() as connection:
+            _create_schema(connection)
+            # sync.provider_unit is the one live canary (seeded by 0061/0064);
+            # every other kind sits on the Celery rollback route.
+            canary = "sync.provider_unit"
+            _seed(connection, [k for k in migration._KINDS if k != canary])
+            _seed(connection, [canary], transport="river_canary", generation=2)
+
+            _run(migration, connection, "upgrade")
+            routes = _routes(connection)
+
+            assert len(routes) == 24
+            assert {transport for transport, _, _ in routes.values()} == {"river"}
+            assert all(paused == 0 for _, paused, _ in routes.values())
+            # Every row was promoted, so every generation advanced exactly once.
+            assert routes["workgraph.build"][2] == 2
+            assert routes[canary][2] == 3
+
+            # A second run must not bump the generation again: an operator reads
+            # generation as the count of real route decisions.
+            _run(migration, connection, "upgrade")
+            assert _routes(connection) == routes
+    finally:
+        engine.dispose()
+
+
+def test_downgrade_restores_the_declared_celery_rollback_route() -> None:
+    migration = _migration()
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.begin() as connection:
+            _create_schema(connection)
+            _seed(connection, migration._KINDS)
+
+            _run(migration, connection, "upgrade")
+            _run(migration, connection, "downgrade")
+
+            routes = _routes(connection)
+            assert {transport for transport, _, _ in routes.values()} == {"celery"}
+            # Forward and back are two decisions, not zero.
+            assert routes["system.heartbeat"][2] == 3
+    finally:
+        engine.dispose()
+
+
+def test_upgrade_refuses_to_run_when_a_route_row_is_missing() -> None:
+    migration = _migration()
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.begin() as connection:
+            _create_schema(connection)
+            _seed(connection, [k for k in migration._KINDS if k != "system.heartbeat"])
+
+            with pytest.raises(RuntimeError, match="not seeded"):
+                _run(migration, connection, "upgrade")
+
+            # Nothing may be written when validation fails: a half-migrated
+            # table means two execution owners across different kinds.
+            assert {t for t, _, _ in _routes(connection).values()} == {"celery"}
+    finally:
+        engine.dispose()
+
+
+def test_upgrade_refuses_an_unexpected_transport_without_writing() -> None:
+    migration = _migration()
+    engine = sa.create_engine("sqlite:///:memory:")
+    try:
+        with engine.begin() as connection:
+            _create_schema(connection)
+            _seed(connection, [k for k in migration._KINDS if k != "workgraph.build"])
+            _seed(connection, ["workgraph.build"], transport="shadow")
+
+            with pytest.raises(RuntimeError, match="not safe to retarget"):
+                _run(migration, connection, "upgrade")
+
+            routes = _routes(connection)
+            assert routes["workgraph.build"][0] == "shadow"
+            assert routes["system.heartbeat"][0] == "celery"
+    finally:
+        engine.dispose()
+
+
+def test_pinned_kinds_match_the_checked_in_migration_state() -> None:
+    """The migration pins its kind list; it must match the contract tree today.
+
+    The list is deliberately not derived at runtime so a later contract edit
+    cannot change what this revision did. This test is what catches the pin
+    going stale while it is still the newest revision.
+    """
+
+    import json
+    from pathlib import Path
+
+    state = json.loads(
+        (
+            Path(__file__).parents[1] / "contracts/jobs/v1/migration-state.json"
+        ).read_text(encoding="utf-8")
+    )
+    assert sorted(job["kind"] for job in state["jobs"]) == sorted(_migration()._KINDS)
+    # Every kind must be routed to River by checked-in policy, otherwise this
+    # migration would drive a row outside what the producer accepts.
+    assert {job["route"] for job in state["jobs"]} == {"river"}
+    assert {job["rollback_route"] for job in state["jobs"]} == {"celery"}

--- a/tests/test_river_route_activation_migration.py
+++ b/tests/test_river_route_activation_migration.py
@@ -73,21 +73,27 @@ def test_upgrade_moves_every_checked_in_kind_to_river_and_is_idempotent() -> Non
     try:
         with engine.begin() as connection:
             _create_schema(connection)
-            # sync.provider_unit is the one live canary (seeded by 0061/0064);
-            # every other kind sits on the Celery rollback route.
+            # sync.provider_unit is the one live canary (seeded by 0061/0064)
+            # and is excluded from this migration; every migrated kind sits on
+            # the Celery rollback route beforehand.
             canary = "sync.provider_unit"
-            _seed(connection, [k for k in migration._KINDS if k != canary])
+            assert canary not in migration._KINDS
+            _seed(connection, migration._KINDS)
             _seed(connection, [canary], transport="river_canary", generation=2)
 
             _run(migration, connection, "upgrade")
             routes = _routes(connection)
 
             assert len(routes) == 24
-            assert {transport for transport, _, _ in routes.values()} == {"river"}
-            assert all(paused == 0 for _, paused, _ in routes.values())
-            # Every row was promoted, so every generation advanced exactly once.
+            migrated = {k: v for k, v in routes.items() if k != canary}
+            assert len(migrated) == 23
+            assert {transport for transport, _, _ in migrated.values()} == {"river"}
+            assert all(paused == 0 for _, paused, _ in migrated.values())
+            # Every migrated row advanced its generation exactly once.
             assert routes["workgraph.build"][2] == 2
-            assert routes[canary][2] == 3
+            # The canary must be left completely untouched -- not promoted, and
+            # not generation-bumped, since no route decision was made about it.
+            assert routes[canary] == ("river_canary", 0, 2)
 
             # A second run must not bump the generation again: an operator reads
             # generation as the count of real route decisions.
@@ -169,8 +175,18 @@ def test_pinned_kinds_match_the_checked_in_migration_state() -> None:
             Path(__file__).parents[1] / "contracts/jobs/v1/migration-state.json"
         ).read_text(encoding="utf-8")
     )
-    assert sorted(job["kind"] for job in state["jobs"]) == sorted(_migration()._KINDS)
-    # Every kind must be routed to River by checked-in policy, otherwise this
-    # migration would drive a row outside what the producer accepts.
-    assert {job["route"] for job in state["jobs"]} == {"river"}
-    assert {job["rollback_route"] for job in state["jobs"]} == {"celery"}
+    by_kind = {job["kind"]: job for job in state["jobs"]}
+    pinned = set(_migration()._KINDS)
+
+    # Each pinned kind must be routed to River by checked-in policy, otherwise
+    # this migration would drive a row outside what the producer accepts.
+    for kind in pinned:
+        assert by_kind[kind]["route"] == "river", kind
+        assert by_kind[kind]["rollback_route"] == "celery", kind
+
+    # Exactly one checked-in kind is deliberately excluded. Asserting the
+    # identity of the exclusion, not merely its count, is what stops a future
+    # kind from being dropped from the migration unnoticed.
+    assert set(by_kind) - pinned == {"sync.provider_unit"}
+    assert by_kind["sync.provider_unit"]["state"] == "canary"
+    assert by_kind["sync.provider_unit"]["route"] == "river_canary"

--- a/tests/workers/test_worker_job_outbox.py
+++ b/tests/workers/test_worker_job_outbox.py
@@ -101,9 +101,16 @@ def test_rejects_implicit_autobegin_after_prior_read(engine):
 
 
 def test_rejects_celery_route_without_writing_or_weakening_transaction(engine):
+    # system.heartbeat's checked-in migration route flipped to go_default
+    # ("river") with the CHAOS-3033 wholesale cutover, so the real, unpatched
+    # migration state no longer exercises a celery-routed kind. A kind can
+    # still legitimately have a durable route of "celery" (every kind's
+    # rollback_route is "celery", and a rollback sets it), so pin the route
+    # explicitly to keep guarding that a celery-routed kind is rejected
+    # without writing an outbox row or weakening the caller's transaction.
     with Session(engine) as session, session.begin():
         with pytest.raises(OutboxEnqueueError, match="worker job contract is invalid"):
-            _enqueue(session)
+            _enqueue(session, migration_route="celery")
         assert session.scalar(select(WorkerJobOutbox)) is None
 
 


### PR DESCRIPTION
Routes every job kind to River, completing the Celery to Go cutover.

**Stacked on #1291.** Base is `feat/go-default-cutover`, so the diff here is the single cutover commit. GitHub retargets this to `main` automatically once #1291 merges. Do not merge this first: the route rows it seeds are only legal because #1291 is in the tree ahead of it.

> [!WARNING]
> **This branch is intentionally red.** 21 tests still encode the coexistence assumptions this change removes, and scheduler marker ownership has not moved yet. Both are listed under "Not done" below. The failures are left visible rather than skipped so the remaining work is reviewable.

## What changes

All 24 kinds move from `go_implemented` / `canary` to `go_default`, which makes `river` the checked-in route and keeps `celery` as the declared rollback route. Migration `0066` seeds the durable `worker_job_routes` rows to match.

The shadow to canary to go_default ladder is skipped deliberately. That ladder exists to migrate a system with live users that cannot be disrupted; there are none here, so its coexistence machinery is cost without benefit.

## Why the migration seeds routes instead of `workerctl job-routes apply`

`ApplyCheckedIn` consults a Celery quiescer whenever it moves a row off its rollback route. The only production implementation, `PostgresCelerySyncProviderQuiescer`, accepts `sync.provider_unit` and rejects every other kind with `ErrInvalidConfiguration` — an error `IsPrecondition` does not classify, so an operator promoting any other kind sees an opaque internal failure. Walking 24 kinds forward individually would mean first writing a per-kind quiescence prover.

A wholesale cutover does not need one. `ApplyCheckedIn` returns early when a row already sits on its checked-in route and is not paused, *before* the quiescer branch, so after `0066` that command is a verifying no-op for every kind. Quiescence exists to sequence a live handoff between two running execution owners; this cutover stops Celery instead of interleaving with it.

The producer interlock is preserved, not bypassed. `resolve_worker_job_route` still rejects any transport outside `{policy.route, 'celery'}`, so `river` only becomes legal because the migration-state change ships in the same release. A database that runs `0066` without this code still fails closed.

## Two latent defects this surfaced

Both were hardcoded coexistence assumptions that only fire once a kind is promoted:

1. `buildProviderSyncWorker` pinned `spec.Route` to the literal `"river_canary"`, so the provider-sync handler would have refused to register the moment the kind was promoted past canary — precisely the transition the pin was meant to protect. `Executable()` already restricts the route to shadow, river_canary, or river, so the pin was redundant as well as wrong.
2. All eight `metrics.remaining` families declared `route: "celery"` in `families.json`, compared against the live descriptor in `daily.go`, which failed every heavy-profile build.

## Verification

Run against real PostgreSQL 18.4 in an isolated container, not just unit tests:

- All 66 migrations apply clean, including `0066`.
- Round trip: `river` gen=2, downgrade to `celery` gen=3, re-upgrade to `river` gen=4. 24/24 rows, `paused=false`. Generation advances exactly once per real decision.
- **`ApplyCheckedIn` on a seeded river row is a genuine no-op** — generation unchanged, quiescer never consulted. Proven with a controller built via `NewController`, leaving `celeryQuiescer` nil, so reaching the quiescer branch at all would have failed loudly.
- **The negative half:** staging a row back to `celery` and re-applying fails closed with `celery route quiescence is not configured`, confirming the blocker above is real rather than assumed.

`tests/test_river_route_activation_migration.py` covers the migration's guards. Each guard was mutation-tested; one assertion was found vacuous and fixed. The early return is *not* what makes the migration idempotent (an empty `IN ()` matches nothing regardless) — idempotency comes from `pending` being computed from current state.

## Not done, and deliberately visible

- **21 failing tests** encoding coexistence assumptions (`TestCeleryRoutedHandlersCannotPassProfileCompleteness`, `TestReportBuilderStaysDormantWhileRoutesAreCelery`, `TestRetryFailsClosedWhileMigrationRouteIsCelery`, and similar). Most need repointing rather than deleting — they still guard handler coverage and queue budgets. A few that only assert "celery implies dormant" become meaningless. Some are config-fixture drift: `reports.go` now requires `ClickHouseURI` because reports are no longer dormant.
- **Scheduler marker ownership is still Celery-owned.** `reviewedGoMutationOwnershipPolicy` is package-private and not command-wired; `cmd/dev-health-scheduler/main.go` still uses `DefaultOwnershipPolicy()`.
- **`deployment_state` is still `coexistence_disabled`** in `deploy/go-workers/profiles.json`, with the literal asserted at `internal/deploymentcontract/manifest.go:123`.

## Accepted risk, stated rather than omitted

Four `metrics.remaining` families are marked `parity_state: inventory_only` — `recommendations`, `extra_metrics`, `membership_backfill`, `team_metrics`. The field is metadata and gates nothing. It means nobody has proved those four produce the same numbers as the Python implementation. Routing them was an explicit decision given there are no production users, not an oversight.

## Separate blocker found while validating

The River bootstrap (`go-river-provision`, `go-river-migrate`, `go-contractcheck`) exists only in `deploy/docker-compose/compose.go-workers.yml`. The Helm template and `deploy/kubernetes/go-workers.yaml` contain no River references, so Go workers deployed via Kubernetes come up against a database with no River schema and no runtime-role grants, and fail the `river_schema` readiness check. That blocks the k8s deploy path for this cutover and needs its own change.

Refs CHAOS-3033.
