### PR TITLE
fix(test): repair the two integration guards the River cutover invalidated

### DIFF
--- a/internal/joboperator/postgres_integration_test.go
+++ b/internal/joboperator/postgres_integration_test.go
@@ -38,7 +38,7 @@ type allowIntegrationDomainGuard struct{}
 func (allowIntegrationDomainGuard) Check(context.Context, Action, JobSummary) error { return nil }
 
 // operatorIntegrationPolicyRegistry changes only the fixture's insertion
-// policy. The operator backend continues to use the checked-in, Celery-routed
+// policy. The operator backend continues to use the checked-in, unmodified
 // registry so this test cannot weaken or misrepresent production routing.
 type operatorIntegrationPolicyRegistry struct {
 	registry *jobruntime.Registry
@@ -117,9 +117,14 @@ func TestPostgresOperatorAuthenticationBackendAndAudit(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// CHAOS-3033 (PR #1292, ee2141eca) moved system.heartbeat (like every
+	// checked-in kind except sync.provider_unit) to state go_default / route
+	// river. This is a drift tripwire on the *current* checked-in policy, not
+	// the pre-cutover celery baseline: it still fails loudly if a future edit
+	// to migration-state.json silently changes heartbeat's routing.
 	heartbeat, ok := registry.Descriptor(jobcontract.KindHeartbeat)
-	if !ok || heartbeat.Executable() {
-		t.Fatalf("checked-in heartbeat policy = %#v, want non-executable", heartbeat)
+	if !ok || !heartbeat.Executable() || heartbeat.MigrationState != "go_default" || heartbeat.Route != "river" {
+		t.Fatalf("checked-in heartbeat policy = %#v, want go_default/river executable", heartbeat)
 	}
 	now := time.Now().UTC().Truncate(time.Microsecond)
 	jobID := insertOperatorIntegrationJob(

--- a/internal/joboutbox/relay_integration_test.go
+++ b/internal/joboutbox/relay_integration_test.go
@@ -81,6 +81,12 @@ func TestGenericOutboxLiveFailureInjectionMatrix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	// CHAOS-3033 (PR #1292, ee2141eca) moved every checked-in job kind except
+	// sync.provider_unit to state go_default / route river. provider_unit
+	// remains the sole canary at river_canary. This loop is a drift tripwire:
+	// it asserts the *current* checked-in policy shape, not the pre-cutover
+	// all-celery baseline, so a future accidental state/route edit in
+	// migration-state.json still fails loudly here.
 	for _, descriptor := range productionRegistry.Descriptors() {
 		if descriptor.Kind == jobcontract.KindSyncProviderUnit {
 			if descriptor.Route != "river_canary" || descriptor.MigrationState != "canary" || descriptor.RollbackRoute != "celery" || !descriptor.Executable() {
@@ -88,8 +94,8 @@ func TestGenericOutboxLiveFailureInjectionMatrix(t *testing.T) {
 			}
 			continue
 		}
-		if descriptor.Route != "celery" || descriptor.Executable() {
-			t.Fatalf("checked-in production route became executable: %#v", descriptor)
+		if descriptor.Route != "river" || descriptor.MigrationState != "go_default" || descriptor.RollbackRoute != "celery" || !descriptor.Executable() {
+			t.Fatalf("checked-in production route drifted from post-cutover go_default/river policy: %#v", descriptor)
 		}
 	}
 	registry := integrationRouteRegistry(productionRegistry, map[string]string{
@@ -332,7 +338,7 @@ INSERT INTO public.worker_job_completion_fences (completion_key) VALUES ($1)`, c
 		assertErrorEvidence(t, ctx, adminPool, "contract_rejected", "stored job contract was rejected")
 	})
 
-	t.Run("all-celery production policy defers known rows but terminalizes unknown rows", func(t *testing.T) {
+	t.Run("celery-deferred known kind defers rows but terminalizes unknown rows", func(t *testing.T) {
 		resetOutboxTables(t, ctx, adminPool)
 		now := time.Now().UTC().Truncate(time.Microsecond)
 		deferred := normalSeed(85, now)
@@ -341,11 +347,18 @@ INSERT INTO public.worker_job_completion_fences (completion_key) VALUES ($1)`, c
 		unknown.Kind = "secret.unknown"
 		seedOutbox(t, ctx, adminPool, unknown)
 
-		productionInserter, err := NewRiverInserter(queuePool, "river", productionRegistry)
+		// Post-CHAOS-3033 the checked-in registry has zero celery-routed
+		// known kinds (see the drift tripwire above), so exercise "deferred
+		// known kind stays pending" against an explicit celery override
+		// instead of an incidentally-still-celery production kind.
+		deferredRegistry := integrationRouteRegistry(productionRegistry, map[string]string{
+			jobcontract.KindHeartbeat: "celery",
+		})
+		deferredInserter, err := NewRiverInserter(queuePool, "river", deferredRegistry)
 		if err != nil {
 			t.Fatal(err)
 		}
-		relay, err := NewRelay(repository, productionInserter, DefaultRelayConfig())
+		relay, err := NewRelay(repository, deferredInserter, DefaultRelayConfig())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -364,11 +377,17 @@ INSERT INTO public.worker_job_completion_fences (completion_key) VALUES ($1)`, c
 		seedOutbox(t, ctx, adminPool, deferred)
 		claim := claimOne(t, ctx, repository, now, time.Second)
 
-		productionInserter, err := NewRiverInserter(queuePool, "river", productionRegistry)
+		// Same rationale as above: force this known kind back onto celery so
+		// the relay's claim-exclusion behavior for a deferred kind is still
+		// exercised even though production no longer defers any kind itself.
+		deferredRegistry := integrationRouteRegistry(productionRegistry, map[string]string{
+			jobcontract.KindHeartbeat: "celery",
+		})
+		deferredInserter, err := NewRiverInserter(queuePool, "river", deferredRegistry)
 		if err != nil {
 			t.Fatal(err)
 		}
-		relay, err := NewRelay(repository, productionInserter, DefaultRelayConfig())
+		relay, err := NewRelay(repository, deferredInserter, DefaultRelayConfig())
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -430,8 +449,12 @@ INSERT INTO public.worker_job_completion_fences (completion_key) VALUES ($1)`, c
 		unknown.Kind = "secret.unknown"
 		seedOutbox(t, ctx, adminPool, unknown)
 
+		// Post-CHAOS-3033 retention_cleanup is already go_default/river in
+		// production, so it must be forced back onto celery here for the
+		// "known but deferred" arm of this scenario to still exist.
 		mixedRegistry := integrationRouteRegistry(productionRegistry, map[string]string{
-			jobcontract.KindHeartbeat: "river",
+			jobcontract.KindHeartbeat:        "river",
+			jobcontract.KindRetentionCleanup: "celery",
 		})
 		mixedInserter, err := NewRiverInserter(queuePool, "river", mixedRegistry)
 		if err != nil {
@@ -714,6 +737,8 @@ func integrationRouteRegistry(
 				descriptors[index].MigrationState = "canary"
 			case "river":
 				descriptors[index].MigrationState = "go_default"
+			case "celery":
+				descriptors[index].MigrationState = "go_implemented"
 			}
 		}
 		byKind[descriptors[index].Kind] = descriptors[index]


### PR DESCRIPTION
`go-storage-integration` is red on `main` for two tests unrelated to the 20-minute deadlock in #1300. Both fail fast:

```
relay_integration_test.go:92: checked-in production route became executable:
  jobruntime.Descriptor{Kind:"investment.chunk", ..., MigrationState:"go_default", Route:"river", RollbackRoute:"celery"}

postgres_integration_test.go:122: checked-in heartbeat policy =
  jobruntime.Descriptor{Kind:"system.heartbeat", ..., MigrationState:"go_default", Route:"river", RollbackRoute:"celery"}, want non-executable
```

## Cause — stale fixture, not a cutover defect

#1292 (ee2141eca) moved 23 of 24 job kinds to `state: go_default` / `route: river`, leaving only `sync.provider_unit` on `canary`/`river_canary`. Both tests encoded "every checked-in kind except provider_unit sits on celery and is therefore non-executable" — true before the cutover, false by design after it.

Checked against the unedited `contracts/jobs/v1/migration-state.json`. **No production defect found in ee2141eca**; the guards were firing on a correct registry.

## The fix keeps the guards guarding

The failure mode to avoid here was updating a literal to the new route, which makes both tests green while quietly deleting what they protect. Two different problems needed two different treatments:

**Drift tripwires** — the top-level loop in `relay_integration_test.go` and the heartbeat assertion in `postgres_integration_test.go` exist to notice when checked-in policy changes. Their literals now name the real current policy (`river` / `go_default` / `celery` rollback / executable), so they resume tripping on the *next* unintended change. Both still run the service under test against the raw, unmodified registry.

**Behavioral subtests** — three subtests ("celery-deferred known kind…", "celery rollback never reclaims…", "relay leaves known celery rows pending…") were exercising the relay's deferred path, which `relay.go`'s `deferredRelayKinds()`/`claimDueExcept()` key purely on `Route == "celery"`. They had been relying on a production kind that *happened* to still be celery. Production now has zero such kinds, so the behavior they test would silently stop being tested.

These now override the route to `celery` explicitly via the existing `integrationRouteRegistry` helper. That decouples the behavior under test from whatever the contract currently promotes — the deferred-relay path stays covered no matter how the migration state moves next.

## Swept for the same staleness elsewhere

`cmd/dev-health-worker/reports_test.go`, `dependencies_test.go`, and `internal/joboperator/service_test.go` were already made cutover-aware in earlier work (`promotedContractRoot` / `demotedContractRoot` / `executableRegistry` helpers). No changes needed.

## Verification

Both tests pass with `-tags=integration` against real Docker, all subtests. `go build ./... && go test ./...` clean.

## Flagged, not fixed here

`go test -tags=integration ./...` reveals a **pre-existing compile break**: `cmd/dev-health-workerctl/main_integration_test.go` does not build because `newJobRouteController`'s signature drifted in #1291, before the commit this PR targets. An integration test that does not compile is not being run at all, and the packaging is such that nothing surfaced it. Untouched here; being handled separately.

## Gate

All stages pass except the two `tests/docs/*` failures caused by `ci/local_validate.sh` not installing `requirements-docs.txt` — a gate defect fixed in #1301, not a code fault.