### PR TITLE
ci: make the integration-test allowlist opt-out, and fix the workerctl test it was hiding

### DIFF
--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -15,7 +15,7 @@ DEV_HEALTH_GO_BUILD_TEMP_ROOT=""
 
 usage() {
   cat <<'EOF'
-Usage: ci/check_go.sh [fmt|vet|test|race|build|contract|integration|fast|all]
+Usage: ci/check_go.sh [fmt|vet|test|race|build|contract|integration-vet|integration-coverage|integration|fast|all]
 
   fmt    Check gofmt without modifying files.
   vet    Run go vet ./... in every Go module.
@@ -25,10 +25,25 @@ Usage: ci/check_go.sh [fmt|vet|test|race|build|contract|integration|fast|all]
   contract
          Validate the job contract tree and, when DEV_HEALTH_CONTRACT_BASE is
          set, reject breaking in-place changes against that directory.
+  integration-vet
+         Compile-check every package under the integration build tag, across
+         the WHOLE tree. No Docker required. This is what would have caught a
+         compile break in an integration-tagged file the day it happened,
+         instead of it sitting broken and silently unrun until someone passed
+         -tags=integration by hand.
+  integration-coverage
+         Discover every integration-tagged package and print the run/skip
+         plan (see INTEGRATION_DENYLIST in this script). No Docker required.
+         Fails if the denylist names a package discovery does not find, or if
+         discovery finds nothing at all.
   integration
-         Run the isolated, integration-tagged testcontainers storage suite.
-  fast   Run fmt, vet, test, build, and contract checks.
-  all    Run fmt, vet, test, race, build, and contract checks (default).
+         Discover and run EVERY integration-tagged package's suite against
+         real containers, except the (small, justified) INTEGRATION_DENYLIST.
+         Inclusion is the default; exclusion is the explicit, loud exception.
+  fast   Run fmt, vet, test, build, contract, integration-vet, and
+         integration-coverage checks.
+  all    Run fmt, vet, test, race, build, contract, integration-vet, and
+         integration-coverage checks (default).
 EOF
 }
 
@@ -210,22 +225,160 @@ check_contract() {
   fi
 }
 
+# INTEGRATION_DENYLIST is the ONLY place an integration-tagged package may be
+# excluded from check_integration. It used to be the other way around: an
+# opt-IN allowlist that ran only the packages someone remembered to add. That
+# shape silently excluded internal/providerfoundation's ClickHouse/Valkey
+# suite, cmd/dev-health-workerctl's suite (which additionally did not even
+# compile — see main_integration_test.go), and was structurally guaranteed to
+# do it again to the next package anyone adds, because "not on the list" and
+# "not written yet" look identical from the gate's point of view.
+#
+# The default for every integration-tagged package is now "runs in CI".
+# Every key here needs a real, load-bearing reason -- "haven't gotten to it"
+# or "it currently fails" are NOT valid reasons; a failing package belongs in
+# the run set, failing loudly, not hidden here. Legitimate reasons look like
+# "needs a live vendor credential CI does not provision."
+declare -A INTEGRATION_DENYLIST=()
+
+# discover_integration_packages populates INTEGRATION_PACKAGES_BY_MODULE
+# (module_dir -> newline-separated list of module-relative "./pkg/dir"
+# entries) with every package that has at least one tracked or untracked,
+# non-vendor *_test.go file whose leading build-constraint comment names the
+# "integration" tag. This is a repo-wide scan for the literal constraint
+# every integration suite in this tree uses today
+# (`//go:build integration`), checked via git's own file listing so it
+# honours the same tracked/untracked/exclude-standard rules as the rest of
+# this script -- not `find`, and not a hand-maintained list.
+discover_integration_packages() {
+  local module_dir go_file dir
+  declare -gA INTEGRATION_PACKAGES_BY_MODULE=()
+
+  for module_dir in "${MODULE_DIRS[@]}"; do
+    local -a found=()
+    while IFS= read -r -d '' go_file; do
+      [ -f "${ROOT}/${module_dir}/${go_file}" ] || continue
+      case "${go_file}" in
+        vendor/*|*/vendor/*) continue ;;
+      esac
+      # Matches `//go:build integration` and combined constraints such as
+      # `//go:build integration && !windows`; go:build lines are always a
+      # single line, so a plain grep for the tag token on that line is exact
+      # for this repository's usage and needs no build-constraint parser.
+      if grep -qE '^//go:build.*(^|[^[:alnum:]_])integration([^[:alnum:]_]|$)' \
+        "${ROOT}/${module_dir}/${go_file}"; then
+        dir="$(dirname -- "${go_file}")"
+        found+=("./${dir}")
+      fi
+    done < <(
+      git -C "${ROOT}/${module_dir}" ls-files --cached --others --exclude-standard -z -- '*_test.go'
+    )
+    if [ "${#found[@]}" -gt 0 ]; then
+      INTEGRATION_PACKAGES_BY_MODULE["${module_dir}"]="$(printf '%s\n' "${found[@]}" | sort -u)"
+    fi
+  done
+}
+
+# integration_denylist_reason prints the reason for "module_dir/pkg" if it is
+# denylisted, or nothing (and a false exit) if it is not.
+integration_denylist_reason() {
+  local key="$1"
+  if [ -n "${INTEGRATION_DENYLIST[${key}]+set}" ]; then
+    printf '%s' "${INTEGRATION_DENYLIST[${key}]}"
+    return 0
+  fi
+  return 1
+}
+
+# check_integration_coverage is the guard: it recomputes discovery
+# independently of check_integration's own run, prints the full plan (run vs.
+# skip, with every skip's reason), and fails loudly if the denylist names a
+# package discovery does not find (a stale or misspelled entry -- the
+# opt-out list drifting unnoticed is exactly the failure mode this replaces,
+# just on the small side of the ledger instead of the large one). It needs no
+# Docker and belongs in the fast path.
+check_integration_coverage() {
+  discover_integration_packages
+  local module_dir pkg key reason
+  local -a denylist_seen=()
+  local total=0
+
+  printf 'integration coverage: discovered packages (module: package)\n'
+  for module_dir in "${MODULE_DIRS[@]}"; do
+    [ -n "${INTEGRATION_PACKAGES_BY_MODULE[${module_dir}]:-}" ] || continue
+    while IFS= read -r pkg; do
+      [ -n "${pkg}" ] || continue
+      total=$((total + 1))
+      key="${module_dir}/${pkg#./}"
+      key="${key#./}"
+      if reason="$(integration_denylist_reason "${key}")"; then
+        denylist_seen+=("${key}")
+        printf '  SKIP %s: %s\n' "${key}" "${reason}"
+      else
+        printf '  RUN  %s\n' "${key}"
+      fi
+    done <<<"${INTEGRATION_PACKAGES_BY_MODULE[${module_dir}]}"
+  done
+
+  if [ "${total}" -eq 0 ]; then
+    die "integration coverage: discovered zero integration-tagged packages -- the discovery mechanism itself is almost certainly broken, not a genuinely test-free tree"
+  fi
+
+  local denylisted_key covered
+  for denylisted_key in "${!INTEGRATION_DENYLIST[@]}"; do
+    covered=0
+    for key in "${denylist_seen[@]}"; do
+      [ "${key}" = "${denylisted_key}" ] && covered=1 && break
+    done
+    if [ "${covered}" -ne 1 ]; then
+      die "INTEGRATION_DENYLIST names '${denylisted_key}', which discover_integration_packages did not find -- stale or misspelled denylist entry"
+    fi
+  done
+
+  printf 'integration coverage: %d package(s) discovered, %d denylisted, %d will run\n' \
+    "${total}" "${#denylist_seen[@]}" "$((total - ${#denylist_seen[@]}))"
+}
+
 check_integration() {
-	printf 'go test integration: PostgreSQL roles, River, outbox, operator, reports, retention, provider sync\n'
-	(
-		cd "${ROOT}"
-		# This list is explicit rather than ./... so the gate never silently
-		# starts (or stops) exercising containers. A package holding
-		# integration-tagged tests but missing from this list is silently
-		# skipped — add every new integration suite here in the same change
-		# that adds its first integration test.
-		GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=20m \
-			./internal/testsupport/containers ./internal/storage/postgres ./internal/storage/river \
-			./internal/joboutbox ./internal/joboperator ./internal/syncreconciler ./internal/syncroute \
-			./internal/scheduler/sync ./internal/scheduler/fixed ./internal/syncdispatchruntime \
-			./internal/jobs/report ./internal/jobs/system ./internal/jobs/pagerduty \
-			./internal/providersync ./internal/providerfoundation
-	)
+  check_integration_coverage
+  local module_dir pkg key reason
+  local -a run_pkgs=()
+
+  for module_dir in "${MODULE_DIRS[@]}"; do
+    [ -n "${INTEGRATION_PACKAGES_BY_MODULE[${module_dir}]:-}" ] || continue
+    run_pkgs=()
+    while IFS= read -r pkg; do
+      [ -n "${pkg}" ] || continue
+      key="${module_dir}/${pkg#./}"
+      key="${key#./}"
+      if reason="$(integration_denylist_reason "${key}")"; then
+        continue
+      fi
+      run_pkgs+=("${pkg}")
+    done <<<"${INTEGRATION_PACKAGES_BY_MODULE[${module_dir}]}"
+    [ "${#run_pkgs[@]}" -gt 0 ] || continue
+
+    printf 'go test integration: %s -> %s\n' "${module_dir}" "${run_pkgs[*]}"
+    (
+      cd "${ROOT}/${module_dir}"
+      GOWORK=off go test -mod=readonly -tags=integration -count=1 -timeout=30m "${run_pkgs[@]}"
+    )
+  done
+}
+
+# check_integration_vet compiles every package under the integration tag,
+# across the WHOLE tree, in every Go module, unconditionally -- no discovery,
+# no denylist. check_integration_coverage's discovery answers "which packages
+# does the Docker-backed run cover"; this answers the orthogonal question "does
+# everything under the tag even compile", which matters independently: a
+# package can compile and still be (legitimately or not) denylisted, or it can
+# be in the run set and simply not build, the way
+# cmd/dev-health-workerctl/main_integration_test.go didn't after its
+# constructor's signature changed underneath it. `go vet -tags=integration
+# ./...` needs no Docker and runs in seconds, so it belongs in the fast path
+# rather than the Docker-backed integration job.
+check_integration_vet() {
+  run_in_modules "go vet -tags=integration" go vet -mod=readonly -tags=integration ./...
 }
 
 discover_modules
@@ -250,6 +403,12 @@ case "${1:-all}" in
   contract)
     check_contract
     ;;
+  integration-vet)
+    check_integration_vet
+    ;;
+  integration-coverage)
+    check_integration_coverage
+    ;;
   integration)
     check_integration
     ;;
@@ -259,6 +418,8 @@ case "${1:-all}" in
     check_test
     check_build
     check_contract
+    check_integration_vet
+    check_integration_coverage
     ;;
   all)
     check_format
@@ -267,6 +428,8 @@ case "${1:-all}" in
     check_race
     check_build
     check_contract
+    check_integration_vet
+    check_integration_coverage
     ;;
   -h|--help|help)
     usage

--- a/cmd/dev-health-workerctl/main_integration_test.go
+++ b/cmd/dev-health-workerctl/main_integration_test.go
@@ -5,61 +5,173 @@ package main
 import (
 	"context"
 	"errors"
+	"net/url"
 	"testing"
 	"time"
 
 	"github.com/full-chaos/dev-health-ops/internal/jobroute"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+	postgresstore "github.com/full-chaos/dev-health-ops/internal/storage/postgres"
+	riverstore "github.com/full-chaos/dev-health-ops/internal/storage/river"
 	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
-func TestNewJobRouteControllerWiresCelerySyncProviderQuiescence(t *testing.T) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
-	defer cancel()
+// newJobRouteController's three pools are not interchangeable in production
+// (see its doc comment in main.go): coordinatorPool is coordinator-exclusive
+// for worker_job_routes/worker_job_outbox/worker_job_runs, domainPool is the
+// least-privilege role that can still read sync_run_units, and queuePool only
+// ever touches the River schema. A test that reused one superuser pool for
+// all three arguments would compile and even pass, but it would prove nothing
+// about the CHAOS-3113 split this constructor exists to encode -- the domain
+// role genuinely cannot run the coordinator's statements in production (that
+// was the bug), so a test pool that CAN run them is asserting something
+// production does not do. This harness therefore provisions three real,
+// least-privilege logins the same way
+// internal/storage/postgres/domain_grant_reconciliation_integration_test.go
+// and coordinator_statement_privileges_integration_test.go do, and derives
+// the coordinator grants from postgres.CoordinatorPosture() -- the single
+// authority CheckCoordinatorAuthorization itself asserts against -- rather
+// than a hand-copied list that could drift from it.
+const (
+	workerctlDomainRole      = "workerctl_domain_runtime"
+	workerctlQueueRole       = "workerctl_queue_runtime"
+	workerctlCoordinatorRole = "workerctl_coordinator_runtime"
+	workerctlDomainPass      = "workerctl_domain_password"
+	workerctlQueuePass       = "workerctl_queue_password"
+	workerctlCoordinatorPass = "workerctl_coordinator_password"
+	workerctlSchema          = "river"
+	workerctlDatabase        = "worker_test"
+)
+
+// startJobRouteHarness starts a real PostgreSQL container, creates the three
+// least-privilege runtime roles the production binary authenticates as, and
+// applies the real pinned River migration (including the real coordinator
+// grants derived from postgres.CoordinatorPosture()) against it. It returns
+// the admin pool (for seeding fixtures) and the instance URI (for connecting
+// as each restricted role).
+func startJobRouteHarness(t *testing.T, ctx context.Context) (*pgxpool.Pool, string) {
+	t.Helper()
 	instance, err := containers.StartPostgres(ctx)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer func() {
+	t.Cleanup(func() {
 		closeCtx, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer closeCancel()
 		if err := instance.Close(closeCtx); err != nil {
 			t.Errorf("close PostgreSQL: %v", err)
 		}
-	}()
-	pool, err := pgxpool.New(ctx, instance.URI)
+	})
+	admin, err := pgxpool.New(ctx, instance.URI)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer pool.Close()
-	if _, err := pool.Exec(ctx, `
-		CREATE SCHEMA river;
-		CREATE TABLE river.river_job (kind text NOT NULL, state text NOT NULL);
-		CREATE TABLE public.worker_job_routes (
+	t.Cleanup(admin.Close)
+
+	setup := []string{
+		"CREATE ROLE " + workerctlDomainRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + workerctlDomainPass + "'",
+		"CREATE ROLE " + workerctlQueueRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + workerctlQueuePass + "'",
+		"CREATE ROLE " + workerctlCoordinatorRole + " LOGIN NOSUPERUSER NOCREATEDB NOCREATEROLE NOREPLICATION NOBYPASSRLS PASSWORD '" + workerctlCoordinatorPass + "'",
+		"GRANT CONNECT ON DATABASE " + workerctlDatabase + " TO " + workerctlDomainRole + ", " + workerctlQueueRole + ", " + workerctlCoordinatorRole,
+		"REVOKE TEMPORARY ON DATABASE " + workerctlDatabase + " FROM PUBLIC",
+		"REVOKE CREATE ON SCHEMA public FROM PUBLIC",
+		// Real production shapes: the three worker_job_* tables newJobRouteController's
+		// coordinator pool touches (control.go), and sync_run_units, which the
+		// domain pool's Celery quiescer reads (quiescer.go).
+		`CREATE TABLE public.worker_job_routes (
 			job_kind text PRIMARY KEY, transport text NOT NULL, paused boolean NOT NULL,
 			generation bigint NOT NULL, updated_at timestamptz NOT NULL
-		);
-		CREATE TABLE public.worker_job_outbox (
+		)`,
+		`CREATE TABLE public.worker_job_outbox (
 			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
-		);
-		CREATE TABLE public.worker_job_runs (
+		)`,
+		`CREATE TABLE public.worker_job_runs (
 			id uuid PRIMARY KEY, job_kind text NOT NULL, status text NOT NULL
-		);
-		CREATE TABLE public.sync_run_units (
+		)`,
+		`CREATE TABLE public.sync_run_units (
 			id uuid PRIMARY KEY, provider text NOT NULL, dataset_key text NOT NULL,
 			status text NOT NULL
-		);
+		)`,
+	}
+	for _, statement := range setup {
+		if _, err := admin.Exec(ctx, statement); err != nil {
+			t.Fatalf("%s: %v", statement, err)
+		}
+	}
+
+	// Derived from CoordinatorPosture(), not restated: this is the same
+	// authority coordinatorGrantStatements uses in the real one-shot
+	// migration command and CheckCoordinatorAuthorization asserts readiness
+	// against. Every table in the posture that this harness never created
+	// (internal_service_credentials, scheduled_jobs, ...) is skipped by
+	// migrate.go's to_regclass guard rather than failing.
+	posture := postgresstore.CoordinatorPosture()
+	coordinatorGrants := make([]riverstore.TableGrant, 0, len(posture.RequiredTables))
+	for _, table := range posture.RequiredTables {
+		coordinatorGrants = append(coordinatorGrants, riverstore.TableGrant{
+			TableName:   table.TableName,
+			AllowInsert: table.AllowInsert,
+			AllowUpdate: table.AllowUpdate,
+			AllowDelete: table.AllowDelete,
+		})
+	}
+	if _, err := riverstore.ApplyPinnedMigrations(ctx, admin, riverstore.MigrationOptions{
+		Schema:            workerctlSchema,
+		DomainRole:        workerctlDomainRole,
+		QueueRole:         workerctlQueueRole,
+		CoordinatorRole:   workerctlCoordinatorRole,
+		CoordinatorGrants: coordinatorGrants,
+	}); err != nil {
+		t.Fatal(err)
+	}
+	return admin, instance.URI
+}
+
+// connectAsRole opens a pool authenticated as one of the harness's restricted
+// logins, mirroring internal/storage/postgres's connectAs test helper.
+func connectAsRole(t *testing.T, ctx context.Context, rawURI, role, password string) *pgxpool.Pool {
+	t.Helper()
+	parsed, err := url.Parse(rawURI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	parsed.User = url.UserPassword(role, password)
+	pool, err := pgxpool.New(ctx, parsed.String())
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	return pool
+}
+
+func TestNewJobRouteControllerWiresCelerySyncProviderQuiescence(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	admin, uri := startJobRouteHarness(t, ctx)
+
+	if _, err := admin.Exec(ctx, `
 		INSERT INTO public.worker_job_routes
 			(job_kind, transport, paused, generation, updated_at)
 		VALUES ('sync.provider_unit', 'celery', FALSE, 1, statement_timestamp())`); err != nil {
 		t.Fatal(err)
 	}
+
 	registry, err := jobruntime.Load("../../contracts/jobs/v1")
 	if err != nil {
 		t.Fatal(err)
 	}
-	controller, err := newJobRouteController(pool, pool, "river", registry)
+
+	// The load-bearing part of this test: coordinatorPool is a REAL
+	// coordinator-role connection, not the admin pool and not the domain
+	// pool. If newJobRouteController were wired back onto the domain role (the
+	// CHAOS-3113 regression), every coordinator statement below would fail
+	// with 42501 rather than the assertions below failing on their own terms.
+	coordinatorPool := connectAsRole(t, ctx, uri, workerctlCoordinatorRole, workerctlCoordinatorPass)
+	domainPool := connectAsRole(t, ctx, uri, workerctlDomainRole, workerctlDomainPass)
+	queuePool := connectAsRole(t, ctx, uri, workerctlQueueRole, workerctlQueuePass)
+
+	controller, err := newJobRouteController(coordinatorPool, domainPool, queuePool, workerctlSchema, registry)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -73,7 +185,7 @@ func TestNewJobRouteControllerWiresCelerySyncProviderQuiescence(t *testing.T) {
 	if _, err := controller.Rollback(ctx, "sync.provider_unit"); err != nil {
 		t.Fatalf("rollback: %v", err)
 	}
-	if _, err := pool.Exec(ctx, `
+	if _, err := admin.Exec(ctx, `
 		INSERT INTO public.sync_run_units (id, provider, dataset_key, status)
 		VALUES ('00000000-0000-4000-8000-000000000002', 'launchdarkly', 'feature-flags', 'running')`); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
Stacked on #1300 — it needs #1300's two commits to be green, because discovery starts running the `joboutbox`/`joboperator` packages whose stale fixtures #1300 repairs. Retargets to `main` automatically when #1300 merges.

## The test that wasn't running

```
vet: cmd/dev-health-workerctl/main_integration_test.go:62:72: not enough arguments in call to newJobRouteController
	have (*pgxpool.Pool, *pgxpool.Pool, string, *jobruntime.Registry)
	want (*pgxpool.Pool, *pgxpool.Pool, *pgxpool.Pool, string, *jobruntime.Registry)
```

#1291 split the route controller onto its own coordinator pool — `worker_job_routes`, `worker_job_outbox`, and `worker_job_runs` became coordinator-exclusive. The test still called the 4-argument signature and has not compiled since.

The test now provisions three **real** least-privilege PostgreSQL roles (domain/queue/coordinator) against a testcontainers Postgres, with coordinator grants derived from `postgres.CoordinatorPosture()` — the same authority production readiness checks against — applied via `riverstore.ApplyPinnedMigrations`. `coordinatorPool` is a genuine coordinator-role connection, not the domain pool wearing a different name; passing the domain pool would have made the test assert something production does not do.

## Why nobody noticed — two independent gaps

**1. The allowlist was opt-in.** `check_integration` ran a hand-maintained package list, so any package nobody remembered to add was silently not tested. That shape has now hidden three things in one day: `internal/providerfoundation`'s ClickHouse and Valkey suites, this workerctl test, and it was structurally guaranteed to hide the next one.

It is now **discovery by default**: a `git ls-files` scan for `//go:build integration` finds every package, and the only way to exclude one is an explicit `INTEGRATION_DENYLIST` entry carrying a written reason, printed on every run. The denylist is currently **empty**.

`check_integration_coverage` is the guard that keeps it honest — it recomputes discovery and fails on a stale or misspelled denylist entry, or on zero discovery. Proven in both directions: a scratch integration-tagged package appears as RUN with no edit to the script, and a bogus denylist entry makes it `die()`.

**2. Nothing compile-checked the integration tag tree-wide.** Added `check_integration_vet` — `go vet -tags=integration ./...`, no Docker, seconds — to the `fast` and `all` paths. Proven to catch this exact break by reverting the test file and re-running it.

The two checks answer different questions and neither subsumes the other: a package can compile and still be denylisted, or be in the run set and simply not build.

## What inversion surfaced

Seven packages beyond providerfoundation and workerctl were never being run: `internal/externalrecompute`, `internal/jobroute`, `internal/jobruntime`, `internal/jobs/metrics/daily`, `internal/jobs/metrics/remaining`, `internal/jobs/workgraph`, `internal/streamrunner`.

**All seven pass** against real Docker (~35s total).

The two that fail — `joboperator`'s `TestPostgresOperatorAuthenticationBackendAndAudit` and `joboutbox`'s `TestGenericOutboxLiveFailureInjectionMatrix` — were deliberately **left failing rather than denylisted**, and reproduce identically on unmodified `a500e6537`. Denylisting a newly-discovered real failure would convert it straight back into the invisibility this change removes. They are fixed by #1300's second commit, which is why this is stacked on it.

## Runtime

The 14-package allowlist took ~6.75m local wall time; 23-package discovery takes ~8.2m, so **+~1.5m**. CI's `go-storage-integration` timeout is 25m and is left **unchanged** — reported with numbers rather than pre-emptively raised. Worth revisiting once a real post-#1300 CI run establishes the actual figure.

Tree-wide `go vet -tags=integration ./...` is clean beyond the one fix.