### PR TITLE
CHAOS-3132: fix ValkeyBackoffGate.Penalize RESP decode masking every rate limit as a budget outage

### DIFF
--- a/internal/providerfoundation/budget.go
+++ b/internal/providerfoundation/budget.go
@@ -173,7 +173,15 @@ type ValkeyBackoffGate struct {
 	Observer BudgetWaitObserver
 }
 
-const backoffPenalizeLua = `local old=tonumber(redis.call('GET',KEYS[1]) or '0'); local proposed=tonumber(ARGV[1]); local applied=math.max(old,proposed); redis.call('SET',KEYS[1],applied,'EX',ARGV[2]); return applied`
+// applied is returned via tostring, not as a bare Lua number. Redis/Valkey's
+// Lua-to-RESP conversion truncates a returned Lua number to an integer reply
+// (dropping the millisecond fraction this value legitimately carries as a
+// Unix-seconds timestamp), and valkey-go's .AsFloat64() only parses
+// string-typed replies — so a bare `return applied` both loses precision on
+// the wire and fails client-side decoding ("message type int64 is not a
+// string") against a real server. tostring keeps the full value and matches
+// the bulk-string reply Penalize's caller already expects.
+const backoffPenalizeLua = `local old=tonumber(redis.call('GET',KEYS[1]) or '0'); local proposed=tonumber(ARGV[1]); local applied=math.max(old,proposed); redis.call('SET',KEYS[1],applied,'EX',ARGV[2]); return tostring(applied)`
 
 func (g ValkeyBackoffGate) key() string {
 	return fmt.Sprintf("rate_limit:%s:%s:%s", keyPart(g.Provider), keyPart(g.OrgID), keyPart(g.Host))

--- a/internal/providerfoundation/budget_penalize_integration_test.go
+++ b/internal/providerfoundation/budget_penalize_integration_test.go
@@ -1,0 +1,111 @@
+//go:build integration
+
+package providerfoundation
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"testing"
+	"time"
+
+	valkeystore "github.com/full-chaos/dev-health-ops/internal/storage/valkey"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+)
+
+// TestValkeyBackoffGatePenalizeAgainstRealValkey is CHAOS-3132 evidence.
+// backoffPenalizeLua's `return applied` is a Lua number, which Valkey
+// RESP-encodes as an integer reply; valkey-go's .AsFloat64() only parses
+// string-typed replies, so against a *mock* client (which never round-trips
+// through the real RESP encoder) this bug is invisible — it only appears
+// once a real server is on the other end. This test fails on the
+// pre-fix script (Penalize returns ErrBudgetUnavailable wrapping "message
+// type int64 is not a string") and passes once the script returns
+// tostring(applied).
+func TestValkeyBackoffGatePenalizeAgainstRealValkey(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartValkey(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate Valkey: %v", err)
+		}
+	})
+	client, err := valkeystore.Open(ctx, valkeystore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(client.Close)
+
+	gate := ValkeyBackoffGate{
+		Client: client, Provider: "github", OrgID: "org-1", Host: "api.github.com",
+		MaxBackoff: time.Minute,
+	}
+
+	if err := gate.Penalize(ctx, 2*time.Second); err != nil {
+		t.Fatalf("Penalize() against a real Valkey server = %v, want nil (backoffPenalizeLua must return a "+
+			"string-typed reply valkey-go's AsFloat64 can parse)", err)
+	}
+
+	// EVAL is atomic and the SET runs server-side before Penalize's reply, so
+	// even on the pre-fix script the key is durably written; a subsequent
+	// GET-based Wait() sees the penalty regardless. Assert that here too so a
+	// regression that broke the SET itself (as opposed to only the reply
+	// decoding) would still be caught.
+	wait, err := gate.Wait(ctx)
+	if err != nil {
+		t.Fatalf("Wait: %v", err)
+	}
+	if wait <= 0 {
+		t.Fatalf("Wait() = %v, want a positive backoff written by Penalize", wait)
+	}
+}
+
+// TestHTTPClientClassifiesRateLimitAgainstRealValkeyBackoffGate reproduces
+// the production symptom of CHAOS-3132: HTTPClient.Do calls Gate.Penalize on
+// a 429 response and, on the pre-fix script, receives ErrBudgetUnavailable
+// back instead of nil — so the caller sees a budget-store outage instead of
+// the intended ProviderError{Class: ErrorRateLimited}. A mocked Gate (as
+// used in TestHTTPClientPenalizesSharedGateWithLocalBackoff) can never
+// observe this: only a real Valkey server RESP-encodes the Lua script's
+// numeric return as an integer reply.
+func TestHTTPClientClassifiesRateLimitAgainstRealValkeyBackoffGate(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	instance, err := containers.StartValkey(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeCtx); err != nil {
+			t.Errorf("terminate Valkey: %v", err)
+		}
+	})
+	valkeyClient, err := valkeystore.Open(ctx, valkeystore.DefaultConfig(instance.URI))
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(valkeyClient.Close)
+
+	client := newTestHTTPClient(t, HTTPDoerFunc(func(request *http.Request) (*http.Response, error) {
+		return testHTTPResponse(request, http.StatusTooManyRequests, nil, `{"error":"limited"}`), nil
+	}), RetryPolicy{MaxAttempts: 1, InitialWait: time.Millisecond, MaxWait: time.Millisecond})
+	client.Gate = &ValkeyBackoffGate{Client: valkeyClient, Provider: "github", MaxBackoff: time.Minute}
+
+	_, err = client.Do(ctx, http.MethodGet, "/items", nil)
+
+	if errors.Is(err, ErrBudgetUnavailable) {
+		t.Fatalf("Do() misclassified a rate limit as a budget-store outage: %v", err)
+	}
+	var providerErr *ProviderError
+	if !errors.As(err, &providerErr) || providerErr.Class != ErrorRateLimited {
+		t.Fatalf("Do() error = %v, want ProviderError{Class: ErrorRateLimited}", err)
+	}
+}

--- a/internal/providerfoundation/budget_wait_integration_test.go
+++ b/internal/providerfoundation/budget_wait_integration_test.go
@@ -4,7 +4,6 @@ package providerfoundation_test
 
 import (
 	"context"
-	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -67,18 +66,12 @@ func TestValkeyBudgetStoreAndBackoffGateObserveRealWait(t *testing.T) {
 		MaxBackoff: time.Minute, CostClass: "medium",
 		Observer: collectorBudgetObserver{collector},
 	}
-	// ValkeyBackoffGate.Penalize's Lua script returns a Lua number, which
-	// Valkey encodes as a RESP integer reply; ValkeyBackoffGate.Wait's own
-	// Penalize call then fails inside valkey-go's AsFloat64 ("message type
-	// int64 is not a string") against a real server — a pre-existing defect
-	// in Penalize unrelated to this metric's wiring (see CHAOS-3118 report;
-	// not fixed here, out of scope). To exercise the real, unbroken Wait path
-	// without that defect, write the same key Penalize documents itself as
-	// writing (rate_limit:<provider>:<org>:<host>, a Unix-seconds float
-	// string) directly, exactly as Wait's own GET expects to read it back.
-	future := strconv.FormatFloat(float64(time.Now().Add(2*time.Second).UnixMilli())/1000, 'f', 3, 64)
-	if err := client.Do(ctx, client.B().Set().Key("rate_limit:github:org-1:api.github.com").Value(future).Build()).Error(); err != nil {
-		t.Fatalf("seed backoff key: %v", err)
+	// Penalize's Lua script now returns tostring(applied) (CHAOS-3132), so
+	// this exercises the real, unbroken Penalize -> Wait round trip against a
+	// real server instead of hand-seeding the key it documents itself as
+	// writing.
+	if err := gate.Penalize(ctx, 2*time.Second); err != nil {
+		t.Fatalf("Penalize: %v", err)
 	}
 	wait, err := gate.Wait(ctx)
 	if err != nil {


### PR DESCRIPTION
## CHAOS-3132

`backoffPenalizeLua` ended with `return applied` — a bare Lua number. Redis/Valkey's Lua→RESP conversion encodes that as a RESP **integer** reply (and truncates the fractional Unix-seconds value it carries). valkey-go's `.AsFloat64()` accepts only a RESP3 double, then falls back to `ToString()`, which rejects integer replies with `message type int64 is not a string`.

So `Penalize`'s own EVAL result could never decode against a real server. It was invisible in unit tests because the package's mocked client never round-trips through the real RESP encoder.

**Runtime consequence.** EVAL is atomic, so the script's server-side `SET` still landed and the backoff key was durably written — but `Penalize` always returned `ErrBudgetUnavailable`. `HTTPClient.Do` treats that as fatal and aborts its retry loop, so **every real 429 surfaced as "budget store unavailable" instead of `ProviderError{Class: ErrorRateLimited}`** — rate-limit backoff masked behind a false outage on every production Penalize call.

Fix is one line: `return tostring(applied)`.

## Evidence

Three integration tests run against a real Valkey via testcontainers — two new in `budget_penalize_integration_test.go`, one reworked in `budget_wait_integration_test.go`.

Mutation-checked rather than asserted: reverting to `return applied` fails all three with exactly the predicted `provider budget unavailable` / `message type int64 is not a string`; restoring passes all three, diff byte-identical.

## CHAOS-3129 — no change needed

The retired `latency` profile is already gone from `deploy/helm/dev-health/values.yaml`, `deploy/go-workers/profiles.json`, the contract schema/manifest, and worker `main.go`. It was removed in 3450c31c6 (#1291) as part of CUT-02. The two remaining "latency-sensitive" comments in values.yaml describe Celery queue characteristics, predate that work, and are accurate. CHAOS-3129 should be closed as already-done.

## Known gap, not addressed here

`internal/providerfoundation`'s integration-tagged tests — including the pre-existing `sinks_clickhouse_integration_test.go` and the two added here — are not in `ci/check_go.sh`'s `check_integration` allowlist, so `go-storage-integration` never runs them. Pre-existing; being handled with CHAOS-3133.

## Gate

`ci/local_validate.sh` green on lint / ruff / mypy / go / river / ch-migrate. The two docs-build failures seen during development were a local venv missing `requirements-docs.txt`, not a code fault — `ci/local_validate.sh` not installing what CI installs is itself being fixed on a separate branch.