### PR TITLE
CHAOS-3131: derive provider-unit routability from the capability matrix

### DIFF
--- a/contracts/jobs/v1/transitional-inventory.json
+++ b/contracts/jobs/v1/transitional-inventory.json
@@ -393,12 +393,12 @@
       "notes": "Beat entry prune-external-ingest-batches, crontab(5,15) UTC"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:745",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:756",
       "surface": "dispatch_sync_run",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 745
+        "line": 756
       },
       "queue_or_cadence": "sync",
       "dispatches": "run_sync_unit (per unit)",
@@ -417,12 +417,12 @@
       "notes": "transport-routes.json kind dispatch_sync_run, route=celery"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1130",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1147",
       "surface": "run_sync_unit",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1130
+        "line": 1147
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -441,12 +441,12 @@
       "notes": "only launchdarkly/feature-flags route-ready in Go"
     },
     {
-      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1954",
+      "id": "celery_task:src/dev_health_ops/workers/sync_units.py:1971",
       "surface": "finalize_sync_run",
       "class": "celery_task",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1954
+        "line": 1971
       },
       "queue_or_cadence": "sync",
       "dispatches": "self",
@@ -2289,12 +2289,12 @@
       "notes": ""
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1026",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1043",
       "surface": "getattr(signature,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1026
+        "line": 1043
       },
       "queue_or_cadence": "n/a",
       "dispatches": "dynamic per-provider signature",
@@ -2313,12 +2313,12 @@
       "notes": "grep-evading form; internal to dispatch_sync_run fan-out"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1589",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:1606",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 1589
+        "line": 1606
       },
       "queue_or_cadence": "n/a",
       "dispatches": "finalize_sync_run",
@@ -2337,12 +2337,12 @@
       "notes": "grep-evading form; internal to unit completion"
     },
     {
-      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2400",
+      "id": "call_site_getattr_indirection:src/dev_health_ops/workers/sync_units.py:2417",
       "surface": "getattr(finalize_sync_run,'apply_async')",
       "class": "call_site_getattr_indirection",
       "source": {
         "file": "src/dev_health_ops/workers/sync_units.py",
-        "line": 2400
+        "line": 2417
       },
       "queue_or_cadence": "sync",
       "dispatches": "finalize_sync_run",

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -1,13 +1,50 @@
-"""Fail-closed transport gate for complete provider sync-unit routes."""
+"""Fail-closed transport gate for complete provider sync-unit routes.
+
+Routability is derived from the checked-in provider capability matrix
+(``contracts/provider-matrix/v1/matrix.json``) instead of a hardcoded
+provider/dataset literal. A pair is routable only when BOTH hold:
+
+  1. The matrix marks the pair ``route_ready`` (TRD: "A provider/dataset pair
+     without a field here can never be enabled, which is why adding github,
+     gitlab, and pagerduty descriptors ... cannot widen the live route
+     surface.").
+  2. Its declared environment switch (see ``_switch_field_name``) is enabled.
+
+Neither condition is sufficient alone (PRD: "Declarative registry with
+complete policy; unknown or incomplete kinds fail readiness."). Landing a new
+``route_ready`` row in the matrix can never, by itself, move live traffic --
+only a change that ALSO wires and enables the matching switch can. This keeps
+CHAOS-3123..3127 (the per-provider readiness work) fully decoupled from any
+edit in this module: flipping a matrix row and turning on its switch is
+sufficient to route a pair, with no code change here.
+"""
 
 from __future__ import annotations
 
+import json
 import os
 from collections.abc import Mapping
 from dataclasses import dataclass
+from functools import cache
+from pathlib import Path
 
 _FALSE = frozenset({"", "0", "false", "no", "off"})
 _TRUE = frozenset({"1", "true", "yes", "on"})
+
+# src/dev_health_ops/workers/provider_unit_route.py -> repo root is 3 parents up.
+_DEFAULT_MATRIX_CONTRACT_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "contracts"
+    / "provider-matrix"
+    / "v1"
+    / "matrix.json"
+)
+
+# Reassignable only by tests (see tests/workers/test_provider_unit_route.py),
+# so a hypothetical second route_ready pair can be exercised end to end
+# through a fixture contract without ever editing the checked-in matrix.
+# Production code never assigns to this.
+_MATRIX_CONTRACT_PATH = _DEFAULT_MATRIX_CONTRACT_PATH
 
 
 class ProviderUnitRouteError(ValueError):
@@ -21,6 +58,59 @@ def _flag(environment: Mapping[str, str], name: str) -> bool:
     if value in _TRUE:
         return True
     raise ProviderUnitRouteError("provider unit route switch is invalid")
+
+
+@cache
+def _load_route_ready_pairs(path: Path) -> frozenset[tuple[str, str]]:
+    """Read a capability matrix contract and return every pair it marks
+    ``route_ready``.
+
+    This is the single Python reader of the contract that Go's
+    ``BuildProviderMatrix`` / ``TestProviderMatrixMatchesCheckedInContract``
+    (``internal/providersync/capability_matrix_test.go``) produces and
+    freezes byte-for-byte (CUT-08). A pair absent from the file, or present
+    with ``route_ready: false``, can never be routable regardless of switch
+    state -- this is the "unknown or incomplete kinds fail readiness" half of
+    the PRD requirement.
+    """
+
+    raw = json.loads(path.read_text())
+    return frozenset(
+        (str(pair["provider"]).strip().lower(), str(pair["dataset"]).strip().lower())
+        for pair in raw.get("pairs", ())
+        if pair.get("route_ready") is True
+    )
+
+
+def _route_ready_pairs() -> frozenset[tuple[str, str]]:
+    return _load_route_ready_pairs(_MATRIX_CONTRACT_PATH)
+
+
+def clear_matrix_cache() -> None:
+    """Drop the cached matrix read.
+
+    Test-only: production reads the checked-in contract exactly once per
+    process and never reloads it mid-run. Tests call this after repointing
+    ``_MATRIX_CONTRACT_PATH`` at a fixture, or after restoring the default,
+    so a stale cache entry from an earlier test can't leak in.
+    """
+
+    _load_route_ready_pairs.cache_clear()
+
+
+def _switch_field_name(provider: str, dataset: str) -> str:
+    """The ``ProviderUnitRouteSwitches`` field name a matrix pair's switch
+    must use -- e.g. ``launchdarkly`` + ``feature-flags`` ->
+    ``launchdarkly_feature_flags``.
+
+    This is a naming convention, not a routing decision on its own: a pair is
+    only enabled if a field of this name also exists on the dataclass AND is
+    True. A provider/dataset combination with no matching field derives a
+    name that resolves to nothing, so it fails closed by construction rather
+    than through an explicit denylist.
+    """
+
+    return f"{provider.strip().lower()}_{dataset.strip().lower()}".replace("-", "_")
 
 
 @dataclass(frozen=True, slots=True)
@@ -52,15 +142,28 @@ class ProviderUnitRouteSwitches:
 
     def routes_to_river(self, provider: str, dataset: str) -> bool:
         self.require_complete_routes()
-        return self.launchdarkly_feature_flags and self.is_canary_scope(
+        return self.is_route_ready(provider, dataset) and self._switch_enabled(
             provider, dataset
         )
 
+    def _switch_enabled(self, provider: str, dataset: str) -> bool:
+        # getattr's default is what makes "no field declared for this pair"
+        # resolve to False instead of raising -- the mechanism behind "a pair
+        # can never be enabled by omission".
+        return bool(getattr(self, _switch_field_name(provider, dataset), False))
+
     @staticmethod
-    def is_canary_scope(provider: str, dataset: str) -> bool:
-        """Return whether a unit is covered by the checked-in canary scope."""
+    def is_route_ready(provider: str, dataset: str) -> bool:
+        """Return whether the checked-in capability matrix marks this
+        provider/dataset pair ``route_ready``.
+
+        This is the only source of readiness in this module: nothing here
+        hardcodes a provider/dataset literal, so a pair becomes eligible the
+        moment the matrix says it is ready -- routability still requires its
+        switch too (see ``routes_to_river``).
+        """
 
         return (
-            provider.strip().lower() == "launchdarkly"
-            and dataset.strip().lower() == "feature-flags"
-        )
+            provider.strip().lower(),
+            dataset.strip().lower(),
+        ) in _route_ready_pairs()

--- a/src/dev_health_ops/workers/sync_units.py
+++ b/src/dev_health_ops/workers/sync_units.py
@@ -108,6 +108,7 @@ from dev_health_ops.workers.job_contracts import ProviderUnitPayload
 from dev_health_ops.workers.job_outbox import enqueue_worker_job
 from dev_health_ops.workers.job_routes import (
     RIVER_CANARY_ROUTE,
+    RIVER_ROUTE,
     WorkerJobRouteError,
     resolve_worker_job_route,
 )
@@ -132,6 +133,16 @@ _TERMINAL_RUN_STATUSES = {
     SyncRunStatus.PARTIAL_FAILED.value,
     SyncRunStatus.FAILED.value,
 }
+# The sync.provider_unit outbox path is reachable under either transitional
+# durable route: river_canary (bounded scope, still comparable to Celery) and
+# river (post-canary, no comparison). Celery and shadow never queue an
+# individual unit here -- shadow's dual-dispatch semantics are not
+# implemented for this producer, and celery is the rollback route every
+# per-pair decision below falls back to. Per-pair routability is decided
+# independently per unit (ProviderUnitRouteSwitches.routes_to_river), so a
+# run whose units span both a ready+enabled pair and pairs that are not is
+# expected to dispatch a mix of river and celery units in the same pass.
+_PROVIDER_UNIT_OUTBOX_ROUTES = frozenset({RIVER_CANARY_ROUTE, RIVER_ROUTE})
 _WORK_ITEM_RESULT_OBSERVATION_FIELDS = (
     "linear_page_count",
     "linear_batch_count",
@@ -955,25 +966,31 @@ def dispatch_sync_run(sync_run_id: str) -> dict[str, Any]:
         provider_unit_route = resolve_worker_job_route(session, "sync.provider_unit")
         provider_unit_routes = (
             ProviderUnitRouteSwitches.from_environment()
-            if provider_unit_route == RIVER_CANARY_ROUTE
+            if provider_unit_route in _PROVIDER_UNIT_OUTBOX_ROUTES
             else None
         )
         units = _claim_units(session, run_uuid, capped_ids=capped_ids)
         signatures = []
         for unit in units:
-            in_canary_scope = ProviderUnitRouteSwitches.is_canary_scope(
-                str(unit.provider), str(unit.dataset_key)
-            )
-            if in_canary_scope and provider_unit_route == RIVER_CANARY_ROUTE:
-                if (
-                    provider_unit_routes is None
-                    or not provider_unit_routes.routes_to_river(
-                        str(unit.provider), str(unit.dataset_key)
-                    )
+            unit_provider = str(unit.provider)
+            unit_dataset = str(unit.dataset_key)
+            # Routability is decided per pair, not per run: the matrix
+            # (ProviderUnitRouteSwitches.is_route_ready) is the only source of
+            # which pairs are even candidates, so a run mixing a route-ready
+            # pair with 58 pairs the matrix has not marked ready dispatches a
+            # mix of river and celery units in the same pass, by design.
+            if provider_unit_routes is not None and (
+                ProviderUnitRouteSwitches.is_route_ready(unit_provider, unit_dataset)
+            ):
+                if not provider_unit_routes.routes_to_river(
+                    unit_provider, unit_dataset
                 ):
-                    # A checked-in canary route without its complete runtime
-                    # capability is an ownership fault, never a reason to
-                    # silently publish legacy Celery work.
+                    # The matrix marks this pair complete and the durable
+                    # route makes the outbox transport live, but this pair's
+                    # own switch is off. That combination is an ownership
+                    # fault -- readiness and enablement fell out of step --
+                    # never a reason to silently fall back to legacy Celery
+                    # dispatch for a pair the matrix says is done.
                     raise WorkerJobRouteError(
                         "sync provider canary capability is unavailable"
                     )

--- a/tests/test_sync_units.py
+++ b/tests/test_sync_units.py
@@ -2685,6 +2685,429 @@ def test_dispatch_sync_run_provider_outbox_claim_rolls_back_and_dedupes(
     assert db_session.query(WorkerJobOutbox).count() == 1
 
 
+# ---------------------------------------------------------------------------
+# CHAOS-3131: matrix-driven per-pair routing + mixed-transport coherence.
+#
+# The outbox path must stay reachable for a ready+enabled pair under BOTH
+# durable routes (river_canary and river), and readiness must generalize past
+# the single hardcoded launchdarkly/feature-flags pair. The riskiest property
+# in the program is that one SyncRun can legitimately contain units bound for
+# both River and Celery in the same dispatch pass, and that run-level status,
+# unit counts, and finalization stay coherent regardless of which transport
+# produced a given unit's terminal state.
+# ---------------------------------------------------------------------------
+
+
+def test_dispatch_sync_run_plain_river_route_also_reaches_outbox(
+    db_session, monkeypatch
+):
+    """Promoting sync.provider_unit from river_canary to plain river must not
+    silently revert every unit to legacy Celery dispatch -- that was the
+    latent bug this ticket closes. The checked-in migration policy for
+    sync.provider_unit is still river_canary
+    (contracts/jobs/v1/migration-state.json, out of this ticket's scope), so
+    a live "river" WorkerJobRoute row cannot be produced through the normal
+    resolver yet. Patching the resolver directly isolates and exercises
+    dispatch_sync_run's own per-pair branch under the route this ticket must
+    support, independent of when the policy itself is promoted.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, unit = _seed_run(
+        db_session,
+        provider="launchdarkly",
+        source_type="project",
+        dataset_key="feature-flags",
+    )
+    _patch_db_session(monkeypatch, db_session)
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED", "true")
+    monkeypatch.setattr(
+        sync_units, "resolve_worker_job_route", lambda *args, **kwargs: "river"
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    rows = db_session.query(WorkerJobOutbox).all()
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert len(unit_publish_calls) == 0
+    assert len(rows) == 1
+    assert rows[0].dedupe_key == f"sync.provider_unit:{unit.id}"
+
+
+def test_dispatch_sync_run_mixed_transport_routes_every_ready_pair_independently(
+    db_session, monkeypatch
+):
+    """Proves the mechanism generalizes past the one production-ready pair,
+    not just that a ready pair coexists with celery fallback (already true
+    before CHAOS-3131). With a SECOND hypothetical route-ready+enabled pair
+    (github/commits, injected via monkeypatch fixture rather than editing the
+    checked-in matrix), a three-unit run routes BOTH ready pairs to the
+    outbox and leaves the one pair the matrix does not recognise on Celery,
+    in the same dispatch pass -- N pairs to River, the rest to Celery.
+    """
+    from dev_health_ops.workers import sync_units
+    from dev_health_ops.workers.provider_unit_route import ProviderUnitRouteSwitches
+
+    run, launchdarkly_unit = _seed_run(
+        db_session,
+        provider="launchdarkly",
+        source_type="project",
+        dataset_key="feature-flags",
+    )
+    github_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=launchdarkly_unit.integration_id,
+        source_id=launchdarkly_unit.source_id,
+        provider="github",
+        dataset_key="commits",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={"sync_git": True, "sync_commits": True},
+    )
+    gitlab_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=launchdarkly_unit.integration_id,
+        source_id=launchdarkly_unit.source_id,
+        provider="gitlab",
+        dataset_key="commits",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={"sync_git": True, "sync_commits": True},
+    )
+    run.total_units = 3
+    db_session.add_all([github_unit, gitlab_unit])
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED", "true")
+    db_session.query(WorkerJobRoute).filter(
+        WorkerJobRoute.job_kind == "sync.provider_unit"
+    ).update({WorkerJobRoute.transport: "river_canary"})
+    db_session.commit()
+
+    ready_pairs = {("launchdarkly", "feature-flags"), ("github", "commits")}
+
+    def fake_is_route_ready(provider: str, dataset: str) -> bool:
+        return (provider.lower(), dataset.lower()) in ready_pairs
+
+    real_routes_to_river = ProviderUnitRouteSwitches.routes_to_river
+
+    def fake_routes_to_river(self, provider, dataset):
+        self.require_complete_routes()
+        if (provider.lower(), dataset.lower()) == ("github", "commits"):
+            return True
+        return real_routes_to_river(self, provider, dataset)
+
+    monkeypatch.setattr(
+        ProviderUnitRouteSwitches, "is_route_ready", staticmethod(fake_is_route_ready)
+    )
+    monkeypatch.setattr(
+        ProviderUnitRouteSwitches, "routes_to_river", fake_routes_to_river
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    rows = {row.dedupe_key for row in db_session.query(WorkerJobOutbox).all()}
+    assert result == {"status": "dispatched", "queued_units": 3}
+    assert rows == {
+        f"sync.provider_unit:{launchdarkly_unit.id}",
+        f"sync.provider_unit:{github_unit.id}",
+    }
+    assert len(unit_publish_calls) == 1
+    assert unit_publish_calls[0][0] == str(gitlab_unit.id)
+
+
+def test_finalize_aggregates_success_across_mixed_transport_units(
+    db_session, monkeypatch
+):
+    """finalize_sync_run reads only SyncRunUnit.status; it must never need to
+    know which transport produced a terminal state. One unit's status is set
+    the way Celery's run_sync_unit would leave it; the other's is set the way
+    the Go River worker's UnitRepository.Complete would leave it (same table,
+    same enum, same result-JSON shape). Finalizing proves the two producers
+    stay coherent at the run-level aggregation boundary.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, celery_unit = _seed_run(db_session, provider="github", dataset_key="commits")
+    river_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=celery_unit.integration_id,
+        source_id=celery_unit.source_id,
+        provider="launchdarkly",
+        dataset_key="feature-flags",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.SUCCESS.value,
+        attempts=1,
+        result={"go_provider_route": {"effects_written": 4, "effects_skipped": 0}},
+    )
+    celery_unit.status = SyncRunUnitStatus.SUCCESS.value
+    run.total_units = 2
+    db_session.add(river_unit)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+
+    result = sync_units.finalize_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    assert result["status"] == "finalized"
+    assert run.status == SyncRunStatus.SUCCESS.value
+    assert run.completed_units == 2
+    assert run.failed_units == 0
+
+
+def test_finalize_aggregates_partial_failure_across_mixed_transport_units(
+    db_session, monkeypatch
+):
+    """Same coherence proof as the all-success case, but for the partial
+    failure branch: the River-origin unit fails while the Celery-origin unit
+    succeeds, and the run must still land PARTIAL_FAILED with correct
+    per-status counts -- proving finalize's aggregation does not implicitly
+    assume every unit in a run shares one transport.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, celery_unit = _seed_run(db_session, provider="github", dataset_key="commits")
+    river_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=celery_unit.integration_id,
+        source_id=celery_unit.source_id,
+        provider="launchdarkly",
+        dataset_key="feature-flags",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.FAILED.value,
+        attempts=1,
+        error="sync provider canary capability is unavailable",
+        result={"error_category": "provider_unit_exhausted"},
+    )
+    celery_unit.status = SyncRunUnitStatus.SUCCESS.value
+    run.total_units = 2
+    db_session.add(river_unit)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+
+    result = sync_units.finalize_sync_run(str(run.id))
+
+    db_session.refresh(run)
+    assert result["status"] == "finalized"
+    assert run.status == SyncRunStatus.PARTIAL_FAILED.value
+    assert run.completed_units == 1
+    assert run.failed_units == 1
+
+
+def test_dispatch_sync_run_denial_fails_planned_units_regardless_of_transport(
+    db_session, monkeypatch
+):
+    """DispatchGuard denial ('cancel') must fail unresolved PLANNED units and
+    leave any unit already in flight alone, regardless of which transport
+    that in-flight unit is running under. Simulates a River unit already
+    RUNNING (as the Go worker's Claim would leave it: lease_owner + heartbeat
+    set) alongside a PLANNED Celery-only unit that has not dispatched yet.
+    """
+    from dev_health_ops.sync.guard import GuardDecision
+    from dev_health_ops.workers import sync_units
+
+    run, river_running = _seed_run(
+        db_session,
+        provider="launchdarkly",
+        source_type="project",
+        dataset_key="feature-flags",
+    )
+    now = datetime.now(timezone.utc)
+    river_running.status = SyncRunUnitStatus.RUNNING.value
+    river_running.attempts = 1
+    river_running.lease_owner = "go-river-worker"
+    river_running.lease_expires_at = now + timedelta(minutes=5)
+    river_running.last_heartbeat_at = now
+    celery_planned = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=river_running.integration_id,
+        source_id=river_running.source_id,
+        provider="github",
+        dataset_key="commits",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={"sync_git": True, "sync_commits": True},
+    )
+    run.status = SyncRunStatus.DISPATCHING.value
+    run.total_units = 2
+    db_session.add(celery_planned)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+    reason = "sync run cancelled by operator"
+    monkeypatch.setattr(
+        sync_units.DispatchGuard,
+        "authorize_run",
+        lambda session, sync_run_id: GuardDecision(
+            False, reason, (str(river_running.id), str(celery_planned.id))
+        ),
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(river_running)
+    db_session.refresh(celery_planned)
+    assert result == {
+        "status": "denied_active",
+        "reason": reason,
+        "failed_planned_units": 1,
+        "failed_stale_dispatching_units": 0,
+    }
+    assert celery_planned.status == SyncRunUnitStatus.FAILED.value
+    # The in-flight River unit is untouched: cancellation must never
+    # terminalize a unit a live consumer might still be executing, no matter
+    # which transport that consumer is.
+    assert river_running.status == SyncRunUnitStatus.RUNNING.value
+    assert unit_publish_calls == []
+
+
+def test_dispatch_sync_run_concurrency_cap_defers_regardless_of_transport(
+    db_session, monkeypatch
+):
+    """A concurrency/budget partial-cap defers a unit before the per-pair
+    transport decision is ever made. Capping a unit that WOULD have routed to
+    River leaves it PLANNED exactly like capping a Celery-only unit would --
+    and once the cap clears, the very next dispatch pass must still route it
+    correctly, proving budget caps and transport routing are independent
+    concerns applied in the right order.
+    """
+    from dev_health_ops.sync.guard import GuardDecision
+    from dev_health_ops.workers import sync_units
+
+    run, river_unit = _seed_run(
+        db_session,
+        provider="launchdarkly",
+        source_type="project",
+        dataset_key="feature-flags",
+    )
+    celery_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=river_unit.integration_id,
+        source_id=river_unit.source_id,
+        provider="github",
+        dataset_key="commits",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={"sync_git": True, "sync_commits": True},
+    )
+    run.total_units = 2
+    db_session.add(celery_unit)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED", "true")
+    db_session.query(WorkerJobRoute).filter(
+        WorkerJobRoute.job_kind == "sync.provider_unit"
+    ).update({WorkerJobRoute.transport: "river_canary"})
+    db_session.commit()
+    monkeypatch.setattr(
+        sync_units.DispatchGuard,
+        "authorize_run",
+        lambda session, sync_run_id: GuardDecision(
+            True, "concurrency cap", (str(river_unit.id),), True
+        ),
+    )
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(river_unit)
+    db_session.refresh(celery_unit)
+    assert result == {"status": "dispatched", "queued_units": 1}
+    assert river_unit.status == SyncRunUnitStatus.PLANNED.value
+    assert celery_unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert db_session.query(WorkerJobOutbox).count() == 0
+    assert len(unit_publish_calls) == 1
+
+    monkeypatch.setattr(
+        sync_units.DispatchGuard,
+        "authorize_run",
+        lambda session, sync_run_id: GuardDecision(True, None, (), False),
+    )
+    result_after_cap_clears = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(river_unit)
+    assert result_after_cap_clears["status"] == "dispatched"
+    assert river_unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert db_session.query(WorkerJobOutbox).count() == 1
+
+
+def test_dispatch_sync_run_reclaims_stale_units_of_both_transports_and_redecides(
+    db_session, monkeypatch
+):
+    """A stale DISPATCHING unit means an earlier dispatch enqueued it but no
+    consumer ever picked it up (broker restart, or the producer died before a
+    River claim landed -- worker loss). Reclaim must work identically for a
+    unit that will route to River and one that stays on Celery, and the
+    transport decision must be re-made fresh on the reclaiming pass rather
+    than reusing whatever was decided (and lost) the first time.
+    """
+    from dev_health_ops.workers import sync_units
+
+    run, river_unit = _seed_run(
+        db_session,
+        provider="launchdarkly",
+        source_type="project",
+        dataset_key="feature-flags",
+    )
+    celery_unit = SyncRunUnit(
+        org_id=run.org_id,
+        sync_run_id=run.id,
+        integration_id=river_unit.integration_id,
+        source_id=river_unit.source_id,
+        provider="github",
+        dataset_key="commits",
+        cost_class="medium",
+        mode=SyncRunMode.INCREMENTAL.value,
+        status=SyncRunUnitStatus.PLANNED.value,
+        attempts=0,
+        processor_flags={"sync_git": True, "sync_commits": True},
+    )
+    stale = datetime.now(timezone.utc) - timedelta(minutes=30)
+    river_unit.status = SyncRunUnitStatus.DISPATCHING.value
+    river_unit.updated_at = stale
+    run.total_units = 2
+    db_session.add(celery_unit)
+    db_session.flush()
+    _patch_db_session(monkeypatch, db_session)
+    _, _, unit_publish_calls = _patch_worker_enqueues(monkeypatch)
+    monkeypatch.setenv("WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED", "true")
+    db_session.query(WorkerJobRoute).filter(
+        WorkerJobRoute.job_kind == "sync.provider_unit"
+    ).update({WorkerJobRoute.transport: "river_canary"})
+    db_session.commit()
+
+    result = sync_units.dispatch_sync_run(str(run.id))
+
+    db_session.refresh(river_unit)
+    db_session.refresh(celery_unit)
+    assert result == {"status": "dispatched", "queued_units": 2}
+    assert river_unit.status == SyncRunUnitStatus.DISPATCHING.value
+    assert celery_unit.status == SyncRunUnitStatus.DISPATCHING.value
+    rows = db_session.query(WorkerJobOutbox).all()
+    assert len(rows) == 1
+    assert rows[0].dedupe_key == f"sync.provider_unit:{river_unit.id}"
+    assert len(unit_publish_calls) == 1
+    assert unit_publish_calls[0][0] == str(celery_unit.id)
+
+
 def test_dispatch_sync_run_continues_accepted_run_after_planner_config_pause(
     db_session, monkeypatch
 ):

--- a/tests/workers/test_provider_matrix_contract.py
+++ b/tests/workers/test_provider_matrix_contract.py
@@ -133,16 +133,21 @@ def test_per_pair_metadata_matches_the_python_registry(
         assert pair["python_source"].endswith(f'["{pair["provider"]}"]'), scope
 
 
-def test_producer_canary_scope_is_a_subset_of_route_ready_descriptors(
+def test_producer_route_readiness_matches_the_checked_in_matrix_exactly(
     matrix: dict[str, Any],
 ) -> None:
-    """CUT-08 acceptance: 'No producer can route a scope whose Go descriptor is
-    absent or disabled.'
+    """CUT-08 acceptance, generalized for CHAOS-3131: 'No producer can route a
+    scope whose Go descriptor is absent or disabled.'
 
-    This is the one regression test binding both sides. It fails if a future
-    change widens ``is_canary_scope`` before the corresponding Go descriptor
-    becomes route-ready — the exact ordering that would make TRD §5.3's
-    ``route_disabled`` hazard reachable.
+    Pre-CHAOS-3131 this only had to hold for one hardcoded pair
+    (``is_canary_scope``). Now that ``ProviderUnitRouteSwitches.is_route_ready``
+    reads the checked-in matrix directly, this is the test that binds Python's
+    readiness notion to Go's: Go regenerates the same contract from
+    ``CompleteRouteSwitches.Descriptor`` and fails CI on any byte-level
+    divergence (``internal/providersync/capability_matrix_test.go`` ->
+    ``TestProviderMatrixMatchesCheckedInContract``), so asserting Python's
+    reader agrees with every row of that file transitively binds Python to
+    Go's descriptor logic without a live cross-language call.
     """
 
     route_ready = {
@@ -150,16 +155,25 @@ def test_producer_canary_scope_is_a_subset_of_route_ready_descriptors(
         for pair in matrix["pairs"]
         if pair["route_ready"]
     }
-    canary = {
+    python_ready = {
         (provider, dataset)
         for provider, dataset in _python_pairs()
-        if ProviderUnitRouteSwitches.is_canary_scope(provider, dataset)
+        if ProviderUnitRouteSwitches.is_route_ready(provider, dataset)
     }
 
-    assert canary, "the producer gate must recognise at least one scope"
-    assert canary <= route_ready, {
-        "producer_scopes_without_a_ready_go_descriptor": sorted(canary - route_ready)
+    assert python_ready, "the producer gate must recognise at least one scope"
+    assert python_ready == route_ready, {
+        "python_says_ready_matrix_disagrees": sorted(python_ready - route_ready),
+        "matrix_says_ready_python_disagrees": sorted(route_ready - python_ready),
     }
+
+    # Membership equality is necessary but not sufficient: a pair that is not
+    # even a member of the frozen provider/dataset universe must also read as
+    # not-ready, so a typo'd or renamed pair fails closed rather than
+    # silently matching nothing.
+    assert not ProviderUnitRouteSwitches.is_route_ready(
+        "not-a-real-provider", "not-a-real-dataset"
+    )
 
 
 def test_producer_gate_cannot_route_any_scope_outside_the_ready_set(

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -1,11 +1,29 @@
 from __future__ import annotations
 
+import json
+from pathlib import Path
+
 import pytest
 
+from dev_health_ops.workers import provider_unit_route
 from dev_health_ops.workers.provider_unit_route import (
     ProviderUnitRouteError,
     ProviderUnitRouteSwitches,
 )
+
+
+@pytest.fixture(autouse=True)
+def _restore_matrix_contract_path():
+    """Every test in this module may repoint the module-level matrix path at
+    a fixture. Always restore the production path and drop any cached read
+    afterwards so later test modules see the real checked-in contract."""
+
+    original = provider_unit_route._MATRIX_CONTRACT_PATH
+    try:
+        yield
+    finally:
+        provider_unit_route._MATRIX_CONTRACT_PATH = original
+        provider_unit_route.clear_matrix_cache()
 
 
 def test_route_switch_is_exact_and_independent() -> None:
@@ -37,3 +55,99 @@ def test_invalid_switch_fails_closed_without_echoing_value() -> None:
             {"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": value}
         )
     assert value not in str(raised.value)
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3131: routability is derived from the checked-in matrix, not from a
+# hardcoded provider/dataset literal.
+# ---------------------------------------------------------------------------
+
+
+def test_is_route_ready_reflects_the_checked_in_matrix() -> None:
+    assert ProviderUnitRouteSwitches.is_route_ready("launchdarkly", "feature-flags")
+    # Same dataset name, different provider: the matrix marks gitlab's
+    # feature-flags pair route_ready=false, so it must stay closed even
+    # though the string "feature-flags" matches.
+    assert not ProviderUnitRouteSwitches.is_route_ready("gitlab", "feature-flags")
+    # Case/whitespace must not matter -- callers pass live DB column values.
+    assert ProviderUnitRouteSwitches.is_route_ready(" LaunchDarkly ", "Feature-Flags")
+
+
+def test_is_route_ready_fails_closed_for_unknown_pairs() -> None:
+    assert not ProviderUnitRouteSwitches.is_route_ready("acme", "widgets")
+    assert not ProviderUnitRouteSwitches.is_route_ready("github", "commits")
+
+
+def _write_matrix_fixture(path: Path, *, ready_pairs: set[tuple[str, str]]) -> None:
+    pairs = []
+    for provider, dataset in sorted(ready_pairs):
+        pairs.append(
+            {
+                "provider": provider,
+                "dataset": dataset,
+                "route_ready": True,
+            }
+        )
+    # A not-ready pair alongside the ready ones proves the loader filters on
+    # route_ready rather than treating "present in the file" as sufficient.
+    pairs.append({"provider": "github", "dataset": "commits", "route_ready": False})
+    path.write_text(json.dumps({"schema_version": 1, "pairs": pairs}))
+
+
+def test_is_route_ready_generalizes_to_a_hypothetical_second_ready_pair(
+    tmp_path,
+) -> None:
+    """Proves the mechanism, not just the one production pair: pointing the
+    loader at a fixture contract with TWO route_ready pairs makes BOTH
+    routable through the exact same code path, with no edit to this module.
+    """
+
+    fixture = tmp_path / "matrix.json"
+    _write_matrix_fixture(
+        fixture,
+        ready_pairs={
+            ("launchdarkly", "feature-flags"),
+            ("acme", "widgets"),
+        },
+    )
+    provider_unit_route._MATRIX_CONTRACT_PATH = fixture
+    provider_unit_route.clear_matrix_cache()
+
+    assert ProviderUnitRouteSwitches.is_route_ready("launchdarkly", "feature-flags")
+    assert ProviderUnitRouteSwitches.is_route_ready("acme", "widgets")
+    # The explicitly not-ready row in the same fixture stays closed.
+    assert not ProviderUnitRouteSwitches.is_route_ready("github", "commits")
+    # A pair entirely absent from the fixture also stays closed.
+    assert not ProviderUnitRouteSwitches.is_route_ready("jira", "incidents")
+
+
+def test_a_hypothetical_ready_pair_still_requires_its_own_switch(tmp_path) -> None:
+    """route_ready alone is never sufficient -- adding a matrix row cannot
+    widen the routable surface by itself. ``acme/widgets`` has no matching
+    field on ProviderUnitRouteSwitches, so it can never be enabled no matter
+    how the matrix reads."""
+
+    fixture = tmp_path / "matrix.json"
+    _write_matrix_fixture(fixture, ready_pairs={("acme", "widgets")})
+    provider_unit_route._MATRIX_CONTRACT_PATH = fixture
+    provider_unit_route.clear_matrix_cache()
+
+    assert ProviderUnitRouteSwitches.is_route_ready("acme", "widgets")
+    switches = ProviderUnitRouteSwitches.from_environment({})
+    assert not switches.routes_to_river("acme", "widgets")
+
+    # Even a switch dataclass with every real field enabled cannot route it,
+    # because none of those fields derive to "acme_widgets".
+    all_enabled = ProviderUnitRouteSwitches(launchdarkly_feature_flags=True)
+    assert not all_enabled.routes_to_river("acme", "widgets")
+
+
+def test_switch_field_name_is_a_pure_naming_convention() -> None:
+    assert (
+        provider_unit_route._switch_field_name("launchdarkly", "feature-flags")
+        == "launchdarkly_feature_flags"
+    )
+    assert (
+        provider_unit_route._switch_field_name("Jira", "Work-Items")
+        == "jira_work_items"
+    )


### PR DESCRIPTION
Makes provider-unit routability derive from the checked-in capability matrix, so a pair can be enabled one at a time as it lands. This is the bottleneck for the whole provider-sync parity program (CHAOS-3122): no provider port can ship without it.

**No pair is enabled by this PR.** The live route surface is unchanged — still exactly `launchdarkly/feature-flags`, verified empirically below.

## The problem

`ProviderUnitRouteSwitches` hardcoded a single pair. `require_complete_routes()` *raised* if the linear or jira switches were set, `routes_to_river()` was `launchdarkly_feature_flags and is_canary_scope(...)`, and `is_canary_scope` string-matched `launchdarkly`/`feature-flags`. There was no switch at all for github, gitlab, or pagerduty. Enabling a second pair required editing a constant.

## The mechanism

`is_route_ready(provider, dataset)` loads and caches `contracts/provider-matrix/v1/matrix.json` and checks `route_ready`. `routes_to_river` requires **both** `is_route_ready(...)` and the pair's own switch, where the field name is derived by naming convention (`launchdarkly` + `feature-flags` → `launchdarkly_feature_flags`) and read via `getattr(self, name, False)`.

Two independent conditions, so a pair cannot be enabled by omission:
- absent from the matrix, or `route_ready: false` → refused regardless of switches;
- no declared switch field → `getattr`'s default resolves to `False`, so adding a matrix row alone can never put traffic on the wire.

Empirically verified against the real matrix with **every declared switch turned on** — the most permissive posture any deployment can reach:

```
routable: 1   (launchdarkly / feature-flags)
refused:  58  (no exceptions raised)
```

## The producer bug this closes

`dispatch_sync_run` reached the outbox only via a branch requiring the durable route to be literally `river_canary`. Promoting `sync.provider_unit` to plain `river` therefore made every unit fall through to legacy Celery dispatch — silently switching *off* the one working River path. The branch now tests membership in `{river_canary, river}` plus per-pair readiness, so the outbox is reachable under either route. The "ready pair with its switch off while a live outbox route exists is an ownership fault" raise is preserved and generalized per pair.

## Mixed-transport coherence

With N pairs on River and 59−N on Celery, one `SyncRun` can contain units of both transports. `finalize_sync_run` reads only `SyncRunUnit.status`, and the model carries no transport column, so aggregation is transport-blind by construction. Tests cover the scenarios the plan's coordination gate names:

- success and partial failure across mixed-transport terminal writes;
- cancel — a DispatchGuard denial leaves an in-flight river unit untouched and fails only the planned celery unit;
- budget caps — a concurrency-capped river-eligible unit stays PLANNED and routes correctly once the cap clears;
- worker loss — stale DISPATCHING units of both transports are reclaimed and re-decided;
- genericity — a fixture matrix with two ready pairs plus a monkeypatched github/commits pair proves the mechanism is not still special-cased to the string `launchdarkly`;
- plain `river` route reaches the outbox.

Not covered, and not claimed: true concurrent multi-process lease-expiry reconciliation and Go-side execution. Both are pre-existing subsystems outside this change, exercised elsewhere in the suite.

## Divergence between languages

Go's `TestProviderMatrixMatchesCheckedInContract` already freezes the matrix byte-for-byte against Go's compiled descriptor registry. The Python side now asserts `is_route_ready` agrees with every row of that same file, transitively binding the two without a live cross-language call. No Go change was needed — `CompleteRouteSwitches.Descriptor` already computed `RouteReady && RouteEnabled` per pair correctly; only Python had the hardcoded gate.

## Incidental

Editing `sync_units.py` shifted six line-anchored rows in `contracts/jobs/v1/transitional-inventory.json`, which anchors by file and line. Re-anchored, no semantic change.

## Verification

Python: 399 passed, 1 skipped across `tests/test_sync_units.py` and `tests/workers/`. Go: `go build ./...` clean and `go test ./...` 0 failures module-wide. ruff and mypy clean.

Refs CHAOS-3131, CHAOS-3122.
