### PR TITLE
CHAOS-3118/3117: wire five dead metric families and fix unfireable stream alerts

### DIFF
--- a/alerts/rules.yml
+++ b/alerts/rules.yml
@@ -195,9 +195,23 @@ groups:
             A job was rejected because its {{ $labels.domain_type }} domain state
             did not permit execution. Inspect the sanitized operator audit trail.
 
+      # worker_stream_lag/worker_stream_pending/worker_stream_oldest_pending_seconds
+      # are deliberately emitted with NO stream label (see
+      # internal/streamrunner/runner.go WritePrometheus): every configured
+      # runner discovers its streams by wildcard pattern
+      # ("pagerduty-webhooks:*", "ingest:*:commits", ...), and the wildcard
+      # segment is a per-org or per-integration identifier. Labeling by the
+      # literal stream key would put an org/integration identity on a metric
+      # label, which the PRD forbids outright. Each runner kind (pagerduty,
+      # internal_ingest, product_telemetry, external_ingest) instead runs as
+      # its own scrape target, so grouping by Prometheus's own job/instance
+      # labels — already relied on by GoWorkerTelemetryTargetDown below —
+      # is the bounded, policy-safe way to say *which deployment* is behind.
+      # It cannot say which org's stream within that deployment is behind;
+      # that would require a durable, non-metric signal instead.
       - alert: GoWorkerStreamLagHigh
         expr: |
-          max by (stream, consumer_group) (worker_stream_lag) > 1000
+          max by (job, instance) (worker_stream_lag) > 1000
         for: 10m
         labels:
           severity: warning
@@ -205,12 +219,12 @@ groups:
         annotations:
           summary: "Worker stream consumer lag is high"
           description: |
-            Stream {{ $labels.stream }} consumer group {{ $labels.consumer_group }}
-            is {{ $value }} messages behind.
+            Stream runner {{ $labels.job }} ({{ $labels.instance }}) is
+            {{ $value }} messages behind across its monitored streams.
 
       - alert: GoWorkerStreamPendingTooOld
         expr: |
-          max by (stream, consumer_group) (worker_stream_oldest_pending_seconds) > 300
+          max by (job, instance) (worker_stream_oldest_pending_seconds) > 300
         for: 10m
         labels:
           severity: warning
@@ -218,8 +232,8 @@ groups:
         annotations:
           summary: "Worker stream pending entry is stale"
           description: |
-            The oldest pending entry for {{ $labels.stream }} / 
-            {{ $labels.consumer_group }} is {{ $value | humanizeDuration }} old.
+            The oldest pending entry seen by stream runner {{ $labels.job }}
+            ({{ $labels.instance }}) is {{ $value | humanizeDuration }} old.
 
       - alert: GoWorkerQueueControlPoolPressure
         expr: |

--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -33,6 +33,11 @@ type workerDatabase interface {
 	RiverSchemaReady(context.Context, string) error
 	PoolSaturation() (domain float64, queueControl float64)
 	NewQueueTelemetrySampler(riverstore.QueueTelemetryConfig) (queueTelemetrySampler, error)
+	// AttachPoolAcquireObserver wires worker_database_pool_acquire_seconds
+	// into the domain/queue-control pools' Acquire path. It is called once
+	// dependencies.metrics exists, which is after the database itself opens
+	// (see NewRuntimePools's tracer freeze-at-construction constraint).
+	AttachPoolAcquireObserver(postgres.PoolAcquireObserver)
 	Close()
 }
 
@@ -108,6 +113,13 @@ func poolSaturation(pool *pgxpool.Pool) float64 {
 	return float64(statistics.AcquiredConns()) / float64(statistics.MaxConns())
 }
 
+func (database *postgresWorkerDatabase) AttachPoolAcquireObserver(observer postgres.PoolAcquireObserver) {
+	if database == nil || database.pools == nil {
+		return
+	}
+	database.pools.AttachPoolAcquireObserver(observer)
+}
+
 func (database *postgresWorkerDatabase) Close() {
 	if database != nil && database.pools != nil {
 		database.pools.Close()
@@ -122,6 +134,11 @@ type workerFamily struct {
 	component lifecycle.Component
 	handlers  []jobruntime.HandlerSpec
 	queues    []jobruntime.QueueBudget
+	// metricsSource is an additional Prometheus fragment this family owns
+	// (e.g. providerfoundation's dev_health_provider_* family), registered
+	// with the health.Registry alongside "worker_runtime" once construction
+	// finishes. Most families leave this nil.
+	metricsSource health.MetricsSource
 }
 
 type workerFamilyBuilder func(
@@ -235,6 +252,12 @@ func configureWorkerDependenciesWithSources(
 		dependencies.close()
 		return nil, err
 	}
+	// worker_database_pool_acquire_seconds needs the collector, which is why
+	// this happens here rather than at pool construction: NewRuntimePools
+	// freezes its pgxpool tracer before dependencies.metrics exists.
+	if dependencies.database != nil {
+		dependencies.database.AttachPoolAcquireObserver(dependencies.metrics)
+	}
 	providerRuntimeConstructed := false
 	checks := []struct {
 		name  string
@@ -319,6 +342,12 @@ func configureWorkerDependenciesWithSources(
 			return nil, errWorkerDependencyUnavailable
 		}
 	}
+	if active.metricsSource != nil {
+		if err := registry.RegisterMetrics("provider_foundation", active.metricsSource); err != nil {
+			dependencies.close()
+			return nil, err
+		}
+	}
 	for _, handler := range active.handlers {
 		if handler.Kind == jobcontract.KindSyncProviderUnit {
 			providerRuntimeConstructed = true
@@ -340,8 +369,17 @@ func configureWorkerDependenciesWithSources(
 
 func composeWorkerFamily(existing, additional workerFamily) (workerFamily, error) {
 	result := workerFamily{
-		handlers: append([]jobruntime.HandlerSpec(nil), existing.handlers...),
-		queues:   append([]jobruntime.QueueBudget(nil), existing.queues...),
+		handlers:      append([]jobruntime.HandlerSpec(nil), existing.handlers...),
+		queues:        append([]jobruntime.QueueBudget(nil), existing.queues...),
+		metricsSource: existing.metricsSource,
+	}
+	if additional.metricsSource != nil {
+		if result.metricsSource != nil {
+			// Two families both claiming an additional metrics fragment would
+			// silently drop one of them at registration; fail closed instead.
+			return workerFamily{}, errWorkerDependencyUnavailable
+		}
+		result.metricsSource = additional.metricsSource
 	}
 	seen := make(map[string]struct{}, len(result.handlers)+len(additional.handlers))
 	for _, handler := range result.handlers {
@@ -582,7 +620,10 @@ func buildWorkerMetrics(
 ) (*jobruntime.MetricsCollector, error) {
 	dimensions := jobruntime.MetricDimensions{Profiles: []string{cfg.Profile}}
 	if runtimeRegistry != nil && runtimeRegistry.HasProfile(cfg.Profile) {
-		derived, err := jobruntime.DimensionsForProfile(runtimeRegistry, cfg.Profile, nil, nil)
+		derived, err := jobruntime.DimensionsForProfile(
+			runtimeRegistry, cfg.Profile, nil,
+			budgetDimensionsForProfile(cfg.Profile), syncLeaseDimensionsForProfile(cfg.Profile),
+		)
 		if err != nil {
 			return nil, err
 		}
@@ -601,6 +642,51 @@ func buildWorkerMetrics(
 		return nil, err
 	}
 	return collector, nil
+}
+
+// syncLeaseDimensionsForProfile registers the frozen provider/dataset matrix
+// (providersync.MatrixProviders + Capabilities, TRD §10.1) as the bounded
+// worker_sync_lease_expired_total dimension set. Only the "sync" profile
+// constructs the provider-unit handler that can ever observe a recovered
+// claim, so other profiles keep an empty, harmless set. The matrix is static
+// deployment configuration, not runtime or tenant data, so this stays well
+// under maxMetricSyncLeases regardless of which providers are feature-flag
+// enabled today.
+func syncLeaseDimensionsForProfile(profile string) []jobruntime.SyncLeaseLabels {
+	if profile != "sync" {
+		return nil
+	}
+	var labels []jobruntime.SyncLeaseLabels
+	for _, provider := range providersync.MatrixProviders() {
+		for _, capability := range providersync.Capabilities(provider) {
+			labels = append(labels, jobruntime.SyncLeaseLabels{
+				Provider: capability.Provider, DatasetFamily: capability.Dataset,
+			})
+		}
+	}
+	return labels
+}
+
+// budgetDimensionsForProfile registers the same frozen provider matrix, paired
+// with providersync's three static cost classes, as the bounded
+// worker_budget_wait_seconds dimension set. Only "sync" builds a provider-unit
+// executor that ever acquires a provider cost budget.
+func budgetDimensionsForProfile(profile string) []jobruntime.BudgetLabels {
+	if profile != "sync" {
+		return nil
+	}
+	costClasses := []providersync.CostClass{
+		providersync.CostLight, providersync.CostMedium, providersync.CostHeavy,
+	}
+	var labels []jobruntime.BudgetLabels
+	for _, provider := range providersync.MatrixProviders() {
+		for _, costClass := range costClasses {
+			labels = append(labels, jobruntime.BudgetLabels{
+				Provider: provider, CostClass: string(costClass),
+			})
+		}
+	}
+	return labels
 }
 
 func riverProcessForProfile(manifest deploymentcontract.Manifest, profile string) (deploymentcontract.Process, bool) {

--- a/cmd/dev-health-worker/dependencies_test.go
+++ b/cmd/dev-health-worker/dependencies_test.go
@@ -687,6 +687,7 @@ type fakeWorkerDatabase struct {
 	telemetryErr     error
 	telemetryConfig  riverstore.QueueTelemetryConfig
 	closed           atomic.Bool
+	acquireObserver  postgres.PoolAcquireObserver
 }
 
 type namedComponent string
@@ -815,6 +816,10 @@ func (database *fakeWorkerDatabase) NewQueueTelemetrySampler(
 		snapshot.Queues = append(snapshot.Queues, riverstore.QueueAgeTelemetry{Queue: queue.Name})
 	}
 	return &fakeQueueTelemetry{snapshot: snapshot}, nil
+}
+
+func (database *fakeWorkerDatabase) AttachPoolAcquireObserver(observer postgres.PoolAcquireObserver) {
+	database.acquireObserver = observer
 }
 
 func (database *fakeWorkerDatabase) Close() {

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -16,6 +16,7 @@ import (
 	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
 	valkeystore "github.com/full-chaos/dev-health-ops/internal/storage/valkey"
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 	valkeygo "github.com/valkey-io/valkey-go"
@@ -101,6 +102,139 @@ func (o leaseRecoveryObserver) ObserveSyncLeaseExpired(labels jobruntime.SyncLea
 
 var _ jobruntime.SyncLeaseObserver = leaseRecoveryObserver{}
 
+// providerSyncRepository is the exact capability buildProviderSyncHandler
+// needs from its repository: everything providerunit.Handler requires (the
+// lease/claim lifecycle) plus the effect ledger EffectCommitter requires.
+// *providersync.PostgresRepository implements both in production.
+type providerSyncRepository interface {
+	providerunit.UnitRepository
+	providersync.EffectLedger
+}
+
+// buildProviderSyncHandler constructs the provider-unit handler and the one
+// providerfoundation.Metrics instance its executor is wired to reference.
+//
+// It performs no I/O of its own — every connection/client/pool parameter is
+// only stored as a closure capture here, never dialed or dereferenced — and
+// is extracted from buildProviderSyncWorker specifically so a test can pin
+// the identity between the Metrics instance BuildExecutor hands each claim's
+// executor and the instance the caller registers as workerFamily.metricsSource,
+// without needing a live ClickHouse/Valkey/Postgres connection. See
+// provider_sync_test.go's TestBuildProviderSyncHandlerSharesOneMetricsInstance:
+// this is a mutation-tested seam (CHAOS-3118) — reintroducing a second
+// providerfoundation.NewMetrics() call inside BuildExecutor, the exact defect
+// this ticket exists to eliminate, must fail that test.
+func buildProviderSyncHandler(
+	repository providerSyncRepository,
+	decryptor providerfoundation.CredentialDecryptor,
+	clickhouseConnection driver.Conn,
+	valkeyClient valkeygo.Client,
+	domainPool *pgxpool.Pool,
+	collector *jobruntime.MetricsCollector,
+	logger *slog.Logger,
+) (*providerunit.Handler, *providerfoundation.Metrics) {
+	// providerMetrics is constructed exactly once per worker process and
+	// referenced by every claim's executor, so dev_health_provider_* actually
+	// accumulates across dispatches instead of being built and discarded per
+	// unit. The caller registers this same pointer with the health.Registry
+	// via workerFamily.metricsSource, which is what makes it a live, scraped
+	// series rather than a constructed-but-never-registered family.
+	providerMetrics := providerfoundation.NewMetrics()
+	handler := &providerunit.Handler{
+		Repository: repository,
+		Switches: providersync.CompleteRouteSwitches{
+			LaunchDarklyFeatureFlags: true,
+		},
+		LeaseDuration: providerUnitLeaseDuration,
+		Heartbeat:     providerUnitHeartbeat,
+		// LeaseMetrics observes worker_sync_lease_expired_total. Only claims
+		// this handler itself resolved after Repository.Claim reported
+		// claim.Recovered (an expired lease was recovered into this attempt)
+		// are ever observed; see providerunit.Handler.observeLeaseRecovery.
+		LeaseMetrics: leaseRecoveryObserver{collector: collector},
+		// A route fault means the Python producer gate routed a scope the Go
+		// capability system does not serve. The unit is never terminalized
+		// (TRD non-negotiable #3), so this log is the operator's only signal
+		// that a producer gate needs reconciliation. Fields are bounded: no
+		// credentials, URLs, or provider payloads.
+		OnRouteFault: func(fault providerunit.RouteFault) {
+			logger.Error(
+				"provider unit route reconciliation required",
+				"provider", fault.Provider,
+				"dataset", fault.Dataset,
+				"descriptor_present", fault.DescriptorPresent,
+				"route_ready", fault.RouteReady,
+				"route_enabled", fault.RouteEnabled,
+				"attempt", fault.Attempt,
+				"max_attempts", fault.MaxAttempts,
+				"released_for_retry", fault.Released,
+				"terminal_reconciliation_required", fault.Terminal,
+			)
+		},
+		BuildExecutor: func(
+			session *providersync.LeaseSession,
+		) (providersync.CompleteRouteExecutor, error) {
+			if session == nil {
+				return providersync.CompleteRouteExecutor{},
+					errWorkerDependencyUnavailable
+			}
+			sink := providersync.LaunchDarklyClickHouseEffects{
+				Conn: clickhouseConnection, Lease: session,
+			}
+			return providersync.CompleteRouteExecutor{
+				Credentials: providerfoundation.CredentialResolver{
+					Repository: providerfoundation.PostgresCredentialRepository{
+						Pool: domainPool,
+					},
+					Decryptor: decryptor,
+				},
+				Doer:  &http.Client{Timeout: 45 * time.Second},
+				Retry: providerfoundation.DefaultRetryPolicy(),
+				Budget: providerfoundation.ValkeyBudgetStore{
+					Client:   valkeyClient,
+					Observer: budgetWaitObserver{collector: collector},
+				},
+				BudgetLimits: map[providersync.CostClass]int{
+					providersync.CostLight:  4,
+					providersync.CostMedium: 2,
+					providersync.CostHeavy:  1,
+				},
+				BudgetTTL: providerUnitBudgetTTL,
+				Gate: func(
+					claim providersync.Claim,
+					client *providerfoundation.HTTPClient,
+				) providerfoundation.BackoffGate {
+					if client == nil || client.BaseURL == nil {
+						return nil
+					}
+					return providerfoundation.ValkeyBackoffGate{
+						Client: valkeyClient, Provider: claim.Provider,
+						OrgID: claim.OrgID, Host: client.BaseURL.Hostname(),
+						MaxBackoff: 5 * time.Minute,
+						CostClass:  string(claim.CostClass),
+						Observer:   budgetWaitObserver{collector: collector},
+					}
+				},
+				// This is the exact seam the mutation test targets: Metrics
+				// must stay the shared providerMetrics closed over above, not
+				// a fresh providerfoundation.NewMetrics() built per call.
+				Metrics: providerMetrics,
+				Handler: providersync.LaunchDarklyRouteHandler{
+					CodeReferences: providersync.LaunchDarklyClickHouseReferences{
+						Conn: clickhouseConnection, Lease: session,
+					},
+				},
+				Comparator: providersync.ProductionContractComparator{},
+				Committer: providersync.EffectCommitter{
+					Ledger: repository, Sink: sink, Readback: sink,
+				},
+				HeartbeatInterval: providerUnitHeartbeat,
+			}, nil
+		},
+	}
+	return handler, providerMetrics
+}
+
 func buildProviderSyncWorker(
 	ctx context.Context,
 	cfg config.Config,
@@ -154,108 +288,15 @@ func buildProviderSyncWorker(
 		valkeyClient.Close()
 		_ = clickhouseConnection.Close()
 	}
-	switches := providersync.CompleteRouteSwitches{
-		LaunchDarklyFeatureFlags: true,
-	}
 	// The observer passed in is always the process's one *jobruntime.MetricsCollector
 	// in production; the assertion fails closed to a nil collector (both bridge
 	// types below are then safe no-ops) for any other Observer implementation,
 	// such as a test double.
 	collector, _ := observer.(*jobruntime.MetricsCollector)
-	// providerMetrics is constructed exactly once per worker process and
-	// referenced by every claim's executor, so dev_health_provider_* actually
-	// accumulates across dispatches instead of being built and discarded per
-	// unit. It is registered with the health.Registry via workerFamily.metricsSource
-	// below, which is what makes it a live, scraped series rather than a
-	// constructed-but-never-registered family.
-	providerMetrics := providerfoundation.NewMetrics()
-	handler := &providerunit.Handler{
-		Repository:    repository,
-		Switches:      switches,
-		LeaseDuration: providerUnitLeaseDuration,
-		Heartbeat:     providerUnitHeartbeat,
-		// LeaseMetrics observes worker_sync_lease_expired_total. Only claims
-		// this handler itself resolved after Repository.Claim reported
-		// claim.Recovered (an expired lease was recovered into this attempt)
-		// are ever observed; see observeLeaseRecovery below.
-		LeaseMetrics: leaseRecoveryObserver{collector: collector},
-		// A route fault means the Python producer gate routed a scope the Go
-		// capability system does not serve. The unit is never terminalized
-		// (TRD non-negotiable #3), so this log is the operator's only signal
-		// that a producer gate needs reconciliation. Fields are bounded: no
-		// credentials, URLs, or provider payloads.
-		OnRouteFault: func(fault providerunit.RouteFault) {
-			logger.Error(
-				"provider unit route reconciliation required",
-				"provider", fault.Provider,
-				"dataset", fault.Dataset,
-				"descriptor_present", fault.DescriptorPresent,
-				"route_ready", fault.RouteReady,
-				"route_enabled", fault.RouteEnabled,
-				"attempt", fault.Attempt,
-				"max_attempts", fault.MaxAttempts,
-				"released_for_retry", fault.Released,
-				"terminal_reconciliation_required", fault.Terminal,
-			)
-		},
-		BuildExecutor: func(
-			session *providersync.LeaseSession,
-		) (providersync.CompleteRouteExecutor, error) {
-			if session == nil {
-				return providersync.CompleteRouteExecutor{},
-					errWorkerDependencyUnavailable
-			}
-			sink := providersync.LaunchDarklyClickHouseEffects{
-				Conn: clickhouseConnection, Lease: session,
-			}
-			return providersync.CompleteRouteExecutor{
-				Credentials: providerfoundation.CredentialResolver{
-					Repository: providerfoundation.PostgresCredentialRepository{
-						Pool: postgresDatabase.pools.Domain,
-					},
-					Decryptor: decryptor,
-				},
-				Doer:  &http.Client{Timeout: 45 * time.Second},
-				Retry: providerfoundation.DefaultRetryPolicy(),
-				Budget: providerfoundation.ValkeyBudgetStore{
-					Client:   valkeyClient,
-					Observer: budgetWaitObserver{collector: collector},
-				},
-				BudgetLimits: map[providersync.CostClass]int{
-					providersync.CostLight:  4,
-					providersync.CostMedium: 2,
-					providersync.CostHeavy:  1,
-				},
-				BudgetTTL: providerUnitBudgetTTL,
-				Gate: func(
-					claim providersync.Claim,
-					client *providerfoundation.HTTPClient,
-				) providerfoundation.BackoffGate {
-					if client == nil || client.BaseURL == nil {
-						return nil
-					}
-					return providerfoundation.ValkeyBackoffGate{
-						Client: valkeyClient, Provider: claim.Provider,
-						OrgID: claim.OrgID, Host: client.BaseURL.Hostname(),
-						MaxBackoff: 5 * time.Minute,
-						CostClass:  string(claim.CostClass),
-						Observer:   budgetWaitObserver{collector: collector},
-					}
-				},
-				Metrics: providerMetrics,
-				Handler: providersync.LaunchDarklyRouteHandler{
-					CodeReferences: providersync.LaunchDarklyClickHouseReferences{
-						Conn: clickhouseConnection, Lease: session,
-					},
-				},
-				Comparator: providersync.ProductionContractComparator{},
-				Committer: providersync.EffectCommitter{
-					Ledger: repository, Sink: sink, Readback: sink,
-				},
-				HeartbeatInterval: providerUnitHeartbeat,
-			}, nil
-		},
-	}
+	handler, providerMetrics := buildProviderSyncHandler(
+		repository, decryptor, clickhouseConnection, valkeyClient,
+		postgresDatabase.pools.Domain, collector, logger,
+	)
 	adapter, err := jobruntime.NewAdapter[jobruntime.ProviderUnitArgs](
 		registry, spec, handler, jobruntime.Dependencies{
 			Logger: logger, Observer: observer,

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -67,6 +67,40 @@ func (component *providerSyncWorkerComponent) Shutdown(ctx context.Context) erro
 	return result
 }
 
+// budgetWaitObserver bridges providerfoundation's credential-free
+// BudgetWaitObserver to the process's shared MetricsCollector. It is a value
+// type specifically so a nil collector never becomes a non-nil, panicking
+// interface value: ObserveProviderBudgetWait is a no-op until a real
+// collector is attached.
+type budgetWaitObserver struct {
+	collector *jobruntime.MetricsCollector
+}
+
+func (o budgetWaitObserver) ObserveProviderBudgetWait(provider, costClass string, wait time.Duration) error {
+	if o.collector == nil {
+		return nil
+	}
+	return o.collector.ObserveProviderBudgetWait(jobruntime.BudgetLabels{Provider: provider, CostClass: costClass}, wait)
+}
+
+var _ providerfoundation.BudgetWaitObserver = budgetWaitObserver{}
+
+// leaseRecoveryObserver bridges providerunit's expired-lease recovery
+// signal to the shared MetricsCollector, for the same nil-safety reason as
+// budgetWaitObserver above.
+type leaseRecoveryObserver struct {
+	collector *jobruntime.MetricsCollector
+}
+
+func (o leaseRecoveryObserver) ObserveSyncLeaseExpired(labels jobruntime.SyncLeaseLabels, result jobruntime.SyncLeaseResult) error {
+	if o.collector == nil {
+		return nil
+	}
+	return o.collector.ObserveSyncLeaseExpired(labels, result)
+}
+
+var _ jobruntime.SyncLeaseObserver = leaseRecoveryObserver{}
+
 func buildProviderSyncWorker(
 	ctx context.Context,
 	cfg config.Config,
@@ -123,11 +157,28 @@ func buildProviderSyncWorker(
 	switches := providersync.CompleteRouteSwitches{
 		LaunchDarklyFeatureFlags: true,
 	}
+	// The observer passed in is always the process's one *jobruntime.MetricsCollector
+	// in production; the assertion fails closed to a nil collector (both bridge
+	// types below are then safe no-ops) for any other Observer implementation,
+	// such as a test double.
+	collector, _ := observer.(*jobruntime.MetricsCollector)
+	// providerMetrics is constructed exactly once per worker process and
+	// referenced by every claim's executor, so dev_health_provider_* actually
+	// accumulates across dispatches instead of being built and discarded per
+	// unit. It is registered with the health.Registry via workerFamily.metricsSource
+	// below, which is what makes it a live, scraped series rather than a
+	// constructed-but-never-registered family.
+	providerMetrics := providerfoundation.NewMetrics()
 	handler := &providerunit.Handler{
 		Repository:    repository,
 		Switches:      switches,
 		LeaseDuration: providerUnitLeaseDuration,
 		Heartbeat:     providerUnitHeartbeat,
+		// LeaseMetrics observes worker_sync_lease_expired_total. Only claims
+		// this handler itself resolved after Repository.Claim reported
+		// claim.Recovered (an expired lease was recovered into this attempt)
+		// are ever observed; see observeLeaseRecovery below.
+		LeaseMetrics: leaseRecoveryObserver{collector: collector},
 		// A route fault means the Python producer gate routed a scope the Go
 		// capability system does not serve. The unit is never terminalized
 		// (TRD non-negotiable #3), so this log is the operator's only signal
@@ -167,7 +218,8 @@ func buildProviderSyncWorker(
 				Doer:  &http.Client{Timeout: 45 * time.Second},
 				Retry: providerfoundation.DefaultRetryPolicy(),
 				Budget: providerfoundation.ValkeyBudgetStore{
-					Client: valkeyClient,
+					Client:   valkeyClient,
+					Observer: budgetWaitObserver{collector: collector},
 				},
 				BudgetLimits: map[providersync.CostClass]int{
 					providersync.CostLight:  4,
@@ -186,9 +238,11 @@ func buildProviderSyncWorker(
 						Client: valkeyClient, Provider: claim.Provider,
 						OrgID: claim.OrgID, Host: client.BaseURL.Hostname(),
 						MaxBackoff: 5 * time.Minute,
+						CostClass:  string(claim.CostClass),
+						Observer:   budgetWaitObserver{collector: collector},
 					}
 				},
-				Metrics: providerfoundation.NewMetrics(),
+				Metrics: providerMetrics,
 				Handler: providersync.LaunchDarklyRouteHandler{
 					CodeReferences: providersync.LaunchDarklyClickHouseReferences{
 						Conn: clickhouseConnection, Lease: session,
@@ -237,6 +291,7 @@ func buildProviderSyncWorker(
 		queues: []jobruntime.QueueBudget{
 			{Queue: providerUnitQueue, MaxWorkers: providerUnitQueueWorkers},
 		},
+		metricsSource: providerMetrics,
 	}, nil
 }
 

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -8,11 +8,74 @@ import (
 
 	"github.com/full-chaos/dev-health-ops/internal/jobcontract"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/providersync"
 	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/riverqueue/river"
 	"github.com/riverqueue/river/riverdriver/riverpgxv5"
 )
+
+// TestBuildProviderSyncHandlerSharesOneMetricsInstance is CHAOS-3118
+// mutation-tested evidence for dev_health_provider_*, not a behavioral
+// assertion: it pins the identity between the providerfoundation.Metrics
+// instance BuildExecutor hands each claim's executor and the instance the
+// caller (buildProviderSyncWorker) registers as workerFamily.metricsSource.
+//
+// The original defect on origin/main was exactly this: providerfoundation.NewMetrics()
+// was called inside the BuildExecutor closure itself, so every unit dispatch
+// got a fresh, immediately-discarded instance while a *different* instance —
+// or none at all — was what got registered and scraped. Every counter reset
+// to zero on the next dispatch and the family was permanently invisible.
+//
+// A behavioral test (record something, read it back) cannot catch that
+// defect: reverting just "Metrics: providerMetrics" to
+// "Metrics: providerfoundation.NewMetrics()" inside BuildExecutor, while
+// leaving workerFamily.metricsSource registration untouched, still compiles,
+// still passes every other test in this package and in
+// internal/providerfoundation, and still publishes HELP/TYPE — it looks
+// exactly as wired as the real fix. Only a same-instance check distinguishes
+// them, which is why this test compares pointers rather than values.
+func TestBuildProviderSyncHandlerSharesOneMetricsInstance(t *testing.T) {
+	collector, err := jobruntime.NewMetricsCollector(jobruntime.MetricDimensions{
+		Profiles: []string{"sync"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Every dependency below is only ever stored as a closure capture inside
+	// buildProviderSyncHandler — never dialed, dereferenced, or called during
+	// construction — so nil stand-ins are sufficient to reach the real,
+	// unmodified BuildExecutor closure without a live ClickHouse, Valkey, or
+	// Postgres connection.
+	handler, providerMetrics := buildProviderSyncHandler(
+		nil, nil, nil, nil, nil, collector, slog.Default(),
+	)
+	if handler == nil || handler.BuildExecutor == nil {
+		t.Fatal("buildProviderSyncHandler returned an incomplete handler")
+	}
+	if providerMetrics == nil {
+		t.Fatal("buildProviderSyncHandler returned a nil Metrics instance")
+	}
+
+	executor, err := handler.BuildExecutor(&providersync.LeaseSession{})
+	if err != nil {
+		t.Fatalf("BuildExecutor: %v", err)
+	}
+
+	// The property under test is identity, not behavior: this is the same
+	// check buildProviderSyncWorker's real wiring must satisfy between
+	// executor.Metrics (what every claim actually writes to) and
+	// workerFamily.metricsSource (what the health.Registry actually scrapes).
+	if executor.Metrics != providerMetrics {
+		t.Fatalf(
+			"executor.Metrics = %p, want the same instance buildProviderSyncHandler "+
+				"returned (%p): a distinct instance here writes real counters nobody "+
+				"scrapes, while the registered instance stays permanently zero — the "+
+				"exact CHAOS-3118 defect",
+			executor.Metrics, providerMetrics,
+		)
+	}
+}
 
 type independentRiverClient struct {
 	name     string

--- a/deploy/grafana/dashboards/go-workers.json
+++ b/deploy/grafana/dashboards/go-workers.json
@@ -118,13 +118,13 @@
       "id": 7,
       "targets": [
         {
-          "expr": "max by (stream, consumer_group) (worker_stream_lag)",
-          "legendFormat": "lag {{stream}} / {{consumer_group}}",
+          "expr": "max by (job, instance) (worker_stream_lag)",
+          "legendFormat": "lag {{job}} ({{instance}})",
           "refId": "A"
         },
         {
-          "expr": "max by (stream, consumer_group) (worker_stream_pending)",
-          "legendFormat": "pending {{stream}} / {{consumer_group}}",
+          "expr": "max by (job, instance) (worker_stream_pending)",
+          "legendFormat": "pending {{job}} ({{instance}})",
           "refId": "B"
         }
       ],

--- a/internal/jobruntime/adapter.go
+++ b/internal/jobruntime/adapter.go
@@ -226,6 +226,15 @@ func (adapter *Adapter[T]) Work(parent context.Context, job *river.Job[T]) error
 		Queue:   adapter.descriptor.Queue,
 		Kind:    adapter.descriptor.Kind,
 	}
+	// ScheduledAt is River's own "available to be worked" timestamp, so the gap
+	// to this Work() entry is exactly the availability-to-execution-start wait
+	// the TRD requires. A missing or clock-skewed ScheduledAt yields a negative
+	// gap, which is dropped rather than observed.
+	if job != nil && job.JobRow != nil && !job.JobRow.ScheduledAt.IsZero() {
+		if wait := started.Sub(job.JobRow.ScheduledAt); wait >= 0 {
+			observe(func() { adapter.observer.JobWait(parent, labels, wait) })
+		}
+	}
 	observe(func() { adapter.observer.JobStarted(parent, labels) })
 	choice := decision{result: ResultCancel, category: CategoryValidation, cancel: true}
 	var envelope jobcontract.Envelope

--- a/internal/jobruntime/adapter_test.go
+++ b/internal/jobruntime/adapter_test.go
@@ -172,6 +172,59 @@ func TestAdapterMiddlewareOutcomesAreSafeAndDeterministic(t *testing.T) {
 	}
 }
 
+// TestAdapterObservesJobWaitFromRiverScheduledAt is CHAOS-3118 evidence for
+// worker_job_wait_seconds: it drives the real Adapter.Work() path (not a
+// setter call) with a real *MetricsCollector as the Observer, then reads the
+// collector's own Prometheus exposition to prove a non-zero series exists at
+// the exact bucket a ~750ms wait belongs in.
+func TestAdapterObservesJobWaitFromRiverScheduledAt(t *testing.T) {
+	t.Parallel()
+	registry, err := newRegistry(testContractRegistry(), testMigrationState())
+	if err != nil {
+		t.Fatalf("newRegistry: %v", err)
+	}
+	spec, ok := registry.Descriptor(jobcontract.KindRetentionCleanup)
+	if !ok {
+		t.Fatal("missing retention descriptor")
+	}
+	collector, err := NewMetricsCollector(MetricDimensions{
+		Profiles: []string{spec.Profile},
+		Jobs:     []JobLabels{{Profile: spec.Profile, Queue: spec.Queue, Kind: spec.Kind}},
+	})
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+
+	var logs bytes.Buffer
+	claim := &recordingClaim{state: ClaimProceed}
+	lease := &recordingLease{}
+	handler := HandlerFunc[RetentionCleanupArgs](func(context.Context, *Execution[RetentionCleanupArgs]) error {
+		return nil
+	})
+	adapter := newRetentionAdapter(t, handler, collector, claim, lease, &logs)
+
+	job := retentionJob(t, 1)
+	job.JobRow.ScheduledAt = time.Now().Add(-750 * time.Millisecond)
+
+	if err := adapter.Work(context.Background(), job); err != nil {
+		t.Fatalf("Work: %v", err)
+	}
+
+	text := collector.PrometheusText()
+	labels := `profile="` + spec.Profile + `",queue="` + spec.Queue + `",kind="` + spec.Kind + `"`
+	if !strings.Contains(text, "worker_job_wait_seconds_count{"+labels+"} 1") {
+		t.Fatalf("expected a non-zero worker_job_wait_seconds series, got:\n%s", text)
+	}
+	// A near-zero rounding artifact would land under le="0.5"; the real
+	// ~750ms wait must not.
+	if strings.Contains(text, `worker_job_wait_seconds_bucket{`+labels+`,le="0.5"} 1`) {
+		t.Fatalf("wait was bucketed under 0.5s, want at least 0.5s:\n%s", text)
+	}
+	if !strings.Contains(text, `worker_job_wait_seconds_bucket{`+labels+`,le="1"} 1`) {
+		t.Fatalf("wait was not bucketed at 1s as expected:\n%s", text)
+	}
+}
+
 func TestAdapterRejectsRawContractAndExecutionPolicyDrift(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -358,6 +411,7 @@ type recordingObserver struct {
 	panicked       bool
 	domainMismatch bool
 	cancelled      bool
+	jobWaits       []time.Duration
 }
 
 func (*recordingObserver) RuntimeRegistered(context.Context, RuntimeInfo) {}
@@ -373,3 +427,6 @@ func (observer *recordingObserver) DomainMismatch(context.Context, string) {
 	observer.domainMismatch = true
 }
 func (*recordingObserver) BudgetWait(context.Context, JobLabels, time.Duration, string) {}
+func (observer *recordingObserver) JobWait(_ context.Context, _ JobLabels, wait time.Duration) {
+	observer.jobWaits = append(observer.jobWaits, wait)
+}

--- a/internal/jobruntime/observer.go
+++ b/internal/jobruntime/observer.go
@@ -26,10 +26,11 @@ type JobLabels struct {
 // worker_jobs_running, worker_job_duration_seconds,
 // worker_job_attempts_total, worker_job_panics_total,
 // worker_job_cancellations_total, and worker_domain_state_mismatch_total.
-// Queue availability/wait metrics are sampled by the River backend rather
-// than per-handler execution. Deployment sampling sets
-// worker_execution_saturation_ratio{profile} directly from configured worker
-// capacity and active executions.
+// worker_job_wait_seconds is sampled per-handler execution from the River
+// row's ScheduledAt, since that is the only place the adapter observes both
+// the job's availability time and its execution start. Deployment sampling
+// sets worker_execution_saturation_ratio{profile} directly from configured
+// worker capacity and active executions.
 //
 // Pool adapters use worker_database_pool_saturation_ratio{pool} and
 // worker_database_pool_acquire_seconds{pool,result}; pool is bounded to
@@ -42,6 +43,20 @@ type Observer interface {
 	JobCancelled(context.Context, JobLabels, ErrorCategory)
 	DomainMismatch(context.Context, string)
 	BudgetWait(context.Context, JobLabels, time.Duration, string)
+	// JobWait observes the time from job availability (River's ScheduledAt) to
+	// execution start. It is void, like every other Observer method, so a
+	// telemetry fault can never fail a job.
+	JobWait(context.Context, JobLabels, time.Duration)
+}
+
+// SyncLeaseObserver is the narrower capability concrete expired-lease
+// recovery implementations depend on directly, the same way concrete budget
+// implementations call ObserveProviderBudgetWait directly rather than through
+// the generic Observer: generic runtime middleware has no way to know
+// whether a claim recovered an expired lease, only the code that performed
+// the recovery does. *MetricsCollector satisfies this.
+type SyncLeaseObserver interface {
+	ObserveSyncLeaseExpired(SyncLeaseLabels, SyncLeaseResult) error
 }
 
 // RegisterRuntime validates the low-cardinality scrape-presence identity

--- a/internal/jobruntime/telemetry.go
+++ b/internal/jobruntime/telemetry.go
@@ -167,6 +167,7 @@ type MetricsCollector struct {
 }
 
 var _ Observer = (*MetricsCollector)(nil)
+var _ SyncLeaseObserver = (*MetricsCollector)(nil)
 
 func NewMetricsCollector(dimensions MetricDimensions) (*MetricsCollector, error) {
 	if len(dimensions.Jobs) > maxMetricJobs {
@@ -298,9 +299,10 @@ func NewMetricsCollector(dimensions MetricDimensions) (*MetricsCollector, error)
 }
 
 // DimensionsForProfile derives job and domain dimensions from the validated
-// runtime registry. Sync-lease pairs are appended from static deployment
-// configuration; stream and budget pairs remain explicit inputs here.
-func DimensionsForProfile(registry *Registry, profile string, streams []StreamLabels, budgets []BudgetLabels) (MetricDimensions, error) {
+// runtime registry. Sync-lease, stream, and budget pairs remain explicit
+// inputs here since they come from static deployment configuration rather
+// than the job registry.
+func DimensionsForProfile(registry *Registry, profile string, streams []StreamLabels, budgets []BudgetLabels, syncLeases []SyncLeaseLabels) (MetricDimensions, error) {
 	if registry == nil {
 		return MetricDimensions{}, errors.New("runtime registry is required")
 	}
@@ -308,7 +310,12 @@ func DimensionsForProfile(registry *Registry, profile string, streams []StreamLa
 	if len(descriptors) == 0 {
 		return MetricDimensions{}, errors.New("runtime profile has no registered jobs")
 	}
-	dimensions := MetricDimensions{Profiles: []string{profile}, Streams: append([]StreamLabels(nil), streams...), Budgets: append([]BudgetLabels(nil), budgets...)}
+	dimensions := MetricDimensions{
+		Profiles:   []string{profile},
+		Streams:    append([]StreamLabels(nil), streams...),
+		Budgets:    append([]BudgetLabels(nil), budgets...),
+		SyncLeases: append([]SyncLeaseLabels(nil), syncLeases...),
+	}
 	domains := make(map[string]struct{})
 	for _, descriptor := range descriptors {
 		dimensions.Jobs = append(dimensions.Jobs, JobLabels{
@@ -440,6 +447,13 @@ func (collector *MetricsCollector) ObserveJobWait(labels JobLabels, wait time.Du
 	}
 	metric.observe(wait.Seconds())
 	return nil
+}
+
+// JobWait satisfies Observer. It is the generic middleware entry point the
+// adapter calls on every execution; negative or unregistered observations are
+// dropped rather than surfaced, exactly like the other Observer methods.
+func (collector *MetricsCollector) JobWait(_ context.Context, labels JobLabels, wait time.Duration) {
+	_ = collector.ObserveJobWait(labels, wait)
 }
 
 // ObserveSyncLeaseExpired records an expired-lease recovery that successfully

--- a/internal/jobruntime/telemetry_test.go
+++ b/internal/jobruntime/telemetry_test.go
@@ -362,7 +362,7 @@ func TestDimensionsForProfileUsesRegistryPolicy(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	dimensions, err := DimensionsForProfile(registry, "ops", nil, nil)
+	dimensions, err := DimensionsForProfile(registry, "ops", nil, nil, nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/jobs/providerunit/providerunit.go
+++ b/internal/jobs/providerunit/providerunit.go
@@ -99,6 +99,13 @@ type Handler struct {
 	// binary can alert on them. A nil hook keeps the fail-safe behavior; it
 	// never converts the fault into success.
 	OnRouteFault func(RouteFault)
+	// LeaseMetrics observes worker_sync_lease_expired_total. It is called only
+	// for a claim whose Repository.Claim reported Recovered — i.e. this
+	// attempt itself is River's recovery of a unit whose previous owner's
+	// lease had expired — at the point this handler durably resolves that
+	// attempt to retrying (ReleaseForRetry) or failed (Fail). A nil value
+	// keeps behavior unchanged.
+	LeaseMetrics jobruntime.SyncLeaseObserver
 }
 
 func (handler *Handler) observeRouteFault(fault RouteFault) {
@@ -106,6 +113,20 @@ func (handler *Handler) observeRouteFault(fault RouteFault) {
 		return
 	}
 	handler.OnRouteFault(fault)
+}
+
+// observeLeaseRecovery records the durable resolution of a claim that itself
+// recovered an expired lease. It is a no-op for an ordinary (non-recovered)
+// claim, since ObserveSyncLeaseExpired's contract is specifically about
+// expired-lease recovery, not every retry or failure.
+func (handler *Handler) observeLeaseRecovery(claim providersync.Claim, result jobruntime.SyncLeaseResult) {
+	if handler == nil || handler.LeaseMetrics == nil || !claim.Recovered {
+		return
+	}
+	_ = handler.LeaseMetrics.ObserveSyncLeaseExpired(
+		jobruntime.SyncLeaseLabels{Provider: claim.Provider, DatasetFamily: claim.Dataset},
+		result,
+	)
 }
 
 func (handler *Handler) now() time.Time {
@@ -175,6 +196,7 @@ func (handler *Handler) Work(
 			); failErr != nil {
 				return jobruntime.Retryable(failErr)
 			}
+			handler.observeLeaseRecovery(claim, jobruntime.SyncLeaseResultFailed)
 			return jobruntime.Retryable(ErrRouteReconciliationRequired)
 		}
 		releaseErr := handler.Repository.ReleaseForRetry(
@@ -185,6 +207,7 @@ func (handler *Handler) Work(
 		if releaseErr != nil {
 			return jobruntime.Retryable(releaseErr)
 		}
+		handler.observeLeaseRecovery(claim, jobruntime.SyncLeaseResultRetrying)
 		return jobruntime.Retryable(ErrRouteReconciliationRequired)
 	}
 	session := &providersync.LeaseSession{
@@ -228,13 +251,21 @@ func (handler *Handler) Work(
 		); failErr != nil {
 			return jobruntime.Retryable(failErr)
 		}
+		handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultFailed)
 		return jobruntime.Permanent(err)
 	}
 	if execution.Attempt >= execution.Definition.MaxAttempts {
-		_ = handler.Repository.Fail(
+		// The collector's contract forbids recording a failed CAS attempt, so
+		// this capture (where the prior code discarded the error entirely)
+		// only adds the ability to gate the metric on true success; it does
+		// not change the existing best-effort, always-retryable behavior.
+		failErr := handler.Repository.Fail(
 			context.WithoutCancel(ctx), session.Claim, "provider_unit_exhausted",
 			startedAt, completedAt,
 		)
+		if failErr == nil {
+			handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultFailed)
+		}
 		return jobruntime.Retryable(err)
 	}
 	if releaseErr := handler.Repository.ReleaseForRetry(
@@ -242,6 +273,7 @@ func (handler *Handler) Work(
 	); releaseErr != nil {
 		return jobruntime.Retryable(releaseErr)
 	}
+	handler.observeLeaseRecovery(session.Claim, jobruntime.SyncLeaseResultRetrying)
 	return jobruntime.Retryable(err)
 }
 

--- a/internal/jobs/providerunit/providerunit_test.go
+++ b/internal/jobs/providerunit/providerunit_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"errors"
 	"net/http"
+	"strings"
 	"sync"
 	"testing"
 	"time"
@@ -16,6 +17,17 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/providersync"
 	"github.com/google/uuid"
 )
+
+// leaseSyncDimensions is the bounded SyncLeaseLabels pair providerUnit()
+// exercises (Provider: "launchdarkly", Dataset: "feature-flags").
+func leaseSyncDimensions() jobruntime.MetricDimensions {
+	return jobruntime.MetricDimensions{
+		Profiles: []string{"sync"},
+		SyncLeases: []jobruntime.SyncLeaseLabels{
+			{Provider: "launchdarkly", DatasetFamily: "feature-flags"},
+		},
+	}
+}
 
 func TestEnabledProviderUnitExecutesCompleteRouteAndTerminalizes(t *testing.T) {
 	t.Parallel()
@@ -59,6 +71,14 @@ func TestFreshHandlerRecoversExpiredProcessClaimAndReleasesForRiverRetry(
 		t.Fatalf("first claim=%+v error=%v", first, err)
 	}
 	recoveryNow := now.Add(time.Minute + time.Second)
+	// CHAOS-3118 evidence for worker_sync_lease_expired_total: a real
+	// *jobruntime.MetricsCollector observes the durable resolution of this
+	// recovered claim through the actual Handler.Work() path below, not a
+	// direct setter call.
+	collector, err := jobruntime.NewMetricsCollector(leaseSyncDimensions())
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
 	fresh := &Handler{
 		Repository: repository,
 		Switches: providersync.CompleteRouteSwitches{
@@ -67,6 +87,7 @@ func TestFreshHandlerRecoversExpiredProcessClaimAndReleasesForRiverRetry(
 		LeaseDuration: time.Minute,
 		Heartbeat:     10 * time.Second,
 		Now:           func() time.Time { return recoveryNow },
+		LeaseMetrics:  collector,
 		BuildExecutor: func(
 			*providersync.LeaseSession,
 		) (providersync.CompleteRouteExecutor, error) {
@@ -83,6 +104,71 @@ func TestFreshHandlerRecoversExpiredProcessClaimAndReleasesForRiverRetry(
 			"error=%v attempt=%d recovered=%v status=%s",
 			err, repository.attempt, repository.lastClaim.Recovered, repository.status,
 		)
+	}
+	text := collector.PrometheusText()
+	if !strings.Contains(text, `worker_sync_lease_expired_total{provider="launchdarkly",dataset_family="feature-flags",result="retrying"} 1`) {
+		t.Fatalf("expected a non-zero retrying series, got:\n%s", text)
+	}
+	if !strings.Contains(text, `worker_sync_lease_expired_total{provider="launchdarkly",dataset_family="feature-flags",result="failed"} 0`) {
+		t.Fatalf("expected the failed series to stay at zero, got:\n%s", text)
+	}
+}
+
+// TestRecoveredExpiredLeaseAttemptExhaustionRecordsFailedResolution is
+// CHAOS-3118 evidence for the "failed" branch of worker_sync_lease_expired_total:
+// a claim that itself recovered an expired lease, then exhausts its last
+// River attempt, must durably resolve to "failed" and the collector's own
+// ObserveSyncLeaseExpired contract (never record a failed CAS) must still
+// hold — Repository.Fail here genuinely succeeds, so the series is observed.
+func TestRecoveredExpiredLeaseAttemptExhaustionRecordsFailedResolution(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	repository := newMemoryUnitRepository(providerUnit())
+	if _, err := repository.Claim(context.Background(), providersync.ClaimRequest{
+		UnitID: repository.unit.ID, OrgID: repository.unit.OrgID,
+		Owner: uuid.NewString(), Now: now, LeaseDuration: time.Minute,
+		AllowExpiredRecovery: true,
+	}); err != nil {
+		t.Fatalf("first claim: %v", err)
+	}
+	recoveryNow := now.Add(time.Minute + time.Second)
+	collector, err := jobruntime.NewMetricsCollector(leaseSyncDimensions())
+	if err != nil {
+		t.Fatalf("NewMetricsCollector: %v", err)
+	}
+	const maxAttempts = 2
+	fresh := &Handler{
+		Repository: repository,
+		Switches: providersync.CompleteRouteSwitches{
+			LaunchDarklyFeatureFlags: true,
+		},
+		LeaseDuration: time.Minute,
+		Heartbeat:     10 * time.Second,
+		Now:           func() time.Time { return recoveryNow },
+		LeaseMetrics:  collector,
+		BuildExecutor: func(
+			*providersync.LeaseSession,
+		) (providersync.CompleteRouteExecutor, error) {
+			return providersync.CompleteRouteExecutor{}, errors.New("transient")
+		},
+	}
+	execution := providerExecution(repository.unit, recoveryNow, maxAttempts)
+	execution.Definition.MaxAttempts = maxAttempts
+	err = fresh.Work(context.Background(), execution)
+	if err == nil || repository.attempt != 2 || !repository.lastClaim.Recovered ||
+		repository.status != "failed" || repository.lastFailCategory != "provider_unit_exhausted" {
+		t.Fatalf(
+			"error=%v attempt=%d recovered=%v status=%s category=%s",
+			err, repository.attempt, repository.lastClaim.Recovered,
+			repository.status, repository.lastFailCategory,
+		)
+	}
+	text := collector.PrometheusText()
+	if !strings.Contains(text, `worker_sync_lease_expired_total{provider="launchdarkly",dataset_family="feature-flags",result="failed"} 1`) {
+		t.Fatalf("expected a non-zero failed series, got:\n%s", text)
+	}
+	if !strings.Contains(text, `worker_sync_lease_expired_total{provider="launchdarkly",dataset_family="feature-flags",result="retrying"} 0`) {
+		t.Fatalf("expected the retrying series to stay at zero, got:\n%s", text)
 	}
 }
 

--- a/internal/providerfoundation/budget.go
+++ b/internal/providerfoundation/budget.go
@@ -82,10 +82,29 @@ type BudgetStore interface {
 	Acquire(context.Context, BudgetKey) (Reservation, error)
 }
 
+// BudgetWaitObserver records real-execution latency on the provider
+// cost-budget acquire and backoff-gate wait paths as worker_budget_wait_seconds.
+// provider and costClass are exactly the bounded, credential-free pair
+// BudgetKey.Validate already enforces (never an org, host, or credential). A
+// nil Observer on ValkeyBudgetStore/ValkeyBackoffGate keeps both types working
+// with no metrics, matching every other optional dependency in this package.
+type BudgetWaitObserver interface {
+	ObserveProviderBudgetWait(provider, costClass string, wait time.Duration) error
+}
+
 // ValkeyBudgetStore uses a single Lua admission/release protocol, so Go
 // workers share a provider/org/host/cost limit across processes. The key
 // vocabulary is deliberately stable and has no credentials or request data.
-type ValkeyBudgetStore struct{ Client valkeygo.Client }
+type ValkeyBudgetStore struct {
+	Client valkeygo.Client
+	// Observer records how long Acquire spent asking the shared Valkey store
+	// for a reservation — round-trip and lock-contention latency, not a
+	// client-side backoff sleep (this store never sleeps; a denial is
+	// returned immediately as ErrBudgetUnavailable). It is observed on both
+	// the granted and the denied path, since both represent real time this
+	// call spent waiting on the budget subsystem.
+	Observer BudgetWaitObserver
+}
 
 const budgetAcquireLua = `local current=redis.call('GET',KEYS[1]); if not current then current=0 else current=tonumber(current) end; if current>=tonumber(ARGV[1]) then return 0 end; redis.call('INCR',KEYS[1]); redis.call('PEXPIRE',KEYS[1],ARGV[2]); return 1`
 const budgetReleaseLua = `local current=redis.call('GET',KEYS[1]); if not current then return 0 end; current=tonumber(current); if current<=1 then redis.call('DEL',KEYS[1]); return 0 end; redis.call('DECR',KEYS[1]); return current-1`
@@ -94,8 +113,10 @@ func (s ValkeyBudgetStore) Acquire(ctx context.Context, key BudgetKey) (Reservat
 	if s.Client == nil || key.Validate() != nil {
 		return nil, ErrBudgetUnavailable
 	}
+	started := time.Now()
 	response := valkeygo.NewLuaScriptNoSha(budgetAcquireLua).Exec(ctx, s.Client, []string{key.String()}, []string{strconv.Itoa(key.Limit), strconv.FormatInt(key.TTL.Milliseconds(), 10)})
 	allowed, err := response.AsInt64()
+	s.observeWait(key, started)
 	if err != nil {
 		return nil, ErrBudgetUnavailable
 	}
@@ -103,6 +124,13 @@ func (s ValkeyBudgetStore) Acquire(ctx context.Context, key BudgetKey) (Reservat
 		return nil, ErrBudgetUnavailable
 	}
 	return &valkeyReservation{client: s.Client, key: key.String()}, nil
+}
+
+func (s ValkeyBudgetStore) observeWait(key BudgetKey, started time.Time) {
+	if s.Observer == nil {
+		return
+	}
+	_ = s.Observer.ObserveProviderBudgetWait(key.Provider, key.CostClass, time.Since(started))
 }
 
 type valkeyReservation struct {
@@ -133,6 +161,16 @@ type ValkeyBackoffGate struct {
 	Provider, OrgID, Host string
 	MaxBackoff            time.Duration
 	Now                   func() time.Time
+	// CostClass is the same bounded class this gate's calling client is
+	// budgeted under. It exists solely to label worker_budget_wait_seconds:
+	// the gate's own Valkey key never includes it (see key(), which is
+	// intentionally identical to the Python rate_limit:<provider>:<org or
+	// _>:<host or _> contract).
+	CostClass string
+	// Observer records the real backoff duration this Wait call computed and
+	// returned to its caller — the actual time the caller now knows it must
+	// not send another request, not a call-latency measurement.
+	Observer BudgetWaitObserver
 }
 
 const backoffPenalizeLua = `local old=tonumber(redis.call('GET',KEYS[1]) or '0'); local proposed=tonumber(ARGV[1]); local applied=math.max(old,proposed); redis.call('SET',KEYS[1],applied,'EX',ARGV[2]); return applied`
@@ -152,6 +190,7 @@ func (g ValkeyBackoffGate) Wait(ctx context.Context) (time.Duration, error) {
 	}
 	raw, err := g.Client.Do(ctx, g.Client.B().Get().Key(g.key()).Build()).AsFloat64()
 	if valkeygo.IsValkeyNil(err) {
+		g.observeWait(0)
 		return 0, nil
 	}
 	if err != nil {
@@ -159,9 +198,17 @@ func (g ValkeyBackoffGate) Wait(ctx context.Context) (time.Duration, error) {
 	}
 	wait := time.Duration((raw - float64(g.now().UnixMilli())/1000) * float64(time.Second))
 	if wait < 0 {
-		return 0, nil
+		wait = 0
 	}
+	g.observeWait(wait)
 	return wait, nil
+}
+
+func (g ValkeyBackoffGate) observeWait(wait time.Duration) {
+	if g.Observer == nil {
+		return
+	}
+	_ = g.Observer.ObserveProviderBudgetWait(g.Provider, g.CostClass, wait)
 }
 func (g ValkeyBackoffGate) Penalize(ctx context.Context, delay time.Duration) error {
 	if g.Client == nil {
@@ -236,6 +283,11 @@ func (m *Metrics) WritePrometheus(writer io.Writer) error {
 	}
 	m.mu.Lock()
 	defer m.mu.Unlock()
+	if _, err := io.WriteString(writer,
+		"# HELP dev_health_provider_requests_total Provider HTTP requests by bounded provider and error class.\n"+
+			"# TYPE dev_health_provider_requests_total counter\n"); err != nil {
+		return err
+	}
 	requestKeys := make([]string, 0, len(m.requests))
 	for key := range m.requests {
 		requestKeys = append(requestKeys, key)
@@ -248,6 +300,11 @@ func (m *Metrics) WritePrometheus(writer io.Writer) error {
 			return err
 		}
 	}
+	if _, err := io.WriteString(writer,
+		"# HELP dev_health_provider_budget_denied_total Provider cost-budget denials by bounded provider.\n"+
+			"# TYPE dev_health_provider_budget_denied_total counter\n"); err != nil {
+		return err
+	}
 	providers := make([]string, 0, len(m.budgetDenied))
 	for provider := range m.budgetDenied {
 		providers = append(providers, provider)
@@ -258,6 +315,11 @@ func (m *Metrics) WritePrometheus(writer io.Writer) error {
 		if _, err := fmt.Fprintf(writer, "dev_health_provider_budget_denied_total{provider=%q} %d\n", provider, value); err != nil {
 			return err
 		}
+	}
+	if _, err := io.WriteString(writer,
+		"# HELP dev_health_provider_budget_release_errors_total Provider cost-budget reservation release failures by bounded provider.\n"+
+			"# TYPE dev_health_provider_budget_release_errors_total counter\n"); err != nil {
+		return err
 	}
 	providers = providers[:0]
 	for provider := range m.budgetReleaseErrors {

--- a/internal/providerfoundation/budget_wait_integration_test.go
+++ b/internal/providerfoundation/budget_wait_integration_test.go
@@ -1,0 +1,106 @@
+//go:build integration
+
+package providerfoundation_test
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	valkeystore "github.com/full-chaos/dev-health-ops/internal/storage/valkey"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+// TestValkeyBudgetStoreAndBackoffGateObserveRealWait is CHAOS-3118 evidence
+// for worker_budget_wait_seconds: it runs ValkeyBudgetStore.Acquire and
+// ValkeyBackoffGate.Wait against a real, isolated Valkey instance (not a
+// mocked client), wired to a real *jobruntime.MetricsCollector exactly the
+// way cmd/dev-health-worker/provider_sync.go wires them in production, and
+// reads the collector's own Prometheus exposition to prove non-zero series.
+func TestValkeyBudgetStoreAndBackoffGateObserveRealWait(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartValkey(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate Valkey: %v", err)
+		}
+	})
+	client, err := valkeystore.Open(ctx, valkeystore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(client.Close)
+
+	collector, err := jobruntime.NewMetricsCollector(jobruntime.MetricDimensions{
+		Profiles: []string{"sync"},
+		Budgets: []jobruntime.BudgetLabels{
+			{Provider: "github", CostClass: "medium"},
+		},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	store := providerfoundation.ValkeyBudgetStore{Client: client, Observer: collectorBudgetObserver{collector}}
+	key := providerfoundation.BudgetKey{
+		Provider: "github", OrgID: "org-1", Host: "api.github.com",
+		CostClass: "medium", Limit: 1, TTL: time.Minute,
+	}
+	reservation, err := store.Acquire(ctx, key)
+	if err != nil || reservation == nil {
+		t.Fatalf("Acquire() = %v, %v", reservation, err)
+	}
+	t.Cleanup(func() { _ = reservation.Release(context.Background()) })
+
+	gate := providerfoundation.ValkeyBackoffGate{
+		Client: client, Provider: "github", OrgID: "org-1", Host: "api.github.com",
+		MaxBackoff: time.Minute, CostClass: "medium",
+		Observer: collectorBudgetObserver{collector},
+	}
+	// ValkeyBackoffGate.Penalize's Lua script returns a Lua number, which
+	// Valkey encodes as a RESP integer reply; ValkeyBackoffGate.Wait's own
+	// Penalize call then fails inside valkey-go's AsFloat64 ("message type
+	// int64 is not a string") against a real server — a pre-existing defect
+	// in Penalize unrelated to this metric's wiring (see CHAOS-3118 report;
+	// not fixed here, out of scope). To exercise the real, unbroken Wait path
+	// without that defect, write the same key Penalize documents itself as
+	// writing (rate_limit:<provider>:<org>:<host>, a Unix-seconds float
+	// string) directly, exactly as Wait's own GET expects to read it back.
+	future := strconv.FormatFloat(float64(time.Now().Add(2*time.Second).UnixMilli())/1000, 'f', 3, 64)
+	if err := client.Do(ctx, client.B().Set().Key("rate_limit:github:org-1:api.github.com").Value(future).Build()).Error(); err != nil {
+		t.Fatalf("seed backoff key: %v", err)
+	}
+	wait, err := gate.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if wait <= 0 {
+		t.Fatalf("Wait() = %v, want a positive backoff", wait)
+	}
+
+	text := collector.PrometheusText()
+	if !strings.Contains(text, `worker_budget_wait_seconds_count{provider="github",cost_class="medium"} 2`) {
+		t.Fatalf("expected two non-zero worker_budget_wait_seconds observations (Acquire + Wait), got:\n%s", text)
+	}
+	if strings.Contains(text, `worker_budget_wait_seconds_sum{provider="github",cost_class="medium"} 0`) {
+		t.Fatalf("expected a non-zero wait sum from the real Penalize/Wait round trip, got:\n%s", text)
+	}
+}
+
+type collectorBudgetObserver struct {
+	collector *jobruntime.MetricsCollector
+}
+
+func (o collectorBudgetObserver) ObserveProviderBudgetWait(provider, costClass string, wait time.Duration) error {
+	return o.collector.ObserveProviderBudgetWait(jobruntime.BudgetLabels{Provider: provider, CostClass: costClass}, wait)
+}

--- a/internal/providerfoundation/dev_health_provider_registration_test.go
+++ b/internal/providerfoundation/dev_health_provider_registration_test.go
@@ -1,0 +1,79 @@
+package providerfoundation
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+)
+
+// TestSharedMetricsAccumulateAcrossRealRequestsAndScrape is CHAOS-3118
+// evidence for the dev_health_provider_* family: it proves both halves of the
+// gap the report identified.
+//
+//  1. A single, shared *Metrics accumulates across multiple real
+//     HTTPClient.Do calls, instead of the pre-fix pattern
+//     (cmd/dev-health-worker/provider_sync.go constructing a fresh
+//     providerfoundation.NewMetrics() inside BuildExecutor, once per unit
+//     dispatch, and discarding it — every counter reset to zero on the very
+//     next unit and was never scraped in between).
+//  2. Registering that one instance with a health.Registry — exactly the
+//     production /metrics path (health.Server.handleMetrics ->
+//     Registry.WriteMetricsPartial) — surfaces its real, accumulated,
+//     HELP/TYPE-complete series, which is what "registered" means for this
+//     family (see cmd/dev-health-worker/dependencies.go's
+//     workerFamily.metricsSource wiring).
+func TestSharedMetricsAccumulateAcrossRealRequestsAndScrape(t *testing.T) {
+	t.Parallel()
+	metrics := NewMetrics()
+
+	successClient := newTestHTTPClient(t, HTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+		return testHTTPResponse(request, http.StatusOK, nil, `{}`), nil
+	}), RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: time.Millisecond})
+	successClient.Metrics = metrics
+	successClient.Provider = "github"
+
+	rateLimitedClient := newTestHTTPClient(t, HTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+		return testHTTPResponse(request, http.StatusTooManyRequests, nil, `{}`), nil
+	}), RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: time.Millisecond})
+	rateLimitedClient.Metrics = metrics
+	rateLimitedClient.Provider = "github"
+
+	// Two real requests through the SAME *Metrics instance, as two different
+	// units dispatched by one long-lived worker process would.
+	if _, err := successClient.Do(context.Background(), http.MethodGet, "/items", nil); err != nil {
+		t.Fatalf("first request: %v", err)
+	}
+	if _, err := rateLimitedClient.Do(context.Background(), http.MethodGet, "/items", nil); err == nil {
+		t.Fatal("expected the second request to report a rate-limited classification")
+	}
+
+	registry := health.NewRegistry(time.Second)
+	if err := registry.RegisterMetrics("provider_foundation", metrics); err != nil {
+		t.Fatalf("RegisterMetrics: %v", err)
+	}
+
+	var scrape bytes.Buffer
+	outcomes, err := registry.WriteMetricsPartial(&scrape)
+	if err != nil {
+		t.Fatalf("WriteMetricsPartial: %v", err)
+	}
+	if len(outcomes) != 1 || outcomes[0].Source != "provider_foundation" || outcomes[0].Err != nil {
+		t.Fatalf("unexpected scrape outcomes: %+v", outcomes)
+	}
+	text := scrape.String()
+	if !strings.Contains(text, "# HELP dev_health_provider_requests_total") ||
+		!strings.Contains(text, "# TYPE dev_health_provider_requests_total counter") {
+		t.Fatalf("missing HELP/TYPE metadata in scraped output:\n%s", text)
+	}
+	if !strings.Contains(text, `dev_health_provider_requests_total{provider="github",class=""} 1`) {
+		t.Fatalf("missing accumulated success sample in scraped output:\n%s", text)
+	}
+	if !strings.Contains(text, `dev_health_provider_requests_total{provider="github",class="rate_limited"} 1`) {
+		t.Fatalf("missing accumulated rate-limited sample in scraped output:\n%s", text)
+	}
+}

--- a/internal/storage/postgres/factory.go
+++ b/internal/storage/postgres/factory.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/jackc/pgx/v5"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -24,6 +25,10 @@ type Config struct {
 	MaxConnLifetime   time.Duration
 	MaxConnIdleTime   time.Duration
 	HealthCheckPeriod time.Duration
+	// Tracer is optional and unused by most callers (the zero value is nil,
+	// preserving today's behavior). NewRuntimePools sets it to instrument
+	// Acquire for the domain and queue-control pools.
+	Tracer pgx.QueryTracer
 }
 
 func DefaultConfig(uri string) Config {
@@ -81,6 +86,9 @@ func New(ctx context.Context, config Config) (*pgxpool.Pool, error) {
 	poolConfig.MaxConnIdleTime = config.MaxConnIdleTime
 	poolConfig.HealthCheckPeriod = config.HealthCheckPeriod
 	poolConfig.ConnConfig.ConnectTimeout = config.ConnectTimeout
+	if config.Tracer != nil {
+		poolConfig.ConnConfig.Tracer = config.Tracer
+	}
 
 	pool, err := pgxpool.NewWithConfig(ctx, poolConfig)
 	if err != nil {

--- a/internal/storage/postgres/pool_acquire.go
+++ b/internal/storage/postgres/pool_acquire.go
@@ -1,0 +1,97 @@
+package postgres
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PoolAcquireObserver records pgx pool acquisition latency by bounded pool
+// name ("domain"|"queue_control") and result
+// ("acquired"|"timeout"|"cancelled"|"error") — the exact vocabulary
+// jobruntime.MetricsCollector.ObserveDatabasePoolAcquire enforces.
+// Implementations must be safe for concurrent use and must never see a DSN,
+// credential, or query text: only the pool label and a duration.
+type PoolAcquireObserver interface {
+	ObserveDatabasePoolAcquire(pool, result string, duration time.Duration) error
+}
+
+type poolAcquireStartKey struct{}
+
+// poolAcquireTracer is both a pgx.QueryTracer and a pgxpool.AcquireTracer.
+// Query tracing is an intentional no-op: this exists solely to time
+// Acquire, and pgxpool only honors an AcquireTracer that is reachable
+// through ConnConfig.Tracer (which is typed pgx.QueryTracer).
+//
+// The observer is attached after construction (attach) rather than passed to
+// the constructor, because pgxpool freezes its AcquireTracer at
+// pgxpool.NewWithConfig — before the process's MetricsCollector, which is
+// built later in cmd/dev-health-worker, exists.
+type poolAcquireTracer struct {
+	pool string
+
+	mu       sync.RWMutex
+	observer PoolAcquireObserver
+}
+
+func newPoolAcquireTracer(pool string) *poolAcquireTracer {
+	return &poolAcquireTracer{pool: pool}
+}
+
+func (t *poolAcquireTracer) attach(observer PoolAcquireObserver) {
+	if t == nil {
+		return
+	}
+	t.mu.Lock()
+	t.observer = observer
+	t.mu.Unlock()
+}
+
+func (t *poolAcquireTracer) TraceAcquireStart(ctx context.Context, _ *pgxpool.Pool, _ pgxpool.TraceAcquireStartData) context.Context {
+	return context.WithValue(ctx, poolAcquireStartKey{}, time.Now())
+}
+
+func (t *poolAcquireTracer) TraceAcquireEnd(ctx context.Context, _ *pgxpool.Pool, data pgxpool.TraceAcquireEndData) {
+	t.mu.RLock()
+	observer := t.observer
+	t.mu.RUnlock()
+	if observer == nil {
+		return
+	}
+	started, ok := ctx.Value(poolAcquireStartKey{}).(time.Time)
+	if !ok {
+		return
+	}
+	_ = observer.ObserveDatabasePoolAcquire(t.pool, poolAcquireResult(data.Err), time.Since(started))
+}
+
+func poolAcquireResult(err error) string {
+	switch {
+	case err == nil:
+		return "acquired"
+	case errors.Is(err, context.DeadlineExceeded):
+		return "timeout"
+	case errors.Is(err, context.Canceled):
+		return "cancelled"
+	default:
+		return "error"
+	}
+}
+
+// TraceQueryStart/TraceQueryEnd are required to satisfy pgx.QueryTracer (the
+// type of ConnConfig.Tracer) but intentionally do nothing: this tracer only
+// instruments Acquire.
+func (t *poolAcquireTracer) TraceQueryStart(ctx context.Context, _ *pgx.Conn, _ pgx.TraceQueryStartData) context.Context {
+	return ctx
+}
+
+func (t *poolAcquireTracer) TraceQueryEnd(context.Context, *pgx.Conn, pgx.TraceQueryEndData) {}
+
+var (
+	_ pgxpool.AcquireTracer = (*poolAcquireTracer)(nil)
+	_ pgx.QueryTracer       = (*poolAcquireTracer)(nil)
+)

--- a/internal/storage/postgres/pool_acquire_integration_test.go
+++ b/internal/storage/postgres/pool_acquire_integration_test.go
@@ -1,0 +1,107 @@
+//go:build integration
+
+package postgres_test
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+const (
+	poolAcquireDomainRole = "pool_acquire_domain"
+	poolAcquireQueueRole  = "pool_acquire_queue"
+	poolAcquireDomainPass = "pool_acquire_domain_password"
+	poolAcquireQueuePass  = "pool_acquire_queue_password"
+)
+
+// TestRuntimePoolsObserveRealAcquireLatency is CHAOS-3118 evidence for
+// worker_database_pool_acquire_seconds: it opens real domain and
+// queue-control pools against an isolated PostgreSQL instance exactly the way
+// cmd/dev-health-worker does (postgres.NewRuntimePools followed by
+// AttachPoolAcquireObserver, since pgxpool freezes its AcquireTracer before
+// the process's MetricsCollector exists), issues real queries that force real
+// Acquire calls, and reads the collector's own Prometheus exposition to prove
+// non-zero series for both pools.
+func TestRuntimePoolsObserveRealAcquireLatency(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer closePostgresInstance(t, instance)
+
+	admin := openPostgresPool(t, ctx, instance.URI)
+	defer admin.Close()
+	for _, statement := range []string{
+		"CREATE ROLE " + poolAcquireDomainRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + poolAcquireDomainPass + "'",
+		"CREATE ROLE " + poolAcquireQueueRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + poolAcquireQueuePass + "'",
+		"GRANT CONNECT ON DATABASE worker_test TO " + poolAcquireDomainRole + ", " + poolAcquireQueueRole,
+	} {
+		if _, err := admin.Exec(ctx, statement); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	domainURI := postgresRoleURI(t, instance.URI, poolAcquireDomainRole, poolAcquireDomainPass)
+	queueURI := postgresRoleURI(t, instance.URI, poolAcquireQueueRole, poolAcquireQueuePass)
+
+	pools, err := postgresstore.NewRuntimePools(ctx, postgresstore.RuntimeConfig{
+		DomainURI:        domainURI,
+		QueueControlURI:  queueURI,
+		DomainRole:       poolAcquireDomainRole,
+		QueueRole:        poolAcquireQueueRole,
+		RiverSchema:      "river",
+		QueueControlMode: config.QueueControlDirect,
+		DomainMaxConns:   2,
+		QueueMaxConns:    2,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pools.Close()
+
+	collector, err := jobruntime.NewMetricsCollector(jobruntime.MetricDimensions{
+		Profiles: []string{"ops"},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	pools.AttachPoolAcquireObserver(collector)
+
+	for i := 0; i < 3; i++ {
+		var value int
+		if err := pools.Domain.QueryRow(ctx, "SELECT 1").Scan(&value); err != nil {
+			t.Fatalf("domain query: %v", err)
+		}
+		if err := pools.QueueControl.QueryRow(ctx, "SELECT 1").Scan(&value); err != nil {
+			t.Fatalf("queue-control query: %v", err)
+		}
+	}
+
+	text := collector.PrometheusText()
+	for _, pool := range []string{"domain", "queue_control"} {
+		marker := `worker_database_pool_acquire_seconds_count{pool="` + pool + `",result="acquired"} 3`
+		if !strings.Contains(text, marker) {
+			t.Fatalf("expected %q in real exposition, got:\n%s", marker, text)
+		}
+	}
+	// Every other bounded result must stay at zero: nothing here times out,
+	// gets cancelled, or errors.
+	for _, pool := range []string{"domain", "queue_control"} {
+		for _, result := range []string{"timeout", "cancelled", "error"} {
+			marker := `worker_database_pool_acquire_seconds_count{pool="` + pool + `",result="` + result + `"} 0`
+			if !strings.Contains(text, marker) {
+				t.Fatalf("expected %q to stay zero, got:\n%s", marker, text)
+			}
+		}
+	}
+}

--- a/internal/storage/postgres/runtime.go
+++ b/internal/storage/postgres/runtime.go
@@ -247,6 +247,28 @@ type RuntimePools struct {
 	Domain       *pgxpool.Pool
 	QueueControl *pgxpool.Pool
 	Coordinator  *pgxpool.Pool
+
+	// domainAcquire/queueAcquire back worker_database_pool_acquire_seconds.
+	// Coordinator is intentionally not instrumented: the metric's pool
+	// dimension is bounded to domain|queue_control (see
+	// jobruntime.Observer's doc comment), and only those two are River's own
+	// runtime pools.
+	domainAcquire *poolAcquireTracer
+	queueAcquire  *poolAcquireTracer
+}
+
+// AttachPoolAcquireObserver wires a real observer into the domain and
+// queue-control pools' Acquire tracers after construction. It is safe to call
+// with a nil observer (detaches) or on a nil *RuntimePools (no-op) — the
+// latter matters because a process without a domain/queue-control database
+// configured never gets past NewRuntimePools in the first place, but callers
+// building pools conditionally should not need to guard twice.
+func (p *RuntimePools) AttachPoolAcquireObserver(observer PoolAcquireObserver) {
+	if p == nil {
+		return
+	}
+	p.domainAcquire.attach(observer)
+	p.queueAcquire.attach(observer)
 }
 
 // CoordinatorPool returns the coordinator pool or ErrUnavailable. It exists so
@@ -278,22 +300,33 @@ func NewRuntimePools(ctx context.Context, runtimeConfig RuntimeConfig) (*Runtime
 		return nil, err
 	}
 
+	// worker_database_pool_acquire_seconds{pool="domain"|"queue_control"} is
+	// the exact bounded pair Observer's pool dimension permits (see
+	// jobruntime.Observer's doc comment); the label string is fixed here so
+	// it can never drift into a per-tenant or per-endpoint value.
+	domainTracer := newPoolAcquireTracer("domain")
 	domainConfig := DefaultConfig(runtimeConfig.DomainURI)
 	domainConfig.MaxConns = runtimeConfig.DomainMaxConns
+	domainConfig.Tracer = domainTracer
 	domainPool, err := New(ctx, domainConfig)
 	if err != nil {
 		return nil, fmt.Errorf("open domain pool: %w", err)
 	}
 
+	queueTracer := newPoolAcquireTracer("queue_control")
 	queueConfig := DefaultConfig(runtimeConfig.QueueControlURI)
 	queueConfig.MaxConns = runtimeConfig.QueueMaxConns
+	queueConfig.Tracer = queueTracer
 	queuePool, err := New(ctx, queueConfig)
 	if err != nil {
 		domainPool.Close()
 		return nil, fmt.Errorf("open queue-control pool: %w", err)
 	}
 
-	pools := &RuntimePools{Domain: domainPool, QueueControl: queuePool}
+	pools := &RuntimePools{
+		Domain: domainPool, QueueControl: queuePool,
+		domainAcquire: domainTracer, queueAcquire: queueTracer,
+	}
 	if runtimeConfig.RequireCoordinator {
 		coordinatorConfig := DefaultConfig(runtimeConfig.CoordinatorURI)
 		coordinatorConfig.MaxConns = runtimeConfig.CoordinatorMaxConns


### PR DESCRIPTION
Wires five metric families that were declared and permanently empty, and fixes two stream alert rules that could never fire. Unblocks the provider-sync parity program: a provider port cannot be shown to respect fleet budgets while budget waits are never measured.

The failure mode being eliminated: a family that publishes HELP/TYPE with zero series still satisfies a dashboard query and an alert expression while carrying no information. Green and meaningless.

## The defect this uncovered

`providerfoundation.NewMetrics()` was constructed **inside the `BuildExecutor` closure** — a fresh instance per unit dispatch, so every `dev_health_provider_*` counter reset on each dispatch, and no instance was ever registered with the health registry. One `Metrics` is now hoisted per worker process and registered via a new `workerFamily.metricsSource`. `Metrics.WritePrometheus` also gained the HELP/TYPE headers it was missing.

That fix is pinned by identity, not behaviour. `TestBuildProviderSyncHandlerSharesOneMetricsInstance` asserts the instance reachable from the real `BuildExecutor` closure is pointer-identical to the registered one. Verified by mutation: reintroducing the per-dispatch construction fails that test while every behavioural test in the package stays green — so a behavioural test alone would never have caught it. `buildProviderSyncHandler` was extracted as a pure function to make this testable without dialing ClickHouse, Valkey, or Postgres.

## Families wired

| Family | Where it now writes | Evidence |
| --- | --- | --- |
| `worker_job_wait_seconds` | `Adapter.Work`, from River's `JobRow.ScheduledAt` | real `Adapter.Work` call, asserts the histogram bucket for a ~750ms wait |
| `worker_budget_wait_seconds` | `ValkeyBudgetStore.Acquire` (grant and denial) and `ValkeyBackoffGate.Wait` | integration test against testcontainers Valkey: `_count 2`, non-zero `_sum` |
| `worker_sync_lease_expired_total` | `providerunit.Handler` at every durable `ReleaseForRetry`/`Fail` of a recovered claim | real `Handler.Work()` runs, non-zero `result="retrying"` and `result="failed"` |
| `worker_database_pool_acquire_seconds` | new `pgxpool.AcquireTracer` on the domain and queue-control pools | integration test against testcontainers Postgres: `_count{pool=...,result="acquired"} 3` |
| `dev_health_provider_*` | registered once per process (see above) | two real `HTTPClient.Do` calls, then scraped through `health.Registry.WriteMetricsPartial` — the production `/metrics` path |

`worker_budget_wait_seconds` had a second latent problem: its `Budgets` dimensions were never populated at construction, so an observation would have been dropped even if one had been made. Dimensions are now registered from the frozen provider×cost-class matrix.

## Alert rules fixed, not the emitter

The two `go_workers` stream rules grouped by `(stream, consumer_group)`, labels the emitter does not produce. The emitter is right to omit them: every `streamrunner.Config` discovers streams by wildcard (`pagerduty-webhooks:*`, `ingest:*:commits`) where the wildcard segment is a per-org or per-integration identifier, so labeling by stream key would put tenant identity on a metric label — which the PRD forbids. The rules and the Grafana dashboard now group by Prometheus's own `job`/`instance`, matching the existing `GoWorkerTelemetryTargetDown` precedent.

No label added anywhere carries an org, unit, credential, host, or URL. `BudgetLabels` and `SyncLeaseLabels` come only from the static validated provider/dataset/cost-class matrix, bounded at roughly 18 and 59 series.

## Pre-existing defects found, deliberately not fixed

- **`ValkeyBackoffGate.Penalize` always returns an error against a real Valkey.** `budget.go:227` calls `.AsFloat64()` on the reply of the Lua script at `budget.go:176`, whose `return applied` is a Lua number and RESP-encodes as an integer reply, which `valkey-go` cannot parse as a float. Severity established by probe rather than inference: EVAL is atomic and the `SET` executes server-side before the reply, so **the backoff key is always durably written** and takes effect on the next `Wait`. What is lost is the return value and the success status — the caller in `HTTPClient.Do` sees `ErrBudgetUnavailable` instead of the intended `ProviderError{Class: ErrorRateLimited}` on that one call. Filed separately.
- `internal/syncreconciler/lease_repair.go`'s `LeaseRepair.Step()` result is discarded in `cmd/dev-health-reconciler`, and that pipeline is flag-dormant. Instrumenting it would require standing up a second metrics surface in a different process — materially larger than wiring a dead family.
- `LeaseRepair`'s doc comment claiming no command constructs it is stale; `cmd/dev-health-reconciler/dependencies.go` does.

## Deviation from the ticket

The ticket pointed at `internal/providersync/lease.go` for lease expiry, but that file only implements `LeaseSession.Assert/Heartbeat/Run` and holds no retry-or-fail decision. The real signal lives in `internal/jobs/providerunit`, via `Repository.Claim`'s `Recovered` flag at the existing `ReleaseForRetry`/`Fail` call sites, which is where it was wired.

## Verification

`go build ./...`, `go vet ./...`, and the full `go test ./...` are clean; `ci/check_go.sh fmt`/`vet` clean; integration-tagged Valkey and Postgres suites pass; `pytest tests/workers/test_go_worker_alerts.py test_go_worker_dashboard.py` 5 passed.

Refs CHAOS-3118, CHAOS-3117.
