### PR TITLE
CHAOS-3114: run dev-health-scheduler on the coordinator pool with a traced grant set

### DIFF
--- a/.github/docs-legacy/architecture/chaos-3033-coordinator-pool-activation.md
+++ b/.github/docs-legacy/architecture/chaos-3033-coordinator-pool-activation.md
@@ -33,8 +33,9 @@ grants applied by `ApplyPinnedMigrations`, and asserts `42501` on each.
 | --- | --- | --- |
 | Third pool | `internal/storage/postgres/runtime.go` | `RuntimePools.Coordinator`, `CoordinatorPool()`, `RuntimeConfig.{CoordinatorURI,CoordinatorRole,CoordinatorMaxConns,RequireCoordinator}`, `WithCoordinator()` |
 | Config | `internal/platform/config/config.go` | `COORDINATOR_DATABASE_URI`, `RIVER_COORDINATOR_DATABASE_ROLE`, `WORKER_COORDINATOR_DATABASE_MAX_CONNS` |
-| Grants | `internal/storage/river/migrate.go` | `coordinatorGrantStatements`, `MigrationOptions.{CoordinatorRole,CoordinatorGrants}`, coordinator arm of the role preflight |
-| Grant source | `cmd/dev-health-worker-migrate/main.go` | derives `CoordinatorGrants` from `postgres.CoordinatorPosture()` |
+| Grants | `internal/storage/river/migrate.go` | `coordinatorGrantStatements`, `MigrationOptions.{CoordinatorRole,CoordinatorGrants,CoordinatorColumnGrants}`, `ColumnGrant`, coordinator arm of the role preflight |
+| Grant source | `cmd/dev-health-worker-migrate/main.go` | derives both grant halves from `postgres.CoordinatorPosture()` |
+| Repoint (CHAOS-3114) | `cmd/dev-health-scheduler/dependencies.go` | the sync repository, occurrence reconciler **and** fixed-schedule engine moved onto the coordinator pool |
 | Role creation | `docker/init-extra-dbs.sh`, `scripts/worker/provision_river_roles.sql` | create the coordinator login; drop the now-stale domain `worker_job_routes` grant |
 | Repoint | `cmd/dev-health-workerctl/main.go`, `cmd/dev-health-reconciler/dependencies.go` | coordinator call sites moved off the domain pool |
 | Contract | `internal/deploymentcontract/manifest.go`, `deploy/go-workers/profiles.json` | a declared coordinator budget now requires the coordinator DSN |
@@ -60,12 +61,16 @@ pointing it at a transaction-mode pooler endpoint is rejected
 `internal/storage/river` cannot import `internal/storage/postgres` — that
 package's own tests import river, so the reverse production import is an import
 cycle. The coordinator grant set is therefore **injected** via
-`MigrationOptions.CoordinatorGrants` and derived by the migration command from
+`MigrationOptions.CoordinatorGrants` (table-wide) and
+`MigrationOptions.CoordinatorColumnGrants` (column-scoped, added by
+CHAOS-3114), both derived by the migration command from
 `postgres.CoordinatorPosture()`, the same declaration
 `CheckCoordinatorAuthorization` asserts against. A second hand-maintained list
 in the migration is exactly the drift that previously let the domain grants and
 the domain assertion disagree. A role without grants, or grants without a role,
-is rejected rather than half-applied.
+is rejected rather than half-applied, as is a relation granted both table-wide
+and column-scoped — the readiness check refuses that combination outright, so
+provisioning it would produce a role that can never report ready.
 
 ### Where each pool is used
 
@@ -73,7 +78,7 @@ is rejected rather than half-applied.
 | --- | --- | --- | --- |
 | `workerctl` | `joboperator.Authenticator` (`internal_service_credentials`), `joboperator.PostgresAuditor` (`worker_operator_audits`), `syncroute.Controller` (`sync_dispatch_transport_routes` UPDATE/FOR UPDATE), `jobroute.Controller` (`worker_job_routes` + the outbox LOCK) | `PostgresDomainGuard` (`SELECT true`, no relation), the operator advisory lock, the jobroute Celery quiescer (`sync_run_units`) | `NewDirectPostgresBackend`, the River quiescer |
 | `reconciler` | `jobroute.NewController` in `buildReconcilerRelay` (always constructed), `syncreconciler.NewMaterializer` (dormant path) | `LeaseRepair`, `Kernel` observe side, `Observer`, `syncroute` **fence** (SELECT-only), `syncDispatchReference` | repository, River inserter, River quiescer, Kernel mutate side |
-| `scheduler` | `schedulersync.NewMutationRepository` (`sync_configurations`/`scheduled_jobs` `FOR UPDATE OF config, job` + UPDATE), `schedulersync.NewOccurrenceCoordinator` and `NewOccurrenceReconciler` (`scheduled_sync_occurrences`) | `schedulerfixed.NewEngine` — **still mixed, see CHAOS-3114 below** | — |
+| `scheduler` | `schedulersync.NewMutationRepository` (`sync_configurations`/`scheduled_jobs` `FOR UPDATE OF config, job` + UPDATE), `schedulersync.NewOccurrenceCoordinator` and `NewOccurrenceReconciler` (`scheduled_sync_occurrences`), **and `schedulerfixed.NewEngine`** — the whole `runOccurrence` transaction, `fixed_schedule_occurrences` together with the domain rows its producers materialize (CHAOS-3114) | nothing composes on it; the pool is opened and gated by `domain_postgres` readiness only, so the process's own domain login is still proven to hold exactly `domainPosture` | — |
 
 `syncroute` appears in both columns because it is two different constructors:
 `syncroute.NewController` mutates routes (coordinator), `syncroute.New` is the
@@ -132,43 +137,116 @@ migration in step 3, and step 3 before step 4.
 
 ### Connection budget
 
-Unchanged at **93 / 100** server connections. The coordinator budget was
-already modeled by `deploymentcontract`
-(`BudgetSummary.DirectCoordinatorConnections`) before this change: reconciler
-2×2, scheduler 2×2, `workerctl` 1×2 = 10 direct coordinator connections. This
-change added only environment wiring, no connections, so
-`TestManifestRejectsConnectionBudgetOverflow` is unaffected.
+Unchanged at **93 / 100** server connections, before and after CHAOS-3114. The
+coordinator budget was already modeled by `deploymentcontract`
+(`BudgetSummary.DirectCoordinatorConnections`): reconciler 2×2, scheduler 2×2,
+`workerctl` 1×2 = 10 direct coordinator connections. The footprint is
+`server_reserved` 15 + PgBouncer 25×2 + direct queue-control 18 + direct
+coordinator 10 = 93. Repointing call sites moves demand between pools that are
+already budgeted; it creates no new connection, so
+`TestManifestRejectsConnectionBudgetOverflow` is unaffected by either half.
+
+Within the scheduler's own `coordinator_max_connections: 2`, both loops are
+single-transaction-at-a-time and run on one goroutine each: `schedulersync.Loop`
+hands off and then reconciles **sequentially** in one step (and
+`dueOccurrenceKeys` drains its rows before `reconcileOne` begins a
+transaction), and `schedulerfixed.Engine` reads its anchor, rolls that read
+back, and only then opens the occurrence transaction. Peak concurrent demand is
+therefore one connection per loop — exactly 2.
 
 ## What remains
 
-- **CHAOS-3114 — `dev-health-scheduler`'s sync path is repointed; its
-  fixed-schedule engine is not.** The sync-path call sites
-  (`schedulersync.NewMutationRepository`, `NewOccurrenceCoordinator`,
-  `NewOccurrenceReconciler`) now run on the coordinator pool, which removes the
-  42501 that `FOR UPDATE OF config, job SKIP LOCKED` would have raised on the
-  first real handoff — that clause needs UPDATE on the locked rows purely to
-  take the lock, even though the statement writes nothing else.
-
-  What remains is `schedulerfixed.Engine.runOccurrence`, which commits, in
-  **one** transaction, `fixed_schedule_occurrences` (coordinator-exclusive)
-  together with `remaining_metric_runs`, `remaining_metric_partitions`, and
-  `work_graph_execution_requests`/`_ledger` (domain-exclusive). No single role
-  can serve that transaction under the declared postures, and the atomicity is
-  deliberate. Resolving it means either splitting the commit (outbox-style) or
-  granting an explicit exception — a design decision, not a pool swap. The fixed
-  loop therefore keeps the domain pool for now. Nothing regresses: the binary is
-  dormant (`checkedInSchedulerActivation` is the zero value, so it opens no pool
-  at all), and the fixed loop is already composed to fail independently of the
-  sync loop.
-
-  `coordinatorPolicyParity` was **deleted**, not left false. It was a bare bool
-  with no test, checklist, or document anywhere defining what it would prove, so
-  it could not honestly gate anything. `goOwnsMarkers` is now the sole
-  composition gate; its one open precondition is the CUT-09/CUT-10 occurrence
-  materializer stub.
 - **Reconciler mutation pipeline** is wired correctly but dormant
   (`checkedInReconcilerActivation.syncMutation` is false). It is repointed now so
   flipping that flag cannot ship the same defect.
+- **The occurrence materializer (CUT-09/CUT-10)** is the sole remaining
+  precondition on `checkedInSchedulerActivation.goOwnsMarkers`.
+  `productionSchedulerRuntimeSources.newOccurrences` still composes
+  `schedulersync.NewUnavailableMaterializer()`, so activating today would
+  durably record occurrences Go can never materialize. The binary stays dormant
+  and opens no pool at all. No privilege precondition remains — see below.
+
+## CHAOS-3114 — both halves shipped
+
+No privilege precondition remains on the scheduler. The sync-path call sites
+(`schedulersync.NewMutationRepository`, `NewOccurrenceCoordinator`,
+`NewOccurrenceReconciler`) moved to the coordinator pool first, removing the
+42501 that `FOR UPDATE OF config, job SKIP LOCKED` would have raised on the
+first real handoff — that clause needs UPDATE on the locked rows purely to take
+the lock, even though the statement writes nothing else.
+
+The second half moved `schedulerfixed.Engine.runOccurrence` onto the same pool.
+It commits, in **one** transaction, `fixed_schedule_occurrences`
+(coordinator-exclusive) together with the rows its producers materialize. The
+resolution was to widen the COORDINATOR role to cover the whole transaction:
+
+- The property the partition protects is that provider-sync workers — the code
+  that handles third-party payloads, and the code that runs as the **domain**
+  login — cannot reach control-plane tables (routes, credentials, audits,
+  schedule markers). Widening the coordinator does not weaken that. Widening the
+  domain role, by granting it `fixed_schedule_occurrences`, would destroy it. The
+  coordinator login is used only by the scheduler, the reconciler, and
+  `workerctl`.
+- The atomicity is deliberate and load-bearing: it is what makes "occurrence
+  recorded ⇒ work enqueued" exactly-once. Splitting it outbox-style would let a
+  fixed schedule double-run or silently skip.
+- Celery Beat, the thing this replaces, already runs as ONE identity spanning
+  both table sets. The Go cutover is not blocked on a privilege model stricter
+  than its predecessor.
+
+The grant set is the **verified statement trace** of `runOccurrence`, not the
+domain role's flags copied across. `coordinatorPosture()` gained:
+
+| Table | Coordinator privileges | Why |
+| --- | --- | --- |
+| `remaining_metric_runs` | SELECT, INSERT | `remaining.StartRunTx` inserts; `loadStartedRun` re-reads on the replay arm. **No UPDATE** — every status transition is handler-side, on the domain role. |
+| `remaining_metric_partitions` | SELECT, INSERT | same `StartRunTx`, plus `verifyStartedPartitions`. No UPDATE, same reason. |
+| `work_graph_execution_requests` | SELECT, INSERT | `workgraph.RequestWriter.WriteTx` inserts and re-reads. No UPDATE: `Claim`/`transition` are handler-side. |
+| `worker_job_outbox` | **+ INSERT** | `joboutbox.Producer.publish`, reached from every producer handoff. UPDATE was already required by the `jobroute` LOCK. |
+| `worker_job_completion_fences` | `completion_key` SELECT + INSERT, **column-scoped** | `joboutbox.MarkCompletionTx`, reached transitively from `StartRunTx` and `WriteTx` on their already-succeeded replay arms. |
+
+Two corrections to what this document previously asserted, both found by tracing
+the code rather than reading the manifest:
+
+- **`work_graph_execution_ledger` is NOT in the transaction.** `WriteTx` never
+  touches it; the ledger belongs to the handler-side `Claim`. The earlier bullet
+  listing it as one of the commit's domain-exclusive tables was wrong, and it is
+  deliberately absent from the coordinator posture.
+- **`worker_job_completion_fences` IS reached from the fixed engine.**
+  `domainPosture()`'s comment previously dismissed the manifest's "possible 2nd
+  reacher" flag on this table as a false positive, on the strength of a grep
+  across `internal/scheduler/fixed` for `MarkCompletionTx`. The grep was scoped
+  to one package while the reach is transitive, through `StartRunTx` and
+  `WriteTx`. The flag was real.
+
+The fence grant stays **column-scoped** for the same reason it is on the domain
+side: `completed_at` is server-owned, and a table-wide grant would let the
+coordinator forge a fence retention never reaps. Supporting that required the
+migration to learn column grants —
+`MigrationOptions.CoordinatorColumnGrants`, derived by
+`cmd/dev-health-worker-migrate` from `CoordinatorPosture().ColumnScoped`, the
+same single-declaration route the table grants already take. A relation may be
+granted table-wide or column-scoped, never both; the migration rejects the
+combination, because the readiness check refuses it outright.
+
+`SELECT` on `completion_key` is required as well as `INSERT`, and not because
+anything reads the row: `INSERT ... ON CONFLICT (completion_key) DO NOTHING`
+names an arbiter, and PostgreSQL refuses the statement with 42501 when only
+`INSERT (completion_key)` is held. Verified empirically against a live server,
+both directions. This is the same class of trap as the LOCK-implied UPDATE:
+invisible to any verb-based reading of the code.
+
+All of it is measured, not inferred:
+`internal/storage/postgres/fixed_engine_statement_privileges_integration_test.go`
+runs the 14 real `runOccurrence` statement shapes as the real coordinator role
+with grants applied by `ApplyPinnedMigrations`, and its mutation half restores
+the pre-3114 grant set and demands 42501 on each of the eight statements this
+change unblocked, plus a closed readiness check.
+
+`coordinatorPolicyParity` was **deleted**, not left false. It was a bare bool
+with no test, checklist, or document anywhere defining what it would prove, so
+it could not honestly gate anything. `goOwnsMarkers` is now the sole composition
+gate, and it stays false.
 
 ## Known disagreements with the manifest
 
@@ -179,8 +257,21 @@ change added only environment wiring, no connections, so
   not by re-granting the table to the domain role. If the reconciler were ever
   reclassified as domain-only, `worker_job_routes` would have to become
   dual-granted instead.
-- `fixed_schedule_occurrences` is attributed coordinator-exclusive, but its only
-  writer shares a transaction with domain-exclusive tables. See CHAOS-3114.
+- `fixed_schedule_occurrences` is attributed coordinator-exclusive, and its only
+  writer shares a transaction with tables the manifest attributes to the domain
+  role. **Resolved** by CHAOS-3114: the coordinator role holds both sides and
+  the whole engine runs as coordinator, so the attribution stands as written —
+  `fixed_schedule_occurrences` was never granted to the domain role and is not
+  dual-granted. What the manifest now understates is the coordinator side of
+  `remaining_metric_runs`, `remaining_metric_partitions`,
+  `work_graph_execution_requests`, `worker_job_outbox` and
+  `worker_job_completion_fences`: each is a dual-grant table, with the
+  coordinator holding strictly less than the domain role on the first three (no
+  UPDATE — the status transitions are handler-side). The Go postures are what
+  the code is built against.
+- `worker_job_completion_fences` carried a "possible 2nd reacher" flag the
+  postures previously dismissed as a false positive. It was real; see CHAOS-3114
+  above. The manifest's flag was right and the dismissal was wrong.
 - `docker/init-extra-dbs.sh` and `scripts/worker/provision_river_roles.sql` still
   carry their own partial domain grant lists, which predate the posture split and
   are superseded by the migration's `REVOKE ALL` + selective re-grant. Their

--- a/.github/docs-legacy/architecture/chaos-3033-coordinator-pool-activation.md
+++ b/.github/docs-legacy/architecture/chaos-3033-coordinator-pool-activation.md
@@ -73,18 +73,19 @@ is rejected rather than half-applied.
 | --- | --- | --- | --- |
 | `workerctl` | `joboperator.Authenticator` (`internal_service_credentials`), `joboperator.PostgresAuditor` (`worker_operator_audits`), `syncroute.Controller` (`sync_dispatch_transport_routes` UPDATE/FOR UPDATE), `jobroute.Controller` (`worker_job_routes` + the outbox LOCK) | `PostgresDomainGuard` (`SELECT true`, no relation), the operator advisory lock, the jobroute Celery quiescer (`sync_run_units`) | `NewDirectPostgresBackend`, the River quiescer |
 | `reconciler` | `jobroute.NewController` in `buildReconcilerRelay` (always constructed), `syncreconciler.NewMaterializer` (dormant path) | `LeaseRepair`, `Kernel` observe side, `Observer`, `syncroute` **fence** (SELECT-only), `syncDispatchReference` | repository, River inserter, River quiescer, Kernel mutate side |
-| `scheduler` | **not repointed — blocked on CHAOS-3114** | — | — |
+| `scheduler` | `schedulersync.NewMutationRepository` (`sync_configurations`/`scheduled_jobs` `FOR UPDATE OF config, job` + UPDATE), `schedulersync.NewOccurrenceCoordinator` and `NewOccurrenceReconciler` (`scheduled_sync_occurrences`) | `schedulerfixed.NewEngine` — **still mixed, see CHAOS-3114 below** | — |
 
 `syncroute` appears in both columns because it is two different constructors:
 `syncroute.NewController` mutates routes (coordinator), `syncroute.New` is the
 read-only fence (domain).
 
-Both repointed binaries additionally gate readiness on
+Every repointed binary additionally gates readiness on
 `CheckCoordinatorAuthorization`. That is not redundant with the domain check:
 cross-role attribution is a *distributed* property, so only the coordinator's
 own check can catch a privilege wrongly granted to the coordinator login. The
-reconciler exposes it as a separately named `coordinator_postgres` readiness
-check so a coordinator privilege fault is attributable.
+reconciler and the scheduler each expose it as a separately named
+`coordinator_postgres` readiness check so a coordinator privilege fault is
+attributable.
 
 ## Deploy prerequisites — ordered
 
@@ -140,21 +141,31 @@ change added only environment wiring, no connections, so
 
 ## What remains
 
-- **CHAOS-3114 — `dev-health-scheduler` cannot be repointed as-is.** Its
-  fixed-schedule `Engine.runOccurrence` commits, in **one** transaction,
-  `fixed_schedule_occurrences` (coordinator-exclusive) together with
-  `remaining_metric_runs`, `remaining_metric_partitions`, and
+- **CHAOS-3114 — `dev-health-scheduler`'s sync path is repointed; its
+  fixed-schedule engine is not.** The sync-path call sites
+  (`schedulersync.NewMutationRepository`, `NewOccurrenceCoordinator`,
+  `NewOccurrenceReconciler`) now run on the coordinator pool, which removes the
+  42501 that `FOR UPDATE OF config, job SKIP LOCKED` would have raised on the
+  first real handoff — that clause needs UPDATE on the locked rows purely to
+  take the lock, even though the statement writes nothing else.
+
+  What remains is `schedulerfixed.Engine.runOccurrence`, which commits, in
+  **one** transaction, `fixed_schedule_occurrences` (coordinator-exclusive)
+  together with `remaining_metric_runs`, `remaining_metric_partitions`, and
   `work_graph_execution_requests`/`_ledger` (domain-exclusive). No single role
   can serve that transaction under the declared postures, and the atomicity is
   deliberate. Resolving it means either splitting the commit (outbox-style) or
-  granting an explicit exception — a design decision, not a pool swap. The
-  binary is dormant today (`checkedInSchedulerActivation` is the zero value, so
-  it opens no pool at all), so nothing regresses by leaving it. Its coordinator
-  call sites, for when this is unblocked: `schedulersync.NewMutationRepository`
-  (`scheduled_jobs` FOR UPDATE + UPDATE), `schedulersync.NewOccurrenceCoordinator`
-  (`scheduled_sync_occurrences`), `schedulersync.NewOccurrenceReconciler`
-  (`scheduled_sync_occurrences`, `scheduled_jobs`), and the mixed
-  `schedulerfixed.NewEngine`.
+  granting an explicit exception — a design decision, not a pool swap. The fixed
+  loop therefore keeps the domain pool for now. Nothing regresses: the binary is
+  dormant (`checkedInSchedulerActivation` is the zero value, so it opens no pool
+  at all), and the fixed loop is already composed to fail independently of the
+  sync loop.
+
+  `coordinatorPolicyParity` was **deleted**, not left false. It was a bare bool
+  with no test, checklist, or document anywhere defining what it would prove, so
+  it could not honestly gate anything. `goOwnsMarkers` is now the sole
+  composition gate; its one open precondition is the CUT-09/CUT-10 occurrence
+  materializer stub.
 - **Reconciler mutation pipeline** is wired correctly but dormant
   (`checkedInReconcilerActivation.syncMutation` is false). It is repointed now so
   flipping that flag cannot ship the same defect.

--- a/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
+++ b/.github/docs-legacy/architecture/chaos-3033-role-partition-manifest.md
@@ -77,6 +77,52 @@ was always in principle traceable and the earlier `unverified-shape` tag
 on `organizations`' coordinator side was more conservative than it needed
 to be.
 
+### Fourth round (CHAOS-3114): the sweep's package boundary was the blind spot
+
+The closure-typed-field sweep below concluded "`sync_configurations` was the
+only miss ... Nothing else to add." That conclusion was scoped to SQL written
+**inside** `internal/scheduler/{sync,fixed}`, and the fixed-schedule engine's
+transaction is not confined to those packages: `Engine.runOccurrence` hands its
+`pgx.Tx` to producers that call into `internal/jobs/metrics/remaining`,
+`internal/jobs/workgraph` and `internal/joboutbox`. A grep bounded by package
+therefore cannot see the coordinator's full statement set — the same class of
+error as the closure-typed field, one level up. The trace that closes it
+follows the `tx` across package boundaries, not the file tree:
+
+| table | role | privileges | confidence | evidence |
+|---|---|---|---|---|
+| remaining_metric_runs | **both** | coordinator: SELECT, INSERT | verified | `internal/jobs/metrics/remaining/postgres.go` `StartRunTx` (INSERT ... ON CONFLICT DO NOTHING) + `loadStartedRun` (replay read), reached from `internal/scheduler/fixed/producers.go` `RemainingMetricsFanoutProducer.Produce`. **No UPDATE**: every status transition is handler-side (domain). |
+| remaining_metric_partitions | **both** | coordinator: SELECT, INSERT | verified | same `StartRunTx`, plus `verifyStartedPartitions`. No UPDATE, same reason. |
+| work_graph_execution_requests | **both** | coordinator: SELECT, INSERT | verified | `internal/jobs/workgraph/publisher.go` `WriteTx` (INSERT ... ON CONFLICT (id) DO NOTHING + identity re-read), reached from `producers.go startGraphBuild`. No UPDATE: `Claim`/`transition` are handler-side. |
+| worker_job_outbox | **both** (three roles) | coordinator: + INSERT | verified | `internal/joboutbox/producer.go` `publish`, reached from every fixed-schedule handoff. The coordinator's UPDATE was already recorded (LOCK-implied); INSERT is the addition. |
+| worker_job_completion_fences | **both** | coordinator: `completion_key` SELECT + INSERT, column-scoped | verified | `internal/joboutbox/completion.go` `MarkCompletionTx`, reached transitively from `StartRunTx` and `WriteTx` on their already-succeeded replay arms. |
+
+Two corrections to the rows below, both from reading the code rather than
+relaying:
+
+- The `worker_job_completion_fences | coordinator? | possible 2nd reacher,
+  unresolved` row was **right**. A later revision of
+  `internal/storage/postgres/domain_authorization.go` dismissed it as a false
+  positive because a grep across `internal/scheduler/fixed` for
+  `MarkCompletionTx` found nothing — but `producers.go:462` calling
+  `joboutbox.CompletionKey` is not the reach; `StartRunTx`/`WriteTx` calling
+  `MarkCompletionTx` is. The row is now `verified`, with a shape: SELECT as
+  well as INSERT, because `INSERT ... ON CONFLICT (completion_key) DO NOTHING`
+  needs SELECT on the arbiter column (verified empirically against a live
+  server). It stays column-scoped — `completed_at` is server-owned.
+- `work_graph_execution_ledger` is **domain-only** and is NOT part of the fixed
+  engine's transaction. `WriteTx` never touches it; it belongs to the
+  handler-side `Claim`. `.github/docs-legacy/architecture/chaos-3033-coordinator-pool-activation.md`
+  previously listed it among the tables `runOccurrence` commits. It does not.
+
+The dual-grant ("both") whitelist at the end of this document therefore grows
+from 8 tables to 11: `remaining_metric_runs`, `remaining_metric_partitions` and
+`work_graph_execution_requests` join it (`worker_job_outbox` was already on it).
+`worker_job_completion_fences` is dual-held too but is not a table-wide
+whitelist entry — `RolePosture.ColumnScoped` carries it for both roles. In each
+of the three new entries the coordinator holds strictly LESS than the domain
+role.
+
 ## Prior dispute (from commit `95c589722`, kept for the record)
 
 Five earlier retags (`organizations`, `org_licenses`, `tier_limits`,

--- a/cmd/dev-health-scheduler/dependencies.go
+++ b/cmd/dev-health-scheduler/dependencies.go
@@ -33,16 +33,20 @@ type postgresSchedulerDatabase struct {
 }
 
 // openSchedulerDatabase opts into the coordinator boundary via
-// WithCoordinator: CHAOS-3114 repoints the sync repository and occurrence
-// reconciler onto the coordinator pool because sync_configurations,
-// scheduled_jobs, and scheduled_sync_occurrences are coordinator-exclusive
-// per internal/storage/postgres/domain_authorization.go, and
+// WithCoordinator: CHAOS-3114 repoints the sync repository, the occurrence
+// reconciler AND the fixed maintenance engine onto the coordinator pool.
+// sync_configurations, scheduled_jobs, scheduled_sync_occurrences and
+// fixed_schedule_occurrences are coordinator-exclusive per
+// internal/storage/postgres/domain_authorization.go, and
 // internal/scheduler/sync/transaction.go's `FOR UPDATE OF config, job
 // SKIP LOCKED` requires UPDATE on those rows even though it writes nothing
 // else. deploy/go-workers/profiles.json already budgets
-// coordinator_max_connections: 2 for the "scheduler" process, so this does
-// not change the connection footprint the deployment contract already
-// accounts for.
+// coordinator_max_connections: 2 for the "scheduler" process, and both loops
+// are single-transaction-at-a-time (the sync loop hands off then reconciles
+// sequentially; the fixed engine runs one occurrence transaction at a time),
+// so peak concurrent demand is one connection per loop -- exactly the
+// budgeted 2, with no change to the connection footprint the deployment
+// contract already accounts for.
 func openSchedulerDatabase(ctx context.Context, cfg config.Config) (schedulerDatabase, error) {
 	runtimeConfig := postgres.RuntimeConfigFromPlatform(cfg).WithCoordinator()
 	pools, err := postgres.NewRuntimePools(ctx, runtimeConfig)
@@ -109,6 +113,14 @@ func (database *postgresSchedulerDatabase) RiverSchemaReady(
 	return err
 }
 
+// DomainPool exists for the readiness identity, not for composition: since
+// CHAOS-3114 repointed the fixed engine, no loop in this process is built on
+// the domain pool at all. The pool is still opened and still gated by
+// DomainReady, because the process's own domain login must be proven to hold
+// exactly domainPosture -- cross-role attribution is distributed, so a
+// privilege wrongly granted to the domain login is caught only by the domain
+// login's own check. Anything wired onto this pool again would need its own
+// justification against coordinatorPosture first.
 func (database *postgresSchedulerDatabase) DomainPool() *pgxpool.Pool {
 	if database == nil || database.pools == nil {
 		return nil
@@ -231,7 +243,10 @@ type schedulerRuntimeSources struct {
 	) (*schedulersync.Loop, error)
 	// newFixedLoop builds the fixed maintenance schedule runtime that replaces
 	// Celery Beat's non-product entries. It shares this process because two
-	// processes must never both believe they own periodic work.
+	// processes must never both believe they own periodic work, and since
+	// CHAOS-3114 it takes the COORDINATOR pool: its occurrence ledger is
+	// coordinator-exclusive and commits with the producers' domain rows in one
+	// transaction.
 	newFixedLoop func(*pgxpool.Pool, *health.Registry) (fixedScheduleRuntime, error)
 	// newOccurrences builds the consumer for the occurrences the sync loop
 	// hands off. It is constructed in the same process for the same reason:
@@ -373,7 +388,21 @@ func buildSchedulerLoopWithSources(
 	if err := registry.RegisterRequired("fixed_schedule_coverage", gate.coverage); err != nil {
 		return nil, err
 	}
-	fixedLoop, err := sources.newFixedLoop(database.DomainPool(), registry)
+	// CHAOS-3114 (second half): the fixed maintenance engine runs on the
+	// coordinator pool too, on the same fail-closed coordinatorPool obtained
+	// above -- there is no domain-pool fallback here either. runOccurrence
+	// commits fixed_schedule_occurrences (coordinator-exclusive) together with
+	// remaining_metric_runs, remaining_metric_partitions,
+	// work_graph_execution_requests, worker_job_outbox and the completion
+	// fence in ONE transaction, and the atomicity is what makes "occurrence
+	// recorded => work enqueued" exactly-once. Splitting it outbox-style would
+	// let a fixed schedule double-run or silently skip, so the coordinator
+	// posture was widened to cover the whole statement set instead
+	// (internal/storage/postgres/domain_authorization.go coordinatorPosture).
+	// The domain role deliberately did NOT gain fixed_schedule_occurrences:
+	// widening the login that provider-sync workers use is what the partition
+	// exists to prevent.
+	fixedLoop, err := sources.newFixedLoop(coordinatorPool, registry)
 	if err != nil || fixedLoop == nil {
 		// The gate stays unattached, so both names report unavailable while the
 		// product loop below runs normally.

--- a/cmd/dev-health-scheduler/dependencies.go
+++ b/cmd/dev-health-scheduler/dependencies.go
@@ -17,29 +17,44 @@ import (
 type schedulerDatabase interface {
 	DomainReady(context.Context) error
 	QueueReady(context.Context) error
+	CoordinatorReady(context.Context) error
 	RiverSchemaReady(context.Context, string) error
 	DomainPool() *pgxpool.Pool
+	CoordinatorPool() (*pgxpool.Pool, error)
 	Close()
 }
 
 type postgresSchedulerDatabase struct {
-	pools       *postgres.RuntimePools
-	domainRole  string
-	queueRole   string
-	riverSchema string
+	pools           *postgres.RuntimePools
+	domainRole      string
+	queueRole       string
+	coordinatorRole string
+	riverSchema     string
 }
 
+// openSchedulerDatabase opts into the coordinator boundary via
+// WithCoordinator: CHAOS-3114 repoints the sync repository and occurrence
+// reconciler onto the coordinator pool because sync_configurations,
+// scheduled_jobs, and scheduled_sync_occurrences are coordinator-exclusive
+// per internal/storage/postgres/domain_authorization.go, and
+// internal/scheduler/sync/transaction.go's `FOR UPDATE OF config, job
+// SKIP LOCKED` requires UPDATE on those rows even though it writes nothing
+// else. deploy/go-workers/profiles.json already budgets
+// coordinator_max_connections: 2 for the "scheduler" process, so this does
+// not change the connection footprint the deployment contract already
+// accounts for.
 func openSchedulerDatabase(ctx context.Context, cfg config.Config) (schedulerDatabase, error) {
-	runtimeConfig := postgres.RuntimeConfigFromPlatform(cfg)
+	runtimeConfig := postgres.RuntimeConfigFromPlatform(cfg).WithCoordinator()
 	pools, err := postgres.NewRuntimePools(ctx, runtimeConfig)
 	if err != nil {
 		return nil, err
 	}
 	return &postgresSchedulerDatabase{
-		pools:       pools,
-		domainRole:  runtimeConfig.DomainRole,
-		queueRole:   runtimeConfig.QueueRole,
-		riverSchema: runtimeConfig.RiverSchema,
+		pools:           pools,
+		domainRole:      runtimeConfig.DomainRole,
+		queueRole:       runtimeConfig.QueueRole,
+		coordinatorRole: runtimeConfig.CoordinatorRole,
+		riverSchema:     runtimeConfig.RiverSchema,
 	}, nil
 }
 
@@ -67,6 +82,22 @@ func (database *postgresSchedulerDatabase) QueueReady(ctx context.Context) error
 	)
 }
 
+// CoordinatorReady proves the coordinator login holds exactly
+// coordinatorPosture. It is a separate readiness gate from DomainReady on
+// purpose: cross-role attribution is distributed, so only the coordinator's
+// own check can catch a privilege wrongly granted to the coordinator role.
+func (database *postgresSchedulerDatabase) CoordinatorReady(ctx context.Context) error {
+	if database == nil || database.pools == nil || database.pools.Coordinator == nil {
+		return errSchedulerActivationUnavailable
+	}
+	return postgres.CheckCoordinatorAuthorization(
+		ctx,
+		database.pools.Coordinator,
+		database.coordinatorRole,
+		database.riverSchema,
+	)
+}
+
 func (database *postgresSchedulerDatabase) RiverSchemaReady(
 	ctx context.Context,
 	schema string,
@@ -83,6 +114,18 @@ func (database *postgresSchedulerDatabase) DomainPool() *pgxpool.Pool {
 		return nil
 	}
 	return database.pools.Domain
+}
+
+// CoordinatorPool never falls back to the domain pool. RuntimePools.
+// CoordinatorPool fails closed with postgres.ErrUnavailable when the
+// coordinator pool was never opened, which is the intended behaviour: a
+// coordinator call site silently running on the domain role is exactly the
+// CHAOS-3113/CHAOS-3114 defect this split removes.
+func (database *postgresSchedulerDatabase) CoordinatorPool() (*pgxpool.Pool, error) {
+	if database == nil || database.pools == nil {
+		return nil, errSchedulerActivationUnavailable
+	}
+	return database.pools.CoordinatorPool()
 }
 
 func (database *postgresSchedulerDatabase) Close() {
@@ -268,6 +311,9 @@ func buildSchedulerLoopWithSources(
 	if err := registry.RegisterRequired("queue_postgres", database.QueueReady); err != nil {
 		return nil, err
 	}
+	if err := registry.RegisterRequired("coordinator_postgres", database.CoordinatorReady); err != nil {
+		return nil, err
+	}
 	if err := registry.RegisterRequired(
 		"river_schema",
 		func(ctx context.Context) error {
@@ -276,7 +322,21 @@ func buildSchedulerLoopWithSources(
 	); err != nil {
 		return nil, err
 	}
-	repository, err := sources.newRepository(database.DomainPool())
+	// CHAOS-3114: the sync handoff repository and occurrence reconciler run
+	// on the coordinator pool, not the domain pool. sync_configurations,
+	// scheduled_jobs, and scheduled_sync_occurrences are coordinator-exclusive
+	// (internal/storage/postgres/domain_authorization.go), and
+	// schedulerHandoffCandidatesSQL's `FOR UPDATE OF config, job SKIP LOCKED`
+	// requires UPDATE on the locked rows purely to take the lock, even though
+	// it writes nothing else -- handing this call site the domain pool fails
+	// every handoff with SQLSTATE 42501 (insufficient_privilege). There is
+	// deliberately no fallback to the domain pool: CoordinatorPool fails
+	// closed with postgres.ErrUnavailable instead.
+	coordinatorPool, err := database.CoordinatorPool()
+	if err != nil || coordinatorPool == nil {
+		return nil, errSchedulerActivationUnavailable
+	}
+	repository, err := sources.newRepository(coordinatorPool)
 	if err != nil || repository == nil {
 		return nil, errSchedulerActivationUnavailable
 	}
@@ -284,7 +344,7 @@ func buildSchedulerLoopWithSources(
 	if coordinator == nil {
 		return nil, errSchedulerActivationUnavailable
 	}
-	occurrences, err := sources.newOccurrences(database.DomainPool())
+	occurrences, err := sources.newOccurrences(coordinatorPool)
 	if err != nil || occurrences == nil {
 		return nil, errSchedulerActivationUnavailable
 	}

--- a/cmd/dev-health-scheduler/dependencies_test.go
+++ b/cmd/dev-health-scheduler/dependencies_test.go
@@ -193,8 +193,14 @@ func TestSchedulerProductionFactoryBuildsReviewedRuntime(t *testing.T) {
 			return stubOccurrenceSource(pool)
 		},
 		newFixedLoop: func(pool *pgxpool.Pool, _ *health.Registry) (fixedScheduleRuntime, error) {
-			if pool != database.pool {
-				t.Fatal("fixed schedule loop received the wrong domain pool")
+			// CHAOS-3114 (second half): the fixed engine runs on the
+			// coordinator pool as well. runOccurrence commits the
+			// coordinator-exclusive occurrence ledger together with the
+			// producers' domain rows in one transaction, and coordinatorPosture
+			// is what covers that whole statement set -- handing this call site
+			// the domain pool fails the ledger claim with SQLSTATE 42501.
+			if pool != database.coordinatorPool {
+				t.Fatal("fixed schedule loop received the wrong pool; want the coordinator pool")
 			}
 			return fixedLoop, nil
 		},

--- a/cmd/dev-health-scheduler/dependencies_test.go
+++ b/cmd/dev-health-scheduler/dependencies_test.go
@@ -31,11 +31,13 @@ func (function schedulerHandoffStepperFunc) HandoffDueResult(
 }
 
 type fakeSchedulerDatabase struct {
-	pool        *pgxpool.Pool
-	domainCalls atomic.Int64
-	queueCalls  atomic.Int64
-	schemaCalls atomic.Int64
-	closed      atomic.Bool
+	pool             *pgxpool.Pool
+	coordinatorPool  *pgxpool.Pool
+	domainCalls      atomic.Int64
+	queueCalls       atomic.Int64
+	coordinatorCalls atomic.Int64
+	schemaCalls      atomic.Int64
+	closed           atomic.Bool
 }
 
 func (database *fakeSchedulerDatabase) DomainReady(context.Context) error {
@@ -48,13 +50,29 @@ func (database *fakeSchedulerDatabase) QueueReady(context.Context) error {
 	return nil
 }
 
+func (database *fakeSchedulerDatabase) CoordinatorReady(context.Context) error {
+	database.coordinatorCalls.Add(1)
+	return nil
+}
+
 func (database *fakeSchedulerDatabase) RiverSchemaReady(context.Context, string) error {
 	database.schemaCalls.Add(1)
 	return nil
 }
 
 func (database *fakeSchedulerDatabase) DomainPool() *pgxpool.Pool { return database.pool }
-func (database *fakeSchedulerDatabase) Close()                    { database.closed.Store(true) }
+
+// CoordinatorPool mirrors postgres.RuntimePools.CoordinatorPool's fail-closed
+// contract: a fake with no coordinatorPool configured reports ErrUnavailable
+// rather than silently handing back the domain pool.
+func (database *fakeSchedulerDatabase) CoordinatorPool() (*pgxpool.Pool, error) {
+	if database.coordinatorPool == nil {
+		return nil, errSchedulerActivationUnavailable
+	}
+	return database.coordinatorPool, nil
+}
+
+func (database *fakeSchedulerDatabase) Close() { database.closed.Store(true) }
 
 // stubOccurrenceStepper stands in for the pending-occurrence consumer the
 // scheduler loop now requires.
@@ -131,7 +149,7 @@ func TestProductionSchedulerRuntimeSourcesRepositoryFollowsSchedulerOwnership(t 
 }
 
 func TestSchedulerProductionFactoryBuildsReviewedRuntime(t *testing.T) {
-	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}}
+	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}, coordinatorPool: &pgxpool.Pool{}}
 	fixedLoop := &fakeFixedLoop{}
 	steps := atomic.Int64{}
 	sources := schedulerRuntimeSources{
@@ -139,8 +157,12 @@ func TestSchedulerProductionFactoryBuildsReviewedRuntime(t *testing.T) {
 			return database, nil
 		},
 		newRepository: func(pool *pgxpool.Pool) (schedulersync.HandoffStepper, error) {
-			if pool != database.pool {
-				t.Fatal("repository received the wrong domain pool")
+			// CHAOS-3114: the handoff repository must run on the coordinator
+			// pool, not the domain pool -- sync_configurations and
+			// scheduled_jobs are coordinator-exclusive and the handoff's
+			// `FOR UPDATE OF config, job` requires UPDATE on both.
+			if pool != database.coordinatorPool {
+				t.Fatal("repository received the wrong pool; want the coordinator pool")
 			}
 			return schedulerHandoffStepperFunc(func(
 				context.Context,
@@ -161,8 +183,15 @@ func TestSchedulerProductionFactoryBuildsReviewedRuntime(t *testing.T) {
 				return nil
 			})
 		},
-		newLoop:        schedulersync.NewLoop,
-		newOccurrences: stubOccurrenceSource,
+		newLoop: schedulersync.NewLoop,
+		newOccurrences: func(pool *pgxpool.Pool) (schedulersync.OccurrenceStepper, error) {
+			// CHAOS-3114: scheduled_sync_occurrences is coordinator-exclusive,
+			// so the reconciler must also run on the coordinator pool.
+			if pool != database.coordinatorPool {
+				t.Fatal("occurrence reconciler received the wrong pool; want the coordinator pool")
+			}
+			return stubOccurrenceSource(pool)
+		},
 		newFixedLoop: func(pool *pgxpool.Pool, _ *health.Registry) (fixedScheduleRuntime, error) {
 			if pool != database.pool {
 				t.Fatal("fixed schedule loop received the wrong domain pool")
@@ -193,12 +222,14 @@ func TestSchedulerProductionFactoryBuildsReviewedRuntime(t *testing.T) {
 		t.Fatalf("readiness = %#v", status)
 	}
 	if steps.Load() != 1 || database.domainCalls.Load() == 0 ||
-		database.queueCalls.Load() == 0 || database.schemaCalls.Load() == 0 {
+		database.queueCalls.Load() == 0 || database.coordinatorCalls.Load() == 0 ||
+		database.schemaCalls.Load() == 0 {
 		t.Fatalf(
-			"steps=%d readiness_calls=(%d,%d,%d)",
+			"steps=%d readiness_calls=(%d,%d,%d,%d)",
 			steps.Load(),
 			database.domainCalls.Load(),
 			database.queueCalls.Load(),
+			database.coordinatorCalls.Load(),
 			database.schemaCalls.Load(),
 		)
 	}
@@ -217,7 +248,7 @@ func TestSchedulerProductionFactoryBuildsReviewedRuntime(t *testing.T) {
 }
 
 func TestSchedulerProductionFactoryClosesDatabaseOnCompositionFailure(t *testing.T) {
-	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}}
+	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}, coordinatorPool: &pgxpool.Pool{}}
 	_, err := buildSchedulerLoopWithSources(
 		context.Background(),
 		config.Config{RiverDatabaseSchema: "river"},
@@ -248,7 +279,7 @@ func TestSchedulerProductionFactoryClosesDatabaseOnCompositionFailure(t *testing
 // Beat's maintenance replacement would turn a maintenance outage into
 // permanently unprocessed product work.
 func TestSyncLoopAndOccurrenceReconcilerRunWithoutTheFixedScheduler(t *testing.T) {
-	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}}
+	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}, coordinatorPool: &pgxpool.Pool{}}
 	steps := atomic.Int64{}
 	registry := health.NewRegistry(100 * time.Millisecond)
 	component, err := buildSchedulerLoopWithSources(
@@ -305,7 +336,7 @@ func TestSyncLoopAndOccurrenceReconcilerRunWithoutTheFixedScheduler(t *testing.T
 // A fixed loop that constructs but fails to START must also not take the
 // product loop down with it.
 func TestFixedSchedulerStartFailureDoesNotStopTheSyncLoop(t *testing.T) {
-	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}}
+	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}, coordinatorPool: &pgxpool.Pool{}}
 	fixedLoop := &fakeFixedLoop{startErr: errors.New("fixed loop cannot start")}
 	component, err := buildSchedulerLoopWithSources(
 		context.Background(),
@@ -358,7 +389,7 @@ func TestFixedSchedulerStartFailureDoesNotStopTheSyncLoop(t *testing.T) {
 // names, so the attempts fail here instead. Either way the constructor returns
 // an error, and the property under test is that composition survives it.
 func TestFixedLoopConstructorFailureAfterClaimingReadinessNamesStillStartsTheSyncLoop(t *testing.T) {
-	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}}
+	database := &fakeSchedulerDatabase{pool: &pgxpool.Pool{}, coordinatorPool: &pgxpool.Pool{}}
 	steps := atomic.Int64{}
 	registry := health.NewRegistry(100 * time.Millisecond)
 	var readinessAttempts, readinessRejected int

--- a/cmd/dev-health-scheduler/fixed.go
+++ b/cmd/dev-health-scheduler/fixed.go
@@ -77,6 +77,14 @@ func buildFixedScheduleProducers(
 // buildFixedScheduleLoop constructs the fixed maintenance schedule runtime. It
 // shares the scheduler process because the two schedulers must never disagree
 // about which process owns periodic work.
+//
+// The pool is the COORDINATOR pool (CHAOS-3114). Everything constructed here
+// runs inside Engine.runOccurrence's single transaction, so one pool has to
+// serve the whole statement set: the occurrence ledger
+// (coordinator-exclusive), the remaining-metrics store and its partition
+// publisher, the work-graph request writer, and the outbox publisher. The
+// stores are handed the same pool only so their non-transactional methods have
+// one; the fixed engine never calls those.
 func buildFixedScheduleLoop(
 	pool *pgxpool.Pool,
 	registry *health.Registry,

--- a/cmd/dev-health-scheduler/main.go
+++ b/cmd/dev-health-scheduler/main.go
@@ -30,30 +30,23 @@ var schedulerSpec = shell.Spec{
 // policy the binary runs with, not a decorative check.
 //
 // Obtaining this policy does NOT make the binary write anything: it still
-// requires checkedInSchedulerActivation's goOwnsMarkers and
-// coordinatorPolicyParity to both be true before this process opens a
-// database pool at all (see below), and at minimum three further
-// preconditions this change does not attempt to satisfy:
+// requires checkedInSchedulerActivation.goOwnsMarkers to be true before this
+// process opens a database pool at all (see below), and at minimum one
+// further precondition this change does not attempt to satisfy:
 //
-//  1. coordinatorPolicyParity has no defined bar anywhere in this repository
-//     today -- no test, doc, or checklist states what "the coordinator
-//     behaves equivalently to the Python one" means well enough to prove.
-//     Setting it true without that definition would defeat the purpose of a
-//     source-reviewed gate.
-//  2. This binary has never been given a coordinator PostgreSQL pool (see
-//     .github/docs-legacy/architecture/chaos-3033-coordinator-pool-activation.md,
-//     "scheduler | not repointed -- blocked on CHAOS-3114"), and
-//     schedulersync.NewMutationRepository/NewOccurrenceCoordinator/
-//     NewOccurrenceReconciler's SQL (scheduled_jobs, sync_configurations
-//     UPDATE, scheduled_sync_occurrences) is coordinator-exclusive per
-//     internal/storage/postgres/domain_authorization.go's coordinatorPosture.
-//     dependencies.go still hands them database.DomainPool(); flipping
-//     activation without repointing that call site would 42501 on the first
-//     real handoff.
-//  3. sources.newOccurrences below still composes
+//   - sources.newOccurrences below still composes
 //     schedulersync.NewUnavailableMaterializer(): the native sync planner is
 //     CUT-09/CUT-10 work, not this change. Activating today would durably
 //     record occurrences Go can never materialize.
+//
+// CHAOS-3114 repointed dependencies.go's sync-path repository and occurrence
+// reconciler construction onto the coordinator pool
+// (schedulersync.NewMutationRepository/NewOccurrenceCoordinator/
+// NewOccurrenceReconciler's SQL -- scheduled_jobs, sync_configurations
+// UPDATE, scheduled_sync_occurrences -- is coordinator-exclusive per
+// internal/storage/postgres/domain_authorization.go's coordinatorPosture),
+// so that 42501 precondition no longer blocks activation. The unavailable
+// materializer above still does.
 var schedulerOwnership = schedulersync.TransferScheduleMarkerOwnershipToGo()
 
 var errSchedulerActivationUnavailable = errors.New("scheduler activation is unavailable")
@@ -61,21 +54,27 @@ var errSchedulerActivationUnavailable = errors.New("scheduler activation is unav
 // schedulerActivation is a source-reviewed, package-private composition seam.
 // It deliberately cannot be influenced by process environment or deployment
 // profile. The production loop factory is retained but remains unreachable
-// until a future change proves coordinator policy parity and sets both gates
-// true.
+// until a future change sets goOwnsMarkers true.
+//
+// coordinatorPolicyParity was removed deliberately (program-owner decision,
+// CHAOS-3114) rather than left at false: it was a bare bool with a prose
+// comment and no test, checklist, or document anywhere in this repository
+// defining what "the coordinator behaves equivalently to the Python one"
+// means or how it would be proven. A gate whose precondition is undefined
+// cannot honestly gate anything -- it only blocks indefinitely while
+// implying a rigour that does not exist. Do not re-add a field like this as
+// a placeholder; if a coordinator-parity gate is ever needed again, it must
+// ship together with the test/checklist/document that defines what it
+// proves.
 //
 // CHAOS-3128 transferred marker-mutation ownership itself (schedulerOwnership
-// above) but deliberately leaves both gates false: coordinatorPolicyParity
-// has no defined bar to prove yet, this binary's sync-path repository and
-// occurrence constructors still run on the domain pool rather than the
-// coordinator pool their SQL requires, and the occurrence materializer is
-// still the CUT-09/CUT-10 stub. See schedulerOwnership's doc comment for the
-// full list. Flipping goOwnsMarkers to true without also resolving those
-// would ship a database permission failure or a stranded-occurrence backlog
-// on the first real due schedule, not a working scheduler.
+// above) but deliberately leaves goOwnsMarkers false: this binary's
+// occurrence materializer is still the CUT-09/CUT-10 stub (see
+// schedulerOwnership's doc comment). Flipping goOwnsMarkers to true without
+// also resolving that would ship a stranded-occurrence backlog on the first
+// real due schedule, not a working scheduler.
 type schedulerActivation struct {
-	goOwnsMarkers           bool
-	coordinatorPolicyParity bool
+	goOwnsMarkers bool
 }
 
 var checkedInSchedulerActivation = schedulerActivation{}
@@ -119,14 +118,15 @@ func configureSchedulerDependenciesWithSources(
 	if registry == nil {
 		return nil, errSchedulerActivationUnavailable
 	}
-	if !activation.goOwnsMarkers || !activation.coordinatorPolicyParity {
-		// schedulerOwnership alone (CHAOS-3128) is not activation: until both
-		// gates are true this process must not even open a PostgreSQL client.
+	if !activation.goOwnsMarkers {
+		// schedulerOwnership alone (CHAOS-3128) is not activation: until this
+		// gate is true this process must not even open a PostgreSQL client.
 		// Keep all externally visible readiness names closed.
 		return nil, processreadiness.RegisterUnavailable(
 			registry,
 			"domain_postgres",
 			"queue_postgres",
+			"coordinator_postgres",
 			"river_schema",
 			"scheduler_loop",
 		)

--- a/cmd/dev-health-scheduler/main.go
+++ b/cmd/dev-health-scheduler/main.go
@@ -39,14 +39,15 @@ var schedulerSpec = shell.Spec{
 //     CUT-09/CUT-10 work, not this change. Activating today would durably
 //     record occurrences Go can never materialize.
 //
-// CHAOS-3114 repointed dependencies.go's sync-path repository and occurrence
-// reconciler construction onto the coordinator pool
+// CHAOS-3114 repointed every database call site in dependencies.go onto the
+// coordinator pool: first the sync-path repository and occurrence reconciler
 // (schedulersync.NewMutationRepository/NewOccurrenceCoordinator/
 // NewOccurrenceReconciler's SQL -- scheduled_jobs, sync_configurations
-// UPDATE, scheduled_sync_occurrences -- is coordinator-exclusive per
-// internal/storage/postgres/domain_authorization.go's coordinatorPosture),
-// so that 42501 precondition no longer blocks activation. The unavailable
-// materializer above still does.
+// UPDATE, scheduled_sync_occurrences), then the fixed maintenance engine,
+// whose runOccurrence transaction is now covered end to end by
+// coordinatorPosture (internal/storage/postgres/domain_authorization.go). No
+// 42501 precondition remains. The unavailable materializer above is the sole
+// remaining blocker on goOwnsMarkers.
 var schedulerOwnership = schedulersync.TransferScheduleMarkerOwnershipToGo()
 
 var errSchedulerActivationUnavailable = errors.New("scheduler activation is unavailable")
@@ -68,11 +69,15 @@ var errSchedulerActivationUnavailable = errors.New("scheduler activation is unav
 // proves.
 //
 // CHAOS-3128 transferred marker-mutation ownership itself (schedulerOwnership
-// above) but deliberately leaves goOwnsMarkers false: this binary's
-// occurrence materializer is still the CUT-09/CUT-10 stub (see
-// schedulerOwnership's doc comment). Flipping goOwnsMarkers to true without
-// also resolving that would ship a stranded-occurrence backlog on the first
-// real due schedule, not a working scheduler.
+// above) but deliberately leaves goOwnsMarkers false, and CHAOS-3114 leaves it
+// false too: this binary's occurrence materializer is still the CUT-09/CUT-10
+// stub (see schedulerOwnership's doc comment). Flipping goOwnsMarkers to true
+// without also resolving that would ship a stranded-occurrence backlog on the
+// first real due schedule, not a working scheduler. The binary therefore stays
+// dormant -- it opens no database pool at all -- and the privilege work in
+// CHAOS-3114 changes nothing about that; it only means the composition this
+// gate guards would no longer fail on a privilege error once the materializer
+// exists.
 type schedulerActivation struct {
 	goOwnsMarkers bool
 }

--- a/cmd/dev-health-scheduler/main_test.go
+++ b/cmd/dev-health-scheduler/main_test.go
@@ -48,7 +48,7 @@ func TestSchedulerSpecConfiguresFailClosedDependencies(t *testing.T) {
 		t.Fatalf("open readiness gate: %v", err)
 	}
 
-	want := []string{"domain_postgres", "queue_postgres", "river_schema", "scheduler_loop"}
+	want := []string{"coordinator_postgres", "domain_postgres", "queue_postgres", "river_schema", "scheduler_loop"}
 	status := registry.Readiness(context.Background())
 	if status.Ready || !slices.Equal(status.Failed, want) {
 		t.Fatalf("readiness = %#v, want failed %v", status, want)
@@ -62,7 +62,7 @@ func TestSchedulerActivationIsPrivateSourceReviewedComposition(t *testing.T) {
 		context.Background(),
 		config.Config{},
 		registry,
-		schedulerActivation{goOwnsMarkers: true, coordinatorPolicyParity: true},
+		schedulerActivation{goOwnsMarkers: true},
 		schedulerDependencySources{buildLoop: func(context.Context, config.Config, *health.Registry) (lifecycle.Component, error) {
 			called = true
 			return schedulerTestComponent{}, nil
@@ -75,9 +75,9 @@ func TestSchedulerActivationIsPrivateSourceReviewedComposition(t *testing.T) {
 	registry = health.NewRegistry(100 * time.Millisecond)
 	_, err = configureSchedulerDependenciesWithSources(
 		context.Background(), config.Config{}, registry,
-		schedulerActivation{goOwnsMarkers: true},
+		schedulerActivation{},
 		schedulerDependencySources{buildLoop: func(context.Context, config.Config, *health.Registry) (lifecycle.Component, error) {
-			t.Fatal("activation without coordinator parity invoked the loop factory")
+			t.Fatal("activation without goOwnsMarkers invoked the loop factory")
 			return nil, nil
 		}},
 	)
@@ -88,12 +88,12 @@ func TestSchedulerActivationIsPrivateSourceReviewedComposition(t *testing.T) {
 		t.Fatal(err)
 	}
 	if status := registry.Readiness(context.Background()); status.Ready || !slices.Contains(status.Failed, "scheduler_loop") {
-		t.Fatalf("non-parity readiness = %#v", status)
+		t.Fatalf("non-activated readiness = %#v", status)
 	}
 
 	_, err = configureSchedulerDependenciesWithSources(
 		context.Background(), config.Config{}, health.NewRegistry(time.Second),
-		schedulerActivation{goOwnsMarkers: true, coordinatorPolicyParity: true},
+		schedulerActivation{goOwnsMarkers: true},
 		schedulerDependencySources{buildLoop: func(context.Context, config.Config, *health.Registry) (lifecycle.Component, error) {
 			return nil, errors.New("private factory failure")
 		}},

--- a/cmd/dev-health-worker-migrate/main.go
+++ b/cmd/dev-health-worker-migrate/main.go
@@ -95,12 +95,14 @@ func execute(
 	if value, present := lookup("RIVER_COORDINATOR_DATABASE_ROLE"); present && strings.TrimSpace(value) != "" {
 		coordinatorRole = value
 	}
+	coordinatorTableGrants, coordinatorColumnGrants := coordinatorGrants()
 	migrationOptions := riverstore.MigrationOptions{
-		Schema:            schema,
-		DomainRole:        domainRole,
-		QueueRole:         queueRole,
-		CoordinatorRole:   coordinatorRole,
-		CoordinatorGrants: coordinatorGrants(),
+		Schema:                  schema,
+		DomainRole:              domainRole,
+		QueueRole:               queueRole,
+		CoordinatorRole:         coordinatorRole,
+		CoordinatorGrants:       coordinatorTableGrants,
+		CoordinatorColumnGrants: coordinatorColumnGrants,
 	}
 	if err := riverstore.ValidateMigrationOptions(migrationOptions); err != nil ||
 		migrationRole == domainRole || migrationRole == queueRole || migrationRole == coordinatorRole {
@@ -184,15 +186,17 @@ func requiredSecret(
 // types, because internal/storage/river cannot import internal/storage/postgres
 // (that direction is an import cycle).
 //
-// Column-scoped privileges are intentionally not translated: coordinatorPosture
-// declares none, and silently dropping any that appeared later would be exactly
-// the grants/assertion drift this indirection exists to prevent — so a future
-// coordinator ColumnScoped entry must fail loudly here instead.
-func coordinatorGrants() []riverstore.TableGrant {
+// Column-scoped privileges are translated too, and both halves come from the
+// same posture. An earlier revision returned nil the moment ColumnScoped was
+// non-empty, so that a coordinator column privilege would fail the migration
+// loudly rather than being silently dropped. CHAOS-3114 added the first such
+// entry (worker_job_completion_fences.completion_key, reached transitively
+// from the fixed-schedule engine's replay arms), so the guard has served its
+// purpose and is replaced by the real translation: dropping a declared column
+// privilege here would leave readiness demanding a grant the migration never
+// emitted, which is precisely the drift this indirection exists to prevent.
+func coordinatorGrants() ([]riverstore.TableGrant, []riverstore.ColumnGrant) {
 	posture := postgresstore.CoordinatorPosture()
-	if len(posture.ColumnScoped) != 0 {
-		return nil
-	}
 	grants := make([]riverstore.TableGrant, 0, len(posture.RequiredTables))
 	for _, table := range posture.RequiredTables {
 		grants = append(grants, riverstore.TableGrant{
@@ -202,5 +206,13 @@ func coordinatorGrants() []riverstore.TableGrant {
 			AllowDelete: table.AllowDelete,
 		})
 	}
-	return grants
+	columns := make([]riverstore.ColumnGrant, 0, len(posture.ColumnScoped))
+	for _, column := range posture.ColumnScoped {
+		columns = append(columns, riverstore.ColumnGrant{
+			TableName:  column.TableName,
+			ColumnName: column.ColumnName,
+			Privilege:  column.Privilege,
+		})
+	}
+	return grants, columns
 }

--- a/cmd/dev-health-worker-migrate/main_test.go
+++ b/cmd/dev-health-worker-migrate/main_test.go
@@ -7,6 +7,8 @@ import (
 	"testing"
 
 	platformsecrets "github.com/full-chaos/dev-health-ops/internal/platform/secrets"
+	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
+	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
 )
 
 func env(values map[string]string) platformsecrets.LookupEnv {
@@ -25,6 +27,59 @@ func TestExecuteHelpAndVersionDoNotRequireDatabase(t *testing.T) {
 		if status := execute(context.Background(), args, env(nil), &stdout, &stderr); status != 0 {
 			t.Fatalf("execute(%v) = %d, stderr=%s", args, status, stderr.String())
 		}
+	}
+}
+
+// coordinatorGrants is the only translation between the coordinator posture
+// and what the migration actually grants, so a dropped entry here is a
+// readiness deadlock: the check would demand a privilege no GRANT ever
+// emitted. Both halves are compared element for element against the posture
+// itself rather than against a restated list -- CHAOS-3114 added the first
+// column-scoped entry, and the pre-3114 code silently returned nil for exactly
+// that case.
+func TestCoordinatorGrantsTranslateThePostureWithoutDroppingAnything(t *testing.T) {
+	t.Parallel()
+
+	posture := postgresstore.CoordinatorPosture()
+	tables, columns := coordinatorGrants()
+	if len(tables) != len(posture.RequiredTables) || len(columns) != len(posture.ColumnScoped) {
+		t.Fatalf(
+			"coordinatorGrants() = %d tables/%d columns, posture declares %d/%d",
+			len(tables), len(columns), len(posture.RequiredTables), len(posture.ColumnScoped),
+		)
+	}
+	for index, table := range posture.RequiredTables {
+		want := riverstore.TableGrant{
+			TableName:   table.TableName,
+			AllowInsert: table.AllowInsert,
+			AllowUpdate: table.AllowUpdate,
+			AllowDelete: table.AllowDelete,
+		}
+		if tables[index] != want {
+			t.Fatalf("table grant %d = %#v, want %#v", index, tables[index], want)
+		}
+	}
+	for index, column := range posture.ColumnScoped {
+		want := riverstore.ColumnGrant{
+			TableName:  column.TableName,
+			ColumnName: column.ColumnName,
+			Privilege:  column.Privilege,
+		}
+		if columns[index] != want {
+			t.Fatalf("column grant %d = %#v, want %#v", index, columns[index], want)
+		}
+	}
+	// The translated set must survive the migration's own validation, or the
+	// command would fail before it ever connects.
+	if err := riverstore.ValidateMigrationOptions(riverstore.MigrationOptions{
+		Schema:                  "river",
+		DomainRole:              "domain_runtime",
+		QueueRole:               "queue_runtime",
+		CoordinatorRole:         "coordinator_runtime",
+		CoordinatorGrants:       tables,
+		CoordinatorColumnGrants: columns,
+	}); err != nil {
+		t.Fatalf("the derived coordinator grant set is rejected by the migration itself: %v", err)
 	}
 }
 

--- a/internal/scheduler/sync/ownership.go
+++ b/internal/scheduler/sync/ownership.go
@@ -76,10 +76,10 @@ func reviewedGoMutationOwnershipPolicy() OwnershipPolicy {
 // actually happen in production. allowsMutation() still requires
 // {owner: go, mode: mutation} on the specific Repository that runs the
 // write, and cmd/dev-health-scheduler's composition root additionally gates
-// on its own checkedInSchedulerActivation flags (goOwnsMarkers,
-// coordinatorPolicyParity) before it will even open a database pool. Those
-// gates exist precisely so that this function's existence does not, by
-// itself, put a marker mutation on the wire.
+// on its own checkedInSchedulerActivation.goOwnsMarkers flag before it will
+// even open a database pool. That gate exists precisely so that this
+// function's existence does not, by itself, put a marker mutation on the
+// wire.
 //
 // Why a second, concurrently running Celery Beat cannot also mutate the same
 // marker once this policy is in effect: HandoffDueResult (transaction.go)
@@ -101,8 +101,8 @@ func reviewedGoMutationOwnershipPolicy() OwnershipPolicy {
 // with Python's for every schedule (see NextOccurrence's golden-vector tests
 // for that), and that Go can complete a materialization once it wins a race
 // (see the occurrence reconciler's Materializer — a stub until CUT-09/CUT-10
-// lands). Both are the separate coordinatorPolicyParity precondition on the
-// composition root, and this function does not claim to satisfy it.
+// lands). Both are separate preconditions on the composition root's
+// goOwnsMarkers gate, and this function does not claim to satisfy either.
 func TransferScheduleMarkerOwnershipToGo() OwnershipPolicy {
 	return reviewedGoMutationOwnershipPolicy()
 }

--- a/internal/storage/postgres/coordinator_statement_privileges_integration_test.go
+++ b/internal/storage/postgres/coordinator_statement_privileges_integration_test.go
@@ -41,12 +41,17 @@ import (
 // statement attached, whereas a posture-versus-grant-list comparison cannot
 // see it, because neither artefact mentions locking at all.
 //
-// Deliberately out of scope: the fixed-schedule engine's scheduler statements
-// (scheduled_jobs / fixed_schedule_occurrences). Those cannot be settled by a
-// role-privilege test, because that engine commits coordinator-exclusive and
-// domain-exclusive writes in ONE transaction and therefore has no correct
-// single role at all. That is CHAOS-3114, an architecture question, and
-// asserting a privilege shape for it here would imply it has a privilege fix.
+// The fixed-schedule engine's statements used to be deliberately out of scope
+// here, on the grounds that an engine committing coordinator-exclusive and
+// domain-exclusive writes in ONE transaction had no correct single role at
+// all. CHAOS-3114 settled that architecture question — the coordinator role
+// was widened to cover the whole runOccurrence transaction, rather than the
+// transaction being split or the domain role being widened — so those
+// statements now have a privilege shape worth pinning. They live in
+// fixed_engine_statement_privileges_integration_test.go, which reuses this
+// file's harness, and NOT in coordinatorStatements() below: most of them run
+// against tables the domain role legitimately holds too, so they are not
+// "denied to domain" statements and belong in their own suite.
 
 const (
 	grantCoordinatorRole = "grant_coordinator_runtime"
@@ -99,7 +104,25 @@ func coordinatorExclusiveDDL() []string {
 		"CREATE TABLE public.sync_run_post_dispatches (id uuid PRIMARY KEY, sync_run_id uuid NOT NULL)",
 		"CREATE TABLE public.scheduled_jobs (id uuid PRIMARY KEY)",
 		"CREATE TABLE public.scheduled_sync_occurrences (id uuid PRIMARY KEY)",
-		"CREATE TABLE public.fixed_schedule_occurrences (id uuid PRIMARY KEY)",
+		// Production column shape (internal/scheduler/fixed/ledger.go), because
+		// fixed_engine_statement_privileges_integration_test.go executes the
+		// real ledger statements against it and a stub would raise 42703 during
+		// parse analysis, before the permission check it means to measure.
+		`CREATE TABLE public.fixed_schedule_occurrences (
+			occurrence_key text PRIMARY KEY,
+			identity_version text NOT NULL,
+			schedule_id text NOT NULL,
+			target_kind text NOT NULL,
+			scheduled_for timestamptz NOT NULL,
+			observed_at timestamptz NOT NULL,
+			status text NOT NULL,
+			handoff_count integer NOT NULL,
+			skip_reason text,
+			completed_at timestamptz,
+			created_at timestamptz NOT NULL,
+			updated_at timestamptz NOT NULL,
+			UNIQUE (schedule_id, scheduled_for)
+		)`,
 	}
 }
 

--- a/internal/storage/postgres/domain_authorization.go
+++ b/internal/storage/postgres/domain_authorization.go
@@ -506,16 +506,20 @@ type RolePosture struct {
 // completion_key; deletion is queue-side, queue_authorization.go). A
 // table-wide privilege would let the domain role forge completed_at and mint
 // a fence retention never reaps, so its posture is column-scoped instead —
-// hence ColumnScoped below rather than a RequiredTables row. The manifest's
-// "possible 2nd reacher" flag on this table (a coordinator-side call into
-// the same helper, unresolved by the grant-deriver tool) was independently
-// run down by hand: internal/scheduler/fixed/producers.go only calls
-// joboutbox.CompletionKey(...), a pure function computing a string stored in
-// a DIFFERENT table's column (worker_job_outbox.prerequisite_completion_key)
-// — it never touches worker_job_completion_fences itself. Confirmed via
-// grep for MarkCompletionTx/worker_job_completion_fences across
-// internal/scheduler/fixed: zero hits. This is a false positive, not an
-// unresolved gap — coordinatorPosture has no row for this table.
+// hence ColumnScoped below rather than a RequiredTables row.
+//
+// The manifest's "possible 2nd reacher" flag on this table (a coordinator-side
+// call into the same helper, unresolved by the grant-deriver tool) was once
+// dismissed here as a false positive on the strength of a grep across
+// internal/scheduler/fixed for MarkCompletionTx/worker_job_completion_fences.
+// That dismissal was WRONG, and CHAOS-3114 corrected it: the grep was scoped
+// to one package while the reach is transitive. The fixed engine's fan-out
+// producer calls remaining.PostgresStore.StartRunTx and
+// workgraph.RequestWriter.WriteTx, and BOTH call joboutbox.MarkCompletionTx on
+// their already-succeeded replay arm. The flag was real. It is now declared on
+// the coordinator side too (see coordinatorPosture's ColumnScoped below); the
+// domain side is unchanged, and this is a second column-scoped role on one
+// table, not a domain-posture change.
 func domainPosture() RolePosture {
 	return RolePosture{
 		RequiredTables: []TablePrivilege{
@@ -612,6 +616,52 @@ func domainPosture() RolePosture {
 //     hold this lock, and separately has no grant at all on worker_job_routes)
 //     is proven by coordinator_statement_privileges_integration_test.go, which
 //     executes the real statements as both roles.
+//
+//   - remaining_metric_runs, remaining_metric_partitions,
+//     work_graph_execution_requests (coordinator: SELECT, INSERT) and the
+//     INSERT half of worker_job_outbox, plus the ColumnScoped
+//     worker_job_completion_fences pair: CHAOS-3114's second half. The
+//     fixed-schedule engine (internal/scheduler/fixed) now runs on the
+//     coordinator pool, and Engine.runOccurrence commits its whole statement
+//     set in ONE transaction — the occurrence claim together with the domain
+//     rows its producers materialize. The flags are the transitive statement
+//     trace of runOccurrence, not the domain role's flags copied across:
+//
+//     fixed_schedule_occurrences  SELECT+INSERT+UPDATE  ledger.go Claim's
+//     `SELECT ... FOR UPDATE` needs UPDATE to take the lock; Complete UPDATEs.
+//     organizations               SELECT                organizations.go.
+//     remaining_metric_runs       SELECT+INSERT         remaining/postgres.go
+//     StartRunTx inserts; loadStartedRun re-reads on replay. NO UPDATE: every
+//     status transition is handler-side, on the domain role.
+//     remaining_metric_partitions SELECT+INSERT         same StartRunTx, plus
+//     verifyStartedPartitions' replay read. NO UPDATE, same reason.
+//     work_graph_execution_requests SELECT+INSERT       workgraph/publisher.go
+//     WriteTx inserts and re-reads. NO UPDATE: Claim/transition are handler-side.
+//     work_graph_execution_ledger is NOT reachable from runOccurrence at all —
+//     WriteTx never touches it — so it is deliberately absent here.
+//     worker_job_outbox           +INSERT               joboutbox/producer.go
+//     publish, reached from every producer's handoff. UPDATE was already
+//     required by the jobroute LOCK above; INSERT is the new half.
+//     worker_job_completion_fences completion_key SELECT+INSERT (ColumnScoped)
+//     joboutbox.MarkCompletionTx, reached transitively from StartRunTx and
+//     WriteTx on their already-succeeded replay arms. SELECT is required as
+//     well as INSERT, and not because anything reads the row: `INSERT ... ON
+//     CONFLICT (completion_key) DO NOTHING` names an arbiter, and PostgreSQL
+//     refuses the statement with 42501 when only INSERT (completion_key) is
+//     held — verified empirically against a live server, both directions. The
+//     grant stays column-scoped for exactly the reason it is on the domain
+//     side: completed_at is server-owned and a table-wide grant would let the
+//     coordinator forge a fence retention never reaps.
+//
+//     Widening the COORDINATOR rather than the domain role is the deliberate
+//     choice. The property the partition protects is that provider-sync
+//     workers — the code that handles third-party payloads, and the code that
+//     runs as the DOMAIN login — cannot reach control-plane tables (routes,
+//     credentials, audits, schedule markers). Adding domain-side tables to the
+//     coordinator does not weaken that; adding fixed_schedule_occurrences to
+//     the domain role would destroy it. The coordinator login is used only by
+//     the scheduler, the reconciler, and workerctl. Celery Beat, which this
+//     replaces, already spans both table sets under ONE identity.
 func coordinatorPosture() RolePosture {
 	return RolePosture{
 		RequiredTables: []TablePrivilege{
@@ -630,7 +680,14 @@ func coordinatorPosture() RolePosture {
 			{"worker_job_runs", false, true, false},
 			{"organizations", false, false, false},
 			{"sync_configurations", false, true, false},
-			{"worker_job_outbox", false, true, false},
+			{"worker_job_outbox", true, true, false},
+			{"remaining_metric_runs", true, false, false},
+			{"remaining_metric_partitions", true, false, false},
+			{"work_graph_execution_requests", true, false, false},
+		},
+		ColumnScoped: []ColumnPrivilege{
+			{"worker_job_completion_fences", "completion_key", "SELECT"},
+			{"worker_job_completion_fences", "completion_key", "INSERT"},
 		},
 	}
 }

--- a/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
+++ b/internal/storage/postgres/domain_grant_reconciliation_integration_test.go
@@ -277,7 +277,30 @@ func startGrantHarness(t *testing.T, ctx context.Context) (*pgxpool.Pool, string
 		"CREATE TABLE public.sync_run_units (id uuid PRIMARY KEY, state text NOT NULL)",
 		"CREATE TABLE public.sync_watermarks (id uuid PRIMARY KEY, state text NOT NULL)",
 		"CREATE TABLE public.sync_dispatch_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
-		"CREATE TABLE public.worker_job_outbox (id uuid PRIMARY KEY, state text NOT NULL)",
+		// Production column shape, not a stub: the fixed-schedule engine's
+		// handoff INSERT names every one of these columns, and an undefined
+		// column (42703) is raised during parse analysis BEFORE the permission
+		// check, which would silently stop the privilege assertions in
+		// fixed_engine_statement_privileges_integration_test.go from measuring
+		// anything.
+		`CREATE TABLE public.worker_job_outbox (
+			id uuid PRIMARY KEY,
+			dedupe_key text NOT NULL UNIQUE,
+			job_kind text NOT NULL,
+			contract_version integer NOT NULL,
+			args json NOT NULL,
+			payload_hash text NOT NULL,
+			queue text NOT NULL,
+			priority integer NOT NULL,
+			max_attempts integer NOT NULL,
+			scheduled_at timestamptz NOT NULL,
+			status text NOT NULL,
+			attempt_count integer NOT NULL,
+			next_attempt_at timestamptz NOT NULL,
+			prerequisite_completion_key text,
+			created_at timestamptz NOT NULL,
+			updated_at timestamptz NOT NULL
+		)`,
 		"CREATE TABLE public.billing_notifications (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.daily_metrics_partitions (id bigint PRIMARY KEY)",
 		"CREATE TABLE public.daily_metrics_runs (id bigint PRIMARY KEY)",
@@ -315,12 +338,25 @@ func startGrantHarness(t *testing.T, ctx context.Context) (*pgxpool.Pool, string
 			AllowDelete: table.AllowDelete,
 		})
 	}
+	// The column-scoped half is derived the same way, for the same reason: the
+	// coordinator posture gained worker_job_completion_fences.completion_key
+	// with CHAOS-3114, and a harness that granted only the table half would
+	// test a privilege set no real migration produces.
+	coordinatorColumnGrants := make([]riverstore.ColumnGrant, 0, len(coordinatorPosture.ColumnScoped))
+	for _, column := range coordinatorPosture.ColumnScoped {
+		coordinatorColumnGrants = append(coordinatorColumnGrants, riverstore.ColumnGrant{
+			TableName:  column.TableName,
+			ColumnName: column.ColumnName,
+			Privilege:  column.Privilege,
+		})
+	}
 	if _, err := riverstore.ApplyPinnedMigrations(ctx, admin, riverstore.MigrationOptions{
-		Schema:            grantSchema,
-		DomainRole:        grantDomainRole,
-		QueueRole:         grantQueueRole,
-		CoordinatorRole:   grantCoordinatorRole,
-		CoordinatorGrants: coordinatorGrants,
+		Schema:                  grantSchema,
+		DomainRole:              grantDomainRole,
+		QueueRole:               grantQueueRole,
+		CoordinatorRole:         grantCoordinatorRole,
+		CoordinatorGrants:       coordinatorGrants,
+		CoordinatorColumnGrants: coordinatorColumnGrants,
 	}); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/storage/postgres/fixed_engine_statement_privileges_integration_test.go
+++ b/internal/storage/postgres/fixed_engine_statement_privileges_integration_test.go
@@ -1,0 +1,350 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+// CHAOS-3114, second half: the fixed maintenance engine
+// (internal/scheduler/fixed) runs on the coordinator pool, so the coordinator
+// role must be able to execute Engine.runOccurrence's ENTIRE statement set in
+// one transaction — the coordinator-exclusive occurrence ledger together with
+// the domain rows its producers materialize.
+//
+// This file executes that statement set as the real coordinator role, with
+// grants applied by ApplyPinnedMigrations (startGrantHarness), for the same
+// reason coordinator_statement_privileges_integration_test.go exists: the
+// posture and the grant list share an author and a construction method, so
+// they cannot check each other. Only running the real statements as the real
+// restricted role can.
+//
+// Two traps this suite exists to catch, both of which a verb-only reading of
+// the code misses:
+//
+//   - `SELECT ... FOR UPDATE` needs UPDATE on the locked rows even though it
+//     writes nothing. The ledger's identity-verification read is exactly that.
+//   - `INSERT ... ON CONFLICT (col) DO NOTHING` needs SELECT on the arbiter
+//     column as well as INSERT, even though DO NOTHING reads nothing back.
+//     That is why the coordinator's worker_job_completion_fences posture is
+//     the SELECT+INSERT column pair and not INSERT alone; verified here, and
+//     empirically against a live server before it was declared.
+//
+// The statements are the production shapes with parameters inlined as
+// literals. Placeholder values are chosen so each statement reaches the
+// permission check: an undefined column or table raises 42703/42P01 during
+// parse analysis, BEFORE the ACL check, which would leave the assertion
+// measuring nothing.
+
+// fixedEngineStatement is one statement runOccurrence (or the window read
+// immediately preceding it) executes, the call site it comes from, and whether
+// the coordinator grant set BEFORE CHAOS-3114 could execute it.
+type fixedEngineStatement struct {
+	name string
+	site string
+	// privilege names what makes this statement need a grant, in the form the
+	// posture declares it.
+	privilege string
+	sql       string
+	// deniedBeforeThisChange marks the statements the pre-CHAOS-3114
+	// coordinator posture could not run. They are the whole justification for
+	// widening the posture, so the mutation test below demands each one fail
+	// with 42501 once those privileges are taken back.
+	deniedBeforeThisChange bool
+}
+
+func fixedEngineStatements() []fixedEngineStatement {
+	const occurrenceKey = "fixed-schedule:heartbeat:2026-07-25T00:00:00Z"
+	return []fixedEngineStatement{
+		{
+			name:      "engine reads the schedule's newest durable occurrence",
+			site:      "internal/scheduler/fixed/engine.go lastRecorded -> ledger.go selectLastOccurrenceSQL",
+			privilege: "fixed_schedule_occurrences SELECT",
+			sql: `SELECT scheduled_for, observed_at
+				FROM public.fixed_schedule_occurrences
+				WHERE schedule_id = 'heartbeat'
+				ORDER BY scheduled_for DESC
+				LIMIT 1`,
+		},
+		{
+			name:      "ledger claims the occurrence",
+			site:      "internal/scheduler/fixed/ledger.go Claim -> insertOccurrenceSQL",
+			privilege: "fixed_schedule_occurrences INSERT (+ SELECT for RETURNING)",
+			sql: `INSERT INTO public.fixed_schedule_occurrences (
+					occurrence_key, identity_version, schedule_id, target_kind,
+					scheduled_for, observed_at, status, handoff_count, created_at, updated_at
+				) VALUES ('` + occurrenceKey + `', 'v1', 'heartbeat', 'ops.heartbeat',
+					now(), now(), 'claimed', 0, now(), now())
+				ON CONFLICT DO NOTHING
+				RETURNING occurrence_key`,
+		},
+		{
+			// The trap. Claim's duplicate arm verifies the persisted identity
+			// under a row lock; FOR UPDATE requires UPDATE on the locked rows
+			// with nothing written, so a reader grepping for UPDATE statements
+			// against this table would conclude SELECT was enough.
+			name:      "ledger verifies a duplicate claim under a row lock",
+			site:      "internal/scheduler/fixed/ledger.go Claim -> selectOccurrenceSQL",
+			privilege: "fixed_schedule_occurrences UPDATE (implied by FOR UPDATE)",
+			sql: `SELECT identity_version, schedule_id, target_kind, scheduled_for
+				FROM public.fixed_schedule_occurrences
+				WHERE occurrence_key = '` + occurrenceKey + `'
+				FOR UPDATE`,
+		},
+		{
+			name:      "ledger records the producer outcome",
+			site:      "internal/scheduler/fixed/ledger.go Complete -> completeOccurrenceSQL",
+			privilege: "fixed_schedule_occurrences UPDATE",
+			sql: `UPDATE public.fixed_schedule_occurrences
+				SET status = 'materialized', handoff_count = 1, skip_reason = NULL,
+					completed_at = now(), updated_at = now()
+				WHERE occurrence_key = '` + occurrenceKey + `' AND status = 'claimed'`,
+		},
+		{
+			name:      "fan-out producer enumerates active organizations",
+			site:      "internal/scheduler/fixed/organizations.go ActiveOrganizationIDs",
+			privilege: "organizations SELECT",
+			sql: `SELECT id::text FROM public.organizations
+				WHERE is_active = TRUE ORDER BY id LIMIT 5001`,
+		},
+		{
+			name:                   "fan-out producer starts a remaining-metrics run",
+			site:                   "internal/jobs/metrics/remaining/postgres.go StartRunTx, reached from internal/scheduler/fixed/producers.go Produce",
+			privilege:              "remaining_metric_runs INSERT",
+			deniedBeforeThisChange: true,
+			sql: `INSERT INTO public.remaining_metric_runs
+					(id, org_id, family, generation, scope_key, generation_seed, status, created_at, updated_at)
+				VALUES (gen_random_uuid(), gen_random_uuid(), 'complexity',
+					'fixed-schedule:complexity_daily_fanout:2026-07-25T00:45:00Z', '2026-07-25', NULL,
+					'pending', now(), now())
+				ON CONFLICT DO NOTHING`,
+		},
+		{
+			// The replay arm: a run whose deterministic identity already exists
+			// is re-read and verified rather than duplicated.
+			name:                   "remaining-metrics replay re-reads the existing run",
+			site:                   "internal/jobs/metrics/remaining/postgres.go loadStartedRun",
+			privilege:              "remaining_metric_runs SELECT",
+			deniedBeforeThisChange: true,
+			sql: `SELECT id::text, org_id::text, family, generation, scope_key, status, generation_seed
+				FROM public.remaining_metric_runs WHERE id = gen_random_uuid()`,
+		},
+		{
+			name:                   "fan-out producer writes each run partition",
+			site:                   "internal/jobs/metrics/remaining/postgres.go StartRunTx",
+			privilege:              "remaining_metric_partitions INSERT",
+			deniedBeforeThisChange: true,
+			sql: `INSERT INTO public.remaining_metric_partitions
+					(id, run_id, ordinal, scope, status, attempt_count, created_at, updated_at)
+				VALUES (gen_random_uuid(), gen_random_uuid(), 1, '{}'::jsonb, 'pending', 0, now(), now())`,
+		},
+		{
+			name:                   "remaining-metrics replay verifies the persisted partitions",
+			site:                   "internal/jobs/metrics/remaining/postgres.go verifyStartedPartitions",
+			privilege:              "remaining_metric_partitions SELECT",
+			deniedBeforeThisChange: true,
+			sql: `SELECT id::text, ordinal, scope
+				FROM public.remaining_metric_partitions
+				WHERE run_id = gen_random_uuid() ORDER BY ordinal`,
+		},
+		{
+			name:                   "membership safety net starts its work-graph build",
+			site:                   "internal/jobs/workgraph/publisher.go WriteTx, reached from internal/scheduler/fixed/producers.go startGraphBuild",
+			privilege:              "work_graph_execution_requests INSERT",
+			deniedBeforeThisChange: true,
+			sql: `INSERT INTO public.work_graph_execution_requests (
+					id, org_id, kind, scope, model_ref, prompt_ref, llm_concurrency,
+					spend_limit_microunits, correlation_id, idempotency_key, state
+				) VALUES (gen_random_uuid(), gen_random_uuid(), 'build', '{}'::jsonb,
+					NULLIF('', ''), NULLIF('', ''), 1, 0, 'correlation', 'idempotency', 'pending')
+				ON CONFLICT (id) DO NOTHING`,
+		},
+		{
+			name:                   "work-graph replay re-reads the existing request",
+			site:                   "internal/jobs/workgraph/publisher.go WriteTx conflict arm",
+			privilege:              "work_graph_execution_requests SELECT",
+			deniedBeforeThisChange: true,
+			sql: `SELECT id::text, org_id::text, kind, scope::text, COALESCE(model_ref, ''),
+					COALESCE(prompt_ref, ''), llm_concurrency, spend_limit_microunits,
+					correlation_id, idempotency_key, state
+				FROM public.work_graph_execution_requests WHERE id = gen_random_uuid()`,
+		},
+		{
+			name:                   "engine publishes the job handoff",
+			site:                   "internal/joboutbox/producer.go publish, reached from internal/scheduler/fixed/engine.go OutboxPublisher.Publish",
+			privilege:              "worker_job_outbox INSERT",
+			deniedBeforeThisChange: true,
+			sql: `INSERT INTO public.worker_job_outbox (
+					id, dedupe_key, job_kind, contract_version, args, payload_hash,
+					queue, priority, max_attempts, scheduled_at, status, attempt_count,
+					next_attempt_at, prerequisite_completion_key, created_at, updated_at
+				) VALUES (gen_random_uuid(), 'heartbeat:2026-07-25T00:00:00Z', 'ops.heartbeat', 1,
+					'{}'::json, 'sha256:0', 'monitoring', 1, 3, now(),
+					'pending', 0, now(), NULLIF('', ''), now(), now())
+				ON CONFLICT (dedupe_key) DO NOTHING`,
+		},
+		{
+			name:      "handoff replay verifies the existing outbox row",
+			site:      "internal/joboutbox/producer.go publish conflict arm",
+			privilege: "worker_job_outbox SELECT",
+			sql: `SELECT job_kind, contract_version, payload_hash,
+					COALESCE(prerequisite_completion_key, '')
+				FROM public.worker_job_outbox WHERE dedupe_key = 'heartbeat:2026-07-25T00:00:00Z'`,
+		},
+		{
+			// The second trap, and the one the pre-3114 analysis got wrong: a
+			// grep across internal/scheduler/fixed for MarkCompletionTx finds
+			// nothing, because the reach is transitive through StartRunTx and
+			// WriteTx's already-succeeded replay arms.
+			name:                   "replayed predecessor mints its completion fence",
+			site:                   "internal/joboutbox/completion.go MarkCompletionTx, reached from remaining.StartRunTx and workgraph.WriteTx inside the occurrence transaction",
+			privilege:              "worker_job_completion_fences completion_key SELECT+INSERT (column-scoped; the arbiter needs SELECT)",
+			deniedBeforeThisChange: true,
+			sql: `INSERT INTO public.worker_job_completion_fences (completion_key)
+				VALUES ('work_graph_execution_request:11111111-1111-5111-8111-111111111111')
+				ON CONFLICT (completion_key) DO NOTHING`,
+		},
+	}
+}
+
+// preCHAOS3114CoordinatorRevocations restores the coordinator role to exactly
+// the grant set it held before this change: remaining_metric_runs,
+// remaining_metric_partitions and work_graph_execution_requests were absent
+// from coordinatorPosture entirely, worker_job_outbox was SELECT+UPDATE (the
+// UPDATE existing only for the jobroute LOCK), and worker_job_completion_fences
+// had no coordinator grant of any kind.
+func preCHAOS3114CoordinatorRevocations() []string {
+	return []string{
+		"REVOKE ALL PRIVILEGES ON TABLE public.remaining_metric_runs FROM " + grantCoordinatorRole,
+		"REVOKE ALL PRIVILEGES ON TABLE public.remaining_metric_partitions FROM " + grantCoordinatorRole,
+		"REVOKE ALL PRIVILEGES ON TABLE public.work_graph_execution_requests FROM " + grantCoordinatorRole,
+		"REVOKE INSERT ON TABLE public.worker_job_outbox FROM " + grantCoordinatorRole,
+		"REVOKE SELECT (completion_key), INSERT (completion_key) " +
+			"ON TABLE public.worker_job_completion_fences FROM " + grantCoordinatorRole,
+	}
+}
+
+// TestFixedEngineStatementsArePermittedToTheCoordinatorRole is the fix being
+// sufficient: every statement Engine.runOccurrence commits succeeds as the
+// coordinator role with the grants the MIGRATION emits, so repointing the
+// fixed loop at the coordinator pool needs no further widening of any role —
+// and specifically no grant of fixed_schedule_occurrences to the domain role.
+func TestFixedEngineStatementsArePermittedToTheCoordinatorRole(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	_, uri := startGrantHarness(t, ctx)
+
+	coordinator := connectAs(t, ctx, uri, grantCoordinatorRole, grantCoordinatorPass)
+	for _, statement := range fixedEngineStatements() {
+		if err := execInRolledBackTransaction(t, ctx, coordinator, statement.sql); err != nil {
+			t.Errorf("%s: denied to the coordinator role, so coordinatorPosture is missing %s\n  site: %s\n  statement: %s\n  error: %v",
+				statement.name, statement.privilege, statement.site, collapse(statement.sql), err)
+		}
+	}
+	// Readiness must accept the same role, or the statements succeeding would
+	// be worthless: the process would never start.
+	if err := CheckCoordinatorAuthorization(ctx, coordinator, grantCoordinatorRole, grantSchema); err != nil {
+		t.Fatalf("coordinator readiness rejected the grants the migration emitted for it: %v", err)
+	}
+}
+
+// TestFixedEngineStatementsAreDeniedByThePreCHAOS3114CoordinatorGrants is the
+// mutation check: it takes the coordinator role back to the grant set it held
+// before this change and demands that every statement this change was made for
+// fails with 42501. Without it, the test above could pass for reasons that
+// have nothing to do with the posture edit.
+//
+// It also pins the negative half of the boundary: the statements that were
+// ALREADY permitted (the occurrence ledger and the organization read) must
+// still succeed, so the revocation is proven to be targeted rather than a
+// blanket one that would make any statement fail.
+func TestFixedEngineStatementsAreDeniedByThePreCHAOS3114CoordinatorGrants(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	admin, uri := startGrantHarness(t, ctx)
+
+	coordinator := connectAs(t, ctx, uri, grantCoordinatorRole, grantCoordinatorPass)
+	for _, revocation := range preCHAOS3114CoordinatorRevocations() {
+		if _, err := admin.Exec(ctx, revocation); err != nil {
+			t.Fatalf("%s: %v", revocation, err)
+		}
+	}
+
+	mutated := 0
+	for _, statement := range fixedEngineStatements() {
+		err := execInRolledBackTransaction(t, ctx, coordinator, statement.sql)
+		if !statement.deniedBeforeThisChange {
+			if err != nil {
+				t.Errorf("%s: the pre-CHAOS-3114 revocation was not targeted; this statement needed no new privilege\n  site: %s\n  error: %v",
+					statement.name, statement.site, err)
+			}
+			continue
+		}
+		mutated++
+		if err == nil {
+			t.Errorf("%s: PERMITTED under the pre-CHAOS-3114 coordinator grants, so %s was not the privilege that unblocked it\n  site: %s\n  statement: %s",
+				statement.name, statement.privilege, statement.site, collapse(statement.sql))
+			continue
+		}
+		if !isInsufficientPrivilege(err) {
+			// A different SQLSTATE means the statement never reached the
+			// permission check, so this assertion would be measuring nothing.
+			t.Errorf("%s: expected insufficient_privilege (42501), got a different failure: %v\n  site: %s\n  statement: %s",
+				statement.name, err, statement.site, collapse(statement.sql))
+		}
+	}
+	if mutated == 0 {
+		t.Fatal("no statement was marked as denied before this change, so this test proves nothing")
+	}
+
+	// Readiness must fail too. The posture and the grants are one declaration,
+	// so a coordinator login carrying the old grant set is not merely unable to
+	// run the engine — it must refuse to report ready at all.
+	if err := CheckCoordinatorAuthorization(ctx, coordinator, grantCoordinatorRole, grantSchema); err == nil {
+		t.Error("coordinator readiness passed with the pre-CHAOS-3114 grant set, so it is not checking the posture it declares")
+	}
+}
+
+// TestFixedEngineCompletionFenceGrantStaysColumnScoped pins the reason the
+// coordinator's fence grant is a column pair rather than a table row:
+// completed_at is server-owned (DEFAULT statement_timestamp()), and a
+// table-wide grant would let the coordinator forge a fence that retention
+// never reaps. The engine only ever inserts completion_key.
+func TestFixedEngineCompletionFenceGrantStaysColumnScoped(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	_, uri := startGrantHarness(t, ctx)
+	coordinator := connectAs(t, ctx, uri, grantCoordinatorRole, grantCoordinatorPass)
+
+	for _, forbidden := range []struct {
+		name string
+		sql  string
+	}{
+		{
+			name: "forging the server-owned completion instant",
+			sql: `INSERT INTO public.worker_job_completion_fences (completion_key, completed_at)
+				VALUES ('remaining_metric_run:11111111-1111-5111-8111-111111111111', now())`,
+		},
+		{
+			name: "reading the server-owned completion instant",
+			sql:  "SELECT completed_at FROM public.worker_job_completion_fences",
+		},
+		{
+			name: "reaping a fence",
+			sql:  "DELETE FROM public.worker_job_completion_fences WHERE completion_key = 'x'",
+		},
+	} {
+		err := execInRolledBackTransaction(t, ctx, coordinator, forbidden.sql)
+		if err == nil {
+			t.Errorf("%s: PERMITTED to the coordinator role; the fence grant is not column-scoped\n  statement: %s",
+				forbidden.name, collapse(forbidden.sql))
+			continue
+		}
+		if !isInsufficientPrivilege(err) {
+			t.Errorf("%s: expected insufficient_privilege (42501), got: %v\n  statement: %s",
+				forbidden.name, err, collapse(forbidden.sql))
+		}
+	}
+}

--- a/internal/storage/postgres/role_posture_integration_test.go
+++ b/internal/storage/postgres/role_posture_integration_test.go
@@ -412,6 +412,15 @@ func TestDomainAndCoordinatorPosturesSatisfyAttributionAgainstTheRealManifest(t 
 	for _, column := range domain.ColumnScoped {
 		tableNames[column.TableName] = struct{}{}
 	}
+	// The coordinator's column-scoped half is unioned in too. Today it names
+	// the same relation the domain side does (worker_job_completion_fences,
+	// CHAOS-3114), so omitting it would pass by coincidence rather than by
+	// construction — and a future coordinator-only column-scoped relation would
+	// have failed this test with an undefined table instead of an attribution
+	// result.
+	for _, column := range coordinator.ColumnScoped {
+		tableNames[column.TableName] = struct{}{}
+	}
 
 	setup := []string{
 		"REVOKE TEMPORARY ON DATABASE worker_test FROM PUBLIC",

--- a/internal/storage/river/migrate.go
+++ b/internal/storage/river/migrate.go
@@ -46,6 +46,24 @@ type TableGrant struct {
 	AllowDelete bool
 }
 
+// ColumnGrant declares one column-scoped privilege for a runtime role on a
+// relation that is deliberately NOT granted table-wide. It exists for the same
+// reason postgres.ColumnPrivilege does: worker_job_completion_fences.
+// completed_at is server-owned, so a table-wide grant would let a runtime role
+// forge a fence retention never reaps. A relation may appear in ColumnGrants
+// or in TableGrants, never in both — a table-wide privilege on a
+// column-scoped relation is exactly what the readiness posture check refuses.
+//
+// Privilege is one of SELECT, INSERT, UPDATE, REFERENCES: the four PostgreSQL
+// column-grantable privileges. It is validated against that closed set rather
+// than sanitized, because a privilege keyword cannot be quoted as an
+// identifier.
+type ColumnGrant struct {
+	TableName  string
+	ColumnName string
+	Privilege  string
+}
+
 type MigrationOptions struct {
 	Schema     string
 	DomainRole string
@@ -57,7 +75,20 @@ type MigrationOptions struct {
 	// so an empty grant set is rejected rather than applied.
 	CoordinatorRole   string
 	CoordinatorGrants []TableGrant
-	Logger            *slog.Logger
+	// CoordinatorColumnGrants is the column-scoped half of the same injected
+	// posture. It is optional even when CoordinatorRole is set, because a
+	// posture with no column-scoped privileges is legitimate; what is NOT
+	// legitimate is supplying it without a role, which is rejected alongside
+	// CoordinatorGrants for the same reason.
+	CoordinatorColumnGrants []ColumnGrant
+	Logger                  *slog.Logger
+}
+
+// columnGrantablePrivileges is PostgreSQL's closed set of column-level
+// privileges. DELETE and TRUNCATE are not column-grantable at all, so a caller
+// asking for either is a construction bug rather than a tightening.
+var columnGrantablePrivileges = map[string]struct{}{
+	"SELECT": {}, "INSERT": {}, "UPDATE": {}, "REFERENCES": {},
 }
 
 type MigrationResult struct {
@@ -235,7 +266,7 @@ func ValidateMigrationOptions(options MigrationOptions) error {
 		// No coordinator provisioning requested. Grants supplied without a role
 		// are a caller bug, not a no-op: it would silently skip the grants the
 		// caller believed it was applying.
-		if len(options.CoordinatorGrants) != 0 {
+		if len(options.CoordinatorGrants) != 0 || len(options.CoordinatorColumnGrants) != 0 {
 			return ErrMigrationConfiguration
 		}
 		return nil
@@ -257,6 +288,27 @@ func ValidateMigrationOptions(options MigrationOptions) error {
 			return ErrMigrationConfiguration
 		}
 		seen[grant.TableName] = struct{}{}
+	}
+	seenColumns := make(map[string]struct{}, len(options.CoordinatorColumnGrants))
+	for _, grant := range options.CoordinatorColumnGrants {
+		if !validIdentifier(grant.TableName) || !validIdentifier(grant.ColumnName) {
+			return ErrMigrationConfiguration
+		}
+		if _, grantable := columnGrantablePrivileges[grant.Privilege]; !grantable {
+			return ErrMigrationConfiguration
+		}
+		// A relation granted table-wide AND column-scoped fails the readiness
+		// posture check outright (it forbids any table-wide privilege on a
+		// column-scoped relation), so applying both here would provision a
+		// role that can never report ready.
+		if _, tableWide := seen[grant.TableName]; tableWide {
+			return ErrMigrationConfiguration
+		}
+		key := grant.TableName + "." + grant.ColumnName + ":" + grant.Privilege
+		if _, duplicate := seenColumns[key]; duplicate {
+			return ErrMigrationConfiguration
+		}
+		seenColumns[key] = struct{}{}
 	}
 	return nil
 }
@@ -446,6 +498,22 @@ func coordinatorGrantStatements(options MigrationOptions) []string {
 		statements = append(statements,
 			"DO $$ BEGIN IF to_regclass('"+qualified+"') IS NOT NULL THEN GRANT "+
 				privileges+" ON TABLE "+pgx.Identifier{"public", grant.TableName}.Sanitize()+
+				" TO "+coordinatorRole+"; END IF; END $$",
+		)
+	}
+	// Column-scoped grants are emitted after the table-wide ones and never
+	// instead of them: the two sets are disjoint by construction
+	// (ValidateMigrationOptions rejects a relation appearing in both), so
+	// order carries no meaning beyond keeping the statement list stable and
+	// diffable. The privilege keyword is taken from the validated closed set
+	// above rather than sanitized, because it is a keyword and not an
+	// identifier; the table and column are sanitized identifiers.
+	for _, grant := range options.CoordinatorColumnGrants {
+		qualified := "public." + grant.TableName
+		statements = append(statements,
+			"DO $$ BEGIN IF to_regclass('"+qualified+"') IS NOT NULL THEN GRANT "+
+				grant.Privilege+" ("+pgx.Identifier{grant.ColumnName}.Sanitize()+
+				") ON TABLE "+pgx.Identifier{"public", grant.TableName}.Sanitize()+
 				" TO "+coordinatorRole+"; END IF; END $$",
 		)
 	}

--- a/internal/storage/river/migrate_test.go
+++ b/internal/storage/river/migrate_test.go
@@ -147,6 +147,18 @@ func TestMigrationOptionsRejectHalfConfiguredCoordinatorProvisioning(t *testing.
 	if err := ValidateMigrationOptions(base); err != nil {
 		t.Fatalf("ValidateMigrationOptions(no coordinator) error = %v", err)
 	}
+	// A column-scoped grant on a relation held table-wide by nobody else in
+	// this option set is the shape CHAOS-3114 introduced, and it must be
+	// accepted -- otherwise the coordinator posture could not be provisioned
+	// at all.
+	withColumns := valid
+	withColumns.CoordinatorColumnGrants = []ColumnGrant{
+		{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "SELECT"},
+		{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "INSERT"},
+	}
+	if err := ValidateMigrationOptions(withColumns); err != nil {
+		t.Fatalf("ValidateMigrationOptions(column-scoped coordinator) error = %v", err)
+	}
 
 	tests := []struct {
 		name   string
@@ -166,6 +178,48 @@ func TestMigrationOptionsRejectHalfConfiguredCoordinatorProvisioning(t *testing.
 			o.CoordinatorGrants = []TableGrant{
 				{TableName: "worker_job_routes", AllowUpdate: true},
 				{TableName: "worker_job_routes"},
+			}
+		}},
+		// The column-scoped half (CHAOS-3114) is validated with the same
+		// strictness. Every rejection below would otherwise provision a role
+		// whose readiness check can never pass, or a statement with an
+		// unsanitizable fragment in it.
+		{"column grants without role", func(o *MigrationOptions) {
+			o.CoordinatorRole = ""
+			o.CoordinatorGrants = nil
+			o.CoordinatorColumnGrants = []ColumnGrant{
+				{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "INSERT"},
+			}
+		}},
+		{"unsafe column identifier", func(o *MigrationOptions) {
+			o.CoordinatorColumnGrants = []ColumnGrant{
+				{TableName: "worker_job_completion_fences", ColumnName: "key\"; DROP TABLE x", Privilege: "INSERT"},
+			}
+		}},
+		{"privilege that is not column grantable", func(o *MigrationOptions) {
+			o.CoordinatorColumnGrants = []ColumnGrant{
+				{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "DELETE"},
+			}
+		}},
+		{"privilege carrying trailing SQL", func(o *MigrationOptions) {
+			o.CoordinatorColumnGrants = []ColumnGrant{
+				{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "INSERT, UPDATE"},
+			}
+		}},
+		{"duplicate column grant", func(o *MigrationOptions) {
+			o.CoordinatorColumnGrants = []ColumnGrant{
+				{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "INSERT"},
+				{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "INSERT"},
+			}
+		}},
+		// Table-wide AND column-scoped on one relation is the combination the
+		// readiness posture check refuses outright, so the migration refuses to
+		// create it.
+		{"relation granted both table-wide and column-scoped", func(o *MigrationOptions) {
+			o.CoordinatorGrants = append(o.CoordinatorGrants,
+				TableGrant{TableName: "worker_job_completion_fences"})
+			o.CoordinatorColumnGrants = []ColumnGrant{
+				{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "INSERT"},
 			}
 		}},
 	}
@@ -200,6 +254,10 @@ func TestCoordinatorGrantStatementsDeriveFromTheInjectedPosture(t *testing.T) {
 			{TableName: "worker_operator_audits", AllowInsert: true, AllowUpdate: true},
 			{TableName: "sync_run_post_dispatches"},
 		},
+		CoordinatorColumnGrants: []ColumnGrant{
+			{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "SELECT"},
+			{TableName: "worker_job_completion_fences", ColumnName: "completion_key", Privilege: "INSERT"},
+		},
 	})
 	joined := strings.Join(statements, "\n")
 
@@ -220,13 +278,25 @@ func TestCoordinatorGrantStatementsDeriveFromTheInjectedPosture(t *testing.T) {
 		"IF to_regclass('public.worker_job_routes') IS NOT NULL THEN",
 		// The coordinator is a public-schema control-plane role only.
 		"REVOKE ALL PRIVILEGES ON SCHEMA \"river\" FROM \"coordinator_runtime\"",
+		// Column-scoped grants carry the column, are sanitized as identifiers,
+		// and are guarded the same way (CHAOS-3114).
+		"GRANT SELECT (\"completion_key\") ON TABLE \"public\".\"worker_job_completion_fences\" TO \"coordinator_runtime\"",
+		"GRANT INSERT (\"completion_key\") ON TABLE \"public\".\"worker_job_completion_fences\" TO \"coordinator_runtime\"",
+		"IF to_regclass('public.worker_job_completion_fences') IS NOT NULL THEN",
 	} {
 		if !strings.Contains(joined, expected) {
 			t.Fatalf("coordinator grants missing %q:\n%s", expected, joined)
 		}
 	}
-	// No privilege the posture never allowed may appear.
-	for _, forbidden := range []string{"DELETE ON TABLE \"public\".\"worker_job_routes\"", "TRUNCATE", "TRIGGER", "REFERENCES"} {
+	// No privilege the posture never allowed may appear. The column-scoped
+	// relation must never acquire a table-wide privilege either: that is what
+	// would let the coordinator forge the server-owned completed_at, and the
+	// readiness check refuses it outright.
+	for _, forbidden := range []string{
+		"DELETE ON TABLE \"public\".\"worker_job_routes\"", "TRUNCATE", "TRIGGER", "REFERENCES",
+		"SELECT ON TABLE \"public\".\"worker_job_completion_fences\"",
+		"INSERT ON TABLE \"public\".\"worker_job_completion_fences\"",
+	} {
 		if strings.Contains(joined, forbidden) {
 			t.Fatalf("coordinator grants unexpectedly include %q:\n%s", forbidden, joined)
 		}


### PR DESCRIPTION
Closes the scheduler's half of the Option B role split. Two commits: the sync path, then the fixed-schedule engine.

## Why it was blocked

`dev-health-scheduler` built its sync-handoff repository, occurrence reconciler, and fixed-schedule engine on the **domain** pool, but the tables they touch are coordinator-exclusive per `domain_authorization.go`. Activating the binary as composed would have raised `42501` on the first real due schedule.

The handoff is the subtle case: `FOR UPDATE OF config, job SKIP LOCKED` requires UPDATE on the locked rows purely to take the lock, even though the statement writes nothing else. A DML-verb reading of that query says "SELECT" and is wrong.

## Why one role rather than splitting the transaction

`Engine.runOccurrence` commits the occurrence marker and the work it schedules in **one** transaction. That atomicity is what makes "occurrence recorded ⇒ work enqueued" exactly-once; splitting it outbox-style would let a fixed schedule double-run or silently skip.

The property the partition protects is that provider-sync workers — code handling third-party payloads — cannot reach control-plane tables. Those workers use the **domain** login. Widening **coordinator** leaves that intact; widening domain would destroy it. The coordinator login is used only by scheduler, reconciler, and workerctl.

And Celery Beat, the thing this replaces, already runs as one identity spanning both sets of tables. The cutover should not be blocked on a privilege model stricter than its predecessor.

## Traced grant set, not inferred

Derived by following the `pgx.Tx` across package boundaries from `runOccurrence` through every callee that receives it — `ledger.Claim/Complete`, all three producers, `remaining.PostgresStore.StartRunTx`, `workgraph.RequestWriter.WriteTx`, `joboutbox.Producer.publish`, `joboutbox.MarkCompletionTx`, `PostgresOrganizationLister` — plus the window's `lastRecorded` read.

| Table | Privileges |
|---|---|
| `fixed_schedule_occurrences` | SELECT, INSERT, **UPDATE** (`FOR UPDATE`) |
| `organizations` | SELECT |
| `remaining_metric_runs` | SELECT, INSERT — no UPDATE |
| `remaining_metric_partitions` | SELECT, INSERT — no UPDATE |
| `work_graph_execution_requests` | SELECT, INSERT — no UPDATE |
| `worker_job_outbox` | SELECT, INSERT |
| `worker_job_completion_fences` | column-scoped `completion_key` SELECT + INSERT |

Verified empirically before being declared: `ON CONFLICT (col) DO NOTHING` needs **SELECT on the arbiter column** as well as INSERT — `INSERT (completion_key)` alone raises 42501.

### It contradicted the documentation twice, and the trace won

- **`work_graph_execution_ledger` is NOT in the transaction.** `WriteTx` never touches it; the ledger belongs to the handler-side `Claim`. The doc listed it. It is deliberately absent from the posture.
- **`worker_job_completion_fences` IS reached.** `domainPosture()`'s comment dismissed the manifest's "possible 2nd reacher" flag as a false positive, on the strength of a grep across `internal/scheduler/fixed` for `MarkCompletionTx`. That grep was package-scoped; the reach is transitive via `StartRunTx` and `WriteTx`. The flag was real, and the manifest's own closure-typed-field sweep has the same boundary defect — recorded as its own correction round rather than patched one row at a time.

## Column scoping

`completed_at` is server-owned (`DEFAULT statement_timestamp()`) and the engine only ever inserts `completion_key`. A table-wide grant would let the coordinator forge a fence that retention never reaps.

That required real plumbing: `riverstore.ColumnGrant` + `MigrationOptions.CoordinatorColumnGrants`, emitted by `coordinatorGrantStatements` under the same `to_regclass` guard, with `dev-health-worker-migrate` deriving **both** halves from `CoordinatorPosture()` — one source, no hand-maintained second list.

Agreement is enforced rather than assumed: `ValidateMigrationOptions` rejects a relation appearing in both the table-wide and column-scoped sets, because `rolePostureQuery` forbids any table-wide privilege on a column-scoped relation. Provisioning both would mint a role that can never report ready.

## Proof

`internal/storage/postgres/fixed_engine_statement_privileges_integration_test.go`, against real PostgreSQL with grants applied by `ApplyPinnedMigrations` rather than by the test:

- 14 real statement shapes permitted to the coordinator role; readiness passes.
- **Mutation:** restore the pre-3114 grant set → all **8** newly-unblocked statements fail `42501`, while the 6 already-permitted ones still succeed (so the revocation is proven targeted, not blanket), and readiness closes.
- The fence grant stays column-scoped: forging `completed_at`, reading it, and deleting a fence are all denied.

## Budget

Unchanged at **93/100** — 15 reserved + 25×2 PgBouncer + 18 direct queue-control + 10 direct coordinator (reconciler 2×2, scheduler 2×2, workerctl 1×2). Repointing moves demand between already-budgeted pools. Within the scheduler's `coordinator_max_connections: 2`, both loops are single-transaction-at-a-time on one goroutine each, so peak concurrent demand is exactly 2.

## Also in here

`coordinatorPolicyParity` is **deleted**, not left false. It was a bare bool with no test, checklist, or document defining what "the coordinator behaves equivalently to the Python one" means, so it blocked indefinitely while implying a rigour that did not exist.

## Still dormant

`goOwnsMarkers` stays **false**. No privilege precondition remains — the sole blocker is now the CUT-09/CUT-10 occurrence materializer stub (`schedulersync.NewUnavailableMaterializer`). Flipping it today would durably record occurrences Go cannot materialize. The doc comment says exactly that.

## Gate

`GATE PASSED` (9038 passed, 62 skipped). Full `-tags integration` suite for `internal/storage/{postgres,river}` green; `go build ./... && go test ./...` clean.