### PR TITLE
CHAOS-3128: transfer schedule-marker ownership to Go with proven two-owner exclusion

### DIFF
--- a/cmd/dev-health-scheduler/dependencies.go
+++ b/cmd/dev-health-scheduler/dependencies.go
@@ -199,8 +199,21 @@ type schedulerRuntimeSources struct {
 
 var productionSchedulerRuntimeSources = schedulerRuntimeSources{
 	openDatabase: openSchedulerDatabase,
+	// This branches on the package-level schedulerOwnership variable (main.go)
+	// rather than calling schedulersync.NewMutationRepository unconditionally,
+	// so that variable is the actual, single source of truth for which
+	// ownership policy this binary composes -- not a value that is validated
+	// but otherwise ignored. OwnershipPolicy's fields stay unexported in the
+	// sync package, so the only two values schedulerOwnership can ever hold
+	// are schedulersync.DefaultOwnershipPolicy() and
+	// schedulersync.TransferScheduleMarkerOwnershipToGo(); this comparison
+	// cannot be fooled into selecting the mutation repository by anything
+	// short of a source change to schedulerOwnership itself.
 	newRepository: func(pool *pgxpool.Pool) (schedulersync.HandoffStepper, error) {
-		return schedulersync.NewMutationRepository(pool)
+		if schedulerOwnership == schedulersync.TransferScheduleMarkerOwnershipToGo() {
+			return schedulersync.NewMutationRepository(pool)
+		}
+		return schedulersync.NewRepository(pool)
 	},
 	newCoordinator: schedulersync.NewOccurrenceCoordinator,
 	newLoop:        schedulersync.NewLoop,

--- a/cmd/dev-health-scheduler/dependencies_test.go
+++ b/cmd/dev-health-scheduler/dependencies_test.go
@@ -96,6 +96,40 @@ func (loop *fakeFixedLoop) Readiness(context.Context) error { return loop.readin
 
 func (loop *fakeFixedLoop) Coverage(context.Context) error { return loop.coverageErr }
 
+// TestProductionSchedulerRuntimeSourcesRepositoryFollowsSchedulerOwnership
+// proves schedulerOwnership (main.go) is the actual source of truth for which
+// repository the production composition builds, not a value that is merely
+// validated. The default-ownership branch is exercised behaviorally (its
+// HandoffDueResult must refuse before ever touching the pool, so a zero-value
+// pool is safe to use here); the transferred branch is checked structurally,
+// since exercising HandoffDueResult against an unconnected pool would reach
+// past the ownership check into pool.BeginTx.
+func TestProductionSchedulerRuntimeSourcesRepositoryFollowsSchedulerOwnership(t *testing.T) {
+	original := schedulerOwnership
+	defer func() { schedulerOwnership = original }()
+	pool := &pgxpool.Pool{}
+
+	schedulerOwnership = schedulersync.DefaultOwnershipPolicy()
+	defaultStepper, err := productionSchedulerRuntimeSources.newRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := defaultStepper.HandoffDueResult(
+		context.Background(), time.Now(), 1, schedulersync.NewOccurrenceCoordinator(),
+	); !errors.Is(err, schedulersync.ErrSchedulerMutationDisabled) {
+		t.Fatalf("default ownership HandoffDueResult() = %v, want ErrSchedulerMutationDisabled", err)
+	}
+
+	schedulerOwnership = schedulersync.TransferScheduleMarkerOwnershipToGo()
+	mutationStepper, err := productionSchedulerRuntimeSources.newRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, ok := mutationStepper.(*schedulersync.Repository); !ok || mutationStepper == nil {
+		t.Fatalf("transferred ownership repository = %#v, want a non-nil *schedulersync.Repository", mutationStepper)
+	}
+}
+
 func TestSchedulerProductionFactoryBuildsReviewedRuntime(t *testing.T) {
 	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}}
 	fixedLoop := &fakeFixedLoop{}

--- a/cmd/dev-health-scheduler/main.go
+++ b/cmd/dev-health-scheduler/main.go
@@ -18,17 +18,61 @@ var schedulerSpec = shell.Spec{
 }
 
 // schedulerOwnership is intentionally fixed in the binary. Do not make it an
-// environment setting: deployment_state remains coexistence_disabled and the
-// Python scheduler retains all production marker-mutation ownership.
-var schedulerOwnership = schedulersync.DefaultOwnershipPolicy()
+// environment setting.
+//
+// CHAOS-3128: this is now schedulersync.TransferScheduleMarkerOwnershipToGo(),
+// the reviewed, in-source ownership transfer -- see that function's doc
+// comment for what calling it does and does not activate, and for why a
+// concurrently running Celery Beat cannot also mutate a marker once this
+// policy is in effect. productionSchedulerRuntimeSources.newRepository below
+// is what actually wires this value into the repository construction Go
+// uses, so this variable is the single source of truth for which ownership
+// policy the binary runs with, not a decorative check.
+//
+// Obtaining this policy does NOT make the binary write anything: it still
+// requires checkedInSchedulerActivation's goOwnsMarkers and
+// coordinatorPolicyParity to both be true before this process opens a
+// database pool at all (see below), and at minimum three further
+// preconditions this change does not attempt to satisfy:
+//
+//  1. coordinatorPolicyParity has no defined bar anywhere in this repository
+//     today -- no test, doc, or checklist states what "the coordinator
+//     behaves equivalently to the Python one" means well enough to prove.
+//     Setting it true without that definition would defeat the purpose of a
+//     source-reviewed gate.
+//  2. This binary has never been given a coordinator PostgreSQL pool (see
+//     .github/docs-legacy/architecture/chaos-3033-coordinator-pool-activation.md,
+//     "scheduler | not repointed -- blocked on CHAOS-3114"), and
+//     schedulersync.NewMutationRepository/NewOccurrenceCoordinator/
+//     NewOccurrenceReconciler's SQL (scheduled_jobs, sync_configurations
+//     UPDATE, scheduled_sync_occurrences) is coordinator-exclusive per
+//     internal/storage/postgres/domain_authorization.go's coordinatorPosture.
+//     dependencies.go still hands them database.DomainPool(); flipping
+//     activation without repointing that call site would 42501 on the first
+//     real handoff.
+//  3. sources.newOccurrences below still composes
+//     schedulersync.NewUnavailableMaterializer(): the native sync planner is
+//     CUT-09/CUT-10 work, not this change. Activating today would durably
+//     record occurrences Go can never materialize.
+var schedulerOwnership = schedulersync.TransferScheduleMarkerOwnershipToGo()
 
 var errSchedulerActivationUnavailable = errors.New("scheduler activation is unavailable")
 
 // schedulerActivation is a source-reviewed, package-private composition seam.
 // It deliberately cannot be influenced by process environment or deployment
 // profile. The production loop factory is retained but remains unreachable
-// until a future owner-transfer change proves coordinator policy parity and
-// sets both gates true.
+// until a future change proves coordinator policy parity and sets both gates
+// true.
+//
+// CHAOS-3128 transferred marker-mutation ownership itself (schedulerOwnership
+// above) but deliberately leaves both gates false: coordinatorPolicyParity
+// has no defined bar to prove yet, this binary's sync-path repository and
+// occurrence constructors still run on the domain pool rather than the
+// coordinator pool their SQL requires, and the occurrence materializer is
+// still the CUT-09/CUT-10 stub. See schedulerOwnership's doc comment for the
+// full list. Flipping goOwnsMarkers to true without also resolving those
+// would ship a database permission failure or a stranded-occurrence backlog
+// on the first real due schedule, not a working scheduler.
 type schedulerActivation struct {
 	goOwnsMarkers           bool
 	coordinatorPolicyParity bool
@@ -76,8 +120,9 @@ func configureSchedulerDependenciesWithSources(
 		return nil, errSchedulerActivationUnavailable
 	}
 	if !activation.goOwnsMarkers || !activation.coordinatorPolicyParity {
-		// The checked-in Celery/coexistence_disabled policy must not even open a
-		// PostgreSQL client. Keep all externally visible readiness names closed.
+		// schedulerOwnership alone (CHAOS-3128) is not activation: until both
+		// gates are true this process must not even open a PostgreSQL client.
+		// Keep all externally visible readiness names closed.
 		return nil, processreadiness.RegisterUnavailable(
 			registry,
 			"domain_postgres",

--- a/cmd/dev-health-scheduler/main_test.go
+++ b/cmd/dev-health-scheduler/main_test.go
@@ -20,8 +20,14 @@ func (schedulerTestComponent) Start(context.Context) error    { return nil }
 func (schedulerTestComponent) Shutdown(context.Context) error { return nil }
 
 func TestSchedulerSpecConfiguresFailClosedDependencies(t *testing.T) {
-	if schedulerOwnership != schedulersync.DefaultOwnershipPolicy() {
+	// CHAOS-3128: schedulerOwnership is the reviewed transfer, not the
+	// checked-in Celery default. That alone must not open a database pool or
+	// change readiness -- both gates below are still checked separately.
+	if schedulerOwnership != schedulersync.TransferScheduleMarkerOwnershipToGo() {
 		t.Fatalf("scheduler ownership = %#v", schedulerOwnership)
+	}
+	if err := schedulerOwnership.Validate(); err != nil {
+		t.Fatalf("transferred ownership failed validation: %v", err)
 	}
 	if schedulerSpec.Service != "dev-health-scheduler" {
 		t.Fatalf("service = %q", schedulerSpec.Service)

--- a/internal/scheduler/sync/ownership.go
+++ b/internal/scheduler/sync/ownership.go
@@ -51,12 +51,60 @@ func DefaultOwnershipPolicy() OwnershipPolicy {
 	}
 }
 
-// reviewedGoMutationOwnershipPolicy is intentionally package-private. Tests
-// and a future audited command composition can exercise the Go-owned kernel,
-// but neither environment nor an external package can manufacture marker
-// mutation authority.
+// reviewedGoMutationOwnershipPolicy is intentionally package-private so that
+// TransferScheduleMarkerOwnershipToGo is the one and only exported spelling
+// of it. Tests reach the value directly because they live in this package;
+// everything outside it goes through the exported wrapper below.
 func reviewedGoMutationOwnershipPolicy() OwnershipPolicy {
 	return OwnershipPolicy{owner: schedulerOwnerGo, mode: schedulerModeMutation}
+}
+
+// TransferScheduleMarkerOwnershipToGo performs the reviewed, in-source
+// transfer of schedule-marker mutation authority from Celery to Go.
+//
+// This is the ownership transfer, not a step toward it. There is no
+// environment variable, deployment profile, or runtime flag that can produce
+// this OwnershipPolicy value: OwnershipPolicy's fields stay unexported, so
+// this function and DefaultOwnershipPolicy are the complete, closed set of
+// policies any caller outside this package can ever obtain. Calling this
+// function and shipping the resulting binary IS the act of transfer; nothing
+// else can activate it, and nothing else is required to have already
+// activated it (see the composition-root gates below, which are a separate,
+// additional precondition on top of this one).
+//
+// Obtaining this policy is necessary but not sufficient for mutation to
+// actually happen in production. allowsMutation() still requires
+// {owner: go, mode: mutation} on the specific Repository that runs the
+// write, and cmd/dev-health-scheduler's composition root additionally gates
+// on its own checkedInSchedulerActivation flags (goOwnsMarkers,
+// coordinatorPolicyParity) before it will even open a database pool. Those
+// gates exist precisely so that this function's existence does not, by
+// itself, put a marker mutation on the wire.
+//
+// Why a second, concurrently running Celery Beat cannot also mutate the same
+// marker once this policy is in effect: HandoffDueResult (transaction.go)
+// deliberately reproduces the Python scheduler's exact row-lock order and
+// clause — `FOR UPDATE OF config, job SKIP LOCKED` against the same
+// public.sync_configurations/public.scheduled_jobs rows Beat locks with
+// SQLAlchemy's `.with_for_update(skip_locked=True)` in the same
+// config -> job -> occurrence order — and advances next_run_at inside the
+// same transaction that holds the lock. PostgreSQL enforces that lock
+// regardless of which process or language acquired it, so at most one of
+// {a Beat transaction, a Go transaction} can ever hold it at a time; the
+// other's SKIP LOCKED clause makes it skip the row this pass rather than
+// block or race past a stale read. That is a database-level guarantee, not
+// an application-level convention either side could accidentally violate by
+// itself — see TestHandoffDuePostgresRespectsExternalRowLock, which proves
+// it against a raw connection standing in for Beat.
+//
+// What this policy does NOT prove: that Go's cron evaluation always agrees
+// with Python's for every schedule (see NextOccurrence's golden-vector tests
+// for that), and that Go can complete a materialization once it wins a race
+// (see the occurrence reconciler's Materializer — a stub until CUT-09/CUT-10
+// lands). Both are the separate coordinatorPolicyParity precondition on the
+// composition root, and this function does not claim to satisfy it.
+func TransferScheduleMarkerOwnershipToGo() OwnershipPolicy {
+	return reviewedGoMutationOwnershipPolicy()
 }
 
 // Validate rejects every owner/mode pair except the bounded current and future

--- a/internal/scheduler/sync/ownership_test.go
+++ b/internal/scheduler/sync/ownership_test.go
@@ -36,6 +36,22 @@ func TestMutationRepositoryRequiresExplicitReviewedConstructor(t *testing.T) {
 	}
 }
 
+func TestTransferScheduleMarkerOwnershipToGoMatchesTheReviewedPolicy(t *testing.T) {
+	transferred := TransferScheduleMarkerOwnershipToGo()
+	if transferred != reviewedGoMutationOwnershipPolicy() {
+		t.Fatalf("TransferScheduleMarkerOwnershipToGo() = %#v, want the reviewed policy", transferred)
+	}
+	if err := transferred.Validate(); err != nil {
+		t.Fatalf("Validate() = %v", err)
+	}
+	if !transferred.allowsMutation() {
+		t.Fatal("the exported ownership transfer does not allow mutation")
+	}
+	if transferred == DefaultOwnershipPolicy() {
+		t.Fatal("the transferred policy must differ from the checked-in default")
+	}
+}
+
 func TestOwnershipPolicyOnlyPermitsExplicitOwnerModePairs(t *testing.T) {
 	for _, test := range []struct {
 		name   string

--- a/internal/scheduler/sync/repository.go
+++ b/internal/scheduler/sync/repository.go
@@ -29,12 +29,14 @@ func NewRepository(pool *pgxpool.Pool) (*Repository, error) {
 }
 
 // NewMutationRepository is the source-reviewed production composition seam
-// for transferring schedule-marker ownership to Go. Calling it is not an
+// for transferring schedule-marker ownership to Go. It composes
+// TransferScheduleMarkerOwnershipToGo — see that function's doc comment for
+// what the transfer does and does not prove. Calling it is not an
 // environment-level activation: the scheduler command additionally requires
 // its checked-in ownership and coordinator-parity gates before this repository
 // can be constructed.
 func NewMutationRepository(pool *pgxpool.Pool) (*Repository, error) {
-	return newRepositoryWithOwnership(pool, reviewedGoMutationOwnershipPolicy())
+	return newRepositoryWithOwnership(pool, TransferScheduleMarkerOwnershipToGo())
 }
 
 // newRepositoryWithOwnership constructs the scheduler repository with an

--- a/internal/scheduler/sync/transaction.go
+++ b/internal/scheduler/sync/transaction.go
@@ -136,6 +136,20 @@ func (repository *Repository) HandoffDue(
 // HandoffDueResult locks and re-evaluates one bounded candidate window. It is
 // the lifecycle-facing form of HandoffDue and exposes only aggregate fallback
 // counts, never organization or configuration identifiers.
+//
+// Two-owner safety (CHAOS-3128): schedulerHandoffCandidatesSQL's
+// `FOR UPDATE OF config, job SKIP LOCKED` clause and lock order
+// (sync_configurations, then scheduled_jobs) are byte-for-byte the same shape
+// SQLAlchemy's `.with_for_update(skip_locked=True)` produces in the Python
+// scheduler's `_maybe_dispatch_config`, against the same rows. PostgreSQL
+// grants that lock to at most one transaction at a time regardless of which
+// process holds it, and the marker advance below runs inside the same
+// transaction as the lock, so a concurrently running Celery Beat and this
+// method can never both mutate the same schedule's marker — one of them gets
+// SKIP LOCKED and moves on rather than reading a value the other is mid-write
+// on. This is what makes TransferScheduleMarkerOwnershipToGo's policy switch
+// safe to flip while Beat is still deployed, not merely convenient; see that
+// function's doc comment and TestHandoffDuePostgresRespectsExternalRowLock.
 func (repository *Repository) HandoffDueResult(
 	ctx context.Context,
 	observedAt time.Time,

--- a/internal/scheduler/sync/transaction_integration_test.go
+++ b/internal/scheduler/sync/transaction_integration_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -280,6 +281,219 @@ func TestHandoffDuePostgresUnsupportedCronFallsBackWithoutMarkerWrite(t *testing
 	}
 	if occurrences != 0 || nextRunAt != nil {
 		t.Fatalf("unsupported fallback mutated occurrences=%d nextRunAt=%v", occurrences, nextRunAt)
+	}
+}
+
+// TestHandoffDuePostgresRespectsExternalRowLock is the CHAOS-3128 two-owners-
+// impossible proof. The "other owner" here is a raw PostgreSQL connection,
+// not another Go repository: it takes exactly the lock clause and lock order
+// (sync_configurations, then scheduled_jobs, both `FOR UPDATE`) that
+// sync_scheduler.py's `_maybe_dispatch_config` takes via SQLAlchemy's
+// `.with_for_update(skip_locked=True)`, so it stands in for a live Celery
+// Beat transaction without any Go-side cooperation. The property under test
+// is enforced by PostgreSQL's row-lock protocol, not by application code on
+// either side agreeing to be polite — see TransferScheduleMarkerOwnershipToGo
+// and HandoffDueResult's doc comments for the argument this proves.
+func TestHandoffDuePostgresRespectsExternalRowLock(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createSchedulerIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+
+	// A second, independent connection plays Celery Beat: same lock order,
+	// same clause shape, held open across the window Go tries to handoff in.
+	beatConn, err := pgx.Connect(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = beatConn.Close(context.Background()) }()
+	beatTx, err := beatConn.Begin(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = beatTx.Rollback(context.Background()) }()
+	if _, err := beatTx.Exec(ctx,
+		"SELECT 1 FROM public.sync_configurations WHERE id = $1 FOR UPDATE",
+		"00000000-0000-4000-8000-000000003038",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := beatTx.Exec(ctx,
+		"SELECT 1 FROM public.scheduled_jobs WHERE id = $1 FOR UPDATE",
+		"00000000-0000-4000-8000-000000003039",
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	repository, err := newRepositoryWithOwnership(pool, reviewedGoMutationOwnershipPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedAt := at("2026-01-01T12:00:00Z")
+	occurrences, err := repository.HandoffDue(ctx, observedAt, 1, NewOccurrenceCoordinator())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(occurrences) != 0 {
+		t.Fatalf(
+			"Go handed off %d occurrences while an external transaction held the row lock",
+			len(occurrences),
+		)
+	}
+
+	// The simulated Beat transaction now "wins": it advances the marker and
+	// commits, exactly as the real Python scheduler would inside the same
+	// locked transaction.
+	if _, err := beatTx.Exec(ctx,
+		"UPDATE public.scheduled_jobs SET next_run_at = $1, updated_at = $2 WHERE id = $3",
+		at("2026-01-01T13:00:00Z"), observedAt, "00000000-0000-4000-8000-000000003039",
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := beatTx.Commit(ctx); err != nil {
+		t.Fatal(err)
+	}
+
+	// Go's next poll must observe the committed marker and correctly treat
+	// the schedule as not due, rather than acting on a stale read.
+	second, err := repository.HandoffDue(ctx, observedAt, 1, NewOccurrenceCoordinator())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(second) != 0 {
+		t.Fatalf("Go re-handled a schedule Beat had already advanced: %d occurrences", len(second))
+	}
+	var occurrenceRows int
+	if err := pool.QueryRow(
+		ctx, "SELECT count(*) FROM public.scheduled_sync_occurrences",
+	).Scan(&occurrenceRows); err != nil {
+		t.Fatal(err)
+	}
+	if occurrenceRows != 0 {
+		t.Fatalf(
+			"occurrence rows = %d, want 0: Beat's dispatch owns this occurrence, not Go's ledger",
+			occurrenceRows,
+		)
+	}
+}
+
+// TestHandoffDuePostgresSurvivesTransactionCrashWithoutPartialWrite is the
+// transaction-crash gate. It severs the underlying connection mid-handoff —
+// after the coordinator has durably written the occurrence but before the
+// marker advance or commit — without ever calling Commit or Rollback, so the
+// property under test is PostgreSQL's own transaction-abort-on-disconnect
+// behavior, not this package's deferred Rollback call.
+func TestHandoffDuePostgresSurvivesTransactionCrashWithoutPartialWrite(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	if err := createSchedulerIntegrationFixture(ctx, pool); err != nil {
+		t.Fatal(err)
+	}
+
+	repository, err := newRepositoryWithOwnership(pool, reviewedGoMutationOwnershipPolicy())
+	if err != nil {
+		t.Fatal(err)
+	}
+	observedAt := at("2026-01-01T12:00:00Z")
+
+	crashed := errors.New("simulated process crash")
+	_, err = repository.HandoffDue(ctx, observedAt, 1, CoordinatorFunc(func(
+		handoffCtx context.Context,
+		transaction HandoffTransaction,
+		occurrence Occurrence,
+	) error {
+		if _, execErr := transaction.Exec(
+			handoffCtx,
+			"INSERT INTO public.scheduler_handoffs (id) VALUES ($1)",
+			occurrence.ID,
+		); execErr != nil {
+			return execErr
+		}
+		postgresTransaction, ok := transaction.(postgresSchedulerTransaction)
+		if !ok {
+			t.Fatal("unexpected transaction type")
+		}
+		// Kill the connection outright, as a crashed process would, instead
+		// of calling Rollback. The repository's deferred Rollback still runs
+		// on the caller side and will fail or no-op against a dead
+		// connection either way -- that is not what leaves no partial write
+		// behind. PostgreSQL aborting the transaction server-side on
+		// disconnect is.
+		if closeErr := postgresTransaction.Tx.Conn().Close(context.Background()); closeErr != nil {
+			t.Logf("closing simulated-crash connection: %v", closeErr)
+		}
+		return crashed
+	}))
+	if err == nil {
+		t.Fatal("HandoffDue() succeeded despite a crashed connection")
+	}
+
+	var handoffs int
+	var nextRunAt *time.Time
+	if err := pool.QueryRow(ctx, `
+		SELECT
+			(SELECT count(*) FROM public.scheduler_handoffs),
+			next_run_at
+		FROM public.scheduled_jobs
+		WHERE id = '00000000-0000-4000-8000-000000003039'
+	`).Scan(&handoffs, &nextRunAt); err != nil {
+		t.Fatal(err)
+	}
+	if handoffs != 0 || nextRunAt != nil {
+		t.Fatalf("crash left a partial write: handoffs=%d nextRunAt=%v", handoffs, nextRunAt)
+	}
+	var occurrenceRows int
+	if err := pool.QueryRow(
+		ctx, "SELECT count(*) FROM public.scheduled_sync_occurrences",
+	).Scan(&occurrenceRows); err != nil {
+		t.Fatal(err)
+	}
+	if occurrenceRows != 0 {
+		t.Fatalf("crash left %d occurrence rows behind", occurrenceRows)
+	}
+
+	// The pool must not be poisoned by one crashed connection: a fresh
+	// transaction has to succeed normally afterward.
+	occurrences, err := repository.HandoffDue(ctx, observedAt, 1, NewOccurrenceCoordinator())
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(occurrences) != 1 {
+		t.Fatalf("post-crash HandoffDue() occurrences = %d, want 1", len(occurrences))
 	}
 }
 


### PR DESCRIPTION
Transfers schedule-marker mutation authority from Celery Beat to the Go scheduler, and proves two owners cannot coexist during the switch.

**The activation gates stay closed.** `checkedInSchedulerActivation` remains `schedulerActivation{}` — this PR makes the transfer *possible* and *proven*, it does not perform it. Three preconditions are documented in `main.go` and remain unmet.

## What changed

`TransferScheduleMarkerOwnershipToGo()` is a new exported constructor wrapping the package-private `reviewedGoMutationOwnershipPolicy()`. The "environment alone cannot activate mutation" property survives by the same means it already did: `OwnershipPolicy`'s fields stay unexported, so this function and `DefaultOwnershipPolicy()` are the complete, closed set of values any external caller can obtain. There is no third value an env var could synthesize.

**A latent inconsistency is fixed.** `productionSchedulerRuntimeSources.newRepository` previously called `NewMutationRepository` *unconditionally*, so the `schedulerOwnership` variable was validated and then ignored while a separate hardcoded call did the real work. It now branches on `schedulerOwnership`, making that variable the single source of truth.

## Two owners are impossible, not merely unlikely

Python's scheduler takes `.with_for_update(of=(SyncConfiguration, ScheduledJob), skip_locked=True)` (`src/dev_health_ops/workers/sync_scheduler.py:400`) against the same rows, in the same `config -> job -> occurrence` order, as Go's `FOR UPDATE OF config, job SKIP LOCKED`, and both advance `next_run_at` inside the lock-holding transaction. PostgreSQL enforces that lock regardless of which process or language acquired it, so at most one of {Beat txn, Go txn} holds it and the other's `SKIP LOCKED` skips the row rather than racing a stale read. That is a database-level guarantee, not an application convention either side could violate unilaterally.

Proven, not asserted — two new Docker-verified integration tests:
- `TestHandoffDuePostgresRespectsExternalRowLock` — a raw second connection stands in for a live Beat transaction with an identical lock clause and order; Go skips it, then sees the marker once "Beat" commits.
- `TestHandoffDuePostgresSurvivesTransactionCrashWithoutPartialWrite` — severs the connection mid-handoff without Commit or Rollback, proving Postgres's own abort-on-disconnect leaves no partial write.

A Postgres advisory lock was deliberately **not** added: Beat does not participate in one, so it would give false confidence, and scoping it across Go replicas would regress already-tested active/active concurrency.

## Preconditions still unmet — activation is not this PR

1. **`coordinatorPolicyParity` has no definition anywhere in the repo.** It is a bare bool with a prose comment; no test, checklist, or document specifies the bar or how it is proven. Setting it would defeat the purpose of a source-reviewed seam.
2. **The scheduler's sync path is wired to the wrong pool.** `scheduled_jobs`, `scheduled_sync_occurrences`, and `sync_configurations` (UPDATE) are coordinator-exclusive per `internal/storage/postgres/domain_authorization.go`, but `dependencies.go` hands the sync repository and occurrences the **domain** pool. Since `FOR UPDATE OF config, job SKIP LOCKED` requires UPDATE on both — as that file's own comment documents — activation would take SQLSTATE 42501 immediately. CHAOS-3114 territory; reported rather than worked around.
3. `NewUnavailableMaterializer()` is still a stub pending CUT-09/CUT-10.

Separately, `deploy/go-workers/profiles.json` ships `dev-health-scheduler` at `min_replicas: 0` — a deployment-dimension gate, untouched here.

## Verification

`go build ./...` clean; `go test ./...` 0 failures across the whole module; `go vet` clean on the touched packages; `go test -tags integration ./internal/scheduler/sync/...` passes (14.8s), covering two-replica, transaction-crash, and outbox-failure-window evidence.

Refs CHAOS-3128, CHAOS-3114.
