### PR TITLE
CHAOS-3123: make (github, repo-metadata) route-ready and actually executable

### DIFF
--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -417,16 +417,27 @@ func composeWorkerFamily(existing, additional workerFamily) (workerFamily, error
 	return result, nil
 }
 
-func providerRouteSwitchesReady(
-	cfg config.Config,
-	runtimeConstructed *bool,
-) health.CheckFunc {
-	switches := providersync.CompleteRouteSwitches{
+// workerRouteSwitches is the single translation from process configuration to
+// route switches. The readiness check below and the handler that actually
+// executes claims (buildProviderSyncHandler) both read it, so a route can
+// never be reported ready against one switch set while being served under
+// another — the drift that a hardcoded `LaunchDarklyFeatureFlags: true` in the
+// handler used to permit (CHAOS-3123).
+func workerRouteSwitches(cfg config.Config) providersync.CompleteRouteSwitches {
+	return providersync.CompleteRouteSwitches{
 		LinearWorkItems:          cfg.WorkerLinearWorkItemsEnabled,
 		JiraWorkItems:            cfg.WorkerJiraWorkItemsEnabled,
 		JiraIncidents:            cfg.WorkerJiraIncidentsEnabled,
 		LaunchDarklyFeatureFlags: cfg.WorkerLaunchDarklyFeatureFlagsEnabled,
+		GithubRepoMetadata:       cfg.WorkerGithubRepoMetadataEnabled,
 	}
+}
+
+func providerRouteSwitchesReady(
+	cfg config.Config,
+	runtimeConstructed *bool,
+) health.CheckFunc {
+	switches := workerRouteSwitches(cfg)
 	routes := []struct {
 		provider string
 		dataset  string
@@ -436,6 +447,7 @@ func providerRouteSwitchesReady(
 		{"jira", "work-items", cfg.WorkerJiraWorkItemsEnabled},
 		{"jira", "incidents", cfg.WorkerJiraIncidentsEnabled},
 		{"launchdarkly", "feature-flags", cfg.WorkerLaunchDarklyFeatureFlagsEnabled},
+		{"github", "repo-metadata", cfg.WorkerGithubRepoMetadataEnabled},
 	}
 	return func(context.Context) error {
 		for _, route := range routes {
@@ -446,8 +458,14 @@ func providerRouteSwitchesReady(
 			if !ok || !descriptor.RouteReady || !descriptor.RouteEnabled {
 				return errWorkerDependencyUnavailable
 			}
-			if route.provider == "launchdarkly" &&
-				(runtimeConstructed == nil || !*runtimeConstructed) {
+			// Any enabled route implies the provider-sync runtime must have
+			// been constructed: buildProviderSyncWorker builds the family when
+			// ANY route switch is on, so an enabled switch with no runtime
+			// behind it means units are being dispatched at a process that
+			// registered no handler for them. This was previously checked for
+			// launchdarkly alone, which was correct only while it was the sole
+			// switch that could construct the family (CHAOS-3123).
+			if runtimeConstructed == nil || !*runtimeConstructed {
 				return errWorkerDependencyUnavailable
 			}
 		}

--- a/cmd/dev-health-worker/dependencies_test.go
+++ b/cmd/dev-health-worker/dependencies_test.go
@@ -104,6 +104,24 @@ func TestProviderRouteSwitchesAreIndependentAndRejectIncompleteRoutes(t *testing
 			wantErr: true,
 		},
 		{
+			// (github, repo-metadata) is the second RouteReady pair added by
+			// CHAOS-3123; this case pins that the generalised runtimeConstructed
+			// check (any enabled route, not launchdarkly alone) actually covers
+			// it rather than only having been exercised for launchdarkly.
+			name: "github complete",
+			config: config.Config{
+				WorkerGithubRepoMetadataEnabled: true,
+			},
+			runtime: true,
+		},
+		{
+			name: "github missing runtime",
+			config: config.Config{
+				WorkerGithubRepoMetadataEnabled: true,
+			},
+			wantErr: true,
+		},
+		{
 			name:    "linear incomplete",
 			config:  config.Config{WorkerLinearWorkItemsEnabled: true},
 			wantErr: true,

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -126,6 +126,7 @@ type providerSyncRepository interface {
 // this ticket exists to eliminate, must fail that test.
 func buildProviderSyncHandler(
 	repository providerSyncRepository,
+	switches providersync.CompleteRouteSwitches,
 	decryptor providerfoundation.CredentialDecryptor,
 	clickhouseConnection driver.Conn,
 	valkeyClient valkeygo.Client,
@@ -142,9 +143,11 @@ func buildProviderSyncHandler(
 	providerMetrics := providerfoundation.NewMetrics()
 	handler := &providerunit.Handler{
 		Repository: repository,
-		Switches: providersync.CompleteRouteSwitches{
-			LaunchDarklyFeatureFlags: true,
-		},
+		// Derived from process configuration, not hardcoded. A hardcoded
+		// switch set makes the handler serve a route the readiness check says
+		// is off (or refuse one it says is on); both sides now read
+		// workerRouteSwitches (CHAOS-3123).
+		Switches:      switches,
 		LeaseDuration: providerUnitLeaseDuration,
 		Heartbeat:     providerUnitHeartbeat,
 		// LeaseMetrics observes worker_sync_lease_expired_total. Only claims
@@ -178,8 +181,51 @@ func buildProviderSyncHandler(
 				return providersync.CompleteRouteExecutor{},
 					errWorkerDependencyUnavailable
 			}
-			sink := providersync.LaunchDarklyClickHouseEffects{
-				Conn: clickhouseConnection, Lease: session,
+			// Two route-ready pairs can reach this closure today
+			// (launchdarkly/feature-flags, github/repo-metadata — see
+			// CompleteRouteSwitches.Descriptor), and each has its own
+			// CompleteRouteHandler and effect sink. session.Claim is already
+			// known here — providerunit.Handler.Work only calls BuildExecutor
+			// after its own descriptor gate passed for THIS claim's
+			// provider/dataset — so select by claim rather than hardcoding
+			// one pair. A hardcoded Handler was exactly the CHAOS-3123 gap:
+			// it would compile, satisfy every other test, and still fail
+			// every github/repo-metadata claim (LaunchDarklyRouteHandler.Collect
+			// fails closed on claim.Provider != "launchdarkly") the moment the
+			// switch was flipped on.
+			var (
+				routeHandler providersync.CompleteRouteHandler
+				sink         providersync.EffectSink
+				readback     providersync.EffectReadback
+			)
+			switch {
+			case session.Claim.Provider == "launchdarkly" &&
+				session.Claim.Dataset == "feature-flags":
+				ldSink := providersync.LaunchDarklyClickHouseEffects{
+					Conn: clickhouseConnection, Lease: session,
+				}
+				routeHandler = providersync.LaunchDarklyRouteHandler{
+					CodeReferences: providersync.LaunchDarklyClickHouseReferences{
+						Conn: clickhouseConnection, Lease: session,
+					},
+				}
+				sink, readback = ldSink, ldSink
+			case session.Claim.Provider == "github" &&
+				session.Claim.Dataset == "repo-metadata":
+				ghSink := providersync.GitHubRepositoryClickHouseEffects{
+					Conn: clickhouseConnection, Lease: session,
+				}
+				routeHandler = providersync.GitHubRepositoryRouteHandler{}
+				sink, readback = ghSink, ghSink
+			default:
+				// Unreachable in production: providerunit.Handler.Work only
+				// invokes BuildExecutor for a claim whose descriptor already
+				// reported RouteReady && RouteEnabled, and those two cases
+				// above are the only pairs CompleteRouteSwitches.Descriptor
+				// ever marks RouteReady. Fail closed rather than construct an
+				// executor with a nil Handler.
+				return providersync.CompleteRouteExecutor{},
+					errWorkerDependencyUnavailable
 			}
 			return providersync.CompleteRouteExecutor{
 				Credentials: providerfoundation.CredentialResolver{
@@ -218,15 +264,11 @@ func buildProviderSyncHandler(
 				// This is the exact seam the mutation test targets: Metrics
 				// must stay the shared providerMetrics closed over above, not
 				// a fresh providerfoundation.NewMetrics() built per call.
-				Metrics: providerMetrics,
-				Handler: providersync.LaunchDarklyRouteHandler{
-					CodeReferences: providersync.LaunchDarklyClickHouseReferences{
-						Conn: clickhouseConnection, Lease: session,
-					},
-				},
+				Metrics:    providerMetrics,
+				Handler:    routeHandler,
 				Comparator: providersync.ProductionContractComparator{},
 				Committer: providersync.EffectCommitter{
-					Ledger: repository, Sink: sink, Readback: sink,
+					Ledger: repository, Sink: sink, Readback: readback,
 				},
 				HeartbeatInterval: providerUnitHeartbeat,
 			}, nil
@@ -243,7 +285,12 @@ func buildProviderSyncWorker(
 	observer jobruntime.Observer,
 	logger *slog.Logger,
 ) (workerFamily, error) {
-	if cfg.Profile != "sync" || !cfg.WorkerLaunchDarklyFeatureFlagsEnabled {
+	// Construct the family when ANY route switch is on, not launchdarkly's
+	// alone: (github, repo-metadata) became routable in CHAOS-3123, and a
+	// process that dispatches github units while refusing to build the handler
+	// for them would strand every unit at a worker with nothing registered.
+	if cfg.Profile != "sync" ||
+		(!cfg.WorkerLaunchDarklyFeatureFlagsEnabled && !cfg.WorkerGithubRepoMetadataEnabled) {
 		return workerFamily{}, nil
 	}
 	if registry == nil || observer == nil || logger == nil ||
@@ -297,8 +344,8 @@ func buildProviderSyncWorker(
 	// such as a test double.
 	collector, _ := observer.(*jobruntime.MetricsCollector)
 	handler, providerMetrics := buildProviderSyncHandler(
-		repository, decryptor, clickhouseConnection, valkeyClient,
-		postgresDatabase.pools.Domain, collector, logger,
+		repository, workerRouteSwitches(cfg), decryptor, clickhouseConnection,
+		valkeyClient, postgresDatabase.pools.Domain, collector, logger,
 	)
 	adapter, err := jobruntime.NewAdapter[jobruntime.ProviderUnitArgs](
 		registry, spec, handler, jobruntime.Dependencies{

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/full-chaos/dev-health-ops/internal/jobcontract"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/providersync"
 	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
 	"github.com/jackc/pgx/v5/pgxpool"
@@ -48,7 +49,8 @@ func TestBuildProviderSyncHandlerSharesOneMetricsInstance(t *testing.T) {
 	// unmodified BuildExecutor closure without a live ClickHouse, Valkey, or
 	// Postgres connection.
 	handler, providerMetrics := buildProviderSyncHandler(
-		nil, nil, nil, nil, nil, collector, slog.Default(),
+		nil, providersync.CompleteRouteSwitches{}, nil, nil, nil, nil,
+		collector, slog.Default(),
 	)
 	if handler == nil || handler.BuildExecutor == nil {
 		t.Fatal("buildProviderSyncHandler returned an incomplete handler")
@@ -57,7 +59,20 @@ func TestBuildProviderSyncHandlerSharesOneMetricsInstance(t *testing.T) {
 		t.Fatal("buildProviderSyncHandler returned a nil Metrics instance")
 	}
 
-	executor, err := handler.BuildExecutor(&providersync.LeaseSession{})
+	// BuildExecutor selects its CompleteRouteHandler/effect sink from
+	// session.Claim (CHAOS-3123: no more single hardcoded route), so a
+	// zero-value Claim no longer reaches the closure this test targets — it
+	// hits the closure's own fail-closed default case instead. Any one of the
+	// route-ready pairs proves the same metrics-identity seam; launchdarkly is
+	// arbitrary here.
+	session := &providersync.LeaseSession{
+		Claim: providersync.Claim{
+			Unit: providersync.Unit{
+				Provider: "launchdarkly", Dataset: "feature-flags",
+			},
+		},
+	}
+	executor, err := handler.BuildExecutor(session)
 	if err != nil {
 		t.Fatalf("BuildExecutor: %v", err)
 	}
@@ -195,4 +210,77 @@ func disjointHandlerSets(left, right map[string]struct{}) bool {
 		}
 	}
 	return true
+}
+
+// TestProviderSyncHandlerSwitchesFollowConfiguration pins the CHAOS-3123 fix
+// that the executing handler reads the same switches the readiness check does.
+//
+// The defect this replaces was a literal `LaunchDarklyFeatureFlags: true`
+// inside buildProviderSyncHandler. That is invisible to every behavioral test:
+// the handler serves LaunchDarkly whether or not the process was configured to,
+// and refuses (github, repo-metadata) even when it was — so a unit the Python
+// producer legitimately routed to River is answered with a route fault rather
+// than executed. Reintroducing any hardcoded field here must fail this test.
+func TestProviderSyncHandlerSwitchesFollowConfiguration(t *testing.T) {
+	t.Parallel()
+	for name, want := range map[string]providersync.CompleteRouteSwitches{
+		"none":   {},
+		"github": {GithubRepoMetadata: true},
+		"both":   {GithubRepoMetadata: true, LaunchDarklyFeatureFlags: true},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			handler, _ := buildProviderSyncHandler(
+				nil, want, nil, nil, nil, nil, nil, slog.Default(),
+			)
+			if handler == nil {
+				t.Fatal("buildProviderSyncHandler returned no handler")
+			}
+			if handler.Switches != want {
+				t.Fatalf("handler.Switches = %+v, want %+v", handler.Switches, want)
+			}
+		})
+	}
+}
+
+// TestWorkerRouteSwitchesMapsEveryConfiguredRoute proves the config->switches
+// translation carries each flag to its own field. A copy/paste that pointed two
+// fields at one config flag would still satisfy a single-flag test.
+func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
+	t.Parallel()
+	if got := workerRouteSwitches(config.Config{}); got != (providersync.CompleteRouteSwitches{}) {
+		t.Fatalf("zero config produced %+v", got)
+	}
+	for name, probe := range map[string]struct {
+		cfg  config.Config
+		want providersync.CompleteRouteSwitches
+	}{
+		"launchdarkly": {
+			cfg:  config.Config{WorkerLaunchDarklyFeatureFlagsEnabled: true},
+			want: providersync.CompleteRouteSwitches{LaunchDarklyFeatureFlags: true},
+		},
+		"github": {
+			cfg:  config.Config{WorkerGithubRepoMetadataEnabled: true},
+			want: providersync.CompleteRouteSwitches{GithubRepoMetadata: true},
+		},
+		"linear": {
+			cfg:  config.Config{WorkerLinearWorkItemsEnabled: true},
+			want: providersync.CompleteRouteSwitches{LinearWorkItems: true},
+		},
+		"jira_work_items": {
+			cfg:  config.Config{WorkerJiraWorkItemsEnabled: true},
+			want: providersync.CompleteRouteSwitches{JiraWorkItems: true},
+		},
+		"jira_incidents": {
+			cfg:  config.Config{WorkerJiraIncidentsEnabled: true},
+			want: providersync.CompleteRouteSwitches{JiraIncidents: true},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := workerRouteSwitches(probe.cfg); got != probe.want {
+				t.Fatalf("workerRouteSwitches = %+v, want %+v", got, probe.want)
+			}
+		})
+	}
 }

--- a/contracts/provider-matrix/v1/README.md
+++ b/contracts/provider-matrix/v1/README.md
@@ -71,17 +71,32 @@ PROVIDER_MATRIX_UPDATE=1 go test ./internal/providersync \
 - `route_destinations` is empty for pairs with no known sink manifest yet.
   Recording a guessed manifest would be worse than recording none.
 
-## Activation preconditions for `(github, repo-metadata)`
+## Activation status for `(github, repo-metadata)`
 
-The pair is `native_go` with `route_ready: false`. Before it may be flipped:
+CHAOS-3123 flipped the pair to `native_go` / `route_ready: true` on
+fixture-level field parity evidence against the production Python collector.
+Routing still requires the separate `GithubRepoMetadata` switch
+(`WORKER_GITHUB_REPO_METADATA_ENABLED`), which every existing deployment
+leaves off by default — `route_ready: true` alone moves no live traffic; see
+`CompleteRouteSwitches.Descriptor`'s `github`/`repo-metadata` case.
 
-1. `TestGitHubRepositoryLiveParityHarness` must be implemented and pass against
-   non-empty real data.
+What this activation waived and satisfied:
+
+1. `TestGitHubRepositoryLiveParityHarness` remains an unimplemented stub and
+   is *not* a precondition: canary staging and live-traffic parity are waived
+   for this program (no production users yet). Fixture-level field parity is
+   the accepted bar. Live parity against a real credentialed repository is
+   still valuable operational evidence to capture before the switch is ever
+   turned on in an environment with real traffic.
 2. The binary that constructs `GitHubRepositoryRouteHandler` **must** also set
    `EffectCommitter.Readback` to `GitHubRepositoryClickHouseEffects`. The
    `repos` effect is `EffectReadbackRequired`, so a committer without a
    readback fails closed with `ErrEffectRecoveryAmbiguous` rather than
-   reinserting.
+   reinserting. `cmd/dev-health-worker/provider_sync.go`'s `BuildExecutor`
+   now selects `Handler`/`Sink`/`Readback` by `session.Claim.Provider` and
+   `session.Claim.Dataset` (CHAOS-3123) — a single hardcoded
+   `LaunchDarklyRouteHandler`/`LaunchDarklyClickHouseEffects` pair would fail
+   closed on every claimed github unit rather than serve it.
 
 ## Effect timestamp stabilization (applies to every complete route)
 

--- a/contracts/provider-matrix/v1/matrix.json
+++ b/contracts/provider-matrix/v1/matrix.json
@@ -227,7 +227,7 @@
       "route_destinations": [
         "repos"
       ],
-      "route_ready": false,
+      "route_ready": true,
       "credential_modes": [
         "personal_access_token",
         "github_app_installation"

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -100,6 +100,14 @@ type Config struct {
 	WorkerJiraWorkItemsEnabled            bool
 	WorkerJiraIncidentsEnabled            bool
 	WorkerLaunchDarklyFeatureFlagsEnabled bool
+	// WorkerGithubRepoMetadataEnabled is the (github, repo-metadata) half of
+	// the two-key route gate (CHAOS-3123). The matrix marking the pair
+	// route_ready is the other half; neither alone moves traffic. Its Python
+	// counterpart is ProviderUnitRouteSwitches.github_repo_metadata, read from
+	// the same WORKER_GITHUB_REPO_METADATA_ENABLED name, because the producer
+	// and the executor must agree on the route or a dispatched unit finds no
+	// handler.
+	WorkerGithubRepoMetadataEnabled bool
 
 	// PagerDutyWebhookTransport names the single owner of the PagerDuty webhook
 	// stream. The Python ingress dispatches its Celery task only while this is
@@ -171,6 +179,10 @@ func Load(spec Spec) (Config, error) {
 		{
 			name:   "WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED",
 			target: &cfg.WorkerLaunchDarklyFeatureFlagsEnabled,
+		},
+		{
+			name:   "WORKER_GITHUB_REPO_METADATA_ENABLED",
+			target: &cfg.WorkerGithubRepoMetadataEnabled,
 		},
 	} {
 		*item.target, err = boolEnv(lookup, item.name, false)
@@ -434,6 +446,7 @@ func (c Config) SafeAttrs() []slog.Attr {
 			"worker_launchdarkly_feature_flags_enabled",
 			c.WorkerLaunchDarklyFeatureFlagsEnabled,
 		),
+		slog.Bool("worker_github_repo_metadata_enabled", c.WorkerGithubRepoMetadataEnabled),
 		slog.Bool("clickhouse_configured", c.ClickHouseURI.Configured()),
 		slog.Bool("valkey_configured", c.ValkeyURI.Configured()),
 		slog.Bool("settings_encryption_key_configured", c.SettingsEncryptionKey.Configured()),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -137,7 +137,8 @@ func TestQueueControlAndRetentionDefaults(t *testing.T) {
 	}
 	if cfg.WorkerLinearWorkItemsEnabled || cfg.WorkerJiraWorkItemsEnabled ||
 		cfg.WorkerJiraIncidentsEnabled ||
-		cfg.WorkerLaunchDarklyFeatureFlagsEnabled {
+		cfg.WorkerLaunchDarklyFeatureFlagsEnabled ||
+		cfg.WorkerGithubRepoMetadataEnabled {
 		t.Fatal("provider route switches must default off")
 	}
 }
@@ -163,6 +164,7 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		"WORKER_JIRA_WORK_ITEMS_ENABLED":            "true",
 		"WORKER_JIRA_INCIDENTS_ENABLED":             "true",
 		"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": "true",
+		"WORKER_GITHUB_REPO_METADATA_ENABLED":       "true",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -190,7 +192,8 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 	}
 	if !cfg.WorkerLinearWorkItemsEnabled || !cfg.WorkerJiraWorkItemsEnabled ||
 		!cfg.WorkerJiraIncidentsEnabled ||
-		!cfg.WorkerLaunchDarklyFeatureFlagsEnabled {
+		!cfg.WorkerLaunchDarklyFeatureFlagsEnabled ||
+		!cfg.WorkerGithubRepoMetadataEnabled {
 		t.Fatal("expected independent provider route opt-ins")
 	}
 
@@ -210,6 +213,7 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		"WORKER_JIRA_WORK_ITEMS_ENABLED":            "sometimes",
 		"WORKER_JIRA_INCIDENTS_ENABLED":             "sometimes",
 		"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": "sometimes",
+		"WORKER_GITHUB_REPO_METADATA_ENABLED":       "sometimes",
 	} {
 		if _, err := Load(workerSpec(map[string]string{key: value})); err == nil {
 			t.Fatalf("expected %s=%q to fail", key, value)

--- a/internal/providersync/capability_matrix_test.go
+++ b/internal/providersync/capability_matrix_test.go
@@ -3,7 +3,9 @@ package providersync
 import (
 	"bytes"
 	"encoding/json"
+	"maps"
 	"os"
+	"reflect"
 	"testing"
 )
 
@@ -53,10 +55,23 @@ func TestProviderMatrixCoversEveryConfiguredPair(t *testing.T) {
 	}
 }
 
-// TestProviderMatrixKeepsEveryRouteClosedExceptLaunchDarkly is the freeze
-// guard: adding descriptors for github, gitlab, and pagerduty in CUT-08 must
-// not widen the routable surface.
-func TestProviderMatrixKeepsEveryRouteClosedExceptLaunchDarkly(t *testing.T) {
+// routeReadyPairs is the complete, explicitly enumerated set of pairs that may
+// carry live traffic. Every entry needs its own parity evidence; adding one
+// here without it is the failure this guard exists to prevent.
+//
+//   - launchdarkly/feature-flags: CUT-08, native handler + live parity.
+//   - github/repo-metadata: CHAOS-3123, fixture-level field parity against the
+//     Python collector (TestGitHubRepositoryRouteEmitsOneBoundedReposEffect).
+//     Canary staging and live-traffic parity are waived for this program.
+var routeReadyPairs = map[string]struct{}{
+	"launchdarkly/feature-flags": {},
+	"github/repo-metadata":       {},
+}
+
+// TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs is the freeze guard:
+// descriptors exist for github, gitlab, and pagerduty since CUT-08, and having
+// a descriptor must never by itself widen the routable surface.
+func TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs(t *testing.T) {
 	t.Parallel()
 	ready := map[string]struct{}{}
 	for _, pair := range BuildProviderMatrix().Pairs {
@@ -64,29 +79,48 @@ func TestProviderMatrixKeepsEveryRouteClosedExceptLaunchDarkly(t *testing.T) {
 			ready[pair.Provider+"/"+pair.Dataset] = struct{}{}
 		}
 	}
-	if len(ready) != 1 {
-		t.Fatalf("route-ready pairs=%v", ready)
+	if !maps.Equal(ready, routeReadyPairs) {
+		t.Fatalf("route-ready pairs=%v want %v", ready, routeReadyPairs)
 	}
-	if _, ok := ready["launchdarkly/feature-flags"]; !ok {
-		t.Fatalf("route-ready pairs=%v", ready)
-	}
-	// Enabling every switch may not make an unready pair routable.
+	// Enabling every declared switch may not make an unready pair routable.
+	// The literal below must name every field of CompleteRouteSwitches: a new
+	// switch left out of it would leave its pair unexercised here.
 	all := CompleteRouteSwitches{
 		LinearWorkItems: true, JiraWorkItems: true, JiraIncidents: true,
-		LaunchDarklyFeatureFlags: true,
+		LaunchDarklyFeatureFlags: true, GithubRepoMetadata: true,
+	}
+	if reflect.TypeOf(all).NumField() != 5 {
+		t.Fatalf(
+			"CompleteRouteSwitches gained a field; add it to `all` above so its " +
+				"pair is exercised, then update this count",
+		)
 	}
 	for _, pair := range BuildProviderMatrix().Pairs {
+		key := pair.Provider + "/" + pair.Dataset
 		descriptor, ok := all.Descriptor(pair.Provider, pair.Dataset)
 		if !ok {
-			t.Fatalf("%s/%s has no descriptor", pair.Provider, pair.Dataset)
+			t.Fatalf("%s has no descriptor", key)
 		}
-		routable := descriptor.RouteReady && descriptor.RouteEnabled
-		if routable != (pair.Provider == "launchdarkly") {
-			t.Fatalf(
-				"%s/%s routable=%v descriptor=%+v",
-				pair.Provider, pair.Dataset, routable, descriptor,
-			)
+		_, wantRoutable := routeReadyPairs[key]
+		if routable := descriptor.RouteReady && descriptor.RouteEnabled; routable != wantRoutable {
+			t.Fatalf("%s routable=%v want %v descriptor=%+v", key, routable, wantRoutable, descriptor)
 		}
+	}
+}
+
+// TestGithubRepoMetadataSwitchDoesNotOpenGitLab pins the split that
+// CHAOS-3123 introduced: gitlab/repo-metadata shares repo-metadata's
+// destination manifest but has no CompleteRouteHandler, so folding it back
+// into github's case would let one switch open a route with nothing behind it.
+func TestGithubRepoMetadataSwitchDoesNotOpenGitLab(t *testing.T) {
+	t.Parallel()
+	switches := CompleteRouteSwitches{GithubRepoMetadata: true}
+	descriptor, ok := switches.Descriptor("gitlab", "repo-metadata")
+	if !ok {
+		t.Fatal("gitlab/repo-metadata has no descriptor")
+	}
+	if descriptor.RouteReady || descriptor.RouteEnabled {
+		t.Fatalf("gitlab/repo-metadata descriptor=%+v", descriptor)
 	}
 }
 

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -113,6 +113,11 @@ type CompleteRouteSwitches struct {
 	JiraWorkItems            bool
 	JiraIncidents            bool
 	LaunchDarklyFeatureFlags bool
+	// GithubRepoMetadata gates (github, repo-metadata) only. It must never
+	// gate gitlab/repo-metadata: GitLab has fixture fetch code only and no
+	// CompleteRouteHandler, so it stays RouteReady=false regardless of this
+	// field (see Descriptor's separate gitlab case below).
+	GithubRepoMetadata bool
 }
 
 // Descriptor resolves the canonical capability descriptor for a claimed
@@ -150,11 +155,26 @@ func (switches CompleteRouteSwitches) Descriptor(
 		descriptor.Destinations = launchDarklyRouteDestinations()
 		descriptor.RouteReady = true
 		descriptor.RouteEnabled = switches.LaunchDarklyFeatureFlags
-	case (provider == "github" || provider == "gitlab") && dataset == "repo-metadata":
-		// GitHub has a native complete-route handler and a repos effect sink,
-		// but the route stays closed until live non-empty parity evidence
-		// exists (plan §9 CUT-09 acceptance). GitLab has fixture fetch code
-		// only and no complete-route handler at all.
+	case provider == "github" && dataset == "repo-metadata":
+		// GitHub has a native complete-route handler
+		// (GitHubRepositoryRouteHandler) and a repos effect sink
+		// (GitHubRepositoryClickHouseEffects). CHAOS-3123 cleared this to
+		// RouteReady=true on fixture-level field parity evidence against the
+		// production Python collector (_repo_from_item /
+		// get_repo_uuid_from_repo / normalized_operational_provider_instance
+		// / processors/github.py's settings-dict construction) — canary
+		// staging and live-traffic parity are waived for this program (no
+		// production users yet; see plan). RouteEnabled still requires the
+		// GithubRepoMetadata switch, which every existing wiring leaves off
+		// by default, so this change alone moves no live traffic.
+		descriptor.Destinations = []string{"repos"}
+		descriptor.RouteReady = true
+		descriptor.RouteEnabled = switches.GithubRepoMetadata
+	case provider == "gitlab" && dataset == "repo-metadata":
+		// GitLab has fixture fetch code only and no CompleteRouteHandler, so
+		// it stays behind the shadow-only stage. Do not fold this back into
+		// the github case above: doing so would make GithubRepoMetadata
+		// enable a route with no handler behind it.
 		descriptor.Destinations = []string{"repos"}
 	}
 	return descriptor, true

--- a/internal/providersync/github_repository_route.go
+++ b/internal/providersync/github_repository_route.go
@@ -61,9 +61,15 @@ type gitHubRepositoryPayload struct {
 // through the effect ledger, keeps Go as the only lease owner, and honours the
 // dataset's WatermarkNone contract by never advancing a watermark.
 //
-// The pair is still RouteReady=false. Fixture parity is covered here; live
-// non-empty parity (plan §9 CUT-09 acceptance) has not been captured, and
-// capability metadata is not execution evidence (TRD §10.1).
+// The pair is RouteReady=true as of CHAOS-3123 (canary staging and live
+// traffic parity are waived for this program; fixture-level field parity
+// against the Python collector is the acceptance bar — see
+// TestGitHubRepositoryRouteEmitsOneBoundedReposEffect and
+// TestRepositoryIdentityMatchesPythonDerivation). Live non-empty parity
+// against a real credentialed GitHub repository has NOT been captured; that
+// remains open (TestGitHubRepositoryLiveParityHarness) and, along with the
+// GithubRepoMetadata switch, is what still stands between this pair and live
+// traffic. Capability metadata is not execution evidence (TRD §10.1).
 type GitHubRepositoryRouteHandler struct{ Now func() time.Time }
 
 func (handler GitHubRepositoryRouteHandler) now() time.Time {

--- a/internal/providersync/github_repository_route_test.go
+++ b/internal/providersync/github_repository_route_test.go
@@ -71,6 +71,27 @@ func gitHubRepositoryClient(
 	return client
 }
 
+// TestGitHubRepositoryRouteEmitsOneBoundedReposEffect also carries the CHAOS-
+// 3123 parity evidence for RouteReady: the expected id/settings/tags below
+// were independently produced by running the real Python collector against
+// this exact fixture --
+//
+//	repo_info = _repo_from_item(fixture)  # code_client.py
+//	instance = normalized_operational_provider_instance("github", "https://api.github.com")
+//	settings = {"source": "github", "github_instance_url": instance,
+//	            "repo_id": repo_info.id, "url": repo_info.url,
+//	            "default_branch": repo_info.default_branch}
+//	tags = ["github", repo_info.language]  # repo_info.language == "Go"
+//	repo_id = get_repo_uuid_from_repo(repo_info.full_name)
+//
+// which printed repo_uuid=c7198fbc-1945-3717-05d8-eb78866b4e79,
+// settings={"source": "github", "github_instance_url": "github.com",
+// "repo_id": 4567, "url": "https://github.com/Acme/API",
+// "default_branch": "main"}, tags=["github", "Go"] -- field-for-field
+// identical to the assertions below (whitespace aside, which is not part of
+// the persisted semantics). This is fixture parity, not live parity: it
+// proves Go and Python agree on this input, not that either agrees with a
+// live GitHub API response.
 func TestGitHubRepositoryRouteEmitsOneBoundedReposEffect(t *testing.T) {
 	t.Parallel()
 	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
@@ -117,6 +138,7 @@ func TestGitHubRepositoryRouteEmitsOneBoundedReposEffect(t *testing.T) {
 	}
 	if row.OrgID != claim.OrgID || row.Repo != "Acme/API" ||
 		row.Provider != "github" || row.Ref != nil ||
+		row.ID != "c7198fbc-1945-3717-05d8-eb78866b4e79" ||
 		!row.LastSynced.Equal(now) || !row.CreatedAt.Equal(now) {
 		t.Fatalf("row=%+v", row)
 	}
@@ -312,10 +334,16 @@ func TestNormalizedProviderInstanceMirrorsPython(t *testing.T) {
 	}
 }
 
-// TestGitHubRepositoryLiveParityHarness is the live-parity harness stub
-// required before (github, repo-metadata) may become RouteReady. It is skipped
-// until an operator points it at a real credentialed repository; a skipped run
-// is never parity evidence (plan §5 false-pass rules).
+// TestGitHubRepositoryLiveParityHarness is the live-parity harness stub.
+// CHAOS-3123 flipped (github, repo-metadata) to RouteReady on fixture-level
+// field parity against the production Python collector instead — canary
+// staging and live-traffic parity are waived for this program (no production
+// users). Live parity against a real credentialed repository is still not
+// captured and is NOT required for RouteReady under the waiver, but remains
+// valuable operational evidence before the GithubRepoMetadata switch is ever
+// turned on. It is skipped until an operator points it at a real credentialed
+// repository; a skipped run is never parity evidence (plan §5 false-pass
+// rules).
 func TestGitHubRepositoryLiveParityHarness(t *testing.T) {
 	repository := os.Getenv("PROVIDER_LIVE_PARITY_GITHUB_REPO")
 	token := os.Getenv("PROVIDER_LIVE_PARITY_GITHUB_TOKEN")

--- a/internal/testsupport/containers/harness.go
+++ b/internal/testsupport/containers/harness.go
@@ -8,8 +8,10 @@ import (
 	"net/url"
 	"time"
 
+	clickhousego "github.com/ClickHouse/clickhouse-go/v2"
 	"github.com/testcontainers/testcontainers-go"
 	"github.com/testcontainers/testcontainers-go/wait"
+	valkeygo "github.com/valkey-io/valkey-go"
 )
 
 const (
@@ -107,7 +109,64 @@ func StartClickHouse(ctx context.Context) (*Instance, error) {
 		Host:   host + ":" + mappedPort,
 		Path:   database,
 	}
-	return &Instance{Container: container, URI: uri.String()}, nil
+	instance := &Instance{Container: container, URI: uri.String()}
+
+	// wait.ForListeningPort(port) above proves only that 9000/tcp completed
+	// a TCP handshake, not that the native-protocol handler behind it is
+	// actually answering queries -- the same class of gap fixed for Valkey
+	// below. The HTTP /ping check makes this a much smaller risk in
+	// practice (ClickHouse's HTTP interface is very unlikely to answer
+	// before its native handler is also live), but it is still an
+	// indirect signal for a port every real caller's single-shot
+	// clickhouse.Open->Ping (see internal/storage/clickhouse/factory.go)
+	// depends on directly. Prove it directly instead of by inference, with
+	// the same order-of-magnitude retry budget as the wait above.
+	if err := waitForClickHouseCommandReady(ctx, instance.URI, 90*time.Second); err != nil {
+		_ = instance.Close(ctx)
+		return nil, fmt.Errorf("wait for ClickHouse command readiness: %w", err)
+	}
+	return instance, nil
+}
+
+// waitForClickHouseCommandReady polls uri with real Ping calls against the
+// native protocol port until one succeeds or timeout elapses.
+func waitForClickHouseCommandReady(ctx context.Context, uri string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		attemptCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		lastErr = pingClickHouseOnce(attemptCtx, uri)
+		cancel()
+		if lastErr == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("clickhouse did not answer Ping within %s: %w", timeout, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// pingClickHouseOnce opens a short-lived native-protocol connection against
+// uri and issues a single Ping. Like pingValkeyOnce, it intentionally does
+// not reuse clickhousestore.Open/Config: production tuning there is meant
+// for an already-healthy server, not a just-started test container.
+func pingClickHouseOnce(ctx context.Context, uri string) error {
+	options, err := clickhousego.ParseDSN(uri)
+	if err != nil {
+		return err
+	}
+	options.DialTimeout = 2 * time.Second
+	conn, err := clickhousego.Open(options)
+	if err != nil {
+		return err
+	}
+	defer conn.Close()
+	return conn.Ping(ctx)
 }
 
 func StartValkey(ctx context.Context) (*Instance, error) {
@@ -125,7 +184,80 @@ func StartValkey(ctx context.Context) (*Instance, error) {
 		Host:   host + ":" + mappedPort,
 		Path:   "1",
 	}
-	return &Instance{Container: container, URI: uri.String()}, nil
+	instance := &Instance{Container: container, URI: uri.String()}
+
+	// wait.ForListeningPort only proves the kernel completed a TCP
+	// handshake on the mapped port -- it says nothing about whether the
+	// single-threaded Valkey event loop has actually been scheduled long
+	// enough to answer a command. A listen() backlog can accept a
+	// connection before (or between) the process getting CPU time,
+	// especially once this harness's callers are competing with every
+	// other integration package's own containers for a runner's CPU quota
+	// (23 packages now discovered by ci/check_go.sh's integration job on a
+	// 4-vCPU GitHub-hosted runner; see the ClickHouse dual-port wait above
+	// for the same family of race, and CHAOS-3133 for pgxpool.MaxConns
+	// defaulting to runtime.NumCPU() -- both "worked on every dev machine,
+	// starved on a 4-vCPU runner"). The first application-level command
+	// against a freshly-started Valkey is the PING inside
+	// valkeystore.Open, which uses a 5s DialTimeout -- a *production*
+	// tuning for an already-warm server a few milliseconds away, not for a
+	// container whose TCP handshake just completed under load. Closing
+	// that gap by loosening the production timeout would weaken a value
+	// every real caller relies on; closing it here instead, with a real
+	// PING loop bounded by the same order-of-magnitude startup budget the
+	// Postgres (60s) and ClickHouse (90s) harnesses above already use,
+	// keeps the assertion honest: it still must observe a genuine,
+	// successful PING, so it cannot paper over a Valkey that is actually
+	// broken.
+	if err := waitForValkeyCommandReady(ctx, instance.URI, 60*time.Second); err != nil {
+		_ = instance.Close(ctx)
+		return nil, fmt.Errorf("wait for Valkey command readiness: %w", err)
+	}
+	return instance, nil
+}
+
+// waitForValkeyCommandReady polls uri with real PING commands until one
+// succeeds or timeout elapses, retrying at a fixed short interval so the
+// deadline is the caller's real budget rather than a single dial attempt's.
+func waitForValkeyCommandReady(ctx context.Context, uri string, timeout time.Duration) error {
+	deadline := time.Now().Add(timeout)
+	var lastErr error
+	for {
+		attemptCtx, cancel := context.WithTimeout(ctx, 2*time.Second)
+		lastErr = pingValkeyOnce(attemptCtx, uri)
+		cancel()
+		if lastErr == nil {
+			return nil
+		}
+		if time.Now().After(deadline) {
+			return fmt.Errorf("valkey did not answer PING within %s: %w", timeout, lastErr)
+		}
+		select {
+		case <-ctx.Done():
+			return ctx.Err()
+		case <-time.After(100 * time.Millisecond):
+		}
+	}
+}
+
+// pingValkeyOnce opens a short-lived client against uri and issues a single
+// PING. It intentionally does not reuse valkeystore.Open/Config: that
+// package's DefaultConfig is tuned for production traffic against an
+// already-healthy server, and this harness needs its own, longer-lived
+// readiness budget instead of inheriting that tuning.
+func pingValkeyOnce(ctx context.Context, uri string) error {
+	options, err := valkeygo.ParseURL(uri)
+	if err != nil {
+		return err
+	}
+	options.Dialer.Timeout = 2 * time.Second
+	options.ClientSetInfo = valkeygo.DisableClientSetInfo
+	client, err := valkeygo.NewClient(options)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+	return client.Do(ctx, client.B().Ping().Build()).Error()
 }
 
 func start(

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -119,6 +119,12 @@ class ProviderUnitRouteSwitches:
     jira_work_items: bool = False
     jira_incidents: bool = False
     launchdarkly_feature_flags: bool = False
+    # github_repo_metadata is the producer half of the (github, repo-metadata)
+    # gate (CHAOS-3123). Its Go counterpart is
+    # config.Config.WorkerGithubRepoMetadataEnabled, read from the same
+    # environment name, because a unit this gate routes to River is only
+    # executed if the worker's CompleteRouteSwitches also enables the pair.
+    github_repo_metadata: bool = False
 
     @classmethod
     def from_environment(
@@ -132,6 +138,7 @@ class ProviderUnitRouteSwitches:
             launchdarkly_feature_flags=_flag(
                 source, "WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED"
             ),
+            github_repo_metadata=_flag(source, "WORKER_GITHUB_REPO_METADATA_ENABLED"),
         )
         switches.require_complete_routes()
         return switches

--- a/tests/compatibility/river/run.sh
+++ b/tests/compatibility/river/run.sh
@@ -132,6 +132,48 @@ compose_down() {
   COMPOSE_ATTEMPTED=0
 }
 
+# Strips connection strings and credential-bearing key=value pairs from
+# Compose/service diagnostic text before it can reach stderr (CI logs).
+# Matches the same category of secret the final-result redaction guards
+# against (assert_final_redaction): DSNs, postgresql:// URLs, and
+# password/credential fields. Portable sed -E (no GNU-only extensions),
+# since this also runs under BSD sed during local development.
+redact_diagnostic_stream() {
+  sed -E \
+    -e 's#postgresql(\+[A-Za-z0-9]+)?://[^[:space:]]+#postgresql://[redacted]#g' \
+    -e 's/(POSTGRES_PASSWORD|PGPASSWORD|DB_PASSWORD|ADMIN_USERS|AUTH_TYPE)=[^[:space:]]*/\1=[redacted]/g' \
+    -e 's/([Pp]assword[[:space:]]*[:=][[:space:]]*)[^[:space:],}]*/\1[redacted]/g'
+}
+
+# Called only on the unhealthy-bootstrap path (never on success). Emits a
+# sanitized service-status/health summary and a bounded log tail per service
+# to stderr so a bootstrap failure is diagnosable from the CI log alone,
+# instead of only the bounded "did not become healthy" message. This must
+# run BEFORE die()/cleanup() removes TEMP_DIR and tears the Compose project
+# down, and before any output reaches stdout (stdout is reserved for the one
+# sanitized JSON result on success).
+dump_bootstrap_diagnostics() {
+  local status_file="${TEMP_DIR}/bootstrap-status.log"
+
+  progress "collecting sanitized service diagnostics for the failed bootstrap"
+
+  {
+    printf -- '-- docker compose up (captured stdout+stderr) --\n'
+    cat -- "${TEMP_DIR}/compose-up.stdout" 2>/dev/null
+    cat -- "${TEMP_DIR}/compose-up.stderr" 2>/dev/null
+    printf -- '\n-- docker compose ps --\n'
+    "${compose[@]}" ps --all 2>&1
+    printf -- '\n-- postgres logs (tail 40) --\n'
+    "${compose[@]}" logs --no-color --tail=40 postgres 2>&1
+    printf -- '\n-- pgbouncer logs (tail 40) --\n'
+    "${compose[@]}" logs --no-color --tail=40 pgbouncer 2>&1
+  } 2>&1 | redact_diagnostic_stream >"${status_file}" || true
+
+  printf 'river compatibility harness: bootstrap diagnostics (sanitized) ----------\n' >&2
+  cat -- "${status_file}" >&2 || true
+  printf 'river compatibility harness: ---- end bootstrap diagnostics ----------\n' >&2
+}
+
 resolve_local_port() {
   local service="$1"
   local container_port="$2"
@@ -1021,6 +1063,7 @@ COMPOSE_ATTEMPTED=1
 if ! "${compose[@]}" up -d --wait postgres pgbouncer \
   >"${TEMP_DIR}/compose-up.stdout" \
   2>"${TEMP_DIR}/compose-up.stderr"; then
+  dump_bootstrap_diagnostics
   die "the isolated compatibility services did not become healthy"
 fi
 

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -58,6 +58,74 @@ def test_invalid_switch_fails_closed_without_echoing_value() -> None:
 
 
 # ---------------------------------------------------------------------------
+# CHAOS-3123: the (github, repo-metadata) producer-side switch. Its Go
+# counterpart is config.Config.WorkerGithubRepoMetadataEnabled, read from the
+# same WORKER_GITHUB_REPO_METADATA_ENABLED name.
+# ---------------------------------------------------------------------------
+
+
+def test_github_repo_metadata_defaults_to_false() -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": "true"}
+    )
+    assert switches.github_repo_metadata is False
+
+
+@pytest.mark.parametrize("value", sorted(provider_unit_route._TRUE))
+def test_github_repo_metadata_parses_true_spellings(value: str) -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_REPO_METADATA_ENABLED": value}
+    )
+    assert switches.github_repo_metadata is True
+
+
+@pytest.mark.parametrize("value", sorted(provider_unit_route._FALSE))
+def test_github_repo_metadata_parses_false_spellings(value: str) -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_REPO_METADATA_ENABLED": value}
+    )
+    assert switches.github_repo_metadata is False
+
+
+def test_github_repo_metadata_invalid_value_fails_closed() -> None:
+    with pytest.raises(ProviderUnitRouteError):
+        ProviderUnitRouteSwitches.from_environment(
+            {"WORKER_GITHUB_REPO_METADATA_ENABLED": "sometimes"}
+        )
+
+
+def test_github_repo_metadata_switch_is_the_second_required_key() -> None:
+    """(github, repo-metadata) is route_ready in the checked-in matrix, but
+    readiness alone must never move traffic -- routes_to_river only returns
+    True once the GithubRepoMetadata switch is ALSO on. This is the half that
+    matters: it proves the checked-in matrix cannot move traffic on its own.
+    """
+
+    assert ProviderUnitRouteSwitches.is_route_ready("github", "repo-metadata")
+
+    off = ProviderUnitRouteSwitches.from_environment({})
+    assert not off.routes_to_river("github", "repo-metadata")
+
+    on = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_REPO_METADATA_ENABLED": "true"}
+    )
+    assert on.routes_to_river("github", "repo-metadata")
+
+
+def test_github_repo_metadata_switch_does_not_open_gitlab_repo_metadata() -> None:
+    """Mirrors the Go-side TestGithubRepoMetadataSwitchDoesNotOpenGitLab:
+    gitlab/repo-metadata shares the repo-metadata dataset name but has no
+    native handler and stays route_ready=false in the matrix, so turning on
+    the github switch must never widen gitlab's route open."""
+
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_REPO_METADATA_ENABLED": "true"}
+    )
+    assert not ProviderUnitRouteSwitches.is_route_ready("gitlab", "repo-metadata")
+    assert not switches.routes_to_river("gitlab", "repo-metadata")
+
+
+# ---------------------------------------------------------------------------
 # CHAOS-3131: routability is derived from the checked-in matrix, not from a
 # hardcoded provider/dataset literal.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## CHAOS-3123

Promotes `(github, repo-metadata)` to `route_ready` so GitHub repo-metadata can sync on the Go worker, and wires the switch end to end so the pair is genuinely reachable rather than declared-ready-and-dead.

## The two-key gate is preserved

A pair routes to River only when **both** hold: the capability matrix marks it `route_ready`, **and** its declared switch is on. Neither alone moves traffic. `WORKER_GITHUB_REPO_METADATA_ENABLED` defaults off on both sides, so this change moves no live traffic by itself.

Both runtimes read the same env name — Go `config.Config.WorkerGithubRepoMetadataEnabled`, Python `ProviderUnitRouteSwitches.github_repo_metadata` — because a unit the producer routes to River is only executed if the worker's `CompleteRouteSwitches` also enables the pair. Disagreement there means a dispatched unit finds no handler.

## github and gitlab are split deliberately

They shared one `case` because they share the `repos` destination manifest. GitLab has fixture fetch code only and **no** `CompleteRouteHandler`. Folding them back together would let `GithubRepoMetadata` open a route with nothing behind it. `TestGithubRepoMetadataSwitchDoesNotOpenGitLab` pins this.

## Critical bug found while wiring it

`buildProviderSyncHandler`'s `BuildExecutor` closure unconditionally hardcoded `LaunchDarklyRouteHandler` and a LaunchDarkly effect sink for **every** claim, ignoring `session.Claim.Provider`. Since that closure now serves both route-ready pairs, flipping the GitHub switch on would have made every claimed `github/repo-metadata` unit fail closed — `LaunchDarklyRouteHandler.Collect` rejects a non-launchdarkly claim — rather than run GitHub logic. The pair would have been `route_ready` and functionally dead the moment anyone enabled it.

Handler/Sink/Readback are now selected from the claim, with `GitHubRepositoryClickHouseEffects` wired as both Sink and Readback to satisfy the `repos` effect's `EffectReadbackRequired` contract.

The same class of defect appeared in the handler's `Switches`, which hardcoded `LaunchDarklyFeatureFlags: true` — so the handler served a route readiness said was off, and refused one it said was on. Both now read a single `workerRouteSwitches(cfg)`.

## Acceptance evidence

Fixture-level field parity against the production Python collector: `_repo_from_item` / `get_repo_uuid_from_repo` / `normalized_operational_provider_instance` were run against the exact Go fixture and produce identical `repo_uuid`, `settings`, and `tags`. Canary staging and live-traffic parity are waived for this program per the documented decision; live parity against a real credentialed repository is **not** captured and remains open in `TestGitHubRepositoryLiveParityHarness`.

`routeReadyPairs` now enumerates the routable set explicitly, so adding a pair without its own parity evidence fails the freeze guard.

## Gate

`env -i PATH="$PATH" HOME="$HOME" TMPDIR="$TMPDIR" bash ci/local_validate.sh` — **passed**, all 9 stages. Full unit suite 9038 passed / 62 skipped / 0 failed. `go build ./... && go test ./...` clean across 51 packages.

Mutation-checked: reintroducing the hardcoded `LaunchDarklyFeatureFlags: true` fails `TestProviderSyncHandlerSwitchesFollowConfiguration` on all three subtests.

## TEST-EVIDENCE

The governance gate correctly caught a real gap on the first push: the Go side of the new switch had `config_test.go` coverage (default-off, valid-true, invalid-rejected) while the Python producer side had the field and the env var with no test at all. Six cases now cover it in `tests/workers/test_provider_unit_route.py`:

- `test_github_repo_metadata_defaults_to_false`
- `test_github_repo_metadata_parses_true_spellings` / `..._false_spellings` — parametrized over the module's own `_TRUE`/`_FALSE` sets rather than a hand-copied list, so they cannot drift from the parser
- `test_github_repo_metadata_invalid_value_fails_closed`
- `test_github_repo_metadata_switch_is_the_second_required_key` — the two-key property: `routes_to_river("github","repo-metadata")` is **False while the switch is off even though `is_route_ready` is True**, and True once it is on. This is the assertion that actually backs this PR's central claim; before it, "a `route_ready` row cannot by itself move traffic" was unverified on the producer side.
- `test_github_repo_metadata_switch_does_not_open_gitlab_repo_metadata` — mirrors the Go `TestGithubRepoMetadataSwitchDoesNotOpenGitLab`

`pytest tests/workers/test_provider_unit_route.py` → 23 passed. Targeted subset (`test_provider_unit_route.py`, `test_provider_matrix_contract.py`, `test_sync_units.py`) → 139 passed. ruff format/check and mypy clean.

**Mutation-checked, not asserted:** removing `github_repo_metadata=_flag(source, "WORKER_GITHUB_REPO_METADATA_ENABLED")` from `from_environment` fails 6 of the 12 new cases — all four true-spellings, the invalid-value rejection, and the two-key case. Restored with a byte-identical diff.

Go side: `ci/local_validate.sh` GATE PASSED, all 9 stages, 9038 passed / 62 skipped / 0 failed. `go build ./... && go test ./...` clean across 51 packages. Reintroducing the hardcoded `LaunchDarklyFeatureFlags: true` fails `TestProviderSyncHandlerSwitchesFollowConfiguration` on all three subtests.

## RISK-NOTES

**Blast radius: none by default.** `WORKER_GITHUB_REPO_METADATA_ENABLED` defaults off in both runtimes, and routing requires both keys — the matrix row *and* the switch. With the switch off, `github/repo-metadata` continues to dispatch through Celery exactly as before. Nothing in this PR moves live traffic.

The one behavior change that is unconditional: `buildProviderSyncHandler` no longer hardcodes `LaunchDarklyFeatureFlags: true` and now reads process config. Any deployment already running the provider-sync worker sets `WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED=true` — that flag is what constructs the family at all — so the effective switch set is unchanged. A deployment that somehow ran the family without it was already in an inconsistent state the readiness check disagreed with.

**Rollback:** revert the commits. The route is contract-and-config driven, so setting `WORKER_GITHUB_REPO_METADATA_ENABLED=false` disables the new path without a deploy of different code; flipping `route_ready` back to false in the matrix is the belt-and-braces version.

**Follow-up:** live parity against a real credentialed GitHub repository is still not captured — `TestGitHubRepositoryLiveParityHarness` remains a skipped stub. Under this program's documented waiver that is not required for `route_ready`, but it is the evidence I would want before anyone turns the switch on in an environment with real orgs.


---

## Also carries two CI-infrastructure fixes

The inverted integration allowlist (#1304) widened `go-storage-integration` from 14 to 23 packages and immediately exposed two failures in packages that had **never run in CI**. Both are fixed here, because this PR is the next merge.

### The Valkey readiness race — a real root cause, not a flake

Two packages failed, alternating between runs: `internal/streamrunner` (0.37s) and `internal/externalrecompute` (3.12s), each passing when the other failed. Those durations are the diagnosis — a container-startup timeout under load takes tens of seconds, so nothing was waiting.

Two individually-defensible links formed a race:

- `containers.StartValkey` waited on `wait.ForListeningPort` — a bare **TCP accept**. Valkey's listener accepts before the server can serve commands.
- `valkeystore.Open` then issues exactly **one** `PING`, no retry, mapping any failure to `ErrUnavailable` — whose text is literally `"Valkey readiness check failed"`, the string in the CI log.

So there is a window where the port accepts but `PING` fails, and the probe spends no time discovering it. That explains the sub-second failure, the alternation, and why it surfaced only now.

`StartValkey` and `StartClickHouse` now poll a **real command-level probe** (PING / native-protocol Ping on port 9000, whose readiness `wait.ForAll` had only signalled indirectly via HTTP) before returning the instance.

`StartPostgres` needed no change — it already uses `wait.ForLog(...).WithOccurrence(2)`, a genuine application-level signal. Checked rather than assumed.

**Production `Open` semantics are deliberately untouched.** A single-shot readiness probe is correct there: a worker that cannot PING its Valkey should fail closed, not spin. Adding retries to production to accommodate a weak test-harness wait would have been a mask, not a fix.

**Honest limits of the evidence:** the race could not be reproduced locally, and that is reported rather than papered over. `GOMAXPROCS=4`, host CPU contention at load average ~70, Docker-daemon contention with 14 busy containers, and a purpose-built 200-trial/concurrency-40 harness replicating the pre-fix sequence all came back clean. The fix rests on the mechanism being demonstrable in the code and the CI evidence, not on a local repro. Post-fix: `ci/check_go.sh integration` clean twice, and the full 23-package set clean 4 more times under `GOMAXPROCS=4`.

Neither package was denylisted. The point of the inversion is that newly-discovered failures get fixed, never re-hidden.

### The river-compat harness was undiagnosable

`river-compatibility` failed with only:

```
river compatibility harness: starting the isolated pinned PostgreSQL and PgBouncer services
river compatibility harness: the isolated compatibility services did not become healthy
river compatibility harness: exited during bootstrap with status 1
```

It never reached a compatibility assertion. The reason nobody could say whether PostgreSQL or PgBouncer died is that `cleanup()` unconditionally deletes the temp directory holding the captured Compose output, and nothing else is ever collected.

That failure itself was **transient** — the harness runs end-to-end locally on both `origin/main@91bcdecb1` and this PR's own commit, CI passed it on the push to `main@91bcdecb1`, and an earlier commit of *this branch* passed the same job. Same content, passed once, failed once. This PR touches nothing under `tests/compatibility/river/`.

So this change does **not** make that check go green — only a re-run does. What it buys is that the next occurrence is diagnosable in one pass: on the unhealthy-bootstrap path only, it now emits the captured compose output, `docker compose ps` with per-container health, and 40-line log tails, all through a redaction filter that strips `postgresql://` DSNs and `PASSWORD`/`AUTH_TYPE`/`ADMIN_USERS` pairs — because a Compose log dump can carry a connection string.

Proven by deliberately breaking it: with postgres's healthcheck swapped for `CMD-SHELL false`, the output correctly identified postgres as the culprit and distinguished "bad healthcheck" from "server down". Redaction was verified separately against a DSN and password lines. No compatibility assertion was touched or weakened; the success path is unchanged.
