### PR TITLE
CHAOS-3151: pin the scheduler and reconciler activation seams

### DIFF
--- a/cmd/dev-health-reconciler/activation_pin_test.go
+++ b/cmd/dev-health-reconciler/activation_pin_test.go
@@ -27,8 +27,15 @@ import (
 // means the flip itself is a one-character change with production consequences
 // and nothing previously noticed it. dependencies.go states the intent directly:
 // "changing from observation to mutation must retain concrete River delivery
-// capabilities in the same reviewed source change." This test is what makes that
-// sentence enforceable rather than aspirational.
+// capabilities in the same reviewed source change."
+//
+// These tests enforce the FIRST half of that sentence and not the second. They
+// make the flip visible and deliberate -- it cannot happen without editing a pin
+// in the same commit. They cannot verify that concrete delivery capability is
+// retained: set the flag and the pin together and everything here passes, 42501
+// and all. A reviewer supplies that evidence; see CHAOS-3146. Reviewed twice now
+// because the original wording claimed the whole sentence, and an overstated
+// comment is how a green test becomes read as permission to flip.
 //
 // Flipping syncMutation today also ships a known 42501: the Materializer runs on
 // the coordinator pool and inserts into public.sync_dispatch_outbox, which
@@ -141,6 +148,53 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 				"test can no longer tell observation from mutation. Fix the test " +
 				"before trusting it: a pin that cannot reach the branch it guards is " +
 				"worse than no pin, because it reports success.",
+		)
+	}
+}
+
+// TestReconcilerSpecUsesTheConfigurationThisFilePins closes the chain from `main`
+// to the function the behavioural pin exercises.
+//
+// The behavioural pin calls configureReconcilerDependenciesWithSourcesAndLogger
+// so it can inject fakes. `shell.Main` does not call that directly -- it calls
+// whatever reconcilerSpec names, which is configureReconcilerDependenciesWithLogger,
+// which delegates to the sources-taking function with production sources. This
+// test pins both ends of that chain: the spec field points where we think, and the
+// delegate is the function under test.
+//
+// Precisely what IS and IS NOT covered, because the distinction is the whole point
+// of this file: the spec field is asserted here; the ACTIVATION VALUE is asserted
+// by the behavioural pin, because configureReconcilerDependenciesWithSourcesAndLogger
+// is the sole supplier of checkedInReconcilerActivation. What is not asserted is
+// the body of configureReconcilerDependenciesWithLogger beyond its identity -- if
+// someone changed it to pass a different activation, the behavioural pin would not
+// see it, because it enters below that point. That is the residual gap, and the
+// mitigation is that the function is four lines of pure delegation. Do not let it
+// grow logic.
+func TestReconcilerSpecUsesTheConfigurationThisFilePins(t *testing.T) {
+	if reconcilerSpec.ConfigureDependencies != nil {
+		t.Fatal(
+			"reconcilerSpec now sets ConfigureDependencies. shell.Main may call that " +
+				"instead of ConfigureDependenciesWithLogger, so the pins here no longer " +
+				"cover the production path. Retarget them.",
+		)
+	}
+	if reconcilerSpec.ConfigureDependenciesWithLogger == nil {
+		t.Fatal(
+			"reconcilerSpec.ConfigureDependenciesWithLogger is nil, so these pins " +
+				"cover nothing that production runs",
+		)
+	}
+
+	// Function values are not comparable in Go; compare code pointers.
+	pinned := reflect.ValueOf(configureReconcilerDependenciesWithLogger).Pointer()
+	wired := reflect.ValueOf(reconcilerSpec.ConfigureDependenciesWithLogger).Pointer()
+	if pinned != wired {
+		t.Fatal(
+			"reconcilerSpec.ConfigureDependenciesWithLogger is NOT " +
+				"configureReconcilerDependenciesWithLogger. The pins therefore describe " +
+				"a function the binary does not call, and activation could ship green. " +
+				"Restore the wiring or retarget the pins -- do not delete this test.",
 		)
 	}
 }

--- a/cmd/dev-health-reconciler/activation_pin_test.go
+++ b/cmd/dev-health-reconciler/activation_pin_test.go
@@ -91,6 +91,21 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 	var shadowBuilt, mutationBuilt bool
 
 	sources := reconcilerSourcesForTest(t, &fakeReconcilerDatabase{})
+	// This test observes WHICH BRANCH the production activation selects. It cannot
+	// observe what production's own buildSyncShadow returns, and that limit is
+	// measured rather than assumed: wrapping the production builder and asserting
+	// on its result was tried and fails on the clean tree, because
+	// syncreconciler.NewShadow needs a real pool and this test runs against a fake
+	// database. Using a real database would make this an integration test, which
+	// changes when and whether it runs -- and an activation pin that CI can skip is
+	// not a pin.
+	//
+	// RESIDUAL RISK, stated because a reader will otherwise assume otherwise:
+	// repoint productionReconcilerDependencySources.buildSyncShadow at an adapter
+	// that returns a MUTATING stepper and this test still passes. The branch is
+	// right and its contents are not checked here. What guards that is
+	// syncreconciler.NewShadow's own tests plus review of that field, not this
+	// file.
 	sources.buildRelay = func(
 		*pgxpool.Pool, *pgxpool.Pool, *pgxpool.Pool, string, *jobruntime.Registry,
 	) (joboutbox.RelayStepper, error) {
@@ -152,8 +167,11 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 	}
 }
 
-// TestReconcilerSpecUsesTheConfigurationThisFilePins closes the chain from `main`
-// to the function the behavioural pin exercises.
+// TestReconcilerSpecUsesTheConfigurationThisFilePins pins ONE LINK of the chain
+// from `main` to the behaviour asserted below. It does not close the chain, and an
+// earlier version of this comment claimed it did while the paragraph below already
+// admitted the gap -- a self-contradiction that shipped. Adversarial review caught
+// it; the honest statement of coverage follows.
 //
 // The behavioural pin calls configureReconcilerDependenciesWithSourcesAndLogger
 // so it can inject fakes. `shell.Main` does not call that directly -- it calls
@@ -162,15 +180,36 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 // test pins both ends of that chain: the spec field points where we think, and the
 // delegate is the function under test.
 //
-// Precisely what IS and IS NOT covered, because the distinction is the whole point
-// of this file: the spec field is asserted here; the ACTIVATION VALUE is asserted
-// by the behavioural pin, because configureReconcilerDependenciesWithSourcesAndLogger
-// is the sole supplier of checkedInReconcilerActivation. What is not asserted is
-// the body of configureReconcilerDependenciesWithLogger beyond its identity -- if
-// someone changed it to pass a different activation, the behavioural pin would not
-// see it, because it enters below that point. That is the residual gap, and the
-// mitigation is that the function is four lines of pure delegation. Do not let it
-// grow logic.
+// PINNED: `reconcilerSpec.ConfigureDependenciesWithLogger` is
+// configureReconcilerDependenciesWithLogger (by code pointer), and
+// ConfigureDependencies is nil so shell.Main cannot take the other field.
+//
+// PINNED: given the checked-in activation, the sources-taking function selects the
+// SHADOW stepper and never the mutation stepper -- asserted by the behavioural test
+// below, which is the sole supplier of checkedInReconcilerActivation.
+//
+// NOT PINNED, and these are real gaps rather than pedantry:
+//
+//   - `main()` calling shell.Main(reconcilerSpec) at all. A test cannot observe
+//     main(); if the binary were rewired to a different spec these tests would not
+//     notice.
+//   - The BODY of configureReconcilerDependenciesWithLogger. Keep its symbol and
+//     change it to supply reconcilerActivation{syncMutation: true}, or to delegate
+//     somewhere else, and both the pointer comparison and the behavioural pin stay
+//     green while the binary mutates. The behavioural pin enters BELOW that
+//     function so it can inject fakes, which is exactly why it cannot see this.
+//     The only mitigation is that the function is four lines of pure delegation:
+//     if it ever grows logic, these pins stop describing production.
+//   - What production's buildSyncShadow actually RETURNS. The behavioural test
+//     substitutes a fake for it, so a mutating stepper behind that field would
+//     pass. Measured, not assumed: wrapping the production builder fails on the
+//     clean tree because it needs a real pool.
+//   - That flipping the seam retains concrete River delivery capability. Set the
+//     flag and the pin together and everything here passes, 42501 and all
+//     (CHAOS-3146).
+//
+// A green run here therefore means "the seam is dormant and changing it is
+// deliberate", never "it is safe to flip".
 func TestReconcilerSpecUsesTheConfigurationThisFilePins(t *testing.T) {
 	if reconcilerSpec.ConfigureDependencies != nil {
 		t.Fatal(

--- a/cmd/dev-health-reconciler/activation_pin_test.go
+++ b/cmd/dev-health-reconciler/activation_pin_test.go
@@ -1,0 +1,128 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// checkedInReconcilerActivationPin is the reviewed expectation for every field of
+// reconcilerActivation.
+//
+// syncMutation is the seam between observing the sync dispatch plane and owning
+// it. The mutation pipeline below it is fully wired and reviewed -- that is
+// deliberate, so flipping the flag cannot ship a half-built composition -- which
+// means the flip itself is a one-character change with production consequences
+// and nothing previously noticed it. dependencies.go states the intent directly:
+// "changing from observation to mutation must retain concrete River delivery
+// capabilities in the same reviewed source change." This test is what makes that
+// sentence enforceable rather than aspirational.
+//
+// Flipping syncMutation today also ships a known 42501: the Materializer runs on
+// the coordinator pool and inserts into public.sync_dispatch_outbox, which
+// coordinatorPosture() declares without INSERT (CHAOS-3146). So the pin's current
+// value is not merely "not yet" -- it is load-bearing.
+var checkedInReconcilerActivationPin = map[string]bool{
+	"syncMutation": false,
+}
+
+// TestCheckedInReconcilerActivationMatchesItsPin fails on a flipped value, an
+// added field, and a removed field.
+//
+// The structural halves matter more than the value. A test comparing the struct
+// against its zero value would pass when a new dormant seam was added, because a
+// new bool defaults to false -- so an unreviewed activation switch could enter
+// the tree already invisible to the gate. Requiring the field SET to match makes
+// the pin bidirectional.
+func TestCheckedInReconcilerActivationMatchesItsPin(t *testing.T) {
+	value := reflect.ValueOf(checkedInReconcilerActivation)
+	structType := value.Type()
+
+	actual := make(map[string]bool, structType.NumField())
+	for index := 0; index < structType.NumField(); index++ {
+		field := structType.Field(index)
+		if field.Type.Kind() != reflect.Bool {
+			// reflect.Value.Bool is the accessor that works on an unexported
+			// field; Interface() panics. A non-bool seam must therefore force a
+			// deliberate extension of this test rather than be silently skipped
+			// and left unpinned.
+			t.Fatalf(
+				"reconcilerActivation.%s is %s, not bool: extend this pin to cover "+
+					"the new kind before adding it, or the seam ships unpinned",
+				field.Name, field.Type.Kind(),
+			)
+		}
+		actual[field.Name] = value.Field(index).Bool()
+	}
+
+	assertPinnedActivationFlags(
+		t, "reconcilerActivation", checkedInReconcilerActivationPin, actual,
+	)
+}
+
+// assertPinnedActivationFlags reports every disagreement rather than the first,
+// so one run shows the whole delta.
+func assertPinnedActivationFlags(t *testing.T, name string, pinned, actual map[string]bool) {
+	t.Helper()
+
+	for _, field := range sortedActivationKeys(actual) {
+		expected, declared := pinned[field]
+		if !declared {
+			t.Errorf(
+				"%s.%s exists in the struct but is not pinned. Add it with its "+
+					"reviewed value; a new activation seam must not enter the tree "+
+					"unpinned.",
+				name, field,
+			)
+			continue
+		}
+		if actual[field] != expected {
+			t.Errorf(
+				"%s.%s is %t, pinned as %t. If this flip is intended, change the "+
+					"pin in THIS commit and record the evidence for it; if it is "+
+					"not, revert it -- this seam changes what the process owns.",
+				name, field, actual[field], expected,
+			)
+		}
+	}
+
+	for _, field := range sortedActivationKeys(pinned) {
+		if _, present := actual[field]; !present {
+			t.Errorf(
+				"%s.%s is pinned but no longer exists. Remove it from the pin in "+
+					"the same commit that removed the field, so the pin cannot "+
+					"accumulate expectations about seams that are gone.",
+				name, field,
+			)
+		}
+	}
+}
+
+func sortedActivationKeys(source map[string]bool) []string {
+	keys := make([]string, 0, len(source))
+	for key := range source {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestReconcilerActivationPinIsNotVacuous guards the guard: a pin comparing an
+// empty set against an empty set passes forever while proving nothing, and that
+// is invisible in a green run.
+func TestReconcilerActivationPinIsNotVacuous(t *testing.T) {
+	if len(checkedInReconcilerActivationPin) == 0 {
+		t.Fatal("the activation pin is empty, so it cannot fail: it proves nothing")
+	}
+
+	structType := reflect.TypeOf(checkedInReconcilerActivation)
+	for _, field := range sortedActivationKeys(checkedInReconcilerActivationPin) {
+		if _, found := structType.FieldByName(field); !found {
+			t.Errorf(
+				"pinned key %q is not a field of reconcilerActivation: the pin is "+
+					"asserting something about a name that does not exist",
+				field,
+			)
+		}
+	}
+}

--- a/cmd/dev-health-reconciler/activation_pin_test.go
+++ b/cmd/dev-health-reconciler/activation_pin_test.go
@@ -1,9 +1,21 @@
 package main
 
 import (
+	"context"
+	"path/filepath"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/joboutbox"
+	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
+	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
+	"github.com/full-chaos/dev-health-ops/internal/syncreconciler"
+	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 // checkedInReconcilerActivationPin is the reviewed expectation for every field of
@@ -22,6 +34,14 @@ import (
 // the coordinator pool and inserts into public.sync_dispatch_outbox, which
 // coordinatorPosture() declares without INSERT (CHAOS-3146). So the pin's current
 // value is not merely "not yet" -- it is load-bearing.
+//
+// What this file does NOT enforce, corrected after adversarial review pointed out
+// the original comment claimed otherwise: it cannot verify that flipping the seam
+// RETAINS concrete River delivery capability. Set the flag and the pin together
+// and both tests pass, 42501 and all. These tests prove the seam is dormant and
+// that changing it is deliberate; the capability evidence is a human's job at
+// review time, and CHAOS-3146 is the specific blocker. Do not let a green test
+// here be read as permission to flip.
 var checkedInReconcilerActivationPin = map[string]bool{
 	"syncMutation": false,
 }
@@ -35,29 +55,171 @@ var checkedInReconcilerActivationPin = map[string]bool{
 // the tree already invisible to the gate. Requiring the field SET to match makes
 // the pin bidirectional.
 func TestCheckedInReconcilerActivationMatchesItsPin(t *testing.T) {
-	value := reflect.ValueOf(checkedInReconcilerActivation)
-	structType := value.Type()
-
-	actual := make(map[string]bool, structType.NumField())
-	for index := 0; index < structType.NumField(); index++ {
-		field := structType.Field(index)
-		if field.Type.Kind() != reflect.Bool {
-			// reflect.Value.Bool is the accessor that works on an unexported
-			// field; Interface() panics. A non-bool seam must therefore force a
-			// deliberate extension of this test rather than be silently skipped
-			// and left unpinned.
-			t.Fatalf(
-				"reconcilerActivation.%s is %s, not bool: extend this pin to cover "+
-					"the new kind before adding it, or the seam ships unpinned",
-				field.Name, field.Type.Kind(),
-			)
-		}
-		actual[field.Name] = value.Field(index).Bool()
-	}
-
+	actual := reconcilerActivationFlags(
+		t, checkedInReconcilerActivation, "reconcilerActivation",
+	)
 	assertPinnedActivationFlags(
 		t, "reconcilerActivation", checkedInReconcilerActivationPin, actual,
 	)
+}
+
+// TestProductionReconcilerSelectsTheShadowStepper asserts the state the process
+// reaches, not the value of a variable.
+//
+// This is the pin that matters, and the structural one above is secondary. It
+// enters through configureReconcilerDependenciesWithSourcesAndLogger -- the
+// wrapper that supplies the PRODUCTION activation -- with fake sources whose
+// mutation and shadow builders each record being called. If anything activates
+// the mutation path, by any route (a second activation literal, an init-time
+// assignment, a parallel activation type), the mutation builder runs and this
+// fails. Adversarial review showed the structural pin alone is silently defeated
+// by a value constructed at the call site; this is what closes that.
+func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
+	// The contract roots are repo-relative, so reach the stepper branch the same
+	// way the neighbouring dependency tests do. Without this the configuration
+	// bails out early and the test cannot see which stepper was chosen -- which it
+	// detects and reports below rather than passing vacuously.
+	t.Chdir(filepath.Join("..", ".."))
+
+	var shadowBuilt, mutationBuilt bool
+
+	sources := reconcilerSourcesForTest(t, &fakeReconcilerDatabase{})
+	sources.buildRelay = func(
+		*pgxpool.Pool, *pgxpool.Pool, *pgxpool.Pool, string, *jobruntime.Registry,
+	) (joboutbox.RelayStepper, error) {
+		return reconcilerStepFunc(func(
+			context.Context, time.Time, int,
+		) (joboutbox.StepResult, error) {
+			return joboutbox.StepResult{}, nil
+		}), nil
+	}
+	sources.buildSyncShadow = func(
+		*pgxpool.Pool, *syncdispatchcontract.Registry,
+	) (syncreconciler.Stepper, error) {
+		shadowBuilt = true
+		return syncStepFunc(func(
+			context.Context, time.Time, int,
+		) (syncreconciler.Observation, error) {
+			return syncreconciler.Observation{}, nil
+		}), nil
+	}
+	sources.buildSyncMutation = func(
+		*pgxpool.Pool, *pgxpool.Pool, *pgxpool.Pool, string,
+		*syncdispatchcontract.Registry,
+	) (syncreconciler.Stepper, error) {
+		mutationBuilt = true
+		return syncStepFunc(func(
+			context.Context, time.Time, int,
+		) (syncreconciler.Observation, error) {
+			return syncreconciler.Observation{}, nil
+		}), nil
+	}
+
+	if _, err := configureReconcilerDependenciesWithSourcesAndLogger(
+		context.Background(),
+		config.Config{RiverDatabaseSchema: "river"},
+		health.NewRegistry(100*time.Millisecond),
+		reconcilerTestLogger(),
+		sources,
+	); err != nil {
+		t.Fatalf("configuring the reconciler with fake sources failed: %v", err)
+	}
+
+	if mutationBuilt {
+		t.Fatal(
+			"the PRODUCTION reconciler configuration built the sync MUTATION " +
+				"stepper. This process must observe, not mutate, until the seam is " +
+				"deliberately flipped -- and flipping it today ships a 42501 " +
+				"(CHAOS-3146). If activation is intended, that is a reviewed source " +
+				"change: update the pin, record the capability evidence, and expect " +
+				"this test to need rewriting.",
+		)
+	}
+	if !shadowBuilt {
+		t.Fatal(
+			"the production reconciler configuration built NEITHER stepper, so this " +
+				"test can no longer tell observation from mutation. Fix the test " +
+				"before trusting it: a pin that cannot reach the branch it guards is " +
+				"worse than no pin, because it reports success.",
+		)
+	}
+}
+
+// reconcilerActivationFlags reads every direct field of the activation struct.
+//
+// Blank fields are rejected rather than collected: two `_ bool` fields collapse
+// into one map key, so a second could be added without failing the exact-set
+// check. A blank field cannot be a usable seam, so refusing them keeps the
+// exact-set claim literally true.
+func reconcilerActivationFlags(t *testing.T, value any, name string) map[string]bool {
+	t.Helper()
+
+	reflected := reflect.ValueOf(value)
+	structType := reflected.Type()
+	flags := make(map[string]bool, structType.NumField())
+	for index := 0; index < structType.NumField(); index++ {
+		field := structType.Field(index)
+		if field.Name == "_" {
+			t.Fatalf(
+				"%s has a blank field at index %d. Blank fields collapse into one "+
+					"map key, which would let a second be added without failing the "+
+					"exact-set check -- and a blank field cannot be a seam.",
+				name, index,
+			)
+		}
+		if field.Type.Kind() != reflect.Bool {
+			// reflect.Value.Bool is the accessor that works on an unexported
+			// field; Interface() panics. A non-bool seam must force a deliberate
+			// extension of this test rather than be silently skipped.
+			t.Fatalf(
+				"%s.%s is %s, not bool: extend this pin to cover the new kind "+
+					"before adding it, or the seam ships unpinned",
+				name, field.Name, field.Type.Kind(),
+			)
+		}
+		flags[field.Name] = reflected.Field(index).Bool()
+	}
+	return flags
+}
+
+// TestAssertPinnedActivationFlagsFailsOnEveryDisagreement exercises the helper's
+// failure branches directly.
+//
+// This helper is duplicated from the scheduler binary because the two are
+// separate `package main`s. Without negative tests, removing either traversal
+// during maintenance leaves this suite green while THIS binary silently loses its
+// guard and the other keeps it -- an asymmetry that is easy to miss precisely
+// because the two files look identical.
+func TestAssertPinnedActivationFlagsFailsOnEveryDisagreement(t *testing.T) {
+	cases := map[string]struct {
+		pinned map[string]bool
+		actual map[string]bool
+	}{
+		"flipped value":     {map[string]bool{"a": false}, map[string]bool{"a": true}},
+		"field not pinned":  {map[string]bool{}, map[string]bool{"a": false}},
+		"pin without field": {map[string]bool{"a": false}, map[string]bool{}},
+	}
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			probe := &testing.T{}
+			assertPinnedActivationFlags(probe, "probe", testCase.pinned, testCase.actual)
+			if !probe.Failed() {
+				t.Fatalf(
+					"assertPinnedActivationFlags accepted %q. One of its two "+
+						"traversals is missing, so a real %s would pass unnoticed.",
+					name, name,
+				)
+			}
+		})
+	}
+
+	probe := &testing.T{}
+	assertPinnedActivationFlags(
+		probe, "probe", map[string]bool{"a": false}, map[string]bool{"a": false},
+	)
+	if probe.Failed() {
+		t.Fatal("assertPinnedActivationFlags rejected a matching pin: too strict")
+	}
 }
 
 // assertPinnedActivationFlags reports every disagreement rather than the first,

--- a/cmd/dev-health-reconciler/activation_pin_test.go
+++ b/cmd/dev-health-reconciler/activation_pin_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"path/filepath"
 	"reflect"
 	"sort"
@@ -81,6 +84,13 @@ func TestCheckedInReconcilerActivationMatchesItsPin(t *testing.T) {
 // assignment, a parallel activation type), the mutation builder runs and this
 // fails. Adversarial review showed the structural pin alone is silently defeated
 // by a value constructed at the call site; this is what closes that.
+//
+// The cfg passed in names the production Service (reconcilerSpec.Service), not
+// only RiverDatabaseSchema. Adversarial review pointed out that a config this
+// unlike config.Load's real output leaves room for a future rewrite to branch
+// on cfg.Service and activate only when the input looks production-shaped --
+// this test would then never see it. This does not close every such route
+// (cfg still has other zero fields), but it removes the cheapest version of it.
 func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 	// The contract roots are repo-relative, so reach the stepper branch the same
 	// way the neighbouring dependency tests do. Without this the configuration
@@ -139,7 +149,7 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 
 	if _, err := configureReconcilerDependenciesWithSourcesAndLogger(
 		context.Background(),
-		config.Config{RiverDatabaseSchema: "river"},
+		config.Config{Service: reconcilerSpec.Service, RiverDatabaseSchema: "river"},
 		health.NewRegistry(100*time.Millisecond),
 		reconcilerTestLogger(),
 		sources,
@@ -167,11 +177,142 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 	}
 }
 
+// TestReconcilerSpecInvokesTheReviewedActivation closes the gap named in the
+// test above's residual-risk statement, and in this file's other comments:
+// that the behavioural pin enters through
+// configureReconcilerDependenciesWithSourcesAndLogger, one level below the
+// production wrapper, so keeping the configureReconcilerDependenciesWithLogger
+// symbol but rewriting its body to supply reconcilerActivation{syncMutation:
+// true}, or to delegate somewhere else, would leave every other pin in this
+// file green.
+//
+// This closes that specific route: it swaps fakes into the PACKAGE VARIABLE
+// productionReconcilerDependencySources -- what
+// configureReconcilerDependenciesWithLogger actually reads -- restores it via
+// defer, and calls reconcilerSpec.ConfigureDependenciesWithLogger, the spec
+// field itself, which TestReconcilerSpecUsesTheConfigurationThisFilePins below
+// pins to be that exact function. Between the two tests, a body rewrite that
+// hardcodes mutation, or that stops reading productionReconcilerDependencySources
+// at all, has nowhere left to hide: this test calls through the real symbol,
+// reached through the real spec field, reading the real (now-faked) global.
+func TestReconcilerSpecInvokesTheReviewedActivation(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+
+	original := productionReconcilerDependencySources
+	defer func() { productionReconcilerDependencySources = original }()
+
+	var shadowBuilt, mutationBuilt bool
+
+	sources := reconcilerSourcesForTest(t, &fakeReconcilerDatabase{})
+	sources.buildRelay = func(
+		*pgxpool.Pool, *pgxpool.Pool, *pgxpool.Pool, string, *jobruntime.Registry,
+	) (joboutbox.RelayStepper, error) {
+		return reconcilerStepFunc(func(
+			context.Context, time.Time, int,
+		) (joboutbox.StepResult, error) {
+			return joboutbox.StepResult{}, nil
+		}), nil
+	}
+	sources.buildSyncShadow = func(
+		*pgxpool.Pool, *syncdispatchcontract.Registry,
+	) (syncreconciler.Stepper, error) {
+		shadowBuilt = true
+		return syncStepFunc(func(
+			context.Context, time.Time, int,
+		) (syncreconciler.Observation, error) {
+			return syncreconciler.Observation{}, nil
+		}), nil
+	}
+	sources.buildSyncMutation = func(
+		*pgxpool.Pool, *pgxpool.Pool, *pgxpool.Pool, string,
+		*syncdispatchcontract.Registry,
+	) (syncreconciler.Stepper, error) {
+		mutationBuilt = true
+		return syncStepFunc(func(
+			context.Context, time.Time, int,
+		) (syncreconciler.Observation, error) {
+			return syncreconciler.Observation{}, nil
+		}), nil
+	}
+	productionReconcilerDependencySources = sources
+
+	if reconcilerSpec.ConfigureDependenciesWithLogger == nil {
+		t.Fatal("reconcilerSpec.ConfigureDependenciesWithLogger is nil; this test has nothing to call through")
+	}
+	if _, err := reconcilerSpec.ConfigureDependenciesWithLogger(
+		context.Background(),
+		config.Config{Service: reconcilerSpec.Service, RiverDatabaseSchema: "river"},
+		health.NewRegistry(100*time.Millisecond),
+		reconcilerTestLogger(),
+	); err != nil {
+		t.Fatalf("configuring the reconciler through the spec field failed: %v", err)
+	}
+
+	if mutationBuilt {
+		t.Fatal(
+			"calling reconcilerSpec.ConfigureDependenciesWithLogger built the sync " +
+				"MUTATION stepper. configureReconcilerDependenciesWithLogger's body " +
+				"must still delegate to checkedInReconcilerActivation through " +
+				"productionReconcilerDependencySources -- a hardcoded activation, or a " +
+				"delegate that bypasses that global, would reach here.",
+		)
+	}
+	if !shadowBuilt {
+		t.Fatal(
+			"calling reconcilerSpec.ConfigureDependenciesWithLogger built NEITHER " +
+				"stepper, so this test can no longer tell observation from mutation.",
+		)
+	}
+}
+
+// TestProductionSyncShadowBuilderReturnsTheShadowStepper closes the specific
+// gap named in TestProductionReconcilerSelectsTheShadowStepper's comment above:
+// that test's fakes replace
+// productionReconcilerDependencySources.buildSyncShadow entirely, so it cannot
+// see what that field's PRODUCTION value actually returns. Adversarial review
+// pointed out that repointing buildSyncShadow at an adapter returning a
+// mutating stepper would still pass, because nothing calls the real field.
+//
+// This calls the real field directly. syncreconciler.NewObserver only rejects a
+// nil pool and performs no I/O during construction -- confirmed by reading
+// NewObserver/NewShadow, not assumed -- so an inert, unconnected *pgxpool.Pool
+// is enough to exercise it without becoming an integration test. The registry
+// is loaded from the real committed contract artifact, the same one production
+// loads, because a nil or fake registry would let construction take a path
+// production never takes.
+func TestProductionSyncShadowBuilderReturnsTheShadowStepper(t *testing.T) {
+	t.Chdir(filepath.Join("..", ".."))
+
+	if productionReconcilerDependencySources.buildSyncShadow == nil {
+		t.Fatal("productionReconcilerDependencySources.buildSyncShadow is nil; nothing to pin")
+	}
+
+	registry, err := syncdispatchcontract.Load(defaultSyncDispatchContractRoot)
+	if err != nil {
+		t.Fatalf("loading the real sync-dispatch contract: %v", err)
+	}
+
+	stepper, err := productionReconcilerDependencySources.buildSyncShadow(&pgxpool.Pool{}, registry)
+	if err != nil {
+		t.Fatalf("the production shadow builder failed against an inert pool: %v", err)
+	}
+	if _, ok := stepper.(*syncreconciler.Shadow); !ok {
+		t.Fatalf(
+			"productionReconcilerDependencySources.buildSyncShadow returned %T, not "+
+				"*syncreconciler.Shadow. This field is what the dormant path actually "+
+				"runs; if it now returns something else, the reviewed shadow-vs-mutation "+
+				"distinction this file pins no longer describes production.",
+			stepper,
+		)
+	}
+}
+
 // TestReconcilerSpecUsesTheConfigurationThisFilePins pins ONE LINK of the chain
-// from `main` to the behaviour asserted below. It does not close the chain, and an
-// earlier version of this comment claimed it did while the paragraph below already
-// admitted the gap -- a self-contradiction that shipped. Adversarial review caught
-// it; the honest statement of coverage follows.
+// from `main` to the behaviour asserted below. A fourth adversarial round found
+// that the round-3 fix corrected the CLAIM here without closing three of the
+// four gaps it named, and found two more (an untested config.Config{} shape,
+// and this PINNED line's own overclaim about what code-pointer equality
+// proves). The honest, now-verified statement of coverage follows.
 //
 // The behavioural pin calls configureReconcilerDependenciesWithSourcesAndLogger
 // so it can inject fakes. `shell.Main` does not call that directly -- it calls
@@ -180,30 +321,44 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 // test pins both ends of that chain: the spec field points where we think, and the
 // delegate is the function under test.
 //
-// PINNED: `reconcilerSpec.ConfigureDependenciesWithLogger` is
-// configureReconcilerDependenciesWithLogger (by code pointer), and
-// ConfigureDependencies is nil so shell.Main cannot take the other field.
+// PINNED: `reconcilerSpec.ConfigureDependenciesWithLogger`'s code pointer equals
+// configureReconcilerDependenciesWithLogger's, and ConfigureDependencies is nil
+// so shell.Main cannot take the other field. This is conclusive PROVIDED both
+// sides stay what they are today -- direct references to the same package-level
+// function declaration, not a closure or bound method value. Go documents a
+// function's code pointer as not necessarily unique for those; a stronger
+// runtime check (comparing runtime.FuncForPC names) would not close that
+// residual case either, because two code paths truly folded onto one address
+// would share one symbol-table entry and so agree under a name comparison too.
+// This is a limit of what reflection can prove, disclosed here rather than
+// silently left off the list the way it was after round 3.
 //
 // PINNED: given the checked-in activation, the sources-taking function selects the
 // SHADOW stepper and never the mutation stepper -- asserted by the behavioural test
 // below, which is the sole supplier of checkedInReconcilerActivation.
 //
+// PINNED: TestReconcilerSpecInvokesTheReviewedActivation, above, calls through
+// reconcilerSpec.ConfigureDependenciesWithLogger itself (not a direct call to
+// the sources-taking function), with fakes swapped into the package variable
+// that function actually reads. Keeping the
+// configureReconcilerDependenciesWithLogger symbol but rewriting its body to
+// hardcode mutation, or to delegate elsewhere, fails there. Round 3 found this
+// gap; it is closed, not disclosed.
+//
+// PINNED: TestProductionSyncShadowBuilderReturnsTheShadowStepper, above, calls
+// productionReconcilerDependencySources.buildSyncShadow directly (not a fake
+// substitute) against an inert pool and the real committed contract, and
+// requires its return type to be *syncreconciler.Shadow. Round 3 found that the
+// behavioural test's fakes conceal this field's real behaviour; this closes it
+// for what construction can prove -- the concrete stepper type actually wired,
+// not the outcome of a fully connected Step() call.
+//
 // NOT PINNED, and these are real gaps rather than pedantry:
 //
-//   - `main()` calling shell.Main(reconcilerSpec) at all. A test cannot observe
-//     main(); if the binary were rewired to a different spec these tests would not
-//     notice.
-//   - The BODY of configureReconcilerDependenciesWithLogger. Keep its symbol and
-//     change it to supply reconcilerActivation{syncMutation: true}, or to delegate
-//     somewhere else, and both the pointer comparison and the behavioural pin stay
-//     green while the binary mutates. The behavioural pin enters BELOW that
-//     function so it can inject fakes, which is exactly why it cannot see this.
-//     The only mitigation is that the function is four lines of pure delegation:
-//     if it ever grows logic, these pins stop describing production.
-//   - What production's buildSyncShadow actually RETURNS. The behavioural test
-//     substitutes a fake for it, so a mutating stepper behind that field would
-//     pass. Measured, not assumed: wrapping the production builder fails on the
-//     clean tree because it needs a real pool.
+//   - `main()` calling shell.Main(reconcilerSpec) at runtime. A running test
+//     cannot observe process startup.
+//     TestReconcilerMainInvokesShellMainWithThePinnedSpec, below, closes the
+//     practical version of this by parsing main.go's committed source instead.
 //   - That flipping the seam retains concrete River delivery capability. Set the
 //     flag and the pin together and everything here passes, 42501 and all
 //     (CHAOS-3146).
@@ -379,5 +534,78 @@ func TestReconcilerActivationPinIsNotVacuous(t *testing.T) {
 				field,
 			)
 		}
+	}
+}
+
+// TestReconcilerMainInvokesShellMainWithThePinnedSpec closes the one gap this
+// file states it cannot: whether `main()` actually calls
+// shell.Main(reconcilerSpec). A running test cannot observe process startup,
+// but it can read the committed source that becomes it. This parses main.go
+// directly and requires func main()'s body to be exactly one statement,
+// calling shell.Main with the identifier every other pin in this file already
+// covers end to end.
+//
+// This is deliberately strict about shape: rewiring main() to call something
+// else, to pass a copy or a second spec, or to do anything at all beyond this
+// one call, fails the test. A future legitimate change to main() must update
+// this test in the same commit, which is the point -- that change becomes
+// visible instead of silently falling outside every other pin's reach.
+func TestReconcilerMainInvokesShellMainWithThePinnedSpec(t *testing.T) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing main.go: %v", err)
+	}
+
+	var mainDecl *ast.FuncDecl
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Recv != nil || function.Name.Name != "main" {
+			continue
+		}
+		mainDecl = function
+	}
+	if mainDecl == nil || mainDecl.Body == nil {
+		t.Fatal(
+			"main.go declares no func main() with a body; the pins in this file " +
+				"cover a function the binary never runs",
+		)
+	}
+	if len(mainDecl.Body.List) != 1 {
+		t.Fatalf(
+			"func main() has %d statements, want exactly 1 (the shell.Main call "+
+				"this test pins). If this is a reviewed change, confirm the new "+
+				"statements cannot skip or alter the shell.Main(reconcilerSpec) call "+
+				"before updating this test.",
+			len(mainDecl.Body.List),
+		)
+	}
+
+	expressionStatement, ok := mainDecl.Body.List[0].(*ast.ExprStmt)
+	if !ok {
+		t.Fatalf("func main()'s only statement is not a call expression: %#v", mainDecl.Body.List[0])
+	}
+	call, ok := expressionStatement.X.(*ast.CallExpr)
+	if !ok {
+		t.Fatalf("func main()'s statement is not a function call: %#v", expressionStatement.X)
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		t.Fatalf("func main() does not call a package-qualified function: %#v", call.Fun)
+	}
+	packageIdent, ok := selector.X.(*ast.Ident)
+	if !ok || packageIdent.Name != "shell" || selector.Sel.Name != "Main" {
+		t.Fatalf("func main() calls %#v, not shell.Main", call.Fun)
+	}
+	if len(call.Args) != 1 {
+		t.Fatalf("shell.Main call has %d arguments, want exactly 1", len(call.Args))
+	}
+	argument, ok := call.Args[0].(*ast.Ident)
+	if !ok || argument.Name != "reconcilerSpec" {
+		t.Fatalf(
+			"func main() passes %#v to shell.Main, not reconcilerSpec -- the pins "+
+				"in this file cover a spec the binary does not use",
+			call.Args[0],
+		)
 	}
 }

--- a/cmd/dev-health-reconciler/activation_pin_test.go
+++ b/cmd/dev-health-reconciler/activation_pin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"go/ast"
+	"go/build/constraint"
 	"go/parser"
 	"go/token"
 	"path/filepath"
@@ -14,7 +15,6 @@ import (
 	"github.com/full-chaos/dev-health-ops/internal/joboutbox"
 	"github.com/full-chaos/dev-health-ops/internal/jobruntime"
 
-	"github.com/full-chaos/dev-health-ops/internal/platform/config"
 	"github.com/full-chaos/dev-health-ops/internal/platform/health"
 	"github.com/full-chaos/dev-health-ops/internal/syncdispatchcontract"
 	"github.com/full-chaos/dev-health-ops/internal/syncreconciler"
@@ -85,12 +85,23 @@ func TestCheckedInReconcilerActivationMatchesItsPin(t *testing.T) {
 // fails. Adversarial review showed the structural pin alone is silently defeated
 // by a value constructed at the call site; this is what closes that.
 //
-// The cfg passed in names the production Service (reconcilerSpec.Service), not
-// only RiverDatabaseSchema. Adversarial review pointed out that a config this
-// unlike config.Load's real output leaves room for a future rewrite to branch
-// on cfg.Service and activate only when the input looks production-shaped --
-// this test would then never see it. This does not close every such route
-// (cfg still has other zero fields), but it removes the cheapest version of it.
+// The cfg passed in is config.Load's own real output for reconcilerSpec.Service
+// with no environment set, not a hand-built literal. Adversarial review found
+// this twice: first that a config unlike config.Load's real output (missing
+// Service) leaves room for a future rewrite to branch on cfg.Service and
+// activate only for production-shaped input; then, after Service was added,
+// that a hand-picked subset still isn't what production computes -- every
+// other field a future rewrite might branch on (for instance
+// cfg.CoordinatorDatabaseRole, non-empty by default even with no environment
+// set) was still left zero, unlike production. Calling config.Load itself
+// closes that gap for every field it can populate without a real secret.
+//
+// NOT covered, and disclosed rather than assumed closed: a field config.Load
+// only populates when a secret environment variable is actually set
+// (cfg.CoordinatorDatabaseURI.Configured(), for instance) still reads zero
+// here, because supplying a real one would make this an integration test. A
+// future rewrite that activates specifically on a CONFIGURED coordinator URI,
+// rather than on checkedInReconcilerActivation, would still pass undetected.
 func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 	// The contract roots are repo-relative, so reach the stepper branch the same
 	// way the neighbouring dependency tests do. Without this the configuration
@@ -149,7 +160,7 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 
 	if _, err := configureReconcilerDependenciesWithSourcesAndLogger(
 		context.Background(),
-		config.Config{Service: reconcilerSpec.Service, RiverDatabaseSchema: "river"},
+		reconcilerProductionShapedConfig(t),
 		health.NewRegistry(100*time.Millisecond),
 		reconcilerTestLogger(),
 		sources,
@@ -243,7 +254,7 @@ func TestReconcilerSpecInvokesTheReviewedActivation(t *testing.T) {
 	}
 	if _, err := reconcilerSpec.ConfigureDependenciesWithLogger(
 		context.Background(),
-		config.Config{Service: reconcilerSpec.Service, RiverDatabaseSchema: "river"},
+		reconcilerProductionShapedConfig(t),
 		health.NewRegistry(100*time.Millisecond),
 		reconcilerTestLogger(),
 	); err != nil {
@@ -367,6 +378,16 @@ func TestProductionSyncShadowBuilderReturnsTheShadowStepper(t *testing.T) {
 //     than the spec's configure fields -- would bypass every pin in this file
 //     the same way a rewired main() would, and nothing here exercises
 //     shell.Main/Execute's own internals to catch it.
+//   - A future configureReconcilerDependenciesWithLogger that branches on a
+//     config.Config field only populated when a real secret environment
+//     variable is set (cfg.CoordinatorDatabaseURI.Configured(), for
+//     instance), rather than on checkedInReconcilerActivation. The
+//     behavioural pin passes config.Load's own defaulted output
+//     (reconcilerProductionShapedConfig), which closes the version of this
+//     where the branch condition is merely non-empty -- config.Load already
+//     defaults most fields -- but not a branch on whether a SECRET was
+//     actually configured, because supplying one would turn this into an
+//     integration test.
 //   - That flipping the seam retains concrete River delivery capability. Set the
 //     flag and the pin together and everything here passes, 42501 and all
 //     (CHAOS-3146).
@@ -568,9 +589,32 @@ func TestReconcilerActivationPinIsNotVacuous(t *testing.T) {
 // close.
 func TestReconcilerMainInvokesShellMainWithThePinnedSpec(t *testing.T) {
 	fileSet := token.NewFileSet()
-	file, err := parser.ParseFile(fileSet, "main.go", nil, 0)
+	file, err := parser.ParseFile(fileSet, "main.go", nil, parser.ParseComments)
 	if err != nil {
 		t.Fatalf("parsing main.go: %v", err)
+	}
+
+	// A build-constrained main.go could be excluded from the build actually
+	// shipped, with a differently-behaving entry point compiling in its place
+	// under a platform- or tag-specific filename -- this test would keep
+	// parsing and passing against a file the binary never contains. Adversarial
+	// review raised this as a plausible ordinary refactor (a platform-specific
+	// entrypoint split), not a contrived one, so it is rejected outright rather
+	// than merely disclosed.
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			if constraint.IsGoBuild(comment.Text) || constraint.IsPlusBuild(comment.Text) {
+				t.Fatalf(
+					"main.go carries a build constraint (%q). This file's pins only "+
+						"cover main.go's content, not whether the build actually "+
+						"includes it -- a constrained main.go could be dead code while "+
+						"another file supplies the real entry point. Remove the "+
+						"constraint, or move the pinned main() to whichever file is "+
+						"unconditionally built and retarget this test at it.",
+					comment.Text,
+				)
+			}
+		}
 	}
 
 	var mainDecl *ast.FuncDecl

--- a/cmd/dev-health-reconciler/activation_pin_test.go
+++ b/cmd/dev-health-reconciler/activation_pin_test.go
@@ -177,14 +177,16 @@ func TestProductionReconcilerSelectsTheShadowStepper(t *testing.T) {
 	}
 }
 
-// TestReconcilerSpecInvokesTheReviewedActivation closes the gap named in the
-// test above's residual-risk statement, and in this file's other comments:
-// that the behavioural pin enters through
-// configureReconcilerDependenciesWithSourcesAndLogger, one level below the
-// production wrapper, so keeping the configureReconcilerDependenciesWithLogger
-// symbol but rewriting its body to supply reconcilerActivation{syncMutation:
-// true}, or to delegate somewhere else, would leave every other pin in this
-// file green.
+// TestReconcilerSpecInvokesTheReviewedActivation closes a DIFFERENT gap than
+// the test above's residual-risk statement (that one -- production's
+// buildSyncShadow return value -- is closed below by
+// TestProductionSyncShadowBuilderReturnsTheShadowStepper, not by this test).
+// This one closes the wrapper-body-bypass gap: the behavioural pin above
+// enters through configureReconcilerDependenciesWithSourcesAndLogger, one
+// level below the production wrapper, so keeping the
+// configureReconcilerDependenciesWithLogger symbol but rewriting its body to
+// supply reconcilerActivation{syncMutation: true}, or to delegate somewhere
+// else, would leave every other pin in this file green.
 //
 // This closes that specific route: it swaps fakes into the PACKAGE VARIABLE
 // productionReconcilerDependencySources -- what
@@ -358,7 +360,13 @@ func TestProductionSyncShadowBuilderReturnsTheShadowStepper(t *testing.T) {
 //   - `main()` calling shell.Main(reconcilerSpec) at runtime. A running test
 //     cannot observe process startup.
 //     TestReconcilerMainInvokesShellMainWithThePinnedSpec, below, closes the
-//     practical version of this by parsing main.go's committed source instead.
+//     half of this a source parse can: that main.go's committed body is
+//     exactly that one call. It does NOT close a second, still-open half: a
+//     future activation route added inside shell.Main/Execute itself -- an
+//     environment variable read directly, or a dispatch on something other
+//     than the spec's configure fields -- would bypass every pin in this file
+//     the same way a rewired main() would, and nothing here exercises
+//     shell.Main/Execute's own internals to catch it.
 //   - That flipping the seam retains concrete River delivery capability. Set the
 //     flag and the pin together and everything here passes, 42501 and all
 //     (CHAOS-3146).
@@ -550,6 +558,14 @@ func TestReconcilerActivationPinIsNotVacuous(t *testing.T) {
 // one call, fails the test. A future legitimate change to main() must update
 // this test in the same commit, which is the point -- that change becomes
 // visible instead of silently falling outside every other pin's reach.
+//
+// The brittleness is intentional, not a defect to fix later: this WILL fail
+// the day someone adds a legitimate second statement to main() (a defer, a
+// flag parse, anything). The correct response to that red is to re-review
+// what the new statement does to activation and rewrite this test to match --
+// never to loosen the assertion to something like "contains a call to
+// shell.Main", which would silently reopen the exact gap this test exists to
+// close.
 func TestReconcilerMainInvokesShellMainWithThePinnedSpec(t *testing.T) {
 	fileSet := token.NewFileSet()
 	file, err := parser.ParseFile(fileSet, "main.go", nil, 0)

--- a/cmd/dev-health-reconciler/dependencies_test.go
+++ b/cmd/dev-health-reconciler/dependencies_test.go
@@ -565,6 +565,26 @@ func reconcilerTestLogger() *slog.Logger {
 	return slog.New(slog.NewJSONHandler(io.Discard, nil))
 }
 
+// reconcilerProductionShapedConfig is config.Load's own output for
+// reconcilerSpec.Service with no environment variables set -- not a hand-built
+// config.Config{} literal. Adversarial review found that a hand-picked subset
+// of fields (even one including Service) still isn't what production
+// computes: every field config.Load defaults to a non-empty value with no
+// environment set (cfg.CoordinatorDatabaseRole, for instance) was left zero in
+// a literal, unlike production. Using config.Load directly removes that gap
+// for every field it can populate without a real secret being configured.
+func reconcilerProductionShapedConfig(t *testing.T) config.Config {
+	t.Helper()
+	cfg, err := config.Load(config.Spec{
+		Service:   reconcilerSpec.Service,
+		LookupEnv: func(string) (string, bool) { return "", false },
+	})
+	if err != nil {
+		t.Fatalf("loading a production-defaulted config for %q: %v", reconcilerSpec.Service, err)
+	}
+	return cfg
+}
+
 func componentNames(components []lifecycle.Component) []string {
 	names := make([]string, 0, len(components))
 	for _, component := range components {

--- a/cmd/dev-health-scheduler/activation_pin_test.go
+++ b/cmd/dev-health-scheduler/activation_pin_test.go
@@ -171,12 +171,17 @@ func TestProductionSchedulerConfigurationIsDormant(t *testing.T) {
 // comparisons would agree and still miss the same case. This is a limit of
 // what reflection can prove, not a gap this file chose to leave open.
 //
-// NOT PINNED: `main()` calling shell.Main(schedulerSpec) at runtime -- a running
-// test cannot observe process startup. TestSchedulerMainInvokesShellMainWithThePinnedSpec
-// below closes the practical version of this gap by parsing main.go's committed
-// source instead of trying to observe its execution. And, as stated above,
-// neither pin proves that flipping the seam retains the capability the seam
-// guards.
+// NOT PINNED (closed at the source level, not the runtime level): `main()`
+// calling shell.Main(schedulerSpec). A running test cannot observe process
+// startup. TestSchedulerMainInvokesShellMainWithThePinnedSpec below covers the
+// half of this that a source parse can: that main.go's committed body is
+// exactly the one call. It does NOT cover a second, still-open half: a future
+// activation route added inside shell.Main/Execute itself -- reading an
+// environment variable directly, or dispatching on something other than the
+// spec's configure fields -- would bypass every pin in this file the same way
+// a rewired main() would, and no test here would notice, because none of them
+// exercise shell.Main/Execute's own internals. And, as stated above, neither
+// pin proves that flipping the seam retains the capability the seam guards.
 func TestSchedulerSpecUsesTheConfigurationThisFilePins(t *testing.T) {
 	if schedulerSpec.ConfigureDependenciesWithLogger != nil {
 		t.Fatal(
@@ -376,6 +381,14 @@ func TestSchedulerActivationPinIsNotVacuous(t *testing.T) {
 // one call, fails the test. A future legitimate change to main() must update
 // this test in the same commit, which is the point -- that change becomes
 // visible instead of silently falling outside every other pin's reach.
+//
+// The brittleness is intentional, not a defect to fix later: this WILL fail
+// the day someone adds a legitimate second statement to main() (a defer, a
+// flag parse, anything). The correct response to that red is to re-review
+// what the new statement does to activation and rewrite this test to match --
+// never to loosen the assertion to something like "contains a call to
+// shell.Main", which would silently reopen the exact gap this test exists to
+// close.
 func TestSchedulerMainInvokesShellMainWithThePinnedSpec(t *testing.T) {
 	fileSet := token.NewFileSet()
 	file, err := parser.ParseFile(fileSet, "main.go", nil, 0)

--- a/cmd/dev-health-scheduler/activation_pin_test.go
+++ b/cmd/dev-health-scheduler/activation_pin_test.go
@@ -1,72 +1,176 @@
 package main
 
 import (
+	"context"
 	"reflect"
 	"sort"
 	"testing"
+	"time"
+
+	"github.com/full-chaos/dev-health-ops/internal/platform/config"
+	"github.com/full-chaos/dev-health-ops/internal/platform/health"
 )
 
+// This file pins the scheduler's activation seam two ways, and the order matters
+// because only the first one is about the binary.
+//
+// The BEHAVIOURAL pin below calls the PRODUCTION entry point --
+// configureSchedulerDependencies, the function shell.Main reaches -- and asserts
+// what the process actually does. That is the property worth having: it holds no
+// matter where the activation value comes from, so constructing a second
+// activation literal, assigning one at init time, or introducing a parallel
+// activation type cannot slip past it.
+//
+// The STRUCTURAL pin is secondary. It compares the checked-in activation value's
+// fields against a reviewed map, which catches a flipped flag and an added seam
+// early and with a precise message -- but it only describes that one variable. An
+// earlier version of this file had ONLY the structural pin and claimed it made
+// the seam's intent "enforceable". That was the same mistake this epic keeps
+// producing: it verified the property its author was thinking about (the
+// variable) rather than the one that mattered (what the binary activates).
+// Adversarial review showed a production value constructed elsewhere passes it
+// silently. Keep both, and do not let the structural one grow claims about the
+// binary.
+//
+// What NEITHER pin can do, stated so nobody infers otherwise: they cannot prove
+// that flipping a seam retains the delivery capability the seam exists to guard.
+// Pinning goOwnsMarkers false says the process is dormant; it says nothing about
+// whether a materializer exists once it is true. That evidence is a human's job
+// at review time, and CHAOS-3145 is where the requirement lives.
+
 // checkedInSchedulerActivationPin is the reviewed expectation for every field of
-// schedulerActivation. It exists so that flipping an activation seam is a
-// deliberate act recorded in the same change that flips it.
-//
-// Why a pin rather than trusting review: schedulerActivation is the seam that
-// decides whether this process owns periodic work. Flipping goOwnsMarkers to
-// true takes the binary from "opens no PostgreSQL pool at all" to "writes
-// scheduler markers", and nothing in CI previously noticed that one-character
-// change. CHAOS-3033 closed 19 issues Done over dormant code precisely because
-// activation state was invisible to every gate; the plan of record's section 5
-// names "a capability listed in the registry but not constructed by a binary" as
-// a false pass, and an unpinned activation flag is how that state arises without
-// anyone deciding to arrive there.
-//
-// Updating this map is the intended way to activate a seam. Do it in the same
-// commit that flips the flag, with the evidence for the flip in the commit
-// message: for goOwnsMarkers that means a constructed materializer, because
-// flipping it alone yields a scheduler that writes but is permanently not-ready
-// (see main.go's own doc comment and CHAOS-3145).
+// schedulerActivation. Update it in the SAME commit that flips a flag, with the
+// evidence for the flip in the commit message.
 var checkedInSchedulerActivationPin = map[string]bool{
 	"goOwnsMarkers": false,
 }
 
-// TestCheckedInSchedulerActivationMatchesItsPin fails on three distinct
-// mistakes, not one.
-//
-// The obvious one is a flipped value. The two that matter more are structural:
-// ADDING a field, and REMOVING one. A test that only compared the struct against
-// its zero value would pass when a new dormant seam was added -- the new field
-// defaults to false, the comparison still holds, and an unreviewed activation
-// switch enters the tree already invisible. Enumerating the fields by reflection
-// and requiring the field SET to match exactly is what makes the pin
-// bidirectional: a new seam must be declared here to compile-and-pass, and a
-// deleted seam must be removed from here.
-func TestCheckedInSchedulerActivationMatchesItsPin(t *testing.T) {
-	value := reflect.ValueOf(checkedInSchedulerActivation)
-	structType := value.Type()
+// schedulerReadinessNamesClosedWhenDormant are the readiness names the dormant
+// path must register as unavailable. Hard-coded rather than read from the
+// production call, because a test that asks the code under test what it should
+// have done proves nothing.
+var schedulerReadinessNamesClosedWhenDormant = []string{
+	"domain_postgres",
+	"queue_postgres",
+	"coordinator_postgres",
+	"river_schema",
+	"scheduler_loop",
+}
 
-	actual := make(map[string]bool, structType.NumField())
-	for index := 0; index < structType.NumField(); index++ {
-		field := structType.Field(index)
-		if field.Type.Kind() != reflect.Bool {
-			// Not pedantry: the pin can only compare what it can read, and
-			// reflect.Value.Bool is the accessor that works on an unexported
-			// field. A non-bool seam is a real possibility (an enum, a count),
-			// and it must force a deliberate extension of this test rather than
-			// being silently skipped and left unpinned.
-			t.Fatalf(
-				"schedulerActivation.%s is %s, not bool: extend this pin to cover "+
-					"the new kind before adding it, or the seam ships unpinned",
-				field.Name, field.Type.Kind(),
-			)
-		}
-		actual[field.Name] = value.Field(index).Bool()
+// TestProductionSchedulerConfigurationIsDormant asserts the state the process
+// reaches, not the value of a variable.
+//
+// This is the pin that survives a second activation literal, an init-time
+// assignment, a parallel activation type, and a test-only reset of the global:
+// it goes through the production wrapper and checks the outcome. If someone
+// activates the scheduler by any route, this test fails.
+func TestProductionSchedulerConfigurationIsDormant(t *testing.T) {
+	registry := health.NewRegistry(time.Second)
+
+	components, err := configureSchedulerDependencies(
+		context.Background(), config.Config{}, registry,
+	)
+
+	if err != nil {
+		t.Fatalf(
+			"the production scheduler configuration returned an error (%v). The "+
+				"dormant path is expected to register closed readiness and return "+
+				"nil error; an error here means this test can no longer tell "+
+				"dormant from activated, so fix the test before trusting it.",
+			err,
+		)
+	}
+	if len(components) != 0 {
+		t.Fatalf(
+			"the production scheduler configuration built %d lifecycle "+
+				"component(s). A dormant scheduler must build none and must not "+
+				"open a PostgreSQL pool. If activation is intended, that is a "+
+				"reviewed source change: update the pin in this file, record the "+
+				"evidence, and expect this test to need rewriting.",
+			len(components),
+		)
 	}
 
+	// SetReady is what a started process does; do it here so Readiness reports
+	// the per-name checks rather than short-circuiting on "runtime".
+	registry.SetReady(true)
+	readiness := registry.Readiness(context.Background())
+	if readiness.Ready {
+		t.Fatal(
+			"the dormant production configuration reports READY. Every externally " +
+				"visible name must stay closed while the scheduler owns nothing, or " +
+				"an operator sees a healthy scheduler that schedules nothing.",
+		)
+	}
+	failed := make(map[string]bool, len(readiness.Failed))
+	for _, name := range readiness.Failed {
+		failed[name] = true
+	}
+	for _, name := range schedulerReadinessNamesClosedWhenDormant {
+		if !failed[name] {
+			t.Errorf(
+				"readiness name %q is not among the failing checks %v. The dormant "+
+					"path must register every one of these as unavailable; a name that "+
+					"is simply absent is worse than one that fails, because /readyz "+
+					"cannot report on a check nobody registered.",
+				name, readiness.Failed,
+			)
+		}
+	}
+}
+
+// TestCheckedInSchedulerActivationMatchesItsPin is the structural pin: a flipped
+// value, an added field, and a removed field each fail.
+//
+// The two structural halves matter as much as the value. A test comparing the
+// struct against its zero value would PASS when a new seam was added, because a
+// new bool defaults to false -- so an unreviewed switch could enter the tree
+// already invisible. Requiring the field SET to match is what makes this
+// bidirectional for this variable.
+func TestCheckedInSchedulerActivationMatchesItsPin(t *testing.T) {
+	actual := activationFlagsOf(t, checkedInSchedulerActivation, "schedulerActivation")
 	assertPinnedFlags(t, "schedulerActivation", checkedInSchedulerActivationPin, actual)
 }
 
-// assertPinnedFlags reports every disagreement rather than the first, so a
-// reviewer sees the whole delta in one run instead of re-running per field.
+// activationFlagsOf reads every direct field of an activation struct by name.
+//
+// Blank fields are rejected rather than collected: two `_ bool` fields collapse
+// into one map key, so the second would be added without failing the exact-set
+// check. A blank field cannot be a usable activation seam anyway, so refusing
+// them keeps the exact-set claim literally true instead of nearly true.
+func activationFlagsOf(t *testing.T, value any, name string) map[string]bool {
+	t.Helper()
+
+	reflected := reflect.ValueOf(value)
+	structType := reflected.Type()
+	flags := make(map[string]bool, structType.NumField())
+	for index := 0; index < structType.NumField(); index++ {
+		field := structType.Field(index)
+		if field.Name == "_" {
+			t.Fatalf(
+				"%s has a blank field at index %d. Blank fields collapse into one "+
+					"map key, which would let a second one be added without failing "+
+					"the exact-set check -- and a blank field cannot be a seam.",
+				name, index,
+			)
+		}
+		if field.Type.Kind() != reflect.Bool {
+			// reflect.Value.Bool is the accessor that works on an unexported
+			// field; Interface() panics. A non-bool seam must force a deliberate
+			// extension of this test rather than be silently skipped.
+			t.Fatalf(
+				"%s.%s is %s, not bool: extend this pin to cover the new kind "+
+					"before adding it, or the seam ships unpinned",
+				name, field.Name, field.Type.Kind(),
+			)
+		}
+		flags[field.Name] = reflected.Field(index).Bool()
+	}
+	return flags
+}
+
+// assertPinnedFlags reports every disagreement rather than the first, so one run
+// shows the whole delta.
 func assertPinnedFlags(t *testing.T, name string, pinned, actual map[string]bool) {
 	t.Helper()
 
@@ -74,9 +178,9 @@ func assertPinnedFlags(t *testing.T, name string, pinned, actual map[string]bool
 		expected, declared := pinned[field]
 		if !declared {
 			t.Errorf(
-				"%s.%s exists in the struct but is not pinned. Add it to the pin "+
-					"with its reviewed value; a new activation seam must not enter "+
-					"the tree unpinned.",
+				"%s.%s exists in the struct but is not pinned. Add it with its "+
+					"reviewed value; a new activation seam must not enter the tree "+
+					"unpinned.",
 				name, field,
 			)
 			continue
@@ -84,8 +188,8 @@ func assertPinnedFlags(t *testing.T, name string, pinned, actual map[string]bool
 		if actual[field] != expected {
 			t.Errorf(
 				"%s.%s is %t, pinned as %t. If this flip is intended, change the "+
-					"pin in THIS commit and record the evidence for the flip; if it "+
-					"is not, revert it -- this seam changes what the process owns.",
+					"pin in THIS commit and record the evidence; if it is not, "+
+					"revert it -- this seam changes what the process owns.",
 				name, field, actual[field], expected,
 			)
 		}
@@ -112,15 +216,49 @@ func sortedKeys(source map[string]bool) []string {
 	return keys
 }
 
-// TestSchedulerActivationPinIsNotVacuous guards the guard.
+// TestAssertPinnedFlagsFailsOnEveryDisagreement exercises the helper's failure
+// branches directly.
 //
-// A pin that compared an empty set against an empty set would pass forever while
-// proving nothing, and that failure mode is invisible in a green run. This
-// asserts the pin actually covers at least one field, and that its keys are the
-// struct's real field names rather than strings that merely look like them -- a
-// typo in a pinned key would otherwise present as "field exists but is not
-// pinned" plus "pinned but no longer exists", which is recoverable, but a pin
-// that silently covered nothing would not be.
+// Without this, the helper is only ever called with a matching singleton, so
+// deleting either of its two loops during maintenance leaves the suite green
+// while one binary silently loses its guard -- the duplicate copy in
+// dev-health-reconciler makes that asymmetry easy to miss. Each case below fails
+// if and only if the corresponding loop exists.
+func TestAssertPinnedFlagsFailsOnEveryDisagreement(t *testing.T) {
+	cases := map[string]struct {
+		pinned map[string]bool
+		actual map[string]bool
+	}{
+		"flipped value":     {map[string]bool{"a": false}, map[string]bool{"a": true}},
+		"field not pinned":  {map[string]bool{}, map[string]bool{"a": false}},
+		"pin without field": {map[string]bool{"a": false}, map[string]bool{}},
+	}
+	for name, testCase := range cases {
+		t.Run(name, func(t *testing.T) {
+			probe := &testing.T{}
+			assertPinnedFlags(probe, "probe", testCase.pinned, testCase.actual)
+			if !probe.Failed() {
+				t.Fatalf(
+					"assertPinnedFlags accepted %q. One of its two traversals is "+
+						"missing, so a real %s would pass unnoticed.",
+					name, name,
+				)
+			}
+		})
+	}
+
+	probe := &testing.T{}
+	assertPinnedFlags(
+		probe, "probe", map[string]bool{"a": false}, map[string]bool{"a": false},
+	)
+	if probe.Failed() {
+		t.Fatal("assertPinnedFlags rejected a matching pin: it is too strict to use")
+	}
+}
+
+// TestSchedulerActivationPinIsNotVacuous guards the guard: a pin comparing an
+// empty set against an empty set passes forever while proving nothing, and that
+// is invisible in a green run.
 func TestSchedulerActivationPinIsNotVacuous(t *testing.T) {
 	if len(checkedInSchedulerActivationPin) == 0 {
 		t.Fatal("the activation pin is empty, so it cannot fail: it proves nothing")

--- a/cmd/dev-health-scheduler/activation_pin_test.go
+++ b/cmd/dev-health-scheduler/activation_pin_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"go/ast"
+	"go/build/constraint"
 	"go/parser"
 	"go/token"
 	"reflect"
@@ -68,19 +69,39 @@ var schedulerReadinessNamesClosedWhenDormant = []string{
 // it goes through the production wrapper and checks the outcome. If someone
 // activates the scheduler by any route, this test fails.
 //
-// The cfg passed in names the production Service (schedulerSpec.Service),
-// not a zero config.Config{}. Adversarial review pointed out that an empty
-// config leaves room for a future configureSchedulerDependencies to branch
-// on cfg.Service or another populated field and activate only when the input
-// looks like config.Load's real output -- a rewrite this test would then miss
-// entirely. Passing the real Service name closes that specific route without
-// needing every other Config field, since activation here does not read them.
+// The cfg passed in is config.Load's own real output for schedulerSpec.Service
+// with no environment set, not a hand-built config.Config{} literal.
+// Adversarial review pointed out twice: first that an empty config leaves room
+// for a future configureSchedulerDependencies to branch on cfg.Service and
+// activate only for realistic input; then, after that was fixed by adding just
+// Service, that a hand-picked subset still isn't what production computes --
+// every other field a future refactor might branch on (for instance
+// cfg.CoordinatorDatabaseRole, which config.Load defaults to a non-empty
+// value even with no environment set) was still left zero, unlike production.
+// Calling config.Load itself removes the gap between "what this test passes"
+// and "what production would actually compute for this input", for every
+// field config.Load can populate without a real secret being set.
+//
+// NOT covered by this, and disclosed rather than assumed closed: a field that
+// config.Load only populates when a secret environment variable is actually
+// set (cfg.CoordinatorDatabaseURI.Configured(), for instance) still reads
+// zero here, because supplying a real one would make this an integration
+// test against infrastructure that may not exist. A future
+// configureSchedulerDependencies that activates specifically on a CONFIGURED
+// coordinator URI, rather than on the checked-in activation map, would still
+// pass this test undetected.
 func TestProductionSchedulerConfigurationIsDormant(t *testing.T) {
 	registry := health.NewRegistry(time.Second)
 
-	components, err := configureSchedulerDependencies(
-		context.Background(), config.Config{Service: schedulerSpec.Service}, registry,
-	)
+	cfg, err := config.Load(config.Spec{
+		Service:   schedulerSpec.Service,
+		LookupEnv: func(string) (string, bool) { return "", false },
+	})
+	if err != nil {
+		t.Fatalf("loading a production-defaulted config for %q: %v", schedulerSpec.Service, err)
+	}
+
+	components, err := configureSchedulerDependencies(context.Background(), cfg, registry)
 
 	if err != nil {
 		t.Fatalf(
@@ -180,8 +201,20 @@ func TestProductionSchedulerConfigurationIsDormant(t *testing.T) {
 // environment variable directly, or dispatching on something other than the
 // spec's configure fields -- would bypass every pin in this file the same way
 // a rewired main() would, and no test here would notice, because none of them
-// exercise shell.Main/Execute's own internals. And, as stated above, neither
-// pin proves that flipping the seam retains the capability the seam guards.
+// exercise shell.Main/Execute's own internals.
+//
+// NOT PINNED: a future configureSchedulerDependencies that branches on a
+// config.Config field only populated when a real secret environment variable
+// is set (cfg.CoordinatorDatabaseURI.Configured(), for instance), rather than
+// on checkedInSchedulerActivation. TestProductionSchedulerConfigurationIsDormant
+// passes config.Load's own defaulted output, which closes the version of this
+// where the branch condition is merely non-empty (config.Load already
+// defaults most fields); it does not close a branch on whether a SECRET was
+// actually configured, because supplying one would turn this into an
+// integration test.
+//
+// And, as stated above, neither pin proves that flipping the seam retains the
+// capability the seam guards.
 func TestSchedulerSpecUsesTheConfigurationThisFilePins(t *testing.T) {
 	if schedulerSpec.ConfigureDependenciesWithLogger != nil {
 		t.Fatal(
@@ -391,9 +424,32 @@ func TestSchedulerActivationPinIsNotVacuous(t *testing.T) {
 // close.
 func TestSchedulerMainInvokesShellMainWithThePinnedSpec(t *testing.T) {
 	fileSet := token.NewFileSet()
-	file, err := parser.ParseFile(fileSet, "main.go", nil, 0)
+	file, err := parser.ParseFile(fileSet, "main.go", nil, parser.ParseComments)
 	if err != nil {
 		t.Fatalf("parsing main.go: %v", err)
+	}
+
+	// A build-constrained main.go could be excluded from the build actually
+	// shipped, with a differently-behaving entry point compiling in its place
+	// under a platform- or tag-specific filename -- this test would keep
+	// parsing and passing against a file the binary never contains. Adversarial
+	// review raised this as a plausible ordinary refactor (a platform-specific
+	// entrypoint split), not a contrived one, so it is rejected outright rather
+	// than merely disclosed.
+	for _, group := range file.Comments {
+		for _, comment := range group.List {
+			if constraint.IsGoBuild(comment.Text) || constraint.IsPlusBuild(comment.Text) {
+				t.Fatalf(
+					"main.go carries a build constraint (%q). This file's pins only "+
+						"cover main.go's content, not whether the build actually "+
+						"includes it -- a constrained main.go could be dead code while "+
+						"another file supplies the real entry point. Remove the "+
+						"constraint, or move the pinned main() to whichever file is "+
+						"unconditionally built and retarget this test at it.",
+					comment.Text,
+				)
+			}
+		}
 	}
 
 	var mainDecl *ast.FuncDecl

--- a/cmd/dev-health-scheduler/activation_pin_test.go
+++ b/cmd/dev-health-scheduler/activation_pin_test.go
@@ -119,6 +119,50 @@ func TestProductionSchedulerConfigurationIsDormant(t *testing.T) {
 	}
 }
 
+// TestSchedulerSpecUsesTheConfigurationThisFilePins closes the last link in the
+// chain from `main` to the assertion above.
+//
+// The behavioural pin calls configureSchedulerDependencies directly. That proves
+// what THAT function does; it does not prove `shell.Main` reaches it. Point
+// schedulerSpec at a different configure function and the pin keeps passing while
+// the binary runs something else entirely -- the same defeat as the original
+// version of this file, one level further out. Comparing the spec's function
+// pointer to the function under test makes the chain complete:
+// main -> shell.Main(schedulerSpec) -> this field -> the tested function.
+//
+// Function values are not comparable in Go, so compare code pointers. A nil field
+// is also a failure: it would mean the binary has no configuration at all, or
+// that the logger-taking variant is now in use and this pin no longer covers the
+// path production takes.
+func TestSchedulerSpecUsesTheConfigurationThisFilePins(t *testing.T) {
+	if schedulerSpec.ConfigureDependenciesWithLogger != nil {
+		t.Fatal(
+			"schedulerSpec now sets ConfigureDependenciesWithLogger. shell.Main may " +
+				"call that instead of ConfigureDependencies, so the behavioural pin " +
+				"below no longer proves anything about the production path. Retarget " +
+				"the pin at whichever field shell.Main actually invokes.",
+		)
+	}
+	if schedulerSpec.ConfigureDependencies == nil {
+		t.Fatal(
+			"schedulerSpec.ConfigureDependencies is nil, so this pin covers nothing " +
+				"that production runs",
+		)
+	}
+
+	pinned := reflect.ValueOf(configureSchedulerDependencies).Pointer()
+	wired := reflect.ValueOf(schedulerSpec.ConfigureDependencies).Pointer()
+	if pinned != wired {
+		t.Fatal(
+			"schedulerSpec.ConfigureDependencies is NOT " +
+				"configureSchedulerDependencies. The behavioural pin therefore tests a " +
+				"function the binary does not call, and activation could ship green. " +
+				"Either restore the wiring or retarget the pin at the function " +
+				"shell.Main really invokes -- do not delete this test.",
+		)
+	}
+}
+
 // TestCheckedInSchedulerActivationMatchesItsPin is the structural pin: a flipped
 // value, an added field, and a removed field each fail.
 //

--- a/cmd/dev-health-scheduler/activation_pin_test.go
+++ b/cmd/dev-health-scheduler/activation_pin_test.go
@@ -1,0 +1,139 @@
+package main
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+)
+
+// checkedInSchedulerActivationPin is the reviewed expectation for every field of
+// schedulerActivation. It exists so that flipping an activation seam is a
+// deliberate act recorded in the same change that flips it.
+//
+// Why a pin rather than trusting review: schedulerActivation is the seam that
+// decides whether this process owns periodic work. Flipping goOwnsMarkers to
+// true takes the binary from "opens no PostgreSQL pool at all" to "writes
+// scheduler markers", and nothing in CI previously noticed that one-character
+// change. CHAOS-3033 closed 19 issues Done over dormant code precisely because
+// activation state was invisible to every gate; the plan of record's section 5
+// names "a capability listed in the registry but not constructed by a binary" as
+// a false pass, and an unpinned activation flag is how that state arises without
+// anyone deciding to arrive there.
+//
+// Updating this map is the intended way to activate a seam. Do it in the same
+// commit that flips the flag, with the evidence for the flip in the commit
+// message: for goOwnsMarkers that means a constructed materializer, because
+// flipping it alone yields a scheduler that writes but is permanently not-ready
+// (see main.go's own doc comment and CHAOS-3145).
+var checkedInSchedulerActivationPin = map[string]bool{
+	"goOwnsMarkers": false,
+}
+
+// TestCheckedInSchedulerActivationMatchesItsPin fails on three distinct
+// mistakes, not one.
+//
+// The obvious one is a flipped value. The two that matter more are structural:
+// ADDING a field, and REMOVING one. A test that only compared the struct against
+// its zero value would pass when a new dormant seam was added -- the new field
+// defaults to false, the comparison still holds, and an unreviewed activation
+// switch enters the tree already invisible. Enumerating the fields by reflection
+// and requiring the field SET to match exactly is what makes the pin
+// bidirectional: a new seam must be declared here to compile-and-pass, and a
+// deleted seam must be removed from here.
+func TestCheckedInSchedulerActivationMatchesItsPin(t *testing.T) {
+	value := reflect.ValueOf(checkedInSchedulerActivation)
+	structType := value.Type()
+
+	actual := make(map[string]bool, structType.NumField())
+	for index := 0; index < structType.NumField(); index++ {
+		field := structType.Field(index)
+		if field.Type.Kind() != reflect.Bool {
+			// Not pedantry: the pin can only compare what it can read, and
+			// reflect.Value.Bool is the accessor that works on an unexported
+			// field. A non-bool seam is a real possibility (an enum, a count),
+			// and it must force a deliberate extension of this test rather than
+			// being silently skipped and left unpinned.
+			t.Fatalf(
+				"schedulerActivation.%s is %s, not bool: extend this pin to cover "+
+					"the new kind before adding it, or the seam ships unpinned",
+				field.Name, field.Type.Kind(),
+			)
+		}
+		actual[field.Name] = value.Field(index).Bool()
+	}
+
+	assertPinnedFlags(t, "schedulerActivation", checkedInSchedulerActivationPin, actual)
+}
+
+// assertPinnedFlags reports every disagreement rather than the first, so a
+// reviewer sees the whole delta in one run instead of re-running per field.
+func assertPinnedFlags(t *testing.T, name string, pinned, actual map[string]bool) {
+	t.Helper()
+
+	for _, field := range sortedKeys(actual) {
+		expected, declared := pinned[field]
+		if !declared {
+			t.Errorf(
+				"%s.%s exists in the struct but is not pinned. Add it to the pin "+
+					"with its reviewed value; a new activation seam must not enter "+
+					"the tree unpinned.",
+				name, field,
+			)
+			continue
+		}
+		if actual[field] != expected {
+			t.Errorf(
+				"%s.%s is %t, pinned as %t. If this flip is intended, change the "+
+					"pin in THIS commit and record the evidence for the flip; if it "+
+					"is not, revert it -- this seam changes what the process owns.",
+				name, field, actual[field], expected,
+			)
+		}
+	}
+
+	for _, field := range sortedKeys(pinned) {
+		if _, present := actual[field]; !present {
+			t.Errorf(
+				"%s.%s is pinned but no longer exists. Remove it from the pin in "+
+					"the same commit that removed the field, so the pin cannot "+
+					"accumulate expectations about seams that are gone.",
+				name, field,
+			)
+		}
+	}
+}
+
+func sortedKeys(source map[string]bool) []string {
+	keys := make([]string, 0, len(source))
+	for key := range source {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+// TestSchedulerActivationPinIsNotVacuous guards the guard.
+//
+// A pin that compared an empty set against an empty set would pass forever while
+// proving nothing, and that failure mode is invisible in a green run. This
+// asserts the pin actually covers at least one field, and that its keys are the
+// struct's real field names rather than strings that merely look like them -- a
+// typo in a pinned key would otherwise present as "field exists but is not
+// pinned" plus "pinned but no longer exists", which is recoverable, but a pin
+// that silently covered nothing would not be.
+func TestSchedulerActivationPinIsNotVacuous(t *testing.T) {
+	if len(checkedInSchedulerActivationPin) == 0 {
+		t.Fatal("the activation pin is empty, so it cannot fail: it proves nothing")
+	}
+
+	structType := reflect.TypeOf(checkedInSchedulerActivation)
+	for _, field := range sortedKeys(checkedInSchedulerActivationPin) {
+		if _, found := structType.FieldByName(field); !found {
+			t.Errorf(
+				"pinned key %q is not a field of schedulerActivation: the pin is "+
+					"asserting something about a name that does not exist",
+				field,
+			)
+		}
+	}
+}

--- a/cmd/dev-health-scheduler/activation_pin_test.go
+++ b/cmd/dev-health-scheduler/activation_pin_test.go
@@ -119,8 +119,10 @@ func TestProductionSchedulerConfigurationIsDormant(t *testing.T) {
 	}
 }
 
-// TestSchedulerSpecUsesTheConfigurationThisFilePins closes the last link in the
-// chain from `main` to the assertion above.
+// TestSchedulerSpecUsesTheConfigurationThisFilePins pins the spec-to-function
+// link. It does not close the chain from `main`, and an earlier version of this
+// comment claimed it did -- see the coverage statement below, which review
+// required after the reconciler file made the same overstatement.
 //
 // The behavioural pin calls configureSchedulerDependencies directly. That proves
 // what THAT function does; it does not prove `shell.Main` reaches it. Point
@@ -134,6 +136,16 @@ func TestProductionSchedulerConfigurationIsDormant(t *testing.T) {
 // is also a failure: it would mean the binary has no configuration at all, or
 // that the logger-taking variant is now in use and this pin no longer covers the
 // path production takes.
+//
+// PINNED: the spec field IS configureSchedulerDependencies, and the logger-taking
+// field is nil so shell.Main cannot take the other one. Combined with the
+// behavioural pin above -- which calls that exact function -- the link from the
+// spec to the observed dormant behaviour is covered.
+//
+// NOT PINNED: `main()` calling shell.Main(schedulerSpec). A test cannot observe
+// main(), so a binary rewired to a different spec would not fail here. And, as
+// stated above, neither pin proves that flipping the seam retains the capability
+// the seam guards.
 func TestSchedulerSpecUsesTheConfigurationThisFilePins(t *testing.T) {
 	if schedulerSpec.ConfigureDependenciesWithLogger != nil {
 		t.Fatal(

--- a/cmd/dev-health-scheduler/activation_pin_test.go
+++ b/cmd/dev-health-scheduler/activation_pin_test.go
@@ -2,6 +2,9 @@ package main
 
 import (
 	"context"
+	"go/ast"
+	"go/parser"
+	"go/token"
 	"reflect"
 	"sort"
 	"testing"
@@ -64,11 +67,19 @@ var schedulerReadinessNamesClosedWhenDormant = []string{
 // assignment, a parallel activation type, and a test-only reset of the global:
 // it goes through the production wrapper and checks the outcome. If someone
 // activates the scheduler by any route, this test fails.
+//
+// The cfg passed in names the production Service (schedulerSpec.Service),
+// not a zero config.Config{}. Adversarial review pointed out that an empty
+// config leaves room for a future configureSchedulerDependencies to branch
+// on cfg.Service or another populated field and activate only when the input
+// looks like config.Load's real output -- a rewrite this test would then miss
+// entirely. Passing the real Service name closes that specific route without
+// needing every other Config field, since activation here does not read them.
 func TestProductionSchedulerConfigurationIsDormant(t *testing.T) {
 	registry := health.NewRegistry(time.Second)
 
 	components, err := configureSchedulerDependencies(
-		context.Background(), config.Config{}, registry,
+		context.Background(), config.Config{Service: schedulerSpec.Service}, registry,
 	)
 
 	if err != nil {
@@ -137,15 +148,35 @@ func TestProductionSchedulerConfigurationIsDormant(t *testing.T) {
 // that the logger-taking variant is now in use and this pin no longer covers the
 // path production takes.
 //
-// PINNED: the spec field IS configureSchedulerDependencies, and the logger-taking
-// field is nil so shell.Main cannot take the other one. Combined with the
-// behavioural pin above -- which calls that exact function -- the link from the
-// spec to the observed dormant behaviour is covered.
+// PINNED: the spec field's code pointer equals configureSchedulerDependencies's
+// code pointer, and the logger-taking field is nil so shell.Main cannot take the
+// other one. Combined with the behavioural pin above -- which calls that exact
+// function -- the link from the spec to the observed dormant behaviour is
+// covered, PROVIDED both sides stay what they are today: direct references to
+// the same plain top-level function declaration.
 //
-// NOT PINNED: `main()` calling shell.Main(schedulerSpec). A test cannot observe
-// main(), so a binary rewired to a different spec would not fail here. And, as
-// stated above, neither pin proves that flipping the seam retains the capability
-// the seam guards.
+// NOT PINNED, and this is a real gap rather than pedantry: that neither side is
+// ever refactored into a closure or a bound method value. Adversarial review
+// pointed out that Go documents a function's code pointer as not necessarily
+// unique -- two closures produced by a shared factory, or two bound method
+// values with different receivers, can compare equal by reflect.Value.Pointer()
+// while invoking different code. That is not what schedulerSpec.
+// ConfigureDependencies or configureSchedulerDependencies are today -- both are
+// direct references to one package-level function declaration, for which this
+// code-pointer comparison is conclusive -- but nothing here would notice the
+// day either one stops being that. A stronger runtime check (comparing
+// runtime.FuncForPC names, for instance) would not close this: if the
+// compiler/linker ever did fold two distinct closures onto one code address,
+// there would be exactly one symbol table entry for it, so name and pointer
+// comparisons would agree and still miss the same case. This is a limit of
+// what reflection can prove, not a gap this file chose to leave open.
+//
+// NOT PINNED: `main()` calling shell.Main(schedulerSpec) at runtime -- a running
+// test cannot observe process startup. TestSchedulerMainInvokesShellMainWithThePinnedSpec
+// below closes the practical version of this gap by parsing main.go's committed
+// source instead of trying to observe its execution. And, as stated above,
+// neither pin proves that flipping the seam retains the capability the seam
+// guards.
 func TestSchedulerSpecUsesTheConfigurationThisFilePins(t *testing.T) {
 	if schedulerSpec.ConfigureDependenciesWithLogger != nil {
 		t.Fatal(
@@ -329,5 +360,78 @@ func TestSchedulerActivationPinIsNotVacuous(t *testing.T) {
 				field,
 			)
 		}
+	}
+}
+
+// TestSchedulerMainInvokesShellMainWithThePinnedSpec closes the one gap the
+// rest of this file states it cannot: whether `main()` actually calls
+// shell.Main(schedulerSpec). A running test cannot observe process startup,
+// but it can read the committed source that becomes it. This parses main.go
+// directly and requires func main()'s body to be exactly one statement,
+// calling shell.Main with the identifier every other pin in this file already
+// covers end to end.
+//
+// This is deliberately strict about shape: rewiring main() to call something
+// else, to pass a copy or a second spec, or to do anything at all beyond this
+// one call, fails the test. A future legitimate change to main() must update
+// this test in the same commit, which is the point -- that change becomes
+// visible instead of silently falling outside every other pin's reach.
+func TestSchedulerMainInvokesShellMainWithThePinnedSpec(t *testing.T) {
+	fileSet := token.NewFileSet()
+	file, err := parser.ParseFile(fileSet, "main.go", nil, 0)
+	if err != nil {
+		t.Fatalf("parsing main.go: %v", err)
+	}
+
+	var mainDecl *ast.FuncDecl
+	for _, declaration := range file.Decls {
+		function, ok := declaration.(*ast.FuncDecl)
+		if !ok || function.Recv != nil || function.Name.Name != "main" {
+			continue
+		}
+		mainDecl = function
+	}
+	if mainDecl == nil || mainDecl.Body == nil {
+		t.Fatal(
+			"main.go declares no func main() with a body; the pins in this file " +
+				"cover a function the binary never runs",
+		)
+	}
+	if len(mainDecl.Body.List) != 1 {
+		t.Fatalf(
+			"func main() has %d statements, want exactly 1 (the shell.Main call "+
+				"this test pins). If this is a reviewed change, confirm the new "+
+				"statements cannot skip or alter the shell.Main(schedulerSpec) call "+
+				"before updating this test.",
+			len(mainDecl.Body.List),
+		)
+	}
+
+	expressionStatement, ok := mainDecl.Body.List[0].(*ast.ExprStmt)
+	if !ok {
+		t.Fatalf("func main()'s only statement is not a call expression: %#v", mainDecl.Body.List[0])
+	}
+	call, ok := expressionStatement.X.(*ast.CallExpr)
+	if !ok {
+		t.Fatalf("func main()'s statement is not a function call: %#v", expressionStatement.X)
+	}
+	selector, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok {
+		t.Fatalf("func main() does not call a package-qualified function: %#v", call.Fun)
+	}
+	packageIdent, ok := selector.X.(*ast.Ident)
+	if !ok || packageIdent.Name != "shell" || selector.Sel.Name != "Main" {
+		t.Fatalf("func main() calls %#v, not shell.Main", call.Fun)
+	}
+	if len(call.Args) != 1 {
+		t.Fatalf("shell.Main call has %d arguments, want exactly 1", len(call.Args))
+	}
+	argument, ok := call.Args[0].(*ast.Ident)
+	if !ok || argument.Name != "schedulerSpec" {
+		t.Fatalf(
+			"func main() passes %#v to shell.Main, not schedulerSpec -- the pins "+
+				"in this file cover a spec the binary does not use",
+			call.Args[0],
+		)
 	}
 }


### PR DESCRIPTION
## What this is

Behavioural pins on the two activation seams of the Go worker cutover — `goOwnsMarkers` in `dev-health-scheduler` and `syncMutation` in `dev-health-reconciler`. Both seams are zero-value `false` today. These tests exist so that flipping either one is a deliberate, visible act rather than a silent activation of code that does not yet deliver the capability it guards.

**Tests only.** No production file is touched; `git diff --name-only origin/main..HEAD` is two `_test.go` files.

A green run here means *"the seam is dormant and changing it is deliberate"* — never *"it is safe to flip"*. That distinction is the point: the epic's central failure mode is seam delivery mistaken for capability delivery, and flipping `syncMutation` today still yields a `42501` on the coordinator's `sync_dispatch_outbox` INSERT (CHAOS-3146).

## What is pinned

Each binary now pins the whole chain from `main` to the observed dormant behaviour:

- **`main` → `shell.Main(spec)`** — a `go/parser` assertion that `func main()`'s body is exactly one statement, `shell.Main(<spec>)`. A running test cannot observe process startup, so this pins the committed source instead.
- **spec field → the reviewed function** — by code pointer, with the other `Configure…` field asserted nil so `shell.Main` cannot take the path the behavioural pin does not cover.
- **the reviewed function → dormant behaviour** — the scheduler builds no components and leaves five readiness names failing; the reconciler selects the shadow stepper and never the mutation stepper.
- **the production wrapper's body** — `TestReconcilerSpecInvokesTheReviewedActivation` swaps fakes into the package var the wrapper actually reads and calls through the spec field itself, so keeping the symbol and changing its body no longer passes.
- **what the production shadow builder returns** — `TestProductionSyncShadowBuilderReturnsTheShadowStepper` calls the real builder with an inert pool and the real contract registry and requires `*syncreconciler.Shadow`.

## What is not pinned, and why

Both files carry explicit NOT-PINNED lists with residual risk stated per item. The three that remain:

- **A future activation route added inside `shell.Main`/`Execute` itself.** It sits in the chain and no pin here constrains it.
- **Function-value identity under refactoring.** `reflect.Value.Pointer()` is conclusive for the direct top-level function references both sides are today, and Go documents that a code pointer is not necessarily unique for closures or bound method values. A `runtime.FuncForPC` name comparison would not close this: a genuine fold to one code address leaves one symbol-table entry, so name and pointer comparison would agree and both miss it. This is a limit of what reflection can prove.
- **That flipping a seam retains the capability it guards** (CHAOS-3146).

An honestly-stated limit is the deliverable here, not a consolation prize — an inaccurate coverage claim is worse than an admitted gap, because a reader who sees `PINNED: X` stops verifying X.

## Review history

Six adversarial review rounds. Every round found a real defect in the previous round's fix, which is why there were six:

1. the pins asserted a fact about a variable rather than about the binary;
2. they proved what a function does, not that `shell.Main` reaches it;
3. the reconciler file claimed to "close the chain" while a paragraph six lines below admitted a gap — the contradiction, not the code, was the defect;
4. **both pins fed production a config shape production never sees** (`Config{}`; only `RiverDatabaseSchema`). Demonstrated, not argued: made activation conditional on `cfg.Service`, and the old test **false-passed**. Round 4 also found the code-pointer wording overclaiming identity, and that round 3's finding on it had never reached the disclosure list;
5. one misattributed residual-risk comment, and one disclosure that existed only in the working tree when the review ran.

Round 5 returned **0 Critical**, and labelled its two remaining findings contrived. **Round 6 existed to test those labels, and refuted one of them** — asking the different question, *is this plausibly accidental, or does it require code whose only effect is defeating the test?*

- **Critical, real.** Round 4's fix added `Service` to the pins, which closed an instance. A hand-picked `config.Config` literal still is not what production computes: `cfg.CoordinatorDatabaseRole` defaults non-empty with no environment set, and the literal left it `""`. A future branch on that field — or on any field `config.Load` defaults — would activate with every pin green. Closed as a **class fix**: both behavioural pins now call `config.Load` under an injected all-absent `LookupEnv`, so every default matches production by construction rather than by transcription. Verified pure: `config.Load` reads the process environment only when the spec's lookup is nil, and its one `net` call is `SplitHostPort` string parsing, so the test cannot behave differently on another machine.
- **High, real** — round 5 had mislabelled this one contrived. Both AST tests parsed `main.go` without checking build constraints, so a `//go:build !linux` stale file would satisfy the shape check while a different entry point actually compiled. An AST test that reads a file without establishing that the file is compiled into the target is measuring the wrong artifact. Now rejected via `go/build/constraint` before the shape check runs.
- **Confirmed contrived**, and left as-is: the rebound `shell` identifier. An import rename does not solve an import cycle, and a local `shell` variable cannot fit inside the required one-statement `main()`.

The residual named rather than implied: a branch on whether a secret was actually *configured* rather than defaulted cannot be closed without an integration test — and an activation pin CI can skip is not a pin.

**The generalisable lesson, recorded because it cost a round:** a "contrived" label is a claim like any other. Drawing a line on adversarial descent is correct, but the line belongs *after* the labels have been challenged once, not on the round that produced them.

Every closure is backed by a mutation showing the **old** test passing and the new one failing; that pair is what distinguishes a test which closes a gap from one that merely sits beside it. Both AST tests were proven non-vacuous by renaming `func main()` and by pointing the parser at a nonexistent file — a source-reading test that finds nothing and passes is a measurement that silently did not happen.

## Gate

`ci/local_validate.sh` green against this base: 9056 passed, 62 skipped, `argMax` live-exec OK, `go vet` clean.

Refs CHAOS-3151, CHAOS-3146
