### PR TITLE
CHAOS-3142: run the working Go execution path in compose alongside Celery

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -266,10 +266,15 @@ SENTRY_SEND_PII="true"
 # ----------------------------------------------------------------------------
 # This file wires the River domain/queue/coordinator role names into
 # postgres's own bootstrap (docker/init-extra-dbs.sh) and the shared Celery
-# env anchor, so a Go worker topology running alongside this stack (see
-# deploy/go-workers/README.md) agrees with it on role identity. Defaults
-# below match what init-extra-dbs.sh already assumes; only set these to
-# override.
+# env anchor. A Go worker topology (see deploy/go-workers/README.md) needs
+# the SAME values to agree with this project on role identity -- but Docker
+# Compose only reads a `.env` file (for both `${VAR}` interpolation and
+# COMPOSE_PROFILES) from the directory of the compose file actually being
+# invoked, or from the shell. This file being correct does NOT propagate
+# these values to a Go worker topology declared in a different compose
+# file/directory; that file's own `.env` (or your shell) needs the same
+# values set explicitly. Defaults below match what init-extra-dbs.sh already
+# assumes; only set these to override.
 # RIVER_DOMAIN_DATABASE_ROLE="devhealth_domain"
 # RIVER_DOMAIN_DATABASE_PASSWORD="devhealth_domain"
 # RIVER_QUEUE_DATABASE_ROLE="devhealth_queue"
@@ -277,16 +282,11 @@ SENTRY_SEND_PII="true"
 # RIVER_COORDINATOR_DATABASE_ROLE="devhealth_coordinator"
 # RIVER_COORDINATOR_DATABASE_PASSWORD="devhealth_coordinator"
 #
-# The two route-ready provider/dataset switches (CHAOS-3123). Read by BOTH
-# this Python producer gate (ProviderUnitRouteSwitches) and a Go worker's
-# config.Config from the SAME variable names — one override must flip both
-# sides, or a unit routed to River finds no handler. Both default to
-# "false"; only flip alongside a reviewed route release.
+# The two route-ready provider/dataset switches (CHAOS-3123). Read by this
+# Python producer gate (ProviderUnitRouteSwitches) and, wherever a Go worker
+# topology runs, its config.Config from the SAME variable names -- one
+# override must flip both sides (in BOTH files' env), or a unit routed to
+# River finds no handler. Both default to "false"; only flip alongside a
+# reviewed route release.
 # WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED="false"
 # WORKER_GITHUB_REPO_METADATA_ENABLED="false"
-#
-# Set to "go" (or export COMPOSE_PROFILES=go in your shell) to include a Go
-# worker topology's compose services in a bare `docker compose up` — see
-# deploy/go-workers/README.md for what that topology is and where it lives.
-# This file itself declares no profile-gated services of its own.
-# COMPOSE_PROFILES="go"

--- a/.env.example
+++ b/.env.example
@@ -260,3 +260,33 @@ SENTRY_TRACES_RATE="0"
 # PII — safe to enable for self-hosted (BugSink/self-hosted Sentry).
 # Includes user IPs, request bodies, etc. in error events.
 SENTRY_SEND_PII="true"
+
+# ----------------------------------------------------------------------------
+# Go execution path (River) — CHAOS-3142
+# ----------------------------------------------------------------------------
+# This file wires the River domain/queue/coordinator role names into
+# postgres's own bootstrap (docker/init-extra-dbs.sh) and the shared Celery
+# env anchor, so a Go worker topology running alongside this stack (see
+# deploy/go-workers/README.md) agrees with it on role identity. Defaults
+# below match what init-extra-dbs.sh already assumes; only set these to
+# override.
+# RIVER_DOMAIN_DATABASE_ROLE="devhealth_domain"
+# RIVER_DOMAIN_DATABASE_PASSWORD="devhealth_domain"
+# RIVER_QUEUE_DATABASE_ROLE="devhealth_queue"
+# RIVER_QUEUE_DATABASE_PASSWORD="devhealth_queue"
+# RIVER_COORDINATOR_DATABASE_ROLE="devhealth_coordinator"
+# RIVER_COORDINATOR_DATABASE_PASSWORD="devhealth_coordinator"
+#
+# The two route-ready provider/dataset switches (CHAOS-3123). Read by BOTH
+# this Python producer gate (ProviderUnitRouteSwitches) and a Go worker's
+# config.Config from the SAME variable names — one override must flip both
+# sides, or a unit routed to River finds no handler. Both default to
+# "false"; only flip alongside a reviewed route release.
+# WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED="false"
+# WORKER_GITHUB_REPO_METADATA_ENABLED="false"
+#
+# Set to "go" (or export COMPOSE_PROFILES=go in your shell) to include a Go
+# worker topology's compose services in a bare `docker compose up` — see
+# deploy/go-workers/README.md for what that topology is and where it lives.
+# This file itself declares no profile-gated services of its own.
+# COMPOSE_PROFILES="go"

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -130,7 +130,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        target: [worker, scheduler, reconciler, stream-runner, operator, contractcheck]
+        target: [worker, scheduler, reconciler, stream-runner, operator, contractcheck, migrate]
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 

--- a/ci/check_go_containers.sh
+++ b/ci/check_go_containers.sh
@@ -187,6 +187,7 @@ smoke_target() {
 
 smoke() {
   local target
+  local migrate_stderr
   for target in "${RUNTIME_TARGETS[@]}"; do
     printf 'container smoke: %s\n' "${target}"
     smoke_target "${target}"
@@ -223,9 +224,14 @@ smoke() {
   docker run --rm "${CONTAINER_SECURITY_ARGS[@]}" "${IMAGE_PREFIX}-migrate:ci" --version \
     | grep -F '"version":"phase1-ci"' >/dev/null \
     || die "migrate did not report injected version metadata"
-  if docker run --rm "${CONTAINER_SECURITY_ARGS[@]}" "${IMAGE_PREFIX}-migrate:ci" >/dev/null 2>&1; then
-    die "migrate did not fail closed without MIGRATION_DATABASE_URI"
-  fi
+  # Assert the *specific* diagnostic, not merely a nonzero exit: a panic, a
+  # missing shared library, or any unrelated startup regression also exits
+  # nonzero, so `if ! docker run` alone would green-light an unusable image.
+  migrate_stderr="$(docker run --rm "${CONTAINER_SECURITY_ARGS[@]}" "${IMAGE_PREFIX}-migrate:ci" 2>&1 >/dev/null)" \
+    && die "migrate did not fail closed without MIGRATION_DATABASE_URI"
+  printf '%s' "${migrate_stderr}" \
+    | grep -F 'configuration error: MIGRATION_DATABASE_URI is required' >/dev/null \
+    || die "migrate did not report the missing MIGRATION_DATABASE_URI diagnostic"
 }
 
 reproducible() {

--- a/ci/check_go_containers.sh
+++ b/ci/check_go_containers.sh
@@ -13,7 +13,7 @@ readonly COMMIT="0000000000000000000000000000000000000000"
 readonly BUILD_TIME="1970-01-01T00:00:00Z"
 readonly SOURCE_DATE_EPOCH="0"
 readonly RUNTIME_TARGETS=(worker scheduler reconciler stream-runner)
-readonly ALL_TARGETS=(worker scheduler reconciler stream-runner operator contractcheck)
+readonly ALL_TARGETS=(worker scheduler reconciler stream-runner operator contractcheck migrate)
 readonly CONTAINER_SECURITY_ARGS=(
   --read-only
   --cap-drop ALL
@@ -207,6 +207,25 @@ smoke() {
   docker run --rm "${CONTAINER_SECURITY_ARGS[@]}" "${IMAGE_PREFIX}-operator:ci" --version \
     | grep -F '"version":"phase1-ci"' >/dev/null \
     || die "operator did not report injected version metadata"
+
+  # migrate (cmd/dev-health-worker-migrate) is a one-shot job, not a
+  # long-running service: it has no readiness surface to smoke-test against,
+  # so -- like contractcheck and operator above -- it is special-cased rather
+  # than run through smoke_target. --version is its only no-op mode that
+  # requires neither a live database nor MIGRATION_DATABASE_URI (--check
+  # connects to PostgreSQL and applies/validates the pinned River schema, so
+  # it cannot run here); running with no arguments at all still proves real
+  # exit behavior by failing closed on the missing required configuration.
+  printf 'container smoke: migrate\n'
+  build_target migrate "${IMAGE_PREFIX}-migrate:ci"
+  [ "$(docker image inspect --format '{{.Config.User}}' "${IMAGE_PREFIX}-migrate:ci")" = "65532:65532" ] \
+    || die "migrate image is not configured for numeric non-root execution"
+  docker run --rm "${CONTAINER_SECURITY_ARGS[@]}" "${IMAGE_PREFIX}-migrate:ci" --version \
+    | grep -F '"version":"phase1-ci"' >/dev/null \
+    || die "migrate did not report injected version metadata"
+  if docker run --rm "${CONTAINER_SECURITY_ARGS[@]}" "${IMAGE_PREFIX}-migrate:ci" >/dev/null 2>&1; then
+    die "migrate did not fail closed without MIGRATION_DATABASE_URI"
+  fi
 }
 
 reproducible() {

--- a/cmd/dev-health-reconciler/dependencies.go
+++ b/cmd/dev-health-reconciler/dependencies.go
@@ -330,6 +330,14 @@ type reconcilerDependencies struct {
 	database    reconcilerDatabase
 	databaseErr error
 
+	// logger and coordinatorRole exist only to make a coordinator_postgres
+	// readiness failure explain itself (see coordinatorReady /
+	// logCoordinatorPostureGaps). Neither is a DSN, host, or credential --
+	// coordinatorRole is a checked-in configuration identifier, and logger is
+	// the same structured logger the rest of the process already uses.
+	logger          *slog.Logger
+	coordinatorRole string
+
 	runtimeRegistry *jobruntime.Registry
 	registryErr     error
 	relayErr        error
@@ -438,7 +446,7 @@ func buildReconcilerDependencies(
 	activation reconcilerActivation,
 	sources reconcilerDependencySources,
 ) *reconcilerDependencies {
-	dependencies := &reconcilerDependencies{}
+	dependencies := &reconcilerDependencies{logger: logger, coordinatorRole: cfg.CoordinatorDatabaseRole}
 	if sources.openDatabase == nil {
 		dependencies.databaseErr = errReconcilerDependencyUnavailable
 	} else {
@@ -567,9 +575,55 @@ func (dependencies *reconcilerDependencies) coordinatorReady(ctx context.Context
 		return errReconcilerDependencyUnavailable
 	}
 	if err := dependencies.database.CoordinatorReady(ctx); err != nil {
+		dependencies.logCoordinatorPostureGaps(ctx)
 		return errReconcilerDependencyUnavailable
 	}
 	return nil
+}
+
+// logCoordinatorPostureGaps re-derives, in a separate best-effort diagnostic
+// query, which of the coordinator role's declared requirements are currently
+// unsatisfied, and logs them at ERROR. Before this existed, a
+// coordinator_postgres readiness failure surfaced only as a check name at
+// the /readyz HTTP surface with no reason in the process logs either --
+// diagnosing CHAOS-3142's actual cause (one required table missing because
+// alembic was two migrations behind head) took manually re-deriving and
+// re-running postgres.CoordinatorPosture()'s table list by hand against the
+// live database. This closes that gap.
+//
+// It never logs a DSN, host, or credential: postgres.PostureGap is built
+// entirely from checked-in table/column identifiers (schema identifiers
+// already committed to this repository, not connection material) and
+// standard SQL privilege keywords -- see
+// internal/storage/postgres/posture_diagnostics_integration_test.go's
+// TestDiagnoseRolePostureNamesTheGapAndNeverLeaksConnectionMaterial, which
+// renders every gap the same way this function does and asserts the
+// rendered line never contains a real connection URI or password.
+//
+// Best-effort and silent on its own failure: losing the diagnostic must
+// never turn an otherwise-handled readiness failure into a harder one, and
+// this runs on every failed poll, so it must never itself become a new
+// failure mode.
+func (dependencies *reconcilerDependencies) logCoordinatorPostureGaps(ctx context.Context) {
+	if dependencies == nil || dependencies.logger == nil || dependencies.database == nil {
+		return
+	}
+	pool := dependencies.database.CoordinatorPool()
+	if pool == nil {
+		return
+	}
+	gaps, err := postgres.DiagnoseRolePosture(ctx, pool, dependencies.coordinatorRole, postgres.CoordinatorPosture())
+	if err != nil || len(gaps) == 0 {
+		return
+	}
+	details := make([]string, len(gaps))
+	for i, gap := range gaps {
+		details[i] = gap.String()
+	}
+	dependencies.logger.ErrorContext(ctx, "coordinator readiness posture gap",
+		"check", "coordinator_postgres",
+		"gaps", details,
+	)
 }
 
 func (dependencies *reconcilerDependencies) registryReady(context.Context) error {

--- a/compose.yml
+++ b/compose.yml
@@ -8,20 +8,44 @@ volumes:
 
 services:
   postgres:
-    image: postgres:latest
+    # Pinned by digest, not `latest`: an unpinned tag silently changed libc
+    # and default-user family (Debian glibc -> Alpine musl) and moved the
+    # image's own default PGDATA path from underneath a stale `PG_DATA` typo
+    # below, which together caused an `up` to start a brand-new empty
+    # cluster in a different subdirectory of the same volume instead of the
+    # real one -- CHAOS-3142 incident, 2026-07-25. This digest is the same
+    # Postgres 18 Alpine image already pinned in
+    # internal/testsupport/containers/harness.go, so the dev stack and the
+    # Go integration-test harness agree on one Postgres build.
+    image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
     container_name: postgres
     restart: always
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
       POSTGRES_DB: postgres
-      PG_DATA: /var/lib/postgresql/
+      # Must be a subdirectory of the volume mount (postgres_data is mounted
+      # at the parent /var/lib/postgresql/), never the mount root itself --
+      # otherwise the image's lost+found and other reserved entries live
+      # alongside PGDATA and a future image-default change silently
+      # relocates the cluster again. Previously misspelled `PG_DATA`, which
+      # the postgres image never reads, so this had no effect for seven
+      # months (commit 581ae01e6) while every cluster was created at the
+      # image's own shifting default path.
+      PGDATA: /var/lib/postgresql/pgdata
       RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
       RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      # CHAOS-3142: the coordinator role of the CHAOS-3033 Option B split.
+      # docker/init-extra-dbs.sh already reads these two (defaulting to
+      # devhealth_coordinator) to create the login and grant CONNECT; without
+      # them here an operator override never reaches the script that
+      # provisions it.
+      RIVER_COORDINATOR_DATABASE_ROLE: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
       # Local development credentials only. Production roles are provisioned
       # through the database provider/secret manager before migration.
       RIVER_DOMAIN_DATABASE_PASSWORD: ${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}
       RIVER_QUEUE_DATABASE_PASSWORD: ${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}
+      RIVER_COORDINATOR_DATABASE_PASSWORD: ${RIVER_COORDINATOR_DATABASE_PASSWORD:-devhealth_coordinator}
     ports:
       - "5555:5432"
     volumes:
@@ -156,11 +180,33 @@ services:
       PGBOUNCER_TRANSACTION_MODE: "true"
       CLICKHOUSE_URI: "clickhouse://ch:ch@clickhouse:8123/default"
       REDIS_URL: "redis://valkey:6379/1"
+      # Pre-existing gap fixed alongside CHAOS-3142: declared in
+      # .env.example but was never actually referenced by this file, so no
+      # override ever reached any container -- provider credential
+      # decryption (src/dev_health_ops/core/encryption.py, read by
+      # workers/task_utils.py for every provider) silently had no key in
+      # local dev. Also required by the go-worker `sync` profile
+      # (SETTINGS_ENCRYPTION_KEY, deploy/go-workers/profiles.json), which
+      # must decrypt the same stored credentials.
+      SETTINGS_ENCRYPTION_KEY: ${SETTINGS_ENCRYPTION_KEY:-}
       # CHAOS-2299: route sync dispatch to per-provider queues. Safe to enable
       # here because the worker -Q lists below consume sync.<provider> in the
       # SAME change. Bare-image deployments must follow the two-phase rollout
       # in workers/queues.py: expand consumer -Q lists first, then flip this.
       PROVIDER_SYNC_QUEUES_ENABLED: "true"
+      # CHAOS-3142/CHAOS-3123: the two route-ready provider/dataset switches.
+      # Read by BOTH this Python producer gate
+      # (ProviderUnitRouteSwitches.from_environment,
+      # src/dev_health_ops/workers/provider_unit_route.py) and the Go worker
+      # (config.Config.WorkerLaunchDarklyFeatureFlagsEnabled /
+      # WorkerGithubRepoMetadataEnabled, cmd/dev-health-worker/dependencies.go
+      # workerRouteSwitches) from the SAME env var names, so one override
+      # flips both sides coherently -- a unit the Python gate routes to River
+      # with the switch off here but on for go-worker (or vice versa) finds
+      # no handler. Both default to "false"; only flip alongside a reviewed
+      # route release.
+      WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED: ${WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED:-false}
+      WORKER_GITHUB_REPO_METADATA_ENABLED: ${WORKER_GITHUB_REPO_METADATA_ENABLED:-false}
       AUTO_RUN_MIGRATIONS: "false"
       STRIPE_SECRET_KEY: ${STRIPE_SECRET_KEY:-}
       STRIPE_WEBHOOK_SECRET: ${STRIPE_WEBHOOK_SECRET:-}
@@ -323,6 +369,161 @@ services:
     <<: *worker-base
     container_name: beat
     command: -A dev_health_ops.workers.celery_app beat --loglevel=info --schedule=/tmp/celerybeat-schedule
+
+  # ---------------------------------------------------------------------------
+  # Go execution path (CHAOS-3142) — additive, profile-gated, default OFF.
+  #
+  # Behind `profiles: [go]` so a bare `docker compose up` is completely
+  # unchanged: none of the three services below are created unless the `go`
+  # profile is explicitly selected (`docker compose --profile go up -d` or
+  # `COMPOSE_PROFILES=go`). Celery/Beat remain the only scheduler and the
+  # only owner of every route unless a reviewed release says otherwise --
+  # starting these containers does not transfer a queue or route.
+  #
+  # go-worker-migrate applies the pinned River schema plus the domain/
+  # queue/coordinator role grants (cmd/dev-health-worker-migrate) using an
+  # elevated, non-runtime DSN. It must complete before go-worker or
+  # go-reconciler start, and it depends on the canonical Python `migrate`
+  # service so the tables its grants target (worker_job_outbox,
+  # worker_job_completion_fences, ...) already exist.
+  # ---------------------------------------------------------------------------
+  go-worker-migrate:
+    build:
+      context: .
+      dockerfile: ./docker/go-worker.Dockerfile
+      target: migrate
+    profiles: ["go"]
+    container_name: dev-health-go-worker-migrate
+    restart: "no"
+    environment:
+      # Direct postgres:5432 with the elevated local superuser -- never a
+      # runtime role, and never pgbouncer. cmd/dev-health-worker-migrate
+      # itself rejects a MIGRATION_DATABASE_URI role that collides with any
+      # of the three runtime roles below.
+      MIGRATION_DATABASE_URI: postgresql://postgres:postgres@postgres:5432/${POSTGRES_DB:-postgres}
+      RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
+      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
+      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      RIVER_COORDINATOR_DATABASE_ROLE: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
+    depends_on:
+      postgres:
+        condition: service_healthy
+      migrate:
+        condition: service_completed_successfully
+
+  # go-worker runs the `sync` deployment profile (deploy/go-workers/profiles.json):
+  # the provider-unit River handler for the two route-ready pairs. Domain
+  # traffic goes through pgbouncer, as Python's does; River queue control is
+  # direct, as every River process requires.
+  go-worker:
+    build:
+      context: .
+      dockerfile: ./docker/go-worker.Dockerfile
+      target: worker
+    profiles: ["go"]
+    container_name: dev-health-go-worker
+    restart: unless-stopped
+    environment:
+      DEV_HEALTH_PROFILE: sync
+      POSTGRES_URI: postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}@pgbouncer:6432/${POSTGRES_DB:-postgres}
+      PGBOUNCER_TRANSACTION_MODE: "true"
+      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@postgres:5432/${POSTGRES_DB:-postgres}
+      # Native protocol port 9000, NOT the HTTP port 8123 the Python
+      # clickhouse-connect client above uses: internal/storage/clickhouse's
+      # Open() uses ClickHouse/clickhouse-go/v2, which speaks the native
+      # wire protocol and eagerly Pings at construction time. Pointing this
+      # at 8123 makes clickhousestore.Open fail immediately with
+      # ErrUnavailable ("ClickHouse readiness check failed") -- found while
+      # live-verifying this compose wiring end-to-end (CHAOS-3142).
+      CLICKHOUSE_URI: clickhouse://ch:ch@clickhouse:9000/${CLICKHOUSE_DB:-default}
+      VALKEY_URI: redis://valkey:6379/1
+      SETTINGS_ENCRYPTION_KEY: ${SETTINGS_ENCRYPTION_KEY:-}
+      RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
+      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
+      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      WORKER_DOMAIN_DATABASE_MAX_CONNS: ${WORKER_DOMAIN_DATABASE_MAX_CONNS:-4}
+      WORKER_DATABASE_MAX_CONNS: ${WORKER_DATABASE_MAX_CONNS:-2}
+      # Same two switches, same names, as the Celery worker/beat env above --
+      # this is the Go half of the CHAOS-3123 route gate
+      # (config.Config.WorkerLaunchDarklyFeatureFlagsEnabled /
+      # WorkerGithubRepoMetadataEnabled). Both default off.
+      #
+      # NOTE (found live-verifying this wiring): with the domain AND queue
+      # DSNs both configured -- as they are here -- cmd/dev-health-worker's
+      # "sync" profile unconditionally constructs the sync.team_autoimport
+      # handler (buildSyncCoordinatorWorker gates only on profile=="sync",
+      # not on either switch) and then requires an EXACT match between
+      # constructed capability and the "sync" registry profile's full
+      # declared job_kinds (cmd/dev-health-worker/dependencies.go
+      # dependencies.profileReady, the CUT-02 "exact startup validation"
+      # gate) -- which also declares sync.provider_unit. So with BOTH
+      # switches at their secure default of false, go-worker's sync profile
+      # fails closed at startup (crash-loops under restart:unless-stopped)
+      # rather than idling ready-but-idle. This is existing, intentional
+      # fail-closed behavior, not a wiring bug -- see docs/... runbook. An
+      # operator must set one switch true (e.g. via a .env override) for
+      # go-worker to reach /readyz "ok".
+      WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED: ${WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED:-false}
+      WORKER_GITHUB_REPO_METADATA_ENABLED: ${WORKER_GITHUB_REPO_METADATA_ENABLED:-false}
+      # sync.team_autoimport's post-sync bridge (buildSyncCoordinatorWorker)
+      # is constructed unconditionally for the sync profile once the domain
+      # DSN is configured, and syncdispatchruntime.NewHTTPBridge fails
+      # closed on an empty BaseURL/BearerToken -- so, even though
+      # deploy/go-workers/profiles.json's "sync" secret_env list does not
+      # mention it, this IS required for go-worker's sync profile to start.
+      # The dev-local token is a placeholder value, not a real secret; the
+      # api target does not currently authenticate this bridge route.
+      WORKER_OPERATIONAL_BRIDGE_URL: ${WORKER_OPERATIONAL_BRIDGE_URL:-http://api:8000}
+      WORKER_OPERATIONAL_BRIDGE_TOKEN: ${WORKER_OPERATIONAL_BRIDGE_TOKEN:-dev-local-operational-bridge-token}
+      WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE: ${WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE:-true}
+      DEV_HEALTH_LOG_LEVEL: ${LOG_LEVEL:-info}
+    depends_on:
+      go-worker-migrate:
+        condition: service_completed_successfully
+      clickhouse:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+      pgbouncer:
+        condition: service_started
+    ports:
+      - "8081:8080"
+
+  # go-reconciler relays worker_job_outbox rows into River and observes the
+  # sync-dispatch outbox. It is a coordinator-role binary
+  # (cmd/dev-health-reconciler/dependencies.go openReconcilerDatabase calls
+  # RuntimeConfig.WithCoordinator): COORDINATOR_DATABASE_URI is required and
+  # MUST be direct postgres:5432, never pgbouncer -- transaction-mode pooling
+  # cannot hold the cross-statement row/table locks the coordinator role
+  # takes (internal/storage/postgres/runtime.go ErrCoordinatorTransactionMode).
+  # It declares no DEV_HEALTH_PROFILE (cmd/dev-health-reconciler/main.go sets
+  # no Profiles), so one must not be set here.
+  go-reconciler:
+    build:
+      context: .
+      dockerfile: ./docker/go-worker.Dockerfile
+      target: reconciler
+    profiles: ["go"]
+    container_name: dev-health-go-reconciler
+    restart: unless-stopped
+    environment:
+      POSTGRES_URI: postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}@pgbouncer:6432/${POSTGRES_DB:-postgres}
+      PGBOUNCER_TRANSACTION_MODE: "true"
+      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@postgres:5432/${POSTGRES_DB:-postgres}
+      COORDINATOR_DATABASE_URI: postgresql://${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}:${RIVER_COORDINATOR_DATABASE_PASSWORD:-devhealth_coordinator}@postgres:5432/${POSTGRES_DB:-postgres}
+      RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
+      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
+      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      RIVER_COORDINATOR_DATABASE_ROLE: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
+      WORKER_DOMAIN_DATABASE_MAX_CONNS: ${WORKER_DOMAIN_DATABASE_MAX_CONNS:-4}
+      WORKER_DATABASE_MAX_CONNS: ${WORKER_DATABASE_MAX_CONNS:-2}
+      WORKER_COORDINATOR_DATABASE_MAX_CONNS: ${WORKER_COORDINATOR_DATABASE_MAX_CONNS:-2}
+      DEV_HEALTH_LOG_LEVEL: ${LOG_LEVEL:-info}
+    depends_on:
+      go-worker-migrate:
+        condition: service_completed_successfully
+    ports:
+      - "8082:8080"
 
   # ---------------------------------------------------------------------------
   # Observability — SigNoz (distributed tracing + metrics)

--- a/compose.yml
+++ b/compose.yml
@@ -1,4 +1,16 @@
-name: dev-health
+# CHAOS-3142 incident, 2026-07-25: this file previously shared the compose
+# project name `dev-health` with the repo-root `compose.yml` (a separate,
+# divergent file with an incompatible postgres definition -- different
+# image, role/database names, PGDATA path, and port). Because Docker Compose
+# tracks service ownership by (project name, service name), an `up` from
+# EITHER file could recreate the OTHER file's already-running containers in
+# place, discarding whatever they had (see the postgres image/PGDATA history
+# below). Naming this project `dev-health-ops` makes that collision
+# structurally impossible: this file now owns its own containers, network,
+# and volumes, entirely separate from whatever the repo-root compose.yml
+# manages. That also means this file's postgres always starts from its own
+# empty volume -- it is no longer a way to attach to another project's data.
+name: dev-health-ops
 
 volumes:
   postgres_data:
@@ -8,15 +20,25 @@ volumes:
 
 services:
   postgres:
-    # Pinned by digest, not `latest`: an unpinned tag silently changed libc
-    # and default-user family (Debian glibc -> Alpine musl) and moved the
-    # image's own default PGDATA path from underneath a stale `PG_DATA` typo
-    # below, which together caused an `up` to start a brand-new empty
-    # cluster in a different subdirectory of the same volume instead of the
-    # real one -- CHAOS-3142 incident, 2026-07-25. This digest is the same
-    # Postgres 18 Alpine image already pinned in
-    # internal/testsupport/containers/harness.go, so the dev stack and the
-    # Go integration-test harness agree on one Postgres build.
+    # CHAOS-3142 incident, 2026-07-25: the immediate trigger was this file
+    # sharing its compose project name with the repo-root compose.yml (see
+    # the `name:` comment above) -- an `up` from either file could recreate
+    # the other's already-running postgres container in place. But this
+    # image was also unpinned (`latest`) and PGDATA was misspelled
+    # (`PG_DATA`, which the postgres image never reads), so the container
+    # that got recreated started an entirely new, empty cluster in whatever
+    # subdirectory that image version's own default PGDATA happened to be,
+    # rather than failing loudly or reusing the real one. Both defects are
+    # fixed independently of the project-name fix, so this file's own
+    # isolated volume can't suffer the same silent-relocation failure mode
+    # on some future `up`. Pinned to the same Postgres 18 Alpine digest
+    # already pinned in internal/testsupport/containers/harness.go, so the
+    # dev stack and the Go integration-test harness agree on one Postgres
+    # build. The repo-root compose.yml already got PGDATA right under
+    # CHAOS-1771 (`PGDATA: /var/lib/postgresql/data/pgdata`, with its own
+    # comment on the same anonymous-volume trap) -- this file adopts the
+    # identical reasoning so the two agree rather than looking like
+    # independent guesses.
     image: postgres:18-alpine@sha256:9a8afca54e7861fd90fab5fdf4c42477a6b1cb7d293595148e674e0a3181de15
     container_name: postgres
     restart: always
@@ -185,9 +207,11 @@ services:
       # override ever reached any container -- provider credential
       # decryption (src/dev_health_ops/core/encryption.py, read by
       # workers/task_utils.py for every provider) silently had no key in
-      # local dev. Also required by the go-worker `sync` profile
-      # (SETTINGS_ENCRYPTION_KEY, deploy/go-workers/profiles.json), which
-      # must decrypt the same stored credentials.
+      # local dev. The Go worker's `sync` profile decrypts the same stored
+      # credentials with the same variable name
+      # (SETTINGS_ENCRYPTION_KEY, deploy/go-workers/profiles.json) wherever
+      # it runs, so this value stays byte-identical to whatever a Go
+      # topology alongside this stack is given.
       SETTINGS_ENCRYPTION_KEY: ${SETTINGS_ENCRYPTION_KEY:-}
       # CHAOS-2299: route sync dispatch to per-provider queues. Safe to enable
       # here because the worker -Q lists below consume sync.<provider> in the
@@ -201,10 +225,10 @@ services:
       # (config.Config.WorkerLaunchDarklyFeatureFlagsEnabled /
       # WorkerGithubRepoMetadataEnabled, cmd/dev-health-worker/dependencies.go
       # workerRouteSwitches) from the SAME env var names, so one override
-      # flips both sides coherently -- a unit the Python gate routes to River
-      # with the switch off here but on for go-worker (or vice versa) finds
-      # no handler. Both default to "false"; only flip alongside a reviewed
-      # route release.
+      # flips both sides coherently wherever the Go worker runs -- a unit
+      # this Python gate routes to River with the switch off here but on for
+      # the Go worker (or vice versa) finds no handler. Both default to
+      # "false"; only flip alongside a reviewed route release.
       WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED: ${WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED:-false}
       WORKER_GITHUB_REPO_METADATA_ENABLED: ${WORKER_GITHUB_REPO_METADATA_ENABLED:-false}
       AUTO_RUN_MIGRATIONS: "false"
@@ -369,161 +393,6 @@ services:
     <<: *worker-base
     container_name: beat
     command: -A dev_health_ops.workers.celery_app beat --loglevel=info --schedule=/tmp/celerybeat-schedule
-
-  # ---------------------------------------------------------------------------
-  # Go execution path (CHAOS-3142) — additive, profile-gated, default OFF.
-  #
-  # Behind `profiles: [go]` so a bare `docker compose up` is completely
-  # unchanged: none of the three services below are created unless the `go`
-  # profile is explicitly selected (`docker compose --profile go up -d` or
-  # `COMPOSE_PROFILES=go`). Celery/Beat remain the only scheduler and the
-  # only owner of every route unless a reviewed release says otherwise --
-  # starting these containers does not transfer a queue or route.
-  #
-  # go-worker-migrate applies the pinned River schema plus the domain/
-  # queue/coordinator role grants (cmd/dev-health-worker-migrate) using an
-  # elevated, non-runtime DSN. It must complete before go-worker or
-  # go-reconciler start, and it depends on the canonical Python `migrate`
-  # service so the tables its grants target (worker_job_outbox,
-  # worker_job_completion_fences, ...) already exist.
-  # ---------------------------------------------------------------------------
-  go-worker-migrate:
-    build:
-      context: .
-      dockerfile: ./docker/go-worker.Dockerfile
-      target: migrate
-    profiles: ["go"]
-    container_name: dev-health-go-worker-migrate
-    restart: "no"
-    environment:
-      # Direct postgres:5432 with the elevated local superuser -- never a
-      # runtime role, and never pgbouncer. cmd/dev-health-worker-migrate
-      # itself rejects a MIGRATION_DATABASE_URI role that collides with any
-      # of the three runtime roles below.
-      MIGRATION_DATABASE_URI: postgresql://postgres:postgres@postgres:5432/${POSTGRES_DB:-postgres}
-      RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
-      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
-      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
-      RIVER_COORDINATOR_DATABASE_ROLE: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
-    depends_on:
-      postgres:
-        condition: service_healthy
-      migrate:
-        condition: service_completed_successfully
-
-  # go-worker runs the `sync` deployment profile (deploy/go-workers/profiles.json):
-  # the provider-unit River handler for the two route-ready pairs. Domain
-  # traffic goes through pgbouncer, as Python's does; River queue control is
-  # direct, as every River process requires.
-  go-worker:
-    build:
-      context: .
-      dockerfile: ./docker/go-worker.Dockerfile
-      target: worker
-    profiles: ["go"]
-    container_name: dev-health-go-worker
-    restart: unless-stopped
-    environment:
-      DEV_HEALTH_PROFILE: sync
-      POSTGRES_URI: postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}@pgbouncer:6432/${POSTGRES_DB:-postgres}
-      PGBOUNCER_TRANSACTION_MODE: "true"
-      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@postgres:5432/${POSTGRES_DB:-postgres}
-      # Native protocol port 9000, NOT the HTTP port 8123 the Python
-      # clickhouse-connect client above uses: internal/storage/clickhouse's
-      # Open() uses ClickHouse/clickhouse-go/v2, which speaks the native
-      # wire protocol and eagerly Pings at construction time. Pointing this
-      # at 8123 makes clickhousestore.Open fail immediately with
-      # ErrUnavailable ("ClickHouse readiness check failed") -- found while
-      # live-verifying this compose wiring end-to-end (CHAOS-3142).
-      CLICKHOUSE_URI: clickhouse://ch:ch@clickhouse:9000/${CLICKHOUSE_DB:-default}
-      VALKEY_URI: redis://valkey:6379/1
-      SETTINGS_ENCRYPTION_KEY: ${SETTINGS_ENCRYPTION_KEY:-}
-      RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
-      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
-      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
-      WORKER_DOMAIN_DATABASE_MAX_CONNS: ${WORKER_DOMAIN_DATABASE_MAX_CONNS:-4}
-      WORKER_DATABASE_MAX_CONNS: ${WORKER_DATABASE_MAX_CONNS:-2}
-      # Same two switches, same names, as the Celery worker/beat env above --
-      # this is the Go half of the CHAOS-3123 route gate
-      # (config.Config.WorkerLaunchDarklyFeatureFlagsEnabled /
-      # WorkerGithubRepoMetadataEnabled). Both default off.
-      #
-      # NOTE (found live-verifying this wiring): with the domain AND queue
-      # DSNs both configured -- as they are here -- cmd/dev-health-worker's
-      # "sync" profile unconditionally constructs the sync.team_autoimport
-      # handler (buildSyncCoordinatorWorker gates only on profile=="sync",
-      # not on either switch) and then requires an EXACT match between
-      # constructed capability and the "sync" registry profile's full
-      # declared job_kinds (cmd/dev-health-worker/dependencies.go
-      # dependencies.profileReady, the CUT-02 "exact startup validation"
-      # gate) -- which also declares sync.provider_unit. So with BOTH
-      # switches at their secure default of false, go-worker's sync profile
-      # fails closed at startup (crash-loops under restart:unless-stopped)
-      # rather than idling ready-but-idle. This is existing, intentional
-      # fail-closed behavior, not a wiring bug -- see docs/... runbook. An
-      # operator must set one switch true (e.g. via a .env override) for
-      # go-worker to reach /readyz "ok".
-      WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED: ${WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED:-false}
-      WORKER_GITHUB_REPO_METADATA_ENABLED: ${WORKER_GITHUB_REPO_METADATA_ENABLED:-false}
-      # sync.team_autoimport's post-sync bridge (buildSyncCoordinatorWorker)
-      # is constructed unconditionally for the sync profile once the domain
-      # DSN is configured, and syncdispatchruntime.NewHTTPBridge fails
-      # closed on an empty BaseURL/BearerToken -- so, even though
-      # deploy/go-workers/profiles.json's "sync" secret_env list does not
-      # mention it, this IS required for go-worker's sync profile to start.
-      # The dev-local token is a placeholder value, not a real secret; the
-      # api target does not currently authenticate this bridge route.
-      WORKER_OPERATIONAL_BRIDGE_URL: ${WORKER_OPERATIONAL_BRIDGE_URL:-http://api:8000}
-      WORKER_OPERATIONAL_BRIDGE_TOKEN: ${WORKER_OPERATIONAL_BRIDGE_TOKEN:-dev-local-operational-bridge-token}
-      WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE: ${WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE:-true}
-      DEV_HEALTH_LOG_LEVEL: ${LOG_LEVEL:-info}
-    depends_on:
-      go-worker-migrate:
-        condition: service_completed_successfully
-      clickhouse:
-        condition: service_healthy
-      valkey:
-        condition: service_healthy
-      pgbouncer:
-        condition: service_started
-    ports:
-      - "8081:8080"
-
-  # go-reconciler relays worker_job_outbox rows into River and observes the
-  # sync-dispatch outbox. It is a coordinator-role binary
-  # (cmd/dev-health-reconciler/dependencies.go openReconcilerDatabase calls
-  # RuntimeConfig.WithCoordinator): COORDINATOR_DATABASE_URI is required and
-  # MUST be direct postgres:5432, never pgbouncer -- transaction-mode pooling
-  # cannot hold the cross-statement row/table locks the coordinator role
-  # takes (internal/storage/postgres/runtime.go ErrCoordinatorTransactionMode).
-  # It declares no DEV_HEALTH_PROFILE (cmd/dev-health-reconciler/main.go sets
-  # no Profiles), so one must not be set here.
-  go-reconciler:
-    build:
-      context: .
-      dockerfile: ./docker/go-worker.Dockerfile
-      target: reconciler
-    profiles: ["go"]
-    container_name: dev-health-go-reconciler
-    restart: unless-stopped
-    environment:
-      POSTGRES_URI: postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}@pgbouncer:6432/${POSTGRES_DB:-postgres}
-      PGBOUNCER_TRANSACTION_MODE: "true"
-      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@postgres:5432/${POSTGRES_DB:-postgres}
-      COORDINATOR_DATABASE_URI: postgresql://${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}:${RIVER_COORDINATOR_DATABASE_PASSWORD:-devhealth_coordinator}@postgres:5432/${POSTGRES_DB:-postgres}
-      RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
-      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
-      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
-      RIVER_COORDINATOR_DATABASE_ROLE: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
-      WORKER_DOMAIN_DATABASE_MAX_CONNS: ${WORKER_DOMAIN_DATABASE_MAX_CONNS:-4}
-      WORKER_DATABASE_MAX_CONNS: ${WORKER_DATABASE_MAX_CONNS:-2}
-      WORKER_COORDINATOR_DATABASE_MAX_CONNS: ${WORKER_COORDINATOR_DATABASE_MAX_CONNS:-2}
-      DEV_HEALTH_LOG_LEVEL: ${LOG_LEVEL:-info}
-    depends_on:
-      go-worker-migrate:
-        condition: service_completed_successfully
-    ports:
-      - "8082:8080"
 
   # ---------------------------------------------------------------------------
   # Observability — SigNoz (distributed tracing + metrics)

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -354,4 +354,154 @@ possibly without realizing a cutover migration is even in the pending set.
 This is a general operational hazard of mounting a live checkout into a
 migration-running service, not specific to CHAOS-3142 or to this migration —
 it deserves review as its own item, independent of the Go execution path
-this document otherwise covers.
+this document otherwise covers. Tracked as CHAOS-3143.
+
+### `SETTINGS_ENCRYPTION_KEY` delivery: the `env_file` path must NOT be parameterized alongside the build context
+
+`go-worker` receives its real, non-placeholder `SETTINGS_ENCRYPTION_KEY` (and
+whatever else a developer's `.env` sets) through an `env_file:` entry, not
+through an `environment:` reference — the service's `environment:` block
+does not name that variable at all, on purpose (see "Provider credentials"
+above: `environment:` wins over `env_file:` when both set the same key, so
+adding `SETTINGS_ENCRYPTION_KEY: ${SETTINGS_ENCRYPTION_KEY:-}` there would
+let an unset shell variable silently override a real key from `env_file`
+with an empty string for anyone who doesn't happen to export it — a strictly
+worse failure mode than the one below, and the fix that was *not* taken for
+that reason).
+
+When a compose project parameterizes `go-worker`'s build context to follow a
+worktree (e.g. `context: ${DEV_HEALTH_OPS_ROOT:-./ops}`, so the branch with
+the `migrate` Dockerfile target and current Go source actually gets built),
+it is tempting to parameterize the adjacent `env_file:` path the same way.
+**Don't.** The build context should follow the worktree; the developer's
+real configuration should not — it lives at a fixed, well-known location
+(`./ops/.env` in this repository) regardless of which worktree's source is
+being built. A worktree checkout has no `.env` of its own. If the
+`env_file:` path is parameterized alongside the build context, it resolves
+to a nonexistent file under a worktree override, and `required: false`
+(there specifically so a missing dev `.env` doesn't hard-fail the service)
+skips it **in complete silence** — no warning, no log line, just a
+container that starts with `SETTINGS_ENCRYPTION_KEY` absent from its
+environment entirely and crash-loops with the generic
+`"dependency_configuration_failed"` message this document already covers.
+This cost real debugging time while building CHAOS-3142: the symptom looked
+identical to (and was initially misdiagnosed as) the "both switches off"
+crash-loop above, and the two have to be told apart by inspecting the
+container's actual environment (`docker inspect --format
+'{{range .Config.Env}}{{println .}}{{end}}'`), not by reading the compose
+file.
+
+## CHAOS-3142 end-to-end proof: final report
+
+This is the durable record of what CHAOS-3142 actually proved, against both
+a real shared local stack and an isolated throwaway one, and exactly where
+it stopped. Written here rather than in a session-scoped note because this
+is the artifact that outlives the session.
+
+### Proven, against a real shared local stack
+
+- Coordinator-role provisioning on a pre-existing, pre-CHAOS-3033-split
+  Postgres cluster: `go-river-provision` created the `devhealth_coordinator`
+  login where none existed before.
+- The exact grant/readiness asymmetry this document names above, hit for
+  real: `coordinatorPosture()` requires `fixed_schedule_occurrences`
+  (`0065_add_fixed_schedule_occurrences.py`), which didn't exist on this
+  database (`alembic_version` was `0064`, two migrations behind head); the
+  `to_regclass`-guarded grant was silently skipped;
+  `coordinator_postgres` readiness failed with no stated reason until a
+  **targeted** `alembic upgrade 0065` (never `head` — see above) created the
+  table and a re-run of `go-worker-migrate` picked up the previously-skipped
+  grant.
+- `go-reconciler` reaching `/readyz` → `{"status":"ok"}` with `RestartCount
+  0` against the real stack, and staying that way — `CheckCoordinatorAuthorization`
+  re-queries live on every poll, so no restart was needed once the grant
+  landed.
+- Non-zero, real metric series from the real reconciler:
+  `worker_outbox_reconciler_up 1`, `sync_dispatch_observer_up 1`, and their
+  paired `..._last_success_age_seconds` gauges reporting sub-second real
+  values — the "present but zero" failure mode this document elsewhere
+  warns against did not occur here.
+
+### Proven, against an isolated throwaway project
+
+Using a separate compose project (`-p <name>`, its own network/volumes,
+never the shared stack), with a hand-seeded additive
+`Integration`/`IntegrationSource`/`IntegrationDataset`/`SyncRun`/
+`SyncRunUnit`/`SyncRunReferenceDiscovery`/`integration_credentials` row set
+for a synthetic org (github/repo-metadata), and the durable route
+(`worker_job_routes.transport`) and Python producer switch
+(`WORKER_GITHUB_REPO_METADATA_ENABLED`) both flipped ONLY inside that
+isolated project — never on shared infrastructure:
+
+- Producer gate (`dispatch_sync_run`) → `worker_job_outbox` row
+  (`status=delivered`) → reconciler relay → River job → Go handler pickup
+  and execution, all confirmed end to end.
+- The Go handler reached a real `github.com` HTTP round-trip (a fake PAT, so
+  a `retryable`, not `permanent`, failure — real network I/O happened, this
+  wasn't a local rejection) and `worker_budget_wait_seconds{provider="github",
+  cost_class="light"}` carried `count=6`, `sum=0.000241334` — a real,
+  non-zero series, not the present-and-zero shape this document elsewhere
+  calls out as the actual failure mode to guard against.
+
+### Not proven
+
+A ClickHouse `repos` row. This needs a real GitHub PAT, which was
+unavailable throughout — nobody working this ticket had one, and none was
+requested from the user. `worker_sync_lease_expired_total` also never
+carried a non-zero series in any run: this is expected and **not a
+regression signal** — that metric only increments on a claim that itself
+recovered an *expired* lease (`providerunit.Handler.observeLeaseRecovery`
+checks `claim.Recovered`, a no-op for an ordinary first-attempt claim), and
+nothing in this proof deliberately expired and re-claimed a lease.
+
+### Not attempted against the real shared stack, and why
+
+Both the durable route flip (`worker_job_routes.transport` for
+`sync.provider_unit` → `river_canary`) and the Python producer switch
+(`WORKER_GITHUB_REPO_METADATA_ENABLED=true` on `dev-health-worker-1`/`api`/
+`beat`) were considered and explicitly not done, for two compounding
+reasons:
+
+1. **They are not independent, and the order matters.** Flipping the
+   durable route alone, with the Python switch still off, is not a smaller,
+   safer version of flipping both — it actively raises. `dispatch_sync_run`
+   (`src/dev_health_ops/workers/sync_units.py`) consults
+   `ProviderUnitRouteSwitches.is_route_ready(provider, dataset)` (matrix-only,
+   unconditional) BEFORE consulting the switch. If the matrix says a pair is
+   route-ready and the durable route already points at River, but the
+   switch is off, that combination is treated as an explicit ownership
+   fault — `dispatch_sync_run` raises
+   `WorkerJobRouteError("sync provider canary capability is unavailable")`
+   rather than degrading to Celery, by design ("never a reason to silently
+   fall back to legacy Celery dispatch for a pair the matrix says is done").
+   So the durable-route flip cannot be evaluated, or left in place, on its
+   own — getting past it requires the Python switch too, immediately, for
+   every org.
+2. **The Python switch requires a live container recreate, not a
+   reversible row.** Neither route switch is wired into `api`/`worker`/
+   `beat`/`worker-heavy`/`worker-ingest` in the repo-root `compose.yml` at
+   all (confirmed: `docker inspect` on the running containers, and a grep of
+   the compose file, both show zero occurrences outside the `go-worker`
+   service block). Setting it means recreating `dev-health-worker-1` — the
+   real Celery worker actively processing real organizations' real sync
+   traffic — with new environment. That is a materially different, and
+   materially bigger, ask than one reversible `UPDATE` on a single
+   `worker_job_routes` row, and it was not authorized.
+
+The marginal evidence a full route flip would have bought was also small:
+the proof already reached the real GitHub-API boundary in the isolated
+project (see above), so completing the durable-route path on the shared
+stack would have re-verified the same mechanism against a different compose
+file, not produced new information — not worth a live Celery worker
+recreate on someone's real environment for that.
+
+### Credential shape, restated for this report
+
+See "Provider credentials the Go executor can decrypt" above for the full
+detail. The two gotchas worth restating here because they are exactly what
+blocked the isolated-project proof until found: the decrypted plaintext
+must be a JSON object (`{"token": "..."}`), not a bare token string; and the
+claim query resolves `credential_id` via `COALESCE(sync_runs.credential_id,
+integrations.credential_id)`, so a credential row that exists but isn't
+linked from `integrations.credential_id` is invisible to a claim even
+though direct `(org_id, provider)` lookup would find it.

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -136,6 +136,17 @@ local Postgres/ClickHouse/Valkey stack. They apply to any compose project
 that starts these services, not to one specific file — see that project's
 own compose file(s) for exactly which services exist and where.
 
+> **`docker compose config` prints every resolved secret in cleartext**,
+> including `SETTINGS_ENCRYPTION_KEY`, database passwords, and any real
+> credential env vars — it resolves and dumps the fully-interpolated
+> compose document, not a redacted one. Do not run it against a real
+> environment's `.env` and paste the output anywhere, including into an
+> agent transcript or a chat log. To check whether a variable is wired at
+> all without revealing its value, grep the rendered `services.<name>` block
+> for the *key* name only, or use `docker compose config --services` /
+> `--format json` piped through `jq 'del(...)'` to strip the fields you
+> don't need before looking at it.
+
 ### One compose project owns one Postgres cluster
 
 Docker Compose tracks container ownership by `(project name, service name)`.
@@ -247,3 +258,100 @@ integrations.credential_id)`, so a credential row that exists but isn't
 linked from `integrations.credential_id` (or the sync run) is invisible to
 a claim even though `PostgresCredentialRepository.ResolveEncrypted` would
 find it directly by `(org_id, provider)`.
+
+### A coordinator (or domain) readiness failure with no stated reason usually means the database is behind on migrations
+
+**Symptom:** `/readyz` reports `{"failed_checks":["coordinator_postgres"], ...}` (or
+`domain_postgres`) and nothing else — no table name, no missing privilege,
+just the check name. There is nothing wrong with the grants your migration
+ran, the role's authentication, or its ownership; every one of those can
+check out individually and the failure still won't clear.
+
+**Why this happens, structurally, and why it isn't a bug:**
+`coordinatorGrantStatements`/`runtimeGrantStatements`
+(`internal/storage/river/migrate.go`) guard every `GRANT` with
+`to_regclass('public.<table>') IS NOT NULL`, by design — a table the current
+Alembic revision hasn't created yet must not fail the whole migration, it
+must just skip that one grant. `CheckRolePosture`
+(`internal/storage/postgres/domain_authorization.go`), the readiness side,
+has no matching leniency: it asserts the FULL declared posture
+(`domainPosture()`/`coordinatorPosture()`) unconditionally, because a table
+that's missing from a production database *is* a real problem to report, not
+one to shrug off. The asymmetry is intentional on both sides individually —
+skip-if-missing on the write side, require-unconditionally on the read side —
+but their combination means: **any database that is behind on Alembic head,
+by even one migration that creates a table either posture requires, gets a
+coordinator or domain readiness check that fails forever, with no stated
+reason, until that specific migration is applied.** This is not a one-off;
+it will recur for the next posture-required table added by a future
+migration, on any database that hasn't caught up yet.
+
+**How to identify it (read-only, safe against a real database):**
+
+```sql
+-- What revision is this database actually at?
+SELECT version_num FROM alembic_version;
+```
+
+Compare that against the highest-numbered file in
+`src/dev_health_ops/alembic/versions/`. If it's behind, check whether any
+migration between the current revision and head creates a table either
+`domainPosture()` or `coordinatorPosture()`
+(`internal/storage/postgres/domain_authorization.go`) requires — grep those
+functions' `RequiredTables`/`ColumnScoped` entries against the pending
+migrations' `op.create_table(...)` calls. You can also confirm a specific
+table directly:
+
+```sql
+SELECT to_regclass('public.<table_name>');  -- NULL means it does not exist
+```
+
+As of CHAOS-3142, `cmd/dev-health-reconciler` logs this automatically: a
+`coordinator_postgres` readiness failure now also emits a redacted ERROR log
+line per unsatisfied requirement — `postgres.DiagnoseRolePosture`, wired at
+`logCoordinatorPostureGaps` — naming the table (and privilege, or
+"table does not exist") without any DSN, host, or credential. Check the
+reconciler's own logs first; the query above is for when you need to trace
+it back to a specific migration yourself.
+
+**Before you reach for `alembic upgrade head` (or the `migrate` service, which
+always goes to head) to fix this: read every pending migration first, not
+just the one that creates the table you need.** "Behind on migrations" and
+"the next migration is inert DDL" are not the same claim, and treating
+`migrate` as a safe, idempotent, always-correct-to-run step because it
+*usually* only adds a column or table is exactly the mistake that cost real
+debugging time while building this ticket — the pending migration on the
+database this was diagnosed against was `0065_add_fixed_schedule_occurrences.py`
+(safe, adds one table), immediately followed by
+`0066_activate_river_worker_job_routes.py` — the CHAOS-3033 Celery-to-River
+cutover migration, which flips checked-in job kinds from `transport='celery'`
+to `transport='river'` and, per its own docstring, requires Go consumers to
+already be running for every affected queue before it commits. Running
+`migrate` to head on a database with no Go workers running yet would have
+silently stopped background processing for every one of those job kinds. If
+a targeted `alembic upgrade <revision>` stopping short of a cutover migration
+is what you need, use that instead of `head`, and confirm first that the
+`api`/`migrate` container actually has your target revision's file available
+(root compose mounts `./ops:/app`, so it does if you're on a branch with that
+migration file; it does not against an unmodified `origin/main` checkout).
+
+### Live landmine: a mounted `ops` checkout is one `migrate` run away from an unattended cutover
+
+Independent of everything else in this document: if the compose project
+running this stack mounts a working copy of this repository into its
+`migrate` service (as the coexistence overlays and CHAOS-3142's own
+repo-root wiring do, so a nested `migrate` target and other Go/Alembic
+artifacts on a feature branch are visible without a rebuild), then **any
+`docker compose up` that (re)starts `migrate`** — not just an explicit,
+reviewed cutover — **applies every pending Alembic migration on that
+checkout, including a cutover migration, unattended, the moment one exists
+in the pending set.** There is no confirmation step, no dry run, and no
+distinction in `migrate`'s own behavior between "add a column" and "flip 23
+job kinds from Celery to River." The migration itself is the only gate, and
+by the time it's pending in a checked-out branch, that gate is one ordinary
+`up` away from being crossed by whoever runs it next, for any reason,
+possibly without realizing a cutover migration is even in the pending set.
+This is a general operational hazard of mounting a live checkout into a
+migration-running service, not specific to CHAOS-3142 or to this migration —
+it deserves review as its own item, independent of the Go execution path
+this document otherwise covers.

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -147,6 +147,46 @@ own compose file(s) for exactly which services exist and where.
 > `--format json` piped through `jq 'del(...)'` to strip the fields you
 > don't need before looking at it.
 
+### Bring-up order: the Python schema is a prerequisite, never a `depends_on`
+
+**`depends_on` ignores profiles.** A profiled service that declares
+`depends_on: migrate` pulls the *unprofiled* Python migrator into the plan, so
+`docker compose --profile go up -d` runs Alembic to **head** — and head is
+`0066_activate_river_worker_job_routes`, the cutover that retargets 23 of 24
+job kinds from Celery to River. Both Go runtimes sit downstream of
+`go-worker-migrate`, so that edge guaranteed precisely the ordering `0066`'s
+own docstring forbids: routes flip to River *before* any River consumer can
+start, and envelopes then accumulate in `worker_job_outbox` with nothing to
+execute them.
+
+`go-worker-migrate` therefore does **not** depend on `migrate`, and standing up
+the Go observation path cannot move real traffic as a side effect.
+`tests/test_compose_config.py::test_go_profile_overlay_never_depends_on_python_migrate`
+is the regression barrier.
+
+Bring the Python schema to the last pre-cutover revision yourself, first:
+
+```bash
+# Explicit, separately authorized, and stops one revision short of the cutover.
+# `revision` is a positional on `upgrade`; omitting it means head, i.e. 0066.
+docker compose run --rm --entrypoint sh migrate -c \
+  'python -m dev_health_ops.cli migrate postgres upgrade 0065'
+
+# Confirm where you actually landed before going further.
+docker compose run --rm --entrypoint sh migrate -c \
+  'python -m dev_health_ops.cli migrate postgres current'
+
+# Only then start the Go path.
+docker compose --profile go up -d go-worker go-reconciler
+```
+
+If the database is behind `0065`, nothing fails loudly at migration time — the
+River grants are `to_regclass`-guarded so a migration can never fail on a
+missing table, they simply no-op. What you get instead is `go-reconciler`
+staying unready. Since CHAOS-3142 that path logs the precise missing
+`table.privilege` gaps via `DiagnoseRolePosture`, so the cause is legible
+rather than a bare "dependency unavailable"; see the migrations section below.
+
 ### One compose project owns one Postgres cluster
 
 Docker Compose tracks container ownership by `(project name, service name)`.
@@ -162,6 +202,30 @@ local Postgres cluster rather than starting a fresh one, confirm which
 compose project actually owns that container (`docker inspect <container>
 --format '{{index .Config.Labels "com.docker.compose.project"}}'`) before
 running any compose command against it from a second file.
+
+**What the rename does and does not change.** `ops/compose.yml` is now project
+`dev-health-ops`. It never owned the long-running local data: those volumes are
+labelled `com.docker.compose.project=dev-health` and belong to the repo-root
+`compose.yml`, whose project name is deliberately unchanged. No
+`dev-health-ops_*` volume existed before this change, so nothing was stranded
+or orphaned — the rename removes `ops/compose.yml`'s ability to hijack the root
+project's containers, which is the whole point.
+
+Two consequences worth knowing:
+
+- Starting `ops/compose.yml` now creates **fresh, empty** `dev-health-ops_*`
+  volumes rather than reattaching the root project's data. That is intended —
+  it is an isolated stack now, not a second view of the shared one. If you
+  actually want the shared cluster, use the root `compose.yml`.
+- `ops/compose.yml` still sets fixed `container_name:` values, several of them
+  bare (`postgres`, `clickhouse`, `valkey`, `worker`, `beat`). Container names
+  are global to the Docker daemon, not scoped per project, so the two projects
+  cannot run *simultaneously*: the second `up` fails with a name conflict.
+  This is a strict improvement over the previous behaviour — the old failure
+  mode was a *silent* recreate of the running container with a foreign
+  definition, and a loud name conflict is a far better outcome than that — but
+  it does mean "rename the project" is not the same as "the two stacks now
+  coexist". Run one at a time, or drop the fixed names.
 
 ### The coordinator DSN must be direct Postgres, never PgBouncer
 
@@ -355,6 +419,13 @@ This is a general operational hazard of mounting a live checkout into a
 migration-running service, not specific to CHAOS-3142 or to this migration —
 it deserves review as its own item, independent of the Go execution path
 this document otherwise covers. Tracked as CHAOS-3143.
+
+What CHAOS-3142 *did* close is the narrower case where bringing up the Go path
+was itself the trigger: `go-worker-migrate` no longer declares
+`depends_on: migrate`, so `--profile go up` cannot pull the Python migrator
+into the plan (see "Bring-up order" above, and its regression test). The
+general hazard remains — any `up` that restarts `migrate` for any other reason
+still runs to head — which is why CHAOS-3143 stays open.
 
 ### `SETTINGS_ENCRYPTION_KEY` delivery: the `env_file` path must NOT be parameterized alongside the build context
 

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -127,3 +127,123 @@ route/rollback ownership, cross-process quiescence, scheduler policy parity,
 provider sync (`sync_provider`) contract support where applicable, and a
 successful coexistence canary. The current checked-in contract fails these
 conditions, so Go-only is not production-authorized.
+
+## Running a Go worker topology against local Postgres (CHAOS-3142)
+
+These are the wiring facts discovered while exercising the additive Go path
+(`go-worker-migrate` → `go-worker` → `go-reconciler`) end to end against a
+local Postgres/ClickHouse/Valkey stack. They apply to any compose project
+that starts these services, not to one specific file — see that project's
+own compose file(s) for exactly which services exist and where.
+
+### One compose project owns one Postgres cluster
+
+Docker Compose tracks container ownership by `(project name, service name)`.
+Two different compose files that both declare the same top-level `name:`
+believe they own the same containers — an `up` from either one can silently
+recreate the other's already-running `postgres` container in place, with
+whatever role/database/PGDATA layout *that* file happens to declare. This
+is not a hypothetical: it is the CHAOS-3142 incident (2026-07-25) that
+motivated hardening `ops/compose.yml`'s postgres service (digest-pinned
+image, `PGDATA` spelled correctly instead of the inert `PG_DATA`, its own
+project name). If you are pointing a Go worker topology at an *existing*
+local Postgres cluster rather than starting a fresh one, confirm which
+compose project actually owns that container (`docker inspect <container>
+--format '{{index .Config.Labels "com.docker.compose.project"}}'`) before
+running any compose command against it from a second file.
+
+### The coordinator DSN must be direct Postgres, never PgBouncer
+
+`COORDINATOR_DATABASE_URI` (read by `go-reconciler` and by
+`dev-health-worker-migrate`'s `MIGRATION_DATABASE_URI`, which is a distinct,
+more-privileged DSN — never reused as a coordinator runtime identity) must
+point at Postgres's own port (`5432` locally), never through PgBouncer's
+transaction-mode pool (`6432` locally). The coordinator holds
+cross-statement row and table locks (`FOR UPDATE`, `LOCK TABLE ... IN SHARE
+ROW EXCLUSIVE MODE`) that a transaction-mode pooler can hand to a different
+server session mid-transaction, silently breaking the lock. Startup rejects
+this explicitly: `internal/storage/postgres/runtime.go`'s
+`ErrCoordinatorTransactionMode` fires when the domain endpoint is
+PgBouncer-pooled and the coordinator DSN resolves to that same endpoint. The
+domain DSN (`POSTGRES_URI`) may continue through PgBouncer, as the Python
+API/Celery processes' `DATABASE_URI` already does; the queue-control DSN
+(`WORKER_DATABASE_URI`) must also be direct, for the same reason.
+
+### ClickHouse: the Go worker needs the native port, not the HTTP port
+
+Python's `CLICKHOUSE_URI` (via `clickhouse-connect`) speaks ClickHouse's
+HTTP interface, port `8123` locally. The Go worker's `CLICKHOUSE_URI` (via
+`internal/storage/clickhouse`, built on `ClickHouse/clickhouse-go/v2`)
+speaks the **native wire protocol**, port `9000` locally, and eagerly
+`Ping()`s at construction time. Pointing the Go worker's `CLICKHOUSE_URI` at
+the HTTP port fails immediately with `ClickHouse readiness check failed`
+(`internal/storage/clickhouse.ErrUnavailable`) — the two processes' env var
+has the same name but must resolve to a different port.
+
+### With both route switches off, `go-worker`'s `sync` profile fails closed at startup
+
+This is intentional, not a bug, and it is worth expecting before you hit it:
+with `POSTGRES_URI` and `WORKER_DATABASE_URI` both configured (as they must
+be to do anything useful) and `DEV_HEALTH_PROFILE=sync`,
+`cmd/dev-health-worker` unconditionally constructs the
+`sync.team_autoimport` handler the moment the domain DSN is present
+(`buildSyncCoordinatorWorker` gates only on `profile == "sync"`, not on
+either route switch). Startup then requires an **exact match** between what
+was actually constructed and the full job-kind/queue set the `sync`
+deployment profile declares
+(`cmd/dev-health-worker/dependencies.go`'s `profileReady` — the CUT-02
+"exact startup validation" gate) — which also declares
+`sync.provider_unit`. With `WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED` and
+`WORKER_GITHUB_REPO_METADATA_ENABLED` both at their secure default of
+`false`, `sync.provider_unit` is never constructed, the match fails, and the
+process exits non-zero — which crash-loops under `restart: unless-stopped`.
+The container never binds `:8080`, so `/readyz` never even becomes reachable
+to show *why*; the reason is in the container's own log line:
+`{"level":"ERROR","msg":"configure runtime dependencies","error_category":"dependency_configuration_failed"}`.
+
+This is fail-closed by design — a worker dispatching `github`/`repo-metadata`
+units into River while refusing to build the handler for them would strand
+every one of those units, which is worse than not starting at all. **To get
+`go-worker`'s `sync` profile to a ready state, set one of the two switches
+to `true`** (for example `WORKER_GITHUB_REPO_METADATA_ENABLED=true`) in
+whatever environment file feeds that compose project. The default stays
+`false` in every checked-in file; this is a per-environment operator choice,
+made alongside enabling the matching route in a reviewed release, never a
+default flip.
+
+### The `sync.team_autoimport` bridge needs `WORKER_OPERATIONAL_BRIDGE_*` even though `profiles.json` doesn't say so
+
+`deploy/go-workers/profiles.json`'s `sync` process entry does not list
+`WORKER_OPERATIONAL_BRIDGE_URL`/`WORKER_OPERATIONAL_BRIDGE_TOKEN` in its
+`secret_env`, but `buildSyncCoordinatorWorker` constructs an HTTP bridge
+(`syncdispatchruntime.NewHTTPBridge`) unconditionally for the `sync` profile
+once the domain DSN is configured, and that constructor fails closed on an
+empty `BaseURL` or `BearerToken`. Set `WORKER_OPERATIONAL_BRIDGE_URL` (an
+HTTP(S) origin reachable from the Go worker's container — typically the
+Python `api` service) and a non-empty `WORKER_OPERATIONAL_BRIDGE_TOKEN`; if
+the origin is plain HTTP rather than HTTPS, also set
+`WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE=true`, matching the pattern
+`deploy/docker-compose/compose.go-workers.yml`'s `go-worker-heavy` service
+already uses.
+
+### Provider credentials the Go executor can decrypt
+
+`internal/providerfoundation.CredentialResolver` reads
+`integration_credentials.credentials_encrypted` and decrypts it with the
+same v1 Fernet-over-PBKDF2 scheme as
+`src/dev_health_ops/core/encryption.py` (`SETTINGS_ENCRYPTION_KEY`, 600,000
+PBKDF2-HMAC-SHA256 iterations, default salt
+`dev-health-ops-settings-encryption-v1`) — the two are wire-compatible, and
+`decrypt_value`/`encrypt_value` in that Python module are the reference
+implementation for constructing a test row by hand. The decrypted
+**plaintext must be a JSON object** (`{"token": "..."}` for a GitHub PAT;
+`ValidateCredentialShape` accepts exactly one of a PAT `token` or the three
+GitHub App fields `app_id`/`private_key`/`installation_id`), not a bare
+token string — decrypting a bare string fails
+`decodeCredential`'s `json.Unmarshal` and surfaces identically to a wrong
+key (`ErrCredentialInvalid`, "provider credential is invalid"). The claim
+row's `credential_id` comes from `COALESCE(sync_runs.credential_id,
+integrations.credential_id)`, so a credential row that exists but isn't
+linked from `integrations.credential_id` (or the sync run) is invisible to
+a claim even though `PostgresCredentialRepository.ResolveEncrypted` would
+find it directly by `(org_id, provider)`.

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -445,27 +445,52 @@ isolated project — never on shared infrastructure:
 
 ### Not proven
 
-A ClickHouse `repos` row. This needs a real GitHub PAT, which was
-unavailable throughout — nobody working this ticket had one, and none was
-requested from the user. `worker_sync_lease_expired_total` also never
-carried a non-zero series in any run: this is expected and **not a
-regression signal** — that metric only increments on a claim that itself
-recovered an *expired* lease (`providerunit.Handler.observeLeaseRecovery`
-checks `claim.Recovered`, a no-op for an ordinary first-attempt claim), and
-nothing in this proof deliberately expired and re-claimed a lease.
+A ClickHouse `repos` row, on either stack. `worker_sync_lease_expired_total`
+also never carried a non-zero series in any run: this is expected and
+**not a regression signal** — that metric only increments on a claim that
+itself recovered an *expired* lease
+(`providerunit.Handler.observeLeaseRecovery` checks `claim.Recovered`, a
+no-op for an ordinary first-attempt claim), and nothing in this proof
+deliberately expired and re-claimed a lease.
+
+**Correction (this section originally overstated the credential blocker —
+see below):** the isolated project's synthetic org needed a fake PAT
+because its Postgres volume was fresh and empty; that limitation does not
+carry over to a stack with real data, and an earlier version of this report
+wrongly transplanted it onto the real shared stack without checking. On the
+real stack the blocker is routing, not credentials — see the next section.
 
 ### Not attempted against the real shared stack, and why
 
-Both the durable route flip (`worker_job_routes.transport` for
-`sync.provider_unit` → `river_canary`) and the Python producer switch
-(`WORKER_GITHUB_REPO_METADATA_ENABLED=true` on `dev-health-worker-1`/`api`/
-`beat`) were considered and explicitly not done, for two compounding
-reasons:
+**Blocked on a deliberate routing decision, not on credential
+availability.** A working, decryptable, correctly-shaped github credential
+already exists on the real shared stack — this was checked directly rather
+than assumed:
+
+- `integrations`: 16 rows with `provider='github'`, 7 with a `credential_id`
+  set.
+- `integration_credentials` for `provider='github'`: 3 active rows, all
+  `last_test_success = true`, most recently tested 2026-07-05.
+- All three decrypt successfully today, using the app's own `decrypt_value`
+  with the **current** `SETTINGS_ENCRYPTION_KEY` (run inside the
+  `dev-health-api-1` container) — which also confirms that key is the one
+  they were encrypted with. Two decrypt to a JSON object with keys
+  `app_id`, `base_url`, `installation_id`, `org`, `private_key`, `token` —
+  a real `token`, in the JSON-object shape `complete_route.go` requires,
+  not a bare string (see "Provider credentials" below). The third is
+  app-only: `app_id`, `installation_id`, `private_key`.
+
+So credential availability and shape are not what stands between this stack
+and a real ClickHouse `repos` row. What does, and was deliberately not
+touched, is the two-key routing interlock, both halves of which were
+considered and explicitly left alone:
 
 1. **They are not independent, and the order matters.** Flipping the
-   durable route alone, with the Python switch still off, is not a smaller,
-   safer version of flipping both — it actively raises. `dispatch_sync_run`
-   (`src/dev_health_ops/workers/sync_units.py`) consults
+   durable route (`worker_job_routes.transport` for `sync.provider_unit`,
+   currently `celery`, would need `river_canary`) alone, with the Python
+   producer switch (`WORKER_GITHUB_REPO_METADATA_ENABLED`) still off, is not
+   a smaller, safer version of flipping both — it actively raises.
+   `dispatch_sync_run` (`src/dev_health_ops/workers/sync_units.py`) consults
    `ProviderUnitRouteSwitches.is_route_ready(provider, dataset)` (matrix-only,
    unconditional) BEFORE consulting the switch. If the matrix says a pair is
    route-ready and the durable route already points at River, but the
@@ -486,14 +511,24 @@ reasons:
    real Celery worker actively processing real organizations' real sync
    traffic — with new environment. That is a materially different, and
    materially bigger, ask than one reversible `UPDATE` on a single
-   `worker_job_routes` row, and it was not authorized.
+   `worker_job_routes` row, and it was not authorized. The user re-decided
+   with the corrected facts above (credentials exist; the blocker is purely
+   the routing interlock) and still chose to stop here — this is a
+   deliberate scope decision, not a missing capability.
 
-The marginal evidence a full route flip would have bought was also small:
-the proof already reached the real GitHub-API boundary in the isolated
-project (see above), so completing the durable-route path on the shared
-stack would have re-verified the same mechanism against a different compose
-file, not produced new information — not worth a live Celery worker
-recreate on someone's real environment for that.
+### Reachability: what completing the chain would actually take
+
+With both interlock halves flipped, the chain **can** complete to a real
+ClickHouse `repos` row using one of the three existing credentials above —
+no GitHub PAT needs to be obtained or seeded. Whoever picks this up needs
+only:
+
+1. `UPDATE worker_job_routes SET transport='river_canary', generation=generation+1, updated_at=now() WHERE job_kind='sync.provider_unit'` — matches the already-checked-in policy in `contracts/jobs/v1/migration-state.json` (`"route": "river_canary"`, from CHAOS-3123), not a new state.
+2. `WORKER_GITHUB_REPO_METADATA_ENABLED=true` on `dev-health-worker-1` (and anywhere else `dispatch_sync_run` runs), which requires recreating that container with the new environment — wire the variable into the repo-root `compose.yml`'s Python service blocks first, the same way it's already wired for `go-worker`.
+3. `go-worker` running and ready (see the crash-loop section above for what that needs).
+
+Revert both (1) and (2) back to `celery`/`false` afterward — this is a
+canary capability being exercised on demand, not a standing cutover.
 
 ### Credential shape, restated for this report
 

--- a/deploy/go-workers/compose-go-profile.yml
+++ b/deploy/go-workers/compose-go-profile.yml
@@ -1,0 +1,291 @@
+# Go execution path overlay — the CHAOS-3142 compose services, kept under
+# version control here because the stack they belong to is not.
+#
+# The canonical local stack is the repo-root /dev-health/compose.yml, which
+# owns PostgreSQL, PgBouncer, ClickHouse, Valkey, the API/web services, the
+# Celery workers, and Beat. That file lives outside any git repository, so
+# these four service definitions would otherwise exist only as untracked text
+# on one machine. This copy is the reviewed, versioned source of truth for
+# them; treat the root file as a working copy of it.
+#
+# TWO WAYS TO USE IT
+#
+#   1. As an overlay, without editing the root file:
+#
+#        cd /path/to/dev-health
+#        docker compose -f compose.yml \
+#          -f ops/deploy/go-workers/compose-go-profile.yml \
+#          --profile go up -d
+#
+#      The root compose.yml MUST be the first -f. Compose resolves every
+#      relative path in every file against the project directory, which it
+#      takes from the first file — so ./ops below only means what it says when
+#      the root file leads.
+#
+#   2. Pasted into the root compose.yml, immediately before its `volumes:`
+#      block. This is how it is currently deployed.
+#
+# In both cases the services sit behind `profiles: [go]`, so a bare
+# `docker compose up -d` creates none of them and the default stack is
+# untouched. Put COMPOSE_PROFILES=go in a .env NEXT TO THE ROOT compose.yml
+# (not ops/.env — compose reads interpolation and COMPOSE_PROFILES only from
+# the .env beside the compose file, or the shell) to include them in a normal
+# `up`.
+#
+# To build against an unmerged ops worktree instead of ./ops:
+#
+#   DEV_HEALTH_OPS_ROOT=./ops/.claude/worktrees/<name> docker compose ... 
+#
+# That override deliberately does NOT apply to env_file — see the comment on
+# go-worker's env_file below for why, and what breaks silently if you change
+# it.
+#
+# Requires the `dev-health` network and the postgres/pgbouncer/clickhouse/
+# valkey/migrate services from the root compose.yml. It is not standalone.
+#
+# See ./README.md for the runbook: the coordinator DSN constraint, the
+# ClickHouse native-port distinction, the fail-closed crash-loop when both
+# route switches are off, and what the end-to-end proof did and did not
+# establish.
+
+services:
+  # ===========================================================================
+  # Go execution path (CHAOS-3142) — additive, profile-gated, default OFF.
+  #
+  # Every service below is behind `profiles: [go]`, so a bare
+  # `docker compose up -d` creates none of them and this stack behaves exactly
+  # as it did before. To run them:
+  #
+  #   docker compose --profile go up -d --build
+  #
+  # or, to have them come up as part of your normal `up`, put this in a `.env`
+  # file NEXT TO THIS FILE (repo root) — which is the intended setup for
+  # watching the Go path locally:
+  #
+  #   COMPOSE_PROFILES=go
+  #
+  # It must be the root .env, not ops/.env. Compose only reads the .env
+  # adjacent to the compose file (or the shell) for `${VAR}` interpolation and
+  # for COMPOSE_PROFILES; a service-level `env_file:` is injected into the
+  # container and cannot select a profile or feed an interpolation. Verified:
+  # ops/.env's POSTGRES_USER/POSTGRES_DB do not reach interpolation here — the
+  # DSNs below resolve to `devhealth` from their own defaults, which happen to
+  # agree.
+  #
+  # Celery and Beat remain the only scheduler and the owner of every route.
+  # Starting these containers does not transfer a queue or reroute a job: the
+  # durable route lives in worker_job_routes plus the checked-in policy at
+  # ops/contracts/jobs/v1/migration-state.json, and neither is touched here.
+  #
+  # NOTE: this is the `dev-health` project. ops/compose.yml is a SEPARATE
+  # project (dev-health-ops) with its own volumes — running `up` from that file
+  # used to recreate this project's containers with a conflicting postgres
+  # definition, which is what caused the CHAOS-3142 incident. Do not try to
+  # attach the Go services to this stack from there.
+  # ===========================================================================
+
+  # Creates the three runtime roles of the CHAOS-3033 Option B split
+  # (domain / queue-control / coordinator) idempotently — the SQL is guarded by
+  # `WHERE NOT EXISTS` per role and validates that all three names are
+  # distinct. Required on any cluster provisioned before the coordinator role
+  # existed: docker/init-extra-dbs.sh only creates roles on a FRESH volume, so
+  # an existing dev cluster has devhealth_domain and devhealth_queue but no
+  # devhealth_coordinator, and go-reconciler cannot start without it.
+  go-river-provision:
+    image: postgres:18-alpine
+    profiles: ["go"]
+    restart: "no"
+    environment:
+      PGPASSWORD: ${POSTGRES_PASSWORD:-devhealth}
+      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
+      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      RIVER_COORDINATOR_DATABASE_ROLE: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
+      RIVER_DOMAIN_DATABASE_PASSWORD: ${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}
+      RIVER_QUEUE_DATABASE_PASSWORD: ${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}
+      RIVER_COORDINATOR_DATABASE_PASSWORD: ${RIVER_COORDINATOR_DATABASE_PASSWORD:-devhealth_coordinator}
+    entrypoint:
+      - /bin/sh
+      - -ec
+      - |
+        exec psql \
+          --host=postgres \
+          --username="${POSTGRES_USER:-devhealth}" \
+          --dbname="${POSTGRES_DB:-devhealth}" \
+          --set=ON_ERROR_STOP=1 \
+          --set=domain_role="$$RIVER_DOMAIN_DATABASE_ROLE" \
+          --set=queue_role="$$RIVER_QUEUE_DATABASE_ROLE" \
+          --set=coordinator_role="$$RIVER_COORDINATOR_DATABASE_ROLE" \
+          --set=domain_password="$$RIVER_DOMAIN_DATABASE_PASSWORD" \
+          --set=queue_password="$$RIVER_QUEUE_DATABASE_PASSWORD" \
+          --set=coordinator_password="$$RIVER_COORDINATOR_DATABASE_PASSWORD" \
+          --file=/opt/dev-health/provision_river_roles.sql
+    volumes:
+      - ${DEV_HEALTH_OPS_ROOT:-./ops}/scripts/worker/provision_river_roles.sql:/opt/dev-health/provision_river_roles.sql:ro
+    depends_on:
+      postgres:
+        condition: service_healthy
+    networks:
+      - dev-health
+
+  # Applies the pinned River schema and the per-table grants for the three
+  # runtime roles. The elevated migration DSN is confined to this one-shot
+  # process; the long-running Go services below only ever receive unprivileged
+  # runtime DSNs. It must complete before either of them starts, and it depends
+  # on the Python `migrate` service because the tables it grants against
+  # (worker_job_outbox, worker_job_completion_fences, ...) are created there.
+  go-worker-migrate:
+    build:
+      context: ${DEV_HEALTH_OPS_ROOT:-./ops}
+      dockerfile: docker/go-worker.Dockerfile
+      target: migrate
+    profiles: ["go"]
+    restart: "no"
+    labels:
+      logging.service.name: dev-health-go-worker-migrate
+      logging.service.namespace: dev-health
+    environment:
+      # Direct postgres:5432, never pgbouncer, and never a runtime role.
+      MIGRATION_DATABASE_URI: postgresql://${POSTGRES_USER:-devhealth}:${POSTGRES_PASSWORD:-devhealth}@postgres:5432/${POSTGRES_DB:-devhealth}
+      RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
+      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
+      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      RIVER_COORDINATOR_DATABASE_ROLE: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
+      LOG_LEVEL: ${LOG_LEVEL:-INFO}
+    depends_on:
+      go-river-provision:
+        condition: service_completed_successfully
+      migrate:
+        condition: service_completed_successfully
+    networks:
+      - dev-health
+
+  # The provider-unit River handler, running the `sync` deployment profile from
+  # ops/deploy/go-workers/profiles.json.
+  #
+  # IMPORTANT — this service fails closed at startup unless at least one route
+  # switch is enabled, and will crash-loop until you enable one. That is
+  # intentional, not a wiring bug: the sync profile constructs the
+  # sync.team_autoimport handler whenever DEV_HEALTH_PROFILE=sync and a domain
+  # DSN is present, then requires an exact match between what it constructed
+  # and the full job_kinds set the sync profile declares — which includes
+  # sync.provider_unit. With both switches off, that match fails. To watch the
+  # path actually execute, set this in the ROOT .env (next to this file) or in
+  # your shell — not ops/.env, which loses to the `environment:` interpolation
+  # below:
+  #
+  #   WORKER_GITHUB_REPO_METADATA_ENABLED=true
+  #
+  # Both switches default to false here on purpose: only 2 of 59
+  # provider/dataset pairs are route-ready, and each switch must be flipped
+  # alongside a reviewed route release. The SAME variable names are read by the
+  # Python producer gate (ops/src/dev_health_ops/workers/provider_unit_route.py)
+  # and by this Go worker, so one override moves both halves coherently — a
+  # unit the producer routes to River while the Go switch is off finds no
+  # handler.
+  go-worker:
+    build:
+      context: ${DEV_HEALTH_OPS_ROOT:-./ops}
+      dockerfile: docker/go-worker.Dockerfile
+      target: worker
+    profiles: ["go"]
+    restart: unless-stopped
+    labels:
+      logging.service.name: dev-health-go-worker
+      logging.service.namespace: dev-health
+    env_file:
+      # NOT ${DEV_HEALTH_OPS_ROOT} — deliberately. The build context follows
+      # that override so a worktree's Dockerfile and Go source get built, but
+      # the developer's real local configuration always lives at ./ops/.env and
+      # a worktree has none. Parameterizing this path made it resolve to a
+      # nonexistent file which `required: false` then skipped in silence, so
+      # SETTINGS_ENCRYPTION_KEY never reached the container and the sync
+      # profile failed closed with a generic "configure runtime dependencies".
+      # profiles.json lists SETTINGS_ENCRYPTION_KEY in the sync process's
+      # secret_env, so it is required, not optional.
+      - path: ./ops/.env
+        required: false
+    environment:
+      DEV_HEALTH_PROFILE: sync
+      POSTGRES_URI: postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}@pgbouncer:6432/${POSTGRES_DB:-devhealth}
+      PGBOUNCER_TRANSACTION_MODE: "true"
+      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@postgres:5432/${POSTGRES_DB:-devhealth}
+      # Native protocol port 9000, NOT the HTTP port 8123 every Python service
+      # in this file uses. internal/storage/clickhouse opens with
+      # ClickHouse/clickhouse-go/v2, which speaks the native wire protocol and
+      # Pings eagerly at construction — pointed at 8123 it fails immediately
+      # with "ClickHouse readiness check failed".
+      CLICKHOUSE_URI: clickhouse://${CLICKHOUSE_USER:-ch}:${CLICKHOUSE_PASSWORD:-ch}@clickhouse:9000/${CLICKHOUSE_DB:-default}
+      VALKEY_URI: redis://valkey:6379/1
+      RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
+      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
+      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      WORKER_DOMAIN_DATABASE_MAX_CONNS: ${WORKER_DOMAIN_DATABASE_MAX_CONNS:-4}
+      WORKER_DATABASE_MAX_CONNS: ${WORKER_DATABASE_MAX_CONNS:-2}
+      WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED: ${WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED:-false}
+      WORKER_GITHUB_REPO_METADATA_ENABLED: ${WORKER_GITHUB_REPO_METADATA_ENABLED:-false}
+      # sync.team_autoimport's post-sync bridge is constructed unconditionally
+      # for the sync profile, and the HTTP bridge fails closed on an empty
+      # base URL or token, so both are required for this service to start even
+      # though the profile's secret_env list does not name them. The token
+      # below is a local placeholder, not a credential.
+      WORKER_OPERATIONAL_BRIDGE_URL: ${WORKER_OPERATIONAL_BRIDGE_URL:-http://api:8000}
+      WORKER_OPERATIONAL_BRIDGE_TOKEN: ${WORKER_OPERATIONAL_BRIDGE_TOKEN:-local-go-worker-bridge-token}
+      WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE: ${WORKER_OPERATIONAL_BRIDGE_ALLOW_INSECURE:-true}
+      DEV_HEALTH_LOG_LEVEL: ${LOG_LEVEL:-info}
+    depends_on:
+      go-worker-migrate:
+        condition: service_completed_successfully
+      clickhouse:
+        condition: service_healthy
+      valkey:
+        condition: service_healthy
+      pgbouncer:
+        condition: service_started
+    ports:
+      # Operator/readiness surface: /readyz, /healthz, /metrics.
+      - "${GO_WORKER_PORT:-8081}:8080"
+    networks:
+      - dev-health
+
+  # Relays worker_job_outbox rows into River and observes the sync-dispatch
+  # outbox. This is a coordinator-role binary, so COORDINATOR_DATABASE_URI is
+  # required and MUST be direct postgres:5432 — transaction-mode pooling cannot
+  # hold the cross-statement row and table locks the coordinator takes, and the
+  # process rejects a pooled coordinator DSN at startup rather than risking
+  # them silently spanning connections. It declares no deployment profile, so
+  # DEV_HEALTH_PROFILE must not be set here.
+  go-reconciler:
+    build:
+      context: ${DEV_HEALTH_OPS_ROOT:-./ops}
+      dockerfile: docker/go-worker.Dockerfile
+      target: reconciler
+    profiles: ["go"]
+    restart: unless-stopped
+    labels:
+      logging.service.name: dev-health-go-reconciler
+      logging.service.namespace: dev-health
+    env_file:
+      - path: ./ops/.env
+        required: false
+    environment:
+      POSTGRES_URI: postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:${RIVER_DOMAIN_DATABASE_PASSWORD:-devhealth_domain}@pgbouncer:6432/${POSTGRES_DB:-devhealth}
+      PGBOUNCER_TRANSACTION_MODE: "true"
+      WORKER_DATABASE_URI: postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:${RIVER_QUEUE_DATABASE_PASSWORD:-devhealth_queue}@postgres:5432/${POSTGRES_DB:-devhealth}
+      COORDINATOR_DATABASE_URI: postgresql://${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}:${RIVER_COORDINATOR_DATABASE_PASSWORD:-devhealth_coordinator}@postgres:5432/${POSTGRES_DB:-devhealth}
+      RIVER_DATABASE_SCHEMA: ${RIVER_DATABASE_SCHEMA:-river}
+      RIVER_DOMAIN_DATABASE_ROLE: ${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}
+      RIVER_QUEUE_DATABASE_ROLE: ${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}
+      RIVER_COORDINATOR_DATABASE_ROLE: ${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}
+      WORKER_DOMAIN_DATABASE_MAX_CONNS: ${WORKER_DOMAIN_DATABASE_MAX_CONNS:-4}
+      WORKER_DATABASE_MAX_CONNS: ${WORKER_DATABASE_MAX_CONNS:-2}
+      WORKER_COORDINATOR_DATABASE_MAX_CONNS: ${WORKER_COORDINATOR_DATABASE_MAX_CONNS:-2}
+      DEV_HEALTH_LOG_LEVEL: ${LOG_LEVEL:-info}
+    depends_on:
+      go-worker-migrate:
+        condition: service_completed_successfully
+      pgbouncer:
+        condition: service_started
+    ports:
+      - "${GO_RECONCILER_PORT:-8082}:8080"
+    networks:
+      - dev-health

--- a/deploy/go-workers/compose-go-profile.yml
+++ b/deploy/go-workers/compose-go-profile.yml
@@ -130,9 +130,30 @@ services:
   # Applies the pinned River schema and the per-table grants for the three
   # runtime roles. The elevated migration DSN is confined to this one-shot
   # process; the long-running Go services below only ever receive unprivileged
-  # runtime DSNs. It must complete before either of them starts, and it depends
-  # on the Python `migrate` service because the tables it grants against
-  # (worker_job_outbox, worker_job_completion_fences, ...) are created there.
+  # runtime DSNs. It must complete before either of them starts.
+  #
+  # It deliberately does NOT `depends_on: migrate`, even though the tables it
+  # grants against (worker_job_outbox, worker_job_completion_fences, ...) are
+  # created by the Python migrator. `depends_on` pulls a service in regardless
+  # of profile, so that edge made `--profile go up -d` run Alembic to *head* --
+  # which is 0066_activate_river_worker_job_routes, the cutover that retargets
+  # 23 job kinds from Celery to River. The Go services sit downstream of this
+  # one, so the graph guaranteed exactly the ordering 0066 forbids: routes flip
+  # to River before any River consumer can start, and work then accumulates in
+  # worker_job_outbox with nothing to execute it. Bringing up the Go path must
+  # never be able to move production traffic as a side effect.
+  #
+  # The Python schema is therefore an explicit, separately authorized
+  # prerequisite. Bring it to the last pre-cutover revision first:
+  #
+  #   docker compose run --rm --entrypoint sh migrate -c \
+  #     'python -m dev_health_ops.cli migrate postgres upgrade 0065'
+  #
+  # If it is behind that, the grants below silently no-op (they are
+  # to_regclass-guarded so a migration can never fail on a missing table) and
+  # go-reconciler stays unready -- but it now logs the precise missing
+  # table.privilege gaps via DiagnoseRolePosture, so the cause is legible
+  # instead of a bare "dependency unavailable". See CHAOS-3143.
   go-worker-migrate:
     build:
       context: ${DEV_HEALTH_OPS_ROOT:-./ops}
@@ -153,8 +174,6 @@ services:
       LOG_LEVEL: ${LOG_LEVEL:-INFO}
     depends_on:
       go-river-provision:
-        condition: service_completed_successfully
-      migrate:
         condition: service_completed_successfully
     networks:
       - dev-health

--- a/docker/go-worker.Dockerfile
+++ b/docker/go-worker.Dockerfile
@@ -36,7 +36,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
         dev-health-reconciler \
         dev-health-stream-runner \
         dev-health-workerctl \
-        worker-contractcheck; do \
+        worker-contractcheck \
+        dev-health-worker-migrate; do \
       GOOS="${TARGETOS}" GOARCH="${TARGETARCH}" go build \
         -buildvcs=false \
         -trimpath \
@@ -63,7 +64,8 @@ RUN --mount=type=cache,target=/go/pkg/mod \
       /runtime/operator/app/deploy/go-workers \
       /runtime/contractcheck/usr/local/bin \
       /runtime/contractcheck/app/contracts/jobs \
-      /runtime/contractcheck/app/deploy/go-workers; \
+      /runtime/contractcheck/app/deploy/go-workers \
+      /runtime/migrate/usr/local/bin; \
     cp /out/dev-health-worker /runtime/worker/usr/local/bin/dev-health-worker; \
     cp /out/dev-health-scheduler /runtime/scheduler/usr/local/bin/dev-health-scheduler; \
     cp -R /src/contracts/jobs/v1 /runtime/scheduler/app/contracts/jobs/v1; \
@@ -80,6 +82,7 @@ RUN --mount=type=cache,target=/go/pkg/mod \
     cp /src/deploy/go-workers/profiles.json /runtime/operator/app/deploy/go-workers/profiles.json; \
     cp -R /src/contracts/jobs/v1 /runtime/contractcheck/app/contracts/jobs/v1; \
     cp /src/deploy/go-workers/profiles.json /runtime/contractcheck/app/deploy/go-workers/profiles.json; \
+    cp /out/dev-health-worker-migrate /runtime/migrate/usr/local/bin/dev-health-worker-migrate; \
     find /runtime -exec touch -d "@${SOURCE_DATE_EPOCH}" {} +
 
 FROM ${GO_RUNTIME_IMAGE} AS runtime
@@ -127,3 +130,13 @@ COPY --from=build --chown=65532:65532 /runtime/contractcheck/ /
 WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/worker-contractcheck"]
 CMD ["validate"]
+
+# migrate is the one-shot River schema/grant migration
+# (cmd/dev-health-worker-migrate). It reads no contract or deployment-profile
+# files at runtime -- only its flags and the MIGRATION_DATABASE_URI /
+# RIVER_*_ROLE environment -- so, unlike the other targets above, its runtime
+# layer stages nothing under /app.
+FROM runtime AS migrate
+COPY --from=build --chown=65532:65532 /runtime/migrate/ /
+WORKDIR /app
+ENTRYPOINT ["/usr/local/bin/dev-health-worker-migrate"]

--- a/docker/go-worker.Dockerfile
+++ b/docker/go-worker.Dockerfile
@@ -134,9 +134,32 @@ CMD ["validate"]
 # migrate is the one-shot River schema/grant migration
 # (cmd/dev-health-worker-migrate). It reads no contract or deployment-profile
 # files at runtime -- only its flags and the MIGRATION_DATABASE_URI /
-# RIVER_*_ROLE environment -- so, unlike the other targets above, its runtime
-# layer stages nothing under /app.
+# RIVER_*_ROLE environment -- so, unlike most targets above, its runtime layer
+# stages nothing under /app.
+#
+# It therefore must NOT declare `WORKDIR /app`, and follows stream-runner (the
+# only other target with no /app tree) in omitting it. The `runtime` base does
+# not create /app, so the two cases are not equivalent:
+#
+#   - targets that stage an app/ tree receive /app from the build stage, where
+#     `find /runtime -exec touch -d @$SOURCE_DATE_EPOCH` has already flattened
+#     its mtime, and WORKDIR is then a no-op on an existing directory;
+#   - a target with no app/ tree makes WORKDIR *create* the directory during
+#     this stage, which is not covered by that normalisation.
+#
+# With `WORKDIR /app` here, `check_go_containers.sh reproducible` failed on two
+# separate CI runs -- `migrate image is not reproducible` -- while all six
+# other targets passed both times. Those seven results isolate this line as the
+# only structural difference: five targets pair WORKDIR with a staged app/
+# tree, stream-runner has neither, and migrate was the sole WORKDIR-without-app
+# combination.
+#
+# Caveat for whoever revisits this: the mechanism above is inferred from that
+# CI evidence, not confirmed locally. A platform-faithful local probe
+# (--platform linux/amd64, SOURCE_DATE_EPOCH=0, --no-cache) found migrate
+# reproducible both with and without the line, so the timestamp normalisation
+# apparently differs between Docker Desktop's BuildKit and the CI runner's.
+# Do not re-add WORKDIR on the strength of a local probe alone.
 FROM runtime AS migrate
 COPY --from=build --chown=65532:65532 /runtime/migrate/ /
-WORKDIR /app
 ENTRYPOINT ["/usr/local/bin/dev-health-worker-migrate"]

--- a/internal/storage/postgres/posture_diagnostics.go
+++ b/internal/storage/postgres/posture_diagnostics.go
@@ -1,0 +1,247 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// PostureGap is one requirement of a RolePosture the connected login does
+// not currently satisfy. It is built entirely from checked-in, non-secret
+// schema identifiers (table and column names this repository already
+// declares in domainPosture/coordinatorPosture) and standard SQL privilege
+// keywords -- never a DSN, host, credential, or any catalog detail beyond
+// what the declared posture itself already names. Safe to log.
+type PostureGap struct {
+	TableName    string
+	ColumnName   string // empty for a table-wide requirement
+	TableMissing bool
+	Missing      []string // e.g. ["INSERT", "UPDATE"]; ["SELECT"] for a column-scoped gap
+}
+
+// String renders one gap as a single redacted line, safe to place in a log
+// message.
+func (gap PostureGap) String() string {
+	if gap.TableMissing {
+		if gap.ColumnName != "" {
+			return fmt.Sprintf("%s.%s: table does not exist", gap.TableName, gap.ColumnName)
+		}
+		return fmt.Sprintf("%s: table does not exist", gap.TableName)
+	}
+	if gap.ColumnName != "" {
+		return fmt.Sprintf("%s.%s: missing %v", gap.TableName, gap.ColumnName, gap.Missing)
+	}
+	return fmt.Sprintf("%s: missing %v", gap.TableName, gap.Missing)
+}
+
+// diagnoseTablePostureQuery re-derives, per required table, whether it
+// exists and which of its required table-wide privileges the given role
+// currently lacks. It deliberately duplicates a small slice of
+// rolePostureQuery's logic rather than generalizing that hardened,
+// security-critical query to also return row-level diagnostics:
+// rolePostureQuery's job is a single trustworthy boolean that readiness
+// gates depend on, and this query's job is a human-readable explanation for
+// when that boolean is false. Keeping them separate means a bug in this
+// diagnostic-only path can never weaken the boolean the readiness gate
+// itself checks.
+const diagnoseTablePostureQuery = `
+WITH required(table_name, allow_insert, allow_update, allow_delete) AS (
+	SELECT * FROM unnest($2::text[], $3::boolean[], $4::boolean[], $5::boolean[])
+), resolved AS (
+	SELECT
+		required.table_name,
+		required.allow_insert,
+		required.allow_update,
+		required.allow_delete,
+		to_regclass('public.' || required.table_name) AS relation
+	FROM required
+)
+SELECT
+	table_name,
+	relation IS NULL AS table_missing,
+	relation IS NOT NULL AND NOT has_table_privilege($1, relation, 'SELECT') AS missing_select,
+	relation IS NOT NULL AND allow_insert AND NOT has_table_privilege($1, relation, 'INSERT') AS missing_insert,
+	relation IS NOT NULL AND allow_update AND NOT has_table_privilege($1, relation, 'UPDATE') AS missing_update,
+	relation IS NOT NULL AND allow_delete AND NOT has_table_privilege($1, relation, 'DELETE') AS missing_delete
+FROM resolved
+ORDER BY table_name
+`
+
+// diagnoseColumnPostureQuery is diagnoseTablePostureQuery's column-scoped
+// counterpart, for the same reason and with the same separation from
+// rolePostureQuery.
+const diagnoseColumnPostureQuery = `
+WITH required(table_name, column_name, privilege) AS (
+	SELECT * FROM unnest($2::text[], $3::text[], $4::text[])
+), resolved AS (
+	SELECT
+		required.table_name,
+		required.column_name,
+		required.privilege,
+		to_regclass('public.' || required.table_name) AS relation
+	FROM required
+)
+SELECT
+	table_name,
+	column_name,
+	privilege,
+	relation IS NULL AS table_missing,
+	relation IS NOT NULL AND NOT has_column_privilege($1, relation, column_name, privilege) AS missing
+FROM resolved
+ORDER BY table_name, column_name, privilege
+`
+
+// DiagnoseRolePosture re-checks a RolePosture's requirements individually
+// and returns the subset the connected login does not currently satisfy. It
+// is deliberately NOT part of CheckRolePosture's hot readiness path: it
+// issues two additional queries re-deriving what CheckRolePosture's single
+// hardened boolean already computed, at higher cost and with a smaller
+// trusted surface, so callers should use it only after CheckRolePosture has
+// already reported failure -- purely to explain why, in a form safe to log.
+//
+// It does NOT prove the inverse of CheckRolePosture (that the role holds
+// nothing beyond its posture): an empty result here means every declared
+// requirement is individually satisfied, which usually but not always means
+// CheckRolePosture would now pass. If CheckRolePosture still fails against
+// an empty diagnostic here, the role holds something it must not (an excess
+// grant), which this function does not attempt to detect -- identifying
+// that would mean walking effective privileges on every relation in the
+// schema against the manifest, the same work rolePostureQuery's catch-all
+// predicates already do inside its single trustworthy boolean, and
+// duplicating that here would be exactly the drift risk CheckRolePosture's
+// own package doc warns against.
+func DiagnoseRolePosture(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	expectedRole string,
+	posture RolePosture,
+) ([]PostureGap, error) {
+	if pool == nil || !validRuntimeIdentifier(expectedRole) {
+		return nil, ErrUnavailable
+	}
+	var gaps []PostureGap
+
+	if len(posture.RequiredTables) > 0 {
+		tableGaps, err := diagnoseTablePosture(ctx, pool, expectedRole, posture.RequiredTables)
+		if err != nil {
+			return nil, err
+		}
+		gaps = append(gaps, tableGaps...)
+	}
+
+	if len(posture.ColumnScoped) > 0 {
+		columnGaps, err := diagnoseColumnPosture(ctx, pool, expectedRole, posture.ColumnScoped)
+		if err != nil {
+			return nil, err
+		}
+		gaps = append(gaps, columnGaps...)
+	}
+
+	return gaps, nil
+}
+
+func diagnoseTablePosture(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	expectedRole string,
+	tables []TablePrivilege,
+) ([]PostureGap, error) {
+	tableNames := make([]string, len(tables))
+	allowInserts := make([]bool, len(tables))
+	allowUpdates := make([]bool, len(tables))
+	allowDeletes := make([]bool, len(tables))
+	for i, table := range tables {
+		tableNames[i] = table.TableName
+		allowInserts[i] = table.AllowInsert
+		allowUpdates[i] = table.AllowUpdate
+		allowDeletes[i] = table.AllowDelete
+	}
+	rows, err := pool.Query(
+		ctx, diagnoseTablePostureQuery, expectedRole, tableNames, allowInserts, allowUpdates, allowDeletes,
+	)
+	if err != nil {
+		return nil, ErrUnavailable
+	}
+	defer rows.Close()
+
+	var gaps []PostureGap
+	for rows.Next() {
+		var (
+			tableName                                                                string
+			tableMissing, missingSelect, missingInsert, missingUpdate, missingDelete bool
+		)
+		if err := rows.Scan(
+			&tableName, &tableMissing, &missingSelect, &missingInsert, &missingUpdate, &missingDelete,
+		); err != nil {
+			return nil, ErrUnavailable
+		}
+		if tableMissing {
+			gaps = append(gaps, PostureGap{TableName: tableName, TableMissing: true})
+			continue
+		}
+		var missing []string
+		if missingSelect {
+			missing = append(missing, "SELECT")
+		}
+		if missingInsert {
+			missing = append(missing, "INSERT")
+		}
+		if missingUpdate {
+			missing = append(missing, "UPDATE")
+		}
+		if missingDelete {
+			missing = append(missing, "DELETE")
+		}
+		if len(missing) > 0 {
+			gaps = append(gaps, PostureGap{TableName: tableName, Missing: missing})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, ErrUnavailable
+	}
+	return gaps, nil
+}
+
+func diagnoseColumnPosture(
+	ctx context.Context,
+	pool *pgxpool.Pool,
+	expectedRole string,
+	columns []ColumnPrivilege,
+) ([]PostureGap, error) {
+	tableNames := make([]string, len(columns))
+	columnNames := make([]string, len(columns))
+	privileges := make([]string, len(columns))
+	for i, column := range columns {
+		tableNames[i] = column.TableName
+		columnNames[i] = column.ColumnName
+		privileges[i] = column.Privilege
+	}
+	rows, err := pool.Query(ctx, diagnoseColumnPostureQuery, expectedRole, tableNames, columnNames, privileges)
+	if err != nil {
+		return nil, ErrUnavailable
+	}
+	defer rows.Close()
+
+	var gaps []PostureGap
+	for rows.Next() {
+		var (
+			tableName, columnName, privilege string
+			tableMissing, missing            bool
+		)
+		if err := rows.Scan(&tableName, &columnName, &privilege, &tableMissing, &missing); err != nil {
+			return nil, ErrUnavailable
+		}
+		if tableMissing {
+			gaps = append(gaps, PostureGap{TableName: tableName, ColumnName: columnName, TableMissing: true})
+			continue
+		}
+		if missing {
+			gaps = append(gaps, PostureGap{TableName: tableName, ColumnName: columnName, Missing: []string{privilege}})
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, ErrUnavailable
+	}
+	return gaps, nil
+}

--- a/internal/storage/postgres/posture_diagnostics_integration_test.go
+++ b/internal/storage/postgres/posture_diagnostics_integration_test.go
@@ -1,0 +1,123 @@
+//go:build integration
+
+package postgres
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestDiagnoseRolePostureNamesTheGapAndNeverLeaksConnectionMaterial is the
+// regression test for the CHAOS-3142 diagnosability gap: a
+// coordinator_postgres readiness failure used to surface only as a check
+// name, with no reason logged anywhere, because CheckRolePosture collapses
+// every failure mode into the same opaque ErrUnavailable. Diagnosing the
+// real incident (coordinatorPosture() required fixed_schedule_occurrences,
+// which did not exist on a database two Alembic migrations behind head, so
+// coordinatorGrantStatements' to_regclass guard silently skipped its GRANT)
+// took manually re-deriving and re-running the posture's table list by hand
+// against the live database.
+//
+// This pins two things DiagnoseRolePosture must get right, using the SAME
+// production grant harness (startGrantHarness / ApplyPinnedMigrations) the
+// coordinator statement-privilege suite uses, so the roles and grants under
+// test are the real ones, not a model of them:
+//
+//  1. A missing-table gap and a missing-privilege gap are both reported,
+//     each naming the actual table (and, for the privilege gap, the actual
+//     missing privilege) -- not a generic "something is wrong".
+//  2. Every gap's rendered log line (PostureGap.String(), exactly what
+//     cmd/dev-health-reconciler/dependencies.go's logCoordinatorPostureGaps
+//     logs) contains the table/privilege it names and NEVER contains this
+//     test's own connection material: the full connection URI, the
+//     coordinator role's password, or a bare "postgres://" scheme prefix.
+func TestDiagnoseRolePostureNamesTheGapAndNeverLeaksConnectionMaterial(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	admin, uri := startGrantHarness(t, ctx)
+	coordinator := connectAs(t, ctx, uri, grantCoordinatorRole, grantCoordinatorPass)
+
+	// Missing-table gap: a table the posture requires that was never
+	// created. This is exactly CHAOS-3142's shape -- a synthetic posture is
+	// used here (rather than dropping a table the harness's other suites
+	// depend on) purely to isolate the missing-table path.
+	const missingTable = "table_that_does_not_exist_for_this_test"
+	tableGaps, err := DiagnoseRolePosture(ctx, coordinator, grantCoordinatorRole, RolePosture{
+		RequiredTables: []TablePrivilege{{TableName: missingTable, AllowUpdate: true}},
+	})
+	if err != nil {
+		t.Fatalf("DiagnoseRolePosture (missing table): %v", err)
+	}
+	if len(tableGaps) != 1 || !tableGaps[0].TableMissing || tableGaps[0].TableName != missingTable {
+		t.Fatalf("expected exactly one table-missing gap naming %q, got %+v", missingTable, tableGaps)
+	}
+
+	// Missing-privilege gap: a real, existing coordinator table with one
+	// privilege the posture requires actually revoked.
+	if _, err := admin.Exec(ctx,
+		"REVOKE UPDATE ON TABLE public.worker_job_outbox FROM "+grantCoordinatorRole,
+	); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		cleanupCtx, cleanupCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cleanupCancel()
+		if _, err := admin.Exec(cleanupCtx,
+			"GRANT UPDATE ON TABLE public.worker_job_outbox TO "+grantCoordinatorRole,
+		); err != nil {
+			t.Errorf("restore worker_job_outbox UPDATE: %v", err)
+		}
+	})
+	privilegeGaps, err := DiagnoseRolePosture(ctx, coordinator, grantCoordinatorRole, RolePosture{
+		RequiredTables: []TablePrivilege{{TableName: "worker_job_outbox", AllowUpdate: true}},
+	})
+	if err != nil {
+		t.Fatalf("DiagnoseRolePosture (missing privilege): %v", err)
+	}
+	if len(privilegeGaps) != 1 || privilegeGaps[0].TableMissing || privilegeGaps[0].TableName != "worker_job_outbox" {
+		t.Fatalf("expected exactly one worker_job_outbox privilege gap, got %+v", privilegeGaps)
+	}
+	if len(privilegeGaps[0].Missing) != 1 || privilegeGaps[0].Missing[0] != "UPDATE" {
+		t.Fatalf("expected the gap to name UPDATE specifically, got %+v", privilegeGaps[0].Missing)
+	}
+
+	// The redaction guarantee: render every gap exactly the way
+	// logCoordinatorPostureGaps does, and assert the line names its own
+	// table/privilege but never contains this test's own connection
+	// material.
+	secrets := []string{uri, grantCoordinatorPass, "postgres://", "@"}
+	for _, gap := range append(tableGaps, privilegeGaps...) {
+		line := gap.String()
+		if !strings.Contains(line, gap.TableName) {
+			t.Errorf("log line %q does not name its own table %q", line, gap.TableName)
+		}
+		for _, secret := range secrets {
+			if secret != "" && strings.Contains(line, secret) {
+				t.Errorf("log line %q leaked connection material (%q)", line, secret)
+			}
+		}
+	}
+}
+
+// TestDiagnoseRolePostureReturnsNoGapsOnceGrantsAreCorrect closes the loop:
+// once the revoked privilege is restored, the diagnostic reports nothing --
+// it does not fire spuriously on a healthy role.
+func TestDiagnoseRolePostureReturnsNoGapsOnceGrantsAreCorrect(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	_, uri := startGrantHarness(t, ctx)
+	coordinator := connectAs(t, ctx, uri, grantCoordinatorRole, grantCoordinatorPass)
+
+	gaps, err := DiagnoseRolePosture(ctx, coordinator, grantCoordinatorRole, CoordinatorPosture())
+	if err != nil {
+		t.Fatalf("DiagnoseRolePosture: %v", err)
+	}
+	if len(gaps) != 0 {
+		t.Errorf("expected no gaps against the real migration-emitted grants, got %+v", gaps)
+	}
+	if err := CheckCoordinatorAuthorization(ctx, coordinator, grantCoordinatorRole, grantSchema); err != nil {
+		t.Fatalf("CheckCoordinatorAuthorization disagrees with DiagnoseRolePosture's empty result: %v", err)
+	}
+}

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -867,190 +867,46 @@ def test_production_stacks_cover_every_celery_queue() -> None:
 
 
 # ---------------------------------------------------------------------------
-# CHAOS-3142: additive Go execution path in compose.yml (go-worker-migrate,
-# go-worker, go-reconciler), profile-gated behind "go" so the default stack
-# is unchanged, plus the postgres image/PGDATA fix from the incident found
-# while wiring it.
+# CHAOS-3142: local-dev postgres hardening, plus the incident that motivated
+# it.
+#
+# This file previously shared its Compose project name (`dev-health`) with
+# the repo-root `compose.yml`, a separate file with an incompatible postgres
+# definition. Because Compose tracks service ownership by
+# (project name, service name), an `up` from either file could recreate the
+# other file's already-running postgres container in place -- which is
+# exactly what happened: the additive Go worker services for this ticket
+# were designed to live here, adding RIVER_COORDINATOR_DATABASE_ROLE to this
+# postgres service's environment, and `docker compose up -d postgres` from
+# this file recreated the repo-root project's live postgres container with
+# this file's incompatible role/database/PGDATA layout. The Go worker
+# services moved to the repo-root compose.yml (the file that actually owns
+# that project), and this file's project name changed so the collision is
+# now structurally impossible. The digest pin and PGDATA fix below are
+# independent, also-real defects that predated and outlasted the same
+# incident; they still matter for this file's own isolated volume.
 # ---------------------------------------------------------------------------
 
-_GO_WORKER_SERVICES = ("go-worker-migrate", "go-worker", "go-reconciler")
 
+def test_ops_compose_project_name_is_not_dev_health() -> None:
+    """The regression barrier for the CHAOS-3142 incident: this file's
+    Compose project name must never again collide with the repo-root
+    compose.yml's `dev-health` project. A shared name lets either file's
+    `up` recreate the other's already-running containers with an
+    incompatible postgres definition -- silently, since Compose reports it
+    as an ordinary "Recreate", not a conflict.
 
-def _active_compose_services(
-    services: dict, active_profiles: frozenset[str]
-) -> set[str]:
-    """Mirror Docker Compose profile activation semantics: a service with no
-    `profiles:` key (or an empty one) is always active. A service that
-    declares `profiles:` is active only if at least one of its declared
-    profiles is in `active_profiles`. Passing an empty `active_profiles`
-    reproduces exactly what a bare `docker compose up` starts.
+    Mutation coverage (manually verified): setting `name: dev-health` back
+    makes this test fail.
     """
-    active: set[str] = set()
-    for name, service in services.items():
-        declared = service.get("profiles") or []
-        if not declared or (active_profiles & set(declared)):
-            active.add(name)
-    return active
-
-
-def test_go_worker_services_are_profile_gated() -> None:
-    """The three CHAOS-3142 Go services must be reachable ONLY through the
-    "go" compose profile, so `docker compose up` with no profile selected
-    starts exactly the same service set it always has.
-
-    Mutation coverage (manually verified): removing a service's
-    `profiles: ["go"]` line, or changing it to a different profile name,
-    makes this test fail -- either the membership assertion (service no
-    longer declares "go") or the default-activation assertion (the service
-    now starts on a bare `up`).
-    """
-    services = _load_yaml(_LEGACY_COMPOSE)["services"]
-    for name in _GO_WORKER_SERVICES:
-        assert name in services, f"compose.yml is missing the {name} service"
-        assert services[name].get("profiles") == ["go"], (
-            f'{name} must declare profiles: ["go"] exactly, '
-            f"got {services[name].get('profiles')!r}"
-        )
-
-    default_active = _active_compose_services(services, frozenset())
-    for name in _GO_WORKER_SERVICES:
-        assert name not in default_active, (
-            f"{name} would start on a bare `docker compose up` (no active "
-            f"profile) -- the default stack must be completely unchanged"
-        )
-
-    go_active = _active_compose_services(services, frozenset({"go"}))
-    for name in _GO_WORKER_SERVICES:
-        assert name in go_active, f"{name} must start once the go profile is selected"
-
-    # The pre-existing default stack (every service with no profiles today)
-    # must be exactly what it was before this change: the three new names
-    # are additive, nothing else lost or gained a profile.
-    non_go_services = {
-        name: service
-        for name, service in services.items()
-        if name not in _GO_WORKER_SERVICES
-    }
-    for name, service in non_go_services.items():
-        assert not service.get("profiles"), (
-            f"{name} unexpectedly gained a compose profile; only the three "
-            f"new CHAOS-3142 services should be profile-gated"
-        )
-
-
-def test_go_worker_migrate_gates_the_other_two_go_services() -> None:
-    """go-worker and go-reconciler must not start until go-worker-migrate
-    (the River schema/grant migration) has completed successfully -- and it
-    must in turn wait for the canonical Python `migrate` service, since its
-    coordinator grants target tables Alembic creates.
-    """
-    services = _load_yaml(_LEGACY_COMPOSE)["services"]
-    for name in ("go-worker", "go-reconciler"):
-        depends_on = services[name]["depends_on"]
-        assert (
-            depends_on["go-worker-migrate"]["condition"]
-            == "service_completed_successfully"
-        ), f"{name} must gate on go-worker-migrate completing successfully"
-    migrate_depends_on = services["go-worker-migrate"]["depends_on"]
-    assert (
-        migrate_depends_on["migrate"]["condition"] == "service_completed_successfully"
-    ), "go-worker-migrate must wait for the canonical Python migrate service"
-
-
-def test_go_reconciler_coordinator_dsn_is_direct_not_pgbouncer() -> None:
-    """Hard constraint: the coordinator connection holds cross-statement
-    row/table locks (FOR UPDATE, LOCK TABLE) and is rejected at Go startup
-    if routed through transaction-mode PgBouncer
-    (internal/storage/postgres/runtime.go ErrCoordinatorTransactionMode).
-    COORDINATOR_DATABASE_URI must target postgres:5432 directly.
-
-    Mutation coverage (manually verified): pointing COORDINATOR_DATABASE_URI
-    at pgbouncer:6432 instead of postgres:5432 makes both assertions fail.
-    """
-    services = _load_yaml(_LEGACY_COMPOSE)["services"]
-    coordinator_uri = services["go-reconciler"]["environment"][
-        "COORDINATOR_DATABASE_URI"
-    ]
-    assert "@postgres:5432/" in coordinator_uri, (
-        f"COORDINATOR_DATABASE_URI must target postgres:5432 directly: {coordinator_uri!r}"
+    compose = _load_yaml(_LEGACY_COMPOSE)
+    assert compose.get("name") != "dev-health", (
+        "CHAOS-3142: this file's compose project name must not be "
+        "'dev-health' -- that collides with the repo-root compose.yml's "
+        "project and lets either file's `up` recreate the other's "
+        "containers with an incompatible postgres definition"
     )
-    assert "pgbouncer" not in coordinator_uri, (
-        f"COORDINATOR_DATABASE_URI must not route through pgbouncer: {coordinator_uri!r}"
-    )
-
-
-def test_go_service_dsn_users_match_declared_roles() -> None:
-    """internal/platform/config.Config validates that a DSN's connection
-    user equals the declared RIVER_*_DATABASE_ROLE unconditionally
-    (internal/storage/postgres/runtime.go Validate). Assert compose wires
-    the identical role-variable substitution into both the DSN user segment
-    and its paired ROLE env var, for go-worker (domain, queue) and
-    go-reconciler (domain, queue, coordinator).
-
-    Mutation coverage (manually verified): changing a DSN's role reference to
-    a different (even correctly-spelled) role variable -- e.g. giving
-    go-reconciler's COORDINATOR_DATABASE_URI the queue role's substitution --
-    makes the corresponding assertion fail.
-    """
-    services = _load_yaml(_LEGACY_COMPOSE)["services"]
-
-    worker_env = services["go-worker"]["environment"]
-    assert worker_env["POSTGRES_URI"].startswith(
-        "postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:"
-    )
-    assert worker_env["WORKER_DATABASE_URI"].startswith(
-        "postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:"
-    )
-
-    reconciler_env = services["go-reconciler"]["environment"]
-    assert reconciler_env["POSTGRES_URI"].startswith(
-        "postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:"
-    )
-    assert reconciler_env["WORKER_DATABASE_URI"].startswith(
-        "postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:"
-    )
-    assert reconciler_env["COORDINATOR_DATABASE_URI"].startswith(
-        "postgresql://${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}:"
-    )
-
-
-def test_go_worker_route_switches_default_off() -> None:
-    """CHAOS-3142/CHAOS-3123: WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED and
-    WORKER_GITHUB_REPO_METADATA_ENABLED must default to "false" everywhere
-    they are wired -- on the Python producer gate's env (the shared &env
-    anchor, inherited by worker/beat) and on go-worker. Both runtimes read
-    the SAME env var names so one override flips both sides coherently;
-    widening either default alone would silently move live traffic through
-    only one side of that gate.
-
-    Mutation coverage (manually verified): changing either default from
-    "false" to "true" (on either service) makes the corresponding assertion
-    fail.
-    """
-    services = _load_yaml(_LEGACY_COMPOSE)["services"]
-    switch_names = (
-        "WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED",
-        "WORKER_GITHUB_REPO_METADATA_ENABLED",
-    )
-
-    shared_env = services["api"]["environment"]  # &env anchor: api, worker, beat
-    go_worker_env = services["go-worker"]["environment"]
-    for switch in switch_names:
-        assert shared_env[switch] == f"${{{switch}:-false}}", (
-            f"{switch} must default to false on the shared Celery env anchor"
-        )
-        assert go_worker_env[switch] == f"${{{switch}:-false}}", (
-            f"{switch} must default to false on go-worker"
-        )
-
-    # worker/worker-heavy/beat inherit the anchor via `<<: *env`/`<<: *worker-base`;
-    # confirm the merge actually carried the keys rather than being shadowed.
-    for name in ("worker", "worker-heavy", "beat"):
-        env = services[name]["environment"]
-        for switch in switch_names:
-            assert env[switch] == f"${{{switch}:-false}}", (
-                f"{switch} must reach {name} through the shared env anchor"
-            )
+    assert compose.get("name"), "compose.yml must declare an explicit project name"
 
 
 def test_local_postgres_image_pinned_and_pgdata_is_subdirectory() -> None:
@@ -1105,3 +961,39 @@ def test_local_postgres_image_pinned_and_pgdata_is_subdirectory() -> None:
     assert pgdata.rstrip("/").startswith(mount_root.rstrip("/") + "/"), (
         f"PGDATA {pgdata!r} must be nested under the volume mount {mount_root!r}"
     )
+
+
+def test_route_switches_default_off_for_producer_gate() -> None:
+    """CHAOS-3142/CHAOS-3123: WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED and
+    WORKER_GITHUB_REPO_METADATA_ENABLED must default to "false" wherever
+    this file wires them -- the shared &env anchor (api, inherited by
+    worker/worker-heavy/beat via <<: *env / <<: *worker-base). This is the
+    Python producer gate's half of the CHAOS-3123 route gate
+    (ProviderUnitRouteSwitches, src/dev_health_ops/workers/provider_unit_route.py);
+    a Go worker topology running alongside this stack must read the same
+    variable names with the same default so a unit the Python gate routes
+    to River never finds no handler.
+
+    Mutation coverage (manually verified): changing either default from
+    "false" to "true" makes the corresponding assertion fail.
+    """
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    switch_names = (
+        "WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED",
+        "WORKER_GITHUB_REPO_METADATA_ENABLED",
+    )
+
+    shared_env = services["api"]["environment"]  # &env anchor: api, worker, beat
+    for switch in switch_names:
+        assert shared_env[switch] == f"${{{switch}:-false}}", (
+            f"{switch} must default to false on the shared Celery env anchor"
+        )
+
+    # worker/worker-heavy/beat inherit the anchor via `<<: *env`/`<<: *worker-base`;
+    # confirm the merge actually carried the keys rather than being shadowed.
+    for name in ("worker", "worker-heavy", "beat"):
+        env = services[name]["environment"]
+        for switch in switch_names:
+            assert env[switch] == f"${{{switch}:-false}}", (
+                f"{switch} must reach {name} through the shared env anchor"
+            )

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -864,3 +864,244 @@ def test_production_stacks_cover_every_celery_queue() -> None:
             f"{name}: production worker pools miss queues {sorted(missing)} "
             f"declared in workers.config.task_queues (consumed: {sorted(consumed)})"
         )
+
+
+# ---------------------------------------------------------------------------
+# CHAOS-3142: additive Go execution path in compose.yml (go-worker-migrate,
+# go-worker, go-reconciler), profile-gated behind "go" so the default stack
+# is unchanged, plus the postgres image/PGDATA fix from the incident found
+# while wiring it.
+# ---------------------------------------------------------------------------
+
+_GO_WORKER_SERVICES = ("go-worker-migrate", "go-worker", "go-reconciler")
+
+
+def _active_compose_services(
+    services: dict, active_profiles: frozenset[str]
+) -> set[str]:
+    """Mirror Docker Compose profile activation semantics: a service with no
+    `profiles:` key (or an empty one) is always active. A service that
+    declares `profiles:` is active only if at least one of its declared
+    profiles is in `active_profiles`. Passing an empty `active_profiles`
+    reproduces exactly what a bare `docker compose up` starts.
+    """
+    active: set[str] = set()
+    for name, service in services.items():
+        declared = service.get("profiles") or []
+        if not declared or (active_profiles & set(declared)):
+            active.add(name)
+    return active
+
+
+def test_go_worker_services_are_profile_gated() -> None:
+    """The three CHAOS-3142 Go services must be reachable ONLY through the
+    "go" compose profile, so `docker compose up` with no profile selected
+    starts exactly the same service set it always has.
+
+    Mutation coverage (manually verified): removing a service's
+    `profiles: ["go"]` line, or changing it to a different profile name,
+    makes this test fail -- either the membership assertion (service no
+    longer declares "go") or the default-activation assertion (the service
+    now starts on a bare `up`).
+    """
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    for name in _GO_WORKER_SERVICES:
+        assert name in services, f"compose.yml is missing the {name} service"
+        assert services[name].get("profiles") == ["go"], (
+            f'{name} must declare profiles: ["go"] exactly, '
+            f"got {services[name].get('profiles')!r}"
+        )
+
+    default_active = _active_compose_services(services, frozenset())
+    for name in _GO_WORKER_SERVICES:
+        assert name not in default_active, (
+            f"{name} would start on a bare `docker compose up` (no active "
+            f"profile) -- the default stack must be completely unchanged"
+        )
+
+    go_active = _active_compose_services(services, frozenset({"go"}))
+    for name in _GO_WORKER_SERVICES:
+        assert name in go_active, f"{name} must start once the go profile is selected"
+
+    # The pre-existing default stack (every service with no profiles today)
+    # must be exactly what it was before this change: the three new names
+    # are additive, nothing else lost or gained a profile.
+    non_go_services = {
+        name: service
+        for name, service in services.items()
+        if name not in _GO_WORKER_SERVICES
+    }
+    for name, service in non_go_services.items():
+        assert not service.get("profiles"), (
+            f"{name} unexpectedly gained a compose profile; only the three "
+            f"new CHAOS-3142 services should be profile-gated"
+        )
+
+
+def test_go_worker_migrate_gates_the_other_two_go_services() -> None:
+    """go-worker and go-reconciler must not start until go-worker-migrate
+    (the River schema/grant migration) has completed successfully -- and it
+    must in turn wait for the canonical Python `migrate` service, since its
+    coordinator grants target tables Alembic creates.
+    """
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    for name in ("go-worker", "go-reconciler"):
+        depends_on = services[name]["depends_on"]
+        assert (
+            depends_on["go-worker-migrate"]["condition"]
+            == "service_completed_successfully"
+        ), f"{name} must gate on go-worker-migrate completing successfully"
+    migrate_depends_on = services["go-worker-migrate"]["depends_on"]
+    assert (
+        migrate_depends_on["migrate"]["condition"] == "service_completed_successfully"
+    ), "go-worker-migrate must wait for the canonical Python migrate service"
+
+
+def test_go_reconciler_coordinator_dsn_is_direct_not_pgbouncer() -> None:
+    """Hard constraint: the coordinator connection holds cross-statement
+    row/table locks (FOR UPDATE, LOCK TABLE) and is rejected at Go startup
+    if routed through transaction-mode PgBouncer
+    (internal/storage/postgres/runtime.go ErrCoordinatorTransactionMode).
+    COORDINATOR_DATABASE_URI must target postgres:5432 directly.
+
+    Mutation coverage (manually verified): pointing COORDINATOR_DATABASE_URI
+    at pgbouncer:6432 instead of postgres:5432 makes both assertions fail.
+    """
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    coordinator_uri = services["go-reconciler"]["environment"][
+        "COORDINATOR_DATABASE_URI"
+    ]
+    assert "@postgres:5432/" in coordinator_uri, (
+        f"COORDINATOR_DATABASE_URI must target postgres:5432 directly: {coordinator_uri!r}"
+    )
+    assert "pgbouncer" not in coordinator_uri, (
+        f"COORDINATOR_DATABASE_URI must not route through pgbouncer: {coordinator_uri!r}"
+    )
+
+
+def test_go_service_dsn_users_match_declared_roles() -> None:
+    """internal/platform/config.Config validates that a DSN's connection
+    user equals the declared RIVER_*_DATABASE_ROLE unconditionally
+    (internal/storage/postgres/runtime.go Validate). Assert compose wires
+    the identical role-variable substitution into both the DSN user segment
+    and its paired ROLE env var, for go-worker (domain, queue) and
+    go-reconciler (domain, queue, coordinator).
+
+    Mutation coverage (manually verified): changing a DSN's role reference to
+    a different (even correctly-spelled) role variable -- e.g. giving
+    go-reconciler's COORDINATOR_DATABASE_URI the queue role's substitution --
+    makes the corresponding assertion fail.
+    """
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+
+    worker_env = services["go-worker"]["environment"]
+    assert worker_env["POSTGRES_URI"].startswith(
+        "postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:"
+    )
+    assert worker_env["WORKER_DATABASE_URI"].startswith(
+        "postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:"
+    )
+
+    reconciler_env = services["go-reconciler"]["environment"]
+    assert reconciler_env["POSTGRES_URI"].startswith(
+        "postgresql://${RIVER_DOMAIN_DATABASE_ROLE:-devhealth_domain}:"
+    )
+    assert reconciler_env["WORKER_DATABASE_URI"].startswith(
+        "postgresql://${RIVER_QUEUE_DATABASE_ROLE:-devhealth_queue}:"
+    )
+    assert reconciler_env["COORDINATOR_DATABASE_URI"].startswith(
+        "postgresql://${RIVER_COORDINATOR_DATABASE_ROLE:-devhealth_coordinator}:"
+    )
+
+
+def test_go_worker_route_switches_default_off() -> None:
+    """CHAOS-3142/CHAOS-3123: WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED and
+    WORKER_GITHUB_REPO_METADATA_ENABLED must default to "false" everywhere
+    they are wired -- on the Python producer gate's env (the shared &env
+    anchor, inherited by worker/beat) and on go-worker. Both runtimes read
+    the SAME env var names so one override flips both sides coherently;
+    widening either default alone would silently move live traffic through
+    only one side of that gate.
+
+    Mutation coverage (manually verified): changing either default from
+    "false" to "true" (on either service) makes the corresponding assertion
+    fail.
+    """
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    switch_names = (
+        "WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED",
+        "WORKER_GITHUB_REPO_METADATA_ENABLED",
+    )
+
+    shared_env = services["api"]["environment"]  # &env anchor: api, worker, beat
+    go_worker_env = services["go-worker"]["environment"]
+    for switch in switch_names:
+        assert shared_env[switch] == f"${{{switch}:-false}}", (
+            f"{switch} must default to false on the shared Celery env anchor"
+        )
+        assert go_worker_env[switch] == f"${{{switch}:-false}}", (
+            f"{switch} must default to false on go-worker"
+        )
+
+    # worker/worker-heavy/beat inherit the anchor via `<<: *env`/`<<: *worker-base`;
+    # confirm the merge actually carried the keys rather than being shadowed.
+    for name in ("worker", "worker-heavy", "beat"):
+        env = services[name]["environment"]
+        for switch in switch_names:
+            assert env[switch] == f"${{{switch}:-false}}", (
+                f"{switch} must reach {name} through the shared env anchor"
+            )
+
+
+def test_local_postgres_image_pinned_and_pgdata_is_subdirectory() -> None:
+    """CHAOS-3142 incident: `postgres:latest` is a moving tag. It silently
+    changed base image family (Debian glibc -> Alpine musl) between when the
+    local dev cluster was created and a later `docker compose up`/pull, and
+    combined with a `PG_DATA` typo (the image only reads `PGDATA`) the new
+    image version picked its own default data directory -- a DIFFERENT
+    subdirectory of the same mounted volume -- and silently initialized a
+    brand-new empty cluster beside the real one instead of using it.
+
+    Pin the image by digest (matching the Postgres build already pinned in
+    internal/testsupport/containers/harness.go) and set PGDATA explicitly to
+    a subdirectory of the /var/lib/postgresql volume mount, never the mount
+    root itself.
+
+    Mutation coverage (manually verified): reverting the image back to
+    `postgres:latest` fails the digest assertion; reverting PGDATA back to
+    `PG_DATA: /var/lib/postgresql/` fails both the "PG_DATA not read" and
+    "PGDATA must be set" assertions; setting `PGDATA: /var/lib/postgresql/`
+    (the mount root) fails the subdirectory assertion.
+    """
+    services = _load_yaml(_LEGACY_COMPOSE)["services"]
+    postgres = services["postgres"]
+
+    assert "@sha256:" in postgres["image"], (
+        f"postgres image must be pinned by digest, not a moving tag: {postgres['image']!r}"
+    )
+    tag = postgres["image"].split("@sha256:", 1)[0]
+    assert not tag.endswith(":latest"), (
+        f"postgres image tag must not be 'latest', even when digest-pinned: {postgres['image']!r}"
+    )
+
+    env = postgres["environment"]
+    assert "PG_DATA" not in env, (
+        "PG_DATA is not an env var the postgres image reads (typo for PGDATA); "
+        "its presence means the fix was reverted or duplicated"
+    )
+    assert "PGDATA" in env, (
+        "PGDATA must be set explicitly so the cluster path is pinned"
+    )
+
+    mount_root = next(
+        volume.split(":", 1)[1]
+        for volume in postgres["volumes"]
+        if volume.startswith("postgres_data:")
+    )
+    pgdata = env["PGDATA"]
+    assert pgdata.rstrip("/") != mount_root.rstrip("/"), (
+        "PGDATA must be a subdirectory of the volume mount, not the mount root itself"
+    )
+    assert pgdata.rstrip("/").startswith(mount_root.rstrip("/") + "/"), (
+        f"PGDATA {pgdata!r} must be nested under the volume mount {mount_root!r}"
+    )

--- a/tests/test_compose_config.py
+++ b/tests/test_compose_config.py
@@ -171,6 +171,7 @@ _REPO_ROOT = Path(__file__).resolve().parents[1]
 _PROD_COMPOSE = _REPO_ROOT / "deploy" / "docker-compose" / "compose.production.yml"
 _LEGACY_COMPOSE = _REPO_ROOT / "compose.yml"
 _SWARM_STACK = _REPO_ROOT / "deploy" / "docker-swarm" / "stack.yml"
+_GO_PROFILE_OVERLAY = _REPO_ROOT / "deploy" / "go-workers" / "compose-go-profile.yml"
 _K8S_DIR = _REPO_ROOT / "deploy" / "kubernetes"
 _HELM_DIR = _REPO_ROOT / "deploy" / "helm" / "dev-health"
 
@@ -997,3 +998,62 @@ def test_route_switches_default_off_for_producer_gate() -> None:
             assert env[switch] == f"${{{switch}:-false}}", (
                 f"{switch} must reach {name} through the shared env anchor"
             )
+
+
+def test_go_profile_overlay_never_depends_on_python_migrate() -> None:
+    """CHAOS-3142/CHAOS-3143: no `go-*` service may `depends_on` the Python
+    `migrate` service.
+
+    `depends_on` pulls a service in regardless of profile, so such an edge makes
+    `docker compose --profile go up -d` run Alembic to *head* -- which is
+    0066_activate_river_worker_job_routes, the cutover that retargets 23 job
+    kinds from Celery to River. Both Go runtimes sit downstream of
+    go-worker-migrate, so the edge guaranteed precisely the ordering 0066's own
+    docstring forbids: routes flip to River before any River consumer can
+    start, and envelopes then pile up in worker_job_outbox with no executor.
+
+    Standing up the Go observation path must never be able to move real traffic
+    as a side effect, so the Python schema stays an explicitly authorized
+    prerequisite (`migrate postgres --revision 0065`) rather than a compose
+    dependency edge.
+
+    Mutation coverage (manually verified): re-adding
+    `migrate: {condition: service_completed_successfully}` to
+    go-worker-migrate's depends_on fails this test.
+    """
+    services = _load_yaml(_GO_PROFILE_OVERLAY)["services"]
+    go_services = {
+        name: spec for name, spec in services.items() if name.startswith("go-")
+    }
+    assert go_services, "the overlay must define the go-* services it exists to carry"
+
+    for name, spec in go_services.items():
+        depends_on = spec.get("depends_on") or {}
+        # Normalise both the mapping (long) and list (short) syntaxes.
+        dependencies = (
+            set(depends_on) if isinstance(depends_on, dict) else set(depends_on)
+        )
+        assert "migrate" not in dependencies, (
+            f"{name} must not depend on the Python `migrate` service: that edge runs "
+            "Alembic to head (0066, the Celery->River cutover) on a plain "
+            "`--profile go up`, before any Go consumer can start"
+        )
+
+
+def test_go_profile_overlay_services_are_all_profile_gated() -> None:
+    """CHAOS-3142: every service the overlay adds must be gated behind the `go`
+    profile, so a default `docker compose up` brings up the unchanged Celery
+    stack and nothing else.
+
+    This is what makes the overlay safe to leave in place permanently -- the
+    developer opts in per-invocation (`--profile go`) or via COMPOSE_PROFILES in
+    the root `.env`, and forgetting to opt in costs nothing.
+
+    Mutation coverage (manually verified): deleting `profiles: ["go"]` from any
+    go-* service fails this test.
+    """
+    services = _load_yaml(_GO_PROFILE_OVERLAY)["services"]
+    for name, spec in services.items():
+        assert spec.get("profiles") == ["go"], (
+            f'{name} must declare profiles: ["go"] so a default `up` never starts it'
+        )


### PR DESCRIPTION
Makes the Go worker and reconciler runnable locally alongside Celery, so Phase 3 provider ports get a real execution loop instead of tests only. Additive and profile-gated: nothing starts unless a profile is selected.

Closes CHAOS-3142.

## What this adds

- A `migrate` target in `docker/go-worker.Dockerfile` for `cmd/dev-health-worker-migrate`, which previously had **no container at all** despite being a hard precondition for the role grants. Registered in both target lists that would otherwise have omitted it silently: the `go-container-security` matrix in `.github/workflows/go.yml` and `ALL_TARGETS` in `ci/check_go_containers.sh`. Deliberately **not** in `RUNTIME_TARGETS` — it is a one-shot job with no readiness surface, so it is smoke-tested like `contractcheck` and `operator`.
- `DiagnoseRolePosture`, so a coordinator readiness failure names the table and the missing privilege instead of reporting only `coordinator_postgres`.
- Runbook in `deploy/go-workers/README.md` and the corresponding `.env.example` entries.

## Two latent defects fixed along the way

**Compose project-name collision.** `ops/compose.yml` and the repo-root `compose.yml` both declared `name: dev-health`. Compose tracks service ownership by (project name, service name), so an `up` from either file recreated the other's running containers with an incompatible postgres definition — different image, role and database names, PGDATA path, and port. This caused a live incident: a recreate started a brand-new empty cluster in a different subdirectory of the same volume while the real 489M cluster sat inert beside it. Renamed this project to `dev-health-ops`, which makes the collision structurally impossible.

**Unpinned postgres image and a seven-month-old typo.** `image: postgres:latest` plus `PG_DATA` — misspelled, so the postgres image never read it (added in `581ae01e6`, which was plainly *trying* to prevent exactly this). When the tag moved to a Debian PG18 image with a different default PGDATA, the recreate above followed. Pinned to the same alpine PG18 digest already used by `internal/testsupport/containers/harness.go` and spelled `PGDATA` correctly.

## Also surfaced

`SETTINGS_ENCRYPTION_KEY` was declared in `.env.example` but never referenced by any compose file, so provider credential decryption had no key in local dev.

A `to_regclass`-guarded GRANT plus an unconditional posture assertion means **any** database behind on migrations gets a permanently failing coordinator readiness with no stated reason. The diagnosability half is fixed here; the underlying asymmetry is recorded in the runbook.

The pending `0066` Celery-to-River cutover is reachable by any routine `docker compose up` that recreates `migrate`. Filed separately as CHAOS-3143 — not addressed here.

TEST-EVIDENCE:
- `tests/test_compose_config.py` 41 passed. Mutation evidence, each confirmed failing when the guarded thing is broken: project name back to `dev-health` -> FAIL; postgres image back to `postgres:latest` -> FAIL; `PGDATA` back to the `PG_DATA` typo -> FAIL; `PGDATA` set to the volume mount root -> FAIL; producer-gate route switch default flipped to true -> FAIL. File restored byte-identically after each.
- `bash ci/check_go.sh fast` PASS. `go build ./...`, `go vet` clean.
- `ci/check_go_containers.sh smoke` PASS including the new `migrate` target: non-root `65532:65532`, injected version metadata, fails closed with no arguments.
- `ci/check_go_containers.sh reproducible` PASS — all 7 `ALL_TARGETS` byte-identical across two `--no-cache` builds, `migrate` included.
- Two new integration tests against a real Postgres via testcontainers, reusing the `startGrantHarness`/`connectAs` pattern so the grants under test are the ones the migration actually emits. `TestDiagnoseRolePostureNamesTheGapAndNeverLeaksConnectionMaterial` proves a missing-table gap and a missing-privilege gap each name the right table and privilege, then renders every gap and asserts the line contains the table name and never the connection URI, the role password, `postgres://`, or `@`. `TestDiagnoseRolePostureReturnsNoGapsOnceGrantsAreCorrect` proves it does not fire spuriously and agrees with `CheckCoordinatorAuthorization`.
- Live-verified against a real local stack: `go-river-provision` created the coordinator role that `init-extra-dbs.sh` only creates on a fresh volume; `go-worker-migrate` applied the previously-skipped grant (`fixed_schedule_occurrences INSERT,SELECT,UPDATE`) once the table existed; `go-reconciler` reached `/readyz` `{"status":"ok"}` with `RestartCount 0`, emitting non-zero series `worker_outbox_reconciler_up 1` and `sync_dispatch_observer_up 1`.

RISK-NOTES:
- Blast radius is local development only. No production surface, no runtime code path outside the new diagnostic, which runs on the failure path exclusively and never in steady state.
- The three compose services are profile-gated; a bare `docker compose up` creates none of them. Verified mechanically: default 21 services, `--profile go` 25, nothing removed.
- Routing is untouched. `worker_job_routes` is neither read nor written; the durable route and the checked-in policy both stay as they were.
- **Behaviour change to be aware of:** renaming the ops compose project means anyone who was using `ops/compose.yml` to reach the canonical dev database loses that path by design. Use the repo-root `compose.yml` instead. The ops file now starts from its own empty volume.
- **Known limitation, documented rather than worked around:** with both route switches at their secure default of `false`, `go-worker`'s `sync` profile fails closed at startup and crash-loops, because `buildSyncCoordinatorWorker` gates on `profile == "sync"` alone while `profileReady` demands an exact match against the sync profile's declared `job_kinds`, which include `sync.provider_unit`. An operator must enable one switch. The runbook gives the exact log line and the exact fix.
- Redaction in the new diagnostic is enforced by test rather than by convention.
- Rollback is reverting this PR, with the caveat that doing so restores the compose project-name collision.
- Not verified: an end-to-end run through to a ClickHouse `repos` row. **Corrected from an earlier draft of this description:** this is blocked on a deliberate routing decision, not on credential availability. A typical developer stack already holds working GitHub credentials — verified on one: 3 active `integration_credentials` rows for github, all `last_test_success = true`, all decrypting under the current `SETTINGS_ENCRYPTION_KEY`, two of them JSON objects carrying a real `token` in the shape `complete_route.go` requires. Completing the chain needs only the two-key interlock: `worker_job_routes.transport` for `sync.provider_unit` moved from `celery` to `river_canary`, and `WORKER_GITHUB_REPO_METADATA_ENABLED` set on the Python producer, which currently means recreating the Celery worker container because no Python service references that variable. Both were declined for this PR as changes to a live control plane that the evidence did not justify. The PAT limitation is real only in an *isolated* project with a fresh volume, where no credential exists and a seeded fake token yields a real HTTP round-trip and a retryable failure.
- `worker_sync_lease_expired_total` stays at zero by construction and should not be read as a regression.


---

## Codex adversarial review

Three findings. Two real and fixed in `5a7030266`; one refuted with evidence.

**[high, real] `--profile go up -d` could have performed the Celery→River cutover before any Go consumer could start.** `depends_on` ignores `profiles`, so `go-worker-migrate`'s `depends_on: migrate` pulled the unprofiled Python migrator into the plan — and it runs Alembic to *head*, which is `0066_activate_river_worker_job_routes` (23 of 24 job kinds, Celery→River). Both Go runtimes sit *downstream* of `go-worker-migrate`, so the declared graph guaranteed exactly the ordering `0066`'s own docstring forbids. Proven by dry-run in both directions:

```
with the edge:    Container dev-health-migrate-1  Creating
without the edge: (migrate absent from the plan)
```

Fixed by removing the edge. The Python schema is now an explicit, separately authorized prerequisite (`migrate postgres upgrade 0065` — one revision short of the cutover). A behind-schema cluster no longer half-works silently: the `to_regclass`-guarded grants still no-op, but `go-reconciler`'s unreadiness now *names* the missing `table.privilege` gaps through the `DiagnoseRolePosture` logging already in this PR. The two changes turn out to be complements. Barrier: `test_go_profile_overlay_never_depends_on_python_migrate`, plus a second test pinning every overlay service to `profiles: ["go"]`. Both mutation-verified.

This narrows CHAOS-3143 but does not close it — any `up` that restarts `migrate` for some *other* reason still runs to head.

**[medium, real] The migrate smoke test accepted any failure as success.** `if docker run ...; then die` passed on *any* nonzero exit, so a panic or an unrelated config regression satisfied the "fails closed without `MIGRATION_DATABASE_URI`" assertion. It now captures stderr and matches the exact diagnostic. Verified to discriminate all four cases: the correct diagnostic passes; unexpected success, a panic, and a *different* configuration error all fail.

**[medium, refuted] "The project rename strands existing volumes."** It does not. No `dev-health-ops_*` volume has ever existed, and the live data belongs to project `dev-health` — confirmed from the volume's own `com.docker.compose.project` label — i.e. the repo-root `compose.yml`, whose name is deliberately unchanged. `ops/compose.yml` never owned that cluster; it was the interloper the rename exists to stop.

The finding's *secondary* observation is valid and is now documented: fixed `container_name:` values are global to the Docker daemon, not scoped per project, so the two projects still cannot run *simultaneously* — the second `up` fails on a name conflict. That is a strict improvement on the previous silent recreate of a running container with a foreign definition, but "renamed" is not "coexisting".

## Correction to this description

The runbook and an earlier revision of this PR published `migrate postgres --revision 0065`. **That flag does not exist** — `revision` is a positional argument on `upgrade`. Corrected to `migrate postgres upgrade 0065`, and the corrected form was executed against a live stack, reporting `0065`.

## Open: `go-container-reproducibility`

This job failed once on `5d108ecf1`, reporting the `migrate` image not byte-identical across two `--no-cache` builds. Status: **not yet explained, and not locally reproducible.**

I hypothesised `WORKDIR /app` (the `migrate` runtime layer stages nothing under `/app`, so `WORKDIR` *creates* it during that stage rather than receiving it mtime-normalized from the build stage — and `stream-runner`, the only other `/app`-less target, omits `WORKDIR` accordingly). **A platform-faithful probe falsified that**: with `--platform linux/amd64` and `SOURCE_DATE_EPOCH=0`, `migrate` is reproducible both *with* and *without* `WORKDIR /app`. The speculative Dockerfile change was reverted rather than shipped behind a false rationale.

Two earlier probes were invalid — one omitted `SOURCE_DATE_EPOCH=0` (the normalization knob the Dockerfile threads into `touch -d @$SOURCE_DATE_EPOCH`), one built host-arch instead of amd64. A `stream-runner` control, which must pass, is what exposed both. Note also that `reproducible()` `die`s on the first mismatch, so naming `migrate` does not establish that the defect is specific to `migrate`.

A control re-run on the unchanged commit is in flight to separate "CI-only flake" from "deterministic". **Not merging until that resolves.**
