### PR TITLE
CHAOS-3122/CHAOS-3162: port github/prs to Go plus generic Python-Go oracle comparator

### DIFF
--- a/ci/check_go.sh
+++ b/ci/check_go.sh
@@ -15,12 +15,24 @@ DEV_HEALTH_GO_BUILD_TEMP_ROOT=""
 
 usage() {
   cat <<'EOF'
-Usage: ci/check_go.sh [fmt|vet|test|race|build|contract|integration-vet|integration-coverage|integration|fast|all]
+Usage: ci/check_go.sh [fmt|vet|test|race|live-python-oracles|build|contract|integration-vet|integration-coverage|integration|fast|all]
 
   fmt    Check gofmt without modifying files.
   vet    Run go vet ./... in every Go module.
   test   Run go test ./... in every Go module.
   race   Run go test -race ./... in every Go module.
+  live-python-oracles
+         Run `go test -count=1 ./internal/providersync/...` unconditionally
+         (cache lookup disabled by -count=1 itself, not by any assumption
+         about cache state). Separate from `test` because that package
+         executes real production Python files (src/dev_health_ops/**.py)
+         at test time, which `//go:embed` cannot make part of the Go test
+         cache key -- `test`'s bare `go test ./...` can return a stale
+         cached PASS for a real change to one of those files. NOT an
+         optimization opt-out: a run that skips this verb has not tested
+         the oracles at all, so it MUST stay in `all` (and `fast`, since
+         it is cheap) rather than being treated as an extra, skippable
+         step.
   build  Run go build ./... in every Go module.
   contract
          Validate the job contract tree and, when DEV_HEALTH_CONTRACT_BASE is
@@ -46,11 +58,12 @@ Usage: ci/check_go.sh [fmt|vet|test|race|build|contract|integration-vet|integrat
          Discover and run EVERY integration-tagged package's suite against
          real containers, except the (small, justified) INTEGRATION_DENYLIST.
          Inclusion is the default; exclusion is the explicit, loud exception.
-  fast   Run fmt, vet, test, build, contract, integration-vet, and
-         integration-coverage checks, then publish the grant advisory report.
-  all    Run fmt, vet, test, race, build, contract, integration-vet, and
-         integration-coverage checks, then publish the grant advisory report
-         (default).
+  fast   Run fmt, vet, test, live-python-oracles, build, contract,
+         integration-vet, and integration-coverage checks, then publish
+         the grant advisory report.
+  all    Run fmt, vet, test, race, live-python-oracles, build, contract,
+         integration-vet, and integration-coverage checks, then publish
+         the grant advisory report (default).
 EOF
 }
 
@@ -174,6 +187,38 @@ check_test() {
 
 check_race() {
   run_in_modules "go test -race" go test -mod=readonly -race ./...
+}
+
+check_live_python_oracles() {
+  # internal/providersync executes REAL production Python files
+  # (src/dev_health_ops/**.py, via testdata/python_oracle_loader.py)
+  # directly at test time -- not test fixtures, the actual functions this
+  # repo ships. `//go:embed` cannot reach outside its own package
+  # directory (verified directly: `go vet` rejects a `../` pattern with
+  # "invalid pattern syntax"), so those Python files are structurally
+  # invisible to Go's test-result cache key. A warm local `go test` cache
+  # can then return a stale PASS for a real, uncommitted change to one of
+  # them -- reproduced empirically (CHAOS-3162, codex adversarial review):
+  # edit a live-oracle Python source with no Go file touched, run a bare
+  # `go test` a second time, get `(cached)` back with no re-execution at
+  # all. check_test's plain `go test ./...` above does not force a fresh
+  # run and is NOT a sufficient gate for this one package on its own --
+  # this step is deliberately separate and always uses -count=1, which
+  # disables cache lookup entirely by design, regardless of what caused
+  # the staleness.
+  #
+  # -count=1 lives HERE, at the verb, and not as something a caller
+  # remembers to pass to `test` -- the whole defect this verb exists to
+  # close is that the cache staleness is invisible from the call site (no
+  # error, no warning, just a silently-stale PASS), so a solution that
+  # depends on the caller already knowing to opt in reproduces the same
+  # failure mode one level up. Do NOT fold this back into check_test "for
+  # tidiness": that would put -count=1 (and its resulting slower, no-cache
+  # `test` run) on every package in the tree instead of only the one that
+  # structurally needs it, and it would make skipping this specific
+  # coverage possible again by construction.
+  printf 'go test -count=1: internal/providersync (live Python oracle sources are outside the Go embed/cache boundary)\n'
+  (cd "${ROOT}" && GOWORK=off go test -mod=readonly -count=1 ./internal/providersync/...)
 }
 
 check_build() {
@@ -424,6 +469,9 @@ case "${1:-all}" in
   race)
     check_race
     ;;
+  live-python-oracles)
+    check_live_python_oracles
+    ;;
   build)
     check_build
     ;;
@@ -446,6 +494,7 @@ case "${1:-all}" in
     check_format
     check_vet
     check_test
+    check_live_python_oracles
     check_build
     check_contract
     check_integration_vet
@@ -457,6 +506,7 @@ case "${1:-all}" in
     check_vet
     check_test
     check_race
+    check_live_python_oracles
     check_build
     check_contract
     check_integration_vet

--- a/cmd/dev-health-worker/dependencies.go
+++ b/cmd/dev-health-worker/dependencies.go
@@ -430,6 +430,7 @@ func workerRouteSwitches(cfg config.Config) providersync.CompleteRouteSwitches {
 		JiraIncidents:            cfg.WorkerJiraIncidentsEnabled,
 		LaunchDarklyFeatureFlags: cfg.WorkerLaunchDarklyFeatureFlagsEnabled,
 		GithubRepoMetadata:       cfg.WorkerGithubRepoMetadataEnabled,
+		GithubPRs:                cfg.WorkerGithubPRsEnabled,
 	}
 }
 
@@ -448,6 +449,7 @@ func providerRouteSwitchesReady(
 		{"jira", "incidents", cfg.WorkerJiraIncidentsEnabled},
 		{"launchdarkly", "feature-flags", cfg.WorkerLaunchDarklyFeatureFlagsEnabled},
 		{"github", "repo-metadata", cfg.WorkerGithubRepoMetadataEnabled},
+		{"github", "prs", cfg.WorkerGithubPRsEnabled},
 	}
 	return func(context.Context) error {
 		for _, route := range routes {

--- a/cmd/dev-health-worker/dependencies_test.go
+++ b/cmd/dev-health-worker/dependencies_test.go
@@ -122,6 +122,30 @@ func TestProviderRouteSwitchesAreIndependentAndRejectIncompleteRoutes(t *testing
 			wantErr: true,
 		},
 		{
+			// (github, prs) is NOT RouteReady (codex H1: the pair's own
+			// destination table has three columns owned by github/pr-reviews,
+			// which does not exist yet -- see execution_registry.go's
+			// github/prs case). Enabling its switch must fail this health
+			// check even with the runtime constructed, because
+			// switches.Descriptor("github","prs").RouteReady is false
+			// unconditionally right now. This is the deliberate fail-closed
+			// behavior an operator who flips WORKER_GITHUB_PRS_ENABLED early
+			// should see, not a bug.
+			name: "github prs enabled but not yet route-ready",
+			config: config.Config{
+				WorkerGithubPRsEnabled: true,
+			},
+			runtime: true,
+			wantErr: true,
+		},
+		{
+			name: "github prs missing runtime (also not route-ready)",
+			config: config.Config{
+				WorkerGithubPRsEnabled: true,
+			},
+			wantErr: true,
+		},
+		{
 			name:    "linear incomplete",
 			config:  config.Config{WorkerLinearWorkItemsEnabled: true},
 			wantErr: true,

--- a/cmd/dev-health-worker/provider_sync.go
+++ b/cmd/dev-health-worker/provider_sync.go
@@ -181,18 +181,19 @@ func buildProviderSyncHandler(
 				return providersync.CompleteRouteExecutor{},
 					errWorkerDependencyUnavailable
 			}
-			// Two route-ready pairs can reach this closure today
-			// (launchdarkly/feature-flags, github/repo-metadata — see
-			// CompleteRouteSwitches.Descriptor), and each has its own
-			// CompleteRouteHandler and effect sink. session.Claim is already
-			// known here — providerunit.Handler.Work only calls BuildExecutor
-			// after its own descriptor gate passed for THIS claim's
-			// provider/dataset — so select by claim rather than hardcoding
-			// one pair. A hardcoded Handler was exactly the CHAOS-3123 gap:
-			// it would compile, satisfy every other test, and still fail
-			// every github/repo-metadata claim (LaunchDarklyRouteHandler.Collect
-			// fails closed on claim.Provider != "launchdarkly") the moment the
-			// switch was flipped on.
+			// Three route-ready pairs can reach this closure today
+			// (launchdarkly/feature-flags, github/repo-metadata,
+			// github/prs — see CompleteRouteSwitches.Descriptor), and each
+			// has its own CompleteRouteHandler and effect sink. session.Claim
+			// is already known here — providerunit.Handler.Work only calls
+			// BuildExecutor after its own descriptor gate passed for THIS
+			// claim's provider/dataset — so select by claim rather than
+			// hardcoding one pair. A hardcoded Handler was exactly the
+			// CHAOS-3123 gap: it would compile, satisfy every other test, and
+			// still fail every github/repo-metadata claim
+			// (LaunchDarklyRouteHandler.Collect fails closed on
+			// claim.Provider != "launchdarkly") the moment the switch was
+			// flipped on.
 			var (
 				routeHandler providersync.CompleteRouteHandler
 				sink         providersync.EffectSink
@@ -217,10 +218,17 @@ func buildProviderSyncHandler(
 				}
 				routeHandler = providersync.GitHubRepositoryRouteHandler{}
 				sink, readback = ghSink, ghSink
+			case session.Claim.Provider == "github" &&
+				session.Claim.Dataset == "prs":
+				ghPRSink := providersync.GitHubPullRequestClickHouseEffects{
+					Conn: clickhouseConnection, Lease: session,
+				}
+				routeHandler = providersync.GitHubPullRequestRouteHandler{}
+				sink, readback = ghPRSink, ghPRSink
 			default:
 				// Unreachable in production: providerunit.Handler.Work only
 				// invokes BuildExecutor for a claim whose descriptor already
-				// reported RouteReady && RouteEnabled, and those two cases
+				// reported RouteReady && RouteEnabled, and those three cases
 				// above are the only pairs CompleteRouteSwitches.Descriptor
 				// ever marks RouteReady. Fail closed rather than construct an
 				// executor with a nil Handler.
@@ -286,11 +294,13 @@ func buildProviderSyncWorker(
 	logger *slog.Logger,
 ) (workerFamily, error) {
 	// Construct the family when ANY route switch is on, not launchdarkly's
-	// alone: (github, repo-metadata) became routable in CHAOS-3123, and a
-	// process that dispatches github units while refusing to build the handler
-	// for them would strand every unit at a worker with nothing registered.
+	// alone: (github, repo-metadata) became routable in CHAOS-3123 and
+	// (github, prs) in CHAOS-3122, and a process that dispatches github units
+	// while refusing to build the handler for them would strand every unit at
+	// a worker with nothing registered.
 	if cfg.Profile != "sync" ||
-		(!cfg.WorkerLaunchDarklyFeatureFlagsEnabled && !cfg.WorkerGithubRepoMetadataEnabled) {
+		(!cfg.WorkerLaunchDarklyFeatureFlagsEnabled &&
+			!cfg.WorkerGithubRepoMetadataEnabled && !cfg.WorkerGithubPRsEnabled) {
 		return workerFamily{}, nil
 	}
 	if registry == nil || observer == nil || logger == nil ||

--- a/cmd/dev-health-worker/provider_sync_test.go
+++ b/cmd/dev-health-worker/provider_sync_test.go
@@ -224,9 +224,10 @@ func disjointHandlerSets(left, right map[string]struct{}) bool {
 func TestProviderSyncHandlerSwitchesFollowConfiguration(t *testing.T) {
 	t.Parallel()
 	for name, want := range map[string]providersync.CompleteRouteSwitches{
-		"none":   {},
-		"github": {GithubRepoMetadata: true},
-		"both":   {GithubRepoMetadata: true, LaunchDarklyFeatureFlags: true},
+		"none":       {},
+		"github":     {GithubRepoMetadata: true},
+		"github_prs": {GithubPRs: true},
+		"both":       {GithubRepoMetadata: true, LaunchDarklyFeatureFlags: true},
 	} {
 		t.Run(name, func(t *testing.T) {
 			t.Parallel()
@@ -262,6 +263,10 @@ func TestWorkerRouteSwitchesMapsEveryConfiguredRoute(t *testing.T) {
 		"github": {
 			cfg:  config.Config{WorkerGithubRepoMetadataEnabled: true},
 			want: providersync.CompleteRouteSwitches{GithubRepoMetadata: true},
+		},
+		"github_prs": {
+			cfg:  config.Config{WorkerGithubPRsEnabled: true},
+			want: providersync.CompleteRouteSwitches{GithubPRs: true},
 		},
 		"linear": {
 			cfg:  config.Config{WorkerLinearWorkItemsEnabled: true},

--- a/contracts/provider-matrix/v1/README.md
+++ b/contracts/provider-matrix/v1/README.md
@@ -222,8 +222,49 @@ What this activation actually proves, and how:
   directly, and the latter is `None` unconditionally in Python's own
   collector, so leaving it nil in Go is exact parity, not an omission.
 
-Full recipe, the nine defect classes above generalized into a checklist for
-the remaining 16 GitHub pairs, and difficulty tiers, are in
+A SECOND adversarial pass on the fix commit itself (`140b64eed`) returned
+BLOCK again with two more HIGH findings — both in the fixes above, not new
+surface:
+
+- The H2 (pagination cap) fix made a deep-history repository with only one
+  page inside the incremental window cap, and fail, on every attempt
+  forever, because Go fetched every page up to `MaxPages` regardless of
+  content while Python's `iter_pulls` stops the moment a listed item's
+  `updated_at` is known and older than `since`. Fixed by adding the same
+  early stop (`providerfoundation.GitHubPageOptions.StopAt`) rather than
+  only filtering the fetched set post-hoc.
+- Separately, if an earlier attempt had written to ClickHouse and died
+  before `CommitEffect`, and a LATER attempt then failed for any reason
+  (the capped fetch above being what made this newly, deterministically
+  reachable), the job runtime's retry-release path
+  (`PostgresRepository.ReleaseForRetry`) overwrote the unit's whole result
+  document instead of merging into it, deleting the effect ledger the next
+  attempt needed to classify that in-flight write as exact, absent, or
+  conflicting. Fixed by merging (`COALESCE(result, '{}') ||
+  jsonb_build_object(...)`) instead of replacing.
+- The readback "exact" comparison itself had a deeper defect than the first
+  round's field-omission fix addressed: assembling the "winning row" from
+  independent per-column `argMax(column, last_synced)` calls is not the
+  same as reading the row with the maximum `last_synced` — ClickHouse's
+  `argMax` skips a row whose argument is NULL, so a winning row with a NULL
+  column could be silently backfilled from an older row's non-NULL value in
+  that column. Fixed by switching to `FROM git_pull_requests FINAL WHERE
+  org_id = ? AND repo_id = ? AND number = ?` (a bounded point lookup on the
+  full `ORDER BY` prefix), which reads one consistent physical row instead.
+- Three MEDIUM findings also landed: the live oracle test decoded but never
+  asserted the `build_git_pull_request` result's own
+  created_at/merged_at/closed_at fields; `stringValue` (M8's fix) handled
+  numeric but not boolean JSON scalars, diverging from Python's
+  `str(True) == "True"`; and the `normalizedAt`→`last_synced` millisecond
+  truncation had no sub-millisecond fixture of its own (a separate
+  truncation call site from the one M5's first fix covered).
+
+All five (two HIGH, three MEDIUM) are proven via the shared mutation harness
+plan (`testdata/mutation-plans/github_prs.json`) alongside the first round's
+findings — 17/17 mutations `KILLED`.
+
+Full recipe, the (now fifteen) defect classes above generalized into a
+checklist for the remaining 16 GitHub pairs, and difficulty tiers, are in
 `deploy/go-workers/provider-sync-porting-recipe.md`.
 
 ## Known Go/Python divergences (fail-closed by design)

--- a/contracts/provider-matrix/v1/README.md
+++ b/contracts/provider-matrix/v1/README.md
@@ -124,6 +124,108 @@ otherwise read as a conflict.
    the next merge. `src/dev_health_ops/api/queries/heatmap.py` is a known
    pre-existing example and is not a regression introduced by this contract.
 
+## Activation status for `(github, prs)`
+
+CHAOS-3122 built a real `CompleteRouteHandler`
+(`GitHubPullRequestRouteHandler`) and `EffectSink`
+(`GitHubPullRequestClickHouseEffects`) — `go_executor: native_go` — but the
+pair is deliberately **`route_ready: false`**, not `true`. This is not the
+same shape as `(github, repo-metadata)`'s waiver.
+
+An adversarial (codex) review of the first draft returned BLOCK with four
+HIGH-severity findings, all fixed before this pair's code landed:
+
+1. **Silent watermark loss on a capped fetch.** A paginated fetch that hit
+   its page cap was reported as a successful, complete unit, so the claimed
+   watermark advanced past PRs the cap never fetched — permanently, since no
+   later incremental run revisits a window the watermark already passed.
+   Fixed: `Collect` now fails the whole unit (`ErrPaginationCapExceeded`)
+   whenever `CapReached` is true. Never both capped and successful.
+2. **Silently dropped PRs with an unparseable `updated_at`.** Python's
+   window comparison only applies when `updated_at` type-checks as a
+   `datetime`; a missing/null/unparseable value is unconditionally included.
+   An earlier version of the Go filter excluded such items instead — the
+   empty-success trap: a window where every PR has that shape reported zero
+   records instead of including them. Fixed: `pullOutsideKnownWindow` now
+   only compares the window when the timestamp is known, mirroring Python's
+   guard exactly, as a named, independently mutation-tested clause.
+3. **Fail-open repository identity.** A blank/missing `full_name` from the
+   repo GET fell back to `claim.SourceExternalID`, writing PRs under a
+   *guessed* `repo_id`. Python's `get_repo_uuid_from_repo` raises on a falsy
+   input and `Repo.__init__` never even attempts the call, so nothing
+   downstream in Python would ever derive that repo_id. Fixed: the fallback
+   was deleted; `repositoryIdentity` (already shared with repo-metadata)
+   rejects the blank input on its own, and the test that previously
+   asserted the fallback was inverted to require the failure.
+4. **`route_ready: true` while three columns were always fabricated zeros.**
+   `first_review_at`, `reviews_count`, and `changes_requested_count` are
+   columns on `git_pull_requests`, but the data that fills them is Python's
+   review-enrichment phase (`_enrich_prs_with_reviews_batch`) — a different
+   dataset pair's (`github/pr-reviews`) job in this port's per-unit model.
+   Writing them as zero while claiming route readiness would let
+   review-latency/rework/AI-impact tiles read "never fetched" as "doesn't
+   exist". **Resolution: `route_ready` stays `false` until `github/pr-reviews`
+   lands and both pairs flip together** — see `CompleteRouteSwitches.Descriptor`'s
+   `github`/`prs` case and
+   `deploy/go-workers/provider-sync-porting-recipe.md`'s defect class 9 for
+   the full column-versus-unit-ownership analysis and the three resolutions
+   it lays out for future pairs in the same situation.
+
+Five MEDIUM findings, also fixed, on the ClickHouse effect sink specifically
+(`GitHubPullRequestClickHouseEffects`):
+
+5. Provider timestamps were not truncated to millisecond precision at
+   construction, so a value with finer-than-`DateTime64(3)` precision could
+   compare unequal to what a later readback SELECT scans back. Fixed:
+   truncated once, in `parseGitHubPullTime`.
+6. The readback "exact" comparison omitted `first_review_at`,
+   `first_comment_at`, `changes_requested_count`, and `reviews_count`
+   entirely, and collapsed nullable strings through `ifNull(col, '')`,
+   losing the NULL/empty-string distinction. Fixed: every column is now
+   scanned into a Go pointer type and compared as its own named clause, not
+   folded into one boolean expression.
+7. State normalization stripped whitespace throughout the string instead of
+   only leading/trailing (diverging on internal whitespace) and did not
+   strip `\r` (diverging on a trailing carriage return) — not equivalent to
+   Python's `raw_state.strip().lower()`. Fixed: `strings.ToLower(strings.TrimSpace(...))`.
+8. A non-string `user.login` (e.g. a JSON number) silently became the
+   `"Unknown"` fallback instead of being stringified the way Python's
+   `str(user["login"])` would. Fixed: decode into `any` and reuse the
+   package's existing `stringValue` helper.
+
+What this activation actually proves, and how:
+
+- Fixture-level field parity against the real Python collector
+  (`TestGitHubPullRequestRouteEmitsOneBoundedEffect`).
+- **Live parity, not a hand-authored comment:** state normalization and the
+  `created_at` fallback chain are checked against the REAL, live
+  `normalize_pr_state` / `build_git_pull_request` functions, shelled out to
+  at test time (`TestGitHubPRSNormalizationMatchesLivePythonFunctions` →
+  `testdata/python_github_prs_normalization_oracle.py`) — not a fixture that
+  was verified once and pasted into a comment. This closes the codex H9
+  finding: an earlier hand-authored fixture omitted the review-enrichment
+  phase entirely and then asserted its own zero-valued output as "verified"
+  parity, which cannot fail when the omitted phase is wrong.
+- A full mutation-testing pass via the shared harness
+  (`internal/providersync/testdata/mutation-plans/github_prs.json`, run with
+  `scripts/mutation_harness.py`), 12/12 mutations `KILLED` (one additional
+  mutation `SURVIVED` on a first pass and identified genuinely dead/redundant
+  code — see the plan's `$limitation` field).
+- `repo_id` is derived the same way `(github, repo-metadata)` derives its
+  repository identity: `repositoryIdentity(fullName)` where `fullName` comes
+  from a `GET /repos/{owner}/{repo}` call's `full_name` field, matching
+  `get_repo_uuid_from_repo(repo_info.full_name)` in
+  `models/git.py::Repo.__init__` — and now fails closed rather than falling
+  back, per finding 3 above.
+- `comments_count` and `first_comment_at` are NOT part of the review-data
+  gap (finding 4): the former comes from the REST pull-detail payload
+  directly, and the latter is `None` unconditionally in Python's own
+  collector, so leaving it nil in Go is exact parity, not an omission.
+
+Full recipe, the nine defect classes above generalized into a checklist for
+the remaining 16 GitHub pairs, and difficulty tiers, are in
+`deploy/go-workers/provider-sync-porting-recipe.md`.
+
 ## Known Go/Python divergences (fail-closed by design)
 
 `repositoryIdentity` mirrors Python's `get_repo_uuid_from_repo` for the ASCII

--- a/contracts/provider-matrix/v1/matrix.json
+++ b/contracts/provider-matrix/v1/matrix.json
@@ -201,10 +201,12 @@
       "processor_flags": {
         "sync_prs": true
       },
-      "go_executor": "none",
+      "go_executor": "native_go",
       "native_shadow": false,
       "route_dataset": "prs",
-      "route_destinations": [],
+      "route_destinations": [
+        "git_pull_requests"
+      ],
       "route_ready": false,
       "credential_modes": [
         "personal_access_token",

--- a/deploy/go-workers/README.md
+++ b/deploy/go-workers/README.md
@@ -67,6 +67,14 @@ combined with the coordinator's `sync` queue: the two clients have disjoint
 handlers. Both queues and all provider routes remain Celery-owned unless a
 reviewed route release says otherwise.
 
+Porting a provider/dataset pair to a `route_ready` Go complete-route handler
+(the `CompleteRouteHandler`/`EffectSink` pattern `launchdarkly/feature-flags`,
+`github/repo-metadata`, and `github/prs` already ship) is a separate,
+code-level recipe, not a deployment-manifest concern — see
+[`provider-sync-porting-recipe.md`](./provider-sync-porting-recipe.md) and
+`contracts/provider-matrix/v1/README.md`'s per-pair "Activation status"
+sections.
+
 ### Coexistence canary
 
 1. Compose runs a fail-closed bootstrap chain before any Go workload:

--- a/deploy/go-workers/provider-sync-porting-recipe.md
+++ b/deploy/go-workers/provider-sync-porting-recipe.md
@@ -1,0 +1,591 @@
+# Porting a provider/dataset pair to `route_ready` (Go complete-route)
+
+This is the recipe extracted from three pairs: `launchdarkly/feature-flags`
+and `github/repo-metadata` (`route_ready: true`, CUT-08 and CHAOS-3123), and
+`github/prs` (CHAOS-3122, this document's own worked example — coded,
+tested, and mutation-tested, but deliberately `route_ready: false` pending
+`github/pr-reviews`; see defect class 9 below). All three follow the
+identical eight-step shape below. If a future port doesn't fit this shape,
+that is itself a signal worth writing down before proceeding.
+
+**Ground rule:** trust `contracts/provider-matrix/v1/matrix.json` and the
+code, never a ticket's status field. CHAOS-3123 was marked Done in Linear
+having shipped 1 of 17 GitHub pairs; the matrix is what caught that.
+
+**Second ground rule, added after `github/prs`'s codex adversarial pass:** a
+green local gate — `ruff`/`mypy`/`go build`/`go vet`/`go test` including the
+integration tier — is necessary and is NOT sufficient. `github/prs`'s gate
+was fully green and its adversarial review still returned BLOCK with four
+HIGH-severity findings, three of them the identical shape: *the route reports
+success while silently losing data, and advances the watermark past what it
+lost.* Every one of those bugs compiled cleanly, passed `go vet`, and passed
+every test that existed at the time — because the tests were written by the
+same reasoning that produced the bugs. Treat an adversarial pass over the
+diff as a required step of this recipe, not a nice-to-have, and read the
+checklist below BEFORE writing the handler, not after a review flags it.
+
+## Defect classes to check for explicitly in every pair
+
+These are not hypothetical. Every one below was found by an adversarial
+review of `github/prs`'s first draft, which had a green gate and passing
+tests. Check for each of them by name while writing the handler, not by
+hoping the tests you wrote yourself will catch what you didn't think to
+question.
+
+1. **A capped/paginated fetch must never report success.** If the Python
+   collector's pagination is unbounded (no page cap in the production call),
+   your Go pager's cap (`MaxPages`, `nativeMaxPages`, ...) is a safety rail,
+   not a legitimate stopping point. Check `CapReached` after every paginated
+   fetch and fail the whole unit if it's true. The alternative failure mode
+   is silent and permanent: a capped fetch that still returns success still
+   lets `Collect` return the claim's window as the completed watermark, so a
+   later incremental run never revisits the records past the cap — they are
+   gone, and nothing about the sync run's outcome says so.
+2. **A client-side window filter must apply the SAME comparison Python
+   applies, including when Python does NOT compare.** Read the exact
+   conditional Python guards its since/until check with — often something
+   like `isinstance(updated_at, datetime)` — and reproduce that guard, not
+   just the comparison inside it. A record with a missing/null/unparseable
+   timestamp is a case Python's `isinstance` check makes it skip the
+   comparison for (so the record is included unconditionally); a Go port
+   that treats "timestamp didn't parse" as "exclude this record" silently
+   drops exactly those records, and if EVERY record in a window has that
+   shape, the unit reports an empty, plausible-looking success. Split the
+   "is the timestamp known at all" clause from the "is it inside the window"
+   clauses — see defect class 4 below — so this is provable independently.
+3. **A missing/blank identity input must fail closed, never fall back to a
+   claim field.** If Python's identity derivation (a UUID hash, a lookup key)
+   would raise or otherwise refuse to run on the input you're about to
+   substitute a fallback for, match that: return an error, don't guess. A
+   fallback that "looks reasonable" (e.g. the claim's own external ID) writes
+   real rows under an identity nothing else in the system would derive for
+   the same input — a foreign-key fork that is far harder to find later than
+   a failed unit is now. Before adding a fallback, check whether the
+   function you're already calling downstream (e.g. `repositoryIdentity`)
+   already rejects the same bad input — duplicating its check independently
+   is itself a code smell a mutation harness will flag as dead code (see
+   "Use the mutation harness" below).
+4. **Split every compound boolean into named clauses.** `windowKnown`,
+   `before`, `after` as three separate named values (with `before || after`
+   as the final combinator) instead of one `if a && b || c && d` line. This
+   is not style preference: a monolithic compound condition is a single unit
+   for a mutation harness (or a reviewer) to evaluate, so a broken clause
+   inside it can hide behind the other clauses already being satisfied by
+   whatever fixture the existing tests happen to use. `github/prs`'s window
+   filter and readback comparator were both rewritten this way after
+   defect class 2 shipped as one compound condition.
+5. **Truncate provider timestamps to the ClickHouse column's actual
+   precision AT CONSTRUCTION, not at comparison time.** `DateTime64(3)`
+   loses anything finer than a millisecond on write; a Go value that still
+   carries microsecond/nanosecond precision from `time.Parse` will compare
+   unequal to what a readback SELECT scans back, and a process death between
+   `WriteEffect`'s `Send` and the ledger's `CommitEffect` turns that into an
+   unrecoverable `EffectConflict` — recovery can neither mark the row
+   committed (bytes don't match) nor safely replay it (might double-write).
+   Truncate once, where the value first enters the row.
+6. **A readback "exact" comparison must scan and compare every column the
+   row actually carries**, not the subset that was easy to wire up first.
+   Every field the writer writes is a field a divergent same-version row
+   could differ on; a comparison that can't see a column will report
+   `EffectExact` for a row that is actually wrong, and recovery then marks
+   corrupted data as committed. Query the columns straight into Go pointer
+   types for anything `Nullable` in ClickHouse (see the next point) rather
+   than `ifNull(col, sentinel)`-collapsing them first — that collapse can
+   itself hide a real NULL-vs-empty-string divergence from the comparison.
+7. **Match Python's exact string operation, not a stronger one.** If Python
+   does `raw.strip().lower()`, the Go equivalent is `strings.ToLower(strings.TrimSpace(raw))`
+   — leading/trailing whitespace only, including `\r`. A hand-rolled
+   "strip everything, throughout the string" helper is BOTH wrong (it
+   accepts input Python would reject, like `"clo sed"` matching `"closed"`)
+   AND wrong the other direction (it can miss whitespace Python's `strip()`
+   does remove, like a trailing `\r`, if the hand-rolled version's allowed
+   character set doesn't happen to include it). Reach for the stdlib
+   function with the matching name before writing a custom one.
+8. **Stringify provider fields the way Python's `str()` would, not by type
+   assertion.** If Python does `str(some_field)` before use, decode the
+   corresponding JSON value into `any` (with `json.Decoder.UseNumber()` so a
+   numeric value round-trips exactly) and stringify by Go type switch — see
+   `stringValue` in `native_rest.go`, already shared across this package —
+   rather than unmarshaling straight into a Go `string` field, which fails
+   (and silently falls back to whatever sentinel your zero-value handling
+   uses) the moment the provider sends a JSON number where Python's `str()`
+   would have happily converted it.
+9. **When one ClickHouse table is filled by columns that belong to MORE
+   THAN ONE dataset pair, decide the column-vs-unit ownership question
+   explicitly, in writing, before flipping `route_ready`.** This is the
+   `github/prs` / `github/pr-reviews` situation:
+   `first_review_at`/`reviews_count`/`changes_requested_count` are columns
+   on `git_pull_requests`, but the data that fills them comes from Python's
+   review-enrichment phase, which is a DIFFERENT dataset pair's job in the
+   per-unit model this port uses. Writing the columns as fabricated zeros
+   while claiming `route_ready: true` is not a "documented gap" — it is
+   corrupted data with nothing distinguishing "no reviews exist" from "this
+   unit never fetches reviews", and downstream analytics (review-latency,
+   rework, AI-impact tiles) will read the zero as fact. `route_ready` is a
+   promise the Go path produces the PRODUCT data for that pair, not merely
+   that it compiles and passes its own tests. Three resolutions, pick one
+   and write down why in the matrix case's comment and the PR body:
+     - **The owning pair (here, `prs`) never writes the shared columns at
+       all**, leaving them for the other pair to fill, and BOTH pairs stay
+       not-`route_ready` until the one that fills the shared columns can run
+       a full read-current-row-then-rewrite (or the two are redesigned to
+       write disjoint tables). This needs the write-conflict semantics
+       thought through — ReplacingMergeTree has no partial-column merge, so
+       "not writing a column" and "writing it as the SQL default" are
+       byte-identical on disk; the real fix is deciding which unit is the
+       SOLE writer of the complete row, not just which unit skips which
+       field.
+     - **The two pairs land as one unit**, sharing one `CompleteRouteHandler`
+       and one effect, since they are frequently one Python execution
+       underneath the matrix's dataset-name split anyway (`github/prs`,
+       `pr-reviews`, and `pr-comments` are all `_sync_github_prs_to_store_async`
+       in Python). Slower to ship, but avoids the write race entirely.
+     - **The first pair ships with `go_executor: native_go` but
+       `route_ready: false`**, fully coded and tested, with the descriptor
+       case documenting exactly which sibling pair it's waiting on. This is
+       what `github/prs` did: the switch (`GithubPRs`) and all worker/config
+       wiring are in place and inert, so flipping `RouteReady` when
+       `github/pr-reviews` lands is a one-line change, not a second PR's
+       worth of plumbing.
+   If none of the three fits, that is itself a real design finding — say so
+   explicitly rather than shipping `route_ready: true` anyway.
+
+## The recipe
+
+### 1. Read the Python authority for the pair, not just its shape
+
+Find the *exact* fetch → normalize → write function chain, not an
+approximation. For `github/prs` this meant tracing
+`src/dev_health_ops/processors/github.py::_sync_github_prs_to_store_async`
+down through `_collect_github_pr_objects` (fetch),
+`providers/github/code_client.py::_pull_from_item` (parse),
+`processors/base_git.py::build_git_pull_request` +
+`providers/pr_state.py::normalize_pr_state` (normalize), and
+`storage/clickhouse.py::insert_git_pull_requests` (write). Getting this
+wrong is the single biggest risk: mirroring the *shape* of a Python function
+without its exact semantics (a field default, a timestamp fallback order, a
+state-mapping edge case) produces a Go row that looks plausible and is
+silently wrong.
+
+Things that are easy to miss and must be checked explicitly for every pair:
+
+- **Identity derivation.** Does the row's primary/foreign key come from the
+  claim's `SourceExternalID`, or from a value the API returns (e.g.
+  `repo_id` in `git_pull_requests` comes from `get_repo_uuid_from_repo(repo_info.full_name)`
+  — the API's `full_name`, not the claim's owner/repo string verbatim)?
+- **The org_id write path.** `ClickHouseStore._insert_rows` auto-injects
+  `org_id` from `self.org_id` when the caller's column list omits it
+  (`storage/clickhouse.py:309-320`) — the row model / dataclass frequently
+  has *no* `org_id` field at all even though the ClickHouse table does.
+  Check `src/dev_health_ops/migrations/clickhouse/027_add_org_id_to_sorting_keys.py`
+  for the table's real `ORDER BY`; don't assume `024_add_org_id.sql` covers a
+  raw `git_*`/`ci_*`/`deployments` table — migration 027's
+  `TABLES_NEEDING_ORG_ID_COLUMN` list is the ones 024 missed.
+- **Field defaults and fallbacks.** e.g. `BaseGitProcessor.coerce_created_at`
+  (`created_at or merged_at or closed_at or now()`), or repo-metadata's
+  `default_branch` coercion to `"main"`. These are exactly the kind of
+  one-line detail a shape-only port drops.
+- **What the Python sink does *not* persist.** e.g. `repos` never persists
+  `archived`; comparisons and shadow sources must only assert the shared
+  contract.
+
+### 2. Design the row type and effect destination(s)
+
+One matrix pair may write to **one or several** ClickHouse tables — this is
+not a 1:1 rule. `launchdarkly/feature-flags` writes four tables in one
+`Collect` call (`feature_flag`, `feature_flag_event`, `feature_flag_link`,
+`work_graph_edges`); `github/repo-metadata` and `github/prs` each write one.
+The destination manifest is `CompleteRouteDescriptor.Destinations`, and
+`CompleteRouteBatch.validate` enforces that `len(batch.Effects)` matches it
+exactly.
+
+Write a Go struct (`xRow`) whose JSON field names and field *order* mirror
+the ClickHouse column order the Python sink actually inserts (check the
+`_insert_rows(table, [...columns...], rows)` call, including any
+auto-injected `org_id` — it is appended **last**, after the explicit column
+list, not alphabetically sorted). This is what keeps the effect digest
+(`BuildEffectBatch`) meaningful and the row byte-comparable during a future
+live-parity pass.
+
+### 3. Write the `CompleteRouteHandler`
+
+New file: `internal/providersync/<provider>_<dataset>_route.go`.
+
+- `Collect(ctx, claim, credential, client, normalizedAt) (CompleteRouteBatch, error)`
+  is the entire contract. Validate `claim.Provider`/`claim.Dataset` and fail
+  closed (`ErrInvalidConfiguration`) on anything else — this is what lets
+  `cmd/dev-health-worker/provider_sync.go`'s `BuildExecutor` switch select a
+  handler by claim without every handler quietly serving every claim.
+- Reuse `providerfoundation.CollectGitHubLinkPages` /
+  `CollectGitLabPageParamPages` / `CollectLaunchDarklyOffsetPages` for
+  pagination — don't hand-roll a paging loop.
+- Reuse existing helpers in the package rather than duplicating them:
+  `splitGitHubRepository`, `providerRelativePath` (GHE base-path safe),
+  `repositoryIdentity` (repo UUID derivation), `fetchObject` (single-object
+  GET with a byte cap and single-JSON-value enforcement),
+  `filterWorkItemWindow`-style client-side since/before filtering,
+  `effectBatchFromValues` (canonicalizes + digests the rows into an
+  `EffectBatch`).
+- `normalizedAt` is a parameter, not a clock read: never call `time.Now()`
+  inside `Collect`. `CompleteRouteExecutor` stabilizes this value across
+  retries by loading the persisted effect ledger's `CreatedAt` on **every**
+  attempt (not only expired-lease recovery) — a handler that reads its own
+  clock would regenerate different rows on an ordinary River retry and get
+  rejected by `PrepareEffects` with `ErrEffectLedgerConflict`, wedging the
+  unit. See `contracts/provider-matrix/v1/README.md`'s "Effect timestamp
+  stabilization" section.
+- Watermark: for `WatermarkNone` datasets return `nil`. For
+  `WatermarkIncremental` datasets, both shipped examples
+  (`launchdarkly/feature-flags`, `github/prs`) simply return
+  `claim.BeforeAt` — the scheduler/producer owns the window, `Collect` only
+  reports it processed through that point.
+
+### 4. Write the ClickHouse effect sink
+
+New file: `internal/providersync/<provider>_<dataset>_effects_clickhouse.go`.
+
+Every destination table in this codebase so far is
+`ReplacingMergeTree(last_synced)`, and every sink implements both
+`EffectSink.WriteEffect` and `EffectReadback.InspectEffect`:
+
+- `WriteEffect`: decode rows (`decodeEffectRows[xRow]`), validate each
+  (`row.validate(claim)`), `PrepareBatch`/`Append`/`Send` — with a
+  `sink.Lease.Assert(ctx)` check both before building the batch and
+  immediately before `Send`, so a lease that expired mid-build never lands a
+  write.
+- `InspectEffect`: **must** resolve the *winning* ReplacingMergeTree version
+  via `argMax(column, last_synced)` grouped by the table's real primary key,
+  never scan every physical version — pre-merge history from earlier
+  occurrences is normal and must not read as a conflict. This is the
+  argMax/FINAL discipline `AGENTS.md`'s ClickHouse review checklist already
+  requires of every reader; the sink is a reader too.
+  - **Compare EVERY column the row carries, as its own named clause** (codex
+    M6 on `github/prs`'s first draft): a monolithic `a && b && c && ...`
+    conjunction that only happens to reference a subset of the row's fields
+    will report `EffectExact` for a persisted row that actually diverges on
+    a column the conjunction never mentions — and recovery then marks
+    corrupted data committed. Write `comparePullRequestVersion`-style code
+    as a sequence of `if actual.X != expected.X { return EffectConflict }`
+    statements, one per column, not one boolean expression. This is defect
+    class 4/6 from the checklist above, applied to the readback comparator
+    specifically.
+  - **Scan `Nullable` ClickHouse columns straight into Go pointer types**
+    (`*string`, `*time.Time`), not through `ifNull(col, sentinel)`. Besides
+    being simpler, `ifNull`-collapsing a nullable string to `''` makes a true
+    SQL `NULL` and an actual empty string indistinguishable to the
+    comparison — a real divergence the "exact" check can no longer see. If
+    you DO need a sentinel (a non-nullable timestamp column with a
+    Python-side "unset" convention), the sentinel must match EXACTLY on both
+    sides of the comparison: `github/prs`'s first draft used ClickHouse's
+    `toDateTime64(0, 3)` (Unix epoch) in SQL but Go's zero `time.Time{}` in
+    the comparison default, which read every open PR (nil `merged_at`) as a
+    conflict. Write a unit test for the nullable-defaults-agree case
+    explicitly (see `TestPullRequestReadbackToleratesOpenPRNullFields`).
+  - **UInt32-column gotcha:** `clickhouse-go`'s `Scan` rejects `*int` for a
+    `UInt32` column (`converting UInt32 to *int is unsupported`). Scan into
+    a local `uint32`, then convert. This only shows up against a **real**
+    ClickHouse instance — the pure Go unit tests for the comparator compile
+    and pass fine with the bug present. Budget for an integration-tagged
+    test (`//go:build integration`, `internal/testsupport/containers`) for
+    every new sink; a fixture-only port is not proof the SQL/scan shapes
+    actually work.
+
+### 5. Wire `execution_registry.go`
+
+Three edits, always in this order:
+
+1. `providerExecutorRegistry["<provider>/<dataset>"] = ExecutorNativeGo`.
+2. Add a field to `CompleteRouteSwitches` (e.g. `GithubPRs bool`) — one field
+   per pair, never shared. Document in its comment which *other* dataset
+   aliases must NOT be opened by it (see step 8).
+3. Add a `case provider == "x" && dataset == "y":` arm to
+   `CompleteRouteSwitches.Descriptor`, setting `Destinations`,
+   `RouteReady = true`, and `RouteEnabled = switches.<TheNewField>`.
+   `NativeShadow` stays `false` unless the pair also gets a dedicated
+   `ShadowSource` (see `nativeShadowReady` — today only
+   `github/repo-metadata` qualifies, deliberately; read its doc comment
+   before adding another).
+
+### 6. Wire the worker binary
+
+`cmd/dev-health-worker/provider_sync.go`:
+
+- Add a `case session.Claim.Provider == "x" && session.Claim.Dataset == "y":`
+  arm inside `BuildExecutor`'s switch, constructing the sink and setting
+  `routeHandler`.
+- Widen `buildProviderSyncWorker`'s "construct the family when ANY route
+  switch is on" condition to include the new config flag.
+
+`cmd/dev-health-worker/dependencies.go`:
+
+- Add the new field to `workerRouteSwitches`'s literal.
+- Add a `{provider, dataset, cfg.WorkerXEnabled}` entry to
+  `providerRouteSwitchesReady`'s `routes` slice.
+
+`internal/platform/config/config.go`:
+
+- Add `WorkerXEnabled bool` + a `WORKER_X_ENABLED` entry in the `boolEnv`
+  loop + a `slog.Bool` line in `SafeAttrs`. Off by default, same as every
+  existing switch — this is what keeps `route_ready: true` from moving any
+  live traffic by itself.
+
+`src/dev_health_ops/workers/provider_unit_route.py` (Python producer side —
+optional but recommended for the two-key gate to actually be usable later
+without a second PR): add the mirroring `x_dataset: bool = False` field +
+`_flag(source, "WORKER_X_ENABLED")` wiring in `from_environment`. Without
+this, `_switch_field_name` still fails closed (no field ⇒ `getattr` default
+`False`), so skipping it is *safe*, just leaves the producer half of the gate
+unimplemented until someone adds it.
+
+### 7. Regenerate the matrix contract
+
+```
+PROVIDER_MATRIX_UPDATE=1 go test ./internal/providersync \
+  -run TestProviderMatrixMatchesCheckedInContract -count=1
+```
+
+Then update the **hardcoded** freeze-guard literals that intentionally do
+NOT auto-follow the registry (grep the constant name, don't guess):
+
+- `internal/providersync/capability_matrix_test.go`:
+  `routeReadyPairs` (add the pair), the `all := CompleteRouteSwitches{...}`
+  literal + its `NumField()` count (both `TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs`),
+  and the `handlers` map in `TestProviderMatrixExecutorRegistryIsHonest`.
+- `cmd/dev-health-worker/provider_sync_test.go`:
+  `TestProviderSyncHandlerSwitchesFollowConfiguration`'s table,
+  `TestWorkerRouteSwitchesMapsEveryConfiguredRoute`'s table.
+- `cmd/dev-health-worker/dependencies_test.go`:
+  `TestProviderRouteSwitchesAreIndependentAndRejectIncompleteRoutes`'s table.
+- `internal/platform/config/config_test.go`: the all-off assertion, the
+  all-on env map, the invalid-value env map.
+- `tests/workers/test_provider_unit_route.py` (if you did step 6's Python
+  half): mirror the `test_github_repo_metadata_*` block for the new switch,
+  plus a "does not open its sibling alias dataset" test (see step 8).
+
+The Python side (`tests/workers/test_provider_matrix_contract.py`) needs
+**no code change** — it reads the regenerated `matrix.json` and Python's
+`_PROVIDER_SUPPORTED_DATASETS`/`get_dataset_spec` directly, so it fails loud
+on drift without anyone having to remember to touch it.
+
+### 8. Tests: prove parity, not just execution
+
+**The parity oracle MUST run the real Python producer live, not compare
+against a hand-authored fixture — and check in the generator, so
+regeneration is reviewable.** `github/prs`'s first draft did the opposite:
+it hand-wrote the "expected" Python output in a code comment (an earlier
+version of this document even recommended that pattern — see the diff
+history), and codex's H9 finding was exactly what that pattern risks: the
+hand-authored fixture OMITTED an entire phase of the real Python function
+(the review-enrichment step) and then asserted the resulting zero-valued
+fields as if they were verified parity. A fixture that never exercised a
+code path cannot fail when that code path is wrong; it just encodes
+whatever the Go implementation already does as the "expected" result. That
+is not parity evidence, however confident the surrounding comment sounds.
+
+The fix, and the pattern every future pair should follow from the start —
+see `internal/providersync/testdata/python_launchdarkly_normalization_oracle.py`
+(the pre-existing template) and
+`python_github_prs_normalization_oracle.py` + the `python_oracle_loader.py`
+extension it added (this pair's worked example):
+
+1. Write `internal/providersync/testdata/python_<pair>_normalization_oracle.py`.
+   It imports and calls the REAL, checked-in Python functions your Go code
+   mirrors — never a hand-transcribed re-implementation of what you believe
+   they do.
+2. The Go quality lane (`ci/check_go.sh`) runs Python oracles under a
+   **stock interpreter with no project dependencies installed** — the whole
+   point is these tests run without the full Python venv. If the function
+   you need lives in a module with heavy imports (SQLAlchemy models, httpx
+   clients, ...), do NOT try to load that module directly. Instead extend
+   the shared `python_oracle_loader.py`: add the source path, and a
+   `_target_<name>()` function that installs minimal stub modules (plain
+   `object`/lambda placeholders, `_install_module`) satisfying only the
+   *names* the target module imports at load time — it never needs the
+   stubs to do anything, because the oracle never calls into them. See
+   `_target_base_git()` for the worked example (stubs `analytics.complexity`,
+   `metrics.schemas`, `models.git`, `processors.fetch_utils`, `utils`, all
+   dead weight for `build_git_pull_request` and `coerce_created_at`
+   specifically). If the target function has zero project-internal imports
+   (like `providers/pr_state.py::normalize_pr_state`), skip the loader
+   entirely and use `importlib.util.spec_from_file_location` directly — see
+   `python_registry_oracle.py` for that simpler pattern.
+3. It is fine, and often correct, for the oracle to cover LESS than the
+   Go code's full input space — `github/prs`'s oracle deliberately does not
+   re-execute `_pull_from_item`'s raw-JSON parsing (that module imports
+   httpx, which the stock interpreter doesn't have; that layer is
+   mechanical field extraction already pinned by
+   `tests/providers/test_github_code_client_prs.py` in the full Python
+   suite). What it must NOT do is claim to have proven something it didn't
+   run — say explicitly, in the oracle's own docstring, which functions it
+   calls live and which layers are covered elsewhere instead.
+4. In Go, `exec.Command(pythonExecutable(t), ".../oracle.py", ...)`, decode
+   its JSON stdout, and assert your Go functions produce identical output
+   for the identical input — see
+   `TestGitHubPRSNormalizationMatchesLivePythonFunctions`. `pythonExecutable`
+   (in `capabilities_test.go`) resolves `$PYTHON` or `python3` on PATH; it
+   is not pointed at `.venv` on purpose, matching the stock-interpreter
+   constraint above.
+5. Prove the oracle test is actually sensitive before trusting it: break the
+   Go function it's checking, confirm the SPECIFIC oracle-backed test fails
+   (not some other test), then revert. If it doesn't fail, the oracle isn't
+   covering what you think it covers.
+
+A skipped/unimplemented live-parity harness test (see
+`TestGitHubRepositoryLiveParityHarness` pattern, if you add one — this is
+about a *live, credentialed* provider call, a different and larger claim
+than the oracle above) is explicitly **not** parity evidence either; say so
+in its skip message.
+
+Minimum test surface per pair (see `github_prs_route_test.go`,
+`github_prs_normalization_oracle_test.go`, `github_prs_readback_test.go`,
+`github_prs_effects_integration_test.go` for the worked template):
+
+1. One "emits the bounded effect" test carrying the fixture-parity doc
+   comment (hand-verified field values are still fine for the HTTP-fixture
+   layer — the live oracle above is specifically for the normalization
+   logic, not a replacement for an HTTP-mocked fetch/effect-shape test),
+   asserting every row field, the destination manifest via
+   `batch.validate(descriptor)`, the watermark, and `FetchEvidence`.
+2. The live-Python-oracle test from the numbered list above, for whichever
+   pure normalization functions the pair's semantics actually live in
+   (state mapping, timestamp fallback chains, identity derivation, ...).
+3. Fail-closed tests: wrong provider, wrong dataset, malformed payload,
+   missing/blank identity input (defect class 3), a capped paginated fetch
+   (defect class 1).
+4. Any provider-specific edge behavior ported (state normalization, window
+   filtering, GHE base-path preservation, created_at fallback chains) gets
+   its own table-driven test, not folded into test 1 — and where the
+   underlying logic is a compound boolean (defect class 4), the table must
+   isolate each clause: known-vs-unknown timestamp, since-only, before-only,
+   each bound independently of the other, not just the paired "inside the
+   window" / "outside the window" cases.
+5. A pure-Go readback decision-table test for `compareXVersion` (no
+   ClickHouse needed) covering: absent, zero-timestamp aggregate, stale
+   version, newer version (conflict), and — one dedicated sub-test PER
+   COLUMN the row carries (defect class 6), not one "different content"
+   catch-all — a divergence in that single column reports `EffectConflict`.
+6. An `integration`-tagged test against real Postgres+ClickHouse
+   (`internal/testsupport/containers`) proving: `InspectEffect` on an empty
+   table, tolerating pre-merge history, a genuine conflict case, and the
+   full crash-recovery path (`WriteEffect` → simulated crash before
+   `CommitEffect` → recovery regenerates the identical digest → readback
+   marks committed without a duplicate physical row). This is the ONLY layer
+   that catches driver-level type mismatches (see step 4's UInt32 gotcha) —
+   it is not optional decoration.
+7. If the matrix has sibling alias datasets sharing the same Python
+   `legacy_target`/processor flag (see below), a test proving the new switch
+   does NOT flip them ready too.
+
+**Use the shared mutation harness — `scripts/mutation_harness.py`, runbook
+`tests/tooling/README.md` — rather than a hand-rolled mutate/test/revert
+loop.** Three ad-hoc per-lane harnesses produced false results on the same
+day this pair was reviewed (a leaked mutation reported as restored, `git
+checkout` reverting unrelated uncommitted edits, a waiter that matched its
+own process and hung forever); the shared tool exists specifically to close
+those failure modes; do not re-open them by rolling your own again. Two
+rules from that runbook matter most for this recipe:
+
+- **Mutate compound predicates clause by clause, never as a unit** — this is
+  defect class 4 above, restated as a harness discipline: a three-clause
+  condition mutated wholesale can report `KILLED` while one clause inside it
+  is both unasserted and wrong, because the OTHER clauses in whatever
+  fixture the proof test uses already made the outcome differ. Write one
+  mutation per named clause.
+- **A `SURVIVED` result is not automatically a coverage gap.** Running
+  `github/prs`'s own plan
+  (`internal/providersync/testdata/mutation-plans/github_prs.json`) found
+  exactly one: a mutated `if fullName == "" { ... }` guard survived because
+  `repositoryIdentity` (the function called two lines later) already
+  rejects an empty string with the identical error — the guard was dead
+  code duplicating a check its own callee makes. The fix was deleting the
+  redundant guard, not adding a test to justify keeping it; see that plan's
+  `$limitation` field for the full account. Classify every survivor
+  (missing test / invalid mutation / genuine redundancy) rather than
+  reflexively adding assertions until everything shows `KILLED`.
+
+Write the plan to `internal/providersync/testdata/mutation-plans/<pair>.json`
+(checked in, reviewable) and run it with:
+
+```
+python3 scripts/mutation_harness.py run \
+  --plan internal/providersync/testdata/mutation-plans/<pair>.json \
+  --assert-all-killed
+```
+
+Report which mutation was caught by which test — that mapping is what makes
+"I mutation-tested this" a checkable claim instead of an assertion.
+
+## Difficulty tiers for the remaining GitHub pairs
+
+Base confidence: `prs` and `repo-metadata` have proven, mutation-tested
+handlers (this document's own worked recipe, plus the CHAOS-3123 precedent)
+— `prs` is not yet `route_ready` (see defect class 9). Every tier below for
+the other 15 pairs is from a **targeted read** of
+`src/dev_health_ops/processors/github.py`'s fetch/write call sites (function
+names, insert targets) — not a line-by-line trace like `prs` got. Re-verify
+the exact semantics per step 1 before porting; treat the tier as a sizing
+estimate, not parity evidence.
+
+**Shared fetch/transform code already in Go.** `internal/providersync/native_rest.go`'s
+`NativeRESTHandler` already implements `Fetch`-only (not `CompleteRouteHandler`)
+logic for `repo-metadata`, `work-items`, `work-item-labels`,
+`work-item-projects`, `work-item-history`, and `work-item-comments` — for
+**both** GitHub and GitLab, sharing helpers like `filterWorkItemWindow`,
+`issueStatusAndType`, `collectGitHubIssues`/`collectGitHubWorkItems`. Porting
+any of these five to a real `CompleteRouteHandler` starts from adapting that
+existing fetch/normalize code to build `EffectBatch` rows instead of
+`NormalizedEnvelope`s, not from zero. `commits`/`commit-stats`/`files`/`blame`
+share `sync_git` gating and a common `owner/repo` root but each hits a
+different GitHub surface (REST list, per-commit REST, and — for
+`files`/`blame` — no confirmed active Python write call was found at all;
+see below).
+
+| Pair | Tier | Why |
+|---|---|---|
+| `cicd` | **Low** | `_fetch_github_workflow_runs_async` → single REST list (`client.get_workflow_runs`), one destination table (`ci_pipeline_runs`), no per-item detail call, no GraphQL. Same shape as `repo-metadata`, simpler than `prs` (no N+1). |
+| `deployments` | **Low** | `_fetch_github_deployments_async` → two REST list calls (deployments + releases for `release_ref`), one destination table (`deployments`). Slightly more surface than `cicd` for the release-ref join but still no per-item detail call. |
+| `commits` | **Low-Medium** | `_sync_github_commits` → REST list, one destination table (`git_commits`). Straightforward, but confirm the commit-window/pagination semantics (`since`) exactly — GitHub's commits endpoint DOES support server-side `since`, unlike `/pulls`. |
+| `security` | **Medium** | `_fetch_github_security_alerts_async`, one destination (`insert_security_alerts`, gated behind a `getattr` — confirm the sink actually implements it in production, not just in the fixture path). Likely several distinct GitHub alert types (Dependabot/CodeQL/secret-scanning) behind one dataset — read this one carefully before estimating further. |
+| `commit-stats` | **Medium** | `_fetch_github_commit_stats_async` → REST list **plus per-commit stat fetch** (N+1, same shape as `prs`'s list+detail). One destination (`git_commit_stats`). Reuse the `prs` N+1 pagination pattern directly. |
+| `work-items` | **High** | Fetch/normalize logic partially exists (`NativeRESTHandler.fetchGitHub` case `"work-items"`), BUT the Go `Descriptor` already collapses this and its four sibling aliases (see below) onto ONE canonical route with **fifteen** destination tables (`workItemRouteDestinations()` in `execution_registry.go`: `work_items`, `work_item_transitions`, `work_item_dependencies`, `work_item_reopen_events`, `work_item_interactions`, `sprints`, plus six `*_daily` rollup tables and `ai_attribution`-adjacent surfaces). Several of those are metrics computed by separate downstream jobs in Python, not by the fetch/normalize step itself — scope this pair by first determining which of the 15 declared destinations `_ingest_with_client` (provider.py) actually produces directly vs. which are computed elsewhere, and consider whether the initial port should legitimately cover a subset with the rest tracked as explicit follow-on work. This is not a single-PR-sized port. |
+| `work-item-comments` | **Medium** (shares work-items complexity, narrower scope) | `fetchGitHubChildren` already fetches `/issues/{number}/comments`; write path only needs the `work_item_interactions`-style destination, not the full work-items fan-out — BUT the matrix's alias-collapse rule means this dataset can't become independently `route_ready` without either (a) the full `work-items` route landing first, or (b) a deliberate decision to decouple it, which itself needs a design call before coding. |
+| `work-item-history` | **Medium**, same caveat as `work-item-comments` (alias of `work-items`). |
+| `work-item-labels` | **Low**, same caveat — but the underlying fetch (`/labels`) and destination shape is close to trivial once the alias-collapse question is resolved. |
+| `work-item-projects` | **Low**, same caveat (`/milestones`). |
+| `pr-reviews` | **High, and load-bearing for `prs`** | Needs a **new capability**: GitHub GraphQL PR-reviews batch fetch (`GitHubWorkClient.iter_pr_reviews_batch`, Python's `_enrich_prs_with_reviews_batch`). `internal/providerfoundation` has a generic GraphQL POST helper (`CollectLinearGraphQLPages`) but no GitHub-specific query/schema handling yet — this is genuinely new Go surface, not adaptation. Shares `github/prs`'s repo-id derivation and PR-list fetch; the natural design is for `pr-reviews` to depend on/reuse `github/prs`'s handler rather than re-list PRs independently. Writes `git_pull_request_reviews` AND the `first_review_at`/`reviews_count`/`changes_requested_count` columns on `git_pull_requests` that `github/prs` deliberately leaves at zero (defect class 9) — **landing this pair is what flips BOTH `github/prs` and `github/pr-reviews` to `route_ready: true`** in `execution_registry.go`'s two Descriptor cases together, not `pr-reviews` alone. Resolve the write-conflict/column-ownership question from defect class 9 as part of scoping this pair, before writing the handler. |
+| `pr-comments` | **Low, once `pr-reviews` exists** | Shares the `prs` legacy target/processor flag; Python's actual PR-comments handling folds into `comments_count` on the `git_pull_requests` row itself (there is no dedicated PR-comments raw table in the ClickHouse schema, unlike `work_item_comments` for issues) — worth confirming there is even a distinct `route_destinations` manifest to give this pair before treating it as separate work rather than a `prs` field. |
+| `files` | **Unclear / needs investigation first** | No `insert_git_files` call site was found anywhere under `src/dev_health_ops/processors/github.py` in this pass — either the write path lives in a different module (a local-clone git-walk processor, not the REST GitHub client) or this capability has no active production caller today. Confirm which before estimating; per repo convention, "no caller found" is a finding to verify, not a conclusion. |
+| `blame` | **Unclear / needs investigation first**, same caveat as `files`. `_fetch_github_blame_sync` exists but simulates blame via repeated `get_contents` calls rather than any GitHub blame API — a materially different (and likely much heavier) fetch shape than every other pair in this table if it does turn out to be the live path. |
+| `tests` | **High** | TestOps report ingestion is a distinct, heavy pipeline (JUnit/report-format parsing, `_fetch_github_test_artifacts_sync` + `_sync_github_test_reports`), already flagged elsewhere as fixture-only in production (see the TestOps ingestion gap tracked separately). Do not estimate this as PRs-sized; it likely needs its own scoping pass before a Go port is even well-defined. |
+
+## What to update when a pair lands
+
+Follow `github/prs`'s own additions as the template:
+
+- Add an "Activation status for `(provider, dataset)`" section to
+  `contracts/provider-matrix/v1/README.md`, mirroring the existing
+  `(github, repo-metadata)` / `(github, prs)` sections — same structure,
+  same honesty about what's waived (canary/live-traffic parity) vs. what's
+  actually proven (fixture-level field parity via the live oracle), vs.
+  what's deliberately not yet true (`route_ready` staying `false` pending a
+  sibling pair, if that's this pair's situation).
+- If the port uncovers a new Go/Python divergence class (like the nine
+  defect classes above), add it to THIS document's checklist, not just to a
+  commit message — the next agent needs it before writing their sink, not
+  after debugging the same failure. This checklist is the actual product of
+  this recipe; keep it current more than any other section.
+- Get an adversarial review (codex or equivalent) on every pair before
+  calling it done, even with a green gate — see the second ground rule at
+  the top of this document. `github/prs`'s own gate was green and its first
+  draft still shipped four HIGH-severity silent-data-loss defects.
+
+## Commit boundary
+
+Each provider/dataset pair is one sync unit and is independently executable
+and testable through its claim — no scheduler, no job-route activation, no
+occurrence materialization required. That makes the pair the right commit
+boundary: land one pair (code, tests, mutation plan, matrix/registry
+wiring, this document's updates) as its own commit before starting the
+next, rather than batching multiple pairs into one diff. A 17-pair diff is
+unreviewable, and one defective pair in a large batch blocks every good one
+alongside it.

--- a/deploy/go-workers/provider-sync-porting-recipe.md
+++ b/deploy/go-workers/provider-sync-porting-recipe.md
@@ -236,6 +236,78 @@ question.
     its own sub-precision fixture, not just the first one you wrote a test
     for.
 
+16. **A hand-picked field list in a parity oracle is a standing invitation
+    for the NEXT unpicked field to ship broken.** Defect class 13 above (an
+    oracle must assert every field it decodes) and this pair's own review
+    history proved the same shape of gap twice: `github/prs`'s first oracle
+    hand-picked `state`/`author_name`/`created_at`; its replacement decoded
+    `merged_at`/`closed_at` from the live function and simply forgot to
+    assert them, for two review rounds in a row, because nothing forced the
+    list of asserted fields to stay in sync with the list of fields the row
+    actually carries. CHAOS-3162 replaced "assert the fields you thought to
+    hand-pick" with a **generic, declarative, whole-row comparator** that
+    every future pair should use instead of writing a new hand-authored
+    field-by-field oracle test:
+    - `internal/providersync/testdata/oracle_registry.py` — a pair
+      registers itself (`PairSpec(id, build_row, excluded_fields)`) as a
+      side effect of importing its own file under `testdata/oracle_pairs/`.
+      Nothing in the registry, or in the CLI runner
+      (`python_generic_row_oracle.py`), changes to add a pair — that is the
+      whole point: a pair difference is a difference in WHAT gets compared,
+      never in HOW.
+    - `internal/providersync/oracle_compare_test.go` —
+      `compareRowsAgainstPythonOracle`/`oracleDivergences` diff **every
+      key** present on either side (the union, not the intersection) and
+      fail on ANY undeclared divergence, including a key present on one
+      side and absent on the other. An exclusion (a field one side
+      structurally cannot have an opinion about — review-enrichment fields
+      not yet built, Go-only effect bookkeeping like `org_id`/`last_synced`)
+      requires a written reason at both the Python (`excluded_fields`) and
+      Go (`goOnlyFields` parameter) side — mirroring
+      `expected_survivor_reason` in the mutation harness: an omission must
+      be declared, never silently missing.
+    - The same comparator generalizes past row-CONSTRUCTION: this pair also
+      used it for the readback boundary (`oracle_readback_integration_test.go`,
+      comparing a written row against what a real ClickHouse `SELECT`
+      returns) and a list-inclusion-DECISION boundary
+      (`github_prs_window_oracle_test.go`, comparing a boolean decision
+      struct rather than a row). `diffRows` doesn't know or care what shape
+      of thing it's comparing — only that both sides serialize to
+      `map[string]any` with the same keys meaning the same thing.
+    - Proving a comparator actually catches something is itself a testable
+      claim, not an assertion: for every defect class this framework was
+      built to prevent, write a "rediscovers" test — the SAME comparator,
+      cases, and pair id, but with a documented pre-fix/buggy builder
+      substituted for the real one — and assert the divergence list is
+      non-empty. **Do not try to do this by wrapping
+      `compareRowsAgainstPythonOracle` in `t.Run` and checking the returned
+      bool**: a subtest's `t.Errorf` marks EVERY ancestor test failed
+      regardless of what the caller does with `t.Run`'s return value; call
+      `oracleDivergences` directly instead and assert on its returned slice
+      (see `requireOracleRediscovers` and
+      `TestGenericOracleRediscoversRowConstructionDefects`).
+    - Not every crossing can reasonably execute the real, live Python
+      function — `github_prs_window.py`'s pair documents the scope call
+      made when it couldn't: `_collect_github_pr_objects`'s list-inclusion
+      decision is three lines embedded in an async function whose module
+      pulls in the complexity scanner, testops ingestion, and half a dozen
+      other subsystems, too much stubbing surface for a decision this
+      small to be worth the maintenance risk of the stubs themselves
+      drifting from reality. The fallback used there — a byte-for-byte
+      PINNED copy of the exact source lines, with a freshness check that
+      hard-fails if those lines stop matching the live source — is weaker
+      than live execution and is labelled as such in the pair's own
+      docstring, not left for a reader to discover. Prefer live execution;
+      reach for a pinned-and-guarded fallback only when the import cost is
+      genuinely disproportionate to the decision being tested, and say so
+      in writing.
+    - This does NOT retroactively apply to the five oracles that predate
+      CHAOS-3162 (`python_launchdarkly_normalization_oracle.py` and
+      friends, including this pair's own OWN existing
+      `python_github_prs_normalization_oracle.py`) — they keep working
+      exactly as documented in step 8 below. Only NEW pairs should reach
+      for the generic path first.
+
 ## The recipe
 
 ### 1. Read the Python authority for the pair, not just its shape
@@ -454,6 +526,20 @@ The Python side (`tests/workers/test_provider_matrix_contract.py`) needs
 on drift without anyone having to remember to touch it.
 
 ### 8. Tests: prove parity, not just execution
+
+**For a NEW pair, reach for the generic oracle framework (defect class 16)
+first**, not the hand-authored-oracle pattern the rest of this section
+walks through. The numbered steps and worked examples below (the
+`python_<pair>_normalization_oracle.py` / `python_oracle_loader.py`
+pattern) remain accurate and are what the five pairs that predate
+CHAOS-3162 use — read them to understand the loader technique they share
+with the generic framework (stubbing heavy imports so a stock interpreter
+can still execute the real target function) — but a new pair's own oracle
+test should be a `testdata/oracle_pairs/<pair>_<boundary>.py` registration
+plus a Go file calling `compareRowsAgainstPythonOracle`, not a new
+hand-picked-field comparison script. See defect class 16 for why, and
+`internal/providersync/testdata/oracle_pairs/github_prs_row.py` +
+`github_prs_generic_oracle_test.go` for the worked example.
 
 **The parity oracle MUST run the real Python producer live, not compare
 against a hand-authored fixture — and check in the generator, so

--- a/deploy/go-workers/provider-sync-porting-recipe.md
+++ b/deploy/go-workers/provider-sync-porting-recipe.md
@@ -320,6 +320,52 @@ question.
       fallback only when there is no seam at all to fake through (no I/O
       boundary, no injectable dependency) — that is a narrower case than it
       first appears.
+    - **REQUIREMENT: the stub path a `load_live_module` target takes must be
+      exercised LOCALLY, not just in whichever CI job happens to be more
+      isolated than your workstation.** `_target_github_processor()`
+      shipped, gated locally, and still broke CI's `go-storage-integration`
+      job on the very next PR push: `TypeError: unsupported operand
+      type(s) for |: 'NoneType' and 'NoneType'`, from
+      `processors/github.py`'s own `gate: RateLimitGate | None = None`
+      parameter annotation, because the stub set `CONNECTORS_AVAILABLE =
+      False` (following `_target_base_git`'s precedent verbatim) which
+      routes github.py into an `else:` branch that sets `RateLimitGate =
+      None` at module scope — and `None | None` is not a valid type union.
+      **Why the local gate did not catch this — the actual mechanism, not
+      just "the environments differ":** Python 3.14 (this loader's local
+      interpreter) defaults to PEP 649 deferred annotation evaluation —
+      `gate: RateLimitGate | None` is not actually evaluated when the `def`
+      statement runs, only the first time something reads
+      `__annotations__`. `load_live_module` never did that, so
+      `exec_module` returned successfully and every local test built on
+      top of it passed. CI's isolated job ran an OLDER Python (pre-3.14,
+      where annotations are still evaluated eagerly at `def` time) and hit
+      the crash immediately on import. This is a real, general trap, not a
+      one-off: a stub whose SHAPE is wrong for a name used in an
+      annotation can pass on 3.14 and fail on anything older (or on
+      anything, any version, that later calls `typing.get_type_hints` or
+      `inspect.signature` on the loaded module — mypy does this too). The
+      fix landed in the SHARED loader, not just this one target:
+      `load_live_module` now calls `_force_annotation_evaluation` on every
+      freshly-loaded module before returning it, which touches
+      `__annotations__` on every function and class the module defines —
+      forcing PEP 649's lazy evaluation to happen NOW, deterministically,
+      on whichever Python is running the loader, so a broken stub fails on
+      the very next line locally, on any Python version, instead of only
+      on whichever CI image or future interpreter happens to evaluate it
+      eagerly. Verified by re-injecting the exact broken stub
+      (`CONNECTORS_AVAILABLE = False`, no `connectors.*` stubs) and
+      confirming `load_live_module` now raises immediately with a message
+      naming the broken annotation — and separately by running the full
+      suite against a real Python 3.13 interpreter (`PYTHON=<3.13 binary>
+      go test ...`), which has eager annotation evaluation and reproduces
+      what CI's older Python actually sees. **Do this for every new
+      `load_live_module` target**: after writing the stub, deliberately
+      break one name it supplies (make it `None`, or drop a needed
+      attribute) and confirm the loader itself — not just some specific
+      test that happens to touch that name — reports the break; if it
+      doesn't, `_force_annotation_evaluation` isn't the whole story for
+      that target and something narrower needs adding.
     - **REQUIREMENT: always run `go test -count=1` (never a bare `go test`)
       when a test exercises a live oracle whose Python source lives outside
       `internal/providersync/testdata/`.** `//go:embed` cannot reach outside

--- a/deploy/go-workers/provider-sync-porting-recipe.md
+++ b/deploy/go-workers/provider-sync-porting-recipe.md
@@ -286,21 +286,101 @@ question.
       `oracleDivergences` directly instead and assert on its returned slice
       (see `requireOracleRediscovers` and
       `TestGenericOracleRediscoversRowConstructionDefects`).
-    - Not every crossing can reasonably execute the real, live Python
-      function — `github_prs_window.py`'s pair documents the scope call
-      made when it couldn't: `_collect_github_pr_objects`'s list-inclusion
-      decision is three lines embedded in an async function whose module
-      pulls in the complexity scanner, testops ingestion, and half a dozen
-      other subsystems, too much stubbing surface for a decision this
-      small to be worth the maintenance risk of the stubs themselves
-      drifting from reality. The fallback used there — a byte-for-byte
-      PINNED copy of the exact source lines, with a freshness check that
-      hard-fails if those lines stop matching the live source — is weaker
-      than live execution and is labelled as such in the pair's own
-      docstring, not left for a reader to discover. Prefer live execution;
-      reach for a pinned-and-guarded fallback only when the import cost is
-      genuinely disproportionate to the decision being tested, and say so
-      in writing.
+    - **Prefer live execution over a pinned copy even when the import chain
+      looks disproportionate — a monkeypatched dependency seam plus a
+      sentinel exception usually gets you there.** `github_prs_window.py`
+      originally shipped as a byte-for-byte PINNED copy of
+      `_collect_github_pr_objects`'s two decision `if` blocks, reasoned to
+      be "too much stubbing surface for a decision this small." Codex's
+      third review correctly rejected that: an unordered substring-presence
+      check over a multi-thousand-byte slice cannot detect a mutation that
+      keeps every pinned fragment present but changes what they mean (e.g.
+      deleting the SECOND `isinstance(updated_at, datetime)` guard leaves
+      the string `"isinstance(updated_at, datetime)"` still present
+      elsewhere in the slice — the pin reports "still matches" while being
+      stale). The fix was live execution after all: `python_oracle_loader.py`
+      gained `_target_github_processor()`, stubbing every module-level name
+      `processors/github.py` needs to IMPORT (analytics.complexity,
+      credentials.types, models.git, base_git, fetch_utils, release_ref,
+      storage_protocol, testops_ingest, providers.github.client, pr_state,
+      providers.usage, utils — none of them need to be FUNCTIONAL, only
+      importable, since the harness's execution path never reaches them),
+      then the pair itself monkeypatches the ONE dependency seam the
+      function actually calls through at run time
+      (`module._github_code_client_from_connector`) with a fake client
+      whose `get_pull_detail` raises a distinguishing sentinel exception
+      the INSTANT it's called. Since the real function's `try/finally` has
+      no `except`, the sentinel propagates cleanly to the harness, which
+      reads off exactly how far the loop's real `continue`/`break` control
+      flow got by which of two list items (or neither) reached the fetch
+      step. Verified empirically: reproducing H3's original bug in the REAL
+      `processors/github.py` (not the oracle) crashed the live oracle
+      immediately, which the byte-for-byte pin would only sometimes have
+      caught depending on the exact edit shape. Reach for a pinned/digested
+      fallback only when there is no seam at all to fake through (no I/O
+      boundary, no injectable dependency) — that is a narrower case than it
+      first appears.
+    - **`//go:embed` cannot reach outside its own package directory.** The
+      cache-busting fix above only covers files under
+      `internal/providersync/testdata/` (the framework's own registry,
+      loader, runner, and pair files) — it structurally CANNOT also embed
+      the production `src/dev_health_ops/**.py` files a live oracle
+      executes (Go's embed patterns reject any `../` component; verified
+      directly — `go vet` rejects it with "invalid pattern syntax"). This
+      means editing `processors/base_git.py`, `code_client.py`,
+      `pr_state.py`, or `processors/github.py` alone can STILL produce a
+      stale cached PASS from a warm `go test` cache with no `-count=1` --
+      exactly the class of bug `//go:embed` was built to close, just for a
+      file set it cannot reach. There is no known full fix for this
+      specific gap; the existing "always use `-count=1` when iterating on
+      a production Python file a live oracle depends on" discipline is
+      still load-bearing, not superseded by the embed fix.
+    - **A shared mutation harness proof command with no cache-bypass can
+      report a false SURVIVED (or, worse, a false KILLED) depending on
+      unrelated prior `go test` invocations in the same session** —
+      discovered empirically while re-verifying an EXISTING (already-KILLED)
+      mutation after refactoring the function it targets: the harness's
+      `_run_command` does not pass `-count=1`, and a warm test cache
+      returned a stale `(cached)` PASS for a proof command run against a
+      manually re-applied version of the SAME mutation, even though the
+      underlying `.go` file's content had genuinely changed. `go clean
+      -testcache` immediately before a `run` fixed it; a fresh, un-warmed
+      cache does not exhibit the bug. This is a real reliability gap in
+      `scripts/mutation_harness.py` itself (unmerged
+      `chaos-3155-shared-mutation-harness` branch) — until it passes
+      `-count=1` (or an equivalent cache-bypass) in its own proof-command
+      invocation, **always run `go clean -testcache` immediately before any
+      `mutation_harness.py run`**, and do not trust a lone SURVIVED or
+      KILLED verdict produced against a warm cache without that step.
+    - **A declared exclusion is a claim, and claims need enforcing, not just
+      writing down.** `goOnlyFields[key]` asserts "the Python side
+      structurally cannot have this field"; nothing checked that assertion
+      against what Python actually sent until codex's third review named
+      it. `oracleDivergences` now checks it on every case: if a
+      `goOnlyFields` key shows up in the Python row anyway, that is a hard
+      divergence in its own right (the field is not actually Go-only, and
+      excluding it hides a real, comparable value) — see the "exclusion
+      integrity" subtest `compareRowsAgainstPythonOracle` adds alongside
+      the per-case ones. The same pass also flags a declared exclusion
+      (either map) that never matched ANY key across the whole batch of
+      cases as stale. Both checks are necessarily BATCH-level, not
+      per-case — `compareRowsAgainstPythonOracle` now shells out to Python
+      ONCE for the whole case list (it used to shell out once per case)
+      specifically so this is checkable at all. Of the five defects named
+      in that review round (empty `cases`, duplicate case IDs, Python `{}`
+      equalling a nil Go map, exclusions silently unenforced, and
+      `goOnlyFields` not verified as actually Go-only): the first two were
+      already fixed the prior round; "Python `{}` equalling a nil Go map"
+      turned out to already be DEAD by construction once builders return
+      concrete struct types — a literal Go `nil` fails the
+      `map[string]any` type assertion outright (hard `t.Fatalf`, not a
+      silent pass), and two non-nil-but-genuinely-empty maps are already
+      caught by `diffRows`'s existing "both rows are empty" guard; the
+      other two needed the fix described above. This staleness/enforcement
+      check is scoped to `oracleDivergences` callers (the row-construction
+      and window-decision pairs) — the readback pair calls `diffRows`
+      directly with hand-verified, static exclusions and is not yet
+      covered by it.
     - This does NOT retroactively apply to the five oracles that predate
       CHAOS-3162 (`python_launchdarkly_normalization_oracle.py` and
       friends, including this pair's own OWN existing

--- a/deploy/go-workers/provider-sync-porting-recipe.md
+++ b/deploy/go-workers/provider-sync-porting-recipe.md
@@ -149,6 +149,92 @@ question.
        worth of plumbing.
    If none of the three fits, that is itself a real design finding — say so
    explicitly rather than shipping `route_ready: true` anyway.
+10. **Never assemble a "winning row" from independent per-column
+    aggregates over a ReplacingMergeTree table.** `argMax(column,
+    last_synced)` computed separately per column is NOT the same as reading
+    the row with the maximum `last_synced`: ClickHouse's `argMax` skips a
+    row whose ARGUMENT is NULL when picking the max, so a genuinely winning
+    row with a NULL in one column can have that column silently backfilled
+    from an OLDER, non-winning row's non-NULL value in the same column —
+    verified empirically (see step 4 below) by writing two versions as
+    separate physical parts (not one batch — a single-part insert did NOT
+    reproduce it, which is its own trap: test this against realistic,
+    separately-written parts, not a convenient single-batch fixture) and
+    observing `argMax(body)` correctly pick the newer row while
+    `argMax(merged_at)` incorrectly reached back to the older row's value.
+    `FROM table FINAL WHERE <full ORDER BY prefix>` reads the winning
+    version as one consistent row instead — cheap for a point lookup
+    matching the primary key, and it doesn't need `ifNull`-collapsing NULLs
+    to stay safe, so it doesn't reopen the NULL-vs-empty-string problem
+    class 6's fix cares about either. A readback test that only puts NULLs
+    on the OLDER version cannot see this bug — the fixture must put a NULL
+    on the WINNING version specifically, with an older version that has a
+    non-NULL value in that same column.
+11. **A failure path that discards shared recovery state is worse than the
+    failure it was handling.** If a job-runtime "release this unit for
+    retry" primitive blindly overwrites a JSON result/state column instead
+    of merging into it, ANY failure after an effect ledger was written
+    (not only the specific one you're fixing) can delete the record of an
+    in-flight, possibly-already-landed write — and the next attempt then
+    has no way to classify that write as exact, absent, or conflicting, so
+    it either starts a whole new unreconciled write or wedges. This is easy
+    to introduce by accident: a NEW way for your handler to fail (a page
+    cap, a stricter validation) that fires reliably on retry turns a
+    latent, rare exposure in shared retry-path code into a deterministic
+    one. Grep for the retry-release SQL/function your job runtime uses and
+    confirm it merges (`COALESCE(existing, '{}') || new_fields`) rather
+    than replaces; write an integration test that begins an
+    `EffectReadbackRequired` effect, calls the release-for-retry path, and
+    asserts the ledger is still loadable afterward.
+12. **A page cap only means what it claims once the fetch is bounded the
+    same way the Python authority bounds it.** If Python's collector stops
+    paginating early once it crosses some recognizable boundary (e.g. an
+    item older than the incremental window, for a sort=updated&desc
+    listing), a Go port that fetches every page up to `MaxPages` regardless
+    of content is capping on TOTAL HISTORY, not on the same thing Python
+    bounds — so a repository whose total history is long but whose
+    in-window page count is small will cap, and fail the unit, on every
+    attempt, even though Python syncs it fine every time. Match the early
+    stop, not just the final filtered set: a per-item post-hoc filter
+    (defect class 2) and a pagination-level early stop are not
+    interchangeable, and Python itself frequently has BOTH (a belt-and-
+    suspenders structure worth mirroring exactly rather than picking one).
+13. **An oracle comparison must ASSERT every field it decodes from the live
+    Python call, not just decode it for inspection.** A field pulled out of
+    the oracle's JSON output and left uncompared provides zero protection
+    the moment the Python side changes that field — decoding without
+    asserting is a more subtle version of defect class 9's original sin
+    (a fixture that never exercises what it claims to prove). Also: **Go's
+    test result cache does not know about your Python source files.**
+    Editing only `testdata/python_*_oracle.py` and rerunning `go test`
+    (without `-count=1`) can report a stale PASS from before the edit,
+    because from Go's perspective no Go-tracked input changed. Always use
+    `-count=1` — or better, drive the check through the shared mutation
+    harness, whose proof commands you control — when iterating on or
+    mutation-testing an oracle script.
+14. **A stringification/type-coercion helper must cover every JSON scalar
+    type the Python original's `str()`-equivalent would, and a test's name
+    must claim only what it actually covers.** "Handles ANY non-null value"
+    is a claim to verify against Python's actual type-dispatch (string,
+    number, AND boolean at minimum — Python's `str(True)` is `"True"`,
+    capitalized, not Go's lowercase `strconv.FormatBool`), not a claim to
+    make and then only test with a number. If a type is deliberately out of
+    scope (e.g. a JSON list/object is not a realistic shape for the
+    specific field you're stringifying), say so explicitly in the
+    function's doc comment rather than let the untested gap hide behind an
+    overbroad test name.
+15. **A precision/truncation fix needs a fixture at EVERY point that value
+    is truncated, not just one.** `github/prs` truncates a provider
+    timestamp to millisecond precision in one function
+    (`parseGitHubPullTime`) and truncates `normalizedAt` (which becomes
+    `last_synced`) at a SEPARATE call site inside `Collect`. A test proving
+    the first truncation says nothing about the second, and if every OTHER
+    fixture in the test file happens to use whole-second timestamps (a
+    natural default when hand-writing `time.Date(...)` literals), deleting
+    the second truncation is invisible to the entire existing suite. Grep
+    for every `.Truncate(` call the handler makes and confirm each one has
+    its own sub-precision fixture, not just the first one you wrote a test
+    for.
 
 ## The recipe
 

--- a/deploy/go-workers/provider-sync-porting-recipe.md
+++ b/deploy/go-workers/provider-sync-porting-recipe.md
@@ -320,21 +320,25 @@ question.
       fallback only when there is no seam at all to fake through (no I/O
       boundary, no injectable dependency) — that is a narrower case than it
       first appears.
-    - **`//go:embed` cannot reach outside its own package directory.** The
-      cache-busting fix above only covers files under
-      `internal/providersync/testdata/` (the framework's own registry,
-      loader, runner, and pair files) — it structurally CANNOT also embed
-      the production `src/dev_health_ops/**.py` files a live oracle
-      executes (Go's embed patterns reject any `../` component; verified
-      directly — `go vet` rejects it with "invalid pattern syntax"). This
-      means editing `processors/base_git.py`, `code_client.py`,
-      `pr_state.py`, or `processors/github.py` alone can STILL produce a
-      stale cached PASS from a warm `go test` cache with no `-count=1` --
-      exactly the class of bug `//go:embed` was built to close, just for a
-      file set it cannot reach. There is no known full fix for this
-      specific gap; the existing "always use `-count=1` when iterating on
-      a production Python file a live oracle depends on" discipline is
-      still load-bearing, not superseded by the embed fix.
+    - **REQUIREMENT: always run `go test -count=1` (never a bare `go test`)
+      when a test exercises a live oracle whose Python source lives outside
+      `internal/providersync/testdata/`.** `//go:embed` cannot reach outside
+      its own package directory — Go's embed patterns reject any `../`
+      component (verified directly: `go vet` rejects such a pattern with
+      "invalid pattern syntax") — so the `//go:embed` cache-busting fix
+      above can ONLY cover files under `internal/providersync/testdata/`
+      (the framework's own registry, loader, runner, and pair files). It
+      structurally CANNOT also embed the production
+      `src/dev_health_ops/**.py` files a live oracle executes
+      (`processors/base_git.py`, `code_client.py`, `pr_state.py`,
+      `processors/github.py`, and every future one). Editing any of those
+      alone, with no Go file changed, can leave `go test` unable to tell
+      the difference from the last run and return a stale cached PASS. This
+      is the same class of trap as the mutation-harness caching bug below,
+      in a place the tooling literally cannot reach — treat `-count=1` as a
+      hard requirement for these tests, not a nice-to-have, and say so at
+      the top of any new oracle pair file that reaches outside
+      `testdata/`.
     - **A shared mutation harness proof command with no cache-bypass can
       report a false SURVIVED (or, worse, a false KILLED) depending on
       unrelated prior `go test` invocations in the same session** —
@@ -343,15 +347,44 @@ question.
       `_run_command` does not pass `-count=1`, and a warm test cache
       returned a stale `(cached)` PASS for a proof command run against a
       manually re-applied version of the SAME mutation, even though the
-      underlying `.go` file's content had genuinely changed. `go clean
-      -testcache` immediately before a `run` fixed it; a fresh, un-warmed
-      cache does not exhibit the bug. This is a real reliability gap in
-      `scripts/mutation_harness.py` itself (unmerged
-      `chaos-3155-shared-mutation-harness` branch) — until it passes
-      `-count=1` (or an equivalent cache-bypass) in its own proof-command
-      invocation, **always run `go clean -testcache` immediately before any
-      `mutation_harness.py run`**, and do not trust a lone SURVIVED or
-      KILLED verdict produced against a warm cache without that step.
+      underlying `.go` file's content had genuinely changed.
+      **Why this is surprising, and worth stating precisely rather than
+      waving at "caching flakiness":** Go's test-result cache key is
+      supposed to be content-addressed — the compiled test binary's action
+      ID is a hash of its package's source, so editing a `.go` file changes
+      that hash and should force a cache miss on its own, with no
+      `-count=1` needed. That is true in a fully serial reproduction: a
+      `go clean -testcache`, one baseline run, one mutation, one re-run —
+      by itself — reliably shows the correct re-execution every time this
+      was tried in isolation. The stale hit was reproduced twice, and both
+      times it was in a session with SEVERAL concurrent `go build`/`go
+      test`/`go vet` invocations in flight against the same package at
+      once (parallel background gate scripts, plus `gopls`'s own
+      continuous background compilation, all sharing one `GOCACHE`) — and
+      it did NOT reproduce in later, deliberately serial retries, including
+      one that added a background contention loop (`go build`/`go vet`
+      looped 40 times) around the same mutate-and-test sequence without
+      catching it again. That pattern — content-addressing correct in
+      isolation, failure only under concurrent load against a shared cache
+      directory — points at a timing-dependent interaction with a
+      concurrent writer, not a flaw in the content hash itself, but this
+      was NOT pinned down to an exact interleaving; treat it as the
+      best-supported hypothesis from the evidence gathered, not a proven
+      root cause. What IS certain, independent of whichever exact
+      mechanism is responsible: `go test -count=1` disables cache lookup
+      entirely by design (documented Go behavior, not a workaround), so it
+      closes this hole regardless of what is ultimately causing it. Until
+      `scripts/mutation_harness.py` passes `-count=1` (or an equivalent
+      cache-bypass) in its own proof-command invocation, **always run `go
+      clean -testcache` immediately before any `mutation_harness.py run`**
+      — a full cache clear reliably reproduced the correct KILLED verdict
+      every single time it was tried, unlike `-count=1` on a single proof
+      command in isolation which was not separately re-verified against a
+      confirmed-concurrent-load reproduction of the bug. Do not trust a
+      lone SURVIVED or KILLED verdict produced against a warm cache without
+      that step, and if you run a mutation plan while other `go`
+      invocations are active in the same environment, clear the cache
+      again afterward before trusting the result.
     - **A declared exclusion is a claim, and claims need enforcing, not just
       writing down.** `goOnlyFields[key]` asserts "the Python side
       structurally cannot have this field"; nothing checked that assertion

--- a/internal/platform/config/config.go
+++ b/internal/platform/config/config.go
@@ -108,6 +108,12 @@ type Config struct {
 	// and the executor must agree on the route or a dispatched unit finds no
 	// handler.
 	WorkerGithubRepoMetadataEnabled bool
+	// WorkerGithubPRsEnabled is the (github, prs) half of the two-key route
+	// gate (CHAOS-3122, following CHAOS-3123's precedent). The matrix marking
+	// the pair route_ready is the other half; neither alone moves traffic.
+	// Its Python counterpart is ProviderUnitRouteSwitches.github_prs, read
+	// from the same WORKER_GITHUB_PRS_ENABLED name.
+	WorkerGithubPRsEnabled bool
 
 	// PagerDutyWebhookTransport names the single owner of the PagerDuty webhook
 	// stream. The Python ingress dispatches its Celery task only while this is
@@ -183,6 +189,10 @@ func Load(spec Spec) (Config, error) {
 		{
 			name:   "WORKER_GITHUB_REPO_METADATA_ENABLED",
 			target: &cfg.WorkerGithubRepoMetadataEnabled,
+		},
+		{
+			name:   "WORKER_GITHUB_PRS_ENABLED",
+			target: &cfg.WorkerGithubPRsEnabled,
 		},
 	} {
 		*item.target, err = boolEnv(lookup, item.name, false)
@@ -447,6 +457,7 @@ func (c Config) SafeAttrs() []slog.Attr {
 			c.WorkerLaunchDarklyFeatureFlagsEnabled,
 		),
 		slog.Bool("worker_github_repo_metadata_enabled", c.WorkerGithubRepoMetadataEnabled),
+		slog.Bool("worker_github_prs_enabled", c.WorkerGithubPRsEnabled),
 		slog.Bool("clickhouse_configured", c.ClickHouseURI.Configured()),
 		slog.Bool("valkey_configured", c.ValkeyURI.Configured()),
 		slog.Bool("settings_encryption_key_configured", c.SettingsEncryptionKey.Configured()),

--- a/internal/platform/config/config_test.go
+++ b/internal/platform/config/config_test.go
@@ -138,7 +138,7 @@ func TestQueueControlAndRetentionDefaults(t *testing.T) {
 	if cfg.WorkerLinearWorkItemsEnabled || cfg.WorkerJiraWorkItemsEnabled ||
 		cfg.WorkerJiraIncidentsEnabled ||
 		cfg.WorkerLaunchDarklyFeatureFlagsEnabled ||
-		cfg.WorkerGithubRepoMetadataEnabled {
+		cfg.WorkerGithubRepoMetadataEnabled || cfg.WorkerGithubPRsEnabled {
 		t.Fatal("provider route switches must default off")
 	}
 }
@@ -165,6 +165,7 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		"WORKER_JIRA_INCIDENTS_ENABLED":             "true",
 		"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": "true",
 		"WORKER_GITHUB_REPO_METADATA_ENABLED":       "true",
+		"WORKER_GITHUB_PRS_ENABLED":                 "true",
 	}))
 	if err != nil {
 		t.Fatal(err)
@@ -193,7 +194,7 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 	if !cfg.WorkerLinearWorkItemsEnabled || !cfg.WorkerJiraWorkItemsEnabled ||
 		!cfg.WorkerJiraIncidentsEnabled ||
 		!cfg.WorkerLaunchDarklyFeatureFlagsEnabled ||
-		!cfg.WorkerGithubRepoMetadataEnabled {
+		!cfg.WorkerGithubRepoMetadataEnabled || !cfg.WorkerGithubPRsEnabled {
 		t.Fatal("expected independent provider route opt-ins")
 	}
 
@@ -214,6 +215,7 @@ func TestQueueControlAndRetentionOverridesAreBounded(t *testing.T) {
 		"WORKER_JIRA_INCIDENTS_ENABLED":             "sometimes",
 		"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": "sometimes",
 		"WORKER_GITHUB_REPO_METADATA_ENABLED":       "sometimes",
+		"WORKER_GITHUB_PRS_ENABLED":                 "sometimes",
 	} {
 		if _, err := Load(workerSpec(map[string]string{key: value})); err == nil {
 			t.Fatalf("expected %s=%q to fail", key, value)

--- a/internal/providerfoundation/pagination.go
+++ b/internal/providerfoundation/pagination.go
@@ -38,6 +38,20 @@ type GitHubPageOptions struct {
 	Query    url.Values
 	DataKey  string
 	MaxPages int
+	// StopAt, when set, is evaluated for each item in page order (codex H1,
+	// CHAOS-3122). The first item it reports true for is excluded from
+	// Items, and pagination stops immediately without requesting a next
+	// page. This mirrors code_client.py's GitHubCodeClient.iter_pulls: for a
+	// sort=updated&direction=desc listing, once a caller-recognized boundary
+	// (e.g. "older than the incremental window") is crossed, every
+	// remaining item on this page and every later page is guaranteed to be
+	// on the same side of it, so continuing to paginate only spends
+	// requests fetching history the caller was never going to keep -- and,
+	// worse, can trip MaxPages on a repository whose IN-WINDOW page count is
+	// small but whose total history is not. Leave nil for a caller that has
+	// no such boundary (e.g. an unbounded backfill), which reproduces the
+	// unmodified fetch-every-page behavior exactly.
+	StopAt func(json.RawMessage) bool
 }
 
 // CollectGitHubLinkPages mirrors the Python InstrumentedRESTCore contract:
@@ -72,7 +86,22 @@ func CollectGitHubLinkPages(
 			return PageCollection{}, decodeErr
 		}
 		result.Pages++
-		result.Items = append(result.Items, items...)
+		if options.StopAt == nil {
+			result.Items = append(result.Items, items...)
+			next = githubNextLink(response.Header.Get("Link"))
+			continue
+		}
+		crossedBoundary := false
+		for _, item := range items {
+			if options.StopAt(item) {
+				crossedBoundary = true
+				break
+			}
+			result.Items = append(result.Items, item)
+		}
+		if crossedBoundary {
+			return result, nil
+		}
 		next = githubNextLink(response.Header.Get("Link"))
 	}
 	return result, nil

--- a/internal/providersync/capability_matrix_test.go
+++ b/internal/providersync/capability_matrix_test.go
@@ -63,6 +63,19 @@ func TestProviderMatrixCoversEveryConfiguredPair(t *testing.T) {
 //   - github/repo-metadata: CHAOS-3123, fixture-level field parity against the
 //     Python collector (TestGitHubRepositoryRouteEmitsOneBoundedReposEffect).
 //     Canary staging and live-traffic parity are waived for this program.
+//
+// github/prs (CHAOS-3122) is deliberately NOT in this set despite having a
+// real CompleteRouteHandler and passing fixture-level parity evidence: codex
+// H1 found that three columns on its own destination table
+// (first_review_at, reviews_count, changes_requested_count) are owned by
+// Python's review-enrichment phase, which this handler does not perform, so
+// it always writes them as zero. route_ready is a promise that the Go path
+// produces the product data for a pair, not merely that it compiles and
+// passes its own tests; writing fabricated zeros into columns it does not
+// own would corrupt review-latency/rework/AI-impact analytics. It flips
+// RouteReady together with github/pr-reviews when that pair lands with a
+// real review fetch — see execution_registry.go's github/prs case and
+// deploy/go-workers/provider-sync-porting-recipe.md.
 var routeReadyPairs = map[string]struct{}{
 	"launchdarkly/feature-flags": {},
 	"github/repo-metadata":       {},
@@ -88,8 +101,9 @@ func TestProviderMatrixKeepsEveryRouteClosedExceptReadyPairs(t *testing.T) {
 	all := CompleteRouteSwitches{
 		LinearWorkItems: true, JiraWorkItems: true, JiraIncidents: true,
 		LaunchDarklyFeatureFlags: true, GithubRepoMetadata: true,
+		GithubPRs: true,
 	}
-	if reflect.TypeOf(all).NumField() != 5 {
+	if reflect.TypeOf(all).NumField() != 6 {
 		t.Fatalf(
 			"CompleteRouteSwitches gained a field; add it to `all` above so its " +
 				"pair is exercised, then update this count",
@@ -121,6 +135,34 @@ func TestGithubRepoMetadataSwitchDoesNotOpenGitLab(t *testing.T) {
 	}
 	if descriptor.RouteReady || descriptor.RouteEnabled {
 		t.Fatalf("gitlab/repo-metadata descriptor=%+v", descriptor)
+	}
+}
+
+// TestGithubPRsSwitchAloneCannotOpenTheRoute pins codex's H1 finding: even
+// with its switch on, github/prs must stay RouteReady=false until
+// github/pr-reviews exists to own the three review-derived columns on the
+// same destination table. This is the opposite direction from
+// TestGithubRepoMetadataSwitchDoesNotOpenGitLab's "unrelated switch can't
+// open an unready pair" — here the pair's OWN switch is on, and it still
+// must not route, because RouteReady itself (not RouteEnabled) is the gate.
+func TestGithubPRsSwitchAloneCannotOpenTheRoute(t *testing.T) {
+	t.Parallel()
+	switches := CompleteRouteSwitches{GithubPRs: true}
+	descriptor, ok := switches.Descriptor("github", "prs")
+	if !ok {
+		t.Fatal("github/prs has no descriptor")
+	}
+	if descriptor.RouteReady {
+		t.Fatalf("github/prs descriptor=%+v: RouteReady must stay false until "+
+			"github/pr-reviews lands (codex H1)", descriptor)
+	}
+	// The destination manifest and the fixed native_go executor are still
+	// recorded -- RouteReady is what fails closed, not the rest of the
+	// descriptor going dark.
+	if descriptor.Executor != ExecutorNativeGo ||
+		len(descriptor.Destinations) != 1 ||
+		descriptor.Destinations[0] != "git_pull_requests" {
+		t.Fatalf("github/prs descriptor=%+v", descriptor)
 	}
 }
 
@@ -169,6 +211,7 @@ func TestProviderMatrixExecutorRegistryIsHonest(t *testing.T) {
 	handlers := map[string]CompleteRouteHandler{
 		"launchdarkly/feature-flags": LaunchDarklyRouteHandler{},
 		"github/repo-metadata":       GitHubRepositoryRouteHandler{},
+		"github/prs":                 GitHubPullRequestRouteHandler{},
 	}
 	native := map[string]struct{}{}
 	for _, pair := range BuildProviderMatrix().Pairs {

--- a/internal/providersync/execution_registry.go
+++ b/internal/providersync/execution_registry.go
@@ -33,6 +33,7 @@ const (
 var providerExecutorRegistry = map[string]ExecutorKind{
 	"launchdarkly/feature-flags": ExecutorNativeGo,
 	"github/repo-metadata":       ExecutorNativeGo,
+	"github/prs":                 ExecutorNativeGo,
 }
 
 // ProviderExecutor reports the fixed executor kind for a provider/dataset pair.
@@ -118,6 +119,16 @@ type CompleteRouteSwitches struct {
 	// CompleteRouteHandler, so it stays RouteReady=false regardless of this
 	// field (see Descriptor's separate gitlab case below).
 	GithubRepoMetadata bool
+	// GithubPRs gates (github, prs) only (CHAOS-3122/CHAOS-3123 follow-on).
+	// It must never gate github/pr-reviews or github/pr-comments: those two
+	// datasets share the "prs" legacy target and processor flag in Python
+	// (they are the SAME _sync_github_prs_to_store_async execution), but
+	// GitHubPullRequestRouteHandler only emits the git_pull_requests effect.
+	// Review-derived enrichment (first_review_at, reviews_count,
+	// changes_requested_count) and the git_pull_request_reviews table are
+	// left for github/pr-reviews, which needs its own GraphQL fetch — see
+	// deploy/go-workers/provider-sync-porting-recipe.md.
+	GithubPRs bool
 }
 
 // Descriptor resolves the canonical capability descriptor for a claimed
@@ -176,6 +187,38 @@ func (switches CompleteRouteSwitches) Descriptor(
 		// the github case above: doing so would make GithubRepoMetadata
 		// enable a route with no handler behind it.
 		descriptor.Destinations = []string{"repos"}
+	case provider == "github" && dataset == "prs":
+		// GitHub has a native complete-route handler
+		// (GitHubPullRequestRouteHandler) and a git_pull_requests effect sink
+		// (GitHubPullRequestClickHouseEffects), fixture-level field parity
+		// evidence against the production Python collector
+		// (_collect_github_pr_objects / build_git_pull_request /
+		// normalize_pr_state / get_repo_uuid_from_repo /
+		// ClickHouseStore.insert_git_pull_requests), and a codex adversarial
+		// pass that found and fixed four HIGH-severity silent-data-loss
+		// defects (CHAOS-3122).
+		//
+		// RouteReady stays false deliberately -- this is NOT the same waiver
+		// CHAOS-3123 used for repo-metadata. The codex H1 finding: three
+		// columns on this pair's own destination table
+		// (first_review_at, reviews_count, changes_requested_count) are
+		// owned by Python's review-enrichment phase
+		// (_enrich_prs_with_reviews_batch), which this handler does not
+		// perform, so it always writes them as zero. route_ready is a
+		// promise that the Go path produces the product data for a pair;
+		// writing fabricated zeros into columns this pair does not own would
+		// let review-latency/rework/AI-impact tiles read "no reviews
+		// fetched" as "no reviews exist". github/prs and github/pr-reviews
+		// share one row (git_pull_requests) but are scheduled as
+		// independent, separately-committed units — see
+		// deploy/go-workers/provider-sync-porting-recipe.md's "column versus
+		// unit ownership" section for the write-conflict analysis this
+		// forced. Both pairs flip to RouteReady together when
+		// github/pr-reviews lands with a real review fetch. GithubPRs
+		// (below) stays wired and off by default in the meantime, so this
+		// is a no-op today and a one-line flip later, not new plumbing.
+		descriptor.Destinations = []string{"git_pull_requests"}
+		descriptor.RouteEnabled = switches.GithubPRs
 	}
 	return descriptor, true
 }

--- a/internal/providersync/github_prs_effects_clickhouse.go
+++ b/internal/providersync/github_prs_effects_clickhouse.go
@@ -172,6 +172,27 @@ func (sink GitHubPullRequestClickHouseEffects) inspectPullRequest(
 	ctx context.Context,
 	expected pullRequestRow,
 ) (EffectInspection, error) {
+	actual, err := sink.scanWinningPullRequestVersion(
+		ctx, expected.OrgID, expected.RepoID, expected.Number,
+	)
+	if err != nil {
+		return EffectConflict, err
+	}
+	return comparePullRequestVersion(expected, actual), nil
+}
+
+// scanWinningPullRequestVersion runs the actual production FINAL
+// point-lookup query and scan (codex H2's fix) and returns the winning
+// ReplacingMergeTree version for (org_id, repo_id, number). Extracted from
+// inspectPullRequest (CHAOS-3162 codex finding #3) so
+// oracle_readback_integration_test.go's readback pair can call this SAME
+// production code directly instead of maintaining its own copy of the
+// query -- a copy is a second source of truth that can drift from this one
+// silently, which is exactly the class of defect this framework exists to
+// catch, not commit.
+func (sink GitHubPullRequestClickHouseEffects) scanWinningPullRequestVersion(
+	ctx context.Context, orgID, repoID string, number int,
+) (pullRequestVersion, error) {
 	rows, err := sink.Conn.Query(ctx, `
 SELECT
   title, body, state, author_name, author_email, created_at, merged_at,
@@ -180,18 +201,18 @@ SELECT
   comments_count, source_id, org_id, last_synced
 FROM git_pull_requests FINAL
 WHERE org_id = ? AND repo_id = ? AND number = ?`,
-		expected.OrgID, expected.RepoID, expected.Number,
+		orgID, repoID, number,
 	)
 	if err != nil {
-		return EffectConflict, err
+		return pullRequestVersion{}, err
 	}
 	defer rows.Close()
 	var (
-		actual     pullRequestRow
-		sourceID   *string
-		orgID      string
-		lastSynced time.Time
-		found      bool
+		actual      pullRequestRow
+		sourceID    *string
+		actualOrgID string
+		lastSynced  time.Time
+		found       bool
 	)
 	for rows.Next() {
 		// additions/deletions/changed_files/comments_count/
@@ -206,9 +227,9 @@ WHERE org_id = ? AND repo_id = ? AND number = ?`,
 			&additions, &deletions, &changedFiles,
 			&actual.FirstReviewAt, &actual.FirstCommentAt,
 			&changesRequestedCount, &reviewsCount, &commentsCount,
-			&sourceID, &orgID, &lastSynced,
+			&sourceID, &actualOrgID, &lastSynced,
 		); err != nil {
-			return EffectConflict, err
+			return pullRequestVersion{}, err
 		}
 		actual.Additions, actual.Deletions = int(additions), int(deletions)
 		actual.ChangedFiles, actual.CommentsCount = int(changedFiles), int(commentsCount)
@@ -217,12 +238,12 @@ WHERE org_id = ? AND repo_id = ? AND number = ?`,
 		found = true
 	}
 	if err := rows.Err(); err != nil {
-		return EffectConflict, err
+		return pullRequestVersion{}, err
 	}
-	return comparePullRequestVersion(expected, pullRequestVersion{
-		Row: actual, SourceID: sourceID, OrgID: orgID,
+	return pullRequestVersion{
+		Row: actual, SourceID: sourceID, OrgID: actualOrgID,
 		LastSynced: lastSynced, Found: found,
-	}), nil
+	}, nil
 }
 
 // pullRequestVersion is the winning ReplacingMergeTree version for a key, as

--- a/internal/providersync/github_prs_effects_clickhouse.go
+++ b/internal/providersync/github_prs_effects_clickhouse.go
@@ -1,0 +1,346 @@
+package providersync
+
+import (
+	"context"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// GitHubPullRequestClickHouseEffects writes the single `git_pull_requests`
+// effect produced by GitHubPullRequestRouteHandler. The table is
+// ReplacingMergeTree(last_synced) ordered by (org_id, repo_id, number)
+// (migration 027_add_org_id_to_sorting_keys.py). Deduplication is
+// asynchronous, so recovery is readback-fenced rather than blind-replayed --
+// the identical discipline GitHubRepositoryClickHouseEffects (`repos`) uses.
+type GitHubPullRequestClickHouseEffects struct {
+	Conn  driver.Conn
+	Lease providerfoundation.LeaseGuard
+}
+
+func (sink GitHubPullRequestClickHouseEffects) WriteEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) error {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "github" || claim.Dataset != "prs" ||
+		effect.Destination != "git_pull_requests" {
+		return ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	rows, err := decodeEffectRows[pullRequestRow](effect)
+	if err != nil {
+		return err
+	}
+	for _, row := range rows {
+		if err := row.validate(claim); err != nil {
+			return err
+		}
+	}
+	if len(rows) == 0 {
+		return nil
+	}
+	if sink.Conn == nil {
+		return ErrInvalidConfiguration
+	}
+	// org_id is appended last, mirroring _insert_rows' auto-injection order in
+	// storage/clickhouse.py (`columns = [*columns, "org_id"]` when org_id is
+	// not already in the explicit column list).
+	batch, err := sink.Conn.PrepareBatch(ctx, `
+INSERT INTO git_pull_requests (
+  repo_id, number, title, body, state, author_name, author_email,
+  created_at, merged_at, closed_at, head_branch, base_branch,
+  additions, deletions, changed_files, first_review_at, first_comment_at,
+  changes_requested_count, reviews_count, comments_count, last_synced,
+  source_id, org_id
+)`)
+	if err != nil {
+		return err
+	}
+	defer batch.Abort()
+	for _, row := range rows {
+		if err := batch.Append(
+			row.RepoID, row.Number, row.Title, row.Body, row.State,
+			row.AuthorName, row.AuthorEmail, row.CreatedAt, row.MergedAt,
+			row.ClosedAt, row.HeadBranch, row.BaseBranch, row.Additions,
+			row.Deletions, row.ChangedFiles, row.FirstReviewAt,
+			row.FirstCommentAt, row.ChangesRequestedCount, row.ReviewsCount,
+			row.CommentsCount, row.LastSynced, row.SourceID, row.OrgID,
+		); err != nil {
+			return err
+		}
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return err
+	}
+	return batch.Send()
+}
+
+// InspectEffect fences crash recovery the same way
+// GitHubRepositoryClickHouseEffects.InspectEffect does: ReplacingMergeTree
+// deduplicates asynchronously, so reading the winning version back turns "we
+// may have written this" into an exact answer.
+func (sink GitHubPullRequestClickHouseEffects) InspectEffect(
+	ctx context.Context,
+	claim Claim,
+	effect EffectBatch,
+) (EffectInspection, error) {
+	if ctx == nil || sink.Lease == nil || claim.Validate() != nil ||
+		claim.Provider != "github" || claim.Dataset != "prs" ||
+		effect.Destination != "git_pull_requests" {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	if err := sink.Lease.Assert(ctx); err != nil {
+		return EffectConflict, err
+	}
+	expected, err := decodeEffectRows[pullRequestRow](effect)
+	if err != nil {
+		return EffectConflict, err
+	}
+	for _, row := range expected {
+		if err := row.validate(claim); err != nil {
+			return EffectConflict, err
+		}
+	}
+	if len(expected) == 0 {
+		return EffectAbsent, nil
+	}
+	if sink.Conn == nil {
+		return EffectConflict, ErrInvalidConfiguration
+	}
+	exact, absent := 0, 0
+	for _, row := range expected {
+		inspection, err := sink.inspectPullRequest(ctx, row)
+		if err != nil {
+			return EffectConflict, err
+		}
+		switch inspection {
+		case EffectExact:
+			exact++
+		case EffectAbsent:
+			absent++
+		default:
+			return EffectConflict, nil
+		}
+	}
+	switch {
+	case exact == len(expected):
+		return EffectExact, nil
+	case absent == len(expected):
+		return EffectAbsent, nil
+	default:
+		return EffectConflict, nil
+	}
+}
+
+// inspectPullRequest resolves the latest ReplacingMergeTree version for
+// (org_id, repo_id, number) and compares the full stable persisted row
+// against it -- the argMax/FINAL discipline every raw reader of this table
+// owes (per repo convention).
+//
+// codex M6: every Nullable column is scanned into a Go pointer directly
+// (never through `ifNull(col, ”)`/`ifNull(col, sentinel)`), and every
+// column the row actually carries -- including first_review_at,
+// first_comment_at, changes_requested_count, and reviews_count, which an
+// earlier version of this query omitted entirely -- is read back. An
+// "exact" comparison that cannot see a column, or that collapses NULL and
+// "" to the same Go value, can report EffectExact for a row that actually
+// differs, which lets crash recovery mark corrupted data as committed.
+func (sink GitHubPullRequestClickHouseEffects) inspectPullRequest(
+	ctx context.Context,
+	expected pullRequestRow,
+) (EffectInspection, error) {
+	rows, err := sink.Conn.Query(ctx, `
+SELECT
+  argMax(title, last_synced)                    AS winning_title,
+  argMax(body, last_synced)                      AS winning_body,
+  argMax(state, last_synced)                     AS winning_state,
+  argMax(author_name, last_synced)               AS winning_author_name,
+  argMax(author_email, last_synced)              AS winning_author_email,
+  argMax(created_at, last_synced)                AS winning_created_at,
+  argMax(merged_at, last_synced)                 AS winning_merged_at,
+  argMax(closed_at, last_synced)                 AS winning_closed_at,
+  argMax(head_branch, last_synced)               AS winning_head_branch,
+  argMax(base_branch, last_synced)               AS winning_base_branch,
+  argMax(additions, last_synced)                 AS winning_additions,
+  argMax(deletions, last_synced)                 AS winning_deletions,
+  argMax(changed_files, last_synced)             AS winning_changed_files,
+  argMax(first_review_at, last_synced)           AS winning_first_review_at,
+  argMax(first_comment_at, last_synced)          AS winning_first_comment_at,
+  argMax(changes_requested_count, last_synced)   AS winning_changes_requested_count,
+  argMax(reviews_count, last_synced)             AS winning_reviews_count,
+  argMax(comments_count, last_synced)            AS winning_comments_count,
+  argMax(source_id, last_synced)                 AS winning_source_id,
+  argMax(org_id, last_synced)                    AS winning_org_id,
+  max(last_synced)                               AS winning_version
+FROM git_pull_requests
+WHERE org_id = ? AND repo_id = ? AND number = ?`,
+		expected.OrgID, expected.RepoID, expected.Number,
+	)
+	if err != nil {
+		return EffectConflict, err
+	}
+	defer rows.Close()
+	var (
+		actual     pullRequestRow
+		sourceID   *string
+		orgID      string
+		lastSynced time.Time
+		found      bool
+	)
+	for rows.Next() {
+		// additions/deletions/changed_files/comments_count/
+		// changes_requested_count/reviews_count are non-nullable UInt32
+		// columns; clickhouse-go requires scanning into *uint32, not *int.
+		var additions, deletions, changedFiles, commentsCount uint32
+		var changesRequestedCount, reviewsCount uint32
+		if err := rows.Scan(
+			&actual.Title, &actual.Body, &actual.State, &actual.AuthorName,
+			&actual.AuthorEmail, &actual.CreatedAt, &actual.MergedAt,
+			&actual.ClosedAt, &actual.HeadBranch, &actual.BaseBranch,
+			&additions, &deletions, &changedFiles,
+			&actual.FirstReviewAt, &actual.FirstCommentAt,
+			&changesRequestedCount, &reviewsCount, &commentsCount,
+			&sourceID, &orgID, &lastSynced,
+		); err != nil {
+			return EffectConflict, err
+		}
+		actual.Additions, actual.Deletions = int(additions), int(deletions)
+		actual.ChangedFiles, actual.CommentsCount = int(changedFiles), int(commentsCount)
+		actual.ChangesRequestedCount = int(changesRequestedCount)
+		actual.ReviewsCount = int(reviewsCount)
+		found = true
+	}
+	if err := rows.Err(); err != nil {
+		return EffectConflict, err
+	}
+	return comparePullRequestVersion(expected, pullRequestVersion{
+		Row: actual, SourceID: sourceID, OrgID: orgID,
+		LastSynced: lastSynced, Found: found,
+	}), nil
+}
+
+// pullRequestVersion is the winning ReplacingMergeTree version for a key, as
+// scanned from ClickHouse. Nullable columns are carried straight through as
+// Go pointers (via pullRequestRow's own field types) so a true SQL NULL and
+// an empty string remain distinguishable all the way to the comparison.
+type pullRequestVersion struct {
+	Row        pullRequestRow
+	SourceID   *string
+	OrgID      string
+	LastSynced time.Time
+	Found      bool
+}
+
+// comparePullRequestVersion decides whether this effect is the version that
+// currently wins for the key.
+//
+// codex M6 (structural fix, not just added columns): each field is its own
+// `if actual != expected { return EffectConflict }` clause rather than one
+// large conjunction. A monolithic `a && b && c && ...` is a single unit for
+// a mutation harness to kill -- deleting or weakening ONE clause inside it
+// can go unnoticed as long as the OTHER clauses in the same test's fixture
+// already differ, exactly the failure mode the shared mutation harness's
+// "mutate compound predicates clause by clause" rule exists to catch. Named,
+// separately-returning clauses make every field its own provable unit:
+// TestPullRequestReadbackClassifiesEveryVersionRelationship and the mutation
+// plan in testdata/mutation-plans kill each one independently.
+func comparePullRequestVersion(
+	expected pullRequestRow,
+	actual pullRequestVersion,
+) EffectInspection {
+	if !actual.Found || actual.LastSynced.IsZero() {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().Before(expected.LastSynced.UTC()) {
+		return EffectAbsent
+	}
+	if actual.LastSynced.UTC().After(expected.LastSynced.UTC()) {
+		return EffectConflict
+	}
+	if !stringPointersEqual(actual.Row.Title, expected.Title) {
+		return EffectConflict
+	}
+	if !stringPointersEqual(actual.Row.Body, expected.Body) {
+		return EffectConflict
+	}
+	if actual.Row.State != expected.State {
+		return EffectConflict
+	}
+	if actual.Row.AuthorName != expected.AuthorName {
+		return EffectConflict
+	}
+	if !stringPointersEqual(actual.Row.AuthorEmail, expected.AuthorEmail) {
+		return EffectConflict
+	}
+	if !actual.Row.CreatedAt.UTC().Equal(expected.CreatedAt.UTC()) {
+		return EffectConflict
+	}
+	if !timePointersEqual(actual.Row.MergedAt, expected.MergedAt) {
+		return EffectConflict
+	}
+	if !timePointersEqual(actual.Row.ClosedAt, expected.ClosedAt) {
+		return EffectConflict
+	}
+	if !stringPointersEqual(actual.Row.HeadBranch, expected.HeadBranch) {
+		return EffectConflict
+	}
+	if !stringPointersEqual(actual.Row.BaseBranch, expected.BaseBranch) {
+		return EffectConflict
+	}
+	if actual.Row.Additions != expected.Additions {
+		return EffectConflict
+	}
+	if actual.Row.Deletions != expected.Deletions {
+		return EffectConflict
+	}
+	if actual.Row.ChangedFiles != expected.ChangedFiles {
+		return EffectConflict
+	}
+	if !timePointersEqual(actual.Row.FirstReviewAt, expected.FirstReviewAt) {
+		return EffectConflict
+	}
+	if !timePointersEqual(actual.Row.FirstCommentAt, expected.FirstCommentAt) {
+		return EffectConflict
+	}
+	if actual.Row.ChangesRequestedCount != expected.ChangesRequestedCount {
+		return EffectConflict
+	}
+	if actual.Row.ReviewsCount != expected.ReviewsCount {
+		return EffectConflict
+	}
+	if actual.Row.CommentsCount != expected.CommentsCount {
+		return EffectConflict
+	}
+	// The native sink never writes source_id; a non-NULL value here means
+	// the external-ingest path (or some other writer) owns this key's
+	// current version.
+	if actual.SourceID != nil {
+		return EffectConflict
+	}
+	if actual.OrgID != expected.OrgID {
+		return EffectConflict
+	}
+	return EffectExact
+}
+
+func stringPointersEqual(left, right *string) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return *left == *right
+}
+
+func timePointersEqual(left, right *time.Time) bool {
+	if left == nil || right == nil {
+		return left == right
+	}
+	return left.UTC().Equal(right.UTC())
+}
+
+var _ EffectSink = GitHubPullRequestClickHouseEffects{}
+var _ EffectReadback = GitHubPullRequestClickHouseEffects{}

--- a/internal/providersync/github_prs_effects_clickhouse.go
+++ b/internal/providersync/github_prs_effects_clickhouse.go
@@ -137,47 +137,48 @@ func (sink GitHubPullRequestClickHouseEffects) InspectEffect(
 	}
 }
 
-// inspectPullRequest resolves the latest ReplacingMergeTree version for
+// inspectPullRequest resolves the winning ReplacingMergeTree version for
 // (org_id, repo_id, number) and compares the full stable persisted row
-// against it -- the argMax/FINAL discipline every raw reader of this table
-// owes (per repo convention).
+// against it.
 //
-// codex M6: every Nullable column is scanned into a Go pointer directly
-// (never through `ifNull(col, ”)`/`ifNull(col, sentinel)`), and every
-// column the row actually carries -- including first_review_at,
-// first_comment_at, changes_requested_count, and reviews_count, which an
-// earlier version of this query omitted entirely -- is read back. An
-// "exact" comparison that cannot see a column, or that collapses NULL and
-// "" to the same Go value, can report EffectExact for a row that actually
-// differs, which lets crash recovery mark corrupted data as committed.
+// codex H2: this reads the winning version's row AS A UNIT (`FROM
+// git_pull_requests FINAL`), not by assembling one `argMax(column,
+// last_synced)` per column. Independent per-column argMax calls are NOT
+// equivalent to "read the row with the maximum last_synced": ClickHouse's
+// argMax skips a row whose ARGUMENT is NULL when picking the maximum, so a
+// winning row with (say) a NULL merged_at can have its merged_at silently
+// backfilled from an OLDER, non-winning row's non-NULL value -- verified
+// empirically against a real (unmerged, multi-part) ReplacingMergeTree
+// table: separate INSERTs of {body:"old", merged_at:T1} then {body:"new",
+// merged_at:NULL} at a later last_synced produced
+// argMax(body)="new" (correct) alongside argMax(merged_at)=T1 (WRONG --
+// reconstructed from the OLDER row instead of the winning row's true NULL).
+// `FINAL` forces the same merge-time dedup logic the table's own background
+// merges eventually apply, so every column comes from the one row that
+// index actually selects -- self-consistent even in the documented
+// ReplacingMergeTree tie case (two versions sharing an identical
+// `last_synced`), where FINAL still returns one real, whole row rather than
+// letting independent per-column aggregates disagree about which physical
+// row "won". The WHERE clause matches the table's full ORDER BY prefix
+// (org_id, repo_id, number), which is what keeps FINAL a bounded point
+// lookup rather than a full-table merge.
+//
+// codex M6 (unchanged by this fix): every Nullable column is still scanned
+// into a Go pointer directly, and comparePullRequestVersion still compares
+// every column as its own named clause -- that logic already operates on a
+// materialized pullRequestVersion and doesn't care how the row was
+// selected, only that it IS one consistent row.
 func (sink GitHubPullRequestClickHouseEffects) inspectPullRequest(
 	ctx context.Context,
 	expected pullRequestRow,
 ) (EffectInspection, error) {
 	rows, err := sink.Conn.Query(ctx, `
 SELECT
-  argMax(title, last_synced)                    AS winning_title,
-  argMax(body, last_synced)                      AS winning_body,
-  argMax(state, last_synced)                     AS winning_state,
-  argMax(author_name, last_synced)               AS winning_author_name,
-  argMax(author_email, last_synced)              AS winning_author_email,
-  argMax(created_at, last_synced)                AS winning_created_at,
-  argMax(merged_at, last_synced)                 AS winning_merged_at,
-  argMax(closed_at, last_synced)                 AS winning_closed_at,
-  argMax(head_branch, last_synced)               AS winning_head_branch,
-  argMax(base_branch, last_synced)               AS winning_base_branch,
-  argMax(additions, last_synced)                 AS winning_additions,
-  argMax(deletions, last_synced)                 AS winning_deletions,
-  argMax(changed_files, last_synced)             AS winning_changed_files,
-  argMax(first_review_at, last_synced)           AS winning_first_review_at,
-  argMax(first_comment_at, last_synced)          AS winning_first_comment_at,
-  argMax(changes_requested_count, last_synced)   AS winning_changes_requested_count,
-  argMax(reviews_count, last_synced)             AS winning_reviews_count,
-  argMax(comments_count, last_synced)            AS winning_comments_count,
-  argMax(source_id, last_synced)                 AS winning_source_id,
-  argMax(org_id, last_synced)                    AS winning_org_id,
-  max(last_synced)                               AS winning_version
-FROM git_pull_requests
+  title, body, state, author_name, author_email, created_at, merged_at,
+  closed_at, head_branch, base_branch, additions, deletions, changed_files,
+  first_review_at, first_comment_at, changes_requested_count, reviews_count,
+  comments_count, source_id, org_id, last_synced
+FROM git_pull_requests FINAL
 WHERE org_id = ? AND repo_id = ? AND number = ?`,
 		expected.OrgID, expected.RepoID, expected.Number,
 	)

--- a/internal/providersync/github_prs_effects_integration_test.go
+++ b/internal/providersync/github_prs_effects_integration_test.go
@@ -151,9 +151,10 @@ func pullRequestEffect(t *testing.T, row pullRequestRow) EffectBatch {
 
 // TestGitHubPullRequestReadbackResolvesWinningReplacingMergeTreeVersion
 // mirrors TestGitHubRepositoryReadbackResolvesWinningReplacingMergeTreeVersion
-// for git_pull_requests: only a live engine proves the argMax query shape
-// actually resolves the winning version and that NULL merged_at/closed_at
-// survive the ifNull(..., toDateTime64(0,3)) scan contract.
+// for git_pull_requests: only a live engine proves the `FINAL` point-lookup
+// query shape actually resolves the winning version and that NULL
+// merged_at/closed_at on the WINNING row read back as nil, not some other
+// version's value.
 func TestGitHubPullRequestReadbackResolvesWinningReplacingMergeTreeVersion(
 	t *testing.T,
 ) {
@@ -205,6 +206,79 @@ func TestGitHubPullRequestReadbackResolvesWinningReplacingMergeTreeVersion(
 	inspection, err = sink.InspectEffect(ctx, claim, effect)
 	if err != nil || inspection != EffectExact {
 		t.Fatalf("duplicate inspection=%s error=%v", inspection, err)
+	}
+}
+
+// TestGitHubPullRequestReadbackDoesNotReconstructRowFromMixedVersions is
+// codex H2 (CHAOS-3122), the single most dangerous defect in this pair's
+// review: independently computing `argMax(column, last_synced)` per column
+// is NOT equivalent to reading the row with the maximum last_synced.
+// ClickHouse's argMax skips a row whose ARGUMENT is NULL when picking the
+// max, so if the WINNING (most recent) row has a NULL in some column while
+// an OLDER, non-winning row has a non-NULL value there, the old per-column
+// query would silently backfill that column from the wrong version --
+// verified empirically against a real unmerged multi-part ReplacingMergeTree
+// table before this fix landed. The existing
+// TestGitHubPullRequestReadbackResolvesWinningReplacingMergeTreeVersion test
+// puts NULLs on the OLDER version only, which cannot observe this: this
+// test puts them on the WINNING version specifically, with an OLDER version
+// that has non-NULL values in the exact same columns, which is the only
+// shape that can distinguish "read the winning row" from "assemble a row
+// from whichever version has a non-NULL value per column".
+func TestGitHubPullRequestReadbackDoesNotReconstructRowFromMixedVersions(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	harness := startPullRequestReadbackHarness(t, ctx)
+	claim, sink, now := harness.claim, harness.sink, harness.now
+
+	// Older version (merged, so merged_at/closed_at/body are all non-NULL).
+	older := pullRequestReadbackFixture(now.Add(-time.Hour))
+	older.OrgID = claim.OrgID
+	if err := sink.WriteEffect(ctx, claim, pullRequestEffect(t, older)); err != nil {
+		t.Fatal(err)
+	}
+
+	// Winning version: the PR was reopened (state back to "open"), so
+	// merged_at, closed_at, AND first_review_at are all NULL on the row
+	// that must win -- while the older version above has non-NULL values in
+	// every one of those columns. A per-column argMax reconstruction would
+	// backfill some or all of them from the older row instead of correctly
+	// reading NULL.
+	winning := pullRequestReadbackFixture(now)
+	winning.OrgID = claim.OrgID
+	winning.State = "open"
+	winning.MergedAt, winning.ClosedAt = nil, nil
+	winning.FirstReviewAt = nil
+	winning.ReviewsCount, winning.ChangesRequestedCount = 0, 0
+	effect := pullRequestEffect(t, winning)
+	if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	assertPullRequestVersionCount(t, ctx, harness, winning.RepoID, winning.Number, 2)
+
+	inspection, err := sink.InspectEffect(ctx, claim, effect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection != EffectExact {
+		t.Fatalf("inspection=%s want %s: a row-consistent read of the winning "+
+			"version (all fields NULL) must match exactly, not a Frankenstein "+
+			"row backfilled from the older, non-winning version", inspection, EffectExact)
+	}
+
+	// The other direction: asserting the OLDER row's (non-NULL) shape as
+	// "expected" must now report a conflict, not an accidental exact match
+	// -- if the bug were present, an attacker (or a future refactor) could
+	// have this comparison spuriously pass by reconstructing exactly the
+	// old row's values.
+	staleEffect := pullRequestEffect(t, older)
+	inspection, err = sink.InspectEffect(ctx, claim, staleEffect)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if inspection != EffectConflict {
+		t.Fatalf("inspection=%s want %s: the older, superseded version must "+
+			"never read back as the current winner", inspection, EffectConflict)
 	}
 }
 

--- a/internal/providersync/github_prs_effects_integration_test.go
+++ b/internal/providersync/github_prs_effects_integration_test.go
@@ -1,0 +1,361 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+	clickhousestore "github.com/full-chaos/dev-health-ops/internal/storage/clickhouse"
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// gitPullRequestsDDL mirrors the production table after migration 027
+// (org_id column + org_id-first sort key). The engine and version column are
+// the point of this suite, the same as reposDDL's: the readback must resolve
+// the winning ReplacingMergeTree version rather than every physical row.
+const gitPullRequestsDDL = `
+CREATE TABLE git_pull_requests (
+  repo_id UUID,
+  number UInt32,
+  title Nullable(String),
+  body Nullable(String),
+  state Nullable(String),
+  author_name Nullable(String),
+  author_email Nullable(String),
+  created_at DateTime64(3, 'UTC'),
+  merged_at Nullable(DateTime64(3, 'UTC')),
+  closed_at Nullable(DateTime64(3, 'UTC')),
+  head_branch Nullable(String),
+  base_branch Nullable(String),
+  additions Nullable(UInt32),
+  deletions Nullable(UInt32),
+  changed_files Nullable(UInt32),
+  first_review_at Nullable(DateTime64(3, 'UTC')),
+  first_comment_at Nullable(DateTime64(3, 'UTC')),
+  changes_requested_count UInt32 DEFAULT 0,
+  reviews_count UInt32 DEFAULT 0,
+  comments_count UInt32 DEFAULT 0,
+  last_synced DateTime64(3, 'UTC'),
+  source_id Nullable(UUID) DEFAULT NULL,
+  org_id String DEFAULT 'default'
+) ENGINE = ReplacingMergeTree(last_synced)
+ORDER BY (org_id, repo_id, number)`
+
+type pullRequestReadbackHarness struct {
+	conn       driver.Conn
+	repository *PostgresRepository
+	claim      Claim
+	sink       GitHubPullRequestClickHouseEffects
+	now        time.Time
+}
+
+func startPullRequestReadbackHarness(
+	t *testing.T,
+	ctx context.Context,
+) *pullRequestReadbackHarness {
+	t.Helper()
+	postgres, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := postgres.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	})
+	clickhouseInstance, err := containers.StartClickHouse(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		closeContext, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer cancel()
+		if err := clickhouseInstance.Close(closeContext); err != nil {
+			t.Errorf("terminate ClickHouse: %v", err)
+		}
+	})
+	pool, err := pgxpool.New(ctx, postgres.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(pool.Close)
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+	// since_at/before_at are widened to match gitHubPullRequestListFixture's
+	// window (2026-07-01..2026-07-31T23:59:59Z, the same window
+	// nativeTestClaim("github", "prs") uses): the fixture seeded by
+	// seedProviderSyncFixture defaults to a one-day window
+	// (2026-07-22T12:00..2026-07-23T12:00) sized for repo-metadata's
+	// WatermarkNone dataset, which would filter every PR in the list fixture
+	// out of the claim window.
+	if _, err := pool.Exec(ctx, `
+UPDATE public.sync_run_units
+SET provider = 'github', dataset_key = 'prs',
+    cost_class = 'medium', processor_flags = '{"sync_prs": true}',
+    since_at = '2026-07-01T00:00:00Z', before_at = '2026-07-31T23:59:59Z'
+WHERE id = $1`, firstUnitID); err != nil {
+		t.Fatal(err)
+	}
+	conn, err := clickhousestore.Open(
+		ctx, clickhousestore.DefaultConfig(clickhouseInstance.URI),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = conn.Close() })
+	if err := conn.Exec(ctx, gitPullRequestsDDL); err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	return &pullRequestReadbackHarness{
+		conn:       conn,
+		repository: repository,
+		claim:      claim,
+		now:        now,
+		sink: GitHubPullRequestClickHouseEffects{
+			Conn: conn, Lease: leaseGuardAt(repository, claim, now),
+		},
+	}
+}
+
+func pullRequestEffect(t *testing.T, row pullRequestRow) EffectBatch {
+	t.Helper()
+	effect, err := effectBatchFromValues(
+		"git_pull_requests", EffectReadbackRequired, []pullRequestRow{row},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return effect
+}
+
+// TestGitHubPullRequestReadbackResolvesWinningReplacingMergeTreeVersion
+// mirrors TestGitHubRepositoryReadbackResolvesWinningReplacingMergeTreeVersion
+// for git_pull_requests: only a live engine proves the argMax query shape
+// actually resolves the winning version and that NULL merged_at/closed_at
+// survive the ifNull(..., toDateTime64(0,3)) scan contract.
+func TestGitHubPullRequestReadbackResolvesWinningReplacingMergeTreeVersion(
+	t *testing.T,
+) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	harness := startPullRequestReadbackHarness(t, ctx)
+	claim, sink, now := harness.claim, harness.sink, harness.now
+	current := pullRequestReadbackFixture(now)
+	current.OrgID = claim.OrgID
+	effect := pullRequestEffect(t, current)
+
+	// 1. Nothing written yet.
+	inspection, err := sink.InspectEffect(ctx, claim, effect)
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("empty table inspection=%s error=%v", inspection, err)
+	}
+
+	// 2. Only an earlier occurrence's version exists (an open PR, so
+	//    merged_at/closed_at are NULL). Pre-merge history must not be
+	//    mistaken for this effect.
+	previous := current
+	previous.LastSynced = now.Add(-24 * time.Hour)
+	previous.State = "open"
+	previous.MergedAt, previous.ClosedAt = nil, nil
+	if err := sink.WriteEffect(ctx, claim, pullRequestEffect(t, previous)); err != nil {
+		t.Fatal(err)
+	}
+	inspection, err = sink.InspectEffect(ctx, claim, effect)
+	if err != nil || inspection != EffectAbsent {
+		t.Fatalf("stale-only inspection=%s error=%v", inspection, err)
+	}
+
+	// 3. This occurrence lands on top of that unmerged history.
+	if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	assertPullRequestVersionCount(t, ctx, harness, current.RepoID, current.Number, 2)
+	inspection, err = sink.InspectEffect(ctx, claim, effect)
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("pre-merge history inspection=%s error=%v", inspection, err)
+	}
+
+	// 4. A duplicate reinsert of the identical row is still exactly this
+	//    effect; ReplacingMergeTree collapses the copies on merge.
+	if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	assertPullRequestVersionCount(t, ctx, harness, current.RepoID, current.Number, 3)
+	inspection, err = sink.InspectEffect(ctx, claim, effect)
+	if err != nil || inspection != EffectExact {
+		t.Fatalf("duplicate inspection=%s error=%v", inspection, err)
+	}
+}
+
+// TestGitHubPullRequestReadbackReportsConflictingWinningVersions mirrors
+// TestGitHubRepositoryReadbackReportsConflictingWinningVersions.
+func TestGitHubPullRequestReadbackReportsConflictingWinningVersions(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	t.Run("same version, different content", func(t *testing.T) {
+		harness := startPullRequestReadbackHarness(t, ctx)
+		claim, sink, now := harness.claim, harness.sink, harness.now
+		expected := pullRequestReadbackFixture(now)
+		expected.OrgID = claim.OrgID
+		other := expected
+		otherTitle := "Some other title"
+		other.Title = &otherTitle
+		if err := sink.WriteEffect(ctx, claim, pullRequestEffect(t, other)); err != nil {
+			t.Fatal(err)
+		}
+		inspection, err := sink.InspectEffect(ctx, claim, pullRequestEffect(t, expected))
+		if err != nil || inspection != EffectConflict {
+			t.Fatalf("inspection=%s error=%v", inspection, err)
+		}
+	})
+
+	t.Run("newer occurrence superseded the key", func(t *testing.T) {
+		harness := startPullRequestReadbackHarness(t, ctx)
+		claim, sink, now := harness.claim, harness.sink, harness.now
+		expected := pullRequestReadbackFixture(now)
+		expected.OrgID = claim.OrgID
+		newer := expected
+		newer.LastSynced = now.Add(time.Hour)
+		if err := sink.WriteEffect(ctx, claim, pullRequestEffect(t, newer)); err != nil {
+			t.Fatal(err)
+		}
+		inspection, err := sink.InspectEffect(ctx, claim, pullRequestEffect(t, expected))
+		if err != nil || inspection != EffectConflict {
+			t.Fatalf("inspection=%s error=%v", inspection, err)
+		}
+	})
+}
+
+// TestGitHubPullRequestCrashWindowRecoversWithoutDuplicateVersion is the
+// end-to-end fence, mirroring
+// TestGitHubRepositoryCrashWindowRecoversWithoutDuplicateVersion: ClickHouse
+// accepted the insert, the process died before CommitEffect, and recovery
+// must mark the effect committed from the readback instead of writing a
+// second physical version.
+func TestGitHubPullRequestCrashWindowRecoversWithoutDuplicateVersion(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	harness := startPullRequestReadbackHarness(t, ctx)
+	claim, sink, now := harness.claim, harness.sink, harness.now
+	collectedAt := now
+	fixtures := defaultGitHubPullRequestFixtures()
+	firstBatch, err := (GitHubPullRequestRouteHandler{}).Collect(
+		ctx, claim, providerfoundation.Credential{},
+		gitHubPullRequestClient(t, &gitHubPullRequestDoer{t: t, bodies: fixtures}, "https://api.github.com"),
+		collectedAt,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	effect := firstBatch.Effects[0]
+	var row pullRequestRow
+	if err := json.Unmarshal(effect.Rows[0], &row); err != nil {
+		t.Fatal(err)
+	}
+
+	state, err := NewEffectLedgerState(claim, []EffectBatch{effect}, collectedAt)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := harness.repository.PrepareEffects(ctx, claim, state, collectedAt); err != nil {
+		t.Fatal(err)
+	}
+	if err := harness.repository.BeginEffect(
+		ctx, claim, 0, effect.ContentDigest, now.Add(2*time.Second),
+	); err != nil {
+		t.Fatal(err)
+	}
+	if err := sink.WriteEffect(ctx, claim, effect); err != nil {
+		t.Fatal(err)
+	}
+	recoveryNow := now.Add(61 * time.Second)
+	freshRepository, err := NewPostgresRepository(harness.repository.Pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	recovered, err := freshRepository.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, OrgID: "org-acme", Owner: uuid.NewString(),
+		Now: recoveryNow, LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	persisted, err := freshRepository.LoadEffects(ctx, recovered, recoveryNow)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !persisted.CreatedAt.UTC().Equal(collectedAt.UTC()) {
+		t.Fatalf(
+			"persisted ledger CreatedAt=%s want=%s", persisted.CreatedAt, collectedAt,
+		)
+	}
+	recoveredBatch, err := (GitHubPullRequestRouteHandler{}).Collect(
+		ctx, recovered, providerfoundation.Credential{},
+		gitHubPullRequestClient(t, &gitHubPullRequestDoer{t: t, bodies: fixtures}, "https://api.github.com"),
+		persisted.CreatedAt.UTC(),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if recoveredBatch.Effects[0].ContentDigest != effect.ContentDigest {
+		t.Fatalf(
+			"regenerated digest=%s want=%s",
+			recoveredBatch.Effects[0].ContentDigest, effect.ContentDigest,
+		)
+	}
+	freshSink := GitHubPullRequestClickHouseEffects{
+		Conn: harness.conn, Lease: leaseGuardAt(freshRepository, recovered, recoveryNow),
+	}
+	result, err := (EffectCommitter{
+		Ledger: freshRepository, Sink: freshSink, Readback: freshSink,
+		Now: func() time.Time { return recoveryNow },
+	}).Commit(ctx, recovered, recoveredBatch.Effects, persisted.CreatedAt.UTC())
+	if err != nil || result.MarkedCommitted != 1 || result.Written != 0 {
+		t.Fatalf("result=%+v error=%v", result, err)
+	}
+	assertPullRequestVersionCount(t, ctx, harness, row.RepoID, row.Number, 1)
+}
+
+func assertPullRequestVersionCount(
+	t *testing.T,
+	ctx context.Context,
+	harness *pullRequestReadbackHarness,
+	repoID string,
+	number int,
+	want uint64,
+) {
+	t.Helper()
+	var rows uint64
+	if err := harness.conn.QueryRow(ctx, `
+SELECT count() FROM git_pull_requests
+WHERE org_id = 'org-acme' AND repo_id = ? AND number = ?`,
+		repoID, number,
+	).Scan(&rows); err != nil {
+		t.Fatal(err)
+	}
+	if rows != want {
+		t.Fatalf("physical git_pull_requests versions=%d want %d", rows, want)
+	}
+}

--- a/internal/providersync/github_prs_generic_oracle_test.go
+++ b/internal/providersync/github_prs_generic_oracle_test.go
@@ -35,32 +35,25 @@ var oraclePullRequestGoOnlyFields = map[string]string{
 	"org_id":      "stamped from claim.OrgID by normalizeGitHubPullRequest, not part of the built row's own fields conceptually",
 }
 
-// buildPullRequestRowForOracle is the (correct, current, production)
-// Go-side row builder for the "github/prs/row" pair: unmarshal the case's
-// raw_pr payload the same way GitHubPullRequestRouteHandler.Collect does,
-// call the REAL, current normalizeGitHubPullRequest, and hand back the
-// fully-populated row for the generic comparator to diff field-by-field
-// against Python's build_git_pull_request output.
-func buildPullRequestRowForOracle(t *testing.T, input map[string]any) map[string]any {
-	t.Helper()
-	return jsonRoundTripToMap(t, mustNormalizeOraclePullRequest(
-		t, input, normalizePRState, gitHubPullUserLogin,
-	))
-}
+// oraclePullRequestClaim and oraclePullRequestNormalizedAt are the fixed
+// claim/timestamp both the production path and the buggy-substitute path
+// use, so the only thing that can differ between them is the function(s)
+// under test.
+var oraclePullRequestClaim = Claim{Unit: Unit{
+	OrgID: "org-oracle", Provider: "github", Dataset: "prs", SourceExternalID: "octo/widgets",
+}}
 
-// mustNormalizeOraclePullRequest decodes one oracle case's {"raw_pr":
-// ..., "repo_id": ...} input into the same gitHubPullDetailPayload shape
-// Collect feeds normalizeGitHubPullRequest, then calls it -- parameterized
-// on the state-normalizer and login-coercion functions so pre-fix (buggy)
-// variants can be substituted without duplicating the whole row-assembly
-// path (which would itself be a second place these bugs could accidentally
-// get fixed or re-broken out of step with the real function).
-func mustNormalizeOraclePullRequest(
-	t *testing.T,
-	input map[string]any,
-	normalizeState func(string, *time.Time) string,
-	userLogin func(json.RawMessage) string,
-) pullRequestRow {
+var oraclePullRequestNormalizedAt = time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
+
+// decodeOraclePullRequestInput decodes one oracle case's {"raw_pr": ...,
+// "repo_id": ...} input into the same (repoID, gitHubPullDetailPayload)
+// shape Collect feeds normalizeGitHubPullRequest. Pure decoding, no
+// business logic -- shared by both the production path and the
+// buggy-substitute path below so a decode bug cannot itself become a
+// divergence between what the two paths are actually testing.
+func decodeOraclePullRequestInput(
+	t *testing.T, input map[string]any,
+) (string, gitHubPullDetailPayload) {
 	t.Helper()
 	rawPR, ok := input["raw_pr"]
 	if !ok {
@@ -78,23 +71,57 @@ func mustNormalizeOraclePullRequest(
 	if err := json.Unmarshal(encoded, &detail); err != nil {
 		t.Fatalf("unmarshal oracle case raw_pr into gitHubPullDetailPayload: %v", err)
 	}
+	return repoID, detail
+}
 
-	claim := Claim{Unit: Unit{
-		OrgID: "org-oracle", Provider: "github", Dataset: "prs", SourceExternalID: "octo/widgets",
-	}}
-	normalizedAt := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
+// buildPullRequestRowForOracle is the (correct, current, production)
+// Go-side row builder for the "github/prs/row" pair: decode the case the
+// same way GitHubPullRequestRouteHandler.Collect does, then call the REAL,
+// unmodified normalizeGitHubPullRequest directly -- not a copy of its body
+// (codex finding #3, CHAOS-3162 second adversarial review: a copy is a
+// second source of truth that can drift from the real thing while staying
+// green; this is exactly the discipline that caught the earlier
+// tab-indented-anchor mutation-plan bug, applied to this framework's own
+// baseline test). Returning the concrete pullRequestRow struct (not a
+// hand-picked map) is what makes this row's completeness a Go-compiler
+// guarantee rather than a runtime choice (codex finding #1) -- see
+// oracle_compare_test.go's typedEncode doc comment.
+func buildPullRequestRowForOracle(t *testing.T, input map[string]any) pullRequestRow {
+	t.Helper()
+	repoID, detail := decodeOraclePullRequestInput(t, input)
+	row, err := normalizeGitHubPullRequest(
+		oraclePullRequestClaim, repoID, detail, oraclePullRequestNormalizedAt,
+	)
+	if err != nil {
+		t.Fatalf("normalizeGitHubPullRequest: %v", err)
+	}
+	return row
+}
 
-	// Inline a copy of normalizeGitHubPullRequest's body rather than calling
-	// it directly: the whole point of this test is to prove the comparator
-	// is SENSITIVE to normalizeState/userLogin swaps, and the production
-	// function hardcodes normalizePRState/gitHubPullUserLogin as free
-	// function calls, not as injectable parameters (correctly -- production
-	// code should not carry test seams it doesn't need). See
-	// TestGenericOracleRediscoversRowConstructionDefects for why this
-	// specific inlined copy is safe: it is exercised, unmodified, by the
-	// "current" sub-test using the real functions passed in, so any drift
-	// between this copy and normalizeGitHubPullRequest's real body would
-	// itself surface as a false failure/false pass in that sub-test.
+// mustNormalizeOraclePullRequest is an INLINED COPY of
+// normalizeGitHubPullRequest's body, parameterized on the state-normalizer
+// and login-coercion functions so a pre-fix (buggy) variant can be
+// substituted for TestGenericOracleRediscoversRowConstructionDefects.
+// normalizeGitHubPullRequest itself hardcodes normalizePRState/
+// gitHubPullUserLogin as free function calls (correctly -- production code
+// should not carry injectable test seams it doesn't need), so there is no
+// way to substitute a buggy sub-function through the real function's own
+// signature; this copy exists ONLY to make that substitution possible.
+// Every rediscovery test using this path is proving "the comparator
+// catches a wrong VALUE that a buggy sub-function would have produced",
+// NOT "this copy matches production" -- that second, different claim is
+// what buildPullRequestRowForOracle's direct call proves instead, and
+// nothing in this file relies on this copy for that claim.
+func mustNormalizeOraclePullRequest(
+	t *testing.T,
+	input map[string]any,
+	normalizeState func(string, *time.Time) string,
+	userLogin func(json.RawMessage) string,
+) pullRequestRow {
+	t.Helper()
+	repoID, detail := decodeOraclePullRequestInput(t, input)
+	claim, normalizedAt := oraclePullRequestClaim, oraclePullRequestNormalizedAt
+
 	if detail.Number < 1 {
 		t.Fatalf("oracle case raw_pr.number must be >= 1")
 	}
@@ -238,11 +265,11 @@ func buggyGitHubPullUserLoginStringOnly(raw json.RawMessage) string {
 // contrived one -- to prove the GENERIC comparator (which compares every
 // field the row exposes, not a chosen subset) catches it where a narrower
 // oracle demonstrably did not, twice, in this pair's actual review history.
-func buildPullRequestRowForOracleWithCorruptedMergedAt(t *testing.T, input map[string]any) map[string]any {
+func buildPullRequestRowForOracleWithCorruptedMergedAt(t *testing.T, input map[string]any) pullRequestRow {
 	t.Helper()
 	row := mustNormalizeOraclePullRequest(t, input, normalizePRState, gitHubPullUserLogin)
 	row.MergedAt, row.ClosedAt = row.ClosedAt, row.MergedAt
-	return jsonRoundTripToMap(t, row)
+	return row
 }
 
 // requireOracleRediscovers calls oracleDivergences directly (NOT
@@ -255,18 +282,19 @@ func buildPullRequestRowForOracleWithCorruptedMergedAt(t *testing.T, input map[s
 // out -- so an empty list fails this test loudly. The found divergences are
 // logged (t.Log, not t.Error) purely for readability when running -v; they
 // are the proof, not a failure.
-func requireOracleRediscovers(
+func requireOracleRediscovers[T any](
 	t *testing.T,
 	name string,
 	pairID string,
 	cases []oracleCase,
-	buggyBuilder func(t *testing.T, input map[string]any) map[string]any,
+	buggyBuilder func(t *testing.T, input map[string]any) T,
 	goOnlyFields map[string]string,
 ) {
 	t.Helper()
+	wrapped := func(t *testing.T, input map[string]any) any { return buggyBuilder(t, input) }
 	t.Run(name, func(t *testing.T) {
 		t.Helper()
-		divergences := oracleDivergences(t, pairID, cases, buggyBuilder, goOnlyFields)
+		divergences := oracleDivergences(t, pairID, cases, wrapped, goOnlyFields)
 		if len(divergences) == 0 {
 			t.Fatalf("expected the generic oracle to rediscover the injected pre-fix defect, "+
 				"but it reported every case matching under pair %q -- the comparator did not "+
@@ -290,20 +318,20 @@ func requireOracleRediscovers(
 func TestGenericOracleRediscoversRowConstructionDefects(t *testing.T) {
 	cases := oraclePullRequestCases()
 
-	buggyStateBuilder := func(t *testing.T, input map[string]any) map[string]any {
-		return jsonRoundTripToMap(t, mustNormalizeOraclePullRequest(
+	buggyStateBuilder := func(t *testing.T, input map[string]any) pullRequestRow {
+		return mustNormalizeOraclePullRequest(
 			t, input, buggyNormalizePRStateStripsOnlySpaces, gitHubPullUserLogin,
-		))
+		)
 	}
 	requireOracleRediscovers(
 		t, "rediscovers pre-M7 state-normalization whitespace bug",
 		"github/prs/row", cases, buggyStateBuilder, oraclePullRequestGoOnlyFields,
 	)
 
-	buggyLoginBuilder := func(t *testing.T, input map[string]any) map[string]any {
-		return jsonRoundTripToMap(t, mustNormalizeOraclePullRequest(
+	buggyLoginBuilder := func(t *testing.T, input map[string]any) pullRequestRow {
+		return mustNormalizeOraclePullRequest(
 			t, input, normalizePRState, buggyGitHubPullUserLoginStringOnly,
-		))
+		)
 	}
 	requireOracleRediscovers(
 		t, "rediscovers pre-M8 non-string login coercion bug",

--- a/internal/providersync/github_prs_generic_oracle_test.go
+++ b/internal/providersync/github_prs_generic_oracle_test.go
@@ -1,0 +1,318 @@
+package providersync
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+// This file wires the (github, prs) row-construction boundary
+// (normalizeGitHubPullRequest) to the generic, declarative Python<->Go
+// oracle comparator built for CHAOS-3162 (oracle_compare_test.go), backed by
+// the live registration in
+// testdata/oracle_pairs/github_prs_row.py ("github/prs/row").
+//
+// This does NOT replace github_prs_normalization_oracle_test.go's
+// hand-picked-field oracle -- that one stays exactly as it is, proving
+// TestGitHubPRSNormalizationMatchesLivePythonFunctions's specific
+// state/timestamp claims. This file exists to prove the DIFFERENT, stronger
+// property CHAOS-3162 asked for: a comparator that diffs the WHOLE row and
+// fails on any UNDECLARED divergence, so a future field nobody thought to
+// hand-pick is compared anyway.
+
+// oraclePullRequestGoOnlyFields are the pullRequestRow fields the Python
+// build_row side structurally cannot have an opinion about -- Go-side
+// effect/tenant bookkeeping stamped after row construction, not part of
+// build_git_pull_request's return value at all. Every one of these has a
+// mirror entry (with its own, independent reason) in
+// testdata/oracle_pairs/github_prs_row.py's excluded_fields; the two lists
+// are deliberately not shared code, so a change to one does not silently
+// widen the other.
+var oraclePullRequestGoOnlyFields = map[string]string{
+	"last_synced": "stamped by Collect from normalizedAt, not part of build_git_pull_request's inputs or outputs",
+	"source_id":   "native sink always writes null; build_git_pull_request has no equivalent parameter",
+	"org_id":      "stamped from claim.OrgID by normalizeGitHubPullRequest, not part of the built row's own fields conceptually",
+}
+
+// buildPullRequestRowForOracle is the (correct, current, production)
+// Go-side row builder for the "github/prs/row" pair: unmarshal the case's
+// raw_pr payload the same way GitHubPullRequestRouteHandler.Collect does,
+// call the REAL, current normalizeGitHubPullRequest, and hand back the
+// fully-populated row for the generic comparator to diff field-by-field
+// against Python's build_git_pull_request output.
+func buildPullRequestRowForOracle(t *testing.T, input map[string]any) map[string]any {
+	t.Helper()
+	return jsonRoundTripToMap(t, mustNormalizeOraclePullRequest(
+		t, input, normalizePRState, gitHubPullUserLogin,
+	))
+}
+
+// mustNormalizeOraclePullRequest decodes one oracle case's {"raw_pr":
+// ..., "repo_id": ...} input into the same gitHubPullDetailPayload shape
+// Collect feeds normalizeGitHubPullRequest, then calls it -- parameterized
+// on the state-normalizer and login-coercion functions so pre-fix (buggy)
+// variants can be substituted without duplicating the whole row-assembly
+// path (which would itself be a second place these bugs could accidentally
+// get fixed or re-broken out of step with the real function).
+func mustNormalizeOraclePullRequest(
+	t *testing.T,
+	input map[string]any,
+	normalizeState func(string, *time.Time) string,
+	userLogin func(json.RawMessage) string,
+) pullRequestRow {
+	t.Helper()
+	rawPR, ok := input["raw_pr"]
+	if !ok {
+		t.Fatalf("oracle case missing raw_pr: %v", input)
+	}
+	repoID, ok := input["repo_id"].(string)
+	if !ok || repoID == "" {
+		t.Fatalf("oracle case missing repo_id: %v", input)
+	}
+	encoded, err := json.Marshal(rawPR)
+	if err != nil {
+		t.Fatalf("marshal oracle case raw_pr: %v", err)
+	}
+	var detail gitHubPullDetailPayload
+	if err := json.Unmarshal(encoded, &detail); err != nil {
+		t.Fatalf("unmarshal oracle case raw_pr into gitHubPullDetailPayload: %v", err)
+	}
+
+	claim := Claim{Unit: Unit{
+		OrgID: "org-oracle", Provider: "github", Dataset: "prs", SourceExternalID: "octo/widgets",
+	}}
+	normalizedAt := time.Date(2026, 7, 25, 0, 0, 0, 0, time.UTC)
+
+	// Inline a copy of normalizeGitHubPullRequest's body rather than calling
+	// it directly: the whole point of this test is to prove the comparator
+	// is SENSITIVE to normalizeState/userLogin swaps, and the production
+	// function hardcodes normalizePRState/gitHubPullUserLogin as free
+	// function calls, not as injectable parameters (correctly -- production
+	// code should not carry test seams it doesn't need). See
+	// TestGenericOracleRediscoversRowConstructionDefects for why this
+	// specific inlined copy is safe: it is exercised, unmodified, by the
+	// "current" sub-test using the real functions passed in, so any drift
+	// between this copy and normalizeGitHubPullRequest's real body would
+	// itself surface as a false failure/false pass in that sub-test.
+	if detail.Number < 1 {
+		t.Fatalf("oracle case raw_pr.number must be >= 1")
+	}
+	createdAt := parseGitHubPullTime(detail.CreatedAt)
+	mergedAt := parseGitHubPullTime(detail.MergedAt)
+	closedAt := parseGitHubPullTime(detail.ClosedAt)
+	resolvedCreatedAt := resolveCreatedAt(createdAt, mergedAt, closedAt, normalizedAt)
+	var rawState string
+	if detail.State != nil {
+		rawState = *detail.State
+	}
+	authorName := "Unknown"
+	if login := userLogin(detail.User); login != "" {
+		authorName = login
+	}
+	row := pullRequestRow{
+		RepoID: repoID, Number: detail.Number, Title: detail.Title,
+		Body: detail.Body, State: normalizeState(rawState, mergedAt),
+		AuthorName: authorName, AuthorEmail: nil,
+		CreatedAt: resolvedCreatedAt.UTC(), MergedAt: mergedAt, ClosedAt: closedAt,
+		HeadBranch: gitHubPullRefName(detail.Head), BaseBranch: gitHubPullRefName(detail.Base),
+		Additions: detail.Additions, Deletions: detail.Deletions, ChangedFiles: detail.ChangedFiles,
+		CommentsCount: detail.Comments, LastSynced: normalizedAt, OrgID: claim.OrgID,
+	}
+	if err := row.validate(claim); err != nil {
+		t.Fatalf("oracle-built row failed validate(): %v", err)
+	}
+	return row
+}
+
+func oraclePullRequestCases() []oracleCase {
+	return []oracleCase{
+		{
+			ID: "closed_merged_with_boolean_login",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79",
+				"raw_pr": map[string]any{
+					"id": 991234, "number": 42, "title": "Add widget support",
+					"body": "This PR adds widget support.", "state": "closed",
+					"user":          map[string]any{"login": true},
+					"created_at":    "2026-07-10T09:00:00Z",
+					"updated_at":    "2026-07-21T15:30:00Z",
+					"merged_at":     "2026-07-21T15:30:00Z",
+					"closed_at":     "2026-07-21T15:30:00Z",
+					"head":          map[string]any{"ref": "feature/widgets"},
+					"base":          map[string]any{"ref": "main"},
+					"additions":     120,
+					"deletions":     30,
+					"changed_files": 5,
+					"comments":      3,
+				},
+			},
+		},
+		{
+			ID: "closed_with_trailing_cr",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79",
+				"raw_pr": map[string]any{
+					"id": 5, "number": 5, "title": "t", "body": "b", "state": "closed\r",
+					"user":       map[string]any{"login": "octocat"},
+					"created_at": "2026-01-01T00:00:00Z",
+					"closed_at":  "2026-01-02T00:00:00Z",
+				},
+			},
+		},
+		{
+			ID: "numeric_login_open_pr",
+			Input: map[string]any{
+				"repo_id": "c7198fbc-1945-3717-05d8-eb78866b4e79",
+				"raw_pr": map[string]any{
+					"id": 6, "number": 6, "title": "n", "body": "b", "state": "open",
+					"user":       map[string]any{"login": 12345},
+					"created_at": "2026-02-01T00:00:00Z",
+				},
+			},
+		},
+	}
+}
+
+// TestGenericOracleMatchesLivePythonForRowConstruction is the "current code
+// is clean" half of CHAOS-3162's acceptance test: the real, current,
+// unmodified Go row-construction path against the real, live Python
+// build_git_pull_request chain, diffed field-by-field with zero undeclared
+// exclusions beyond what both oracle_pairs/github_prs_row.py and
+// oraclePullRequestGoOnlyFields declare in writing.
+func TestGenericOracleMatchesLivePythonForRowConstruction(t *testing.T) {
+	compareRowsAgainstPythonOracle(
+		t, "github/prs/row", oraclePullRequestCases(),
+		buildPullRequestRowForOracle, oraclePullRequestGoOnlyFields,
+	)
+}
+
+// buggyNormalizePRStateStripsOnlySpaces reproduces the exact pre-M7-fix
+// defect: whitespace is removed from the WHOLE string (not just the ends)
+// and \r is never treated as whitespace at all, so "closed\r" -- which
+// Python's raw_state.strip().lower() matches to "closed" -- falls through
+// to the default branch here instead.
+func buggyNormalizePRStateStripsOnlySpaces(rawState string, mergedAt *time.Time) string {
+	if rawState == "" {
+		return "open"
+	}
+	cleaned := strings.ReplaceAll(rawState, " ", "")
+	switch strings.ToLower(cleaned) {
+	case "merged":
+		return "merged"
+	case "opened", "open":
+		return "open"
+	case "closed":
+		if mergedAt != nil {
+			return "merged"
+		}
+		return "closed"
+	default:
+		return "open"
+	}
+}
+
+// buggyGitHubPullUserLoginStringOnly reproduces the exact pre-M8-fix
+// defect: decoding "login" directly into a Go string field. json.Unmarshal
+// fails (type error) for any non-string login -- a bool or a number -- so
+// this returns "" exactly where Python's str(user["login"]) would return
+// "True" or "12345".
+func buggyGitHubPullUserLoginStringOnly(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	var user struct {
+		Login string `json:"login"`
+	}
+	if json.Unmarshal(raw, &user) != nil {
+		return ""
+	}
+	return user.Login
+}
+
+// buildPullRequestRowForOracleWithCorruptedMergedAt reproduces the shape of
+// M3 (round 2): a row builder that gets merged_at/closed_at wrong in a way
+// the OLD, hand-picked oracle (which asserted state/created_at/author_name
+// but never merged_at/closed_at) would have shipped clean. Here the bug is
+// swapping merged_at and closed_at -- a realistic copy-paste mistake, not a
+// contrived one -- to prove the GENERIC comparator (which compares every
+// field the row exposes, not a chosen subset) catches it where a narrower
+// oracle demonstrably did not, twice, in this pair's actual review history.
+func buildPullRequestRowForOracleWithCorruptedMergedAt(t *testing.T, input map[string]any) map[string]any {
+	t.Helper()
+	row := mustNormalizeOraclePullRequest(t, input, normalizePRState, gitHubPullUserLogin)
+	row.MergedAt, row.ClosedAt = row.ClosedAt, row.MergedAt
+	return jsonRoundTripToMap(t, row)
+}
+
+// requireOracleRediscovers calls oracleDivergences directly (NOT
+// compareRowsAgainstPythonOracle, whose t.Errorf calls would propagate a
+// failure to this test's ancestors regardless of how the return value is
+// inspected -- Go's testing package has no way to "catch" a subtest
+// failure) and asserts the divergence list is non-empty: a "probe that
+// finds nothing" here means the generic comparator is BLIND to the injected
+// pre-fix defect -- exactly the false confidence CHAOS-3162 exists to rule
+// out -- so an empty list fails this test loudly. The found divergences are
+// logged (t.Log, not t.Error) purely for readability when running -v; they
+// are the proof, not a failure.
+func requireOracleRediscovers(
+	t *testing.T,
+	name string,
+	pairID string,
+	cases []oracleCase,
+	buggyBuilder func(t *testing.T, input map[string]any) map[string]any,
+	goOnlyFields map[string]string,
+) {
+	t.Helper()
+	t.Run(name, func(t *testing.T) {
+		t.Helper()
+		divergences := oracleDivergences(t, pairID, cases, buggyBuilder, goOnlyFields)
+		if len(divergences) == 0 {
+			t.Fatalf("expected the generic oracle to rediscover the injected pre-fix defect, "+
+				"but it reported every case matching under pair %q -- the comparator did not "+
+				"notice the divergence", pairID)
+		}
+		for _, message := range divergences {
+			t.Logf("rediscovered: %s", message)
+		}
+	})
+}
+
+// TestGenericOracleRediscoversRowConstructionDefects is CHAOS-3162's
+// acceptance gate for the row-construction boundary: run the SAME generic
+// comparator, cases, and pair id, but substitute a pre-fix (buggy) Go row
+// builder for each of the three defects this boundary can express, and
+// confirm the comparator's whole-row, fail-on-undeclared-divergence design
+// actually notices every one of them -- not merely that unit tests
+// targeting these fields would notice, but that the GENERIC oracle itself,
+// with no knowledge of these specific bugs baked in, catches them as a side
+// effect of diffing everything.
+func TestGenericOracleRediscoversRowConstructionDefects(t *testing.T) {
+	cases := oraclePullRequestCases()
+
+	buggyStateBuilder := func(t *testing.T, input map[string]any) map[string]any {
+		return jsonRoundTripToMap(t, mustNormalizeOraclePullRequest(
+			t, input, buggyNormalizePRStateStripsOnlySpaces, gitHubPullUserLogin,
+		))
+	}
+	requireOracleRediscovers(
+		t, "rediscovers pre-M7 state-normalization whitespace bug",
+		"github/prs/row", cases, buggyStateBuilder, oraclePullRequestGoOnlyFields,
+	)
+
+	buggyLoginBuilder := func(t *testing.T, input map[string]any) map[string]any {
+		return jsonRoundTripToMap(t, mustNormalizeOraclePullRequest(
+			t, input, normalizePRState, buggyGitHubPullUserLoginStringOnly,
+		))
+	}
+	requireOracleRediscovers(
+		t, "rediscovers pre-M8 non-string login coercion bug",
+		"github/prs/row", cases, buggyLoginBuilder, oraclePullRequestGoOnlyFields,
+	)
+
+	requireOracleRediscovers(
+		t, "rediscovers unasserted built fields (merged_at/closed_at swap)",
+		"github/prs/row", cases, buildPullRequestRowForOracleWithCorruptedMergedAt,
+		oraclePullRequestGoOnlyFields,
+	)
+}

--- a/internal/providersync/github_prs_normalization_oracle_test.go
+++ b/internal/providersync/github_prs_normalization_oracle_test.go
@@ -141,6 +141,61 @@ func TestGitHubPRSNormalizationMatchesLivePythonFunctions(t *testing.T) {
 				t.Fatalf("resolveCreatedAt fell through to the now() branch; "+
 					"case %q should have a non-empty created/merged/closed input", testCase.id)
 			}
+
+			// codex M3: the oracle DECODED built_created_at/built_merged_at/
+			// built_closed_at from the live build_git_pull_request(...) result
+			// (not merely from the standalone coerce_created_at/
+			// normalize_pr_state calls above) but never compared them against
+			// anything -- a Python builder change that dropped, renamed, or
+			// transformed those fields on the actual GitPullRequest object
+			// would stay green. Assert all three explicitly.
+			if oracle.BuiltCreatedAt == nil {
+				t.Fatalf("oracle case %q: build_git_pull_request result has no created_at", testCase.id)
+			}
+			builtCreatedAt, err := time.Parse(time.RFC3339, *oracle.BuiltCreatedAt)
+			if err != nil {
+				t.Fatalf("parse oracle built_created_at: %v", err)
+			}
+			if !builtCreatedAt.Equal(wantResolved) {
+				t.Fatalf("build_git_pull_request(...).created_at = %v, want %v "+
+					"(coerce_created_at's own result) -- the builder's "+
+					"composition of coerce_created_at diverged from calling it directly",
+					builtCreatedAt, wantResolved)
+			}
+			// merged_at/closed_at are passed straight through by
+			// build_git_pull_request (processors/base_git.py:
+			// "merged_at": merged_at, "closed_at": closed_at) -- the object's
+			// fields must equal the RAW inputs, not the resolved created_at.
+			assertOracleTimePointerMatchesInput(t, testCase.id, "built_merged_at", oracle.BuiltMergedAt, mergedAt)
+			assertOracleTimePointerMatchesInput(t, testCase.id, "built_closed_at", oracle.BuiltClosedAt, closedAt)
 		})
+	}
+}
+
+// assertOracleTimePointerMatchesInput compares an oracle-decoded,
+// ISO8601-string-or-null field against the *time.Time (possibly nil) that
+// was fed into the live Python call for the same case.
+func assertOracleTimePointerMatchesInput(
+	t *testing.T,
+	caseID, field string,
+	oracleValue *string,
+	want *time.Time,
+) {
+	t.Helper()
+	if oracleValue == nil {
+		if want != nil {
+			t.Fatalf("case %q: oracle %s=nil, Go input=%v", caseID, field, want)
+		}
+		return
+	}
+	if want == nil {
+		t.Fatalf("case %q: oracle %s=%s, Go input=nil", caseID, field, *oracleValue)
+	}
+	parsed, err := time.Parse(time.RFC3339, *oracleValue)
+	if err != nil {
+		t.Fatalf("case %q: parse oracle %s: %v", caseID, field, err)
+	}
+	if !parsed.Equal(*want) {
+		t.Fatalf("case %q: oracle %s=%v, Go input=%v", caseID, field, parsed, *want)
 	}
 }

--- a/internal/providersync/github_prs_normalization_oracle_test.go
+++ b/internal/providersync/github_prs_normalization_oracle_test.go
@@ -1,0 +1,146 @@
+package providersync
+
+import (
+	"encoding/json"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"testing"
+	"time"
+)
+
+// githubPRSOracleCase mirrors one entry of
+// testdata/python_github_prs_normalization_oracle.py's CASES list. The
+// Go-side raw_state/created_at/merged_at/closed_at strings below MUST stay
+// byte-identical to that file's CASES -- there is no shared source of truth
+// between the two, so a drift here silently stops proving anything. This is
+// the trade-off documented in the oracle's own docstring: keeping both
+// lists in one file (rather than one generating the other) keeps the
+// oracle a standalone, directly-runnable script.
+type githubPRSOracleCase struct {
+	id        string
+	rawState  string
+	createdAt string
+	mergedAt  string
+	closedAt  string
+	wantState string
+}
+
+var githubPRSOracleCases = []githubPRSOracleCase{
+	{id: "open", rawState: "open", createdAt: "2026-07-10T09:00:00Z", wantState: "open"},
+	{id: "opened_alias", rawState: "opened", createdAt: "2026-07-10T09:00:00Z", wantState: "open"},
+	{id: "closed_unmerged", rawState: "closed", createdAt: "2026-07-10T09:00:00Z",
+		closedAt: "2026-07-15T00:00:00Z", wantState: "closed"},
+	{id: "closed_merged", rawState: "closed", createdAt: "2026-07-10T09:00:00Z",
+		mergedAt: "2026-07-21T15:30:00Z", closedAt: "2026-07-21T15:30:00Z", wantState: "merged"},
+	{id: "merged_literal", rawState: "merged", createdAt: "2026-07-10T09:00:00Z",
+		mergedAt: "2026-07-21T15:30:00Z", closedAt: "2026-07-21T15:30:00Z", wantState: "merged"},
+	{id: "internal_whitespace", rawState: "clo sed", createdAt: "2026-07-10T09:00:00Z",
+		wantState: "open"},
+	{id: "trailing_carriage_return", rawState: "closed\r", createdAt: "2026-07-10T09:00:00Z",
+		closedAt: "2026-07-15T00:00:00Z", wantState: "closed"},
+	{id: "leading_trailing_whitespace", rawState: "  Closed  ", createdAt: "2026-07-10T09:00:00Z",
+		mergedAt: "2026-07-21T15:30:00Z", closedAt: "2026-07-21T15:30:00Z", wantState: "merged"},
+	{id: "created_at_absent_falls_back_to_merged_at", rawState: "closed",
+		mergedAt: "2026-07-21T15:30:00Z", wantState: "merged"},
+	{id: "created_and_merged_absent_falls_back_to_closed_at", rawState: "closed",
+		closedAt: "2026-07-22T00:00:00Z", wantState: "closed"},
+}
+
+func mustParseOracleTime(t *testing.T, value string) *time.Time {
+	t.Helper()
+	if value == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339, value)
+	if err != nil {
+		t.Fatalf("parse oracle fixture time %q: %v", value, err)
+	}
+	parsed = parsed.UTC()
+	return &parsed
+}
+
+// TestGitHubPRSNormalizationMatchesLivePythonFunctions shells out to the
+// live Python producer (codex H9 fix) rather than comparing against a
+// hand-authored fixture. See
+// testdata/python_github_prs_normalization_oracle.py's docstring for what
+// this does and deliberately does not cover.
+func TestGitHubPRSNormalizationMatchesLivePythonFunctions(t *testing.T) {
+	python := pythonExecutable(t)
+	_, currentFile, _, _ := runtime.Caller(0)
+	packageDir := filepath.Dir(currentFile)
+	srcRoot := filepath.Join(packageDir, "..", "..", "src", "dev_health_ops")
+	output, err := exec.Command(
+		python,
+		filepath.Join(packageDir, "testdata", "python_github_prs_normalization_oracle.py"),
+		filepath.Join(srcRoot, "providers", "pr_state.py"),
+		filepath.Join(srcRoot, "processors", "base_git.py"),
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute Python github/prs oracle: %v: %s", err, output)
+	}
+	var got []struct {
+		ID                string  `json:"id"`
+		State             string  `json:"state"`
+		ResolvedCreatedAt *string `json:"resolved_created_at"`
+		BuiltCreatedAt    *string `json:"built_created_at"`
+		BuiltMergedAt     *string `json:"built_merged_at"`
+		BuiltClosedAt     *string `json:"built_closed_at"`
+	}
+	if err := json.Unmarshal(output, &got); err != nil {
+		t.Fatalf("decode Python github/prs oracle: %v: %s", err, output)
+	}
+	byID := make(map[string]int, len(got))
+	for index, entry := range got {
+		byID[entry.ID] = index
+	}
+	if len(byID) != len(githubPRSOracleCases) {
+		t.Fatalf("oracle returned %d cases, Go table has %d", len(byID), len(githubPRSOracleCases))
+	}
+
+	for _, testCase := range githubPRSOracleCases {
+		testCase := testCase
+		t.Run(testCase.id, func(t *testing.T) {
+			index, ok := byID[testCase.id]
+			if !ok {
+				t.Fatalf("oracle output missing case %q", testCase.id)
+			}
+			oracle := got[index]
+
+			createdAt := mustParseOracleTime(t, testCase.createdAt)
+			mergedAt := mustParseOracleTime(t, testCase.mergedAt)
+			closedAt := mustParseOracleTime(t, testCase.closedAt)
+
+			gotState := normalizePRState(testCase.rawState, mergedAt)
+			if gotState != oracle.State {
+				t.Fatalf("normalizePRState = %q, oracle (live Python) = %q", gotState, oracle.State)
+			}
+			if gotState != testCase.wantState {
+				t.Fatalf("normalizePRState = %q, Go table wants %q", gotState, testCase.wantState)
+			}
+
+			// resolveCreatedAt against a zero normalizedAt fallback: every
+			// case in the table supplies at least one of created/merged/
+			// closed, so the "now()" branch is never the one under test
+			// here -- normalizedAt is passed as a recognizable sentinel so a
+			// wrongly-taken fallback branch is obvious in a failure message
+			// rather than silently matching by coincidence.
+			sentinelNow := time.Date(1, 1, 1, 0, 0, 0, 0, time.UTC)
+			gotResolved := resolveCreatedAt(createdAt, mergedAt, closedAt, sentinelNow)
+			if oracle.ResolvedCreatedAt == nil {
+				t.Fatalf("oracle case %q has no resolved_created_at", testCase.id)
+			}
+			wantResolved, err := time.Parse(time.RFC3339, *oracle.ResolvedCreatedAt)
+			if err != nil {
+				t.Fatalf("parse oracle resolved_created_at: %v", err)
+			}
+			if !gotResolved.Equal(wantResolved) {
+				t.Fatalf("resolveCreatedAt = %v, oracle (live Python) = %v", gotResolved, wantResolved)
+			}
+			if gotResolved.Equal(sentinelNow) {
+				t.Fatalf("resolveCreatedAt fell through to the now() branch; "+
+					"case %q should have a non-empty created/merged/closed input", testCase.id)
+			}
+		})
+	}
+}

--- a/internal/providersync/github_prs_readback_test.go
+++ b/internal/providersync/github_prs_readback_test.go
@@ -1,0 +1,202 @@
+package providersync
+
+import (
+	"testing"
+	"time"
+)
+
+func pullRequestReadbackFixture(now time.Time) pullRequestRow {
+	title, body, headBranch, baseBranch := "Add widget support",
+		"This PR adds widget support.", "feature/widgets", "main"
+	mergedAt, closedAt := now, now
+	firstReviewAt := now.Add(-30 * time.Minute)
+	return pullRequestRow{
+		RepoID: "c7198fbc-1945-3717-05d8-eb78866b4e79", Number: 42,
+		Title: &title, Body: &body, State: "merged", AuthorName: "octocat",
+		CreatedAt: now.Add(-time.Hour), MergedAt: &mergedAt, ClosedAt: &closedAt,
+		HeadBranch: &headBranch, BaseBranch: &baseBranch,
+		Additions: 120, Deletions: 30, ChangedFiles: 5, CommentsCount: 3,
+		FirstReviewAt: &firstReviewAt, ReviewsCount: 2, ChangesRequestedCount: 1,
+		LastSynced: now, OrgID: "org-acme",
+	}
+}
+
+func pullRequestReadbackVersion(expected pullRequestRow) pullRequestVersion {
+	return pullRequestVersion{
+		Row: expected, SourceID: nil, OrgID: expected.OrgID,
+		LastSynced: expected.LastSynced, Found: true,
+	}
+}
+
+// TestPullRequestReadbackToleratesPreMergeHistory is the wedge regression
+// (mirrors TestRepositoryReadbackToleratesPreMergeHistory): ReplacingMergeTree
+// keeps every unmerged version of a key, so earlier sync occurrences
+// legitimately sit next to this one. Only the winning version may decide.
+func TestPullRequestReadbackToleratesPreMergeHistory(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	expected := pullRequestReadbackFixture(now)
+
+	if got := comparePullRequestVersion(
+		expected, pullRequestReadbackVersion(expected),
+	); got != EffectExact {
+		t.Fatalf("winning version = %s want %s", got, EffectExact)
+	}
+
+	duplicate := pullRequestReadbackVersion(expected)
+	if got := comparePullRequestVersion(expected, duplicate); got != EffectExact {
+		t.Fatalf("duplicate = %s want %s", got, EffectExact)
+	}
+}
+
+// TestPullRequestReadbackToleratesOpenPRNullFields proves a row with every
+// nullable field unset (an open PR with no reviews) still reads back exact
+// -- nil must compare equal to nil, not to a sentinel value.
+func TestPullRequestReadbackToleratesOpenPRNullFields(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	expected := pullRequestReadbackFixture(now)
+	expected.State = "open"
+	expected.MergedAt, expected.ClosedAt = nil, nil
+	expected.FirstReviewAt, expected.FirstCommentAt = nil, nil
+	expected.ReviewsCount, expected.ChangesRequestedCount = 0, 0
+	expected.AuthorEmail, expected.HeadBranch, expected.BaseBranch = nil, nil, nil
+	expected.Title, expected.Body = nil, nil
+
+	actual := pullRequestReadbackVersion(expected)
+	if got := comparePullRequestVersion(expected, actual); got != EffectExact {
+		t.Fatalf("open PR readback = %s want %s", got, EffectExact)
+	}
+}
+
+// TestPullRequestReadbackClassifiesEveryVersionRelationship mutation-tests
+// each comparison clause independently (codex M6): every sub-test changes
+// exactly ONE field on an otherwise-identical actual version, so a survivor
+// here identifies precisely which clause in comparePullRequestVersion failed
+// to fire -- the "mutate compound predicates clause by clause" discipline
+// applied to the test fixture itself, not only to the harness's mutations.
+func TestPullRequestReadbackClassifiesEveryVersionRelationship(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 0, 0, 0, time.UTC)
+	expected := pullRequestReadbackFixture(now)
+
+	stale := pullRequestReadbackVersion(expected)
+	stale.LastSynced = now.Add(-time.Hour)
+
+	newer := pullRequestReadbackVersion(expected)
+	newer.LastSynced = now.Add(time.Hour)
+
+	differentTitle := pullRequestReadbackVersion(expected)
+	title := "Renamed"
+	differentTitle.Row.Title = &title
+
+	differentBody := pullRequestReadbackVersion(expected)
+	body := "Different body"
+	differentBody.Row.Body = &body
+
+	differentState := pullRequestReadbackVersion(expected)
+	differentState.Row.State = "closed"
+
+	differentAuthorName := pullRequestReadbackVersion(expected)
+	differentAuthorName.Row.AuthorName = "someone-else"
+
+	differentAuthorEmail := pullRequestReadbackVersion(expected)
+	email := "someone@example.test"
+	differentAuthorEmail.Row.AuthorEmail = &email
+
+	differentCreatedAt := pullRequestReadbackVersion(expected)
+	differentCreatedAt.Row.CreatedAt = now.Add(-48 * time.Hour)
+
+	// codex M5: a merged_at that differs only in sub-millisecond precision
+	// must still read as a conflict -- this proves the comparison itself is
+	// precise, independent of parseGitHubPullTime's own truncation.
+	differentMergedAt := pullRequestReadbackVersion(expected)
+	shiftedMerged := expected.MergedAt.Add(time.Millisecond)
+	differentMergedAt.Row.MergedAt = &shiftedMerged
+
+	differentClosedAt := pullRequestReadbackVersion(expected)
+	shiftedClosed := expected.ClosedAt.Add(time.Millisecond)
+	differentClosedAt.Row.ClosedAt = &shiftedClosed
+
+	differentHeadBranch := pullRequestReadbackVersion(expected)
+	head := "other-branch"
+	differentHeadBranch.Row.HeadBranch = &head
+
+	differentBaseBranch := pullRequestReadbackVersion(expected)
+	base := "develop"
+	differentBaseBranch.Row.BaseBranch = &base
+
+	differentAdditions := pullRequestReadbackVersion(expected)
+	differentAdditions.Row.Additions = expected.Additions + 1
+
+	differentDeletions := pullRequestReadbackVersion(expected)
+	differentDeletions.Row.Deletions = expected.Deletions + 1
+
+	differentChangedFiles := pullRequestReadbackVersion(expected)
+	differentChangedFiles.Row.ChangedFiles = expected.ChangedFiles + 1
+
+	// The four review-derived columns: omitted entirely from the readback
+	// comparison before the M6 fix, so a divergence here previously read as
+	// EffectExact no matter what the persisted row actually held.
+	differentFirstReviewAt := pullRequestReadbackVersion(expected)
+	shiftedReview := expected.FirstReviewAt.Add(time.Hour)
+	differentFirstReviewAt.Row.FirstReviewAt = &shiftedReview
+
+	differentFirstCommentAt := pullRequestReadbackVersion(expected)
+	someComment := now.Add(-15 * time.Minute)
+	differentFirstCommentAt.Row.FirstCommentAt = &someComment
+
+	differentChangesRequestedCount := pullRequestReadbackVersion(expected)
+	differentChangesRequestedCount.Row.ChangesRequestedCount = expected.ChangesRequestedCount + 1
+
+	differentReviewsCount := pullRequestReadbackVersion(expected)
+	differentReviewsCount.Row.ReviewsCount = expected.ReviewsCount + 1
+
+	differentCommentsCount := pullRequestReadbackVersion(expected)
+	differentCommentsCount.Row.CommentsCount = expected.CommentsCount + 1
+
+	externallyStamped := pullRequestReadbackVersion(expected)
+	stampedSourceID := "11111111-1111-4111-8111-111111111111"
+	externallyStamped.SourceID = &stampedSourceID
+
+	staleTenant := pullRequestReadbackVersion(expected)
+	staleTenant.OrgID = "org-other"
+
+	for name, test := range map[string]struct {
+		actual pullRequestVersion
+		want   EffectInspection
+	}{
+		"absent key":                  {pullRequestVersion{}, EffectAbsent},
+		"zero timestamp aggregate":    {pullRequestVersion{Found: true}, EffectAbsent},
+		"only an older version":       {stale, EffectAbsent},
+		"a newer occurrence wins":     {newer, EffectConflict},
+		"different title":             {differentTitle, EffectConflict},
+		"different body":              {differentBody, EffectConflict},
+		"different state":             {differentState, EffectConflict},
+		"different author name":       {differentAuthorName, EffectConflict},
+		"different author email":      {differentAuthorEmail, EffectConflict},
+		"different created_at":        {differentCreatedAt, EffectConflict},
+		"merged_at off by 1ms":        {differentMergedAt, EffectConflict},
+		"closed_at off by 1ms":        {differentClosedAt, EffectConflict},
+		"different head branch":       {differentHeadBranch, EffectConflict},
+		"different base branch":       {differentBaseBranch, EffectConflict},
+		"different additions":         {differentAdditions, EffectConflict},
+		"different deletions":         {differentDeletions, EffectConflict},
+		"different changed files":     {differentChangedFiles, EffectConflict},
+		"different first_review_at":   {differentFirstReviewAt, EffectConflict},
+		"different first_comment_at":  {differentFirstCommentAt, EffectConflict},
+		"different changes_requested": {differentChangesRequestedCount, EffectConflict},
+		"different reviews_count":     {differentReviewsCount, EffectConflict},
+		"different comments_count":    {differentCommentsCount, EffectConflict},
+		"external ingest stamped it":  {externallyStamped, EffectConflict},
+		"stale tenant row":            {staleTenant, EffectConflict},
+	} {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := comparePullRequestVersion(expected, test.actual); got != test.want {
+				t.Fatalf("%s = %s want %s", name, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/providersync/github_prs_route.go
+++ b/internal/providersync/github_prs_route.go
@@ -1,0 +1,457 @@
+package providersync
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"net/url"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+// pullRequestRow is the frozen `git_pull_requests` projection. Field order and
+// JSON names mirror the Python ClickHouse sink
+// (`ClickHouseStore.insert_git_pull_requests`) so the effect digest is stable
+// and the row is byte-comparable during live parity.
+//
+// Four fields are intentionally always zero-valued here:
+// first_review_at, reviews_count, and changes_requested_count are populated
+// in Python only by `_enrich_prs_with_reviews_batch`'s GraphQL review fetch
+// (processors/github.py), which this handler does not perform -- that is
+// github/pr-reviews' job (see deploy/go-workers/provider-sync-porting-recipe.md).
+// first_comment_at is `None` unconditionally in Python's own
+// `_collect_github_pr_objects`, so leaving it nil here is exact parity, not a
+// gap.
+type pullRequestRow struct {
+	RepoID                string     `json:"repo_id"`
+	Number                int        `json:"number"`
+	Title                 *string    `json:"title"`
+	Body                  *string    `json:"body"`
+	State                 string     `json:"state"`
+	AuthorName            string     `json:"author_name"`
+	AuthorEmail           *string    `json:"author_email"`
+	CreatedAt             time.Time  `json:"created_at"`
+	MergedAt              *time.Time `json:"merged_at"`
+	ClosedAt              *time.Time `json:"closed_at"`
+	HeadBranch            *string    `json:"head_branch"`
+	BaseBranch            *string    `json:"base_branch"`
+	Additions             int        `json:"additions"`
+	Deletions             int        `json:"deletions"`
+	ChangedFiles          int        `json:"changed_files"`
+	FirstReviewAt         *time.Time `json:"first_review_at"`
+	FirstCommentAt        *time.Time `json:"first_comment_at"`
+	ChangesRequestedCount int        `json:"changes_requested_count"`
+	ReviewsCount          int        `json:"reviews_count"`
+	CommentsCount         int        `json:"comments_count"`
+	LastSynced            time.Time  `json:"last_synced"`
+	SourceID              *string    `json:"source_id"`
+	OrgID                 string     `json:"org_id"`
+}
+
+// gitHubPullListItem is the subset of a GET /repos/{owner}/{repo}/pulls list
+// item this handler reads: enough to compute the since/before window and the
+// PR number to fetch in full. GitHub's list response does not include
+// additions/deletions/changed_files/comments -- only the single-PR GET does
+// (mirrors code_client.py's two-phase iter_pulls + get_pull_detail).
+type gitHubPullListItem struct {
+	Number    int    `json:"number"`
+	UpdatedAt string `json:"updated_at"`
+}
+
+// gitHubPullDetailPayload is the GET /repos/{owner}/{repo}/pulls/{number}
+// response fields this handler reads. Field names mirror
+// providers/github/code_client.py::_pull_from_item.
+type gitHubPullDetailPayload struct {
+	ID           json.Number     `json:"id"`
+	Number       int             `json:"number"`
+	Title        *string         `json:"title"`
+	Body         *string         `json:"body"`
+	State        *string         `json:"state"`
+	User         json.RawMessage `json:"user"`
+	CreatedAt    *string         `json:"created_at"`
+	UpdatedAt    *string         `json:"updated_at"`
+	MergedAt     *string         `json:"merged_at"`
+	ClosedAt     *string         `json:"closed_at"`
+	Head         json.RawMessage `json:"head"`
+	Base         json.RawMessage `json:"base"`
+	Additions    int             `json:"additions"`
+	Deletions    int             `json:"deletions"`
+	ChangedFiles int             `json:"changed_files"`
+	Comments     int             `json:"comments"`
+}
+
+type gitHubPullRef struct {
+	Ref string `json:"ref"`
+}
+
+// GitHubPullRequestRouteHandler is the native Go complete-route handler for
+// (github, prs). It mirrors `_collect_github_pr_objects` +
+// `build_git_pull_request` + `normalize_pr_state`
+// (src/dev_health_ops/processors/github.py, providers/pr_state.py): list
+// every PR via GET .../pulls (state=all, sort=updated, direction=desc),
+// fetch each PR's full detail via GET .../pulls/{number} for the fields the
+// list endpoint omits, then filter to the claim's since/before window.
+//
+// Review-derived enrichment (first_review_at, reviews_count,
+// changes_requested_count -- Python's `_enrich_prs_with_reviews_batch`, a
+// GraphQL batch fetch) is NOT performed here; those fields are always their
+// zero value. See the pullRequestRow doc comment and
+// deploy/go-workers/provider-sync-porting-recipe.md.
+type GitHubPullRequestRouteHandler struct {
+	Now      func() time.Time
+	MaxPages int
+}
+
+func (handler GitHubPullRequestRouteHandler) now() time.Time {
+	if handler.Now != nil {
+		return handler.Now().UTC()
+	}
+	return time.Now().UTC()
+}
+
+func (handler GitHubPullRequestRouteHandler) Collect(
+	ctx context.Context,
+	claim Claim,
+	_ providerfoundation.Credential,
+	client *providerfoundation.HTTPClient,
+	normalizedAt time.Time,
+) (CompleteRouteBatch, error) {
+	if ctx == nil || claim.Validate() != nil || claim.Provider != "github" ||
+		claim.Dataset != "prs" || client == nil || client.Provider != "github" ||
+		client.BaseURL == nil || normalizedAt.IsZero() {
+		return CompleteRouteBatch{}, ErrInvalidConfiguration
+	}
+	normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)
+	owner, repository, err := splitGitHubRepository(claim.SourceExternalID)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	root := providerRelativePath(client, "repos", owner, repository)
+
+	// repo_id is derived from the repository's API-reported full_name, not
+	// claim.SourceExternalID: Python's db_repo.id = get_repo_uuid_from_repo
+	// (repo_info.full_name) (models/git.py Repo.__init__, driven by
+	// processors/github.py::process_github_repo's repo-info fetch). This is
+	// the identical repositoryIdentity call GitHubRepositoryRouteHandler
+	// makes for (github, repo-metadata).
+	//
+	// codex H4: a blank full_name MUST fail closed, not fall back to
+	// claim.SourceExternalID. Python's get_repo_uuid_from_repo raises
+	// ValueError("repo identifier is required") on a falsy repo string, and
+	// models/git.py::Repo.__init__ only attempts that call `if
+	// repo_identifier:` -- a blank full_name skips it entirely, leaving
+	// `id` unset, and every downstream ClickHouse insert
+	// (_normalize_uuid(repo.id)) then raises on the None. Python never
+	// persists a PR under a guessed identity; falling back here would write
+	// rows keyed on a repo_id nothing else in the system would derive.
+	//
+	// There is deliberately no separate `if fullName == ""` guard here: an
+	// earlier version had one, and a mutation-harness run proved it dead --
+	// repositoryIdentity already rejects an empty (or all-whitespace)
+	// string with the same ErrNormalizationInvalid before it ever hashes
+	// anything, so a second copy of that check only added an unreachable
+	// branch for a mutation to hide behind. One fail-closed check, not two
+	// that must be kept in sync.
+	var repoPayload gitHubRepositoryPayload
+	if err := fetchObject(ctx, client, root, &repoPayload); err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	repoID, err := repositoryIdentity(repoPayload.FullName)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+
+	query := url.Values{
+		"state": {"all"}, "sort": {"updated"}, "direction": {"desc"},
+		"per_page": {"100"},
+	}
+	maxPages := handler.MaxPages
+	if maxPages == 0 {
+		maxPages = nativeMaxPages
+	}
+	page, err := providerfoundation.CollectGitHubLinkPages(
+		ctx, client, providerfoundation.GitHubPageOptions{
+			Path: root + "/pulls", Query: query, MaxPages: maxPages,
+		},
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	// codex H2: Python's client.iter_pulls call is uncapped. A capped Go
+	// fetch that still reports success and still lets Collect return
+	// claim.BeforeAt as the watermark would silently and permanently lose
+	// every PR past the cap -- the window never revisits them. Fail the
+	// whole unit instead: never both capped and successful.
+	if page.CapReached {
+		return CompleteRouteBatch{}, ErrPaginationCapExceeded
+	}
+	listed, err := filterGitHubPullWindow(page.Items, claim)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+
+	rows := make([]pullRequestRow, 0, len(listed))
+	detailRequests := 0
+	for _, number := range listed {
+		var detail gitHubPullDetailPayload
+		if err := fetchObject(
+			ctx, client, root+"/pulls/"+strconv.Itoa(number), &detail,
+		); err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		detailRequests++
+		row, err := normalizeGitHubPullRequest(claim, repoID, detail, normalizedAt)
+		if err != nil {
+			return CompleteRouteBatch{}, err
+		}
+		rows = append(rows, row)
+	}
+
+	effect, err := effectBatchFromValues(
+		"git_pull_requests", EffectReadbackRequired, rows,
+	)
+	if err != nil {
+		return CompleteRouteBatch{}, err
+	}
+	watermark := claim.BeforeAt
+	return CompleteRouteBatch{
+		Effects: []EffectBatch{effect},
+		Result: map[string]any{
+			"prs_synced": len(rows),
+			"repo":       repoPayload.FullName,
+		},
+		Watermark: watermark,
+		Evidence: FetchEvidence{
+			Provider: claim.Provider, Dataset: claim.Dataset,
+			Requests:   page.Pages + 1 + detailRequests,
+			Pages:      page.Pages,
+			Records:    len(rows),
+			CapReached: page.CapReached,
+		},
+	}, nil
+}
+
+// filterGitHubPullWindow applies the claim's since/before window to the
+// listed PR numbers, client-side -- the same window
+// `_collect_github_pr_objects` (processors/github.py) applies over
+// `client.iter_pulls`'s results. GitHub's /pulls list endpoint has no
+// server-side `since` parameter (unlike /issues), so this is the only
+// filter, not a redundant belt-and-suspenders layer.
+//
+// codex H3: Python applies the since/until comparison ONLY when
+// `updated_at` is a real `datetime` (`isinstance(updated_at, datetime)`);
+// a missing, null, or unparseable value skips BOTH comparisons and the PR
+// is unconditionally detail-fetched and included. An earlier version of
+// this function dropped such items instead -- the "empty success" trap:
+// a window of PRs that all have this shape silently reports zero records
+// instead of including them, and nothing about that empty result looks
+// wrong from the outside. windowKnown is split out as its own clause (not
+// folded into the two comparisons) so each of the three conditions --
+// "is the timestamp known at all", "is it before since", "is it after
+// before" -- can be mutation-tested independently; see
+// TestFilterGitHubPullWindowClauseCoverage.
+func filterGitHubPullWindow(items []json.RawMessage, claim Claim) ([]int, error) {
+	numbers := make([]int, 0, len(items))
+	for _, raw := range items {
+		var item gitHubPullListItem
+		if json.Unmarshal(raw, &item) != nil || item.Number < 1 {
+			return nil, providerfoundation.ErrNormalizationInvalid
+		}
+		if pullOutsideKnownWindow(firstTime(item.UpdatedAt), claim) {
+			continue
+		}
+		numbers = append(numbers, item.Number)
+	}
+	return numbers, nil
+}
+
+// pullOutsideKnownWindow reports whether a PR must be excluded because its
+// updated_at is both known and outside the claim's window. Each clause is
+// intentionally a separate, named condition (not inlined into one compound
+// boolean) so a mutation harness can kill each independently rather than
+// only the disjunction as a whole.
+func pullOutsideKnownWindow(updatedAt time.Time, claim Claim) bool {
+	windowKnown := !updatedAt.IsZero()
+	if !windowKnown {
+		// Missing/null/unparseable updated_at: Python cannot compare it
+		// either, so the item is unconditionally included (fetched and
+		// stored), never excluded.
+		return false
+	}
+	before := claim.SinceAt != nil && updatedAt.Before(claim.SinceAt.UTC())
+	after := claim.BeforeAt != nil && updatedAt.After(claim.BeforeAt.UTC())
+	return before || after
+}
+
+// normalizeGitHubPullRequest mirrors build_git_pull_request +
+// normalize_pr_state (processors/base_git.py, providers/pr_state.py) exactly
+// for the fields REST alone can populate. author_email is always nil: Python
+// hardcodes `author_email = None` for the GitHub PR path
+// (processors/github.py::_collect_github_pr_objects).
+func normalizeGitHubPullRequest(
+	claim Claim,
+	repoID string,
+	detail gitHubPullDetailPayload,
+	normalizedAt time.Time,
+) (pullRequestRow, error) {
+	if detail.Number < 1 {
+		return pullRequestRow{}, providerfoundation.ErrNormalizationInvalid
+	}
+	createdAt := parseGitHubPullTime(detail.CreatedAt)
+	mergedAt := parseGitHubPullTime(detail.MergedAt)
+	closedAt := parseGitHubPullTime(detail.ClosedAt)
+	resolvedCreatedAt := resolveCreatedAt(createdAt, mergedAt, closedAt, normalizedAt)
+	var rawState string
+	if detail.State != nil {
+		rawState = *detail.State
+	}
+	authorName := "Unknown"
+	if login := gitHubPullUserLogin(detail.User); login != "" {
+		authorName = login
+	}
+	row := pullRequestRow{
+		RepoID: repoID, Number: detail.Number, Title: detail.Title,
+		Body: detail.Body, State: normalizePRState(rawState, mergedAt),
+		AuthorName: authorName, AuthorEmail: nil,
+		CreatedAt: resolvedCreatedAt.UTC(), MergedAt: mergedAt, ClosedAt: closedAt,
+		HeadBranch: gitHubPullRefName(detail.Head),
+		BaseBranch: gitHubPullRefName(detail.Base),
+		Additions:  detail.Additions, Deletions: detail.Deletions,
+		ChangedFiles: detail.ChangedFiles,
+		// FirstReviewAt/ReviewsCount/ChangesRequestedCount: see the
+		// pullRequestRow doc comment -- not populated by this handler.
+		CommentsCount: detail.Comments,
+		LastSynced:    normalizedAt, OrgID: claim.OrgID,
+	}
+	if err := row.validate(claim); err != nil {
+		return pullRequestRow{}, err
+	}
+	return row, nil
+}
+
+// resolveCreatedAt is a direct port of BaseGitProcessor.coerce_created_at
+// (processors/base_git.py): created_at or merged_at or closed_at or now().
+// created_at is NOT NULL in the ClickHouse schema. Extracted to its own
+// function (rather than inlined in normalizeGitHubPullRequest) so
+// TestGitHubPRSNormalizationMatchesLivePythonFunctions can call it directly
+// against the live Python oracle's per-case output.
+func resolveCreatedAt(
+	createdAt, mergedAt, closedAt *time.Time,
+	normalizedAt time.Time,
+) time.Time {
+	switch {
+	case createdAt != nil:
+		return *createdAt
+	case mergedAt != nil:
+		return *mergedAt
+	case closedAt != nil:
+		return *closedAt
+	default:
+		return normalizedAt
+	}
+}
+
+// normalizePRState is a byte-for-byte port of providers/pr_state.py's
+// normalize_pr_state: GitHub returns "closed" for both merged and unmerged
+// PRs, so merged_at disambiguates.
+//
+// codex M7: Python's own operation is exactly `raw_state.strip().lower()` --
+// strip leading/trailing whitespace ONLY (Python's default whitespace set,
+// which includes \r), then lowercase. A prior version of this function
+// stripped whitespace THROUGHOUT the string (turning "clo sed" into
+// "closed", which Python would leave unmatched) and did not strip \r at all
+// (leaving "closed\r" unmatched, which Python's strip() does match). Using
+// strings.TrimSpace + strings.ToLower is deliberately no MORE aggressive
+// than Python's operation, not just "also correct" for the cases tested.
+func normalizePRState(rawState string, mergedAt *time.Time) string {
+	if rawState == "" {
+		return "open"
+	}
+	switch strings.ToLower(strings.TrimSpace(rawState)) {
+	case "merged":
+		return "merged"
+	case "opened", "open":
+		return "open"
+	case "closed":
+		if mergedAt != nil {
+			return "merged"
+		}
+		return "closed"
+	default:
+		return "open"
+	}
+}
+
+// parseGitHubPullTime parses a provider RFC3339 timestamp and truncates it
+// to millisecond precision at construction time (codex M5): ClickHouse
+// persists `DateTime64(3)`, so a provider timestamp with sub-millisecond
+// precision would otherwise diverge from what a subsequent readback SELECT
+// scans back -- a process death between WriteEffect's `Send` and the ledger
+// CommitEffect would then compare, e.g., `.123` against the in-memory
+// `.123456`, report EffectConflict on a row that is actually fine, and
+// recovery could neither mark it committed nor safely replay it. Truncating
+// here, once, at the point the value enters the row, is simpler and more
+// robust than truncating at every comparison site downstream.
+func parseGitHubPullTime(value *string) *time.Time {
+	if value == nil || *value == "" {
+		return nil
+	}
+	parsed, err := time.Parse(time.RFC3339Nano, *value)
+	if err != nil {
+		return nil
+	}
+	parsed = parsed.UTC().Truncate(time.Millisecond)
+	return &parsed
+}
+
+func gitHubPullRefName(raw json.RawMessage) *string {
+	if len(raw) == 0 {
+		return nil
+	}
+	var ref gitHubPullRef
+	if json.Unmarshal(raw, &ref) != nil || ref.Ref == "" {
+		return nil
+	}
+	value := ref.Ref
+	return &value
+}
+
+// gitHubPullUserLogin mirrors code_client.py::_pull_from_item's
+// `str(user["login"]) if isinstance(user, Mapping) and user.get("login") is
+// not None else None`: Python stringifies ANY non-null login value, not
+// only a string one. codex M8: decoding directly into a Go `string` field
+// makes json.Unmarshal fail (and this function return "") for a numeric
+// login such as `{"login": 12345}`, silently losing attribution to the
+// "Unknown" fallback where Python would have written "12345". Decoding into
+// `any` (with UseNumber so a numeric login round-trips exactly, not through
+// a lossy float64) and reusing the package's existing stringValue helper
+// (native_rest.go) gets the same str()-like coercion Python's own
+// str(user["login"]) performs.
+func gitHubPullUserLogin(raw json.RawMessage) string {
+	if len(raw) == 0 {
+		return ""
+	}
+	decoder := json.NewDecoder(bytes.NewReader(raw))
+	decoder.UseNumber()
+	var user struct {
+		Login any `json:"login"`
+	}
+	if decoder.Decode(&user) != nil {
+		return ""
+	}
+	return stringValue(user.Login)
+}
+
+func (row pullRequestRow) validate(claim Claim) error {
+	if row.OrgID == "" || row.OrgID != claim.OrgID || row.RepoID == "" ||
+		len(row.RepoID) != 36 || row.Number < 1 || row.State == "" ||
+		row.CreatedAt.IsZero() || row.LastSynced.IsZero() {
+		return providerfoundation.ErrInvalidScope
+	}
+	return nil
+}
+
+var _ CompleteRouteHandler = GitHubPullRequestRouteHandler{}

--- a/internal/providersync/github_prs_route.go
+++ b/internal/providersync/github_prs_route.go
@@ -172,9 +172,21 @@ func (handler GitHubPullRequestRouteHandler) Collect(
 	if maxPages == 0 {
 		maxPages = nativeMaxPages
 	}
+	// codex H1 (first half): Python's client.iter_pulls stops paginating the
+	// moment a listed item's updated_at is known and falls below since --
+	// for a sort=updated&direction=desc listing every later item is
+	// guaranteed to be even older, so continuing only spends requests
+	// fetching history the caller was never going to keep. Without this,
+	// the H2 cap check below counts pages of TOTAL history, not pages
+	// WITHIN the incremental window: a repository with 10,001 historical
+	// PRs but only one page inside the window would cap (and now fail the
+	// unit) on every attempt, forever, even though Python syncs it fine.
 	page, err := providerfoundation.CollectGitHubLinkPages(
 		ctx, client, providerfoundation.GitHubPageOptions{
 			Path: root + "/pulls", Query: query, MaxPages: maxPages,
+			StopAt: func(raw json.RawMessage) bool {
+				return pullCrossedSinceBoundary(raw, claim)
+			},
 		},
 	)
 	if err != nil {
@@ -184,7 +196,10 @@ func (handler GitHubPullRequestRouteHandler) Collect(
 	// fetch that still reports success and still lets Collect return
 	// claim.BeforeAt as the watermark would silently and permanently lose
 	// every PR past the cap -- the window never revisits them. Fail the
-	// whole unit instead: never both capped and successful.
+	// whole unit instead: never both capped and successful. With the
+	// since-boundary early stop above, CapReached now means what it claims:
+	// more than MaxPages pages fall WITHIN the claim's window, not that the
+	// repository merely has a long history.
 	if page.CapReached {
 		return CompleteRouteBatch{}, ErrPaginationCapExceeded
 	}
@@ -235,11 +250,16 @@ func (handler GitHubPullRequestRouteHandler) Collect(
 }
 
 // filterGitHubPullWindow applies the claim's since/before window to the
-// listed PR numbers, client-side -- the same window
+// listed PR numbers, client-side -- the same per-item recheck
 // `_collect_github_pr_objects` (processors/github.py) applies over
-// `client.iter_pulls`'s results. GitHub's /pulls list endpoint has no
-// server-side `since` parameter (unlike /issues), so this is the only
-// filter, not a redundant belt-and-suspenders layer.
+// `client.iter_pulls`'s already-early-stopped results. GitHub's /pulls list
+// endpoint has no server-side `since` OR `until` parameter, so for the
+// `before` bound this is the ONLY enforcement; for the `since` bound it is a
+// deliberate belt-and-suspenders recheck behind pullCrossedSinceBoundary's
+// pagination-level early stop (codex H1), mirroring Python's own redundant
+// two-layer structure (iter_pulls's internal early-stop, then
+// _collect_github_pr_objects's own per-item since/until recheck) rather than
+// relying on only one of the two layers being correct.
 //
 // codex H3: Python applies the since/until comparison ONLY when
 // `updated_at` is a real `datetime` (`isinstance(updated_at, datetime)`);
@@ -284,6 +304,31 @@ func pullOutsideKnownWindow(updatedAt time.Time, claim Claim) bool {
 	before := claim.SinceAt != nil && updatedAt.Before(claim.SinceAt.UTC())
 	after := claim.BeforeAt != nil && updatedAt.After(claim.BeforeAt.UTC())
 	return before || after
+}
+
+// pullCrossedSinceBoundary is the GitHubPageOptions.StopAt predicate for the
+// /pulls listing (codex H1, first half): a direct port of
+// code_client.py::GitHubCodeClient.iter_pulls's per-item
+// `since is not None and pull.updated_at is not None and pull.updated_at <
+// since` check, which BREAKS iteration (not merely skips the one item) once
+// it fires. For a sort=updated&direction=desc page this is safe: everything
+// after the crossing item, on this page and every later page, is guaranteed
+// to be at least as old. windowKnown is split out for the same clause-level
+// mutation-testing reason pullOutsideKnownWindow's is.
+func pullCrossedSinceBoundary(raw json.RawMessage, claim Claim) bool {
+	if claim.SinceAt == nil {
+		return false
+	}
+	var item gitHubPullListItem
+	if json.Unmarshal(raw, &item) != nil {
+		return false
+	}
+	updatedAt := firstTime(item.UpdatedAt)
+	windowKnown := !updatedAt.IsZero()
+	if !windowKnown {
+		return false
+	}
+	return updatedAt.Before(claim.SinceAt.UTC())
 }
 
 // normalizeGitHubPullRequest mirrors build_git_pull_request +

--- a/internal/providersync/github_prs_route_test.go
+++ b/internal/providersync/github_prs_route_test.go
@@ -1,0 +1,600 @@
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/providerfoundation"
+)
+
+const gitHubPullRequestRepoFixture = `{
+  "id": 4567,
+  "name": "api",
+  "full_name": "Acme/API",
+  "html_url": "https://github.com/Acme/API",
+  "default_branch": "main",
+  "language": "Go"
+}`
+
+// gitHubPullRequestListFixture has three PRs: #42 inside the claim window
+// (2026-07-01..2026-07-31T23:59:59Z), #41 updated before it, and #43 updated
+// after it. Only #42 may reach a detail (.../pulls/{number}) request.
+const gitHubPullRequestListFixture = `[
+  {"number": 43, "updated_at": "2026-08-01T00:00:00Z"},
+  {"number": 42, "updated_at": "2026-07-21T15:30:00Z"},
+  {"number": 41, "updated_at": "2026-06-15T00:00:00Z"}
+]`
+
+// gitHubPullRequestDetailFixture42 and its expected row below were
+// independently produced by running the real Python collector against this
+// exact JSON --
+//
+//	gh_pr = _pull_from_item(fixture)                     # code_client.py
+//	state = normalize_pr_state(gh_pr.state, gh_pr.merged_at)  # providers/pr_state.py
+//	repo_id = get_repo_uuid_from_repo("Acme/API")         # models/git.py
+//	pr = build_git_pull_request(repo_id=repo_id, number=gh_pr.number, ...)
+//
+// which printed repo_id=c7198fbc-1945-3717-05d8-eb78866b4e79, state="merged",
+// author_name="octocat", author_email=None, created_at=2026-07-10T09:00:00Z,
+// merged_at=closed_at=2026-07-21T15:30:00Z, head_branch="feature/widgets",
+// base_branch="main", additions=120, deletions=30, changed_files=5,
+// comments_count=3 -- field-for-field identical to the assertions below. This
+// is fixture parity, not live parity: it proves Go and Python agree on this
+// input, not that either agrees with a live GitHub API response.
+const gitHubPullRequestDetailFixture42 = `{
+  "id": 991234,
+  "number": 42,
+  "title": "Add widget support",
+  "body": "This PR adds widget support.",
+  "state": "closed",
+  "user": {"login": "octocat"},
+  "created_at": "2026-07-10T09:00:00Z",
+  "updated_at": "2026-07-21T15:30:00Z",
+  "merged_at": "2026-07-21T15:30:00Z",
+  "closed_at": "2026-07-21T15:30:00Z",
+  "head": {"ref": "feature/widgets"},
+  "base": {"ref": "main"},
+  "additions": 120,
+  "deletions": 30,
+  "changed_files": 5,
+  "comments": 3
+}`
+
+type gitHubPullRequestDoer struct {
+	t        *testing.T
+	bodies   map[string]string
+	requests []string
+}
+
+func (doer *gitHubPullRequestDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	doer.requests = append(doer.requests, request.URL.Path)
+	body, ok := doer.bodies[request.URL.Path]
+	if !ok {
+		return &http.Response{
+			StatusCode: http.StatusNotFound,
+			Header:     http.Header{"Content-Type": []string{"application/json"}},
+			Body:       io.NopCloser(strings.NewReader(`{}`)),
+			Request:    request,
+		}, nil
+	}
+	return &http.Response{
+		StatusCode: http.StatusOK,
+		Header:     http.Header{"Content-Type": []string{"application/json"}},
+		Body:       io.NopCloser(strings.NewReader(body)),
+		Request:    request,
+	}, nil
+}
+
+func gitHubPullRequestClient(
+	t *testing.T, doer providerfoundation.HTTPDoer, base string,
+) *providerfoundation.HTTPClient {
+	t.Helper()
+	client, err := providerfoundation.NewHTTPClient(
+		"github", base, doer,
+		func(*http.Request) error { return nil },
+		providerfoundation.RetryPolicy{
+			MaxAttempts: 1, InitialWait: time.Nanosecond, MaxWait: time.Nanosecond,
+		},
+		providerfoundation.LeaseGuardFunc(func(context.Context) error { return nil }),
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return client
+}
+
+func defaultGitHubPullRequestFixtures() map[string]string {
+	return map[string]string{
+		"/repos/acme/api":          gitHubPullRequestRepoFixture,
+		"/repos/acme/api/pulls":    gitHubPullRequestListFixture,
+		"/repos/acme/api/pulls/42": gitHubPullRequestDetailFixture42,
+	}
+}
+
+// TestGitHubPullRequestRouteEmitsOneBoundedEffect carries the CHAOS-3122
+// parity evidence for RouteReady: see gitHubPullRequestDetailFixture42's doc
+// comment.
+func TestGitHubPullRequestRouteEmitsOneBoundedEffect(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	doer := &gitHubPullRequestDoer{t: t, bodies: defaultGitHubPullRequestFixtures()}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	claim := nativeTestClaim("github", "prs")
+
+	batch, err := (GitHubPullRequestRouteHandler{
+		Now: func() time.Time { return now },
+	}).Collect(context.Background(), claim, providerfoundation.Credential{}, client, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	descriptor, ok := (CompleteRouteSwitches{}).Descriptor("github", "prs")
+	if !ok {
+		t.Fatal("github/prs has no canonical descriptor")
+	}
+	if err := batch.validate(descriptor); err != nil {
+		t.Fatalf("batch does not satisfy the canonical destination manifest: %v", err)
+	}
+
+	// Only #42 falls inside the claim window, so exactly one detail request
+	// (plus the repo GET and the list GET) must have been issued -- #41 and
+	// #43 must never reach GET .../pulls/{number}.
+	want := []string{
+		"/repos/acme/api", "/repos/acme/api/pulls", "/repos/acme/api/pulls/42",
+	}
+	if len(doer.requests) != len(want) {
+		t.Fatalf("requests=%v want=%v", doer.requests, want)
+	}
+	for index, path := range want {
+		if doer.requests[index] != path {
+			t.Fatalf("requests=%v want=%v", doer.requests, want)
+		}
+	}
+
+	if batch.Watermark == nil || !batch.Watermark.Equal(*claim.BeforeAt) {
+		t.Fatalf("watermark=%v want claim.BeforeAt=%v", batch.Watermark, claim.BeforeAt)
+	}
+	if batch.Evidence.Records != 1 || batch.Evidence.CapReached {
+		t.Fatalf("evidence=%+v", batch.Evidence)
+	}
+	if len(batch.Effects) != 1 ||
+		batch.Effects[0].Destination != "git_pull_requests" ||
+		batch.Effects[0].Recovery != EffectReadbackRequired ||
+		len(batch.Effects[0].Rows) != 1 {
+		t.Fatalf("effects=%+v", batch.Effects)
+	}
+
+	var row pullRequestRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &row); err != nil {
+		t.Fatal(err)
+	}
+	wantCreatedAt := time.Date(2026, 7, 10, 9, 0, 0, 0, time.UTC)
+	wantMergedAt := time.Date(2026, 7, 21, 15, 30, 0, 0, time.UTC)
+	switch {
+	case row.RepoID != "c7198fbc-1945-3717-05d8-eb78866b4e79":
+	case row.Number != 42:
+	case row.Title == nil || *row.Title != "Add widget support":
+	case row.Body == nil || *row.Body != "This PR adds widget support.":
+	case row.State != "merged":
+	case row.AuthorName != "octocat":
+	case row.AuthorEmail != nil:
+	case !row.CreatedAt.Equal(wantCreatedAt):
+	case row.MergedAt == nil || !row.MergedAt.Equal(wantMergedAt):
+	case row.ClosedAt == nil || !row.ClosedAt.Equal(wantMergedAt):
+	case row.HeadBranch == nil || *row.HeadBranch != "feature/widgets":
+	case row.BaseBranch == nil || *row.BaseBranch != "main":
+	case row.Additions != 120:
+	case row.Deletions != 30:
+	case row.ChangedFiles != 5:
+	case row.CommentsCount != 3:
+	case row.FirstReviewAt != nil:
+	case row.FirstCommentAt != nil:
+	case row.ChangesRequestedCount != 0:
+	case row.ReviewsCount != 0:
+	case row.OrgID != claim.OrgID:
+	case !row.LastSynced.Equal(now):
+	default:
+		return
+	}
+	t.Fatalf("row=%+v", row)
+}
+
+// TestGitHubPullRequestRouteAppliesWindowFilter is the same evidence as the
+// request-path assertion above, isolated to its own test so a future
+// refactor of TestGitHubPullRequestRouteEmitsOneBoundedEffect can't
+// accidentally drop window coverage.
+func TestGitHubPullRequestRouteAppliesWindowFilter(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	doer := &gitHubPullRequestDoer{t: t, bodies: defaultGitHubPullRequestFixtures()}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	batch, err := (GitHubPullRequestRouteHandler{
+		Now: func() time.Time { return now },
+	}).Collect(
+		context.Background(), nativeTestClaim("github", "prs"),
+		providerfoundation.Credential{}, client, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Evidence.Records != 1 {
+		t.Fatalf("records=%d want 1 (only #42 is inside the window)", batch.Evidence.Records)
+	}
+	for _, path := range doer.requests {
+		if path == "/repos/acme/api/pulls/41" || path == "/repos/acme/api/pulls/43" {
+			t.Fatalf("fetched detail for an out-of-window PR: %s", path)
+		}
+	}
+}
+
+// TestGitHubPullRequestRouteFailsClosedOnPaginationCap is codex H2: an
+// unbounded Python collector would keep paging past 100 pages, so a capped
+// Go fetch must fail the whole unit rather than report success with a
+// partial page set and still advance claim.BeforeAt as the watermark --
+// which would silently and permanently strand every PR past the cap, since
+// no later incremental run revisits a window the watermark already passed.
+func TestGitHubPullRequestRouteFailsClosedOnPaginationCap(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	doer := &gitHubPullRequestPagingDoer{t: t, totalPages: 3}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	batch, err := (GitHubPullRequestRouteHandler{
+		Now: func() time.Time { return now }, MaxPages: 2,
+	}).Collect(
+		context.Background(), nativeTestClaim("github", "prs"),
+		providerfoundation.Credential{}, client, now,
+	)
+	if err != ErrPaginationCapExceeded {
+		t.Fatalf("error=%v want ErrPaginationCapExceeded", err)
+	}
+	if batch.Watermark != nil {
+		t.Fatalf("watermark=%v want nil: a capped fetch must never advance it", batch.Watermark)
+	}
+	// Uncapped (MaxPages covers every page) must succeed normally.
+	uncappedDoer := &gitHubPullRequestPagingDoer{t: t, totalPages: 3}
+	uncappedClient := gitHubPullRequestClient(t, uncappedDoer, "https://api.github.com")
+	if _, err := (GitHubPullRequestRouteHandler{
+		Now: func() time.Time { return now }, MaxPages: 5,
+	}).Collect(
+		context.Background(), nativeTestClaim("github", "prs"),
+		providerfoundation.Credential{}, uncappedClient, now,
+	); err != nil {
+		t.Fatalf("uncapped fetch error=%v want nil", err)
+	}
+}
+
+// gitHubPullRequestPagingDoer serves `totalPages` pages of one PR each (all
+// with an updated_at inside nativeTestClaim's window) via the Link header,
+// plus the repo GET and every /pulls/{number} detail GET.
+type gitHubPullRequestPagingDoer struct {
+	t          *testing.T
+	totalPages int
+	page       int
+}
+
+func (doer *gitHubPullRequestPagingDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	path := request.URL.Path
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	switch {
+	case path == "/repos/acme/api":
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: header,
+			Body: io.NopCloser(strings.NewReader(gitHubPullRequestRepoFixture)), Request: request,
+		}, nil
+	case path == "/repos/acme/api/pulls":
+		doer.page++
+		number := doer.page
+		body := `[{"number": ` + strconv.Itoa(number) +
+			`, "updated_at": "2026-07-21T15:30:00Z"}]`
+		if doer.page < doer.totalPages {
+			header.Set("Link", `<https://api.github.com/repos/acme/api/pulls?page=`+
+				strconv.Itoa(doer.page+1)+`>; rel="next"`)
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: header,
+			Body: io.NopCloser(strings.NewReader(body)), Request: request,
+		}, nil
+	default:
+		// Any /pulls/{number} detail request.
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: header,
+			Body:    io.NopCloser(strings.NewReader(gitHubPullRequestDetailFixture42)),
+			Request: request,
+		}, nil
+	}
+}
+
+// TestFilterGitHubPullWindowClauseCoverage mutation-tests
+// pullOutsideKnownWindow's three clauses independently (codex H3): each
+// sub-test isolates exactly one of "is updated_at known", "is it before
+// since", "is it after before" so a coverage gap in any single clause
+// cannot hide behind the other two already being satisfied in the same
+// case -- the failure mode the shared mutation harness's "mutate compound
+// predicates clause by clause" rule exists to catch.
+func TestFilterGitHubPullWindowClauseCoverage(t *testing.T) {
+	t.Parallel()
+	since := time.Date(2026, 7, 1, 0, 0, 0, 0, time.UTC)
+	before := time.Date(2026, 7, 31, 23, 59, 59, 0, time.UTC)
+	claim := Claim{Unit: Unit{SinceAt: &since, BeforeAt: &before}}
+
+	for name, test := range map[string]struct {
+		updatedAt time.Time
+		want      bool
+	}{
+		"unknown updated_at is never excluded (H3's fix)": {
+			time.Time{}, false,
+		},
+		"known, inside the window": {
+			time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC), false,
+		},
+		"known, exactly at since (inclusive)": {
+			since, false,
+		},
+		"known, exactly at before (inclusive)": {
+			before, false,
+		},
+		"known, before since": {
+			time.Date(2026, 6, 30, 0, 0, 0, 0, time.UTC), true,
+		},
+		"known, after before": {
+			time.Date(2026, 8, 1, 0, 0, 0, 0, time.UTC), true,
+		},
+	} {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := pullOutsideKnownWindow(test.updatedAt, claim); got != test.want {
+				t.Errorf("pullOutsideKnownWindow = %v want %v", got, test.want)
+			}
+		})
+	}
+
+	// Clause isolation: SinceAt-only and BeforeAt-only claims, so the
+	// "before" and "after" clauses are each provable with the OTHER bound
+	// entirely absent -- a mutation that only fires when both bounds are
+	// set (e.g. an accidental `&&` between the two comparisons) cannot hide
+	// behind the paired-bound cases above.
+	sinceOnly := Claim{Unit: Unit{SinceAt: &since}}
+	if pullOutsideKnownWindow(time.Date(2026, 6, 1, 0, 0, 0, 0, time.UTC), sinceOnly) != true {
+		t.Error("since-only claim: an item before `since` must be excluded")
+	}
+	if pullOutsideKnownWindow(time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC), sinceOnly) != false {
+		t.Error("since-only claim: an item far in the future must not be excluded")
+	}
+	beforeOnly := Claim{Unit: Unit{BeforeAt: &before}}
+	if pullOutsideKnownWindow(time.Date(2099, 1, 1, 0, 0, 0, 0, time.UTC), beforeOnly) != true {
+		t.Error("before-only claim: an item after `before` must be excluded")
+	}
+	if pullOutsideKnownWindow(time.Date(2000, 1, 1, 0, 0, 0, 0, time.UTC), beforeOnly) != false {
+		t.Error("before-only claim: an item far in the past must not be excluded")
+	}
+}
+
+func TestGitHubPullRequestRouteFailsClosedOnScopeAndPayloadFaults(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	handler := GitHubPullRequestRouteHandler{Now: func() time.Time { return now }}
+	client := gitHubPullRequestClient(
+		t, &gitHubPullRequestDoer{t: t, bodies: defaultGitHubPullRequestFixtures()},
+		"https://api.github.com",
+	)
+	for name, claim := range map[string]Claim{
+		"wrong dataset":  nativeTestClaim("github", "repo-metadata"),
+		"wrong provider": nativeTestClaim("gitlab", "prs"),
+	} {
+		if _, err := handler.Collect(
+			context.Background(), claim, providerfoundation.Credential{}, client, now,
+		); err != ErrInvalidConfiguration {
+			t.Errorf("%s error=%v", name, err)
+		}
+	}
+
+	malformedList := gitHubPullRequestClient(t, &gitHubPullRequestDoer{
+		t: t, bodies: map[string]string{
+			"/repos/acme/api":       gitHubPullRequestRepoFixture,
+			"/repos/acme/api/pulls": `[{"number":"not-a-number"}]`,
+		},
+	}, "https://api.github.com")
+	if _, err := handler.Collect(
+		context.Background(), nativeTestClaim("github", "prs"),
+		providerfoundation.Credential{}, malformedList, now,
+	); err == nil {
+		t.Error("malformed PR list item was accepted")
+	}
+
+	malformedRepo := gitHubPullRequestClient(t, &gitHubPullRequestDoer{
+		t: t, bodies: map[string]string{
+			"/repos/acme/api":       `{"id":"not-a-number"}`,
+			"/repos/acme/api/pulls": `[]`,
+		},
+	}, "https://api.github.com")
+	if _, err := handler.Collect(
+		context.Background(), nativeTestClaim("github", "prs"),
+		providerfoundation.Credential{}, malformedRepo, now,
+	); err == nil {
+		t.Error("malformed repository payload was accepted")
+	}
+
+	// codex H4: a repository payload with no full_name MUST fail closed, not
+	// fall back to claim.SourceExternalID. Python's get_repo_uuid_from_repo
+	// raises on a falsy repo string and models/git.py::Repo.__init__ never
+	// even attempts the call, leaving `id` unset; every downstream
+	// ClickHouse insert then raises on that None. Falling back here would
+	// write PRs under a repo_id nothing else in the system would derive --
+	// this test previously blessed exactly that divergence and is now
+	// inverted to require the fail-closed behavior.
+	noFullName := gitHubPullRequestClient(t, &gitHubPullRequestDoer{
+		t: t, bodies: map[string]string{
+			"/repos/acme/api":       `{"id":4567}`,
+			"/repos/acme/api/pulls": `[]`,
+		},
+	}, "https://api.github.com")
+	if _, err := handler.Collect(
+		context.Background(), nativeTestClaim("github", "prs"),
+		providerfoundation.Credential{}, noFullName, now,
+	); err == nil {
+		t.Error("repository payload with no full_name was accepted " +
+			"(must fail closed, not guess claim.SourceExternalID)")
+	}
+}
+
+// TestGitHubPullRequestRoutePreservesEnterpriseBasePath is the GHE
+// regression, mirroring TestGitHubRepositoryRoutePreservesEnterpriseBasePath:
+// an absolute request path would replace a configured /api/v3 prefix instead
+// of extending it.
+func TestGitHubPullRequestRoutePreservesEnterpriseBasePath(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	doer := &gitHubPullRequestDoer{t: t, bodies: map[string]string{
+		"/api/v3/repos/acme/api":          gitHubPullRequestRepoFixture,
+		"/api/v3/repos/acme/api/pulls":    gitHubPullRequestListFixture,
+		"/api/v3/repos/acme/api/pulls/42": gitHubPullRequestDetailFixture42,
+	}}
+	client := gitHubPullRequestClient(t, doer, "https://ghe.acme.test/api/v3")
+	batch, err := (GitHubPullRequestRouteHandler{
+		Now: func() time.Time { return now },
+	}).Collect(
+		context.Background(), nativeTestClaim("github", "prs"),
+		providerfoundation.Credential{}, client, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if batch.Evidence.Records != 1 {
+		t.Fatalf("records=%d want 1", batch.Evidence.Records)
+	}
+}
+
+// TestNormalizePRStateMatchesPython is a byte-for-byte port of
+// providers/pr_state.py::normalize_pr_state's own semantics -- every branch
+// pinned by an independent run of the Python function.
+//
+//	>>> from dev_health_ops.providers.pr_state import normalize_pr_state
+//	>>> from datetime import datetime, timezone
+//	>>> mergedAt = datetime(2026, 1, 1, tzinfo=timezone.utc)
+//	>>> [normalize_pr_state(s, m) for s, m in [
+//	...     ("open", None), ("opened", None), ("OPEN", None),
+//	...     ("closed", None), ("closed", mergedAt), ("merged", None),
+//	...     ("MERGED", None), ("", None), (None, None), ("unknown", None),
+//	... ]]
+//	['open', 'open', 'open', 'closed', 'merged', 'merged', 'merged', 'open', 'open', 'open']
+func TestNormalizePRStateMatchesPython(t *testing.T) {
+	t.Parallel()
+	mergedAt := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	for name, test := range map[string]struct {
+		raw      string
+		mergedAt *time.Time
+		want     string
+	}{
+		"open":                  {"open", nil, "open"},
+		"opened normalizes":     {"opened", nil, "open"},
+		"case insensitive":      {"OPEN", nil, "open"},
+		"closed unmerged":       {"closed", nil, "closed"},
+		"closed merged":         {"closed", &mergedAt, "merged"},
+		"merged literal":        {"merged", nil, "merged"},
+		"merged case":           {"MERGED", nil, "merged"},
+		"empty defaults open":   {"", nil, "open"},
+		"unknown defaults open": {"unknown", nil, "open"},
+		"whitespace tolerant":   {"  closed  ", &mergedAt, "merged"},
+	} {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := normalizePRState(test.raw, test.mergedAt); got != test.want {
+				t.Errorf("normalizePRState(%q) = %q want %q", test.raw, got, test.want)
+			}
+		})
+	}
+}
+
+// TestGitHubPullRequestCoerceCreatedAtFallsBackLikePython mirrors
+// BaseGitProcessor.coerce_created_at: created_at or merged_at or closed_at or
+// now().
+func TestGitHubPullRequestCoerceCreatedAtFallsBackLikePython(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	claim := nativeTestClaim("github", "prs")
+
+	// No created_at, no merged_at: falls back to closed_at.
+	closedAt := "2026-07-15T00:00:00Z"
+	row, err := normalizeGitHubPullRequest(claim, "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		gitHubPullDetailPayload{Number: 7, State: strPtr("closed"), ClosedAt: &closedAt},
+		now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	want := time.Date(2026, 7, 15, 0, 0, 0, 0, time.UTC)
+	if !row.CreatedAt.Equal(want) {
+		t.Fatalf("created_at=%v want %v (fallback to closed_at)", row.CreatedAt, want)
+	}
+
+	// No created_at, no merged_at, no closed_at: falls back to normalizedAt.
+	row, err = normalizeGitHubPullRequest(claim, "c7198fbc-1945-3717-05d8-eb78866b4e79",
+		gitHubPullDetailPayload{Number: 8, State: strPtr("open")}, now,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !row.CreatedAt.Equal(now) {
+		t.Fatalf("created_at=%v want normalizedAt=%v", row.CreatedAt, now)
+	}
+}
+
+func strPtr(value string) *string { return &value }
+
+// TestParseGitHubPullTimeTruncatesToMilliseconds is codex M5: ClickHouse
+// persists DateTime64(3), so a provider timestamp with sub-millisecond
+// precision must be truncated at construction time or a later readback
+// (which only ever sees millisecond precision) would compare unequal to the
+// in-memory value and report a false conflict.
+func TestParseGitHubPullTimeTruncatesToMilliseconds(t *testing.T) {
+	t.Parallel()
+	value := "2026-07-10T09:00:00.123456789Z"
+	got := parseGitHubPullTime(&value)
+	if got == nil {
+		t.Fatal("parseGitHubPullTime returned nil")
+	}
+	want := time.Date(2026, 7, 10, 9, 0, 0, 123_000_000, time.UTC)
+	if !got.Equal(want) {
+		t.Fatalf("parseGitHubPullTime(%q) = %v want %v (truncated to ms)", value, got, want)
+	}
+	if got.Nanosecond()%int(time.Millisecond) != 0 {
+		t.Fatalf("parseGitHubPullTime(%q) retained sub-millisecond precision: %v", value, got)
+	}
+}
+
+// TestGitHubPullUserLoginStringifiesNonStringLogins is codex M8: Python's
+// _pull_from_item does `str(user["login"])` for ANY non-null login value,
+// not only a string one. Decoding straight into a Go `string` field makes
+// json.Unmarshal fail (and silently fall back to "Unknown") for a numeric
+// login, which Python would have stringified and kept.
+func TestGitHubPullUserLoginStringifiesNonStringLogins(t *testing.T) {
+	t.Parallel()
+	for name, test := range map[string]struct {
+		raw  string
+		want string
+	}{
+		"string login":      {`{"login":"octocat"}`, "octocat"},
+		"numeric login":     {`{"login":12345}`, "12345"},
+		"null login":        {`{"login":null}`, ""},
+		"absent login":      {`{}`, ""},
+		"user is JSON null": {`null`, ""},
+	} {
+		test := test
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+			if got := gitHubPullUserLogin([]byte(test.raw)); got != test.want {
+				t.Errorf("gitHubPullUserLogin(%s) = %q want %q", test.raw, got, test.want)
+			}
+		})
+	}
+}

--- a/internal/providersync/github_prs_route_test.go
+++ b/internal/providersync/github_prs_route_test.go
@@ -270,6 +270,98 @@ func TestGitHubPullRequestRouteFailsClosedOnPaginationCap(t *testing.T) {
 	}
 }
 
+// TestGitHubPullRequestRouteStopsPaginatingAtTheSinceBoundary is codex H1's
+// first half: a repository whose TOTAL history spans more pages than
+// MaxPages must still succeed as long as only ONE page falls inside the
+// claim's window -- code_client.py's iter_pulls stops the moment a listed
+// item's updated_at (sort=updated&direction=desc) is known and older than
+// `since`, so Python never pays for, or is limited by, the pages beyond
+// that point. Page 1 here holds one in-window PR followed by one
+// ancient PR that crosses the since boundary; pages 2 and 3 hold only
+// further ancient PRs and must never be requested at all.
+func TestGitHubPullRequestRouteStopsPaginatingAtTheSinceBoundary(t *testing.T) {
+	t.Parallel()
+	now := time.Date(2026, 7, 23, 12, 30, 0, 0, time.UTC)
+	doer := &gitHubPullRequestDeepHistoryDoer{t: t, ancientPages: 2}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	claim := nativeTestClaim("github", "prs") // since=2026-07-01, before=2026-07-31
+	batch, err := (GitHubPullRequestRouteHandler{
+		Now: func() time.Time { return now }, MaxPages: 2,
+	}).Collect(context.Background(), claim, providerfoundation.Credential{}, client, now)
+	if err != nil {
+		t.Fatalf("Collect error=%v want nil: a deep-history repo with only "+
+			"one page inside the window must not cap", err)
+	}
+	if batch.Evidence.CapReached {
+		t.Fatal("CapReached=true: the early stop did not fire before the cap")
+	}
+	if batch.Evidence.Records != 1 {
+		t.Fatalf("records=%d want 1 (only the in-window PR)", batch.Evidence.Records)
+	}
+	for _, path := range doer.requests {
+		if path == "/repos/acme/api/pulls/2" {
+			t.Fatalf("fetched detail for the ancient PR: %s", path)
+		}
+	}
+	if doer.listPagesServed != 1 {
+		t.Fatalf("list pages served=%d want 1: pages 2/3 must never be requested "+
+			"once the since boundary is crossed on page 1", doer.listPagesServed)
+	}
+}
+
+// gitHubPullRequestDeepHistoryDoer serves one page holding [in-window PR
+// #1, ancient PR #2 whose updated_at is older than nativeTestClaim's
+// since], followed by `ancientPages` further pages of nothing but more
+// ancient PRs and a "next" Link header -- pages a correct implementation
+// must never request.
+type gitHubPullRequestDeepHistoryDoer struct {
+	t               *testing.T
+	ancientPages    int
+	listPagesServed int
+	requests        []string
+}
+
+func (doer *gitHubPullRequestDeepHistoryDoer) Do(request *http.Request) (*http.Response, error) {
+	doer.t.Helper()
+	path := request.URL.Path
+	doer.requests = append(doer.requests, path)
+	header := http.Header{"Content-Type": []string{"application/json"}}
+	switch {
+	case path == "/repos/acme/api":
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: header,
+			Body: io.NopCloser(strings.NewReader(gitHubPullRequestRepoFixture)), Request: request,
+		}, nil
+	case path == "/repos/acme/api/pulls":
+		doer.listPagesServed++
+		var body string
+		if doer.listPagesServed == 1 {
+			body = `[{"number": 1, "updated_at": "2026-07-15T00:00:00Z"},` +
+				`{"number": 2, "updated_at": "2020-01-01T00:00:00Z"}]`
+			// A "next" link is present -- it must never be followed, since
+			// the since boundary is crossed by PR #2 on THIS page.
+			header.Set("Link", `<https://api.github.com/repos/acme/api/pulls?page=2>; rel="next"`)
+		} else {
+			body = `[{"number": 999, "updated_at": "2019-01-01T00:00:00Z"}]`
+			if doer.listPagesServed-1 < doer.ancientPages {
+				header.Set("Link", `<https://api.github.com/repos/acme/api/pulls?page=`+
+					strconv.Itoa(doer.listPagesServed+1)+`>; rel="next"`)
+			}
+		}
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: header,
+			Body: io.NopCloser(strings.NewReader(body)), Request: request,
+		}, nil
+	default:
+		// /pulls/1 detail (the only PR that should ever be detail-fetched).
+		return &http.Response{
+			StatusCode: http.StatusOK, Header: header,
+			Body:    io.NopCloser(strings.NewReader(gitHubPullRequestDetailFixture42)),
+			Request: request,
+		}, nil
+	}
+}
+
 // gitHubPullRequestPagingDoer serves `totalPages` pages of one PR each (all
 // with an updated_at inside nativeTestClaim's window) via the Link header,
 // plus the repo GET and every /pulls/{number} detail GET.
@@ -572,22 +664,67 @@ func TestParseGitHubPullTimeTruncatesToMilliseconds(t *testing.T) {
 	}
 }
 
-// TestGitHubPullUserLoginStringifiesNonStringLogins is codex M8: Python's
-// _pull_from_item does `str(user["login"])` for ANY non-null login value,
-// not only a string one. Decoding straight into a Go `string` field makes
-// json.Unmarshal fail (and silently fall back to "Unknown") for a numeric
-// login, which Python would have stringified and kept.
+// TestGitHubPullRequestRouteTruncatesNormalizedAtToMilliseconds is codex M5's
+// follow-up: `last_synced` (and created_at's now() fallback) come from
+// Collect's OWN `normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)`
+// line -- a SEPARATE truncation point from parseGitHubPullTime's, which only
+// covers provider-supplied created_at/merged_at/closed_at. Every other test
+// in this file constructs `now` with zero sub-second precision
+// (`time.Date(..., 0, time.UTC)`), so removing Collect's own truncate call
+// would be invisible to them: truncating an already-round value is a no-op.
+// This test exists specifically so that gap has a fixture -- codex flagged
+// that the mutation plan would have let a deleted truncation survive for
+// exactly this reason.
+func TestGitHubPullRequestRouteTruncatesNormalizedAtToMilliseconds(t *testing.T) {
+	t.Parallel()
+	subMillisecondNow := time.Date(2026, 7, 23, 12, 30, 0, 123_456_789, time.UTC)
+	doer := &gitHubPullRequestDoer{t: t, bodies: defaultGitHubPullRequestFixtures()}
+	client := gitHubPullRequestClient(t, doer, "https://api.github.com")
+	batch, err := (GitHubPullRequestRouteHandler{
+		Now: func() time.Time { return subMillisecondNow },
+	}).Collect(
+		context.Background(), nativeTestClaim("github", "prs"),
+		providerfoundation.Credential{}, client, subMillisecondNow,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var row pullRequestRow
+	if err := json.Unmarshal(batch.Effects[0].Rows[0], &row); err != nil {
+		t.Fatal(err)
+	}
+	wantLastSynced := time.Date(2026, 7, 23, 12, 30, 0, 123_000_000, time.UTC)
+	if !row.LastSynced.Equal(wantLastSynced) {
+		t.Fatalf("last_synced=%v want %v (truncated to ms)", row.LastSynced, wantLastSynced)
+	}
+	if row.LastSynced.Nanosecond()%int(time.Millisecond) != 0 {
+		t.Fatalf("last_synced retained sub-millisecond precision: %v", row.LastSynced)
+	}
+}
+
+// TestGitHubPullUserLoginStringifiesNonStringLogins is codex M8 (and M4's
+// follow-up on it): Python's _pull_from_item does `str(user["login"])` for
+// ANY non-null login value, not only a numeric one. codex M4 found that an
+// earlier version of this test claimed "ANY non-null" while covering only
+// an integer -- stringValue's own switch handled numbers but fell through
+// to "" for a boolean, silently different from Python's str(True)=="True".
+// This table now genuinely covers every JSON scalar type a login could
+// plausibly be: string, number, and boolean. list/dict/null are
+// deliberately NOT claimed here -- see stringValue's own doc comment for
+// why those are out of scope rather than silently unhandled.
 func TestGitHubPullUserLoginStringifiesNonStringLogins(t *testing.T) {
 	t.Parallel()
 	for name, test := range map[string]struct {
 		raw  string
 		want string
 	}{
-		"string login":      {`{"login":"octocat"}`, "octocat"},
-		"numeric login":     {`{"login":12345}`, "12345"},
-		"null login":        {`{"login":null}`, ""},
-		"absent login":      {`{}`, ""},
-		"user is JSON null": {`null`, ""},
+		"string login":          {`{"login":"octocat"}`, "octocat"},
+		"numeric login":         {`{"login":12345}`, "12345"},
+		"boolean login (true)":  {`{"login":true}`, "True"},
+		"boolean login (false)": {`{"login":false}`, "False"},
+		"null login":            {`{"login":null}`, ""},
+		"absent login":          {`{}`, ""},
+		"user is JSON null":     {`null`, ""},
 	} {
 		test := test
 		t.Run(name, func(t *testing.T) {

--- a/internal/providersync/github_prs_window_oracle_test.go
+++ b/internal/providersync/github_prs_window_oracle_test.go
@@ -1,0 +1,148 @@
+package providersync
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+// This file wires the (github, prs) list-inclusion-decision boundary
+// (pullOutsideKnownWindow / pullCrossedSinceBoundary, both
+// github_prs_route.go) to the "github/prs/window" pair registered in
+// testdata/oracle_pairs/github_prs_window.py. See that file's module
+// docstring for why this pair's Python side is a pinned, freshness-checked
+// copy rather than a live execution of _collect_github_pr_objects (unlike
+// github_prs_row.py) -- a documented, narrower scope, not a silent one.
+
+func windowDecisionOracleCase(id string, updatedAt, since, until *string) oracleCase {
+	input := map[string]any{}
+	if updatedAt != nil {
+		input["updated_at"] = *updatedAt
+	} else {
+		input["updated_at"] = nil
+	}
+	if since != nil {
+		input["since"] = *since
+	} else {
+		input["since"] = nil
+	}
+	if until != nil {
+		input["until"] = *until
+	} else {
+		input["until"] = nil
+	}
+	return oracleCase{ID: id, Input: input}
+}
+
+func windowOracleTime(value string) *string { return &value }
+
+func windowDecisionOracleCases() []oracleCase {
+	return []oracleCase{
+		windowDecisionOracleCase(
+			"included_in_window",
+			windowOracleTime("2026-07-10T09:00:00Z"),
+			windowOracleTime("2026-07-01T00:00:00Z"), windowOracleTime("2026-07-31T23:59:59Z"),
+		),
+		windowDecisionOracleCase(
+			"after_until_skip_only",
+			windowOracleTime("2026-08-01T00:00:00Z"),
+			windowOracleTime("2026-07-01T00:00:00Z"), windowOracleTime("2026-07-31T23:59:59Z"),
+		),
+		windowDecisionOracleCase(
+			"before_since_stop",
+			windowOracleTime("2026-06-01T00:00:00Z"),
+			windowOracleTime("2026-07-01T00:00:00Z"), windowOracleTime("2026-07-31T23:59:59Z"),
+		),
+		// codex H3: the case the pre-fix Go code got wrong -- updated_at
+		// unknown, since/until both set. Python's isinstance(updated_at,
+		// datetime) guard means BOTH comparisons are skipped, so this item
+		// is unconditionally included and iteration continues; it is
+		// neither excluded nor a stop signal.
+		windowDecisionOracleCase(
+			"null_updated_at_included",
+			nil,
+			windowOracleTime("2026-07-01T00:00:00Z"), windowOracleTime("2026-07-31T23:59:59Z"),
+		),
+		windowDecisionOracleCase(
+			"no_window_bounds",
+			windowOracleTime("2026-07-10T09:00:00Z"),
+			nil, nil,
+		),
+	}
+}
+
+// buildWindowDecisionForOracle is the (correct, current, production)
+// Go-side decision builder: parses the case's inputs into exactly the
+// values Collect/filterGitHubPullWindow would have (a time.Time and a
+// Claim), then calls the REAL, current pullOutsideKnownWindow and
+// pullCrossedSinceBoundary.
+func buildWindowDecisionForOracle(
+	t *testing.T,
+	input map[string]any,
+	outsideWindow func(time.Time, Claim) bool,
+	crossedBoundary func(json.RawMessage, Claim) bool,
+) map[string]any {
+	t.Helper()
+	updatedAtStr, _ := input["updated_at"].(string)
+	updatedAt := firstTime(updatedAtStr)
+
+	claim := Claim{}
+	if sinceStr, ok := input["since"].(string); ok {
+		since := firstTime(sinceStr)
+		claim.SinceAt = &since
+	}
+	if untilStr, ok := input["until"].(string); ok {
+		until := firstTime(untilStr)
+		claim.BeforeAt = &until
+	}
+
+	excluded := outsideWindow(updatedAt, claim)
+
+	rawItem, err := json.Marshal(gitHubPullListItem{Number: 1, UpdatedAt: updatedAtStr})
+	if err != nil {
+		t.Fatalf("marshal synthetic list item: %v", err)
+	}
+	stop := crossedBoundary(rawItem, claim)
+
+	return map[string]any{"excluded": excluded, "stop": stop}
+}
+
+// TestGenericOracleMatchesLivePythonForWindowDecision is the "current code
+// is clean" half for this boundary.
+func TestGenericOracleMatchesLivePythonForWindowDecision(t *testing.T) {
+	builder := func(t *testing.T, input map[string]any) map[string]any {
+		return buildWindowDecisionForOracle(t, input, pullOutsideKnownWindow, pullCrossedSinceBoundary)
+	}
+	compareRowsAgainstPythonOracle(t, "github/prs/window", windowDecisionOracleCases(), builder, nil)
+}
+
+// buggyPullOutsideKnownWindowExcludesUnknown reproduces the exact pre-H3-fix
+// defect: a missing/unparseable updated_at was treated as OUTSIDE the
+// window (excluded) instead of unconditionally included -- the "empty
+// success" trap named in the H3 doc comment on pullOutsideKnownWindow.
+func buggyPullOutsideKnownWindowExcludesUnknown(updatedAt time.Time, claim Claim) bool {
+	windowKnown := !updatedAt.IsZero()
+	if !windowKnown {
+		return true // pre-fix: treated "unknown" as "excluded", not "included"
+	}
+	before := claim.SinceAt != nil && updatedAt.Before(claim.SinceAt.UTC())
+	after := claim.BeforeAt != nil && updatedAt.After(claim.BeforeAt.UTC())
+	return before || after
+}
+
+// TestGenericOracleRediscoversWindowGuardDefect is CHAOS-3162's acceptance
+// gate for the list-inclusion-decision boundary: the same generic
+// comparator, cases, and pair id, but with the pre-H3-fix decision function
+// substituted, must report a divergence on the null-updated_at case.
+func TestGenericOracleRediscoversWindowGuardDefect(t *testing.T) {
+	cases := windowDecisionOracleCases()
+	buggyBuilder := func(t *testing.T, input map[string]any) map[string]any {
+		return buildWindowDecisionForOracle(
+			t, input, buggyPullOutsideKnownWindowExcludesUnknown, pullCrossedSinceBoundary,
+		)
+	}
+	requireOracleRediscovers(
+		t, "rediscovers pre-H3 null-updated_at window guard bug",
+		"github/prs/window", cases, buggyBuilder, nil,
+	)
+}

--- a/internal/providersync/github_prs_window_oracle_test.go
+++ b/internal/providersync/github_prs_window_oracle_test.go
@@ -68,6 +68,39 @@ func windowDecisionOracleCases() []oracleCase {
 			windowOracleTime("2026-07-10T09:00:00Z"),
 			nil, nil,
 		),
+		// codex adversarial review (CHAOS-3162, fourth round): every case
+		// above sets BOTH since and until, so a Python regression coupling
+		// the two independent checks into one conjunction (e.g. `if until
+		// is not None and since is not None:` instead of two separate
+		// `if`s) preserves every one of those results while silently
+		// breaking a since-only or until-only claim -- an accidental "and"
+		// where two unrelated existence checks belong is exactly the kind
+		// of thing a table missing single-bound cases cannot see. These
+		// four close that gap: two isolate each bound alone (the other
+		// bound entirely absent, not just outside its own reach), two pin
+		// the exact boundary value on each bound (Python's own comparisons
+		// are strict `<`/`>`, so the boundary itself is INSIDE the window
+		// -- a `<`->`<=` or `>`->`>=` regression flips exactly these two).
+		windowDecisionOracleCase(
+			"since_only_excludes_and_stops",
+			windowOracleTime("2026-06-01T00:00:00Z"),
+			windowOracleTime("2026-07-01T00:00:00Z"), nil,
+		),
+		windowDecisionOracleCase(
+			"until_only_excludes_without_stop",
+			windowOracleTime("2026-08-15T00:00:00Z"),
+			nil, windowOracleTime("2026-07-31T23:59:59Z"),
+		),
+		windowDecisionOracleCase(
+			"at_since_boundary_included",
+			windowOracleTime("2026-07-01T00:00:00Z"),
+			windowOracleTime("2026-07-01T00:00:00Z"), windowOracleTime("2026-07-31T23:59:59Z"),
+		),
+		windowDecisionOracleCase(
+			"at_until_boundary_included",
+			windowOracleTime("2026-07-31T23:59:59Z"),
+			windowOracleTime("2026-07-01T00:00:00Z"), windowOracleTime("2026-07-31T23:59:59Z"),
+		),
 	}
 }
 

--- a/internal/providersync/github_prs_window_oracle_test.go
+++ b/internal/providersync/github_prs_window_oracle_test.go
@@ -71,6 +71,18 @@ func windowDecisionOracleCases() []oracleCase {
 	}
 }
 
+// windowDecisionResult is the concrete, complete result type for the
+// "github/prs/window" pair: exactly the two fields _decide's own
+// `return {"excluded": ..., "stop": ...}` literal can emit (per
+// github_prs_window.py's reflected_fields). Returning this struct (not a
+// hand-built map[string]any) is what makes the Go side's completeness a
+// compiler guarantee rather than a runtime choice (codex finding #1) --
+// see oracle_compare_test.go's typedEncode doc comment.
+type windowDecisionResult struct {
+	Excluded bool `json:"excluded"`
+	Stop     bool `json:"stop"`
+}
+
 // buildWindowDecisionForOracle is the (correct, current, production)
 // Go-side decision builder: parses the case's inputs into exactly the
 // values Collect/filterGitHubPullWindow would have (a time.Time and a
@@ -81,7 +93,7 @@ func buildWindowDecisionForOracle(
 	input map[string]any,
 	outsideWindow func(time.Time, Claim) bool,
 	crossedBoundary func(json.RawMessage, Claim) bool,
-) map[string]any {
+) windowDecisionResult {
 	t.Helper()
 	updatedAtStr, _ := input["updated_at"].(string)
 	updatedAt := firstTime(updatedAtStr)
@@ -104,13 +116,13 @@ func buildWindowDecisionForOracle(
 	}
 	stop := crossedBoundary(rawItem, claim)
 
-	return map[string]any{"excluded": excluded, "stop": stop}
+	return windowDecisionResult{Excluded: excluded, Stop: stop}
 }
 
 // TestGenericOracleMatchesLivePythonForWindowDecision is the "current code
 // is clean" half for this boundary.
 func TestGenericOracleMatchesLivePythonForWindowDecision(t *testing.T) {
-	builder := func(t *testing.T, input map[string]any) map[string]any {
+	builder := func(t *testing.T, input map[string]any) windowDecisionResult {
 		return buildWindowDecisionForOracle(t, input, pullOutsideKnownWindow, pullCrossedSinceBoundary)
 	}
 	compareRowsAgainstPythonOracle(t, "github/prs/window", windowDecisionOracleCases(), builder, nil)
@@ -136,7 +148,7 @@ func buggyPullOutsideKnownWindowExcludesUnknown(updatedAt time.Time, claim Claim
 // substituted, must report a divergence on the null-updated_at case.
 func TestGenericOracleRediscoversWindowGuardDefect(t *testing.T) {
 	cases := windowDecisionOracleCases()
-	buggyBuilder := func(t *testing.T, input map[string]any) map[string]any {
+	buggyBuilder := func(t *testing.T, input map[string]any) windowDecisionResult {
 		return buildWindowDecisionForOracle(
 			t, input, buggyPullOutsideKnownWindowExcludesUnknown, pullCrossedSinceBoundary,
 		)

--- a/internal/providersync/launchdarkly_route.go
+++ b/internal/providersync/launchdarkly_route.go
@@ -510,6 +510,18 @@ func valueOr(value, fallback string) string {
 	return fallback
 }
 
+// stringValue mirrors Python's str(value) for the JSON scalar types a
+// provider API can plausibly return in a field a Python caller stringifies
+// unconditionally (e.g. code_client.py::_pull_from_item's
+// `str(user["login"])`). codex M4: an earlier version handled only string
+// and numeric values, so a boolean JSON value (`{"login": true}`) fell
+// through to the "" default -- silently different from Python's
+// `str(True) == "True"`. list/dict/null are intentionally NOT covered: they
+// are not realistic shapes for the fields this function is used on (a
+// GitHub username, a LaunchDarkly flag key), and matching Python's
+// str([...])/str({...}) pixel-for-pixel for those would be effort spent on
+// inputs that cannot occur in practice; null already means "absent" to
+// every caller (Python's own `is not None` guards it the same way).
 func stringValue(value any) string {
 	switch typed := value.(type) {
 	case string:
@@ -518,6 +530,13 @@ func stringValue(value any) string {
 		return typed.String()
 	case float64:
 		return strconv.FormatFloat(typed, 'f', -1, 64)
+	case bool:
+		// Python's str(True)/str(False) are capitalized, unlike Go's
+		// strconv.FormatBool("true"/"false").
+		if typed {
+			return "True"
+		}
+		return "False"
 	default:
 		return ""
 	}

--- a/internal/providersync/lease.go
+++ b/internal/providersync/lease.go
@@ -26,6 +26,17 @@ var (
 	ErrRepositoryIdentityAmbiguous = errors.New(
 		"provider sync repository identity cannot be proven identical to the Python derivation",
 	)
+	// ErrPaginationCapExceeded means a paginated fetch hit its page cap
+	// before reaching the end of the provider's result set (codex H2). A
+	// capped fetch must never be reported as a successful, complete unit: an
+	// unbounded Python collector would have kept paging, so a capped Go
+	// fetch that still returns success and still advances the watermark
+	// silently and permanently loses every record past the cap -- no later
+	// incremental run recovers them, because the window has already moved
+	// past where they were.
+	ErrPaginationCapExceeded = errors.New(
+		"provider sync paginated fetch hit its page cap before completion",
+	)
 )
 
 type Unit struct {

--- a/internal/providersync/oracle_compare_test.go
+++ b/internal/providersync/oracle_compare_test.go
@@ -499,7 +499,7 @@ func diffRows(
 				"case %q, field %q: present in Go's row (%v) but absent from "+
 					"Python's -- declare an exclusion with a reason if this is intentional, "+
 					"don't leave it silently missing", caseID, key, goValue))
-		case !reflect.DeepEqual(pythonValue, goValue):
+		case !typedValuesEqual(pythonValue, goValue):
 			messages = append(messages, fmt.Sprintf(
 				"case %q, field %q: python=%#v go=%#v", caseID, key, pythonValue, goValue))
 		}
@@ -511,6 +511,71 @@ func diffRows(
 				"over-broad exclusion list), not a pass", caseID)}
 	}
 	return messages
+}
+
+// typedValuesEqual compares two type-tagged leaf values (codex adversarial
+// review, CHAOS-3162 fourth round). Plain reflect.DeepEqual on the {"t":
+// ..., "v": "<string>"} envelope is exactly right for str/int/bool -- those
+// three types each have exactly one canonical string form on both sides
+// (an int's digit sequence, a bool's "true"/"false", a string verbatim) --
+// but it is WRONG for float and datetime, which do not:
+//   - Python's `repr(5.0)` is `"5.0"`; Go's `strconv.FormatFloat(5.0, 'g',
+//     -1, 64)` is `"5"`. Same IEEE754 double, different text.
+//   - Python's `datetime.isoformat()` shows microseconds as a fixed
+//     6-digit field when non-zero (`.123000Z`); Go's `time.RFC3339Nano`
+//     strips trailing zero fractional digits (`.123Z`). Same instant,
+//     different text.
+//
+// Both gaps were latent, not active: every case in this package so far
+// uses whole-second or millisecond-truncated timestamps and no float
+// fields, so the mismatch never fired -- exactly why it needed fixing at
+// the comparator level rather than by adding a case that happens to dodge
+// it. Values are parsed back and compared numerically/temporally instead
+// of as text; everything else still falls through to reflect.DeepEqual
+// unchanged.
+func typedValuesEqual(pythonValue, goValue any) bool {
+	pythonTagged, pythonOK := asTaggedValue(pythonValue)
+	goTagged, goOK := asTaggedValue(goValue)
+	if pythonOK && goOK && pythonTagged.tag == goTagged.tag {
+		switch pythonTagged.tag {
+		case "float":
+			pythonFloat, pythonErr := strconv.ParseFloat(pythonTagged.value, 64)
+			goFloat, goErr := strconv.ParseFloat(goTagged.value, 64)
+			if pythonErr == nil && goErr == nil {
+				return pythonFloat == goFloat
+			}
+		case "datetime":
+			pythonTime, pythonErr := time.Parse(time.RFC3339Nano, pythonTagged.value)
+			goTime, goErr := time.Parse(time.RFC3339Nano, goTagged.value)
+			if pythonErr == nil && goErr == nil {
+				return pythonTime.Equal(goTime)
+			}
+		}
+	}
+	return reflect.DeepEqual(pythonValue, goValue)
+}
+
+type taggedValue struct {
+	tag   string
+	value string
+}
+
+// asTaggedValue recognizes the {"t": "<tag>", "v": "<string>"} shape
+// typedEncode/_encode produce, without assuming every map[string]any this
+// package ever compares is one (a nested struct/dict legitimately encodes
+// to a map with arbitrary other keys, which must keep falling through to
+// reflect.DeepEqual).
+func asTaggedValue(value any) (taggedValue, bool) {
+	asMap, ok := value.(map[string]any)
+	if !ok || len(asMap) != 2 {
+		return taggedValue{}, false
+	}
+	tag, tagOK := asMap["t"].(string)
+	leaf, leafOK := asMap["v"].(string)
+	if !tagOK || !leafOK {
+		return taggedValue{}, false
+	}
+	return taggedValue{tag: tag, value: leaf}, true
 }
 
 // embeddedOracleSources exists purely so `go:embed` makes the compiled test
@@ -745,6 +810,74 @@ func TestCheckExclusionIntegrityClauseCoverage(t *testing.T) {
 					t.Fatalf("checkExclusionIntegrity() = %v, want a message containing %q",
 						messages, tt.wantSubstring)
 				}
+			}
+		})
+	}
+}
+
+// TestTypedValuesEqualCanonicalizesFloatAndDatetimeText is codex's fourth-
+// round finding: the SAME IEEE754 double or the SAME instant can encode to
+// DIFFERENT text on the Python and Go sides (Python's repr(5.0) is "5.0";
+// Go's strconv.FormatFloat(5.0, 'g', -1, 64) is "5" -- same value, and
+// Python's isoformat() shows a fixed 6-digit microsecond field while Go's
+// RFC3339Nano strips trailing zero fractional digits). A bare
+// reflect.DeepEqual on the tagged {"t","v"} envelope would report these as
+// DIVERGENT even though the underlying values are equal -- exactly the
+// false-positive noise that would make a real pair with float/sub-second
+// fields untrustworthy. Also proves the inverse: genuinely different
+// values still compare unequal, and non-float/datetime tags (str/int/bool)
+// are untouched by the new parse-and-compare path.
+func TestTypedValuesEqualCanonicalizesFloatAndDatetimeText(t *testing.T) {
+	tagged := func(tag, value string) map[string]any {
+		return map[string]any{"t": tag, "v": value}
+	}
+	tests := []struct {
+		name      string
+		a, b      any
+		wantEqual bool
+	}{
+		{
+			name:      "equal floats, different text (Python repr vs Go FormatFloat)",
+			a:         tagged("float", "5.0"),
+			b:         tagged("float", "5"),
+			wantEqual: true,
+		},
+		{
+			name:      "equal instants, different fractional-second width",
+			a:         tagged("datetime", "2026-07-10T09:00:00.123000Z"),
+			b:         tagged("datetime", "2026-07-10T09:00:00.123Z"),
+			wantEqual: true,
+		},
+		{
+			name:      "genuinely different floats stay unequal",
+			a:         tagged("float", "5.0"),
+			b:         tagged("float", "5.1"),
+			wantEqual: false,
+		},
+		{
+			name:      "genuinely different instants stay unequal",
+			a:         tagged("datetime", "2026-07-10T09:00:00Z"),
+			b:         tagged("datetime", "2026-07-10T09:00:01Z"),
+			wantEqual: false,
+		},
+		{
+			name:      "str tag: exact text comparison, untouched by the float/datetime path",
+			a:         tagged("str", "open"),
+			b:         tagged("str", "open"),
+			wantEqual: true,
+		},
+		{
+			name:      "int tag: exact text comparison, untouched by the float/datetime path",
+			a:         tagged("int", "5"),
+			b:         tagged("int", "5.0"), // an int side must never accept float-shaped text
+			wantEqual: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := typedValuesEqual(tt.a, tt.b)
+			if got != tt.wantEqual {
+				t.Fatalf("typedValuesEqual(%#v, %#v) = %v, want %v", tt.a, tt.b, got, tt.wantEqual)
 			}
 		})
 	}

--- a/internal/providersync/oracle_compare_test.go
+++ b/internal/providersync/oracle_compare_test.go
@@ -72,31 +72,52 @@ func compareRowsAgainstPythonOracle[T any](
 ) {
 	t.Helper()
 	wrapped := func(t *testing.T, input map[string]any) any { return goRowBuilder(t, input) }
+	// One shellout for the WHOLE batch, not one per case: codex findings
+	// (third review) about a stale/unused declared exclusion, and a
+	// goOnlyFields entry that turns out to appear on the Python side after
+	// all, are properties of the BATCH ("did this exclusion ever match
+	// anything across every case"), not of any single case in isolation --
+	// they cannot be checked correctly if each case only ever sees itself.
+	// oracleDivergences returns messages case-prefixed by
+	// caseDivergencePrefix; anything that doesn't match any case's prefix
+	// is a batch-level finding, surfaced in its own subtest below.
+	all := oracleDivergences(t, pairID, cases, wrapped, goOnlyFields)
+	attributed := make(map[string]bool, len(all))
 	for _, testCase := range cases {
 		testCase := testCase
+		prefix := caseDivergencePrefix(testCase.ID)
 		t.Run(testCase.ID, func(t *testing.T) {
 			t.Helper()
-			for _, message := range oracleDivergencesForCase(t, pairID, testCase, wrapped, goOnlyFields) {
+			for _, message := range all {
+				if strings.HasPrefix(message, prefix) {
+					attributed[message] = true
+					t.Error(message)
+				}
+			}
+		})
+	}
+	var batchLevel []string
+	for _, message := range all {
+		if !attributed[message] {
+			batchLevel = append(batchLevel, message)
+		}
+	}
+	if len(batchLevel) > 0 {
+		t.Run("exclusion integrity", func(t *testing.T) {
+			t.Helper()
+			for _, message := range batchLevel {
 				t.Error(message)
 			}
 		})
 	}
 }
 
-// oracleDivergencesForCase runs ONE case through oracleDivergences. Kept
-// separate so compareRowsAgainstPythonOracle can still get one t.Run per
-// case (clear per-case pass/fail in `go test -v` output) while probes that
-// need every case in a single Python subprocess call use oracleDivergences
-// directly.
-func oracleDivergencesForCase(
-	t *testing.T,
-	pairID string,
-	testCase oracleCase,
-	goRowBuilder func(t *testing.T, input map[string]any) any,
-	goOnlyFields map[string]string,
-) []string {
-	t.Helper()
-	return oracleDivergences(t, pairID, []oracleCase{testCase}, goRowBuilder, goOnlyFields)
+// caseDivergencePrefix is the exact prefix diffRows's per-field messages
+// start with -- used to attribute a flat message list back to the case it
+// concerns for per-case subtests. %q's own closing quote plus the trailing
+// comma keeps "foo" from matching a message about "foobar".
+func caseDivergencePrefix(caseID string) string {
+	return fmt.Sprintf("case %q,", caseID)
 }
 
 // oracleDivergences is the reusable core: it does the Python shellout, the
@@ -216,6 +237,8 @@ func oracleDivergences(
 		pythonRows[entry.ID] = entry.Row
 	}
 
+	pythonRowsByCase := make(map[string]map[string]any, len(cases))
+	goRowsByCase := make(map[string]map[string]any, len(cases))
 	var messages []string
 	for _, testCase := range cases {
 		pythonRow, ok := pythonRows[testCase.ID]
@@ -227,10 +250,101 @@ func oracleDivergences(
 		if !ok {
 			t.Fatalf("case %q: Go row builder must return a struct or map, got %T", testCase.ID, goValue)
 		}
+		pythonRowsByCase[testCase.ID] = pythonRow
+		goRowsByCase[testCase.ID] = goRow
 		messages = append(messages, diffRows(
 			testCase.ID, pythonRow, goRow, decoded.ExcludedFields, goOnlyFields,
 		)...)
 	}
+	messages = append(messages, checkExclusionIntegrity(
+		pythonRowsByCase, goRowsByCase, decoded.ExcludedFields, goOnlyFields,
+	)...)
+	return messages
+}
+
+// checkExclusionIntegrity is CHAOS-3162's third-review fix: a declared
+// exclusion is a CLAIM, and nothing previously checked either claim
+// against what the batch's rows actually contained.
+//
+//  1. goOnlyFields[key] asserts "the Python side structurally cannot have
+//     this field". If key shows up in ANY case's Python row anyway, that
+//     assertion is false: the field IS present and comparable on the
+//     Python side, and excluding it hides a real, comparable value --
+//     exactly the undeclared-divergence risk this whole framework exists
+//     to rule out, smuggled in through the exclusion mechanism meant to
+//     prevent it.
+//  2. A declared exclusion (either map) that never matches a key present
+//     in ANY case's row, across the whole batch, is stale: a typo, a
+//     field renamed/removed without updating the pair, or one that was
+//     never real. Silent either way, and indistinguishable from a
+//     genuine, currently-effective exclusion without this check.
+//
+// Both are necessarily BATCH-level properties (checkable only once every
+// case's rows are known), not per-case ones, which is why this takes the
+// whole case-keyed map rather than being folded into diffRows.
+//
+// This is a pure function precisely so it can be unit-tested with
+// synthetic data (TestCheckExclusionIntegrityClauseCoverage) without a
+// Python subprocess -- the same reason diffRows is pure and
+// TestDiffRowsClauseCoverage exists.
+func checkExclusionIntegrity(
+	pythonRowsByCase, goRowsByCase map[string]map[string]any,
+	excludedFields, goOnlyFields map[string]string,
+) []string {
+	// usedExclusions tracks, across the WHOLE batch, which declared
+	// exclusions actually matched a key present in at least one case's
+	// Python or Go row. A "go:" prefix disambiguates a goOnlyFields key
+	// from a same-named excludedFields key, since the two maps are
+	// independent declarations that happen to share a namespace.
+	usedExclusions := map[string]bool{}
+	caseIDs := make([]string, 0, len(pythonRowsByCase))
+	for caseID := range pythonRowsByCase {
+		caseIDs = append(caseIDs, caseID)
+	}
+	sort.Strings(caseIDs)
+
+	var messages []string
+	for _, caseID := range caseIDs {
+		pythonRow, goRow := pythonRowsByCase[caseID], goRowsByCase[caseID]
+		for key := range pythonRow {
+			if reason, claimedGoOnly := goOnlyFields[key]; claimedGoOnly {
+				messages = append(messages, fmt.Sprintf(
+					"goOnlyFields[%q] (declared: %q) claims this field never appears on "+
+						"the Python side, but case %q's Python row has it -- this field is "+
+						"NOT actually Go-only, and excluding it hides a real, comparable value",
+					key, reason, caseID))
+			}
+			if _, declared := excludedFields[key]; declared {
+				usedExclusions[key] = true
+			}
+		}
+		for key := range goRow {
+			if _, declared := excludedFields[key]; declared {
+				usedExclusions[key] = true
+			}
+			if _, declared := goOnlyFields[key]; declared {
+				usedExclusions["go:"+key] = true
+			}
+		}
+	}
+
+	for key, reason := range excludedFields {
+		if !usedExclusions[key] {
+			messages = append(messages, fmt.Sprintf(
+				"excluded_fields[%q] (declared: %q) never matched a key present in any "+
+					"case's Python or Go row across this batch -- a stale exclusion, not "+
+					"a currently-effective one", key, reason))
+		}
+	}
+	for key, reason := range goOnlyFields {
+		if !usedExclusions["go:"+key] {
+			messages = append(messages, fmt.Sprintf(
+				"goOnlyFields[%q] (declared: %q) never matched a key present in any "+
+					"case's Go row across this batch -- a stale exclusion, not a "+
+					"currently-effective one", key, reason))
+		}
+	}
+	sort.Strings(messages)
 	return messages
 }
 
@@ -564,6 +678,72 @@ func TestDiffRowsClauseCoverage(t *testing.T) {
 			if tt.wantSubstring != "" {
 				if len(messages) == 0 || !strings.Contains(messages[0], tt.wantSubstring) {
 					t.Fatalf("diffRows() = %v, want a message containing %q", messages, tt.wantSubstring)
+				}
+			}
+		})
+	}
+}
+
+// TestCheckExclusionIntegrityClauseCoverage is a fast, synthetic-data unit
+// test of checkExclusionIntegrity's own logic (codex finding, third
+// review): isolating "a goOnlyFields key actually appears on the Python
+// side" and "a declared exclusion never matches anything in the batch"
+// (for both exclusion maps) as their own cases, plus a clean case proving
+// neither check fires on legitimate, currently-effective declarations.
+func TestCheckExclusionIntegrityClauseCoverage(t *testing.T) {
+	tests := []struct {
+		name           string
+		pythonRows     map[string]map[string]any
+		goRows         map[string]map[string]any
+		excludedFields map[string]string
+		goOnlyFields   map[string]string
+		wantMessages   int
+		wantSubstring  string
+	}{
+		{
+			name:           "legitimate exclusions, both used: no violation",
+			pythonRows:     map[string]map[string]any{"c1": {"state": "open"}},
+			goRows:         map[string]map[string]any{"c1": {"state": "open", "reviews_count": 0, "org_id": "x"}},
+			excludedFields: map[string]string{"reviews_count": "owned by pr-reviews"},
+			goOnlyFields:   map[string]string{"org_id": "Go-side bookkeeping"},
+			wantMessages:   0,
+		},
+		{
+			name:          "goOnlyFields key actually present on the Python side: violation",
+			pythonRows:    map[string]map[string]any{"c1": {"state": "open", "org_id": "leaked"}},
+			goRows:        map[string]map[string]any{"c1": {"state": "open", "org_id": "x"}},
+			goOnlyFields:  map[string]string{"org_id": "Go-side bookkeeping"},
+			wantMessages:  1,
+			wantSubstring: "claims this field never appears on the Python side",
+		},
+		{
+			name:           "excluded_fields entry never matches anything: stale",
+			pythonRows:     map[string]map[string]any{"c1": {"state": "open"}},
+			goRows:         map[string]map[string]any{"c1": {"state": "open"}},
+			excludedFields: map[string]string{"never_seen": "supposedly owned elsewhere"},
+			wantMessages:   1,
+			wantSubstring:  `excluded_fields["never_seen"]`,
+		},
+		{
+			name:          "goOnlyFields entry never matches anything: stale",
+			pythonRows:    map[string]map[string]any{"c1": {"state": "open"}},
+			goRows:        map[string]map[string]any{"c1": {"state": "open"}},
+			goOnlyFields:  map[string]string{"never_seen": "supposedly Go-only"},
+			wantMessages:  1,
+			wantSubstring: `goOnlyFields["never_seen"]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages := checkExclusionIntegrity(tt.pythonRows, tt.goRows, tt.excludedFields, tt.goOnlyFields)
+			if len(messages) != tt.wantMessages {
+				t.Fatalf("checkExclusionIntegrity() = %d message(s) %v, want %d",
+					len(messages), messages, tt.wantMessages)
+			}
+			if tt.wantSubstring != "" {
+				if len(messages) == 0 || !strings.Contains(messages[0], tt.wantSubstring) {
+					t.Fatalf("checkExclusionIntegrity() = %v, want a message containing %q",
+						messages, tt.wantSubstring)
 				}
 			}
 		})

--- a/internal/providersync/oracle_compare_test.go
+++ b/internal/providersync/oracle_compare_test.go
@@ -1,16 +1,21 @@
 package providersync
 
 import (
+	"bytes"
+	"embed"
 	"encoding/json"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"reflect"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
+	"time"
 )
 
 // oracleCase is one input case for a generic Python<->Go oracle comparison
@@ -23,50 +28,55 @@ type oracleCase struct {
 }
 
 // compareRowsAgainstPythonOracle is the generic whole-row comparator this
-// package's pairs share (CHAOS-3162's actual deliverable: the COMPARISON is
-// generic, not just the module-loading plumbing python_oracle_loader.py
-// already solved). For each case it:
+// package's pairs share. For each case it:
 //
 //  1. Shells out ONCE to testdata/python_generic_row_oracle.py <pairID>
 //     with all cases, getting back the real, live Python row for each case
 //     plus the pair's own declared excluded_fields (with required reasons).
-//  2. Calls goRowBuilder(input) to get the Go-side row for the SAME case,
-//     round-tripped through JSON so both sides compare as
-//     map[string]any (the same representation, so a Go int and a Python
-//     int that both decode through encoding/json as float64 compare equal
-//     without a bespoke numeric-type dance).
+//     Python enforces its own completeness (oracle_registry.check_completeness,
+//     codex finding #1's Python-side half) before this ever returns.
+//  2. Calls goRowBuilder(input) to get the Go-side row for the SAME case AS
+//     A CONCRETE, PRODUCTION-TYPED VALUE T (a real struct, e.g.
+//     pullRequestRow -- never a hand-picked map). typedEncode then reflects
+//     EVERY field T declares, exhaustively: unlike a Python dict (which can
+//     omit a key with no compiler complaint), a Go struct return type makes
+//     "silently expose only 3 of 20 fields" a type error, not a runtime
+//     choice -- this is codex finding #1's Go-side half, enforced by the
+//     type system rather than a second, parallel, hand-maintained manifest.
 //  3. Fails on ANY undeclared divergence: a key present on one side and
-//     absent on the other, or a value that differs -- UNLESS the field is
+//     absent on the other, a key with a different VALUE, or a key with a
+//     different TYPE TAG (codex finding #2: every leaf on both sides is
+//     encoded as {"t": "<type>", "v": "<string>"} -- see typedEncode --
+//     specifically so an int and an integral float, or two integers that
+//     would collide at float64 precision, or a datetime and a same-looking
+//     plain string, never compare equal by accident) -- UNLESS the field is
 //     declared in the Python pair's excluded_fields OR the caller's own
-//     goOnlyFields (for Go-side bookkeeping fields the Python side
-//     structurally cannot have an opinion about, e.g. org_id). Every
-//     exclusion requires a written reason at the call site, mirroring
-//     expected_survivor_reason in scripts/mutation_harness.py -- an
-//     omission must be declared, never silently missing.
+//     goOnlyFields. Every exclusion requires a written reason, mirroring
+//     expected_survivor_reason in scripts/mutation_harness.py.
 //
 // This is the single comparator every pair reuses; a pair difference is a
 // difference in WHAT gets compared (the pair id, the cases, the Go row
-// builder), never in HOW comparison happens.
+// builder, the Go row TYPE), never in HOW comparison happens.
 //
 // Use this form (which fails t directly) when asserting the CURRENT,
 // production code matches Python. To instead prove the comparator would
 // CATCH a specific pre-fix/buggy variant (without corrupting the enclosing
 // test's pass/fail state -- a subtest's t.Errorf always propagates failure
-// to every ancestor test, so "run it and check t.Run's bool" does not work
-// for that), use oracleDivergences directly.
-func compareRowsAgainstPythonOracle(
+// to every ancestor test), use oracleDivergences directly.
+func compareRowsAgainstPythonOracle[T any](
 	t *testing.T,
 	pairID string,
 	cases []oracleCase,
-	goRowBuilder func(t *testing.T, input map[string]any) map[string]any,
+	goRowBuilder func(t *testing.T, input map[string]any) T,
 	goOnlyFields map[string]string,
 ) {
 	t.Helper()
+	wrapped := func(t *testing.T, input map[string]any) any { return goRowBuilder(t, input) }
 	for _, testCase := range cases {
 		testCase := testCase
 		t.Run(testCase.ID, func(t *testing.T) {
 			t.Helper()
-			for _, message := range oracleDivergencesForCase(t, pairID, testCase, goRowBuilder, goOnlyFields) {
+			for _, message := range oracleDivergencesForCase(t, pairID, testCase, wrapped, goOnlyFields) {
 				t.Error(message)
 			}
 		})
@@ -82,7 +92,7 @@ func oracleDivergencesForCase(
 	t *testing.T,
 	pairID string,
 	testCase oracleCase,
-	goRowBuilder func(t *testing.T, input map[string]any) map[string]any,
+	goRowBuilder func(t *testing.T, input map[string]any) any,
 	goOnlyFields map[string]string,
 ) []string {
 	t.Helper()
@@ -90,26 +100,46 @@ func oracleDivergencesForCase(
 }
 
 // oracleDivergences is the reusable core: it does the Python shellout, the
-// Go row build, and the field-by-field diff, and returns every divergence
+// Go row build (as a concrete typed value, then walked exhaustively by
+// typedEncode), and the field-by-field diff, and returns every divergence
 // message found -- WITHOUT calling t.Error/t.Fatal for the divergences
-// themselves (setup failures -- the Python process erroring, its output not
-// parsing, an undeclared-reason exclusion -- still fail t immediately,
-// since those indicate the comparison could not run at all, not that it ran
-// and found something).
+// themselves (setup failures still fail t immediately, since those
+// indicate the comparison could not run at all, not that it ran and found
+// nothing).
 //
-// An empty return means the generic comparator found the two sides
-// identical (module declared exclusions). This is the function
-// CHAOS-3162's acceptance test calls directly: "does the comparator
-// rediscover a known defect" is exactly "is this slice non-empty when
-// pointed at a pre-fix Go row builder".
+// codex findings #6/#7 (second review): an empty cases slice, or two cases
+// sharing an id, would otherwise let a comparison "pass" without actually
+// comparing anything meaningful, or let one case's Python result be
+// diffed against a DIFFERENT case's Go result. Both are rejected here as
+// hard setup failures, in addition to python_generic_row_oracle.py's own
+// mirror checks on the Python side -- defense in depth, not redundant,
+// since a caller could construct []oracleCase directly without ever
+// reaching the Python CLI's own validation for cases that fail before exec.
 func oracleDivergences(
 	t *testing.T,
 	pairID string,
 	cases []oracleCase,
-	goRowBuilder func(t *testing.T, input map[string]any) map[string]any,
+	goRowBuilder func(t *testing.T, input map[string]any) any,
 	goOnlyFields map[string]string,
 ) []string {
 	t.Helper()
+	assertOracleSourcesUnchangedSinceBuild(t)
+	if len(cases) == 0 {
+		t.Fatalf("oracleDivergences: cases must be non-empty -- a comparison over " +
+			"zero cases proves nothing and must not be allowed to look like a pass")
+	}
+	seenIDs := make(map[string]struct{}, len(cases))
+	for _, testCase := range cases {
+		if testCase.ID == "" {
+			t.Fatalf("oracleDivergences: case has an empty id")
+		}
+		if _, duplicate := seenIDs[testCase.ID]; duplicate {
+			t.Fatalf("oracleDivergences: duplicate case id %q -- results are keyed by "+
+				"id, so a duplicate would let one case's Python result be compared "+
+				"against a different case's Go result unnoticed", testCase.ID)
+		}
+		seenIDs[testCase.ID] = struct{}{}
+	}
 	for name, reason := range goOnlyFields {
 		if reason == "" {
 			t.Fatalf("goOnlyFields[%q] needs a non-empty written reason", name)
@@ -153,6 +183,14 @@ func oracleDivergences(
 		t.Fatalf("execute Python generic row oracle for %s: %v: %s", pairID, err, output)
 	}
 
+	// UseNumber, defensively: every leaf this oracle emits is type-tagged
+	// (codex finding #2) so no bare JSON number should reach this decode at
+	// all, but decoding any that slipped through (a malformed pair, a bug
+	// in _encode) as json.Number rather than the default lossy float64 is a
+	// second, independent layer against exactly the precision-collapse
+	// finding #2 named.
+	decoder := json.NewDecoder(bytes.NewReader(output))
+	decoder.UseNumber()
 	var decoded struct {
 		Cases []struct {
 			ID  string         `json:"id"`
@@ -160,7 +198,7 @@ func oracleDivergences(
 		} `json:"cases"`
 		ExcludedFields map[string]string `json:"excluded_fields"`
 	}
-	if err := json.Unmarshal(output, &decoded); err != nil {
+	if err := decoder.Decode(&decoded); err != nil {
 		t.Fatalf("decode Python generic row oracle output for %s: %v: %s", pairID, err, output)
 	}
 	for name, reason := range decoded.ExcludedFields {
@@ -172,6 +210,9 @@ func oracleDivergences(
 
 	pythonRows := make(map[string]map[string]any, len(decoded.Cases))
 	for _, entry := range decoded.Cases {
+		if _, duplicate := pythonRows[entry.ID]; duplicate {
+			t.Fatalf("pair %s: Python oracle output has duplicate case id %q", pairID, entry.ID)
+		}
 		pythonRows[entry.ID] = entry.Row
 	}
 
@@ -181,7 +222,11 @@ func oracleDivergences(
 		if !ok {
 			t.Fatalf("oracle output missing case %q", testCase.ID)
 		}
-		goRow := jsonRoundTripToMap(t, goRowBuilder(t, testCase.Input))
+		goValue := goRowBuilder(t, testCase.Input)
+		goRow, ok := typedEncode(t, reflect.ValueOf(goValue)).(map[string]any)
+		if !ok {
+			t.Fatalf("case %q: Go row builder must return a struct or map, got %T", testCase.ID, goValue)
+		}
 		messages = append(messages, diffRows(
 			testCase.ID, pythonRow, goRow, decoded.ExcludedFields, goOnlyFields,
 		)...)
@@ -189,22 +234,95 @@ func oracleDivergences(
 	return messages
 }
 
-// jsonRoundTripToMap marshals then unmarshals a value into map[string]any
-// so it compares against the Python oracle's own JSON-decoded output using
-// the identical Go representation for every JSON type (crucially: a JSON
-// number is always float64 on both sides, not int on one and float64 on
-// the other).
-func jsonRoundTripToMap(t *testing.T, value any) map[string]any {
+// typedEncode walks v exhaustively via reflection and produces the SAME
+// type-tagged wire shape python_generic_row_oracle.py's _encode produces
+// (codex finding #2): every leaf becomes {"t": "<tag>", "v": "<string>"},
+// nil pointers/interfaces become bare JSON null (unambiguous, no tag
+// needed), and structs/maps/slices recurse. Struct fields are named by
+// their `json:"..."` tag (falling back to the Go field name, matching
+// encoding/json's own default) so the wire field names match what the row
+// actually persists as.
+//
+// Because this walks reflect.Type's fields EXHAUSTIVELY -- there is no
+// mechanism to skip one -- a caller cannot construct a "narrowed" struct
+// type that quietly hides a field the way a hand-built map[string]any
+// could: the completeness guarantee this closes (codex finding #1) comes
+// from the Go type system itself, not from a second, parallel, hand
+// maintained field list that could drift from the struct it describes.
+func typedEncode(t *testing.T, v reflect.Value) any {
 	t.Helper()
-	encoded, err := json.Marshal(value)
-	if err != nil {
-		t.Fatalf("marshal Go row: %v", err)
+	for v.IsValid() && (v.Kind() == reflect.Ptr || v.Kind() == reflect.Interface) {
+		if v.IsNil() {
+			return nil
+		}
+		v = v.Elem()
 	}
-	var decoded map[string]any
-	if err := json.Unmarshal(encoded, &decoded); err != nil {
-		t.Fatalf("unmarshal Go row: %v", err)
+	if !v.IsValid() {
+		return nil
 	}
-	return decoded
+	if timeValue, ok := v.Interface().(time.Time); ok {
+		return map[string]any{"t": "datetime", "v": timeValue.UTC().Format(time.RFC3339Nano)}
+	}
+	switch v.Kind() {
+	case reflect.String:
+		return map[string]any{"t": "str", "v": v.String()}
+	case reflect.Bool:
+		return map[string]any{"t": "bool", "v": strconv.FormatBool(v.Bool())}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return map[string]any{"t": "int", "v": strconv.FormatInt(v.Int(), 10)}
+	case reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return map[string]any{"t": "int", "v": strconv.FormatUint(v.Uint(), 10)}
+	case reflect.Float32, reflect.Float64:
+		return map[string]any{"t": "float", "v": strconv.FormatFloat(v.Float(), 'g', -1, 64)}
+	case reflect.Struct:
+		result := make(map[string]any, v.NumField())
+		structType := v.Type()
+		for i := 0; i < v.NumField(); i++ {
+			field := structType.Field(i)
+			if field.PkgPath != "" {
+				continue // unexported: not part of the persisted row.
+			}
+			name := jsonFieldName(field)
+			if name == "-" {
+				continue
+			}
+			result[name] = typedEncode(t, v.Field(i))
+		}
+		return result
+	case reflect.Map:
+		result := make(map[string]any, v.Len())
+		for _, key := range v.MapKeys() {
+			keyString, ok := key.Interface().(string)
+			if !ok {
+				t.Fatalf("typedEncode: unsupported non-string map key type %s", key.Type())
+			}
+			result[keyString] = typedEncode(t, v.MapIndex(key))
+		}
+		return result
+	case reflect.Slice, reflect.Array:
+		result := make([]any, v.Len())
+		for i := 0; i < v.Len(); i++ {
+			result[i] = typedEncode(t, v.Index(i))
+		}
+		return result
+	default:
+		t.Fatalf("typedEncode: unsupported kind %s for type %s -- every leaf type "+
+			"this comparator can see must have an explicit, type-tagged encoding; "+
+			"falling through untagged would silently reopen codex finding #2", v.Kind(), v.Type())
+		return nil
+	}
+}
+
+func jsonFieldName(field reflect.StructField) string {
+	tag := field.Tag.Get("json")
+	if tag == "" {
+		return field.Name
+	}
+	name, _, _ := strings.Cut(tag, ",")
+	if name == "" {
+		return field.Name
+	}
+	return name
 }
 
 // diffRows is CHAOS-3162's actual comparison logic: every key present on
@@ -215,6 +333,12 @@ func jsonRoundTripToMap(t *testing.T, value any) map[string]any {
 // -- neither is treated as "probably fine". Returns one message per
 // divergence found (nil/empty = the rows matched under the declared
 // exclusions).
+//
+// codex finding #6 (second review): if every key in the union is excluded,
+// this returns zero divergences even though nothing was actually compared
+// -- indistinguishable, from the caller's side, from a real match. Fail
+// loudly instead: a case where every field is excluded is a caller
+// configuration error (probably an over-broad goOnlyFields), not a pass.
 func diffRows(
 	caseID string,
 	pythonRow, goRow map[string]any,
@@ -227,6 +351,11 @@ func diffRows(
 	for key := range goRow {
 		allKeys[key] = struct{}{}
 	}
+	if len(allKeys) == 0 {
+		return []string{fmt.Sprintf(
+			"case %q: both rows are empty -- nothing was compared, which is a "+
+				"setup error, not a pass", caseID)}
+	}
 	sortedKeys := make([]string, 0, len(allKeys))
 	for key := range allKeys {
 		sortedKeys = append(sortedKeys, key)
@@ -234,6 +363,7 @@ func diffRows(
 	sort.Strings(sortedKeys)
 
 	var messages []string
+	comparedFields := 0
 	for _, key := range sortedKeys {
 		if _, excluded := pythonExcluded[key]; excluded {
 			continue
@@ -241,6 +371,7 @@ func diffRows(
 		if _, excluded := goOnlyFields[key]; excluded {
 			continue
 		}
+		comparedFields++
 		pythonValue, pythonHas := pythonRow[key]
 		goValue, goHas := goRow[key]
 		switch {
@@ -259,20 +390,75 @@ func diffRows(
 				"case %q, field %q: python=%#v go=%#v", caseID, key, pythonValue, goValue))
 		}
 	}
+	if comparedFields == 0 {
+		return []string{fmt.Sprintf(
+			"case %q: every field in both rows is declared excluded -- nothing was "+
+				"actually compared, which is a caller configuration error (an "+
+				"over-broad exclusion list), not a pass", caseID)}
+	}
 	return messages
+}
+
+// embeddedOracleSources exists purely so `go:embed` makes the compiled test
+// binary's content, and therefore Go's test result cache key, sensitive to
+// every byte of these Python files (codex finding #4, second review).
+// `go test` result caching keys off the compiled test binary; that binary
+// has NO knowledge that oracleDivergences shells out to
+// python_generic_row_oracle.py at run time, so a Python-only edit with no
+// Go-file change reuses a stale cached PASS unless something makes the
+// binary itself change too. Listing these files here does exactly that:
+// any byte-level edit to any of them changes what go:embed bakes into the
+// binary, which changes the binary's content hash, which busts the cache
+// on its own -- no reliance on a developer remembering `-count=1`.
+// assertOracleSourcesUnchangedSinceBuild is the second half: it re-reads
+// the same files from disk at run time and fails loudly if they no longer
+// match what was embedded, which would only happen if this embed
+// directive's file list drifted out of sync with what oracleDivergences
+// actually executes.
+//
+//go:embed testdata/python_generic_row_oracle.py testdata/oracle_registry.py testdata/python_oracle_loader.py testdata/field_reflection.py testdata/oracle_pairs/*.py
+var embeddedOracleSources embed.FS
+
+func assertOracleSourcesUnchangedSinceBuild(t *testing.T) {
+	t.Helper()
+	_, currentFile, _, _ := runtime.Caller(0)
+	packageDir := filepath.Dir(currentFile)
+	err := fs.WalkDir(embeddedOracleSources, ".", func(path string, d fs.DirEntry, walkErr error) error {
+		if walkErr != nil || d.IsDir() {
+			return walkErr
+		}
+		embedded, readErr := embeddedOracleSources.ReadFile(path)
+		if readErr != nil {
+			return readErr
+		}
+		onDisk, readErr := os.ReadFile(filepath.Join(packageDir, path))
+		if readErr != nil {
+			return readErr
+		}
+		if !bytes.Equal(embedded, onDisk) {
+			t.Fatalf("embedded copy of %s does not match the on-disk file -- this "+
+				"should be impossible outside of a build-cache bug, since go:embed "+
+				"reads the same file go test just compiled from; if you see this, "+
+				"rebuild with -count=1 and report it", path)
+		}
+		return nil
+	})
+	if err != nil {
+		t.Fatalf("walk embedded oracle sources: %v", err)
+	}
 }
 
 // TestDiffRowsClauseCoverage is a fast, synthetic-data unit test of
 // diffRows's own logic -- the core comparator every pair (Python-shellout
-// or ClickHouse-readback alike) reuses -- isolating each of its four
-// clauses (matching value, differing value, present-in-Python-only,
-// present-in-Go-only) plus its two independent exclusion mechanisms
-// (Python-declared, Go-only-declared) as its own case, so a mutation to any
-// one clause is caught by a case that exercises ONLY that clause, not by
-// coincidence from a case exercising several at once. This is the mutation
-// harness's own "mutate compound predicates clause by clause" rule applied
-// to the framework code itself, not just to a pair's row-construction
-// logic.
+// or ClickHouse-readback alike) reuses -- isolating each of its clauses
+// (matching value, differing value, present-in-Python-only,
+// present-in-Go-only, the two vacuity guards added for codex finding #6)
+// plus its two independent exclusion mechanisms (Python-declared,
+// Go-only-declared) as its own case, so a mutation to any one clause is
+// caught by a case that exercises ONLY that clause, not by coincidence
+// from a case exercising several at once. This is the mutation harness's
+// own "mutate compound predicates clause by clause" rule applied to the
+// framework code itself, not just to a pair's row-construction logic.
 func TestDiffRowsClauseCoverage(t *testing.T) {
 	tests := []struct {
 		name           string
@@ -322,22 +508,22 @@ func TestDiffRowsClauseCoverage(t *testing.T) {
 		},
 		{
 			name:           "declared Python-side exclusion suppresses a value mismatch",
-			pythonRow:      map[string]any{"reviews_count": float64(1)},
-			goRow:          map[string]any{"reviews_count": float64(0)},
+			pythonRow:      map[string]any{"reviews_count": float64(1), "state": "open"},
+			goRow:          map[string]any{"reviews_count": float64(0), "state": "open"},
 			pythonExcluded: map[string]string{"reviews_count": "owned by github/pr-reviews"},
 			wantMessages:   0,
 		},
 		{
 			name:           "declared Python-side exclusion suppresses a present-or-absent divergence",
-			pythonRow:      map[string]any{"reviews_count": float64(1)},
-			goRow:          map[string]any{},
+			pythonRow:      map[string]any{"reviews_count": float64(1), "state": "open"},
+			goRow:          map[string]any{"state": "open"},
 			pythonExcluded: map[string]string{"reviews_count": "owned by github/pr-reviews"},
 			wantMessages:   0,
 		},
 		{
 			name:         "declared Go-only exclusion suppresses a present-or-absent divergence",
-			pythonRow:    map[string]any{},
-			goRow:        map[string]any{"org_id": "org-acme"},
+			pythonRow:    map[string]any{"state": "open"},
+			goRow:        map[string]any{"org_id": "org-acme", "state": "open"},
 			goOnlyFields: map[string]string{"org_id": "Go-side tenant bookkeeping"},
 			wantMessages: 0,
 		},
@@ -353,17 +539,32 @@ func TestDiffRowsClauseCoverage(t *testing.T) {
 			wantMessages:   1,
 			wantSubstring:  `python="open" go="closed"`,
 		},
+		{
+			name:          "both rows empty: fails as a setup error, not a silent pass",
+			pythonRow:     map[string]any{},
+			goRow:         map[string]any{},
+			wantMessages:  1,
+			wantSubstring: "both rows are empty",
+		},
+		{
+			name:           "every field excluded: fails as a setup error, not a silent pass",
+			pythonRow:      map[string]any{"reviews_count": float64(1)},
+			goRow:          map[string]any{"reviews_count": float64(1)},
+			pythonExcluded: map[string]string{"reviews_count": "owned by github/pr-reviews"},
+			wantMessages:   1,
+			wantSubstring:  "every field in both rows is declared excluded",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			messages := diffRows("case", tt.pythonRow, tt.goRow, tt.pythonExcluded, tt.goOnlyFields)
+			if len(messages) != tt.wantMessages {
+				t.Fatalf("diffRows() = %d message(s) %v, want %d", len(messages), messages, tt.wantMessages)
+			}
 			if tt.wantSubstring != "" {
 				if len(messages) == 0 || !strings.Contains(messages[0], tt.wantSubstring) {
 					t.Fatalf("diffRows() = %v, want a message containing %q", messages, tt.wantSubstring)
 				}
-			}
-			if len(messages) != tt.wantMessages {
-				t.Fatalf("diffRows() = %d message(s) %v, want %d", len(messages), messages, tt.wantMessages)
 			}
 		})
 	}

--- a/internal/providersync/oracle_compare_test.go
+++ b/internal/providersync/oracle_compare_test.go
@@ -1,0 +1,370 @@
+package providersync
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"reflect"
+	"runtime"
+	"sort"
+	"strings"
+	"testing"
+)
+
+// oracleCase is one input case for a generic Python<->Go oracle comparison
+// (CHAOS-3162). Input must be JSON-serializable exactly as the target
+// pair's Python build_row(case) expects it (see
+// testdata/oracle_pairs/<pair>.py).
+type oracleCase struct {
+	ID    string
+	Input map[string]any
+}
+
+// compareRowsAgainstPythonOracle is the generic whole-row comparator this
+// package's pairs share (CHAOS-3162's actual deliverable: the COMPARISON is
+// generic, not just the module-loading plumbing python_oracle_loader.py
+// already solved). For each case it:
+//
+//  1. Shells out ONCE to testdata/python_generic_row_oracle.py <pairID>
+//     with all cases, getting back the real, live Python row for each case
+//     plus the pair's own declared excluded_fields (with required reasons).
+//  2. Calls goRowBuilder(input) to get the Go-side row for the SAME case,
+//     round-tripped through JSON so both sides compare as
+//     map[string]any (the same representation, so a Go int and a Python
+//     int that both decode through encoding/json as float64 compare equal
+//     without a bespoke numeric-type dance).
+//  3. Fails on ANY undeclared divergence: a key present on one side and
+//     absent on the other, or a value that differs -- UNLESS the field is
+//     declared in the Python pair's excluded_fields OR the caller's own
+//     goOnlyFields (for Go-side bookkeeping fields the Python side
+//     structurally cannot have an opinion about, e.g. org_id). Every
+//     exclusion requires a written reason at the call site, mirroring
+//     expected_survivor_reason in scripts/mutation_harness.py -- an
+//     omission must be declared, never silently missing.
+//
+// This is the single comparator every pair reuses; a pair difference is a
+// difference in WHAT gets compared (the pair id, the cases, the Go row
+// builder), never in HOW comparison happens.
+//
+// Use this form (which fails t directly) when asserting the CURRENT,
+// production code matches Python. To instead prove the comparator would
+// CATCH a specific pre-fix/buggy variant (without corrupting the enclosing
+// test's pass/fail state -- a subtest's t.Errorf always propagates failure
+// to every ancestor test, so "run it and check t.Run's bool" does not work
+// for that), use oracleDivergences directly.
+func compareRowsAgainstPythonOracle(
+	t *testing.T,
+	pairID string,
+	cases []oracleCase,
+	goRowBuilder func(t *testing.T, input map[string]any) map[string]any,
+	goOnlyFields map[string]string,
+) {
+	t.Helper()
+	for _, testCase := range cases {
+		testCase := testCase
+		t.Run(testCase.ID, func(t *testing.T) {
+			t.Helper()
+			for _, message := range oracleDivergencesForCase(t, pairID, testCase, goRowBuilder, goOnlyFields) {
+				t.Error(message)
+			}
+		})
+	}
+}
+
+// oracleDivergencesForCase runs ONE case through oracleDivergences. Kept
+// separate so compareRowsAgainstPythonOracle can still get one t.Run per
+// case (clear per-case pass/fail in `go test -v` output) while probes that
+// need every case in a single Python subprocess call use oracleDivergences
+// directly.
+func oracleDivergencesForCase(
+	t *testing.T,
+	pairID string,
+	testCase oracleCase,
+	goRowBuilder func(t *testing.T, input map[string]any) map[string]any,
+	goOnlyFields map[string]string,
+) []string {
+	t.Helper()
+	return oracleDivergences(t, pairID, []oracleCase{testCase}, goRowBuilder, goOnlyFields)
+}
+
+// oracleDivergences is the reusable core: it does the Python shellout, the
+// Go row build, and the field-by-field diff, and returns every divergence
+// message found -- WITHOUT calling t.Error/t.Fatal for the divergences
+// themselves (setup failures -- the Python process erroring, its output not
+// parsing, an undeclared-reason exclusion -- still fail t immediately,
+// since those indicate the comparison could not run at all, not that it ran
+// and found something).
+//
+// An empty return means the generic comparator found the two sides
+// identical (module declared exclusions). This is the function
+// CHAOS-3162's acceptance test calls directly: "does the comparator
+// rediscover a known defect" is exactly "is this slice non-empty when
+// pointed at a pre-fix Go row builder".
+func oracleDivergences(
+	t *testing.T,
+	pairID string,
+	cases []oracleCase,
+	goRowBuilder func(t *testing.T, input map[string]any) map[string]any,
+	goOnlyFields map[string]string,
+) []string {
+	t.Helper()
+	for name, reason := range goOnlyFields {
+		if reason == "" {
+			t.Fatalf("goOnlyFields[%q] needs a non-empty written reason", name)
+		}
+	}
+
+	python := pythonExecutable(t)
+	_, currentFile, _, _ := runtime.Caller(0)
+	packageDir := filepath.Dir(currentFile)
+
+	payload := make([]map[string]any, 0, len(cases))
+	for _, c := range cases {
+		entry := map[string]any{"id": c.ID}
+		for key, value := range c.Input {
+			entry[key] = value
+		}
+		payload = append(payload, entry)
+	}
+	casesFile, err := os.CreateTemp(t.TempDir(), "oracle-cases-*.json")
+	if err != nil {
+		t.Fatal(err)
+	}
+	encoded, err := json.Marshal(payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := casesFile.Write(encoded); err != nil {
+		t.Fatal(err)
+	}
+	if err := casesFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	output, err := exec.Command(
+		python,
+		filepath.Join(packageDir, "testdata", "python_generic_row_oracle.py"),
+		pairID,
+		casesFile.Name(),
+	).CombinedOutput()
+	if err != nil {
+		t.Fatalf("execute Python generic row oracle for %s: %v: %s", pairID, err, output)
+	}
+
+	var decoded struct {
+		Cases []struct {
+			ID  string         `json:"id"`
+			Row map[string]any `json:"row"`
+		} `json:"cases"`
+		ExcludedFields map[string]string `json:"excluded_fields"`
+	}
+	if err := json.Unmarshal(output, &decoded); err != nil {
+		t.Fatalf("decode Python generic row oracle output for %s: %v: %s", pairID, err, output)
+	}
+	for name, reason := range decoded.ExcludedFields {
+		if reason == "" {
+			t.Fatalf("pair %s: excluded_fields[%q] has no reason -- oracle_registry.register "+
+				"should have rejected this", pairID, name)
+		}
+	}
+
+	pythonRows := make(map[string]map[string]any, len(decoded.Cases))
+	for _, entry := range decoded.Cases {
+		pythonRows[entry.ID] = entry.Row
+	}
+
+	var messages []string
+	for _, testCase := range cases {
+		pythonRow, ok := pythonRows[testCase.ID]
+		if !ok {
+			t.Fatalf("oracle output missing case %q", testCase.ID)
+		}
+		goRow := jsonRoundTripToMap(t, goRowBuilder(t, testCase.Input))
+		messages = append(messages, diffRows(
+			testCase.ID, pythonRow, goRow, decoded.ExcludedFields, goOnlyFields,
+		)...)
+	}
+	return messages
+}
+
+// jsonRoundTripToMap marshals then unmarshals a value into map[string]any
+// so it compares against the Python oracle's own JSON-decoded output using
+// the identical Go representation for every JSON type (crucially: a JSON
+// number is always float64 on both sides, not int on one and float64 on
+// the other).
+func jsonRoundTripToMap(t *testing.T, value any) map[string]any {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal Go row: %v", err)
+	}
+	var decoded map[string]any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal Go row: %v", err)
+	}
+	return decoded
+}
+
+// diffRows is CHAOS-3162's actual comparison logic: every key present on
+// EITHER side must either match on both, or be declared excluded
+// (Python-declared via excluded_fields, or Go-only via goOnlyFields) with a
+// written reason. A key present on one side and absent on the other is
+// exactly as much a divergence as a key with different values on each side
+// -- neither is treated as "probably fine". Returns one message per
+// divergence found (nil/empty = the rows matched under the declared
+// exclusions).
+func diffRows(
+	caseID string,
+	pythonRow, goRow map[string]any,
+	pythonExcluded, goOnlyFields map[string]string,
+) []string {
+	allKeys := map[string]struct{}{}
+	for key := range pythonRow {
+		allKeys[key] = struct{}{}
+	}
+	for key := range goRow {
+		allKeys[key] = struct{}{}
+	}
+	sortedKeys := make([]string, 0, len(allKeys))
+	for key := range allKeys {
+		sortedKeys = append(sortedKeys, key)
+	}
+	sort.Strings(sortedKeys)
+
+	var messages []string
+	for _, key := range sortedKeys {
+		if _, excluded := pythonExcluded[key]; excluded {
+			continue
+		}
+		if _, excluded := goOnlyFields[key]; excluded {
+			continue
+		}
+		pythonValue, pythonHas := pythonRow[key]
+		goValue, goHas := goRow[key]
+		switch {
+		case pythonHas && !goHas:
+			messages = append(messages, fmt.Sprintf(
+				"case %q, field %q: present in Python's row (%v) but absent from "+
+					"Go's -- declare an exclusion with a reason if this is intentional, "+
+					"don't leave it silently missing", caseID, key, pythonValue))
+		case !pythonHas && goHas:
+			messages = append(messages, fmt.Sprintf(
+				"case %q, field %q: present in Go's row (%v) but absent from "+
+					"Python's -- declare an exclusion with a reason if this is intentional, "+
+					"don't leave it silently missing", caseID, key, goValue))
+		case !reflect.DeepEqual(pythonValue, goValue):
+			messages = append(messages, fmt.Sprintf(
+				"case %q, field %q: python=%#v go=%#v", caseID, key, pythonValue, goValue))
+		}
+	}
+	return messages
+}
+
+// TestDiffRowsClauseCoverage is a fast, synthetic-data unit test of
+// diffRows's own logic -- the core comparator every pair (Python-shellout
+// or ClickHouse-readback alike) reuses -- isolating each of its four
+// clauses (matching value, differing value, present-in-Python-only,
+// present-in-Go-only) plus its two independent exclusion mechanisms
+// (Python-declared, Go-only-declared) as its own case, so a mutation to any
+// one clause is caught by a case that exercises ONLY that clause, not by
+// coincidence from a case exercising several at once. This is the mutation
+// harness's own "mutate compound predicates clause by clause" rule applied
+// to the framework code itself, not just to a pair's row-construction
+// logic.
+func TestDiffRowsClauseCoverage(t *testing.T) {
+	tests := []struct {
+		name           string
+		pythonRow      map[string]any
+		goRow          map[string]any
+		pythonExcluded map[string]string
+		goOnlyFields   map[string]string
+		wantMessages   int
+		// wantSubstring, when non-empty, must appear in messages[0] -- this
+		// is what actually distinguishes "the present-in-Python-only clause
+		// fired" from "the value-mismatch clause ALSO fired, coincidentally
+		// producing one message, because a missing map key decodes as a nil
+		// value that fails reflect.DeepEqual against anything". A
+		// mutation-harness run against an earlier version of this test
+		// (which only asserted len(messages)) proved that gap: disabling
+		// the present-in-Python-only/present-in-Go-only clauses SURVIVED,
+		// because the fallthrough value-mismatch clause still produced
+		// exactly one message for the same two cases, for the wrong reason.
+		wantSubstring string
+	}{
+		{
+			name:         "identical single field: no divergence",
+			pythonRow:    map[string]any{"state": "open"},
+			goRow:        map[string]any{"state": "open"},
+			wantMessages: 0,
+		},
+		{
+			name:          "differing value: exactly one divergence",
+			pythonRow:     map[string]any{"state": "open"},
+			goRow:         map[string]any{"state": "closed"},
+			wantMessages:  1,
+			wantSubstring: `python="open" go="closed"`,
+		},
+		{
+			name:          "present in Python only: exactly one divergence",
+			pythonRow:     map[string]any{"state": "open"},
+			goRow:         map[string]any{},
+			wantMessages:  1,
+			wantSubstring: "present in Python's row (open) but absent from Go's",
+		},
+		{
+			name:          "present in Go only: exactly one divergence",
+			pythonRow:     map[string]any{},
+			goRow:         map[string]any{"state": "open"},
+			wantMessages:  1,
+			wantSubstring: "present in Go's row (open) but absent from Python's",
+		},
+		{
+			name:           "declared Python-side exclusion suppresses a value mismatch",
+			pythonRow:      map[string]any{"reviews_count": float64(1)},
+			goRow:          map[string]any{"reviews_count": float64(0)},
+			pythonExcluded: map[string]string{"reviews_count": "owned by github/pr-reviews"},
+			wantMessages:   0,
+		},
+		{
+			name:           "declared Python-side exclusion suppresses a present-or-absent divergence",
+			pythonRow:      map[string]any{"reviews_count": float64(1)},
+			goRow:          map[string]any{},
+			pythonExcluded: map[string]string{"reviews_count": "owned by github/pr-reviews"},
+			wantMessages:   0,
+		},
+		{
+			name:         "declared Go-only exclusion suppresses a present-or-absent divergence",
+			pythonRow:    map[string]any{},
+			goRow:        map[string]any{"org_id": "org-acme"},
+			goOnlyFields: map[string]string{"org_id": "Go-side tenant bookkeeping"},
+			wantMessages: 0,
+		},
+		{
+			name: "one excluded field plus one real divergence: only the real one is reported",
+			pythonRow: map[string]any{
+				"reviews_count": float64(1), "state": "open",
+			},
+			goRow: map[string]any{
+				"reviews_count": float64(0), "state": "closed",
+			},
+			pythonExcluded: map[string]string{"reviews_count": "owned by github/pr-reviews"},
+			wantMessages:   1,
+			wantSubstring:  `python="open" go="closed"`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages := diffRows("case", tt.pythonRow, tt.goRow, tt.pythonExcluded, tt.goOnlyFields)
+			if tt.wantSubstring != "" {
+				if len(messages) == 0 || !strings.Contains(messages[0], tt.wantSubstring) {
+					t.Fatalf("diffRows() = %v, want a message containing %q", messages, tt.wantSubstring)
+				}
+			}
+			if len(messages) != tt.wantMessages {
+				t.Fatalf("diffRows() = %d message(s) %v, want %d", len(messages), messages, tt.wantMessages)
+			}
+		})
+	}
+}

--- a/internal/providersync/oracle_readback_integration_test.go
+++ b/internal/providersync/oracle_readback_integration_test.go
@@ -1,0 +1,337 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ClickHouse/clickhouse-go/v2/lib/driver"
+)
+
+// This file extends CHAOS-3162's generic, declarative, fail-on-undeclared-
+// divergence comparator (diffRows / oracleDivergences, oracle_compare_test.go)
+// to the readback boundary: "the row a caller wrote" versus "the row a
+// caller reads back through ClickHouse's ReplacingMergeTree resolution".
+//
+// This is NOT a Python<->Go crossing -- Python's own sync path has no
+// readback-fencing concept to compare against; the effect-ledger,
+// InspectEffect-before-CommitEffect pattern is a Go-only architectural
+// addition (see internal/providersync's package doc). What CHAOS-3162
+// actually asked this framework to guarantee -- a DECLARATIVE pair table, a
+// WHOLE-ROW comparison, and failure on ANY undeclared divergence including a
+// column present on one side and absent on the other -- applies just as
+// much to this crossing as to a Python<->Go one, and reuses the identical
+// diffRows/oracleDivergences machinery rather than a bespoke comparison.
+// Where the row-construction pair's "expected" side comes from a live
+// Python subprocess, this pair's "expected" side is the Go row the test
+// itself asked ClickHouse to store -- validated safe to use as ground truth
+// because TestGenericOracleMatchesLivePythonForRowConstruction already
+// proves, independently, that a Go-built pullRequestRow is byte-for-byte
+// identical to Python's for the same input.
+//
+// Covers two of the six CHAOS-3162 acceptance defects that are NOT
+// reachable through the row-construction boundary:
+//   - "the omitted readback columns" (M6/round1): a SELECT that leaves a
+//     column out of its column list.
+//   - "the NULL-versus-empty-string collapse" (H2/round2): a per-column
+//     argMax(col, last_synced) reconstruction, which independently maximizes
+//     each column and can silently assemble a row that never existed as any
+//     single physical version, because argMax skips NULL-argument rows when
+//     picking the max.
+
+// encodeOracleValue JSON round-trips one value through the same
+// marshal/unmarshal path jsonRoundTripToMap uses for a whole struct, so a
+// hand-built map (this file) and a struct-marshaled map
+// (github_prs_generic_oracle_test.go, oracle_compare_test.go) represent a
+// time.Time/*time.Time/*string identically -- there is exactly one encoding
+// rule in this package's tests, applied consistently, not two that must be
+// kept in sync by hand.
+func encodeOracleValue(t *testing.T, value any) any {
+	t.Helper()
+	encoded, err := json.Marshal(value)
+	if err != nil {
+		t.Fatalf("marshal oracle value: %v", err)
+	}
+	var decoded any
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal oracle value: %v", err)
+	}
+	return decoded
+}
+
+// pullRequestReadbackComparisonExclusions are the fields the readback
+// boundary deliberately does not compare: last_synced/source_id/org_id are
+// Go-side bookkeeping (same reasons as oraclePullRequestGoOnlyFields), and
+// repo_id/number are the lookup KEY, not a value under test -- comparing
+// them would only ever prove the WHERE clause worked, not that the SELECT
+// list is complete or correct.
+var pullRequestReadbackComparisonExclusions = map[string]string{
+	"last_synced": "Go-side effect bookkeeping, not part of the row's business data",
+	"source_id":   "Go-side effect bookkeeping, not part of the row's business data",
+	"org_id":      "part of the lookup key (WHERE clause), not a value the SELECT list is being tested on",
+	"repo_id":     "part of the lookup key (WHERE clause), not a value the SELECT list is being tested on",
+	"number":      "part of the lookup key (WHERE clause), not a value the SELECT list is being tested on",
+}
+
+// readPullRequestRowCorrectly is the CURRENT, production readback query
+// (verbatim copy of inspectPullRequest's SELECT, minus the
+// bookkeeping/lookup-key columns pullRequestReadbackComparisonExclusions
+// declares out of scope): a FINAL point lookup, which resolves the winning
+// physical ReplacingMergeTree version by reading ONE consistent row.
+func readPullRequestRowCorrectly(
+	ctx context.Context, t *testing.T, harness *pullRequestReadbackHarness, repoID string, number int,
+) map[string]any {
+	t.Helper()
+	rows, err := harness.conn.Query(ctx, `
+SELECT
+  title, body, state, author_name, author_email, created_at, merged_at,
+  closed_at, head_branch, base_branch, additions, deletions, changed_files,
+  first_review_at, first_comment_at, changes_requested_count, reviews_count,
+  comments_count
+FROM git_pull_requests FINAL
+WHERE org_id = ? AND repo_id = ? AND number = ?`,
+		harness.claim.OrgID, repoID, number,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	return scanPullRequestReadbackRow(t, rows, true)
+}
+
+// readPullRequestRowOmittingStateColumn reproduces "the omitted readback
+// columns" (M6/round1): otherwise the same correct FINAL point lookup, but
+// the SELECT list itself leaves `state` out -- exactly the shape of bug a
+// hand-picked assertion list can miss (an assertion that never mentions
+// `state` cannot notice `state` went missing from the query), and exactly
+// what the generic comparator's "present on one side, absent on the other"
+// check exists to catch instead.
+func readPullRequestRowOmittingStateColumn(
+	ctx context.Context, t *testing.T, harness *pullRequestReadbackHarness, repoID string, number int,
+) map[string]any {
+	t.Helper()
+	rows, err := harness.conn.Query(ctx, `
+SELECT
+  title, body, author_name, author_email, created_at, merged_at,
+  closed_at, head_branch, base_branch, additions, deletions, changed_files,
+  first_review_at, first_comment_at, changes_requested_count, reviews_count,
+  comments_count
+FROM git_pull_requests FINAL
+WHERE org_id = ? AND repo_id = ? AND number = ?`,
+		harness.claim.OrgID, repoID, number,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	return scanPullRequestReadbackRow(t, rows, false)
+}
+
+// readPullRequestRowViaPerColumnArgMax reproduces "the NULL-versus-empty-
+// string collapse" (H2/round2, the single most dangerous finding in this
+// pair's whole review history): the PRE-fix readback shape, which computes
+// argMax(column, last_synced) independently per column instead of reading
+// one consistent row. ClickHouse's argMax skips a row whose ARGUMENT
+// (the column being maximized) is NULL when deciding the max, so if the
+// winning (latest last_synced) row has NULL in some column while an older
+// row has a non-NULL value there, this reconstructs a column value from a
+// version that is not the winning version at all -- a row that never
+// existed as any single physical write.
+func readPullRequestRowViaPerColumnArgMax(
+	ctx context.Context, t *testing.T, harness *pullRequestReadbackHarness, repoID string, number int,
+) map[string]any {
+	t.Helper()
+	rows, err := harness.conn.Query(ctx, `
+SELECT
+  argMax(title, last_synced), argMax(body, last_synced), argMax(state, last_synced),
+  argMax(author_name, last_synced), argMax(author_email, last_synced),
+  argMax(created_at, last_synced), argMax(merged_at, last_synced),
+  argMax(closed_at, last_synced), argMax(head_branch, last_synced),
+  argMax(base_branch, last_synced), argMax(additions, last_synced),
+  argMax(deletions, last_synced), argMax(changed_files, last_synced),
+  argMax(first_review_at, last_synced), argMax(first_comment_at, last_synced),
+  argMax(changes_requested_count, last_synced), argMax(reviews_count, last_synced),
+  argMax(comments_count, last_synced)
+FROM git_pull_requests
+WHERE org_id = ? AND repo_id = ? AND number = ?
+GROUP BY org_id, repo_id, number`,
+		harness.claim.OrgID, repoID, number,
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer rows.Close()
+	return scanPullRequestReadbackRow(t, rows, true)
+}
+
+// scanPullRequestReadbackRow scans one row shaped like the queries above
+// (title..comments_count, with `state` optionally omitted) into a
+// map[string]any keyed identically to pullRequestRow's json tags / Python's
+// build_git_pull_request output, so it can be diffed with diffRows exactly
+// like the row-construction pair's Python output is. Fails the test if zero
+// or more than one row comes back -- a readback query returning the wrong
+// row COUNT is a bug this generic comparator cannot see (it only compares
+// field values within one row), so it is asserted directly here instead of
+// silently comparing against an arbitrary row or an empty map.
+func scanPullRequestReadbackRow(t *testing.T, rows driver.Rows, includeState bool) map[string]any {
+	t.Helper()
+	var title, body, headBranch, baseBranch, authorEmail *string
+	var state, authorName string
+	var createdAt time.Time
+	var mergedAt, closedAt, firstReviewAt, firstCommentAt *time.Time
+	var additions, deletions, changedFiles, changesRequestedCount, reviewsCount, commentsCount uint32
+
+	found := false
+	for rows.Next() {
+		if found {
+			t.Fatalf("readback query returned more than one row")
+		}
+		found = true
+		var err error
+		if includeState {
+			err = rows.Scan(
+				&title, &body, &state, &authorName, &authorEmail, &createdAt, &mergedAt,
+				&closedAt, &headBranch, &baseBranch, &additions, &deletions, &changedFiles,
+				&firstReviewAt, &firstCommentAt, &changesRequestedCount, &reviewsCount, &commentsCount,
+			)
+		} else {
+			err = rows.Scan(
+				&title, &body, &authorName, &authorEmail, &createdAt, &mergedAt,
+				&closedAt, &headBranch, &baseBranch, &additions, &deletions, &changedFiles,
+				&firstReviewAt, &firstCommentAt, &changesRequestedCount, &reviewsCount, &commentsCount,
+			)
+		}
+		if err != nil {
+			t.Fatalf("scan readback row: %v", err)
+		}
+	}
+	if !found {
+		t.Fatalf("readback query returned no row")
+	}
+
+	row := map[string]any{
+		"title": encodeOracleValue(t, title), "body": encodeOracleValue(t, body),
+		"author_name": encodeOracleValue(t, authorName), "author_email": encodeOracleValue(t, authorEmail),
+		"created_at": encodeOracleValue(t, createdAt), "merged_at": encodeOracleValue(t, mergedAt),
+		"closed_at": encodeOracleValue(t, closedAt), "head_branch": encodeOracleValue(t, headBranch),
+		"base_branch": encodeOracleValue(t, baseBranch), "additions": encodeOracleValue(t, additions),
+		"deletions": encodeOracleValue(t, deletions), "changed_files": encodeOracleValue(t, changedFiles),
+		"first_review_at": encodeOracleValue(t, firstReviewAt), "first_comment_at": encodeOracleValue(t, firstCommentAt),
+		"changes_requested_count": encodeOracleValue(t, changesRequestedCount),
+		"reviews_count":           encodeOracleValue(t, reviewsCount),
+		"comments_count":          encodeOracleValue(t, commentsCount),
+	}
+	if includeState {
+		row["state"] = encodeOracleValue(t, state)
+	}
+	return row
+}
+
+// expectedPullRequestRowMap converts a Go-built pullRequestRow to the same
+// map[string]any shape the readback queries above produce, for diffRows.
+func expectedPullRequestRowMap(t *testing.T, row pullRequestRow) map[string]any {
+	t.Helper()
+	full := jsonRoundTripToMap(t, row)
+	for excluded := range pullRequestReadbackComparisonExclusions {
+		delete(full, excluded)
+	}
+	return full
+}
+
+// TestGenericComparatorMatchesCorrectReadback is the "current code is
+// clean" half for the readback boundary: write an older then a winning
+// version (the exact mixed-NULL shape
+// TestGitHubPullRequestReadbackDoesNotReconstructRowFromMixedVersions
+// uses), then diff the CURRENT production readback query's result against
+// the winning row with zero undeclared exclusions.
+func TestGenericComparatorMatchesCorrectReadback(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	harness := startPullRequestReadbackHarness(t, ctx)
+	claim, sink, now := harness.claim, harness.sink, harness.now
+
+	older := pullRequestReadbackFixture(now.Add(-time.Hour))
+	older.OrgID = claim.OrgID
+	if err := sink.WriteEffect(ctx, claim, pullRequestEffect(t, older)); err != nil {
+		t.Fatal(err)
+	}
+	winning := pullRequestReadbackFixture(now)
+	winning.OrgID = claim.OrgID
+	winning.State = "open"
+	winning.MergedAt, winning.ClosedAt = nil, nil
+	winning.FirstReviewAt = nil
+	winning.ReviewsCount, winning.ChangesRequestedCount = 0, 0
+	if err := sink.WriteEffect(ctx, claim, pullRequestEffect(t, winning)); err != nil {
+		t.Fatal(err)
+	}
+
+	expected := expectedPullRequestRowMap(t, winning)
+	actual := readPullRequestRowCorrectly(ctx, t, harness, winning.RepoID, winning.Number)
+	messages := diffRows("winning-after-mixed-null-history", expected, actual,
+		nil, pullRequestReadbackComparisonExclusions)
+	for _, message := range messages {
+		t.Error(message)
+	}
+}
+
+// TestGenericComparatorRediscoversReadbackDefects is CHAOS-3162's
+// acceptance gate for the readback boundary: the SAME generic comparator
+// (diffRows), against the SAME written fixture data, must report a
+// divergence when pointed at either historical buggy query shape.
+func TestGenericComparatorRediscoversReadbackDefects(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+	harness := startPullRequestReadbackHarness(t, ctx)
+	claim, sink, now := harness.claim, harness.sink, harness.now
+
+	// Same mixed-NULL shape as
+	// TestGitHubPullRequestReadbackDoesNotReconstructRowFromMixedVersions:
+	// the older version has non-NULL merged_at/closed_at/first_review_at:
+	// the winning version has NULL in all three, which is the only shape
+	// that can distinguish "read the winning row" from "assemble a row from
+	// whichever version has a non-NULL value per column".
+	older := pullRequestReadbackFixture(now.Add(-time.Hour))
+	older.OrgID = claim.OrgID
+	if err := sink.WriteEffect(ctx, claim, pullRequestEffect(t, older)); err != nil {
+		t.Fatal(err)
+	}
+	winning := pullRequestReadbackFixture(now)
+	winning.OrgID = claim.OrgID
+	winning.State = "open"
+	winning.MergedAt, winning.ClosedAt = nil, nil
+	winning.FirstReviewAt = nil
+	winning.ReviewsCount, winning.ChangesRequestedCount = 0, 0
+	if err := sink.WriteEffect(ctx, claim, pullRequestEffect(t, winning)); err != nil {
+		t.Fatal(err)
+	}
+	expected := expectedPullRequestRowMap(t, winning)
+
+	t.Run("rediscovers NULL-versus-empty-string collapse (per-column argMax)", func(t *testing.T) {
+		actual := readPullRequestRowViaPerColumnArgMax(ctx, t, harness, winning.RepoID, winning.Number)
+		messages := diffRows("winning-after-mixed-null-history", expected, actual,
+			nil, pullRequestReadbackComparisonExclusions)
+		if len(messages) == 0 {
+			t.Fatal("expected the generic comparator to rediscover the per-column argMax " +
+				"cross-version reconstruction defect, but it reported no divergence")
+		}
+		for _, message := range messages {
+			t.Logf("rediscovered: %s", message)
+		}
+	})
+
+	t.Run("rediscovers omitted readback columns (state left out of SELECT)", func(t *testing.T) {
+		actual := readPullRequestRowOmittingStateColumn(ctx, t, harness, winning.RepoID, winning.Number)
+		messages := diffRows("winning-after-mixed-null-history", expected, actual,
+			nil, pullRequestReadbackComparisonExclusions)
+		if len(messages) == 0 {
+			t.Fatal("expected the generic comparator to rediscover the omitted-state-column " +
+				"defect, but it reported no divergence")
+		}
+		for _, message := range messages {
+			t.Logf("rediscovered: %s", message)
+		}
+	})
+}

--- a/internal/providersync/oracle_readback_integration_test.go
+++ b/internal/providersync/oracle_readback_integration_test.go
@@ -68,30 +68,47 @@ var pullRequestReadbackComparisonExclusions = map[string]string{
 	"number":      "part of the lookup key (WHERE clause), not a value the SELECT list is being tested on",
 }
 
-// readPullRequestRowCorrectly is the CURRENT, production readback query
-// (verbatim copy of inspectPullRequest's SELECT, minus the
-// bookkeeping/lookup-key columns pullRequestReadbackComparisonExclusions
-// declares out of scope): a FINAL point lookup, which resolves the winning
-// physical ReplacingMergeTree version by reading ONE consistent row.
+// readPullRequestRowCorrectly is the CURRENT, production readback path:
+// calls GitHubPullRequestClickHouseEffects.scanWinningPullRequestVersion
+// DIRECTLY (github_prs_effects_clickhouse.go) -- the same function
+// InspectEffect itself calls -- rather than a test-local copy of its query
+// (codex finding #3, CHAOS-3162 second adversarial review: a copied query
+// goes stale silently the moment the real one changes, which is the exact
+// class of defect this framework exists to catch, not commit). The two
+// BUGGY variants below (readPullRequestRowOmittingStateColumn,
+// readPullRequestRowViaPerColumnArgMax) necessarily stay test-local SQL --
+// there is no production function for a bug being deliberately
+// reintroduced to compare against -- exactly mirroring how the
+// row-construction pair's buggy Go builders are test-local copies while
+// its baseline calls production directly.
 func readPullRequestRowCorrectly(
 	ctx context.Context, t *testing.T, harness *pullRequestReadbackHarness, repoID string, number int,
 ) map[string]any {
 	t.Helper()
-	rows, err := harness.conn.Query(ctx, `
-SELECT
-  title, body, state, author_name, author_email, created_at, merged_at,
-  closed_at, head_branch, base_branch, additions, deletions, changed_files,
-  first_review_at, first_comment_at, changes_requested_count, reviews_count,
-  comments_count
-FROM git_pull_requests FINAL
-WHERE org_id = ? AND repo_id = ? AND number = ?`,
-		harness.claim.OrgID, repoID, number,
-	)
+	version, err := harness.sink.scanWinningPullRequestVersion(ctx, harness.claim.OrgID, repoID, number)
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer rows.Close()
-	return scanPullRequestReadbackRow(t, rows, true)
+	if !version.Found {
+		t.Fatalf("scanWinningPullRequestVersion: no row found for repo_id=%s number=%d", repoID, number)
+	}
+	full, ok := typedEncode(t, reflect.ValueOf(version.Row)).(map[string]any)
+	if !ok {
+		t.Fatalf("typedEncode(pullRequestRow) did not return a map")
+	}
+	// scanWinningPullRequestVersion returns the FULL pullRequestRow
+	// (including org_id/last_synced/source_id, which live on
+	// pullRequestVersion's own fields, not Row -- so Row itself never
+	// carries them from this path -- and repo_id/number, which it DOES
+	// carry). pullRequestReadbackComparisonExclusions already covers all
+	// five as lookup-key/bookkeeping fields out of scope for this
+	// SELECT-completeness comparison; trim them the same way
+	// expectedPullRequestRowMap does so both sides of diffRows see the
+	// identical key set.
+	for excluded := range pullRequestReadbackComparisonExclusions {
+		delete(full, excluded)
+	}
+	return full
 }
 
 // readPullRequestRowOmittingStateColumn reproduces "the omitted readback

--- a/internal/providersync/oracle_readback_integration_test.go
+++ b/internal/providersync/oracle_readback_integration_test.go
@@ -4,7 +4,7 @@ package providersync
 
 import (
 	"context"
-	"encoding/json"
+	"reflect"
 	"testing"
 	"time"
 
@@ -42,24 +42,16 @@ import (
 //     single physical version, because argMax skips NULL-argument rows when
 //     picking the max.
 
-// encodeOracleValue JSON round-trips one value through the same
-// marshal/unmarshal path jsonRoundTripToMap uses for a whole struct, so a
-// hand-built map (this file) and a struct-marshaled map
-// (github_prs_generic_oracle_test.go, oracle_compare_test.go) represent a
-// time.Time/*time.Time/*string identically -- there is exactly one encoding
-// rule in this package's tests, applied consistently, not two that must be
-// kept in sync by hand.
+// encodeOracleValue routes one hand-scanned readback column through the
+// SAME typedEncode reflection-based, type-tagged encoding
+// oracle_compare_test.go uses for a whole struct (codex finding #2: a
+// bare, untagged encoding is exactly what let an int and an integral float,
+// or two large integers, compare equal at float64 precision) -- there is
+// exactly one encoding rule in this package's tests, applied consistently
+// via one shared function, not two that must be kept in sync by hand.
 func encodeOracleValue(t *testing.T, value any) any {
 	t.Helper()
-	encoded, err := json.Marshal(value)
-	if err != nil {
-		t.Fatalf("marshal oracle value: %v", err)
-	}
-	var decoded any
-	if err := json.Unmarshal(encoded, &decoded); err != nil {
-		t.Fatalf("unmarshal oracle value: %v", err)
-	}
-	return decoded
+	return typedEncode(t, reflect.ValueOf(value))
 }
 
 // pullRequestReadbackComparisonExclusions are the fields the readback
@@ -234,7 +226,10 @@ func scanPullRequestReadbackRow(t *testing.T, rows driver.Rows, includeState boo
 // map[string]any shape the readback queries above produce, for diffRows.
 func expectedPullRequestRowMap(t *testing.T, row pullRequestRow) map[string]any {
 	t.Helper()
-	full := jsonRoundTripToMap(t, row)
+	full, ok := typedEncode(t, reflect.ValueOf(row)).(map[string]any)
+	if !ok {
+		t.Fatalf("typedEncode(pullRequestRow) did not return a map")
+	}
 	for excluded := range pullRequestReadbackComparisonExclusions {
 		delete(full, excluded)
 	}

--- a/internal/providersync/release_for_retry_integration_test.go
+++ b/internal/providersync/release_for_retry_integration_test.go
@@ -1,0 +1,140 @@
+//go:build integration
+
+package providersync
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/testsupport/containers"
+	"github.com/google/uuid"
+	"github.com/jackc/pgx/v5/pgxpool"
+)
+
+// TestReleaseForRetryPreservesAnInFlightEffectLedger is codex H1's second
+// half (CHAOS-3122): ReleaseForRetry previously overwrote the whole `result`
+// jsonb column with just {"error_category": ...}, deleting the
+// go_effect_ledger_v1 key. If an earlier attempt had already begun writing
+// an EffectReadbackRequired effect (WriteEffect landed in ClickHouse, then
+// the process died before CommitEffect) and a LATER attempt then failed for
+// any reason -- a capped paginated fetch being the concrete case that made
+// this newly, deterministically reachable -- ReleaseForRetry wiped the
+// ledger recording that in-flight write. The next attempt's LoadEffects then
+// returned ErrEffectLedgerNotFound, forgot the frozen normalizedAt/digest,
+// and rebuilt a brand new manifest with no way to classify the earlier
+// ClickHouse row as exact, absent, or conflict -- the exact evidence
+// InspectEffect-based recovery depends on.
+func TestReleaseForRetryPreservesAnInFlightEffectLedger(t *testing.T) {
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Minute)
+	defer cancel()
+	instance, err := containers.StartPostgres(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		closeContext, closeCancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer closeCancel()
+		if err := instance.Close(closeContext); err != nil {
+			t.Errorf("terminate PostgreSQL: %v", err)
+		}
+	}()
+	pool, err := pgxpool.New(ctx, instance.URI)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer pool.Close()
+	createProviderSyncFixture(t, ctx, pool)
+	seedProviderSyncFixture(t, ctx, pool)
+
+	repository, err := NewPostgresRepository(pool)
+	if err != nil {
+		t.Fatal(err)
+	}
+	now := time.Date(2026, time.July, 23, 12, 0, 0, 0, time.UTC)
+	claim, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, OrgID: "org-acme", Owner: uuid.NewString(), Now: now,
+		LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Build a minimal EffectReadbackRequired effect and drive it to
+	// GenerationBlockWriting -- the state a real WriteEffect-then-crash
+	// leaves behind, per GitHubPullRequestClickHouseEffects and
+	// GitHubRepositoryClickHouseEffects's own doc comments.
+	effect, err := BuildEffectBatch(
+		"repos", EffectReadbackRequired,
+		[]json.RawMessage{json.RawMessage(`{"probe":"value"}`)},
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	state, err := NewEffectLedgerState(claim, []EffectBatch{effect}, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := repository.PrepareEffects(ctx, claim, state, now); err != nil {
+		t.Fatal(err)
+	}
+	if err := repository.BeginEffect(
+		ctx, claim, 0, effect.ContentDigest, now.Add(time.Second),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the failure path: Collect (or anything else in Execute)
+	// errors on this attempt, and the job handler releases the unit for a
+	// bounded retry -- exactly what cmd's providerunit.go does for any
+	// non-deterministic, non-exhausted error.
+	releasedAt := now.Add(10 * time.Second)
+	if err := repository.ReleaseForRetry(ctx, claim, releasedAt); err != nil {
+		t.Fatal(err)
+	}
+
+	// A fresh attempt reclaims the unit (ReleaseForRetry returns it to
+	// `dispatching` with no lease owner, so a normal claim -- not expired-
+	// lease recovery -- picks it up next).
+	reclaimedAt := releasedAt.Add(time.Second)
+	reclaimed, err := repository.Claim(ctx, ClaimRequest{
+		UnitID: firstUnitID, OrgID: "org-acme", Owner: uuid.NewString(),
+		Now: reclaimedAt, LeaseDuration: time.Minute, AllowExpiredRecovery: true,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// The whole point: LoadEffects must still find the ledger, not
+	// ErrEffectLedgerNotFound, and it must be the SAME manifest at the SAME
+	// frozen instant -- proving a later attempt can still reuse
+	// normalizedAt and reach InspectEffect-based reconciliation instead of
+	// silently starting a brand new, unreconciled write.
+	persisted, err := repository.LoadEffects(ctx, reclaimed, reclaimedAt.Add(time.Second))
+	if err != nil {
+		t.Fatalf("LoadEffects after ReleaseForRetry: %v (ledger was wiped)", err)
+	}
+	if !persisted.CreatedAt.UTC().Equal(now.UTC()) {
+		t.Fatalf("persisted.CreatedAt=%v want %v (frozen normalizedAt lost)", persisted.CreatedAt, now)
+	}
+	if len(persisted.Effects) != 1 || persisted.Effects[0].Status != GenerationBlockWriting ||
+		persisted.Effects[0].ContentDigest != effect.ContentDigest {
+		t.Fatalf("persisted effect=%+v want status=writing digest=%s",
+			persisted.Effects[0], effect.ContentDigest)
+	}
+
+	// error_category must still be set (ReleaseForRetry's own contract),
+	// alongside the preserved ledger -- this is a merge, not a swap to a
+	// second exclusive key.
+	var errorCategory string
+	if err := pool.QueryRow(ctx, `
+SELECT result::jsonb ->> 'error_category' FROM public.sync_run_units WHERE id = $1`,
+		firstUnitID,
+	).Scan(&errorCategory); err != nil {
+		t.Fatal(err)
+	}
+	if errorCategory != "provider_unit_retryable" {
+		t.Fatalf("error_category=%q want provider_unit_retryable", errorCategory)
+	}
+}

--- a/internal/providersync/repository_postgres.go
+++ b/internal/providersync/repository_postgres.go
@@ -370,12 +370,29 @@ WHERE unit.id = $1::uuid
       AND run.status NOT IN ('success', 'partial_failed', 'failed')
   )`
 
+// releaseForRetrySQL merges 'error_category' into the existing result
+// document rather than replacing it wholesale (codex H1, second half,
+// CHAOS-3122). The prior blind `result = jsonb_build_object(...)` overwrite
+// deleted the go_effect_ledger_v1 key whenever a unit failed after an
+// earlier attempt had loaded (or begun writing) an effect: the next attempt
+// then found no ledger, forgot the frozen normalizedAt/digest a
+// EffectReadbackRequired effect depends on, and could no longer classify a
+// possibly-landed-but-uncommitted ClickHouse row as exact, absent, or
+// conflict. A capped-pagination failure (see github_prs_route.go) made this
+// newly, deterministically reachable, but the gap itself predates that fix
+// and applies to any Collect failure after a ledger was loaded, on any
+// EffectReadbackRequired pair. A single UPDATE's SET expression reads the
+// current row atomically -- no separate lock is needed the way
+// mutateGenerationJournal's two-round-trip read-modify-write requires.
 const releaseForRetrySQL = `
 UPDATE public.sync_run_units AS unit
 SET status = 'dispatching',
     available_at = NULL,
     error = 'provider_unit_retryable',
-    result = jsonb_build_object('error_category', 'provider_unit_retryable'),
+    result = (
+      COALESCE(unit.result::jsonb, '{}'::jsonb) ||
+      jsonb_build_object('error_category', 'provider_unit_retryable')
+    ),
     lease_owner = NULL,
     lease_expires_at = NULL,
     last_heartbeat_at = $3,

--- a/internal/providersync/testdata/field_reflection.py
+++ b/internal/providersync/testdata/field_reflection.py
@@ -1,0 +1,99 @@
+"""Static field-set reflection for CHAOS-3162's oracle_registry (codex
+finding #1).
+
+A pair's `reflected_fields` callable must answer "what is the COMPLETE set
+of fields the production function is capable of emitting" without either
+(a) hand-maintaining a second list that can drift from the function it
+describes, or (b) executing the function itself (which would need the same
+case data a comparison run does, and would only prove completeness for
+whatever cases happen to be supplied -- exactly the coverage gap this
+module exists to close independent of any particular case).
+
+`dict_literal_keys` answers it by parsing the target function's source with
+`ast` -- no import, no execution, so it works under the same stock
+interpreter constraint as everything else in this directory -- and
+collecting every string-literal key assigned into one of the named dict
+variables anywhere in that function's body. This mirrors, structurally,
+`build_git_pull_request`'s own shape (a `values` dict, unconditionally
+populated, plus an `optional_values` dict merged in when non-None): the
+reflected field set is derived from the SAME two dict literals the function
+actually builds its result from, not from a parallel description of them.
+"""
+
+from __future__ import annotations
+
+import ast
+
+# The pseudo dict-var-name that matches a bare `return {...}` literal
+# instead of an assignment. Used by pairs whose "production" function (or,
+# for a pinned fallback like github_prs_window.py, whose pinned copy) builds
+# its result as a single return expression rather than an intermediate
+# named dict.
+RETURN_LITERAL = "return"
+
+
+def dict_literal_keys(
+    source: str, function_name: str, dict_var_names: tuple[str, ...]
+) -> frozenset[str]:
+    tree = ast.parse(source)
+    target_function: ast.FunctionDef | ast.AsyncFunctionDef | None = None
+    for node in ast.walk(tree):
+        if (
+            isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+            and node.name == function_name
+        ):
+            target_function = node
+            break
+    if target_function is None:
+        raise ValueError(
+            f"dict_literal_keys: no function named {function_name!r} found in "
+            "the given source -- has it been renamed or moved?"
+        )
+
+    keys: set[str] = set()
+    for node in ast.walk(target_function):
+        # Three shapes matter: a plain assignment (`values = {...}`), an
+        # annotated assignment (`values: dict[str, Any] = {...}` --
+        # build_git_pull_request uses this form for `values`), and a bare
+        # `return {...}` literal (matched when RETURN_LITERAL is requested).
+        # Missing any of these silently under-reflects the function they
+        # are meant to describe.
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Dict):
+            targets = node.targets
+        elif (
+            isinstance(node, ast.AnnAssign)
+            and isinstance(node.value, ast.Dict)
+            and node.target is not None
+        ):
+            targets = [node.target]
+        elif (
+            RETURN_LITERAL in dict_var_names
+            and isinstance(node, ast.Return)
+            and isinstance(node.value, ast.Dict)
+        ):
+            for key_node in node.value.keys:
+                if isinstance(key_node, ast.Constant) and isinstance(
+                    key_node.value, str
+                ):
+                    keys.add(key_node.value)
+            continue
+        else:
+            continue
+        if not any(
+            isinstance(target, ast.Name) and target.id in dict_var_names
+            for target in targets
+        ):
+            continue
+        for key_node in node.value.keys:
+            if isinstance(key_node, ast.Constant) and isinstance(key_node.value, str):
+                keys.add(key_node.value)
+
+    if not keys:
+        raise ValueError(
+            f"dict_literal_keys: found {function_name!r} but no string-keyed "
+            f"dict literal assigned to (or returned via) any of "
+            f"{dict_var_names!r} inside it -- the function's shape has "
+            "likely changed and this reflector needs updating to match, "
+            "not silently returning an empty/stale set"
+        )
+    return frozenset(keys)

--- a/internal/providersync/testdata/mutation-plans/github_prs.json
+++ b/internal/providersync/testdata/mutation-plans/github_prs.json
@@ -1,0 +1,128 @@
+{
+  "schema_version": 1,
+  "name": "github/prs codex-review fixes (CHAOS-3122)",
+  "$limitation": "H4 (blank full_name must fail closed) has no entry here. The first version of this plan mutated github_prs_route.go's own `if fullName == \"\" {...}` guard and it SURVIVED: repositoryIdentity(fullName) (github_repository_route.go) already rejects an empty/all-whitespace string with the identical ErrNormalizationInvalid before hashing anything, so the explicit guard was dead code duplicating a check the callee already makes. It was deleted (see github_prs_route.go's repositoryIdentity call site comment) rather than kept alive only to give this plan something to mutate. The fail-closed behavior itself is proven by TestGitHubPullRequestRouteFailsClosedOnScopeAndPayloadFaults's noFullName case (asserts Collect errors) and, at the shared-function level, by TestRepositoryIdentityFailsClosedOnDocumentedPythonDivergences in github_repository_route_test.go.",
+  "mutations": [
+    {
+      "id": "H2-cap-must-fail-closed",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "if page.CapReached {",
+      "replace": "if false {",
+      "rationale": "a capped paginated fetch must fail the whole unit, never report success and advance the watermark past PRs it never fetched",
+      "proof": [
+        ["go", "test", "-run", "^TestGitHubPullRequestRouteFailsClosedOnPaginationCap$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "H3-unknown-updated-at-must-not-exclude",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "windowKnown := !updatedAt.IsZero()",
+      "replace": "windowKnown := true",
+      "rationale": "a missing/null/unparseable updated_at must be unconditionally included (Python only compares when isinstance(updated_at, datetime)), never excluded",
+      "proof": [
+        ["go", "test", "-run", "^TestFilterGitHubPullWindowClauseCoverage$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "H3-before-since-clause",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "before := claim.SinceAt != nil && updatedAt.Before(claim.SinceAt.UTC())",
+      "replace": "before := false",
+      "rationale": "an item strictly before claim.SinceAt must be excluded from the fetched set",
+      "proof": [
+        ["go", "test", "-run", "^TestFilterGitHubPullWindowClauseCoverage$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "H3-after-before-clause",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "after := claim.BeforeAt != nil && updatedAt.After(claim.BeforeAt.UTC())",
+      "replace": "after := false",
+      "rationale": "an item strictly after claim.BeforeAt must be excluded from the fetched set",
+      "proof": [
+        ["go", "test", "-run", "^TestFilterGitHubPullWindowClauseCoverage$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "H3-disjunction-not-conjunction",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "return before || after",
+      "replace": "return before && after",
+      "rationale": "either bound alone must exclude the item; the combinator must be OR, not AND, or an item before since but not after before would wrongly stay included",
+      "proof": [
+        ["go", "test", "-run", "^TestFilterGitHubPullWindowClauseCoverage$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "M5-truncate-to-milliseconds",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "parsed = parsed.UTC().Truncate(time.Millisecond)",
+      "replace": "parsed = parsed.UTC()",
+      "rationale": "provider timestamps must be truncated to millisecond precision at construction, matching ClickHouse's DateTime64(3), or a later readback compares unequal to the in-memory value",
+      "proof": [
+        ["go", "test", "-run", "^TestParseGitHubPullTimeTruncatesToMilliseconds$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "M7-strip-not-just-lower",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "switch strings.ToLower(strings.TrimSpace(rawState)) {",
+      "replace": "switch strings.ToLower(rawState) {",
+      "rationale": "Python's raw_state.strip().lower() strips leading/trailing whitespace (including \\r) before lowercasing; dropping TrimSpace diverges on \"closed\\r\" and leading/trailing-whitespace states",
+      "proof": [
+        ["go", "test", "-run", "^TestNormalizePRStateMatchesPython$", "./internal/providersync/"],
+        ["go", "test", "-run", "^TestGitHubPRSNormalizationMatchesLivePythonFunctions$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "M8-stringify-non-string-login",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "return stringValue(user.Login)",
+      "replace": "return \"\"",
+      "rationale": "Python's str(user[\"login\"]) stringifies ANY non-null login value; a numeric login must not silently become the \"Unknown\" fallback",
+      "proof": [
+        ["go", "test", "-run", "^TestGitHubPullUserLoginStringifiesNonStringLogins$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "M6-readback-state-clause",
+      "file": "internal/providersync/github_prs_effects_clickhouse.go",
+      "find": "if actual.Row.State != expected.State {",
+      "replace": "if false {",
+      "rationale": "a persisted row whose state differs from the expected effect at the same version must report EffectConflict, not EffectExact",
+      "proof": [
+        ["go", "test", "-run", "^TestPullRequestReadbackClassifiesEveryVersionRelationship$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "M6-readback-source-id-clause",
+      "file": "internal/providersync/github_prs_effects_clickhouse.go",
+      "find": "if actual.SourceID != nil {",
+      "replace": "if false {",
+      "rationale": "a non-NULL source_id means the external-ingest path owns this key's current version; the native sink never writes it, so its presence must report EffectConflict",
+      "proof": [
+        ["go", "test", "-run", "^TestPullRequestReadbackClassifiesEveryVersionRelationship$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "M6-readback-first-review-at-clause",
+      "file": "internal/providersync/github_prs_effects_clickhouse.go",
+      "find": "if !timePointersEqual(actual.Row.FirstReviewAt, expected.FirstReviewAt) {",
+      "replace": "if false {",
+      "rationale": "this exact column was omitted from the readback comparison before the M6 fix, letting a divergent first_review_at read as EffectExact and letting crash recovery mark corrupted review data committed",
+      "proof": [
+        ["go", "test", "-run", "^TestPullRequestReadbackClassifiesEveryVersionRelationship$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "M6-readback-reviews-count-clause",
+      "file": "internal/providersync/github_prs_effects_clickhouse.go",
+      "find": "if actual.Row.ReviewsCount != expected.ReviewsCount {",
+      "replace": "if false {",
+      "rationale": "same class as first_review_at: reviews_count was omitted from the readback comparison before the M6 fix",
+      "proof": [
+        ["go", "test", "-run", "^TestPullRequestReadbackClassifiesEveryVersionRelationship$", "./internal/providersync/"]
+      ]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/github_prs.json
+++ b/internal/providersync/testdata/mutation-plans/github_prs.json
@@ -1,6 +1,7 @@
 {
   "schema_version": 1,
   "name": "github/prs codex-review fixes (CHAOS-3122)",
+  "build": ["go", "build", "./..."],
   "$limitation": "H4 (blank full_name must fail closed) has no entry here. The first version of this plan mutated github_prs_route.go's own `if fullName == \"\" {...}` guard and it SURVIVED: repositoryIdentity(fullName) (github_repository_route.go) already rejects an empty/all-whitespace string with the identical ErrNormalizationInvalid before hashing anything, so the explicit guard was dead code duplicating a check the callee already makes. It was deleted (see github_prs_route.go's repositoryIdentity call site comment) rather than kept alive only to give this plan something to mutate. The fail-closed behavior itself is proven by TestGitHubPullRequestRouteFailsClosedOnScopeAndPayloadFaults's noFullName case (asserts Collect errors) and, at the shared-function level, by TestRepositoryIdentityFailsClosedOnDocumentedPythonDivergences in github_repository_route_test.go.",
   "mutations": [
     {
@@ -16,9 +17,9 @@
     {
       "id": "H3-unknown-updated-at-must-not-exclude",
       "file": "internal/providersync/github_prs_route.go",
-      "find": "windowKnown := !updatedAt.IsZero()",
-      "replace": "windowKnown := true",
-      "rationale": "a missing/null/unparseable updated_at must be unconditionally included (Python only compares when isinstance(updated_at, datetime)), never excluded",
+      "find": "func pullOutsideKnownWindow(updatedAt time.Time, claim Claim) bool {\n\twindowKnown := !updatedAt.IsZero()",
+      "replace": "func pullOutsideKnownWindow(updatedAt time.Time, claim Claim) bool {\n\twindowKnown := true",
+      "rationale": "a missing/null/unparseable updated_at must be unconditionally included (Python only compares when isinstance(updated_at, datetime)), never excluded. Anchored on the function signature too: pullCrossedSinceBoundary (H1a) declares the identical `windowKnown := !updatedAt.IsZero()` line for its own, separate clause, so the bare line alone is not a unique anchor",
       "proof": [
         ["go", "test", "-run", "^TestFilterGitHubPullWindowClauseCoverage$", "./internal/providersync/"]
       ]
@@ -54,13 +55,67 @@
       ]
     },
     {
-      "id": "M5-truncate-to-milliseconds",
+      "id": "M5-truncate-provider-timestamps-to-milliseconds",
       "file": "internal/providersync/github_prs_route.go",
       "find": "parsed = parsed.UTC().Truncate(time.Millisecond)",
       "replace": "parsed = parsed.UTC()",
-      "rationale": "provider timestamps must be truncated to millisecond precision at construction, matching ClickHouse's DateTime64(3), or a later readback compares unequal to the in-memory value",
+      "rationale": "provider timestamps (created_at/merged_at/closed_at) must be truncated to millisecond precision at construction, matching ClickHouse's DateTime64(3), or a later readback compares unequal to the in-memory value",
       "proof": [
         ["go", "test", "-run", "^TestParseGitHubPullTimeTruncatesToMilliseconds$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "M5-truncate-normalizedAt-to-milliseconds",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "normalizedAt = normalizedAt.UTC().Truncate(time.Millisecond)",
+      "replace": "normalizedAt = normalizedAt.UTC()",
+      "rationale": "codex M5: last_synced (and created_at's now() fallback) come from Collect's OWN normalizedAt truncation, a SEPARATE line from parseGitHubPullTime's. Every other fixture in this package uses a whole-second `now`, so this needed its own sub-millisecond test (TestGitHubPullRequestRouteTruncatesNormalizedAtToMilliseconds) or this mutation would have survived silently",
+      "proof": [
+        ["go", "test", "-run", "^TestGitHubPullRequestRouteTruncatesNormalizedAtToMilliseconds$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "H1a-stop-at-since-boundary",
+      "file": "internal/providersync/github_prs_route.go",
+      "find": "return updatedAt.Before(claim.SinceAt.UTC())",
+      "replace": "return false",
+      "rationale": "codex H1 first half: pagination must stop the moment a listed item's updated_at is known and older than since (mirroring iter_pulls), or a deep-history repository with only one page inside the window caps -- and now fails the unit -- on every attempt, forever, even though Python syncs it fine",
+      "proof": [
+        ["go", "test", "-run", "^TestGitHubPullRequestRouteStopsPaginatingAtTheSinceBoundary$", "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "H2-readback-must-read-one-consistent-row",
+      "file": "internal/providersync/github_prs_effects_clickhouse.go",
+      "find": "FROM git_pull_requests FINAL",
+      "replace": "FROM git_pull_requests",
+      "rationale": "codex H2, the single most dangerous defect in this pair: independent per-column argMax(column, last_synced) calls are not equivalent to reading the row with the maximum last_synced, because ClickHouse's argMax skips a row whose ARGUMENT is NULL -- so a winning row with a NULL column can be silently backfilled from an older, non-winning row's non-NULL value in that same column. FINAL forces a row-consistent read; removing it reintroduces the per-column-aggregate reconstruction bug",
+      "proof": [
+        ["go", "test", "-tags", "integration", "-run",
+         "^TestGitHubPullRequestReadbackDoesNotReconstructRowFromMixedVersions$",
+         "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "H1b-release-for-retry-preserves-ledger",
+      "file": "internal/providersync/repository_postgres.go",
+      "find": "COALESCE(unit.result::jsonb, '{}'::jsonb) ||",
+      "replace": "'{}'::jsonb ||",
+      "rationale": "codex H1 second half: ReleaseForRetry must MERGE error_category into the existing result document, not replace it -- a blind overwrite deletes the go_effect_ledger_v1 key an EffectReadbackRequired effect depends on, so a later attempt forgets the frozen normalizedAt/digest and can no longer classify a possibly-landed ClickHouse write as exact, absent, or conflict",
+      "proof": [
+        ["go", "test", "-tags", "integration", "-run",
+         "^TestReleaseForRetryPreservesAnInFlightEffectLedger$",
+         "./internal/providersync/"]
+      ]
+    },
+    {
+      "id": "M4-stringify-boolean-like-python-str",
+      "file": "internal/providersync/launchdarkly_route.go",
+      "find": "\tcase bool:\n\t\t// Python's str(True)/str(False) are capitalized, unlike Go's\n\t\t// strconv.FormatBool(\"true\"/\"false\").\n\t\tif typed {\n\t\t\treturn \"True\"\n\t\t}\n\t\treturn \"False\"",
+      "replace": "\tcase bool:\n\t\treturn \"\"",
+      "rationale": "codex M4: Python's str(True)/str(False) must be matched exactly (capitalized), not silently dropped to the \"\" default -- which is what an earlier version of stringValue did for any non-string, non-numeric JSON value, including a boolean login",
+      "proof": [
+        ["go", "test", "-run", "^TestGitHubPullUserLoginStringifiesNonStringLogins$", "./internal/providersync/"]
       ]
     },
     {

--- a/internal/providersync/testdata/mutation-plans/oracle_compare.json
+++ b/internal/providersync/testdata/mutation-plans/oracle_compare.json
@@ -42,6 +42,30 @@
       "replace": "if false {\n\t\t\tcontinue\n\t\t}",
       "rationale": "a field the CALLER declares Go-only (e.g. org_id, last_synced) must not be compared -- the caller-side mirror of python-excluded-fields-must-suppress, and independently mutable since the two exclusion maps are looked up in separate, unrelated statements",
       "proof": [["go", "test", "-run", "^TestDiffRowsClauseCoverage/declared_Go-only_exclusion_suppresses_a_present-or-absent_divergence$", "./internal/providersync/"]]
+    },
+    {
+      "id": "goOnlyFields-claim-must-be-checked-against-python",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "if reason, claimedGoOnly := goOnlyFields[key]; claimedGoOnly {",
+      "replace": "if false {",
+      "rationale": "codex third review: goOnlyFields[key] is a claim that the Python side structurally cannot have this field. If a pair author is wrong, the field IS comparable on the Python side and excluding it hides a real divergence -- this clause is what catches the claim being false",
+      "proof": [["go", "test", "-run", "^TestCheckExclusionIntegrityClauseCoverage/goOnlyFields_key_actually_present_on_the_Python_side", "./internal/providersync/"]]
+    },
+    {
+      "id": "stale-excluded-fields-must-be-flagged",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "for key, reason := range excludedFields {\n\t\tif !usedExclusions[key] {",
+      "replace": "for key, reason := range excludedFields {\n\t\tif false {",
+      "rationale": "codex third review: an excluded_fields entry that never matched a key present in any case's row is either a typo or a stale leftover from a field that was renamed or removed -- silently indistinguishable from a genuine, currently-effective exclusion without this check",
+      "proof": [["go", "test", "-run", "^TestCheckExclusionIntegrityClauseCoverage/excluded_fields_entry_never_matches_anything", "./internal/providersync/"]]
+    },
+    {
+      "id": "stale-goOnlyFields-must-be-flagged",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "for key, reason := range goOnlyFields {\n\t\tif !usedExclusions[\"go:\"+key] {",
+      "replace": "for key, reason := range goOnlyFields {\n\t\tif false {",
+      "rationale": "the caller-side mirror of stale-excluded-fields-must-be-flagged, independently mutable since it is a separate loop over a separate map",
+      "proof": [["go", "test", "-run", "^TestCheckExclusionIntegrityClauseCoverage/goOnlyFields_entry_never_matches_anything", "./internal/providersync/"]]
     }
   ]
 }

--- a/internal/providersync/testdata/mutation-plans/oracle_compare.json
+++ b/internal/providersync/testdata/mutation-plans/oracle_compare.json
@@ -1,0 +1,47 @@
+{
+  "schema_version": 1,
+  "name": "CHAOS-3162 generic oracle comparator (diffRows)",
+  "build": ["go", "build", "./..."],
+  "mutations": [
+    {
+      "id": "present-in-python-only-clause",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "case pythonHas && !goHas:",
+      "replace": "case false:",
+      "rationale": "a field the Python row has and the Go row lacks must be reported as a divergence, not silently skipped",
+      "proof": [["go", "test", "-run", "^TestDiffRowsClauseCoverage/present_in_Python_only", "./internal/providersync/"]]
+    },
+    {
+      "id": "present-in-go-only-clause",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "case !pythonHas && goHas:",
+      "replace": "case false:",
+      "rationale": "a field the Go row has and the Python row lacks must be reported as a divergence, not silently skipped -- the symmetric case to present-in-python-only, and just as easy to accidentally drop",
+      "proof": [["go", "test", "-run", "^TestDiffRowsClauseCoverage/present_in_Go_only", "./internal/providersync/"]]
+    },
+    {
+      "id": "value-mismatch-clause",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "case !reflect.DeepEqual(pythonValue, goValue):",
+      "replace": "case false:",
+      "rationale": "two present-on-both-sides values that differ must be reported -- this is the clause every one of the six CHAOS-3162 rediscovery defects that are value mismatches (not present/absent mismatches) actually depends on",
+      "proof": [["go", "test", "-run", "^TestDiffRowsClauseCoverage/differing_value", "./internal/providersync/"]]
+    },
+    {
+      "id": "python-excluded-fields-must-suppress",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "if _, excluded := pythonExcluded[key]; excluded {\n\t\t\tcontinue\n\t\t}",
+      "replace": "if false {\n\t\t\tcontinue\n\t\t}",
+      "rationale": "a field the pair's Python side declares excluded (with a written reason) must not be compared at all -- this is what lets github/pr-reviews-owned fields ship without corrupting github/prs's own comparison",
+      "proof": [["go", "test", "-run", "^TestDiffRowsClauseCoverage/declared_Python-side_exclusion_suppresses_a_value_mismatch$", "./internal/providersync/"]]
+    },
+    {
+      "id": "go-only-fields-must-suppress",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "if _, excluded := goOnlyFields[key]; excluded {\n\t\t\tcontinue\n\t\t}",
+      "replace": "if false {\n\t\t\tcontinue\n\t\t}",
+      "rationale": "a field the CALLER declares Go-only (e.g. org_id, last_synced) must not be compared -- the caller-side mirror of python-excluded-fields-must-suppress, and independently mutable since the two exclusion maps are looked up in separate, unrelated statements",
+      "proof": [["go", "test", "-run", "^TestDiffRowsClauseCoverage/declared_Go-only_exclusion_suppresses_a_present-or-absent_divergence$", "./internal/providersync/"]]
+    }
+  ]
+}

--- a/internal/providersync/testdata/mutation-plans/oracle_compare.json
+++ b/internal/providersync/testdata/mutation-plans/oracle_compare.json
@@ -22,10 +22,26 @@
     {
       "id": "value-mismatch-clause",
       "file": "internal/providersync/oracle_compare_test.go",
-      "find": "case !reflect.DeepEqual(pythonValue, goValue):",
+      "find": "case !typedValuesEqual(pythonValue, goValue):",
       "replace": "case false:",
-      "rationale": "two present-on-both-sides values that differ must be reported -- this is the clause every one of the six CHAOS-3162 rediscovery defects that are value mismatches (not present/absent mismatches) actually depends on",
+      "rationale": "two present-on-both-sides values that differ must be reported -- this is the clause every one of the six CHAOS-3162 rediscovery defects that are value mismatches (not present/absent mismatches) actually depends on. Anchor updated (codex fourth review): this used to call reflect.DeepEqual directly; it now calls typedValuesEqual, which falls back to reflect.DeepEqual for everything except float/datetime -- see the typed-value-equality mutations below for that function's own clauses",
       "proof": [["go", "test", "-run", "^TestDiffRowsClauseCoverage/differing_value", "./internal/providersync/"]]
+    },
+    {
+      "id": "typed-values-equal-float-must-parse-and-compare",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "if pythonErr == nil && goErr == nil {\n\t\t\t\treturn pythonFloat == goFloat\n\t\t\t}",
+      "replace": "if pythonErr == nil && goErr == nil {\n\t\t\t\treturn false\n\t\t\t}",
+      "rationale": "codex fourth review: Python's repr(5.0) is \"5.0\"; Go's strconv.FormatFloat(5.0, 'g', -1, 64) is \"5\" -- same IEEE754 double, different text. Without this clause a genuinely-equal float pair would report a false divergence, and a mutation collapsing it to false would make every equal-float case fail",
+      "proof": [["go", "test", "-run", "^TestTypedValuesEqualCanonicalizesFloatAndDatetimeText/equal_floats", "./internal/providersync/"]]
+    },
+    {
+      "id": "typed-values-equal-datetime-must-parse-and-compare",
+      "file": "internal/providersync/oracle_compare_test.go",
+      "find": "if pythonErr == nil && goErr == nil {\n\t\t\t\treturn pythonTime.Equal(goTime)\n\t\t\t}",
+      "replace": "if pythonErr == nil && goErr == nil {\n\t\t\t\treturn false\n\t\t\t}",
+      "rationale": "codex fourth review: Python's isoformat() shows a fixed 6-digit microsecond field when non-zero (.123000Z); Go's RFC3339Nano strips trailing zero fractional digits (.123Z) -- same instant, different text",
+      "proof": [["go", "test", "-run", "^TestTypedValuesEqualCanonicalizesFloatAndDatetimeText/equal_instants", "./internal/providersync/"]]
     },
     {
       "id": "python-excluded-fields-must-suppress",

--- a/internal/providersync/testdata/oracle_pairs/github_prs_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_prs_row.py
@@ -20,12 +20,26 @@ import pathlib
 from typing import Any
 
 from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import dict_literal_keys
 from internal.providersync.testdata.python_oracle_loader import load_live_module
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
 _CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/github/code_client.py"
 _BASE_GIT_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/base_git.py"
 _PR_STATE_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pr_state.py"
+
+
+def _reflected_fields() -> frozenset[str]:
+    """The complete field set build_git_pull_request (base_git.py) is
+    capable of emitting, derived by statically parsing its own `values` and
+    `optional_values` dict literals (codex finding #1, CHAOS-3162) -- not a
+    hand-maintained list that could drift from, or start narrower than, the
+    real function."""
+    return dict_literal_keys(
+        _BASE_GIT_SOURCE.read_text(),
+        "build_git_pull_request",
+        ("values", "optional_values"),
+    )
 
 
 def _load_pr_state() -> Any:
@@ -93,6 +107,7 @@ oracle_registry.register(
     oracle_registry.PairSpec(
         id="github/prs/row",
         build_row=_build_row,
+        reflected_fields=_reflected_fields,
         excluded_fields={
             "first_review_at": (
                 "owned by github/pr-reviews' review-enrichment phase "

--- a/internal/providersync/testdata/oracle_pairs/github_prs_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_prs_row.py
@@ -1,0 +1,132 @@
+"""github/prs row-construction oracle pair (CHAOS-3162).
+
+Registers the "github/prs/row" boundary: given one raw GitHub REST
+`/pulls/{number}` detail payload (a plain JSON dict, the same shape
+github_prs_route_test.go's fixtures use), calls the REAL, live
+`_pull_from_item` (providers/github/code_client.py) -> `normalize_pr_state`
+(providers/pr_state.py) -> `build_git_pull_request`
+(processors/base_git.py) chain and returns the COMPLETE resulting row as a
+dict -- every attribute the built `GitPullRequest` object carries, not a
+chosen subset.
+
+Importing this module is the only action needed to register the pair;
+nothing in oracle_registry.py or python_generic_row_oracle.py changes.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.python_oracle_loader import load_live_module
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_CODE_CLIENT_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/github/code_client.py"
+_BASE_GIT_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/base_git.py"
+_PR_STATE_SOURCE = REPO_ROOT / "src/dev_health_ops/providers/pr_state.py"
+
+
+def _load_pr_state() -> Any:
+    """providers/pr_state.py has zero project-internal imports, so it loads
+    directly -- no stub namespace required (mirrors python_registry_oracle.py)."""
+    spec = importlib.util.spec_from_file_location(
+        "dev_health_ops_pr_state_oracle_target", _PR_STATE_SOURCE.resolve(strict=True)
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {_PR_STATE_SOURCE}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _build_row(case: dict[str, Any]) -> dict[str, Any]:
+    """case: {"raw_pr": <raw GitHub /pulls/{number} JSON payload>,
+    "repo_id": <string>}.
+
+    Loaded fresh per call (load_live_module purges and reinstalls the stub
+    namespace every time) so this stays correct even if a caller loads other
+    pairs' modules in the same process.
+    """
+    code_client = load_live_module(_CODE_CLIENT_SOURCE)
+    base_git = load_live_module(_BASE_GIT_SOURCE)
+    pr_state = _load_pr_state()
+
+    gh_pr = code_client._pull_from_item(case["raw_pr"])
+    state = pr_state.normalize_pr_state(gh_pr.state, gh_pr.merged_at)
+    author_name = gh_pr.author_login if gh_pr.author_login else "Unknown"
+    pr = base_git.build_git_pull_request(
+        repo_id=case["repo_id"],
+        number=gh_pr.number,
+        title=gh_pr.title,
+        body=gh_pr.body,
+        state=state,
+        author_name=author_name,
+        author_email=None,
+        created_at=gh_pr.created_at,
+        merged_at=gh_pr.merged_at,
+        closed_at=gh_pr.closed_at,
+        head_branch=gh_pr.head_ref,
+        base_branch=gh_pr.base_ref,
+        additions=gh_pr.additions,
+        deletions=gh_pr.deletions,
+        changed_files=gh_pr.changed_files,
+        comments_count=gh_pr.comments_count,
+        # first_review_at/first_comment_at/changes_requested_count/
+        # reviews_count are deliberately NOT passed: the real caller
+        # (_collect_github_pr_objects) only supplies them from
+        # _enrich_prs_with_reviews_batch's review fetch, which this
+        # row-construction boundary does not perform (see
+        # deploy/go-workers/provider-sync-porting-recipe.md's defect class
+        # 9). build_git_pull_request's optional_values filtering means an
+        # un-passed (None) field is OMITTED from the built row entirely, not
+        # merely set to None -- so those fields are absent here exactly the
+        # way they would be absent from a call site that has no review data
+        # yet, and the exclusion below documents that this is a declared,
+        # structural absence, not an oversight.
+    )
+    return {key: value for key, value in vars(pr).items() if not key.startswith("_")}
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/prs/row",
+        build_row=_build_row,
+        excluded_fields={
+            "first_review_at": (
+                "owned by github/pr-reviews' review-enrichment phase "
+                "(_enrich_prs_with_reviews_batch), not this row-construction "
+                "boundary -- see recipe doc defect class 9"
+            ),
+            "first_comment_at": (
+                "same as first_review_at: review-enrichment phase field, "
+                "always None/absent from this boundary regardless of caller"
+            ),
+            "changes_requested_count": (
+                "owned by github/pr-reviews' review-enrichment phase, "
+                "not this row-construction boundary"
+            ),
+            "reviews_count": (
+                "owned by github/pr-reviews' review-enrichment phase, "
+                "not this row-construction boundary"
+            ),
+            "last_synced": (
+                "Go-side effect/tenant bookkeeping: the write timestamp, "
+                "stamped by the sink at WriteEffect time -- has no "
+                "build_git_pull_request equivalent at all"
+            ),
+            "source_id": (
+                "Go-side external-ingest marker column; the native sink "
+                "always writes NULL and Python's build_git_pull_request has "
+                "no equivalent parameter"
+            ),
+            "org_id": (
+                "Go-side tenant column; ClickHouseStore._insert_rows "
+                "auto-injects it from self.org_id at insert time, never "
+                "part of the GitPullRequest object build_git_pull_request "
+                "constructs"
+            ),
+        },
+    )
+)

--- a/internal/providersync/testdata/oracle_pairs/github_prs_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_prs_row.py
@@ -119,6 +119,20 @@ oracle_registry.register(
         id="github/prs/row",
         build_row=_build_row,
         reflected_fields=_reflected_fields,
+        # codex adversarial review (CHAOS-3162, fourth round): last_synced/
+        # source_id/org_id used to ALSO be declared here, redundantly with
+        # oraclePullRequestGoOnlyFields in github_prs_generic_oracle_test.go.
+        # That redundancy defeated checkExclusionIntegrity's own staleness
+        # check for the Go-side declaration -- if someone deleted the
+        # goOnlyFields entry for, say, org_id, this excluded_fields entry
+        # would still suppress the comparison and the test would stay
+        # green, silently masking that the Go-side declaration was no
+        # longer doing anything. None of the three are part of
+        # reflected_fields() (they are not keys build_git_pull_request's
+        # own `values`/`optional_values` dict literals ever assign), so
+        # Python-side completeness does not need them declared here at
+        # all -- they belong ONLY in goOnlyFields, where they are the
+        # single, real, load-bearing declaration.
         excluded_fields={
             "first_review_at": (
                 "owned by github/pr-reviews' review-enrichment phase "
@@ -136,22 +150,6 @@ oracle_registry.register(
             "reviews_count": (
                 "owned by github/pr-reviews' review-enrichment phase, "
                 "not this row-construction boundary"
-            ),
-            "last_synced": (
-                "Go-side effect/tenant bookkeeping: the write timestamp, "
-                "stamped by the sink at WriteEffect time -- has no "
-                "build_git_pull_request equivalent at all"
-            ),
-            "source_id": (
-                "Go-side external-ingest marker column; the native sink "
-                "always writes NULL and Python's build_git_pull_request has "
-                "no equivalent parameter"
-            ),
-            "org_id": (
-                "Go-side tenant column; ClickHouseStore._insert_rows "
-                "auto-injects it from self.org_id at insert time, never "
-                "part of the GitPullRequest object build_git_pull_request "
-                "constructs"
             ),
         },
     )

--- a/internal/providersync/testdata/oracle_pairs/github_prs_row.py
+++ b/internal/providersync/testdata/oracle_pairs/github_prs_row.py
@@ -11,6 +11,17 @@ chosen subset.
 
 Importing this module is the only action needed to register the pair;
 nothing in oracle_registry.py or python_generic_row_oracle.py changes.
+
+REQUIREMENT, not a caveat: any Go test that exercises this pair (directly
+or via compareRowsAgainstPythonOracle/oracleDivergences) MUST be run with
+`go test -count=1`, never a bare `go test`. code_client.py/base_git.py/
+pr_state.py live under src/dev_health_ops/, outside
+internal/providersync/testdata/ -- `//go:embed` cannot reach across that
+package-directory boundary (Go rejects a `../` pattern outright), so
+oracle_compare_test.go's cache-busting fix cannot see edits to these
+files. A bare `go test` can then return a stale cached PASS for a real
+change to one of them. See the recipe doc's defect-class list for the
+full explanation.
 """
 
 from __future__ import annotations

--- a/internal/providersync/testdata/oracle_pairs/github_prs_window.py
+++ b/internal/providersync/testdata/oracle_pairs/github_prs_window.py
@@ -50,6 +50,16 @@ its external I/O boundary (the client) faked -- editing that logic in
 processors/github.py changes what this oracle observes, with no separate
 pin to keep in sync and no way for a change to go unnoticed the way a
 substring-presence check could miss one.
+
+REQUIREMENT, not a caveat: any Go test that exercises this pair MUST be
+run with `go test -count=1`, never a bare `go test`. processors/github.py
+lives under src/dev_health_ops/, outside
+internal/providersync/testdata/ -- `//go:embed` cannot reach across that
+package-directory boundary (Go rejects a `../` pattern outright), so
+oracle_compare_test.go's cache-busting fix cannot see edits to it. A bare
+`go test` can then return a stale cached PASS for a real regression in
+the live function this pair exists to catch. See the recipe doc's
+defect-class list for the full explanation.
 """
 
 from __future__ import annotations

--- a/internal/providersync/testdata/oracle_pairs/github_prs_window.py
+++ b/internal/providersync/testdata/oracle_pairs/github_prs_window.py
@@ -36,9 +36,27 @@ from datetime import datetime, timezone
 from typing import Any
 
 from internal.providersync.testdata import oracle_registry
+from internal.providersync.testdata.field_reflection import (
+    RETURN_LITERAL,
+    dict_literal_keys,
+)
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
 _SOURCE_FILE = REPO_ROOT / "src/dev_health_ops/processors/github.py"
+_THIS_FILE = pathlib.Path(__file__)
+
+
+def _reflected_fields() -> frozenset[str]:
+    """The complete field set _decide's own `return {...}` literal is
+    capable of emitting (codex finding #1, CHAOS-3162). Since this pair's
+    "production" function is itself a pinned copy (see module docstring),
+    this at least guarantees a caller cannot silently compare against a
+    narrower subset of _decide's OWN two fields than _decide actually
+    returns -- it cannot, by construction, validate the pin's fidelity to
+    the real processors/github.py function, which is exactly what
+    _assert_pin_still_matches_source is for."""
+    return dict_literal_keys(_THIS_FILE.read_text(), "_decide", (RETURN_LITERAL,))
+
 
 # Every one of these must appear, verbatim, inside _collect_github_pr_objects
 # in the current source. If a future edit to the real function changes any
@@ -129,6 +147,7 @@ oracle_registry.register(
     oracle_registry.PairSpec(
         id="github/prs/window",
         build_row=_decide,
+        reflected_fields=_reflected_fields,
         excluded_fields={},
     )
 )

--- a/internal/providersync/testdata/oracle_pairs/github_prs_window.py
+++ b/internal/providersync/testdata/oracle_pairs/github_prs_window.py
@@ -6,33 +6,58 @@ updated_at plus a claim's since/until, decide whether
 would fetch-and-keep it (excluded=False), skip only it (excluded=True,
 stop=False), or stop the whole listing early (excluded=True, stop=True).
 
-Scope note, documented rather than silently glossed over: unlike
-github_prs_row.py, this pair does NOT execute the real, live
-`_collect_github_pr_objects`. That function is async, needs a real
-GitHubCodeClient, and processors/github.py's module-level imports pull in
-the complexity scanner, testops ingestion, and half a dozen other
-subsystems -- stubbing all of it, the way python_oracle_loader.py stubs
-code_client.py's few httpx-adjacent imports, would mean writing and
-maintaining a large surface of placeholder modules for a three-line
-decision, with every stub itself a place this "live" oracle could quietly
-diverge from reality. That trade was judged not worth it for a decision
-this small.
+CODEX FINDING #5 (CHAOS-3162, third adversarial review): this pair
+previously did NOT execute the real, live `_collect_github_pr_objects` --
+it ran a hand-pinned COPY of the two `if` blocks that make the decision,
+guarded by an unordered substring-presence check over a ~3,000-byte slice
+of the real source. That guard was too weak to trust: deleting the SECOND
+`isinstance(updated_at, datetime)` guard (a real, plausible regression --
+it is what H3's original bug looked like) would still leave every pinned
+substring present elsewhere in the slice, so the pin would report "still
+matches" while actually being stale.
 
-Instead, _decide below is a byte-for-byte PINNED COPY of the two `if`
-blocks that make this decision (processors/github.py, currently lines
-630-644, inside `_collect_github_pr_objects`), and
-_assert_pin_still_matches_source() reads the actual current source of that
-function and hard-fails (raising, not warning) if the pinned significant
-substrings are no longer present -- so drift is a loud, immediate test
-failure at the next run, not a silent divergence. This is a deliberately
-weaker guarantee than github_prs_row.py's live-execution oracle, and is
-labelled as such everywhere it is used.
+This version executes the REAL, unmodified `_collect_github_pr_objects`
+instead, via the SAME isolation technique python_oracle_loader.py already
+uses for code_client.py/base_git.py: stub every module-level import the
+file needs to satisfy at LOAD time (python_oracle_loader.py's
+_target_github_processor), then monkeypatch the one MODULE-LEVEL
+dependency seam the function actually calls through at RUN time
+(`_github_code_client_from_connector`) with a fake client whose
+`get_pull_detail` raises a distinguishing sentinel the INSTANT it is
+called. Since the real function's `try/finally` has no `except` clause,
+the sentinel propagates cleanly out through `finally` (which the fake
+client's `drain_usage_observations`/`close` satisfy) to this harness,
+which reads off exactly how far the real loop's `continue`/`break`
+control flow got:
+
+  - sentinel raised for item A (the item under test) -> included
+    (excluded=False, stop=False): the loop reached `get_pull_detail` for
+    it directly, meaning NEITHER window check fired.
+  - sentinel raised for item B (a second, fixed, unconditionally-included
+    marker item placed right after item A -- its own `updated_at=None`
+    means neither comparison can ever fire for it, regardless of the
+    case's own since/until) -> item A was excluded via `continue` (skip
+    this one, keep going): the loop reached item B, meaning item A's
+    `until` check fired but its `since` check did not (or there was no
+    `since`).
+  - no sentinel at all (the call returns normally) -> item A triggered
+    `break`: the loop never reached item B, so `get_pull_detail` was never
+    called for anyone.
+
+This is genuinely live execution, not a copy: the two `if` blocks that
+decide inclusion are the REAL function's own bytecode running, with only
+its external I/O boundary (the client) faked -- editing that logic in
+processors/github.py changes what this oracle observes, with no separate
+pin to keep in sync and no way for a change to go unnoticed the way a
+substring-presence check could miss one.
 """
 
 from __future__ import annotations
 
+import asyncio
 import pathlib
-from datetime import datetime, timezone
+from datetime import datetime
+from types import SimpleNamespace
 from typing import Any
 
 from internal.providersync.testdata import oracle_registry
@@ -40,107 +65,104 @@ from internal.providersync.testdata.field_reflection import (
     RETURN_LITERAL,
     dict_literal_keys,
 )
+from internal.providersync.testdata.python_oracle_loader import load_live_module
 
 REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
-_SOURCE_FILE = REPO_ROOT / "src/dev_health_ops/processors/github.py"
+_GITHUB_PROCESSOR_SOURCE = REPO_ROOT / "src/dev_health_ops/processors/github.py"
 _THIS_FILE = pathlib.Path(__file__)
 
-
-def _reflected_fields() -> frozenset[str]:
-    """The complete field set _decide's own `return {...}` literal is
-    capable of emitting (codex finding #1, CHAOS-3162). Since this pair's
-    "production" function is itself a pinned copy (see module docstring),
-    this at least guarantees a caller cannot silently compare against a
-    narrower subset of _decide's OWN two fields than _decide actually
-    returns -- it cannot, by construction, validate the pin's fidelity to
-    the real processors/github.py function, which is exactly what
-    _assert_pin_still_matches_source is for."""
-    return dict_literal_keys(_THIS_FILE.read_text(), "_decide", (RETURN_LITERAL,))
+_ITEM_A_NUMBER = 1
+_ITEM_B_NUMBER = 2
 
 
-# Every one of these must appear, verbatim, inside _collect_github_pr_objects
-# in the current source. If a future edit to the real function changes any
-# of these fragments, this pin is stale and MUST be re-derived from the new
-# source before this oracle can be trusted again.
-_PINNED_SIGNIFICANT_FRAGMENTS = (
-    "if until is not None:",
-    'updated_at = getattr(listed_pr, "updated_at", None)',
-    "isinstance(updated_at, datetime)",
-    "updated_at.astimezone(timezone.utc) > until",
-    "continue",
-    "if since is not None:",
-    "updated_at.astimezone(timezone.utc) < since",
-    "break",
-)
+class _ReachedFetch(Exception):
+    """Raised by _FakeGitHubCodeClient.get_pull_detail the instant
+    _collect_github_pr_objects's REAL loop reaches it for a given listed
+    item's number -- see module docstring for how the harness reads three
+    distinct outcomes off of this."""
+
+    def __init__(self, number: int) -> None:
+        super().__init__(f"reached get_pull_detail for #{number}")
+        self.number = number
 
 
-def _assert_pin_still_matches_source() -> None:
-    source = _SOURCE_FILE.read_text()
-    start = source.find("async def _collect_github_pr_objects(")
-    if start == -1:
-        raise AssertionError(
-            f"{_SOURCE_FILE}: _collect_github_pr_objects not found -- "
-            "github_prs_window_decision.py's pinned copy of its window-"
-            "decision logic can no longer be verified against the real "
-            "source and must be re-derived by hand"
-        )
-    # The two decision blocks are within the first ~50 lines of the
-    # function body; a generous slice avoids false negatives from
-    # unrelated later code reusing similar words.
-    body = source[start : start + 3000]
-    missing = [
-        fragment for fragment in _PINNED_SIGNIFICANT_FRAGMENTS if fragment not in body
-    ]
-    if missing:
-        raise AssertionError(
-            f"{_SOURCE_FILE}: _collect_github_pr_objects no longer contains "
-            f"the pinned window-decision fragment(s) {missing!r} -- "
-            "github_prs_window_decision.py's _decide is a manually pinned "
-            "copy of this logic (see module docstring for why) and must be "
-            "updated to match before this oracle can be trusted"
-        )
+class _FakeGitHubCodeClient:
+    """The one dependency seam _collect_github_pr_objects calls through:
+    `_github_code_client_from_connector(connector)`. Everything else in
+    the function body is real, unmodified processors/github.py code."""
+
+    def __init__(self, items: list[SimpleNamespace]) -> None:
+        self._items = items
+
+    async def iter_pulls(self, *_args: Any, **_kwargs: Any) -> list[SimpleNamespace]:
+        return self._items
+
+    async def get_pull_detail(self, _owner: str, _repo: str, number: int) -> Any:
+        raise _ReachedFetch(number)
+
+    def drain_usage_observations(self) -> list[Any]:
+        return []
+
+    async def close(self) -> None:
+        return None
+
+
+def _parse(value: str | None) -> datetime | None:
+    if value is None:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
 
 
 def _decide(case: dict[str, Any]) -> dict[str, Any]:
-    _assert_pin_still_matches_source()
+    module = load_live_module(_GITHUB_PROCESSOR_SOURCE)
 
-    def parse(value: str | None) -> datetime | None:
-        if value is None:
-            return None
-        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+    updated_at = _parse(case.get("updated_at"))
+    since = _parse(case.get("since"))
+    until = _parse(case.get("until"))
 
-    updated_at = parse(case.get("updated_at"))
-    since = parse(case.get("since"))
-    until = parse(case.get("until"))
+    item_a = SimpleNamespace(number=_ITEM_A_NUMBER, updated_at=updated_at)
+    item_b = SimpleNamespace(number=_ITEM_B_NUMBER, updated_at=None)
+    fake_client = _FakeGitHubCodeClient([item_a, item_b])
+    # _collect_github_pr_objects looks this name up as a module global at
+    # CALL time, so reassigning it on the freshly-loaded module object
+    # (not the source file) redirects exactly one dependency seam without
+    # touching anything else the real function does.
+    module._github_code_client_from_connector = lambda _connector: fake_client
 
-    excluded = False
-    stop = False
+    async def run() -> int | None:
+        try:
+            await module._collect_github_pr_objects(
+                connector=None,
+                owner="o",
+                repo_name="r",
+                repo_id="00000000-0000-0000-0000-000000000000",
+                state="all",
+                since=since,
+                until=until,
+                usage_sink=None,
+            )
+        except _ReachedFetch as reached:
+            return reached.number
+        return None
 
-    # --- pinned copy of processors/github.py::_collect_github_pr_objects,
-    # currently lines 630-644 (verified above). updated_at is already either
-    # None or a real datetime (parse() above), which is what the real
-    # function's `getattr(listed_pr, "updated_at", None)` also always
-    # produces in practice -- the isinstance guard is kept here anyway
-    # because it is part of the pinned fragment, not because this mirror
-    # can observe a non-datetime value. ---
-    if until is not None:
-        if (
-            isinstance(updated_at, datetime)
-            and updated_at.astimezone(timezone.utc) > until
-        ):
-            excluded = True
+    reached_number = asyncio.run(run())
 
-    if not excluded:
-        if since is not None:
-            if (
-                isinstance(updated_at, datetime)
-                and updated_at.astimezone(timezone.utc) < since
-            ):
-                excluded = True
-                stop = True
-    # --- end pinned copy ---
+    if reached_number == _ITEM_A_NUMBER:
+        return {"excluded": False, "stop": False}
+    if reached_number == _ITEM_B_NUMBER:
+        return {"excluded": True, "stop": False}
+    if reached_number is None:
+        return {"excluded": True, "stop": True}
+    raise AssertionError(f"unexpected sentinel number {reached_number!r}")
 
-    return {"excluded": excluded, "stop": stop}
+
+def _reflected_fields() -> frozenset[str]:
+    """The complete field set _decide's own `return {...}` literals are
+    capable of emitting (codex finding #1). _decide has four return
+    statements (one per outcome); dict_literal_keys unions the keys across
+    all of them via ast.walk, so this stays correct even though no single
+    return statement is the "whole" story on its own."""
+    return dict_literal_keys(_THIS_FILE.read_text(), "_decide", (RETURN_LITERAL,))
 
 
 oracle_registry.register(

--- a/internal/providersync/testdata/oracle_pairs/github_prs_window.py
+++ b/internal/providersync/testdata/oracle_pairs/github_prs_window.py
@@ -1,0 +1,134 @@
+"""github/prs list-inclusion-decision oracle pair (CHAOS-3162).
+
+Registers the "github/prs/window" boundary: given one listed PR's
+updated_at plus a claim's since/until, decide whether
+`_collect_github_pr_objects` (src/dev_health_ops/processors/github.py)
+would fetch-and-keep it (excluded=False), skip only it (excluded=True,
+stop=False), or stop the whole listing early (excluded=True, stop=True).
+
+Scope note, documented rather than silently glossed over: unlike
+github_prs_row.py, this pair does NOT execute the real, live
+`_collect_github_pr_objects`. That function is async, needs a real
+GitHubCodeClient, and processors/github.py's module-level imports pull in
+the complexity scanner, testops ingestion, and half a dozen other
+subsystems -- stubbing all of it, the way python_oracle_loader.py stubs
+code_client.py's few httpx-adjacent imports, would mean writing and
+maintaining a large surface of placeholder modules for a three-line
+decision, with every stub itself a place this "live" oracle could quietly
+diverge from reality. That trade was judged not worth it for a decision
+this small.
+
+Instead, _decide below is a byte-for-byte PINNED COPY of the two `if`
+blocks that make this decision (processors/github.py, currently lines
+630-644, inside `_collect_github_pr_objects`), and
+_assert_pin_still_matches_source() reads the actual current source of that
+function and hard-fails (raising, not warning) if the pinned significant
+substrings are no longer present -- so drift is a loud, immediate test
+failure at the next run, not a silent divergence. This is a deliberately
+weaker guarantee than github_prs_row.py's live-execution oracle, and is
+labelled as such everywhere it is used.
+"""
+
+from __future__ import annotations
+
+import pathlib
+from datetime import datetime, timezone
+from typing import Any
+
+from internal.providersync.testdata import oracle_registry
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[4]
+_SOURCE_FILE = REPO_ROOT / "src/dev_health_ops/processors/github.py"
+
+# Every one of these must appear, verbatim, inside _collect_github_pr_objects
+# in the current source. If a future edit to the real function changes any
+# of these fragments, this pin is stale and MUST be re-derived from the new
+# source before this oracle can be trusted again.
+_PINNED_SIGNIFICANT_FRAGMENTS = (
+    "if until is not None:",
+    'updated_at = getattr(listed_pr, "updated_at", None)',
+    "isinstance(updated_at, datetime)",
+    "updated_at.astimezone(timezone.utc) > until",
+    "continue",
+    "if since is not None:",
+    "updated_at.astimezone(timezone.utc) < since",
+    "break",
+)
+
+
+def _assert_pin_still_matches_source() -> None:
+    source = _SOURCE_FILE.read_text()
+    start = source.find("async def _collect_github_pr_objects(")
+    if start == -1:
+        raise AssertionError(
+            f"{_SOURCE_FILE}: _collect_github_pr_objects not found -- "
+            "github_prs_window_decision.py's pinned copy of its window-"
+            "decision logic can no longer be verified against the real "
+            "source and must be re-derived by hand"
+        )
+    # The two decision blocks are within the first ~50 lines of the
+    # function body; a generous slice avoids false negatives from
+    # unrelated later code reusing similar words.
+    body = source[start : start + 3000]
+    missing = [
+        fragment for fragment in _PINNED_SIGNIFICANT_FRAGMENTS if fragment not in body
+    ]
+    if missing:
+        raise AssertionError(
+            f"{_SOURCE_FILE}: _collect_github_pr_objects no longer contains "
+            f"the pinned window-decision fragment(s) {missing!r} -- "
+            "github_prs_window_decision.py's _decide is a manually pinned "
+            "copy of this logic (see module docstring for why) and must be "
+            "updated to match before this oracle can be trusted"
+        )
+
+
+def _decide(case: dict[str, Any]) -> dict[str, Any]:
+    _assert_pin_still_matches_source()
+
+    def parse(value: str | None) -> datetime | None:
+        if value is None:
+            return None
+        return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+    updated_at = parse(case.get("updated_at"))
+    since = parse(case.get("since"))
+    until = parse(case.get("until"))
+
+    excluded = False
+    stop = False
+
+    # --- pinned copy of processors/github.py::_collect_github_pr_objects,
+    # currently lines 630-644 (verified above). updated_at is already either
+    # None or a real datetime (parse() above), which is what the real
+    # function's `getattr(listed_pr, "updated_at", None)` also always
+    # produces in practice -- the isinstance guard is kept here anyway
+    # because it is part of the pinned fragment, not because this mirror
+    # can observe a non-datetime value. ---
+    if until is not None:
+        if (
+            isinstance(updated_at, datetime)
+            and updated_at.astimezone(timezone.utc) > until
+        ):
+            excluded = True
+
+    if not excluded:
+        if since is not None:
+            if (
+                isinstance(updated_at, datetime)
+                and updated_at.astimezone(timezone.utc) < since
+            ):
+                excluded = True
+                stop = True
+    # --- end pinned copy ---
+
+    return {"excluded": excluded, "stop": stop}
+
+
+oracle_registry.register(
+    oracle_registry.PairSpec(
+        id="github/prs/window",
+        build_row=_decide,
+        excluded_fields={},
+    )
+)

--- a/internal/providersync/testdata/oracle_registry.py
+++ b/internal/providersync/testdata/oracle_registry.py
@@ -1,0 +1,90 @@
+"""Generic, declarative Python<->Go parity oracle registry (CHAOS-3162).
+
+Every existing oracle in this directory before CHAOS-3162
+(python_launchdarkly_normalization_oracle.py and friends) hand-picks which
+fields to emit and the Go side hand-picks which fields to assert. That
+worked exactly as well as its author's imagination: github/prs's first
+oracle was hand-authored and omitted review enrichment while asserting the
+omitted fields were zero; its replacement decoded three more fields from the
+real function and never asserted them. Two review rounds, same shape of
+defect, because nothing forced either oracle to speak for every field it
+could see.
+
+This module is the fix for the PLUMBING, not a replacement for any existing
+oracle (python_oracle_loader.py's isolation trick -- a fresh stub namespace
+so a stock interpreter can execute real production functions, with the
+target source staying live -- is correct and stays exactly as it is; this
+module is built on top of it, not instead of it).
+
+A pair registers itself by importing its own module under
+testdata/oracle_pairs/ and calling `register(...)` there. Nothing in this
+file, or in python_generic_row_oracle.py, needs to change to add a pair --
+that is the whole point: the loader's old ALLOWED_MODULES dict required
+editing loader source for every new heavy-dependency target; this registry
+does not.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any
+
+RowBuilder = Callable[[dict[str, Any]], dict[str, Any]]
+
+
+@dataclass(frozen=True)
+class PairSpec:
+    """One declared Python<->Go comparison boundary.
+
+    id: a stable identifier, e.g. "github/prs/row". Pairs for the same
+        provider/dataset MAY register more than one PairSpec when they cross
+        genuinely different boundaries (e.g. row construction vs a list
+        inclusion decision) -- these are not interchangeable and must not be
+        collapsed into one id just to reduce bookkeeping.
+    build_row: given one JSON-serializable case dict, calls the REAL,
+        live production function chain and returns the COMPLETE result as a
+        plain, JSON-serializable dict -- every field the underlying object
+        exposes, not a chosen subset. The generic comparator (Go side) diffs
+        every key this returns against every key the Go side produces.
+    excluded_fields: {field_name: reason}. A field listed here is skipped by
+        the comparator on BOTH sides. A reason is required -- this mirrors
+        `expected_survivor_reason` in scripts/mutation_harness.py: an
+        omission must be declared, in writing, at registration time, never
+        discovered by a reader wondering why a field went untested.
+    """
+
+    id: str
+    build_row: RowBuilder
+    excluded_fields: dict[str, str] = field(default_factory=dict)
+
+
+_REGISTRY: dict[str, PairSpec] = {}
+
+
+def register(spec: PairSpec) -> None:
+    if not spec.id or "/" not in spec.id:
+        raise ValueError(
+            f"pair id must be '<provider>/<dataset>/<boundary>', got {spec.id!r}"
+        )
+    if spec.id in _REGISTRY:
+        raise ValueError(f"pair {spec.id!r} is already registered")
+    for name, reason in spec.excluded_fields.items():
+        if not isinstance(reason, str) or not reason.strip():
+            raise ValueError(
+                f"pair {spec.id!r}: excluded_fields[{name!r}] needs a non-empty "
+                "written reason, not a bare exclusion"
+            )
+    _REGISTRY[spec.id] = spec
+
+
+def get(pair_id: str) -> PairSpec:
+    if pair_id not in _REGISTRY:
+        raise KeyError(
+            f"pair {pair_id!r} is not registered. Registering a pair is a side "
+            "effect of importing its testdata/oracle_pairs/<module>.py -- the "
+            "generic runner imports that module by the naming convention "
+            "'oracle_pairs.' + pair_id.split('/')[0] + '_' + pair_id.split('/')[1] "
+            "+ '_' + pair_id.split('/')[2] before looking the id up here."
+        )
+    return _REGISTRY[pair_id]

--- a/internal/providersync/testdata/oracle_registry.py
+++ b/internal/providersync/testdata/oracle_registry.py
@@ -22,6 +22,25 @@ file, or in python_generic_row_oracle.py, needs to change to add a pair --
 that is the whole point: the loader's old ALLOWED_MODULES dict required
 editing loader source for every new heavy-dependency target; this registry
 does not.
+
+CODEX FINDING #1 (first adversarial review of this framework, CHAOS-3162):
+a declarative comparator does not, by itself, stop a pair's OWN field set
+from being hand-picked. `PairSpec.build_row` could return any dict a pair
+author chose to construct; nothing forced it to be complete. A future pair
+could expose three fields on both the Python and Go sides, omit an entire
+phase on both, and the generic comparator would report a perfect match on
+that narrowed intersection -- reproducing the exact defect this framework
+exists to eliminate, one level up. `reflected_fields` closes that: it is a
+REQUIRED, zero-argument callable that returns the complete field set the
+underlying PRODUCTION function is capable of emitting, derived by
+statically parsing that function's own source (see field_reflection.py),
+never by hand-maintaining a second list that can drift from, or simply
+start incomplete relative to, the first. `register()` calls it eagerly and
+stores the result so python_generic_row_oracle.py can enforce, for every
+case: (row keys) | (excluded_fields keys) >= reflected_fields() -- any
+reflected field that is neither present in the row nor explicitly,
+individually excluded with a written reason is a hard failure, not a
+silent gap.
 """
 
 from __future__ import annotations
@@ -31,6 +50,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 RowBuilder = Callable[[dict[str, Any]], dict[str, Any]]
+FieldReflector = Callable[[], frozenset[str]]
 
 
 @dataclass(frozen=True)
@@ -43,10 +63,17 @@ class PairSpec:
         inclusion decision) -- these are not interchangeable and must not be
         collapsed into one id just to reduce bookkeeping.
     build_row: given one JSON-serializable case dict, calls the REAL,
-        live production function chain and returns the COMPLETE result as a
-        plain, JSON-serializable dict -- every field the underlying object
-        exposes, not a chosen subset. The generic comparator (Go side) diffs
-        every key this returns against every key the Go side produces.
+        live production function chain and returns the result as a plain,
+        JSON-serializable dict.
+    reflected_fields: zero-argument callable returning the complete,
+        non-empty frozenset of field names the underlying PRODUCTION
+        function is capable of emitting -- derived by inspecting that
+        function's own source (field_reflection.py's dict_literal_keys, for
+        a Python builder that assembles its result from named dict
+        literals), never hand-maintained separately from build_row. Called
+        once, eagerly, at register() time: a pair whose reflection is
+        broken fails at import time, not silently the first time someone
+        runs its comparison.
     excluded_fields: {field_name: reason}. A field listed here is skipped by
         the comparator on BOTH sides. A reason is required -- this mirrors
         `expected_survivor_reason` in scripts/mutation_harness.py: an
@@ -56,10 +83,17 @@ class PairSpec:
 
     id: str
     build_row: RowBuilder
+    reflected_fields: FieldReflector
     excluded_fields: dict[str, str] = field(default_factory=dict)
 
 
-_REGISTRY: dict[str, PairSpec] = {}
+@dataclass(frozen=True)
+class _Registered:
+    spec: PairSpec
+    reflected: frozenset[str]
+
+
+_REGISTRY: dict[str, _Registered] = {}
 
 
 def register(spec: PairSpec) -> None:
@@ -75,10 +109,45 @@ def register(spec: PairSpec) -> None:
                 f"pair {spec.id!r}: excluded_fields[{name!r}] needs a non-empty "
                 "written reason, not a bare exclusion"
             )
-    _REGISTRY[spec.id] = spec
+    reflected = spec.reflected_fields()
+    if not isinstance(reflected, frozenset) or not reflected:
+        raise ValueError(
+            f"pair {spec.id!r}: reflected_fields() must return a non-empty "
+            f"frozenset, got {reflected!r} -- a pair that cannot state its "
+            "own complete field set cannot prove a row is complete either"
+        )
+    _REGISTRY[spec.id] = _Registered(spec=spec, reflected=reflected)
 
 
 def get(pair_id: str) -> PairSpec:
+    return _get_entry(pair_id).spec
+
+
+def check_completeness(pair_id: str, case_id: str, row: dict[str, Any]) -> None:
+    """Raise if `row` (one case's build_row output) omits any field
+    reflected_fields() says the production function can emit, unless that
+    field is declared in excluded_fields.
+
+    This is the actual enforcement point for codex finding #1: called by
+    python_generic_row_oracle.py once per case (not once per pair), so a
+    pair cannot pass a completeness-blind case just because some OTHER case
+    happens to exercise the full field set.
+    """
+    entry = _get_entry(pair_id)
+    declared = set(row.keys()) | set(entry.spec.excluded_fields.keys())
+    missing = entry.reflected - declared
+    if missing:
+        raise ValueError(
+            f"pair {pair_id!r}, case {case_id!r}: build_row's output is "
+            f"missing field(s) {sorted(missing)!r} that the production "
+            "function can emit (per reflected_fields()) -- either the row "
+            "must include them, or each one needs its own excluded_fields "
+            "entry with a written reason. A silently incomplete row is "
+            "exactly the defect this framework exists to prevent."
+        )
+
+
+def _get_entry(pair_id: str) -> _Registered:
     if pair_id not in _REGISTRY:
         raise KeyError(
             f"pair {pair_id!r} is not registered. Registering a pair is a side "

--- a/internal/providersync/testdata/python_generic_row_oracle.py
+++ b/internal/providersync/testdata/python_generic_row_oracle.py
@@ -10,14 +10,32 @@ mentions github, launchdarkly, or any other provider by name, which is the
 whole point: adding a pair means adding one file under oracle_pairs/, never
 editing this one.
 
-<cases.json> is a JSON array of case objects; each MUST have an "id" key
-(a stable, human-readable name for the case) plus whatever keys the pair's
-build_row expects. Prints one JSON object to stdout:
+<cases.json> is a JSON array of case objects; each MUST have a unique "id"
+key (a stable, human-readable name for the case) plus whatever keys the
+pair's build_row expects. The array must be non-empty: a vacuous comparison
+(nothing to compare) is a caller error, not a silent pass -- codex findings
+#6/#7, CHAOS-3162's second adversarial review.
+
+Prints one JSON object to stdout:
 
     {
-      "cases": [{"id": ..., "row": {...fully JSON-encoded...}}, ...],
+      "cases": [{"id": ..., "row": {...typed-encoded...}}, ...],
       "excluded_fields": {"field": "reason", ...}
     }
+
+Every LEAF value in "row" is TYPE-TAGGED: {"t": "<pytype>", "v": "<string>"}
+(bare JSON `null` for None, which needs no type tag since it carries no
+ambiguity). This is codex finding #2, CHAOS-3162's second adversarial
+review: bare JSON numbers decode as Go float64, which collapses an int and
+an integral float to the same value AND loses precision above 2**53; a bare
+ISO string is indistinguishable from a genuinely-string field that happens
+to look like a timestamp. Tagging every leaf with its Python type and
+carrying the value as an untouched STRING (never a JSON number, which is
+the one JSON representation with a lossy default Go decode) closes both
+holes: the comparator on the Go side compares the (tag, string) pairs
+structurally, so "5" tagged int and "5" tagged float compare UNEQUAL, and
+"9007199254740992" compares by exact string equality, never by decoding
+through float64 at all.
 """
 
 from __future__ import annotations
@@ -45,6 +63,20 @@ def _module_name_for_pair(pair_id: str) -> str:
 
 
 def _encode(value: Any) -> Any:
+    """Type-tag every leaf value (codex finding #2). See module docstring
+    for the wire format and why. bool is checked before int: in Python,
+    bool is an int subclass, so `isinstance(True, int)` is True and an
+    int-first check would silently mis-tag every boolean as "int"."""
+    if value is None:
+        return None
+    if isinstance(value, bool):
+        return {"t": "bool", "v": "true" if value else "false"}
+    if isinstance(value, int):
+        return {"t": "int", "v": str(value)}
+    if isinstance(value, float):
+        return {"t": "float", "v": repr(value)}
+    if isinstance(value, str):
+        return {"t": "str", "v": value}
     if isinstance(value, datetime):
         # Always UTC, always explicit -- never the ambient system timezone
         # (an earlier version of this function used value.astimezone() with
@@ -53,14 +85,20 @@ def _encode(value: Any) -> Any:
         # process happened to run).
         if value.tzinfo is None:
             value = value.replace(tzinfo=timezone.utc)
-        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        encoded = value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+        return {"t": "datetime", "v": encoded}
     if isinstance(value, date):
-        return value.isoformat()
+        return {"t": "date", "v": value.isoformat()}
     if isinstance(value, dict):
         return {key: _encode(item) for key, item in value.items()}
     if isinstance(value, (list, tuple)):
         return [_encode(item) for item in value]
-    return value
+    raise TypeError(
+        f"_encode: unsupported type {type(value)!r} for value {value!r} -- "
+        "every leaf type this oracle can emit must have an explicit, "
+        "type-tagged encoding; falling through to an untagged pass-through "
+        "would silently reopen codex finding #2"
+    )
 
 
 def main() -> int:
@@ -75,13 +113,34 @@ def main() -> int:
     cases = json.loads(pathlib.Path(cases_path).read_text())
     if not isinstance(cases, list):
         raise ValueError("cases.json must be a JSON array")
+    if not cases:
+        raise ValueError(
+            "cases.json is empty -- a comparison run with zero cases proves "
+            "nothing and must not be allowed to look like a pass (codex "
+            "findings #6/#7, CHAOS-3162 second review)"
+        )
 
+    seen_ids: set[str] = set()
     results = []
     for case in cases:
         case_id = case.get("id")
         if not case_id:
             raise ValueError(f"case missing required 'id' key: {case}")
+        if case_id in seen_ids:
+            raise ValueError(
+                f"duplicate case id {case_id!r} -- python_generic_row_oracle.py "
+                "keys its output by case id, so a duplicate would let one "
+                "case's Python result be compared against a DIFFERENT case's "
+                "Go result on the caller side without either side detecting "
+                "it (codex finding #6, CHAOS-3162 second review)"
+            )
+        seen_ids.add(case_id)
         row = spec.build_row(case)
+        if not isinstance(row, dict):
+            raise TypeError(
+                f"case {case_id!r}: build_row returned {type(row)!r}, not a dict"
+            )
+        oracle_registry.check_completeness(pair_id, case_id, row)
         results.append({"id": case_id, "row": _encode(row)})
 
     print(json.dumps({"cases": results, "excluded_fields": spec.excluded_fields}))

--- a/internal/providersync/testdata/python_generic_row_oracle.py
+++ b/internal/providersync/testdata/python_generic_row_oracle.py
@@ -52,14 +52,45 @@ sys.path.insert(0, str(REPO_ROOT))
 
 from internal.providersync.testdata import oracle_registry  # noqa: E402
 
+_ORACLE_PAIRS_DIR = pathlib.Path(__file__).resolve().parent / "oracle_pairs"
+_ORACLE_PAIRS_PACKAGE = "internal.providersync.testdata.oracle_pairs"
 
-def _module_name_for_pair(pair_id: str) -> str:
-    parts = pair_id.split("/")
-    if len(parts) != 3:
-        raise ValueError(
-            f"pair id must be '<provider>/<dataset>/<boundary>', got {pair_id!r}"
-        )
-    return "internal.providersync.testdata.oracle_pairs." + "_".join(parts)
+
+def _known_pair_modules() -> dict[str, str]:
+    """Enumerate the checked-in oracle_pairs/*.py files and return a
+    {pair_id: module_name} whitelist.
+
+    Security note (github-advanced-security / Semgrep
+    python.lang.security.audit.non-literal-import.non-literal-import,
+    flagged on PR #1307): `main` previously formatted `sys.argv[1]`
+    straight into `importlib.import_module(...)` -- a caller-controlled
+    string driving a dynamic import is exactly the shape that rule exists
+    to catch, regardless of how narrow this specific CLI's actual blast
+    radius is. The fix is a real whitelist, not a suppression: this
+    function is the ONLY place that walks the filesystem, and it can only
+    ever discover FILES ALREADY CHECKED INTO THIS REPOSITORY under
+    oracle_pairs/ -- a pair_id that does not correspond to one of them is
+    rejected in `main` before `importlib.import_module` is ever called,
+    with a plain dict-key lookup (`_known_pair_modules()[pair_id]`) as the
+    only value ever passed to it. This is also a real behavioral
+    improvement independent of the scanner: "import whatever string you
+    are handed" becomes "import one of the pairs this framework knows
+    about", which is the property CHAOS-3162's own registry already
+    enforces one step later (oracle_registry.get raises for an
+    unregistered id) -- this closes the SAME gap one step earlier, before
+    an attempted import can even reach arbitrary application code that
+    happens to sit under that dotted path.
+    """
+    known: dict[str, str] = {}
+    for path in sorted(_ORACLE_PAIRS_DIR.glob("*.py")):
+        if path.stem.startswith("_"):
+            continue
+        parts = path.stem.split("_")
+        if len(parts) != 3:
+            continue
+        pair_id = "/".join(parts)
+        known[pair_id] = f"{_ORACLE_PAIRS_PACKAGE}.{path.stem}"
+    return known
 
 
 def _encode(value: Any) -> Any:
@@ -107,7 +138,30 @@ def main() -> int:
         return 2
     pair_id, cases_path = sys.argv[1], sys.argv[2]
 
-    importlib.import_module(_module_name_for_pair(pair_id))
+    known_modules = _known_pair_modules()
+    if pair_id not in known_modules:
+        raise ValueError(
+            f"pair id {pair_id!r} does not correspond to a checked-in "
+            f"testdata/oracle_pairs/*.py file -- known pairs: "
+            f"{sorted(known_modules)!r}"
+        )
+    # The only string this ever passes to importlib.import_module is a
+    # dict VALUE from _known_pair_modules()'s own filesystem enumeration --
+    # never sys.argv[1] (or anything derived from it) directly, and the
+    # `pair_id not in known_modules` check above already rejected anything
+    # that isn't a checked-in testdata/oracle_pairs/*.py file. Confirmed by
+    # running the exact rule directly (`semgrep --config
+    # r/python.lang.security.audit.non-literal-import.non-literal-import`):
+    # it still flags this line even with the whitelist in place, because it
+    # is a purely syntactic check on import_module's argument shape (any
+    # non-literal expression) with no data-flow awareness of the preceding
+    # validation -- there is no call shape this rule would accept for a
+    # loader whose whole job is resolving one of several checked-in
+    # modules by name. Narrow, justified suppression, not a workaround: see
+    # _known_pair_modules's docstring for the actual security property.
+    module_name = known_modules[pair_id]
+    # nosemgrep: python.lang.security.audit.non-literal-import.non-literal-import
+    importlib.import_module(module_name)
     spec = oracle_registry.get(pair_id)
 
     cases = json.loads(pathlib.Path(cases_path).read_text())

--- a/internal/providersync/testdata/python_generic_row_oracle.py
+++ b/internal/providersync/testdata/python_generic_row_oracle.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Generic CLI runner for the declarative oracle registry (CHAOS-3162).
+
+Usage:
+    python3 python_generic_row_oracle.py <pair_id> <cases.json>
+
+<pair_id> is e.g. "github/prs/row". Importing its registration module is a
+side effect of the naming convention below -- this file itself never
+mentions github, launchdarkly, or any other provider by name, which is the
+whole point: adding a pair means adding one file under oracle_pairs/, never
+editing this one.
+
+<cases.json> is a JSON array of case objects; each MUST have an "id" key
+(a stable, human-readable name for the case) plus whatever keys the pair's
+build_row expects. Prints one JSON object to stdout:
+
+    {
+      "cases": [{"id": ..., "row": {...fully JSON-encoded...}}, ...],
+      "excluded_fields": {"field": "reason", ...}
+    }
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import pathlib
+import sys
+from datetime import date, datetime, timezone
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from internal.providersync.testdata import oracle_registry  # noqa: E402
+
+
+def _module_name_for_pair(pair_id: str) -> str:
+    parts = pair_id.split("/")
+    if len(parts) != 3:
+        raise ValueError(
+            f"pair id must be '<provider>/<dataset>/<boundary>', got {pair_id!r}"
+        )
+    return "internal.providersync.testdata.oracle_pairs." + "_".join(parts)
+
+
+def _encode(value: Any) -> Any:
+    if isinstance(value, datetime):
+        # Always UTC, always explicit -- never the ambient system timezone
+        # (an earlier version of this function used value.astimezone() with
+        # no argument, which silently converted to local time and would have
+        # made every timestamp comparison fail depending on where the
+        # process happened to run).
+        if value.tzinfo is None:
+            value = value.replace(tzinfo=timezone.utc)
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, date):
+        return value.isoformat()
+    if isinstance(value, dict):
+        return {key: _encode(item) for key, item in value.items()}
+    if isinstance(value, (list, tuple)):
+        return [_encode(item) for item in value]
+    return value
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print(__doc__, file=sys.stderr)
+        return 2
+    pair_id, cases_path = sys.argv[1], sys.argv[2]
+
+    importlib.import_module(_module_name_for_pair(pair_id))
+    spec = oracle_registry.get(pair_id)
+
+    cases = json.loads(pathlib.Path(cases_path).read_text())
+    if not isinstance(cases, list):
+        raise ValueError("cases.json must be a JSON array")
+
+    results = []
+    for case in cases:
+        case_id = case.get("id")
+        if not case_id:
+            raise ValueError(f"case missing required 'id' key: {case}")
+        row = spec.build_row(case)
+        results.append({"id": case_id, "row": _encode(row)})
+
+    print(json.dumps({"cases": results, "excluded_fields": spec.excluded_fields}))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/internal/providersync/testdata/python_github_prs_normalization_oracle.py
+++ b/internal/providersync/testdata/python_github_prs_normalization_oracle.py
@@ -1,0 +1,217 @@
+#!/usr/bin/env python3
+"""Emit the live Python github/prs normalization output as JSON for Go parity
+tests (CHAOS-3122 / codex H9 fix).
+
+H9 found that the previous parity fixture was hand-authored, omitted the
+review-enrichment phase entirely, and then asserted the resulting zero-valued
+review fields as if they were verified parity -- the fixture encoded the Go
+implementation's incomplete contract as the "expected" result. This oracle
+closes the part of that finding that is actually `github/prs`'s to close:
+`normalize_pr_state` (providers/pr_state.py) and `build_git_pull_request` /
+`BaseGitProcessor.coerce_created_at` (processors/base_git.py) -- the exact
+functions that own state normalization and the created_at fallback chain,
+which is where the M7/H4-class defects actually lived -- are called LIVE, not
+re-derived by hand, for a battery of edge cases (internal whitespace, a
+trailing \r, every created_at fallback branch).
+
+first_review_at/reviews_count/changes_requested_count are NOT covered by this
+oracle and are not claimed as parity anywhere in the Go test: `github/prs`
+does not populate them (see pullRequestRow's doc comment), so there is no
+Python output to compare them against until `github/pr-reviews` lands. The
+matrix entry stays not-route-ready for exactly this reason -- see
+deploy/go-workers/provider-sync-porting-recipe.md's H1 resolution.
+
+`_pull_from_item`'s raw-JSON-to-dataclass extraction
+(providers/github/code_client.py) is intentionally NOT re-executed here: that
+module imports httpx, which the stock interpreter this oracle runs under
+(ci/check_go.sh) does not have. That layer is mechanical field extraction
+already pinned independently by tests/providers/test_github_code_client_prs.py
+in the full Python suite, and github_prs_route.go's own doc comments record
+the exact field mapping this Go code mirrors. What this oracle DOES cover is
+the layer that actually contained defects: state normalization and the
+created_at fallback chain.
+
+Regenerate this comparison by re-running the Go test that shells out to this
+script -- there is nothing to check in beyond this file; it is the generator.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+from datetime import datetime, timezone
+from typing import Any
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[3]
+sys.path.insert(0, str(REPO_ROOT))
+
+from internal.providersync.testdata.python_oracle_loader import (  # noqa: E402
+    load_live_module,
+)
+
+
+def _load_pr_state(source: pathlib.Path) -> Any:
+    """providers/pr_state.py has zero project-internal imports, so it loads
+    directly -- no stub namespace required (mirrors python_registry_oracle.py)."""
+    import importlib.util
+
+    spec = importlib.util.spec_from_file_location(
+        "dev_health_ops_pr_state_oracle_target", source.resolve(strict=True)
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load {source}")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _parse(value: str | None) -> datetime | None:
+    if not value:
+        return None
+    return datetime.fromisoformat(value.replace("Z", "+00:00"))
+
+
+def encode(value: Any) -> Any:
+    if isinstance(value, datetime):
+        return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+    if isinstance(value, dict):
+        return {key: encode(item) for key, item in value.items()}
+    if isinstance(value, list):
+        return [encode(item) for item in value]
+    return value
+
+
+# Every case below is a (raw_state, created_at, merged_at, closed_at) tuple
+# fed through the live `normalize_pr_state` + `build_git_pull_request` +
+# `coerce_created_at` chain -- covering the exact edge cases codex's H7
+# and H4 findings were about: internal whitespace, a trailing \r, "opened"
+# vs "open", "closed" with and without merged_at, and every created_at
+# fallback branch (created_at present / merged_at fallback / closed_at
+# fallback / all absent -> None, which BaseGitProcessor.coerce_created_at
+# resolves to "now" -- represented here as None so the Go test can assert its
+# own normalizedAt fallback separately rather than racing wall-clock values).
+CASES: list[dict[str, Any]] = [
+    {
+        "id": "open",
+        "raw_state": "open",
+        "created_at": "2026-07-10T09:00:00Z",
+        "merged_at": None,
+        "closed_at": None,
+    },
+    {
+        "id": "opened_alias",
+        "raw_state": "opened",
+        "created_at": "2026-07-10T09:00:00Z",
+        "merged_at": None,
+        "closed_at": None,
+    },
+    {
+        "id": "closed_unmerged",
+        "raw_state": "closed",
+        "created_at": "2026-07-10T09:00:00Z",
+        "merged_at": None,
+        "closed_at": "2026-07-15T00:00:00Z",
+    },
+    {
+        "id": "closed_merged",
+        "raw_state": "closed",
+        "created_at": "2026-07-10T09:00:00Z",
+        "merged_at": "2026-07-21T15:30:00Z",
+        "closed_at": "2026-07-21T15:30:00Z",
+    },
+    {
+        "id": "merged_literal",
+        "raw_state": "merged",
+        "created_at": "2026-07-10T09:00:00Z",
+        "merged_at": "2026-07-21T15:30:00Z",
+        "closed_at": "2026-07-21T15:30:00Z",
+    },
+    {
+        "id": "internal_whitespace",
+        "raw_state": "clo sed",
+        "created_at": "2026-07-10T09:00:00Z",
+        "merged_at": None,
+        "closed_at": None,
+    },
+    {
+        "id": "trailing_carriage_return",
+        "raw_state": "closed\r",
+        "created_at": "2026-07-10T09:00:00Z",
+        "merged_at": None,
+        "closed_at": "2026-07-15T00:00:00Z",
+    },
+    {
+        "id": "leading_trailing_whitespace",
+        "raw_state": "  Closed  ",
+        "created_at": "2026-07-10T09:00:00Z",
+        "merged_at": "2026-07-21T15:30:00Z",
+        "closed_at": "2026-07-21T15:30:00Z",
+    },
+    {
+        "id": "created_at_absent_falls_back_to_merged_at",
+        "raw_state": "closed",
+        "created_at": None,
+        "merged_at": "2026-07-21T15:30:00Z",
+        "closed_at": None,
+    },
+    {
+        "id": "created_and_merged_absent_falls_back_to_closed_at",
+        "raw_state": "closed",
+        "created_at": None,
+        "merged_at": None,
+        "closed_at": "2026-07-22T00:00:00Z",
+    },
+]
+
+
+def main() -> int:
+    if len(sys.argv) != 3:
+        print("usage: oracle.py <pr_state.py> <base_git.py>", file=sys.stderr)
+        return 2
+    pr_state_source = pathlib.Path(sys.argv[1])
+    base_git_source = pathlib.Path(sys.argv[2])
+
+    pr_state = _load_pr_state(pr_state_source)
+    base_git = load_live_module(base_git_source)
+
+    results: list[dict[str, Any]] = []
+    for case in CASES:
+        merged_at = _parse(case["merged_at"])
+        closed_at = _parse(case["closed_at"])
+        created_at = _parse(case["created_at"])
+        state = pr_state.normalize_pr_state(case["raw_state"], merged_at)
+        resolved_created_at = base_git.BaseGitProcessor.coerce_created_at(
+            created_at, merged_at, closed_at
+        )
+        pr = base_git.build_git_pull_request(
+            repo_id="00000000-0000-0000-0000-000000000000",
+            number=1,
+            title="t",
+            body="b",
+            state=state,
+            author_name="a",
+            author_email=None,
+            created_at=created_at,
+            merged_at=merged_at,
+            closed_at=closed_at,
+            head_branch="h",
+            base_branch="m",
+        )
+        results.append(
+            {
+                "id": case["id"],
+                "state": state,
+                "resolved_created_at": encode(resolved_created_at),
+                "built_created_at": encode(pr.created_at),
+                "built_merged_at": encode(pr.merged_at),
+                "built_closed_at": encode(pr.closed_at),
+            }
+        )
+
+    print(json.dumps(results, sort_keys=True, separators=(",", ":")))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -38,6 +38,7 @@ _LINEAR_BUDGET_SOURCE = _source("dev_health_ops/providers/linear/budget.py")
 _JIRA_BUDGET_SOURCE = _source("dev_health_ops/providers/jira/budget.py")
 _LAUNCHDARKLY_BUDGET_SOURCE = _source("dev_health_ops/providers/launchdarkly/budget.py")
 _DATASET_ADAPTERS_SOURCE = _source("dev_health_ops/processors/dataset_adapters.py")
+_BASE_GIT_SOURCE = _source("dev_health_ops/processors/base_git.py")
 
 _SAFE_SOURCE_MODULES: dict[str, Path] = {
     "dev_health_ops.sync.budget_types": _BUDGET_TYPES_SOURCE,
@@ -103,7 +104,58 @@ def _target_dataset_adapters() -> None:
     )
 
 
+def _target_base_git() -> None:
+    """Stub base_git.py's heavy, unrelated imports (CHAOS-3122).
+
+    ``BaseGitProcessor.coerce_created_at`` and the module-level
+    ``build_git_pull_request`` are pure functions; everything base_git.py
+    imports beyond them (complexity scanning, ORM models, the async batch
+    collector) is dead weight for this oracle and, more importantly, is not
+    importable under the stock interpreter this loader exists for. Each stub
+    only needs to satisfy the *names* base_git.py imports at module-load
+    time -- it never calls into any of them.
+    """
+    _install_module(
+        "dev_health_ops.analytics.complexity",
+        {"DEFAULT_COMPLEXITY_CONFIG_PATH": None, "ComplexityScanner": object},
+    )
+    _install_module(
+        "dev_health_ops.metrics.schemas",
+        {"FileComplexitySnapshot": object, "RepoComplexityDaily": object},
+    )
+    # GitPullRequest must be a real, introspectable class: build_git_pull_request
+    # returns `GitPullRequest(**values)` and the oracle reads the result's
+    # attributes back out. A plain kwargs-storing stand-in is sufficient --
+    # nothing here depends on SQLAlchemy instrumentation.
+    _install_module(
+        "dev_health_ops.models.git",
+        {
+            "CiPipelineRun": object,
+            "Deployment": object,
+            "GitBlame": object,
+            "GitCommitStat": object,
+            "GitFile": object,
+            "GitPullRequest": type(
+                "GitPullRequest",
+                (),
+                {"__init__": lambda self, **kwargs: self.__dict__.update(kwargs)},
+            ),
+        },
+    )
+    _install_module(
+        "dev_health_ops.processors.fetch_utils", {"AsyncBatchCollector": object}
+    )
+    # False keeps base_git.py's `elif CONNECTORS_AVAILABLE:` branch from firing,
+    # so it never needs dev_health_ops.connectors.utils stubbed too.
+    _install_module("dev_health_ops.utils", {"CONNECTORS_AVAILABLE": False})
+
+
 ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
+    _BASE_GIT_SOURCE: (
+        "dev_health_ops.processors.base_git",
+        _BASE_GIT_SOURCE,
+        _target_base_git,
+    ),
     _LAUNCHDARKLY_PROCESSOR_SOURCE: (
         "dev_health_ops.processors.launchdarkly",
         _LAUNCHDARKLY_PROCESSOR_SOURCE,
@@ -158,7 +210,9 @@ def _register_module(name: str, module: ModuleType) -> None:
 def _install_namespace() -> None:
     for name in (
         "dev_health_ops",
+        "dev_health_ops.analytics",
         "dev_health_ops.credentials",
+        "dev_health_ops.models",
         "dev_health_ops.metrics",
         "dev_health_ops.metrics.sinks",
         "dev_health_ops.processors",

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -39,6 +39,7 @@ _JIRA_BUDGET_SOURCE = _source("dev_health_ops/providers/jira/budget.py")
 _LAUNCHDARKLY_BUDGET_SOURCE = _source("dev_health_ops/providers/launchdarkly/budget.py")
 _DATASET_ADAPTERS_SOURCE = _source("dev_health_ops/processors/dataset_adapters.py")
 _BASE_GIT_SOURCE = _source("dev_health_ops/processors/base_git.py")
+_GITHUB_CODE_CLIENT_SOURCE = _source("dev_health_ops/providers/github/code_client.py")
 
 _SAFE_SOURCE_MODULES: dict[str, Path] = {
     "dev_health_ops.sync.budget_types": _BUDGET_TYPES_SOURCE,
@@ -150,11 +151,82 @@ def _target_base_git() -> None:
     _install_module("dev_health_ops.utils", {"CONNECTORS_AVAILABLE": False})
 
 
+def _target_github_code_client() -> None:
+    """Stub code_client.py's imports, INCLUDING httpx itself (CHAOS-3162).
+
+    ``_pull_from_item`` is a pure ``Mapping -> GitHubPullData`` function: it
+    never touches httpx, an HTTP connection, or any of this module's other
+    imports. The only reason loading the file needs them satisfied at all is
+    that Python evaluates every top-level `import`/`from` statement when a
+    module loads, regardless of which names the function you actually want
+    ends up using. `from __future__ import annotations` (present at the top
+    of code_client.py) is what makes stubbing httpx ITSELF safe: it defers
+    every type annotation (e.g. `transport: httpx.AsyncBaseTransport | None`)
+    to a string, so an annotation referencing a stub attribute that doesn't
+    exist is never evaluated. Verified empirically: loading the real file
+    under this exact stub set and calling `_pull_from_item({"user":
+    {"login": True}, ...})` returns `author_login='True'` -- the live
+    `str(user["login"])` call, not a re-implementation of it.
+    """
+    _install_module("httpx", {})
+    _install_module(
+        "dev_health_ops.connectors.models",
+        {"FileBlame": object, "SecurityAlertData": object},
+    )
+    _install_module(
+        "dev_health_ops.exceptions",
+        {
+            "APIException": Exception,
+            "AuthenticationException": Exception,
+            "NotFoundException": Exception,
+            "RateLimitException": Exception,
+        },
+    )
+    _install_module(
+        "dev_health_ops.providers._http",
+        {
+            "GITHUB_DIAGNOSTIC_HEADER_NAMES": (),
+            "InstrumentedRESTCore": object,
+            "_default_is_retryable_status": lambda *_args, **_kwargs: False,
+            "github_rest_base_url": lambda *_args, **_kwargs: "",
+        },
+    )
+    _install_module("dev_health_ops.providers.github.client", {"GitHubAuth": object})
+    _install_module(
+        "dev_health_ops.providers.github.graphql",
+        {
+            "BLAME_QUERY": "",
+            "blame_variables": lambda *_args, **_kwargs: {},
+            "build_blob_texts_query": lambda *_args, **_kwargs: "",
+            "github_graphql_url": lambda *_args, **_kwargs: "",
+            "parse_blame_response": lambda *_args, **_kwargs: None,
+            "parse_blob_texts_response": lambda *_args, **_kwargs: None,
+            "raise_for_graphql_errors": lambda *_args, **_kwargs: None,
+        },
+    )
+    _install_module(
+        "dev_health_ops.providers.github.ratelimit",
+        {
+            "classify_github_403": lambda *_args, **_kwargs: None,
+            "github_retry_after_seconds": lambda *_args, **_kwargs: None,
+        },
+    )
+    _install_module("dev_health_ops.sync.budget_types", {"BudgetDimension": object})
+    _install_module(
+        "dev_health_ops.sync.rate_limit_signal", {"RateLimitSignal": object}
+    )
+
+
 ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
     _BASE_GIT_SOURCE: (
         "dev_health_ops.processors.base_git",
         _BASE_GIT_SOURCE,
         _target_base_git,
+    ),
+    _GITHUB_CODE_CLIENT_SOURCE: (
+        "dev_health_ops.providers.github.code_client",
+        _GITHUB_CODE_CLIENT_SOURCE,
+        _target_github_code_client,
     ),
     _LAUNCHDARKLY_PROCESSOR_SOURCE: (
         "dev_health_ops.processors.launchdarkly",
@@ -211,12 +283,14 @@ def _install_namespace() -> None:
     for name in (
         "dev_health_ops",
         "dev_health_ops.analytics",
+        "dev_health_ops.connectors",
         "dev_health_ops.credentials",
         "dev_health_ops.models",
         "dev_health_ops.metrics",
         "dev_health_ops.metrics.sinks",
         "dev_health_ops.processors",
         "dev_health_ops.providers",
+        "dev_health_ops.providers.github",
         "dev_health_ops.providers.jira",
         "dev_health_ops.providers.launchdarkly",
         "dev_health_ops.providers.linear",

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -217,6 +217,108 @@ def _target_github_code_client() -> None:
     )
 
 
+_GITHUB_PROCESSOR_SOURCE = _source("dev_health_ops/processors/github.py")
+
+
+def _target_github_processor() -> None:
+    """Stub processors/github.py's heavy, unrelated imports (CHAOS-3162).
+
+    _collect_github_pr_objects's list-inclusion decision (the `if until is
+    not None: ... continue` / `if since is not None: ... break` pair) is
+    the ONLY logic github_prs_window.py's live-execution harness exercises
+    -- it substitutes a fake client (via a monkeypatched
+    _github_code_client_from_connector) whose get_pull_detail raises a
+    sentinel the instant it is called, so the harness never reaches
+    build_git_pull_request or any of the other names this module imports.
+    Every stub below only needs to satisfy the *name* at module-load time,
+    exactly like _target_base_git's -- github.py does not carry `from
+    __future__ import annotations`, so a handful of these (GitSyncStore,
+    used in a `store: GitSyncStore | Any` parameter annotation) must be
+    real class OBJECTS, not instances, so Python's `X | Y` union-type
+    syntax evaluates without error at `def` time.
+    """
+    _install_module(
+        "dev_health_ops.analytics.complexity",
+        {"DEFAULT_COMPLEXITY_CONFIG_PATH": None, "ComplexityScanner": object},
+    )
+    _install_module("dev_health_ops.credentials.types", {"GitHubCredentials": object})
+    _install_module("dev_health_ops.exceptions", {"RateLimitException": Exception})
+    _install_module("dev_health_ops.metrics.sinks.ingestion", {"IngestionSink": object})
+    _install_module(
+        "dev_health_ops.models.git",
+        {
+            "CiPipelineRun": object,
+            "Deployment": object,
+            "GitBlame": object,
+            "GitCommit": object,
+            "GitCommitStat": object,
+            "GitPullRequest": object,
+            "GitPullRequestReview": object,
+            "Repo": object,
+        },
+    )
+    _install_module(
+        "dev_health_ops.processors.base_git",
+        {
+            "BaseGitProcessor": object,
+            "backfill_file_records": _unsupported_dependency,
+            "blame_backfill_needed": _unsupported_dependency,
+            "build_ci_pipeline_run": _unsupported_dependency,
+            "build_deployment": _unsupported_dependency,
+            "build_git_pull_request": _unsupported_dependency,
+            "check_backfill_needs": _unsupported_dependency,
+            "historical_backfill_day": _unsupported_dependency,
+            "resolve_commit_stats_limit": _unsupported_dependency,
+            "select_unblamed_paths": _unsupported_dependency,
+            "write_historical_complexity": _unsupported_dependency,
+        },
+    )
+    _install_module(
+        "dev_health_ops.processors.fetch_utils",
+        {
+            "AsyncBatchCollector": object,
+            "SyncBatchCollector": object,
+            "safe_parse_datetime": _unsupported_dependency,
+        },
+    )
+    _install_module(
+        "dev_health_ops.processors.release_ref",
+        {"get_release_ref_enrichment": _unsupported_dependency},
+    )
+    _install_module(
+        "dev_health_ops.processors.storage_protocol", {"GitSyncStore": object}
+    )
+    _install_module(
+        "dev_health_ops.processors.testops_ingest",
+        {
+            "MAX_ARTIFACTS_PER_RUN": 0,
+            "MAX_RUNS_PER_SYNC": 0,
+            "ingest_report_members": _unsupported_dependency,
+        },
+    )
+    _install_module(
+        "dev_health_ops.providers.github.client",
+        {"GitHubAuth": object, "GitHubWorkClient": object},
+    )
+    _install_module(
+        "dev_health_ops.providers.pr_state",
+        {"normalize_pr_state": _unsupported_dependency},
+    )
+    _install_module(
+        "dev_health_ops.providers.usage",
+        {"drain_provider_usage": _unsupported_dependency},
+    )
+    _install_module(
+        "dev_health_ops.utils",
+        {
+            "AGGREGATE_STATS_MARKER": "__AGGREGATE__",
+            "BATCH_SIZE": 1000,
+            "CONNECTORS_AVAILABLE": False,
+            "is_skippable": _unsupported_dependency,
+        },
+    )
+
+
 ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
     _BASE_GIT_SOURCE: (
         "dev_health_ops.processors.base_git",
@@ -227,6 +329,11 @@ ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
         "dev_health_ops.providers.github.code_client",
         _GITHUB_CODE_CLIENT_SOURCE,
         _target_github_code_client,
+    ),
+    _GITHUB_PROCESSOR_SOURCE: (
+        "dev_health_ops.processors.github",
+        _GITHUB_PROCESSOR_SOURCE,
+        _target_github_processor,
     ),
     _LAUNCHDARKLY_PROCESSOR_SOURCE: (
         "dev_health_ops.processors.launchdarkly",

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -236,6 +236,34 @@ def _target_github_processor() -> None:
     used in a `store: GitSyncStore | Any` parameter annotation) must be
     real class OBJECTS, not instances, so Python's `X | Y` union-type
     syntax evaluates without error at `def` time.
+
+    CI incident (CHAOS-3162, after this pair's third review landed):
+    CONNECTORS_AVAILABLE was originally stubbed False, the same way
+    _target_base_git's own doc comment recommends ("keeps the branch from
+    firing, never needs connectors.utils stubbed too"). That is safe for
+    base_git.py, which has no annotation depending on a name from that
+    branch's `else:` fallback -- but github.py's own `else:` branch (fired
+    when CONNECTORS_AVAILABLE is False) sets `RateLimitGate = None` at
+    module scope, and two functions annotate a parameter as
+    `gate: RateLimitGate | None = None` -- `None | None` raises
+    `TypeError: unsupported operand type(s) for |`. This is a bug in
+    processors/github.py's own fallback shape, not something a stub can
+    route around by picking a *different* falsy value -- the only way to
+    avoid it is to take the OTHER branch (CONNECTORS_AVAILABLE = True) and
+    give every name pulled in by the `elif CONNECTORS_AVAILABLE:` import
+    block (below) a real placeholder class instead of the one that
+    actually crashes.
+
+    Why this shipped green locally and only failed in CI: Python 3.14
+    (this loader's own local interpreter) defaults to PEP 649 deferred
+    annotation evaluation -- `gate: RateLimitGate | None` is not actually
+    evaluated at `def` time on 3.14, only the FIRST time something reads
+    `__annotations__` (mypy, `typing.get_type_hints`, or an older,
+    pre-3.14 Python, which is what CI's isolated job runs and evaluates
+    eagerly). `load_live_module` now forces that evaluation immediately
+    after every load (see _force_annotation_evaluation below), specifically
+    so this class of stub-shape bug fails on the very next line locally,
+    on ANY Python version, instead of shipping through a 3.14 blind spot.
     """
     _install_module(
         "dev_health_ops.analytics.complexity",
@@ -308,15 +336,38 @@ def _target_github_processor() -> None:
         "dev_health_ops.providers.usage",
         {"drain_provider_usage": _unsupported_dependency},
     )
+    # CONNECTORS_AVAILABLE = True (not the _target_base_git precedent of
+    # False -- see the module-load CI incident above): this takes
+    # github.py's `elif CONNECTORS_AVAILABLE:` branch instead of its
+    # `else:` fallback, which is what actually needs every name below to
+    # be a real class, not a sentinel.
     _install_module(
         "dev_health_ops.utils",
         {
             "AGGREGATE_STATS_MARKER": "__AGGREGATE__",
             "BATCH_SIZE": 1000,
-            "CONNECTORS_AVAILABLE": False,
+            "CONNECTORS_AVAILABLE": True,
             "is_skippable": _unsupported_dependency,
         },
     )
+    _install_module(
+        "dev_health_ops.connectors",
+        {
+            "BatchResult": object,
+            "ConnectorException": Exception,
+            "GitHubConnector": object,
+        },
+    )
+    _install_module("dev_health_ops.connectors.models", {"Repository": object})
+    _install_module(
+        "dev_health_ops.connectors.utils",
+        {"RateLimitConfig": object, "RateLimitGate": object},
+    )
+    # The third-party PyGithub package (`import github`), not
+    # dev_health_ops -- also only imported inside the
+    # `elif CONNECTORS_AVAILABLE:` branch, and also only needs to be
+    # importable, not functional, for this pair's execution path.
+    _install_module("github", {"RateLimitExceededException": Exception})
 
 
 ALLOWED_MODULES: dict[Path, tuple[str, Path, Callable[[], None]]] = {
@@ -432,6 +483,69 @@ def _load_safe_source(name: str) -> ModuleType:
     return _load_source_module(name, source)
 
 
+def _force_annotation_evaluation(module_name: str, module: ModuleType) -> None:
+    """Force every function/class annotation in a freshly-loaded module to
+    evaluate NOW, deterministically, on whichever Python is running this
+    loader -- rather than lazily, maybe never, depending on interpreter
+    version.
+
+    CHAOS-3162 CI incident (the reason this exists): a stub for
+    processors/github.py supplied `None` for a name used in a
+    `gate: RateLimitGate | None = None` parameter annotation.
+    `None | None` raises `TypeError`. Python 3.14 defaults to PEP 649
+    deferred annotation evaluation -- the broken annotation is not actually
+    evaluated at `def` time, only the first time something reads
+    `__annotations__` -- so `load_live_module` returned successfully on a
+    local 3.14 interpreter, and every test built on top of it passed. CI's
+    isolated `go-storage-integration` job ran an OLDER Python (pre-3.14,
+    eager annotation evaluation by default) and failed immediately on
+    import, on a code path no local run had ever exercised. A stub whose
+    SHAPE is wrong for an annotation (a bare sentinel standing in for a
+    type) is exactly the same class of defect as a stub whose shape is
+    wrong for a value CHAOS-3162 spent two review rounds closing -- the fix
+    here is the same discipline applied to the loader itself: make the
+    broken path the one that always runs, not the one only some future
+    Python (or some future CI image) happens to discover.
+
+    Accessing `member.__annotations__` is sufficient to trigger PEP 649's
+    lazy `__annotate__` call on 3.14+; on older Pythons the annotations
+    were already eager and this is a harmless re-read. Either way, a
+    broken stub now raises HERE, inside load_live_module, on every Python
+    version, not conditionally depending on which one happens to be
+    running.
+    """
+    import inspect
+
+    for name, member in vars(module).items():
+        if inspect.isclass(member) and member.__module__ != module.__name__:
+            continue  # an imported (stub) class, not one this module defines
+        if inspect.isfunction(member) and member.__module__ != module.__name__:
+            continue
+        if not (inspect.isfunction(member) or inspect.isclass(member)):
+            continue
+        try:
+            _ = member.__annotations__
+        except TypeError as exc:
+            raise RuntimeError(
+                f"{module_name}.{name}'s annotations failed to evaluate: {exc} -- "
+                "a stub in this loader's configure() is very likely the wrong "
+                "SHAPE for a name used in an annotation (e.g. a bare None "
+                "standing in for a type, which does not support `X | None`). "
+                "See _force_annotation_evaluation's docstring."
+            ) from exc
+        if inspect.isclass(member):
+            for method_name, method in vars(member).items():
+                if inspect.isfunction(method):
+                    try:
+                        _ = method.__annotations__
+                    except TypeError as exc:
+                        raise RuntimeError(
+                            f"{module_name}.{name}.{method_name}'s annotations "
+                            f"failed to evaluate: {exc} -- see "
+                            "_force_annotation_evaluation's docstring."
+                        ) from exc
+
+
 def load_live_module(source: Path) -> Any:
     """Execute the canonical production module allowlisted for ``source``."""
     expected = source.resolve(strict=True)
@@ -451,4 +565,5 @@ def load_live_module(source: Path) -> Any:
     origin = Path(spec.origin).resolve(strict=True)
     if origin != canonical_source:
         raise RuntimeError(f"oracle imported {origin}, expected {canonical_source}")
+    _force_annotation_evaluation(module_name, module)
     return module

--- a/internal/providersync/testdata/python_oracle_loader.py
+++ b/internal/providersync/testdata/python_oracle_loader.py
@@ -159,16 +159,33 @@ def _target_github_code_client() -> None:
     imports. The only reason loading the file needs them satisfied at all is
     that Python evaluates every top-level `import`/`from` statement when a
     module loads, regardless of which names the function you actually want
-    ends up using. `from __future__ import annotations` (present at the top
-    of code_client.py) is what makes stubbing httpx ITSELF safe: it defers
-    every type annotation (e.g. `transport: httpx.AsyncBaseTransport | None`)
-    to a string, so an annotation referencing a stub attribute that doesn't
-    exist is never evaluated. Verified empirically: loading the real file
-    under this exact stub set and calling `_pull_from_item({"user":
-    {"login": True}, ...})` returns `author_login='True'` -- the live
-    `str(user["login"])` call, not a re-implementation of it.
+    ends up using.
+
+    CORRECTED (CHAOS-3162, fourth adversarial review): an earlier version of
+    this docstring claimed `from __future__ import annotations` (present at
+    the top of code_client.py) makes stubbing httpx as a fully EMPTY module
+    safe, because "an annotation referencing a stub attribute that doesn't
+    exist is never evaluated." That was true only as long as nothing ever
+    resolved those annotations -- true of `_pull_from_item` itself, NOT true
+    in general: `load_live_module` now calls `_force_annotation_evaluation`,
+    which resolves every annotation via `typing.get_type_hints`, and
+    `_lowered_github_headers(response: httpx.Response)` genuinely needs
+    `httpx.Response` to exist. An empty httpx stub loaded successfully and
+    silently, with the broken annotation never surfacing until something
+    (mypy, `get_type_hints`, an eager-evaluation Python) actually looked --
+    the SAME class of bug as the RateLimitGate incident, just a level
+    deeper (in a *different* stubbed module) than the one that shipped it.
+    httpx therefore needs every name an ANNOTATION in this file
+    dereferences, even though `_pull_from_item` itself never touches httpx
+    at runtime.
+
+    Verified empirically: loading the real file under this stub set and
+    calling `_pull_from_item({"user": {"login": True}, ...})` still returns
+    `author_login='True'` -- the live `str(user["login"])` call, not a
+    re-implementation of it -- and `_force_annotation_evaluation` now
+    passes cleanly against every function/class this module defines.
     """
-    _install_module("httpx", {})
+    _install_module("httpx", {"Response": object, "AsyncBaseTransport": object})
     _install_module(
         "dev_health_ops.connectors.models",
         {"FileBlame": object, "SecurityAlertData": object},
@@ -507,43 +524,68 @@ def _force_annotation_evaluation(module_name: str, module: ModuleType) -> None:
     broken path the one that always runs, not the one only some future
     Python (or some future CI image) happens to discover.
 
-    Accessing `member.__annotations__` is sufficient to trigger PEP 649's
-    lazy `__annotate__` call on 3.14+; on older Pythons the annotations
-    were already eager and this is a harmless re-read. Either way, a
-    broken stub now raises HERE, inside load_live_module, on every Python
-    version, not conditionally depending on which one happens to be
-    running.
+    CODEX FINDING (CHAOS-3162, fourth adversarial review): the first version
+    of this function only touched `member.__annotations__` directly. That
+    is sufficient to trigger PEP 649's lazy `__annotate__` call on 3.14+ for
+    a module WITHOUT `from __future__ import annotations` (like
+    processors/github.py, the RateLimitGate incident) -- but modules WITH
+    that future-import (like code_client.py) store STRING literals in
+    `__annotations__` unconditionally, on every Python version, regardless
+    of PEP 649. Reading `__annotations__` on such a module never evaluates
+    anything and never raises -- proven empirically: an httpx stub with NO
+    `Response` attribute loads `code_client.py` successfully even though
+    `_lowered_github_headers(response: httpx.Response)` requires it, and
+    only `typing.get_type_hints()` (which actually RESOLVES a string
+    annotation against the function's `__globals__`, string-annotated
+    module or not) surfaces `AttributeError: module 'httpx' has no
+    attribute 'Response'`. This function now uses `get_type_hints` instead
+    of a bare attribute read, closing that gap uniformly for both
+    annotation styles.
+
+    One deliberate exception: `NameError` is NOT treated as a failure here.
+    Forward-referencing a TYPE_CHECKING-only import in a string annotation
+    (e.g. `-> "GitHubCodeClient":` when `GitHubCodeClient` is only imported
+    under `if TYPE_CHECKING:`) is a normal, load-bearing Python idiom this
+    codebase already uses (processors/github.py's own
+    `_github_code_client_from_connector`) -- that name is never meant to
+    resolve at runtime, and failing loudly on it would break legitimate
+    production code, not catch a stub bug. `TypeError` (an operator applied
+    to the wrong shape, e.g. `None | None`) and `AttributeError` (a stub
+    missing an attribute real code dereferences) cannot come from a
+    deliberately-unresolvable forward reference -- only from a name that DID
+    resolve, to something the wrong shape. Those two stay hard failures.
     """
     import inspect
+    import typing
+
+    def _check(qualified_name: str, member: object) -> None:
+        try:
+            typing.get_type_hints(member)
+        except NameError:
+            return  # a TYPE_CHECKING-only forward reference; expected, not a stub bug.
+        except (TypeError, AttributeError) as exc:
+            raise RuntimeError(
+                f"{qualified_name}'s annotations failed to evaluate: {exc} -- "
+                "a stub in this loader's configure() is very likely the wrong "
+                "SHAPE for a name used in an annotation (e.g. a bare None "
+                "standing in for a type, which does not support `X | None`, "
+                "or an empty stub module missing an attribute the real "
+                "annotation dereferences). See _force_annotation_evaluation's "
+                "docstring."
+            ) from exc
 
     for name, member in vars(module).items():
         if inspect.isclass(member) and member.__module__ != module.__name__:
             continue  # an imported (stub) class, not one this module defines
         if inspect.isfunction(member) and member.__module__ != module.__name__:
             continue
-        if not (inspect.isfunction(member) or inspect.isclass(member)):
-            continue
-        try:
-            _ = member.__annotations__
-        except TypeError as exc:
-            raise RuntimeError(
-                f"{module_name}.{name}'s annotations failed to evaluate: {exc} -- "
-                "a stub in this loader's configure() is very likely the wrong "
-                "SHAPE for a name used in an annotation (e.g. a bare None "
-                "standing in for a type, which does not support `X | None`). "
-                "See _force_annotation_evaluation's docstring."
-            ) from exc
-        if inspect.isclass(member):
+        if inspect.isfunction(member):
+            _check(f"{module_name}.{name}", member)
+        elif inspect.isclass(member):
+            _check(f"{module_name}.{name}", member)
             for method_name, method in vars(member).items():
                 if inspect.isfunction(method):
-                    try:
-                        _ = method.__annotations__
-                    except TypeError as exc:
-                        raise RuntimeError(
-                            f"{module_name}.{name}.{method_name}'s annotations "
-                            f"failed to evaluate: {exc} -- see "
-                            "_force_annotation_evaluation's docstring."
-                        ) from exc
+                    _check(f"{module_name}.{name}.{method_name}", method)
 
 
 def load_live_module(source: Path) -> Any:

--- a/src/dev_health_ops/workers/provider_unit_route.py
+++ b/src/dev_health_ops/workers/provider_unit_route.py
@@ -125,6 +125,11 @@ class ProviderUnitRouteSwitches:
     # environment name, because a unit this gate routes to River is only
     # executed if the worker's CompleteRouteSwitches also enables the pair.
     github_repo_metadata: bool = False
+    # github_prs is the producer half of the (github, prs) gate (CHAOS-3122,
+    # following CHAOS-3123's precedent). Its Go counterpart is
+    # config.Config.WorkerGithubPRsEnabled, read from the same
+    # WORKER_GITHUB_PRS_ENABLED environment name.
+    github_prs: bool = False
 
     @classmethod
     def from_environment(
@@ -139,6 +144,7 @@ class ProviderUnitRouteSwitches:
                 source, "WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED"
             ),
             github_repo_metadata=_flag(source, "WORKER_GITHUB_REPO_METADATA_ENABLED"),
+            github_prs=_flag(source, "WORKER_GITHUB_PRS_ENABLED"),
         )
         switches.require_complete_routes()
         return switches

--- a/tests/workers/test_provider_unit_route.py
+++ b/tests/workers/test_provider_unit_route.py
@@ -126,6 +126,76 @@ def test_github_repo_metadata_switch_does_not_open_gitlab_repo_metadata() -> Non
 
 
 # ---------------------------------------------------------------------------
+# CHAOS-3122: the (github, prs) producer-side switch. Its Go counterpart is
+# config.Config.WorkerGithubPRsEnabled, read from the same
+# WORKER_GITHUB_PRS_ENABLED name.
+# ---------------------------------------------------------------------------
+
+
+def test_github_prs_defaults_to_false() -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_LAUNCHDARKLY_FEATURE_FLAGS_ENABLED": "true"}
+    )
+    assert switches.github_prs is False
+
+
+@pytest.mark.parametrize("value", sorted(provider_unit_route._TRUE))
+def test_github_prs_parses_true_spellings(value: str) -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_PRS_ENABLED": value}
+    )
+    assert switches.github_prs is True
+
+
+@pytest.mark.parametrize("value", sorted(provider_unit_route._FALSE))
+def test_github_prs_parses_false_spellings(value: str) -> None:
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_PRS_ENABLED": value}
+    )
+    assert switches.github_prs is False
+
+
+def test_github_prs_invalid_value_fails_closed() -> None:
+    with pytest.raises(ProviderUnitRouteError):
+        ProviderUnitRouteSwitches.from_environment(
+            {"WORKER_GITHUB_PRS_ENABLED": "sometimes"}
+        )
+
+
+def test_github_prs_is_not_yet_route_ready() -> None:
+    """(github, prs) has a real Go handler (CHAOS-3122) but is deliberately
+    NOT route_ready: codex H1 found that first_review_at/reviews_count/
+    changes_requested_count on git_pull_requests are owned by Python's
+    review-enrichment phase, which the Go handler does not perform, so it
+    would always write fabricated zeros into columns it does not own. The
+    switch exists and is wired end to end (so flipping RouteReady later is a
+    one-line change, not new plumbing) but can never route traffic while the
+    matrix says not-ready -- routes_to_river must stay False even with the
+    switch on."""
+
+    assert not ProviderUnitRouteSwitches.is_route_ready("github", "prs")
+
+    on = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_PRS_ENABLED": "true"}
+    )
+    assert not on.routes_to_river("github", "prs")
+
+
+def test_github_prs_switch_does_not_open_pr_reviews_or_pr_comments() -> None:
+    """github/pr-reviews and github/pr-comments share the "prs" legacy target
+    in Python (they are the same _sync_github_prs_to_store_async execution),
+    but neither has its own Go handler yet and both stay route_ready=false in
+    the matrix, so turning on GithubPRs must never widen either open."""
+
+    switches = ProviderUnitRouteSwitches.from_environment(
+        {"WORKER_GITHUB_PRS_ENABLED": "true"}
+    )
+    for dataset in ("pr-reviews", "pr-comments"):
+        assert not ProviderUnitRouteSwitches.is_route_ready("github", dataset)
+        assert not switches.routes_to_river("github", dataset)
+
+
+# ---------------------------------------------------------------------------
 # CHAOS-3131: routability is derived from the checked-in matrix, not from a
 # hardcoded provider/dataset literal.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Ports (github, prs) to the Go complete-route path (CHAOS-3122/CHAOS-3123 epic), then builds a generic, declarative Python↔Go parity comparator (CHAOS-3162) and proves it against this pair before porting the next one.

- `github/prs` is coded, tested, and mutation-tested, but shipped `route_ready: false` on purpose (see `execution_registry.go`'s doc comment): `first_review_at`/`reviews_count`/`changes_requested_count` are owned by the not-yet-built `github/pr-reviews` review-enrichment phase, and writing them as fabricated zeros while claiming route-ready would corrupt downstream analytics. GitHub stays at 1/17 pairs ready.
- Two rounds of adversarial (codex) review landed fixes for 9 findings total — see commits `140b64eed` and `0cc50a7e5` and the recipe doc's defect classes 1–15.
- CHAOS-3162 (commit `47359b875`) replaces "one hand-picked-field oracle per pair" with a shared, whole-row, fail-on-undeclared-divergence comparator, reused across three different boundary shapes on this same pair.

## CHAOS-3162: what the comparator actually proved

**Rediscovery is the load-bearing evidence, not the tests passing.** Re-ran the comparator against pre-fix/buggy substitutes and confirmed it independently rediscovers all six defects from this pair's two adversarial review rounds, with no prior knowledge of the specific bug baked into the test:

1. state-normalization whitespace (M7) — `TestGenericOracleRediscoversRowConstructionDefects`
2. non-string login coercion (M8) — same
3. unasserted built fields, merged_at/closed_at swap (M3) — same
4. null-updated_at window guard (H3) — `TestGenericOracleRediscoversWindowGuardDefect`
5. omitted readback columns (M6, round 1) — `TestGenericComparatorRediscoversReadbackDefects`
6. NULL-vs-empty-string argMax collapse (H2, round 2) — same

Reused the identical comparator (`diffRows`/`oracleDivergences` in `oracle_compare_test.go`) across three structurally different crossings — row construction (live Python), a list-inclusion decision, and a real ClickHouse readback — which is the part that makes this worth building for 57 pairs rather than one.

**The comparator had its own defect, found by mutating it.** The first mutation-testing pass of `oracle_compare.json` showed the `present-in-Python-only` and `present-in-Go-only` clauses SURVIVED when disabled — not because they were dead code, but because the disabled clause's test case still fell through to the value-mismatch clause, which produced *one message* for the wrong reason. The test was asserting message **count**, not **content** — a comparator built specifically to stop a test from confirming what its author expected was itself confirming a count instead of a claim. Fixed by asserting message content in `TestDiffRowsClauseCoverage`; re-run is 5/5 KILLED.

**Honest scope limitation, stated on the record rather than left for a reader to discover:** the window-decision pair (`testdata/oracle_pairs/github_prs_window.py`) does **not** execute the real, live `_collect_github_pr_objects` — that function is async, needs a real `GitHubCodeClient`, and its module pulls in the complexity scanner, testops ingestion, and half a dozen other subsystems. Stubbing all of that for a three-line decision was judged not worth the risk of the stubs themselves drifting from reality. Instead `_decide` is a byte-for-byte **pinned copy** of the two `if` blocks that make the decision (currently `processors/github.py` lines 630–644), guarded by `_assert_pin_still_matches_source()`, which reads the live source at test time and hard-fails if the pinned fragments are no longer present.
  - **What the freshness check guarantees:** if the pinned source lines change or disappear, this pair's test fails loudly the next time it runs — the pin cannot go silently stale.
  - **What it does NOT guarantee:** that the pinned copy's *behavior* matches the live function today, only that its *text* still matches. A change to the live function that preserves these exact substrings but alters control flow around them (or something upstream that changes what values reach this code) would not be caught. Do not treat `github/prs/window` as live-verified the way `github/prs/row` (which does run the real, live Python) is — it is pin-verified, a weaker and explicitly narrower claim.

**Tooling provenance:** `scripts/mutation_harness.py` (used both for `github_prs.json`'s existing plan and the new `oracle_compare.json` plan) lives on the still-unmerged `chaos-3155-shared-mutation-harness` branch, invoked here via `--root` against this worktree. Both plans should be re-run once that branch lands, since the harness itself has changed since these plans were last run against it (it now distinguishes a non-building mutation as INVALID rather than KILLED, and flags a declared survivor that starts being killed).

**Not in scope:** migrating the five oracles that predate CHAOS-3162 (`python_launchdarkly_normalization_oracle.py`, `github/repo-metadata`'s oracle, and this pair's own pre-existing `python_github_prs_normalization_oracle.py`). They keep working exactly as documented; only new pairs reach for the generic path.

## Commits

- `140b64eed` — port github/prs to Go (code+tests complete, route_ready held back)
- `0cc50a7e5` — fix codex re-review findings (2 HIGH, 3 MEDIUM)
- `47359b875` — CHAOS-3162 generic oracle comparator

## Test plan

- [x] `bash ci/check_go.sh all` (fmt, vet, test, race, build, contract, integration-vet, integration-coverage) — green
- [x] `go test -tags integration ./internal/providersync/...` against real Postgres+ClickHouse containers — green (129s)
- [x] `python3 scripts/mutation_harness.py run --plan internal/providersync/testdata/mutation-plans/github_prs.json --assert-all-killed` — 17/17 KILLED
- [x] `python3 scripts/mutation_harness.py run --plan internal/providersync/testdata/mutation-plans/oracle_compare.json --assert-all-killed` — 5/5 KILLED (after the message-content fix above)
- [x] Rediscovery: all six named defects rediscovered by the generic comparator against documented pre-fix substitutes
- [x] `ruff check` / `ruff format --check` / `mypy` on new Python testdata files
- [ ] Codex adversarial review of the CHAOS-3162 commit (`47359b875`) — in progress in parallel; will fix before porting pair three if it lands findings
