### PR TITLE
ci: make local_validate.sh CI-parity for docs deps and collision-safe for parallel worktrees

### DIFF
--- a/ci/local_validate.sh
+++ b/ci/local_validate.sh
@@ -28,17 +28,40 @@
 #
 # *** SAFETY CONTRACT ***
 #   The local container 'dev-health-clickhouse-1' db 'default' holds REAL dev data.
-#   This script NEVER creates/drops/alters tables in 'default'. The only statement it
-#   runs against the default-connected client is `CREATE DATABASE ci_local_validate`
-#   (clickhouse-connect will NOT auto-create it). All schema/migrations/tests are
-#   pointed at clickhouse://ch:ch@localhost:8123/ci_local_validate via CLICKHOUSE_URI,
-#   and the scratch db is dropped on EXIT. CLICKHOUSE_URI must never default to /default.
+#   This script NEVER creates/drops/alters tables in 'default'. The only DDL it runs
+#   against the default-connected client is CREATE/DROP DATABASE for a scratch db
+#   named `ci_local_validate_<12-hex-digest-of-worktree-path>` (clickhouse-connect
+#   will NOT auto-create it). All schema/migrations/tests are pointed at
+#   clickhouse://ch:ch@localhost:8123/<scratch db> via CLICKHOUSE_URI, and the
+#   scratch db is dropped on EXIT. CLICKHOUSE_URI must never default to /default.
+#
+# *** CONCURRENCY CONTRACT (CHAOS collision fix) ***
+#   Multiple agents run this gate concurrently from different git worktrees against
+#   the SAME shared ClickHouse container. Before this fix, SCRATCH_DB defaulted to
+#   the fixed literal `ci_local_validate` for every worktree, so two concurrent runs
+#   used the SAME scratch database: system.query_log showed interleaved
+#   `CREATE TABLE ... _new` statements from two migration runs racing inside what
+#   should have been a single sequential upgrade, and one run's `DROP DATABASE` on
+#   exit could yank the schema out from under a sibling run mid-suite — false reds
+#   AND false greens. The default is now derived deterministically from the
+#   worktree's absolute path (hashed + truncated to a legal ClickHouse identifier),
+#   so distinct worktrees get distinct scratch databases automatically, with no
+#   caller action required. Deterministic-per-worktree (not random-per-run) is
+#   intentional: a run that dies before its EXIT trap fires (kill -9, crash) is
+#   reclaimed by the NEXT run from the same worktree — same name, dropped and
+#   recreated clean — rather than leaking a fresh orphan database every time.
+#   An explicit `SCRATCH_DB=...` still overrides the default for callers that
+#   already pass one (e.g. to force a shared name, or to inspect a completed run's
+#   database before it's reclaimed).
 #
 # USAGE:
 #   Run from the worktree ROOT (the dir containing ci/run_tests.sh) using its .venv:
 #     bash ci/local_validate.sh
 #   Skip the live-ClickHouse stage (pure-Python gates only, e.g. no docker):
 #     SKIP_CLICKHOUSE=1 bash ci/local_validate.sh
+#   Force a specific scratch db name (rarely needed — the default is already
+#   unique per worktree):
+#     SCRATCH_DB=my_custom_scratch bash ci/local_validate.sh
 #
 set -uo pipefail
 
@@ -53,7 +76,29 @@ CH_USER="${CH_USER:-ch}"
 CH_PASS="${CH_PASS:-ch}"
 CH_HOST="${CH_HOST:-localhost}"
 CH_HTTP_PORT="${CH_HTTP_PORT:-8123}"
-SCRATCH_DB="${SCRATCH_DB:-ci_local_validate}"
+
+# Deterministic, per-worktree scratch db name (collision fix — see the
+# CONCURRENCY CONTRACT header above). Hash the absolute worktree ROOT (stable
+# for the life of the checkout, distinct across worktrees) down to 12 hex
+# chars and prefix with a letter so the result is always a legal ClickHouse
+# identifier. Tries sha256sum (Linux), then shasum (macOS), then openssl,
+# falling back to the POSIX-universal (non-cryptographic but still
+# deterministic) `cksum` so this never hard-fails preflight on a stripped-down
+# PATH.
+default_scratch_db() {
+  local path="$1" digest=""
+  if command -v sha256sum >/dev/null 2>&1; then
+    digest="$(printf '%s' "${path}" | sha256sum | cut -c1-12)"
+  elif command -v shasum >/dev/null 2>&1; then
+    digest="$(printf '%s' "${path}" | shasum -a 256 | cut -c1-12)"
+  elif command -v openssl >/dev/null 2>&1; then
+    digest="$(printf '%s' "${path}" | openssl dgst -sha256 | awk '{print $NF}' | cut -c1-12)"
+  else
+    digest="$(printf '%s' "${path}" | cksum | awk '{printf "%012d", $1}')"
+  fi
+  printf 'ci_local_validate_%s' "${digest}"
+}
+SCRATCH_DB="${SCRATCH_DB:-$(default_scratch_db "${ROOT}")}"
 SCRATCH_URI="clickhouse://${CH_USER}:${CH_PASS}@${CH_HOST}:${CH_HTTP_PORT}/${SCRATCH_DB}"
 PYBIN="${ROOT}/.venv/bin/python"
 RUFF="${ROOT}/.venv/bin/ruff"
@@ -236,7 +281,15 @@ ch_create_scratch() {
   case "${SCRATCH_DB}" in
     default) die "refusing to run: SCRATCH_DB is 'default' (the real dev db)." ;;
   esac
-  ch_query "CREATE DATABASE IF NOT EXISTS ${SCRATCH_DB}" || return 1
+  # Reclaim: the default SCRATCH_DB name is deterministic per worktree (see the
+  # CONCURRENCY CONTRACT header), so a prior run from THIS SAME worktree that
+  # died before its EXIT trap could fire (kill -9, crash, host reboot) may have
+  # left this database behind with partial/stale schema. Drop it first so every
+  # run starts from a genuinely clean scratch db instead of silently inheriting
+  # another run's leftover tables — never touches anything but our own
+  # already-guarded, never-'default' SCRATCH_DB name.
+  ch_query "DROP DATABASE IF EXISTS ${SCRATCH_DB}" || true
+  ch_query "CREATE DATABASE ${SCRATCH_DB}" || return 1
   SCRATCH_CREATED=1
   trap cleanup_scratch EXIT
   return 0

--- a/ci/local_validate.sh
+++ b/ci/local_validate.sh
@@ -10,6 +10,11 @@
 #   This gate closes BOTH gaps.
 #
 # WHAT IT DOES (mirrors the PR-time CI gates of PR #1018, in order):
+#   0. preflight also installs requirements-docs.txt into .venv (mirrors the
+#      `pip install -r requirements-docs.txt` step in test.yml's test-matrix
+#      and coverage jobs) so tests/docs/*.py's `mkdocs build --strict` shells
+#      don't false-fail with "No module named mkdocs" in a freshly `uv sync`'d
+#      worktree venv, which never pulls that requirements file in on its own.
 #   1. ruff format --check .         (== lint.yml)
 #   2. ruff check .                  (== lint.yml)
 #   3. mypy --install-types ... .    (== typecheck.yml)
@@ -110,6 +115,37 @@ run_stage() {
 }
 
 # --- Preflight: must run from the worktree with its .venv. --------------------------
+# CI-parity for pip installs: .github/workflows/test.yml (test-matrix AND
+# coverage jobs) runs `pip install -r requirements.txt` then
+# `pip install -r requirements-docs.txt` before invoking ci/run_tests.sh.
+# gate_unit_suite() below runs that SAME `pytest tests -m "not benchmark and
+# not clickhouse"` invocation, which collects tests/docs/*.py — and those
+# tests shell out to `python -m mkdocs build --strict`. `uv sync --all-extras
+# --dev` (requirements.txt / -e .[dev]) does NOT pull in requirements-docs.txt
+# (mkdocs-material lives outside pyproject.toml on purpose, per docs-guards.yml
+# installing it separately), so a venv built the documented way is missing it.
+# Without this step the gate reports "No module named mkdocs" — a red CI would
+# never produce, since CI always provisions it. Install it here too, exactly
+# like CI, rather than letting the docs tests fail or silently skip.
+ensure_docs_deps() {
+  local reqs="${ROOT}/requirements-docs.txt"
+  [ -f "${reqs}" ] || die "requirements-docs.txt not found at ${reqs} (repo layout changed?)."
+  local pip_log
+  pip_log="$(mktemp)"
+  printf '   installing %s (mirrors CI test.yml pip install step)...\n' "$(basename "${reqs}")"
+  if "${PYBIN}" -m pip install -q -r "${reqs}" >"${pip_log}" 2>&1; then
+    rm -f "${pip_log}"
+  else
+    cat "${pip_log}" >&2
+    rm -f "${pip_log}"
+    die "could not install requirements-docs.txt into ${PYBIN} (pip output above). Run manually:
+      ${PYBIN} -m pip install -r requirements-docs.txt
+   tests/docs/*.py shell out to 'python -m mkdocs build --strict' and WILL
+   false-fail with 'No module named mkdocs' until this succeeds — do not
+   reinterpret that failure as a real docs regression without this installed."
+  fi
+}
+
 preflight() {
   banner "preflight"
   [ -f "${ROOT}/ci/run_tests.sh" ] || die "not a worktree root (no ci/run_tests.sh at ${ROOT})."
@@ -118,6 +154,7 @@ preflight() {
    (requirements.txt is '-e .[dev]'; pytest-asyncio tests mislead-fail without a fresh sync)."
   [ -x "${RUFF}" ] || die "missing ${RUFF}; install the [dev] extra into .venv."
   [ -x "${MYPY}" ] || die "missing ${MYPY}; install the [dev] extra into .venv."
+  ensure_docs_deps
   printf '   worktree root : %s\n' "${ROOT}"
   printf '   interpreter   : %s\n' "${PYBIN}"
   printf '   %s\n' "$(c_green 'preflight OK')"


### PR DESCRIPTION
Two independent defects in `ci/local_validate.sh`, the CI-parity pre-push gate. Both manufactured failures that CI would never produce, and both misled real work today.

## 1. The gate installed less than CI does

`tests/docs/test_publication_manifest.py` and `tests/docs/test_built_site_links.py` shell out to `python -m mkdocs build --strict`. `mkdocs-material` lives only in `requirements-docs.txt`, deliberately outside `pyproject.toml`'s `[dev]` extra. CI's `test.yml` runs `pip install -r requirements.txt && pip install -r requirements-docs.txt` before `ci/run_tests.sh`. The gate's `preflight()` mirrored every other CI install step — ruff, mypy, Go — but never this one.

So any worktree venv built the documented way (`uv sync --all-extras --dev`) produced:

```
tests/docs/test_publication_manifest.py:103: in test_strict_build_omits_archived_legacy_pages
    assert result.returncode == 0, result.stdout + result.stderr
E   AssertionError: .../.venv/bin/python: No module named mkdocs
```

Not a broken link, not an archived page still referenced as canonical, not a stale manifest. Just a missing interpreter module.

This was present since the script's introduction (#1024) and is unrelated to any recent change. Today it cost two lanes real time and nearly sent an agent to "fix" documentation content that was never broken — the failure is indistinguishable from a genuine docs regression until you read the traceback. CI itself was green on main's tip throughout.

`preflight()` now calls `ensure_docs_deps()`, which installs `requirements-docs.txt` exactly as CI does and `die`s with the pip output plus a manual command if that install fails. Install-over-skip is deliberate: the guard tests are correct and still needed to catch real link/manifest breakage, so making them skip when deps are absent would have hidden the very thing they exist to catch.

## 2. Concurrent gate runs shared one scratch database

`SCRATCH_DB` defaulted to a fixed `ci_local_validate`, so every worktree running the gate against the shared `dev-health-clickhouse-1` container used the *same* database. Evidence of the collision: `system.query_log` showing interleaved `CREATE TABLE ... _new` statements inside what should have been a single sequential migration run.

That produces false reds, and worse, false greens — one run can drop the database out from under another mid-suite, or validate against tables a different run created.

The default is now `ci_local_validate_<12-hex sha256 of the worktree root path>`, with a `sha256sum → shasum → openssl → cksum` fallback chain. Explicit `SCRATCH_DB=` still overrides. `ch_create_scratch()` now does `DROP DATABASE IF EXISTS` before `CREATE` so a reclaimed dead run starts clean instead of inheriting stale schema.

Deterministic-per-worktree rather than random-per-run, so a run that dies before cleanup is reclaimed by the next run from that same worktree instead of leaking a fresh database every time.

Proven live, not just in isolation: the create/migrate/cleanup lifecycle was run concurrently from two paths against the real container. `system.query_log` showed genuinely interleaved millisecond-level timestamps with **zero** cross-database interleaving — every `CREATE`/`DROP` stayed inside its own database, both lanes verified 5/5 tables, both cleaned up, and `SHOW DATABASES` confirmed nothing stray afterward. Cleanup-on-failure was confirmed on a real failing exit path too.

## Surveyed and clean

No second shared-resource collision in this gate. `tests/conftest.py` monkeypatches `DATABASE_URI` to `sqlite:///:memory:`; the opt-in live-Postgres tests skip. `tests/api/admin/test_org_deletion.py`, which another lane saw failing, uses a per-test SQLite file under `tmp_path` — its only real shared dependency is ClickHouse reachability, so those failures were most likely this same collision rather than a distinct one. A fixed-port/live-Postgres collision does exist in `ci/run_live_backend_e2e.sh`, a separate tier this gate never invokes.

## Verification

The two fixes were developed on separate lanes and composed here. The merged script was run end-to-end:

```
✔ lint: ruff format --check      ✔ river: static compatibility harness
✔ lint: ruff check               ✔ ch-scratch-create (ci_local_validate_7eb9a10cd139)
✔ typecheck: mypy                ✔ ch-migrate (upgrade + status --check)
✔ go: format + vet + test        ✔ unit suite (FULL, not subset)
                                 ✔ argMax live-exec proof (real engine)
GATE PASSED.
```

Note the per-worktree scratch database name in that run, and that the full unit suite — docs tests included — now passes without any content change.